### PR TITLE
fix: refresh recognition.lang before dictation start (#5483)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -930,6 +930,7 @@ function _micToastKeyForRecognitionError(error){
     }
     if(recognition && !_forceMediaRecorder && !_rawAudioMode){
       _activeCaptureMode='speech';
+      recognition.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
       recognition.start();
       _setRecording(true);
       return;


### PR DESCRIPTION
## Summary

Resolves #5483. Sets `recognition.lang` immediately before `.start()` in the plain dictation path (`_startMicCapture`, boot.js:933), matching the pattern already used in `_ensureSpeechRecognition()`.

## Root Cause

After a runtime locale change via `setLocale()` (Settings dropdown), the cached `recognition` object retains its boot-time `.lang`. The next dictation runs in the wrong language, falling back to `en-US` if the preference was set after boot.

## Change

```diff
 if(recognition && !_forceMediaRecorder && !_rawAudioMode){
   _activeCaptureMode='speech';
+  recognition.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
   recognition.start();
   _setRecording(true);
 }
```

The voice mode path (boot.js:1291) is unaffected — it rebuilds `_recognition = new SpeechRecognition()` on every `_startListening()` call, so its `.lang` is always fresh.

## Verification

1. Boot in `en-US`
2. Switch locale to `pt-BR` in Settings
3. Start dictation → `recognition.lang` should be `pt-BR`, not `en-US`

/cc @nesquena-hermes