### PR TITLE
fix: re-pin auto-scroll in scrollIfPinned after user scrolls back to bottom

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -4858,7 +4858,7 @@ if(typeof window!=='undefined'){
       }else if(movedDown&&nearBottom){
         _nearBottomCount=_nearBottomCount+1;
         if(_nearBottomCount>=2){
-          if(!_messageUserUnpinned||bottomDistance<=80){
+          if(!_messageUserUnpinned||bottomDistance<=250){
             _messageUserUnpinned=false;
             _scrollPinned=true;
           }
@@ -5516,7 +5516,21 @@ function _settleFinalScroll(token){
 }
 function scrollIfPinned(){
   if(!_autoScrollFollow) return;
-  if(_messageUserUnpinned) return;
+  if(_messageUserUnpinned){
+    // Only scrollToBottom() cleared this flag, so one scroll-up permanently
+    // killed auto-follow. Re-pin through the same _nearBottomCount debounce
+    // the scroll listener uses (~4859-4866) instead of flipping the flags
+    // on the first chunk that lands near bottom, since this runs on every
+    // streamed chunk and would otherwise fight a reader who's actively
+    // scrolling away, and bypass the listener's own re-pin guards.
+    if(_messageBottomDistance()>250){ _nearBottomCount=0; return; }
+    _nearBottomCount=_nearBottomCount+1;
+    if(_nearBottomCount<2) return;
+    _nearBottomCount=0;
+    if(_recentNonMessageScrollIntent()||_recentMessageTouchScrollIntent()) return;
+    _messageUserUnpinned=false;
+    _scrollPinned=true;
+  }
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
   if(_messageBottomDistance()>500) _setMessageScrollToBottom();

--- a/static/ui.js
+++ b/static/ui.js
@@ -4858,10 +4858,10 @@ if(typeof window!=='undefined'){
       }else if(movedDown&&nearBottom){
         _nearBottomCount=_nearBottomCount+1;
         if(_nearBottomCount>=2){
-          if(!_messageUserUnpinned||bottomDistance<=250){
-            _messageUserUnpinned=false;
-            _scrollPinned=true;
-          }
+          // nearBottom already guarantees bottomDistance<250, so the
+          // re-pin threshold is always satisfied when we reach this branch.
+          _messageUserUnpinned=false;
+          _scrollPinned=true;
           _nearBottomCount=0;
         }
       }else if(!_messageUserUnpinned){


### PR DESCRIPTION
When a user scrolls up during streaming, `_messageUserUnpinned` is set `true` and `scrollIfPinned()` permanently stops auto-following — only `scrollToBottom()` clears the flag, but `scrollIfPinned()` is what runs on every streamed chunk.

**Fix**: Add a re-pin path in `scrollIfPinned()` that mirrors the scroll listener's `_nearBottomCount` debounce:
1. After 2 consecutive near-bottom (250px) streaming chunks
2. Without active scroll intent (`_recentNonMessageScrollIntent`, `_recentMessageTouchScrollIntent`)
3. Clear the unpinned flag and resume auto-follow

Also normalize the listener's re-pin threshold from 80px to 250px to match its own `nearBottom` gate, eliminating a dead zone (81-249px) where the counter could reach 2 but the re-pin would silently fail.

**Before**: one scroll-up → permanent auto-follow lockout
**After**: scroll back near bottom → 2 chunks confirm → auto-follow resumes