### PR TITLE
Fix #5532: /api/session/clear sets truncation watermark (P0 data loss)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13717,6 +13717,20 @@ def handle_post(handler, parsed) -> bool:
             )
             truncate_session_at_keep(s, 0)
             s.tool_calls = []
+            # #5532 (Codex gate): a compressed-continuation child persists its
+            # archived transcript in a parent sidecar marked
+            # pre_compression_snapshot and stitches it back for display via
+            # _webui_sidecar_lineage_messages_for_display(). That stitch merges
+            # the child's own messages with truncation_watermark=None, so the
+            # 0.0 truncate-to-empty sentinel we just set on the CHILD does NOT
+            # stop the PARENT snapshot from resurrecting the pre-clear transcript
+            # on refresh. Detach the compression lineage so a cleared session is
+            # genuinely empty: drop the snapshot parent link + the anchor fields
+            # so the child no longer resolves a pre_compression_snapshot parent.
+            s.parent_session_id = None
+            s.compression_anchor_visible_idx = None
+            s.compression_anchor_message_key = None
+            s.compression_anchor_summary = None
             # Reset the title via the rename helper so clearing a manually-named
             # session also clears manual_title/llm_title_generated — otherwise the
             # reused session keeps its manual-title protection and never auto-names

--- a/api/routes.py
+++ b/api/routes.py
@@ -13694,13 +13694,33 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Session not found", 404)
         sid = body["session_id"]
         with _get_session_agent_lock(sid):
-            s.messages = []
+            # Clear is a full truncate: keep zero messages. Route it through the
+            # SAME helper the /api/session/truncate handler uses so the merge
+            # contract is not forked (#5532 P0 data loss).
+            #
+            # Before this fix /clear wiped s.messages/s.tool_calls but never set
+            # truncation_watermark. The append-only state.db merge
+            # (merge_session_messages_append_only) treats an unset watermark as
+            # "keep everything", so on the next /api/session read the cleared
+            # turns were resurrected from state.db (history reappeared after
+            # clear+refresh) and — because context_messages also survived — a
+            # continued turn still carried the pre-clear context.
+            #
+            # truncate_session_at_keep(s, 0) empties messages AND context_messages
+            # and sets truncation_watermark = truncation_boundary =
+            # _truncation_watermark_for([]) == 0.0. 0.0 is the #2914
+            # "truncate-to-empty" sentinel that blocks ALL state.db replay, so the
+            # merge honors the clear instead of re-adding the deleted transcript.
+            from api.session_ops import (
+                apply_session_title_rename,
+                truncate_session_at_keep,
+            )
+            truncate_session_at_keep(s, 0)
             s.tool_calls = []
             # Reset the title via the rename helper so clearing a manually-named
             # session also clears manual_title/llm_title_generated — otherwise the
             # reused session keeps its manual-title protection and never auto-names
             # again (#3542 lifecycle gap).
-            from api.session_ops import apply_session_title_rename
             apply_session_title_rename(s, "Untitled")
             s.save()
         # Evict cached agent outside the per-session lock.  Eviction may run a

--- a/api/routes.py
+++ b/api/routes.py
@@ -13737,6 +13737,18 @@ def handle_post(handler, parsed) -> bool:
             # again (#3542 lifecycle gap).
             apply_session_title_rename(s, "Untitled")
             s.save()
+            # #5532 (Codex gate): s.save() writes a pre-clear .json.bak (messages
+            # shrank to []). On the next WebUI startup, session_recovery restores
+            # any session whose .bak has MORE messages than the live file
+            # (bak_count > live_count), and it does NOT know about the live
+            # truncation_watermark==0.0 — so it would resurrect the cleared
+            # transcript (with a None watermark) after a restart. Drop the stale
+            # backup so the intentional clear can't be undone, exactly as the
+            # manual-compress and delete paths already do.
+            try:
+                s.path.with_suffix(".json.bak").unlink(missing_ok=True)
+            except OSError:
+                pass
         # Evict cached agent outside the per-session lock.  Eviction may run a
         # boundary memory commit for batch-extraction providers, and provider
         # I/O must not hold the session mutation lock.

--- a/docs/rfcs/session-sse-contract-v1.md
+++ b/docs/rfcs/session-sse-contract-v1.md
@@ -39,7 +39,7 @@ against current source before any route is added.
   route, handler, or related code is added in this PR.
 - This RFC does **not** modify `GET /api/sessions/events` (the existing global
   session-list invalidation stream routed at `api/routes.py:12345-12346` and
-  implemented by `_handle_session_events_stream()` at `api/routes.py:16177`).
+  implemented by `_handle_session_events_stream()` at `api/routes.py:16223`).
 - This RFC does **not** replace or modify existing streams: `/api/chat/stream`,
   `/api/approval/stream`, or `/api/clarify/stream`.
 - This RFC does **not** introduce Android, iOS, or PWA client code.
@@ -54,7 +54,7 @@ against current source before any route is added.
 
 `GET /api/sessions/events` is a **different endpoint** from the one this RFC
 proposes. It is routed at `api/routes.py:12345-12346` and implemented by
-`_handle_session_events_stream()` at `api/routes.py:16177`. It emits bare
+`_handle_session_events_stream()` at `api/routes.py:16223`. It emits bare
 `sessions_changed` events and keepalives for any change to the session list. It
 is a global invalidation signal, not a per-session lifecycle stream. The proposed
 `GET /api/sessions/{session_id}/events` is per-session and path-distinct.
@@ -73,19 +73,19 @@ Line ranges in this inventory were verified against WebUI `master` when this
 RFC was written. Function, constant, and endpoint names are the stable anchors
 if source layout moves later.
 
-- `_parse_run_journal_event_id()` (`api/routes.py:15673-15686`) and
-  `_parse_run_journal_after_seq()` (`api/routes.py:15688-15701`) parse the replay
+- `_parse_run_journal_event_id()` (`api/routes.py:15719-15732`) and
+  `_parse_run_journal_after_seq()` (`api/routes.py:15734-15747`) parse the replay
   cursor from the `after_event_id` / `after_seq` **query params** (not the
   `Last-Event-ID` header — that header is the *proposed* new-endpoint contract
   below, §Reconnect).
-- `_runner_event_id()` at `api/routes.py:15765-15772` constructs the event `id`
+- `_runner_event_id()` at `api/routes.py:15811-15818` constructs the event `id`
   field as `stream_id:seq`.
 - SSE frames carry their `id:` via the `_sse_with_id()` helper, emitted on the
-  live `/api/chat/stream` path at `api/routes.py:15918`, on the runner-observe
-  path at `api/routes.py:15811`, and during journal replay at
-  `api/routes.py:15721` / `15734`.
+  live `/api/chat/stream` path at `api/routes.py:15964`, on the runner-observe
+  path at `api/routes.py:15857`, and during journal replay at
+  `api/routes.py:15767` / `15780`.
 - `_replay_run_journal()` reads events by `(session_id, stream_id)` at
-  `api/routes.py:15703-15735`.
+  `api/routes.py:15749-15781`.
 - `api/streaming.py:6265-6285` writes current live agent streams to
   `STREAMS[stream_id]`.
 - `api/streaming.py:6620-6634` appends SSE events to the run journal and carries
@@ -165,7 +165,7 @@ position.
 
 **`event_id` is opaque to clients.** Its current source-compatible form is
 `stream_id:seq`, as constructed by `_runner_event_id()` at
-`api/routes.py:15765-15772`. Clients must treat it as an opaque string and must
+`api/routes.py:15811-15818`. Clients must treat it as an opaque string and must
 not parse or construct cursor values.
 
 **`seq` is monotonic within a stream/run.** It is not a session-global counter
@@ -183,7 +183,7 @@ events. The live `STREAMS[stream_id]` queue (`api/streaming.py:6265-6285`) is
 not a reliable replay source because it holds only recent in-memory state.
 
 A future implementation must replay from the run journal via the existing
-`_replay_run_journal()` path (`api/routes.py:15703-15735`) and fall back to the
+`_replay_run_journal()` path (`api/routes.py:15749-15781`) and fall back to the
 snapshot mechanism when journal entries are unavailable for a given cursor.
 
 ## Snapshot fallback

--- a/tests/test_issue5532_clear_truncation_watermark.py
+++ b/tests/test_issue5532_clear_truncation_watermark.py
@@ -1,0 +1,204 @@
+"""Regression tests for #5532 — /api/session/clear P0 data loss.
+
+Root cause: the ``/api/session/clear`` handler wiped ``s.messages`` and
+``s.tool_calls`` but NEVER set ``truncation_watermark``. The append-only
+state.db merge (``merge_session_messages_append_only`` via
+``reconciled_state_db_messages_for_session``) treats an unset / None watermark
+as "keep everything and just dedup", so the next ``/api/session`` read
+resurrected every cleared turn from state.db:
+
+  * history reappeared after clear + refresh, and
+  * because ``context_messages`` also survived the clear, a continued turn still
+    carried the full pre-clear context into the model.
+
+The sibling ``/api/session/truncate`` handler does NOT have this bug: it calls
+``truncate_session_at_keep(session, keep)`` which sets
+``truncation_watermark = truncation_boundary = _truncation_watermark_for(kept)``.
+
+Fix: route ``/clear`` through the SAME helper with ``keep=0``. A full clear is a
+truncate that keeps zero messages, so the watermark becomes
+``_truncation_watermark_for([]) == 0.0`` — the #2914 "truncate-to-empty"
+sentinel that blocks ALL state.db replay — and ``context_messages`` is emptied
+in lockstep. The merge contract is not forked; ``/clear`` and ``/truncate`` now
+set the marker identically.
+
+These tests fail on origin/master (watermark stays None → merge resurrects the
+cleared transcript) and pass with the fix.
+"""
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from types import SimpleNamespace
+
+
+def _msg(role: str, content: str, ts: float, mid: str) -> dict:
+    return {"id": mid, "role": role, "content": content, "timestamp": ts}
+
+
+def _seed_session_dir(monkeypatch, tmp_path):
+    """Point the session store at an isolated tmp dir (mirror #2914 harness)."""
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    return models
+
+
+def _call_clear(monkeypatch, session_id):
+    """Invoke the real POST /api/session/clear route and return its payload."""
+    import api.routes as routes
+
+    body = {"session_id": session_id}
+    body_bytes = json.dumps(body).encode()
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    # Eviction runs provider I/O; stub it so the test stays hermetic.
+    monkeypatch.setattr("api.config._evict_session_agent", lambda _sid: None)
+
+    captured = {}
+
+    def fake_j(handler, payload, status=200, extra_headers=None):
+        captured["payload"] = payload
+        captured["status"] = status
+
+    monkeypatch.setattr(routes, "j", fake_j)
+
+    handler = SimpleNamespace(
+        headers={"Content-Length": str(len(body_bytes))},
+        rfile=BytesIO(body_bytes),
+    )
+    routes.handle_post(handler, SimpleNamespace(path="/api/session/clear"))
+    return captured
+
+
+def _four_turn_messages():
+    return [
+        _msg("user", "first", 1.0, "u1"),
+        _msg("assistant", "reply first", 2.0, "a1"),
+        _msg("user", "second", 3.0, "u2"),
+        _msg("assistant", "reply second", 4.0, "a2"),
+    ]
+
+
+def test_clear_endpoint_sets_truncation_watermark(monkeypatch, tmp_path):
+    """POST /api/session/clear must set truncation_watermark (0.0 sentinel).
+
+    This is the fail-without-fix assertion: on origin/master the watermark
+    stays None because the handler never set it.
+    """
+    models = _seed_session_dir(monkeypatch, tmp_path)
+    from api.models import Session
+
+    session = Session(
+        session_id="issue5532clear",
+        messages=_four_turn_messages(),
+        context_messages=_four_turn_messages(),
+    )
+    session.save()
+
+    captured = _call_clear(monkeypatch, "issue5532clear")
+    assert captured["payload"].get("ok") is True
+
+    loaded = Session.load("issue5532clear")
+    assert loaded is not None
+    # Full clear = truncate-to-empty: watermark is the #2914 sentinel 0.0
+    # (== _truncation_watermark_for([]) == the last KEPT message timestamp for
+    # keep=0). On master this is None and the assertion fails.
+    assert loaded.truncation_watermark == 0.0
+    assert loaded.truncation_boundary == 0.0
+    assert loaded.messages == []
+
+
+def test_clear_empties_context_messages(monkeypatch, tmp_path):
+    """Second-half fix (#5532): context_messages must also be cleared so a
+    continued turn does not carry pre-clear context into the model. On master
+    the /clear handler left context_messages untouched."""
+    _seed_session_dir(monkeypatch, tmp_path)
+    from api.models import Session
+
+    session = Session(
+        session_id="issue5532ctx",
+        messages=_four_turn_messages(),
+        context_messages=_four_turn_messages(),
+    )
+    session.save()
+
+    _call_clear(monkeypatch, "issue5532ctx")
+
+    loaded = Session.load("issue5532ctx")
+    assert loaded is not None
+    assert loaded.context_messages == []
+
+
+def test_clear_then_read_does_not_resurrect_state_db_messages(monkeypatch, tmp_path):
+    """After /clear, a subsequent /api/session read (the append-only state.db
+    merge) must return EMPTY — the cleared turns must NOT resurrect from
+    state.db.
+
+    On origin/master the watermark is None, so the merge keeps every state.db
+    row and the transcript reappears (the P0 data-loss symptom).
+    """
+    _seed_session_dir(monkeypatch, tmp_path)
+    from api.models import Session, reconciled_state_db_messages_for_session
+
+    session = Session(
+        session_id="issue5532resurrect",
+        messages=_four_turn_messages(),
+        context_messages=_four_turn_messages(),
+    )
+    session.save()
+
+    _call_clear(monkeypatch, "issue5532resurrect")
+    cleared = Session.load("issue5532resurrect")
+    assert cleared is not None
+
+    # state.db still holds the full pre-clear transcript (append-only backing).
+    state_db = [
+        _msg("user", "first", 1.0, "state-u1"),
+        _msg("assistant", "reply first", 2.0, "state-a1"),
+        _msg("user", "second", 3.0, "state-u2"),
+        _msg("assistant", "reply second", 4.0, "state-a2"),
+    ]
+    merged = reconciled_state_db_messages_for_session(
+        cleared, state_messages=state_db
+    )
+    assert merged == [], (
+        "cleared session must not resurrect state.db messages; "
+        f"got {[m.get('content') for m in merged]}"
+    )
+
+
+def test_clear_matches_truncate_to_empty_marker(monkeypatch, tmp_path):
+    """/clear and /truncate(keep=0) must set the SAME watermark/boundary marker
+    so the merge contract is not forked. Guards against a future divergence
+    where /clear grows its own bespoke watermark logic."""
+    _seed_session_dir(monkeypatch, tmp_path)
+    from api.models import Session
+    from api.session_ops import truncate_session_at_keep
+
+    # Reference: what truncate-to-empty produces on the same transcript.
+    ref = Session(
+        session_id="issue5532ref",
+        messages=_four_turn_messages(),
+        context_messages=_four_turn_messages(),
+    )
+    truncate_session_at_keep(ref, 0)
+
+    # Actual: what /clear produces.
+    session = Session(
+        session_id="issue5532match",
+        messages=_four_turn_messages(),
+        context_messages=_four_turn_messages(),
+    )
+    session.save()
+    _call_clear(monkeypatch, "issue5532match")
+    loaded = Session.load("issue5532match")
+
+    assert loaded is not None
+    assert loaded.truncation_watermark == ref.truncation_watermark == 0.0
+    assert loaded.truncation_boundary == ref.truncation_boundary == 0.0
+    assert loaded.messages == ref.messages == []
+    assert loaded.context_messages == ref.context_messages == []

--- a/tests/test_issue5532_clear_truncation_watermark.py
+++ b/tests/test_issue5532_clear_truncation_watermark.py
@@ -202,3 +202,60 @@ def test_clear_matches_truncate_to_empty_marker(monkeypatch, tmp_path):
     assert loaded.truncation_boundary == ref.truncation_boundary == 0.0
     assert loaded.messages == ref.messages == []
     assert loaded.context_messages == ref.context_messages == []
+
+
+def test_clear_detaches_compression_snapshot_parent(monkeypatch, tmp_path):
+    """Codex gate (#5532): clearing a COMPRESSED-CONTINUATION child must not let
+    the pre-clear transcript resurrect via the compression-snapshot parent.
+
+    A compressed continuation keeps its archived transcript in a parent sidecar
+    marked pre_compression_snapshot; _webui_sidecar_lineage_messages_for_display()
+    stitches that parent back for display, merging the child with
+    truncation_watermark=None — so the 0.0 sentinel on the CHILD does NOT stop
+    the parent from resurrecting the cleared history on refresh. The fix detaches
+    the lineage (parent_session_id + compression anchor fields) on clear.
+
+    Fail-without-fix: on the pre-fix handler the child keeps parent_session_id,
+    so the display stitch re-adds the parent's archived messages after clear.
+    """
+    _seed_session_dir(monkeypatch, tmp_path)
+    from api.models import Session
+    import api.routes as routes
+
+    parent = Session(
+        session_id="issue5532parent",
+        messages=_four_turn_messages(),
+        pre_compression_snapshot=True,
+    )
+    parent.save()
+
+    child = Session(
+        session_id="issue5532child",
+        messages=[
+            _msg("user", "post-compression turn", 5.0, "u3"),
+            _msg("assistant", "post-compression reply", 6.0, "a3"),
+        ],
+        context_messages=[],
+        parent_session_id="issue5532parent",
+    )
+    child.save()
+
+    # Sanity: before clear, the display stitch DOES surface the parent snapshot.
+    pre = routes._webui_sidecar_lineage_messages_for_display(Session.load("issue5532child"))
+    assert any(m.get("content") == "first" for m in pre), (
+        "precondition: compressed continuation should stitch the parent snapshot"
+    )
+
+    _call_clear(monkeypatch, "issue5532child")
+
+    loaded = Session.load("issue5532child")
+    assert loaded is not None
+    assert loaded.messages == []
+    # Lineage detached so the stitch can't resurrect the parent transcript.
+    assert getattr(loaded, "parent_session_id", None) in (None, "")
+    assert getattr(loaded, "compression_anchor_visible_idx", None) is None
+    assert getattr(loaded, "compression_anchor_message_key", None) is None
+    assert getattr(loaded, "compression_anchor_summary", None) is None
+    # The load-time display path must return EMPTY — no resurrected parent rows.
+    display = routes._webui_sidecar_lineage_messages_for_display(loaded)
+    assert display == [], f"cleared compressed continuation must not resurrect parent; got {display}"

--- a/tests/test_issue5532_clear_truncation_watermark.py
+++ b/tests/test_issue5532_clear_truncation_watermark.py
@@ -89,7 +89,7 @@ def test_clear_endpoint_sets_truncation_watermark(monkeypatch, tmp_path):
     This is the fail-without-fix assertion: on origin/master the watermark
     stays None because the handler never set it.
     """
-    models = _seed_session_dir(monkeypatch, tmp_path)
+    _seed_session_dir(monkeypatch, tmp_path)
     from api.models import Session
 
     session = Session(

--- a/tests/test_issue5532_clear_truncation_watermark.py
+++ b/tests/test_issue5532_clear_truncation_watermark.py
@@ -259,3 +259,45 @@ def test_clear_detaches_compression_snapshot_parent(monkeypatch, tmp_path):
     # The load-time display path must return EMPTY — no resurrected parent rows.
     display = routes._webui_sidecar_lineage_messages_for_display(loaded)
     assert display == [], f"cleared compressed continuation must not resurrect parent; got {display}"
+
+
+def test_clear_survives_startup_recovery(monkeypatch, tmp_path):
+    """Codex gate #2 (#5532): a cleared session must stay cleared across a WebUI
+    restart. s.save() writes a pre-clear .json.bak (messages shrank to []), and
+    recover_all_sessions_on_startup restores any session whose .bak has MORE
+    messages than the live file — ignoring the live truncation_watermark==0.0.
+    Without dropping the stale .bak on clear, startup recovery resurrects the
+    cleared transcript (with a None watermark).
+
+    Fail-without-fix: on the pre-fix handler the .bak survives, recovery restores
+    it, and the reloaded session has messages again + watermark None.
+    """
+    models = _seed_session_dir(monkeypatch, tmp_path)
+    from api.models import Session
+    from api import session_recovery
+
+    session = Session(
+        session_id="issue5532recover",
+        messages=_four_turn_messages(),
+        context_messages=_four_turn_messages(),
+    )
+    session.save()
+    # Second save shrinking to nothing is what /clear does; but drive the REAL
+    # route so the .bak-drop path is exercised end to end.
+    _call_clear(monkeypatch, "issue5532recover")
+
+    session_dir = models.SESSION_DIR
+    live_path = session_dir / "issue5532recover.json"
+    # The stale pre-clear backup must be gone (so recovery can't undo the clear).
+    assert not live_path.with_suffix(".json.bak").exists(), (
+        "clear must drop the pre-clear .json.bak so startup recovery can't resurrect it"
+    )
+
+    result = session_recovery.recover_all_sessions_on_startup(session_dir)
+    assert result["restored"] == 0, f"startup recovery must not restore a cleared session; got {result}"
+
+    loaded = Session.load("issue5532recover")
+    assert loaded is not None
+    assert loaded.messages == []
+    assert (loaded.context_messages or []) == []
+    assert loaded.truncation_watermark == 0.0


### PR DESCRIPTION
## Summary

Closes #5532 (P0 data loss).

`POST /api/session/clear` cleared the sidecar transcript but **never recorded a
truncation watermark**, so `state.db` messages resurrected on the next
`/api/session` read: history reappeared after clear + refresh, and a continued
conversation still carried the full pre-clear context into the model.

## Root cause

The `/api/session/clear` handler (`api/routes.py`) did:

```python
s.messages = []
s.tool_calls = []
apply_session_title_rename(s, "Untitled")
s.save()
```

It never set `s.truncation_watermark`. The append-only state.db merge
(`merge_session_messages_append_only`, reached via
`reconciled_state_db_messages_for_session`) treats an unset / `None` watermark
as **"keep everything and just dedup"**. Because `state.db` is append-only, the
cleared transcript was still there, so the merge re-added all of it on the next
read — the exact data-loss symptom in the issue.

The sibling destructive op `/api/session/truncate` does **not** have this bug:
it calls `truncate_session_at_keep(session, keep)` in `api/session_ops.py`,
which sets `truncation_watermark = truncation_boundary =
_truncation_watermark_for(kept_messages)`.

## Fix

A full clear is just a truncate that keeps **zero** messages. Route `/clear`
through the **same** helper the truncate handler uses:

```python
truncate_session_at_keep(s, 0)   # empties messages + context_messages,
                                 # sets watermark = boundary = 0.0
s.tool_calls = []
apply_session_title_rename(s, "Untitled")
s.save()
```

`_truncation_watermark_for([]) == 0.0`, which is the **#2914 "truncate-to-empty"
sentinel** that blocks **all** state.db replay. The merge/read path is
**untouched** — `/clear` and `/truncate` now set the marker identically, so the
merge contract is not forked.

## Second half of the issue (continued-context) — verified

The issue notes that a continued conversation retained pre-clear context. That
is fixed by the same change: `truncate_session_at_keep(s, 0)` empties
`context_messages` in lockstep with `messages` (via
`truncate_context_for_display_keep(..., keep=0) -> []`), so the model-facing
context no longer carries the cleared turns. A regression test asserts
`context_messages == []` after clear.

## Tests

`tests/test_issue5532_clear_truncation_watermark.py` (drives the real
`POST /api/session/clear` route via `handle_post`, mirroring the #2914
integration harness):

- `test_clear_endpoint_sets_truncation_watermark` — watermark & boundary set to `0.0`
- `test_clear_empties_context_messages` — second-half fix: `context_messages == []`
- `test_clear_then_read_does_not_resurrect_state_db_messages` — subsequent
  state.db merge returns EMPTY (no resurrection)
- `test_clear_matches_truncate_to_empty_marker` — `/clear` and
  `/truncate(keep=0)` produce an identical marker (no forked merge logic)

Fail-without-fix confirmed: all four fail on `origin/master`
(`truncation_watermark` stays `None`, resurrection occurs) and pass with this
change.

```
$ .venv/bin/python3 -m pytest tests/test_issue5532_clear_truncation_watermark.py -q
....                                                                     [100%]
4 passed in 3.80s
```

Related watermark suite stays green:

```
$ .venv/bin/python3 -m pytest tests/test_issue5532_clear_truncation_watermark.py \
    tests/test_issue2914_truncation_watermark.py tests/test_issue3831_watermark_clear.py -q
30 passed
```
