### PR TITLE
fix: prevent unintended session switch on stray pointerup

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7688,6 +7688,7 @@ function renderSessionListFromCache(){
       }
     };
     const _finishSessionGesture=(clientX,clientY,target,pointerType)=>{
+      if(_gestureState==='idle') return false;  // press never began on this row
       const wasDragging=_gestureState==='dragging'||_swipeTracking;
       _clearLongPressTimer();
       if(_renamingSid){_gestureState='idle';return false;}

--- a/tests/test_session_touch_actions.py
+++ b/tests/test_session_touch_actions.py
@@ -307,5 +307,9 @@ def test_session_gesture_finish_ignores_idle_state():
         "Missing idle-state guard at the beginning of _finishSessionGesture"
     
     # Also verify that the fork row handler has the same guard (consistency check)
-    fork_start = SESSIONS_JS.find("rowEl.onpointerup=(e)=>{\n          if(e.pointerType==='mouse'||_gestureState==='idle') return;")
-    assert fork_start != -1, "Fork row pointerup handler should have idle guard"
+    # Fork handler pattern: rowEl.onpointerup followed by pointerType/button check, then idle guard
+    fork_handler_start = SESSIONS_JS.find("rowEl.onpointerup=(e)=>{")
+    assert fork_handler_start != -1, "Fork row pointerup handler not found"
+    fork_handler_snippet = SESSIONS_JS[fork_handler_start:fork_handler_start+200]
+    assert "if(_gestureState==='idle') return;" in fork_handler_snippet, \
+        "Fork row pointerup handler should have idle guard"

--- a/tests/test_session_touch_actions.py
+++ b/tests/test_session_touch_actions.py
@@ -283,3 +283,29 @@ def test_touch_session_rows_preserve_vertical_scroll():
     assert "user-select:none" in item_rule
     assert "-webkit-user-select:none" in item_rule
     assert "-webkit-touch-callout:none" in item_rule
+
+
+def test_session_gesture_finish_ignores_idle_state():
+    """Test that _finishSessionGesture bails early when _gestureState is 'idle'.
+    
+    This prevents unintended session switches when a drag starts outside the
+    session row and ends on top of it. The gesture must have begun with a
+    pointerdown on the row itself (_gestureState='pressing'), otherwise the
+    pointerup should be ignored.
+    
+    See: https://github.com/nesquena/hermes-webui/issues/5462
+    """
+    # Find the _finishSessionGesture function
+    fn_start = SESSIONS_JS.find("const _finishSessionGesture=(clientX,clientY,target,pointerType)=>{")
+    assert fn_start != -1, "_finishSessionGesture function not found"
+    
+    # Extract the first ~200 characters of the function body
+    fn_body_start = SESSIONS_JS[fn_start:fn_start+200]
+    
+    # Verify the idle-state guard is present at the beginning
+    assert "if(_gestureState==='idle') return false;" in fn_body_start, \
+        "Missing idle-state guard at the beginning of _finishSessionGesture"
+    
+    # Also verify that the fork row handler has the same guard (consistency check)
+    fork_start = SESSIONS_JS.find("rowEl.onpointerup=(e)=>{\n          if(e.pointerType==='mouse'||_gestureState==='idle') return;")
+    assert fork_start != -1, "Fork row pointerup handler should have idle guard"


### PR DESCRIPTION
## Summary

Adds an idle-state guard to `_finishSessionGesture` so that `pointerup` events whose matching `pointerdown` began outside the session row are ignored, preventing unintended session switches when dragging from the content area.

Closes #5462

## Root Cause

The top-level session row's `_finishSessionGesture` (line 7634) was missing the `_gestureState==='idle'` guard that the fork-child handler already has (line 7210). When a drag started in the main content area and ended on top of a session row, the `pointerup` would trigger a session switch even though no `pointerdown` occurred on that row.

## Changes

- **`static/sessions.js`**: Added `if(_gestureState==='idle') return false;` at the beginning of `_finishSessionGesture`, matching the pattern used in the fork row handler.
- **`tests/test_session_touch_actions.py`**: Added regression test `test_session_gesture_finish_ignores_idle_state` to verify the guard is present and consistent with the fork handler.

## Testing

- Static test verifies the idle-state guard is present in `_finishSessionGesture`
- Static test verifies consistency with the fork-child handler's existing guard
- Existing tests for tap, swipe-to-archive, and long-press-menu behaviors remain unaffected (they set `_gestureState='pressing'` via `_beginSessionGesture` before any release)

## Manual Verification

1. Open a conversation, mousedown in the center content area, drag left over the sidebar, release on a different conversation row → with the guard, no switch; without it, it switches (current bug).
2. Regular single click on a row still navigates (pointerdown→`'pressing'`, pointerup→tap path).
3. Swipe-to-archive / long-press menu on a row still work (those set `'dragging'`/open the menu before release).
4. Text selection drags that end over the sidebar no longer hijack navigation.

## Attribution

Thanks to @nesquena-hermes for the thorough diagnosis in #5462 — made this very approachable for a first contribution.