### PR TITLE
fix(#5428): surface stale WebUI client recovery

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2730,6 +2730,7 @@ window._applyTitlebarProfileVisibility=_applyTitlebarProfileVisibility;
   try{
     const s=await api('/api/settings');
     _bootSettings=s;
+    if(typeof checkWebUIVersionSkew==='function'){try{checkWebUIVersionSkew(s);}catch(_){}}
     window._sendKey=s.send_key||'enter';
     // Persist default workspace so the blank new-chat page can show it
     // and workspace actions (New file/folder) work before the first session (#804).

--- a/static/index.html
+++ b/static/index.html
@@ -29,6 +29,7 @@
 <link rel="preload" href="static/pwa-startup.js?v=__WEBUI_VERSION__" as="script">
 <script src="static/pwa-startup.js?v=__WEBUI_VERSION__"></script>
 <script>window.__HERMES_CONFIG__={maxUploadBytes:__MAX_UPLOAD_BYTES__,csrfToken:__CSRF_TOKEN_JSON__};</script>
+<script>window.__HERMES_WEBUI_BUNDLE_VERSION__='__WEBUI_VERSION__';</script>
 <script>(function(){
   var cfg=window.__HERMES_CONFIG__||{},token=cfg.csrfToken||'';
   if(!token||!window.fetch)return;
@@ -414,6 +415,15 @@
         <button class="update-btn" onclick="dismissUpdate()">Later</button>
         <button class="update-btn update-primary" id="btnApplyUpdate" onclick="applyUpdates()">Update Now</button>
         <button class="update-btn" id="btnForceUpdate" style="display:none;background:var(--error,#e05);color:#fff;border-color:var(--error,#e05)" onclick="forceUpdate(this)">Force update</button>
+      </div>
+    </div>
+    <div class="update-banner" id="staleClientBanner">
+      <div style="display:flex;flex-direction:column;flex:1;min-width:0">
+        <span id="staleClientMessage"></span>
+        <span id="staleClientVersions" style="font-size:11px;margin-top:4px;color:var(--muted)"></span>
+      </div>
+      <div style="display:flex;gap:8px;flex-shrink:0;flex-wrap:wrap">
+        <button class="update-btn update-primary" id="btnStaleClientRefresh" type="button" onclick="hardRefreshWebUIClient()">Hard refresh now</button>
       </div>
     </div>
     <div id="mainChat" class="main-view">

--- a/static/panels.js
+++ b/static/panels.js
@@ -2240,6 +2240,73 @@ async function hardRefreshWebUIClient(){
   window.location.reload();
 }
 
+function _normalizeWebUIVersion(value){
+  if(!value) return '';
+  const s=String(value).trim();
+  if(!s||s==='__WEBUI_VERSION__'||s==='not detected') return '';
+  return s;
+}
+
+function _currentWebUIBundleVersion(){
+  try{
+    const raw=window.__HERMES_WEBUI_BUNDLE_VERSION__;
+    if(!raw) return '';
+    let s=String(raw);
+    try{ s=decodeURIComponent(s.replace(/\+/g,' ')); }catch(_){}
+    return _normalizeWebUIVersion(s);
+  }catch(_){ return ''; }
+}
+
+function _showStaleWebUIClientBanner(clientVersion,serverVersion){
+  const banner=document.getElementById('staleClientBanner');
+  if(!banner) return;
+  const msg=document.getElementById('staleClientMessage');
+  const versions=document.getElementById('staleClientVersions');
+  if(msg) msg.textContent='This tab is running a different WebUI version. Hard refresh to restore full functionality.';
+  if(versions) versions.textContent='Running: '+clientVersion+' → Server: '+serverVersion;
+  banner.style.display='flex';
+}
+
+function checkWebUIVersionSkew(settings){
+  try{
+    if(!settings) return;
+    const client=_currentWebUIBundleVersion();
+    const server=_normalizeWebUIVersion(settings.webui_version);
+    if(!client||!server) return;
+    if(client===server) return;
+    _showStaleWebUIClientBanner(client,server);
+  }catch(_){}
+}
+window.checkWebUIVersionSkew=checkWebUIVersionSkew;
+
+function _startWebUIVersionSkewMonitor(){
+  let _pollTimer=null;
+  function _isBannerVisible(){
+    const banner=document.getElementById('staleClientBanner');
+    return !!(banner&&banner.style.display==='flex');
+  }
+  function _check(){
+    if(_isBannerVisible()) return;
+    Promise.resolve().then(function(){ return api('/api/settings'); }).then(function(s){ checkWebUIVersionSkew(s); }).catch(function(){});
+  }
+  function _startPoll(){
+    if(_pollTimer||document.hidden) return;
+    _pollTimer=setInterval(function(){
+      if(document.hidden){ clearInterval(_pollTimer); _pollTimer=null; return; }
+      if(_isBannerVisible()){ clearInterval(_pollTimer); _pollTimer=null; return; }
+      _check();
+    },60000);
+  }
+  _check();
+  document.addEventListener('visibilitychange',function(){
+    if(!document.hidden){ _check(); _startPoll(); }
+    else if(_pollTimer){ clearInterval(_pollTimer); _pollTimer=null; }
+  });
+  window.addEventListener('focus',function(){ _check(); });
+  _startPoll();
+}
+_startWebUIVersionSkewMonitor();
+
 function _kanbanLooksLikeStaleClientError(err){
   const msg = String((err && err.message) || err || '').toLowerCase();
   return !!(err && err.status === 404 && (
@@ -8209,6 +8276,7 @@ function _syncSettingsMaxTokensPlaceholder(field, fallbackValue){
 async function loadSettingsPanel(){
   try{
     const settings=await api('/api/settings');
+    checkWebUIVersionSkew(settings);
     // Populate the version badges from the server — keeps them in sync with git
     // tags automatically without any manual release step.
     const webuiBadge = $('settings-webui-version-badge');

--- a/tests/test_5428_stale_client_recovery.py
+++ b/tests/test_5428_stale_client_recovery.py
@@ -1,0 +1,220 @@
+"""Regression tests for #5428 — stale WebUI client recovery.
+
+Source-contract tests verify the static files contain the expected anchors.
+Node-backed behavioral tests exercise the extracted helpers with a stub DOM.
+"""
+import json
+import re
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+INDEX_HTML = ROOT / "static" / "index.html"
+PANELS_JS = ROOT / "static" / "panels.js"
+BOOT_JS = ROOT / "static" / "boot.js"
+
+
+# ---------------------------------------------------------------------------
+# Source-contract tests
+# ---------------------------------------------------------------------------
+
+def test_index_html_stamps_bundle_version():
+    """index.html stamps window.__HERMES_WEBUI_BUNDLE_VERSION__ before deferred scripts."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert "window.__HERMES_WEBUI_BUNDLE_VERSION__='__WEBUI_VERSION__';" in html
+
+
+def test_index_html_has_stale_client_banner():
+    """index.html contains the stale-client banner and hard-refresh button."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert 'id="staleClientBanner"' in html
+    assert 'id="staleClientMessage"' in html
+    assert 'id="staleClientVersions"' in html
+    assert 'id="btnStaleClientRefresh"' in html
+    # Verify the button in the banner calls hardRefreshWebUIClient()
+    banner_start = html.index('id="staleClientBanner"')
+    segment = html[banner_start : banner_start + 800]
+    assert "hardRefreshWebUIClient()" in segment, (
+        "btnStaleClientRefresh is not wired to hardRefreshWebUIClient() inside the banner"
+    )
+
+
+def test_boot_js_calls_check_webui_version_skew():
+    """boot.js calls checkWebUIVersionSkew(s) after the successful boot settings response."""
+    src = BOOT_JS.read_text(encoding="utf-8")
+    assert "checkWebUIVersionSkew(s)" in src
+
+
+def test_panels_js_load_settings_calls_check_webui_version_skew():
+    """panels.js calls checkWebUIVersionSkew(settings) from loadSettingsPanel()."""
+    src = PANELS_JS.read_text(encoding="utf-8")
+    pattern = r"async function loadSettingsPanel\(\)[\s\S]{0,2000}?checkWebUIVersionSkew\(settings\)"
+    assert re.search(pattern, src), (
+        "checkWebUIVersionSkew(settings) not found within loadSettingsPanel()"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Node-backed behavioral harness
+# ---------------------------------------------------------------------------
+
+def _extract_skew_helpers(panels_src: str) -> str:
+    """Return the version-skew helper block (from _normalizeWebUIVersion to Kanban helpers)."""
+    start = panels_src.index("function _normalizeWebUIVersion(")
+    end = panels_src.index("function _kanbanLooksLikeStaleClientError(")
+    return panels_src[start:end]
+
+
+def _make_stub(bundle_version: str, extra_globals: str = "") -> str:
+    """Return the Node.js preamble that stubs the browser globals."""
+    return textwrap.dedent(f"""\
+        'use strict';
+        const _bannerEl = {{ style: {{ display: '' }} }};
+        const _msgEl = {{ _text: '' }};
+        const _verEl = {{ _text: '' }};
+        Object.defineProperty(_msgEl, 'textContent', {{
+            set(v) {{ _msgEl._text = v; }}, get() {{ return _msgEl._text; }}
+        }});
+        Object.defineProperty(_verEl, 'textContent', {{
+            set(v) {{ _verEl._text = v; }}, get() {{ return _verEl._text; }}
+        }});
+        global.document = {{
+            getElementById(id) {{
+                if (id === 'staleClientBanner') return _bannerEl;
+                if (id === 'staleClientMessage') return _msgEl;
+                if (id === 'staleClientVersions') return _verEl;
+                return null;
+            }},
+            addEventListener() {{}},
+            hidden: false,
+        }};
+        global.window = {{
+            __HERMES_WEBUI_BUNDLE_VERSION__: {json.dumps(bundle_version)},
+            addEventListener() {{}},
+        }};
+        global.api = () => Promise.resolve({{}});
+        {extra_globals}
+    """)
+
+
+_CAPTURE_AND_EXIT = textwrap.dedent("""\
+    const _result = {
+        display: _bannerEl.style.display,
+        message: _msgEl._text,
+        versions: _verEl._text,
+    };
+    process.stdout.write(JSON.stringify(_result) + '\\n');
+    process.exit(0);
+""")
+
+
+def _run_harness(stub: str, helpers: str, action: str) -> dict:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is required for browser helper harness tests")
+    script = (
+        stub
+        + "\n"
+        + helpers
+        + "\nPromise.resolve().then(async () => {\n"
+        + action
+        + "\n}).then(() => {\n"
+        + _CAPTURE_AND_EXIT
+        + "\n}).catch((err) => { console.error(err && err.stack || err); process.exit(1); });"
+    )
+    proc = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert proc.returncode == 0, f"node exit {proc.returncode}: {proc.stderr[:500]}"
+    return json.loads(proc.stdout.strip())
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests — positive (mismatch triggers banner)
+# ---------------------------------------------------------------------------
+
+def test_node_mismatch_shows_banner():
+    """client=v1, server=v2 reveals staleClientBanner and writes both versions."""
+    helpers = _extract_skew_helpers(PANELS_JS.read_text(encoding="utf-8"))
+    result = _run_harness(
+        _make_stub("v1"),
+        helpers,
+        'checkWebUIVersionSkew({ webui_version: "v2" });',
+    )
+    assert result["display"] == "flex", f"Banner not shown on mismatch: {result}"
+    assert "v1" in result["versions"] and "v2" in result["versions"], (
+        f"Version text missing client+server: {result['versions']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests — negative space (no false-positive fires)
+# ---------------------------------------------------------------------------
+
+def test_node_equal_versions_no_banner():
+    """client=v1, server=v1 keeps banner hidden."""
+    helpers = _extract_skew_helpers(PANELS_JS.read_text(encoding="utf-8"))
+    result = _run_harness(
+        _make_stub("v1"),
+        helpers,
+        'checkWebUIVersionSkew({ webui_version: "v1" });',
+    )
+    assert result["display"] != "flex", f"Banner wrongly shown for equal versions: {result}"
+
+
+def test_node_missing_server_version_no_banner():
+    """Missing webui_version in settings keeps banner hidden."""
+    helpers = _extract_skew_helpers(PANELS_JS.read_text(encoding="utf-8"))
+    result = _run_harness(
+        _make_stub("v1"),
+        helpers,
+        "checkWebUIVersionSkew({});",
+    )
+    assert result["display"] != "flex", f"Banner wrongly shown for missing server version: {result}"
+
+
+def test_node_placeholder_client_version_no_banner():
+    """Unresolved __WEBUI_VERSION__ literal as bundle stamp keeps banner hidden."""
+    helpers = _extract_skew_helpers(PANELS_JS.read_text(encoding="utf-8"))
+    result = _run_harness(
+        _make_stub("__WEBUI_VERSION__"),
+        helpers,
+        'checkWebUIVersionSkew({ webui_version: "v2" });',
+    )
+    assert result["display"] != "flex", (
+        f"Banner wrongly shown when client version is unresolved placeholder: {result}"
+    )
+
+
+def test_node_null_settings_no_banner():
+    """null/undefined settings keeps banner hidden and does not throw."""
+    helpers = _extract_skew_helpers(PANELS_JS.read_text(encoding="utf-8"))
+    result = _run_harness(
+        _make_stub("v1"),
+        helpers,
+        "checkWebUIVersionSkew(null); checkWebUIVersionSkew(undefined);",
+    )
+    assert result["display"] != "flex", (
+        f"Banner wrongly shown for null/undefined settings: {result}"
+    )
+
+
+def test_node_rejected_settings_fetch_no_banner():
+    """The monitor's rejected /api/settings poll is swallowed and keeps the banner hidden."""
+    helpers = _extract_skew_helpers(PANELS_JS.read_text(encoding="utf-8"))
+    result = _run_harness(
+        _make_stub(
+            "v1",
+            "let _apiCalls = 0; "
+            "global.api = () => { _apiCalls += 1; return Promise.reject(new Error('network error')); };",
+        ),
+        helpers,
+        "await Promise.resolve(); if (_apiCalls !== 1) throw new Error('monitor did not poll settings');",
+    )
+    assert result["display"] != "flex", (
+        f"Banner wrongly shown for rejected settings fetch: {result}"
+    )


### PR DESCRIPTION
## Thinking Path

- The issue points to old tabs continuing to run a pre-upgrade WebUI bundle against a newer server, while fresh tabs load the updated assets and work.
- The app already versions static assets and exposes `settings.webui_version`, but already-running tabs never compare their boot bundle version with the live server version.
- This adds a browser-side skew guard that surfaces a hard-refresh recovery banner instead of leaving stale tabs silently wedged.

## What Changed

- `static/index.html`: stamps the running WebUI bundle version and adds a stale-client recovery banner near the existing update banner.
- `static/panels.js`: adds the shared version-skew checker, banner wiring, visible-tab detection, and hard-refresh action reuse.
- `static/boot.js`: checks the boot `/api/settings` response for a version mismatch.
- `tests/test_5428_stale_client_recovery.py`: covers the source wiring and executes the browser helper against mismatch, monitor failure, and negative-space cases.

## Why It Matters

After an in-place upgrade, old tabs now get a visible recovery path as soon as the app can prove they are running a stale bundle. The fix keeps normal interactions intact and lets the user choose the hard refresh, which avoids silently discarding in-progress work.

## Verification

- `pytest tests/test_5428_stale_client_recovery.py -v`
- `pytest tests/test_5428_stale_client_recovery.py tests/test_kanban_ui_static.py::test_kanban_task_detail_renderer_executes_with_log_and_formats_feedback -v`
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs static/panels.js static/boot.js`

Full-suite CI context, not a required local check: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5428.

## Model Used

GPT 5.5 via Codex CLI
