### PR TITLE
feat(#5457): add project default workspace for new chats

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13040,14 +13040,7 @@ def handle_post(handler, parsed) -> bool:
             workspace = str(resolve_trusted_workspace(body.get("workspace"))) if body.get("workspace") else None
         except (TypeError, ValueError) as e:
             return bad(handler, str(e))
-        try:
-            fallback_workspace = (
-                str(resolve_trusted_workspace(body.get("fallback_workspace")))
-                if body.get("fallback_workspace")
-                else None
-            )
-        except (TypeError, ValueError) as e:
-            return bad(handler, str(e))
+        fallback_workspace = None
         # Use the project's stored default workspace when no explicit workspace was supplied.
         if not workspace and _body_project_id:
             _proj_ws = _get_project_default_workspace_for_session(
@@ -13055,6 +13048,12 @@ def handle_post(handler, parsed) -> bool:
             )
             if _proj_ws:
                 workspace = _proj_ws
+        # Validate the lower-priority fallback only when it can still be selected.
+        if not workspace and body.get("fallback_workspace"):
+            try:
+                fallback_workspace = str(resolve_trusted_workspace(body["fallback_workspace"]))
+            except (TypeError, ValueError) as e:
+                return bad(handler, str(e))
         if not workspace and fallback_workspace:
             workspace = fallback_workspace
         worktree_info = None

--- a/api/routes.py
+++ b/api/routes.py
@@ -12116,7 +12116,14 @@ def handle_get(handler, parsed) -> bool:
         isolated_profile_mode = _is_isolated_profile_mode()
         all_profiles = _all_profiles_enabled(parsed)
         if all_profiles:
-            scoped = all_projects
+            scoped = []
+            for project in all_projects:
+                if _profiles_match(project.get("profile"), active_profile):
+                    scoped.append(project)
+                    continue
+                foreign_project = dict(project)
+                foreign_project.pop("default_workspace", None)
+                scoped.append(foreign_project)
             other_profile_count = 0
         else:
             scoped = [p for p in all_projects
@@ -12778,6 +12785,31 @@ def _validate_session_toolsets_shape(toolsets):
         raise ValueError("each toolset must be a non-empty string")
     return toolsets
 
+
+def _get_visible_project_for_session(project_id: str, active_profile: str):
+    """Return the project visible to *active_profile*, or None when it is foreign or missing."""
+    if not project_id:
+        return None
+    for proj in load_projects():
+        if proj.get("project_id") == project_id and _profiles_match(proj.get("profile"), active_profile):
+            return proj
+    return None
+
+
+def _get_project_default_workspace_for_session(project_id: str, active_profile: str) -> "str | None":
+    """Return the stored default_workspace for *project_id* visible to *active_profile*, or None."""
+    proj = _get_visible_project_for_session(project_id, active_profile)
+    if not proj:
+        return None
+    dw = proj.get("default_workspace")
+    if not dw:
+        return None
+    try:
+        return str(resolve_trusted_workspace(dw))
+    except (TypeError, ValueError):
+        return None
+
+
 def handle_post(handler, parsed) -> bool:
     """Handle all POST routes. Returns True if handled, False for 404."""
     diag = RequestDiagnostics.maybe_start("POST", parsed.path, logger=logger)
@@ -12999,10 +13031,32 @@ def handle_post(handler, parsed) -> bool:
         return j(handler, {"ok": True, "prompt": new_prompt})
 
     if parsed.path == "/api/session/new":
+        _body_project_id = body.get("project_id") or None
+        _request_profile = body.get("profile") or get_active_profile_name()
+        _visible_project = _get_visible_project_for_session(_body_project_id, _request_profile)
+        if not _visible_project:
+            _body_project_id = None
         try:
             workspace = str(resolve_trusted_workspace(body.get("workspace"))) if body.get("workspace") else None
         except (TypeError, ValueError) as e:
             return bad(handler, str(e))
+        try:
+            fallback_workspace = (
+                str(resolve_trusted_workspace(body.get("fallback_workspace")))
+                if body.get("fallback_workspace")
+                else None
+            )
+        except (TypeError, ValueError) as e:
+            return bad(handler, str(e))
+        # Use the project's stored default workspace when no explicit workspace was supplied.
+        if not workspace and _body_project_id:
+            _proj_ws = _get_project_default_workspace_for_session(
+                _body_project_id, _request_profile
+            )
+            if _proj_ws:
+                workspace = _proj_ws
+        if not workspace and fallback_workspace:
+            workspace = fallback_workspace
         worktree_info = None
         worktree_requested = (
             body.get("worktree") is True
@@ -13062,7 +13116,7 @@ def handle_post(handler, parsed) -> bool:
             model=model,
             model_provider=model_provider,
             profile=body.get("profile") or None,
-            project_id=body.get("project_id") or None,
+            project_id=_body_project_id,
             worktree_info=worktree_info,
             enabled_toolsets=enabled_toolsets,
         )
@@ -14708,6 +14762,13 @@ def handle_post(handler, parsed) -> bool:
             "profile": _requested_profile or get_active_profile_name() or 'default',
             "created_at": time.time(),
         }
+        if "default_workspace" in body:
+            _dw_raw = body.get("default_workspace")
+            if _dw_raw:
+                try:
+                    proj["default_workspace"] = str(resolve_trusted_workspace(_dw_raw))
+                except (TypeError, ValueError) as _e:
+                    return bad(handler, f"invalid default_workspace: {_e}")
         projects.append(proj)
         save_projects(projects)
         return j(handler, {"ok": True, "project": proj})
@@ -14735,6 +14796,15 @@ def handle_post(handler, parsed) -> bool:
             if color and not _re.match(r"^#[0-9a-fA-F]{3,8}$", color):
                 return bad(handler, "Invalid color format")
             proj["color"] = color
+        if "default_workspace" in body:
+            _dw_raw = body.get("default_workspace")
+            if _dw_raw:
+                try:
+                    proj["default_workspace"] = str(resolve_trusted_workspace(_dw_raw))
+                except (TypeError, ValueError) as _e:
+                    return bad(handler, f"invalid default_workspace: {_e}")
+            else:
+                proj.pop("default_workspace", None)
         save_projects(projects)
         return j(handler, {"ok": True, "project": proj})
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -6571,6 +6571,7 @@ async function switchToProfile(name) {
   const _prevProfileName = S.activeProfile || 'default';
   const _switchGen = ++_profileSwitchGeneration;
   const _openingExistingSidebarSession = !!(typeof _profileSwitchOpeningExistingSession !== 'undefined' && _profileSwitchOpeningExistingSession);
+  const _callerOwnsNewSession = !!(typeof _profileSwitchCallerOwnsNewSession !== 'undefined' && _profileSwitchCallerOwnsNewSession);
   if (_chip) { _chip.classList.add('switching'); _chip.disabled = true; }
   if (_titlebarBtn) { _titlebarBtn.classList.add('switching'); _titlebarBtn.disabled = true; }
   // Optimistic name update — shows the target name right away
@@ -6760,6 +6761,13 @@ async function switchToProfile(name) {
       if (_switchGen !== _profileSwitchGeneration) return;
       if (workspaceVisible && typeof clearWorkspaceTreeSkeleton === 'function') clearWorkspaceTreeSkeleton();
       showToast(t('profile_switched', name));
+    } else if (sessionInProgress && _callerOwnsNewSession) {
+      // Project-targeted newSession() already owns the replacement chat, so the
+      // profile switch must not recursively await the same in-flight promise.
+      if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
+      await renderSessionList();
+      if (_switchGen !== _profileSwitchGeneration) return;
+      if (typeof _openProfileSwitchSessionBrowser === 'function') _openProfileSwitchSessionBrowser();
     } else if (sessionInProgress) {
       // The current session has messages and belongs to the previous profile.
       // Start a new session for the new profile so nothing gets cross-tagged.

--- a/static/panels.js
+++ b/static/panels.js
@@ -6731,7 +6731,9 @@ async function switchToProfile(name) {
       S._profileDefaultWorkspace = data.default_workspace;
       // Also set the one-shot flag consumed by newSession() so the first new
       // session after a profile switch inherits this workspace (#424).
-      S._profileSwitchWorkspace = data.default_workspace;
+      if (!_callerOwnsNewSession) {
+        S._profileSwitchWorkspace = data.default_workspace;
+      }
 
       if (S.session && !sessionInProgress) {
         // Empty session (no messages yet) — safe to update it in place

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -963,7 +963,12 @@ async function _ensureProjectProfileForNewSession(project){
   const activeProfile=S.activeProfile||'default';
   if(_profileMatchesActiveProfile(targetProfile,activeProfile)) return true;
   if(typeof switchToProfile!=='function') return false;
-  await switchToProfile(targetProfile);
+  _profileSwitchCallerOwnsNewSession=true;
+  try{
+    await switchToProfile(targetProfile);
+  }finally{
+    _profileSwitchCallerOwnsNewSession=false;
+  }
   return _profileMatchesActiveProfile(targetProfile,S.activeProfile||'default');
 }
 
@@ -997,10 +1002,11 @@ async function newSession(flash, options={}){
     // Keep explicit workspace ownership on the server for project-targeted chats.
     const switchWs=S._profileSwitchWorkspace;
     S._profileSwitchWorkspace=null;
-    const inheritWs=switchWs||(S._profileDefaultWorkspace||null)||(S.session?S.session.workspace:null);
-    const fallbackWs=inheritWs;
+    const explicitWs=switchWs||null;
+    const fallbackWs=explicitWs?null:((S._profileDefaultWorkspace||null)||(S.session?S.session.workspace:null));
     const reqBody={ profile:S.activeProfile||'default' };
-    if(hasProjectTarget) reqBody.fallback_workspace=fallbackWs;
+    if(explicitWs) reqBody.workspace=explicitWs;
+    else if(hasProjectTarget) reqBody.fallback_workspace=fallbackWs;
     else reqBody.workspace=fallbackWs;
     if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
     if(options&&options.worktree) reqBody.worktree=true;
@@ -3209,6 +3215,7 @@ let _activeProject = null;  // project_id filter (null = show all, NO_PROJECT_FI
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes-show-all-profiles';
 let _showAllProfiles = false;  // false = filter to active profile only
 let _profileSwitchOpeningExistingSession = false;  // true while cross-profile sidebar click switches profile before loadSession()
+let _profileSwitchCallerOwnsNewSession = false;  // true while project-targeted newSession() owns the post-switch replacement
 let _otherProfileCount = 0;       // count of sessions from other profiles (server-reported)
 let _archivedWebuiCount = 0;      // archived WebUI sessions not fetched until requested
 let _archivedCliCount = 0;        // archived non-WebUI sessions not fetched until requested

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -945,6 +945,28 @@ function _setNewSessionPending(pending){
   }
 }
 
+function _resolveProjectForNewSession(options){
+  let pid;
+  if(Object.prototype.hasOwnProperty.call(options,'project_id')){
+    pid=options.project_id;
+  }else if(typeof _activeProject!=='undefined'&&_activeProject&&_activeProject!==NO_PROJECT_FILTER){
+    pid=_activeProject;
+  }
+  if(!pid) return null;
+  const _projects=typeof _allProjects!=='undefined'?_allProjects:[];
+  return _projects.find(p=>p.project_id===pid)||null;
+}
+
+async function _ensureProjectProfileForNewSession(project){
+  const targetProfile=project&&typeof project.profile==='string'?project.profile.trim():'';
+  if(!_showAllProfiles||!targetProfile) return false;
+  const activeProfile=S.activeProfile||'default';
+  if(_profileMatchesActiveProfile(targetProfile,activeProfile)) return true;
+  if(typeof switchToProfile!=='function') return false;
+  await switchToProfile(targetProfile);
+  return _profileMatchesActiveProfile(targetProfile,S.activeProfile||'default');
+}
+
 async function newSession(flash, options={}){
   if(_newSessionInFlight){
     if(typeof showToast==='function') showToast(_newSessionPendingText(),1500);
@@ -962,14 +984,24 @@ async function newSession(flash, options={}){
     _messagesTruncated=false;
     _oldestIdx=0;
     clearLiveToolCards();
-    // One-shot profile-switch workspace wins first; otherwise prefer the profile default.
+    const _newSessionProj=_resolveProjectForNewSession(options);
+    if(_newSessionProj&&!await _ensureProjectProfileForNewSession(_newSessionProj)){
+      const targetProfile=_newSessionProj&&typeof _newSessionProj.profile==='string'?_newSessionProj.profile.trim():'';
+      if(targetProfile&&!_profileMatchesActiveProfile(targetProfile,S.activeProfile||'default')){
+        throw new Error('Switch to '+targetProfile+' before opening a new chat in this project');
+      }
+    }
+    const hasProjectTarget=Object.prototype.hasOwnProperty.call(options,'project_id')
+      ? !!options.project_id
+      : !!(_activeProject&&_activeProject!==NO_PROJECT_FILTER);
+    // Keep explicit workspace ownership on the server for project-targeted chats.
     const switchWs=S._profileSwitchWorkspace;
     S._profileSwitchWorkspace=null;
     const inheritWs=switchWs||(S._profileDefaultWorkspace||null)||(S.session?S.session.workspace:null);
-    const reqBody={
-      workspace:inheritWs,
-      profile:S.activeProfile||'default',
-    };
+    const fallbackWs=inheritWs;
+    const reqBody={ profile:S.activeProfile||'default' };
+    if(hasProjectTarget) reqBody.fallback_workspace=fallbackWs;
+    else reqBody.workspace=fallbackWs;
     if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
     if(options&&options.worktree) reqBody.worktree=true;
     if(Object.prototype.hasOwnProperty.call(options,'project_id')){
@@ -1001,35 +1033,17 @@ async function newSession(flash, options={}){
       newModelState=_readPersistedModelState();
     }
     if(newModelState&&newModelState.model){
+      // Keep #2518's provider fast path even when project-targeted chats let
+      // the server pick project-default vs inherited workspace.
       reqBody.model=newModelState.model;
-      // Cold-start / picker-without-provider fallback: when the dropdown option's
-      // data-provider is empty/'default' or the persisted state predates provider
-      // tracking, newModelState.model_provider is null. POST /api/session/new's
-      // fast path in _resolve_compatible_session_model_state requires both model
-      // and a truthy model_provider; without it, the request falls into
-      // get_available_models() and a 3-4s cold catalog rebuild. window._activeProvider
-      // is hydrated at boot (ui.js) and on config refresh (panels.js), so it's a
-      // safe default that matches the user's configured route. S.session.model_provider
-      // is the previous-session fallback when the dropdown is unhydrated.
-      //
-      // Guard: a slash-qualified model (e.g. "gemini/gemini-2.5") or an
-      // @provider:model string already carries a foreign provider namespace from
-      // a previous session that was served by a different backend. Attaching
-      // the current _activeProvider to such a slug would let the server's fast
-      // path pass it through without consulting the catalog, silently
-      // re-pointing the new session at the wrong backend (the very case the
-      // slow-path normalization in _resolve_compatible_session_model_state is
-      // designed to fix — see routes.py docstring around line 1891-1894). For
-      // those models we leave the wire shape with model_provider=null so the
-      // slow path's cross-provider repair still runs. Closes the open
-      // follow-up from #2518.
+      // newModelState.model_provider wins; fallback order stays
+      // window._activeProvider, then S.session&&S.session.model_provider, to
+      // keep /api/session/new on the fast path from #2518.
+      // Slash and @-qualified models keep model_provider null so the server's
+      // slow-path repair still owns foreign-provider normalization.
       const _bareModel=!/[/]/.test(newModelState.model)&&!newModelState.model.startsWith('@');
-      // Second guard (#3410-followup): even a bare model can carry a known
-      // family prefix (gpt→openai, claude→anthropic, gemini→google). If that
-      // family maps to a DIFFERENT provider than the fallback we'd attach, the
-      // server fast path passes the pair through verbatim (no validation) and
-      // silently routes to the wrong backend — so leave model_provider=null and
-      // let the slow-path family repair run (mirrors routes.py _normalize_provider_id).
+      // #3410 follow-up: bare models whose family disagrees with the fallback
+      // provider also stay null so the server repairs them.
       const _fallbackProvider=_bareModel
         ? ((usingConfiguredDefault?window._activeProvider:(window._activeProvider||(S.session&&S.session.model_provider)))||'')
         : '';
@@ -8235,6 +8249,63 @@ function _startProjectRename(proj, chip){
   setTimeout(()=>{inp.focus();inp.select();},10);
 }
 
+function _projectWorkspaceDisplayKey(path){
+  return String(path||'').trim().replace(/\\/g,'/').replace(/\/+$/,'');
+}
+
+function _showProjectDefaultWorkspacePicker(proj, wsList, anchorEvent){
+  document.querySelectorAll('.project-ws-picker').forEach(el=>el.remove());
+  const pick=document.createElement('div');
+  pick.className='project-ws-picker';
+  pick.style.cssText='position:fixed;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:6px 0;z-index:9999;min-width:200px;max-width:340px;max-height:300px;overflow-y:auto;box-shadow:0 4px 16px rgba(0,0,0,.35);';
+  const vw=window.innerWidth||document.documentElement.clientWidth||0;
+  const vh=window.innerHeight||document.documentElement.clientHeight||0;
+  const x=Math.max(8,Math.min(anchorEvent.clientX||8,(vw||348)-348));
+  const y=Math.max(8,Math.min(anchorEvent.clientY||8,(vh||316)-316));
+  pick.style.left=x+'px';
+  pick.style.top=y+'px';
+  const makeRow=(label,ws,danger)=>{
+    const row=document.createElement('div');
+    const isCurrent=_projectWorkspaceDisplayKey(ws)===_projectWorkspaceDisplayKey(proj.default_workspace);
+    row.textContent=label+(isCurrent?' ✓':'');
+    row.style.cssText='padding:7px 14px;cursor:pointer;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'+(danger?'color:var(--error,#e94560);':'color:var(--text);');
+    row.onmouseenter=()=>row.style.background='var(--hover-bg)';
+    row.onmouseleave=()=>row.style.background='';
+    row.onclick=async()=>{
+      pick.remove();
+      document.removeEventListener('click',dismiss);
+      try{
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:proj.name,color:proj.color||null,default_workspace:ws||null})});
+        await renderSessionList();
+        showToast(ws?'Default workspace set':'Default workspace cleared');
+      }catch(err){
+        showToast('Failed: '+(err.message||err));
+      }
+    };
+    return row;
+  };
+  if(proj.default_workspace){
+    pick.appendChild(makeRow('Clear default',null,true));
+    const sep=document.createElement('hr');
+    sep.style.cssText='border:none;border-top:1px solid var(--border);margin:4px 0;';
+    pick.appendChild(sep);
+  }
+  if(!wsList||!wsList.length){
+    const none=document.createElement('div');
+    none.textContent='No saved workspaces';
+    none.style.cssText='padding:7px 14px;font-size:12px;color:var(--text);';
+    pick.appendChild(none);
+  }else{
+    wsList.forEach(ws=>{
+      const label=typeof ws==='string'?ws:(ws.path||ws.name||String(ws));
+      pick.appendChild(makeRow(label,label,false));
+    });
+  }
+  document.body.appendChild(pick);
+  const dismiss=()=>{pick.remove();document.removeEventListener('click',dismiss);};
+  setTimeout(()=>document.addEventListener('click',dismiss),0);
+}
+
 function _showProjectContextMenu(e, proj, chip){
   document.querySelectorAll('.project-ctx-menu').forEach(el=>el.remove());
   const menu=document.createElement('div');
@@ -8276,6 +8347,23 @@ function _showProjectContextMenu(e, proj, chip){
     colorRow.appendChild(dot);
   });
   menu.appendChild(colorRow);
+
+  // Default workspace
+  const wsItem=document.createElement('div');
+  wsItem.textContent='Default workspace'+(proj.default_workspace?' ✓':'');
+  wsItem.style.cssText='padding:7px 14px;cursor:pointer;font-size:13px;color:var(--text);';
+  wsItem.onmouseenter=()=>wsItem.style.background='var(--hover-bg)';
+  wsItem.onmouseleave=()=>wsItem.style.background='';
+  wsItem.onclick=async(wsEv)=>{
+    menu.remove();
+    try{
+      const data=await api('/api/workspaces',{method:'GET'});
+      _showProjectDefaultWorkspacePicker(proj,(data&&data.workspaces)||[],wsEv||e);
+    }catch(err){
+      showToast('Failed to load workspaces: '+(err.message||err));
+    }
+  };
+  menu.appendChild(wsItem);
 
   // Divider + Delete
   const sep=document.createElement('hr');

--- a/tests/test_4676_project_new_session_shortcuts.py
+++ b/tests/test_4676_project_new_session_shortcuts.py
@@ -10,6 +10,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SESSIONS_JS = ROOT / "static" / "sessions.js"
+PANELS_JS = ROOT / "static" / "panels.js"
 STYLE_CSS = ROOT / "static" / "style.css"
 NODE = shutil.which("node")
 
@@ -81,15 +82,18 @@ def _run_new_session_case(
     profile_default_workspace=None,
     switch_workspace=None,
     session=None,
+    messages=None,
     active_profile="default",
     show_all_profiles=False,
+    timeout_ms=250,
     return_meta=False,
 ):
     _DRIVER = r"""
 const fs = require('fs');
-const [path, argsJson] = process.argv.slice(-2);
+const [sessionsPath, panelsPath, argsJson] = process.argv.slice(-3);
 const args = JSON.parse(argsJson);
-const src = fs.readFileSync(path, 'utf8');
+const sessionsSrc = fs.readFileSync(sessionsPath, 'utf8');
+const panelsSrc = fs.readFileSync(panelsPath, 'utf8');
 
 function extractFunction(source, name) {
   const marker = `function ${name}(`;
@@ -123,10 +127,11 @@ function extractAsyncFunction(source, name) {
   throw new Error('function body not closed for ' + name);
 }
 
-const profileMatchSrc = extractFunction(src, '_profileMatchesActiveProfile');
-const resolverSrc = extractFunction(src, '_resolveProjectForNewSession');
-const ensureProjectProfileSrc = extractAsyncFunction(src, '_ensureProjectProfileForNewSession');
-const newSessionSrc = extractAsyncFunction(src, 'newSession');
+const profileMatchSrc = extractFunction(sessionsSrc, '_profileMatchesActiveProfile');
+const resolverSrc = extractFunction(sessionsSrc, '_resolveProjectForNewSession');
+const ensureProjectProfileSrc = extractAsyncFunction(sessionsSrc, '_ensureProjectProfileForNewSession');
+const newSessionSrc = extractAsyncFunction(sessionsSrc, 'newSession');
+const switchToProfileSrc = extractAsyncFunction(panelsSrc, 'switchToProfile');
 
 globalThis.window = globalThis;
 globalThis.document = {
@@ -144,21 +149,28 @@ globalThis.document = {
     return node;
   },
 };
-globalThis.localStorage = { getItem: () => null, setItem: () => {} };
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
 globalThis.history = { replaceState: () => {} };
 globalThis.NO_PROJECT_FILTER = '__none__';
 globalThis._activeProject = args.activeProject;
 globalThis._allProjects = args.allProjects || [];
 globalThis._showAllProfiles = !!args.showAllProfiles;
+globalThis._profileSwitchCallerOwnsNewSession = false;
+globalThis._profileSwitchOpeningExistingSession = false;
+globalThis._profileSwitchGeneration = 0;
+globalThis._workspacePanelMode = 'closed';
+globalThis._renamingSid = null;
 globalThis._sessionSourceFilter = 'webui';
 globalThis._newSessionInFlight = null;
 globalThis._messagesTruncated = false;
 globalThis._oldestIdx = 0;
 globalThis.INFLIGHT = {};
+globalThis._skillsData = null;
+globalThis._workspaceList = null;
 globalThis.S = {
   session: args.session || null,
   toolCalls: [],
-  messages: [],
+  messages: args.messages || [],
   activeProfile: args.activeProfile || 'default',
   activeProfileIsDefault: !args.activeProfile || args.activeProfile === 'default',
   _pendingSessionToolsets: null,
@@ -177,44 +189,67 @@ for (const name of [
   'clearLiveToolCards', 'setComposerStatus', 'setStatus', 'updateSendBtn',
   'syncTopbar', 'renderMessages', 'startSessionStream', '_setSessionViewedCount',
   '_setActiveSessionUrl', '_rememberNewChatDraftSession', '_hydrateTodosFromSession',
-  '_setLiveAssistantTps', '_syncCtxIndicator', 'showToast'
+  '_setLiveAssistantTps', '_syncCtxIndicator', 'showToast', 'closeSessionActionMenu',
+  '_invalidateSessionListRenders', '_setProfileSwitchListEmbargo', 'showSessionListSkeleton',
+  'bumpWorkspaceTreeGen', 'showWorkspaceTreeSkeleton', 'startGatewaySSE', 'applyBotName',
+  '_clearPersistedModelState', 'animateNextSessionListRefresh', '_openProfileSwitchSessionBrowser',
+  'clearWorkspaceTreeSkeleton', '_profileSwitchPanelLoad', '_refreshProfileSwitchBackground'
 ]) {
   globalThis[name] = () => {};
 }
 globalThis.loadDir = async () => null;
+globalThis.renderSessionList = async () => null;
 globalThis._applyModelToDropdown = () => true;
 globalThis._modelStateForSelect = () => ({ model: 'gpt-4', model_provider: 'openai' });
 globalThis._readPersistedModelState = () => null;
 globalThis.getModelLabel = (v) => v || '';
 globalThis._defaultModel = null;
+globalThis.t = (key, value) => value ? `${key}:${value}` : String(key || '');
 
 const calls = [];
 const switchCalls = [];
-globalThis.api = async (_url, opts) => {
-  calls.push(JSON.parse(opts.body));
-  return { session: { session_id: 's-1', messages: [], model: 'gpt-4', model_provider: 'openai', workspace: null, message_count: 0, last_usage: {} } };
-};
-globalThis.switchToProfile = async (name) => {
-  switchCalls.push(String(name || ''));
-  globalThis.S.activeProfile = name || 'default';
-  globalThis.S.activeProfileIsDefault = !name || name === 'default';
-  if (globalThis.S._profileDefaultWorkspace == null && args.profileDefaultWorkspaceAfterSwitch) {
-    globalThis.S._profileDefaultWorkspace = args.profileDefaultWorkspaceAfterSwitch;
+let sessionNewCalls = 0;
+globalThis.api = async (url, opts) => {
+  const body = opts && opts.body ? JSON.parse(opts.body) : {};
+  if (url === '/api/profile/switch') {
+    switchCalls.push(String(body.name || ''));
+    return {
+      active: body.name || 'default',
+      is_default: !body.name || body.name === 'default',
+      default_workspace: args.switchWorkspace !== undefined ? args.switchWorkspace : (args.profileDefaultWorkspace || null),
+      default_model: null,
+      default_model_provider: null,
+    };
   }
-  if (args.switchWorkspaceAfterSwitch !== undefined) {
-    globalThis.S._profileSwitchWorkspace = args.switchWorkspaceAfterSwitch;
+  if (url === '/api/session/new') {
+    sessionNewCalls += 1;
+    calls.push(body);
+    return { session: { session_id: `s-${sessionNewCalls}`, messages: [], model: 'gpt-4', model_provider: 'openai', workspace: body.workspace || null, message_count: 0, last_usage: {} } };
   }
-  return true;
+  if (url === '/api/session/update') {
+    return { ok: true };
+  }
+  throw new Error('unexpected api url: ' + url);
 };
 
 eval(profileMatchSrc);
 eval(resolverSrc);
 eval(ensureProjectProfileSrc);
 eval(newSessionSrc);
+eval(switchToProfileSrc);
 
 (async () => {
-  await newSession(false, args.options);
-  console.log(JSON.stringify({ body: calls[0] || {}, switchCalls, activeProfile: globalThis.S.activeProfile }));
+  const result = await Promise.race([
+    newSession(false, args.options).then(() => ({ timedOut: false })),
+    new Promise((resolve) => setTimeout(() => resolve({ timedOut: true }), args.timeoutMs || 250)),
+  ]);
+  console.log(JSON.stringify({
+    timedOut: !!result.timedOut,
+    body: calls[0] || {},
+    switchCalls,
+    activeProfile: globalThis.S.activeProfile,
+    callCount: sessionNewCalls,
+  }));
 })().catch(err => {
   console.error(String(err && err.stack ? err.stack : err));
   process.exit(1);
@@ -229,10 +264,12 @@ eval(newSessionSrc);
         "activeProfile": active_profile,
         "switchWorkspace": switch_workspace,
         "showAllProfiles": show_all_profiles,
+        "messages": messages or [],
+        "timeoutMs": timeout_ms,
         "session": session if session is not None else {"session_id": "session-1"},
     }
     result = subprocess.run(
-        [NODE, "-e", _DRIVER, str(SESSIONS_JS), json.dumps(payload)],
+        [NODE, "-e", _DRIVER, str(SESSIONS_JS), str(PANELS_JS), json.dumps(payload)],
         capture_output=True,
         text=True,
         timeout=30,
@@ -327,8 +364,8 @@ def test_new_session_profile_switch_workspace_overrides_project_default_workspac
         session={"session_id": "session-1", "workspace": "/workspace/session"},
     )
     assert body["project_id"] == "active-project"
-    assert "workspace" not in body
-    assert body["fallback_workspace"] == "/workspace/switch"
+    assert body["workspace"] == "/workspace/switch"
+    assert "fallback_workspace" not in body
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -368,11 +405,39 @@ def test_new_session_cross_profile_project_switches_before_request():
         show_all_profiles=True,
         return_meta=True,
     )
+    assert out["timedOut"] is False
     assert out["switchCalls"] == ["other"]
     assert out["activeProfile"] == "other"
+    assert out["callCount"] == 1
     assert out["body"]["project_id"] == "foreign-project"
     assert out["body"]["profile"] == "other"
-    assert out["body"]["fallback_workspace"] == "/workspace/profile-switch"
+    assert out["body"]["workspace"] == "/workspace/profile-switch"
+    assert "fallback_workspace" not in out["body"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_cross_profile_project_new_owns_single_session_creation_during_switch():
+    out = _run_new_session_case(
+        {"project_id": "foreign-project"},
+        all_projects=[
+            {
+                "project_id": "foreign-project",
+                "name": "Foreign",
+                "profile": "other",
+                "default_workspace": "/workspace/foreign",
+            },
+        ],
+        switch_workspace="/workspace/profile-switch",
+        session={"session_id": "session-1", "workspace": "/workspace/session"},
+        messages=[{"role": "user", "content": "keep"}],
+        show_all_profiles=True,
+        return_meta=True,
+    )
+    assert out["timedOut"] is False
+    assert out["switchCalls"] == ["other"]
+    assert out["callCount"] == 1
+    assert out["body"]["project_id"] == "foreign-project"
+    assert out["body"]["workspace"] == "/workspace/profile-switch"
 
 
 _HELPER = r"""
@@ -596,7 +661,7 @@ def test_resolve_project_helper_exists():
 
 
 def test_new_session_workspace_precedence_defers_project_default_to_server():
-    """Project-targeted newSession() must send fallback_workspace and leave project default to the server."""
+    """Project-targeted newSession() must keep one-shot workspace explicit and defer inherited fallback to the server."""
     src = _read(SESSIONS_JS)
     idx = src.find("async function newSession(")
     assert idx >= 0, "newSession function not found in sessions.js"
@@ -608,8 +673,20 @@ def test_new_session_workspace_precedence_defers_project_default_to_server():
     assert resolver_idx < req_body_idx, (
         "_resolveProjectForNewSession must be called before reqBody is built"
     )
+    assert "const explicitWs=switchWs||null;" in new_session_src
+    assert "if(explicitWs) reqBody.workspace=explicitWs;" in new_session_src
     assert "reqBody.fallback_workspace=fallbackWs;" in new_session_src
     assert "const projectWs=" not in new_session_src
+
+
+def test_new_session_marks_cross_profile_switch_as_caller_owned():
+    src = _read(SESSIONS_JS)
+    assert "let _profileSwitchCallerOwnsNewSession = false;" in src
+    ensure_idx = src.find("async function _ensureProjectProfileForNewSession(project)")
+    assert ensure_idx >= 0, "_ensureProjectProfileForNewSession not found in sessions.js"
+    ensure_src = src[ensure_idx: ensure_idx + 600]
+    assert "_profileSwitchCallerOwnsNewSession=true;" in ensure_src
+    assert "_profileSwitchCallerOwnsNewSession=false;" in ensure_src
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")

--- a/tests/test_4676_project_new_session_shortcuts.py
+++ b/tests/test_4676_project_new_session_shortcuts.py
@@ -74,12 +74,38 @@ def test_project_quick_create_styles_exist_and_are_discrete_to_pointer_layouts()
     assert "@media (hover:none) and (pointer:coarse)" in css
 
 
-def _run_new_session_case(options, active_project=None):
+def _run_new_session_case(
+    options,
+    active_project=None,
+    all_projects=None,
+    profile_default_workspace=None,
+    switch_workspace=None,
+    session=None,
+    active_profile="default",
+    show_all_profiles=False,
+    return_meta=False,
+):
     _DRIVER = r"""
 const fs = require('fs');
 const [path, argsJson] = process.argv.slice(-2);
 const args = JSON.parse(argsJson);
 const src = fs.readFileSync(path, 'utf8');
+
+function extractFunction(source, name) {
+  const marker = `function ${name}(`;
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(name + ' not found');
+  const brace = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error('function body not closed for ' + name);
+}
 
 function extractAsyncFunction(source, name) {
   const marker = `async function ${name}(`;
@@ -97,6 +123,9 @@ function extractAsyncFunction(source, name) {
   throw new Error('function body not closed for ' + name);
 }
 
+const profileMatchSrc = extractFunction(src, '_profileMatchesActiveProfile');
+const resolverSrc = extractFunction(src, '_resolveProjectForNewSession');
+const ensureProjectProfileSrc = extractAsyncFunction(src, '_ensureProjectProfileForNewSession');
 const newSessionSrc = extractAsyncFunction(src, 'newSession');
 
 globalThis.window = globalThis;
@@ -119,6 +148,8 @@ globalThis.localStorage = { getItem: () => null, setItem: () => {} };
 globalThis.history = { replaceState: () => {} };
 globalThis.NO_PROJECT_FILTER = '__none__';
 globalThis._activeProject = args.activeProject;
+globalThis._allProjects = args.allProjects || [];
+globalThis._showAllProfiles = !!args.showAllProfiles;
 globalThis._sessionSourceFilter = 'webui';
 globalThis._newSessionInFlight = null;
 globalThis._messagesTruncated = false;
@@ -128,10 +159,11 @@ globalThis.S = {
   session: args.session || null,
   toolCalls: [],
   messages: [],
-  activeProfile: 'default',
+  activeProfile: args.activeProfile || 'default',
+  activeProfileIsDefault: !args.activeProfile || args.activeProfile === 'default',
   _pendingSessionToolsets: null,
-  _profileSwitchWorkspace: null,
-  _profileDefaultWorkspace: null,
+  _profileSwitchWorkspace: args.switchWorkspace || null,
+  _profileDefaultWorkspace: args.profileDefaultWorkspace || null,
 };
 globalThis._defaultModel = null;
 globalThis._activeProvider = 'openai';
@@ -157,16 +189,32 @@ globalThis.getModelLabel = (v) => v || '';
 globalThis._defaultModel = null;
 
 const calls = [];
+const switchCalls = [];
 globalThis.api = async (_url, opts) => {
   calls.push(JSON.parse(opts.body));
   return { session: { session_id: 's-1', messages: [], model: 'gpt-4', model_provider: 'openai', workspace: null, message_count: 0, last_usage: {} } };
 };
+globalThis.switchToProfile = async (name) => {
+  switchCalls.push(String(name || ''));
+  globalThis.S.activeProfile = name || 'default';
+  globalThis.S.activeProfileIsDefault = !name || name === 'default';
+  if (globalThis.S._profileDefaultWorkspace == null && args.profileDefaultWorkspaceAfterSwitch) {
+    globalThis.S._profileDefaultWorkspace = args.profileDefaultWorkspaceAfterSwitch;
+  }
+  if (args.switchWorkspaceAfterSwitch !== undefined) {
+    globalThis.S._profileSwitchWorkspace = args.switchWorkspaceAfterSwitch;
+  }
+  return true;
+};
 
+eval(profileMatchSrc);
+eval(resolverSrc);
+eval(ensureProjectProfileSrc);
 eval(newSessionSrc);
 
 (async () => {
   await newSession(false, args.options);
-  console.log(JSON.stringify({ body: calls[0] || {} }));
+  console.log(JSON.stringify({ body: calls[0] || {}, switchCalls, activeProfile: globalThis.S.activeProfile }));
 })().catch(err => {
   console.error(String(err && err.stack ? err.stack : err));
   process.exit(1);
@@ -175,8 +223,13 @@ eval(newSessionSrc);
 
     payload = {
         "activeProject": active_project,
+        "allProjects": all_projects or [],
         "options": options,
-        "session": {"session_id": "session-1"},
+        "profileDefaultWorkspace": profile_default_workspace,
+        "activeProfile": active_profile,
+        "switchWorkspace": switch_workspace,
+        "showAllProfiles": show_all_profiles,
+        "session": session if session is not None else {"session_id": "session-1"},
     }
     result = subprocess.run(
         [NODE, "-e", _DRIVER, str(SESSIONS_JS), json.dumps(payload)],
@@ -189,7 +242,8 @@ eval(newSessionSrc);
         raise RuntimeError(
             f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}"
         )
-    return json.loads(result.stdout.strip().splitlines()[-1])["body"]
+    out = json.loads(result.stdout.strip().splitlines()[-1])
+    return out if return_meta else out["body"]
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -209,6 +263,116 @@ def test_new_session_respects_explicit_project_id_none():
 def test_new_session_falls_back_to_active_project_when_override_missing():
     body = _run_new_session_case({}, active_project="active-project")
     assert body["project_id"] == "active-project"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_project_target_uses_fallback_workspace_before_profile_default():
+    body = _run_new_session_case(
+        {"project_id": "explicit-project"},
+        active_project="active-project",
+        all_projects=[
+            {
+                "project_id": "explicit-project",
+                "name": "Explicit",
+                "default_workspace": "/workspace/project",
+            },
+            {
+                "project_id": "active-project",
+                "name": "Active",
+                "default_workspace": "/workspace/active",
+            },
+        ],
+        profile_default_workspace="/workspace/profile",
+        session={"session_id": "session-1", "workspace": "/workspace/session"},
+    )
+    assert body["project_id"] == "explicit-project"
+    assert "workspace" not in body
+    assert body["fallback_workspace"] == "/workspace/profile"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_active_project_uses_fallback_workspace_before_profile_default():
+    body = _run_new_session_case(
+        {},
+        active_project="active-project",
+        all_projects=[
+            {
+                "project_id": "active-project",
+                "name": "Active",
+                "default_workspace": "/workspace/active",
+            },
+        ],
+        profile_default_workspace="/workspace/profile",
+        session={"session_id": "session-1", "workspace": "/workspace/session"},
+    )
+    assert body["project_id"] == "active-project"
+    assert "workspace" not in body
+    assert body["fallback_workspace"] == "/workspace/profile"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_profile_switch_workspace_overrides_project_default_workspace():
+    body = _run_new_session_case(
+        {},
+        active_project="active-project",
+        all_projects=[
+            {
+                "project_id": "active-project",
+                "name": "Active",
+                "default_workspace": "/workspace/active",
+            },
+        ],
+        profile_default_workspace="/workspace/profile",
+        switch_workspace="/workspace/switch",
+        session={"session_id": "session-1", "workspace": "/workspace/session"},
+    )
+    assert body["project_id"] == "active-project"
+    assert "workspace" not in body
+    assert body["fallback_workspace"] == "/workspace/switch"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_explicit_project_id_none_does_not_use_active_project_default_workspace():
+    body = _run_new_session_case(
+        {"project_id": None},
+        active_project="active-project",
+        all_projects=[
+            {
+                "project_id": "active-project",
+                "name": "Active",
+                "default_workspace": "/workspace/active",
+            },
+        ],
+        profile_default_workspace="/workspace/profile",
+        session={"session_id": "session-1", "workspace": "/workspace/session"},
+    )
+    assert body["project_id"] is None
+    assert body["workspace"] == "/workspace/profile"
+    assert "fallback_workspace" not in body
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_cross_profile_project_switches_before_request():
+    out = _run_new_session_case(
+        {"project_id": "foreign-project"},
+        all_projects=[
+            {
+                "project_id": "foreign-project",
+                "name": "Foreign",
+                "profile": "other",
+                "default_workspace": "/workspace/foreign",
+            },
+        ],
+        profile_default_workspace="/workspace/profile",
+        switch_workspace="/workspace/profile-switch",
+        show_all_profiles=True,
+        return_meta=True,
+    )
+    assert out["switchCalls"] == ["other"]
+    assert out["activeProfile"] == "other"
+    assert out["body"]["project_id"] == "foreign-project"
+    assert out["body"]["profile"] == "other"
+    assert out["body"]["fallback_workspace"] == "/workspace/profile-switch"
 
 
 _HELPER = r"""
@@ -418,3 +582,83 @@ def test_project_chip_quick_create_swallows_duplicate_inflight_rejections():
     assert out["filterProjectId"] == "keep-me"
     assert {"type": "set-filter", "projectId": "project-123"} not in out["calls"]
     assert out["toasts"] == ["New conversation already in progress"]
+
+
+# ── #5457: project default workspace selection ────────────────────────────────
+
+
+def test_resolve_project_helper_exists():
+    """`_resolveProjectForNewSession` must be defined in sessions.js."""
+    src = _read(SESSIONS_JS)
+    assert "function _resolveProjectForNewSession(" in src, (
+        "_resolveProjectForNewSession helper not found in sessions.js"
+    )
+
+
+def test_new_session_workspace_precedence_defers_project_default_to_server():
+    """Project-targeted newSession() must send fallback_workspace and leave project default to the server."""
+    src = _read(SESSIONS_JS)
+    idx = src.find("async function newSession(")
+    assert idx >= 0, "newSession function not found in sessions.js"
+    new_session_src = src[idx: idx + 2500]
+    # The project resolver must be called before building reqBody
+    resolver_idx = new_session_src.find("_resolveProjectForNewSession(")
+    req_body_idx = new_session_src.find("const reqBody=")
+    assert resolver_idx != -1, "_resolveProjectForNewSession not called in newSession"
+    assert resolver_idx < req_body_idx, (
+        "_resolveProjectForNewSession must be called before reqBody is built"
+    )
+    assert "reqBody.fallback_workspace=fallbackWs;" in new_session_src
+    assert "const projectWs=" not in new_session_src
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_uses_active_project_default_workspace():
+    """When a project is active, newSession() sends fallback_workspace instead of project-derived workspace."""
+    all_projects = [
+        {"project_id": "proj-ws", "name": "MyProject", "default_workspace": "/home/user/projws"},
+    ]
+    body = _run_new_session_case({}, active_project="proj-ws", all_projects=all_projects)
+    assert body.get("fallback_workspace") is None
+    assert "workspace" not in body
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_uses_explicit_project_id_default_workspace():
+    """When project_id is passed explicitly, the request defers project-default resolution to the server."""
+    all_projects = [
+        {"project_id": "proj-ws", "name": "MyProject", "default_workspace": "/home/user/projws"},
+    ]
+    body = _run_new_session_case(
+        {"project_id": "proj-ws"},
+        active_project=None,
+        all_projects=all_projects,
+    )
+    assert body.get("fallback_workspace") is None
+    assert "workspace" not in body
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_project_id_none_does_not_inherit_project_workspace():
+    """project_id:null means no project — project default workspace must NOT be applied."""
+    all_projects = [
+        {"project_id": "proj-ws", "name": "MyProject", "default_workspace": "/home/user/projws"},
+    ]
+    body = _run_new_session_case(
+        {"project_id": None},
+        active_project="proj-ws",
+        all_projects=all_projects,
+    )
+    assert body.get("workspace") is None
+    assert "fallback_workspace" not in body
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_project_without_default_workspace_leaves_fallback_workspace_null():
+    """A project with no default_workspace still leaves server-side project resolution responsible for workspace."""
+    all_projects = [
+        {"project_id": "proj-plain", "name": "PlainProject"},
+    ]
+    body = _run_new_session_case({}, active_project="proj-plain", all_projects=all_projects)
+    assert body.get("fallback_workspace") is None
+    assert "workspace" not in body

--- a/tests/test_4676_project_new_session_shortcuts.py
+++ b/tests/test_4676_project_new_session_shortcuts.py
@@ -81,6 +81,7 @@ def _run_new_session_case(
     all_projects=None,
     profile_default_workspace=None,
     switch_workspace=None,
+    switch_response_workspace=None,
     session=None,
     messages=None,
     active_profile="default",
@@ -174,8 +175,8 @@ globalThis.S = {
   activeProfile: args.activeProfile || 'default',
   activeProfileIsDefault: !args.activeProfile || args.activeProfile === 'default',
   _pendingSessionToolsets: null,
-  _profileSwitchWorkspace: args.switchWorkspace || null,
-  _profileDefaultWorkspace: args.profileDefaultWorkspace || null,
+  _profileSwitchWorkspace: args.switchWorkspace !== undefined ? args.switchWorkspace : null,
+  _profileDefaultWorkspace: args.profileDefaultWorkspace !== undefined ? args.profileDefaultWorkspace : null,
 };
 globalThis._defaultModel = null;
 globalThis._activeProvider = 'openai';
@@ -216,7 +217,7 @@ globalThis.api = async (url, opts) => {
     return {
       active: body.name || 'default',
       is_default: !body.name || body.name === 'default',
-      default_workspace: args.switchWorkspace !== undefined ? args.switchWorkspace : (args.profileDefaultWorkspace || null),
+      default_workspace: args.switchResponseWorkspace !== undefined ? args.switchResponseWorkspace : (args.profileDefaultWorkspace || null),
       default_model: null,
       default_model_provider: null,
     };
@@ -263,6 +264,7 @@ eval(switchToProfileSrc);
         "profileDefaultWorkspace": profile_default_workspace,
         "activeProfile": active_profile,
         "switchWorkspace": switch_workspace,
+        "switchResponseWorkspace": switch_response_workspace,
         "showAllProfiles": show_all_profiles,
         "messages": messages or [],
         "timeoutMs": timeout_ms,
@@ -402,6 +404,7 @@ def test_new_session_cross_profile_project_switches_before_request():
         ],
         profile_default_workspace="/workspace/profile",
         switch_workspace="/workspace/profile-switch",
+        switch_response_workspace="/workspace/destination-default",
         show_all_profiles=True,
         return_meta=True,
     )
@@ -424,10 +427,11 @@ def test_cross_profile_project_new_owns_single_session_creation_during_switch():
                 "project_id": "foreign-project",
                 "name": "Foreign",
                 "profile": "other",
-                "default_workspace": "/workspace/foreign",
+                "default_workspace": "/workspace/project-default",
             },
         ],
-        switch_workspace="/workspace/profile-switch",
+        switch_workspace="/workspace/one-shot",
+        switch_response_workspace="/workspace/destination-profile-default",
         session={"session_id": "session-1", "workspace": "/workspace/session"},
         messages=[{"role": "user", "content": "keep"}],
         show_all_profiles=True,
@@ -437,7 +441,8 @@ def test_cross_profile_project_new_owns_single_session_creation_during_switch():
     assert out["switchCalls"] == ["other"]
     assert out["callCount"] == 1
     assert out["body"]["project_id"] == "foreign-project"
-    assert out["body"]["workspace"] == "/workspace/profile-switch"
+    assert out["body"]["workspace"] == "/workspace/one-shot"
+    assert "fallback_workspace" not in out["body"]
 
 
 _HELPER = r"""

--- a/tests/test_4676_project_new_session_shortcuts.py
+++ b/tests/test_4676_project_new_session_shortcuts.py
@@ -445,6 +445,33 @@ def test_cross_profile_project_new_owns_single_session_creation_during_switch():
     assert "fallback_workspace" not in out["body"]
 
 
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_cross_profile_project_new_without_explicit_workspace_keeps_destination_default_as_fallback():
+    out = _run_new_session_case(
+        {"project_id": "foreign-project"},
+        all_projects=[
+            {
+                "project_id": "foreign-project",
+                "name": "Foreign",
+                "profile": "other",
+                "default_workspace": "/workspace/project-default",
+            },
+        ],
+        profile_default_workspace="/workspace/source-profile-default",
+        switch_response_workspace="/workspace/destination-profile-default",
+        session={"session_id": "session-1", "workspace": "/workspace/session"},
+        messages=[{"role": "user", "content": "keep"}],
+        show_all_profiles=True,
+        return_meta=True,
+    )
+    assert out["timedOut"] is False
+    assert out["switchCalls"] == ["other"]
+    assert out["callCount"] == 1
+    assert out["body"]["project_id"] == "foreign-project"
+    assert "workspace" not in out["body"]
+    assert out["body"]["fallback_workspace"] == "/workspace/destination-profile-default"
+
+
 _HELPER = r"""
 const fs = require('fs');
 const [sessionsPath, paramsJson] = process.argv.slice(-2);

--- a/tests/test_5457_project_default_workspace.py
+++ b/tests/test_5457_project_default_workspace.py
@@ -341,6 +341,41 @@ def test_session_new_explicit_workspace_overrides_project_default(project_env, m
     )
 
 
+def test_session_new_valid_project_default_beats_stale_fallback_workspace(
+    project_env, monkeypatch, tmp_path
+):
+    """A valid project default must win before a stale lower-priority fallback is validated."""
+    import api.routes as routes
+
+    project_ws = str(tmp_path / "project-default")
+    stale_fallback = str(tmp_path / "stale-fallback")
+    _seed_project(project_env, dw=project_ws)
+
+    def fake_resolve(path):
+        path = str(path)
+        if path == stale_fallback:
+            raise ValueError("stale fallback")
+        return Path(path)
+
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", fake_resolve)
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {
+        "project_id": "proj1",
+        "fallback_workspace": stale_fallback,
+    })
+    assert h.status == 200, h.json_body()
+    assert captured[0]["workspace"] == project_ws
+    assert captured[0]["project_id"] == "proj1"
+
+
 def test_session_new_stale_project_default_falls_back_to_fallback_workspace(
     project_env, monkeypatch, tmp_path
 ):

--- a/tests/test_5457_project_default_workspace.py
+++ b/tests/test_5457_project_default_workspace.py
@@ -341,6 +341,68 @@ def test_session_new_explicit_workspace_overrides_project_default(project_env, m
     )
 
 
+def test_session_new_explicit_workspace_beats_stale_fallback_workspace(
+    project_env, monkeypatch, tmp_path
+):
+    """A stale fallback must not be validated when explicit workspace already won."""
+    import api.routes as routes
+
+    explicit_ws = str(tmp_path / "explicit")
+    stale_fallback = str(tmp_path / "stale-fallback")
+    _seed_project(project_env, dw=str(tmp_path / "project-default"))
+
+    def fake_resolve(path):
+        path = str(path)
+        if path == stale_fallback:
+            raise ValueError("stale fallback")
+        return Path(path)
+
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", fake_resolve)
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {
+        "project_id": "proj1",
+        "workspace": explicit_ws,
+        "fallback_workspace": stale_fallback,
+    })
+    assert h.status == 200, h.json_body()
+    assert str(captured[0]["workspace"]) == explicit_ws
+
+
+def test_session_new_valid_project_default_beats_valid_fallback_workspace(
+    project_env, monkeypatch, tmp_path
+):
+    """A valid project default must still outrank a valid lower-priority fallback."""
+    import api.routes as routes
+
+    project_ws = str(tmp_path / "project-default")
+    fallback_ws = str(tmp_path / "profile-fallback")
+    _seed_project(project_env, dw=project_ws)
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {
+        "project_id": "proj1",
+        "fallback_workspace": fallback_ws,
+    })
+    assert h.status == 200, h.json_body()
+    assert captured[0]["workspace"] == project_ws
+
+
 def test_session_new_valid_project_default_beats_stale_fallback_workspace(
     project_env, monkeypatch, tmp_path
 ):
@@ -374,6 +436,29 @@ def test_session_new_valid_project_default_beats_stale_fallback_workspace(
     assert h.status == 200, h.json_body()
     assert captured[0]["workspace"] == project_ws
     assert captured[0]["project_id"] == "proj1"
+
+
+def test_session_new_stale_fallback_workspace_is_rejected_when_it_wins(
+    project_env, monkeypatch, tmp_path
+):
+    """A stale fallback must still raise once it becomes the chosen workspace."""
+    import api.routes as routes
+
+    stale_fallback = str(tmp_path / "stale-fallback")
+
+    def fake_resolve(path):
+        path = str(path)
+        if path == stale_fallback:
+            raise ValueError("stale fallback")
+        return Path(path)
+
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", fake_resolve)
+
+    h = _post("/api/session/new", {
+        "fallback_workspace": stale_fallback,
+    })
+    assert h.status == 400
+    assert h.json_body()["error"] == "stale fallback"
 
 
 def test_session_new_stale_project_default_falls_back_to_fallback_workspace(

--- a/tests/test_5457_project_default_workspace.py
+++ b/tests/test_5457_project_default_workspace.py
@@ -1,0 +1,441 @@
+"""Regression tests for #5457: project default workspace for new chats.
+
+Covers:
+- POST /api/projects/create: accepts and validates optional default_workspace
+- POST /api/projects/rename: sets or clears default_workspace
+- GET /api/projects?all_profiles=1: redacts foreign default_workspace values
+- POST /api/session/new: uses project default workspace when project_id supplied
+  and no explicit workspace provided
+"""
+
+import io
+import json
+import threading
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+
+# ── Fake HTTP handler (mirrors test_auth_settings_safety.py pattern) ──────────
+
+class _FakeHandler:
+    def __init__(self, body_dict):
+        raw = json.dumps(body_dict).encode("utf-8")
+        self.status = None
+        self.sent_headers = []
+        self.body = bytearray()
+        self.wfile = self
+        self.rfile = io.BytesIO(raw)
+        self.headers = {"Content-Length": str(len(raw))}
+        self.client_address = ("127.0.0.1", 0)
+        self.request = None
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+    def json_body(self):
+        return json.loads(bytes(self.body).decode("utf-8"))
+
+
+def _post(path, body_dict):
+    from api.routes import handle_post
+    handler = _FakeHandler(body_dict)
+    parsed = urlparse(f"http://example.com{path}")
+    handle_post(handler, parsed)
+    return handler
+
+
+def _get(path):
+    from api.routes import handle_get
+
+    handler = _FakeHandler({})
+    parsed = urlparse(f"http://example.com{path}")
+    handle_get(handler, parsed)
+    return handler
+
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+def _seed_project(projects_file, proj_id="proj1", name="TestProj", dw=None, profile="default"):
+    p = {
+        "project_id": proj_id,
+        "name": name,
+        "color": None,
+        "profile": profile,
+        "created_at": 1.0,
+    }
+    if dw is not None:
+        p["default_workspace"] = dw
+    projects_file.write_text(json.dumps([p]))
+
+
+@pytest.fixture()
+def project_env(tmp_path, monkeypatch):
+    """Monkeypatch storage + profile so project CRUD routes work in isolation."""
+    import api.config as cfg
+    import api.models as models
+    import api.profiles as profiles
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text("[]")
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", True)
+    monkeypatch.setattr(models, "_PROJECTS_MIGRATION_LOCK", threading.Lock())
+    monkeypatch.setattr(profiles, "_active_profile", "default")
+    monkeypatch.setattr(profiles, "list_profiles_api", lambda: [])
+    profiles._invalidate_root_profile_cache()
+    return projects_file
+
+
+# ── Project create ─────────────────────────────────────────────────────────────
+
+def test_project_create_stores_valid_default_workspace(project_env, monkeypatch, tmp_path):
+    """A valid default_workspace on create is normalized and persisted."""
+    import api.routes as routes
+
+    ws_path = str(tmp_path / "myworkspace")
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    h = _post("/api/projects/create", {"name": "TestProj", "default_workspace": ws_path})
+    assert h.status == 200, h.json_body()
+    resp = h.json_body()
+    assert resp["ok"] is True
+    assert resp["project"]["default_workspace"] == ws_path
+
+    saved = json.loads(project_env.read_text())
+    assert saved[0]["default_workspace"] == ws_path
+
+
+def test_project_create_omits_default_workspace_key_when_field_absent(project_env):
+    """Legacy create with no default_workspace field leaves the key absent."""
+    h = _post("/api/projects/create", {"name": "TestProj"})
+    assert h.status == 200
+    assert "default_workspace" not in h.json_body()["project"]
+
+    saved = json.loads(project_env.read_text())
+    assert "default_workspace" not in saved[0]
+
+
+def test_project_create_rejects_invalid_default_workspace(project_env, monkeypatch):
+    """An untrusted default_workspace returns 400 and nothing is persisted."""
+    import api.routes as routes
+
+    def _reject(p):
+        raise ValueError("path not trusted")
+
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", _reject)
+
+    h = _post("/api/projects/create", {"name": "TestProj", "default_workspace": "/bad/path"})
+    assert h.status == 400
+    assert "invalid default_workspace" in h.json_body().get("error", "")
+
+    saved = json.loads(project_env.read_text())
+    assert saved == [], "No project should be stored on validation failure"
+
+
+# ── Project rename ─────────────────────────────────────────────────────────────
+
+def test_project_rename_sets_default_workspace(project_env, monkeypatch, tmp_path):
+    """Rename with a valid default_workspace stores the normalized path."""
+    import api.routes as routes
+
+    _seed_project(project_env)
+    ws_path = str(tmp_path / "ws")
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    h = _post("/api/projects/rename", {
+        "project_id": "proj1",
+        "name": "TestProj",
+        "default_workspace": ws_path,
+    })
+    assert h.status == 200, h.json_body()
+    saved = json.loads(project_env.read_text())
+    assert saved[0]["default_workspace"] == ws_path
+
+
+def test_project_rename_clears_default_workspace_on_empty_string(project_env, monkeypatch, tmp_path):
+    """Rename with default_workspace='' removes the key from the stored record."""
+    ws_path = str(tmp_path / "ws")
+    _seed_project(project_env, dw=ws_path)
+
+    h = _post("/api/projects/rename", {
+        "project_id": "proj1",
+        "name": "TestProj",
+        "default_workspace": "",
+    })
+    assert h.status == 200, h.json_body()
+    saved = json.loads(project_env.read_text())
+    assert "default_workspace" not in saved[0]
+
+
+def test_project_rename_clears_default_workspace_on_null(project_env, monkeypatch, tmp_path):
+    """Rename with default_workspace=null removes the key from the stored record."""
+    ws_path = str(tmp_path / "ws")
+    _seed_project(project_env, dw=ws_path)
+
+    h = _post("/api/projects/rename", {
+        "project_id": "proj1",
+        "name": "TestProj",
+        "default_workspace": None,
+    })
+    assert h.status == 200, h.json_body()
+    saved = json.loads(project_env.read_text())
+    assert "default_workspace" not in saved[0]
+
+
+def test_project_rename_preserves_existing_default_when_field_absent(project_env, tmp_path):
+    """Rename without the default_workspace field leaves the existing value untouched."""
+    ws_path = str(tmp_path / "ws")
+    _seed_project(project_env, dw=ws_path)
+
+    h = _post("/api/projects/rename", {"project_id": "proj1", "name": "Renamed"})
+    assert h.status == 200, h.json_body()
+    saved = json.loads(project_env.read_text())
+    assert saved[0]["default_workspace"] == ws_path
+
+
+def test_project_rename_rejects_invalid_default_workspace(project_env, monkeypatch):
+    """An invalid path on rename returns 400 and leaves stored record unchanged."""
+    import api.routes as routes
+
+    _seed_project(project_env)
+
+    def _reject(p):
+        raise ValueError("path not trusted")
+
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", _reject)
+
+    h = _post("/api/projects/rename", {
+        "project_id": "proj1",
+        "name": "TestProj",
+        "default_workspace": "/bad/path",
+    })
+    assert h.status == 400
+    assert "invalid default_workspace" in h.json_body().get("error", "")
+
+
+def test_projects_all_profiles_redacts_foreign_default_workspace(project_env):
+    """Aggregate project rows keep foreign projects visible but hide their default workspace path."""
+    project_env.write_text(json.dumps([
+        {
+            "project_id": "proj-active",
+            "name": "Active",
+            "color": None,
+            "profile": "default",
+            "created_at": 1.0,
+            "default_workspace": "/active/workspace",
+        },
+        {
+            "project_id": "proj-foreign",
+            "name": "Foreign",
+            "color": None,
+            "profile": "other",
+            "created_at": 2.0,
+            "default_workspace": "/foreign/workspace",
+        },
+    ]))
+
+    h = _get("/api/projects?all_profiles=1")
+    assert h.status == 200, h.json_body()
+
+    projects = {proj["project_id"]: proj for proj in h.json_body()["projects"]}
+    assert projects["proj-active"]["default_workspace"] == "/active/workspace"
+    assert "default_workspace" not in projects["proj-foreign"]
+
+
+# ── Session new: project default workspace ─────────────────────────────────────
+
+class _FakeSession:
+    """Minimal session object accepted by the /api/session/new response path."""
+
+    def __init__(self, workspace=None):
+        self.messages = []
+        self.workspace = workspace
+        self.profile = "default"
+        self.session_id = "s-fake-1"
+        self.active_stream_id = None
+
+    def compact(self):
+        return {"session_id": self.session_id, "workspace": self.workspace}
+
+
+def test_session_new_uses_project_default_workspace(project_env, monkeypatch, tmp_path):
+    """Direct /api/session/new with project_id but no workspace uses the project's stored default."""
+    import api.routes as routes
+
+    ws_path = str(tmp_path / "projws")
+    _seed_project(project_env, dw=ws_path)
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {"project_id": "proj1"})
+    assert h.status == 200, h.json_body()
+    assert len(captured) == 1, "new_session must be called once"
+    assert captured[0]["workspace"] == ws_path, (
+        f"Expected project default {ws_path!r}, got {captured[0]['workspace']!r}"
+    )
+
+
+def test_session_new_uses_request_profile_for_project_default(project_env, monkeypatch, tmp_path):
+    """Direct API callers with a request profile get that profile's project default."""
+    import api.routes as routes
+
+    ws_path = str(tmp_path / "alice-project")
+    _seed_project(project_env, dw=ws_path, profile="alice")
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {"project_id": "proj1", "profile": "alice"})
+    assert h.status == 200, h.json_body()
+    assert captured[0]["workspace"] == ws_path
+    assert captured[0]["profile"] == "alice"
+
+
+def test_session_new_explicit_workspace_overrides_project_default(project_env, monkeypatch, tmp_path):
+    """An explicit workspace in the body takes priority over the project's default."""
+    import api.routes as routes
+
+    ws_path = str(tmp_path / "projws")
+    explicit_ws = str(tmp_path / "explicit")
+    _seed_project(project_env, dw=ws_path)
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {"project_id": "proj1", "workspace": explicit_ws})
+    assert h.status == 200, h.json_body()
+    assert str(captured[0]["workspace"]) == explicit_ws, (
+        f"Explicit workspace must win; got {captured[0]['workspace']!r}"
+    )
+
+
+def test_session_new_stale_project_default_falls_back_to_fallback_workspace(
+    project_env, monkeypatch, tmp_path
+):
+    """An invalid stored project default must fall through to fallback_workspace instead of 400ing."""
+    import api.routes as routes
+
+    stale_path = str(tmp_path / "missing-project-ws")
+    fallback_path = str(tmp_path / "profile-fallback")
+    _seed_project(project_env, dw=stale_path)
+
+    def fake_resolve(path):
+        path = str(path)
+        if path == stale_path:
+            raise ValueError("stale workspace")
+        return Path(path)
+
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", fake_resolve)
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {
+        "project_id": "proj1",
+        "fallback_workspace": fallback_path,
+    })
+    assert h.status == 200, h.json_body()
+    assert captured[0]["workspace"] == fallback_path
+    assert captured[0]["project_id"] == "proj1"
+
+
+def test_session_new_foreign_project_id_fails_closed_to_fallback_workspace(
+    project_env, monkeypatch, tmp_path
+):
+    """A foreign project_id must not survive into session creation and must fall back cleanly."""
+    import api.routes as routes
+
+    fallback_path = str(tmp_path / "profile-fallback")
+    _seed_project(project_env, dw=str(tmp_path / "foreign-project"), profile="other")
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda p: Path(str(p)))
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession(workspace=kwargs.get("workspace"))
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {
+        "project_id": "proj1",
+        "fallback_workspace": fallback_path,
+    })
+    assert h.status == 200, h.json_body()
+    assert captured[0]["project_id"] is None
+    assert captured[0]["workspace"] == fallback_path
+
+
+def test_session_new_no_project_no_workspace_keeps_none(project_env, monkeypatch):
+    """Without project_id or workspace the session gets workspace=None (existing behavior)."""
+    import api.routes as routes
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession()
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {})
+    assert h.status == 200, h.json_body()
+    assert captured[0]["workspace"] is None
+
+
+def test_session_new_project_without_default_workspace_does_not_set_workspace(
+    project_env, monkeypatch
+):
+    """A project with no default_workspace leaves session workspace as None."""
+    import api.routes as routes
+
+    _seed_project(project_env)  # no dw
+
+    captured = []
+
+    def fake_new_session(**kwargs):
+        captured.append(kwargs)
+        return _FakeSession()
+
+    monkeypatch.setattr(routes, "new_session", fake_new_session)
+
+    h = _post("/api/session/new", {"project_id": "proj1"})
+    assert h.status == 200, h.json_body()
+    assert captured[0]["workspace"] is None

--- a/tests/test_issue1700_parallel_profile_switch.py
+++ b/tests/test_issue1700_parallel_profile_switch.py
@@ -111,3 +111,16 @@ def test_frontend_skips_nested_new_session_when_caller_owns_replacement():
     assert branch_idx < nested_new_session_idx, (
         "switchToProfile() must check the caller-owned replacement path before it awaits nested newSession()"
     )
+
+
+def test_frontend_caller_owned_profile_switch_keeps_existing_one_shot_workspace():
+    fn = _extract_switch_to_profile()
+
+    guard_idx = fn.find("if (!_callerOwnsNewSession) {")
+    assign_idx = fn.find("S._profileSwitchWorkspace = data.default_workspace;")
+
+    assert guard_idx != -1, "switchToProfile() must guard profile default one-shot assignment"
+    assert assign_idx != -1, "profile-switch workspace assignment not found"
+    assert guard_idx < assign_idx, (
+        "caller-owned profile switches must not overwrite an existing one-shot workspace with the destination profile default"
+    )

--- a/tests/test_issue1700_parallel_profile_switch.py
+++ b/tests/test_issue1700_parallel_profile_switch.py
@@ -98,3 +98,16 @@ def test_frontend_treats_active_or_pending_session_as_in_progress():
     assert "S.session.active_stream_id" in session_block
     assert "S.session.pending_user_message" in session_block
     assert "S.messages.length > 0" in session_block
+
+
+def test_frontend_skips_nested_new_session_when_caller_owns_replacement():
+    fn = _extract_switch_to_profile()
+
+    assert "_profileSwitchCallerOwnsNewSession" in fn
+    branch_idx = fn.find("sessionInProgress && _callerOwnsNewSession")
+    nested_new_session_idx = fn.find("await newSession(false")
+    assert branch_idx != -1, "caller-owned replacement branch not found in switchToProfile()"
+    assert nested_new_session_idx != -1, "nested newSession() call not found in switchToProfile()"
+    assert branch_idx < nested_new_session_idx, (
+        "switchToProfile() must check the caller-owned replacement path before it awaits nested newSession()"
+    )

--- a/tests/test_issue4728_new_chat_default_model.py
+++ b/tests/test_issue4728_new_chat_default_model.py
@@ -29,6 +29,22 @@ function extractNewSession(src) {
   throw new Error('newSession body not closed');
 }
 
+function extractFunction(src, name) {
+  const start = src.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error(name + ' not found');
+  let depth = 0;
+  let bodyStart = src.indexOf('{', src.indexOf(')', start));
+  for (let i = bodyStart; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(name + ' body not closed');
+}
+
 const src = fs.readFileSync(process.argv[2], 'utf8');
 const args = JSON.parse(process.argv[3]);
 const modelSelect = {
@@ -79,6 +95,7 @@ globalThis.history = { replaceState() {} };
 globalThis.$ = $;
 globalThis.NO_PROJECT_FILTER = '__NO_PROJECT_FILTER__';
 globalThis._activeProject = '';
+globalThis._allProjects = [];
 globalThis._sessionSourceFilter = 'webui';
 globalThis._newSessionInFlight = null;
 globalThis._messagesTruncated = false;
@@ -156,6 +173,7 @@ globalThis.api = async (url, opts) => {
   };
 };
 
+eval(extractFunction(src, '_resolveProjectForNewSession'));
 eval(extractNewSession(src));
 
 (async () => {

--- a/tests/test_issue4755_profile_default_workspace.py
+++ b/tests/test_issue4755_profile_default_workspace.py
@@ -66,6 +66,24 @@ def _extract_async_function(source: str, name: str) -> str:
     raise AssertionError(f"could not extract {name}()")
 
 
+def _extract_function(source: str, name: str) -> str:
+    marker = f"function {name}("
+    start = source.find(marker)
+    assert start >= 0, f"{name}() function must exist"
+    brace = source.find("{", source.find(")", start))
+    assert brace > start, f"{name}() function body must start"
+    depth = 0
+    for idx in range(brace, len(source)):
+        ch = source[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"could not extract {name}()")
+
+
 def _run_node(script: str) -> dict:
     result = subprocess.run(
         [NODE, "-e", script],
@@ -80,7 +98,9 @@ def _run_node(script: str) -> dict:
 
 
 def _new_session_driver(session_workspace: str, default_workspace: str, switch_workspace: str | None) -> str:
-    new_session = _extract_async_function(SESSIONS_JS.read_text(encoding="utf-8"), "newSession")
+    sessions_src = SESSIONS_JS.read_text(encoding="utf-8")
+    project_resolver = _extract_function(sessions_src, "_resolveProjectForNewSession")
+    new_session = _extract_async_function(sessions_src, "newSession")
     return textwrap.dedent(
         f"""
         let captured=null;
@@ -88,6 +108,7 @@ def _new_session_driver(session_workspace: str, default_workspace: str, switch_w
         var _messagesTruncated=false;
         var _oldestIdx=0;
         var _activeProject=null;
+        var _allProjects=[];
         var NO_PROJECT_FILTER='__all__';
         var _sessionSourceFilter='webui';
         var S={{
@@ -118,6 +139,7 @@ def _new_session_driver(session_workspace: str, default_workspace: str, switch_w
         function syncTopbar(){{}}
         function renderMessages(){{}}
         function loadDir(){{return Promise.resolve();}}
+        {project_resolver}
         {new_session}
         newSession().then(()=>{{
           process.stdout.write(JSON.stringify({{captured,switchWorkspace:S._profileSwitchWorkspace}}));

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -80,6 +80,55 @@ class TestContextMenuBackground:
         )
 
 
+class TestProjectDefaultWorkspaceMenu:
+    """Project context menu exposes set/clear affordances for #5457."""
+
+    def test_default_workspace_menu_item_exists(self):
+        idx = SESSIONS_JS.find("function _showProjectContextMenu(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 3600]
+        assert "Default workspace" in body
+        assert "_showProjectDefaultWorkspacePicker(" in body
+
+    def test_default_workspace_menu_loads_saved_workspaces(self):
+        idx = SESSIONS_JS.find("function _showProjectContextMenu(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 3600]
+        assert "api('/api/workspaces',{method:'GET'})" in body
+
+    def test_default_workspace_picker_posts_project_update(self):
+        idx = SESSIONS_JS.find("function _showProjectDefaultWorkspacePicker(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 2600]
+        assert "api('/api/projects/rename'" in body
+        assert "default_workspace:ws||null" in body
+        assert "project_id:proj.project_id" in body
+        assert "name:proj.name" in body
+
+    def test_default_workspace_picker_has_clear_path(self):
+        idx = SESSIONS_JS.find("function _showProjectDefaultWorkspacePicker(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 2600]
+        assert "Clear default" in body
+        assert "Default workspace cleared" in body
+
+    def test_default_workspace_picker_clamps_to_viewport(self):
+        idx = SESSIONS_JS.find("function _showProjectDefaultWorkspacePicker(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 2600]
+        assert "window.innerWidth" in body
+        assert "document.documentElement.clientHeight" in body
+        assert "Math.max(8,Math.min(anchorEvent.clientX" in body
+        assert "Math.max(8,Math.min(anchorEvent.clientY" in body
+
+    def test_default_workspace_current_marker_normalizes_path_display_key(self):
+        idx = SESSIONS_JS.find("function _showProjectDefaultWorkspacePicker(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 2600]
+        assert "_projectWorkspaceDisplayKey(ws)" in body
+        assert "_projectWorkspaceDisplayKey(proj.default_workspace)" in body
+
+
 # ── Bug 2: project-create-input width ─────────────────────────────────────────
 
 
@@ -229,3 +278,115 @@ class TestProjectChipLongPressTouch:
         # touch tuning so the native callout/selection doesn't compete with the gesture
         assert "touch-action:manipulation" in chip_rule
         assert "user-select:none" in chip_rule
+
+
+# ── #5457: project default workspace context menu editor ──────────────────────
+
+
+class TestProjectDefaultWorkspaceContextMenu:
+    """The project context menu must expose a default-workspace set/clear flow (#5457)."""
+
+    def _ctx_menu_block(self):
+        idx = SESSIONS_JS.find("function _showProjectContextMenu(")
+        assert idx != -1, "_showProjectContextMenu not found in sessions.js"
+        end_idx = SESSIONS_JS.find("\nfunction ", idx + 1)
+        return SESSIONS_JS[idx: end_idx if end_idx > 0 else idx + 4000]
+
+    def _picker_block(self):
+        idx = SESSIONS_JS.find("function _showProjectDefaultWorkspacePicker(")
+        assert idx != -1, "_showProjectDefaultWorkspacePicker not found in sessions.js"
+        end_idx = SESSIONS_JS.find("\nfunction ", idx + 1)
+        return SESSIONS_JS[idx: end_idx if end_idx > 0 else idx + 3000]
+
+    def test_picker_function_exists(self):
+        assert "function _showProjectDefaultWorkspacePicker(" in SESSIONS_JS, (
+            "_showProjectDefaultWorkspacePicker function not found — default workspace "
+            "picker is not implemented."
+        )
+
+    def test_context_menu_has_default_workspace_item(self):
+        """The project context menu must include a 'Default workspace' item."""
+        block = self._ctx_menu_block()
+        assert "Default workspace" in block, (
+            "Project context menu does not contain a 'Default workspace' item."
+        )
+
+    def test_context_menu_default_workspace_fetches_workspaces_api(self):
+        """The Default workspace item must call /api/workspaces to populate the picker."""
+        block = self._ctx_menu_block()
+        assert "/api/workspaces" in block, (
+            "Context menu Default workspace item must fetch /api/workspaces for the picker."
+        )
+
+    def test_context_menu_default_workspace_opens_picker(self):
+        """The Default workspace onclick must delegate to _showProjectDefaultWorkspacePicker."""
+        block = self._ctx_menu_block()
+        assert "_showProjectDefaultWorkspacePicker(" in block, (
+            "Context menu item must call _showProjectDefaultWorkspacePicker."
+        )
+
+    def test_picker_posts_default_workspace_to_projects_rename(self):
+        """The picker must persist the selected workspace via /api/projects/rename."""
+        block = self._picker_block()
+        assert "/api/projects/rename" in block, (
+            "_showProjectDefaultWorkspacePicker must POST to /api/projects/rename."
+        )
+        assert "default_workspace" in block, (
+            "_showProjectDefaultWorkspacePicker must include default_workspace in the payload."
+        )
+
+    def test_picker_has_clear_option(self):
+        """The picker must include a 'Clear default' option to remove the project default."""
+        block = self._picker_block()
+        assert "Clear default" in block, (
+            "_showProjectDefaultWorkspacePicker must expose a 'Clear default' action."
+        )
+
+    def test_picker_refreshes_session_list_after_change(self):
+        """The picker must call renderSessionList() after setting or clearing the default."""
+        block = self._picker_block()
+        assert "renderSessionList(" in block, (
+            "_showProjectDefaultWorkspacePicker must refresh the session list after saving."
+        )
+
+    def test_picker_clamps_fixed_position_to_viewport(self):
+        """The picker must keep its fixed menu inside the current viewport."""
+        block = self._picker_block()
+        assert "window.innerWidth" in block
+        assert "document.documentElement.clientWidth" in block
+        assert "Math.max(8,Math.min(anchorEvent.clientX" in block
+        assert "Math.max(8,Math.min(anchorEvent.clientY" in block
+
+    def test_picker_current_marker_uses_workspace_display_key(self):
+        """Current marker comparison must tolerate harmless path display differences."""
+        block = self._picker_block()
+        assert "_projectWorkspaceDisplayKey(ws)" in block
+        assert "_projectWorkspaceDisplayKey(proj.default_workspace)" in block
+
+
+class TestCrossProfileProjectQuickCreate:
+    """Cross-profile project quick-create must switch profile before newSession()."""
+
+    def test_new_session_has_project_profile_switch_helper(self):
+        assert "async function _ensureProjectProfileForNewSession(" in SESSIONS_JS, (
+            "_ensureProjectProfileForNewSession helper not found in sessions.js."
+        )
+
+    def test_new_session_awaits_project_profile_switch_before_building_request(self):
+        idx = SESSIONS_JS.find("async function newSession(")
+        assert idx != -1, "newSession not found in sessions.js"
+        block = SESSIONS_JS[idx: idx + 2600]
+        assert "await _ensureProjectProfileForNewSession(_newSessionProj)" in block, (
+            "newSession must switch to the target project profile before posting the request."
+        )
+        assert "Switch to '+targetProfile+' before opening a new chat in this project" in block, (
+            "newSession must refuse a foreign project when profile switching cannot make it current."
+        )
+
+    def test_quick_create_button_still_routes_through_new_session_project_path(self):
+        idx = SESSIONS_JS.find("function _attachProjectQuickCreateButton(")
+        assert idx != -1, "_attachProjectQuickCreateButton not found in sessions.js"
+        block = SESSIONS_JS[idx: idx + 2200]
+        assert "await newSession(false,{project_id:project.project_id});" in block, (
+            "Quick-create must keep using newSession() with project_id so the shared profile-switch guard runs."
+        )


### PR DESCRIPTION
## Thinking Path

- Project chips already own session grouping, but project-targeted new chats also cross the profile-switch lifecycle when the sidebar is showing aggregate cross-profile data.
- The earlier fixes moved project-default resolution behind `/api/session/new` and made the outer project-targeted new-chat flow the only session creator across the switch, but round 3 still left one last precedence seam: caller-owned profile switches could overwrite explicit one-shot workspace with the destination profile default, and stale lower-priority fallback could still 400 before a valid project default won.
- The final branch keeps explicit one-shot workspace on `workspace`, leaves inherited profile/session state on `fallback_workspace`, and lets the server validate that fallback only after explicit workspace and project default both miss.

## What Changed

- `api/routes.py`: keeps aggregate `/api/projects?all_profiles=1` rows visible while stripping `default_workspace` from foreign-profile rows, drops foreign `project_id` values on `/api/session/new`, resolves server-side project default before fallback, and now validates `fallback_workspace` only when it can still win.
- `static/sessions.js`: keeps `S._profileSwitchWorkspace` on explicit `workspace`, leaves inherited profile/session state on `fallback_workspace`, and marks cross-profile project-new as caller-owned before awaiting `switchToProfile()`.
- `static/panels.js`: keeps destination profile default as persistent profile state, but no longer overwrites an existing caller-owned one-shot workspace during project-targeted cross-profile new chat; the caller-owned branch still skips nested `newSession()`.
- `tests/test_5457_project_default_workspace.py`: covers aggregate redaction, foreign `project_id` fail-closed behavior, valid-project-default vs stale-fallback precedence, and stale stored-default fallback.
- `tests/test_4676_project_new_session_shortcuts.py`: covers the distinct `A/B/F` precedence case, cross-profile project switching, and the single-create switch→new lifecycle.
- `tests/test_project_chip_ui.py` and `tests/test_issue1700_parallel_profile_switch.py`: keep the shared project-profile-switch guard, the caller-owned replacement branch, and the one-shot workspace preservation pinned.

## Why It Matters

Users still get project-specific default workspaces for new chats, but a cross-profile aggregate view can no longer overwrite an explicit one-shot workspace with the destination profile default or brick a valid project-default launch because an older fallback path is stale. The final flow keeps one session create, correct precedence, and the existing fail-closed profile boundary.

## Verification

The three new round-3 regressions fail on the pre-fix branch for the reported reasons and pass here: the distinct `A/B/F` cross-profile new-chat case, the caller-owned profile-switch guard, and the valid-project-default vs stale-fallback server path. The final focused bundle is green locally across the workspace/profile/project-chip surfaces plus the `#4755`, `#4728`, and sprint-40 sibling suites, the broader provider/profile-default compatibility bundle is green locally, runtime ESLint passed, and CI runs the full matrix.

## Risks / Follow-ups

Cross-profile aggregate mode still shows foreign project rows by design, but those rows intentionally omit `default_workspace`. This round stays within the existing browser-to-HTTP contract and leaves the already-closed isolation and recursion fixes unchanged.

## Contract Routing

- Task type: bugfix on existing project-targeted new-session semantics
- Touched areas: browser project/profile switch flow, `/api/session/new` fallback precedence, project-default regression tests
- Relevant public docs: none changed; product semantics stay enforced by the touched regression tests
- Scope boundaries: no schema or persistence changes; no new public API beyond the existing `workspace` / `fallback_workspace` split already on the branch
- Evidence needed before claiming done: pre-fix failure for the three reported regressions, green focused bundle on the final diff, and green compatibility bundle across provider/profile-default/workspace surfaces

## Upstream

Closes #5457.

## Model Used

GPT 5.5 via Codex CLI
