### PR TITLE
fix(ux): add loading feedback and proper styling to session-list Retry button (#5501)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6698,8 +6698,16 @@ function renderSessionListFromCache(){
     }
     const retry=document.createElement('button');
     retry.type='button';
+    retry.className='session-list-error-retry';
     retry.textContent='Retry';
-    retry.onclick=(e)=>{e.stopPropagation();_sessionListLoadError=null;void renderSessionList({deferWhileInteracting:false});};
+    retry.onclick=(e)=>{
+      e.stopPropagation();
+      if(retry.disabled)return;
+      retry.disabled=true;
+      retry.textContent='Retrying…';
+      _sessionListLoadError=null;
+      void renderSessionList({deferWhileInteracting:false});
+    };
     note.appendChild(retry);
     list.appendChild(note);
   }

--- a/static/style.css
+++ b/static/style.css
@@ -5525,6 +5525,17 @@ main.main > #mainPlugin{display:none;}
 .session-source-tab:hover{background:rgba(255,255,255,.08);color:var(--text);}
 .session-source-tab.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg);}
 .session-empty-note{padding:20px 14px;color:var(--muted);font-size:12px;text-align:center;opacity:.7;}
+.session-list-error{opacity:1;}
+.session-list-error-retry{
+  display:inline-block;margin-top:14px;padding:8px 28px;
+  font-size:13px;font-weight:500;line-height:1.4;
+  color:#fff;background:var(--accent-bg);border:1px solid var(--accent-bg);
+  border-radius:6px;cursor:pointer;transition:opacity .15s;
+}
+.session-list-error-retry:hover{filter:brightness(1.15);}
+.session-list-error-retry:disabled{
+  opacity:.55;cursor:not-allowed;filter:none;
+}
 .project-bar{display:flex;gap:4px;padding:4px 10px 8px;flex-wrap:wrap;align-items:center;flex-shrink:0;}
 .project-chip{font-size:10px;font-weight:600;padding:3px 8px;border-radius:12px;cursor:pointer;border:1px solid var(--border2);background:var(--input-bg);color:var(--muted);transition:all .15s;white-space:nowrap;display:inline-flex;align-items:center;gap:4px;-webkit-user-select:none;user-select:none;-webkit-touch-callout:none;touch-action:manipulation;}
 .project-chip:hover{background:rgba(255,255,255,.08);color:var(--text);}


### PR DESCRIPTION
Closes #5501

## Summary

The session-list load-error Retry button had two issues (reported by @rodifer):

1. **No retry feedback** — clicking looked broken because the async render painted nothing new until the fetch resolved (up to 90 s). The button appeared dead.
2. **Unstyled / dimmed** — raw browser-default gray button inheriting opacity:.7 from the parent .session-empty-note, so it looked grayed-out and disabled.

## What changed

- **sessions.js**: on retry click, disable the button + show "Retrying…" label immediately, with a guard against double-clicks.
- **style.css**: reset opacity on the error container; add .session-list-error-retry with accent-brand styling, hover brighten, and a disabled state that visually confirms the button is processing.

## Before / After (screenshot)

Before: unstyled gray Retry button, dimmed, no feedback on click.
After: styled pill button matching app theme, shows "Retrying…" with disabled state during the in-flight fetch.

## Diff size

+20/-1 across 2 files (sessions.js + style.css). No new deps, no new config.