### PR TITLE
fix(#5571): keep fork children out of compression stitch

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8052,6 +8052,9 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
     segments = []
     current = session
     session_messages = list(getattr(session, "messages", []) or [])
+    source = str(getattr(session, "session_source", "") or "").strip().lower()
+    if source == "fork":
+        return session_messages
     seen = {str(getattr(session, "session_id", "") or "")}
     for _ in range(max(0, int(max_hops))):
         parent_id = str(getattr(current, "parent_session_id", "") or "").strip()

--- a/api/routes.py
+++ b/api/routes.py
@@ -8053,8 +8053,7 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
     current = session
     session_messages = list(getattr(session, "messages", []) or [])
     source = str(getattr(session, "session_source", "") or "").strip().lower()
-    if source == "fork":
-        return session_messages
+    root_is_fork = source == "fork"
     seen = {str(getattr(session, "session_id", "") or "")}
     for _ in range(max(0, int(max_hops))):
         parent_id = str(getattr(current, "parent_session_id", "") or "").strip()
@@ -8062,6 +8061,9 @@ def _webui_sidecar_lineage_messages_for_display(session, *, max_hops: int = 20) 
             break
         parent = Session.load(parent_id)
         if not parent or not getattr(parent, "pre_compression_snapshot", False):
+            break
+        parent_source = str(getattr(parent, "session_source", "") or "").strip().lower()
+        if root_is_fork and parent_source != "fork":
             break
         if not segments and _messages_start_with_visible_prefix(
             session_messages,

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -278,13 +278,6 @@ def test_webui_fork_session_does_not_stitch_non_snapshot_parent(monkeypatch):
 
 def test_webui_fork_session_does_not_stitch_snapshot_parent(monkeypatch):
     """A fork child must stay isolated even if its parent later becomes a snapshot."""
-    parent = SimpleNamespace(
-        session_id="parent-snapshot-fork",
-        parent_session_id=None,
-        pre_compression_snapshot=True,
-        truncation_watermark=None,
-        messages=[{"role": "user", "content": "parent should stay separate", "timestamp": 1.0}],
-    )
     child = SimpleNamespace(
         session_id="child-snapshot-fork",
         parent_session_id="parent-snapshot-fork",
@@ -294,14 +287,17 @@ def test_webui_fork_session_does_not_stitch_snapshot_parent(monkeypatch):
         messages=[{"role": "user", "content": "fork child only", "timestamp": 2.0}],
     )
 
-    monkeypatch.setattr(routes.Session, "load", lambda sid: parent if sid == "parent-snapshot-fork" else None)
+    def fail_load(sid):
+        raise AssertionError(f"fork sidecar should not load parent {sid}")
+
+    monkeypatch.setattr(routes.Session, "load", fail_load)
 
     assert [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)] == [
         "fork child only",
     ]
 
 
-def test_webui_merged_lineage_keeps_fork_child_isolated(monkeypatch):
+def test_webui_merged_lineage_keeps_session_source_fork_isolated(monkeypatch):
     parent = SimpleNamespace(
         session_id="merged-parent-fork",
         messages=[{"role": "user", "content": "parent only", "timestamp": 1.0}],
@@ -310,7 +306,7 @@ def test_webui_merged_lineage_keeps_fork_child_isolated(monkeypatch):
         session_id="merged-fork",
         parent_session_id="merged-parent-fork",
         session_source="fork",
-        relationship_type="child_session",
+        relationship_type="",
         messages=[{"role": "user", "content": "fork starts here", "timestamp": 2.0}],
         truncation_watermark=None,
     )
@@ -320,6 +316,27 @@ def test_webui_merged_lineage_keeps_fork_child_isolated(monkeypatch):
     merged = routes._merged_webui_lineage_messages_for_display(fork, fork.messages)
 
     assert [m["content"] for m in merged] == ["fork starts here"]
+
+
+def test_webui_merged_lineage_keeps_child_relationship_isolated(monkeypatch):
+    parent = SimpleNamespace(
+        session_id="merged-parent-child",
+        messages=[{"role": "user", "content": "parent only", "timestamp": 1.0}],
+    )
+    child = SimpleNamespace(
+        session_id="merged-child",
+        parent_session_id="merged-parent-child",
+        session_source="",
+        relationship_type="child_session",
+        messages=[{"role": "user", "content": "child starts here", "timestamp": 2.0}],
+        truncation_watermark=None,
+    )
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: parent)
+
+    merged = routes._merged_webui_lineage_messages_for_display(child, child.messages)
+
+    assert [m["content"] for m in merged] == ["child starts here"]
 
 
 def test_webui_lineage_display_keeps_child_tail_after_snapshot_watermark(monkeypatch):

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -276,6 +276,52 @@ def test_webui_fork_session_does_not_stitch_non_snapshot_parent(monkeypatch):
     ]
 
 
+def test_webui_fork_session_does_not_stitch_snapshot_parent(monkeypatch):
+    """A fork child must stay isolated even if its parent later becomes a snapshot."""
+    parent = SimpleNamespace(
+        session_id="parent-snapshot-fork",
+        parent_session_id=None,
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "parent should stay separate", "timestamp": 1.0}],
+    )
+    child = SimpleNamespace(
+        session_id="child-snapshot-fork",
+        parent_session_id="parent-snapshot-fork",
+        session_source="fork",
+        pre_compression_snapshot=False,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "fork child only", "timestamp": 2.0}],
+    )
+
+    monkeypatch.setattr(routes.Session, "load", lambda sid: parent if sid == "parent-snapshot-fork" else None)
+
+    assert [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)] == [
+        "fork child only",
+    ]
+
+
+def test_webui_merged_lineage_keeps_fork_child_isolated(monkeypatch):
+    parent = SimpleNamespace(
+        session_id="merged-parent-fork",
+        messages=[{"role": "user", "content": "parent only", "timestamp": 1.0}],
+    )
+    fork = SimpleNamespace(
+        session_id="merged-fork",
+        parent_session_id="merged-parent-fork",
+        session_source="fork",
+        relationship_type="child_session",
+        messages=[{"role": "user", "content": "fork starts here", "timestamp": 2.0}],
+        truncation_watermark=None,
+    )
+
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: parent)
+
+    merged = routes._merged_webui_lineage_messages_for_display(fork, fork.messages)
+
+    assert [m["content"] for m in merged] == ["fork starts here"]
+
+
 def test_webui_lineage_display_keeps_child_tail_after_snapshot_watermark(monkeypatch):
     """A child sidecar watermark must not delete the child's persisted continuation tail."""
     parent = SimpleNamespace(

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -278,6 +278,14 @@ def test_webui_fork_session_does_not_stitch_non_snapshot_parent(monkeypatch):
 
 def test_webui_fork_session_does_not_stitch_snapshot_parent(monkeypatch):
     """A fork child must stay isolated even if its parent later becomes a snapshot."""
+    parent = SimpleNamespace(
+        session_id="parent-snapshot-fork",
+        parent_session_id=None,
+        session_source="webui",
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "parent should stay separate", "timestamp": 1.0}],
+    )
     child = SimpleNamespace(
         session_id="child-snapshot-fork",
         parent_session_id="parent-snapshot-fork",
@@ -287,13 +295,58 @@ def test_webui_fork_session_does_not_stitch_snapshot_parent(monkeypatch):
         messages=[{"role": "user", "content": "fork child only", "timestamp": 2.0}],
     )
 
-    def fail_load(sid):
-        raise AssertionError(f"fork sidecar should not load parent {sid}")
-
-    monkeypatch.setattr(routes.Session, "load", fail_load)
+    monkeypatch.setattr(routes.Session, "load", lambda sid: parent if sid == "parent-snapshot-fork" else None)
 
     assert [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)] == [
         "fork child only",
+    ]
+
+
+def test_webui_compressed_fork_stitches_fork_snapshots_only(monkeypatch):
+    original_parent = SimpleNamespace(
+        session_id="original-fork-parent",
+        parent_session_id=None,
+        session_source="webui",
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "original parent should stay separate", "timestamp": 0.0}],
+    )
+    first_snapshot = SimpleNamespace(
+        session_id="fork-compression-snapshot-1",
+        parent_session_id="original-fork-parent",
+        session_source="fork",
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[{"role": "user", "content": "before first fork compression", "timestamp": 1.0}],
+    )
+    second_snapshot = SimpleNamespace(
+        session_id="fork-compression-snapshot-2",
+        parent_session_id="fork-compression-snapshot-1",
+        session_source="fork",
+        pre_compression_snapshot=True,
+        truncation_watermark=None,
+        messages=[{"role": "assistant", "content": "before second fork compression", "timestamp": 2.0}],
+    )
+    child = SimpleNamespace(
+        session_id="fork-compression-child",
+        parent_session_id="fork-compression-snapshot-2",
+        session_source="fork",
+        pre_compression_snapshot=False,
+        truncation_watermark=None,
+        messages=[{"role": "assistant", "content": "after fork compression", "timestamp": 3.0}],
+    )
+    by_id = {
+        "original-fork-parent": original_parent,
+        "fork-compression-snapshot-1": first_snapshot,
+        "fork-compression-snapshot-2": second_snapshot,
+    }
+
+    monkeypatch.setattr(routes.Session, "load", lambda sid: by_id.get(sid))
+
+    assert [m["content"] for m in routes._webui_sidecar_lineage_messages_for_display(child)] == [
+        "before first fork compression",
+        "before second fork compression",
+        "after fork compression",
     ]
 
 


### PR DESCRIPTION
## Thinking Path

- Clear Conversation preserves genuine fork parent links so sidebar nesting and the "Forked from" label keep working after a clear.
- The display stitch has overlapping fork states: a plain fork must not stitch its original non-fork parent, while a fork that later gets compressed can have one or more fork-sourced compression snapshots.
- `_webui_sidecar_lineage_messages_for_display` now allows a fork root to stitch fork-sourced snapshot parents and stops at the first non-fork ancestor, preserving fork compression history without resurrecting the original parent.

## What Changed

- `api/routes.py`: allow compressed fork continuations to stitch fork-sourced snapshots while keeping ordinary fork children isolated from non-fork parents.
- `tests/test_session_lineage_full_transcript.py`: keep the original fork-with-later-snapshot-parent regression and add a multiply-compressed fork regression that proves fork snapshots are restored without appending the original parent.

## Why It Matters

A cleared fork child stays independent if its original parent is compressed later, while a compressed fork continuation still shows the pre-compression turns that belong to that fork.

## Verification

- `pytest tests/test_session_lineage_full_transcript.py -v --timeout=60`, 11 passed.
- `pytest tests/test_issue5532_clear_truncation_watermark.py -v --timeout=60`, 7 passed.

Full-suite CI context, not a required local check: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5571.

## Model Used

GPT 5.5 via Codex CLI
