### PR TITLE
fix(#5523): show running tools as running in Transparent Stream

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -10721,7 +10721,7 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     node=_decorateTransparentEventRow(buildToolCard(toolCall),{
       type:'tool',
       name:toolCall&&toolCall.name,
-      status:_transparentToolStatus(toolCall,true),
+      status:_transparentToolStatus(toolCall,settled),
       toolCall,
       ...meta,
     });

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -632,8 +632,20 @@ def test_transparent_interrupted_status_on_settled_tools():
     assert "function _transparentToolStatus(tc, settled)" in UI_JS
     assert "settled?'Interrupted':'Running'" in UI_JS
     start = UI_JS.index("function _anchorSceneTransparentNodeForRow(row, opts){")
-    end = UI_JS.index("\nfunction ", start + 1)
+    depth = 0
+    end = None
+    for idx in range(start, len(UI_JS)):
+        char = UI_JS[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                end = idx + 1
+                break
+    assert end is not None, "_anchorSceneTransparentNodeForRow body did not close"
     body = UI_JS[start:end]
+    assert "else if(row.role==='tool')" in body
     assert "_transparentToolStatus(toolCall,settled)" in body
     assert "_transparentToolStatus(toolCall,true)" not in body
     assert "_transparentToolStatus(event.toolCall,true)" in UI_JS

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -631,6 +631,11 @@ def test_transparent_interrupted_status_on_settled_tools():
     permanent Running shimmer). (Trifecta O-Edge.)"""
     assert "function _transparentToolStatus(tc, settled)" in UI_JS
     assert "settled?'Interrupted':'Running'" in UI_JS
+    start = UI_JS.index("function _anchorSceneTransparentNodeForRow(row, opts){")
+    end = UI_JS.index("\nfunction ", start + 1)
+    body = UI_JS[start:end]
+    assert "_transparentToolStatus(toolCall,settled)" in body
+    assert "_transparentToolStatus(toolCall,true)" not in body
     assert "_transparentToolStatus(event.toolCall,true)" in UI_JS
 
 

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -799,7 +799,7 @@ def test_transparent_stream_renders_persisted_anchor_scene_after_reload():
     # tool + thinking rows are rendered as transparent event rows
     assert "_decorateTransparentEventRow(_thinkingActivityNode" in row
     assert "_decorateTransparentEventRow(buildToolCard(toolCall)" in row
-    assert "_transparentToolStatus(toolCall,true)" in row
+    assert "_transparentToolStatus(toolCall,settled)" in row
     assert 'data-anchor-settled-scene-row' in row
     assert "if(anchorOwnedAssistantRawIdxs.has(aIdx)) continue;" in render
 


### PR DESCRIPTION
## Thinking Path

- Transparent Stream already distinguishes live and settled tool rows through `_transparentToolStatus(tc, settled)`.
- The live anchor-scene builder was discarding that distinction by passing `true` into the helper even when the caller supplied `settled:false`.
- The fix keeps the status helper unchanged and corrects the one stale caller argument, while preserving the settled replay path.

## What Changed

- `static/ui.js`: pass the anchor-scene `settled` option into `_transparentToolStatus()` for live Transparent Stream tool rows.
- `tests/test_issue3820_chat_activity_display_mode.py`: pin the live caller to `settled` and keep the existing settled replay assertion.

## Why It Matters

Running tools should read as running. Transparent Stream no longer tells users a live tool was interrupted while it is still executing.

## Verification

```
pytest tests/test_issue3820_chat_activity_display_mode.py::test_transparent_interrupted_status_on_settled_tools -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5523.

## Model Used

GPT 5.5 via Codex CLI
