### PR TITLE
fix(ux): increase approval card height cap on mobile (#5385)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3159,7 +3159,7 @@
     /* Approval card */
     .approval-card{padding-left:10px;padding-right:10px;bottom:8px;overflow:visible;}
     .approval-inner{max-height:min(52vh,360px);overflow-y:auto;overscroll-behavior:contain;-webkit-overflow-scrolling:touch;padding:12px 12px 14px;border-radius:12px;box-shadow:0 -10px 30px rgba(0,0,0,.24);}
-    @supports (height:100dvh){.approval-inner{max-height:min(52dvh,360px);}}
+    @supports (height:100dvh){.approval-inner{max-height:min(60dvh,420px);}}
     .approval-header{margin-bottom:8px;}
     .approval-collapse,.approval-dismiss{width:44px;height:44px;line-height:1;overflow:hidden;}
     .approval-cmd{max-height:86px;margin-bottom:10px;}


### PR DESCRIPTION
Closes #5385

## Summary

The command/tool approval popup on mobile was capped at `min(52dvh,360px)`, which rendered too small on Android WebView — users had to scroll within the popup to see all action buttons.

## What changed

Bumped the dvh-supported cap from `min(52dvh,360px)` to `min(60dvh,420px)`.

This gives ~15% more vertical room, which is enough to show all standard approval button rows without requiring internal scrolling on most Android devices.

## Diff

+1/-1 in `static/style.css` (single `@supports` line in mobile section).