### PR TITLE
fix(#5575): preserve completed assistant replies during settle

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8370,13 +8370,31 @@ def _run_agent_streaming(
                     source=getattr(s, 'pending_user_source', None) or 'webui',
                     drop_replayed_assistant=_drop_replayed_assistant,
                 )
+                _is_agent_result_terminal = _agent_result_terminal_failure(result)
                 _terminal_failure = (
-                    _agent_result_terminal_failure(result)
+                    _is_agent_result_terminal
                     or (
                         _saved_transcript_lacks_final_answer
                         and _classification['type'] not in {'cancelled', 'interrupted'}
                     )
                 )
+                _result_status = str(result.get('status') or result.get('state') or '').strip().lower()
+                _soft_partial_terminal_failure = (
+                    _is_agent_result_terminal
+                    and (_result_status == 'partial' or bool(result.get('partial')))
+                    and _result_status not in {'failed', 'error', 'compression_exhausted'}
+                    and not result.get('failed')
+                    and not result.get('compression_exhausted')
+                    and not _tool_limit_reached
+                    and not _last_err
+                )
+                if (
+                    _terminal_failure
+                    and _soft_partial_terminal_failure
+                    and _classification['type'] == 'no_response'
+                    and not _saved_transcript_lacks_final_answer
+                ):
+                    _terminal_failure = False
                 if _terminal_failure:
                     _assistant_added = False
                 elif _tool_limit_reached and not _session_lacks_final_assistant_answer(s.messages):

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -170,13 +170,14 @@ def test_compression_exhausted_result_is_terminal_failure_even_after_streamed_te
 
 def test_terminal_failure_gates_shape_check_to_no_streamed_text():
     src = _read("api/streaming.py")
-    start = src.find("_terminal_failure = (")
-    assert start != -1, "terminal failure assignment not found"
+    start = src.find("_is_agent_result_terminal = _agent_result_terminal_failure(result)")
+    assert start != -1, "terminal failure result assignment not found"
     end = src.find("if _terminal_failure:", start)
     assert end != -1, "terminal failure guard not found"
     block = src[start:end]
 
-    assert "_agent_result_terminal_failure(result)" in block
+    assert "_is_agent_result_terminal = _agent_result_terminal_failure(result)" in block
+    assert "_is_agent_result_terminal" in block
     assert "_saved_transcript_lacks_final_answer" in block
     assert "_classification['type'] not in {'cancelled', 'interrupted'}" in block
     assert "not _token_sent" not in block

--- a/tests/test_cancelled_turn_status.py
+++ b/tests/test_cancelled_turn_status.py
@@ -147,13 +147,14 @@ class TestCancelledTurnPersistenceGuards:
 
     def test_streamed_progress_without_final_assistant_still_reports_error(self):
         src = _read("api/streaming.py")
-        failure_idx = src.find("_terminal_failure = (")
-        assert failure_idx != -1, "terminal-failure guard not found"
+        failure_idx = src.find("_is_agent_result_terminal = _agent_result_terminal_failure(result)")
+        assert failure_idx != -1, "terminal-failure result guard not found"
         apperror_idx = src.find("put('apperror', _error_payload)", failure_idx)
         assert apperror_idx != -1, "terminal-failure guard must emit apperror"
         block = src[failure_idx:apperror_idx]
 
-        assert "_agent_result_terminal_failure(result)" in block
+        assert "_is_agent_result_terminal = _agent_result_terminal_failure(result)" in block
+        assert "_is_agent_result_terminal" in block
         assert "if _terminal_failure or (not _assistant_added and not _token_sent):" in block, (
             "Explicit terminal failures, including compression/tool-tail failures, must report "
             "an error even when interim progress already streamed."

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -455,6 +455,158 @@ def test_non_auth_silent_failure_still_uses_no_response(tmp_path, monkeypatch):
     assert saved.messages[-1]["_error"] is True
 
 
+def test_completed_assistant_answer_with_stale_partial_flag_settles_done(tmp_path, monkeypatch):
+    session = _prepare_session(
+        "completed_answer_stale_partial",
+        "stream_completed_answer_stale_partial",
+        pending_user_message="Please finish cleanly",
+    )
+
+    class CompletedAnswerStalePartialAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            history = list(kwargs.get("conversation_history") or [])
+            return {
+                "status": "partial",
+                "partial": True,
+                "messages": history + [{"role": "assistant", "content": "Completed answer"}],
+                "error": "",
+            }
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_completed_answer_stale_partial",
+        CompletedAnswerStalePartialAgent,
+        workspace=str(tmp_path),
+    )
+    saved = Session.load("completed_answer_stale_partial")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    assert any(event == "done" for event, _ in events)
+    assert not any(event == "apperror" for event, _ in events)
+    assert saved.messages[-1]["role"] == "assistant"
+    assert saved.messages[-1]["content"] == "Completed answer"
+    assert not any(msg.get("_error") for msg in saved.messages)
+
+
+def test_stale_partial_with_unfinished_tool_call_still_reports_no_response(tmp_path, monkeypatch):
+    session = _prepare_session(
+        "unfinished_tool_call_stale_partial",
+        "stream_unfinished_tool_call_stale_partial",
+        pending_user_message="Use a tool first",
+    )
+
+    class UnfinishedToolCallStalePartialAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            history = list(kwargs.get("conversation_history") or [])
+            return {
+                "status": "partial",
+                "partial": True,
+                "messages": history + [
+                    {"role": "user", "content": "Use a tool first"},
+                    {
+                        "role": "assistant",
+                        "content": "Checking the tool result",
+                        "tool_calls": [{"id": "call_1", "type": "function"}],
+                    },
+                ],
+                "error": "",
+            }
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_unfinished_tool_call_stale_partial",
+        UnfinishedToolCallStalePartialAgent,
+        workspace=str(tmp_path),
+    )
+    saved = Session.load("unfinished_tool_call_stale_partial")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    apperrors = [data for event, data in events if event == "apperror"]
+    assert apperrors, "expected apperror for unfinished tool-call partial"
+    assert apperrors[-1]["type"] == "no_response"
+    assert not any(event == "done" for event, _ in events)
+    assert saved.messages[-1]["_error"] is True
+
+
+def test_stale_partial_repeated_prompt_replay_still_reports_no_response(tmp_path, monkeypatch):
+    session = _prepare_session(
+        "repeated_prompt_replay_stale_partial",
+        "stream_repeated_prompt_replay_stale_partial",
+        pending_user_message="Please repeat this",
+    )
+    _seed_prior_turn(
+        session,
+        prior_user="Please repeat this",
+        prior_assistant="Old answer",
+    )
+
+    class RepeatedPromptReplayStalePartialAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            if self.stream_delta_callback is not None:
+                self.stream_delta_callback("Partial text before stale replay")
+            return {
+                "status": "partial",
+                "partial": True,
+                "messages": list(kwargs.get("conversation_history") or []),
+                "error": "",
+            }
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_repeated_prompt_replay_stale_partial",
+        RepeatedPromptReplayStalePartialAgent,
+        workspace=str(tmp_path),
+    )
+    saved = Session.load("repeated_prompt_replay_stale_partial")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    apperrors = [data for event, data in events if event == "apperror"]
+    assert apperrors, "expected apperror for repeated-prompt stale replay"
+    assert apperrors[-1]["type"] == "no_response"
+    assert not any(event == "done" for event, _ in events)
+    assert saved.messages[-1]["_error"] is True
+
+
+def test_hard_failure_with_completed_answer_still_reports_no_response(tmp_path, monkeypatch):
+    session = _prepare_session(
+        "hard_failure_completed_answer",
+        "stream_hard_failure_completed_answer",
+        pending_user_message="Please finish despite failure",
+    )
+
+    class HardFailureCompletedAnswerAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            history = list(kwargs.get("conversation_history") or [])
+            return {
+                "status": "failed",
+                "messages": history + [{"role": "assistant", "content": "Completed answer"}],
+                "error": "",
+            }
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_hard_failure_completed_answer",
+        HardFailureCompletedAnswerAgent,
+        workspace=str(tmp_path),
+    )
+    saved = Session.load("hard_failure_completed_answer")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    apperrors = [data for event, data in events if event == "apperror"]
+    assert apperrors, "expected apperror for hard failed result"
+    assert apperrors[-1]["type"] == "no_response"
+    assert not any(event == "done" for event, _ in events)
+    assert saved.messages[-1]["_error"] is True
+
+
 def test_non_auth_partial_delivery_persists_error_turn(tmp_path, monkeypatch):
     session = _prepare_session("partial_escape", "stream_partial_escape", pending_user_message="Please handle partial silence")
 


### PR DESCRIPTION
## Thinking Path

- The streaming settlement path already computes whether the merged current turn lacks a final assistant answer, but a stale terminal or partial result flag can still force the generic `no_response` error path afterward.
- Partial streamed text is not enough to prove success, since existing tests intentionally keep `no_response` for real mid-answer silent failures.
- The fix keeps the guard in `api/streaming.py`, follows the issue-thread recommendation to scope it to soft `partial` results, and uses the existing final-answer checks to skip only the generic silent error path when the current turn already has a completed assistant reply.

## What Changed

- `api/streaming.py`: suppresses only the generic `no_response` terminal error path when the already-merged current turn has a final assistant answer, letting normal `done` settlement continue.
- `tests/test_issue5121_provider_auth_terminal_error.py`: adds regressions for stale soft-partial results with completed answers, repeated-prompt replays, unfinished tool calls, and hard-failure preservation.

## Why It Matters

Users should not see a completed answer followed by a misleading `No response from provider` card. Real silent failures, partial failures, auth/quota errors, cancellation, replayed rows, and terminal tool/compression cases keep their existing error behavior.

## Verification

- `pytest tests/test_auto_compression_terminal_failure.py::test_terminal_failure_gates_shape_check_to_no_streamed_text tests/test_cancelled_turn_status.py::TestCancelledTurnPersistenceGuards::test_streamed_progress_without_final_assistant_still_reports_error tests/test_issue5121_provider_auth_terminal_error.py tests/test_auto_compression_terminal_failure.py::test_compression_exhausted_result_is_terminal_failure_even_after_streamed_text tests/test_auto_compression_terminal_failure.py::test_completed_tool_tail_without_final_assistant_is_not_successful_done tests/test_cancelled_turn_status.py::TestCancelledTurnPersistenceGuards::test_silent_failure_path_checks_cancel_event_before_persisting_provider_error -v --timeout=60`
- Full-suite CI context: `pytest tests/ -v --timeout=60`

## Upstream

Closes #5575.

## Model Used

GPT 5.5 via Codex CLI
