### PR TITLE
fix: refresh recognition.lang before dictation restart (#5483)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -930,6 +930,7 @@ function _micToastKeyForRecognitionError(error){
     }
     if(recognition && !_forceMediaRecorder && !_rawAudioMode){
       _activeCaptureMode='speech';
+      recognition.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
       recognition.start();
       _setRecording(true);
       return;


### PR DESCRIPTION
## Summary

Adds a one-line fix to set `recognition.lang` before `recognition.start()` in the speech restart path inside `_micToastKeyForRecognitionError` (~line 933 in `static/boot.js`). This was the only code path missing the language assignment.

## Root Cause

There are two code paths where `SpeechRecognition` is started:
1. **`_ensureSpeechRecognition()`** (new instance creation) — ✅ already sets `recognition.lang`
2. **`_micToastKeyForRecognitionError()`** (restart after error) — ❌ was missing `recognition.lang`

When speech recognition restarts after certain errors, it fell back to `en-US` regardless of the user's configured locale.

## Change
- **`static/boot.js`**: Added one line before `recognition.start()`:
  ```js
  recognition.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
  ```

## Testing
- One-line change, matches the exact pattern already used in `_ensureSpeechRecognition()`
- Non-English locales (e.g., pt-BR) now persist through speech restart

Closes #5483