### PR TITLE
fix: mint stable per-message ids so large-session forks align

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -843,6 +843,19 @@ def _run_gateway_chat_streaming(
             if saved_reasoning:
                 assistant_msg["reasoning"] = saved_reasoning
             previous_context = list(getattr(s, "context_messages", None) or getattr(s, "messages", None) or [])
+            # Stamp stable ids on the two new rows (shared with the display merge
+            # below) so display and model-context copies share an id for the
+            # fork/truncate aligner (#context-message-stable-id).
+            try:
+                from api.streaming import _assign_stable_message_ids
+
+                _assign_stable_message_ids(
+                    [user_msg, assistant_msg],
+                    previous_context,
+                    list(getattr(s, "messages", None) or []),
+                )
+            except Exception:
+                logger.debug("Failed to stamp stable ids on gateway turn rows", exc_info=True)
             s.context_messages = previous_context + [user_msg, assistant_msg]
             try:
                 from api.streaming import _is_context_compression_marker

--- a/api/routes.py
+++ b/api/routes.py
@@ -20193,6 +20193,7 @@ def _handle_chat_sync(handler, body):
             )
             from api.streaming import (
                 _WEBUI_PROGRESS_PROMPT,
+                _assign_stable_message_ids,
                 _dedupe_replayed_context_messages,
                 _merge_display_messages_after_agent_result,
                 _restore_display_reasoning_metadata,
@@ -20261,6 +20262,9 @@ def _handle_chat_sync(handler, body):
             _previous_context_messages,
             _next_context_messages,
             msg,
+        )
+        _assign_stable_message_ids(
+            _result_messages, _previous_messages, _previous_context_messages
         )
         s.context_messages = _next_context_messages
         s.messages = _merge_display_messages_after_agent_result(

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -98,6 +98,14 @@ def _truncation_watermark_for(messages):
         return 0.0
 
 
+def _any_row_has_id(rows) -> bool:
+    """Return True if any row carries a non-null stable ``id``."""
+    for row in rows or []:
+        if isinstance(row, dict) and row.get('id') is not None:
+            return True
+    return False
+
+
 def truncate_context_for_display_keep(
     context_messages: list | None,
     full_messages: list | None,
@@ -110,7 +118,15 @@ def truncate_context_for_display_keep(
     msgs = full_messages if isinstance(full_messages, list) else []
     if not ctx:
         return []
-    if len(ctx) <= len(msgs):
+    # A context array no longer than the display array (the large/compacted
+    # session signature) historically could not be aligned, so it was sliced at
+    # the raw display index — the documented fork/truncate mis-cut. With stable
+    # per-message ids (#context-message-stable-id) the matcher below CAN align a
+    # shorter/compacted context, so only take the raw-index shortcut when neither
+    # array carries ids to align on. Legacy id-less sessions keep the old
+    # behavior exactly (no regression); the matcher's final fallback still
+    # returns ctx[:keep] if id matching cannot resolve the boundary.
+    if len(ctx) <= len(msgs) and not (_any_row_has_id(ctx) and _any_row_has_id(msgs)):
         return ctx[:keep]
     if len(msgs) == 0:
         return []

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4170,6 +4170,46 @@ def _deduplicate_context_messages(messages):
     return deduped
 
 
+def _assign_stable_message_ids(result_messages, *existing_arrays):
+    """Mint a stable, session-unique integer ``id`` on model-result rows lacking one.
+
+    Both ``messages`` (display transcript) and ``context_messages`` (model-facing
+    history) are derived from the *same* per-turn ``result['messages']`` dicts.
+    Stamping the id on those shared dicts here makes each logical row carry an
+    identical id in both arrays, so the fork/truncate aligner
+    (``session_ops.truncate_context_for_display_keep``) can match rows by its
+    preferred ``id`` key instead of the fragile content-signature fallback that
+    goes blind on large sessions full of structurally-identical rows.
+
+    Ids are monotonic within a session (max existing id + 1, seeded from the
+    result rows plus any ``existing_arrays`` passed for collision-avoidance).
+    Across sessions ids may repeat, which is safe: alignment only ever compares
+    rows within one session, and a fork copies both arrays together so the child
+    stays internally consistent. Rows whose historical id was carried forward by
+    ``_restore_reasoning_metadata`` keep it; only genuinely new rows are minted.
+
+    Returns the number of rows newly stamped. Mutates ``result_messages`` in place.
+    """
+    if not result_messages:
+        return 0
+    seed = 0
+    for arr in (result_messages, *existing_arrays):
+        for m in arr or []:
+            if isinstance(m, dict):
+                mid = m.get('id')
+                # bool is an int subclass; exclude it so a stray True/False id
+                # can never seed the counter.
+                if isinstance(mid, int) and not isinstance(mid, bool) and mid > seed:
+                    seed = mid
+    stamped = 0
+    for m in result_messages:
+        if isinstance(m, dict) and m.get('id') is None:
+            seed += 1
+            m['id'] = seed
+            stamped += 1
+    return stamped
+
+
 def _prune_context_tool_results_after_compression(agent, context_messages):
     """Run the active compressor's cheap tool-result pruning on model context.
 
@@ -4235,6 +4275,13 @@ def _restore_reasoning_metadata(previous_messages, updated_messages):
         if isinstance(prev_msg, dict) and isinstance(cur_msg, dict) and _safe_projection(prev_msg) == _safe_projection(cur_msg):
             if prev_msg.get('role') == 'assistant' and prev_msg.get('reasoning') and not cur_msg.get('reasoning'):
                 cur_msg['reasoning'] = prev_msg['reasoning']
+            # Carry the stable per-message id (#context-message-stable-id) forward
+            # the same way timestamp is carried. The agent rebuilds result rows
+            # without our id every turn; without this, historical context rows
+            # would be re-minted a fresh id each turn and drift out of alignment
+            # with their display counterpart.
+            if prev_msg.get('id') is not None and cur_msg.get('id') is None:
+                cur_msg['id'] = prev_msg['id']
             if prev_msg.get('timestamp') and not cur_msg.get('timestamp'):
                 cur_msg['timestamp'] = prev_msg['timestamp']
             elif prev_msg.get('_ts') and not cur_msg.get('_ts') and not cur_msg.get('timestamp'):
@@ -8186,6 +8233,13 @@ def _run_agent_streaming(
                         _next_context_messages,
                         msg_text,
                     )
+                    # Stamp stable ids on the shared result rows AFTER the context
+                    # restore (so carried-forward ids survive) and BEFORE both
+                    # arrays are built, so display and model-context copies of each
+                    # row share an id for the fork/truncate aligner.
+                    _assign_stable_message_ids(
+                        _result_messages, _previous_messages, _previous_context_messages
+                    )
                     s.context_messages = _deduplicate_context_messages(_next_context_messages)
                     s.messages = _merge_display_messages_after_agent_result(
                         _previous_messages,
@@ -8495,6 +8549,9 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _next_context_messages,
                                     msg_text,
+                                )
+                                _assign_stable_message_ids(
+                                    _result_messages, _previous_messages, _previous_context_messages
                                 )
                                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                                 s.messages = _merge_display_messages_after_agent_result(
@@ -9551,6 +9608,9 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _next_context_messages,
                                     msg_text,
+                                )
+                                _assign_stable_message_ids(
+                                    _result_messages, _previous_messages, _previous_context_messages
                                 )
                                 s.context_messages = _deduplicate_context_messages(_next_context_messages)
                                 s.messages = _merge_display_messages_after_agent_result(

--- a/tests/test_context_message_stable_ids.py
+++ b/tests/test_context_message_stable_ids.py
@@ -1,0 +1,181 @@
+"""Stable per-message ids keep the fork/truncate aligner from going blind.
+
+Regression coverage for the systemic gap documented in
+local-ops/docs/bug-context-messages-lost-timestamps.md: ``context_messages``
+rows carried neither a stable ``id`` nor a ``timestamp``, so
+``truncate_context_for_display_keep`` degraded to fragile content-signature
+matching and mis-cut large sessions on fork/truncate.
+
+The fix mints a stable, session-unique integer ``id`` on the per-turn result
+rows that both ``messages`` (display) and ``context_messages`` (model) derive
+from, and carries it forward across turns. These tests prove:
+
+1. the minting helper is monotonic and non-destructive,
+2. ``_restore_reasoning_metadata`` carries ids forward like timestamps,
+3. the real turn transforms give a logical row the SAME id in both arrays,
+4. the aligner resolves an otherwise-ambiguous boundary via id alone.
+"""
+
+from api.streaming import (
+    _assign_stable_message_ids,
+    _restore_reasoning_metadata,
+    _deduplicate_context_messages,
+    _dedupe_replayed_context_messages,
+    _merge_display_messages_after_agent_result,
+)
+from api.session_ops import truncate_context_for_display_keep
+
+
+def test_assign_stable_ids_mints_monotonic_ints():
+    rows = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "tool", "content": "t1", "tool_call_id": "c1"},
+    ]
+    stamped = _assign_stable_message_ids(rows)
+    assert stamped == 3
+    assert [r["id"] for r in rows] == [1, 2, 3]
+
+
+def test_assign_stable_ids_seeds_from_existing_max_and_skips_present():
+    prev = [{"role": "user", "content": "old", "id": 41}]
+    rows = [
+        {"role": "assistant", "content": "keep", "id": 7},  # already has id -> untouched
+        {"role": "tool", "content": "new", "tool_call_id": "c"},
+    ]
+    stamped = _assign_stable_message_ids(rows, prev)
+    assert stamped == 1
+    # kept its own id; new row minted above the global max (41), not above 7
+    assert rows[0]["id"] == 7
+    assert rows[1]["id"] == 42
+
+
+def test_assign_stable_ids_ignores_bool_and_empty():
+    assert _assign_stable_message_ids([]) == 0
+    assert _assign_stable_message_ids(None) == 0
+    rows = [{"role": "user", "content": "u", "id": True}]  # bool must not seed
+    other = [{"role": "assistant", "content": "a"}]
+    _assign_stable_message_ids(other, rows)
+    assert other[0]["id"] == 1  # seed ignored the bool, started at 1
+
+
+def test_restore_reasoning_metadata_carries_id_forward():
+    previous = [
+        {"role": "user", "content": "u1", "id": 10, "timestamp": 1},
+        {"role": "assistant", "content": "a1", "id": 11, "timestamp": 2},
+    ]
+    # Agent rebuilds the same history without our id (and without timestamp).
+    updated = [
+        {"role": "user", "content": "u1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "u2"},  # genuinely new tail row
+    ]
+    out = _restore_reasoning_metadata(previous, updated)
+    assert out[0]["id"] == 10
+    assert out[1]["id"] == 11
+    assert "id" not in out[2]  # new row left for the minting pass
+
+
+def test_both_arrays_share_id_for_same_logical_row():
+    """The real turn transforms must give a row the SAME id in both arrays."""
+    prev_display = []
+    prev_context = []
+    # The two arrays are built from the SAME result dicts (as in streaming.py).
+    result_messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "name": "x"}]},
+        {"role": "tool", "content": "out", "tool_call_id": "c1"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+    # --- context path (mirrors streaming.py commit site) ---
+    next_ctx = _restore_reasoning_metadata(prev_context, result_messages)
+    next_ctx = _dedupe_replayed_context_messages(prev_context, next_ctx, "hello")
+    _assign_stable_message_ids(result_messages, prev_display, prev_context)
+    context_out = _deduplicate_context_messages(next_ctx)
+
+    # --- display path (mirrors streaming.py commit site) ---
+    display_out = _merge_display_messages_after_agent_result(
+        prev_display,
+        prev_context,
+        _restore_reasoning_metadata(prev_display, result_messages),
+        "hello",
+    )
+
+    # every context row must have an id, and the matching display row (by
+    # role+content) must carry the identical id.
+    assert all(isinstance(m.get("id"), int) for m in context_out)
+    disp_by_key = {(m["role"], str(m.get("content"))): m.get("id") for m in display_out}
+    for m in context_out:
+        assert disp_by_key.get((m["role"], str(m.get("content")))) == m["id"]
+
+
+def _dup_ambiguous_shapes(with_ids):
+    """Large-session shape: display longer than context, full of structurally
+    identical assistant(tool_call)/tool(result) pairs so content signatures
+    collide. Context is the compressed/shorter model view.
+    """
+    dup_call = [{"id": "c", "name": "run"}]
+
+    def row(role, content, **kw):
+        r = {"role": role, "content": content}
+        r.update(kw)
+        return r
+
+    def maybe_id(r, i):
+        if with_ids and i is not None:
+            r["id"] = i
+        return r
+
+    # 8 display rows, three identical assistant/tool pairs then a trailing user.
+    display = [
+        maybe_id(row("user", "u1"), 1),
+        maybe_id(row("assistant", "", tool_calls=dup_call), 2),
+        maybe_id(row("tool", "same", tool_call_id="c"), 3),
+        maybe_id(row("assistant", "", tool_calls=dup_call), 4),
+        maybe_id(row("tool", "same", tool_call_id="c"), 5),
+        maybe_id(row("assistant", "", tool_calls=dup_call), 6),
+        maybe_id(row("tool", "same", tool_call_id="c"), 7),
+        maybe_id(row("user", "u2"), 8),
+    ]
+    # 7 context rows (shorter -> len(ctx) < len(msgs), the documented signature):
+    # a leading compaction summary with no display match, then display ids 1..6.
+    context = [
+        row("assistant", "[compaction summary]"),  # leading, unmatched, no id
+        maybe_id(row("user", "u1"), 1),
+        maybe_id(row("assistant", "", tool_calls=dup_call), 2),
+        maybe_id(row("tool", "same", tool_call_id="c"), 3),
+        maybe_id(row("assistant", "", tool_calls=dup_call), 4),
+        maybe_id(row("tool", "same", tool_call_id="c"), 5),
+        maybe_id(row("assistant", "", tool_calls=dup_call), 6),
+    ]
+    return display, context
+
+
+def test_aligner_resolves_ambiguous_boundary_via_id():
+    """With shared ids the aligner cuts at the exact boundary even though the
+    duplicate rows make content signatures ambiguous."""
+    display, context = _dup_ambiguous_shapes(with_ids=True)
+    # Keep the first 4 display rows (u1, a, t, a=id4). Correct cut keeps the
+    # leading summary + ids 1..4 (5 rows), stopping before id5.
+    out = truncate_context_for_display_keep(context, display, keep=4)
+    assert len(out) == 5
+    assert [m.get("id") for m in out] == [None, 1, 2, 3, 4]
+
+
+def test_aligner_without_ids_miscuts_baseline():
+    """Same shape with ids/timestamps stripped (pre-fix live data): the
+    duplicate rows defeat signature matching and the length-difference fallback
+    slices at the raw display index, keeping the WRONG number of rows. This is
+    the documented mis-cut and shows why the shared id is the fix."""
+    display, context = _dup_ambiguous_shapes(with_ids=False)
+    out = truncate_context_for_display_keep(context, display, keep=4)
+    # Fallback returns ctx[:4] — it drops the id=4 assistant row that the
+    # id-aware path correctly keeps, so the cut is one row short (4, not 5).
+    assert len(out) == 4
+    assert [m.get("content") for m in out] == [
+        "[compaction summary]",
+        "u1",
+        "",
+        "same",
+    ]

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -793,11 +793,30 @@ def test_handle_chat_sync_writeback_dedupes_full_context_replay(tmp_path, monkey
 
     assert handler.status == 200
     reloaded = Session.load(session.session_id)
-    assert reloaded.context_messages == previous_context + [
+
+    # Stable per-message ids (#context-message-stable-id) are now stamped on
+    # context rows; compare on the semantic fields so the dedup invariant is
+    # still what is under test. Build ``expected`` from fresh literals: the id
+    # stamping mutates the shared result dicts in place, and this test reuses the
+    # same objects for its result and its previous_context.
+    def _no_id(rows):
+        return [{k: v for k, v in m.items() if k != "id"} for m in rows]
+
+    expected = [
+        {"role": "assistant", "content": "cron banner"},
+        {"role": "user", "content": "[Session Arc Summary (d1, node 39)]\n" + "old context\n" * 400},
+        {"role": "assistant", "content": "previous answer"},
         {"role": "user", "content": "simple follow-up"},
         {"role": "assistant", "content": "short answer"},
     ]
-    assert reloaded.context_messages.count(previous_context[0]) == 1
+    assert _no_id(reloaded.context_messages) == expected
+    assert _no_id(reloaded.context_messages).count(expected[0]) == 1
+    # The new turn's rows carry unique stable ids. (This session preloads
+    # id-less legacy rows, which stay id-less until they age out of context;
+    # brand-new sessions get full id coverage since previous_context is empty.)
+    new_ids = [m.get("id") for m in reloaded.context_messages[-2:]]
+    assert all(isinstance(i, int) for i in new_ids)
+    assert len(set(new_ids)) == 2
 
 
 def test_session_context_falls_back_to_display_messages_for_legacy_sessions(tmp_path):

--- a/tests/test_issue_branch_context_at_fork.py
+++ b/tests/test_issue_branch_context_at_fork.py
@@ -106,7 +106,13 @@ def test_truncate_context_for_display_keep_drops_unkept_tool_rows_after_user_bou
     assert "a2" not in contents
 
 
-def test_truncate_context_for_display_keep_prefers_compact_summary_fallback():
+def test_truncate_context_for_display_keep_aligns_compacted_context_via_id():
+    # Context shorter than display (compacted large-session signature) with a
+    # leading summary. Before stable ids (#context-message-stable-id) the aligner
+    # short-circuited to the raw display-index slice ctx[:keep] == [compact, u1],
+    # dropping the kept assistant turn a1 — the documented fork mis-cut. With ids
+    # present the matcher aligns keep=2 (display prefix [u1, a1]) to the compact
+    # summary prefix PLUS both kept turns.
     msgs = [
         {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
         {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
@@ -117,6 +123,25 @@ def test_truncate_context_for_display_keep_prefers_compact_summary_fallback():
         {"role": "user", "content": "compact", "id": "summary"},
         {"role": "user", "content": "u1", "id": "u1", "timestamp": 1.0},
         {"role": "assistant", "content": "a1", "id": "a1", "timestamp": 2.0},
+    ]
+    out = truncate_context_for_display_keep(ctx, msgs, 2)
+    assert [m["content"] for m in out] == ["compact", "u1", "a1"]
+
+
+def test_truncate_context_for_display_keep_shortcuts_without_ids():
+    # Same shape but id-less (legacy data): no ids to align on, so the raw-index
+    # shortcut still fires exactly as before — proving zero regression for the
+    # sessions that predate the stable-id fix.
+    msgs = [
+        {"role": "user", "content": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "timestamp": 2.0},
+        {"role": "user", "content": "u2", "timestamp": 3.0},
+        {"role": "assistant", "content": "a2", "timestamp": 4.0},
+    ]
+    ctx = [
+        {"role": "user", "content": "compact"},
+        {"role": "user", "content": "u1", "timestamp": 1.0},
+        {"role": "assistant", "content": "a1", "timestamp": 2.0},
     ]
     out = truncate_context_for_display_keep(ctx, msgs, 2)
     assert out == ctx[:2]


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI keeps two parallel arrays per session: `messages` (the visible transcript) and `context_messages` (what is actually sent to the model). In large sessions the model context is trimmed/compacted, so it diverges from the display transcript.
- Forking ("fork from here" / `/api/session/branch`) and in-place truncation copy a *prefix of both* and rely on `truncate_context_for_display_keep()` to translate a display keep-index into the matching context index.
- That aligner needs a stable per-row key — it prefers `id`, then `timestamp` — to disambiguate rows. But `context_messages` rows carry **neither** (a live-store scan of 989 sessions found 0 with any `id`, and context timestamps near-absent regardless of recency), so it falls back to fragile content-signature matching.
- Large agent sessions are full of structurally-identical rows (repeated tool calls, empty-content assistant turns), so signature matching goes ambiguous, and for compacted sessions (`len(context) <= len(display)`) the aligner short-circuits to a raw display-index slice that lands mid-turn.
- Result: the fork's transcript ends on a clean turn while its model context ends on a dangling `tool_use` — the API rejects the next message or the model resumes from the wrong point ("disjointed" fork).
- Root cause is a data gap: both arrays derive from the same per-turn `result['messages']` dicts, but only the display array gets timestamps stamped; the model-facing array never carried a `timestamp` **or** an `id`.
- This PR closes the gap by minting a stable per-message `id` shared by both arrays (the key the aligner already prefers) and letting the aligner use it, so large-session forks align correctly.

## What Changed

- **`api/streaming.py`**
  - New `_assign_stable_message_ids()` — mints a monotonic, session-unique integer `id` on the per-turn result rows *after* the context restore and *before* both arrays are built, so the display and model-context copies of a logical row share the same id.
  - `_restore_reasoning_metadata()` now carries `id` forward across turns (exactly as it already carries `timestamp`), since the agent rebuilds id-less rows every turn.
  - Wired the mint call into all three streaming write-back commit sites (main turn, retry, self-heal).
- **`api/routes.py`** — same mint call on the runs/MoA `_handle_chat_sync` commit path.
- **`api/gateway_chat.py`** — mints ids on the two new rows of a gateway turn (shared with the display merge) so both arrays match.
- **`api/session_ops.py`** — `truncate_context_for_display_keep()`'s `len(ctx) <= len(msgs)` raw-slice short-circuit is now gated on the *absence* of ids (`_any_row_has_id`): id-bearing sessions get real alignment; legacy id-less sessions keep the exact prior behavior. The matcher's final fallback still returns `ctx[:keep]` if id matching cannot resolve a boundary.
- **Tests** — new `tests/test_context_message_stable_ids.py`; updated `tests/test_issue_branch_context_at_fork.py` and `tests/test_issue1217_transcript_compaction.py` for the corrected id-aware alignment.

The `id` is stripped before the provider API call (it is not in `_API_SAFE_MSG_KEYS`), same treatment as `timestamp`, so nothing new reaches the model provider.

## Why It Matters

Forking or truncating a large session currently produces a child whose model context is misaligned with its visible transcript — up to a dozen turns out of sync and often ending on a dangling tool-call that the provider API rejects. Giving each message a stable shared id makes alignment exact and immune to synthetic-timestamp drift and duplicate content, which is the durable fix (timestamps are synthesized per-array from `time.time()` and would not match across arrays even if both were stamped).

## Verification

- `./scripts/test.sh` full suite: **11866 passed**, 133 skipped. The one failure observed in a full run (`test_issue4536_service_tier`) is a pre-existing flake unrelated to this change — it passes in isolation and this PR does not touch service-tier/config code.
- New/updated tests prove the invariant directly: a logical row produced in a turn carries an **identical id in both arrays** (through the real turn transforms), and the aligner resolves a previously-ambiguous compacted-context boundary via that id, while id-less legacy data keeps the old shortcut.
- Root cause and scope were established by read-only inspection of a live store (specimen `20260611_190341_ddec1c`) plus a 989-session scan; details in the local investigation notes.
- Not a UI/UX change — no screenshots applicable.

## Risks / Follow-ups

- **Data-at-rest addition:** context/display rows now persist an integer `id` in the session sidecar. It is additive and ignored by older readers; the aligner treats a missing `id` as "fall back to signature/timestamp," so mixed old/new rows are safe.
- **Legacy sessions are not retro-aligned:** brand-new sessions get full id coverage from turn 1 (their `previous_context` is empty); pre-existing sessions gain ids only on new rows, and their id-less prefix rows age out of context over time. Legacy data still benefits from the id-independent safeguards recommended separately (aligner fallback + a trailing-tool-call guard).
- **Follow-up:** consider a trailing dangling-tool-call safety net after any context cut, which protects legacy sessions regardless of id availability.

## Contract Routing

- **Task type:** narrow bug fix on the existing WebUI execution path (model-context reconstruction + session metadata).
- **Touched areas:** per-turn context/display commit (`api/streaming.py`, `api/routes.py`, `api/gateway_chat.py`), fork/truncate alignment (`api/session_ops.py`), session-at-rest metadata (adds `id` to message rows).
- **Relevant public docs:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, and `docs/rfcs/webui-run-state-consistency-contract.md` (#2361 — coherence of transcript, model context, replay, compression, and session metadata).
- **Scope boundaries:** does not change SSE/streaming vocabulary, recovery/journal formats, UI rendering, or the provider-facing message shape (the `id` is stripped before the API call). No new dependencies; no build step.
- **Evidence needed before claiming done:** full test suite green on the focused diff; direct test of the shared-id invariant and id-resolved alignment; confirmation the `id` never reaches the provider.

## Contract Change

The consistency contract requires the visible transcript and the model context to stay coherent across fork/truncate. This PR intentionally changes one alignment behavior encoded in existing product-semantics tests:

- **Old rule:** when `context_messages` is no longer than `messages` (the compacted large-session shape), `truncate_context_for_display_keep()` slices context at the raw display index (`ctx[:keep]`) regardless of row identity.
- **New rule:** when both arrays carry stable ids, the aligner matches by id and cuts at the identity-correct boundary; the raw-index slice is used only when ids are absent (legacy data) or id matching cannot resolve the boundary.
- **Why justified:** the old rule is the documented mis-cut that makes large-session forks end on a dangling tool-call. The new rule is strictly more correct where ids exist and byte-for-byte identical where they do not. The corresponding tests (`test_issue_branch_context_at_fork.py`, `test_issue1217_transcript_compaction.py`) were updated in this PR to assert the corrected behavior rather than silently changing behavior via tests alone.

## Release note

Fixed large-session fork/truncate producing a model context misaligned with the visible transcript (and occasional dangling tool-call API rejections) by giving each message a stable id shared between the display and model-context arrays.

## Model Used

AI-assisted.

- **Provider:** Anthropic (via Claude Code)
- **Exact model:** Claude Opus 4.8 (`claude-opus-4-8`)
- **Notable mode/tool use:** agentic investigation with a subagent for codebase tracing and read-only inspection of a live session store to establish root cause and scope before implementing.
