### PR TITLE
fix(#5451): apply voice-mode pref before recomputing composer divider

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2998,7 +2998,6 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     // closure-local to the voice-mode IIFE and not visible here.
     if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
     _applyComposerFooterVisibilitySettings();
-    if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
     // TTS: apply enabled state on boot so buttons show/hide correctly (#499)
     if(typeof _applyTtsEnabled==='function') _applyTtsEnabled(localStorage.getItem('hermes-tts-enabled')==='true');
   }catch(e){

--- a/static/boot.js
+++ b/static/boot.js
@@ -2994,7 +2994,9 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     // .composer-divider (#5451) sees #btnVoiceMode final display even
     // when a server/localStorage sync path flipped the pref between
     // module init and settings-load completion (round-2 SILENT race).
-    if(typeof _applyVoiceModePref==='function') _applyVoiceModePref();
+    // Note: must use window._applyVoiceModePref — the bare name is
+    // closure-local to the voice-mode IIFE and not visible here.
+    if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
     _applyComposerFooterVisibilitySettings();
     if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
     // TTS: apply enabled state on boot so buttons show/hide correctly (#499)
@@ -3053,7 +3055,9 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     // a server/localStorage sync path flipped the pref between module init
     // and settings-load completion (round-2 SILENT race fix; safe no-op on
     // the failure-fallback path because _applyVoiceModePref is idempotent).
-    if(typeof _applyVoiceModePref==='function') _applyVoiceModePref();
+    // Note: must use window._applyVoiceModePref — the bare name is
+    // closure-local to the voice-mode IIFE and not visible here.
+    if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
     _applyComposerFooterVisibilitySettings();
     if(typeof _applyTtsEnabled==='function') _applyTtsEnabled(localStorage.getItem('hermes-tts-enabled')==='true');
   }

--- a/static/boot.js
+++ b/static/boot.js
@@ -2743,6 +2743,21 @@ function _applyComposerFooterVisibilitySettings(){
   if(hidden.hide_composer_reasoning&&typeof closeReasoningDropdown==='function') closeReasoningDropdown();
   if(hidden.hide_composer_toolsets&&typeof closeToolsetsDropdown==='function') closeToolsetsDropdown();
   if(hidden.hide_composer_mobile_config&&typeof closeMobileComposerConfig==='function') closeMobileComposerConfig();
+
+  // Hide the divider when all left-group buttons before it are hidden
+  // Stops a lone vertical separator from appearing when attach/saved-prompts/mic/voice are all hidden.
+  const _divider=document.querySelector('.composer-divider');
+  if(_divider){
+    const _leftBtnSelectors=['#btnAttach','#btnSavedPrompts','#btnMic','#btnVoiceMode'];
+    const _allLeftHidden=_leftBtnSelectors.every(sel=>{
+      const el=document.querySelector(sel);
+      return !el||el.classList.contains('composer-control-hidden')||el.style.display==='none';
+    });
+    // Use classList.toggle directly instead of _setComposerControlHidden
+    // so we don't strip the intentional aria-hidden="true" on the decorative divider
+    // when buttons are visible (Greptile feedback).
+    _divider.classList.toggle('composer-control-hidden',_allLeftHidden);
+  }
 }
 window._applyComposerFooterVisibilitySettings=_applyComposerFooterVisibilitySettings;
 
@@ -2975,6 +2990,11 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       if(typeof applyLocaleToDOM==='function')applyLocaleToDOM();
     }
     _mirrorSpeechSettingsFromServer(s);
+    // Apply voice-mode visibility BEFORE computing the divider so the
+    // .composer-divider (#5451) sees #btnVoiceMode final display even
+    // when a server/localStorage sync path flipped the pref between
+    // module init and settings-load completion (round-2 SILENT race).
+    if(typeof _applyVoiceModePref==='function') _applyVoiceModePref();
     _applyComposerFooterVisibilitySettings();
     if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
     // TTS: apply enabled state on boot so buttons show/hide correctly (#499)
@@ -3028,6 +3048,12 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       setLocale(_lang);
       if(typeof applyLocaleToDOM==='function')applyLocaleToDOM();
     }
+    // Apply voice-mode visibility BEFORE computing the divider so the
+    // .composer-divider (#5451) sees #btnVoiceMode final display even when
+    // a server/localStorage sync path flipped the pref between module init
+    // and settings-load completion (round-2 SILENT race fix; safe no-op on
+    // the failure-fallback path because _applyVoiceModePref is idempotent).
+    if(typeof _applyVoiceModePref==='function') _applyVoiceModePref();
     _applyComposerFooterVisibilitySettings();
     if(typeof _applyTtsEnabled==='function') _applyTtsEnabled(localStorage.getItem('hermes-tts-enabled')==='true');
   }

--- a/static/panels.js
+++ b/static/panels.js
@@ -8907,6 +8907,9 @@ async function loadSettingsPanel(){
     // Voice-mode button visibility (#1488).
     // Toggling re-applies immediately via the boot.js helper so the user sees
     // the audio-waveform button appear/disappear without a reload.
+    // Also recomputes composer footer visibility so the .composer-divider
+    // (which tracks whether all left-group buttons are hidden, see #5451)
+    // stays in sync when #btnVoiceMode appears or disappears here.
     const voiceModeCb=$('settingsVoiceModeEnabled');
     if(voiceModeCb){
       voiceModeCb.checked=_speechBool('voice_mode_button','hermes-voice-mode-button',false);
@@ -8914,6 +8917,7 @@ async function loadSettingsPanel(){
         _markSpeechPreferenceChanged('voice_mode_button');
         localStorage.setItem('hermes-voice-mode-button',this.checked?'true':'false');
         if(typeof window._applyVoiceModePref==='function') window._applyVoiceModePref();
+        if(typeof window._applyComposerFooterVisibilitySettings==='function') window._applyComposerFooterVisibilitySettings();
         _schedulePreferencesAutosave();
       };
     }


### PR DESCRIPTION
## Round-2 SILENT fix: boot-order stale divider (#5451 sibling)

Closes the second SILENT the gate-certifier flagged on `sha:e341a424`: the
`applySettingsToUI()` async IIFE computes the composer divider while
`#btnVoiceMode`'s inline display is still set from the module-init
`_applyVoiceModePref()` at IIFE time. If anything flips
`hermes-voice-mode-button` between module init and settings-load
completion (today: nothing — the key is localStorage-only; tomorrow:
any future server-sync path), the divider computes against the pre-sync
button visibility and stays stale until some unrelated visibility
mutation recomputes it.

## What changes

`static/boot.js`: force `_applyVoiceModePref()` immediately before the
divider recompute in **both** the success and failure-fallback branches
of the settings-load IIFE. The function is idempotent (re-reads
localStorage and re-applies `modeBtn.style.display` + optionally
deactivates an active voice session). Safe no-op when nothing changed
the pref.

## Why both branches

- **success branch**: the path the gate-certifier's round-2 review
  cited (settings-load completes successfully, server may have
  rewritten the pref — or may not yet, but the recompute is now
  defensive against that future).
- **failure-fallback branch**: same logic, same race surface; fixing
  only one would leave the other path stale. `_applyVoiceModePref` is
  idempotent so a redundant call in the fallback is harmless.

## Verification

- `node -c static/boot.js` — syntax OK
- `pytest tests/test_issue4598_composer_control_visibility.py
  tests/test_issue1488_composer_voice_buttons.py` — 26/26 pass
- `python scripts/ruff_lint.py` — no new violations

## Related

- PR #5451 (`fix/hide-composer-separators`) — round-1 voice-mode
  toggle SILENT fix in panels.js:8796.
- Gate-certifier round-2 review on `sha:e341a424` — pointed at
  `boot.js:2969/2970` (line numbers from the pre-rebase head;
  current locations are 2890/2942 in both IIFE branches).