### PR TITLE
fix(#5585): preserve gateway steer input

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9893,11 +9893,10 @@ def _handle_chat_steer(handler, body: dict) -> bool:
     of the tool output on its next iteration. The user's stream is NOT
     interrupted.
 
-    If no agent is cached, the agent is too old to support steer, or no
+    If no local agent is cached, the agent is too old to support steer, or no
     stream is active, return {"accepted": False, "fallback": "<reason>"}.
-    The frontend must surface that failure without cancelling the active run;
-    Steer is active-run guidance, not implicit permission to Queue, Interrupt,
-    or Stop-and-send.
+    Gateway-owned streams have no WebUI-local agent to steer, so the frontend
+    queues the text as the next turn instead of dropping it behind a cache miss.
 
     Returns 200 with {"accepted": bool, "fallback": str|None,
     "stream_id": str|None}.
@@ -9931,6 +9930,24 @@ def _handle_chat_steer(handler, body: dict) -> bool:
         except Exception:
             logger.debug("Failed to close steer identity-mismatched cached agent for session %s", sid, exc_info=True)
     if not cached:
+        try:
+            s = get_session(sid)
+            active_stream_id = getattr(s, "active_stream_id", None) or None
+        except KeyError:
+            active_stream_id = None
+        if active_stream_id:
+            with _cfg.STREAMS_LOCK:
+                stream_alive = active_stream_id in _cfg.STREAMS
+            if stream_alive:
+                try:
+                    from api.gateway_chat import _STREAM_RUN_IDS
+                    gateway_run_id = _STREAM_RUN_IDS.get(str(active_stream_id or ""))
+                except Exception as exc:
+                    gateway_run_id = None
+                    logger.debug("Gateway run lookup failed for session=%s stream_id=%s: %s", sid, active_stream_id, exc)
+                if gateway_run_id:
+                    return j(handler, {"accepted": False, "fallback": "gateway_steer_queued",
+                                       "stream_id": active_stream_id})
         # No active agent for this session — caller surfaces a steer failure
         # without cancelling the active run.
         return j(handler, {"accepted": False, "fallback": "no_cached_agent",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9940,12 +9940,13 @@ def _handle_chat_steer(handler, body: dict) -> bool:
                 stream_alive = active_stream_id in _cfg.STREAMS
             if stream_alive:
                 try:
-                    from api.gateway_chat import _STREAM_RUN_IDS
-                    gateway_run_id = _STREAM_RUN_IDS.get(str(active_stream_id or ""))
+                    with _cfg.ACTIVE_RUNS_LOCK:
+                        active_run = dict((_cfg.ACTIVE_RUNS or {}).get(str(active_stream_id or "")) or {})
+                    gateway_owned = active_run.get("backend") == "gateway"
                 except Exception as exc:
-                    gateway_run_id = None
-                    logger.debug("Gateway run lookup failed for session=%s stream_id=%s: %s", sid, active_stream_id, exc)
-                if gateway_run_id:
+                    gateway_owned = False
+                    logger.debug("Gateway ownership lookup failed for session=%s stream_id=%s: %s", sid, active_stream_id, exc)
+                if gateway_owned:
                     return j(handler, {"accepted": False, "fallback": "gateway_steer_queued",
                                        "stream_id": active_stream_id})
         # No active agent for this session — caller surfaces a steer failure

--- a/static/commands.js
+++ b/static/commands.js
@@ -1382,6 +1382,15 @@ function _applyQueuedSteerCleanup(msg,result){
   const sameOwner=S.session&&S.session.session_id===result.ownerSid;
   const filesStillCurrent=Array.isArray(S.pendingFiles)&&S.pendingFiles.length===files.length&&S.pendingFiles.every((f,i)=>f===files[i]);
   if(sameOwner&&filesStillCurrent){S.pendingFiles=[];renderTray();}
+  if(sameOwner){
+    const inp=$('msg');
+    const text=String(msg||'');
+    if(inp&&(inp.value===text||(text&&inp.value===`/steer ${text}`))){
+      inp.value='';
+      if(typeof autoResize==='function')autoResize();
+      if(typeof updateSendBtn==='function')updateSendBtn();
+    }
+  }
   if(result.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(result.ownerSid,msg,files);
 }
 

--- a/static/commands.js
+++ b/static/commands.js
@@ -1391,7 +1391,21 @@ function _applyQueuedSteerCleanup(msg,result){
       if(typeof updateSendBtn==='function')updateSendBtn();
     }
   }
-  if(result.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(result.ownerSid,msg,files);
+  _steerClearComposerDraftIfSafe(result.ownerSid,msg,files);
+}
+
+function _steerComposerAllowsDraftClear(ownerSid,msg){
+  if(!(ownerSid&&typeof S!=='undefined'&&S.session&&S.session.session_id===ownerSid))return true;
+  const inp=$('msg');
+  if(!inp)return true;
+  const text=String(msg||'');
+  return inp.value===''||inp.value===text||(text&&inp.value===`/steer ${text}`);
+}
+
+function _steerClearComposerDraftIfSafe(ownerSid,msg,files){
+  if(ownerSid&&typeof _clearComposerDraft==='function'&&_steerComposerAllowsDraftClear(ownerSid,msg)){
+    _clearComposerDraft(ownerSid,msg,files);
+  }
 }
 
 function _showSteerRecovery(msg, explicitSteer, fallback) {

--- a/static/commands.js
+++ b/static/commands.js
@@ -1347,12 +1347,7 @@ async function cmdSteer(args){
   }
   if(!S.session){showToast(t('no_active_session'));return;}
   const _steerResult=await _trySteer(msg, /*explicitSteer=*/true);
-  if(_steerResult&&_steerResult.queuedFallback){
-    const _sameOwner=S.session&&S.session.session_id===_steerResult.ownerSid;
-    const _filesStillCurrent=Array.isArray(S.pendingFiles)&&S.pendingFiles.length===_steerResult.files.length&&S.pendingFiles.every((f,i)=>f===_steerResult.files[i]);
-    if(_sameOwner&&_filesStillCurrent){S.pendingFiles=[];renderTray();}
-    if(_steerResult.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(_steerResult.ownerSid,msg,_steerResult.files);
-  }
+  _applyQueuedSteerCleanup(msg,_steerResult);
 }
 
 function _steerFailureMessageKey(fallback) {
@@ -1381,6 +1376,15 @@ function _showSteerIndicator(text){
   if(typeof scrollToBottom==='function') scrollToBottom();
 }
 
+function _applyQueuedSteerCleanup(msg,result){
+  if(!result||!result.queuedFallback)return;
+  const files=Array.isArray(result.files)?result.files:[];
+  const sameOwner=S.session&&S.session.session_id===result.ownerSid;
+  const filesStillCurrent=Array.isArray(S.pendingFiles)&&S.pendingFiles.length===files.length&&S.pendingFiles.every((f,i)=>f===files[i]);
+  if(sameOwner&&filesStillCurrent){S.pendingFiles=[];renderTray();}
+  if(result.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(result.ownerSid,msg,files);
+}
+
 function _showSteerRecovery(msg, explicitSteer, fallback) {
   const inner = document.getElementById('msgInner');
   if (!inner) return;
@@ -1395,9 +1399,10 @@ function _showSteerRecovery(msg, explicitSteer, fallback) {
   const retryBtn = document.createElement('button');
   retryBtn.className = 'steer-recovery-retry';
   retryBtn.textContent = t('steer_recovery_retry');
-  retryBtn.addEventListener('click', () => {
+  retryBtn.addEventListener('click', async () => {
     el.remove();
-    void _trySteer(msg, explicitSteer).catch(console.error);
+    const result=await _trySteer(msg, explicitSteer).catch(e=>{console.error(e);return null;});
+    _applyQueuedSteerCleanup(msg,result);
   });
   el.appendChild(retryBtn);
   const dismissBtn = document.createElement('button');

--- a/static/commands.js
+++ b/static/commands.js
@@ -1384,7 +1384,7 @@ function _showSteerIndicator(text){
 // (accepted local steer, gateway-queued fallback, recovery retry) routes cleanup
 // through _steerFinalizeComposer so the three surfaces cannot diverge again.
 function _steerComposerSafeToClear(ownerSid,msg,files){
-  if(!_steerOwnerIsCurrent(ownerSid))return true;
+  if(!_steerOwnerIsCurrent(ownerSid))return _steerPersistedDraftSafeToClear(ownerSid,msg,files);
   const inp=$('msg');
   if(!inp)return true;
   const text=String(msg||'');
@@ -1394,6 +1394,32 @@ function _steerComposerSafeToClear(ownerSid,msg,files){
   const submitted=new Set(Array.isArray(files)?files:[]);
   const staged=Array.isArray(S.pendingFiles)?S.pendingFiles:[];
   return staged.every(f=>submitted.has(f));
+}
+
+// A switched-away owner's replacement content lives only in the server-persisted
+// draft (loadSession/_saveComposerDraftNow saved it on switch); the visible
+// textarea shows another session and is no evidence about it. Mirror the
+// current-owner check against that persisted draft instead of the textarea: the
+// composer text is cleared on submit before the switch, so the consumed steer
+// persists as empty text (or the steer echo on the failure-restore path) with no
+// staged file outside the delivered set. Anything else — replacement text, or a
+// file staged during the await — is preserved. No recorded draft means nothing
+// non-empty is persisted (safe no-op); if the persistence helpers are unavailable,
+// fail closed and skip the clear.
+function _steerPersistedDraftSafeToClear(ownerSid,msg,files){
+  if(typeof _composerDraftLastPersistedForSid!=='function'||typeof _composerDraftFilesForPersist!=='function'||typeof _composerDraftFileSignature!=='function')return false;
+  const draft=_composerDraftLastPersistedForSid(ownerSid);
+  if(draft==null)return true;
+  const text=String(msg||'');
+  const dtext=String(draft.text||'');
+  const textSafe=dtext===''||dtext===text||(text&&dtext===`/steer ${text}`);
+  if(!textSafe)return false;
+  // Persisted files are canonical plain objects, not the original File refs, so a
+  // subset check must compare by signature (mirrors the current-owner identity check).
+  const _sig=f=>JSON.stringify(_composerDraftFileSignature(f));
+  const submitted=new Set(_composerDraftFilesForPersist(Array.isArray(files)?files:[]).map(_sig));
+  const dfiles=_composerDraftFilesForPersist(Array.isArray(draft.files)?draft.files:[]);
+  return dfiles.every(f=>submitted.has(_sig(f)));
 }
 
 function _steerFinalizeComposer(ownerSid,msg,files,explicitSteer){
@@ -1500,6 +1526,28 @@ async function _steerPersistDraftForOwner(ownerSid, originalMsg, explicitSteer, 
   await _saveComposerDraftNow(ownerSid,_steerRestoreText(originalMsg,explicitSteer),filesSnapshot);
 }
 
+// Steer failed (not accepted, not gateway-queued): restore the steer text so the
+// user can retry, Queue, or Interrupt — but never over replacement content typed or
+// staged during the await. Current owner: read the live textarea. Switched-away
+// owner: read the persisted-draft evidence, the same guard the clear path uses, so
+// a replacement draft loadSession saved on switch is not overwritten by the echo.
+// One helper for all three failure sites (upload error, empty text, non-accept) so
+// the restore mutation cannot diverge across them.
+async function _steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,filesSnapshot){
+  if(_steerOwnerIsCurrent(ownerSid)){
+    const inp=$('msg');
+    const echo=_steerRestoreText(originalMsg,explicitSteer);
+    if(inp&&(inp.value===''||inp.value===echo)){
+      inp.value=echo;
+      if(typeof autoResize==='function')autoResize();
+    }
+    if(typeof renderTray==='function')renderTray();
+    return;
+  }
+  if(!_steerPersistedDraftSafeToClear(ownerSid,originalMsg,filesSnapshot))return;
+  await _steerPersistDraftForOwner(ownerSid,originalMsg,explicitSteer,filesSnapshot);
+}
+
 // #5459 gate: cache successful steer uploads by owner session so a failed-steer
 // RETRY reuses the uploaded paths instead of re-uploading the same File objects.
 // Keyed by ownerSid; invalidated when the staged file set changes or on accepted
@@ -1555,31 +1603,13 @@ async function _trySteer(msg, explicitSteer){
   try{
     steerText=await _steerTextWithPendingFiles(originalMsg,ownerSid,pendingFilesSnapshot);
   }catch(e){
-    if(_steerOwnerIsCurrent(ownerSid)){
-      const inp=$('msg');
-      if(inp){
-        inp.value=_steerRestoreText(originalMsg,explicitSteer);
-        if(typeof autoResize==='function')autoResize();
-      }
-      if(typeof renderTray==='function')renderTray();
-    }else{
-      await _steerPersistDraftForOwner(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
-    }
+    await _steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
     _steerSetComposerStatusForOwner(ownerSid,'');
     showToast(`${t('upload_failed')}${e&&e.message?e.message:e}`,3500);
     return false;
   }
   if(!steerText){
-    if(_steerOwnerIsCurrent(ownerSid)){
-      const inp=$('msg');
-      if(inp){
-        inp.value=_steerRestoreText(originalMsg,explicitSteer);
-        if(typeof autoResize==='function')autoResize();
-      }
-      if(typeof renderTray==='function')renderTray();
-    }else{
-      await _steerPersistDraftForOwner(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
-    }
+    await _steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
     showToast(t('cmd_steer_no_msg'));
     return false;
   }
@@ -1619,16 +1649,7 @@ async function _trySteer(msg, explicitSteer){
   // Do not fall back to interrupt: Steer failure is not permission to cancel
   // the active run. Restore the draft so the user can explicitly Queue or
   // Interrupt if that is what they want next. Pending files remain staged.
-  if(_steerOwnerIsCurrent(ownerSid)){
-    const inp=$('msg');
-    if(inp){
-      inp.value=_steerRestoreText(originalMsg,explicitSteer);
-      if(typeof autoResize==='function')autoResize();
-    }
-    if(typeof renderTray==='function')renderTray();
-  }else{
-    await _steerPersistDraftForOwner(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
-  }
+  await _steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
   const fallbackCode = result && result.fallback;
   showToast(t(_steerFailureMessageKey(fallbackCode)), 3500);
   if(_steerOwnerIsCurrent(ownerSid)) _showSteerRecovery(originalMsg, explicitSteer, fallbackCode);

--- a/static/commands.js
+++ b/static/commands.js
@@ -1347,7 +1347,7 @@ async function cmdSteer(args){
   }
   if(!S.session){showToast(t('no_active_session'));return;}
   const _steerResult=await _trySteer(msg, /*explicitSteer=*/true);
-  _applyQueuedSteerCleanup(msg,_steerResult);
+  if(_steerResult&&_steerResult.handled)_steerFinalizeComposer(_steerResult.ownerSid,msg,_steerResult.files,/*explicitSteer=*/true);
 }
 
 function _steerFailureMessageKey(fallback) {
@@ -1376,36 +1376,49 @@ function _showSteerIndicator(text){
   if(typeof scrollToBottom==='function') scrollToBottom();
 }
 
-function _applyQueuedSteerCleanup(msg,result){
-  if(!result||!result.queuedFallback)return;
-  const files=Array.isArray(result.files)?result.files:[];
-  const sameOwner=S.session&&S.session.session_id===result.ownerSid;
-  const filesStillCurrent=Array.isArray(S.pendingFiles)&&S.pendingFiles.length===files.length&&S.pendingFiles.every((f,i)=>f===files[i]);
-  if(sameOwner&&filesStillCurrent){S.pendingFiles=[];renderTray();}
-  if(sameOwner){
+// Steer/recovery composer cleanup. A session's visible textarea, persisted draft,
+// and staged files may be cleared only when the live composer for that owner still
+// holds exactly what was submitted (empty, the same text, or `/steer <text>`) with
+// no replacement files staged; if the user typed or staged new content during the
+// steer await, all three are preserved. Every handled steer/recovery outcome
+// (accepted local steer, gateway-queued fallback, recovery retry) routes cleanup
+// through _steerFinalizeComposer so the three surfaces cannot diverge again.
+function _steerComposerSafeToClear(ownerSid,msg,files){
+  if(!_steerOwnerIsCurrent(ownerSid))return true;
+  const inp=$('msg');
+  if(!inp)return true;
+  const text=String(msg||'');
+  const textSafe=inp.value===''||inp.value===text||(text&&inp.value===`/steer ${text}`);
+  if(!textSafe)return false;
+  // Any file staged during the await that is not part of the submitted set is replacement content.
+  const submitted=new Set(Array.isArray(files)?files:[]);
+  const staged=Array.isArray(S.pendingFiles)?S.pendingFiles:[];
+  return staged.every(f=>submitted.has(f));
+}
+
+function _steerFinalizeComposer(ownerSid,msg,files,explicitSteer){
+  const ownerCurrent=_steerOwnerIsCurrent(ownerSid);
+  const delivered=Array.isArray(files)?files:[];
+  // Evaluate safety against the pre-consume staged set so a replacement file still
+  // blocks the textarea/draft clear even after the delivered files are removed below.
+  const safe=_steerComposerSafeToClear(ownerSid,msg,delivered);
+  // Delivered/queued files are consumed regardless of composer edits — remove them by
+  // object identity so any file staged during the await survives (#5459 gate).
+  if(ownerCurrent&&Array.isArray(S.pendingFiles)&&S.pendingFiles.length&&delivered.length){
+    const _delivered=new Set(delivered);
+    const _remaining=S.pendingFiles.filter(f=>!_delivered.has(f));
+    if(_remaining.length!==S.pendingFiles.length){S.pendingFiles=_remaining;if(typeof renderTray==='function')renderTray();}
+  }
+  if(!safe)return;
+  if(ownerCurrent){
     const inp=$('msg');
-    const text=String(msg||'');
-    if(inp&&(inp.value===text||(text&&inp.value===`/steer ${text}`))){
+    if(inp){
       inp.value='';
       if(typeof autoResize==='function')autoResize();
       if(typeof updateSendBtn==='function')updateSendBtn();
     }
   }
-  _steerClearComposerDraftIfSafe(result.ownerSid,msg,files);
-}
-
-function _steerComposerAllowsDraftClear(ownerSid,msg){
-  if(!(ownerSid&&typeof S!=='undefined'&&S.session&&S.session.session_id===ownerSid))return true;
-  const inp=$('msg');
-  if(!inp)return true;
-  const text=String(msg||'');
-  return inp.value===''||inp.value===text||(text&&inp.value===`/steer ${text}`);
-}
-
-function _steerClearComposerDraftIfSafe(ownerSid,msg,files){
-  if(ownerSid&&typeof _clearComposerDraft==='function'&&_steerComposerAllowsDraftClear(ownerSid,msg)){
-    _clearComposerDraft(ownerSid,msg,files);
-  }
+  if(ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(ownerSid,_steerRestoreText(msg,explicitSteer),delivered);
 }
 
 function _showSteerRecovery(msg, explicitSteer, fallback) {
@@ -1425,7 +1438,7 @@ function _showSteerRecovery(msg, explicitSteer, fallback) {
   retryBtn.addEventListener('click', async () => {
     el.remove();
     const result=await _trySteer(msg, explicitSteer).catch(e=>{console.error(e);return null;});
-    _applyQueuedSteerCleanup(msg,result);
+    if(result&&result.handled)_steerFinalizeComposer(result.ownerSid,msg,result.files,explicitSteer);
   });
   el.appendChild(retryBtn);
   const dismissBtn = document.createElement('button');
@@ -1580,26 +1593,14 @@ async function _trySteer(msg, explicitSteer){
     result={accepted:false, fallback:'network_error'};
   }
   if(result&&result.accepted){
-    // The captured files+text were delivered to ownerSid — clear that session's
-    // draft (it may not be the live session anymore if the user switched during
-    // the upload/API await, which is fine: we're clearing the OWNER's draft).
+    // The captured files+text were delivered to ownerSid. Composer cleanup (draft,
+    // textarea, and delivered-file removal) is owned by the caller's
+    // _steerFinalizeComposer so the accepted, gateway-queued, and retry paths share
+    // one content-preservation guard. Only the transient in-chat indicator is shown
+    // here — it must survive the done event's S.messages replacement and self-removes
+    // when the turn completes. Show it only if the user still views the owning session.
     _steerUploadCache=null; // delivered — invalidate the retry cache
-    if(ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(ownerSid,_steerRestoreText(originalMsg,explicitSteer),pendingFilesSnapshot);
-    // Show a transient steer indicator in the chat (NOT in S.messages — it must
-    // survive the done event's S.messages=d.session.messages replacement).
-    // The indicator self-removes when the turn completes (done/cancel/error
-    // all call renderMessages which rebuilds msgInner). Only mutate the visible
-    // tray/DOM if the user is still looking at the owning session.
-    if(_steerOwnerIsCurrent(ownerSid)){
-      // Remove ONLY the files we captured+delivered, by object identity, so any
-      // files staged during the upload/API await are preserved (#5459 gate).
-      if(typeof S!=='undefined'&&Array.isArray(S.pendingFiles)&&S.pendingFiles.length&&pendingFilesSnapshot.length){
-        const _delivered=new Set(pendingFilesSnapshot);
-        const _remaining=S.pendingFiles.filter(f=>!_delivered.has(f));
-        if(_remaining.length!==S.pendingFiles.length){S.pendingFiles=_remaining;if(typeof renderTray==='function')renderTray();}
-      }
-      _showSteerIndicator(_steerIndicatorText(originalMsg,pendingFilesSnapshot));
-    }
+    if(_steerOwnerIsCurrent(ownerSid)) _showSteerIndicator(_steerIndicatorText(originalMsg,pendingFilesSnapshot));
     showToast(t('cmd_steer_delivered'),2500);
     return {handled:true,queuedFallback:false,ownerSid,files:ownerFiles};
   }

--- a/static/commands.js
+++ b/static/commands.js
@@ -1565,6 +1565,21 @@ async function _trySteer(msg, explicitSteer){
     showToast(t('cmd_steer_delivered'),2500);
     return true;
   }
+  if(result&&result.fallback==='gateway_steer_queued'&&S.session&&typeof queueSessionMessage==='function'){
+    const _modelState=typeof _chatPayloadModelState==='function'
+      ? _chatPayloadModelState()
+      : {model:S.model,model_provider:S.model_provider};
+    queueSessionMessage(S.session.session_id,{
+      text:msg,
+      files:Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[],
+      model:_modelState.model,
+      model_provider:_modelState.model_provider,
+      profile:S.activeProfile||'default',
+    });
+    if(typeof updateQueueBadge==='function')updateQueueBadge(S.session.session_id);
+    showToast(t('steer_leftover_queued'),3000);
+    return true;
+  }
   // Do not fall back to interrupt: Steer failure is not permission to cancel
   // the active run. Restore the draft so the user can explicitly Queue or
   // Interrupt if that is what they want next. Pending files remain staged.

--- a/static/commands.js
+++ b/static/commands.js
@@ -1346,7 +1346,13 @@ async function cmdSteer(args){
     return;
   }
   if(!S.session){showToast(t('no_active_session'));return;}
-  await _trySteer(msg, /*explicitSteer=*/true);
+  const _steerResult=await _trySteer(msg, /*explicitSteer=*/true);
+  if(_steerResult&&_steerResult.queuedFallback){
+    const _sameOwner=S.session&&S.session.session_id===_steerResult.ownerSid;
+    const _filesStillCurrent=Array.isArray(S.pendingFiles)&&S.pendingFiles.length===_steerResult.files.length&&S.pendingFiles.every((f,i)=>f===_steerResult.files[i]);
+    if(_sameOwner&&_filesStillCurrent){S.pendingFiles=[];renderTray();}
+    if(_steerResult.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(_steerResult.ownerSid,msg,_steerResult.files);
+  }
 }
 
 function _steerFailureMessageKey(fallback) {
@@ -1415,8 +1421,7 @@ function _showSteerRecovery(msg, explicitSteer, fallback) {
  * @param {boolean} explicitSteer - True if the user explicitly invoked /steer
  *   (vs the busy-mode auto-fallback). Affects draft restore prefix only;
  *   toast wording is determined by the failure reason code.
- * @returns {Promise<boolean>} true when the steer was delivered, false when the
- *   draft was restored and the active stream was left untouched.
+ * @returns {Promise<object>} Outcome for caller-side composer cleanup.
  */
 function _steerUploadedAttachmentPaths(uploaded){
   if(!Array.isArray(uploaded))return[];
@@ -1495,9 +1500,14 @@ async function _steerTextWithPendingFiles(msg, ownerSid, filesSnapshot){
 }
 
 async function _trySteer(msg, explicitSteer){
+  const ownerSid=(typeof S!=='undefined'&&S.session&&S.session.session_id)||null;
+  const ownerFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
+  const ownerProfile=S.activeProfile||'default';
+  const ownerModelState=typeof _chatPayloadModelState==='function'
+    ? _chatPayloadModelState()
+    : {model:S.model,model_provider:S.model_provider};
   let result=null;
   const originalMsg=String(msg||'').trim();
-  const ownerSid=(typeof S!=='undefined'&&S.session&&S.session.session_id)||null;
   const pendingFilesSnapshot=typeof S!=='undefined'&&Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
   if(!ownerSid){showToast(t('no_active_session'));return false;}
   let steerText=originalMsg;
@@ -1563,22 +1573,19 @@ async function _trySteer(msg, explicitSteer){
       _showSteerIndicator(_steerIndicatorText(originalMsg,pendingFilesSnapshot));
     }
     showToast(t('cmd_steer_delivered'),2500);
-    return true;
+    return {handled:true,queuedFallback:false,ownerSid,files:ownerFiles};
   }
-  if(result&&result.fallback==='gateway_steer_queued'&&S.session&&typeof queueSessionMessage==='function'){
-    const _modelState=typeof _chatPayloadModelState==='function'
-      ? _chatPayloadModelState()
-      : {model:S.model,model_provider:S.model_provider};
-    queueSessionMessage(S.session.session_id,{
+  if(result&&result.fallback==='gateway_steer_queued'&&ownerSid&&typeof queueSessionMessage==='function'){
+    queueSessionMessage(ownerSid,{
       text:msg,
-      files:Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[],
-      model:_modelState.model,
-      model_provider:_modelState.model_provider,
-      profile:S.activeProfile||'default',
+      files:ownerFiles,
+      model:ownerModelState.model,
+      model_provider:ownerModelState.model_provider,
+      profile:ownerProfile,
     });
-    if(typeof updateQueueBadge==='function')updateQueueBadge(S.session.session_id);
+    if(typeof updateQueueBadge==='function')updateQueueBadge(ownerSid);
     showToast(t('steer_leftover_queued'),3000);
-    return true;
+    return {handled:true,queuedFallback:true,ownerSid,files:ownerFiles};
   }
   // Do not fall back to interrupt: Steer failure is not permission to cancel
   // the active run. Restore the draft so the user can explicitly Queue or
@@ -1596,7 +1603,7 @@ async function _trySteer(msg, explicitSteer){
   const fallbackCode = result && result.fallback;
   showToast(t(_steerFailureMessageKey(fallbackCode)), 3500);
   if(_steerOwnerIsCurrent(ownerSid)) _showSteerRecovery(originalMsg, explicitSteer, fallbackCode);
-  return false;
+  return {handled:false,queuedFallback:false,ownerSid,files:ownerFiles};
 }
 
 async function cmdTitle(args){

--- a/static/messages.js
+++ b/static/messages.js
@@ -1372,23 +1372,19 @@ async function send(){
       }
     const defaultMessageMode=window._defaultMessageMode||'steer';
       if(defaultMessageMode==='steer'&&S.activeStreamId&&typeof _trySteer==='function'){
-        const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
-        // Real steer: clear the input first so the user gets immediate
-        // feedback, then ship the steer payload via /api/chat/steer.
-        // _trySteer captures the owner session/files before awaiting uploads,
-        // restores/persists the draft on failure, and clears the owner draft
-        // only after /api/chat/steer accepts.
+        // Real steer: clear the input first (synchronous, pre-await, so no
+        // replacement content can exist yet) for immediate feedback, then ship the
+        // steer payload via /api/chat/steer. _trySteer captures the owner
+        // session/files before awaiting uploads and restores/persists the draft on
+        // failure.
         $('msg').value='';autoResize();
         // Do NOT clear pendingFiles yet — a failed steer restores the draft and
         // must keep staged files available for the user's next explicit action.
         const _steerResult=await _trySteer(text, /*explicitSteer=*/false);
-        const _steerDelivered=_steerResult&&_steerResult.handled;
-        // After a delivered steer, clear any staged files because the text-only
-        // steer payload has been handled. On failure, keep files staged.
-        const _sameSteerOwner=_steerResult&&S.session&&S.session.session_id===_steerResult.ownerSid;
-        const _steerFilesStillCurrent=_steerResult&&Array.isArray(S.pendingFiles)&&S.pendingFiles.length===_steerResult.files.length&&S.pendingFiles.every((f,i)=>f===_steerResult.files[i]);
-        if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}
-        if(_steerDelivered&&typeof _steerClearComposerDraftIfSafe==='function') _steerClearComposerDraftIfSafe(_steerResult.ownerSid,text,_steerDraftFiles);
+        // Delivered/queued steer cleanup (draft, textarea, and delivered files) routes
+        // through the shared guard so replacement text or files typed during the await
+        // are preserved on this path exactly as on the /steer and retry paths.
+        if(_steerResult&&_steerResult.handled&&typeof _steerFinalizeComposer==='function') _steerFinalizeComposer(_steerResult.ownerSid,text,_steerResult.files,/*explicitSteer=*/false);
       } else if(defaultMessageMode==='interrupt'){
         // Queue the message, then cancel so drain re-sends it.
         const _modelState=_chatPayloadModelState();

--- a/static/messages.js
+++ b/static/messages.js
@@ -1388,7 +1388,7 @@ async function send(){
         const _sameSteerOwner=_steerResult&&S.session&&S.session.session_id===_steerResult.ownerSid;
         const _steerFilesStillCurrent=_steerResult&&Array.isArray(S.pendingFiles)&&S.pendingFiles.length===_steerResult.files.length&&S.pendingFiles.every((f,i)=>f===_steerResult.files[i]);
         if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}
-        if(_steerDelivered&&_steerResult.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(_steerResult.ownerSid,text,_steerDraftFiles);
+        if(_steerDelivered&&typeof _steerClearComposerDraftIfSafe==='function') _steerClearComposerDraftIfSafe(_steerResult.ownerSid,text,_steerDraftFiles);
       } else if(defaultMessageMode==='interrupt'){
         // Queue the message, then cancel so drain re-sends it.
         const _modelState=_chatPayloadModelState();

--- a/static/messages.js
+++ b/static/messages.js
@@ -1372,17 +1372,23 @@ async function send(){
       }
     const defaultMessageMode=window._defaultMessageMode||'steer';
       if(defaultMessageMode==='steer'&&S.activeStreamId&&typeof _trySteer==='function'){
+        const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
         // Real steer: clear the input first so the user gets immediate
         // feedback, then ship the steer payload via /api/chat/steer.
         // _trySteer captures the owner session/files before awaiting uploads,
         // restores/persists the draft on failure, and clears the owner draft
         // only after /api/chat/steer accepts.
         $('msg').value='';autoResize();
-        // Do NOT clear pendingFiles yet — _trySteer uploads with clearPending=false,
-        // and a failed steer must keep staged files available for the user's next explicit action.
-        await _trySteer(text, /*explicitSteer=*/false);
-        // _trySteer clears staged files only after /api/chat/steer accepts, and
-        // only when the visible session still matches the captured owner sid.
+        // Do NOT clear pendingFiles yet — a failed steer restores the draft and
+        // must keep staged files available for the user's next explicit action.
+        const _steerResult=await _trySteer(text, /*explicitSteer=*/false);
+        const _steerDelivered=_steerResult&&_steerResult.handled;
+        // After a delivered steer, clear any staged files because the text-only
+        // steer payload has been handled. On failure, keep files staged.
+        const _sameSteerOwner=_steerResult&&S.session&&S.session.session_id===_steerResult.ownerSid;
+        const _steerFilesStillCurrent=_steerResult&&Array.isArray(S.pendingFiles)&&S.pendingFiles.length===_steerResult.files.length&&S.pendingFiles.every((f,i)=>f===_steerResult.files[i]);
+        if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}
+        if(_steerDelivered&&_steerResult.ownerSid&&typeof _clearComposerDraft==='function') _clearComposerDraft(_steerResult.ownerSid,text,_steerDraftFiles);
       } else if(defaultMessageMode==='interrupt'){
         // Queue the message, then cancel so drain re-sends it.
         const _modelState=_chatPayloadModelState();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -34,6 +34,13 @@ let _draftSaveTimer = null;
 const _DRAFT_SAVE_DELAY_MS = 400;
 const NEW_CHAT_DRAFT_SESSION_KEY = 'hermes-new-chat-draft-session';
 const _composerDraftKnownPayloadSessions = new Set();
+// Per-session canonicalized copy of the last non-empty draft persisted to the
+// server. `_composerDraftKnownPayloadSessions` only records THAT a session has a
+// payload; this records WHAT that payload is (text + files), so a clear targeting
+// a session whose composer is not currently visible can be authorized against the
+// owner's actual persisted content instead of the (irrelevant) visible textarea.
+// Empty drafts hold no entry.
+const _composerDraftLastPersistedBySid = new Map();
 const _composerDraftRestoreSuppressedUntilBySid = new Map();
 const _COMPOSER_DRAFT_RESTORE_SUPPRESS_MS = 30000;
 
@@ -237,12 +244,22 @@ function _rememberComposerDraftPayloadState(sid, text, files) {
   const normalizedFiles = Array.isArray(files) ? files.filter(Boolean) : [];
   if (_composerDraftHasPayload(normalizedText, normalizedFiles)) {
     _composerDraftKnownPayloadSessions.add(sid);
+    _composerDraftLastPersistedBySid.set(sid, { text: normalizedText, files: _composerDraftFilesForPersist(normalizedFiles) });
   } else {
     _composerDraftKnownPayloadSessions.delete(sid);
+    _composerDraftLastPersistedBySid.delete(sid);
   }
   if (S.session && S.session.session_id === sid) {
     S.session.composer_draft = { text: normalizedText, files: normalizedFiles };
   }
+}
+
+// The owner session's last persisted non-empty draft ({text, files}), or null when
+// nothing non-empty is on record. Lets a clear for a non-visible owner compare
+// against what the server actually holds for that session.
+function _composerDraftLastPersistedForSid(sid) {
+  if (!sid) return null;
+  return _composerDraftLastPersistedBySid.get(sid) || null;
 }
 
 // Immediate save used before session switches.

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -175,7 +175,8 @@ class TestSlashCommandHandlers:
         assert "inp.value===text" in cleanup_body
         assert "inp.value===`/steer ${text}`" in cleanup_body
         assert "updateSendBtn()" in cleanup_body
-        assert "_clearComposerDraft(result.ownerSid,msg,files)" in cleanup_body
+        assert "_steerClearComposerDraftIfSafe(result.ownerSid,msg,files)" in cleanup_body
+        assert "function _steerComposerAllowsDraftClear" in COMMANDS_JS
 
     def test_steer_recovery_retry_consumes_queued_fallback_cleanup(self):
         recovery_body = _source_between(COMMANDS_JS, "function _showSteerRecovery", "\n/**")
@@ -358,7 +359,7 @@ class TestSendBusyBranchDispatch:
         assert "const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];" in branch
         assert "S.session.session_id===_steerResult.ownerSid" in branch
         assert "if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}" in branch
-        assert "_clearComposerDraft(_steerResult.ownerSid,text,_steerDraftFiles)" in branch
+        assert "_steerClearComposerDraftIfSafe(_steerResult.ownerSid,text,_steerDraftFiles)" in branch
         assert branch.index("const _steerResult=await _trySteer") < branch.index("if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}")
         try_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
         accepted_idx = try_body.find("if(result&&result.accepted)")

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -168,9 +168,17 @@ class TestSlashCommandHandlers:
         idx_steer = COMMANDS_JS.find("async function cmdSteer(")
         assert idx_steer >= 0, "cmdSteer not found"
         steer_body = COMMANDS_JS[idx_steer:COMMANDS_JS.find("function _steerFailureMessageKey", idx_steer)]
-        assert "queuedFallback" in steer_body
-        assert "S.session.session_id===_steerResult.ownerSid" in steer_body
-        assert "_clearComposerDraft(_steerResult.ownerSid,msg,_steerResult.files)" in steer_body
+        assert "_applyQueuedSteerCleanup(msg,_steerResult)" in steer_body
+        cleanup_body = _source_between(COMMANDS_JS, "function _applyQueuedSteerCleanup", "\nfunction _showSteerRecovery")
+        assert "queuedFallback" in cleanup_body
+        assert "S.session.session_id===result.ownerSid" in cleanup_body
+        assert "_clearComposerDraft(result.ownerSid,msg,files)" in cleanup_body
+
+    def test_steer_recovery_retry_consumes_queued_fallback_cleanup(self):
+        recovery_body = _source_between(COMMANDS_JS, "function _showSteerRecovery", "\n/**")
+        assert "retryBtn.addEventListener('click', async () => {" in recovery_body
+        assert "const result=await _trySteer(msg, explicitSteer).catch" in recovery_body
+        assert "_applyQueuedSteerCleanup(msg,result)" in recovery_body
 
 
 class TestBusySendButton:

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -102,19 +102,27 @@ class TestSlashCommandHandlers:
         idx = COMMANDS_JS.find("async function cmdSteer(")
         assert idx >= 0
         body = COMMANDS_JS[idx:idx + 800]
-        # cmdSteer delegates to _trySteer; fallback must not queue+cancel.
+        # cmdSteer delegates to _trySteer; fallback must not cancel the stream.
         assert "_trySteer" in body, "cmdSteer must call _trySteer to use the real /api/chat/steer endpoint"
         # The shared helper must contain the non-destructive fallback path.
         helper_idx = COMMANDS_JS.find("async function _trySteer(")
         assert helper_idx >= 0, "_trySteer helper must exist"
         helper_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
-        assert "queueSessionMessage" not in helper_body
+        assert "queueSessionMessage" in helper_body
         assert "cancelStream" not in helper_body
         assert "inp.value" in helper_body
         assert "if(result&&result.accepted)" in helper_body
         assert "S.pendingFiles=_remaining" in helper_body
         # Toast should differ from interrupt to signal it's the steer path
         assert "_steerFailureMessageKey" in helper_body or "steer_fail_" in helper_body
+
+    def test_try_steer_queues_gateway_fallback(self):
+        helper_idx = COMMANDS_JS.find("async function _trySteer(")
+        assert helper_idx >= 0
+        helper_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
+        assert "gateway_steer_queued" in helper_body
+        assert "queueSessionMessage" in helper_body
+        assert "cancelStream" not in helper_body
 
 
 # ── send() busy branch ───────────────────────────────────────────────────
@@ -140,19 +148,19 @@ class TestSlashCommandHandlers:
                 f"{fn_name} must call renderTray() after clearing pendingFiles"
             )
         # cmdSteer delegates to _trySteer; the helper clears files only on
-        # accepted steer, and (post-#5459-gate) removes ONLY the delivered files
-        # by identity so files staged during the upload await are preserved. The
-        # fallback path restores the draft and keeps staged files available.
+        # accepted steer, and removes only the delivered files by identity so
+        # files staged during the upload await are preserved. The fallback path
+        # restores the draft and keeps staged files available.
         try_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
         accepted_idx = try_body.find("if(result&&result.accepted)")
         failure_idx = try_body.find("// Do not fall back to interrupt")
-        # Identity-based removal of the delivered snapshot on accepted steer.
         clear_idx = try_body.find("S.pendingFiles=_remaining", accepted_idx)
         assert accepted_idx >= 0, "_trySteer must branch on accepted steer responses"
         assert clear_idx > accepted_idx, "accepted steer should clear the delivered staged files"
         assert "_delivered=new Set(pendingFilesSnapshot)" in try_body, (
             "accepted steer must remove only the delivered files by identity, preserving newly staged ones"
         )
+        assert "S.pendingFiles=[]" not in try_body
         assert failure_idx > clear_idx, "staged files must not be cleared in the failure path"
         assert "renderTray()" in try_body[failure_idx:]
 

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -172,6 +172,9 @@ class TestSlashCommandHandlers:
         cleanup_body = _source_between(COMMANDS_JS, "function _applyQueuedSteerCleanup", "\nfunction _showSteerRecovery")
         assert "queuedFallback" in cleanup_body
         assert "S.session.session_id===result.ownerSid" in cleanup_body
+        assert "inp.value===text" in cleanup_body
+        assert "inp.value===`/steer ${text}`" in cleanup_body
+        assert "updateSendBtn()" in cleanup_body
         assert "_clearComposerDraft(result.ownerSid,msg,files)" in cleanup_body
 
     def test_steer_recovery_retry_consumes_queued_fallback_cleanup(self):

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -132,8 +132,9 @@ class TestSlashCommandHandlers:
         preserves staged files so the user can choose the next explicit action.
 
         cmdQueue and cmdInterrupt call queueSessionMessage themselves and clear
-        S.pendingFiles directly. cmdSteer delegates to _trySteer. _trySteer no
-        longer clears files on failure because it no longer falls back to
+        S.pendingFiles directly. cmdSteer delegates to _trySteer and clears
+        only when the gateway fallback consumed the captured files. _trySteer
+        no longer clears files on failure because it no longer falls back to
         cancel-and-queue behavior.
         """
         # cmdQueue and cmdInterrupt clear pendingFiles directly
@@ -163,6 +164,13 @@ class TestSlashCommandHandlers:
         assert "S.pendingFiles=[]" not in try_body
         assert failure_idx > clear_idx, "staged files must not be cleared in the failure path"
         assert "renderTray()" in try_body[failure_idx:]
+
+        idx_steer = COMMANDS_JS.find("async function cmdSteer(")
+        assert idx_steer >= 0, "cmdSteer not found"
+        steer_body = COMMANDS_JS[idx_steer:COMMANDS_JS.find("function _steerFailureMessageKey", idx_steer)]
+        assert "queuedFallback" in steer_body
+        assert "S.session.session_id===_steerResult.ownerSid" in steer_body
+        assert "_clearComposerDraft(_steerResult.ownerSid,msg,_steerResult.files)" in steer_body
 
 
 class TestBusySendButton:
@@ -334,10 +342,13 @@ class TestSendBusyBranchDispatch:
         branch_end = MESSAGES_JS.find("} else if(defaultMessageMode==='interrupt')", steer_idx)
         assert branch_end > steer_idx, "busy steer branch end not found"
         branch = MESSAGES_JS[steer_idx:branch_end]
-        assert "await _trySteer(text, /*explicitSteer=*/false)" in branch
-        assert "_trySteer captures the owner session/files before awaiting uploads" in branch
-        assert "_trySteer clears staged files only after /api/chat/steer accepts" in branch
-        assert "_clearComposerDraft(S.session.session_id,text" not in branch
+        assert "const _steerResult=await _trySteer" in branch
+        assert "const _steerDelivered=_steerResult&&_steerResult.handled;" in branch
+        assert "const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];" in branch
+        assert "S.session.session_id===_steerResult.ownerSid" in branch
+        assert "if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}" in branch
+        assert "_clearComposerDraft(_steerResult.ownerSid,text,_steerDraftFiles)" in branch
+        assert branch.index("const _steerResult=await _trySteer") < branch.index("if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}")
         try_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
         accepted_idx = try_body.find("if(result&&result.accepted)")
         failure_idx = try_body.find("// Do not fall back to interrupt")
@@ -370,15 +381,12 @@ class TestSendBusyBranchDispatch:
         ONLY the delivered files by identity, preserving files staged during the
         upload/API await."""
         try_body = _source_between(COMMANDS_JS, "async function _steerTextWithPendingFiles(", "\nasync function cmdTitle")
-        # (1) upload cache keyed by session + file signature, reused on retry,
-        # invalidated on delivery.
         assert "_steerUploadCache" in try_body
         assert "_steerFilesSignature(" in try_body
         assert "_steerUploadCache={sid:ownerSid,sig,paths}" in try_body
         assert "_steerUploadCache=null" in try_body
-        # (2) identity-based removal of only the delivered snapshot.
-        assert "_delivered=new Set(pendingFilesSnapshot)" in try_body
-        assert "S.pendingFiles=_remaining" in try_body
+        assert "_delivered=new Set(pendingFilesSnapshot)" in COMMANDS_JS
+        assert "S.pendingFiles=_remaining" in COMMANDS_JS
 
 
     def test_slash_commands_intercepted_before_busymode_routing(self):

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -112,7 +112,7 @@ class TestSlashCommandHandlers:
         assert "cancelStream" not in helper_body
         assert "inp.value" in helper_body
         assert "if(result&&result.accepted)" in helper_body
-        assert "S.pendingFiles=_remaining" in helper_body
+        assert "return {handled:true,queuedFallback:false,ownerSid,files:ownerFiles};" in helper_body
         # Toast should differ from interrupt to signal it's the steer path
         assert "_steerFailureMessageKey" in helper_body or "steer_fail_" in helper_body
 
@@ -152,37 +152,42 @@ class TestSlashCommandHandlers:
         # accepted steer, and removes only the delivered files by identity so
         # files staged during the upload await are preserved. The fallback path
         # restores the draft and keeps staged files available.
+        # File removal and draft clearing on accepted steer now live in the shared
+        # _steerFinalizeComposer guard (run by the caller after _trySteer returns).
+        # _trySteer itself must not mutate staged files or the draft.
         try_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
         accepted_idx = try_body.find("if(result&&result.accepted)")
         failure_idx = try_body.find("// Do not fall back to interrupt")
-        clear_idx = try_body.find("S.pendingFiles=_remaining", accepted_idx)
         assert accepted_idx >= 0, "_trySteer must branch on accepted steer responses"
-        assert clear_idx > accepted_idx, "accepted steer should clear the delivered staged files"
-        assert "_delivered=new Set(pendingFilesSnapshot)" in try_body, (
-            "accepted steer must remove only the delivered files by identity, preserving newly staged ones"
-        )
+        assert "S.pendingFiles=_remaining" not in try_body
         assert "S.pendingFiles=[]" not in try_body
-        assert failure_idx > clear_idx, "staged files must not be cleared in the failure path"
-        assert "renderTray()" in try_body[failure_idx:]
+        assert "_clearComposerDraft(" not in try_body, "steer draft clearing must route through the shared guard"
+        assert "renderTray()" in try_body[failure_idx:], "failure path restores the owner tray"
+
+        finalize_body = _source_between(COMMANDS_JS, "function _steerFinalizeComposer", "\nfunction _showSteerRecovery")
+        assert "_delivered=new Set(delivered)" in finalize_body, (
+            "the shared guard removes only the delivered files by identity, preserving newly staged ones"
+        )
+        assert "S.pendingFiles=_remaining" in finalize_body
 
         idx_steer = COMMANDS_JS.find("async function cmdSteer(")
         assert idx_steer >= 0, "cmdSteer not found"
         steer_body = COMMANDS_JS[idx_steer:COMMANDS_JS.find("function _steerFailureMessageKey", idx_steer)]
-        assert "_applyQueuedSteerCleanup(msg,_steerResult)" in steer_body
-        cleanup_body = _source_between(COMMANDS_JS, "function _applyQueuedSteerCleanup", "\nfunction _showSteerRecovery")
-        assert "queuedFallback" in cleanup_body
-        assert "S.session.session_id===result.ownerSid" in cleanup_body
-        assert "inp.value===text" in cleanup_body
-        assert "inp.value===`/steer ${text}`" in cleanup_body
-        assert "updateSendBtn()" in cleanup_body
-        assert "_steerClearComposerDraftIfSafe(result.ownerSid,msg,files)" in cleanup_body
-        assert "function _steerComposerAllowsDraftClear" in COMMANDS_JS
+        assert "_steerFinalizeComposer(_steerResult.ownerSid,msg,_steerResult.files,/*explicitSteer=*/true)" in steer_body
+        predicate_body = _source_between(COMMANDS_JS, "function _steerComposerSafeToClear", "\nfunction _steerFinalizeComposer")
+        assert "inp.value===text" in predicate_body
+        assert "inp.value===`/steer ${text}`" in predicate_body
+        assert "staged.every(f=>submitted.has(f))" in predicate_body, "the safe-clear predicate must consider staged files, not just text"
+        assert "_steerComposerSafeToClear(ownerSid,msg,delivered)" in finalize_body
+        assert "if(!safe)return;" in finalize_body
+        assert "updateSendBtn()" in finalize_body
+        assert "_clearComposerDraft(ownerSid,_steerRestoreText(msg,explicitSteer),delivered)" in finalize_body
 
     def test_steer_recovery_retry_consumes_queued_fallback_cleanup(self):
         recovery_body = _source_between(COMMANDS_JS, "function _showSteerRecovery", "\n/**")
         assert "retryBtn.addEventListener('click', async () => {" in recovery_body
         assert "const result=await _trySteer(msg, explicitSteer).catch" in recovery_body
-        assert "_applyQueuedSteerCleanup(msg,result)" in recovery_body
+        assert "_steerFinalizeComposer(result.ownerSid,msg,result.files,explicitSteer)" in recovery_body
 
 
 class TestBusySendButton:
@@ -355,19 +360,18 @@ class TestSendBusyBranchDispatch:
         assert branch_end > steer_idx, "busy steer branch end not found"
         branch = MESSAGES_JS[steer_idx:branch_end]
         assert "const _steerResult=await _trySteer" in branch
-        assert "const _steerDelivered=_steerResult&&_steerResult.handled;" in branch
-        assert "const _steerDraftFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];" in branch
-        assert "S.session.session_id===_steerResult.ownerSid" in branch
-        assert "if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}" in branch
-        assert "_steerClearComposerDraftIfSafe(_steerResult.ownerSid,text,_steerDraftFiles)" in branch
-        assert branch.index("const _steerResult=await _trySteer") < branch.index("if(_steerDelivered&&_sameSteerOwner&&_steerFilesStillCurrent){S.pendingFiles=[];renderTray();}")
+        # Busy-send routes delivered/queued cleanup through the shared guard, which only
+        # clears files/textarea/draft when the composer still holds the submitted payload.
+        assert "_steerFinalizeComposer(_steerResult.ownerSid,text,_steerResult.files,/*explicitSteer=*/false)" in branch
+        assert "_steerResult.handled" in branch
+        assert branch.index("const _steerResult=await _trySteer") < branch.index("_steerFinalizeComposer(")
+        # Failed steer (not handled) never reaches the guard, so staged files stay intact.
         try_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
         accepted_idx = try_body.find("if(result&&result.accepted)")
         failure_idx = try_body.find("// Do not fall back to interrupt")
-        clear_idx = try_body.find("S.pendingFiles=_remaining", accepted_idx)
-        assert accepted_idx >= 0 and clear_idx > accepted_idx
-        assert "_clearComposerDraft(ownerSid,_steerRestoreText(originalMsg,explicitSteer),pendingFilesSnapshot)" in try_body
-        assert failure_idx > clear_idx, "failed steer must leave staged files intact"
+        assert accepted_idx >= 0 and failure_idx > accepted_idx
+        assert "S.pendingFiles=_remaining" not in try_body, "file cleanup moved to the shared guard"
+        assert "renderTray()" in try_body[failure_idx:], "failed steer restores the owner tray without clearing files"
 
     def test_reentrant_send_does_not_queue_staged_files_while_steer_uploads(self):
         """Repeated Enter during steer upload must not double-send staged files.
@@ -397,7 +401,7 @@ class TestSendBusyBranchDispatch:
         assert "_steerFilesSignature(" in try_body
         assert "_steerUploadCache={sid:ownerSid,sig,paths}" in try_body
         assert "_steerUploadCache=null" in try_body
-        assert "_delivered=new Set(pendingFilesSnapshot)" in COMMANDS_JS
+        assert "_delivered=new Set(delivered)" in COMMANDS_JS
         assert "S.pendingFiles=_remaining" in COMMANDS_JS
 
 

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -110,7 +110,7 @@ class TestSlashCommandHandlers:
         helper_body = _source_between(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
         assert "queueSessionMessage" in helper_body
         assert "cancelStream" not in helper_body
-        assert "inp.value" in helper_body
+        assert "_steerRestoreDraftOnFailure(" in helper_body
         assert "if(result&&result.accepted)" in helper_body
         assert "return {handled:true,queuedFallback:false,ownerSid,files:ownerFiles};" in helper_body
         # Toast should differ from interrupt to signal it's the steer path
@@ -162,7 +162,7 @@ class TestSlashCommandHandlers:
         assert "S.pendingFiles=_remaining" not in try_body
         assert "S.pendingFiles=[]" not in try_body
         assert "_clearComposerDraft(" not in try_body, "steer draft clearing must route through the shared guard"
-        assert "renderTray()" in try_body[failure_idx:], "failure path restores the owner tray"
+        assert "_steerRestoreDraftOnFailure(" in try_body[failure_idx:], "failure path restores the owner draft via the guarded helper"
 
         finalize_body = _source_between(COMMANDS_JS, "function _steerFinalizeComposer", "\nfunction _showSteerRecovery")
         assert "_delivered=new Set(delivered)" in finalize_body, (
@@ -371,7 +371,7 @@ class TestSendBusyBranchDispatch:
         failure_idx = try_body.find("// Do not fall back to interrupt")
         assert accepted_idx >= 0 and failure_idx > accepted_idx
         assert "S.pendingFiles=_remaining" not in try_body, "file cleanup moved to the shared guard"
-        assert "renderTray()" in try_body[failure_idx:], "failed steer restores the owner tray without clearing files"
+        assert "_steerRestoreDraftOnFailure(" in try_body[failure_idx:], "failed steer restores the owner draft without clearing files"
 
     def test_reentrant_send_does_not_queue_staged_files_while_steer_uploads(self):
         """Repeated Enter during steer upload must not double-send staged files.

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -163,6 +163,15 @@ def _run_steer_finalize_harness(body: str) -> None:
         "function _steerComposerSafeToClear",
         "\nfunction _showSteerRecovery",
     )
+    # Real signature functions (file canon + payload signature) so the persisted-draft
+    # comparison is exercised exactly as production computes it. This block spans
+    # _composerDraftFileSignature, _composerDraftFilesForPersist, and
+    # _composerDraftPayloadSignature.
+    sig_src = _block(
+        SESSIONS_JS,
+        "function _composerDraftFileSignature(file)",
+        "function _composerDraftPayloadSignatureForSid(sid)",
+    )
     script = textwrap.dedent(
         """
         const assert = require('assert');
@@ -173,10 +182,21 @@ def _run_steer_finalize_harness(body: str) -> None:
         function _clearComposerDraft(sid,text,files){draftClears.push({sid,text,files});}
         function _steerOwnerIsCurrent(sid){return !!(sid && S && S.session && S.session.session_id===sid);}
         function _steerRestoreText(msg,explicit){return explicit?('/steer '+msg):msg;}
+        %(sig)s
+        // Per-sid persisted drafts the guard reads for a switched-away owner. Tests
+        // populate this to mimic what loadSession/_saveComposerDraftNow recorded.
+        let _persistedDrafts = {};
+        function _composerDraftLastPersistedForSid(sid){
+          return Object.prototype.hasOwnProperty.call(_persistedDrafts, sid) ? _persistedDrafts[sid] : null;
+        }
         eval(%(guard)s);
         %(body)s
         """
-    ) % {"guard": json.dumps(guard_src), "body": body}
+    ) % {
+        "guard": json.dumps(guard_src),
+        "sig": sig_src,
+        "body": body,
+    }
     proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
 
@@ -214,3 +234,243 @@ def test_accepted_steer_replacement_file_keeps_persisted_draft():
         assert.strictEqual(S.pendingFiles.length, 1, 'the newly staged file must not be dropped');
         """
     )
+
+
+# ── Cross-session (switched-away owner) — the round-7 class ────────────────────
+# The owner's replacement content lives only in the server-persisted draft; the
+# visible textarea belongs to another session. The guard must read the owner's
+# persisted-draft signature, not the textarea. One test per representation x
+# context cell that was fixed, plus the current-owner cells re-asserted above.
+
+def test_cross_session_replacement_text_keeps_persisted_draft():
+    """Context B, R3: send steer, type replacement, switch session, finalize.
+    The owner's persisted replacement draft must NOT be wiped."""
+    _run_steer_finalize_harness(
+        """
+        // Visible session is 'B'; owner 'A' is switched away.
+        let S = {session:{session_id:'B'}, pendingFiles:[{name:'B-file.png'}]};
+        const msgEl = {value:'unrelated text in session B'};
+        function $(id){return msgEl;}
+        // loadSession/_saveComposerDraftNow persisted A's replacement text on switch.
+        _persistedDrafts['A'] = {text:'my replacement for A', files:[]};
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(draftClears.length, 0, 'switched-away owner replacement draft must be preserved');
+        assert.strictEqual(msgEl.value, 'unrelated text in session B', 'visible session composer untouched');
+        assert.strictEqual(S.pendingFiles.length, 1, 'visible session staged files untouched');
+        """
+    )
+
+
+def test_cross_session_replacement_file_keeps_persisted_draft():
+    """Context B, R3 with files: owner persisted a draft holding a replacement file
+    not in the delivered steer set. Must be preserved."""
+    _run_steer_finalize_harness(
+        """
+        let S = {session:{session_id:'B'}, pendingFiles:[]};
+        const msgEl = {value:''};
+        function $(id){return msgEl;}
+        // A's persisted draft (text cleared on submit) has a replacement file that
+        // was staged during the await; the steer delivered no files.
+        _persistedDrafts['A'] = {text:'', files:[{name:'replacement.pdf', path:'/r.pdf', size:5, type:'application/pdf'}]};
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(draftClears.length, 0, 'switched-away owner replacement file draft must be preserved');
+        """
+    )
+
+
+def test_cross_session_unedited_echo_clears_stale_draft():
+    """Context B, R3 safe case: owner switched away WITHOUT editing. The composer text
+    is cleared on submit, so its persisted draft is empty text with (at most) the
+    delivered files — the consumed steer. That stale echo must be cleared."""
+    _run_steer_finalize_harness(
+        """
+        const f = {name:'a.pdf', path:'/a.pdf', size:9, type:'application/pdf'};
+        // Unedited file steer: persisted draft is {text:'', files:[delivered]}.
+        let S = {session:{session_id:'B'}, pendingFiles:[]};
+        function $(id){return {value:''};}
+        _persistedDrafts['A'] = {text:'', files:[f]};
+        _steerFinalizeComposer('A','hint',[f],false);
+        assert.strictEqual(draftClears.length, 1, 'unedited file-steer echo (empty text) must be cleared');
+        assert.strictEqual(draftClears[0].sid, 'A', 'the owner draft is the one cleared');
+
+        // Failure-restore echo shape: persisted text equals the bare msg.
+        draftClears = [];
+        _persistedDrafts['A'] = {text:'hint', files:[]};
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(draftClears.length, 1, 'persisted bare-msg echo must be cleared');
+
+        // Explicit steer failure-restore echo: persisted text equals `/steer hint`.
+        draftClears = [];
+        _persistedDrafts['A'] = {text:'/steer hint', files:[]};
+        _steerFinalizeComposer('A','hint',[],true);
+        assert.strictEqual(draftClears.length, 1, 'persisted /steer-echo must be cleared');
+        """
+    )
+
+
+def test_cross_session_no_persisted_draft_is_safe_noop():
+    """Context B, R3: no recorded draft for the owner means nothing non-empty is
+    persisted, so the clear is authorized (harmless no-op) and never blocked."""
+    _run_steer_finalize_harness(
+        """
+        let S = {session:{session_id:'B'}, pendingFiles:[]};
+        function $(id){return {value:''};}
+        // _persistedDrafts empty -> _composerDraftLastPersistedForSid('A') is null.
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(draftClears.length, 1, 'no persisted draft -> safe to clear');
+        """
+    )
+
+
+def test_cross_session_guard_fails_closed_without_persist_helpers():
+    """If the persistence helpers are unavailable, the non-current branch must fail
+    closed (skip the clear) rather than run blind."""
+    import json, shutil, subprocess, textwrap
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        import pytest
+        pytest.skip("node not available")
+    guard_src = _block(COMMANDS_JS, "function _steerComposerSafeToClear", "\nfunction _showSteerRecovery")
+    script = textwrap.dedent(
+        """
+        const assert = require('assert');
+        let draftClears = [];
+        function renderTray(){}
+        function _clearComposerDraft(sid,text,files){draftClears.push({sid});}
+        function _steerOwnerIsCurrent(sid){return !!(sid && S && S.session && S.session.session_id===sid);}
+        function _steerRestoreText(msg,explicit){return explicit?('/steer '+msg):msg;}
+        // Deliberately DO NOT define the persistence helpers the guard needs.
+        eval(%(guard)s);
+        let S = {session:{session_id:'B'}, pendingFiles:[]};
+        function $(id){return {value:''};}
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(draftClears.length, 0, 'no evidence available -> skip the clear, never run blind');
+        """
+    ) % {"guard": json.dumps(guard_src)}
+    proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+
+
+def test_failure_restore_preserves_switched_away_replacement_draft():
+    """Steer FAILURE path, switched-away owner: _steerRestoreDraftOnFailure must not
+    overwrite the owner's replacement draft with the steer echo. Only overwrite when
+    the persisted draft is the consumed steer (empty / echo)."""
+    import json, shutil, subprocess, textwrap
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        import pytest
+        pytest.skip("node not available")
+    # Extract the failure helper + the guard it delegates to.
+    guard_src = _block(COMMANDS_JS, "function _steerComposerSafeToClear", "\nfunction _steerFinalizeComposer")
+    restore_src = _block(COMMANDS_JS, "async function _steerRestoreDraftOnFailure", "\n// #5459 gate")
+    sig_src = _block(SESSIONS_JS, "function _composerDraftFileSignature(file)", "function _composerDraftPayloadSignatureForSid(sid)")
+    script = textwrap.dedent(
+        """
+        const assert = require('assert');
+        %(sig)s
+        let _persistedDrafts = {};
+        let persistCalls = [];
+        function _composerDraftLastPersistedForSid(sid){
+          return Object.prototype.hasOwnProperty.call(_persistedDrafts, sid) ? _persistedDrafts[sid] : null;
+        }
+        function _steerOwnerIsCurrent(sid){return !!(sid && S && S.session && S.session.session_id===sid);}
+        function _steerRestoreText(msg,explicit){return explicit?('/steer '+msg):msg;}
+        function autoResize(){}
+        function renderTray(){}
+        function _saveComposerDraftNow(sid,text,files){persistCalls.push({sid,text}); return Promise.resolve();}
+        async function _steerPersistDraftForOwner(sid,msg,explicit,files){
+          if(!sid) return;
+          await _saveComposerDraftNow(sid,_steerRestoreText(msg,explicit),files);
+        }
+        eval(%(guard)s);
+        eval(%(restore)s);
+        (async()=>{
+          // Owner 'A' switched away; its persisted draft is a REPLACEMENT.
+          let S1 = {session:{session_id:'B'}, pendingFiles:[]};
+          globalThis.S = S1;
+          function $(){ return {value:''}; }
+          globalThis.$ = $;
+          _persistedDrafts['A'] = {text:'replacement I typed then switched', files:[]};
+          await _steerRestoreDraftOnFailure('A','fixthis',true,[]);
+          assert.strictEqual(persistCalls.length, 0, 'failure restore must NOT overwrite a replacement draft');
+
+          // Owner 'A' switched away with the consumed steer (empty draft): restore echo.
+          persistCalls = [];
+          _persistedDrafts = {};   // nothing persisted -> safe to restore the failed steer
+          await _steerRestoreDraftOnFailure('A','fixthis',true,[]);
+          assert.strictEqual(persistCalls.length, 1, 'failed steer is restored when no replacement exists');
+          assert.strictEqual(persistCalls[0].text, '/steer fixthis');
+        })().catch(err=>{console.error(err); process.exit(1);});
+        """
+    ) % {"guard": json.dumps(guard_src), "restore": json.dumps(restore_src), "sig": sig_src}
+    proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+
+
+def test_failure_restore_preserves_current_owner_replacement_text():
+    """Steer FAILURE path, current owner: do not clobber replacement text the user
+    typed after submit cleared the composer."""
+    import json, shutil, subprocess, textwrap
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        import pytest
+        pytest.skip("node not available")
+    guard_src = _block(COMMANDS_JS, "function _steerComposerSafeToClear", "\nfunction _steerFinalizeComposer")
+    restore_src = _block(COMMANDS_JS, "async function _steerRestoreDraftOnFailure", "\n// #5459 gate")
+    script = textwrap.dedent(
+        """
+        const assert = require('assert');
+        function _steerOwnerIsCurrent(sid){return !!(sid && S && S.session && S.session.session_id===sid);}
+        function _steerRestoreText(msg,explicit){return explicit?('/steer '+msg):msg;}
+        function autoResize(){}
+        function renderTray(){}
+        function _composerDraftLastPersistedForSid(){return null;}
+        function _composerDraftFilesForPersist(f){return Array.isArray(f)?f:[];}
+        function _composerDraftFileSignature(f){return {v:String((f&&f.name)||f||'')};}
+        async function _steerPersistDraftForOwner(){throw new Error('current owner must not persist');}
+        eval(%(guard)s);
+        eval(%(restore)s);
+        (async()=>{
+          globalThis.S = {session:{session_id:'A'}, pendingFiles:[]};
+          // User typed a replacement after submit cleared the composer.
+          const msgEl = {value:'my replacement'};
+          globalThis.$ = function(){ return msgEl; };
+          await _steerRestoreDraftOnFailure('A','fixthis',true,[]);
+          assert.strictEqual(msgEl.value, 'my replacement', 'replacement text must not be clobbered by the failed steer');
+
+          // Empty composer (normal failure): restore the failed steer for retry.
+          msgEl.value = '';
+          await _steerRestoreDraftOnFailure('A','fixthis',true,[]);
+          assert.strictEqual(msgEl.value, '/steer fixthis', 'failed steer restored into an empty composer');
+        })().catch(err=>{console.error(err); process.exit(1);});
+        """
+    ) % {"guard": json.dumps(guard_src), "restore": json.dumps(restore_src)}
+    proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+
+
+def test_guard_evidence_covers_effect_source_shape():
+    """The non-current-owner branch no longer returns an unconditional true, the
+    per-sid persisted draft (the evidence) is maintained at the single persist choke
+    point, and the failure-restore path routes through one guarded helper."""
+    assert "if(!_steerOwnerIsCurrent(ownerSid))return _steerPersistedDraftSafeToClear(ownerSid,msg,files);" in COMMANDS_JS
+    assert "if(!_steerOwnerIsCurrent(ownerSid))return true;" not in COMMANDS_JS, (
+        "the guard must not authorize a non-current-owner clear without evidence"
+    )
+    assert "function _steerPersistedDraftSafeToClear(ownerSid,msg,files)" in COMMANDS_JS
+    assert "async function _steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,filesSnapshot)" in COMMANDS_JS
+    # All three failure sites route through the one helper; no inline restore blocks remain.
+    trysteer_body = _block(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
+    assert trysteer_body.count("_steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot)") == 3
+    assert "inp.value=_steerRestoreText(originalMsg,explicitSteer)" not in trysteer_body, (
+        "failure restore must not clobber the composer inline; route through the guarded helper"
+    )
+    assert "const _composerDraftLastPersistedBySid = new Map();" in SESSIONS_JS
+    remember_body = _block(
+        SESSIONS_JS,
+        "function _rememberComposerDraftPayloadState(sid, text, files)",
+        "function _composerDraftLastPersistedForSid",
+    )
+    assert "_composerDraftLastPersistedBySid.set(sid, { text: normalizedText, files: _composerDraftFilesForPersist(normalizedFiles) });" in remember_body
+    assert "_composerDraftLastPersistedBySid.delete(sid);" in remember_body
+    assert "function _composerDraftLastPersistedForSid(sid)" in SESSIONS_JS

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -54,7 +54,7 @@ def test_busy_send_paths_clear_persisted_composer_draft():
     busy_body = _block(MESSAGES_JS, "if(S.busy||compressionRunning){", "  if(S.session&&(S.session.read_only||S.session.is_read_only))")
     assert "_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);" in busy_body
     assert busy_body.count("_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);") >= 2
-    assert "_clearComposerDraft(_steerResult.ownerSid,text,_steerDraftFiles)" in busy_body, "delivered steer must clear persisted draft with the submitted payload signature"
+    assert "_steerClearComposerDraftIfSafe(_steerResult.ownerSid,text,_steerDraftFiles)" in busy_body, "delivered steer must clear persisted draft only when the visible composer still holds the submitted payload"
     assert "_clearComposerDraft(S.session.session_id,text" not in busy_body
     try_steer_body = _block(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
     assert "_clearComposerDraft(ownerSid,_steerRestoreText(originalMsg,explicitSteer),pendingFilesSnapshot)" in try_steer_body, (

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -54,6 +54,7 @@ def test_busy_send_paths_clear_persisted_composer_draft():
     busy_body = _block(MESSAGES_JS, "if(S.busy||compressionRunning){", "  if(S.session&&(S.session.read_only||S.session.is_read_only))")
     assert "_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);" in busy_body
     assert busy_body.count("_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);") >= 2
+    assert "_clearComposerDraft(_steerResult.ownerSid,text,_steerDraftFiles)" in busy_body, "delivered steer must clear persisted draft with the submitted payload signature"
     assert "_clearComposerDraft(S.session.session_id,text" not in busy_body
     try_steer_body = _block(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
     assert "_clearComposerDraft(ownerSid,_steerRestoreText(originalMsg,explicitSteer),pendingFilesSnapshot)" in try_steer_body, (

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -54,12 +54,19 @@ def test_busy_send_paths_clear_persisted_composer_draft():
     busy_body = _block(MESSAGES_JS, "if(S.busy||compressionRunning){", "  if(S.session&&(S.session.read_only||S.session.is_read_only))")
     assert "_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);" in busy_body
     assert busy_body.count("_clearComposerAfterQueuedSelectionSend(S.session&&S.session.session_id);") >= 2
-    assert "_steerClearComposerDraftIfSafe(_steerResult.ownerSid,text,_steerDraftFiles)" in busy_body, "delivered steer must clear persisted draft only when the visible composer still holds the submitted payload"
-    assert "_clearComposerDraft(S.session.session_id,text" not in busy_body
-    try_steer_body = _block(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
-    assert "_clearComposerDraft(ownerSid,_steerRestoreText(originalMsg,explicitSteer),pendingFilesSnapshot)" in try_steer_body, (
-        "delivered steer must clear the captured owner draft with the submitted payload signature"
+    assert "_steerFinalizeComposer(_steerResult.ownerSid,text,_steerResult.files,/*explicitSteer=*/false)" in busy_body, (
+        "delivered/queued steer must route composer cleanup through the shared guard so a replacement draft is preserved"
     )
+    assert "_clearComposerDraft(S.session.session_id,text" not in busy_body
+    # Draft clearing on the steer path lives only in the shared guard, never inline
+    # in _trySteer, so the accepted-steer path can no longer wipe a replacement draft.
+    try_steer_body = _block(COMMANDS_JS, "async function _trySteer(", "\nasync function cmdTitle")
+    assert "_clearComposerDraft(" not in try_steer_body, "steer draft clearing must route through _steerFinalizeComposer"
+    finalize_body = _block(COMMANDS_JS, "function _steerFinalizeComposer", "\nfunction _showSteerRecovery")
+    assert "_clearComposerDraft(ownerSid,_steerRestoreText(msg,explicitSteer),delivered)" in finalize_body, (
+        "the shared guard clears the captured owner draft with the submitted payload signature"
+    )
+    assert "if(!safe)return;" in finalize_body, "textarea and draft clears must be gated by the combined text+files+owner predicate"
 
 
 def test_file_signature_survives_server_draft_round_trip():
@@ -137,4 +144,73 @@ def test_file_signature_survives_server_draft_round_trip():
     )
     assert out["differsFromOther"] is True, (
         "a genuinely different draft must NOT collide with the sent signature"
+    )
+
+
+def _run_steer_finalize_harness(body: str) -> None:
+    """Eval the shared steer cleanup guard and run `body` against it under node."""
+    import json
+    import shutil
+    import subprocess
+    import textwrap
+
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        import pytest
+        pytest.skip("node not available")
+    guard_src = _block(
+        COMMANDS_JS,
+        "function _steerComposerSafeToClear",
+        "\nfunction _showSteerRecovery",
+    )
+    script = textwrap.dedent(
+        """
+        const assert = require('assert');
+        let draftClears = [];
+        function renderTray(){}
+        function autoResize(){}
+        function updateSendBtn(){}
+        function _clearComposerDraft(sid,text,files){draftClears.push({sid,text,files});}
+        function _steerOwnerIsCurrent(sid){return !!(sid && S && S.session && S.session.session_id===sid);}
+        function _steerRestoreText(msg,explicit){return explicit?('/steer '+msg):msg;}
+        eval(%(guard)s);
+        %(body)s
+        """
+    ) % {"guard": json.dumps(guard_src), "body": body}
+    proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+
+
+def test_accepted_steer_replacement_text_keeps_persisted_draft():
+    """#5585: an accepted local steer must not wipe the persisted draft when the
+    user typed replacement text during the steer await. Previously an unguarded
+    _clearComposerDraft in _trySteer cleared it; the shared _steerFinalizeComposer
+    guard now skips the clear when the live composer holds replacement text."""
+    _run_steer_finalize_harness(
+        """
+        let S = {session:{session_id:'A'}, pendingFiles:[]};
+        const msgEl = {value:'my replacement'};   // typed during the steer await
+        function $(id){return msgEl;}
+        // Accepted local steer for owner 'A', still the live session.
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(msgEl.value, 'my replacement', 'replacement text must stay in the composer');
+        assert.strictEqual(draftClears.length, 0, 'persisted draft must survive replacement text');
+        """
+    )
+
+
+def test_accepted_steer_replacement_file_keeps_persisted_draft():
+    """#5585: the safe-clear predicate must consider staged files, not just text.
+    An empty textarea with a newly staged replacement file must not clear the draft
+    (the round-6 defect where _steerComposerAllowsDraftClear ignored files)."""
+    _run_steer_finalize_harness(
+        """
+        let S = {session:{session_id:'A'}, pendingFiles:[{name:'new.pdf'}]}; // staged during await
+        const msgEl = {value:''};   // textarea empty
+        function $(id){return msgEl;}
+        // Text-only steer delivered (no files submitted); a replacement file is staged.
+        _steerFinalizeComposer('A','hint',[],false);
+        assert.strictEqual(draftClears.length, 0, 'persisted draft must survive a replacement staged file');
+        assert.strictEqual(S.pendingFiles.length, 1, 'the newly staged file must not be dropped');
+        """
     )

--- a/tests/test_issue4749_steer_reason_and_recovery.py
+++ b/tests/test_issue4749_steer_reason_and_recovery.py
@@ -37,6 +37,7 @@ BACKEND_CODES = {
     "not_running",
     "stream_dead",
     "steer_error",
+    "gateway_steer_queued",
 }
 
 FRONTEND_NETWORK_CODE = "network_error"

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -356,9 +356,13 @@ class TestFrontendWiring:
         assert "body:JSON.stringify({session_id:ownerSid,text:steerText})" in body, (
             "steer endpoint must receive the captured owner session id and attachment-enriched text"
         )
-        assert "_clearComposerDraft(ownerSid,_steerRestoreText(originalMsg,explicitSteer),pendingFilesSnapshot)" in body
+        # Composer cleanup (draft clear + delivered-file removal) is owned by the
+        # shared _steerFinalizeComposer guard, not _trySteer itself.
+        assert "_clearComposerDraft(" not in body, "draft clearing must route through _steerFinalizeComposer, not _trySteer"
+        assert "return {handled:true,queuedFallback:false,ownerSid,files:ownerFiles};" in body
         assert "if(_steerOwnerIsCurrent(ownerSid))" in body
-        assert "S.pendingFiles=_remaining" in body, "accepted steer should clear the delivered files (by identity) after paths are injected"
+        finalize = _source_between(cmds, "function _steerFinalizeComposer", "\nfunction _showSteerRecovery")
+        assert "S.pendingFiles=_remaining" in finalize, "the shared guard removes the delivered files by identity"
 
     def test_file_steer_does_not_read_live_session_after_upload_await(self):
         cmds = self.cmds
@@ -501,9 +505,11 @@ class TestFrontendWiring:
             pytest.skip("node not available")
         assert node is not None
 
+        # Include the shared cleanup guard: draft clearing moved out of _trySteer
+        # into _steerFinalizeComposer, which the caller runs after _trySteer returns.
         steer_src = _source_between(
             self.cmds,
-            "function _steerUploadedAttachmentPaths",
+            "function _steerComposerSafeToClear",
             "\nasync function cmdTitle",
         )
         script = textwrap.dedent(
@@ -520,6 +526,8 @@ class TestFrontendWiring:
             function setComposerStatus(){{}}
             function showToast(){{}}
             function renderTray(){{trayRenders += 1;}}
+            function autoResize(){{}}
+            function updateSendBtn(){{}}
             function _showSteerIndicator(){{indicatorCalls += 1;}}
             function _showSteerRecovery(){{}}
             function _clearComposerDraft(sid,text,files){{draftClears.push({{sid,text,files}});}}
@@ -537,6 +545,9 @@ class TestFrontendWiring:
             eval({json.dumps(steer_src)});
             (async()=>{{
               const delivered = await _trySteer('hint', false);
+              // Caller runs the shared cleanup for the captured owner ('A'), which is
+              // no longer the live session ('B') after the mid-upload switch.
+              _steerFinalizeComposer(delivered.ownerSid, 'hint', delivered.files, false);
               assert.strictEqual(delivered.handled, true);
               assert.strictEqual(delivered.queuedFallback, false);
               assert.strictEqual(uploadOptions.sessionId, 'A');
@@ -569,7 +580,7 @@ class TestFrontendWiring:
 
         cleanup_src = _source_between(
             self.cmds,
-            "function _applyQueuedSteerCleanup",
+            "function _steerComposerSafeToClear",
             "\nfunction _showSteerRecovery",
         )
         script = textwrap.dedent(
@@ -586,16 +597,22 @@ class TestFrontendWiring:
             function autoResize(){{resized += 1;}}
             function updateSendBtn(){{sendUpdates += 1;}}
             function _clearComposerDraft(sid,text,files){{draftClears.push({{sid,text,files}});}}
+            function _steerOwnerIsCurrent(sid){{return !!(sid && S && S.session && S.session.session_id===sid);}}
+            function _steerRestoreText(msg,explicit){{return explicit?('/steer '+msg):msg;}}
             eval({json.dumps(cleanup_src)});
-            _applyQueuedSteerCleanup('retry me', {{queuedFallback:true, ownerSid:'A', files:S.pendingFiles}});
+            // Unchanged composer (still holds the submitted `/steer retry me`): all
+            // three surfaces clear.
+            _steerFinalizeComposer('A', 'retry me', S.pendingFiles, false);
             assert.strictEqual(msgEl.value, '');
             assert.strictEqual(S.pendingFiles.length, 0);
             assert.strictEqual(trayRenders, 1);
             assert.strictEqual(resized, 1);
             assert.strictEqual(sendUpdates, 1);
             assert.strictEqual(draftClears.length, 1);
+            // Replacement text typed during the await: textarea AND persisted draft
+            // are both preserved.
             msgEl.value = 'new text';
-            _applyQueuedSteerCleanup('retry me', {{queuedFallback:true, ownerSid:'A', files:[]}});
+            _steerFinalizeComposer('A', 'retry me', [], false);
             assert.strictEqual(msgEl.value, 'new text');
             assert.strictEqual(resized, 1);
             assert.strictEqual(sendUpdates, 1);

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -36,14 +36,24 @@ def _restore_auth_sessions():
 
 @pytest.fixture
 def _clear_caches():
-    """Snapshot SESSION_AGENT_CACHE and STREAMS so tests don't bleed."""
-    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK, STREAMS, STREAMS_LOCK
+    """Snapshot live-run caches so tests don't bleed."""
+    from api.config import (
+        ACTIVE_RUNS,
+        ACTIVE_RUNS_LOCK,
+        SESSION_AGENT_CACHE,
+        SESSION_AGENT_CACHE_LOCK,
+        STREAMS,
+        STREAMS_LOCK,
+    )
     with SESSION_AGENT_CACHE_LOCK:
         cache_snap = dict(SESSION_AGENT_CACHE)
         SESSION_AGENT_CACHE.clear()
     with STREAMS_LOCK:
         streams_snap = dict(STREAMS)
         STREAMS.clear()
+    with ACTIVE_RUNS_LOCK:
+        active_runs_snap = dict(ACTIVE_RUNS)
+        ACTIVE_RUNS.clear()
     yield
     with SESSION_AGENT_CACHE_LOCK:
         SESSION_AGENT_CACHE.clear()
@@ -51,6 +61,9 @@ def _clear_caches():
     with STREAMS_LOCK:
         STREAMS.clear()
         STREAMS.update(streams_snap)
+    with ACTIVE_RUNS_LOCK:
+        ACTIVE_RUNS.clear()
+        ACTIVE_RUNS.update(active_runs_snap)
 
 
 def _make_handler():
@@ -119,29 +132,46 @@ class TestHandleChatSteerFallbacks:
         assert body["fallback"] == "no_cached_agent"
 
     def test_gateway_run_steer_queues_without_cached_agent(self, _clear_caches):
-        from api.config import STREAMS, STREAMS_LOCK
-        from api.gateway_chat import _STREAM_RUN_IDS
+        from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK, STREAMS, STREAMS_LOCK
         from api.streaming import _handle_chat_steer
         import queue as _q
         sid, stream_id = "sid_gateway", "stream_gateway"
-        _STREAM_RUN_IDS[stream_id] = "run abc/1"
+        with ACTIVE_RUNS_LOCK:
+            ACTIVE_RUNS[stream_id] = {"session_id": sid, "backend": "gateway"}
         with STREAMS_LOCK:
             STREAMS[stream_id] = _q.Queue()
         sess = MagicMock()
         sess.active_stream_id = stream_id
 
-        try:
-            with patch("api.streaming.get_session", return_value=sess):
-                handler = _make_handler()
-                _handle_chat_steer(handler, {"session_id": sid, "text": "Use Python instead"})
-        finally:
-            _STREAM_RUN_IDS.pop(stream_id, None)
+        with patch("api.streaming.get_session", return_value=sess):
+            handler = _make_handler()
+            _handle_chat_steer(handler, {"session_id": sid, "text": "Use Python instead"})
 
         assert _captured_response(handler) == {
             "accepted": False,
             "fallback": "gateway_steer_queued",
             "stream_id": stream_id,
         }
+
+    def test_legacy_gateway_stream_without_run_id_still_queues(self, _clear_caches):
+        from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK, STREAMS, STREAMS_LOCK
+        from api.gateway_chat import _STREAM_RUN_IDS
+        from api.streaming import _handle_chat_steer
+        import queue as _q
+        sid, stream_id = "sid_gateway_legacy", "stream_gateway_legacy"
+        _STREAM_RUN_IDS.pop(stream_id, None)
+        with ACTIVE_RUNS_LOCK:
+            ACTIVE_RUNS[stream_id] = {"session_id": sid, "backend": "gateway"}
+        with STREAMS_LOCK:
+            STREAMS[stream_id] = _q.Queue()
+        sess = MagicMock()
+        sess.active_stream_id = stream_id
+
+        with patch("api.streaming.get_session", return_value=sess):
+            handler = _make_handler()
+            _handle_chat_steer(handler, {"session_id": sid, "text": "Use Python instead"})
+
+        assert _captured_response(handler)["fallback"] == "gateway_steer_queued"
 
     def test_agent_lacks_steer_method(self, _clear_caches):
         from api.streaming import _handle_chat_steer

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -556,6 +556,53 @@ class TestFrontendWiring:
         )
         subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
 
+    def test_gateway_queued_cleanup_clears_unchanged_composer_text(self):
+        import json
+        import shutil
+        import subprocess
+        import textwrap
+
+        node = shutil.which("node")
+        if not node:  # pragma: no cover
+            pytest.skip("node not available")
+        assert node is not None
+
+        cleanup_src = _source_between(
+            self.cmds,
+            "function _applyQueuedSteerCleanup",
+            "\nfunction _showSteerRecovery",
+        )
+        script = textwrap.dedent(
+            f"""
+            const assert = require('assert');
+            let S = {{session:{{session_id:'A'}}, pendingFiles:[{{name:'a.pdf'}}]}};
+            let trayRenders = 0;
+            let resized = 0;
+            let sendUpdates = 0;
+            let draftClears = [];
+            const msgEl = {{value:'/steer retry me'}};
+            function $(id){{assert.strictEqual(id, 'msg'); return msgEl;}}
+            function renderTray(){{trayRenders += 1;}}
+            function autoResize(){{resized += 1;}}
+            function updateSendBtn(){{sendUpdates += 1;}}
+            function _clearComposerDraft(sid,text,files){{draftClears.push({{sid,text,files}});}}
+            eval({json.dumps(cleanup_src)});
+            _applyQueuedSteerCleanup('retry me', {{queuedFallback:true, ownerSid:'A', files:S.pendingFiles}});
+            assert.strictEqual(msgEl.value, '');
+            assert.strictEqual(S.pendingFiles.length, 0);
+            assert.strictEqual(trayRenders, 1);
+            assert.strictEqual(resized, 1);
+            assert.strictEqual(sendUpdates, 1);
+            assert.strictEqual(draftClears.length, 1);
+            msgEl.value = 'new text';
+            _applyQueuedSteerCleanup('retry me', {{queuedFallback:true, ownerSid:'A', files:[]}});
+            assert.strictEqual(msgEl.value, 'new text');
+            assert.strictEqual(resized, 1);
+            assert.strictEqual(sendUpdates, 1);
+            """
+        )
+        subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
+
     def test_send_busy_steer_accepts_file_only_input(self):
         idx = self.msgs.find("if(S.busy||compressionRunning)")
         assert idx >= 0

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -305,6 +305,7 @@ class TestFrontendWiring:
         cls.cmds = (Path(__file__).parent.parent / "static" / "commands.js").read_text(encoding="utf-8")
         cls.msgs = (Path(__file__).parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
         cls.i18n = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(encoding="utf-8")
+        cls.sessions = (Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
 
     def test_cmd_steer_calls_endpoint(self):
         idx = self.cmds.find("async function cmdSteer(")
@@ -330,7 +331,11 @@ class TestFrontendWiring:
         assert "ownerSid" in body
         assert "ownerFiles" in body
         assert "cancelStream" not in body, "fallback path must not cancel the stream"
-        assert "inp.value" in body, "fallback path must restore the composer draft"
+        # Draft restore on failure now routes through the guarded helper so it never
+        # clobbers replacement content typed/staged during the await.
+        assert "_steerRestoreDraftOnFailure(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot)" in body, (
+            "fallback path must restore the composer draft via the guarded helper"
+        )
 
     def test_send_busy_steer_uses_try_steer(self):
         # send() in messages.js: when busyMode === 'steer', should call _trySteer
@@ -512,6 +517,13 @@ class TestFrontendWiring:
             "function _steerComposerSafeToClear",
             "\nasync function cmdTitle",
         )
+        # Real signature helpers so the non-current-owner clear is authorized by the
+        # owner's persisted-draft evidence, exactly as production computes it.
+        sig_src = _source_between(
+            self.sessions,
+            "function _composerDraftFileSignature(file)",
+            "function _composerDraftPayloadSignatureForSid(sid)",
+        )
         script = textwrap.dedent(
             f"""
             const assert = require('assert');
@@ -531,8 +543,17 @@ class TestFrontendWiring:
             function _showSteerIndicator(){{indicatorCalls += 1;}}
             function _showSteerRecovery(){{}}
             function _clearComposerDraft(sid,text,files){{draftClears.push({{sid,text,files}});}}
+            {sig_src}
+            let _persistedDrafts = {{}};
+            function _composerDraftLastPersistedForSid(sid){{
+              return Object.prototype.hasOwnProperty.call(_persistedDrafts, sid) ? _persistedDrafts[sid] : null;
+            }}
             async function uploadPendingFiles(options){{
               uploadOptions = options;
+              // The mid-upload switch A->B runs loadSession, which persists A's live
+              // composer via _saveComposerDraftNow. The busy-send path cleared the
+              // text on submit, so the unedited steer echo is {{text:'', files:[a.pdf]}}.
+              _persistedDrafts['A'] = {{text:'', files:[{{name:'a.pdf'}}]}};
               S.session = {{session_id:'B'}};
               S.pendingFiles = [{{name:'b.pdf'}}];
               return [{{path:'/tmp/a.pdf'}}];

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -599,6 +599,7 @@ class TestFrontendWiring:
             assert.strictEqual(msgEl.value, 'new text');
             assert.strictEqual(resized, 1);
             assert.strictEqual(sendUpdates, 1);
+            assert.strictEqual(draftClears.length, 1);
             """
         )
         subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -8,12 +8,8 @@ text to the next tool-result message — no interruption.
 Falls back to {"accepted": false, "fallback": "<reason>"} when the agent
 isn't running, isn't cached, or doesn't support steer (older agent versions).
 The frontend uses the fallback signal to restore the draft without cancelling
-the active run.
-
-Plus a leftover-delivery flow: if the agent finishes its turn before the
-steer is consumed (no tool-call boundary), _drain_pending_steer is called
-after run_conversation returns and a `pending_steer_leftover` SSE event is
-emitted so the frontend can queue the leftover text as a next-turn message.
+the active run. Gateway-owned runs have no cached WebUI agent, so their
+fallback tells the frontend to queue the text as the next turn.
 """
 import sys
 import os
@@ -121,6 +117,31 @@ class TestHandleChatSteerFallbacks:
         body = _captured_response(handler)
         assert body["accepted"] is False
         assert body["fallback"] == "no_cached_agent"
+
+    def test_gateway_run_steer_queues_without_cached_agent(self, _clear_caches):
+        from api.config import STREAMS, STREAMS_LOCK
+        from api.gateway_chat import _STREAM_RUN_IDS
+        from api.streaming import _handle_chat_steer
+        import queue as _q
+        sid, stream_id = "sid_gateway", "stream_gateway"
+        _STREAM_RUN_IDS[stream_id] = "run abc/1"
+        with STREAMS_LOCK:
+            STREAMS[stream_id] = _q.Queue()
+        sess = MagicMock()
+        sess.active_stream_id = stream_id
+
+        try:
+            with patch("api.streaming.get_session", return_value=sess):
+                handler = _make_handler()
+                _handle_chat_steer(handler, {"session_id": sid, "text": "Use Python instead"})
+        finally:
+            _STREAM_RUN_IDS.pop(stream_id, None)
+
+        assert _captured_response(handler) == {
+            "accepted": False,
+            "fallback": "gateway_steer_queued",
+            "stream_id": stream_id,
+        }
 
     def test_agent_lacks_steer_method(self, _clear_caches):
         from api.streaming import _handle_chat_steer
@@ -272,9 +293,10 @@ class TestFrontendWiring:
     def test_try_steer_handles_fallback_without_cancelling(self):
         idx = self.cmds.find("async function _trySteer(")
         body = _source_between(self.cmds, "async function _trySteer(", "\nasync function cmdTitle")
-        # Must check result.accepted and surface fallback without queueing or cancelling.
+        # Must check result.accepted and surface fallback without cancelling.
         assert "result&&result.accepted" in body or "result.accepted" in body
-        assert "queueSessionMessage" not in body
+        assert "gateway_steer_queued" in body
+        assert "queueSessionMessage" in body
         assert "cancelStream" not in body, "fallback path must not cancel the stream"
         assert "inp.value" in body, "fallback path must restore the composer draft"
 

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -297,6 +297,8 @@ class TestFrontendWiring:
         assert "result&&result.accepted" in body or "result.accepted" in body
         assert "gateway_steer_queued" in body
         assert "queueSessionMessage" in body
+        assert "ownerSid" in body
+        assert "ownerFiles" in body
         assert "cancelStream" not in body, "fallback path must not cancel the stream"
         assert "inp.value" in body, "fallback path must restore the composer draft"
 
@@ -398,7 +400,8 @@ class TestFrontendWiring:
             eval({json.dumps(steer_src)});
             (async()=>{{
               const delivered = await _trySteer('hint', false);
-              assert.strictEqual(delivered, true);
+              assert.strictEqual(delivered.handled, true);
+              assert.strictEqual(delivered.queuedFallback, false);
               assert.strictEqual(indicatorText, 'hint');
               assert.ok(apiPayload.text.includes('[Attached files for this steer: /tmp/a.pdf]'));
               assert.ok(!indicatorText.includes('Attached files'));
@@ -447,7 +450,8 @@ class TestFrontendWiring:
             eval({json.dumps(steer_src)});
             (async()=>{{
               const delivered = await _trySteer('', false);
-              assert.strictEqual(delivered, true);
+              assert.strictEqual(delivered.handled, true);
+              assert.strictEqual(delivered.queuedFallback, false);
               assert.strictEqual(indicatorText, 'Attached files: a.pdf');
               assert.ok(apiPayload.text.includes('[Attached files for this steer: /tmp/a.pdf]'));
               assert.ok(!indicatorText.includes('file tools/read_file'));
@@ -503,7 +507,8 @@ class TestFrontendWiring:
             eval({json.dumps(steer_src)});
             (async()=>{{
               const delivered = await _trySteer('hint', false);
-              assert.strictEqual(delivered, true);
+              assert.strictEqual(delivered.handled, true);
+              assert.strictEqual(delivered.queuedFallback, false);
               assert.strictEqual(uploadOptions.sessionId, 'A');
               assert.strictEqual(uploadOptions.files.length, 1);
               assert.strictEqual(uploadOptions.files[0].name, 'a.pdf');
@@ -528,7 +533,7 @@ class TestFrontendWiring:
         assert "if(text||S.pendingFiles.length)" in block, (
             "busy send must route file-only composer submissions through queue/interrupt/steer"
         )
-        assert "_trySteer uploads with clearPending=false" in self.msgs
+        assert "a failed steer restores the draft" in self.msgs
 
     def test_upload_pending_files_can_preserve_staged_files_for_steer(self):
         ui = (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Thinking Path

- WebUI `/steer` works for in-process runs because the backend has a cached local `AIAgent`, but gateway runs are owned by the gateway process and only leave WebUI with a live stream id mapped to a run id.
- Treating that gateway-owned run like a local cached-agent run produces a false `no_cached_agent` failure while the run is still active.
- Hermes-agent does not expose a current API-run steer route for WebUI to call, and open agent-side run-steer work already covers that backend surface, so WebUI should preserve the user's text by queueing it as the next turn instead of dropping it behind the cache miss.
- The queued fallback cleanup has to consume the same visible draft it just queued. Recovery Retry restores the textarea before retrying, so the shared cleanup helper also clears the visible composer when the owner still matches and the textarea still contains that same steer text.

## What Changed

- `api/streaming.py`: detects live gateway-backed streams when `/api/chat/steer` has no local cached agent and returns a `gateway_steer_queued` fallback.
- `static/commands.js`: handles that fallback by enqueueing the steer text on the active session without cancelling the current stream, then clears the visible composer textarea only when it still equals the queued text or `/steer ...` form.
- `static/messages.js`: routes busy-send steer cleanup through the shared queued-fallback cleanup path.
- `tests/test_real_steer.py`: covers the gateway-backed no-cache path, queued fallback cleanup, and the local cached-agent and draft-restore behavior.
- `tests/test_1062_busy_input_modes.py`: pins the frontend static checks so only the gateway fallback queues, while generic steer failures still avoid cancellation.

## Why It Matters

Gateway-backed WebUI sessions no longer lose busy-turn input behind a misleading local cache-miss error. If live steering is not available for that gateway run, the message is preserved as the next queued turn without leaving duplicate text in the composer after Retry.

## Verification

- `python -m pytest tests/test_issue4749_steer_reason_and_recovery.py tests/test_real_steer.py tests/test_1062_busy_input_modes.py tests/test_gateway_approval_runs_api.py tests/test_composer_draft_after_send.py -q --timeout=60`
- `node --check static/commands.js`
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"`
- `git diff --check`

Full-suite CI context, not run locally: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5585.

## Model Used

GPT-5 via Codex CLI
