### PR TITLE
docs(#5269): document gateway approval runs API opt-in

### DIFF
--- a/docs/advanced-chat-setup.md
+++ b/docs/advanced-chat-setup.md
@@ -63,6 +63,18 @@ HERMES_WEBUI_GATEWAY_API_KEY=... \
 ./ctl.sh restart
 ```
 
+Gateway-backed approval prompts need one more explicit opt-in because they use the Gateway runs API path:
+
+```bash
+HERMES_WEBUI_CHAT_BACKEND=gateway \
+HERMES_WEBUI_GATEWAY_BASE_URL=http://127.0.0.1:8642 \
+HERMES_WEBUI_GATEWAY_API_KEY=... \
+HERMES_WEBUI_GATEWAY_USE_RUNS_API=true \
+./ctl.sh restart
+```
+
+Use this when the connected gateway advertises approval support and you want tool approval cards to appear in WebUI. Without `HERMES_WEBUI_GATEWAY_USE_RUNS_API=true`, gateway chat stays on the legacy chat-completions transport and approval-capable commands can remain pending in the agent without a WebUI approval card.
+
 `HERMES_WEBUI_CHAT_BACKEND` is intentionally strict: only `gateway`,
 `api_server`, or `api-server` enable the bridge. Generic truthy values such as
 `1` or `true` are ignored so existing deployments do not change execution

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -185,6 +185,20 @@ services:
       # HERMES_WEBUI_GATEWAY_BASE_URL=http://hermes-agent:8642 also works.
 ```
 
+If WebUI browser chat is routed through that gateway and you expect approval prompts for guarded tools, set the gateway chat backend and opt into the runs API path in the **WebUI service**:
+
+```yaml
+services:
+  hermes-webui:
+    environment:
+      - HERMES_WEBUI_CHAT_BACKEND=gateway
+      - HERMES_WEBUI_GATEWAY_BASE_URL=http://hermes-agent:8642
+      - HERMES_WEBUI_GATEWAY_USE_RUNS_API=true
+      # HERMES_WEBUI_GATEWAY_API_KEY=... when the gateway requires API auth.
+```
+
+`HERMES_WEBUI_GATEWAY_USE_RUNS_API=true` is required for gateway approval cards because approval-capable gateway runs emit approval requests on the runs API transport. Leaving it unset keeps browser chat on the legacy chat-completions path.
+
 Do not copy only `API_SERVER_ENABLED=true` / `API_SERVER_HOST=0.0.0.0` into the
 agent service as a standalone fix. If you intentionally enable the agent API
 server, the agent also requires a real `API_SERVER_KEY` (at least 8 characters),

--- a/tests/test_issue5269_gateway_approval_docs.py
+++ b/tests/test_issue5269_gateway_approval_docs.py
@@ -2,21 +2,23 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-ADVANCED = (ROOT / "docs" / "advanced-chat-setup.md").read_text(encoding="utf-8")
-DOCKER = (ROOT / "docs" / "docker.md").read_text(encoding="utf-8")
 
 
 def test_advanced_chat_docs_name_gateway_approval_runs_api_opt_in():
-    assert "HERMES_WEBUI_CHAT_BACKEND=gateway" in ADVANCED
-    assert "HERMES_WEBUI_GATEWAY_USE_RUNS_API=true" in ADVANCED
-    assert "approval prompts" in ADVANCED
-    assert "approval card" in ADVANCED
-    assert "legacy chat-completions transport" in ADVANCED
+    advanced = (ROOT / "docs" / "advanced-chat-setup.md").read_text(encoding="utf-8")
+
+    assert "HERMES_WEBUI_CHAT_BACKEND=gateway" in advanced
+    assert "HERMES_WEBUI_GATEWAY_USE_RUNS_API=true" in advanced
+    assert "approval prompts" in advanced
+    assert "approval card" in advanced
+    assert "legacy chat-completions transport" in advanced
 
 
 def test_docker_docs_name_webui_service_runs_api_opt_in_for_approval_cards():
-    assert "HERMES_WEBUI_CHAT_BACKEND=gateway" in DOCKER
-    assert "HERMES_WEBUI_GATEWAY_BASE_URL=http://hermes-agent:8642" in DOCKER
-    assert "HERMES_WEBUI_GATEWAY_USE_RUNS_API=true" in DOCKER
-    assert "approval cards" in DOCKER
-    assert "WebUI service" in DOCKER
+    docker = (ROOT / "docs" / "docker.md").read_text(encoding="utf-8")
+
+    assert "HERMES_WEBUI_CHAT_BACKEND=gateway" in docker
+    assert "HERMES_WEBUI_GATEWAY_BASE_URL=http://hermes-agent:8642" in docker
+    assert "HERMES_WEBUI_GATEWAY_USE_RUNS_API=true" in docker
+    assert "approval cards" in docker
+    assert "WebUI service" in docker

--- a/tests/test_issue5269_gateway_approval_docs.py
+++ b/tests/test_issue5269_gateway_approval_docs.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ADVANCED = (ROOT / "docs" / "advanced-chat-setup.md").read_text(encoding="utf-8")
+DOCKER = (ROOT / "docs" / "docker.md").read_text(encoding="utf-8")
+
+
+def test_advanced_chat_docs_name_gateway_approval_runs_api_opt_in():
+    assert "HERMES_WEBUI_CHAT_BACKEND=gateway" in ADVANCED
+    assert "HERMES_WEBUI_GATEWAY_USE_RUNS_API=true" in ADVANCED
+    assert "approval prompts" in ADVANCED
+    assert "approval card" in ADVANCED
+    assert "legacy chat-completions transport" in ADVANCED
+
+
+def test_docker_docs_name_webui_service_runs_api_opt_in_for_approval_cards():
+    assert "HERMES_WEBUI_CHAT_BACKEND=gateway" in DOCKER
+    assert "HERMES_WEBUI_GATEWAY_BASE_URL=http://hermes-agent:8642" in DOCKER
+    assert "HERMES_WEBUI_GATEWAY_USE_RUNS_API=true" in DOCKER
+    assert "approval cards" in DOCKER
+    assert "WebUI service" in DOCKER


### PR DESCRIPTION
## Thinking Path

- The latest issue thread narrowed the missing approval dialog to a commented-out runs API opt-in in the WebUI container.
- The runtime should keep that transport explicit, because the existing gateway chat path intentionally does not switch to runs API only because the gateway advertises approvals.
- The docs now put the approval-card opt-in next to the multi-container gateway setup so operators do not have to discover it from an issue comment.

## What Changed

- `docs/advanced-chat-setup.md`: document `HERMES_WEBUI_GATEWAY_USE_RUNS_API=true` for gateway-backed approval prompts.
- `docs/docker.md`: add the same approval prompt note in the multi-container gateway setup guidance.
- `tests/test_issue5269_gateway_approval_docs.py`: pin the docs coverage for the approval opt-in.

## Why It Matters

Multi-container users can have an approval-capable gateway and still miss WebUI approval cards if the WebUI container stays on the legacy chat-completions transport. The docs now state the required opt-in where that setup is configured.

## Verification

```
pytest tests/test_issue5269_gateway_approval_docs.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Refs #5269.

## Model Used

GPT 5.5 via Codex CLI
