### PR TITLE
fix(#5578): stop login next= param from nesting into itself and exploding the URL

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -685,6 +685,31 @@ def parse_cookie(handler) -> str | None:
     return morsel.value if morsel else None
 
 
+def _safe_login_inner_next(query: str | None) -> str:
+    """#5578: extract a SAFE, non-login `next` from a login page's own query.
+
+    When an expired-auth bounce lands on `/session/login?next=X`, we want to
+    preserve a legitimate inner destination X across the redirect to the real
+    login route — but only if X is itself safe (path-absolute, not protocol-
+    relative/backslash, no control chars) AND not login-shaped / not itself
+    carrying a nested `next=`. Anything else collapses to '' (no next), which
+    kills the self-referential chain. Mirrors _safe_login_redirect_path().
+    """
+    import urllib.parse as _u
+    raw = _u.parse_qs(query or "").get("next", [""])[0]
+    path = str(raw or "").strip()
+    if not path or path[0] != "/" or path[1:2] in {"/", "\\"}:
+        return ""
+    if re.search(r"[\x00-\x1f\x7f\s]", path) or len(path) > 2048:
+        return ""
+    _p = path.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    if _p == "/login" or _p.endswith("/login"):
+        return ""
+    if re.search(r"(?:\?|%3f|%253f|&|%26)next(?:=|%3d|%253d)", path, re.IGNORECASE):
+        return ""
+    return path
+
+
 def check_auth(handler, parsed) -> bool:
     """Check if request is authorized. Returns True if OK.
     If not authorized, sends 401 (API) or 302 redirect (page) and returns False."""
@@ -727,19 +752,32 @@ def check_auth(handler, parsed) -> bool:
         # the full original URL (the browser auto-decodes once).
         # (Opus pre-release advisor finding for v0.50.258.)
         import urllib.parse as _urlparse
-        # #5578: if the page being redirected is ALREADY login-shaped
-        # (/login, /session/login, or a subpath-mounted */login), do NOT wrap
-        # its full `path?query` — that query already carries a `next=`, so
-        # quoting the whole thing into a fresh `next=` nests the login URL into
+        # #5578: if the page being redirected is ALREADY login-shaped, do NOT
+        # wrap its full `path?query` into a fresh `next=` — that query already
+        # carries a `next=`, so quoting the whole thing nests the login URL into
         # itself and re-encodes it on every expired-auth bounce, exploding the
         # URL until the tab breaks. This guard runs in check_auth() (BEFORE
-        # route handling), which is the actual source of the server-side loop;
-        # the downstream _safe_login_redirect_path() never executes for this
-        # page-redirect. Redirect to bare `login` (no next); the login page
-        # preserves its own already-safe inner `next` from the current URL.
+        # route handling), the actual source of the server-side loop.
+        #
+        # The login page is served ONLY at the public `/login` route (see
+        # PUBLIC_PATHS + the routes.py `/login` handler); the app's client route
+        # `/session/login` is NOT public, so a bare relative `login` from
+        # `/session/login` resolves to `/session/login` again and re-triggers
+        # check_auth() — an infinite redirect. Resolve to the real login route
+        # with `../login`, which lands on `/login` from a `/session/*` scope and
+        # on `<mount>/login` under a subpath mount (verified via urljoin). Carry
+        # through only a validated, non-login inner `next` so a legitimate
+        # post-login destination still survives a bounce that happened to land
+        # on the login page.
         _login_path = (parsed.path or '/').rstrip('/')
         if _login_path == '/login' or _login_path.endswith('/login'):
-            handler.send_header('Location', 'login')
+            # /login itself is public → check_auth never redirects it; this only
+            # fires for the non-public client login route (e.g. /session/login).
+            _target = '../login' if '/' in _login_path.lstrip('/') else 'login'
+            _inner = _safe_login_inner_next(parsed.query)
+            if _inner:
+                _target += '?next=' + _urlparse.quote(_inner, safe='/')
+            handler.send_header('Location', _target)
             handler.send_header('Content-Length', '0')
             handler.end_headers()
             return False

--- a/api/auth.py
+++ b/api/auth.py
@@ -727,6 +727,22 @@ def check_auth(handler, parsed) -> bool:
         # the full original URL (the browser auto-decodes once).
         # (Opus pre-release advisor finding for v0.50.258.)
         import urllib.parse as _urlparse
+        # #5578: if the page being redirected is ALREADY login-shaped
+        # (/login, /session/login, or a subpath-mounted */login), do NOT wrap
+        # its full `path?query` — that query already carries a `next=`, so
+        # quoting the whole thing into a fresh `next=` nests the login URL into
+        # itself and re-encodes it on every expired-auth bounce, exploding the
+        # URL until the tab breaks. This guard runs in check_auth() (BEFORE
+        # route handling), which is the actual source of the server-side loop;
+        # the downstream _safe_login_redirect_path() never executes for this
+        # page-redirect. Redirect to bare `login` (no next); the login page
+        # preserves its own already-safe inner `next` from the current URL.
+        _login_path = (parsed.path or '/').rstrip('/')
+        if _login_path == '/login' or _login_path.endswith('/login'):
+            handler.send_header('Location', 'login')
+            handler.send_header('Content-Length', '0')
+            handler.end_headers()
+            return False
         _path_with_query = parsed.path or '/'
         if parsed.query:
             _path_with_query += '?' + parsed.query

--- a/api/auth.py
+++ b/api/auth.py
@@ -686,14 +686,15 @@ def parse_cookie(handler) -> str | None:
 
 
 def _safe_login_inner_next(query: str | None) -> str:
-    """#5578: extract a SAFE, non-login `next` from a login page's own query.
+    """#5578: extract a SAFE, non-login inner redirect from a login page's query.
 
-    When an expired-auth bounce lands on `/session/login?next=X`, we want to
-    preserve a legitimate inner destination X across the redirect to the real
-    login route — but only if X is itself safe (path-absolute, not protocol-
-    relative/backslash, no control chars) AND not login-shaped / not itself
-    carrying a nested `next=`. Anything else collapses to '' (no next), which
-    kills the self-referential chain. Mirrors _safe_login_redirect_path().
+    When an expired-auth bounce lands back on the login page (which already
+    carries its own `next` in the query), we want to preserve a legitimate inner
+    destination X across the redirect to the real login route — but only if X is
+    itself safe (path-absolute, not protocol-relative/backslash, no control
+    chars) AND not login-shaped / not itself carrying a nested next param.
+    Anything else collapses to '' (no inner redirect), which kills the
+    self-referential chain. Mirrors _safe_login_redirect_path().
     """
     import urllib.parse as _u
     raw = _u.parse_qs(query or "").get("next", [""])[0]

--- a/api/routes.py
+++ b/api/routes.py
@@ -9238,6 +9238,20 @@ def _safe_login_redirect_path(raw_path: str | None) -> str:
         return "/"
     if re.search(r"[\x00-\x1f\x7f\s]", path):
         return "/"
+    # #5578: reject a `next` that points back at the login page (or that already
+    # carries its own nested `next`), so an expired-auth bounce on the login page
+    # can't feed the redirect its own address and grow the URL exponentially.
+    # Length cap is belt-and-suspenders: a legitimate app path is never this long.
+    if len(path) > 2048:
+        return "/"
+    _path_only = path.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    if _path_only.endswith("/login") or _path_only == "/login":
+        return "/"
+    # A raw or (any depth of) percent-encoded `next=` inside the value is the
+    # signature of a nested login-redirect chain — never legitimate here. The
+    # `=` may itself be encoded (%3D / %253D …) at deeper nesting levels.
+    if re.search(r"(?:\?|%3f|%253f|&|%26)next(?:=|%3d|%253d)", path, re.IGNORECASE):
+        return "/"
     return path
 
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -3071,6 +3071,10 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       return true;
     };
     const redirectToLogin=(nextUrl)=>{
+      // #5578: never nest the login URL into its own next= — if already on a
+      // login-shaped page, reload 'login' bare (the page keeps its inner next).
+      const _p=(window.location.pathname||'').replace(/\/+$/,'');
+      if(/(?:^|\/)login$/.test(_p)){window.location.href='login';return;}
       window.location.href='login?next='+encodeURIComponent(nextUrl);
     };
     return {

--- a/static/login.js
+++ b/static/login.js
@@ -32,6 +32,13 @@ document.addEventListener('DOMContentLoaded', function () {
       if (raw.charAt(0) !== '/') return './';             // must be path-absolute
       if (raw.charAt(1) === '/' || raw.charAt(1) === '\\') return './'; // reject // and \\
       if (/[\x00-\x1f\x7f\s]/.test(raw)) return './';  // reject control chars / whitespace
+      // #5578: never redirect back to the login page, and never accept a `next`
+      // that already nests its own `next=` — that self-referential chain is what
+      // grows the URL exponentially on repeated expired-auth bounces.
+      if (raw.length > 2048) return './';
+      var pathOnly = raw.split('?')[0].split('#')[0].replace(/\/+$/, '');
+      if (pathOnly === '/login' || /\/login$/.test(pathOnly)) return './';
+      if (/(?:\?|%3f|%253f|&|%26)next(?:=|%3d|%253d)/i.test(raw)) return './';
       return raw;
     } catch (_) { return './'; }
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -201,7 +201,8 @@ else initOfflineMonitor();
 // Redirect to login when the server responds with 401 (auth session expired).
 // Handles iOS PWA standalone mode and keeps subpath mounts like /hermes/ from
 // escaping to the personal site root /login.
-function _redirectIfUnauth(res){if(res&&res.status===401){window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);return true;}return false;}
+// #5578: on a login-shaped page, reload 'login' WITHOUT a next (avoid self-nesting).
+function _redirectIfUnauth(res){if(res&&res.status===401){var _p=(window.location.pathname||'').replace(/\/+$/,'');if(/(?:^|\/)login$/.test(_p)){window.location.href='login';}else{window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);}return true;}return false;}
 function _getSessionQueue(sid, create=false){
   if(!sid) return [];
   if(!SESSION_QUEUES[sid]&&create) SESSION_QUEUES[sid]=[];

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -46,7 +46,21 @@ async function api(path,opts={}){
           // re-authenticate. This is especially important for iOS PWA (standalone mode)
           // and for subpath mounts like /hermes/, where /login escapes to the site root.
           if(res.status===401){
-            if(redirect401) window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);
+            // #5578: if we're ALREADY on the login page, appending
+            // window.location.pathname+search (which contains ?next=…) into a
+            // fresh next= wraps the login URL into itself and re-encodes it —
+            // exponential URL growth on each expired-auth bounce until the tab
+            // breaks. On the login page, just reload login WITHOUT a next (the
+            // page preserves its own inner next); elsewhere, capture the path.
+            if(redirect401){
+              // Already on the login page? Reload login WITHOUT a next.
+              const _p=(window.location.pathname||'').replace(/\/+$/,'');
+              if(/(?:^|\/)login$/.test(_p)){
+                window.location.href='login';
+              }else{
+                window.location.href='login?next='+encodeURIComponent(window.location.pathname+window.location.search);
+              }
+            }
             // Callers can opt out of navigation and handle the unauthenticated state themselves.
             return;
           }

--- a/tests/test_issue5578_login_next_nesting.py
+++ b/tests/test_issue5578_login_next_nesting.py
@@ -86,3 +86,24 @@ class TestClientGuardsWired:
         assert "window.location.href='login';" in WORKSPACE_JS
         # And the non-login path still captures the real destination.
         assert "'login?next='+encodeURIComponent" in WORKSPACE_JS
+
+    def test_all_client_401_helpers_guard_login_page(self):
+        # #5578 Codex round-2: workspace.js was fixed but two more client 401
+        # redirect helpers (ui.js _redirectIfUnauth, boot.js redirectToLogin)
+        # also nested the login URL. All three must carry the on-login guard.
+        UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+        BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+        assert "login$/.test(_p)" in UI_JS, "ui.js _redirectIfUnauth must guard the login page"
+        assert "login$/.test(_p)" in BOOT_JS, "boot.js redirectToLogin must guard the login page"
+
+
+class TestServerCheckAuthGuard:
+    def test_check_auth_does_not_nest_login_redirect(self):
+        # #5578 Codex round-2 (BRICK): check_auth() runs BEFORE route handling,
+        # so the server-side page-redirect loop never reached
+        # _safe_login_redirect_path(). check_auth() must itself refuse to wrap a
+        # login-shaped path into a fresh next=.
+        AUTH_PY = (ROOT / "api" / "auth.py").read_text(encoding="utf-8")
+        assert "endswith('/login')" in AUTH_PY or "_login_path.endswith('/login')" in AUTH_PY, (
+            "check_auth() must detect a login-shaped path and skip the next= wrap"
+        )

--- a/tests/test_issue5578_login_next_nesting.py
+++ b/tests/test_issue5578_login_next_nesting.py
@@ -107,3 +107,23 @@ class TestServerCheckAuthGuard:
         assert "endswith('/login')" in AUTH_PY or "_login_path.endswith('/login')" in AUTH_PY, (
             "check_auth() must detect a login-shaped path and skip the next= wrap"
         )
+
+    def test_check_auth_resolves_to_real_public_login_route(self):
+        # #5578 Codex round-3 (BRICK): a bare relative 'login' from /session/login
+        # resolves BACK to /session/login (not public, not the /login route) and
+        # loops forever. Must use '../login' so it lands on the real public
+        # /login route (and <mount>/login under a subpath mount).
+        AUTH_PY = (ROOT / "api" / "auth.py").read_text(encoding="utf-8")
+        assert "'../login'" in AUTH_PY, (
+            "check_auth() must redirect a session-scoped login path to ../login "
+            "(the real public /login), not a bare relative login that loops"
+        )
+
+    def test_inner_next_helper_drops_login_and_nested(self):
+        # The preserved inner next must itself be safe + non-login + non-nested.
+        import api.auth as auth
+        assert auth._safe_login_inner_next("next=/session/login") == ""
+        assert auth._safe_login_inner_next("next=/x%3Fnext%3D/y") == ""
+        assert auth._safe_login_inner_next("next=//evil") == ""
+        assert auth._safe_login_inner_next("next=/session/abc123") == "/session/abc123"
+        assert auth._safe_login_inner_next("") == ""

--- a/tests/test_issue5578_login_next_nesting.py
+++ b/tests/test_issue5578_login_next_nesting.py
@@ -1,0 +1,88 @@
+"""Regression test for #5578 — login `next=` self-nesting URL explosion.
+
+Bug: an expired-auth 401 while already on `/session/login?next=…` fed the login
+redirect its own URL. Each of the three guards (workspace.js api() 401 handler,
+login.js `_safeNextPath`, routes.py `_safe_login_redirect_path`) validated against
+open-redirect but NONE rejected a `next` pointing back at the login page, so the
+nested `/session/login?next=/session/login%3Fnext%3D…` chain re-percent-encoded
+and grew exponentially on every bounce until the tab broke (~12k chars).
+
+Fix: all three guards now reject a `next` that targets the login page or already
+carries a nested `next=`, plus a length cap — while preserving legitimate
+`next=/some/real/path` redirects and the existing open-redirect protections.
+"""
+from pathlib import Path
+
+from api.routes import _safe_login_redirect_path as guard
+
+ROOT = Path(__file__).resolve().parents[1]
+LOGIN_JS = (ROOT / "static" / "login.js").read_text(encoding="utf-8")
+WORKSPACE_JS = (ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+
+
+# ── server guard: the self-nesting cases the bug exploited ──────────────────
+
+class TestServerGuardRejectsNesting:
+    def test_rejects_login_self_reference(self):
+        assert guard("/login") == "/"
+        assert guard("/session/login") == "/"
+        assert guard("/session/login/") == "/"
+        assert guard("/hermes/session/login") == "/"  # subpath mount
+
+    def test_rejects_nested_next_chain(self):
+        nested = "/session/login?next=/session/login%3Fnext%3D/session/login"
+        assert guard(nested) == "/"
+
+    def test_rejects_encoded_next_at_any_depth(self):
+        # raw ?next=, single-encoded %3Fnext, double-encoded %253Fnext
+        assert guard("/x?next=/y") == "/"
+        assert guard("/x%3Fnext%3D/y") == "/"
+        assert guard("/x%253Fnext%253D/y") == "/"
+        assert guard("/x&next=/y") == "/"
+
+    def test_rejects_overlong_next(self):
+        assert guard("/" + "a" * 3000) == "/"
+
+    def test_the_exact_12k_explosion_collapses(self):
+        # Reconstruct the reported exponential chain; the guard must collapse it.
+        enc = "%3Fnext%3D"
+        blown = "/session/login" + (enc + "/session/login") * 40
+        assert len(blown) > 500
+        assert guard(blown) == "/"
+
+
+class TestServerGuardPreservesLegitimateRedirects:
+    def test_preserves_real_session_path(self):
+        assert guard("/session/abc123") == "/session/abc123"
+
+    def test_preserves_root_and_plain_paths(self):
+        assert guard("/") == "/"
+        assert guard("/workspace") == "/workspace"
+        assert guard("/session/xyz?tab=files") == "/session/xyz?tab=files"
+
+    def test_still_rejects_open_redirect_classics(self):
+        # The pre-existing protections must remain intact.
+        assert guard("//evil.example") == "/"
+        assert guard("/\\evil") == "/"
+        assert guard("https://evil.example") == "/"
+        assert guard("/x\x00y") == "/"
+        assert guard("") == "/"
+        assert guard(None) == "/"
+
+
+# ── client guards: static wiring (both JS sites carry the self-ref guard) ───
+
+class TestClientGuardsWired:
+    def test_login_js_rejects_login_self_and_nested_next(self):
+        # _safeNextPath must carry the login-self + nested-next + length guards.
+        assert "/login$/.test(pathOnly)" in LOGIN_JS or "/login$/" in LOGIN_JS
+        assert "next=" in LOGIN_JS and "%253f" in LOGIN_JS.lower()
+        assert "2048" in LOGIN_JS
+
+    def test_workspace_js_skips_next_on_login_page(self):
+        # The 401 handler must NOT append the whole login URL as next when it's
+        # already on the login page (the recursion source).
+        assert "login$/.test(_p)" in WORKSPACE_JS
+        assert "window.location.href='login';" in WORKSPACE_JS
+        # And the non-login path still captures the real destination.
+        assert "'login?next='+encodeURIComponent" in WORKSPACE_JS


### PR DESCRIPTION
## Summary

Fixes #5578: an expired-auth `401` while already on `/session/login?next=X` fed the login redirect its **own** URL, nesting `/session/login?next=…` into itself and re-percent-encoding on every bounce (`?` → `%3F` → `%253F` → …) until the URL grew past the browser limit and the tab broke (~12k chars reported).

## Root cause
All three redirect guards validated against open-redirect but **none rejected a `next` pointing back at the login page**, so the self-referential chain passed through re-encoded on each auth bounce:
1. `static/workspace.js:49` — the `api()` 401 handler wrapped `window.location.pathname+search` (which already contains `?next=X` when on the login page) into a fresh `next=`.
2. `static/login.js` `_safeNextPath()` — preserved the nested chain.
3. `api/routes.py` `_safe_login_redirect_path()` — re-emitted it via `quote(...)`, adding an encoding layer each pass.

## Fix (surgical, all three layers — preserves existing protections + happy path)
- **`_safe_login_redirect_path()`** (routes.py) and **`_safeNextPath()`** (login.js): after the existing validation, reject a `next` whose path targets the login route (`/login`, `/session/login`, subpath-mounted `*/login`), reject a `next` that already carries a raw or any-depth percent-encoded `next=` (`=`, `%3D`, `%253D`), and cap length at 2048.
- **`workspace.js` 401 handler**: if already **on** the login page, reload `login` **without** appending a `next` (the recursion source); non-login pages still capture the real destination.

The existing open-redirect protections (protocol-relative, absolute-URL, backslash, control-char rejection) are untouched — this only **adds** a self-reference/loop guard. A legitimate `next=/session/<id>` still works.

## Tests
`tests/test_issue5578_login_next_nesting.py`:
- Server guard rejects login self-reference (incl. subpath mount), nested `next` chains, encoded `next=` at any depth, overlong `next`, and the reconstructed exponential explosion.
- Preserves legit `/session/<id>` / `/workspace` paths **and** still rejects the open-redirect classics (`//`, `\`, absolute URL, control chars, empty/None).
- Static wiring asserts both JS guards carry the self-ref + nested-next + on-login-page checks.

**Fail-without-fix verified** (7/10 fail on `origin/master`). **69 auth/login regression tests green**; ruff clean on changed files.

Closes #5578.
