### PR TITLE
fix: fire-and-forget commit_session_memory to unblock new-session POST

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13067,21 +13067,34 @@ def handle_post(handler, parsed) -> bool:
                 # the new session (#5420).
                 prev_session_id = None
             if prev_session_id:
-                try:
-                    from api.session_lifecycle import commit_session_memory
-                    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
-                    prev_agent = None
-                    with SESSION_AGENT_CACHE_LOCK:
-                        _cached = SESSION_AGENT_CACHE.get(prev_session_id)
-                        if _cached:
-                            prev_agent = _cached[0]
-                    commit_session_memory(prev_session_id, agent=prev_agent)
-                except Exception:
-                    logger.debug(
-                        "Lifecycle commit for prev_session %s failed",
-                        prev_session_id,
-                        exc_info=True,
-                    )
+                # Fire-and-forget: commit_memory_session() can take 1-5+ seconds
+                # (extraction call to the memory provider), and blocking the
+                # response here made "+ New Chat" feel slow/unresponsive.
+                # commit_session_memory() already serialises overlapping commits
+                # for a session via its own in-flight guard, so running it off
+                # the request thread is safe.
+                def _commit_prev_session_memory(_sid=prev_session_id):
+                    try:
+                        from api.session_lifecycle import commit_session_memory
+                        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+                        prev_agent = None
+                        with SESSION_AGENT_CACHE_LOCK:
+                            _cached = SESSION_AGENT_CACHE.get(_sid)
+                            if _cached:
+                                prev_agent = _cached[0]
+                        commit_session_memory(_sid, agent=prev_agent)
+                    except Exception:
+                        logger.warning(
+                            "Lifecycle commit for prev_session %s failed",
+                            _sid,
+                            exc_info=True,
+                        )
+
+                threading.Thread(
+                    target=_commit_prev_session_memory,
+                    daemon=True,
+                    name=f"commit-memory-{prev_session_id}",
+                ).start()
         s = new_session(
             workspace=workspace,
             model=model,

--- a/api/routes.py
+++ b/api/routes.py
@@ -13090,11 +13090,14 @@ def handle_post(handler, parsed) -> bool:
                             exc_info=True,
                         )
 
-                threading.Thread(
+                t = threading.Thread(
                     target=_commit_prev_session_memory,
                     daemon=True,
                     name=f"commit-memory-{prev_session_id}",
-                ).start()
+                )
+                from api.session_lifecycle import _register_background_commit_thread
+                _register_background_commit_thread(t)
+                t.start()
         s = new_session(
             workspace=workspace,
             model=model,

--- a/api/session_lifecycle.py
+++ b/api/session_lifecycle.py
@@ -45,6 +45,26 @@ _condition = threading.Condition(_lock)
 
 _sessions: dict[str, dict] = {}
 
+# Background commit threads spawned by fire-and-forget paths (e.g. POST /api/session/new).
+# Tracked so drain_all_on_shutdown() can join them before interpreter teardown,
+# preventing silent data loss when daemon threads are abandoned mid-commit.
+_background_commit_threads: set[threading.Thread] = set()
+_background_commit_threads_lock = threading.Lock()
+
+
+def _register_background_commit_thread(t: threading.Thread) -> None:
+    with _background_commit_threads_lock:
+        _background_commit_threads.add(t)
+
+
+def _drain_background_commit_threads(timeout: float = 5.0) -> None:
+    with _background_commit_threads_lock:
+        threads = list(_background_commit_threads)
+        _background_commit_threads.clear()
+    for t in threads:
+        if t.is_alive():
+            t.join(timeout)
+
 
 def _new_entry() -> dict:
     return {
@@ -226,6 +246,11 @@ def commit_session_memory(session_id: str, agent=None, *, wait: bool = False, ti
 
 
 def drain_all_on_shutdown() -> None:
+    # Drain in-flight background commit threads first (fire-and-forget from
+    # POST /api/session/new) so their commit work completes before we drain
+    # any remaining uncommitted generations inline.
+    _drain_background_commit_threads()
+
     while True:
         with _lock:
             snapshot = [sid for sid, entry in _sessions.items() if entry["generation"] > entry["committed_generation"]]


### PR DESCRIPTION
`commit_session_memory()` can take 1-5+ seconds (extraction call to the memory provider), blocking the `POST /api/session/new` response and making the "+ New Chat" button feel slow or unresponsive.

**Fix**: Move the commit to a daemon thread so the response returns immediately. `commit_session_memory()` already serialises overlapping commits for a session via its own in-flight guard, so this is safe.

Also bump the failure log from `logger.debug` to `logger.warning` so lost commits are visible in logs (daemon threads can be killed on shutdown).

**Before**: request handler blocks until memory commit completes
**After**: response returns immediately, memory commit runs in background