### PR TITLE
fix(composer): suppress stale draft restore after send

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1029,8 +1029,10 @@ function _composerTextWithPendingSelections(){
 function _clearComposerAfterQueuedSelectionSend(){
   const sid=arguments.length?arguments[0]:(S.session&&S.session.session_id);
   const composer=(typeof $==='function'&&$('msg'))||document.getElementById('msg');
+  const draftText=composer?String(composer.value||''):'';
+  const draftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
   if(composer)composer.value='';
-  if(sid&&typeof _clearComposerDraft==='function') _clearComposerDraft(sid);
+  if(sid&&typeof _clearComposerDraft==='function') _clearComposerDraft(sid,draftText,draftFiles);
   _clearPendingSelections();
   if(typeof autoResize==='function') autoResize();
 }
@@ -1308,7 +1310,7 @@ async function send(){
       const _modelState=_chatPayloadModelState();
       queueSessionMessage(_targetSid,{text:_text,files:[...S.pendingFiles],model:_modelState.model,model_provider:_modelState.model_provider,profile:S.activeProfile||'default'});
       _clearComposerAfterQueuedSelectionSend();
-      if(_targetSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(_targetSid);
+      if(_targetSid&&typeof _clearComposerDraft==='function'&&_targetSid!==(S.session&&S.session.session_id)) _clearComposerDraft(_targetSid,_text,S.pendingFiles?[...S.pendingFiles]:[]);
       S.pendingFiles=[];renderTray();
       updateQueueBadge(_targetSid);
       showToast(`Queued: "${_text.slice(0,40)}${_text.length>40?'…':''}"`,2000);
@@ -1365,6 +1367,7 @@ async function send(){
       }
     const defaultMessageMode=window._defaultMessageMode||'steer';
       if(defaultMessageMode==='steer'&&S.activeStreamId&&typeof _trySteer==='function'){
+        const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
         // Real steer: clear the input first so the user gets immediate
         // feedback, then ship the steer payload via /api/chat/steer.
         // _trySteer restores the draft and leaves the active stream running if
@@ -1376,7 +1379,7 @@ async function send(){
         // After a delivered steer, clear any staged files because the text-only
         // steer payload has been handled. On failure, keep files staged.
         if(_steerDelivered){S.pendingFiles=[];renderTray();}
-        if(_steerDelivered&&S.session&&typeof _clearComposerDraft==='function') _clearComposerDraft(S.session.session_id);
+        if(_steerDelivered&&S.session&&typeof _clearComposerDraft==='function') _clearComposerDraft(S.session.session_id,text,_steerDraftFiles);
       } else if(defaultMessageMode==='interrupt'){
         // Queue the message, then cancel so drain re-sends it.
         const _modelState=_chatPayloadModelState();
@@ -1581,7 +1584,8 @@ async function send(){
     }
   }
   if(!msgText){setComposerStatus('Nothing to send');return;}
-
+  const _submittedDraftTextForClear=$('msg').value||'';
+  const _submittedDraftFilesForClear=Array.isArray(_failedSendFilesSnapshot)?[..._failedSendFilesSnapshot]:[];
   $('msg').value='';autoResize();
   // Clear persisted composer draft since message was sent. Capture the promise
   // so the #5472 failed-send restore can chain its re-persist AFTER this clear
@@ -1589,7 +1593,7 @@ async function send(){
   // text:<draft>) can be reordered under HTTP/2 multiplexing and leave the
   // server draft empty after a reload. (Opus #5484 NIT.)
   let _composerDraftClearPromise=null;
-  if (activeSid && typeof _clearComposerDraft === 'function') _composerDraftClearPromise=_clearComposerDraft(activeSid);
+  if (activeSid && typeof _clearComposerDraft === 'function') _composerDraftClearPromise=_clearComposerDraft(activeSid,_submittedDraftTextForClear,_submittedDraftFilesForClear);
   const displayText=_slashDisplayTextOverride||text||(uploaded.length?`Uploaded: ${uploadedNames.join(', ')}`:'(file upload)');
   const userMsg={role:'user',content:displayText,attachments:uploaded.length?uploadedNames:undefined,_ts:Date.now()/1000};
   S.toolCalls=[];  // clear tool calls from previous turn

--- a/static/messages.js
+++ b/static/messages.js
@@ -1027,8 +1027,10 @@ function _composerTextWithPendingSelections(){
 }
 
 function _clearComposerAfterQueuedSelectionSend(){
+  const sid=arguments.length?arguments[0]:(S.session&&S.session.session_id);
   const composer=(typeof $==='function'&&$('msg'))||document.getElementById('msg');
   if(composer)composer.value='';
+  if(sid&&typeof _clearComposerDraft==='function') _clearComposerDraft(sid);
   _clearPendingSelections();
   if(typeof autoResize==='function') autoResize();
 }
@@ -1306,6 +1308,7 @@ async function send(){
       const _modelState=_chatPayloadModelState();
       queueSessionMessage(_targetSid,{text:_text,files:[...S.pendingFiles],model:_modelState.model,model_provider:_modelState.model_provider,profile:S.activeProfile||'default'});
       _clearComposerAfterQueuedSelectionSend();
+      if(_targetSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(_targetSid);
       S.pendingFiles=[];renderTray();
       updateQueueBadge(_targetSid);
       showToast(`Queued: "${_text.slice(0,40)}${_text.length>40?'…':''}"`,2000);
@@ -1373,12 +1376,13 @@ async function send(){
         // After a delivered steer, clear any staged files because the text-only
         // steer payload has been handled. On failure, keep files staged.
         if(_steerDelivered){S.pendingFiles=[];renderTray();}
+        if(_steerDelivered&&S.session&&typeof _clearComposerDraft==='function') _clearComposerDraft(S.session.session_id);
       } else if(defaultMessageMode==='interrupt'){
         // Queue the message, then cancel so drain re-sends it.
         const _modelState=_chatPayloadModelState();
         queueSessionMessage(S.session.session_id,{text,files:[...S.pendingFiles],model:_modelState.model,model_provider:_modelState.model_provider,profile:S.activeProfile||'default'});
         updateQueueBadge(S.session.session_id);
-        $('msg').value='';autoResize();
+        _clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);
         S.pendingFiles=[];renderTray();
         if(S.activeStreamId&&typeof cancelStream==='function'){
           showToast(t('busy_interrupt_confirm'),2000);
@@ -1391,7 +1395,7 @@ async function send(){
         // 'steer' mode when no stream is active or _trySteer is unavailable.
         const _modelState=_chatPayloadModelState();
         queueSessionMessage(S.session.session_id,{text,files:[...S.pendingFiles],model:_modelState.model,model_provider:_modelState.model_provider,profile:S.activeProfile||'default'});
-        $('msg').value='';autoResize();
+        _clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);
         S.pendingFiles=[];renderTray();
         updateQueueBadge(S.session.session_id);
         showToast(`Queued: "${text.slice(0,40)}${text.length>40?'…':''}"`,2000);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -37,11 +37,44 @@ const _composerDraftKnownPayloadSessions = new Set();
 const _composerDraftRestoreSuppressedUntilBySid = new Map();
 const _COMPOSER_DRAFT_RESTORE_SUPPRESS_MS = 30000;
 
-function _suppressComposerDraftRestoreAfterSubmit(sid) {
+function _composerDraftFileSignature(file) {
+  if (typeof file === 'string') return { value: file };
+  if (!file || typeof file !== 'object') return { value: String(file || '') };
+  return {
+    name: String(file.name || file.filename || ''),
+    path: String(file.path || ''),
+    size: Number.isFinite(Number(file.size)) ? Number(file.size) : null,
+    type: String(file.type || file.mime || ''),
+  };
+}
+
+function _composerDraftPayloadSignature(text, files) {
+  const normalizedText = String(text || '');
+  const normalizedFiles = Array.isArray(files) ? files.filter(Boolean).map(_composerDraftFileSignature) : [];
+  return JSON.stringify({ text: normalizedText, files: normalizedFiles });
+}
+
+function _composerDraftPayloadSignatureForSid(sid) {
+  if (typeof S === 'undefined' || !S.session || S.session.session_id !== sid) return null;
+  const draft = S.session.composer_draft || null;
+  if (!draft) return null;
+  return _composerDraftPayloadSignature(draft.text, draft.files);
+}
+
+function _suppressComposerDraftRestoreAfterSubmit(sid, text, files) {
   if (!sid) return;
+  const previous = _composerDraftRestoreSuppressedUntilBySid.get(sid);
+  let signature = null;
+  if (arguments.length >= 2) {
+    signature = _composerDraftPayloadSignature(text, files);
+  } else if (previous && typeof previous === 'object') {
+    signature = previous.signature || null;
+  } else {
+    signature = _composerDraftPayloadSignatureForSid(sid);
+  }
   _composerDraftRestoreSuppressedUntilBySid.set(
     sid,
-    Date.now() + _COMPOSER_DRAFT_RESTORE_SUPPRESS_MS,
+    { until: Date.now() + _COMPOSER_DRAFT_RESTORE_SUPPRESS_MS, signature },
   );
   // Local state must reflect the submitted/cleared composer immediately. The
   // POST that clears the server-side draft is async; same-session refreshes can
@@ -54,15 +87,23 @@ function _clearComposerDraftRestoreSuppression(sid) {
   _composerDraftRestoreSuppressedUntilBySid.delete(sid);
 }
 
-function _isComposerDraftRestoreSuppressed(sid) {
+function _isComposerDraftRestoreSuppressed(sid, text, files) {
   if (!sid) return false;
-  const until = _composerDraftRestoreSuppressedUntilBySid.get(sid);
+  const suppression = _composerDraftRestoreSuppressedUntilBySid.get(sid);
+  if (!suppression) return false;
+  const until = (suppression && typeof suppression === 'object') ? suppression.until : suppression;
   if (!until) return false;
   if (Date.now() > until) {
     _composerDraftRestoreSuppressedUntilBySid.delete(sid);
     return false;
   }
-  return true;
+  const signature = (suppression && typeof suppression === 'object') ? suppression.signature : null;
+  // Legacy/unknown callers still fail closed for the current TTL, but all send
+  // paths now pass a payload signature so a different cross-tab draft can restore.
+  if (!signature) return true;
+  if (_composerDraftPayloadSignature(text, files) === signature) return true;
+  _composerDraftRestoreSuppressedUntilBySid.delete(sid);
+  return false;
 }
 
 function _profileMatchesActiveProfile(profile, activeProfile){
@@ -211,7 +252,7 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
   const restoreSid = targetSid || (S.session && S.session.session_id);
   const hasServerDraftPayload = _composerDraftHasPayload(text, files);
 
-  if (restoreSid && hasServerDraftPayload && _isComposerDraftRestoreSuppressed(restoreSid)) return;
+  if (restoreSid && hasServerDraftPayload && _isComposerDraftRestoreSuppressed(restoreSid, text, files)) return;
   if (restoreSid && !hasServerDraftPayload) _clearComposerDraftRestoreSuppression(restoreSid);
 
   // Same-session force refreshes are driven by external state changes and may
@@ -241,11 +282,12 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
 }
 
 // Clear the saved draft for a session (called when message is sent).
-function _clearComposerDraft(sid) {
+function _clearComposerDraft(sid, text, files) {
   if (!sid) return;
   clearTimeout(_draftSaveTimer);
   _clearRememberedNewChatDraftSession(sid);
-  _suppressComposerDraftRestoreAfterSubmit(sid);
+  if (arguments.length >= 2) _suppressComposerDraftRestoreAfterSubmit(sid, text, files);
+  else _suppressComposerDraftRestoreAfterSubmit(sid);
   return api('/api/session/draft', {
     method: 'POST',
     body: JSON.stringify({ session_id: sid, text: '' }),

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -34,6 +34,36 @@ let _draftSaveTimer = null;
 const _DRAFT_SAVE_DELAY_MS = 400;
 const NEW_CHAT_DRAFT_SESSION_KEY = 'hermes-new-chat-draft-session';
 const _composerDraftKnownPayloadSessions = new Set();
+const _composerDraftRestoreSuppressedUntilBySid = new Map();
+const _COMPOSER_DRAFT_RESTORE_SUPPRESS_MS = 30000;
+
+function _suppressComposerDraftRestoreAfterSubmit(sid) {
+  if (!sid) return;
+  _composerDraftRestoreSuppressedUntilBySid.set(
+    sid,
+    Date.now() + _COMPOSER_DRAFT_RESTORE_SUPPRESS_MS,
+  );
+  // Local state must reflect the submitted/cleared composer immediately. The
+  // POST that clears the server-side draft is async; same-session refreshes can
+  // otherwise race in with the old draft and repopulate the textarea.
+  _rememberComposerDraftPayloadState(sid, '', []);
+}
+
+function _clearComposerDraftRestoreSuppression(sid) {
+  if (!sid) return;
+  _composerDraftRestoreSuppressedUntilBySid.delete(sid);
+}
+
+function _isComposerDraftRestoreSuppressed(sid) {
+  if (!sid) return false;
+  const until = _composerDraftRestoreSuppressedUntilBySid.get(sid);
+  if (!until) return false;
+  if (Date.now() > until) {
+    _composerDraftRestoreSuppressedUntilBySid.delete(sid);
+    return false;
+  }
+  return true;
+}
 
 function _profileMatchesActiveProfile(profile, activeProfile){
   const eventName = (typeof profile === 'string' && profile.trim()) ? profile.trim() : 'default';
@@ -103,6 +133,7 @@ function _saveComposerDraft(sid, text, files) {
   const normalizedText = String(text || '');
   const normalizedFiles = Array.isArray(files) ? files.filter(Boolean) : [];
   if (_composerDraftHasPayload(normalizedText, normalizedFiles)) {
+    _clearComposerDraftRestoreSuppression(sid);
     _composerDraftKnownPayloadSessions.add(sid);
   }
   _draftSaveTimer = setTimeout(() => {
@@ -144,6 +175,9 @@ function _saveComposerDraftNow(sid, text, files) {
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = Array.isArray(files) ? files.filter(Boolean) : [];
+  if (_composerDraftHasPayload(normalizedText, normalizedFiles)) {
+    _clearComposerDraftRestoreSuppression(sid);
+  }
   // Most chat switches leave an empty composer. Avoid putting the switch path
   // behind a network POST unless there is new local draft content or an existing
   // server draft that must be cleared.
@@ -174,6 +208,11 @@ function _restoreComposerDraft(draft, targetSid, opts={}) {
   const files = (draft && Array.isArray(draft.files)) ? draft.files : [];
   const current = ta.value || '';
   const preserveActiveInput = !!(opts && opts.preserveActiveInput);
+  const restoreSid = targetSid || (S.session && S.session.session_id);
+  const hasServerDraftPayload = _composerDraftHasPayload(text, files);
+
+  if (restoreSid && hasServerDraftPayload && _isComposerDraftRestoreSuppressed(restoreSid)) return;
+  if (restoreSid && !hasServerDraftPayload) _clearComposerDraftRestoreSuppression(restoreSid);
 
   // Same-session force refreshes are driven by external state changes and may
   // finish seconds after the user continued typing. In that case the local
@@ -206,6 +245,7 @@ function _clearComposerDraft(sid) {
   if (!sid) return;
   clearTimeout(_draftSaveTimer);
   _clearRememberedNewChatDraftSession(sid);
+  _suppressComposerDraftRestoreAfterSubmit(sid);
   return api('/api/session/draft', {
     method: 'POST',
     body: JSON.stringify({ session_id: sid, text: '' }),

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -310,9 +310,13 @@ class TestSendBusyBranchDispatch:
         assert send_idx >= 0, "send() not found"
         steer_idx = MESSAGES_JS.find("defaultMessageMode==='steer'", send_idx)
         assert steer_idx >= 0, "busy steer branch not found"
-        branch = MESSAGES_JS[steer_idx:steer_idx + 900]
+        branch_end = MESSAGES_JS.find("} else if(defaultMessageMode==='interrupt')", steer_idx)
+        assert branch_end > steer_idx, "busy steer branch end not found"
+        branch = MESSAGES_JS[steer_idx:branch_end]
         assert "const _steerDelivered=await _trySteer" in branch
+        assert "const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];" in branch
         assert "if(_steerDelivered){S.pendingFiles=[];renderTray();}" in branch
+        assert "_clearComposerDraft(S.session.session_id,text,_steerDraftFiles)" in branch
         assert branch.index("const _steerDelivered=await _trySteer") < branch.index("if(_steerDelivered){S.pendingFiles=[];renderTray();}")
 
 

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -15,9 +15,10 @@ def _block(source: str, start_marker: str, end_marker: str) -> str:
 def test_clear_composer_draft_suppresses_same_session_stale_restore():
     """An async draft-clear POST must not allow old server draft text to repopulate #msg."""
     assert "const _composerDraftRestoreSuppressedUntilBySid = new Map();" in SESSIONS_JS
-    assert "function _suppressComposerDraftRestoreAfterSubmit(sid)" in SESSIONS_JS
-    clear_body = _block(SESSIONS_JS, "function _clearComposerDraft(sid)", "const SESSION_VIEWED_COUNTS_KEY")
-    suppress_idx = clear_body.index("_suppressComposerDraftRestoreAfterSubmit(sid);")
+    assert "function _composerDraftPayloadSignature(text, files)" in SESSIONS_JS
+    assert "function _suppressComposerDraftRestoreAfterSubmit(sid, text, files)" in SESSIONS_JS
+    clear_body = _block(SESSIONS_JS, "function _clearComposerDraft(sid, text, files)", "const SESSION_VIEWED_COUNTS_KEY")
+    suppress_idx = clear_body.index("_suppressComposerDraftRestoreAfterSubmit(sid, text, files);")
     post_idx = clear_body.index("api('/api/session/draft'")
     assert suppress_idx < post_idx, "restore suppression must be local and immediate before async POST"
 
@@ -33,7 +34,7 @@ def test_restore_skips_suppressed_non_empty_server_draft_only():
     restore_body = _block(SESSIONS_JS, "function _restoreComposerDraft(draft, targetSid", "// Clear the saved draft")
     assert "const restoreSid = targetSid || (S.session && S.session.session_id);" in restore_body
     assert "const hasServerDraftPayload = _composerDraftHasPayload(text, files);" in restore_body
-    assert "hasServerDraftPayload && _isComposerDraftRestoreSuppressed(restoreSid)" in restore_body
+    assert "hasServerDraftPayload && _isComposerDraftRestoreSuppressed(restoreSid, text, files)" in restore_body
     assert "!hasServerDraftPayload) _clearComposerDraftRestoreSuppression(restoreSid);" in restore_body
 
 
@@ -41,13 +42,15 @@ def test_busy_send_paths_clear_persisted_composer_draft():
     helper_body = _block(MESSAGES_JS, "function _clearComposerAfterQueuedSelectionSend", "function _flushSelectionBlocksToComposer")
     assert "function _clearComposerAfterQueuedSelectionSend()" in helper_body
     assert "const sid=arguments.length?arguments[0]:(S.session&&S.session.session_id);" in helper_body
-    assert "_clearComposerDraft(sid)" in helper_body
+    assert "const draftText=composer?String(composer.value||''):'';" in helper_body
+    assert "const draftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];" in helper_body
+    assert "_clearComposerDraft(sid,draftText,draftFiles)" in helper_body
 
     in_progress_body = _block(MESSAGES_JS, "if (_sendInProgress) {", "  _sendInProgress = true;")
     assert "_clearComposerAfterQueuedSelectionSend();" in in_progress_body
-    assert "_clearComposerDraft(_targetSid);" in in_progress_body
+    assert "_clearComposerDraft(_targetSid,_text,S.pendingFiles?[...S.pendingFiles]:[])" in in_progress_body
 
     busy_body = _block(MESSAGES_JS, "if(S.busy||compressionRunning){", "  if(S.session&&(S.session.read_only||S.session.is_read_only))")
     assert "_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);" in busy_body
     assert busy_body.count("_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);") >= 2
-    assert "_clearComposerDraft(S.session.session_id)" in busy_body, "delivered steer must clear persisted draft"
+    assert "_clearComposerDraft(S.session.session_id,text,_steerDraftFiles)" in busy_body, "delivered steer must clear persisted draft with the submitted payload signature"

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -1,0 +1,53 @@
+"""Regression coverage for stale composer_draft restoration after send."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT.joinpath("static", "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = ROOT.joinpath("static", "messages.js").read_text(encoding="utf-8")
+
+
+def _block(source: str, start_marker: str, end_marker: str) -> str:
+    start = source.index(start_marker)
+    end = source.index(end_marker, start)
+    return source[start:end]
+
+
+def test_clear_composer_draft_suppresses_same_session_stale_restore():
+    """An async draft-clear POST must not allow old server draft text to repopulate #msg."""
+    assert "const _composerDraftRestoreSuppressedUntilBySid = new Map();" in SESSIONS_JS
+    assert "function _suppressComposerDraftRestoreAfterSubmit(sid)" in SESSIONS_JS
+    clear_body = _block(SESSIONS_JS, "function _clearComposerDraft(sid)", "const SESSION_VIEWED_COUNTS_KEY")
+    suppress_idx = clear_body.index("_suppressComposerDraftRestoreAfterSubmit(sid);")
+    post_idx = clear_body.index("api('/api/session/draft'")
+    assert suppress_idx < post_idx, "restore suppression must be local and immediate before async POST"
+
+
+def test_non_empty_draft_save_clears_submit_restore_suppression():
+    save_body = _block(SESSIONS_JS, "function _saveComposerDraft(sid, text, files)", "function _composerDraftHasPayload")
+    assert "_clearComposerDraftRestoreSuppression(sid);" in save_body
+    now_body = _block(SESSIONS_JS, "function _saveComposerDraftNow(sid, text, files)", "// Restore composer draft")
+    assert "_clearComposerDraftRestoreSuppression(sid);" in now_body
+
+
+def test_restore_skips_suppressed_non_empty_server_draft_only():
+    restore_body = _block(SESSIONS_JS, "function _restoreComposerDraft(draft, targetSid", "// Clear the saved draft")
+    assert "const restoreSid = targetSid || (S.session && S.session.session_id);" in restore_body
+    assert "const hasServerDraftPayload = _composerDraftHasPayload(text, files);" in restore_body
+    assert "hasServerDraftPayload && _isComposerDraftRestoreSuppressed(restoreSid)" in restore_body
+    assert "!hasServerDraftPayload) _clearComposerDraftRestoreSuppression(restoreSid);" in restore_body
+
+
+def test_busy_send_paths_clear_persisted_composer_draft():
+    helper_body = _block(MESSAGES_JS, "function _clearComposerAfterQueuedSelectionSend", "function _flushSelectionBlocksToComposer")
+    assert "function _clearComposerAfterQueuedSelectionSend()" in helper_body
+    assert "const sid=arguments.length?arguments[0]:(S.session&&S.session.session_id);" in helper_body
+    assert "_clearComposerDraft(sid)" in helper_body
+
+    in_progress_body = _block(MESSAGES_JS, "if (_sendInProgress) {", "  _sendInProgress = true;")
+    assert "_clearComposerAfterQueuedSelectionSend();" in in_progress_body
+    assert "_clearComposerDraft(_targetSid);" in in_progress_body
+
+    busy_body = _block(MESSAGES_JS, "if(S.busy||compressionRunning){", "  if(S.session&&(S.session.read_only||S.session.is_read_only))")
+    assert "_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);" in busy_body
+    assert busy_body.count("_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);") >= 2
+    assert "_clearComposerDraft(S.session.session_id)" in busy_body, "delivered steer must clear persisted draft"

--- a/tests/test_issue5060_boot_composer_preserve.py
+++ b/tests/test_issue5060_boot_composer_preserve.py
@@ -44,12 +44,22 @@ def _draft_restore_suppression_block() -> str:
     return SESSIONS_JS[start:end]
 
 
-def _run_case(*, initial_text: str, draft: dict | None, opts: dict | None, current_sid, force_reload: bool, suppress_restore: bool = False) -> dict:
+def _run_case(*, initial_text: str, draft: dict | None, opts: dict | None, current_sid, force_reload: bool, suppress_restore: bool | dict = False) -> dict:
     if NODE is None:
         pytest.skip("node not on PATH")
     restore_fn = _function_block(SESSIONS_JS, "function _restoreComposerDraft(draft, targetSid, opts={}) {")
     draft_block = _draft_restore_block()
     suppression_block = _draft_restore_suppression_block()
+    if isinstance(suppress_restore, dict):
+        suppress_call = (
+            "_suppressComposerDraftRestoreAfterSubmit("
+            f"sid, {json.dumps(suppress_restore.get('text', ''))}, {json.dumps(suppress_restore.get('files', []))}"
+            ");"
+        )
+    elif suppress_restore:
+        suppress_call = "_suppressComposerDraftRestoreAfterSubmit(sid);"
+    else:
+        suppress_call = ""
     script = f"""
 const state = {{
   value: {json.dumps(initial_text)},
@@ -65,13 +75,14 @@ function autoResize() {{
 function updateSendBtn() {{
   state.updateSendBtnCount += 1;
 }}
+let _loadingSessionId = null;
+const sid = 'boot-session';
 const S = {{
   session: {{
+    session_id: sid,
     composer_draft: {json.dumps(draft)},
   }},
 }};
-let _loadingSessionId = null;
-const sid = 'boot-session';
 const currentSid = {json.dumps(current_sid)};
 const forceReload = {json.dumps(force_reload)};
 const opts = {json.dumps(opts or {})};
@@ -82,7 +93,7 @@ function _rememberComposerDraftPayloadState(sid, text, files) {{
   state.rememberedDraft = {{sid, text, files}};
 }}
 {suppression_block}
-if ({json.dumps(suppress_restore)}) _suppressComposerDraftRestoreAfterSubmit(sid);
+{suppress_call}
 {restore_fn}
 {draft_block}
 process.stdout.write(JSON.stringify({{
@@ -152,11 +163,26 @@ def test_same_session_submitted_clear_blocks_stale_server_draft_restore():
         opts={"preserveActiveInput": True},
         current_sid="boot-session",
         force_reload=True,
-        suppress_restore=True,
+        suppress_restore={"text": "old submitted suffix", "files": []},
     )
     assert data["value"] == ""
     assert data["autoResizeCount"] == 0
     assert data["updateSendBtnCount"] == 0
+
+
+def test_same_session_submitted_clear_allows_different_cross_tab_draft_restore():
+    """A different same-session draft saved by another tab must not be hidden by send-time suppression."""
+    data = _run_case(
+        initial_text="",
+        draft={"text": "new cross-tab draft", "files": []},
+        opts={"preserveActiveInput": True},
+        current_sid="boot-session",
+        force_reload=True,
+        suppress_restore={"text": "old submitted suffix", "files": []},
+    )
+    assert data["value"] == "new cross-tab draft"
+    assert data["autoResizeCount"] == 1
+    assert data["updateSendBtnCount"] == 1
 
 
 def test_cross_session_restore_keeps_existing_draft_semantics():

--- a/tests/test_issue5060_boot_composer_preserve.py
+++ b/tests/test_issue5060_boot_composer_preserve.py
@@ -38,11 +38,18 @@ def _draft_restore_block() -> str:
     return SESSIONS_JS[start:end]
 
 
-def _run_case(*, initial_text: str, draft: dict | None, opts: dict | None, current_sid, force_reload: bool) -> dict:
+def _draft_restore_suppression_block() -> str:
+    start = SESSIONS_JS.index("const _composerDraftRestoreSuppressedUntilBySid")
+    end = SESSIONS_JS.index("function _profileMatchesActiveProfile", start)
+    return SESSIONS_JS[start:end]
+
+
+def _run_case(*, initial_text: str, draft: dict | None, opts: dict | None, current_sid, force_reload: bool, suppress_restore: bool = False) -> dict:
     if NODE is None:
         pytest.skip("node not on PATH")
     restore_fn = _function_block(SESSIONS_JS, "function _restoreComposerDraft(draft, targetSid, opts={}) {")
     draft_block = _draft_restore_block()
+    suppression_block = _draft_restore_suppression_block()
     script = f"""
 const state = {{
   value: {json.dumps(initial_text)},
@@ -68,6 +75,14 @@ const sid = 'boot-session';
 const currentSid = {json.dumps(current_sid)};
 const forceReload = {json.dumps(force_reload)};
 const opts = {json.dumps(opts or {})};
+function _composerDraftHasPayload(text, files) {{
+  return !!(String(text || '') || (Array.isArray(files) && files.filter(Boolean).length));
+}}
+function _rememberComposerDraftPayloadState(sid, text, files) {{
+  state.rememberedDraft = {{sid, text, files}};
+}}
+{suppression_block}
+if ({json.dumps(suppress_restore)}) _suppressComposerDraftRestoreAfterSubmit(sid);
 {restore_fn}
 {draft_block}
 process.stdout.write(JSON.stringify({{
@@ -121,6 +136,27 @@ def test_boot_restore_still_populates_empty_composer_from_saved_draft():
     assert data["value"] == "server draft"
     assert data["autoResizeCount"] == 1
     assert data["updateSendBtnCount"] == 1
+
+
+def test_same_session_submitted_clear_blocks_stale_server_draft_restore():
+    """After send clears the composer, a stale same-session refresh must not refill it.
+
+    Mobile browsers can deliver refresh/input timing such that the textarea is
+    empty locally while /api/session still returns the previous non-empty
+    composer_draft. The submitted-clear suppression should keep that old draft
+    out of the input.
+    """
+    data = _run_case(
+        initial_text="",
+        draft={"text": "old submitted suffix", "files": []},
+        opts={"preserveActiveInput": True},
+        current_sid="boot-session",
+        force_reload=True,
+        suppress_restore=True,
+    )
+    assert data["value"] == ""
+    assert data["autoResizeCount"] == 0
+    assert data["updateSendBtnCount"] == 0
 
 
 def test_cross_session_restore_keeps_existing_draft_semantics():

--- a/tests/test_issue5472_preserve_draft_on_failed_send.py
+++ b/tests/test_issue5472_preserve_draft_on_failed_send.py
@@ -99,12 +99,14 @@ def test_send_still_clears_composer_on_the_happy_path():
     # assertion must actually guard the main send path's clear. (Opus #5484 NIT.)
     main_clear = (
         "if (activeSid && typeof _clearComposerDraft === 'function') "
-        "_composerDraftClearPromise=_clearComposerDraft(activeSid);"
+        "_composerDraftClearPromise=_clearComposerDraft(activeSid,_submittedDraftTextForClear,_submittedDraftFilesForClear);"
     )
     assert main_clear in MESSAGES_JS, "main send path must clear the persisted draft at send time"
     # The composer textarea wipe must sit immediately above that clear.
     clear_idx = MESSAGES_JS.find(main_clear)
     window_before = MESSAGES_JS[clear_idx - 700:clear_idx]
+    assert "const _submittedDraftTextForClear=$('msg').value||'';" in window_before
+    assert "const _submittedDraftFilesForClear=Array.isArray(_failedSendFilesSnapshot)?[..._failedSendFilesSnapshot]:[];" in window_before
     assert "$('msg').value='';autoResize();" in window_before, (
         "the main-path composer wipe must precede the persisted-draft clear"
     )


### PR DESCRIPTION
## Summary

- suppress same-session restoration of stale non-empty `composer_draft` immediately after a message submission clears the composer
- clear persisted composer drafts from busy send paths (`queue`, `interrupt`, and delivered `steer`) instead of only clearing the textarea
- add regressions for stale draft restoration after send and for busy-path draft clearing

## Why

Mobile/browser timing can show a sent user bubble while the composer is empty locally but `/api/session` still returns the previous non-empty `composer_draft`. A same-session refresh can then repopulate `#msg` with the tail of the already-submitted message.

`_clearComposerDraft()` already posts an empty draft, but that POST is asynchronous. This change adds a short local suppression window so old server draft payloads cannot be restored before the empty draft response catches up. Fresh user typing clears the suppression.

## Tests

- `node --check static/sessions.js`
- `node --check static/messages.js`
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_issue5060_boot_composer_preserve.py tests/test_composer_draft_after_send.py tests/test_issue_new_chat_draft_restore.py tests/test_real_steer.py -q`

Result: `39 passed`
