### PR TITLE
fix(#5472): preserve composer draft when a send fails

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1216,6 +1216,33 @@ function applySessionTitleUpdate(sid, titleText, options={}){
   return true;
 }
 
+// #5472: when a provider/background error aborts a send, send() has already
+// cleared the composer (`$('msg').value=''`) and the persisted draft
+// (`_clearComposerDraft`) before the turn was durably accepted server-side.
+// That turns a failed send into a dead-end retype (and, since /api/chat/start
+// never persisted pending state on a throw, the optimistic bubble can also be
+// lost on reload). Restore the user's typed text and keep staged files so the
+// user can re-send with one key press. Mirrors the draft-restore idiom already
+// used by _trySteer (commands.js) and _stashClarifyDraft.
+function _restoreComposerDraftAfterFailedSend(draftText, sid){
+  const inp=$('msg');
+  if(!inp) return false;
+  const restore=String(draftText||'');
+  const hasFiles=!!(S.pendingFiles&&S.pendingFiles.length);
+  if(!restore&&!hasFiles) return false;
+  // Do not clobber a new message the user began typing during the async window.
+  if(String(inp.value||'').trim()) return false;
+  inp.value=restore;
+  if(typeof autoResize==='function') autoResize();
+  if(typeof updateSendBtn==='function') updateSendBtn();
+  // Re-persist so the restored draft also survives a reload (send() cleared the
+  // server-side draft at start). Files are already staged in S.pendingFiles.
+  if(sid&&typeof _saveComposerDraftNow==='function'){
+    try{ _saveComposerDraftNow(sid, restore, S.pendingFiles?[...S.pendingFiles]:[]); }catch(_){ }
+  }
+  return true;
+}
+
 async function send(){
   // Static guards expect _defaultMessageMode to stay near send() while the actual
   // read remains in the S.busy branch below.
@@ -1677,6 +1704,11 @@ async function send(){
     if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
     S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
     _queueDrainSid=activeSid;renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
+    // #5472: the send was rejected before the turn was durably started, so the
+    // composer text (cleared at send time) would otherwise be lost. Put it back
+    // and re-persist the draft so the user can re-send without retyping. Staged
+    // files remain in S.pendingFiles.
+    _restoreComposerDraftAfterFailedSend(text, activeSid);
     if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
     // Reconcile with server truth after immediately clearing the optimistic spinner.
     if(typeof renderSessionList==='function') void renderSessionList();

--- a/static/messages.js
+++ b/static/messages.js
@@ -1217,28 +1217,46 @@ function applySessionTitleUpdate(sid, titleText, options={}){
 }
 
 // #5472: when a provider/background error aborts a send, send() has already
-// cleared the composer (`$('msg').value=''`) and the persisted draft
-// (`_clearComposerDraft`) before the turn was durably accepted server-side.
-// That turns a failed send into a dead-end retype (and, since /api/chat/start
-// never persisted pending state on a throw, the optimistic bubble can also be
-// lost on reload). Restore the user's typed text and keep staged files so the
-// user can re-send with one key press. Mirrors the draft-restore idiom already
-// used by _trySteer (commands.js) and _stashClarifyDraft.
-function _restoreComposerDraftAfterFailedSend(draftText, sid){
+// cleared the composer (`$('msg').value=''`), the persisted draft
+// (`_clearComposerDraft`), and the staged files (uploadPendingFiles() sets
+// `S.pendingFiles=[]`) before the turn was durably accepted server-side. On a
+// start-time throw the turn is never persisted, so the user loses the entire
+// typed message + attachments and must retype. Restore the ORIGINAL captured
+// draft text + staged files so the user can re-send with one key press.
+// Mirrors the draft-restore idiom already used by _trySteer (commands.js) and
+// _stashClarifyDraft.
+//
+// `draftText` and `filesSnapshot` are immutable snapshots captured in send()
+// BEFORE slash rewrites (/moa, bundles) mutate the payload and BEFORE
+// uploadPendingFiles() drains S.pendingFiles — so we restore what the user
+// actually typed, not the transformed send payload.
+function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid){
+  const restore=String(draftText||'');
+  const files=Array.isArray(filesSnapshot)?filesSnapshot.filter(Boolean):[];
+  if(!restore&&!files.length) return false;
+  // Persist the draft for the failed send's own session so it survives a reload
+  // regardless of which session is currently visible. Files staged in the
+  // composer are File objects (not serializable), so only text is persisted;
+  // the in-memory S.pendingFiles restore below covers the immediate re-send.
+  if(sid&&typeof _saveComposerDraftNow==='function'){
+    try{ _saveComposerDraftNow(sid, restore, []); }catch(_){ }
+  }
+  // Only mutate the VISIBLE composer / staged tray when the failed send belongs
+  // to the session the user is currently looking at — otherwise a background
+  // send failure would pollute another session's composer. (Codex #5484 catch.)
+  const visibleSid=(S.session&&S.session.session_id)||null;
+  if(sid&&visibleSid&&sid!==visibleSid) return false;
   const inp=$('msg');
   if(!inp) return false;
-  const restore=String(draftText||'');
-  const hasFiles=!!(S.pendingFiles&&S.pendingFiles.length);
-  if(!restore&&!hasFiles) return false;
   // Do not clobber a new message the user began typing during the async window.
   if(String(inp.value||'').trim()) return false;
   inp.value=restore;
   if(typeof autoResize==='function') autoResize();
   if(typeof updateSendBtn==='function') updateSendBtn();
-  // Re-persist so the restored draft also survives a reload (send() cleared the
-  // server-side draft at start). Files are already staged in S.pendingFiles.
-  if(sid&&typeof _saveComposerDraftNow==='function'){
-    try{ _saveComposerDraftNow(sid, restore, S.pendingFiles?[...S.pendingFiles]:[]); }catch(_){ }
+  // Re-stage the originally attached files so a one-key resend keeps them.
+  if(files.length){
+    S.pendingFiles=files;
+    if(typeof renderTray==='function') renderTray();
   }
   return true;
 }
@@ -1274,6 +1292,15 @@ async function send(){
   _flushSelectionBlocksToComposer();
   text=$('msg').value.trim();
   if(!text&&!S.pendingFiles.length){_sendInProgress=false;_sendInProgressSid=null;return;}
+
+  // #5472: snapshot the ORIGINAL user-typed composer state now — before slash
+  // rewrites (/moa, bundles) mutate `text` and before uploadPendingFiles()
+  // clears S.pendingFiles. If /api/chat/start throws (turn never durably
+  // started), _restoreComposerDraftAfterFailedSend() puts this exact text +
+  // staged files back so the user can re-send without retyping. Captured as an
+  // immutable snapshot so later reassignments to `text` don't leak into it.
+  const _failedSendDraftText=text;
+  const _failedSendFilesSnapshot=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
 
   // Dismiss handoff hint when user sends a message (resets seen_at).
   if(S.session&&S.session.session_id&&typeof _dismissHandoffHint==='function'){
@@ -1705,10 +1732,10 @@ async function send(){
     S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
     _queueDrainSid=activeSid;renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
     // #5472: the send was rejected before the turn was durably started, so the
-    // composer text (cleared at send time) would otherwise be lost. Put it back
-    // and re-persist the draft so the user can re-send without retyping. Staged
-    // files remain in S.pendingFiles.
-    _restoreComposerDraftAfterFailedSend(text, activeSid);
+    // composer text + attachments (cleared at send time) would otherwise be
+    // lost. Put back the ORIGINAL captured draft (not the mutated /moa/bundle
+    // payload) and re-stage files so the user can re-send without retyping.
+    _restoreComposerDraftAfterFailedSend(_failedSendDraftText, _failedSendFilesSnapshot, activeSid);
     if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
     // Reconcile with server truth after immediately clearing the optimistic spinner.
     if(typeof renderSessionList==='function') void renderSessionList();

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -269,15 +269,23 @@ class TestSendBusyBranchDispatch:
         # The send() function should read window._defaultMessageMode in the busy block
         send_idx = MESSAGES_JS.find("async function send(")
         assert send_idx >= 0
-        # Look in the first ~3000 chars of send() for the busy mode read
-        send_body = MESSAGES_JS[send_idx:send_idx + 3000]
+        # Bound the window to the actual send() body (up to the LIVE_STREAMS decl
+        # that immediately follows it) rather than an arbitrary char count, so
+        # unrelated additions near the top of send() don't push the assertion
+        # target out of a fixed window (#5472 caught this).
+        send_end = MESSAGES_JS.find("const LIVE_STREAMS=", send_idx)
+        assert send_end > send_idx, "could not bound send() body"
+        send_body = MESSAGES_JS[send_idx:send_end]
         assert "_defaultMessageMode" in send_body, (
             "send() must read window._defaultMessageMode in the S.busy branch"
         )
 
     def test_send_calls_cancel_stream_on_interrupt(self):
         send_idx = MESSAGES_JS.find("async function send(")
-        send_body = MESSAGES_JS[send_idx:send_idx + 5000]
+        assert send_idx >= 0
+        send_end = MESSAGES_JS.find("const LIVE_STREAMS=", send_idx)
+        assert send_end > send_idx, "could not bound send() body"
+        send_body = MESSAGES_JS[send_idx:send_end]
         # The interrupt branch must call cancelStream
         assert "cancelStream" in send_body
         # And queue before cancel (otherwise the drain has nothing to pick up)

--- a/tests/test_issue5472_preserve_draft_on_failed_send.py
+++ b/tests/test_issue5472_preserve_draft_on_failed_send.py
@@ -1,23 +1,26 @@
 """Regression coverage for #5472 — preserve the composer draft when a send fails.
 
 Bug: when a provider/background error aborts a send, ``send()`` in
-``static/messages.js`` has already cleared the composer (``$('msg').value=''``)
-and the persisted draft (``_clearComposerDraft``) at send time — before the turn
-is durably accepted by ``/api/chat/start``. On a start-time throw the turn is
-never persisted server-side, so the user loses the entire typed message and must
-retype it.
+``static/messages.js`` has already cleared the composer (``$('msg').value=''``),
+the persisted draft (``_clearComposerDraft``), AND the staged files
+(``uploadPendingFiles()`` sets ``S.pendingFiles=[]``) at send time — before the
+turn is durably accepted by ``/api/chat/start``. On a start-time throw the turn
+is never persisted, so the user loses the entire typed message + attachments and
+must retype.
 
-Fix: a new ``_restoreComposerDraftAfterFailedSend(text, sid)`` helper puts the
-typed text back into the composer, keeps staged files in ``S.pendingFiles``, and
-re-persists the draft so it also survives a reload. It is called from the
-``/api/chat/start`` throw handler's general-error branch.
+Fix: ``send()`` snapshots the ORIGINAL typed text + staged files BEFORE slash
+rewrites (/moa, bundles) mutate the payload and BEFORE the upload drains
+``S.pendingFiles``. On a start-time throw,
+``_restoreComposerDraftAfterFailedSend(text, files, sid)`` restores that exact
+snapshot, re-stages the files, and re-persists the draft. It is session-aware
+(never pollutes a different session's visible composer) and never clobbers a new
+message the user began typing during the async window.
 
 This module verifies BOTH:
-  1. (static) the helper exists and is wired into the send-error path with the
-     right guards, and
-  2. (behavioral, via node's ``vm``) the helper's actual branching logic —
-     restores text, keeps a new in-progress draft from being clobbered, no-ops
-     on an empty draft with no files, and re-persists via _saveComposerDraftNow.
+  1. (static) the snapshot capture + wiring into the send-error path, and
+  2. (behavioral, via node's ``vm``) the helper's branching logic, including the
+     three Codex-caught edges: original-vs-mutated payload, dropped attachments,
+     and cross-session composer pollution.
 """
 import json
 import shutil
@@ -43,33 +46,48 @@ def _helper_body() -> str:
     return MESSAGES_JS[start:end]
 
 
-def test_helper_exists_with_expected_guards():
+def test_helper_has_new_three_arg_signature_and_guards():
     body = _helper_body()
-    # Reads the live composer element.
-    assert "const inp=$('msg')" in body
+    assert "function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid)" in body
     # No-op when there is nothing to restore (no text AND no staged files).
-    assert "if(!restore&&!hasFiles) return false;" in body
+    assert "if(!restore&&!files.length) return false;" in body
+    # Session-aware: never mutate a different session's visible composer.
+    assert "const visibleSid=(S.session&&S.session.session_id)||null;" in body
+    assert "if(sid&&visibleSid&&sid!==visibleSid) return false;" in body
     # Never clobber a message the user began typing during the async window.
     assert "if(String(inp.value||'').trim()) return false;" in body
-    # Restores the text into the composer and re-persists the draft.
+    # Restores text and re-stages files.
     assert "inp.value=restore;" in body
-    assert "_saveComposerDraftNow(sid, restore, S.pendingFiles?[...S.pendingFiles]:[])" in body
+    assert "S.pendingFiles=files;" in body
 
 
-def test_helper_is_wired_into_chat_start_error_path():
-    # The general-error branch of the /api/chat/start catch pushes an Error
-    # assistant turn, then must call the restore helper with the original text.
+def test_send_captures_immutable_snapshot_before_rewrites_and_upload():
+    # The snapshot must be captured right after the post-flush trim, BEFORE the
+    # busy branch / slash-command rewrites and BEFORE uploadPendingFiles().
+    snap_idx = MESSAGES_JS.find("const _failedSendDraftText=text;")
+    files_idx = MESSAGES_JS.find(
+        "const _failedSendFilesSnapshot=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];"
+    )
+    moa_idx = MESSAGES_JS.find("text=_moaArgs;")
+    upload_idx = MESSAGES_JS.find("uploaded=await uploadPendingFiles();")
+    assert snap_idx != -1 and files_idx != -1, "send() must snapshot text + files for #5472"
+    assert moa_idx != -1 and upload_idx != -1
+    # Snapshot happens before both the /moa rewrite and the upload drain.
+    assert snap_idx < moa_idx, "text snapshot must precede the /moa rewrite of `text`"
+    assert files_idx < upload_idx, "files snapshot must precede uploadPendingFiles() drain"
+
+
+def test_error_branch_restores_original_snapshot_not_mutated_payload():
     start = MESSAGES_JS.find("S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});")
     assert start != -1, "the /api/chat/start error branch must still push an Error turn"
-    window = MESSAGES_JS[start:start + 800]
-    assert "_restoreComposerDraftAfterFailedSend(text, activeSid);" in window, (
-        "the send-error path must restore the composer draft after a failed send"
-    )
+    window = MESSAGES_JS[start:start + 900]
+    assert (
+        "_restoreComposerDraftAfterFailedSend(_failedSendDraftText, _failedSendFilesSnapshot, activeSid);"
+        in window
+    ), "the send-error path must restore the ORIGINAL captured snapshot (not `text`)"
 
 
 def test_send_still_clears_composer_on_the_happy_path():
-    # Guard against a regression that would leave the composer populated on a
-    # successful send: the send path must still clear + clear-draft up front.
     assert "$('msg').value='';autoResize();" in MESSAGES_JS
     assert "if (activeSid && typeof _clearComposerDraft === 'function') _clearComposerDraft(activeSid);" in MESSAGES_JS
 
@@ -78,93 +96,105 @@ def test_send_still_clears_composer_on_the_happy_path():
 # Behavioral test — actually execute the helper in a JS sandbox
 # ---------------------------------------------------------------------------
 
-def _run_helper_in_node(draft_text, initial_input, pending_files):
-    """Execute _restoreComposerDraftAfterFailedSend in a node vm sandbox and
-    return the resulting state as a dict."""
+def _run_helper_in_node(draft_text, files_snapshot, initial_input, visible_sid, sid="sid-1"):
+    """Execute _restoreComposerDraftAfterFailedSend in a node vm sandbox."""
     node = shutil.which("node")
-    if not node:  # pragma: no cover - environment without node
+    if not node:  # pragma: no cover
         pytest.skip("node not available")
 
-    # Extract the helper source verbatim so the test exercises the shipped code.
     body = _helper_body()
-
     harness = textwrap.dedent(
         """
         const state = {
           input: {value: %(initial_input)s, resized: false},
-          pendingFiles: %(pending_files)s,
+          pendingFiles: [],
+          trayRendered: false,
           saved: null,
           sendBtnUpdated: false,
         };
         const $ = (id) => (id === 'msg' ? state.input : null);
-        const S = {pendingFiles: state.pendingFiles};
+        const S = {pendingFiles: state.pendingFiles, session: %(session)s};
         function autoResize(){ state.input.resized = true; }
         function updateSendBtn(){ state.sendBtnUpdated = true; }
+        function renderTray(){ state.trayRendered = true; }
         function _saveComposerDraftNow(sid, text, files){ state.saved = {sid, text, files}; }
 
         %(helper)s
 
-        const ret = _restoreComposerDraftAfterFailedSend(%(draft_text)s, 'sid-1');
+        const ret = _restoreComposerDraftAfterFailedSend(%(draft_text)s, %(files)s, %(sid)s);
         console.log(JSON.stringify({
           ret,
           inputValue: state.input.value,
           resized: state.input.resized,
           sendBtnUpdated: state.sendBtnUpdated,
+          trayRendered: state.trayRendered,
+          pendingFiles: S.pendingFiles,
           saved: state.saved,
         }));
         """
     ) % {
         "initial_input": json.dumps(initial_input),
-        "pending_files": json.dumps(pending_files),
+        "session": json.dumps({"session_id": visible_sid} if visible_sid else None),
         "helper": body,
         "draft_text": json.dumps(draft_text),
+        "files": json.dumps(files_snapshot),
+        "sid": json.dumps(sid),
     }
-
-    proc = subprocess.run(
-        [node, "-e", harness],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
     return json.loads(proc.stdout.strip())
 
 
 def test_restores_typed_text_into_empty_composer():
-    out = _run_helper_in_node(draft_text="my long message", initial_input="", pending_files=[])
+    out = _run_helper_in_node("my long message", [], "", visible_sid="sid-1")
     assert out["ret"] is True
     assert out["inputValue"] == "my long message"
-    assert out["resized"] is True
-    assert out["sendBtnUpdated"] is True
-    # Re-persisted so the restored draft survives a reload.
+    assert out["resized"] is True and out["sendBtnUpdated"] is True
+    # Draft persisted for reload (text only — File objects aren't serializable).
     assert out["saved"] == {"sid": "sid-1", "text": "my long message", "files": []}
 
 
-def test_does_not_clobber_a_new_in_progress_draft():
-    # The user started typing a NEW message during the async send window — the
-    # restore must not overwrite it.
-    out = _run_helper_in_node(
-        draft_text="original failed message",
-        initial_input="something new I am typing",
-        pending_files=[],
-    )
-    assert out["ret"] is False
-    assert out["inputValue"] == "something new I am typing"
-    assert out["saved"] is None
+def test_restores_original_text_not_mutated_moa_payload():
+    # The snapshot passed in is the user's ORIGINAL "/moa summarize this", even
+    # though send() would have rewritten `text` to just "summarize this".
+    out = _run_helper_in_node("/moa summarize this", [], "", visible_sid="sid-1")
+    assert out["ret"] is True
+    assert out["inputValue"] == "/moa summarize this"
 
 
-def test_noop_when_nothing_to_restore():
-    out = _run_helper_in_node(draft_text="", initial_input="", pending_files=[])
-    assert out["ret"] is False
-    assert out["saved"] is None
+def test_restages_attachments_that_upload_already_drained():
+    files = [{"name": "a.pdf"}, {"name": "b.png"}]
+    out = _run_helper_in_node("look at these", files, "", visible_sid="sid-1")
+    assert out["ret"] is True
+    assert out["pendingFiles"] == files
+    assert out["trayRendered"] is True
 
 
 def test_restores_when_only_staged_files_remain():
-    # Empty text but staged attachments — still a recoverable send, so re-persist.
-    out = _run_helper_in_node(
-        draft_text="",
-        initial_input="",
-        pending_files=[{"name": "a.pdf", "path": "/w/a.pdf"}],
-    )
+    files = [{"name": "a.pdf"}]
+    out = _run_helper_in_node("", files, "", visible_sid="sid-1")
     assert out["ret"] is True
-    assert out["saved"]["files"] == [{"name": "a.pdf", "path": "/w/a.pdf"}]
+    assert out["pendingFiles"] == files
+
+
+def test_does_not_clobber_a_new_in_progress_draft():
+    out = _run_helper_in_node("original failed", [], "something new", visible_sid="sid-1")
+    assert out["ret"] is False
+    assert out["inputValue"] == "something new"
+
+
+def test_does_not_pollute_a_different_visible_session():
+    # The failed send belongs to sid-1, but the user has switched to sid-2. The
+    # visible composer must NOT be touched — but the draft is still persisted for
+    # sid-1 so it survives a switch-back / reload.
+    out = _run_helper_in_node("failed on old session", [], "", visible_sid="sid-2")
+    assert out["ret"] is False
+    assert out["inputValue"] == ""
+    assert out["pendingFiles"] == []
+    assert out["saved"] == {"sid": "sid-1", "text": "failed on old session", "files": []}
+
+
+def test_noop_when_nothing_to_restore():
+    out = _run_helper_in_node("", [], "", visible_sid="sid-1")
+    assert out["ret"] is False
+    assert out["saved"] is None

--- a/tests/test_issue5472_preserve_draft_on_failed_send.py
+++ b/tests/test_issue5472_preserve_draft_on_failed_send.py
@@ -1,0 +1,170 @@
+"""Regression coverage for #5472 — preserve the composer draft when a send fails.
+
+Bug: when a provider/background error aborts a send, ``send()`` in
+``static/messages.js`` has already cleared the composer (``$('msg').value=''``)
+and the persisted draft (``_clearComposerDraft``) at send time — before the turn
+is durably accepted by ``/api/chat/start``. On a start-time throw the turn is
+never persisted server-side, so the user loses the entire typed message and must
+retype it.
+
+Fix: a new ``_restoreComposerDraftAfterFailedSend(text, sid)`` helper puts the
+typed text back into the composer, keeps staged files in ``S.pendingFiles``, and
+re-persists the draft so it also survives a reload. It is called from the
+``/api/chat/start`` throw handler's general-error branch.
+
+This module verifies BOTH:
+  1. (static) the helper exists and is wired into the send-error path with the
+     right guards, and
+  2. (behavioral, via node's ``vm``) the helper's actual branching logic —
+     restores text, keeps a new in-progress draft from being clobbered, no-ops
+     on an empty draft with no files, and re-persists via _saveComposerDraftNow.
+"""
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+MESSAGES_JS = ROOT.joinpath("static", "messages.js").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Static wiring assertions
+# ---------------------------------------------------------------------------
+
+def _helper_body() -> str:
+    start = MESSAGES_JS.find("function _restoreComposerDraftAfterFailedSend(")
+    assert start != -1, "the _restoreComposerDraftAfterFailedSend helper must exist"
+    end = MESSAGES_JS.find("\nasync function send(", start)
+    assert end != -1, "helper must be defined immediately before send()"
+    return MESSAGES_JS[start:end]
+
+
+def test_helper_exists_with_expected_guards():
+    body = _helper_body()
+    # Reads the live composer element.
+    assert "const inp=$('msg')" in body
+    # No-op when there is nothing to restore (no text AND no staged files).
+    assert "if(!restore&&!hasFiles) return false;" in body
+    # Never clobber a message the user began typing during the async window.
+    assert "if(String(inp.value||'').trim()) return false;" in body
+    # Restores the text into the composer and re-persists the draft.
+    assert "inp.value=restore;" in body
+    assert "_saveComposerDraftNow(sid, restore, S.pendingFiles?[...S.pendingFiles]:[])" in body
+
+
+def test_helper_is_wired_into_chat_start_error_path():
+    # The general-error branch of the /api/chat/start catch pushes an Error
+    # assistant turn, then must call the restore helper with the original text.
+    start = MESSAGES_JS.find("S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});")
+    assert start != -1, "the /api/chat/start error branch must still push an Error turn"
+    window = MESSAGES_JS[start:start + 800]
+    assert "_restoreComposerDraftAfterFailedSend(text, activeSid);" in window, (
+        "the send-error path must restore the composer draft after a failed send"
+    )
+
+
+def test_send_still_clears_composer_on_the_happy_path():
+    # Guard against a regression that would leave the composer populated on a
+    # successful send: the send path must still clear + clear-draft up front.
+    assert "$('msg').value='';autoResize();" in MESSAGES_JS
+    assert "if (activeSid && typeof _clearComposerDraft === 'function') _clearComposerDraft(activeSid);" in MESSAGES_JS
+
+
+# ---------------------------------------------------------------------------
+# Behavioral test — actually execute the helper in a JS sandbox
+# ---------------------------------------------------------------------------
+
+def _run_helper_in_node(draft_text, initial_input, pending_files):
+    """Execute _restoreComposerDraftAfterFailedSend in a node vm sandbox and
+    return the resulting state as a dict."""
+    node = shutil.which("node")
+    if not node:  # pragma: no cover - environment without node
+        pytest.skip("node not available")
+
+    # Extract the helper source verbatim so the test exercises the shipped code.
+    body = _helper_body()
+
+    harness = textwrap.dedent(
+        """
+        const state = {
+          input: {value: %(initial_input)s, resized: false},
+          pendingFiles: %(pending_files)s,
+          saved: null,
+          sendBtnUpdated: false,
+        };
+        const $ = (id) => (id === 'msg' ? state.input : null);
+        const S = {pendingFiles: state.pendingFiles};
+        function autoResize(){ state.input.resized = true; }
+        function updateSendBtn(){ state.sendBtnUpdated = true; }
+        function _saveComposerDraftNow(sid, text, files){ state.saved = {sid, text, files}; }
+
+        %(helper)s
+
+        const ret = _restoreComposerDraftAfterFailedSend(%(draft_text)s, 'sid-1');
+        console.log(JSON.stringify({
+          ret,
+          inputValue: state.input.value,
+          resized: state.input.resized,
+          sendBtnUpdated: state.sendBtnUpdated,
+          saved: state.saved,
+        }));
+        """
+    ) % {
+        "initial_input": json.dumps(initial_input),
+        "pending_files": json.dumps(pending_files),
+        "helper": body,
+        "draft_text": json.dumps(draft_text),
+    }
+
+    proc = subprocess.run(
+        [node, "-e", harness],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+    return json.loads(proc.stdout.strip())
+
+
+def test_restores_typed_text_into_empty_composer():
+    out = _run_helper_in_node(draft_text="my long message", initial_input="", pending_files=[])
+    assert out["ret"] is True
+    assert out["inputValue"] == "my long message"
+    assert out["resized"] is True
+    assert out["sendBtnUpdated"] is True
+    # Re-persisted so the restored draft survives a reload.
+    assert out["saved"] == {"sid": "sid-1", "text": "my long message", "files": []}
+
+
+def test_does_not_clobber_a_new_in_progress_draft():
+    # The user started typing a NEW message during the async send window — the
+    # restore must not overwrite it.
+    out = _run_helper_in_node(
+        draft_text="original failed message",
+        initial_input="something new I am typing",
+        pending_files=[],
+    )
+    assert out["ret"] is False
+    assert out["inputValue"] == "something new I am typing"
+    assert out["saved"] is None
+
+
+def test_noop_when_nothing_to_restore():
+    out = _run_helper_in_node(draft_text="", initial_input="", pending_files=[])
+    assert out["ret"] is False
+    assert out["saved"] is None
+
+
+def test_restores_when_only_staged_files_remain():
+    # Empty text but staged attachments — still a recoverable send, so re-persist.
+    out = _run_helper_in_node(
+        draft_text="",
+        initial_input="",
+        pending_files=[{"name": "a.pdf", "path": "/w/a.pdf"}],
+    )
+    assert out["ret"] is True
+    assert out["saved"]["files"] == [{"name": "a.pdf", "path": "/w/a.pdf"}]


### PR DESCRIPTION
## Summary

Fixes the data-loss half of #5472: when a provider/background error aborts a send, the user's typed message can vanish and they have to retype it.

`send()` clears the composer (`$('msg').value=''`) and the persisted draft (`_clearComposerDraft`) **at send time** — before `/api/chat/start` has durably accepted the turn. On a start-time throw the turn is never persisted server-side, so the optimistic user bubble can be lost on reload *and* the composer is already empty. A failed send becomes a dead-end retype.

## Fix

New helper `_restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid)` (static/messages.js):

- Restores the user's **original** typed text (an immutable snapshot captured before `/moa`/bundle rewrites mutate the payload and before the upload drains staged files).
- Re-stages the originally attached files (`uploadPendingFiles()` clears `S.pendingFiles` before the start call, so they must be restored from the snapshot) and re-renders the tray.
- Re-persists the draft text via `_saveComposerDraftNow(sid, …)` so it also survives a reload.

Guards:
- No-op when there's nothing to restore (no text **and** no staged files).
- **Session-aware:** only mutates the visible composer/tray when the failed send belongs to the currently-viewed session — a background send failure never pollutes another session's composer. The sid-keyed draft persist stays unconditional so the draft still survives a switch-back/reload.
- Never clobbers a **new** message the user began typing during the async send window.

It's wired into the `/api/chat/start` throw handler's general-error branch — the path where the turn is genuinely never persisted. The SSE-terminal error path is intentionally left alone: post-#5129 it already materializes the pending user turn server-side (`_materialize_pending_user_turn_before_error()`), so restoring to the composer there would duplicate the transcript bubble.

This mirrors the draft-restore idioms already in the codebase (`_trySteer` in commands.js, `_stashClarifyDraft`).

## Scope

This PR ships **Part A** (preserve draft on send failure) from #5472. Because Part A restores the exact text + attachments for a one-keypress re-send, it resolves the headline pain without a new visible surface.

**Part B** — a dedicated first-class "Retry" button rendered on the failed turn — is a *new visible affordance* (screenshot-gated) and is deferred to a follow-up for maintainer UX sign-off.

**Part C** — "always show the error, never a silent drop" — is verification of already-landed hardening (#5129 + the materialize-before-error step); no code change needed here.

## Tests

`tests/test_issue5472_preserve_draft_on_failed_send.py`:
- 5 static-wiring assertions (helper 3-arg signature + guards; the immutable snapshot is captured before `/moa` rewrite and before the upload drain; error branch restores the snapshot not the mutated payload; happy-path still clears the composer).
- 6 node-`vm` **behavioral** tests that execute the shipped helper source in a sandbox: restores typed text + re-persists; restores the **original** `/moa` command (not the rewritten payload); re-stages attachments the upload already drained; restores when only staged files remain; does **not** pollute a different visible session (but still persists the draft for the failed session); no-ops when nothing to restore.

All 11 pass; 51 related composer/send/draft/steer/upload tests still green.

## Gate

Codex + Opus reviewed the first commit and converged on three real edges (original-vs-mutated `/moa` payload, dropped attachments after the upload drain, cross-session composer pollution). All three are fixed in the second commit and covered by new tests; re-gated clean.

Closes #5472 (Part A).
