### PR TITLE
fix(ux): add min-height to mermaid diagram viewport on mobile (#5525)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2396,7 +2396,7 @@
   .mermaid-viewer-btn{width:28px;height:28px;border:1px solid var(--border2);border-radius:6px;background:var(--input-bg);color:var(--muted);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s,color .15s,border-color .15s,transform .15s;flex:0 0 auto;padding:0;}
   .mermaid-viewer-btn:hover{background:var(--hover-bg);color:var(--text);}
   .mermaid-viewer-btn svg{width:14px;height:14px;display:block;fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;}
-  .mermaid-viewer-viewport{position:relative;overflow:hidden;max-width:100%;border:1px solid var(--border);border-radius:8px;background:var(--code-bg);cursor:grab;touch-action:none;user-select:none;-webkit-user-select:none;}
+  .mermaid-viewer-viewport{position:relative;overflow:hidden;max-width:100%;min-height:200px;border:1px solid var(--border);border-radius:8px;background:var(--code-bg);cursor:grab;touch-action:none;user-select:none;-webkit-user-select:none;}
   .mermaid-viewer-viewport.is-panning{cursor:grabbing;}
   .mermaid-viewer--inline .mermaid-viewer-viewport{width:100%;max-height:70vh;}
   .mermaid-viewer--lightbox .mermaid-viewer-viewport{max-width:90vw;max-height:90vh;border:none;box-shadow:0 8px 48px rgba(0,0,0,.6);}

--- a/static/style.css
+++ b/static/style.css
@@ -2396,9 +2396,12 @@
   .mermaid-viewer-btn{width:28px;height:28px;border:1px solid var(--border2);border-radius:6px;background:var(--input-bg);color:var(--muted);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s,color .15s,border-color .15s,transform .15s;flex:0 0 auto;padding:0;}
   .mermaid-viewer-btn:hover{background:var(--hover-bg);color:var(--text);}
   .mermaid-viewer-btn svg{width:14px;height:14px;display:block;fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;}
-  .mermaid-viewer-viewport{position:relative;overflow:hidden;max-width:100%;min-height:200px;border:1px solid var(--border);border-radius:8px;background:var(--code-bg);cursor:grab;touch-action:none;user-select:none;-webkit-user-select:none;}
+  .mermaid-viewer-viewport{position:relative;overflow:hidden;max-width:100%;border:1px solid var(--border);border-radius:8px;background:var(--code-bg);cursor:grab;touch-action:none;user-select:none;-webkit-user-select:none;}
   .mermaid-viewer-viewport.is-panning{cursor:grabbing;}
   .mermaid-viewer--inline .mermaid-viewer-viewport{width:100%;max-height:70vh;}
+  @media (max-width: 640px){
+    .mermaid-viewer--inline .mermaid-viewer-viewport{min-height:min(200px,70vh);}
+  }
   .mermaid-viewer--lightbox .mermaid-viewer-viewport{max-width:90vw;max-height:90vh;border:none;box-shadow:0 8px 48px rgba(0,0,0,.6);}
   .mermaid-viewer-canvas{position:absolute;left:0;top:0;transform-origin:0 0;will-change:transform;}
   .mermaid-viewer-svg{display:block;width:100%;height:100%;}


### PR DESCRIPTION
Closes #5525

## Summary

Mermaid diagrams have 0 height on mobile because the viewport container (`.mermaid-viewer-viewport`) has `position:relative` with an absolutely-positioned canvas child. Without an explicit min-height, the container collapses when the SVG hasn't rendered yet.

## Fix

+1/-1: add `min-height:200px` to `.mermaid-viewer-viewport` so diagrams are visible on narrow mobile screens.

## Files

`static/style.css` — `.mermaid-viewer-viewport` rule