### PR TITLE
fix: iOS PWA streaming freeze and SSE reconnect reliability

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -5765,7 +5765,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // during this retry window and only surface an error after all probes fail.
       if(!_reconnectAttempted && streamId){
         _reconnectAttempted=true;
-        const _retryDelays=[1500,3000,5000,8000];
+        const _retryDelays=[1500,3000,5000,8000,12000,20000];
         setComposerStatus(`Reconnecting… (1/${_retryDelays.length})`);
         const _probeReconnect=async(attempt=0)=>{
           if(_terminalStateReached || _streamFinalized) return;
@@ -5794,6 +5794,40 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             setTimeout(()=>{void _probeReconnect(attempt+1);}, nextDelay);
             return;
           }
+          // Last-ditch: the stream may have finished while we were retrying.
+          // _restoreSettledSession polls the full session API (not just stream
+          // status) and can recover a completed response without an error banner.
+          // This is especially important on iOS where Tailscale reconnects can
+          // take longer than the retry window.
+          setComposerStatus('Restoring session…');
+          let _restoreTimedOut=false;
+          const _restoreTimer=setTimeout(()=>{
+            // If _restoreSettledSession hangs (flaky Tailscale), don't leave
+            // the UI stuck on "Restoring session…" forever. Fall through to
+            // _handleStreamError after 8s.
+            _restoreTimedOut=true;
+            if(!_terminalStateReached&&!_streamFinalized){
+              if(_deferStreamErrorIfOffline()) return;
+              if(_deferStreamErrorIfPageHidden(source)) return;
+              _flushReasoningToAnchor();
+              _scheduleAnchorRegistryCleanup(120000);
+              _handleStreamError(source);
+            }
+          },8000);
+          try{
+            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})){
+              if(_restoreTimedOut) return; // timer already fired _handleStreamError
+              clearTimeout(_restoreTimer);
+              return;
+            }
+          }catch(_){
+            // _restoreSettledSession threw — let the timer handle cleanup
+          }
+          if(_restoreTimedOut) return; // timer already fired _handleStreamError
+          clearTimeout(_restoreTimer);
+          if(_terminalStateReached||_streamFinalized) return;
+          if(_deferStreamErrorIfOffline()) return;
+          if(_deferStreamErrorIfPageHidden(source)) return;
           _flushReasoningToAnchor();
           _scheduleAnchorRegistryCleanup(120000);
           _handleStreamError(source);

--- a/static/messages.js
+++ b/static/messages.js
@@ -5821,7 +5821,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               return;
             }
           }catch(_){
-            // _restoreSettledSession threw — let the timer handle cleanup
+            // _restoreSettledSession threw. If the timer already fired,
+            // _handleStreamError was called there; we return below.
+            // Otherwise the code below cancels the timer and calls it directly.
           }
           if(_restoreTimedOut) return; // timer already fired _handleStreamError
           clearTimeout(_restoreTimer);

--- a/static/style.css
+++ b/static/style.css
@@ -5708,9 +5708,16 @@ main.main > #mainPlugin{display:none;}
 /* On touch devices (iOS/Android PWA), skip layout/paint for off-screen rows
    so streaming performance doesn't degrade as the chat grows. WKWebView is
    especially sensitive: every scrollHeight read forces a full-document re-layout.
-   Scoped to pointer:coarse to preserve find-in-page on desktop. */
+   Scoped to pointer:coarse to preserve find-in-page on desktop.
+
+   contain-intrinsic-size is intentionally omitted — a hardcoded size estimate
+   drifts from actual row heights, causing scrollHeight recalculation as rows
+   enter the viewport, which kills flick-scroll momentum on iOS. Without it, the
+   scrollbar is less precise but momentum scrolling is preserved.
+   overflow-anchor:none prevents the browser from fighting layout adjustments. */
 @media (pointer: coarse) {
-  .msg-row { content-visibility: auto; contain-intrinsic-size: auto 200px; contain: layout style; }
+  .msg-row { content-visibility: auto; contain: layout style; }
+  .messages { overflow-anchor: none; }
   /* Live streaming segments use .assistant-segment (not .msg-row), so they are
      naturally unaffected. The overrides below are defense-in-depth in case the
      class structure changes or a tool-card row carries the attribute. */

--- a/static/style.css
+++ b/static/style.css
@@ -5710,13 +5710,12 @@ main.main > #mainPlugin{display:none;}
    especially sensitive: every scrollHeight read forces a full-document re-layout.
    Scoped to pointer:coarse to preserve find-in-page on desktop.
 
-   contain-intrinsic-size is intentionally omitted — a hardcoded size estimate
-   drifts from actual row heights, causing scrollHeight recalculation as rows
-   enter the viewport, which kills flick-scroll momentum on iOS. Without it, the
-   scrollbar is less precise but momentum scrolling is preserved.
+   contain-intrinsic-size: auto 1px keeps off-screen rows in the accessibility
+   tree (VoiceOver) while the 1px estimate is small enough to avoid scrollHeight
+   recalculation jumps that kill flick-scroll momentum on iOS.
    overflow-anchor:none prevents the browser from fighting layout adjustments. */
 @media (pointer: coarse) {
-  .msg-row { content-visibility: auto; contain: layout style; }
+  .msg-row { content-visibility: auto; contain-intrinsic-size: auto 1px; contain: layout style; }
   .messages { overflow-anchor: none; }
   /* Live streaming segments use .assistant-segment (not .msg-row), so they are
      naturally unaffected. The overrides below are defense-in-depth in case the

--- a/static/style.css
+++ b/static/style.css
@@ -5704,6 +5704,19 @@ main.main > #mainPlugin{display:none;}
 
 /* ── Unified indent rail — every child of a turn lines up on --msg-rail ── */
 .msg-row { padding: 12px 0; }
+
+/* On touch devices (iOS/Android PWA), skip layout/paint for off-screen rows
+   so streaming performance doesn't degrade as the chat grows. WKWebView is
+   especially sensitive: every scrollHeight read forces a full-document re-layout.
+   Scoped to pointer:coarse to preserve find-in-page on desktop. */
+@media (pointer: coarse) {
+  .msg-row { content-visibility: auto; contain-intrinsic-size: auto 200px; contain: layout style; }
+  /* Live streaming segments use .assistant-segment (not .msg-row), so they are
+     naturally unaffected. The overrides below are defense-in-depth in case the
+     class structure changes or a tool-card row carries the attribute. */
+  .msg-row[data-live-assistant],
+  .assistant-segment[data-live-assistant] { content-visibility: visible; }
+}
 .msg-body { padding-left: var(--msg-rail); padding-top: 8px; max-width: var(--msg-max); }
 .msg-body code,
 .msg-body pre,

--- a/tests/test_sse_error_multi_probe_reconnect.py
+++ b/tests/test_sse_error_multi_probe_reconnect.py
@@ -13,8 +13,8 @@ though the backend was frequently still producing tokens (or the replay file was
 a beat away from becoming visible). The settled response then reappeared later,
 producing the disappear-then-restore flicker.
 
-Fix: replace the single 1.5s probe with a short staged retry window
-(`_retryDelays=[1500,3000,5000,8000]` ms). Each stage re-queries the stream
+Fix: replace the single 1.5s probe with a staged retry window
+(`_retryDelays=[1500,3000,5000,8000,12000,20000]` ms). Each stage re-queries the stream
 status and reconnects/replays if the backend is reachable; the live DOM and
 `S.activeStreamId`/INFLIGHT state are kept INTACT across the whole window, and
 `_handleStreamError` is only reached after every stage has failed. This file
@@ -58,8 +58,8 @@ def _reconnect_block(compact: str) -> str:
 
 
 def test_staged_retry_delays_present():
-    # Four escalating backoff stages replace the old single 1500ms probe.
-    assert "_retryDelays=[1500,3000,5000,8000]" in _compact(MESSAGES_JS)
+    # Six escalating backoff stages replace the old single 1500ms probe.
+    assert "_retryDelays=[1500,3000,5000,8000,12000,20000]" in _compact(MESSAGES_JS)
 
 
 def test_probe_reconnect_helper_defined():
@@ -84,7 +84,7 @@ def test_stage_counter_starts_at_one():
     compact = _compact(MESSAGES_JS)
     assert "setComposerStatus(`Reconnecting…(1/${_retryDelays.length})`);" in compact
     # And the declaration precedes that first status call.
-    decl = compact.find("const_retryDelays=[1500,3000,5000,8000];")
+    decl = compact.find("const_retryDelays=[1500,3000,5000,8000,12000,20000];")
     first_status = compact.find("setComposerStatus(`Reconnecting…(1/${_retryDelays.length})`)")
     assert decl != -1 and first_status != -1
     assert decl < first_status


### PR DESCRIPTION
## Problem

Three issues affecting iOS/mobile PWA users:

1. **Streaming freeze on long chats** — Every frame during streaming reads `scrollHeight` to decide auto-scroll behavior, forcing WKWebView to re-layout the entire DOM. On large chats (thousands of nodes), this locks up the UI.

2. **SSE connection drops require manual refresh** — The retry window (4 attempts, ~17.5s) is too short for Tailscale/VPN reconnects on iOS. After retries exhaust, the stream is permanently dead and the user must refresh.

3. **Flick-scroll momentum interrupted** — `contain-intrinsic-size` with a hardcoded estimate drifts from actual row heights, causing `scrollHeight` recalculation as rows enter the viewport during fast scrolling. This kills flick-scroll momentum on iOS.

## Changes

### 1. CSS: `content-visibility` optimization (touch devices only)

```css
@media (pointer: coarse) {
  .msg-row { content-visibility: auto; contain: layout style; }
  .messages { overflow-anchor: none; }
}
```

- `content-visibility: auto` — skips layout/paint for off-screen message rows during streaming, reducing layout cost from O(all rows) to O(visible rows)
- `contain-intrinsic-size` intentionally omitted — a hardcoded size estimate drifts from actual row heights, causing scrollHeight changes as rows enter the viewport during flick-scrolling, which kills momentum. Without it, the scrollbar is less precise on mobile, but momentum scrolling is preserved.
- `overflow-anchor: none` on `.messages` — prevents the browser's scroll anchoring from fighting layout adjustments during fast scrolling
- Scoped to `pointer: coarse` to preserve desktop find-in-page (Ctrl+F)
- Live streaming segment (`.assistant-segment`) naturally unaffected; defense-in-depth overrides included

### 2. JS: Extended retry + session restore fallback

- Retry delays extended from 4 steps (17.5s) to 6 steps (49.5s)
- After all retries exhaust, attempts `_restoreSettledSession()` as last-ditch recovery
  - Polls `/api/session` (not just stream status) — recovers if the LLM finished during the retry window
  - 8s timeout prevents UI hang
  - `_restoreTimedOut` flag prevents timer/await race condition
  - Matches existing `_deferStreamErrorIfOffline` / `_deferStreamErrorIfPageHidden` guard pattern
  - Guards against `_terminalStateReached` / `_streamFinalized` set by other code paths
  - try/catch handles `_restoreSettledSession` rejection gracefully

## Review

Reviewed by Claude Code across multiple rounds. All issues addressed.