### PR TITLE
fix(#5587): keep active CLI sessions visible before final output

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -214,9 +214,18 @@ def is_cli_session_row_visible(row: dict) -> bool:
     if not is_cli_session_row(row):
         return True
 
-    message_count = _as_positive_int(row.get("actual_message_count") or row.get("message_count"))
+    actual_message_count = _as_positive_int(row.get("actual_message_count"))
+    message_count = actual_message_count or _as_positive_int(row.get("message_count"))
     if message_count <= 0:
         return False
+
+    if (
+        actual_message_count > 0
+        and _count_user_turns(row) > 0
+        and row.get("ended_at") is None
+        and not row.get("end_reason")
+    ):
+        return True
 
     if "tui" in {
         _normalize_source_name(row.get("source")),

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -293,6 +293,66 @@ def test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enab
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_active_cli_state_db_session_with_persisted_user_turn_is_visible_in_cli_bucket():
+    """Active default-title CLI rows with persisted user content stay visible in the CLI bucket."""
+    conn = _ensure_state_db()
+    active_sid = 'cli_active_visible_001'
+    older_sid = 'cli_older_visible_001'
+    ended_sid = 'cli_ended_hidden_001'
+    now = time.time()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions "
+            "(id, source, title, model, started_at, message_count, ended_at, end_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (active_sid, 'cli', 'Untitled', 'openai/gpt-5', now + 20, 0, None, None),
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (active_sid,))
+        _insert_message(conn, active_sid, 'user', 'Active CLI session still running', now + 21)
+
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions "
+            "(id, source, title, model, started_at, message_count, ended_at, end_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (older_sid, 'cli', 'Named CLI Session', 'openai/gpt-5', now, 1, None, None),
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (older_sid,))
+        _insert_message(conn, older_sid, 'user', 'Older visible CLI session', now + 1)
+
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions "
+            "(id, source, title, model, started_at, message_count, ended_at, end_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (ended_sid, 'cli', 'Untitled', 'openai/gpt-5', now + 10, 1, now + 11, 'cli-close'),
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (ended_sid,))
+        _insert_message(conn, ended_sid, 'user', 'Ended CLI session', now + 11)
+        conn.commit()
+
+        post('/api/settings', {'show_cli_sessions': True})
+
+        data, status = get('/api/sessions?sidebar_source=cli')
+        assert status == 200
+        sessions = data.get('sessions', [])
+        session_ids = [s.get('session_id') for s in sessions]
+        assert active_sid in session_ids
+        assert older_sid in session_ids
+        assert ended_sid not in session_ids, "ended default-title CLI rows with one user turn stay hidden"
+
+        active = next(s for s in sessions if s.get('session_id') == active_sid)
+        older = next(s for s in sessions if s.get('session_id') == older_sid)
+        assert active.get('message_count') == 1
+        assert active.get('updated_at') > older.get('updated_at')
+        assert session_ids.index(active_sid) < session_ids.index(older_sid)
+    finally:
+        try:
+            _remove_test_sessions(conn, active_sid, older_sid, ended_sid)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
 def test_gateway_sessions_without_messages_are_hidden_from_sidebar():
     """Regression: empty agent session rows must not appear as broken sidebar entries."""
     conn = _ensure_state_db()


### PR DESCRIPTION
## Thinking Path

- The session list already asks the backend for the active source bucket, and the backend already reads CLI sessions from `state.db`.
- The missing row is filtered before source-bucket selection because the shared CLI visibility predicate treats a default-titled one-user-turn CLI session as low-value, even when it is the active persisted CLI run.
- The fix keeps the existing default-title threshold, but adds a narrow active state.db exception for CLI rows with persisted user content.

## What Changed

- `api/agent_sessions.py`: make `is_cli_session_row_visible(...)` keep active CLI state.db rows with persisted user content visible before final output.
- `tests/test_gateway_sync.py`: add a regression for `/api/sessions?sidebar_source=cli` using a temporary active `state.db` CLI row, plus the inactive short-row boundary.

## Why It Matters

CLI sessions become resumable from hermes-webui as soon as the first user turn is persisted, instead of waiting for title generation, final assistant output, or a sidecar refresh. Empty and inactive default-title rows keep the existing noise filters.

## Verification

- `pytest tests/test_gateway_sync.py::test_active_cli_state_db_session_with_persisted_user_turn_is_visible_in_cli_bucket tests/test_gateway_sync.py::test_gateway_sessions_without_messages_are_hidden_from_sidebar tests/test_gateway_sync.py::test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enabled tests/test_issue4766_sidebar_source_pushdown.py::test_sidebar_source_webui_excludes_cli_rows tests/test_issue4766_sidebar_source_pushdown.py::test_session_list_query_string_respects_sidebar_source_and_flags -v --timeout=60`
- CI context: `pytest tests/ -v --timeout=60`

## Upstream

Closes #5587.

## Model Used

GPT-5 via Codex CLI
