### PR TITLE
perf(sidebar): pause background session polling while the tab is hidden (#5455)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4595,6 +4595,7 @@ const _activeSessionExternalRefreshMs = 30000;
 let _streamingPollTimer = null;
 let _sessionTimeRefreshTimer = null;
 let _streamingPollVisibilityHandler = null;
+let _sessionTimeRefreshVisibilityHandler = null;
 let _activeSessionExternalRefreshTimer = null;
 let _activeSessionExternalRefreshInFlight = false;
 let _deferredActiveSessionExternalRefreshReason = '';
@@ -4646,11 +4647,17 @@ function stopStreamingPoll(){
 function ensureSessionTimeRefreshPoll(){
   if(_sessionTimeRefreshTimer) return;
   _sessionTimeRefreshTimer = setInterval(() => {
-    // Relative-time labels only matter when visible; the tab-shown refresh in
-    // startStreamingPoll re-renders the list (and its timestamps) on return.
+    // Relative-time labels only matter when visible; the visibilitychange
+    // handler below refreshes timestamps immediately when the tab is shown.
     if(typeof document !== 'undefined' && document.hidden) return;
     renderSessionListFromCache();
   }, _sessionTimeRefreshMs);
+  if(typeof document !== 'undefined' && !_sessionTimeRefreshVisibilityHandler){
+    _sessionTimeRefreshVisibilityHandler = () => {
+      if(!document.hidden) renderSessionListFromCache();
+    };
+    document.addEventListener('visibilitychange', _sessionTimeRefreshVisibilityHandler);
+  }
 }
 
 function _deferActiveSessionExternalRefresh(reason){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4594,6 +4594,7 @@ const _sessionTimeRefreshMs = 60000;
 const _activeSessionExternalRefreshMs = 30000;
 let _streamingPollTimer = null;
 let _sessionTimeRefreshTimer = null;
+let _streamingPollVisibilityHandler = null;
 let _activeSessionExternalRefreshTimer = null;
 let _activeSessionExternalRefreshInFlight = false;
 let _deferredActiveSessionExternalRefreshReason = '';
@@ -4617,11 +4618,26 @@ let _sessionListRefreshPendingReason = '';
 function startStreamingPoll(){
   if(_streamingPollTimer) return;
   _streamingPollTimer = setInterval(() => {
+    // Skip while the tab is hidden: this poll fetches /api/sessions and rebuilds
+    // the sidebar, work the user cannot see. The visibilitychange handler below
+    // brings the list current the moment the tab is shown again, so no update is
+    // lost — the background tab just stops burning network + DOM churn.
+    if(typeof document !== 'undefined' && document.hidden) return;
     void renderSessionList({deferWhileInteracting:true});
   }, _streamingPollMs);
+  if(typeof document !== 'undefined' && !_streamingPollVisibilityHandler){
+    _streamingPollVisibilityHandler = () => {
+      if(!document.hidden) void renderSessionList({deferWhileInteracting:true});
+    };
+    document.addEventListener('visibilitychange', _streamingPollVisibilityHandler);
+  }
 }
 
 function stopStreamingPoll(){
+  if(_streamingPollVisibilityHandler && typeof document !== 'undefined'){
+    document.removeEventListener('visibilitychange', _streamingPollVisibilityHandler);
+    _streamingPollVisibilityHandler = null;
+  }
   if(!_streamingPollTimer) return;
   clearInterval(_streamingPollTimer);
   _streamingPollTimer = null;
@@ -4630,6 +4646,9 @@ function stopStreamingPoll(){
 function ensureSessionTimeRefreshPoll(){
   if(_sessionTimeRefreshTimer) return;
   _sessionTimeRefreshTimer = setInterval(() => {
+    // Relative-time labels only matter when visible; the tab-shown refresh in
+    // startStreamingPoll re-renders the list (and its timestamps) on return.
+    if(typeof document !== 'undefined' && document.hidden) return;
     renderSessionListFromCache();
   }, _sessionTimeRefreshMs);
 }

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -79,6 +79,17 @@ def test_active_session_external_refresh_has_focus_and_visibility_hooks():
     assert "ensureActiveSessionExternalRefreshPoll();" in SESSIONS_JS
 
 
+def test_session_time_refresh_has_own_visibility_hook():
+    """Skipped hidden-tab timestamp ticks must refresh immediately on return."""
+    start = SESSIONS_JS.find("function ensureSessionTimeRefreshPoll()")
+    assert start != -1
+    block = SESSIONS_JS[start:start + 900]
+    assert "_sessionTimeRefreshVisibilityHandler" in SESSIONS_JS
+    assert "document.addEventListener('visibilitychange', _sessionTimeRefreshVisibilityHandler);" in block
+    assert "if(!document.hidden) renderSessionListFromCache();" in block
+    assert "startStreamingPoll re-renders the list" not in block
+
+
 def test_session_list_external_refresh_uses_sse_invalidation_not_polling():
     """New sessions should refresh the sidebar from server invalidation events."""
     assert "async function refreshSessionList(reason='manual', opts={})" in SESSIONS_JS


### PR DESCRIPTION
## Problem
The 30s streaming poll (`renderSessionList` → `GET /api/sessions` + full sidebar rebuild) and the 60s relative-time refresh (`renderSessionListFromCache` → full DOM rebuild) ran unconditionally, **including in hidden background tabs** — so a backgrounded window kept fetching and rebuilding a sidebar it could not show. Part of the #5455 latency work.

## Change
Guard both interval callbacks with `document.hidden`, and refresh the list on `visibilitychange` when the tab is shown again (mirroring the existing gateway poll). No update is lost — the list re-syncs the moment the tab becomes visible.

## Behavior
Visually neutral while the tab is visible; a hidden tab simply stops burning network and DOM churn.

## Verification
`node --check` + the repo ESLint runtime guard pass.

Refs #5455.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
