### PR TITLE
Project review fixes

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -48,6 +48,64 @@ GID=1000
 # HERMES_WEBUI_PASSWORD=change-me-to-something-strong
 
 # ──────────────────────────────────────────────────────────────────────────
+# Additional security / limit knobs — advanced
+# ──────────────────────────────────────────────────────────────────────────
+# The WebUI process reads more HERMES_WEBUI_* variables than the compose
+# files forward by default. To use any of these in Docker, uncomment it here
+# AND add a matching passthrough line under `environment:` in your compose
+# file (e.g. `- HERMES_WEBUI_SESSION_TTL=${HERMES_WEBUI_SESSION_TTL:-}`).
+# Full descriptions live in .env.example.
+#
+# Auth cookie lifetime in seconds (default 2592000 = 30 days):
+# HERMES_WEBUI_SESSION_TTL=2592000
+#
+# Force the Secure cookie flag when serving HTTPS via a reverse proxy:
+# HERMES_WEBUI_SECURE=1
+#
+# Allowed public origins (scheme required) when behind a reverse proxy:
+# HERMES_WEBUI_ALLOWED_ORIGINS=https://myapp.example.com
+#
+# Enable the passkey/WebAuthn login surface (default off):
+# HERMES_WEBUI_PASSKEY=1
+#
+# Allow remote onboarding writes when no password is set (only if YOU
+# control network access — firewall/VPN):
+# HERMES_WEBUI_ONBOARDING_OPEN=1
+#
+# Caps for "download folder as ZIP":
+# HERMES_WEBUI_FOLDER_ZIP_MAX_MB=1024
+# HERMES_WEBUI_FOLDER_ZIP_MAX_FILES=50000
+
+# ──────────────────────────────────────────────────────────────────────────
+# Additional security / limit knobs — advanced
+# ──────────────────────────────────────────────────────────────────────────
+# The WebUI process reads more HERMES_WEBUI_* variables than the compose
+# files forward by default. To use any of these in Docker, uncomment it here
+# AND add a matching passthrough line under `environment:` in your compose
+# file (e.g. `- HERMES_WEBUI_SESSION_TTL=${HERMES_WEBUI_SESSION_TTL:-}`).
+# Full descriptions live in .env.example.
+#
+# Auth cookie lifetime in seconds (default 2592000 = 30 days):
+# HERMES_WEBUI_SESSION_TTL=2592000
+#
+# Force the Secure cookie flag when serving HTTPS via a reverse proxy:
+# HERMES_WEBUI_SECURE=1
+#
+# Allowed public origins (scheme required) when behind a reverse proxy:
+# HERMES_WEBUI_ALLOWED_ORIGINS=https://myapp.example.com
+#
+# Enable the passkey/WebAuthn login surface (default off):
+# HERMES_WEBUI_PASSKEY=1
+#
+# Allow remote onboarding writes when no password is set (only if YOU
+# control network access — firewall/VPN):
+# HERMES_WEBUI_ONBOARDING_OPEN=1
+#
+# Caps for "download folder as ZIP":
+# HERMES_WEBUI_FOLDER_ZIP_MAX_MB=1024
+# HERMES_WEBUI_FOLDER_ZIP_MAX_FILES=50000
+
+# ──────────────────────────────────────────────────────────────────────────
 # Permission handling for bind-mounted .hermes — advanced
 # ──────────────────────────────────────────────────────────────────────────
 # By default, the WebUI's startup credential-permission fixer enforces

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,161 @@
 
 # Display name for the assistant in the UI (default: Hermes)
 # HERMES_WEBUI_BOT_NAME=Hermes
+
+# ── Security & remote access ─────────────────────────────────────────────────
+
+# Password for the login page. REQUIRED if you bind to anything other than
+# 127.0.0.1 — without it, anyone who can reach the port can run commands.
+# HERMES_WEBUI_PASSWORD=change-me-to-something-strong
+
+# Enable the passkey/WebAuthn login surface (default: off).
+# Alternative: set `webui_passkey_enabled: true` in the profile's config.yaml.
+# HERMES_WEBUI_PASSKEY=1
+
+# Auth cookie lifetime in seconds (default: 2592000 = 30 days).
+# Clamped to [60, 31536000]. Also settable as session_ttl_seconds in settings.json.
+# HERMES_WEBUI_SESSION_TTL=2592000
+
+# Force the Secure flag on auth cookies: 1/true or 0/false.
+# Unset = auto-detect (direct TLS socket, or X-Forwarded-Proto: https from a
+# reverse proxy — only trustworthy when a proxy is actually in front).
+# HERMES_WEBUI_SECURE=1
+
+# Extra allowed origins for CSRF/origin checks when serving behind a reverse
+# proxy or on a public hostname. Comma-separated; each entry MUST include the
+# scheme. Entries without a scheme are ignored with a warning.
+# HERMES_WEBUI_ALLOWED_ORIGINS=https://myapp.example.com:8000
+
+# Serve HTTPS directly (both must be set; otherwise plain HTTP).
+# HERMES_WEBUI_TLS_CERT=/path/to/fullchain.pem
+# HERMES_WEBUI_TLS_KEY=/path/to/privkey.pem
+
+# Extra connect-src sources appended to the Content-Security-Policy
+# (space-separated, e.g. for a self-hosted telemetry or API endpoint).
+# HERMES_WEBUI_CSP_CONNECT_EXTRA=https://api.example.com wss://api.example.com
+
+# ── Uploads & limits ─────────────────────────────────────────────────────────
+
+# Where chat attachments are stored (default: <state dir>/attachments).
+# Attachments are transient agent context, kept out of the workspace by default.
+# HERMES_WEBUI_ATTACHMENT_DIR=~/.hermes/webui/attachments
+
+# Caps for the "download folder as ZIP" feature in the workspace browser.
+# HERMES_WEBUI_FOLDER_ZIP_MAX_MB=1024
+# HERMES_WEBUI_FOLDER_ZIP_MAX_FILES=50000
+
+# Requests slower than this many seconds get a stack-dump diagnostic in the log
+# (default: 5.0; set 0 to log every request's timing).
+# HERMES_WEBUI_SLOW_REQUEST_SECONDS=5.0
+
+# ── Onboarding ───────────────────────────────────────────────────────────────
+
+# By default, when no password is set, onboarding write endpoints only accept
+# requests from local/private addresses. Set to 1 to explicitly allow remote
+# onboarding on a server where YOU control network access (firewall/VPN).
+# HERMES_WEBUI_ONBOARDING_OPEN=1
+
+# Skip the first-run onboarding wizard entirely.
+# HERMES_WEBUI_SKIP_ONBOARDING=1
+
+# ── Advanced integrations ────────────────────────────────────────────────────
+
+# Script whose stdout prefills new-session context (legacy generic hook; the
+# WebUI dynamic-recall hook in config.yaml takes precedence when configured).
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT=/path/to/script
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT=10
+# HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS=20000
+
+# Extra sources for the notes drawer (see docs for the expected format).
+# HERMES_WEBUI_EXTERNAL_NOTES_SOURCES=
+
+# Override the Claude Code projects directory scanned by the CLI session
+# bridge (default: auto-discovered ~/.claude/projects).
+# HERMES_WEBUI_CLAUDE_PROJECTS_DIR=~/.claude/projects
+
+# Override the Codex CLI home scanned by the CLI session bridge and model
+# catalog merge (default: ~/.codex).
+# CODEX_HOME=~/.codex
+
+# Path to the LLM wiki root shown in the wiki panel (default: resolved from
+# HERMES_HOME's wiki env file).
+# WIKI_PATH=/path/to/wiki
+
+# ── Security & remote access ─────────────────────────────────────────────────
+
+# Password for the login page. REQUIRED if you bind to anything other than
+# 127.0.0.1 — without it, anyone who can reach the port can run commands.
+# HERMES_WEBUI_PASSWORD=change-me-to-something-strong
+
+# Enable the passkey/WebAuthn login surface (default: off).
+# Alternative: set `webui_passkey_enabled: true` in the profile's config.yaml.
+# HERMES_WEBUI_PASSKEY=1
+
+# Auth cookie lifetime in seconds (default: 2592000 = 30 days).
+# Clamped to [60, 31536000]. Also settable as session_ttl_seconds in settings.json.
+# HERMES_WEBUI_SESSION_TTL=2592000
+
+# Force the Secure flag on auth cookies: 1/true or 0/false.
+# Unset = auto-detect (direct TLS socket, or X-Forwarded-Proto: https from a
+# reverse proxy — only trustworthy when a proxy is actually in front).
+# HERMES_WEBUI_SECURE=1
+
+# Extra allowed origins for CSRF/origin checks when serving behind a reverse
+# proxy or on a public hostname. Comma-separated; each entry MUST include the
+# scheme. Entries without a scheme are ignored with a warning.
+# HERMES_WEBUI_ALLOWED_ORIGINS=https://myapp.example.com:8000
+
+# Serve HTTPS directly (both must be set; otherwise plain HTTP).
+# HERMES_WEBUI_TLS_CERT=/path/to/fullchain.pem
+# HERMES_WEBUI_TLS_KEY=/path/to/privkey.pem
+
+# Extra connect-src sources appended to the Content-Security-Policy
+# (space-separated, e.g. for a self-hosted telemetry or API endpoint).
+# HERMES_WEBUI_CSP_CONNECT_EXTRA=https://api.example.com wss://api.example.com
+
+# ── Uploads & limits ─────────────────────────────────────────────────────────
+
+# Where chat attachments are stored (default: <state dir>/attachments).
+# Attachments are transient agent context, kept out of the workspace by default.
+# HERMES_WEBUI_ATTACHMENT_DIR=~/.hermes/webui/attachments
+
+# Caps for the "download folder as ZIP" feature in the workspace browser.
+# HERMES_WEBUI_FOLDER_ZIP_MAX_MB=1024
+# HERMES_WEBUI_FOLDER_ZIP_MAX_FILES=50000
+
+# Requests slower than this many seconds get a stack-dump diagnostic in the log
+# (default: 5.0; set 0 to log every request's timing).
+# HERMES_WEBUI_SLOW_REQUEST_SECONDS=5.0
+
+# ── Onboarding ───────────────────────────────────────────────────────────────
+
+# By default, when no password is set, onboarding write endpoints only accept
+# requests from local/private addresses. Set to 1 to explicitly allow remote
+# onboarding on a server where YOU control network access (firewall/VPN).
+# HERMES_WEBUI_ONBOARDING_OPEN=1
+
+# Skip the first-run onboarding wizard entirely.
+# HERMES_WEBUI_SKIP_ONBOARDING=1
+
+# ── Advanced integrations ────────────────────────────────────────────────────
+
+# Script whose stdout prefills new-session context (legacy generic hook; the
+# WebUI dynamic-recall hook in config.yaml takes precedence when configured).
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT=/path/to/script
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT=10
+# HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS=20000
+
+# Extra sources for the notes drawer (see docs for the expected format).
+# HERMES_WEBUI_EXTERNAL_NOTES_SOURCES=
+
+# Override the Claude Code projects directory scanned by the CLI session
+# bridge (default: auto-discovered ~/.claude/projects).
+# HERMES_WEBUI_CLAUDE_PROJECTS_DIR=~/.claude/projects
+
+# Override the Codex CLI home scanned by the CLI session bridge and model
+# catalog merge (default: ~/.codex).
+# CODEX_HOME=~/.codex
+
+# Path to the LLM wiki root shown in the wiki panel (default: resolved from
+# HERMES_HOME's wiki env file).
+# WIKI_PATH=/path/to/wiki

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,52 @@ jobs:
         if: always()
         run: python3 scripts/ruff_lint.py --all
 
+  # JS runtime-error guard (ESLint). The JS twin of the ruff gate above. Runs the
+  # runtime-guard config (no-const-assign, no-import-assign — the #3162 brick-class
+  # bug family) over static/*.js. tests/test_static_js_runtime_lint.py runs the same
+  # check in-suite but skips gracefully when eslint is absent, so this job is the
+  # hard gate that guarantees the guard actually runs on every PR.
+  lint-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          # No cache: the repo intentionally has no package-lock.json (eslint is
+          # the sole dev dep, installed with --no-save); a fresh install is fast.
+
+      - name: Install ESLint
+        run: npm install --no-save --no-audit --no-fund
+
+      - name: ESLint runtime guard (static/*.js)
+        run: npm run lint:runtime
+
+  # JS runtime-error guard (ESLint). The JS twin of the ruff gate above. Runs the
+  # runtime-guard config (no-const-assign, no-import-assign — the #3162 brick-class
+  # bug family) over static/*.js. tests/test_static_js_runtime_lint.py runs the same
+  # check in-suite but skips gracefully when eslint is absent, so this job is the
+  # hard gate that guarantees the guard actually runs on every PR.
+  lint-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          # No cache: the repo intentionally has no package-lock.json (eslint is
+          # the sole dev dep, installed with --no-save); a fresh install is fast.
+
+      - name: Install ESLint
+        run: npm install --no-save --no-audit --no-fund
+
+      - name: ESLint runtime guard (static/*.js)
+        run: npm run lint:runtime
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,8 +7,8 @@
 >
 > Keep this document updated as architecture changes are made.
 
-> Current shipped build: `v0.51.54` (May 13, 2026).
-> Automated coverage: 5303 tests via `pytest tests/ --collect-only -q`. CI runs on Python 3.11, 3.12, and 3.13 against every PR.
+> Current shipped build: `v0.51.191` (May 31, 2026).
+> Automated coverage: 7085 tests via `pytest tests/ --collect-only -q`. CI runs on Python 3.11, 3.12, and 3.13 against every PR.
 >
 > Notable architecture state as of v0.51.54: the bootstrap and first-run onboarding flow own setup discovery; the default WebUI state directory is `~/.hermes/webui`; `ctl.sh` provides a daemon wrapper for homelab installs; chat streaming is still WebUI-owned SSE with stream-ownership guards, cancellation, async manual compression, and turn-journal audit plumbing; provider/model discovery is profile-aware with live-model cache invalidation and custom-provider scoping.
 
@@ -76,7 +76,7 @@ actions. The topbar remains focused on conversation context and the workspace/fi
       boot.js              Event wiring, mobile sidebar/workspace nav, voice input, boot IIFE (~1607 lines)
     tests/
       conftest.py          Isolated test server/state fixtures (~644 lines)
-      488 test files       5303 tests collected via pytest
+      698 test files       7085 tests collected via pytest
       test_regressions.py  Permanent regression gate (~976 lines)
     CONTRIBUTING.md        Contributor workflow and PR expectations.
     ROADMAP.md             Feature and product roadmap document.
@@ -704,7 +704,7 @@ Current structure:
         ui.js, workspace.js, sessions.js, messages.js, panels.js, commands.js, boot.js
       tests/
         conftest.py           Isolated test server/state fixtures
-        488 test files        5303 tests collected
+        698 test files        7085 tests collected
         test_regressions.py   Permanent regression gate
 
 Route extraction to api/routes.py completed in Sprint 11. server.py remains a
@@ -804,7 +804,7 @@ Optional password gate for non-SSH-tunnel deployments.
 
 ### Phase I: Test Infrastructure -- COMPLETE
 
-5303 tests across 488 test files + regression gates. The pytest fixture derives
+7085 tests across 698 test files + regression gates. The pytest fixture derives
 an isolated port and state directory from the repo path unless
 `HERMES_WEBUI_TEST_PORT` / `HERMES_WEBUI_TEST_STATE_DIR` pin them explicitly.
 Production data never touched.

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Or using the agent venv explicitly:
 
 Tests run against an isolated server with a separate state directory.
 Production data and real cron jobs are never touched. Current snapshot:
-**5303 tests collected** across **488 test files**.
+**7085 tests collected** across **698 test files**.
 
 ---
 
@@ -634,7 +634,7 @@ static/
   boot.js               Mobile nav, voice input, boot IIFE (~1607 lines)
 tests/
   conftest.py           Isolated test server/state fixtures
-  488 test files         5303 tests collected
+  698 test files         7085 tests collected
 Dockerfile              python:3.12-slim container image
 docker-compose.yml      Compose with named volume and optional auth
 .github/workflows/      CI: multi-arch Docker build + GitHub Release on tag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.51.31 (May 9, 2026) — 5028 tests collected — Release H 12-PR contributor batch (image-mode fix + race fixes + composer drafts + locale parity + custom-provider dedup + TTL config + heartbeat polish)
+> Last updated: v0.51.191 (July 3, 2026 doc sync) — 7085 tests collected across 698 test files — Release FK (stage-batch3 — skills-detail markdown styling + launchd duplicate-start guard)
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 
@@ -228,7 +228,7 @@ Remaining gaps and forward work live in [Forward Work](#forward-work) below.
 - [x] PWA installation (manifest + icons + Android support)
 
 ### Internationalization
-- [x] 9 locales — English, Japanese, Russian, Spanish, German, Chinese (zh + zh-Hant), Portuguese, Korean, French
+- [x] 12 locales — English, Italian, Japanese, Russian, Spanish, German, Chinese (zh + zh-Hant), Portuguese, Korean, French, Turkish
 - [x] Key-parity test ensures every locale has every key
 - [x] Right-to-left and CJK input (IME composition fixes)
 
@@ -260,26 +260,26 @@ Remaining gaps and forward work live in [Forward Work](#forward-work) below.
 
 | Theme | Tracking | Why |
 |---|---|---|
-| Persistent-host stability | #1458 | Bootstrap fork pattern crashes under launchd / systemd — partial fix shipped (foreground mode); state.db FD leak and HTTP-unhealthy wedge remain |
-| Free-tier OpenRouter variants visible | #1426 | `:free` tool-support filter currently hides them from the picker |
+| Persistent-host stability | #1458 | Bug #1 (bootstrap fork crash, #1483) and Bug #2 (state.db FD leak, #1494/#1495) are fixed; Bug #3 (HTTP-unhealthy wedge without FD exhaustion) remains open pending diagnostic data |
 | macOS scroll override regression | #1360 | Auto-scroll sometimes overrides user scroll on the desktop app |
 | GLM dual-use (main + auxiliary) | #1291 | Currently mutually exclusive; same provider can't serve both surfaces |
-| Auto-assign session to filtered project | #1468 | When user is filtering by project X, new session should default to project X |
-| Update banner "What's new?" link | #1512 | Surface release highlights from the update banner |
 | Sunset legacy `LMSTUDIO_API_KEY` env var | #1502 | Tracking issue — alias stays for one minor cycle, then removed |
 | Hermes Agent dashboard cross-link | #1459 | Detect a running Hermes Agent and surface link in nav |
-| Gateway status card in Settings | #1457 | Current gateway-status dots only on profile picker |
 | Insights — daily token chart + per-model breakdown | #1456 | Existing usage badge is per-message; need rollup view |
 | Logs tab — view agent / errors / gateway logs | #1455 | Currently requires terminal access to log files |
 | Model picker collision handling | #1425 | Same-name models from different providers aren't disambiguated in dropdown |
-| "Reveal in Finder" right-click on workspace | #1424 | macOS desktop app convenience |
 | Configurable session persistence timing | #1406 | Currently every checkpoint, want operator control |
-| Silent credential self-heal on 401 | #1401 | Gateway auth.json drift should resolve without user re-auth |
 | LLM Wiki status panel | #1257 | On / off toggle for Wiki integration |
 | Lightweight in-app Canvas editing | #1255 | Text canvas for prompt drafting / shared notes |
 | Provider / Model source-of-truth alignment | #1240 | Reconcile WebUI vs CLI vs Gateway provider resolution |
 | Built-in SearXNG web search | #1037 | Lightweight search tool with on / off toggle |
 | Subagent session relationship view | #1004 | Show subagent hierarchy in sidebar with expand / collapse |
+
+Shipped from this list (v0.50.283 full-sweep batch, 2026-05-03 — see CHANGELOG):
+free-tier OpenRouter variants (#1426), auto-assign session to filtered project
+(#1468), update-banner "What's new?" link (#1512, PR #1549), gateway status card
+in Settings (#1457, PR #1552), "Reveal in Finder" (#1424), and silent credential
+self-heal on 401 (#1401, PR #1553).
 
 ### Backlog (deferred, listed for visibility)
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -2,7 +2,7 @@
 
 > Forward-looking sprint plan and active queue.
 >
-> Current state: v0.50.281 | 3995 tests | port 8787
+> Current state: v0.51.191 | 7085 tests | port 8787
 > Target A (CLI parity): ✅ Complete
 > Target B (Claude parity): ~95% — full subagent transparency UI and code-execution cells remain
 >

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
-> Automated coverage: 5303 tests collected via `pytest tests/ --collect-only -q`. Tests run on every PR via GitHub Actions on Python 3.11, 3.12, and 3.13. The suite covers the bootstrap/static wizard, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, CSS regression coverage for thinking/tool card animation, streaming session persistence, mobile layout breakpoints, locale parity across 11 languages, and hundreds of issue/PR-pinned regression tests.
+> Automated coverage: 7085 tests collected via `pytest tests/ --collect-only -q`. Tests run on every PR via GitHub Actions on Python 3.11, 3.12, and 3.13. The suite covers the bootstrap/static wizard, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, CSS regression coverage for thinking/tool card animation, streaming session persistence, mobile layout breakpoints, locale parity across 11 languages, and hundreds of issue/PR-pinned regression tests.
 > Run: `pytest tests/ -v --timeout=60`
 >
 > Local regression focus: verify that a previously closed workspace panel stays visually closed from first paint through boot completion on desktop refresh; there should be no brief open-then-close flash.
@@ -91,7 +91,9 @@ environment before launching the server, needs no secrets, and does not drive a
 real model (it verifies the app *loads and initializes* cleanly — the brick class
 that breaks the page for everyone). A full chat golden-path E2E (send → stream →
 render → switch → reload) lives in the maintainer's private QA harness, which has
-the agent + a mock LLM provider available.
+the agent + a mock LLM provider available. **Contributors: that harness is NOT in
+this repo** — don't go looking for it. Everything under `tests/` here runs without
+the agent or any credentials.
 
 
 `tests/test_static_js_runtime_lint.py` runs this automatically when eslint is present
@@ -1926,7 +1928,7 @@ Bridged CLI sessions:
 ---
 
 *Last updated: v0.51.54, May 13, 2026*
-*Total automated tests collected: 5303*
+*Total automated tests collected: 7085*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/routes.py
+++ b/api/routes.py
@@ -1414,46 +1414,63 @@ def _csrf_rejection_error(handler) -> str:
     return "Cross-origin request rejected"
 
 
+def _origin_target_allowed(handler, target: str) -> bool:
+    """Return True when an Origin/Referer value is same-origin or allowlisted.
+
+    Same-origin means the origin's host:port matches Host, X-Forwarded-Host
+    (reverse proxy), or X-Real-Host. Explicit public origins come from the
+    HERMES_WEBUI_ALLOWED_ORIGINS env var. Shared by the CSRF gate and the
+    CORS preflight handler so both enforce the same policy.
+    """
+    m = _re.match(r"^https?://([^/]+)", target)
+    if not m:
+        return False
+    origin_host = m.group(1)
+    origin_scheme = m.group(0).split('://')[0].lower()  # 'http' or 'https'
+    origin_name, origin_port = _normalize_host_port(origin_host)
+    # Check against explicitly allowed public origins (env var)
+    if m.group(0).rstrip('/').lower() in _allowed_public_origins():
+        return True
+    # Allow same-origin: check Host, X-Forwarded-Host (reverse proxy), and
+    # X-Real-Host against the origin. Reverse proxies (Caddy, nginx) set
+    # X-Forwarded-Host to the client's original Host header.
+    allowed_hosts = [
+        h.strip()
+        for h in [
+            handler.headers.get("Host", ""),
+            handler.headers.get("X-Forwarded-Host", ""),
+            handler.headers.get("X-Real-Host", ""),
+        ]
+        if h.strip()
+    ]
+    for allowed in allowed_hosts:
+        allowed_name, allowed_port = _normalize_host_port(allowed)
+        if origin_name == allowed_name and _ports_match(origin_scheme, origin_port, allowed_port):
+            return True
+    return False
+
+
+def preflight_allow_origin(handler) -> str:
+    """CORS preflight: return the Origin value to echo back, or '' to omit.
+
+    Echoes the request Origin only when it is same-origin or explicitly
+    allowlisted via HERMES_WEBUI_ALLOWED_ORIGINS — the preflight must not
+    advertise wider access (`*`) than the CSRF gate actually permits.
+    """
+    origin = handler.headers.get("Origin", "").strip()
+    if not origin:
+        return ""
+    return origin if _origin_target_allowed(handler, origin) else ""
+
+
 def _check_csrf(handler) -> bool:
     """Reject cross-origin or tokenless authenticated browser unsafe requests."""
     _clear_csrf_failure_reason(handler)
     origin = handler.headers.get("Origin", "")
     referer = handler.headers.get("Referer", "")
-    host = handler.headers.get("Host", "")
     if not _is_browser_unsafe_request(handler):
         return True  # non-browser clients (curl, MCP, agent) have no Origin
-    target = origin or referer
-    # Extract host:port from origin/referer
-    m = _re.match(r"^https?://([^/]+)", target)
-    if not m:
-        return _set_csrf_failure_reason(handler, "origin_mismatch")
-    origin_host = m.group(1)
-    origin_scheme = m.group(0).split('://')[0].lower()  # 'http' or 'https'
-    origin_name, origin_port = _normalize_host_port(origin_host)
-    origin_allowed = False
-    # Check against explicitly allowed public origins (env var)
-    origin_value = m.group(0).rstrip('/').lower()
-    if origin_value in _allowed_public_origins():
-        origin_allowed = True
-    if not origin_allowed:
-        # Allow same-origin: check Host, X-Forwarded-Host (reverse proxy), and
-        # X-Real-Host against the origin. Reverse proxies (Caddy, nginx) set
-        # X-Forwarded-Host to the client's original Host header.
-        allowed_hosts = [
-            h.strip()
-            for h in [
-                host,
-                handler.headers.get("X-Forwarded-Host", ""),
-                handler.headers.get("X-Real-Host", ""),
-            ]
-            if h.strip()
-        ]
-        for allowed in allowed_hosts:
-            allowed_name, allowed_port = _normalize_host_port(allowed)
-            if origin_name == allowed_name and _ports_match(origin_scheme, origin_port, allowed_port):
-                origin_allowed = True
-                break
-    if not origin_allowed:
+    if not _origin_target_allowed(handler, origin or referer):
         return _set_csrf_failure_reason(handler, "origin_mismatch")
 
     from api.auth import CSRF_HEADER_NAME, is_auth_enabled, parse_cookie, verify_csrf_token

--- a/api/upload.py
+++ b/api/upload.py
@@ -144,7 +144,7 @@ def extract_archive(file_bytes: bytes, filename: str, workspace: Path):
     Returns a dict with ``extracted`` (int), ``files`` (list[str]).
     Raises ValueError on zip-slip or unsupported format.
     """
-    import zipfile, tarfile, io, os, shutil
+    import zipfile, tarfile, io, os, shutil, stat
 
     name = Path(filename).name
     stem = Path(filename).stem  # strip .zip / .tar.gz etc.
@@ -176,6 +176,12 @@ def extract_archive(file_bytes: bytes, filename: str, workspace: Path):
                     # Skip directories
                     if member.is_dir():
                         continue
+                    # Skip symlink members — never materialize them (neither as
+                    # links nor as files holding the link-target text). The tar
+                    # branch gets this for free from member.isfile().
+                    unix_mode = member.external_attr >> 16
+                    if unix_mode and stat.S_ISLNK(unix_mode):
+                        continue
                     # Zip-slip protection
                     member_path = (dest_dir / member.filename).resolve()
                     if not member_path.is_relative_to(dest_dir.resolve()):
@@ -202,7 +208,7 @@ def extract_archive(file_bytes: bytes, filename: str, workspace: Path):
                                     f'Possible zip bomb.'
                                 )
                             dst.write(chunk)
-                    extracted_files.append(str(member_path.relative_to(workspace.resolve())))
+                    extracted_files.append(member_path.relative_to(workspace.resolve()).as_posix())
 
         elif _mode == 'tar':
             with tarfile.open(fileobj=io.BytesIO(file_bytes)) as tf:
@@ -237,7 +243,7 @@ def extract_archive(file_bytes: bytes, filename: str, workspace: Path):
                                         f'Possible zip bomb.'
                                     )
                                 dst.write(chunk)
-                    extracted_files.append(str(member_path.relative_to(workspace.resolve())))
+                    extracted_files.append(member_path.relative_to(workspace.resolve()).as_posix())
     except Exception:
         # Clean up partially-extracted directory to avoid orphaned folders
         try:

--- a/server.py
+++ b/server.py
@@ -166,7 +166,14 @@ from api.auth import check_auth
 from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
 from api.helpers import j, get_profile_cookie, _CLIENT_DISCONNECT_ERRORS
 from api.profiles import set_request_profile, clear_request_profile
-from api.routes import handle_delete, handle_get, handle_patch, handle_post, handle_put
+from api.routes import (
+    handle_delete,
+    handle_get,
+    handle_patch,
+    handle_post,
+    handle_put,
+    preflight_allow_origin,
+)
 from api.startup import auto_install_agent_deps, fix_credential_permissions
 from api.updates import WEBUI_VERSION
 
@@ -379,12 +386,21 @@ class Handler(BaseHTTPRequestHandler):
         self._handle_write(handle_patch)
 
     def do_OPTIONS(self) -> None:
-        """Handle CORS preflight requests."""
+        """Handle CORS preflight requests.
+
+        Echo the request Origin only when it is same-origin or allowlisted
+        via HERMES_WEBUI_ALLOWED_ORIGINS (same policy as the CSRF gate) —
+        never advertise `*`. Disallowed origins get a 200 with no CORS
+        headers, which the browser treats as a preflight denial.
+        """
         self._req_t0 = time.time()
+        allow_origin = preflight_allow_origin(self)
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        if allow_origin:
+            self.send_header("Access-Control-Allow-Origin", allow_origin)
+            self.send_header("Vary", "Origin")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
         self.end_headers()
 
     def do_DELETE(self) -> None:

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1742,7 +1742,7 @@ const LOCALES = {
      copy_file_path: 'Copia percorso file',
      open_in_vscode: 'Apri in VS Code',
      open_in_vscode_failed: 'Apertura in VS Code fallita: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: 'Cartella download',
     path_copied: 'Percorso file copiato negli appunti',
     path_copy_failed: 'Copia percorso fallita: ',
     session_rename: 'Rinomina conversazione',
@@ -1865,18 +1865,18 @@ const LOCALES = {
     settings_tab_appearance: 'Aspetto',
     settings_tab_preferences: 'Preferenze',
     settings_tab_plugins: 'Plugin',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'Plugin',
+    settings_plugins_meta: 'Visualizza i plugin Hermes installati e gli hook del ciclo di vita che registrano. Questo pannello è di sola lettura.',
+    settings_plugins_empty: 'Nessun plugin Hermes attualmente visibile. Installa o abilita i plugin dalla CLI/config di Hermes per vederli qui.',
+    plugins_unnamed: 'Plugin senza nome',
+    plugins_no_description: 'Nessuna descrizione fornita.',
+    plugins_no_hooks: 'Nessun hook del ciclo di vita registrato',
+    plugins_registered_hooks: 'Hook registrati',
+    plugins_enabled: 'Abilitato',
+    plugins_disabled: 'Disabilitato',
+    plugins_active_provider: 'Attivo (provider)',
+    plugins_provider_no_hooks: 'Plugin provider — nessun hook di visibilità agente',
+    plugins_load_failed: 'Caricamento plugin fallito: ',
     settings_tab_system: 'Sistema',
     settings_title: 'Impostazioni',
     settings_save_btn: 'Salva Impostazioni',
@@ -3054,7 +3054,7 @@ const LOCALES = {
      copy_file_path: 'ファイルパスをコピー',
      open_in_vscode: 'VS Codeで開く',
      open_in_vscode_failed: 'VS Codeで開けませんでした: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: 'ダウンロードフォルダ',
     path_copied: 'ファイルパスをクリップボードにコピーしました',
     path_copy_failed: 'パスのコピーに失敗しました: ',
     session_rename: '会話の名前を変更',
@@ -3177,18 +3177,18 @@ const LOCALES = {
     settings_tab_appearance: '外観',
     settings_tab_preferences: '環境設定',
     settings_tab_plugins: 'プラグイン',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'プラグイン',
+    settings_plugins_meta: 'インストール済みの Hermes プラグインと、それらが登録するライフサイクルフックを表示します。このパネルは読み取り専用です。',
+    settings_plugins_empty: '現在表示できる Hermes プラグインはありません。Hermes CLI/設定からプラグインをインストールまたは有効化するとここに表示されます。',
+    plugins_unnamed: '名称未設定のプラグイン',
+    plugins_no_description: '説明がありません。',
+    plugins_no_hooks: '登録されたライフサイクルフックはありません',
+    plugins_registered_hooks: '登録済みフック',
+    plugins_enabled: '有効',
+    plugins_disabled: '無効',
+    plugins_active_provider: 'アクティブ (プロバイダー)',
+    plugins_provider_no_hooks: 'プロバイダープラグイン — エージェント可視フックなし',
+    plugins_load_failed: 'プラグインの読み込みに失敗しました: ',
     settings_tab_system: 'システム',
     settings_title: '設定',
     settings_save_btn: '設定を保存',
@@ -4125,7 +4125,7 @@ const LOCALES = {
     new_session_creating: 'Создаём новую беседу…',
     compressing: 'Запрашиваю сжатие контекста...',
     token_usage_on: 'Отображение токенов включено',
-    usage_personality_none: 'none', // TODO: translate
+    usage_personality_none: 'нет',
     token_usage_off: 'Отображение токенов выключено',
     usage_cache_hit_detail: 'Кэш: {0}% попаданий ({1} чтение / {2} запись)',
     usage_cached_percent: '{0}% из кэша',
@@ -4208,16 +4208,16 @@ const LOCALES = {
     session_worktree_badge: 'Worktree',
     model_search_placeholder: 'Поиск моделей…',
     model_scope_advisory: 'Применяется к этой беседе со следующего сообщения.',
-    session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
-    session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
-    session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
-    session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
+    session_toolsets: 'Наборы инструментов сессии',
+    session_toolsets_desc: 'Ограничить доступные инструменты для этой сессии (пусто = глобальная конфигурация)',
+    session_toolsets_global: 'Глобально (по умолчанию)',
+    session_toolsets_custom: 'Пользовательский',
+    session_toolsets_placeholder: 'инструмент1, инструмент2, …',
+    session_toolsets_apply: 'Применить',
+    session_toolsets_clear: 'Очистить (использовать глобальные)',
+    session_toolsets_applied: 'Наборы инструментов обновлены',
+    session_toolsets_cleared: 'Наборы инструментов очищены — используется глобальная конфигурация',
+    session_toolsets_failed: 'Не удалось обновить наборы инструментов: ',
     model_scope_toast: 'Применяется к этой беседе со следующего сообщения.',
     reference_only_label: 'Только справка',
     settings_label_skin: 'Скин',
@@ -4291,7 +4291,7 @@ const LOCALES = {
      copy_file_path: 'Копировать путь к файлу',
      open_in_vscode: 'Открыть в VS Code',
      open_in_vscode_failed: 'Не удалось открыть в VS Code: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: 'Папка загрузок',
     path_copied: 'Путь к файлу скопирован в буфер обмена',
     path_copy_failed: 'Не удалось скопировать путь: ',
     session_rename: 'Переименовать беседу',
@@ -4466,19 +4466,19 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_settings: 'Настройки',
 
-    logs_title: 'Logs',  // TODO: translate
-    logs_file: 'File',  // TODO: translate
-    logs_tail: 'Tail',  // TODO: translate
-    logs_auto_refresh: 'Auto-refresh (5s)',  // TODO: translate
-    logs_wrap: 'Wrap lines',  // TODO: translate
-    logs_copy_all: 'Copy all',  // TODO: translate
-    logs_empty: 'No log lines yet.',  // TODO: translate
-    logs_loading: 'Loading logs…',  // TODO: translate
-    logs_load_failed: 'Logs failed to load',  // TODO: translate
-    logs_status_idle: 'Choose a log file to view recent lines.',  // TODO: translate
-    logs_no_mtime: 'not written yet',  // TODO: translate
-    logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
-    logs_copied: 'Logs copied',  // TODO: translate
+    logs_title: 'Логи',
+    logs_file: 'Файл',
+    logs_tail: 'Хвост',
+    logs_auto_refresh: 'Автообновление (5с)',
+    logs_wrap: 'Перенос строк',
+    logs_copy_all: 'Копировать всё',
+    logs_empty: 'Строк лога пока нет.',
+    logs_loading: 'Загрузка логов…',
+    logs_load_failed: 'Не удалось загрузить логи',
+    logs_status_idle: 'Выберите файл лога, чтобы увидеть последние строки.',
+    logs_no_mtime: 'ещё не записан',
+    logs_truncated_hint: 'Показан хвост большого файла лога; старые данные пропущены для экономии памяти.',
+    logs_copied: 'Логи скопированы',
     logs_severity: 'Уровень',
     logs_severity_all: 'Все',
     logs_severity_errors: 'Ошибки',
@@ -4680,16 +4680,16 @@ const LOCALES = {
     provider_category_specialized: 'Специализированные',
     onboarding_api_key_label: 'Ключ API',
     onboarding_api_key_placeholder: 'Оставьте пустым, чтобы сохранить уже сохранённый ключ',
-    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
-    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
-    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
-    oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
-    oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
-    oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
-    oauth_codex_polling: 'Waiting for authorization...', // TODO: translate
-    oauth_codex_success: 'Codex OAuth login successful!', // TODO: translate
-    oauth_codex_error: 'OAuth login failed', // TODO: translate
-    oauth_codex_expired: 'Code expired, please try again', // TODO: translate
+    onboarding_api_key_label_optional: 'Ключ API (необязательно)',
+    onboarding_api_key_placeholder_optional: 'Оставьте пустым для серверов без ключа',
+    onboarding_api_key_help_keyless: 'Большинство установок LM Studio / Ollama / vLLM работают без ключа — оставьте поле пустым, если ваш сервер не требует аутентификации. Используйте кнопку «Проверить соединение» для проверки.',
+    oauth_login_codex: 'Войти через Codex (ChatGPT)',
+    oauth_codex_step1: 'Шаг 1: Откройте этот URL и введите код',
+    oauth_codex_step2: 'Шаг 2: Введите этот код на странице',
+    oauth_codex_polling: 'Ожидание авторизации...',
+    oauth_codex_success: 'Вход через Codex OAuth выполнен!',
+    oauth_codex_error: 'Ошибка входа OAuth',
+    oauth_codex_expired: 'Код истёк, попробуйте ещё раз',
     onboarding_api_key_help_prefix: 'Сохраняется как секрет в вашем файле `.env` Hermes с помощью',
     onboarding_base_url_label: 'Базовый URL',
     onboarding_base_url_placeholder: 'https://your-endpoint.example/v1',
@@ -4715,19 +4715,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Выберите модель перед продолжением.',
     onboarding_error_provider_required: 'Выберите режим настройки перед продолжением.',
     onboarding_error_base_url_required: 'Для собственных endpoint-ов требуется базовый URL.',
-    onboarding_probe_test_button: 'Test connection', // TODO: translate
-    onboarding_probe_probing: 'Testing connection…', // TODO: translate
-    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
-    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
-    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
-    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
-    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
-    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
-    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
-    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
-    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
+    onboarding_probe_test_button: 'Проверить соединение',
+    onboarding_probe_probing: 'Проверка соединения…',
+    onboarding_probe_ok: 'Подключено. Доступно моделей: {n}.',
+    onboarding_probe_error_generic: 'Не удалось подключиться к настроенному базовому URL.',
+    onboarding_probe_error_invalid_url: 'Базовый URL должен начинаться с http:// или https://.',
+    onboarding_probe_error_dns: 'Не удалось разрешить имя хоста. Проверьте URL или используйте IP-адрес хоста.',
+    onboarding_probe_error_connect_refused: 'Соединение отклонено — сервер может быть не запущен по этому адресу. Из Docker попробуйте IP хоста вместо localhost.',
+    onboarding_probe_error_timeout: 'Endpoint не ответил вовремя. Проверьте, что сервер запущен и URL указан верно.',
+    onboarding_probe_error_http_4xx: 'Endpoint вернул ошибку клиента. Проверьте аутентификацию и путь URL (обычно заканчивается на /v1).',
+    onboarding_probe_error_http_5xx: 'Endpoint вернул ошибку сервера. Проверьте логи сервера LM Studio / Ollama.',
+    onboarding_probe_error_parse: 'Endpoint не вернул список моделей в ожидаемом формате. Убедитесь, что URL указывает на корень OpenAI-совместимого API.',
+    onboarding_probe_error_unreachable: 'Не удалось подключиться к настроенному базовому URL.',
+    onboarding_error_probe_failed: 'Не удалось проверить настроенный базовый URL.',
     onboarding_error_workspace_required: 'Рабочее пространство обязательно.',
     onboarding_error_model_required: 'Модель обязательна.',
     onboarding_complete: 'Первичная настройка завершена',
@@ -5059,18 +5059,18 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Плагины',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'Плагины',
+    settings_plugins_meta: 'Просмотр установленных плагинов Hermes и хуков жизненного цикла, которые они регистрируют. Эта панель доступна только для чтения.',
+    settings_plugins_empty: 'Плагины Hermes сейчас не видны. Установите или включите плагины через Hermes CLI/конфигурацию, чтобы увидеть их здесь.',
+    plugins_unnamed: 'Плагин без имени',
+    plugins_no_description: 'Описание не указано.',
+    plugins_no_hooks: 'Нет зарегистрированных хуков жизненного цикла',
+    plugins_registered_hooks: 'Зарегистрированные хуки',
+    plugins_enabled: 'Включён',
+    plugins_disabled: 'Отключён',
+    plugins_active_provider: 'Активен (провайдер)',
+    plugins_provider_no_hooks: 'Плагин-провайдер — без хуков видимости агента',
+    plugins_load_failed: 'Не удалось загрузить плагины: ',
     settings_tab_system: 'System',
     status_updated: 'Updated',
     status_ephemeral: 'Ephemeral snapshot — not saved to transcript history.',
@@ -5153,24 +5153,24 @@ const LOCALES = {
     settings_label_tts_rate: 'Скорость речи',
     settings_label_tts_pitch: 'Тон речи',
 
-    checkpoint_date: 'Date',  // TODO: translate
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
-    checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
-    checkpoint_diff_title: 'Changes in checkpoint',  // TODO: translate
-    checkpoint_empty: 'No checkpoints found for this workspace.',  // TODO: translate
-    checkpoint_error: 'Failed to load checkpoints',  // TODO: translate
-    checkpoint_files: 'Files',  // TODO: translate
-    checkpoint_loading: 'Loading checkpoints…',  // TODO: translate
-    checkpoint_message: 'Message',  // TODO: translate
-    checkpoint_restore: 'Restore',  // TODO: translate
-    checkpoint_restore_confirm_message: (ckpt) => `Restore workspace to checkpoint "${ckpt}"? This will overwrite files with the saved versions. Files added after this checkpoint will not be deleted.`,  // TODO: translate
-    checkpoint_restore_confirm_title: 'Restore checkpoint?',  // TODO: translate
-    checkpoint_restored: 'Checkpoint restored',  // TODO: translate
-    checkpoint_title: 'Checkpoints',  // TODO: translate
-    checkpoint_view_diff: 'View diff',  // TODO: translate
-    insights_activity_by_day: 'Activity by Day',  // TODO: translate
-    insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
-    insights_cost: 'Estimated Cost',  // TODO: translate
+    checkpoint_date: 'Дата',
+    checkpoint_diff_files_changed: (n) => `Изменено файлов: ${n}`,
+    checkpoint_diff_no_changes: 'Различий между этой контрольной точкой и текущим рабочим пространством не найдено.',
+    checkpoint_diff_title: 'Изменения в контрольной точке',
+    checkpoint_empty: 'Контрольные точки для этого рабочего пространства не найдены.',
+    checkpoint_error: 'Не удалось загрузить контрольные точки',
+    checkpoint_files: 'Файлы',
+    checkpoint_loading: 'Загрузка контрольных точек…',
+    checkpoint_message: 'Сообщение',
+    checkpoint_restore: 'Восстановить',
+    checkpoint_restore_confirm_message: (ckpt) => `Восстановить рабочее пространство до контрольной точки "${ckpt}"? Файлы будут перезаписаны сохранёнными версиями. Файлы, добавленные после этой контрольной точки, удалены не будут.`,
+    checkpoint_restore_confirm_title: 'Восстановить контрольную точку?',
+    checkpoint_restored: 'Контрольная точка восстановлена',
+    checkpoint_title: 'Контрольные точки',
+    checkpoint_view_diff: 'Показать различия',
+    insights_activity_by_day: 'Активность по дням',
+    insights_activity_by_hour: 'Активность по часам',
+    insights_cost: 'Оценочная стоимость',
     insights_daily_tokens: 'Daily Tokens',
     insights_model_name: 'Model',
     insights_model_sessions: 'Sessions',
@@ -5178,33 +5178,33 @@ const LOCALES = {
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
-    insights_footer: 'Showing data from the last {days} days',  // TODO: translate
-    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
-    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
-    insights_skill_usage_total: 'Total invocations',  // TODO: translate
-    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
-    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
-    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
-    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
-    insights_input_tokens: 'Input',  // TODO: translate
-    insights_messages: 'Messages',  // TODO: translate
-    insights_models: 'Models',  // TODO: translate
-    insights_no_cost: 'N/A',  // TODO: translate
-    insights_output_tokens: 'Output',  // TODO: translate
-    insights_peak_hour: 'Peak: {hour}',  // TODO: translate
-    insights_sessions: 'Sessions',  // TODO: translate
-    insights_title: 'Usage Analytics',  // TODO: translate
-    insights_token_breakdown: 'Token Breakdown',  // TODO: translate
-    insights_tokens: 'Tokens',  // TODO: translate
-    insights_total: 'Total',  // TODO: translate
-    settings_desc_api_redact: 'Self-hosted users can disable for transparency (not recommended for shared instances).',  // TODO: translate
-    settings_label_api_redact: 'Redact sensitive data in API responses',  // TODO: translate
-    subagent_children: 'Subagent sessions',  // TODO: translate
+    insights_footer: 'Показаны данные за последние {days} дней',
+    insights_skill_usage_title: 'Использование навыков',
+    insights_skill_usage_sub: 'Частота вызова инструментов',
+    insights_skill_usage_total: 'Всего вызовов',
+    insights_skill_usage_skills_used: 'Использовано навыков',
+    insights_skill_usage_no_data: 'Данных об использовании навыков пока нет',
+    insights_skill_usage_no_data_hint: 'Навыки появятся здесь после использования в беседах.',
+    insights_skill_usage_footer: 'Данные из ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Навык',
+    insights_skill_usage_col_uses: 'Использования',
+    insights_skill_usage_col_views: 'Просмотры',
+    insights_skill_usage_col_share: '% использования',
+    insights_skill_usage_col_patches: 'Патчи',
+    insights_input_tokens: 'Ввод',
+    insights_messages: 'Сообщения',
+    insights_models: 'Модели',
+    insights_no_cost: 'Н/Д',
+    insights_output_tokens: 'Вывод',
+    insights_peak_hour: 'Пик: {hour}',
+    insights_sessions: 'Сессии',
+    insights_title: 'Аналитика использования',
+    insights_token_breakdown: 'Разбивка токенов',
+    insights_tokens: 'Токены',
+    insights_total: 'Итого',
+    settings_desc_api_redact: 'Пользователи self-hosted могут отключить для прозрачности (не рекомендуется для общих инстансов).',
+    settings_label_api_redact: 'Скрывать конфиденциальные данные в ответах API',
+    subagent_children: 'Сессии субагентов',
   },
 
   es: {
@@ -5366,16 +5366,16 @@ const LOCALES = {
     workspace_worktree_created: 'Conversación en worktree creada',
     workspace_worktree_failed: 'Error al crear worktree: ',
     session_worktree_badge: 'Worktree',
-    session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
-    session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
-    session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
-    session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
+    session_toolsets: 'Conjuntos de herramientas de sesión',
+    session_toolsets_desc: 'Restringe las herramientas disponibles para esta sesión (vacío = usar config global)',
+    session_toolsets_global: 'Global (predeterminado)',
+    session_toolsets_custom: 'Personalizado',
+    session_toolsets_placeholder: 'herramienta1, herramienta2, …',
+    session_toolsets_apply: 'Aplicar',
+    session_toolsets_clear: 'Limpiar (usar global)',
+    session_toolsets_applied: 'Conjuntos de herramientas actualizados',
+    session_toolsets_cleared: 'Conjuntos de herramientas borrados — usando config global',
+    session_toolsets_failed: 'Error al actualizar conjuntos de herramientas: ',
     model_scope_advisory: 'Se aplica a esta conversación desde tu próximo mensaje.',
     model_scope_toast: 'Se aplica a esta conversación desde tu próximo mensaje.',
     // commands.js
@@ -5419,7 +5419,7 @@ const LOCALES = {
     compress_failed_label: 'La compresión falló',
     focus_label: 'Tema',
     token_usage_on: 'Uso de tokens activado',
-    usage_personality_none: 'none', // TODO: translate
+    usage_personality_none: 'ninguna',
     token_usage_off: 'Uso de tokens desactivado',
     usage_cache_hit_detail: 'Caché: {0}% de acierto ({1} lectura / {2} escritura)',
     usage_cached_percent: '{0}% en caché',
@@ -5520,7 +5520,7 @@ const LOCALES = {
      copy_file_path: 'Copiar ruta del archivo',
      open_in_vscode: 'Abrir en VS Code',
      open_in_vscode_failed: 'Error al abrir en VS Code: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: 'Carpeta de descargas',
     path_copied: 'Ruta del archivo copiada al portapapeles',
     path_copy_failed: 'Error al copiar la ruta: ',
     session_rename: 'Renombrar conversación',
@@ -5715,19 +5715,19 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_settings: 'Ajustes',
 
-    logs_title: 'Logs',  // TODO: translate
-    logs_file: 'File',  // TODO: translate
-    logs_tail: 'Tail',  // TODO: translate
-    logs_auto_refresh: 'Auto-refresh (5s)',  // TODO: translate
-    logs_wrap: 'Wrap lines',  // TODO: translate
-    logs_copy_all: 'Copy all',  // TODO: translate
-    logs_empty: 'No log lines yet.',  // TODO: translate
-    logs_loading: 'Loading logs…',  // TODO: translate
-    logs_load_failed: 'Logs failed to load',  // TODO: translate
-    logs_status_idle: 'Choose a log file to view recent lines.',  // TODO: translate
-    logs_no_mtime: 'not written yet',  // TODO: translate
-    logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
-    logs_copied: 'Logs copied',  // TODO: translate
+    logs_title: 'Registros',
+    logs_file: 'Archivo',
+    logs_tail: 'Cola',
+    logs_auto_refresh: 'Actualización automática (5s)',
+    logs_wrap: 'Ajustar líneas',
+    logs_copy_all: 'Copiar todo',
+    logs_empty: 'Aún no hay líneas de registro.',
+    logs_loading: 'Cargando registros…',
+    logs_load_failed: 'Error al cargar los registros',
+    logs_status_idle: 'Elige un archivo de registro para ver las líneas recientes.',
+    logs_no_mtime: 'aún no escrito',
+    logs_truncated_hint: 'Mostrando el final de un archivo de registro grande; se omitieron los bytes más antiguos para limitar la memoria.',
+    logs_copied: 'Registros copiados',
     logs_severity: 'Severidad',
     logs_severity_all: 'Todo',
     logs_severity_errors: 'Errores',
@@ -5932,16 +5932,16 @@ const LOCALES = {
     provider_category_specialized: 'Especializados',
     onboarding_api_key_label: 'API key',
     onboarding_api_key_placeholder: 'Déjala en blanco para conservar una key ya guardada',
-    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
-    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
-    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
-    oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
-    oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
-    oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
-    oauth_codex_polling: 'Waiting for authorization...', // TODO: translate
-    oauth_codex_success: 'Codex OAuth login successful!', // TODO: translate
-    oauth_codex_error: 'OAuth login failed', // TODO: translate
-    oauth_codex_expired: 'Code expired, please try again', // TODO: translate
+    onboarding_api_key_label_optional: 'API key (opcional)',
+    onboarding_api_key_placeholder_optional: 'Déjalo en blanco para servidores sin clave',
+    onboarding_api_key_help_keyless: 'La mayoría de instalaciones de LM Studio / Ollama / vLLM funcionan sin clave — deja esto en blanco si tu servidor no requiere autenticación. Usa el botón Probar conexión para verificar.',
+    oauth_login_codex: 'Iniciar sesión con Codex (ChatGPT)',
+    oauth_codex_step1: 'Paso 1: Visita esta URL e introduce el código',
+    oauth_codex_step2: 'Paso 2: Introduce este código en la página',
+    oauth_codex_polling: 'Esperando autorización...',
+    oauth_codex_success: '¡Inicio de sesión OAuth de Codex correcto!',
+    oauth_codex_error: 'Error en el inicio de sesión OAuth',
+    oauth_codex_expired: 'Código caducado, inténtalo de nuevo',
     onboarding_api_key_help_prefix: 'Se guarda como secreto en tu archivo .env de Hermes usando',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://tu-endpoint.example/v1',
@@ -5967,19 +5967,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Elige un modelo antes de continuar.',
     onboarding_error_provider_required: 'Elige un modo de configuración antes de continuar.',
     onboarding_error_base_url_required: 'La base URL es obligatoria para endpoints personalizados.',
-    onboarding_probe_test_button: 'Test connection', // TODO: translate
-    onboarding_probe_probing: 'Testing connection…', // TODO: translate
-    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
-    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
-    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
-    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
-    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
-    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
-    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
-    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
-    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
+    onboarding_probe_test_button: 'Probar conexión',
+    onboarding_probe_probing: 'Probando conexión…',
+    onboarding_probe_ok: 'Conectado. {n} modelo(s) disponible(s).',
+    onboarding_probe_error_generic: 'No se pudo acceder a la URL base configurada.',
+    onboarding_probe_error_invalid_url: 'La URL base debe empezar por http:// o https://.',
+    onboarding_probe_error_dns: 'No se pudo resolver el host. Comprueba la URL o usa la dirección IP del host.',
+    onboarding_probe_error_connect_refused: 'Conexión rechazada — puede que el servidor no esté en ejecución en esa dirección. Desde Docker, prueba la IP del host en lugar de localhost.',
+    onboarding_probe_error_timeout: 'El endpoint no respondió a tiempo. Comprueba que el servidor esté en ejecución y que la URL sea correcta.',
+    onboarding_probe_error_http_4xx: 'El endpoint devolvió un error de cliente. Comprueba la autenticación y la ruta de la URL (normalmente termina en /v1).',
+    onboarding_probe_error_http_5xx: 'El endpoint devolvió un error de servidor. Comprueba los logs del servidor LM Studio / Ollama.',
+    onboarding_probe_error_parse: 'El endpoint no devolvió una lista de modelos con el formato esperado. Verifica que la URL apunte a la raíz de la API compatible con OpenAI.',
+    onboarding_probe_error_unreachable: 'No se pudo acceder a la URL base configurada.',
+    onboarding_error_probe_failed: 'No se pudo validar la URL base configurada.',
     onboarding_error_workspace_required: 'El espacio de trabajo es obligatorio.',
     onboarding_error_model_required: 'El modelo es obligatorio.',
     onboarding_complete: 'Onboarding completado',
@@ -6296,18 +6296,18 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'Plugins',
+    settings_plugins_meta: 'Consulta los plugins de Hermes instalados y los hooks de ciclo de vida que registran. Este panel es de solo lectura.',
+    settings_plugins_empty: 'No hay plugins de Hermes visibles actualmente. Instala o habilita plugins desde la CLI/config de Hermes para verlos aquí.',
+    plugins_unnamed: 'Plugin sin nombre',
+    plugins_no_description: 'Sin descripción.',
+    plugins_no_hooks: 'Sin hooks de ciclo de vida registrados',
+    plugins_registered_hooks: 'Hooks registrados',
+    plugins_enabled: 'Habilitado',
+    plugins_disabled: 'Deshabilitado',
+    plugins_active_provider: 'Activo (proveedor)',
+    plugins_provider_no_hooks: 'Plugin proveedor — sin hooks de visibilidad del agente',
+    plugins_load_failed: 'Error al cargar plugins: ',
     settings_tab_system: 'System',
     status_updated: 'Updated',
     status_ephemeral: 'Ephemeral snapshot — not saved to transcript history.',
@@ -6379,34 +6379,34 @@ const LOCALES = {
     settings_label_tts_auto_read: 'Leer respuestas automáticamente',
     settings_desc_tts_auto_read: 'Leer en voz alta las respuestas del asistente automáticamente',
     // Composer voice-mode pref (#1488)
-    settings_label_voice_mode: 'Hands-free voice mode button',  // TODO: translate
+    settings_label_voice_mode: 'Botón de modo de voz manos libres',
     settings_desc_voice_mode: 'Show the voice-mode button (audio waveform) next to the dictation mic. Lets you speak naturally — Hermes auto-sends after a pause and reads replies aloud. Requires a browser that supports both speech recognition and TTS.',
     settings_label_raw_audio: 'Send raw audio instead of transcribing',
     settings_desc_raw_audio: 'Record and send the original audio file to the agent instead of converting it to text first. The agent can then transcribe it or process the raw audio (emotion, background noise, custom STT). Like Telegram\'s voice message behavior.',
     voice_send_raw: 'Send raw audio',
-    voice_raw_attached: 'Audio attached. Press Send or type more.',  // TODO: translate
+    voice_raw_attached: 'Audio adjuntado. Pulsa Enviar o escribe más.',
     settings_label_tts_voice: 'Voz',
     settings_desc_tts_voice: 'Seleccionar voz para síntesis de voz',
     settings_label_tts_rate: 'Velocidad de voz',
     settings_label_tts_pitch: 'Tono de voz',
-    checkpoint_date: 'Date',  // TODO: translate
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
-    checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
-    checkpoint_diff_title: 'Changes in checkpoint',  // TODO: translate
-    checkpoint_empty: 'No checkpoints found for this workspace.',  // TODO: translate
-    checkpoint_error: 'Failed to load checkpoints',  // TODO: translate
-    checkpoint_files: 'Files',  // TODO: translate
-    checkpoint_loading: 'Loading checkpoints…',  // TODO: translate
-    checkpoint_message: 'Message',  // TODO: translate
-    checkpoint_restore: 'Restore',  // TODO: translate
-    checkpoint_restore_confirm_message: (ckpt) => `Restore workspace to checkpoint "${ckpt}"? This will overwrite files with the saved versions. Files added after this checkpoint will not be deleted.`,  // TODO: translate
-    checkpoint_restore_confirm_title: 'Restore checkpoint?',  // TODO: translate
-    checkpoint_restored: 'Checkpoint restored',  // TODO: translate
-    checkpoint_title: 'Checkpoints',  // TODO: translate
-    checkpoint_view_diff: 'View diff',  // TODO: translate
-    insights_activity_by_day: 'Activity by Day',  // TODO: translate
-    insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
-    insights_cost: 'Estimated Cost',  // TODO: translate
+    checkpoint_date: 'Fecha',
+    checkpoint_diff_files_changed: (n) => `${n} archivo${n === 1 ? '' : 's'} modificado${n === 1 ? '' : 's'}`,
+    checkpoint_diff_no_changes: 'No se encontraron diferencias entre este punto de control y el espacio de trabajo actual.',
+    checkpoint_diff_title: 'Cambios en el punto de control',
+    checkpoint_empty: 'No se encontraron puntos de control para este espacio de trabajo.',
+    checkpoint_error: 'Error al cargar los puntos de control',
+    checkpoint_files: 'Archivos',
+    checkpoint_loading: 'Cargando puntos de control…',
+    checkpoint_message: 'Mensaje',
+    checkpoint_restore: 'Restaurar',
+    checkpoint_restore_confirm_message: (ckpt) => `¿Restaurar el espacio de trabajo al punto de control "${ckpt}"? Esto sobrescribirá los archivos con las versiones guardadas. Los archivos añadidos después de este punto de control no se eliminarán.`,
+    checkpoint_restore_confirm_title: '¿Restaurar punto de control?',
+    checkpoint_restored: 'Punto de control restaurado',
+    checkpoint_title: 'Puntos de control',
+    checkpoint_view_diff: 'Ver diff',
+    insights_activity_by_day: 'Actividad por día',
+    insights_activity_by_hour: 'Actividad por hora',
+    insights_cost: 'Coste estimado',
     insights_daily_tokens: 'Daily Tokens',
     insights_model_name: 'Model',
     insights_model_sessions: 'Sessions',
@@ -6414,45 +6414,45 @@ const LOCALES = {
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
-    insights_footer: 'Showing data from the last {days} days',  // TODO: translate
-    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
-    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
-    insights_skill_usage_total: 'Total invocations',  // TODO: translate
-    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
-    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
-    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
-    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
-    insights_input_tokens: 'Input',  // TODO: translate
-    insights_messages: 'Messages',  // TODO: translate
-    insights_models: 'Models',  // TODO: translate
-    insights_no_cost: 'N/A',  // TODO: translate
-    insights_output_tokens: 'Output',  // TODO: translate
-    insights_peak_hour: 'Peak: {hour}',  // TODO: translate
-    insights_sessions: 'Sessions',  // TODO: translate
-    insights_title: 'Usage Analytics',  // TODO: translate
-    insights_token_breakdown: 'Token Breakdown',  // TODO: translate
-    insights_tokens: 'Tokens',  // TODO: translate
-    insights_total: 'Total',  // TODO: translate
-    settings_desc_api_redact: 'Self-hosted users can disable for transparency (not recommended for shared instances).',  // TODO: translate
-    settings_label_api_redact: 'Redact sensitive data in API responses',  // TODO: translate
-    voice_error: 'Voice not supported in this browser',  // TODO: translate
-    voice_listening: 'Listening…',  // TODO: translate
-    voice_mode_active: 'Voice mode on',  // TODO: translate
-    voice_mode_off: 'Voice mode off',  // TODO: translate
-    voice_speaking: 'Speaking…',  // TODO: translate
-    voice_thinking: 'Thinking…',  // TODO: translate
+    insights_footer: 'Mostrando datos de los últimos {days} días',
+    insights_skill_usage_title: 'Uso de skills',
+    insights_skill_usage_sub: 'Frecuencia de invocación de herramientas',
+    insights_skill_usage_total: 'Invocaciones totales',
+    insights_skill_usage_skills_used: 'Skills usadas',
+    insights_skill_usage_no_data: 'Aún no hay datos de uso de skills',
+    insights_skill_usage_no_data_hint: 'Las skills aparecerán aquí cuando se usen en las conversaciones.',
+    insights_skill_usage_footer: 'Recuentos de ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Skill',
+    insights_skill_usage_col_uses: 'Usos',
+    insights_skill_usage_col_views: 'Vistas',
+    insights_skill_usage_col_share: '% de uso',
+    insights_skill_usage_col_patches: 'Parches',
+    insights_input_tokens: 'Entrada',
+    insights_messages: 'Mensajes',
+    insights_models: 'Modelos',
+    insights_no_cost: 'N/D',
+    insights_output_tokens: 'Salida',
+    insights_peak_hour: 'Pico: {hour}',
+    insights_sessions: 'Sesiones',
+    insights_title: 'Analítica de uso',
+    insights_token_breakdown: 'Desglose de tokens',
+    insights_tokens: 'Tokens',
+    insights_total: 'Total',
+    settings_desc_api_redact: 'Los usuarios autoalojados pueden desactivarlo por transparencia (no recomendado para instancias compartidas).',
+    settings_label_api_redact: 'Ocultar datos sensibles en las respuestas de la API',
+    voice_error: 'Voz no compatible con este navegador',
+    voice_listening: 'Escuchando…',
+    voice_mode_active: 'Modo de voz activado',
+    voice_mode_off: 'Modo de voz desactivado',
+    voice_speaking: 'Hablando…',
+    voice_thinking: 'Pensando…',
     // Composer voice buttons (#1488)
-    voice_dictate: 'Dictate',  // TODO: translate
+    voice_dictate: 'Dictar',
     voice_dictate_active: 'Stop dictation',
-    voice_recording_active: 'Detener grabación',  // TODO: translate
-    voice_mode_toggle: 'Voice mode',  // TODO: translate
-    voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
-    subagent_children: 'Subagent sessions',  // TODO: translate
+    voice_recording_active: 'Detener grabación',
+    voice_mode_toggle: 'Modo de voz',
+    voice_mode_toggle_active: 'Salir del modo de voz',
+    subagent_children: 'Sesiones de subagente',
   },
 
   de: {
@@ -6643,7 +6643,7 @@ const LOCALES = {
     compress_failed_label: 'Komprimierung fehlgeschlagen',
     focus_label: 'Thema',
     token_usage_on: 'Token-Verbrauch an',
-    usage_personality_none: 'none', // TODO: translate
+    usage_personality_none: 'keine',
     token_usage_off: 'Token-Verbrauch aus',
     usage_cache_hit_detail: 'Cache: {0}% Treffer ({1} gelesen / {2} geschrieben)',
     usage_cached_percent: '{0}% im Cache',
@@ -6753,7 +6753,7 @@ const LOCALES = {
      copy_file_path: 'Dateipfad kopieren',
      open_in_vscode: 'In VS Code öffnen',
      open_in_vscode_failed: 'In VS Code öffnen fehlgeschlagen: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: 'Download-Ordner',
     path_copied: 'Dateipfad in die Zwischenablage kopiert',
     path_copy_failed: 'Pfad konnte nicht kopiert werden: ',
     session_rename: 'Unterhaltung umbenennen',
@@ -6948,19 +6948,19 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_settings: 'Einstellungen',
 
-    logs_title: 'Logs',  // TODO: translate
-    logs_file: 'File',  // TODO: translate
-    logs_tail: 'Tail',  // TODO: translate
-    logs_auto_refresh: 'Auto-refresh (5s)',  // TODO: translate
-    logs_wrap: 'Wrap lines',  // TODO: translate
-    logs_copy_all: 'Copy all',  // TODO: translate
-    logs_empty: 'No log lines yet.',  // TODO: translate
-    logs_loading: 'Loading logs…',  // TODO: translate
-    logs_load_failed: 'Logs failed to load',  // TODO: translate
-    logs_status_idle: 'Choose a log file to view recent lines.',  // TODO: translate
-    logs_no_mtime: 'not written yet',  // TODO: translate
-    logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
-    logs_copied: 'Logs copied',  // TODO: translate
+    logs_title: 'Logs',
+    logs_file: 'Datei',
+    logs_tail: 'Tail',
+    logs_auto_refresh: 'Automatisch aktualisieren (5s)',
+    logs_wrap: 'Zeilenumbruch',
+    logs_copy_all: 'Alles kopieren',
+    logs_empty: 'Noch keine Log-Zeilen.',
+    logs_loading: 'Logs werden geladen…',
+    logs_load_failed: 'Logs konnten nicht geladen werden',
+    logs_status_idle: 'Wählen Sie eine Log-Datei, um die letzten Zeilen anzuzeigen.',
+    logs_no_mtime: 'noch nicht geschrieben',
+    logs_truncated_hint: 'Es wird das Ende einer großen Log-Datei angezeigt; ältere Bytes wurden übersprungen, um den Speicher zu begrenzen.',
+    logs_copied: 'Logs kopiert',
     logs_severity: 'Schweregrad',
     logs_severity_all: 'Alle',
     logs_severity_errors: 'Fehler',
@@ -7249,18 +7249,18 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'Plugins',
+    settings_plugins_meta: 'Installierte Hermes-Plugins und die von ihnen registrierten Lifecycle-Hooks anzeigen. Dieses Panel ist schreibgeschützt.',
+    settings_plugins_empty: 'Derzeit sind keine Hermes-Plugins sichtbar. Installieren oder aktivieren Sie Plugins über die Hermes-CLI/Konfiguration, um sie hier zu sehen.',
+    plugins_unnamed: 'Unbenanntes Plugin',
+    plugins_no_description: 'Keine Beschreibung vorhanden.',
+    plugins_no_hooks: 'Keine registrierten Lifecycle-Hooks',
+    plugins_registered_hooks: 'Registrierte Hooks',
+    plugins_enabled: 'Aktiviert',
+    plugins_disabled: 'Deaktiviert',
+    plugins_active_provider: 'Aktiv (Provider)',
+    plugins_provider_no_hooks: 'Provider-Plugin — keine Agent-Sichtbarkeits-Hooks',
+    plugins_load_failed: 'Plugins konnten nicht geladen werden: ',
     settings_tab_system: 'System',
     status_updated: 'Updated',
     status_ephemeral: 'Ephemeral snapshot — not saved to transcript history.',
@@ -7309,16 +7309,16 @@ const LOCALES = {
     workspace_worktree_created: 'Worktree-Unterhaltung erstellt',
     workspace_worktree_failed: 'Worktree-Erstellung fehlgeschlagen: ',
     session_worktree_badge: 'Worktree',
-    session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
-    session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
-    session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
-    session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
+    session_toolsets: 'Sitzungs-Toolsets',
+    session_toolsets_desc: 'Verfügbare Tools für diese Sitzung einschränken (leer = globale Konfiguration verwenden)',
+    session_toolsets_global: 'Global (Standard)',
+    session_toolsets_custom: 'Benutzerdefiniert',
+    session_toolsets_placeholder: 'Tool1, Tool2, …',
+    session_toolsets_apply: 'Anwenden',
+    session_toolsets_clear: 'Leeren (global verwenden)',
+    session_toolsets_applied: 'Toolsets aktualisiert',
+    session_toolsets_cleared: 'Toolsets geleert — globale Konfiguration wird verwendet',
+    session_toolsets_failed: 'Toolsets konnten nicht aktualisiert werden: ',
     session_time_unknown: 'Unbekannt',
     session_time_minutes_ago: (n) => `Vor ${n} Minuten`,
     session_time_hours_ago: (n) => `Vor ${n} Stunden`,
@@ -7382,16 +7382,16 @@ const LOCALES = {
     provider_category_specialized: 'Spezialisiert',
     onboarding_api_key_label: 'API-Schlüssel',
     onboarding_api_key_placeholder: 'sk-…',
-    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
-    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
-    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
-    oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
-    oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
-    oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
-    oauth_codex_polling: 'Waiting for authorization...', // TODO: translate
-    oauth_codex_success: 'Codex OAuth login successful!', // TODO: translate
-    oauth_codex_error: 'OAuth login failed', // TODO: translate
-    oauth_codex_expired: 'Code expired, please try again', // TODO: translate
+    onboarding_api_key_label_optional: 'API-Schlüssel (optional)',
+    onboarding_api_key_placeholder_optional: 'Für Server ohne Schlüssel leer lassen',
+    onboarding_api_key_help_keyless: 'Die meisten LM-Studio-/Ollama-/vLLM-Installationen laufen ohne Schlüssel — lassen Sie dieses Feld leer, wenn Ihr Server keine Authentifizierung erfordert. Prüfen Sie es mit der Schaltfläche „Verbindung testen“.',
+    oauth_login_codex: 'Mit Codex (ChatGPT) anmelden',
+    oauth_codex_step1: 'Schritt 1: Besuchen Sie diese URL und geben Sie den Code ein',
+    oauth_codex_step2: 'Schritt 2: Geben Sie diesen Code auf der Seite ein',
+    oauth_codex_polling: 'Warten auf Autorisierung...',
+    oauth_codex_success: 'Codex-OAuth-Anmeldung erfolgreich!',
+    oauth_codex_error: 'OAuth-Anmeldung fehlgeschlagen',
+    oauth_codex_expired: 'Code abgelaufen, bitte erneut versuchen',
     onboarding_api_key_help_prefix: 'Gefunden unter',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://api.openai.com/v1',
@@ -7413,19 +7413,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Bitte wählen Sie ein Modell.',
     onboarding_error_provider_required: 'Anbieter erforderlich.',
     onboarding_error_base_url_required: 'Base URL erforderlich.',
-    onboarding_probe_test_button: 'Test connection', // TODO: translate
-    onboarding_probe_probing: 'Testing connection…', // TODO: translate
-    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
-    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
-    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
-    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
-    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
-    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
-    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
-    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
-    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
+    onboarding_probe_test_button: 'Verbindung testen',
+    onboarding_probe_probing: 'Verbindung wird getestet…',
+    onboarding_probe_ok: 'Verbunden. {n} Modell(e) verfügbar.',
+    onboarding_probe_error_generic: 'Die konfigurierte Basis-URL konnte nicht erreicht werden.',
+    onboarding_probe_error_invalid_url: 'Die Basis-URL muss mit http:// oder https:// beginnen.',
+    onboarding_probe_error_dns: 'Der Host konnte nicht aufgelöst werden. Prüfen Sie die URL oder verwenden Sie die IP-Adresse des Hosts.',
+    onboarding_probe_error_connect_refused: 'Verbindung abgelehnt — möglicherweise läuft an dieser Adresse kein Server. Versuchen Sie aus Docker heraus die Host-IP statt localhost.',
+    onboarding_probe_error_timeout: 'Der Endpunkt hat nicht rechtzeitig geantwortet. Prüfen Sie, ob der Server läuft und die URL korrekt ist.',
+    onboarding_probe_error_http_4xx: 'Der Endpunkt hat einen Client-Fehler zurückgegeben. Prüfen Sie die Authentifizierung und den URL-Pfad (endet üblicherweise auf /v1).',
+    onboarding_probe_error_http_5xx: 'Der Endpunkt hat einen Server-Fehler zurückgegeben. Prüfen Sie die Logs des LM-Studio-/Ollama-Servers.',
+    onboarding_probe_error_parse: 'Der Endpunkt hat keine Modellliste im erwarteten Format zurückgegeben. Prüfen Sie, ob die URL auf die OpenAI-kompatible API-Wurzel zeigt.',
+    onboarding_probe_error_unreachable: 'Die konfigurierte Basis-URL konnte nicht erreicht werden.',
+    onboarding_error_probe_failed: 'Die konfigurierte Basis-URL konnte nicht validiert werden.',
     onboarding_error_workspace_required: 'Arbeitsbereich erforderlich.',
     onboarding_error_model_required: 'Modell erforderlich.',
     onboarding_complete: 'Einrichtung abgeschlossen!',
@@ -7630,35 +7630,35 @@ const LOCALES = {
     settings_label_tts_auto_read: 'Antworten automatisch vorlesen',
     settings_desc_tts_auto_read: 'Assistenten-Antworten automatisch vorlesen',
     // Composer voice-mode pref (#1488)
-    settings_label_voice_mode: 'Hands-free voice mode button',  // TODO: translate
+    settings_label_voice_mode: 'Schaltfläche für Freisprech-Sprachmodus',
     settings_desc_voice_mode: 'Show the voice-mode button (audio waveform) next to the dictation mic. Lets you speak naturally — Hermes auto-sends after a pause and reads replies aloud. Requires a browser that supports both speech recognition and TTS.',
     settings_label_raw_audio: 'Send raw audio instead of transcribing',
     settings_desc_raw_audio: 'Record and send the original audio file to the agent instead of converting it to text first. The agent can then transcribe it or process the raw audio (emotion, background noise, custom STT). Like Telegram\'s voice message behavior.',
     voice_send_raw: 'Send raw audio',
-    voice_raw_attached: 'Audio attached. Press Send or type more.',  // TODO: translate
+    voice_raw_attached: 'Audio angehängt. Drücken Sie Senden oder tippen Sie weiter.',
     settings_label_tts_voice: 'Stimme',
     settings_desc_tts_voice: 'Stimme für Sprachsynthese auswählen',
     settings_label_tts_rate: 'Sprechgeschwindigkeit',
     settings_label_tts_pitch: 'Tonhöhe',
 
-    checkpoint_date: 'Date',  // TODO: translate
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
-    checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
-    checkpoint_diff_title: 'Changes in checkpoint',  // TODO: translate
-    checkpoint_empty: 'No checkpoints found for this workspace.',  // TODO: translate
-    checkpoint_error: 'Failed to load checkpoints',  // TODO: translate
-    checkpoint_files: 'Files',  // TODO: translate
-    checkpoint_loading: 'Loading checkpoints…',  // TODO: translate
-    checkpoint_message: 'Message',  // TODO: translate
-    checkpoint_restore: 'Restore',  // TODO: translate
-    checkpoint_restore_confirm_message: (ckpt) => `Restore workspace to checkpoint "${ckpt}"? This will overwrite files with the saved versions. Files added after this checkpoint will not be deleted.`,  // TODO: translate
-    checkpoint_restore_confirm_title: 'Restore checkpoint?',  // TODO: translate
-    checkpoint_restored: 'Checkpoint restored',  // TODO: translate
-    checkpoint_title: 'Checkpoints',  // TODO: translate
-    checkpoint_view_diff: 'View diff',  // TODO: translate
-    insights_activity_by_day: 'Activity by Day',  // TODO: translate
-    insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
-    insights_cost: 'Estimated Cost',  // TODO: translate
+    checkpoint_date: 'Datum',
+    checkpoint_diff_files_changed: (n) => `${n} Datei${n === 1 ? '' : 'en'} geändert`,
+    checkpoint_diff_no_changes: 'Keine Unterschiede zwischen diesem Checkpoint und dem aktuellen Arbeitsbereich gefunden.',
+    checkpoint_diff_title: 'Änderungen im Checkpoint',
+    checkpoint_empty: 'Keine Checkpoints für diesen Arbeitsbereich gefunden.',
+    checkpoint_error: 'Checkpoints konnten nicht geladen werden',
+    checkpoint_files: 'Dateien',
+    checkpoint_loading: 'Checkpoints werden geladen…',
+    checkpoint_message: 'Nachricht',
+    checkpoint_restore: 'Wiederherstellen',
+    checkpoint_restore_confirm_message: (ckpt) => `Arbeitsbereich auf Checkpoint "${ckpt}" zurücksetzen? Dabei werden Dateien mit den gespeicherten Versionen überschrieben. Nach diesem Checkpoint hinzugefügte Dateien werden nicht gelöscht.`,
+    checkpoint_restore_confirm_title: 'Checkpoint wiederherstellen?',
+    checkpoint_restored: 'Checkpoint wiederhergestellt',
+    checkpoint_title: 'Checkpoints',
+    checkpoint_view_diff: 'Diff anzeigen',
+    insights_activity_by_day: 'Aktivität nach Tag',
+    insights_activity_by_hour: 'Aktivität nach Stunde',
+    insights_cost: 'Geschätzte Kosten',
     insights_daily_tokens: 'Daily Tokens',
     insights_model_name: 'Model',
     insights_model_sessions: 'Sessions',
@@ -7666,45 +7666,45 @@ const LOCALES = {
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
-    insights_footer: 'Showing data from the last {days} days',  // TODO: translate
-    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
-    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
-    insights_skill_usage_total: 'Total invocations',  // TODO: translate
-    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
-    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
-    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
-    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
-    insights_input_tokens: 'Input',  // TODO: translate
-    insights_messages: 'Messages',  // TODO: translate
-    insights_models: 'Models',  // TODO: translate
-    insights_no_cost: 'N/A',  // TODO: translate
-    insights_output_tokens: 'Output',  // TODO: translate
-    insights_peak_hour: 'Peak: {hour}',  // TODO: translate
-    insights_sessions: 'Sessions',  // TODO: translate
-    insights_title: 'Usage Analytics',  // TODO: translate
-    insights_token_breakdown: 'Token Breakdown',  // TODO: translate
-    insights_tokens: 'Tokens',  // TODO: translate
-    insights_total: 'Total',  // TODO: translate
-    settings_desc_api_redact: 'Self-hosted users can disable for transparency (not recommended for shared instances).',  // TODO: translate
-    settings_label_api_redact: 'Redact sensitive data in API responses',  // TODO: translate
-    voice_error: 'Voice not supported in this browser',  // TODO: translate
-    voice_listening: 'Listening…',  // TODO: translate
-    voice_mode_active: 'Voice mode on',  // TODO: translate
-    voice_mode_off: 'Voice mode off',  // TODO: translate
-    voice_speaking: 'Speaking…',  // TODO: translate
-    voice_thinking: 'Thinking…',  // TODO: translate
+    insights_footer: 'Daten der letzten {days} Tage',
+    insights_skill_usage_title: 'Skill-Nutzung',
+    insights_skill_usage_sub: 'Häufigkeit der Tool-Aufrufe',
+    insights_skill_usage_total: 'Aufrufe gesamt',
+    insights_skill_usage_skills_used: 'Verwendete Skills',
+    insights_skill_usage_no_data: 'Noch keine Skill-Nutzungsdaten',
+    insights_skill_usage_no_data_hint: 'Skills erscheinen hier, sobald sie in Unterhaltungen verwendet werden.',
+    insights_skill_usage_footer: 'Zählungen aus ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Skill',
+    insights_skill_usage_col_uses: 'Nutzungen',
+    insights_skill_usage_col_views: 'Ansichten',
+    insights_skill_usage_col_share: 'Nutzung %',
+    insights_skill_usage_col_patches: 'Patches',
+    insights_input_tokens: 'Eingabe',
+    insights_messages: 'Nachrichten',
+    insights_models: 'Modelle',
+    insights_no_cost: 'N/V',
+    insights_output_tokens: 'Ausgabe',
+    insights_peak_hour: 'Spitze: {hour}',
+    insights_sessions: 'Sitzungen',
+    insights_title: 'Nutzungsanalyse',
+    insights_token_breakdown: 'Token-Aufschlüsselung',
+    insights_tokens: 'Tokens',
+    insights_total: 'Gesamt',
+    settings_desc_api_redact: 'Selbst gehostete Nutzer können dies zur Transparenz deaktivieren (nicht empfohlen für geteilte Instanzen).',
+    settings_label_api_redact: 'Sensible Daten in API-Antworten schwärzen',
+    voice_error: 'Sprache wird in diesem Browser nicht unterstützt',
+    voice_listening: 'Höre zu…',
+    voice_mode_active: 'Sprachmodus an',
+    voice_mode_off: 'Sprachmodus aus',
+    voice_speaking: 'Spreche…',
+    voice_thinking: 'Denke nach…',
     // Composer voice buttons (#1488)
-    voice_dictate: 'Dictate',  // TODO: translate
+    voice_dictate: 'Diktieren',
     voice_dictate_active: 'Stop dictation',
-    voice_recording_active: 'Aufnahme stoppen',  // TODO: translate
-    voice_mode_toggle: 'Voice mode',  // TODO: translate
-    voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
-    subagent_children: 'Subagent sessions',  // TODO: translate
+    voice_recording_active: 'Aufnahme stoppen',
+    voice_mode_toggle: 'Sprachmodus',
+    voice_mode_toggle_active: 'Sprachmodus beenden',
+    subagent_children: 'Subagent-Sitzungen',
   },
 
   zh: {
@@ -7870,7 +7870,7 @@ const LOCALES = {
     session_toolsets_desc: '限制此会话可用工具（留空 = 使用全局配置）',
     session_toolsets_global: '全局（默认）',
     session_toolsets_custom: '自定义',
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
+    session_toolsets_placeholder: '工具1, 工具2, …',
     session_toolsets_apply: '应用',
     session_toolsets_clear: '清除（使用全局）',
     session_toolsets_applied: '工具集已更新',
@@ -8038,7 +8038,7 @@ const LOCALES = {
      copy_file_path: '\u590d\u5236\u6587\u4ef6\u8def\u5f84',
      open_in_vscode: '在VS Code中打开',
      open_in_vscode_failed: '在VS Code中打开失败：',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: '下载文件夹',
     path_copied: '\u6587\u4ef6\u8def\u5f84\u5df2\u590d\u5236\u5230\u526a\u8d34\u677f',
     path_copy_failed: '\u590d\u5236\u8def\u5f84\u5931\u8d25\uff1a',
     session_rename: '\u91cd\u547d\u540d\u5bf9\u8bdd',
@@ -8887,7 +8887,7 @@ const LOCALES = {
     settings_label_tts_rate: '语速',
     settings_label_tts_pitch: '音调',
     checkpoint_date: '日期',
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
+    checkpoint_diff_files_changed: (n) => `${n} 个文件已更改`,
     checkpoint_diff_no_changes: '此检查点与当前工作区之间无差异。',
     checkpoint_diff_title: '检查点变更',
     checkpoint_empty: '此工作区未找到检查点。',
@@ -9186,7 +9186,7 @@ const LOCALES = {
      copy_file_path: '\u8907\u88fd\u6a94\u6848\u8def\u5f91',
      open_in_vscode: '在VS Code中開啟',
      open_in_vscode_failed: '在VS Code中開啟失敗：',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: '下載資料夾',
     path_copied: '\u6a94\u6848\u8def\u5f91\u5df2\u8907\u88fd\u5230\u526a\u8cbc\u7c3f',
     path_copy_failed: '\u8907\u88fd\u8def\u5f91\u5931\u6557\uff1a',
     session_rename: '\u91cd\u65b0\u547d\u540d\u5c0d\u8a71',
@@ -9608,9 +9608,9 @@ const LOCALES = {
     onboarding_api_key_help_prefix: '\u900f\u904e\u4ee5\u4e0b\u65b9\u5f0f\u5132\u5b58\u70ba Hermes .env \u6a94\u6848\u4e2d\u7684\u6a5f\u5bc6',
     onboarding_api_key_label: 'API \u91d1\u9470',
     onboarding_api_key_placeholder: '\u7559\u7a7a\u4ee5\u4fdd\u7559\u5df2\u5132\u5b58\u7684\u91d1\u9470',
-    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
-    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
-    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
+    onboarding_api_key_label_optional: 'API 金鑰（選填）',
+    onboarding_api_key_placeholder_optional: '無需金鑰的伺服器請留空',
+    onboarding_api_key_help_keyless: '大多數 LM Studio / Ollama / vLLM 安裝無需金鑰即可運作。若伺服器不需要驗證請留空，並可使用「測試連線」按鈕確認。',
     onboarding_back: '\u4e0a\u4e00\u6b65',
     onboarding_badge: '\u9996\u6b21\u57f7\u884c',
     onboarding_base_url_help: '\u7528\u65bc OpenAI \u76f8\u5bb9\u8def\u7531\u5668\u3001\u81ea\u67b6\u4f3a\u670d\u5668\u3001LiteLLM\u3001Ollama\u3001LM Studio\u3001vLLM \u7b49\u7aef\u9ede\u3002',
@@ -9634,19 +9634,19 @@ const LOCALES = {
     onboarding_custom_model_placeholder: 'your_model_name',
     onboarding_env_file: '.env \u6a94\u6848\uff1a',
     onboarding_error_base_url_required: '\u81ea\u8a02\u7aef\u9ede\u9700\u8981\u57fa\u790e URL\u3002',
-    onboarding_probe_test_button: 'Test connection', // TODO: translate
-    onboarding_probe_probing: 'Testing connection…', // TODO: translate
-    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
-    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
-    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
-    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
-    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
-    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
-    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
-    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
-    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
+    onboarding_probe_test_button: '測試連線',
+    onboarding_probe_probing: '正在測試連線…',
+    onboarding_probe_ok: '已連線。{n} 個模型可用。',
+    onboarding_probe_error_generic: '無法連上設定的基礎 URL。',
+    onboarding_probe_error_invalid_url: '基礎 URL 必須以 http:// 或 https:// 開頭。',
+    onboarding_probe_error_dns: '無法解析主機名稱。請檢查 URL，或改用主機的 IP 位址。',
+    onboarding_probe_error_connect_refused: '連線遭拒 — 該位址上可能沒有執行伺服器。在 Docker 內請改用主機 IP 而非 localhost。',
+    onboarding_probe_error_timeout: '端點未及時回應。請確認伺服器正在執行且 URL 正確。',
+    onboarding_probe_error_http_4xx: '端點回傳用戶端錯誤。請檢查驗證資訊與 URL 路徑（通常以 /v1 結尾）。',
+    onboarding_probe_error_http_5xx: '端點回傳伺服器錯誤。請檢查 LM Studio / Ollama 伺服器日誌。',
+    onboarding_probe_error_parse: '端點未回傳預期格式的模型清單。請確認 URL 指向 OpenAI 相容的 API 根路徑。',
+    onboarding_probe_error_unreachable: '無法連上設定的基礎 URL。',
+    onboarding_error_probe_failed: '無法驗證設定的基礎 URL。',
     onboarding_error_choose_model: '\u8acb\u5148\u9078\u64c7\u6a21\u578b\u518d\u7e7c\u7e8c\u3002',
     onboarding_error_choose_workspace: '\u8acb\u5148\u9078\u64c7\u5de5\u4f5c\u5340\u518d\u7e7c\u7e8c\u3002',
     onboarding_error_model_required: '\u9700\u8981\u6a21\u578b\u3002',
@@ -9680,13 +9680,13 @@ const LOCALES = {
     onboarding_password_will_replace: '\u5c07\u53d6\u4ee3',
     onboarding_provider_label: '\u8a2d\u5b9a\u6a21\u5f0f',
     onboarding_quick_setup_badge: '\u5feb\u901f\u8a2d\u5b9a',
-    oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
-    oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
-    oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
-    oauth_codex_polling: 'Waiting for authorization...', // TODO: translate
-    oauth_codex_success: 'Codex OAuth login successful!', // TODO: translate
-    oauth_codex_error: 'OAuth login failed', // TODO: translate
-    oauth_codex_expired: 'Code expired, please try again', // TODO: translate
+    oauth_login_codex: '使用 Codex (ChatGPT) 登入',
+    oauth_codex_step1: '步驟 1：前往此網址並輸入代碼',
+    oauth_codex_step2: '步驟 2：在頁面上輸入此代碼',
+    oauth_codex_polling: '等待授權…',
+    oauth_codex_success: 'Codex OAuth 登入成功！',
+    oauth_codex_error: 'OAuth 登入失敗',
+    oauth_codex_expired: '代碼已過期，請重試',
     provider_category_easy_start: '\u5feb\u901f\u958b\u59cb',
     provider_category_self_hosted: '\u672c\u5730 / \u958b\u6e90',
     provider_category_specialized: '\u5c08\u696d\u670d\u52d9',
@@ -9762,16 +9762,16 @@ const LOCALES = {
     ws_search_placeholder: '搜尋工作區…',
     ws_no_results: '找不到工作區',
     model_search_placeholder: '\u641c\u5c0b\u6a21\u578b\u2026',
-    session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
-    session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
-    session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
-    session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
+    session_toolsets: '會話工具集',
+    session_toolsets_desc: '限制此會話可用工具（留空 = 使用全域設定）',
+    session_toolsets_global: '全域（預設）',
+    session_toolsets_custom: '自訂',
+    session_toolsets_placeholder: '工具1, 工具2, …',
+    session_toolsets_apply: '套用',
+    session_toolsets_clear: '清除（使用全域）',
+    session_toolsets_applied: '工具集已更新',
+    session_toolsets_cleared: '工具集已清除 — 使用全域設定',
+    session_toolsets_failed: '更新工具集失敗：',
     model_scope_advisory: '\u5f9e\u4e0b\u4e00\u5247\u8a0a\u606f\u8d77\u9069\u7528\u65bc\u6b64\u6703\u8a71\u3002',
     model_scope_toast: '\u5f9e\u4e0b\u4e00\u5247\u8a0a\u606f\u8d77\u9069\u7528\u65bc\u6b64\u6703\u8a71\u3002',
     my_notes: '\u6211\u7684\u5099\u8a3b',
@@ -10195,35 +10195,35 @@ const LOCALES = {
     settings_label_tts_auto_read: '自動朗讀回覆',
     settings_desc_tts_auto_read: '自動朗讀助手回覆',
     // Composer voice-mode pref (#1488)
-    settings_label_voice_mode: 'Hands-free voice mode button',  // TODO: translate
+    settings_label_voice_mode: '免持語音模式按鈕',
     settings_desc_voice_mode: 'Show the voice-mode button (audio waveform) next to the dictation mic. Lets you speak naturally — Hermes auto-sends after a pause and reads replies aloud. Requires a browser that supports both speech recognition and TTS.',
     settings_label_raw_audio: 'Send raw audio instead of transcribing',
     settings_desc_raw_audio: 'Record and send the original audio file to the agent instead of converting it to text first. The agent can then transcribe it or process the raw audio (emotion, background noise, custom STT). Like Telegram\'s voice message behavior.',
     voice_send_raw: 'Send raw audio',
-    voice_raw_attached: 'Audio attached. Press Send or type more.',  // TODO: translate
+    voice_raw_attached: '已附加音訊。按傳送或繼續輸入。',
     settings_label_tts_voice: '語音',
     settings_desc_tts_voice: '選擇語音合成聲音',
     settings_label_tts_rate: '語速',
     settings_label_tts_pitch: '音調',
 
-    checkpoint_date: 'Date',  // TODO: translate
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
-    checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
-    checkpoint_diff_title: 'Changes in checkpoint',  // TODO: translate
-    checkpoint_empty: 'No checkpoints found for this workspace.',  // TODO: translate
-    checkpoint_error: 'Failed to load checkpoints',  // TODO: translate
-    checkpoint_files: 'Files',  // TODO: translate
-    checkpoint_loading: 'Loading checkpoints…',  // TODO: translate
-    checkpoint_message: 'Message',  // TODO: translate
-    checkpoint_restore: 'Restore',  // TODO: translate
-    checkpoint_restore_confirm_message: (ckpt) => `Restore workspace to checkpoint "${ckpt}"? This will overwrite files with the saved versions. Files added after this checkpoint will not be deleted.`,  // TODO: translate
-    checkpoint_restore_confirm_title: 'Restore checkpoint?',  // TODO: translate
-    checkpoint_restored: 'Checkpoint restored',  // TODO: translate
-    checkpoint_title: 'Checkpoints',  // TODO: translate
-    checkpoint_view_diff: 'View diff',  // TODO: translate
-    insights_activity_by_day: 'Activity by Day',  // TODO: translate
-    insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
-    insights_cost: 'Estimated Cost',  // TODO: translate
+    checkpoint_date: '日期',
+    checkpoint_diff_files_changed: (n) => `${n} 個檔案已變更`,
+    checkpoint_diff_no_changes: '此檢查點與目前工作區之間沒有差異。',
+    checkpoint_diff_title: '檢查點變更',
+    checkpoint_empty: '此工作區找不到檢查點。',
+    checkpoint_error: '載入檢查點失敗',
+    checkpoint_files: '檔案',
+    checkpoint_loading: '載入檢查點中…',
+    checkpoint_message: '訊息',
+    checkpoint_restore: '還原',
+    checkpoint_restore_confirm_message: (ckpt) => `將工作區還原到檢查點「${ckpt}」？此操作將以已儲存的版本覆寫檔案。此檢查點之後新增的檔案不會被刪除。`,
+    checkpoint_restore_confirm_title: '還原檢查點？',
+    checkpoint_restored: '檢查點已還原',
+    checkpoint_title: '檢查點',
+    checkpoint_view_diff: '檢視差異',
+    insights_activity_by_day: '按日活動',
+    insights_activity_by_hour: '按時活動',
+    insights_cost: '預估費用',
     insights_daily_tokens: 'Daily Tokens',
     insights_model_name: 'Model',
     insights_model_sessions: 'Sessions',
@@ -10231,7 +10231,7 @@ const LOCALES = {
     insights_model_cost: 'Cost',
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
-    insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_footer: '顯示最近 {days} 天的數據',
     insights_skill_usage_title: '技能使用統計',
     insights_skill_usage_sub: '工具調用頻次',
     insights_skill_usage_total: '總調用次數',
@@ -10239,37 +10239,37 @@ const LOCALES = {
     insights_skill_usage_no_data: '暫無技能使用數據',
     insights_skill_usage_no_data_hint: '在會話中使用技能後，數據將在此顯示。',
     insights_skill_usage_footer: '數據來源於 ~/.hermes/skills/',
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
-    insights_input_tokens: 'Input',  // TODO: translate
-    insights_messages: 'Messages',  // TODO: translate
-    insights_models: 'Models',  // TODO: translate
-    insights_no_cost: 'N/A',  // TODO: translate
-    insights_output_tokens: 'Output',  // TODO: translate
-    insights_peak_hour: 'Peak: {hour}',  // TODO: translate
-    insights_sessions: 'Sessions',  // TODO: translate
-    insights_title: 'Usage Analytics',  // TODO: translate
-    insights_token_breakdown: 'Token Breakdown',  // TODO: translate
-    insights_tokens: 'Tokens',  // TODO: translate
-    insights_total: 'Total',  // TODO: translate
-    settings_desc_api_redact: 'Self-hosted users can disable for transparency (not recommended for shared instances).',  // TODO: translate
-    settings_label_api_redact: 'Redact sensitive data in API responses',  // TODO: translate
-    voice_error: 'Voice not supported in this browser',  // TODO: translate
-    voice_listening: 'Listening…',  // TODO: translate
-    voice_mode_active: 'Voice mode on',  // TODO: translate
-    voice_mode_off: 'Voice mode off',  // TODO: translate
-    voice_speaking: 'Speaking…',  // TODO: translate
-    voice_thinking: 'Thinking…',  // TODO: translate
+    insights_skill_usage_col_skill: '技能',
+    insights_skill_usage_col_uses: '使用次數',
+    insights_skill_usage_col_views: '檢視次數',
+    insights_skill_usage_col_share: '使用佔比',
+    insights_skill_usage_col_patches: '修補',
+    insights_input_tokens: '輸入',
+    insights_messages: '訊息',
+    insights_models: '模型',
+    insights_no_cost: 'N/A',
+    insights_output_tokens: '輸出',
+    insights_peak_hour: '高峰：{hour}',
+    insights_sessions: '會話',
+    insights_title: '使用分析',
+    insights_token_breakdown: 'Token 明細',
+    insights_tokens: 'Token',
+    insights_total: '總計',
+    settings_desc_api_redact: '自架用戶可停用以提升透明度（不建議用於共享實例）。',
+    settings_label_api_redact: '在 API 回應中隱藏敏感資料',
+    voice_error: '此瀏覽器不支援語音功能',
+    voice_listening: '正在聆聽…',
+    voice_mode_active: '語音模式已開啟',
+    voice_mode_off: '語音模式已關閉',
+    voice_speaking: '正在說話…',
+    voice_thinking: '思考中…',
     // Composer voice buttons (#1488)
-    voice_dictate: 'Dictate',  // TODO: translate
+    voice_dictate: '聽寫',
     voice_dictate_active: 'Stop dictation',
-    voice_recording_active: '停止錄音',  // TODO: translate
-    voice_mode_toggle: 'Voice mode',  // TODO: translate
-    voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
-    subagent_children: 'Subagent sessions',  // TODO: translate
+    voice_recording_active: '停止錄音',
+    voice_mode_toggle: '語音模式',
+    voice_mode_toggle_active: '離開語音模式',
+    subagent_children: '子代理會話',
   },
 
   pt: {
@@ -10360,16 +10360,16 @@ const LOCALES = {
     model_custom_label: 'ID de modelo customizado',
     model_custom_placeholder: 'ex: openai/gpt-5.4',
     model_search_placeholder: 'Buscar modelos…',
-    session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
-    session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
-    session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
-    session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
+    session_toolsets: 'Conjuntos de ferramentas da sessão',
+    session_toolsets_desc: 'Restringir as ferramentas disponíveis para esta sessão (vazio = usar config global)',
+    session_toolsets_global: 'Global (padrão)',
+    session_toolsets_custom: 'Personalizado',
+    session_toolsets_placeholder: 'ferramenta1, ferramenta2, …',
+    session_toolsets_apply: 'Aplicar',
+    session_toolsets_clear: 'Limpar (usar global)',
+    session_toolsets_applied: 'Conjuntos de ferramentas atualizados',
+    session_toolsets_cleared: 'Conjuntos de ferramentas limpos — usando config global',
+    session_toolsets_failed: 'Falha ao atualizar conjuntos de ferramentas: ',
     model_search_no_results: 'Nenhum modelo encontrado',
     model_group_configured: 'Configurados',
     ws_search_placeholder: 'Buscar espaços de trabalho…',
@@ -10577,7 +10577,7 @@ const LOCALES = {
      copy_file_path: 'Copiar caminho do arquivo',
      open_in_vscode: 'Abrir no VS Code',
      open_in_vscode_failed: 'Falha ao abrir no VS Code: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: 'Pasta de downloads',
     path_copied: 'Caminho do arquivo copiado para a área de transferência',
     path_copy_failed: 'Falha ao copiar caminho: ',
     session_rename: 'Renomear conversa',
@@ -10695,18 +10695,18 @@ const LOCALES = {
     settings_tab_appearance: 'Aparência',
     settings_tab_preferences: 'Preferências',
     settings_tab_plugins: 'Plugins',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'Plugins',
+    settings_plugins_meta: 'Veja os plugins Hermes instalados e os hooks de ciclo de vida que eles registram. Este painel é somente leitura.',
+    settings_plugins_empty: 'Nenhum plugin Hermes visível no momento. Instale ou habilite plugins pela CLI/config do Hermes para vê-los aqui.',
+    plugins_unnamed: 'Plugin sem nome',
+    plugins_no_description: 'Nenhuma descrição fornecida.',
+    plugins_no_hooks: 'Nenhum hook de ciclo de vida registrado',
+    plugins_registered_hooks: 'Hooks registrados',
+    plugins_enabled: 'Habilitado',
+    plugins_disabled: 'Desabilitado',
+    plugins_active_provider: 'Ativo (provedor)',
+    plugins_provider_no_hooks: 'Plugin de provedor — sem hooks de visibilidade do agente',
+    plugins_load_failed: 'Falha ao carregar plugins: ',
     settings_tab_system: 'Sistema',
     settings_title: 'Configurações',
     settings_save_btn: 'Salvar Configurações',
@@ -10870,19 +10870,19 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_settings: 'Configurações',
 
-    logs_title: 'Logs',  // TODO: translate
-    logs_file: 'File',  // TODO: translate
-    logs_tail: 'Tail',  // TODO: translate
-    logs_auto_refresh: 'Auto-refresh (5s)',  // TODO: translate
-    logs_wrap: 'Wrap lines',  // TODO: translate
-    logs_copy_all: 'Copy all',  // TODO: translate
-    logs_empty: 'No log lines yet.',  // TODO: translate
-    logs_loading: 'Loading logs…',  // TODO: translate
-    logs_load_failed: 'Logs failed to load',  // TODO: translate
-    logs_status_idle: 'Choose a log file to view recent lines.',  // TODO: translate
-    logs_no_mtime: 'not written yet',  // TODO: translate
-    logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
-    logs_copied: 'Logs copied',  // TODO: translate
+    logs_title: 'Logs',
+    logs_file: 'Arquivo',
+    logs_tail: 'Últimas linhas',
+    logs_auto_refresh: 'Atualização automática (5s)',
+    logs_wrap: 'Quebrar linhas',
+    logs_copy_all: 'Copiar tudo',
+    logs_empty: 'Ainda não há linhas de log.',
+    logs_loading: 'Carregando logs…',
+    logs_load_failed: 'Falha ao carregar os logs',
+    logs_status_idle: 'Escolha um arquivo de log para ver as linhas recentes.',
+    logs_no_mtime: 'ainda não gravado',
+    logs_truncated_hint: 'Mostrando o final de um arquivo de log grande; bytes mais antigos foram ignorados para limitar a memória.',
+    logs_copied: 'Logs copiados',
     logs_severity: 'Severidade',
     logs_severity_all: 'Todos',
     logs_severity_errors: 'Erros',
@@ -11086,17 +11086,17 @@ const LOCALES = {
     provider_category_self_hosted: 'Open / self-hosted',
     provider_category_specialized: 'Especializado',
     onboarding_api_key_label: 'API key',
-    oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
-    oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
-    oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
-    oauth_codex_polling: 'Waiting for authorization...', // TODO: translate
-    oauth_codex_success: 'Codex OAuth login successful!', // TODO: translate
-    oauth_codex_error: 'OAuth login failed', // TODO: translate
-    oauth_codex_expired: 'Code expired, please try again', // TODO: translate
+    oauth_login_codex: 'Entrar com Codex (ChatGPT)',
+    oauth_codex_step1: 'Passo 1: Acesse esta URL e insira o código',
+    oauth_codex_step2: 'Passo 2: Insira este código na página',
+    oauth_codex_polling: 'Aguardando autorização...',
+    oauth_codex_success: 'Login OAuth do Codex concluído!',
+    oauth_codex_error: 'Falha no login OAuth',
+    oauth_codex_expired: 'Código expirado, tente novamente',
     onboarding_api_key_placeholder: 'Deixe em branco para manter key existente',
-    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
-    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
-    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
+    onboarding_api_key_label_optional: 'Chave de API (opcional)',
+    onboarding_api_key_placeholder_optional: 'Deixe em branco para servidores sem chave',
+    onboarding_api_key_help_keyless: 'A maioria das instalações de LM Studio / Ollama / vLLM funciona sem chave — deixe em branco se o seu servidor não exigir autenticação. Use o botão Testar conexão para verificar.',
     onboarding_api_key_help_prefix: 'Salvo como segredo no .env do Hermes usando',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://seu-endpoint.exemplo/v1',
@@ -11122,19 +11122,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Escolha modelo antes de continuar.',
     onboarding_error_provider_required: 'Escolha modo de setup antes de continuar.',
     onboarding_error_base_url_required: 'Base URL é necessária para endpoints customizados.',
-    onboarding_probe_test_button: 'Test connection', // TODO: translate
-    onboarding_probe_probing: 'Testing connection…', // TODO: translate
-    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
-    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
-    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
-    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
-    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
-    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
-    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
-    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
-    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
+    onboarding_probe_test_button: 'Testar conexão',
+    onboarding_probe_probing: 'Testando conexão…',
+    onboarding_probe_ok: 'Conectado. {n} modelo(s) disponível(is).',
+    onboarding_probe_error_generic: 'Não foi possível acessar a URL base configurada.',
+    onboarding_probe_error_invalid_url: 'A URL base deve começar com http:// ou https://.',
+    onboarding_probe_error_dns: 'Não foi possível resolver o host. Verifique a URL ou use o endereço IP do host.',
+    onboarding_probe_error_connect_refused: 'Conexão recusada — o servidor pode não estar em execução nesse endereço. De dentro do Docker, tente o IP do host em vez de localhost.',
+    onboarding_probe_error_timeout: 'O endpoint não respondeu a tempo. Verifique se o servidor está em execução e se a URL está correta.',
+    onboarding_probe_error_http_4xx: 'O endpoint retornou um erro de cliente. Verifique a autenticação e o caminho da URL (normalmente termina em /v1).',
+    onboarding_probe_error_http_5xx: 'O endpoint retornou um erro de servidor. Verifique os logs do servidor LM Studio / Ollama.',
+    onboarding_probe_error_parse: 'O endpoint não retornou uma lista de modelos no formato esperado. Verifique se a URL aponta para a raiz da API compatível com OpenAI.',
+    onboarding_probe_error_unreachable: 'Não foi possível acessar a URL base configurada.',
+    onboarding_error_probe_failed: 'Não foi possível validar a URL base configurada.',
     onboarding_error_workspace_required: 'Workspace é necessário.',
     onboarding_error_model_required: 'Modelo é necessário.',
     onboarding_complete: 'Configuração completa',
@@ -11331,73 +11331,73 @@ const LOCALES = {
     settings_label_tts_auto_read: 'Ler respostas automaticamente',
     settings_desc_tts_auto_read: 'Ler automaticamente as respostas do assistente',
     // Composer voice-mode pref (#1488)
-    settings_label_voice_mode: 'Hands-free voice mode button',  // TODO: translate
+    settings_label_voice_mode: 'Botão do modo de voz mãos-livres',
     settings_desc_voice_mode: 'Show the voice-mode button (audio waveform) next to the dictation mic. Lets you speak naturally — Hermes auto-sends after a pause and reads replies aloud. Requires a browser that supports both speech recognition and TTS.',
     settings_label_raw_audio: 'Send raw audio instead of transcribing',
     settings_desc_raw_audio: 'Record and send the original audio file to the agent instead of converting it to text first. The agent can then transcribe it or process the raw audio (emotion, background noise, custom STT). Like Telegram\'s voice message behavior.',
     voice_send_raw: 'Send raw audio',
-    voice_raw_attached: 'Audio attached. Press Send or type more.',  // TODO: translate
+    voice_raw_attached: 'Áudio anexado. Pressione Enviar ou digite mais.',
     settings_label_tts_voice: 'Voz',
     settings_desc_tts_voice: 'Selecionar voz para síntese de voz',
     settings_label_tts_rate: 'Velocidade da fala',
     settings_label_tts_pitch: 'Tom da fala',
-    checkpoint_date: 'Date',  // TODO: translate
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
-    checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
-    checkpoint_diff_title: 'Changes in checkpoint',  // TODO: translate
-    checkpoint_empty: 'No checkpoints found for this workspace.',  // TODO: translate
-    checkpoint_error: 'Failed to load checkpoints',  // TODO: translate
-    checkpoint_files: 'Files',  // TODO: translate
-    checkpoint_loading: 'Loading checkpoints…',  // TODO: translate
-    checkpoint_message: 'Message',  // TODO: translate
-    checkpoint_restore: 'Restore',  // TODO: translate
-    checkpoint_restore_confirm_message: (ckpt) => `Restore workspace to checkpoint "${ckpt}"? This will overwrite files with the saved versions. Files added after this checkpoint will not be deleted.`,  // TODO: translate
-    checkpoint_restore_confirm_title: 'Restore checkpoint?',  // TODO: translate
-    checkpoint_restored: 'Checkpoint restored',  // TODO: translate
-    checkpoint_title: 'Checkpoints',  // TODO: translate
-    checkpoint_view_diff: 'View diff',  // TODO: translate
-    insights_activity_by_day: 'Activity by Day',  // TODO: translate
-    insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
-    insights_cost: 'Estimated Cost',  // TODO: translate
-    insights_footer: 'Showing data from the last {days} days',  // TODO: translate
-    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
-    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
-    insights_skill_usage_total: 'Total invocations',  // TODO: translate
-    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
-    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
-    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
-    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
-    insights_input_tokens: 'Input',  // TODO: translate
-    insights_messages: 'Messages',  // TODO: translate
-    insights_models: 'Models',  // TODO: translate
-    insights_no_cost: 'N/A',  // TODO: translate
-    insights_output_tokens: 'Output',  // TODO: translate
-    insights_peak_hour: 'Peak: {hour}',  // TODO: translate
-    insights_sessions: 'Sessions',  // TODO: translate
-    insights_title: 'Usage Analytics',  // TODO: translate
-    insights_token_breakdown: 'Token Breakdown',  // TODO: translate
-    insights_tokens: 'Tokens',  // TODO: translate
-    insights_total: 'Total',  // TODO: translate
-    settings_desc_api_redact: 'Self-hosted users can disable for transparency (not recommended for shared instances).',  // TODO: translate
-    settings_label_api_redact: 'Redact sensitive data in API responses',  // TODO: translate
-    voice_error: 'Voice not supported in this browser',  // TODO: translate
-    voice_listening: 'Listening…',  // TODO: translate
-    voice_mode_active: 'Voice mode on',  // TODO: translate
-    voice_mode_off: 'Voice mode off',  // TODO: translate
-    voice_speaking: 'Speaking…',  // TODO: translate
-    voice_thinking: 'Thinking…',  // TODO: translate
+    checkpoint_date: 'Data',
+    checkpoint_diff_files_changed: (n) => `${n} arquivo${n === 1 ? '' : 's'} alterado${n === 1 ? '' : 's'}`,
+    checkpoint_diff_no_changes: 'Nenhuma diferença encontrada entre este checkpoint e o workspace atual.',
+    checkpoint_diff_title: 'Alterações no checkpoint',
+    checkpoint_empty: 'Nenhum checkpoint encontrado para este workspace.',
+    checkpoint_error: 'Falha ao carregar checkpoints',
+    checkpoint_files: 'Arquivos',
+    checkpoint_loading: 'Carregando checkpoints…',
+    checkpoint_message: 'Mensagem',
+    checkpoint_restore: 'Restaurar',
+    checkpoint_restore_confirm_message: (ckpt) => `Restaurar o workspace para o checkpoint "${ckpt}"? Isso substituirá os arquivos pelas versões salvas. Arquivos adicionados após este checkpoint não serão excluídos.`,
+    checkpoint_restore_confirm_title: 'Restaurar checkpoint?',
+    checkpoint_restored: 'Checkpoint restaurado',
+    checkpoint_title: 'Checkpoints',
+    checkpoint_view_diff: 'Ver diff',
+    insights_activity_by_day: 'Atividade por dia',
+    insights_activity_by_hour: 'Atividade por hora',
+    insights_cost: 'Custo estimado',
+    insights_footer: 'Mostrando dados dos últimos {days} dias',
+    insights_skill_usage_title: 'Uso de skills',
+    insights_skill_usage_sub: 'Frequência de invocação de ferramentas',
+    insights_skill_usage_total: 'Total de invocações',
+    insights_skill_usage_skills_used: 'Skills usadas',
+    insights_skill_usage_no_data: 'Ainda não há dados de uso de skills',
+    insights_skill_usage_no_data_hint: 'As skills aparecerão aqui quando forem usadas nas conversas.',
+    insights_skill_usage_footer: 'Contagens de ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Skill',
+    insights_skill_usage_col_uses: 'Usos',
+    insights_skill_usage_col_views: 'Visualizações',
+    insights_skill_usage_col_share: '% de uso',
+    insights_skill_usage_col_patches: 'Patches',
+    insights_input_tokens: 'Entrada',
+    insights_messages: 'Mensagens',
+    insights_models: 'Modelos',
+    insights_no_cost: 'N/D',
+    insights_output_tokens: 'Saída',
+    insights_peak_hour: 'Pico: {hour}',
+    insights_sessions: 'Sessões',
+    insights_title: 'Análise de uso',
+    insights_token_breakdown: 'Detalhamento de tokens',
+    insights_tokens: 'Tokens',
+    insights_total: 'Total',
+    settings_desc_api_redact: 'Usuários self-hosted podem desativar para maior transparência (não recomendado para instâncias compartilhadas).',
+    settings_label_api_redact: 'Ocultar dados sensíveis nas respostas da API',
+    voice_error: 'Voz não suportada neste navegador',
+    voice_listening: 'Ouvindo…',
+    voice_mode_active: 'Modo de voz ativado',
+    voice_mode_off: 'Modo de voz desativado',
+    voice_speaking: 'Falando…',
+    voice_thinking: 'Pensando…',
     // Composer voice buttons (#1488)
-    voice_dictate: 'Dictate',  // TODO: translate
+    voice_dictate: 'Ditar',
     voice_dictate_active: 'Stop dictation',
-    voice_recording_active: 'Parar gravação',  // TODO: translate
-    voice_mode_toggle: 'Voice mode',  // TODO: translate
-    voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
-    subagent_children: 'Subagent sessions',  // TODO: translate
+    voice_recording_active: 'Parar gravação',
+    voice_mode_toggle: 'Modo de voz',
+    voice_mode_toggle_active: 'Sair do modo de voz',
+    subagent_children: 'Sessões de subagente',
     // login-flow keys (issue #1442)
     sign_out_failed: 'Falha ao sair: ',
     auth_disabled: 'Autenticação desativada — proteção por senha removida',
@@ -11553,16 +11553,16 @@ const LOCALES = {
     model_custom_label: 'Custom model ID',
     model_custom_placeholder: 'e.g. openai/gpt-5.4',
     model_search_placeholder: 'Search models…',
-    session_toolsets: 'Session Toolsets', // TODO: translate
-    session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
-    session_toolsets_global: 'Global (default)', // TODO: translate
-    session_toolsets_custom: 'Custom', // TODO: translate
-    session_toolsets_placeholder: 'tool1, tool2, \u2026', // TODO: translate
-    session_toolsets_apply: 'Apply', // TODO: translate
-    session_toolsets_clear: 'Clear (use global)', // TODO: translate
-    session_toolsets_applied: 'Toolsets updated', // TODO: translate
-    session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
-    session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
+    session_toolsets: '세션 도구 세트',
+    session_toolsets_desc: '이 세션에서 사용 가능한 도구 제한 (비워두면 전역 설정 사용)',
+    session_toolsets_global: '전역 (기본값)',
+    session_toolsets_custom: '사용자 지정',
+    session_toolsets_placeholder: '도구1, 도구2, …',
+    session_toolsets_apply: '적용',
+    session_toolsets_clear: '지우기 (전역 사용)',
+    session_toolsets_applied: '도구 세트 업데이트됨',
+    session_toolsets_cleared: '도구 세트 지워짐 — 전역 설정 사용 중',
+    session_toolsets_failed: '도구 세트 업데이트 실패: ',
     model_search_no_results: 'No models found',
     model_group_configured: '구성됨',
     ws_search_placeholder: '워크스페이스 검색…',
@@ -11787,7 +11787,7 @@ const LOCALES = {
      copy_file_path: '파일 경로 복사',
      open_in_vscode: 'VS Code에서 열기',
      open_in_vscode_failed: 'VS Code에서 열기 실패: ',
-     download_folder: 'Download Folder', // TODO: translate
+     download_folder: '다운로드 폴더',
     path_copied: '파일 경로가 클립보드에 복사되었습니다',
     path_copy_failed: '경로 복사 실패: ',
     session_rename: '대화 이름 변경',
@@ -11910,18 +11910,18 @@ const LOCALES = {
     settings_tab_appearance: '외형',
     settings_tab_preferences: '환경설정',
     settings_tab_plugins: '플러그인',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: '플러그인',
+    settings_plugins_meta: '설치된 Hermes 플러그인과 해당 플러그인이 등록하는 라이프사이클 훅을 확인합니다. 이 패널은 읽기 전용입니다.',
+    settings_plugins_empty: '현재 표시할 Hermes 플러그인이 없습니다. Hermes CLI/설정에서 플러그인을 설치하거나 활성화하면 여기에 표시됩니다.',
+    plugins_unnamed: '이름 없는 플러그인',
+    plugins_no_description: '설명이 없습니다.',
+    plugins_no_hooks: '등록된 라이프사이클 훅 없음',
+    plugins_registered_hooks: '등록된 훅',
+    plugins_enabled: '활성화됨',
+    plugins_disabled: '비활성화됨',
+    plugins_active_provider: '활성 (제공자)',
+    plugins_provider_no_hooks: '제공자 플러그인 — 에이전트 가시성 훅 없음',
+    plugins_load_failed: '플러그인 로드 실패: ',
     settings_tab_system: '시스템',
     settings_title: '설정',
     settings_save_btn: '설정 저장',
@@ -12084,19 +12084,19 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_settings: '설정',
 
-    logs_title: 'Logs',  // TODO: translate
-    logs_file: 'File',  // TODO: translate
-    logs_tail: 'Tail',  // TODO: translate
-    logs_auto_refresh: 'Auto-refresh (5s)',  // TODO: translate
-    logs_wrap: 'Wrap lines',  // TODO: translate
-    logs_copy_all: 'Copy all',  // TODO: translate
-    logs_empty: 'No log lines yet.',  // TODO: translate
-    logs_loading: 'Loading logs…',  // TODO: translate
-    logs_load_failed: 'Logs failed to load',  // TODO: translate
-    logs_status_idle: 'Choose a log file to view recent lines.',  // TODO: translate
-    logs_no_mtime: 'not written yet',  // TODO: translate
-    logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
-    logs_copied: 'Logs copied',  // TODO: translate
+    logs_title: '로그',
+    logs_file: '파일',
+    logs_tail: '끝부분',
+    logs_auto_refresh: '자동 새로고침 (5초)',
+    logs_wrap: '줄 바꿈',
+    logs_copy_all: '전체 복사',
+    logs_empty: '아직 로그가 없습니다.',
+    logs_loading: '로그 불러오는 중…',
+    logs_load_failed: '로그를 불러오지 못했습니다',
+    logs_status_idle: '최근 로그를 보려면 로그 파일을 선택하세요.',
+    logs_no_mtime: '아직 기록되지 않음',
+    logs_truncated_hint: '큰 로그 파일의 끝부분을 표시하고 있습니다. 메모리 사용을 줄이기 위해 이전 데이터는 생략되었습니다.',
+    logs_copied: '로그 복사됨',
     logs_severity: '심각도',
     logs_severity_all: '전체',
     logs_severity_errors: '오류',
@@ -12300,17 +12300,17 @@ const LOCALES = {
     provider_category_self_hosted: 'Open / self-hosted',
     provider_category_specialized: 'Specialized',
     onboarding_api_key_label: 'API key',
-    oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
-    oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
-    oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
-    oauth_codex_polling: 'Waiting for authorization...', // TODO: translate
-    oauth_codex_success: 'Codex OAuth login successful!', // TODO: translate
-    oauth_codex_error: 'OAuth login failed', // TODO: translate
-    oauth_codex_expired: 'Code expired, please try again', // TODO: translate
+    oauth_login_codex: 'Codex (ChatGPT)로 로그인',
+    oauth_codex_step1: '1단계: 이 URL을 방문하여 코드를 입력하세요',
+    oauth_codex_step2: '2단계: 페이지에 이 코드를 입력하세요',
+    oauth_codex_polling: '승인 대기 중...',
+    oauth_codex_success: 'Codex OAuth 로그인 성공!',
+    oauth_codex_error: 'OAuth 로그인 실패',
+    oauth_codex_expired: '코드가 만료되었습니다. 다시 시도해 주세요',
     onboarding_api_key_placeholder: 'Leave blank to keep an existing saved key',
-    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
-    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
-    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
+    onboarding_api_key_label_optional: 'API 키 (선택)',
+    onboarding_api_key_placeholder_optional: '키가 없는 서버는 비워두세요',
+    onboarding_api_key_help_keyless: '대부분의 LM Studio / Ollama / vLLM 설치는 키 없이 실행됩니다 — 서버에 인증이 필요 없으면 비워두세요. 연결 테스트 버튼으로 확인할 수 있습니다.',
     onboarding_api_key_help_prefix: 'Saved as a secret in your Hermes .env file using',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://your-endpoint.example/v1',
@@ -12336,19 +12336,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Choose a model before continuing.',
     onboarding_error_provider_required: 'Choose a setup mode before continuing.',
     onboarding_error_base_url_required: 'Base URL is required for custom endpoints.',
-    onboarding_probe_test_button: 'Test connection', // TODO: translate
-    onboarding_probe_probing: 'Testing connection…', // TODO: translate
-    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
-    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
-    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
-    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
-    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
-    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
-    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
-    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
-    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
-    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
+    onboarding_probe_test_button: '연결 테스트',
+    onboarding_probe_probing: '연결 테스트 중…',
+    onboarding_probe_ok: '연결됨. 사용 가능한 모델 {n}개.',
+    onboarding_probe_error_generic: '설정된 기본 URL에 연결할 수 없습니다.',
+    onboarding_probe_error_invalid_url: '기본 URL은 http:// 또는 https://로 시작해야 합니다.',
+    onboarding_probe_error_dns: '호스트를 확인할 수 없습니다. URL을 확인하거나 호스트의 IP 주소를 사용하세요.',
+    onboarding_probe_error_connect_refused: '연결이 거부되었습니다 — 해당 주소에서 서버가 실행 중이 아닐 수 있습니다. Docker 내부에서는 localhost 대신 호스트 IP를 사용해 보세요.',
+    onboarding_probe_error_timeout: '엔드포인트가 제시간에 응답하지 않았습니다. 서버가 실행 중인지, URL이 올바른지 확인하세요.',
+    onboarding_probe_error_http_4xx: '엔드포인트가 클라이언트 오류를 반환했습니다. 인증과 URL 경로(보통 /v1로 끝남)를 확인하세요.',
+    onboarding_probe_error_http_5xx: '엔드포인트가 서버 오류를 반환했습니다. LM Studio / Ollama 서버 로그를 확인하세요.',
+    onboarding_probe_error_parse: '엔드포인트가 예상 형식의 모델 목록을 반환하지 않았습니다. URL이 OpenAI 호환 API 루트를 가리키는지 확인하세요.',
+    onboarding_probe_error_unreachable: '설정된 기본 URL에 연결할 수 없습니다.',
+    onboarding_error_probe_failed: '설정된 기본 URL을 검증할 수 없습니다.',
     onboarding_error_workspace_required: 'Workspace is required.',
     onboarding_error_model_required: 'Model is required.',
     onboarding_complete: '설정 완료',
@@ -12629,34 +12629,34 @@ const LOCALES = {
     settings_label_tts_auto_read: '답변 자동 읽기',
     settings_desc_tts_auto_read: '도움말 답변을 자동으로 읽어줌',
     // Composer voice-mode pref (#1488)
-    settings_label_voice_mode: 'Hands-free voice mode button',  // TODO: translate
+    settings_label_voice_mode: '핸즈프리 음성 모드 버튼',
     settings_desc_voice_mode: 'Show the voice-mode button (audio waveform) next to the dictation mic. Lets you speak naturally — Hermes auto-sends after a pause and reads replies aloud. Requires a browser that supports both speech recognition and TTS.',
     settings_label_raw_audio: 'Send raw audio instead of transcribing',
     settings_desc_raw_audio: 'Record and send the original audio file to the agent instead of converting it to text first. The agent can then transcribe it or process the raw audio (emotion, background noise, custom STT). Like Telegram\'s voice message behavior.',
     voice_send_raw: 'Send raw audio',
-    voice_raw_attached: 'Audio attached. Press Send or type more.',  // TODO: translate
+    voice_raw_attached: '오디오가 첨부되었습니다. 보내기를 누르거나 계속 입력하세요.',
     settings_label_tts_voice: '음성',
     settings_desc_tts_voice: '음성 합성 음성 선택',
     settings_label_tts_rate: '말 속도',
     settings_label_tts_pitch: '말 톤',
-    checkpoint_date: 'Date',  // TODO: translate
-    checkpoint_diff_files_changed: (n) => `${n} file${n === 1 ? '' : 's'} changed`,  // TODO: translate
-    checkpoint_diff_no_changes: 'No differences found between this checkpoint and the current workspace.',  // TODO: translate
-    checkpoint_diff_title: 'Changes in checkpoint',  // TODO: translate
-    checkpoint_empty: 'No checkpoints found for this workspace.',  // TODO: translate
-    checkpoint_error: 'Failed to load checkpoints',  // TODO: translate
-    checkpoint_files: 'Files',  // TODO: translate
-    checkpoint_loading: 'Loading checkpoints…',  // TODO: translate
-    checkpoint_message: 'Message',  // TODO: translate
-    checkpoint_restore: 'Restore',  // TODO: translate
-    checkpoint_restore_confirm_message: (ckpt) => `Restore workspace to checkpoint "${ckpt}"? This will overwrite files with the saved versions. Files added after this checkpoint will not be deleted.`,  // TODO: translate
-    checkpoint_restore_confirm_title: 'Restore checkpoint?',  // TODO: translate
-    checkpoint_restored: 'Checkpoint restored',  // TODO: translate
-    checkpoint_title: 'Checkpoints',  // TODO: translate
-    checkpoint_view_diff: 'View diff',  // TODO: translate
-    insights_activity_by_day: 'Activity by Day',  // TODO: translate
-    insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
-    insights_cost: 'Estimated Cost',  // TODO: translate
+    checkpoint_date: '날짜',
+    checkpoint_diff_files_changed: (n) => `${n}개 파일 변경됨`,
+    checkpoint_diff_no_changes: '이 체크포인트와 현재 워크스페이스 간에 차이가 없습니다.',
+    checkpoint_diff_title: '체크포인트의 변경 사항',
+    checkpoint_empty: '이 워크스페이스에 체크포인트가 없습니다.',
+    checkpoint_error: '체크포인트를 불러오지 못했습니다',
+    checkpoint_files: '파일',
+    checkpoint_loading: '체크포인트 불러오는 중…',
+    checkpoint_message: '메시지',
+    checkpoint_restore: '복원',
+    checkpoint_restore_confirm_message: (ckpt) => `워크스페이스를 체크포인트 "${ckpt}"(으)로 복원할까요? 저장된 버전으로 파일을 덮어씁니다. 이 체크포인트 이후에 추가된 파일은 삭제되지 않습니다.`,
+    checkpoint_restore_confirm_title: '체크포인트를 복원할까요?',
+    checkpoint_restored: '체크포인트 복원됨',
+    checkpoint_title: '체크포인트',
+    checkpoint_view_diff: '차이 보기',
+    insights_activity_by_day: '일별 활동',
+    insights_activity_by_hour: '시간별 활동',
+    insights_cost: '예상 비용',
     insights_daily_tokens: '일별 토큰',
     insights_model_name: '모델',
     insights_model_sessions: '세션',
@@ -12664,45 +12664,45 @@ const LOCALES = {
     insights_model_cost: '비용',
     insights_model_share: '비율',
     insights_no_usage_data: '아직 사용 데이터가 없습니다',
-    insights_footer: 'Showing data from the last {days} days',  // TODO: translate
-    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
-    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
-    insights_skill_usage_total: 'Total invocations',  // TODO: translate
-    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
-    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
-    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
-    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
-    insights_input_tokens: 'Input',  // TODO: translate
-    insights_messages: 'Messages',  // TODO: translate
-    insights_models: 'Models',  // TODO: translate
-    insights_no_cost: 'N/A',  // TODO: translate
-    insights_output_tokens: 'Output',  // TODO: translate
-    insights_peak_hour: 'Peak: {hour}',  // TODO: translate
-    insights_sessions: 'Sessions',  // TODO: translate
-    insights_title: 'Usage Analytics',  // TODO: translate
-    insights_token_breakdown: 'Token Breakdown',  // TODO: translate
-    insights_tokens: 'Tokens',  // TODO: translate
-    insights_total: 'Total',  // TODO: translate
-    settings_desc_api_redact: 'Self-hosted users can disable for transparency (not recommended for shared instances).',  // TODO: translate
-    settings_label_api_redact: 'Redact sensitive data in API responses',  // TODO: translate
-    voice_error: 'Voice not supported in this browser',  // TODO: translate
-    voice_listening: 'Listening…',  // TODO: translate
-    voice_mode_active: 'Voice mode on',  // TODO: translate
-    voice_mode_off: 'Voice mode off',  // TODO: translate
-    voice_speaking: 'Speaking…',  // TODO: translate
-    voice_thinking: 'Thinking…',  // TODO: translate
+    insights_footer: '최근 {days}일 데이터 표시',
+    insights_skill_usage_title: '스킬 사용량',
+    insights_skill_usage_sub: '도구 호출 빈도',
+    insights_skill_usage_total: '총 호출 수',
+    insights_skill_usage_skills_used: '사용된 스킬',
+    insights_skill_usage_no_data: '아직 스킬 사용 데이터가 없습니다',
+    insights_skill_usage_no_data_hint: '대화에서 스킬을 사용하면 여기에 표시됩니다.',
+    insights_skill_usage_footer: '~/.hermes/skills/ 기준 집계',
+    insights_skill_usage_col_skill: '스킬',
+    insights_skill_usage_col_uses: '사용 횟수',
+    insights_skill_usage_col_views: '조회 수',
+    insights_skill_usage_col_share: '사용률',
+    insights_skill_usage_col_patches: '패치',
+    insights_input_tokens: '입력',
+    insights_messages: '메시지',
+    insights_models: '모델',
+    insights_no_cost: 'N/A',
+    insights_output_tokens: '출력',
+    insights_peak_hour: '피크: {hour}',
+    insights_sessions: '세션',
+    insights_title: '사용량 분석',
+    insights_token_breakdown: '토큰 내역',
+    insights_tokens: '토큰',
+    insights_total: '합계',
+    settings_desc_api_redact: '자체 호스팅 사용자는 투명성을 위해 비활성화할 수 있습니다 (공유 인스턴스에는 권장하지 않음).',
+    settings_label_api_redact: 'API 응답에서 민감한 데이터 숨기기',
+    voice_error: '이 브라우저에서는 음성이 지원되지 않습니다',
+    voice_listening: '듣는 중…',
+    voice_mode_active: '음성 모드 켜짐',
+    voice_mode_off: '음성 모드 꺼짐',
+    voice_speaking: '말하는 중…',
+    voice_thinking: '생각 중…',
     // Composer voice buttons (#1488)
-    voice_dictate: 'Dictate',  // TODO: translate
+    voice_dictate: '받아쓰기',
     voice_dictate_active: 'Stop dictation',
-    voice_recording_active: '녹음 중지',  // TODO: translate
-    voice_mode_toggle: 'Voice mode',  // TODO: translate
-    voice_mode_toggle_active: 'Exit voice mode',  // TODO: translate
-    subagent_children: 'Subagent sessions',  // TODO: translate
+    voice_recording_active: '녹음 중지',
+    voice_mode_toggle: '음성 모드',
+    voice_mode_toggle_active: '음성 모드 종료',
+    subagent_children: '하위 에이전트 세션',
   },
 
   fr: {
@@ -13027,7 +13027,7 @@ const LOCALES = {
     reveal_in_finder: 'Révéler dans le gestionnaire de fichiers',
     reveal_failed: 'Échec de la révélation :',
     copy_file_path: 'Copier le chemin du fichier',
-    download_folder: 'Download Folder', // TODO: translate
+    download_folder: 'Dossier de téléchargement',
     path_copied: 'Chemin du fichier copié dans le presse-papiers',
     path_copy_failed: 'Échec de la copie du chemin :',
     session_rename: 'Renommer la conversation',
@@ -13139,18 +13139,18 @@ const LOCALES = {
     settings_tab_appearance: 'Apparence',
     settings_tab_preferences: 'Préférences',
     settings_tab_plugins: 'Plugins',
-    settings_plugins_title: 'Plugins',  // TODO: translate
-    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
-    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
-    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
-    plugins_no_description: 'No description provided.',  // TODO: translate
-    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
-    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
-    plugins_enabled: 'Enabled',  // TODO: translate
-    plugins_disabled: 'Disabled',  // TODO: translate
-    plugins_active_provider: 'Active (provider)',  // TODO: translate
-    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',  // TODO: translate
-    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
+    settings_plugins_title: 'Plugins',
+    settings_plugins_meta: 'Affichez les plugins Hermes installés et les hooks de cycle de vie qu\'ils enregistrent. Ce panneau est en lecture seule.',
+    settings_plugins_empty: 'Aucun plugin Hermes n\'est actuellement visible. Installez ou activez des plugins depuis la CLI/config Hermes pour les voir ici.',
+    plugins_unnamed: 'Plugin sans nom',
+    plugins_no_description: 'Aucune description fournie.',
+    plugins_no_hooks: 'Aucun hook de cycle de vie enregistré',
+    plugins_registered_hooks: 'Hooks enregistrés',
+    plugins_enabled: 'Activé',
+    plugins_disabled: 'Désactivé',
+    plugins_active_provider: 'Actif (fournisseur)',
+    plugins_provider_no_hooks: 'Plugin fournisseur — aucun hook de visibilité agent',
+    plugins_load_failed: 'Échec du chargement des plugins : ',
     settings_tab_system: 'Système',
     settings_title: 'Paramètres',
     settings_save_btn: 'Enregistrer les paramètres',
@@ -13357,11 +13357,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'Aucune donnée d\'utilisation des skills pour le moment',
     insights_skill_usage_no_data_hint: 'Les skills apparaîtront ici une fois utilisés dans les conversations.',
     insights_skill_usage_footer: 'Comptages depuis ~/.hermes/skills/',
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',
+    insights_skill_usage_col_uses: 'Utilisations',
+    insights_skill_usage_col_views: 'Vues',
+    insights_skill_usage_col_share: '% d\'utilisation',
+    insights_skill_usage_col_patches: 'Correctifs',
     workspace_desc: 'Ajoutez et changez d\'espace de travail pour vos sessions.',
     session_lineage_toggle_hint: '{0} — les tours de contexte précédents sont repliés ici. Cliquez pour les afficher ou les masquer.',
     session_lineage_static_hint: '{0} — les tours de contexte précédents sont repliés ici.',
@@ -15223,18 +15223,18 @@ const LOCALES = {
     insights_model_share: 'Paylaşmak',
     insights_no_usage_data: 'Henüz kullanım verisi yok',
     insights_footer: 'Son {days} günün verileri gösteriliyor',
-    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
-    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
-    insights_skill_usage_total: 'Total invocations',  // TODO: translate
-    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
-    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
-    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
-    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
-    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
-    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
-    insights_skill_usage_col_views: 'Views',  // TODO: translate
-    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
-    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_skill_usage_title: 'Beceri kullanımı',
+    insights_skill_usage_sub: 'Araç çağırma sıklığı',
+    insights_skill_usage_total: 'Toplam çağrı',
+    insights_skill_usage_skills_used: 'Kullanılan beceriler',
+    insights_skill_usage_no_data: 'Henüz beceri kullanım verisi yok',
+    insights_skill_usage_no_data_hint: 'Beceriler konuşmalarda kullanıldığında burada görünür.',
+    insights_skill_usage_footer: '~/.hermes/skills/ üzerinden sayımlar',
+    insights_skill_usage_col_skill: 'Beceri',
+    insights_skill_usage_col_uses: 'Kullanım',
+    insights_skill_usage_col_views: 'Görüntüleme',
+    insights_skill_usage_col_share: 'Kullanım %',
+    insights_skill_usage_col_patches: 'Yamalar',
     insights_input_tokens: 'Giriş',
     insights_messages: 'Mesajlar',
     insights_models: 'Modeller',

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -305,7 +305,7 @@ def test_parent_indicator_hover_only_style():
 
 def test_i18n_branch_keys():
     """Verify all branch-related i18n keys exist in English locale."""
-    with open('static/i18n.js') as f:
+    with open('static/i18n.js', encoding='utf-8') as f:
         src = f.read()
     required_keys = [
         'cmd_branch',

--- a/tests/test_archive_extraction_symlink_safety.py
+++ b/tests/test_archive_extraction_symlink_safety.py
@@ -1,0 +1,82 @@
+"""Archive extraction must never materialize symlinks or archive permission bits.
+
+extract_archive copies member bytes manually (open/write) instead of using
+extractall(), so archive-declared modes are never applied and tar symlinks are
+skipped via member.isfile(). Zip symlink members (Unix S_IFLNK in
+external_attr) are skipped explicitly. These tests lock that contract in.
+"""
+
+import io
+import os
+import stat
+import sys
+import tarfile
+import zipfile
+
+import pytest
+
+from api.upload import extract_archive
+
+
+def _zip_with_symlink_and_exec() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("normal.txt", "hello")
+        link = zipfile.ZipInfo("evil-link")
+        link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        zf.writestr(link, "../../outside-target")
+        script = zipfile.ZipInfo("script.sh")
+        script.external_attr = (stat.S_IFREG | 0o755) << 16
+        zf.writestr(script, "#!/bin/sh\necho pwned\n")
+    return buf.getvalue()
+
+
+def _tar_with_symlink() -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        data = b"hello"
+        info = tarfile.TarInfo("normal.txt")
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+        link = tarfile.TarInfo("evil-link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside-target"
+        tf.addfile(link)
+    return buf.getvalue()
+
+
+def _assert_no_symlinks(root):
+    offenders = [p for p in root.rglob("*") if p.is_symlink()]
+    assert not offenders, f"symlinks materialized from archive: {offenders}"
+
+
+class TestZipExtraction:
+    def test_symlink_member_skipped(self, tmp_path):
+        result = extract_archive(_zip_with_symlink_and_exec(), "bundle.zip", tmp_path)
+        _assert_no_symlinks(tmp_path)
+        names = [os.path.basename(f) for f in result["files"]]
+        assert "normal.txt" in names
+        assert "evil-link" not in names
+        # The link-target text must not have been written as a plain file either.
+        assert not list(tmp_path.rglob("evil-link"))
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")
+    def test_exec_bit_not_applied(self, tmp_path):
+        extract_archive(_zip_with_symlink_and_exec(), "bundle.zip", tmp_path)
+        script = next(tmp_path.rglob("script.sh"))
+        assert not (script.stat().st_mode & 0o111), "archive exec bit leaked through"
+
+    def test_nothing_written_outside_workspace(self, tmp_path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        extract_archive(_zip_with_symlink_and_exec(), "bundle.zip", ws)
+        assert not (tmp_path / "outside-target").exists()
+
+
+class TestTarExtraction:
+    def test_symlink_member_skipped(self, tmp_path):
+        result = extract_archive(_tar_with_symlink(), "bundle.tar", tmp_path)
+        _assert_no_symlinks(tmp_path)
+        names = [os.path.basename(f) for f in result["files"]]
+        assert names == ["normal.txt"]
+        assert not list(tmp_path.rglob("evil-link"))

--- a/tests/test_batch_fixes.py
+++ b/tests/test_batch_fixes.py
@@ -15,7 +15,7 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text()
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 # ── Group A: /root workspace ──────────────────────────────────────────────────

--- a/tests/test_cors_preflight_allowlist.py
+++ b/tests/test_cors_preflight_allowlist.py
@@ -1,0 +1,79 @@
+"""CORS preflight must not advertise wider access than the CSRF gate permits.
+
+server.py's do_OPTIONS previously answered every preflight with
+``Access-Control-Allow-Origin: *``. It now echoes the request Origin only
+when it is same-origin (Host / X-Forwarded-Host / X-Real-Host match) or
+explicitly allowlisted via HERMES_WEBUI_ALLOWED_ORIGINS — the same policy
+enforced by _check_csrf.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from api.routes import preflight_allow_origin
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _preflight(headers):
+    return preflight_allow_origin(SimpleNamespace(headers=headers))
+
+
+class TestPreflightAllowOrigin:
+    def test_no_origin_header_omits_cors(self):
+        """Non-browser OPTIONS (no Origin) gets no Allow-Origin header."""
+        assert _preflight({}) == ""
+
+    def test_same_origin_echoed(self):
+        assert _preflight({
+            "Origin": "http://127.0.0.1:8787",
+            "Host": "127.0.0.1:8787",
+        }) == "http://127.0.0.1:8787"
+
+    def test_cross_origin_rejected(self):
+        assert _preflight({
+            "Origin": "http://evil.com",
+            "Host": "127.0.0.1:8787",
+        }) == ""
+
+    def test_wildcard_never_returned(self):
+        """Even a same-origin match echoes the Origin, never '*'."""
+        result = _preflight({
+            "Origin": "http://localhost:8787",
+            "Host": "localhost:8787",
+        })
+        assert result != "*"
+
+    def test_allowlisted_public_origin_echoed(self, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_WEBUI_ALLOWED_ORIGINS", "https://myapp.example.com:8000"
+        )
+        assert _preflight({
+            "Origin": "https://myapp.example.com:8000",
+            "Host": "127.0.0.1:8787",
+        }) == "https://myapp.example.com:8000"
+
+    def test_non_allowlisted_public_origin_rejected(self, monkeypatch):
+        monkeypatch.setenv(
+            "HERMES_WEBUI_ALLOWED_ORIGINS", "https://myapp.example.com:8000"
+        )
+        assert _preflight({
+            "Origin": "https://evil.example.com:8000",
+            "Host": "127.0.0.1:8787",
+        }) == ""
+
+    def test_forwarded_host_matches(self):
+        """Reverse proxy: Origin matches X-Forwarded-Host, not the raw Host."""
+        assert _preflight({
+            "Origin": "https://webui.example.com",
+            "Host": "127.0.0.1:8787",
+            "X-Forwarded-Host": "webui.example.com:443",
+        }) == "https://webui.example.com"
+
+
+class TestServerNoWildcard:
+    def test_server_source_has_no_wildcard_allow_origin(self):
+        """Regression guard: the literal `*` Allow-Origin must not come back."""
+        src = (ROOT / "server.py").read_text(encoding="utf-8")
+        assert '"Access-Control-Allow-Origin", "*"' not in src
+        assert "preflight_allow_origin" in src

--- a/tests/test_cron_no_agent_edit.py
+++ b/tests/test_cron_no_agent_edit.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-PANELS_JS = (ROOT / "static" / "panels.js").read_text()
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
 
 def _function_body(name: str) -> str:

--- a/tests/test_csv_table_rendering.py
+++ b/tests/test_csv_table_rendering.py
@@ -112,7 +112,7 @@ def test_csv_line_ending_normalization():
 
 def test_csv_i18n_keys():
     """Verify CSV i18n keys exist in all 7 locales."""
-    with open('static/i18n.js') as f:
+    with open('static/i18n.js', encoding='utf-8') as f:
         src = f.read()
     required_keys = ['csv_loading', 'csv_too_large', 'csv_no_data', 'csv_error']
     for key in required_keys:

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -299,7 +299,7 @@ def test_start_allows_alternate_port_while_launchd_job_runs_on_default(tmp_path)
         assert result.returncode == 0, combined
         pid_file = tmp_path / ".hermes" / "webui.pid"
         if pid_file.exists():
-            started_pid = int(pid_file.read_text().strip())
+            started_pid = int(pid_file.read_text(encoding="utf-8").strip())
     finally:
         if started_pid:
             try:

--- a/tests/test_excalidraw_inline_embed.py
+++ b/tests/test_excalidraw_inline_embed.py
@@ -142,7 +142,7 @@ def test_excalidraw_embed_wrap_structure():
 
 def test_excalidraw_i18n_keys():
     """Verify Excalidraw i18n keys exist in all 7 locales."""
-    with open('static/i18n.js') as f:
+    with open('static/i18n.js', encoding='utf-8') as f:
         src = f.read()
     required_keys = [
         'excalidraw_loading', 'excalidraw_too_large', 'excalidraw_invalid',

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1167,7 +1167,7 @@ def test_sessions_response_distinguishes_same_user_different_chat_identity_from_
     sessions_file = _get_test_state_dir() / 'sessions' / 'sessions.json'
     original_sessions_json = None
     if sessions_file.exists():
-        original_sessions_json = sessions_file.read_text()
+        original_sessions_json = sessions_file.read_text(encoding="utf-8")
     sessions_file.parent.mkdir(parents=True, exist_ok=True)
     sessions_payload = {
         "agent:main:telegram:dm:1143399746": {

--- a/tests/test_issue1095_pasted_images.py
+++ b/tests/test_issue1095_pasted_images.py
@@ -9,12 +9,12 @@ import pytest
 
 
 def _read_js(name):
-    with open(os.path.join('static', name)) as f:
+    with open(os.path.join('static', name), encoding='utf-8') as f:
         return f.read()
 
 
 def _read_css():
-    with open(os.path.join('static', 'style.css')) as f:
+    with open(os.path.join('static', 'style.css'), encoding='utf-8') as f:
         return f.read()
 
 

--- a/tests/test_issue1096_copy_buttons.py
+++ b/tests/test_issue1096_copy_buttons.py
@@ -3,7 +3,7 @@ import re
 
 
 def _src(name: str) -> str:
-    with open(f"static/{name}") as f:
+    with open(f"static/{name}", encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/test_issue1228_model_picker_duplicate_ids.py
+++ b/tests/test_issue1228_model_picker_duplicate_ids.py
@@ -186,7 +186,7 @@ class TestFrontendNormRegex(unittest.TestCase):
     @staticmethod
     def _read_js():
         import pathlib
-        return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text()
+        return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
 
     def _extract_norm(self):
         """Extract the norm() lambda from ui.js source."""
@@ -236,7 +236,7 @@ class TestFrontendPreferredProviderMatch(unittest.TestCase):
     @staticmethod
     def _read_js():
         import pathlib
-        return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text()
+        return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
 
     def test_find_model_prefers_matching_provider_for_slash_collision(self):
         import re

--- a/tests/test_issue1298_cancel_and_activity.py
+++ b/tests/test_issue1298_cancel_and_activity.py
@@ -285,7 +285,7 @@ class TestIssue1298ActivityGroupExpandPersistence:
     """
 
     def test_ui_js_tracks_user_expand_intent_for_live_activity_group(self):
-        src = (REPO_ROOT / "static" / "ui.js").read_text()
+        src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
         assert "_liveActivityUserExpanded" in src, (
             "ui.js must declare a per-turn tracker for the user's expand intent "
             "on the live activity group (#1298)"
@@ -299,7 +299,7 @@ class TestIssue1298ActivityGroupExpandPersistence:
         """ensureActivityGroup() must consult _liveActivityUserExpanded when
         creating a fresh live group so the user's prior expand survives the
         destroy/recreate cycle."""
-        src = (REPO_ROOT / "static" / "ui.js").read_text()
+        src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
         # Find the ensureActivityGroup function body
         m = re.search(
             r"function ensureActivityGroup\(inner, opts\)\{(.*?)\n\}",
@@ -319,7 +319,7 @@ class TestIssue1298ActivityGroupExpandPersistence:
     def test_finalize_thinking_card_respects_user_expand(self):
         """finalizeThinkingCard() must NOT force-collapse the live activity
         group when the user has explicitly expanded it (#1298)."""
-        src = (REPO_ROOT / "static" / "ui.js").read_text()
+        src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
         m = re.search(
             r"function finalizeThinkingCard\(\)\{(.*?)\n\}",
             src, re.DOTALL,
@@ -340,7 +340,7 @@ class TestIssue1298ActivityGroupExpandPersistence:
     def test_inline_onclick_records_user_intent(self):
         """The summary button's click path must call _onLiveActivityToggle
         so user clicks update the tracker (#1298)."""
-        src = (REPO_ROOT / "static" / "ui.js").read_text()
+        src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
         # The summary button is built inline inside ensureActivityGroup.
         assert "_onLiveActivityToggle" in src, (
             "_onLiveActivityToggle helper must be defined"
@@ -370,7 +370,7 @@ class TestIssue1298ActivityGroupExpandPersistence:
         """clearLiveToolCards() — invoked between turns — must reset the
         per-turn user-expand tracker so the next turn starts collapsed by
         default (#1298)."""
-        src = (REPO_ROOT / "static" / "ui.js").read_text()
+        src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
         m = re.search(
             r"function clearLiveToolCards\(\)\{(.*?)\n\}",
             src, re.DOTALL,

--- a/tests/test_issue1438_fence_anchoring.py
+++ b/tests/test_issue1438_fence_anchoring.py
@@ -36,7 +36,7 @@ import pytest
 from tests.test_sprint16 import render_md  # Python mirror of renderMd()
 
 
-UI_JS = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text()
+UI_JS = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def _strip_pre_blocks(out: str) -> str:

--- a/tests/test_issue1488_composer_voice_buttons.py
+++ b/tests/test_issue1488_composer_voice_buttons.py
@@ -20,7 +20,7 @@ import re
 
 
 def _src(name: str) -> str:
-    with open(f"static/{name}") as f:
+    with open(f"static/{name}", encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/test_issue1614_project_profile_filtering.py
+++ b/tests/test_issue1614_project_profile_filtering.py
@@ -47,7 +47,7 @@ def test_ensure_cron_project_creates_per_profile(tmp_path, monkeypatch):
     assert pid_haku != pid_kinni, "Per-profile cron projects must have distinct ids"
 
     # Verify on disk
-    saved = json.loads(projects_file.read_text())
+    saved = json.loads(projects_file.read_text(encoding="utf-8"))
     cron_rows = [p for p in saved if p['name'] == 'Cron Jobs']
     assert len(cron_rows) == 2
     assert {r['profile'] for r in cron_rows} == {'haku', 'kinni'}
@@ -96,7 +96,7 @@ def test_ensure_cron_project_back_tags_legacy_untagged(tmp_path, monkeypatch):
     returned = models.ensure_cron_project()
     assert returned == legacy_pid
 
-    saved = json.loads(projects_file.read_text())
+    saved = json.loads(projects_file.read_text(encoding="utf-8"))
     assert saved[0]['profile'] == 'haku', "Legacy untagged cron project must be back-tagged"
 
 
@@ -166,7 +166,7 @@ def test_load_projects_backfills_from_session_index(tmp_path, monkeypatch):
     assert by_id['tagged3']['profile'] == 'haku', "Already-tagged unchanged"
 
     # Persisted to disk
-    saved = json.loads(projects_file.read_text())
+    saved = json.loads(projects_file.read_text(encoding="utf-8"))
     saved_by_id = {p['project_id']: p for p in saved}
     assert saved_by_id['abc111']['profile'] == 'haku'
     assert saved_by_id['def222']['profile'] == 'kinni'

--- a/tests/test_issue1669_sidebar_scroll_jump_fix.py
+++ b/tests/test_issue1669_sidebar_scroll_jump_fix.py
@@ -22,7 +22,7 @@ SESSIONS_JS = Path(__file__).parent.parent / "static" / "sessions.js"
 
 
 def _read_source():
-    return SESSIONS_JS.read_text()
+    return SESSIONS_JS.read_text(encoding="utf-8")
 
 
 def test_render_restores_scroll_top_for_non_virtualized_lists():

--- a/tests/test_issue1743_model_picker_race.py
+++ b/tests/test_issue1743_model_picker_race.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-UI_JS = (ROOT / "static" / "ui.js").read_text()
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def _body_between(src: str, start: str, end: str) -> str:

--- a/tests/test_issue1765_codex_quota.py
+++ b/tests/test_issue1765_codex_quota.py
@@ -46,9 +46,9 @@ def test_provider_error_payload_includes_bounded_redacted_details(monkeypatch):
 
 
 def test_frontend_renders_apperror_details_in_collapsible_block():
-    messages_js = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'messages.js').read_text()
-    ui_js = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'ui.js').read_text()
-    style_css = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'style.css').read_text()
+    messages_js = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'messages.js').read_text(encoding="utf-8")
+    ui_js = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'ui.js').read_text(encoding="utf-8")
+    style_css = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'style.css').read_text(encoding="utf-8")
     apperror_idx = messages_js.find("source.addEventListener('apperror'")
     warning_idx = messages_js.find("source.addEventListener('warning'", apperror_idx)
     assert apperror_idx != -1 and warning_idx != -1

--- a/tests/test_issue1796_error_toasts.py
+++ b/tests/test_issue1796_error_toasts.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-UI_JS = (ROOT / "static" / "ui.js").read_text()
-STYLE_CSS = (ROOT / "static" / "style.css").read_text()
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
 def test_error_toast_default_duration_is_substantially_longer_than_info_toasts():

--- a/tests/test_issue1850_csp_connect_src_jsdelivr.py
+++ b/tests/test_issue1850_csp_connect_src_jsdelivr.py
@@ -12,7 +12,7 @@ _HELPERS_PY = Path(__file__).resolve().parents[1] / "api/helpers.py"
 
 
 def _helpers_src() -> str:
-    return _HELPERS_PY.read_text()
+    return _HELPERS_PY.read_text(encoding="utf-8")
 
 
 class TestCSPConnectSrcJsdelivr:

--- a/tests/test_issue2066_stale_sidebar_spinner.py
+++ b/tests/test_issue2066_stale_sidebar_spinner.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 
 
-SESSIONS_JS = (Path(__file__).resolve().parent.parent / "static" / "sessions.js").read_text()
+SESSIONS_JS = (Path(__file__).resolve().parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
 
 
 def _function_block(name: str, next_name: str) -> str:

--- a/tests/test_issue2386_localstorage_quota.py
+++ b/tests/test_issue2386_localstorage_quota.py
@@ -4,7 +4,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def _script(path):
-    return (ROOT / path).read_text()
+    return (ROOT / path).read_text(encoding="utf-8")
 
 
 def _assert_storage_setitem_guarded(src, needle):

--- a/tests/test_issue2419_cache_usage_display.py
+++ b/tests/test_issue2419_cache_usage_display.py
@@ -34,7 +34,7 @@ def test_session_compact_exposes_prompt_cache_counters():
 
 
 def test_streaming_usage_payload_includes_prompt_cache_counters():
-    src = (ROOT / "api" / "streaming.py").read_text()
+    src = (ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
 
     assert "session_cache_read_tokens" in src
     assert "session_cache_write_tokens" in src
@@ -44,7 +44,7 @@ def test_streaming_usage_payload_includes_prompt_cache_counters():
 
 
 def test_context_indicator_surfaces_cache_hit_rate():
-    src = (ROOT / "static" / "ui.js").read_text()
+    src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
     assert "cacheReadTok=usage.cache_read_tokens||0" in src
     assert "cacheWriteTok=usage.cache_write_tokens||0" in src
@@ -61,7 +61,7 @@ def test_context_indicator_surfaces_cache_hit_rate():
 
 
 def test_cache_usage_labels_are_localized():
-    src = (ROOT / "static" / "i18n.js").read_text()
+    src = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 
     assert src.count("usage_cache_hit_detail:") == 12
     assert src.count("usage_cached_percent:") == 12
@@ -70,7 +70,7 @@ def test_cache_usage_labels_are_localized():
 
 
 def test_done_handler_preserves_per_turn_cache_deltas():
-    src = (ROOT / "static" / "messages.js").read_text()
+    src = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 
     assert "_prevCacheRead=(S.session&&S.session.cache_read_tokens)||0" in src
     assert "curCacheRead=d.usage.cache_read_tokens||0" in src

--- a/tests/test_issue2508_session_pin_cap.py
+++ b/tests/test_issue2508_session_pin_cap.py
@@ -11,9 +11,9 @@ from tests._pytest_port import BASE, TEST_STATE_DIR
 
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-ROUTES_PY = (ROOT / "api" / "routes.py").read_text()
-SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text()
-STYLE_CSS = (ROOT / "static" / "style.css").read_text()
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
 def post(path, body=None):

--- a/tests/test_issue2569_model_provider_picker.py
+++ b/tests/test_issue2569_model_provider_picker.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-UI_JS = (ROOT / "static" / "ui.js").read_text()
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def test_temporary_configured_model_option_carries_provider_badge():

--- a/tests/test_issue2628_cli_sessions_perf.py
+++ b/tests/test_issue2628_cli_sessions_perf.py
@@ -68,7 +68,7 @@ def test_importable_agent_rows_push_sidebar_limit_into_sql(tmp_path):
     assert [row["id"] for row in rows][:3] == ["cli_perf_0119", "cli_perf_0118", "cli_perf_0117"]
     assert {row["actual_message_count"] for row in rows} == {5}
 
-    src = (REPO_ROOT / "api" / "agent_sessions.py").read_text()
+    src = (REPO_ROOT / "api" / "agent_sessions.py").read_text(encoding="utf-8")
     assert "WITH candidates AS" in src
     assert "JOIN candidates c ON c.id = s.id" in src
     assert "SELECT MAX(mx.timestamp) FROM messages mx WHERE mx.session_id = s.id" in src

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -209,7 +209,7 @@ class TestYoloI18n:
 
     @pytest.fixture(scope="class")
     def i18n_js(self):
-        with open("static/i18n.js", "r") as f:
+        with open("static/i18n.js", "r", encoding="utf-8") as f:
             return f.read()
 
     @pytest.mark.parametrize("locale", LOCALES)

--- a/tests/test_issue470.py
+++ b/tests/test_issue470.py
@@ -19,7 +19,7 @@ import re
 import html as _html
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/test_issue486_487.py
+++ b/tests/test_issue486_487.py
@@ -21,8 +21,8 @@ import re
 import html as _html
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
-STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text()
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/test_issue487b.py
+++ b/tests/test_issue487b.py
@@ -14,7 +14,7 @@ import pathlib
 import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 # ── Source-level check ────────────────────────────────────────────────────────

--- a/tests/test_issue607.py
+++ b/tests/test_issue607.py
@@ -124,19 +124,19 @@ class TestGemma4MessagesJsThinkPairs:
     """Verify static/messages.js contains the correct Gemma 4 pair."""
 
     def test_messages_js_has_correct_gemma4_open(self):
-        js = pathlib.Path("static/messages.js").read_text()
+        js = pathlib.Path("static/messages.js").read_text(encoding="utf-8")
         # Must have double-pipe format: <|turn|>thinking
         assert "<|turn|>thinking" in js, (
             "messages.js is missing correct Gemma 4 open delimiter '<|turn|>thinking'"
         )
 
     def test_messages_js_no_wrong_gemma4_open(self):
-        js = pathlib.Path("static/messages.js").read_text()
+        js = pathlib.Path("static/messages.js").read_text(encoding="utf-8")
         # Must NOT have single-pipe wrong format: <|turn>thinking
         assert "<|turn>thinking" not in js, (
             "messages.js still contains wrong Gemma 4 delimiter '<|turn>thinking' (missing |)"
         )
 
     def test_messages_js_has_gemma4_close(self):
-        js = pathlib.Path("static/messages.js").read_text()
+        js = pathlib.Path("static/messages.js").read_text(encoding="utf-8")
         assert "<turn|>" in js, "messages.js missing Gemma 4 close delimiter '<turn|>'"

--- a/tests/test_issue734_message_windowing.py
+++ b/tests/test_issue734_message_windowing.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-UI_JS = (REPO / "static" / "ui.js").read_text()
-CSS = (REPO / "static" / "style.css").read_text()
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
 def test_message_windowing_caps_initial_dom_to_recent_messages():

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -50,7 +50,7 @@ class TestSaveSkipIndex:
         s = _make_session("s1")
         s.save()
         assert s.path.exists()
-        data = json.loads(s.path.read_text())
+        data = json.loads(s.path.read_text(encoding="utf-8"))
         assert data["session_id"] == "s1"
         assert len(data["messages"]) == 1
 
@@ -59,7 +59,7 @@ class TestSaveSkipIndex:
         s = _make_session("s2")
         s.save(skip_index=True)
         assert s.path.exists()
-        data = json.loads(s.path.read_text())
+        data = json.loads(s.path.read_text(encoding="utf-8"))
         assert data["session_id"] == "s2"
 
     def test_save_with_skip_index_skips_index_rebuild(self):
@@ -75,7 +75,7 @@ class TestSaveSkipIndex:
         s.save()
         index = models.SESSION_INDEX_FILE
         assert index.exists(), "Index file should be created by default save()"
-        data = json.loads(index.read_text())
+        data = json.loads(index.read_text(encoding="utf-8"))
         sids = [e["session_id"] for e in data]
         assert "s4" in sids
 
@@ -89,7 +89,7 @@ class TestSaveSkipIndex:
         s.messages.append({"role": "user", "content": "thanks"})
         s.save()
         assert models.SESSION_INDEX_FILE.exists()
-        data = json.loads(s.path.read_text())
+        data = json.loads(s.path.read_text(encoding="utf-8"))
         assert len(data["messages"]) == 3
 
     def test_skip_index_save_with_touch_updated_at_false(self):
@@ -98,7 +98,7 @@ class TestSaveSkipIndex:
         original_updated_at = s.updated_at
         time.sleep(0.05)
         s.save(skip_index=True, touch_updated_at=False)
-        data = json.loads(s.path.read_text())
+        data = json.loads(s.path.read_text(encoding="utf-8"))
         assert data["updated_at"] == original_updated_at
         assert not models.SESSION_INDEX_FILE.exists()
 
@@ -166,7 +166,7 @@ class TestPeriodicCheckpoint:
             f"got {save_count[0]}"
         )
         # Verify the JSON is on disk and readable
-        data = json.loads(s.path.read_text())
+        data = json.loads(s.path.read_text(encoding="utf-8"))
         assert data["pending_user_message"] == "do a long task"
 
     def test_checkpoint_does_not_fire_without_activity(self):
@@ -266,7 +266,7 @@ class TestPeriodicCheckpoint:
         stop_event.set()
         t.join(timeout=1)
 
-        data = json.loads(s.path.read_text())
+        data = json.loads(s.path.read_text(encoding="utf-8"))
         assert data["updated_at"] > ts_before, "Checkpoint should update updated_at"
 
 
@@ -569,7 +569,7 @@ class TestIssue765FollowupHardening:
                                 s.save(skip_index=True)
                             # Read back the on-disk JSON to verify atomicity
                             try:
-                                snap = json.loads(s.path.read_text())
+                                snap = json.loads(s.path.read_text(encoding="utf-8"))
                                 with _lock:
                                     checkpoint_snapshots.append(snap.get("messages"))
                             except Exception:
@@ -620,7 +620,7 @@ class TestIssue765FollowupHardening:
 
             assert not errors, f"Checkpoint thread encountered errors: {errors}"
             # Verify the on-disk JSON is parseable
-            data = json.loads(s.path.read_text())
+            data = json.loads(s.path.read_text(encoding="utf-8"))
             assert data["session_id"] == "race_test"
             # Messages must be a list (not corrupted by concurrent mutation)
             assert isinstance(data["messages"], list)
@@ -707,7 +707,7 @@ class TestIssue765FollowupHardening:
                                 s.save(skip_index=True)
                             # Read back the on-disk JSON to verify atomicity
                             try:
-                                snap = json.loads(s.path.read_text())
+                                snap = json.loads(s.path.read_text(encoding="utf-8"))
                                 with _snap_lock:
                                     checkpoint_snapshots.append(snap)
                             except Exception:
@@ -734,7 +734,7 @@ class TestIssue765FollowupHardening:
             t.join(timeout=2)
 
             assert not errors, f"Checkpoint thread encountered errors: {errors}"
-            data = json.loads(s.path.read_text())
+            data = json.loads(s.path.read_text(encoding="utf-8"))
             assert data["session_id"] == "cancel_race"
             assert data["active_stream_id"] is None, (
                 "active_stream_id must be None after cancel cleanup"

--- a/tests/test_issue798.py
+++ b/tests/test_issue798.py
@@ -259,7 +259,7 @@ def test_concurrent_new_sessions_get_correct_profiles():
 def test_sessions_js_sends_profile_in_new_session_post():
     """R19i: sessions.js newSession() must include profile:S.activeProfile in the
     JSON body sent to /api/session/new — the client-side half of the #798 fix."""
-    js = (Path(__file__).parent.parent / 'static' / 'sessions.js').read_text()
+    js = (Path(__file__).parent.parent / 'static' / 'sessions.js').read_text(encoding="utf-8")
     assert 'profile:S.activeProfile' in js or 'profile: S.activeProfile' in js, (
         "sessions.js newSession() must send profile: S.activeProfile in the POST body "
         "so the server uses the tab's active profile, not the process global."

--- a/tests/test_issue856_active_session_read_state.py
+++ b/tests/test_issue856_active_session_read_state.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 
-MESSAGES_JS = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+MESSAGES_JS = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
 
 
 def test_messages_js_defines_active_session_viewed_helper():

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 
 
-SESSIONS_JS = (Path(__file__).resolve().parent.parent / "static" / "sessions.js").read_text()
-STYLE_CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text()
+SESSIONS_JS = (Path(__file__).resolve().parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
 
 
 def test_pinned_indicator_renders_inside_title_row():
@@ -126,7 +126,7 @@ def test_plain_mouse_hover_does_not_mark_session_row_dragging():
 
 
 def test_sidebar_uses_local_inflight_state_for_immediate_spinner():
-    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
 
     assert "function _isSessionLocallyStreaming(s)" in SESSIONS_JS
     assert "isActive && Boolean(S.busy)" in SESSIONS_JS
@@ -151,7 +151,7 @@ def test_date_group_caret_expanded_down_collapsed_right():
 def test_apperror_path_calls_render_session_list():
     """apperror handler must call renderSessionList() to clear the streaming indicator
     immediately rather than waiting for the 5s streaming poll interval."""
-    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
     apperror_idx = messages_js.find("source.addEventListener('apperror'")
     assert apperror_idx != -1, "apperror handler not found in messages.js"
     warning_idx = messages_js.find("source.addEventListener('warning'", apperror_idx)

--- a/tests/test_issue895_894_nous_prefix.py
+++ b/tests/test_issue895_894_nous_prefix.py
@@ -137,7 +137,7 @@ class TestSetDefaultModelPreservesAtPrefix:
         `@nous:anthropic/claude-opus-4.6`). `_applyModelToDropdown()` normalises
         on both sides and picks the matching option.
         """
-        js = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text()
+        js = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
         # Find the block that sets _settingsHermesDefaultModelOnOpen
         anchor = "_settingsHermesDefaultModelOnOpen=(models&&models.default_model)||"
         idx = js.find(anchor)

--- a/tests/test_issue_1932_goal_hook_unrelated_turns.py
+++ b/tests/test_issue_1932_goal_hook_unrelated_turns.py
@@ -39,7 +39,7 @@ def test_streaming_source_code_gates_on_stream_goal_related():
     """The streaming code must check STREAM_GOAL_RELATED[stream_id] before
     calling evaluate_goal_after_turn, so unrelated turns skip the hook."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text(encoding="utf-8")
 
     # Must import STREAM_GOAL_RELATED
     assert "STREAM_GOAL_RELATED" in streaming_py, (
@@ -63,7 +63,7 @@ def test_streaming_sets_pending_goal_continuation_on_goal_continue():
     """When goal_continue is emitted, streaming.py must set
     PENDING_GOAL_CONTINUATION so the next /chat/start marks the stream."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text(encoding="utf-8")
 
     assert "PENDING_GOAL_CONTINUATION" in streaming_py, (
         "streaming.py must reference PENDING_GOAL_CONTINUATION"
@@ -83,7 +83,7 @@ def test_routes_reads_pending_goal_continuation():
     """The chat/start handler must check PENDING_GOAL_CONTINUATION and mark
     the new stream as goal-related."""
     from pathlib import Path
-    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
+    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text(encoding="utf-8")
 
     assert "PENDING_GOAL_CONTINUATION" in routes_py, (
         "routes.py must reference PENDING_GOAL_CONTINUATION"
@@ -100,7 +100,7 @@ def test_routes_reads_pending_goal_continuation():
 def test_routes_marks_goal_kickoff_as_goal_related():
     """The /api/goal handler must mark the kickoff stream as goal-related."""
     from pathlib import Path
-    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
+    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text(encoding="utf-8")
 
     # After kickoff stream is started, it must mark the stream
     kickoff_idx = routes_py.find("kickoff_prompt")
@@ -115,7 +115,7 @@ def test_routes_marks_goal_kickoff_as_goal_related():
 def test_start_chat_stream_accepts_goal_related():
     """_start_chat_stream_for_session must accept goal_related kwarg."""
     from pathlib import Path
-    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
+    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text(encoding="utf-8")
 
     assert "goal_related" in routes_py, (
         "routes.py must reference goal_related parameter"
@@ -130,7 +130,7 @@ def test_run_agent_streaming_uses_goal_related():
     """_run_agent_streaming must accept goal_related kwarg and use it to
     gate the goal evaluation hook."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text(encoding="utf-8")
 
     # Function must accept goal_related parameter
     func_def_idx = streaming_py.find("def _run_agent_streaming")
@@ -150,7 +150,7 @@ def test_run_agent_streaming_uses_goal_related():
 def test_stream_goal_related_cleaned_up():
     """STREAM_GOAL_RELATED entries must be cleaned up when streams end."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text(encoding="utf-8")
 
     # Must have cleanup of STREAM_GOAL_RELATED
     assert "STREAM_GOAL_RELATED" in streaming_py

--- a/tests/test_issue_code_syntax_highlight.py
+++ b/tests/test_issue_code_syntax_highlight.py
@@ -5,7 +5,7 @@ UI_JS = Path(__file__).resolve().parent.parent / "static" / "ui.js"
 
 
 def _read_ui_js() -> str:
-    return UI_JS.read_text()
+    return UI_JS.read_text(encoding="utf-8")
 
 
 def test_fenced_code_blocks_add_prism_language_class():

--- a/tests/test_issues_907_908_909_model_dropdown.py
+++ b/tests/test_issues_907_908_909_model_dropdown.py
@@ -136,7 +136,7 @@ class TestIssue909InjectedModelLabel:
 
     def test_config_uses_label_helper_not_raw_split(self):
         from pathlib import Path
-        config_src = (Path(__file__).resolve().parent.parent / "api" / "config.py").read_text()
+        config_src = (Path(__file__).resolve().parent.parent / "api" / "config.py").read_text(encoding="utf-8")
         # The raw label-building pattern should be replaced by the helper
         assert "_get_label_for_model" in config_src, (
             "api/config.py must call _get_label_for_model() for injected default model labels (#909)"

--- a/tests/test_model_picker_escaping.py
+++ b/tests/test_model_picker_escaping.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_model_picker_escapes_provider_supplied_model_labels():
-    src = (ROOT / "static" / "ui.js").read_text()
+    src = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
     assert '<span class="model-opt-id">${esc(m.id)}</span>' in src
     assert '<span class="model-opt-name">${esc(m.name)}</span>' in src
@@ -14,7 +14,7 @@ def test_model_picker_escapes_provider_supplied_model_labels():
 
 
 def test_providers_panel_escapes_load_error_text():
-    src = (ROOT / "static" / "panels.js").read_text()
+    src = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
     assert "Failed to load providers: '+esc(e.message||String(e))+'" in src
     assert "Failed to load providers: '+e.message+'" not in src

--- a/tests/test_model_selection_refresh_persistence.py
+++ b/tests/test_model_selection_refresh_persistence.py
@@ -9,9 +9,9 @@ next ``loadSession()`` before ``syncTopbar()`` projects server metadata.
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-BOOT_JS = (ROOT / "static" / "boot.js").read_text()
-SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text()
-UI_JS = (ROOT / "static" / "ui.js").read_text()
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def _body_between(src: str, start: str, end: str) -> str:

--- a/tests/test_native_image_attachments.py
+++ b/tests/test_native_image_attachments.py
@@ -356,7 +356,7 @@ class TestBuildNativeMultimodalMessage:
 
     def test_sync_chat_history_sanitizer_receives_config(self):
         """#2398: fallback POST /api/chat must use the text-mode history sanitizer too."""
-        src = Path('api/routes.py').read_text()
+        src = Path('api/routes.py').read_text(encoding="utf-8")
         call = 'conversation_history=_sanitize_messages_for_api(_previous_context_messages, cfg=get_config())'
         assert call in src, (
             'The legacy synchronous /api/chat endpoint must pass current config into '

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -111,7 +111,7 @@ class TestGitInfoParallel:
 
     def test_uses_thread_pool(self):
         source = pathlib.Path(__file__).parent.parent / "api" / "workspace.py"
-        src = source.read_text()
+        src = source.read_text(encoding="utf-8")
         fn = src[src.find("def git_info_for_workspace") :]
         fn = fn[: fn.find("\ndef ")]
 

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -10,7 +10,7 @@ import pytest
 
 
 def _read_js(name):
-    with open(os.path.join('static', name)) as f:
+    with open(os.path.join('static', name), encoding='utf-8') as f:
         return f.read()
 
 
@@ -288,7 +288,7 @@ class TestI18nKeys:
     HTML_KEYS = ['html_loading', 'html_too_large', 'html_error', 'html_open_full', 'html_sandbox_label']
 
     def _find_locale_block(self, locale):
-        with open('static/i18n.js') as f:
+        with open('static/i18n.js', encoding='utf-8') as f:
             content = f.read()
         start = content.find(f"'{locale}':")
         if start < 0:

--- a/tests/test_pr2520_extract_attachment_dir.py
+++ b/tests/test_pr2520_extract_attachment_dir.py
@@ -43,8 +43,8 @@ class TestExtractArchiveAttachmentDir:
         dest = Path(result["dest"])
         assert dest.is_relative_to(session_dir)
         assert dest.name == "demo"
-        assert (dest / "hello.txt").read_text() == "Hello, world!"
-        assert (dest / "sub" / "nested.txt").read_text() == "Nested file"
+        assert (dest / "hello.txt").read_text(encoding="utf-8") == "Hello, world!"
+        assert (dest / "sub" / "nested.txt").read_text(encoding="utf-8") == "Nested file"
 
     def test_session_cleanup_covers_extracted_archives(self, tmp_path, monkeypatch):
         inbox = tmp_path / "att-inbox"

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -242,7 +242,7 @@ class TestSetProviderKey:
             # Verify .env file was written
             env_path = tmp_path / ".env"
             assert env_path.exists(), f".env not written to {env_path}; HERMES_HOME={__import__('os').environ.get('HERMES_HOME')!r}"
-            content = env_path.read_text()
+            content = env_path.read_text(encoding="utf-8")
             assert "ANTHROPIC_API_KEY=sk-ant-test-key-12345678" in content
         finally:
             config.cfg.clear()
@@ -274,7 +274,7 @@ class TestSetProviderKey:
 
             # Verify .env file no longer has the key
             env_path = tmp_path / ".env"
-            content = env_path.read_text() if env_path.exists() else ""
+            content = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
             assert "ANTHROPIC_API_KEY" not in content
         finally:
             config.cfg.clear()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -119,7 +119,7 @@ def test_session_with_tool_calls_in_json_loads_ok(cleanup_test_sessions):
     sessions_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"))) / "sessions"
     session_file = sessions_dir / f"{sid}.json"
     if session_file.exists():
-        d = json.loads(session_file.read_text())
+        d = json.loads(session_file.read_text(encoding="utf-8"))
         d["tool_calls"] = [
             {"name": "terminal", "snippet": "test output", "tid": "test_tid_001", "assistant_msg_idx": 1}
         ]
@@ -140,7 +140,7 @@ def test_streaming_py_imports_has_pending(cleanup_test_sessions):
     """R4: api/streaming.py must import or define has_pending.
     When missing, the approval check mid-stream caused NameError.
     """
-    src = (REPO_ROOT / "api/streaming.py").read_text()
+    src = (REPO_ROOT / "api/streaming.py").read_text(encoding="utf-8")
     assert "has_pending" in src, "has_pending not found in api/streaming.py"
     # Verify it's imported (not just used)
     assert "import" in src and "has_pending" in src, \
@@ -151,7 +151,7 @@ def test_aiagent_imported_in_streaming(cleanup_test_sessions):
     """R2b: api/streaming.py must import AIAgent.
     When missing, the streaming thread crashed immediately after being spawned.
     """
-    src = (REPO_ROOT / "api/streaming.py").read_text()
+    src = (REPO_ROOT / "api/streaming.py").read_text(encoding="utf-8")
     assert "AIAgent" in src, "AIAgent not referenced in api/streaming.py"
     assert "from run_agent import AIAgent" in src or "import AIAgent" in src, \
         "AIAgent must be imported in api/streaming.py"
@@ -174,8 +174,8 @@ def test_server_py_sse_loop_breaks_on_cancel(cleanup_test_sessions):
     """
     import re
     # Check server.py first, then api/routes.py (Sprint 11 extracted routes)
-    src = (REPO_ROOT / "server.py").read_text()
-    routes_src = (REPO_ROOT / "api" / "routes.py").read_text() if (REPO_ROOT / "api" / "routes.py").exists() else ""
+    src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+    routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8") if (REPO_ROOT / "api" / "routes.py").exists() else ""
     combined = src + routes_src
     m = re.search(r"if event in \([^)]+\):\s*break", combined)
     assert m, "SSE break condition not found in server.py or api/routes.py"
@@ -193,7 +193,7 @@ def test_real_jobs_json_not_polluted_by_tests(cleanup_test_sessions):
     if not real_jobs_path.exists():
         return  # no jobs file at all -- fine
 
-    jobs = json.loads(real_jobs_path.read_text())
+    jobs = json.loads(real_jobs_path.read_text(encoding="utf-8"))
     if isinstance(jobs, dict):
         jobs = jobs.get("jobs", [])
 
@@ -212,7 +212,7 @@ def test_all_api_modules_importable(cleanup_test_sessions):
     import ast, pathlib
     api_dir = REPO_ROOT / "api"
     for module_file in api_dir.glob("*.py"):
-        src = module_file.read_text()
+        src = module_file.read_text(encoding="utf-8")
         try:
             ast.parse(src)
         except SyntaxError as e:
@@ -222,7 +222,7 @@ def test_all_api_modules_importable(cleanup_test_sessions):
 def test_server_py_importable(cleanup_test_sessions):
     """server.py must parse without syntax errors after any split."""
     import ast, pathlib
-    src = (REPO_ROOT / "server.py").read_text()
+    src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
     try:
         ast.parse(src)
     except SyntaxError as e:
@@ -235,7 +235,7 @@ def test_loadSession_resets_busy_state_for_idle_session(cleanup_test_sessions):
     When missing, switching from a busy session to an idle one left the Send button
     disabled, showed the wrong activity bar, and pointed Cancel at the wrong stream.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     # The fix adds explicit S.busy=false in the non-inflight else branch
     assert "S.busy=false;" in src,         "sessions.js loadSession must set S.busy=false when loading a non-inflight session"
     # btnSend state must be refreshed via updateSendBtn
@@ -248,7 +248,7 @@ def test_done_handler_guards_setbusy_with_inflight_check(cleanup_test_sessions):
     When missing, finishing session A while viewing in-flight session B would
     disable B's Send button.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # The fix wraps setBusy(false) in an active-pane ownership guard. Newer
     # implementations may centralize the guard in a helper rather than repeat the
     # raw INFLIGHT expression at every terminal event site.
@@ -264,9 +264,9 @@ def test_refresh_handler_does_not_drop_tool_messages_needed_by_todos(cleanup_tes
     destroy the raw session messages because loadTodos reconstructs state from the
     latest todo tool output.
     """
-    sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
-    ui_src = (REPO_ROOT / "static/ui.js").read_text()
-    panels_src = (REPO_ROOT / "static/panels.js").read_text()
+    sessions_src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
+    ui_src = (REPO_ROOT / "static/ui.js").read_text(encoding="utf-8")
+    panels_src = (REPO_ROOT / "static/panels.js").read_text(encoding="utf-8")
 
     assert "data.session.messages=(data.session.messages||[]).filter(" not in sessions_src, \
         "sessions.js must not overwrite raw session.messages when filtering transcript display"
@@ -280,7 +280,7 @@ def test_cancel_button_not_cleared_across_sessions(cleanup_test_sessions):
     """R7c: The Cancel button and activeStreamId must only be cleared when the
     done/error event belongs to the currently viewed session.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # Both clear operations must be inside the activeSid === S.session guard
     # We check for the pattern added by the fix
     assert "S.session.session_id===activeSid" in src,         "messages.js must guard activeStreamId/Cancel clearing with session identity check"
@@ -314,8 +314,8 @@ def test_deleted_session_does_not_appear_in_list(cleanup_test_sessions):
 
 def test_server_delete_prunes_session_index(cleanup_test_sessions):
     """session/delete should prune the deleted row without discarding the index."""
-    src = (REPO_ROOT / "server.py").read_text()
-    routes_src = (REPO_ROOT / "api" / "routes.py").read_text() if (REPO_ROOT / "api" / "routes.py").exists() else ""
+    src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+    routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8") if (REPO_ROOT / "api" / "routes.py").exists() else ""
     # Find the delete handler in either file
     for label, text in [("server.py", src), ("api/routes.py", routes_src)]:
         # Accept both single-quote and double-quote style (formatting varies by contributor)
@@ -333,7 +333,7 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
 
 def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
     """session/delete must remove sidecar backups so deleted sessions stay deleted."""
-    routes_src = (REPO_ROOT / "api" / "routes.py").read_text()
+    routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
     delete_idx = max(
         routes_src.find("if parsed.path == '/api/session/delete':"),
         routes_src.find('if parsed.path == "/api/session/delete":'),
@@ -351,7 +351,7 @@ def test_token_handler_guards_session_id(cleanup_test_sessions):
     if the user switched sessions mid-stream.
     Sprint 12: handler moved into _wireSSE(source), so search source.addEventListener.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # Sprint 12 refactored es.addEventListener -> source.addEventListener inside _wireSSE()
     token_idx = src.find("source.addEventListener('token'")
     if token_idx < 0:
@@ -370,7 +370,7 @@ def test_tool_handler_guards_session_id(cleanup_test_sessions):
     When missing, tool cards from session A would render into session B's message area.
     Sprint 12: handler moved into _wireSSE(source), so search source.addEventListener.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     tool_idx = src.find("source.addEventListener('tool'")
     if tool_idx < 0:
         tool_idx = src.find("es.addEventListener('tool'")
@@ -387,7 +387,7 @@ def test_respond_approval_uses_approval_session_id(cleanup_test_sessions):
     the approval, not S.session.session_id (which may be a different session
     if the user switched while approval was pending).
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # The fix introduces _approvalSessionId to track the correct session
     assert "_approvalSessionId" in src,         "messages.js must use _approvalSessionId in respondApproval"
     # respondApproval must use _approvalSessionId, not S.session.session_id directly
@@ -404,7 +404,7 @@ def test_tool_status_only_shown_for_current_session(cleanup_test_sessions):
     status. Live tool cards in the current conversation are the authoritative
     progress UI, which avoids cross-session status leakage entirely.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # Sprint 12: handler moved into _wireSSE(source)
     tool_idx = src.find("source.addEventListener('tool'")
     if tool_idx < 0:
@@ -424,7 +424,7 @@ def test_loadSession_inflight_restores_live_tool_cards(cleanup_test_sessions):
     When missing, tool cards disappeared on switch-away even though the session
     was still processing.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     # INFLIGHT branch must call appendLiveToolCard
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
@@ -440,7 +440,7 @@ def test_done_handler_sets_busy_false_before_renderMessages(cleanup_test_session
     whether settled tool cards are rendered. When S.busy=true during renderMessages(),
     tool cards are skipped entirely after a response completes.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # Sprint 12: handler moved into _wireSSE(source)
     done_idx = src.find("source.addEventListener('done'")
     if done_idx < 0:
@@ -465,7 +465,7 @@ def test_send_uses_session_model_as_authoritative_source(cleanup_test_sessions):
     current dropdown list, the select value would be stale after switching sessions,
     causing the wrong model to be sent.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # The model field in the chat/start payload must prefer S.session.model.
     # PR #1591 (May 2026) added optimistic `upsertActiveSessionForLocalTurn`
     # comments that mention `/api/chat/start` BEFORE the actual POST call, so
@@ -485,7 +485,7 @@ def test_newSession_clears_live_tool_cards(cleanup_test_sessions):
     """R15: newSession() must call clearLiveToolCards() so live cards from a
     previous in-flight session don't persist when starting a fresh conversation.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     new_sess_idx = src.find("async function newSession(")
     assert new_sess_idx >= 0
     # Find end of newSession (next async function)
@@ -499,7 +499,7 @@ def test_newSession_resets_busy_state_for_fresh_chat(cleanup_test_sessions):
     Without this, starting a second chat while another session is streaming leaves
     S.busy=true, so the first send in the new chat gets incorrectly queued.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     new_sess_idx = src.find("async function newSession(")
     assert new_sess_idx >= 0
     next_fn = src.find("async function ", new_sess_idx + 10)
@@ -517,9 +517,9 @@ def test_session_scoped_message_queue_frontend_wiring(cleanup_test_sessions):
     The frontend should use a session-keyed queue store and drain only the active
     session's queued messages when that session becomes idle.
     """
-    ui_src = (REPO_ROOT / "static/ui.js").read_text()
-    messages_src = (REPO_ROOT / "static/messages.js").read_text()
-    sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
+    ui_src = (REPO_ROOT / "static/ui.js").read_text(encoding="utf-8")
+    messages_src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
+    sessions_src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     assert "const SESSION_QUEUES" in ui_src
     assert "function queueSessionMessage" in ui_src
     assert "function shiftQueuedSessionMessage" in ui_src
@@ -535,7 +535,7 @@ def test_chat_start_persists_pending_turn_metadata_for_reload_recovery(cleanup_t
     """R15c: chat/start must expose enough pending-turn metadata for a reload to
     rebuild the in-flight conversation instead of showing a blank session.
     """
-    routes_src = (REPO_ROOT / "api/routes.py").read_text()
+    routes_src = (REPO_ROOT / "api/routes.py").read_text(encoding="utf-8")
     assert 's.active_stream_id = stream_id' in routes_src
     assert 's.pending_user_message = msg' in routes_src
     assert 's.pending_attachments = attachments' in routes_src
@@ -547,9 +547,9 @@ def test_reload_path_restores_pending_message_and_reattaches_live_stream(cleanup
     """R15d: the frontend reload path must show the pending user turn and
     reattach to the live SSE stream after loadSession().
     """
-    sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
-    ui_src = (REPO_ROOT / "static/ui.js").read_text()
-    messages_src = (REPO_ROOT / "static/messages.js").read_text()
+    sessions_src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
+    ui_src = (REPO_ROOT / "static/ui.js").read_text(encoding="utf-8")
+    messages_src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     assert 'getPendingSessionMessage' in ui_src
     assert 'pending_user_message' in ui_src
     assert 'function attachLiveStream' in messages_src
@@ -568,8 +568,8 @@ def test_live_stream_tokens_persist_partial_assistant_for_session_switch(cleanup
     and the live stream must rebind to the rebuilt DOM after switching away and back.
     Without this, partial assistant output disappears until the final done payload lands.
     """
-    messages_src = (REPO_ROOT / "static/messages.js").read_text()
-    ui_src = (REPO_ROOT / "static/ui.js").read_text()
+    messages_src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
+    ui_src = (REPO_ROOT / "static/ui.js").read_text(encoding="utf-8")
 
     assert "content:assistantText" in messages_src, \
         "messages.js must persist the partial assistant text into INFLIGHT state"
@@ -592,7 +592,7 @@ def test_live_stream_tokens_persist_partial_assistant_for_session_switch(cleanup
         "renderMessages must preserve a live-assistant DOM anchor when rebuilding the thread"
     assert "snapshotLiveTurnHtmlForSession(activeSid)" in messages_src, \
         "live turn DOM snapshots should preserve the interleaved timeline across session switches"
-    assert "restoreLiveTurnHtmlForSession(sid)" in (REPO_ROOT / "static/sessions.js").read_text(), \
+    assert "restoreLiveTurnHtmlForSession(sid)" in (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8"), \
         "loadSession should restore the live turn snapshot before replaying flat tool cards"
 
 
@@ -600,8 +600,8 @@ def test_inflight_session_state_tracks_live_tool_cards_per_session(cleanup_test_
     """R16b: live tool cards must be stored on the in-flight session, not only in the
     global S.toolCalls array, so switching chats does not lose or misattach them.
     """
-    messages_src = (REPO_ROOT / "static/messages.js").read_text()
-    sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
+    messages_src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
+    sessions_src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
 
     assert "INFLIGHT[activeSid].toolCalls.push(tc);" in messages_src, \
         "tool SSE handler must persist live tool calls onto the in-flight session"
@@ -615,7 +615,7 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     same tool call appears once inline and once in the live tool host after a
     session switch.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+1600]
@@ -628,7 +628,7 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
 
 
 def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test_sessions):
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+1200]
@@ -653,7 +653,7 @@ def test_browser_session_url_accepts_api_session_id_param(cleanup_test_sessions)
     legitimately produce `/?session_id=<sid>`; ignoring it falls back to stale
     localStorage and renders the wrong or empty conversation.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     start = src.find("function _sessionIdFromLocation")
     assert start >= 0, "session URL parser not found"
     end = src.find("function _sessionUrlForSid", start)
@@ -668,7 +668,7 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     final pending text with an `[Attached files: ...]` suffix.  The INFLIGHT
     merge must treat those as the same user turn instead of rendering both.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     assert "function _stripAttachedFilesMarker" in src, (
         "sessions.js must normalize the server-side attached-files suffix before deduping user turns"
     )
@@ -694,7 +694,7 @@ def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_card
     and replays them before assigning S.activeStreamId, the compact Activity
     counter drops the previously-seen tools after a focus change.
     """
-    src = (REPO_ROOT / "static/sessions.js").read_text()
+    src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+1600]
@@ -714,7 +714,7 @@ def test_streaming_bridge_accepts_current_tool_progress_callback_signature(clean
     The agent now calls tool_progress_callback(event_type, name, preview, args, **kwargs).
     If the WebUI bridge only accepts (name, preview, args), live tool updates silently vanish.
     """
-    src = (REPO_ROOT / "api/streaming.py").read_text()
+    src = (REPO_ROOT / "api/streaming.py").read_text(encoding="utf-8")
     assert "def on_tool(*cb_args, **cb_kwargs):" in src, \
         "streaming.py must accept variable callback args for tool progress events"
     assert "reasoning_callback=on_reasoning" in src, \
@@ -732,7 +732,7 @@ def test_streaming_reads_reasoning_effort_from_config_dict(cleanup_test_sessions
     regardless of what `/reasoning <level>` had been set to.  This static
     source assertion pins the fix because the runtime symptom is silent.
     """
-    src = (REPO_ROOT / "api/streaming.py").read_text()
+    src = (REPO_ROOT / "api/streaming.py").read_text(encoding="utf-8")
     assert "_cfg.cfg" not in src, \
         "get_config() returns a dict; accessing _cfg.cfg drops reasoning_config to None"
     assert "_cfg.get('agent', {})" in src or '_cfg.get("agent", {})' in src, \
@@ -746,7 +746,7 @@ def test_streaming_agent_cache_signature_includes_reasoning_config(cleanup_test_
     matches the old entry and the operator's `/reasoning xhigh` change has
     no effect on the live session.
     """
-    src = (REPO_ROOT / "api/streaming.py").read_text()
+    src = (REPO_ROOT / "api/streaming.py").read_text(encoding="utf-8")
     start = src.find("_sig_blob = _json.dumps")
     end = src.find("_agent_sig", start)
     assert start >= 0 and end > start, "agent cache signature block not found"
@@ -760,7 +760,7 @@ def test_messages_js_supports_live_reasoning_and_tool_completion(cleanup_test_se
     Without these handlers, the operator only sees generic Thinking… or nothing
     until the final done snapshot redraws the whole turn.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     # reasoningText is initialised at closure scope in attachLiveStream.
     # On initial connect it defaults to ''; on reconnect it restores from
     # INFLIGHT so the already-rendered content survives the session switch.
@@ -785,7 +785,7 @@ def test_messages_js_supports_interim_assistant_events(cleanup_test_sessions):
     Without a dedicated SSE handler, Codex-style interim status text disappears
     from the live answer and users only see the final response after tool calls.
     """
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     assert "source.addEventListener('interim_assistant'" in src or 'source.addEventListener("interim_assistant"' in src, \
         "messages.js must listen for interim_assistant SSE events"
     assert "function _resetAssistantSegment()" in src, \
@@ -798,7 +798,7 @@ def test_ui_js_can_upgrade_thinking_spinner_into_live_reasoning_card(cleanup_tes
     """R19: ui.js must be able to replace the placeholder thinking spinner with
     streamed reasoning text while a turn is in progress.
     """
-    src = (REPO_ROOT / "static/ui.js").read_text()
+    src = (REPO_ROOT / "static/ui.js").read_text(encoding="utf-8")
     assert "function _thinkingMarkup(text='')" in src or 'function _thinkingMarkup(text="")' in src, \
         "ui.js must centralize thinking row markup so it can switch between spinner and live text"
     assert "function updateThinking(text=''){appendThinking(text);}" in src or 'function updateThinking(text=""){appendThinking(text);}' in src, \
@@ -812,7 +812,7 @@ def test_ui_js_keeps_split_thinking_cards_and_assistant_header(cleanup_test_sess
     turns inside a single assistant turn container, preserving one assistant header
     for the whole response while keeping multiple thinking cards distinct.
     """
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     assert "pendingTurnThinking" not in src, \
         "renderMessages must not merge distinct thinking blocks into one settled card"
     assert "_createAssistantTurn(" in src, \
@@ -825,7 +825,7 @@ def test_ui_js_keeps_reasoning_only_assistant_messages_visible(cleanup_test_sess
     """R19c: assistant messages that only contain reasoning must still survive
     rerenders, otherwise prior thinking cards disappear on the next turn.
     """
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     assert "function _messageHasReasoningPayload(m)" in src, \
         "ui.js must detect reasoning-only assistant messages"
     assert "hasTc||hasTu||_messageHasReasoningPayload(m)" in src.replace(' ', ''), \
@@ -836,7 +836,7 @@ def test_ui_js_does_not_hide_anchor_segments_that_contain_thinking(cleanup_test_
     """R19c2/R19c3: reasoning-only messages must remain visible through the
     shared compact timeline activity UI, even when the anchor segment has no prose.
     """
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     compact = src.replace(' ', '').replace('\n', '')
     assert "assistantThinking.set(rawIdx,thinkingText)" in compact, \
         "renderMessages must preserve reasoning text before hiding empty anchor segments"
@@ -848,7 +848,7 @@ def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(cleanup_tes
     """R19d: live streaming must reuse the existing live assistant turn wrapper created
     by appendThinking(), otherwise the header gets recreated when answer tokens start.
     """
-    src = (REPO_ROOT / "static" / "messages.js").read_text()
+    src = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
     assert "function ensureAssistantRow(force=false)" in src or 'function ensureAssistantRow(force = false)' in src, \
         "ensureAssistantRow should manage the live assistant content segment"
     assert "let turn=$('liveAssistantTurn');" in src, \
@@ -865,7 +865,7 @@ def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(cleanup_tes
 
 def test_messages_js_finalizes_thinking_card_before_tool_card(cleanup_test_sessions):
     """R19e: later reasoning after a tool call must render in a fresh card."""
-    src = (REPO_ROOT / "static/messages.js").read_text()
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
     assert "finalizeThinkingCard" in src, \
         "tool handler must finalize the current live thinking card before appending a tool card"
     assert "liveReasoningText='';" in src or 'liveReasoningText = "";' in src, \
@@ -918,7 +918,7 @@ def test_skills_slash_command_defined():
     must still exist and be registered, otherwise ``/skills`` would fall
     through to \"not yet supported\".
     """
-    src = (REPO_ROOT / "static/commands.js").read_text()
+    src = (REPO_ROOT / "static/commands.js").read_text(encoding="utf-8")
 
     # 1. cmdSkills function must be defined
     assert "async function cmdSkills" in src or "function cmdSkills" in src, \
@@ -934,9 +934,9 @@ def test_reload_recovery_persists_durable_inflight_state(cleanup_test_sessions):
     Without these helpers, loadSession() references loadInflightState() but a full
     browser reload has no saved state to hydrate, so recovery silently no-ops.
     """
-    ui_src = (REPO_ROOT / "static/ui.js").read_text()
-    messages_src = (REPO_ROOT / "static/messages.js").read_text()
-    sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
+    ui_src = (REPO_ROOT / "static/ui.js").read_text(encoding="utf-8")
+    messages_src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
+    sessions_src = (REPO_ROOT / "static/sessions.js").read_text(encoding="utf-8")
 
     assert "const INFLIGHT_STATE_KEY = 'hermes-webui-inflight-state'" in ui_src
     assert "function saveInflightState(sid, state)" in ui_src

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text()
+MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 
 
 def test_reattach_path_uses_replay_when_status_reports_journal():

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -4,7 +4,7 @@ import io
 
 
 ROOT = Path(__file__).resolve().parents[1]
-ROUTES_SRC = (ROOT / "api" / "routes.py").read_text()
+ROUTES_SRC = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 
 
 def test_stream_status_exposes_replay_summary():

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -169,7 +169,7 @@ def test_boot_does_not_drop_zero_message_inflight_session():
 
 def test_batch_select_i18n_keys():
     """Verify all batch select i18n keys exist in all locales."""
-    with open('static/i18n.js') as f:
+    with open('static/i18n.js', encoding='utf-8') as f:
         src = f.read()
     required_keys = [
         'session_select_mode',
@@ -202,7 +202,7 @@ def test_batch_select_i18n_keys():
 
 def test_i18n_string_placeholder_interpolation_supported():
     """String-valued translations with {0} placeholders should interpolate args."""
-    with open('static/i18n.js') as f:
+    with open('static/i18n.js', encoding='utf-8') as f:
         src = f.read()
     assert "String(val).replace(/\\{(\\d+)\\}/g" in src, \
         "t() must interpolate {0}-style placeholders for string-valued translations"

--- a/tests/test_session_discoverability_repair.py
+++ b/tests/test_session_discoverability_repair.py
@@ -91,8 +91,8 @@ def test_repair_discoverability_dry_run_plans_without_mutating_files(tmp_path):
         "clear_index_cli_flag",
         "materialize_sidecar_from_state_db",
     }
-    assert json.loads((tmp_path / f"{stale}.json").read_text())["is_cli_session"] is True
-    assert json.loads((tmp_path / "_index.json").read_text())[0]["is_cli_session"] is True
+    assert json.loads((tmp_path / f"{stale}.json").read_text(encoding="utf-8"))["is_cli_session"] is True
+    assert json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))[0]["is_cli_session"] is True
     assert not (tmp_path / f"{missing}.json").exists()
     assert not (tmp_path / "backup").exists()
 
@@ -107,7 +107,7 @@ def test_repair_discoverability_apply_requires_backup_dir(tmp_path):
 
     assert result["ok"] is False
     assert result["error"] == "backup_dir_required_for_apply"
-    assert json.loads((tmp_path / f"{sid}.json").read_text())["is_cli_session"] is True
+    assert json.loads((tmp_path / f"{sid}.json").read_text(encoding="utf-8"))["is_cli_session"] is True
 
 
 def test_repair_discoverability_apply_backs_up_and_repairs_safe_findings(tmp_path):
@@ -133,11 +133,11 @@ def test_repair_discoverability_apply_backs_up_and_repairs_safe_findings(tmp_pat
         "clear_index_cli_flag",
         "materialize_sidecar_from_state_db",
     }
-    assert json.loads((tmp_path / f"{stale}.json").read_text())["is_cli_session"] is False
-    assert json.loads((tmp_path / "_index.json").read_text())[0]["is_cli_session"] is False
-    index_rows = json.loads((tmp_path / "_index.json").read_text())
+    assert json.loads((tmp_path / f"{stale}.json").read_text(encoding="utf-8"))["is_cli_session"] is False
+    assert json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))[0]["is_cli_session"] is False
+    index_rows = json.loads((tmp_path / "_index.json").read_text(encoding="utf-8"))
     assert {row["session_id"] for row in index_rows} == {stale, missing}
-    recovered = json.loads((tmp_path / f"{missing}.json").read_text())
+    recovered = json.loads((tmp_path / f"{missing}.json").read_text(encoding="utf-8"))
     assert recovered["title"] == "Recovered From State"
     assert recovered["message_count"] == 2
     assert len(recovered["messages"]) == 2
@@ -172,4 +172,4 @@ def test_repair_discoverability_cli_defaults_to_dry_run(tmp_path):
     result = json.loads(completed.stdout)
     assert result["dry_run"] is True
     assert [action["action"] for action in result["planned"]] == ["clear_sidecar_cli_flag", "clear_index_cli_flag"]
-    assert json.loads((tmp_path / f"{sid}.json").read_text())["is_cli_session"] is True
+    assert json.loads((tmp_path / f"{sid}.json").read_text(encoding="utf-8"))["is_cli_session"] is True

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -244,7 +244,7 @@ def test_parse_multipart_text_file():
     )
     # We only need parse_multipart; import it without running the server
     # Parse manually by reading the source and exec only the function
-    src = pathlib.Path(__file__).parent.parent.joinpath("api/upload.py").read_text()
+    src = pathlib.Path(__file__).parent.parent.joinpath("api/upload.py").read_text(encoding="utf-8")
     # Extract and exec parse_multipart
     import re
     # Find the function
@@ -280,7 +280,7 @@ def test_parse_multipart_text_file():
 
 def test_parse_multipart_binary_file():
     """parse_multipart handles binary (PNG header bytes) without corruption."""
-    src = pathlib.Path(__file__).parent.parent.joinpath("api/upload.py").read_text()
+    src = pathlib.Path(__file__).parent.parent.joinpath("api/upload.py").read_text(encoding="utf-8")
     import re
     m = re.search(r"(def parse_multipart\(.*?)(?=\ndef )", src, re.DOTALL)
     ns = {}

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -48,11 +48,11 @@ def test_api_modules_exist(cleanup_test_sessions):
 
 def test_server_py_under_750_lines(cleanup_test_sessions):
     """server.py should be under 750 lines after the split."""
-    lines = len((REPO_ROOT / "server.py").read_text().splitlines())
+    lines = len((REPO_ROOT / "server.py").read_text(encoding="utf-8").splitlines())
     assert lines < 750, f"server.py is {lines} lines -- split may not have landed"
 
 def test_api_config_has_cancel_flags(cleanup_test_sessions):
-    src = (REPO_ROOT / "api/config.py").read_text()
+    src = (REPO_ROOT / "api/config.py").read_text(encoding="utf-8")
     assert "CANCEL_FLAGS" in src
     assert "STREAMS" in src
 

--- a/tests/test_sprint16.py
+++ b/tests/test_sprint16.py
@@ -138,7 +138,7 @@ def render_md(raw):
 def test_render_md_pre_pass_converts_strong(cleanup_test_sessions):
     """ui.js renderMd() must have pre-pass that converts <strong> to **."""
     src = REPO_ROOT / "static" / "ui.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "<strong>" in code and "**" in code, "pre-pass for <strong> not found"
     # Verify the specific conversion pattern
     assert re.search(r"<strong>.*?\*\*", code, re.S), \
@@ -148,7 +148,7 @@ def test_render_md_pre_pass_converts_strong(cleanup_test_sessions):
 def test_render_md_has_safety_net(cleanup_test_sessions):
     """ui.js must have a safety-net that escapes unknown HTML tags after the pipeline."""
     src = REPO_ROOT / "static" / "ui.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "SAFE_TAGS" in code, "SAFE_TAGS allowlist regex not found in ui.js"
     assert "esc(tag)" in code, "safety-net esc(tag) call not found in ui.js"
 
@@ -156,21 +156,21 @@ def test_render_md_has_safety_net(cleanup_test_sessions):
 def test_render_md_stashes_code_blocks(cleanup_test_sessions):
     """ui.js pre-pass must stash code blocks before replacing safe HTML tags."""
     src = REPO_ROOT / "static" / "ui.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "fence_stash" in code, "fence_stash not found in renderMd pre-pass"
 
 
 def test_render_md_handles_br_tag(cleanup_test_sessions):
     """ui.js must convert <br> to newline in pre-pass."""
     src = REPO_ROOT / "static" / "ui.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert re.search(r"<br\\s\*", code) or "<br" in code, "<br> handling not found"
 
 
 def test_render_md_no_placeholder_remnants(cleanup_test_sessions):
     """Old Unicode placeholder approach (\\uE001-\\uE005) must be gone."""
     src = REPO_ROOT / "static" / "ui.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     for old_ph in ["\\uE001", "\\uE002", "\\uE003", "\\uE004", "\\uE005"]:
         assert old_ph not in code, \
             f"Old placeholder {old_ph} still present — broken implementation not cleaned up"
@@ -179,7 +179,7 @@ def test_render_md_no_placeholder_remnants(cleanup_test_sessions):
 def test_render_md_safe_tag_allowlist_complete(cleanup_test_sessions):
     """SAFE_TAGS allowlist must include all tags the pipeline emits."""
     src = REPO_ROOT / "static" / "ui.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     required = ["strong", "em", "code", "pre", "ul", "ol", "li",
                 "table", "blockquote", "hr", "br", "a", "div"]
     safe_tags_match = re.search(r"SAFE_TAGS\s*=\s*/(.+?)/i", code)
@@ -657,7 +657,7 @@ def test_multiple_paragraphs_separated(cleanup_test_sessions):
 
 def test_table_structure_in_ui_js(cleanup_test_sessions):
     """ui.js must contain table rendering logic with thead/tbody structure."""
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     assert "<table>" in src or "table>" in src, "table rendering not found in ui.js"
     assert "thead" in src, "thead not found in table renderer"
     assert "tbody" in src, "tbody not found in table renderer"
@@ -701,12 +701,12 @@ def test_strong_text_not_double_escaped(cleanup_test_sessions):
 
 def test_inline_md_helper_in_ui_js(cleanup_test_sessions):
     """ui.js must define inlineMd() helper function."""
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     assert "function inlineMd(" in src, "inlineMd() helper not found in ui.js"
 
 def test_inline_md_used_in_list_handler(cleanup_test_sessions):
     """List handler in ui.js must call inlineMd() not esc() for item text."""
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     # Find the list block handler
     ul_idx = src.find("html+='<ul>'") or src.find('html+=`<ul>`') or src.find("let html='<ul>'")
     assert ul_idx >= 0 or "inlineMd(text)" in src, "inlineMd not called in list handler"
@@ -715,14 +715,14 @@ def test_inline_md_used_in_list_handler(cleanup_test_sessions):
 
 def test_inline_md_used_in_blockquote_handler(cleanup_test_sessions):
     """Blockquote handler in ui.js must call inlineMd() not esc() for content."""
-    src = (REPO_ROOT / "static" / "ui.js").read_text()
+    src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     assert "inlineMd(t)" in src, "inlineMd not called in blockquote/heading handler"
 
 
 def test_sessions_js_has_svg_icons(cleanup_test_sessions):
     """sessions.js must define ICONS object with SVG strings for sidebar buttons."""
     src = REPO_ROOT / "static" / "sessions.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "const ICONS=" in code or "const ICONS =" in code, "ICONS constant not found"
     for icon in ["pin", "folder", "archive", "trash", "dup"]:
         assert icon + ":" in code or f"'{icon}'" in code, f"ICONS.{icon} not found"
@@ -732,7 +732,7 @@ def test_sessions_js_has_svg_icons(cleanup_test_sessions):
 def test_sessions_js_has_dropdown_actions(cleanup_test_sessions):
     """sessions.js must use a single trigger button and dropdown for session actions."""
     src = REPO_ROOT / "static" / "sessions.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "session-actions-trigger" in code, "session action trigger button not found in sessions.js"
     assert "session-action-menu" in code, "session action dropdown menu not found in sessions.js"
 
@@ -740,7 +740,7 @@ def test_sessions_js_has_dropdown_actions(cleanup_test_sessions):
 def test_style_css_has_session_actions_dropdown(cleanup_test_sessions):
     """style.css must define trigger and dropdown styles for session actions."""
     src = REPO_ROOT / "static" / "style.css"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert ".session-actions" in code, ".session-actions not found in style.css"
     assert ".session-action-menu" in code, ".session-action-menu not found in style.css"
     assert "position:fixed" in code or "position: fixed" in code, \
@@ -750,7 +750,7 @@ def test_style_css_has_session_actions_dropdown(cleanup_test_sessions):
 def test_style_css_active_session_uses_accent(cleanup_test_sessions):
     """Active session style should use accent color variable, not hardcoded hex."""
     src = REPO_ROOT / "static" / "style.css"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "var(--accent" in code and ".session-item.active" in code, \
         "Active session must use var(--accent) variables in style.css"
 
@@ -765,7 +765,7 @@ def test_sessions_js_uses_action_menu_not_per_row_buttons(cleanup_test_sessions)
     membership instead.
     """
     src = REPO_ROOT / "static" / "sessions.js"
-    code = src.read_text()
+    code = src.read_text(encoding="utf-8")
     assert "session-actions-trigger" in code, "session-actions-trigger not found in sessions.js"
     assert "_openSessionActionMenu" in code, "_openSessionActionMenu not found in sessions.js"
     assert "closeSessionActionMenu" in code, "closeSessionActionMenu not found in sessions.js"

--- a/tests/test_sprint29.py
+++ b/tests/test_sprint29.py
@@ -573,7 +573,7 @@ class TestContentDisposition:
         import ast
         import pathlib
         routes_src = pathlib.Path(__file__).parent.parent / "api" / "routes.py"
-        src = routes_src.read_text()
+        src = routes_src.read_text(encoding="utf-8")
         assert "text/html" in src
         assert "application/xhtml+xml" in src
         assert "image/svg+xml" in src
@@ -672,7 +672,7 @@ class TestPasswordHashing:
         # Remember original content so we can restore it
         original = None
         if SETTINGS_FILE.exists():
-            original = SETTINGS_FILE.read_text()
+            original = SETTINGS_FILE.read_text(encoding="utf-8")
 
         try:
             save_settings({"_set_password": "test_pbkdf2_pw"})
@@ -695,7 +695,7 @@ class TestStartupWarning:
     def test_warning_code_present_in_server(self):
         """server.py must contain non-loopback warning code."""
         src = pathlib.Path(__file__).parent.parent / "server.py"
-        text = src.read_text()
+        text = src.read_text(encoding="utf-8")
         assert "0.0.0.0" in text or "non-loopback" in text.lower() or "WARNING" in text, \
             "server.py must contain non-loopback warning logic"
         assert "is_auth_enabled" in text, \
@@ -709,7 +709,7 @@ class TestSSRFCheck:
     def test_ssrf_guard_code_present_in_config(self):
         """config.py must contain SSRF DNS resolution guard."""
         src = pathlib.Path(__file__).parent.parent / "api" / "config.py"
-        text = src.read_text()
+        text = src.read_text(encoding="utf-8")
         assert "getaddrinfo" in text, "SSRF guard must resolve DNS with getaddrinfo"
         assert "is_private" in text, "SSRF guard must check is_private IP"
         assert "is_loopback" in text, "SSRF guard must check is_loopback IP"
@@ -717,7 +717,7 @@ class TestSSRFCheck:
     def test_known_local_providers_whitelisted(self):
         """Ollama and localhost endpoints should NOT be blocked by SSRF guard."""
         src = pathlib.Path(__file__).parent.parent / "api" / "config.py"
-        text = src.read_text()
+        text = src.read_text(encoding="utf-8")
         assert "ollama" in text.lower()
         assert "localhost" in text.lower()
         assert "lmstudio" in text.lower() or "lm-studio" in text.lower()

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -424,7 +424,7 @@ class TestApprovalCardTimerLogic:
 
     def test_approval_min_visible_ms_constant_present(self):
         """APPROVAL_MIN_VISIBLE_MS constant exists and is 30000."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert 'APPROVAL_MIN_VISIBLE_MS' in src
         import re
         m = re.search(r'APPROVAL_MIN_VISIBLE_MS\s*=\s*(\d+)', src)
@@ -433,35 +433,35 @@ class TestApprovalCardTimerLogic:
 
     def test_hide_approval_card_has_force_parameter(self):
         """hideApprovalCard() accepts a force parameter."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert 'hideApprovalCard(force=false)' in src or \
                'hideApprovalCard(force = false)' in src, \
             'hideApprovalCard must have force=false default parameter'
 
     def test_hide_approval_card_checks_force_flag(self):
         """hideApprovalCard body has a conditional on force."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         # The guard: if (!force && _approvalVisibleSince)
         assert '!force' in src, 'hideApprovalCard must check !force before deferred hide'
 
     def test_approval_hide_timer_variable_present(self):
         """Module-level _approvalHideTimer variable is declared."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_approvalHideTimer' in src
 
     def test_approval_visible_since_variable_present(self):
         """Module-level _approvalVisibleSince variable is declared."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_approvalVisibleSince' in src
 
     def test_approval_signature_variable_present(self):
         """Module-level _approvalSignature variable is declared."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_approvalSignature' in src
 
     def test_respond_approval_calls_hide_with_force(self):
         """respondApproval must call hideApprovalCard(true) — not no-arg."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         # Extract respondApproval function body
         import re
         m = re.search(r'async function respondApproval.*?(?=\nasync function|\nfunction |\Z)',
@@ -478,7 +478,7 @@ class TestApprovalCardTimerLogic:
 
     def test_stream_done_calls_hide_with_force(self):
         """Done SSE event handler must call hideApprovalCard(true)."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         # Find the done event handler section (stopApprovalPolling followed by hideApprovalCard)
         import re
         # Look for pattern: stopApprovalPolling();\n + hideApprovalCard
@@ -493,7 +493,7 @@ class TestApprovalCardTimerLogic:
 
     def test_poll_loop_still_uses_no_force(self):
         """Poll loop approval hides (when pending gone) keep no-force behavior."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         # Poll/SSE empty-state hides should preserve the 30s visibility guard.
         # Owner-scoped prompt cleanup now routes this through the helper, whose
         # default force=false is behavior-equivalent to the old hideApprovalCard().
@@ -505,7 +505,7 @@ class TestApprovalCardTimerLogic:
 
     def test_show_approval_card_signature_dedup(self):
         """showApprovalCard uses a signature to avoid resetting timer on repeat polls."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         # The sig computation must use JSON.stringify on card content
         import re
         m = re.search(r'function showApprovalCard.*?(?=\nfunction |\nasync function |\Z)',
@@ -517,7 +517,7 @@ class TestApprovalCardTimerLogic:
 
     def test_clear_approval_hide_timer_helper_present(self):
         """_clearApprovalHideTimer helper exists to cancel deferred hides."""
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_clearApprovalHideTimer' in src, \
             '_clearApprovalHideTimer helper must exist to cancel deferred setTimeout'
 
@@ -534,7 +534,7 @@ class TestClarifyCardTimerLogic:
         return pathlib.Path(__file__).parent.parent / 'static' / 'style.css'
 
     def test_clarify_min_visible_ms_constant_present(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert 'CLARIFY_MIN_VISIBLE_MS' in src
         import re
         m = re.search(r'CLARIFY_MIN_VISIBLE_MS\s*=\s*(\d+)', src)
@@ -542,42 +542,42 @@ class TestClarifyCardTimerLogic:
         assert int(m.group(1)) == 30000, f'Expected 30000, got {m.group(1)}'
 
     def test_hide_clarify_card_has_force_parameter(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert 'hideClarifyCard(force=false)' in src or \
                'hideClarifyCard(force=false, reason=' in src or \
                'hideClarifyCard(force = false)' in src, \
             'hideClarifyCard must have force=false default parameter'
 
     def test_hide_clarify_card_checks_force_flag(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '!force' in src, 'hideClarifyCard must check !force before deferred hide'
 
     def test_clarify_hide_timer_variable_present(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_clarifyHideTimer' in src
 
     def test_clarify_visible_since_variable_present(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_clarifyVisibleSince' in src
 
     def test_clarify_signature_variable_present(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_clarifySignature' in src
 
     def test_clarify_countdown_element_present(self):
-        html = self._get_html().read_text()
+        html = self._get_html().read_text(encoding="utf-8")
         assert 'id="clarifyCountdown"' in html, \
             'clarify card must include a countdown element so users see timeout risk'
 
     def test_clarify_countdown_uses_pending_expiry(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert '_clarifyCountdownTimer' in src
         assert 'function _startClarifyCountdown' in src
         assert 'expires_at' in src, \
             'clarify countdown must use expires_at from the pending payload'
 
     def test_clarify_countdown_does_not_restart_for_same_expiry(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         m = re.search(r'function _startClarifyCountdown.*?(?=\nfunction |\nasync function |\Z)',
                       src, re.DOTALL)
         assert m, '_startClarifyCountdown function not found'
@@ -591,14 +591,14 @@ class TestClarifyCardTimerLogic:
             'same-expiry guard must run before clearing the current interval'
 
     def test_hide_clarify_card_can_preserve_draft(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert 'function _stashClarifyDraft' in src
         assert 'sessionStorage.setItem' in src
         assert "$('msg')" in src, \
             'clarify timeout should keep the typed draft visible in the composer'
 
     def test_clarify_draft_appends_to_existing_composer_text(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         m = re.search(r'function _stashClarifyDraft.*?(?=\nfunction |\nasync function |\Z)',
                       src, re.DOTALL)
         assert m, '_stashClarifyDraft function not found'
@@ -609,7 +609,7 @@ class TestClarifyCardTimerLogic:
             'preserved clarify drafts should be separated from existing composer text'
 
     def test_cancel_stream_does_not_preserve_clarify_draft(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         m = re.search(r"source\.addEventListener\('cancel'.*?\n    \}\);",
                       src, re.DOTALL)
         assert m, 'cancel event handler not found'
@@ -620,7 +620,7 @@ class TestClarifyCardTimerLogic:
         ), 'explicit stream cancel must not use the timeout/terminal draft preservation path'
 
     def test_clarify_urgent_countdown_has_non_color_cue(self):
-        css = self._get_css().read_text()
+        css = self._get_css().read_text(encoding="utf-8")
         m = re.search(r'\.clarify-countdown\.urgent\{([^}]*)\}', css)
         assert m, 'urgent clarify countdown style missing'
         body = m.group(1)
@@ -628,7 +628,7 @@ class TestClarifyCardTimerLogic:
             'urgent countdown styling must include a non-color visual cue'
 
     def test_respond_clarify_sends_clarify_id_and_waits_for_ack(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         import re
         m = re.search(r'async function respondClarify.*?(?=\nasync function|\nfunction |\Z)',
                       src, re.DOTALL)
@@ -649,14 +649,14 @@ class TestClarifyCardTimerLogic:
             'respondClarify must wait for the API response before calling hideClarifyCard (issue #2639)'
 
     def test_clarify_poll_loop_uses_no_force(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         assert "_hideClarifyCardIfOwner(sid, false, 'expired');" in src or \
                "else { hideClarifyCard(false, 'expired'); }" in src or \
                "else {hideClarifyCard(false,'expired');}" in src, \
             'Clarify poll loop should hide without force=true'
 
     def test_show_clarify_card_signature_dedup(self):
-        src = self._get_js().read_text()
+        src = self._get_js().read_text(encoding="utf-8")
         import re
         m = re.search(r'function showClarifyCard.*?(?=\nfunction |\nasync function |\Z)',
                       src, re.DOTALL)

--- a/tests/test_sprint31.py
+++ b/tests/test_sprint31.py
@@ -25,7 +25,7 @@ class TestWriteEndpointToConfig:
     def test_writes_base_url(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
         _write_endpoint_to_config(tmp_path, base_url="http://localhost:11434")
-        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert cfg["model"]["base_url"] == "http://localhost:11434"
 
     def test_writes_api_key(self, tmp_path):
@@ -37,7 +37,7 @@ class TestWriteEndpointToConfig:
     def test_writes_both(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
         _write_endpoint_to_config(tmp_path, base_url="http://localhost:8080", api_key="mykey")
-        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert cfg["model"]["base_url"] == "http://localhost:8080"
         assert "api_key" not in cfg["model"]
 
@@ -47,7 +47,7 @@ class TestWriteEndpointToConfig:
         (tmp_path / "config.yaml").write_text(yaml.dump(existing))
         from api.profiles import _write_endpoint_to_config
         _write_endpoint_to_config(tmp_path, base_url="http://localhost:1234")
-        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         # Existing keys preserved
         assert cfg["model"]["default"] == "gpt-4o"
         assert cfg["model"]["provider"] == "openai"

--- a/tests/test_sprint37.py
+++ b/tests/test_sprint37.py
@@ -5,8 +5,8 @@ import pathlib
 import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-BOOT_JS   = (REPO_ROOT / "static" / "boot.js").read_text()
-HTML      = (REPO_ROOT / "static" / "index.html").read_text()
+BOOT_JS   = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+HTML      = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
 
 
 # ── Persistence: save on change ───────────────────────────────────────────────

--- a/tests/test_sprint38.py
+++ b/tests/test_sprint38.py
@@ -7,8 +7,8 @@ and the streaming render path (messages.js _streamDisplay logic).
 import pathlib
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-UI_JS     = (REPO_ROOT / "static" / "ui.js").read_text()
-MSG_JS    = (REPO_ROOT / "static" / "messages.js").read_text()
+UI_JS     = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+MSG_JS    = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 
 
 # ── ui.js: static render path ────────────────────────────────────────────────

--- a/tests/test_sprint4.py
+++ b/tests/test_sprint4.py
@@ -94,7 +94,7 @@ def test_file_create(cleanup_test_sessions):
     fname = f"test_{uuid.uuid4().hex[:6]}.txt"
     result, status = post("/api/file/create", {"session_id": sid, "path": fname, "content": "hello sprint4"})
     assert status == 200 and result["ok"] is True
-    assert (ws / fname).read_text() == "hello sprint4"
+    assert (ws / fname).read_text(encoding="utf-8") == "hello sprint4"
 
 def test_file_create_requires_fields(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)

--- a/tests/test_sprint40.py
+++ b/tests/test_sprint40.py
@@ -16,8 +16,8 @@ from unittest.mock import patch
 import api.onboarding as mod
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-I18N_JS = (REPO_ROOT / "static" / "i18n.js").read_text()
-ONBOARDING_JS = (REPO_ROOT / "static" / "onboarding.js").read_text()
+I18N_JS = (REPO_ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+ONBOARDING_JS = (REPO_ROOT / "static" / "onboarding.js").read_text(encoding="utf-8")
 
 
 # ── Backend: _build_setup_catalog ──────────────────────────────────────────
@@ -152,7 +152,7 @@ class TestOAuthOnboardingJs(unittest.TestCase):
 
     def test_style_css_has_oauth_card_rules(self):
         """style.css must contain the .onboarding-oauth-card rules."""
-        css = (REPO_ROOT / "static" / "style.css").read_text()
+        css = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
         self.assertIn("onboarding-oauth-card", css)
         self.assertIn("onboarding-oauth-ready", css)
         self.assertIn("onboarding-oauth-pending", css)

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -18,9 +18,9 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 REPO_ROOT  = _REPO_ROOT
-STYLE_CSS  = (REPO_ROOT / "static" / "style.css").read_text()
-SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text()
-PANELS_JS   = (REPO_ROOT / "static" / "panels.js").read_text()
+STYLE_CSS  = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+PANELS_JS   = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
 try:
     from api import config as _api_config
@@ -101,7 +101,7 @@ class TestGatewaySessionNullModel(unittest.TestCase):
         """api/models.py must not use `or 'unknown'` for the model field
         so that a NULL model in state.db is returned as None (falsy) to
         the frontend rather than the truthy string 'unknown'."""
-        models_src = (REPO_ROOT / "api" / "models.py").read_text()
+        models_src = (REPO_ROOT / "api" / "models.py").read_text(encoding="utf-8")
         # Ensure the old fallback pattern is gone
         self.assertNotIn(
             "'model': row['model'] or 'unknown'",
@@ -113,7 +113,7 @@ class TestGatewaySessionNullModel(unittest.TestCase):
     def test_gateway_watcher_null_model_returns_none_not_unknown(self):
         """api/gateway_watcher.py must not use `or 'unknown'` for the model
         field so that a NULL model in state.db is returned as None (falsy)."""
-        gw_src = (REPO_ROOT / "api" / "gateway_watcher.py").read_text()
+        gw_src = (REPO_ROOT / "api" / "gateway_watcher.py").read_text(encoding="utf-8")
         self.assertNotIn(
             "'model': row['model'] or 'unknown'",
             gw_src,
@@ -124,8 +124,8 @@ class TestGatewaySessionNullModel(unittest.TestCase):
     def test_gateway_session_model_uses_none_fallback(self):
         """Both source files must use `row['model'] or None` (explicit None
         fallback) for the model field assignment."""
-        models_src = (REPO_ROOT / "api" / "models.py").read_text()
-        gw_src = (REPO_ROOT / "api" / "gateway_watcher.py").read_text()
+        models_src = (REPO_ROOT / "api" / "models.py").read_text(encoding="utf-8")
+        gw_src = (REPO_ROOT / "api" / "gateway_watcher.py").read_text(encoding="utf-8")
         self.assertIn(
             "'model': row['model'] or None,",
             models_src,

--- a/tests/test_sprint41.py
+++ b/tests/test_sprint41.py
@@ -12,10 +12,10 @@ import re
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-CSS = (REPO_ROOT / "static" / "style.css").read_text()
-HTML = (REPO_ROOT / "static" / "index.html").read_text()
-MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text()
-STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text()
+CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+HTML = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
 
 
 # ── streaming.py: title auto-generation condition ─────────────────────────

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -19,7 +19,7 @@ import unittest
 from unittest import mock
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text()
+STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
 
 
 # ── Shared helpers for sprint-42 additional tests ────────────────────────────
@@ -679,7 +679,7 @@ def test_cleanTitle_is_let_not_const():
 # ── Sprint 42 additional tests: thinking panel persistence (#427) ────────
 def test_streaming_persists_reasoning_in_session():
     """streaming.py must accumulate reasoning_text and patch last assistant message."""
-    src = (REPO / 'api' / 'streaming.py').read_text()
+    src = (REPO / 'api' / 'streaming.py').read_text(encoding="utf-8")
 
     # _reasoning_text must be initialised
     assert "_reasoning_text = ''" in src, \
@@ -707,7 +707,7 @@ def test_streaming_persists_reasoning_in_session():
 
 def test_done_handler_patches_reasoning_field():
     """messages.js done SSE handler must patch reasoningText onto the last assistant message."""
-    src = (REPO / 'static' / 'messages.js').read_text()
+    src = (REPO / 'static' / 'messages.js').read_text(encoding="utf-8")
 
     # The persistence comment must be present inside the done handler
     assert "Persist reasoning trace so thinking card survives page reload" in src, \
@@ -733,7 +733,7 @@ def test_done_handler_patches_reasoning_field():
 
 def test_rendermessages_reads_reasoning_from_messages():
     """ui.js renderMessages must read m.reasoning to display the thinking card."""
-    src = (REPO / 'static' / 'ui.js').read_text()
+    src = (REPO / 'static' / 'ui.js').read_text(encoding="utf-8")
 
     # m.reasoning must be read in the render path
     assert 'm.reasoning' in src, \
@@ -756,7 +756,7 @@ def test_streaming_restores_prior_reasoning_metadata_after_followup():
     history before saving the session, including reinserting dropped
     reasoning-only assistant segments.
     """
-    src = (REPO / 'api' / 'streaming.py').read_text()
+    src = (REPO / 'api' / 'streaming.py').read_text(encoding="utf-8")
     assert "def _restore_reasoning_metadata(" in src, \
         "streaming.py must define a helper to restore prior reasoning metadata"
     assert "_next_context_messages" in src and "s.context_messages" in src, \
@@ -769,7 +769,7 @@ def test_streaming_restores_prior_reasoning_metadata_after_followup():
 
 def test_routes_restores_prior_reasoning_metadata_after_followup():
     """The non-streaming route path must preserve prior reasoning metadata too."""
-    src = (REPO / 'api' / 'routes.py').read_text()
+    src = (REPO / 'api' / 'routes.py').read_text(encoding="utf-8")
     assert "_restore_reasoning_metadata" in src, \
         "routes.py must import reasoning metadata restoration helper"
     assert "_next_context_messages" in src and "s.context_messages" in src, \

--- a/tests/test_sprint43.py
+++ b/tests/test_sprint43.py
@@ -18,16 +18,16 @@ import sys
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-GATEWAY_WATCHER_PY = (REPO_ROOT / "api" / "gateway_watcher.py").read_text()
-CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text()
-BOOTSTRAP_PY = (REPO_ROOT / "bootstrap.py").read_text()
-SERVER_PY = (REPO_ROOT / "server.py").read_text()
-ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text()
-AUTH_PY = (REPO_ROOT / "api" / "auth.py").read_text()
-PROFILES_PY = (REPO_ROOT / "api" / "profiles.py").read_text()
-STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text()
-WORKSPACE_PY = (REPO_ROOT / "api" / "workspace.py").read_text()
-STATE_SYNC_PY = (REPO_ROOT / "api" / "state_sync.py").read_text()
+GATEWAY_WATCHER_PY = (REPO_ROOT / "api" / "gateway_watcher.py").read_text(encoding="utf-8")
+CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+BOOTSTRAP_PY = (REPO_ROOT / "bootstrap.py").read_text(encoding="utf-8")
+SERVER_PY = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+AUTH_PY = (REPO_ROOT / "api" / "auth.py").read_text(encoding="utf-8")
+PROFILES_PY = (REPO_ROOT / "api" / "profiles.py").read_text(encoding="utf-8")
+STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+WORKSPACE_PY = (REPO_ROOT / "api" / "workspace.py").read_text(encoding="utf-8")
+STATE_SYNC_PY = (REPO_ROOT / "api" / "state_sync.py").read_text(encoding="utf-8")
 
 
 # ── B324: MD5 usedforsecurity=False ─────────────────────────────────────────

--- a/tests/test_sprint48.py
+++ b/tests/test_sprint48.py
@@ -15,7 +15,7 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text()
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 # ── Bug #702 — XML tool-call leak on DeepSeek ────────────────────────────────

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -186,7 +186,7 @@ def test_file_save(cleanup_test_sessions):
     fname = f"save_{uuid.uuid4().hex[:6]}.txt"
     (ws / fname).write_text("original content")
     result, status = post("/api/file/save", {"session_id": sid, "path": fname, "content": "updated"})
-    assert status == 200 and (ws / fname).read_text() == "updated"
+    assert status == 200 and (ws / fname).read_text(encoding="utf-8") == "updated"
 
 def test_file_save_requires_fields(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)

--- a/tests/test_sprint50.py
+++ b/tests/test_sprint50.py
@@ -12,7 +12,7 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text()
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 def test_cmd_dropdown_moved_inside_composer_box():

--- a/tests/test_sprint6.py
+++ b/tests/test_sprint6.py
@@ -45,7 +45,7 @@ def test_index_html_file_exists():
     assert p.stat().st_size > 5000, "index.html seems too small"
 
 def test_server_py_has_no_html_string():
-    txt = (REPO_ROOT / "server.py").read_text()
+    txt = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
     assert 'HTML = r"""' not in txt, "server.py still contains inline HTML string"
     assert "doctype html" not in txt.lower(), "server.py still contains raw HTML"
 

--- a/tests/test_sprint7.py
+++ b/tests/test_sprint7.py
@@ -92,7 +92,7 @@ def test_skill_save_delete_roundtrip(cleanup_test_sessions):
     data, status = post("/api/skills/save", {"name": skill_name, "content": content})
     assert status == 200 and data.get("ok") is True
     skill_path = pathlib.Path(data["path"])
-    assert skill_path.exists() and skill_path.read_text() == content
+    assert skill_path.exists() and skill_path.read_text(encoding="utf-8") == content
     del_data, del_status = post("/api/skills/delete", {"name": skill_name})
     assert del_status == 200 and del_data.get("ok") is True
     assert not skill_path.exists()

--- a/tests/test_stage299_opus_fixes.py
+++ b/tests/test_stage299_opus_fixes.py
@@ -18,7 +18,7 @@ ROUTES_PY = Path(__file__).parent.parent / "api" / "routes.py"
 
 
 def _read_source():
-    return ROUTES_PY.read_text()
+    return ROUTES_PY.read_text(encoding="utf-8")
 
 
 def test_wiki_max_files_constant_present():
@@ -72,7 +72,7 @@ def test_count_files_returns_zero_for_forbidden_root(tmp_path, monkeypatch):
 
 def test_render_llm_wiki_status_uses_url_scheme_guard():
     """Opus SHOULD-FIX #1: docs_url interpolated into href must be scheme-guarded."""
-    panels_js = (Path(__file__).parent.parent / "static" / "panels.js").read_text()
+    panels_js = (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
     # Find the _renderLlmWikiStatus function body
     start = panels_js.find("function _renderLlmWikiStatus")
     end = panels_js.find("\nfunction ", start + 1)

--- a/tests/test_svg_audio_video_rendering.py
+++ b/tests/test_svg_audio_video_rendering.py
@@ -109,7 +109,7 @@ def test_media_label_class():
 
 def test_i18n_keys():
     """Verify media rendering i18n keys exist in all locales."""
-    with open('static/i18n.js') as f:
+    with open('static/i18n.js', encoding='utf-8') as f:
         src = f.read()
     required_keys = [
         'media_audio_label',

--- a/tests/test_terminal_process_cleanup.py
+++ b/tests/test_terminal_process_cleanup.py
@@ -161,7 +161,7 @@ def test_close_all_terminals_closes_snapshot(monkeypatch):
 
 def test_terminal_module_registers_graceful_shutdown_reaper():
     """atexit is still the reap path; pdeathsig must NOT be re-introduced."""
-    src = terminal.Path(terminal.__file__).read_text()
+    src = terminal.Path(terminal.__file__).read_text(encoding="utf-8")
 
     assert "atexit.register(close_all_terminals)" in src
     # The PR_SET_PDEATHSIG implementation broke every Linux user (#2853);

--- a/tests/test_uiux_docs_theme_contract.py
+++ b/tests/test_uiux_docs_theme_contract.py
@@ -24,7 +24,7 @@ LEGACY_THEME_LABELS = ("Solarized", "Monokai", "Nord", "OLED")
 
 def test_uiux_demo_docs_use_current_theme_skin_axes():
     for doc_path in DEMO_DOCS:
-        html = doc_path.read_text()
+        html = doc_path.read_text(encoding="utf-8")
         assert 'data-theme="' not in html, f"{doc_path} should not use legacy data-theme"
         assert 'class="dark" data-skin="slate"' in html
         assert "classList.toggle('dark'" in html


### PR DESCRIPTION
## What changed

A batch of fixes and cleanups from a full project review, spanning security, upload handling, i18n, CI, docs, and test portability (88 files, +1710/−1246):

- **fix(security):** CORS preflight now echoes only same-origin or explicitly allowlisted origins instead of reflecting arbitrary ones (`server.py`, `api/routes.py`)
- **fix(upload):** zip extraction skips symlink members explicitly and normalizes extract results to POSIX paths (`api/upload.py`)
- **i18n:** translated all 714 remaining `TODO-translate` placeholders in `static/i18n.js`
- **ci:** the ESLint runtime guard now runs as a hard gate on every PR (`.github/workflows/tests.yml`)
- **docs(env):** documented ~20 environment variables the code reads but no `.env` template listed (`.env.example`, `.env.docker.example`)
- **docs:** synced ROADMAP/SPRINTS/README/ARCHITECTURE/TESTING with v0.51.191 reality
- **test:** test suite reads repo files as UTF-8 explicitly so it runs on Windows (bulk of the modified test files)

## Why

These issues were surfaced by a project-wide review: the CORS reflection and zip-symlink handling are security-relevant, the i18n placeholders were shipping untranslated UI, and the test suite failed on Windows default encodings.

## Notes for reviewers

- The CORS and zip-extraction commits are the security-relevant ones and deserve the closest look.
- The i18n commit is large but mechanical (placeholder → translation); the test-file churn is almost entirely the explicit `encoding="utf-8"` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
