### PR TITLE
docs: document HERMES_WEBUI_* env vars + refresh stale version/test/locale numbers

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -48,6 +48,37 @@ GID=1000
 # HERMES_WEBUI_PASSWORD=change-me-to-something-strong
 
 # ──────────────────────────────────────────────────────────────────────────
+# Additional security / networking / limit knobs — advanced
+# ──────────────────────────────────────────────────────────────────────────
+# The WebUI process reads more HERMES_WEBUI_* variables than the compose
+# files forward by default. To use any of these in Docker, uncomment it here
+# AND add a matching passthrough line under `environment:` in your compose
+# file (e.g. `- HERMES_WEBUI_SESSION_TTL=${HERMES_WEBUI_SESSION_TTL:-}`).
+# Full descriptions live in .env.example.
+#
+# Auth cookie lifetime in seconds (default 2592000 = 30 days):
+# HERMES_WEBUI_SESSION_TTL=2592000
+#
+# Force the Secure cookie flag when serving HTTPS via a reverse proxy:
+# HERMES_WEBUI_SECURE=1
+#
+# Allowed public origins (scheme required) when behind a reverse proxy:
+# HERMES_WEBUI_ALLOWED_ORIGINS=https://myapp.example.com
+#
+# Trust reverse-proxy forwarded headers (only enable behind a proxy YOU run):
+# HERMES_WEBUI_TRUST_FORWARDED_HOST=1
+# HERMES_WEBUI_TRUST_FORWARDED_FOR=1
+# HERMES_WEBUI_TRUST_FORWARDED_PROTO=1
+#
+# Enable the passkey/WebAuthn login surface (default off):
+# HERMES_WEBUI_PASSKEY=1
+#
+# Archive extraction cap (MB) and "download folder as ZIP" caps:
+# HERMES_WEBUI_MAX_EXTRACTED_MB=2048
+# HERMES_WEBUI_FOLDER_ZIP_MAX_MB=1024
+# HERMES_WEBUI_FOLDER_ZIP_MAX_FILES=50000
+
+# ──────────────────────────────────────────────────────────────────────────
 # Permission handling for bind-mounted .hermes — advanced
 # ──────────────────────────────────────────────────────────────────────────
 # By default, the WebUI's startup credential-permission fixer enforces

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,99 @@
 
 # Display name for the assistant in the UI (default: Hermes)
 # HERMES_WEBUI_BOT_NAME=Hermes
+
+# ── Security & remote access ─────────────────────────────────────────────────
+
+# Password for the login page. REQUIRED if you bind to anything other than
+# 127.0.0.1 — without it, anyone who can reach the port can run commands.
+# HERMES_WEBUI_PASSWORD=change-me-to-something-strong
+
+# Enable the passkey/WebAuthn login surface (default: off).
+# Alternative: set `webui_passkey_enabled: true` in the profile's config.yaml.
+# HERMES_WEBUI_PASSKEY=1
+
+# Auth cookie lifetime in seconds (default: 2592000 = 30 days).
+# Clamped to [60, 31536000]. Also settable as session_ttl_seconds in settings.json.
+# HERMES_WEBUI_SESSION_TTL=2592000
+
+# Force the Secure flag on auth cookies: 1/true or 0/false.
+# Unset = auto-detect (direct TLS socket, or a trusted X-Forwarded-Proto).
+# HERMES_WEBUI_SECURE=1
+
+# Override the auth cookie name (default: derived internally).
+# HERMES_WEBUI_COOKIE_NAME=hermes_webui_session
+
+# Extra allowed origins for CSRF/origin checks when serving behind a reverse
+# proxy or on a public hostname. Comma-separated; each entry MUST include the
+# scheme. Entries without a scheme are ignored with a warning.
+# HERMES_WEBUI_ALLOWED_ORIGINS=https://myapp.example.com:8000
+
+# Serve HTTPS directly (both must be set; otherwise plain HTTP).
+# HERMES_WEBUI_TLS_CERT=/path/to/fullchain.pem
+# HERMES_WEBUI_TLS_KEY=/path/to/privkey.pem
+
+# Extra sources appended to the Content-Security-Policy (space-separated).
+# HERMES_WEBUI_CSP_CONNECT_EXTRA=https://api.example.com wss://api.example.com
+# HERMES_WEBUI_CSP_FRAME_EXTRA=https://embed.example.com
+
+# ── Reverse-proxy header trust (opt-in; only enable behind a proxy YOU run) ───
+# By default these forwarded headers are NOT trusted, because any direct client
+# could forge them. Enable (1/true/yes/on) only when a reverse proxy you control
+# sets them. TRUST_FORWARDED_HOST: honor X-Forwarded-Host/X-Real-Host in origin
+# checks. TRUST_FORWARDED_FOR: honor X-Forwarded-For for the client IP.
+# TRUST_FORWARDED_PROTO: honor X-Forwarded-Proto for HTTPS detection.
+# HERMES_WEBUI_TRUST_FORWARDED_HOST=1
+# HERMES_WEBUI_TRUST_FORWARDED_FOR=1
+# HERMES_WEBUI_TRUST_FORWARDED_PROTO=1
+
+# ── Uploads & limits ─────────────────────────────────────────────────────────
+
+# Where chat attachments are stored (default: <state dir>/attachments).
+# Attachments are transient agent context, kept out of the workspace by default.
+# HERMES_WEBUI_ATTACHMENT_DIR=~/.hermes/webui/attachments
+
+# Cap on total bytes an uploaded archive may expand to (zip-bomb guard).
+# Default derives from the upload size limit; override in MB.
+# HERMES_WEBUI_MAX_EXTRACTED_MB=2048
+
+# Caps for the "download folder as ZIP" feature in the workspace browser.
+# HERMES_WEBUI_FOLDER_ZIP_MAX_MB=1024
+# HERMES_WEBUI_FOLDER_ZIP_MAX_FILES=50000
+
+# Requests slower than this many seconds get a stack-dump diagnostic in the log
+# (default: 5.0; set 0 to log every request's timing).
+# HERMES_WEBUI_SLOW_REQUEST_SECONDS=5.0
+
+# ── Onboarding ───────────────────────────────────────────────────────────────
+
+# Skip the first-run onboarding wizard entirely.
+# HERMES_WEBUI_SKIP_ONBOARDING=1
+
+# ── Advanced integrations ────────────────────────────────────────────────────
+
+# Script whose stdout prefills new-session context (legacy generic hook; the
+# WebUI dynamic-recall hook in config.yaml takes precedence when configured).
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT=/path/to/script
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT=10
+# HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS=20000
+
+# Extra sources for the notes drawer (see docs for the expected format).
+# HERMES_WEBUI_EXTERNAL_NOTES_SOURCES=
+
+# Directory scanned for WebUI plugins (default: ~/.hermes/plugins).
+# HERMES_WEBUI_PLUGINS_DIR=~/.hermes/plugins
+
+# API key used when polling the Hermes gateway health endpoint.
+# HERMES_WEBUI_GATEWAY_API_KEY=
+
+# Override the Claude Code projects directory scanned by the CLI session
+# bridge (default: auto-discovered ~/.claude/projects).
+# HERMES_WEBUI_CLAUDE_PROJECTS_DIR=~/.claude/projects
+
+# Override the Codex CLI home scanned by the CLI session bridge and model
+# catalog merge (default: ~/.codex).
+# CODEX_HOME=~/.codex
+
+# Path to the LLM wiki root shown in the wiki panel (default: resolved from
+# HERMES_HOME's wiki env file).
+# WIKI_PATH=/path/to/wiki

--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,8 @@
 # Script whose stdout prefills new-session context (legacy generic hook; the
 # WebUI dynamic-recall hook in config.yaml takes precedence when configured).
 # HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT=/path/to/script
-# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT=10
-# HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS=20000
+# HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT=5
+# HERMES_WEBUI_PREFILL_CONTEXT_MAX_CHARS=12000
 
 # Extra sources for the notes drawer (see docs for the expected format).
 # HERMES_WEBUI_EXTERNAL_NOTES_SOURCES=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,8 +7,8 @@
 >
 > Keep this document updated as architecture changes are made.
 
-> Current shipped build: `v0.51.192` (May 31, 2026).
-> Automated coverage: ~7,150 tests via `pytest tests/ --collect-only -q`. CI runs on
+> Current shipped build: `v0.51.792` (July 1, 2026).
+> Automated coverage: ~11,500 tests via `pytest tests/ --collect-only -q`. CI runs on
 > Python 3.11, 3.12, and 3.13 (3 parallel shards each) against every PR, plus a ruff
 > lint gate, a headless browser smoke test, and a Docker smoke test.
 >
@@ -86,7 +86,7 @@ actions. The topbar remains focused on conversation context and the workspace/fi
       sw.js                Service worker: offline shell cache, version-pinned assets
     tests/
       conftest.py          Isolated test server/state fixtures
-      ~700 test files      ~7,150 tests collected via pytest (run `pytest --collect-only -q` for exact)
+      ~1,150 test files    ~11,500 tests collected via pytest (run `pytest --collect-only -q` for exact)
       test_regressions.py  Permanent regression gate
     CONTRIBUTING.md        Contributor workflow and PR expectations.
     ROADMAP.md             Feature and product roadmap document.
@@ -718,7 +718,7 @@ Current structure:
         ui.js, workspace.js, sessions.js, messages.js, panels.js, commands.js, boot.js
       tests/
         conftest.py           Isolated test server/state fixtures
-        488 test files        5303 tests collected
+        ~1,150 test files     ~11,500 tests collected
         test_regressions.py   Permanent regression gate
 
 Route extraction to api/routes.py completed in Sprint 11. server.py remains a
@@ -818,7 +818,7 @@ Optional password gate for non-SSH-tunnel deployments.
 
 ### Phase I: Test Infrastructure -- COMPLETE
 
-5303 tests across 488 test files + regression gates. The pytest fixture derives
+~11,500 tests across ~1,150 test files + regression gates. The pytest fixture derives
 an isolated port and state directory from the repo path unless
 `HERMES_WEBUI_TEST_PORT` / `HERMES_WEBUI_TEST_STATE_DIR` pin them explicitly.
 Production data never touched.

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ system/Homebrew interpreter.
 
 Tests run against an isolated server with a separate state directory.
 Production data and real cron jobs are never touched. Current snapshot:
-**~7,150 tests collected** across **~700 test files**, run in CI on Python 3.11,
+**~11,500 tests collected** across **~1,150 test files**, run in CI on Python 3.11,
 3.12, and 3.13 (3 parallel shards each).
 
 ---
@@ -567,7 +567,7 @@ boot.js           Mobile nav, voice input, theme/skin boot, bfcache handler
 **Tests + packaging**
 
 ```
-tests/            Pytest suite (~7,150 tests; isolated server/state fixtures)
+tests/            Pytest suite (~11,500 tests; isolated server/state fixtures)
 pyproject.toml    Tooling config (ruff lint gate) — not a packaged distribution
 Dockerfile        python:3.12-slim container image
 docker-compose.yml  Compose with named volume and optional auth

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.51.192 (May 31, 2026) — ~7,150 tests collected. Recent themes: forward-looking ruff lint gate (#3273), Windows upgrade state-stranding hotfix (#2905), per-model context_length default-only guard (#3256), gateway-configured banner + tooltip i18n, and an ongoing concentric PR-triage cadence.
+> Last updated: v0.51.792 (July 1, 2026) — ~11,500 tests collected. Recent themes: forward-looking ruff lint gate (#3273), Windows upgrade state-stranding hotfix (#2905), per-model context_length default-only guard (#3256), gateway-configured banner + tooltip i18n, and an ongoing concentric PR-triage cadence.
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 
@@ -230,7 +230,7 @@ Remaining gaps and forward work live in [Forward Work](#forward-work) below.
 - [x] PWA installation (manifest + icons + Android support)
 
 ### Internationalization
-- [x] 9 locales — English, Japanese, Russian, Spanish, German, Chinese (zh + zh-Hant), Portuguese, Korean, French
+- [x] 14 locales — English, Italian, Japanese, Russian, Spanish, German, Chinese (zh + zh-Hant), Portuguese, Korean, French, Turkish, Polish, Vietnamese
 - [x] Key-parity test ensures every locale has every key
 - [x] Right-to-left and CJK input (IME composition fixes)
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -2,7 +2,7 @@
 
 > Forward-looking sprint plan and active queue.
 >
-> Current state: v0.50.281 | 3995 tests | port 8787
+> Current state: v0.51.792 | ~11,500 tests | port 8787
 > Target A (CLI parity): ✅ Complete
 > Target B (Claude parity): ~95% — full subagent transparency UI and code-execution cells remain
 >

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
-> Automated coverage: ~7,150 tests collected via `./scripts/test.sh tests/ --collect-only -q`. Tests run on every PR via GitHub Actions on Python 3.11, 3.12, and 3.13 (3 parallel shards each), alongside a ruff lint gate, a headless browser smoke test, and a Docker smoke test. The suite covers the bootstrap/static wizard, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, CSS regression coverage for thinking/tool card animation, streaming session persistence, mobile layout breakpoints, locale parity across 11 languages, and hundreds of issue/PR-pinned regression tests.
+> Automated coverage: ~11,500 tests collected via `./scripts/test.sh tests/ --collect-only -q`. Tests run on every PR via GitHub Actions on Python 3.11, 3.12, and 3.13 (3 parallel shards each), alongside a ruff lint gate, a headless browser smoke test, and a Docker smoke test. The suite covers the bootstrap/static wizard, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, CSS regression coverage for thinking/tool card animation, streaming session persistence, mobile layout breakpoints, locale parity across 14 languages, and hundreds of issue/PR-pinned regression tests.
 > Run: `./scripts/test.sh`
 >
 > Local regression focus: verify that a previously closed workspace panel stays visually closed from first paint through boot completion on desktop refresh; there should be no brief open-then-close flash.
@@ -1925,8 +1925,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.51.192, May 31, 2026*
-*Total automated tests collected: ~7,150 (run `./scripts/test.sh tests/ --collect-only -q` for the exact current count)*
+*Last updated: v0.51.792, July 1, 2026*
+*Total automated tests collected: ~11,500 (run `./scripts/test.sh tests/ --collect-only -q` for the exact current count)*
 *Regression gate: tests/test_regressions.py*
 *Run: ./scripts/test.sh*
 *Source: <repo>/*


### PR DESCRIPTION
Split out of #5530 per the gate-certifier's request — documentation only, no code.

## What
- **`.env.example` / `.env.docker.example`**: document ~25 `HERMES_WEBUI_*` variables the server reads but no template listed — security, reverse-proxy header trust, upload limits, onboarding, and advanced integrations — with defaults taken from the code.
- **README / ROADMAP / ARCHITECTURE / SPRINTS / TESTING**: refresh stale version stamps (v0.51.192 → v0.51.792), test counts (~7,150 → ~11,500 / ~1,150 files, matching `--collect-only`), and locale count (9 → 14). Curated narrative left untouched.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
