### PR TITLE
Fix "Copy conversation link" to copy an openable URL, not a session:// reference

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3669,7 +3669,7 @@ async function _copyTextToClipboard(text){
 async function _copySessionLink(session){
   const sid=session&&session.session_id;
   if(!sid) return;
-  const ref=_sessionInternalReferenceForSession(session);
+  const ref=(window.location.origin||'')+_sessionUrlForSid(sid);
   try{
     await _copyTextToClipboard(ref);
     showToast(t('session_link_copied'));


### PR DESCRIPTION
### Problem

"Copy conversation link" copies a Markdown reference that uses a custom `session://` scheme — `[<title>](session://<session-id>)` — built by `_sessionInternalReferenceForSession()`. That's handy for pasting a cross-reference back into a Hermes chat, but it isn't a link you can actually open or share: pasted into a browser (or anywhere outside the app) it does nothing, which is surprising for a control labelled "Copy conversation link."

### Fix

Copy the canonical web URL to the conversation instead — `window.location.origin` joined with the path already produced by `_sessionUrlForSid(sid)` — so the copied value opens the conversation directly (behind whatever auth sits in front of it).

```js
// before
const ref = _sessionInternalReferenceForSession(session);
// after
const ref = (window.location.origin || '') + _sessionUrlForSid(sid);
```

### Open question (hence draft)

If producing the `session://` reference is intentional here, you may prefer to keep it and expose the web URL as a separate action (e.g. "Copy web link") rather than change existing behaviour. Happy to go whichever way — flagging as a draft for your call.
