### PR TITLE
fix(#3954): move new chat shortcut to ctrl cmd shift o

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2025,8 +2025,8 @@ document.addEventListener('keydown',async e=>{
   if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')){
     const t=e.target;
     const isText=t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable);
-    if(isText) return;
     e.preventDefault();
+    if(isText) return;
     // If the current session has no messages AND nothing is in flight, just focus
     // the composer rather than creating another empty session that will clutter
     // the sidebar list (#1171). See the matching guard in $('btnNewChat').onclick

--- a/static/boot.js
+++ b/static/boot.js
@@ -1997,7 +1997,7 @@ $('msg').addEventListener('keydown',e=>{
     }
   }
 });
-// B14: Cmd/Ctrl+K creates a new chat from anywhere
+// B14: Cmd/Ctrl+Shift+O creates a new chat from anywhere
 document.addEventListener('keydown',async e=>{
   // Cmd/Ctrl+B toggles desktop sidebar collapse (VS Code convention).
   // Skip when typing in an input/textarea/contenteditable so text-edit
@@ -2022,7 +2022,7 @@ document.addEventListener('keydown',async e=>{
       return;
     }
   }
-  if((e.metaKey||e.ctrlKey)&&e.key==='k'){
+  if((e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')){
     const t=e.target;
     const isText=t&&(t.tagName==='INPUT'||t.tagName==='TEXTAREA'||t.isContentEditable);
     if(isText) return;
@@ -2034,11 +2034,11 @@ document.addEventListener('keydown',async e=>{
     if(_currentSessionIsReusableEmptyChat()){
       $('msg').focus();return;
     }
-    // Cmd/Ctrl+K should always create a new conversation, even while the current
-    // one is still streaming. The old !S.busy guard meant users had to wait for
-    // a long generation to finish before they could start something new — exactly
-    // the moment they want to switch context. newSession() leaves the in-flight
-    // stream running on its own session; the user just gets a fresh blank one.
+    // Cmd/Ctrl+Shift+O should always create a new conversation, even while the
+    // current one is still streaming. The old !S.busy guard meant users had to
+    // wait for a long generation to finish before they could start something new —
+    // exactly the moment they want to switch context. newSession() leaves the
+    // in-flight stream running on its own session; the user just gets a fresh one.
     await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();
   }
   // Cmd/Ctrl+, opens/closes Settings (VS Code convention).

--- a/static/index.html
+++ b/static/index.html
@@ -195,7 +195,7 @@
       <div class="panel-head">
         <span data-i18n="tab_chat">Chat</span>
         <div class="panel-head-actions">
-          <button class="panel-head-btn has-tooltip has-tooltip--bottom-right" id="btnNewChat" data-tooltip="New conversation (Cmd+K)" data-i18n-title="new_conversation" aria-label="New conversation">
+          <button class="panel-head-btn has-tooltip has-tooltip--bottom-right" id="btnNewChat" data-tooltip="New conversation (Cmd+Shift+O)" data-i18n-title="new_conversation" aria-label="New conversation">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           </button>
         </div>

--- a/tests/test_1432_newchat_and_1423_profile_input.py
+++ b/tests/test_1432_newchat_and_1423_profile_input.py
@@ -22,10 +22,10 @@ def _current_session_is_reusable_empty_chat_body(src):
 
 
 class TestIssue1432NewChatGuardInFlight:
-    """`+` button and Cmd/Ctrl+K must create a new chat even while the current
-    session is still streaming. The empty-session guard from #1171 was checking
-    `message_count===0` only, which is true the entire time the first user
-    message is in flight (server-side count not yet updated). The guard now
+    """`+` button and Cmd/Ctrl+Shift+O must create a new chat even while the
+    current session is still streaming. The empty-session guard from #1171 was
+    checking `message_count===0` only, which is true the entire time the first
+    user message is in flight (server-side count not yet updated). The guard now
     also requires `!S.busy && !S.session.active_stream_id &&
     !S.session.pending_user_message` — same in-flight signal used at
     `static/messages.js:_restoreSettledSession()`.
@@ -55,7 +55,7 @@ class TestIssue1432NewChatGuardInFlight:
         assert '_currentSessionIsReusableEmptyChat()' in body, \
             "btnNewChat handler must use the shared empty-session guard"
 
-    def test_cmdK_handler_checks_in_flight_state(self):
+    def test_cmdShiftO_handler_checks_in_flight_state(self):
         src = _read('boot.js')
         helper = _current_session_is_reusable_empty_chat_body(src)
 
@@ -68,13 +68,13 @@ class TestIssue1432NewChatGuardInFlight:
         assert 'pending_user_message' in helper, \
             "shared New Chat guard missing pending_user_message check (#1432)"
 
-        # Locate the Cmd/Ctrl+K branch — it sits inside a keydown listener
-        idx = src.find("(e.metaKey||e.ctrlKey)&&e.key==='k'")
-        assert idx >= 0, "Cmd/Ctrl+K handler not found in boot.js"
+        # Locate the Cmd/Ctrl+Shift+O branch — it sits inside a keydown listener
+        idx = src.find("(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')")
+        assert idx >= 0, "Cmd/Ctrl+Shift+O handler not found in boot.js"
         # Read the next ~1500 chars (handler body)
         body = src[idx:idx + 1500]
         assert '_currentSessionIsReusableEmptyChat()' in body, \
-            "Cmd/Ctrl+K handler must use the shared empty-session guard"
+            "Cmd/Ctrl+Shift+O handler must use the shared empty-session guard"
 
     def test_in_flight_signal_matches_restoreSettledSession(self):
         """The new in-flight check uses the same signal as the canonical

--- a/tests/test_issue3954_new_chat_shortcut.py
+++ b/tests/test_issue3954_new_chat_shortcut.py
@@ -87,8 +87,8 @@ class TestIssue3954NewChatShortcutMoved:
         body = BOOT_JS[idx:idx + 1500]
         assert "_currentSessionIsReusableEmptyChat()" in body
 
-    def test_new_shortcut_text_input_guard_before_prevent_default(self):
-        """Text-input guard fires before preventDefault() (#5099 preserved for new chord)."""
+    def test_new_shortcut_prevents_browser_default_before_text_guard(self):
+        """Browser default is suppressed before text inputs skip chat creation."""
         idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
         assert idx >= 0
         body = BOOT_JS[idx:idx + 1500]
@@ -96,8 +96,8 @@ class TestIssue3954NewChatShortcutMoved:
         prevent_idx = body.find("e.preventDefault()")
         assert guard_idx >= 0, "Text-input guard missing from Ctrl/Cmd+Shift+O branch"
         assert prevent_idx >= 0, "preventDefault() missing from Ctrl/Cmd+Shift+O branch"
-        assert guard_idx < prevent_idx, (
-            "Text-input guard must come before preventDefault() in Ctrl/Cmd+Shift+O branch"
+        assert prevent_idx < guard_idx, (
+            "preventDefault() must come before the text-input return in Ctrl/Cmd+Shift+O branch"
         )
 
     def test_tooltip_updated_to_new_shortcut(self):

--- a/tests/test_issue3954_new_chat_shortcut.py
+++ b/tests/test_issue3954_new_chat_shortcut.py
@@ -1,0 +1,116 @@
+"""Focused regression tests for #3954 — move New Chat shortcut from Ctrl+K to Ctrl+Shift+O.
+
+Base behavior: Ctrl/Cmd+K was the app-level New Chat chord; Ctrl/Cmd+Shift+O was absent.
+Head behavior: Ctrl/Cmd+Shift+O is the New Chat chord; global Ctrl/Cmd+K new-chat path is removed.
+
+The WebUI handler listens for the requested chord when the page receives the keydown event.
+No claim is made about browser-chrome or OS delivery of Ctrl/Cmd+Shift+O.
+"""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+
+NEW_CHAT_NEEDLE = "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')"
+
+
+class TestIssue3954NewChatShortcutMoved:
+    def test_new_shortcut_branch_exists(self):
+        """Ctrl/Cmd+Shift+O branch is present in boot.js."""
+        assert NEW_CHAT_NEEDLE in BOOT_JS, (
+            "Cmd/Ctrl+Shift+O New Chat handler not found in static/boot.js"
+        )
+
+    def test_new_shortcut_requires_shift(self):
+        """The new branch condition requires e.shiftKey."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        assert "e.shiftKey" in BOOT_JS[idx:idx + 120]
+
+    def test_new_shortcut_excludes_alt(self):
+        """The new branch condition excludes e.altKey to avoid AltGr conflicts."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        assert "!e.altKey" in BOOT_JS[idx:idx + 120]
+
+    def test_new_shortcut_key_is_case_insensitive(self):
+        """The key check covers both 'o' and 'O' for caps-lock tolerance."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        window = BOOT_JS[idx:idx + 120]
+        assert "e.key==='o'" in window
+        assert "e.key==='O'" in window
+
+    def test_old_ctrl_k_new_chat_branch_removed(self):
+        """Global Ctrl/Cmd+K no longer creates a new chat (old branch removed)."""
+        matches = [m.start() for m in re.finditer(r"\(e\.metaKey\|\|e\.ctrlKey\)&&e\.key===.k.", BOOT_JS)]
+        for m_idx in matches:
+            window = BOOT_JS[m_idx:m_idx + 600]
+            assert "newSession()" not in window, (
+                "Ctrl/Cmd+K must not create a new session — old global shortcut must be removed"
+            )
+
+    def test_new_shortcut_calls_new_session(self):
+        """Ctrl/Cmd+Shift+O branch calls newSession() to create the conversation."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        body = BOOT_JS[idx:idx + 1500]
+        assert "newSession()" in body
+
+    def test_new_shortcut_calls_render_session_list(self):
+        """Ctrl/Cmd+Shift+O branch calls renderSessionList() to refresh the sidebar."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        body = BOOT_JS[idx:idx + 1500]
+        assert "renderSessionList()" in body
+
+    def test_new_shortcut_closes_mobile_sidebar(self):
+        """Ctrl/Cmd+Shift+O branch calls closeMobileSidebar() so the chat is visible."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        body = BOOT_JS[idx:idx + 1500]
+        assert "closeMobileSidebar()" in body
+
+    def test_new_shortcut_focuses_composer(self):
+        """Ctrl/Cmd+Shift+O branch focuses the composer after creating the session."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        body = BOOT_JS[idx:idx + 1500]
+        assert "$('msg').focus()" in body
+
+    def test_new_shortcut_uses_reusable_empty_guard(self):
+        """Ctrl/Cmd+Shift+O branch reuses an existing empty session (#1171/#1432)."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        body = BOOT_JS[idx:idx + 1500]
+        assert "_currentSessionIsReusableEmptyChat()" in body
+
+    def test_new_shortcut_text_input_guard_before_prevent_default(self):
+        """Text-input guard fires before preventDefault() (#5099 preserved for new chord)."""
+        idx = BOOT_JS.find(NEW_CHAT_NEEDLE)
+        assert idx >= 0
+        body = BOOT_JS[idx:idx + 1500]
+        guard_idx = body.find("if(isText) return")
+        prevent_idx = body.find("e.preventDefault()")
+        assert guard_idx >= 0, "Text-input guard missing from Ctrl/Cmd+Shift+O branch"
+        assert prevent_idx >= 0, "preventDefault() missing from Ctrl/Cmd+Shift+O branch"
+        assert guard_idx < prevent_idx, (
+            "Text-input guard must come before preventDefault() in Ctrl/Cmd+Shift+O branch"
+        )
+
+    def test_tooltip_updated_to_new_shortcut(self):
+        """btnNewChat tooltip advertises the new Cmd+Shift+O shortcut."""
+        assert "Cmd+Shift+O" in INDEX_HTML, (
+            "btnNewChat tooltip must advertise Cmd+Shift+O, not the old Cmd+K"
+        )
+        assert 'data-tooltip="New conversation (Cmd+K)"' not in INDEX_HTML, (
+            "Old Cmd+K tooltip text must be removed from index.html"
+        )
+
+    def test_comment_updated_to_new_shortcut(self):
+        """Boot.js shortcut comment names Cmd/Ctrl+Shift+O, not Cmd/Ctrl+K."""
+        assert "Cmd/Ctrl+Shift+O creates a new chat" in BOOT_JS, (
+            "Boot.js shortcut comment must be updated to Cmd/Ctrl+Shift+O"
+        )

--- a/tests/test_issue5099_ctrl_k_text_input_guard.py
+++ b/tests/test_issue5099_ctrl_k_text_input_guard.py
@@ -2,8 +2,9 @@
 
 Emacs-adjacent users expect Ctrl+K to kill to end-of-line while the composer
 or other editable fields are focused. The new Cmd/Ctrl+Shift+O shortcut must
-still guard text inputs before calling preventDefault(), matching the existing
-Ctrl+B guard pattern. Ctrl+K no longer creates a new chat globally.
+still skip new-chat creation in text inputs, but it suppresses the browser
+default first when the page receives that chord. Ctrl+K no longer creates a new
+chat globally.
 """
 from pathlib import Path
 
@@ -24,21 +25,18 @@ class TestIssue5099NewChatShortcutTextInputGuard:
         assert "isContentEditable" in branch
         assert "if(isText) return" in branch
 
-    def test_new_chat_shortcut_prevent_default_after_text_guard(self):
+    def test_new_chat_shortcut_prevents_browser_default_before_text_guard(self):
         branch = _new_chat_branch_window()
         guard_idx = branch.find("if(isText) return")
         prevent_idx = branch.find("e.preventDefault()")
         assert guard_idx >= 0 and prevent_idx >= 0, (
-            "Ctrl/Cmd+Shift+O must guard text inputs before calling preventDefault()"
+            "Ctrl/Cmd+Shift+O must both suppress browser defaults and guard text inputs"
         )
-        assert guard_idx < prevent_idx, (
-            "preventDefault() must not run before the text-input early return"
+        assert prevent_idx < guard_idx, (
+            "preventDefault() must run before the text-input early return"
         )
 
-    def test_new_chat_shortcut_guard_matches_ctrl_b_idiom(self):
-        ctrl_b_idx = BOOT_JS.find("(e.key==='b'||e.key==='B')")
-        assert ctrl_b_idx >= 0, "Ctrl+B handler not found in boot.js"
-        ctrl_b_block = BOOT_JS[max(0, ctrl_b_idx - 250):ctrl_b_idx + 300]
+    def test_new_chat_shortcut_keeps_text_guard_shape(self):
         new_chat_block = _new_chat_branch_window()
         for needle in (
             "const t=e.target",
@@ -47,7 +45,6 @@ class TestIssue5099NewChatShortcutTextInputGuard:
             "tagName==='TEXTAREA'",
             "isContentEditable",
         ):
-            assert needle in ctrl_b_block, f"Ctrl+B guard missing {needle!r}"
             assert needle in new_chat_block, f"Ctrl/Cmd+Shift+O guard missing {needle!r}"
 
     def test_new_chat_shortcut_still_creates_new_session_outside_inputs(self):

--- a/tests/test_issue5099_ctrl_k_text_input_guard.py
+++ b/tests/test_issue5099_ctrl_k_text_input_guard.py
@@ -1,44 +1,45 @@
-"""Static-analysis tests for #5099 (Ctrl+K must not steal kill-line in text fields).
+"""Static-analysis tests for #5099 (New Chat shortcut must not steal text-input shortcuts).
 
 Emacs-adjacent users expect Ctrl+K to kill to end-of-line while the composer
-or other editable fields are focused. Cmd/Ctrl+K should still create a new chat
-when focus is outside text inputs, matching the existing Ctrl+B guard pattern.
+or other editable fields are focused. The new Cmd/Ctrl+Shift+O shortcut must
+still guard text inputs before calling preventDefault(), matching the existing
+Ctrl+B guard pattern. Ctrl+K no longer creates a new chat globally.
 """
 from pathlib import Path
 
 BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(encoding="utf-8")
 
 
-def _ctrl_k_branch_window() -> str:
-    idx = BOOT_JS.find("(e.metaKey||e.ctrlKey)&&e.key==='k'")
-    assert idx >= 0, "Cmd/Ctrl+K handler not found in boot.js"
+def _new_chat_branch_window() -> str:
+    idx = BOOT_JS.find("(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')")
+    assert idx >= 0, "Cmd/Ctrl+Shift+O handler not found in boot.js"
     return BOOT_JS[idx:idx + 1500]
 
 
-class TestIssue5099CtrlKTextInputGuard:
-    def test_ctrl_k_skips_text_inputs(self):
-        branch = _ctrl_k_branch_window()
+class TestIssue5099NewChatShortcutTextInputGuard:
+    def test_new_chat_shortcut_skips_text_inputs(self):
+        branch = _new_chat_branch_window()
         assert "tagName==='INPUT'" in branch
         assert "tagName==='TEXTAREA'" in branch
         assert "isContentEditable" in branch
         assert "if(isText) return" in branch
 
-    def test_ctrl_k_prevent_default_after_text_guard(self):
-        branch = _ctrl_k_branch_window()
+    def test_new_chat_shortcut_prevent_default_after_text_guard(self):
+        branch = _new_chat_branch_window()
         guard_idx = branch.find("if(isText) return")
         prevent_idx = branch.find("e.preventDefault()")
         assert guard_idx >= 0 and prevent_idx >= 0, (
-            "Ctrl+K must guard text inputs before calling preventDefault()"
+            "Ctrl/Cmd+Shift+O must guard text inputs before calling preventDefault()"
         )
         assert guard_idx < prevent_idx, (
             "preventDefault() must not run before the text-input early return"
         )
 
-    def test_ctrl_k_guard_matches_ctrl_b_idiom(self):
+    def test_new_chat_shortcut_guard_matches_ctrl_b_idiom(self):
         ctrl_b_idx = BOOT_JS.find("(e.key==='b'||e.key==='B')")
         assert ctrl_b_idx >= 0, "Ctrl+B handler not found in boot.js"
         ctrl_b_block = BOOT_JS[max(0, ctrl_b_idx - 250):ctrl_b_idx + 300]
-        ctrl_k_block = _ctrl_k_branch_window()
+        new_chat_block = _new_chat_branch_window()
         for needle in (
             "const t=e.target",
             "const isText=t&&",
@@ -47,9 +48,21 @@ class TestIssue5099CtrlKTextInputGuard:
             "isContentEditable",
         ):
             assert needle in ctrl_b_block, f"Ctrl+B guard missing {needle!r}"
-            assert needle in ctrl_k_block, f"Ctrl+K guard missing {needle!r}"
+            assert needle in new_chat_block, f"Ctrl/Cmd+Shift+O guard missing {needle!r}"
 
-    def test_ctrl_k_still_creates_new_session_outside_inputs(self):
-        branch = _ctrl_k_branch_window()
+    def test_new_chat_shortcut_still_creates_new_session_outside_inputs(self):
+        branch = _new_chat_branch_window()
         assert "newSession()" in branch
         assert "closeMobileSidebar()" in branch
+
+    def test_ctrl_k_is_not_global_new_chat_chord(self):
+        """Ctrl/Cmd+K must no longer be the app-level New Chat shortcut."""
+        # There must be no branch of the form (metaKey||ctrlKey)&&key==='k'
+        # that also calls newSession() — the old global new-chat path is removed.
+        import re
+        matches = [m.start() for m in re.finditer(r"\(e\.metaKey\|\|e\.ctrlKey\)&&e\.key===.k.", BOOT_JS)]
+        for m_idx in matches:
+            window = BOOT_JS[m_idx:m_idx + 600]
+            assert "newSession()" not in window, (
+                "Ctrl/Cmd+K must not create a new session (old global shortcut removed)"
+            )

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -843,34 +843,35 @@ def test_new_conversation_closes_mobile_sidebar():
     assert "closeMobileSidebar" in handler_block, \
         "btnNewChat handler must closeMobileSidebar() after creating the new session"
 
-    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
-    assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
-    shortcut_block = "\n".join(boot_js.splitlines()[boot_js.splitlines().index(shortcut_line):boot_js.splitlines().index(shortcut_line)+24])
+    shortcut_needle = "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')"
+    idx = boot_js.find(shortcut_needle)
+    assert idx >= 0, "Cmd/Ctrl+Shift+O new chat shortcut missing from static/boot.js"
+    shortcut_block = boot_js[idx:idx + 1200]
     assert "closeMobileSidebar" in shortcut_block, \
-        "Cmd/Ctrl+K new chat shortcut must closeMobileSidebar() after creating the new session"
+        "Cmd/Ctrl+Shift+O new chat shortcut must closeMobileSidebar() after creating the new session"
 
 
 def test_new_conversation_shortcut_works_while_busy():
-    """Cmd/Ctrl+K should still create a new conversation while the current one is busy.
+    """Cmd/Ctrl+Shift+O should still create a new conversation while the current one is busy.
 
     The previous behavior gated the shortcut on !S.busy, which meant users had
     to wait for a long generation to finish before they could start something
     new — the exact moment they want to switch context.
     """
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
-    assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
-    # Inspect the next 10 lines after the keybinding match — the gating block
+    shortcut_needle = "(e.metaKey||e.ctrlKey)&&e.shiftKey&&!e.altKey&&(e.key==='o'||e.key==='O')"
+    idx = boot_js.find(shortcut_needle)
+    assert idx >= 0, "Cmd/Ctrl+Shift+O new chat shortcut missing from static/boot.js"
+    # Inspect the block after the keybinding match — the gating block
     # would live there if it had been kept.
-    idx = boot_js.splitlines().index(shortcut_line)
-    shortcut_block = "\n".join(boot_js.splitlines()[idx:idx + 10])
+    shortcut_block = boot_js[idx:idx + 800]
     # Strip the existing message-count guard (which is unrelated and stays) so
     # we only check for an S.busy gate on the newSession() call itself.
     assert "if(!S.busy)" not in shortcut_block, (
-        "Cmd/Ctrl+K must not be blocked by the current session's busy state"
+        "Cmd/Ctrl+Shift+O must not be blocked by the current session's busy state"
     )
     assert "if (!S.busy)" not in shortcut_block, (
-        "Cmd/Ctrl+K must not be blocked by the current session's busy state"
+        "Cmd/Ctrl+Shift+O must not be blocked by the current session's busy state"
     )
 
 


### PR DESCRIPTION
## Thinking Path

- The New Chat shortcut still listens for `Ctrl/Cmd+K`, which is the conflict reported in #3954.
- The change moves the app-level handler and button tooltip to `Ctrl/Cmd+Shift+O`, while keeping the existing empty-session reuse, busy-session, text-input guard, and mobile-sidebar behavior.
- When the page receives the new chord inside an input, it suppresses the browser default before skipping chat creation, so the shortcut does not leak into browser UI while the user is typing.
- The tests now pin both sides of the contract: the new chord creates a conversation, and the old `Ctrl/Cmd+K` chord no longer does.

## What Changed

- `static/boot.js`: rebinds the New Chat keydown handler from `Ctrl/Cmd+K` to `Ctrl/Cmd+Shift+O` and updates shortcut comments.
- `static/index.html`: updates the New Conversation tooltip to the new shortcut.
- `tests/test_issue3954_new_chat_shortcut.py`: covers the new shortcut and absence of the old global New Chat binding.
- `tests/test_issue5099_ctrl_k_text_input_guard.py`, `tests/test_mobile_layout.py`, and `tests/test_1432_newchat_and_1423_profile_input.py`: update shortcut expectations while preserving existing behavior checks and browser-default suppression for text inputs.

## Why It Matters

`Ctrl/Cmd+K` is no longer consumed by New Chat, so keyboard navigation and text-editing habits keep their expected behavior. Users still get a global New Chat shortcut through the requested `Ctrl/Cmd+Shift+O` chord when the page receives it, and typing surfaces do not create a chat or leak the chord to browser UI.

## Verification

```bash
python -m pytest tests/test_issue3954_new_chat_shortcut.py -v --timeout=60
python -m pytest tests/test_issue5099_ctrl_k_text_input_guard.py -v --timeout=60
python -m pytest tests/test_mobile_layout.py tests/test_1432_newchat_and_1423_profile_input.py -v --timeout=60
python -m pytest tests/test_3845_keyboard_session_nav.py -v --timeout=60
```

Full-suite CI context: `python -m pytest tests/ -v --timeout=60`.

## Risks / Follow-ups

This changes only the app-level keydown handler and tooltip. It does not claim that every browser or operating system delivers `Ctrl/Cmd+Shift+O` to the page.

## Upstream

Closes #3954.

## Model Used

GPT 5.5 via Codex CLI

