### PR TITLE
test(auth): reset password hash cache between tests (#5588)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1060,6 +1060,7 @@ def _invalidate_models_cache_after_test():
 
 @pytest.fixture(autouse=True)
 def _invalidate_auth_password_hash_cache_after_test():
+    """Clear auth cache around tests that toggle password auth through env vars."""
     try:
         from api.auth import _invalidate_password_hash_cache
         _invalidate_password_hash_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1058,6 +1058,21 @@ def _invalidate_models_cache_after_test():
         pass
 
 
+@pytest.fixture(autouse=True)
+def _invalidate_auth_password_hash_cache_after_test():
+    try:
+        from api.auth import _invalidate_password_hash_cache
+        _invalidate_password_hash_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        from api.auth import _invalidate_password_hash_cache
+        _invalidate_password_hash_cache()
+    except Exception:
+        pass
+
+
 # ── Per-test session cleanup ──────────────────────────────────────────────────
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Thinking Path

- `test_session_static_auth_exemption` intentionally enables auth with `HERMES_WEBUI_PASSWORD` and refreshes the password-hash cache so static assets can be checked under auth.
- That leaves the process cache populated after pytest restores the env var, so later profile-cookie helper tests still see auth as enabled and reject handlerless cookie construction.
- The fix resets the auth password-hash cache at the pytest boundary, matching the existing cache-isolation fixture pattern without changing production auth caching.

## What Changed

- `tests/conftest.py`: clears `api.auth`'s password-hash cache before and after each test.

## Why It Matters

This removes an order-dependent test failure where one auth-enabled static-asset test can make unrelated profile-cookie tests fail. The production PBKDF2 cache stays intact.

## Verification

```
pytest tests/test_session_static_assets.py tests/test_issue803.py::TestProfileCookieHelpers -p no:randomly -q
pytest tests/test_auth_password_hash_cache.py -p no:randomly -q
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5588.

## Model Used

GPT 5.5 via Codex CLI
