### PR TITLE
fix(#5583): keep mobile nav actions visible

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2104,7 +2104,7 @@
    (see line ~681). The rail rule is no longer needed. */
   .rail .nav-tab.active::before{content:'';position:absolute;left:-6px;top:50%;bottom:auto;transform:translateY(-50%);width:3px;height:16px;background:var(--accent);border-radius:0 2px 2px 0;}
   .dashboard-link{position:relative;}
-  .dashboard-link-visible{display:flex!important;}
+  .dashboard-link-visible,.nav-action-visible{display:flex!important;}
   .dashboard-external-badge{position:absolute;right:5px;top:5px;width:9px;height:9px;border-radius:2px;border:1px solid var(--accent);background:var(--sidebar);box-shadow:0 0 0 2px var(--sidebar);opacity:.95;}
   .dashboard-external-badge::after{content:'';position:absolute;right:-2px;top:-2px;width:5px;height:5px;border-top:1.5px solid var(--accent);border-right:1.5px solid var(--accent);}
   .sidebar-nav .dashboard-external-badge{right:8px;top:7px;width:8px;height:8px;}
@@ -3100,8 +3100,7 @@
     .sidebar-nav .nav-tab svg{width:20px;height:20px;}
     .sidebar-nav .nav-tab.active{background:var(--accent-bg);}
     .sidebar-nav .nav-tab.active::before{left:-4px;top:50%;bottom:auto;transform:translateY(-50%);width:3px;height:16px;border-radius:0 2px 2px 0;}
-    .sidebar-nav .dashboard-link,
-    .sidebar-nav .dashboard-link.dashboard-link-visible{display:none!important;}
+    .sidebar-nav .dashboard-link:not(.nav-action-visible){display:none!important;}
     .sidebar .panel-view{height:100%;margin-left:52px;}
     .sidebar .panel-head{padding-right:52px;}
     .mobile-sidebar-close{display:inline-flex!important;position:absolute;right:4px;top:calc(4px + var(--app-titlebar-safe-top));width:44px;height:44px;z-index:4;background:var(--surface);border:1px solid var(--border);}

--- a/static/style.css
+++ b/static/style.css
@@ -3100,7 +3100,7 @@
     .sidebar-nav .nav-tab svg{width:20px;height:20px;}
     .sidebar-nav .nav-tab.active{background:var(--accent-bg);}
     .sidebar-nav .nav-tab.active::before{left:-4px;top:50%;bottom:auto;transform:translateY(-50%);width:3px;height:16px;border-radius:0 2px 2px 0;}
-    .sidebar-nav .dashboard-link:not(.nav-action-visible){display:none!important;}
+    .sidebar-nav .dashboard-link:not(.nav-action-visible),.sidebar-nav [data-nav-action-mirror]:not(.nav-action-visible){display:none!important;}
     .sidebar .panel-view{height:100%;margin-left:52px;}
     .sidebar .panel-head{padding-right:52px;}
     .mobile-sidebar-close{display:inline-flex!important;position:absolute;right:4px;top:calc(4px + var(--app-titlebar-safe-top));width:44px;height:44px;z-index:4;background:var(--surface);border:1px solid var(--border);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -1290,6 +1290,17 @@ function _dashboardBrowserUrl(status){
   const displayHost=browserHost.includes(':')&&!browserHost.startsWith('[')?'['+browserHost+']':browserHost;
   return source.protocol+'//'+displayHost+':'+status.port;
 }
+function _stripInlineEventHandlers(node){
+  if(!node)return;
+  const strip=el=>{
+    Array.from(el.attributes||[]).forEach(attr=>{
+      if(attr.name&&attr.name.toLowerCase().startsWith('on'))el.removeAttribute(attr.name);
+    });
+    if('onclick' in el)el.onclick=null;
+    Array.from(el.children||[]).forEach(strip);
+  };
+  strip(node);
+}
 function _syncNavActionMirrors(){
   const rail=document.querySelector('.rail');
   const sidebar=document.querySelector('.sidebar-nav');
@@ -1305,6 +1316,7 @@ function _syncNavActionMirrors(){
     let mirror=mirrors.find(el=>el.getAttribute('data-nav-action-mirror')===source.id);
     if(!mirror){
       mirror=source.cloneNode(true);
+      _stripInlineEventHandlers(mirror);
       mirror.id=source.id+'Mobile';
       mirror.classList.remove('rail-btn');
       mirror.classList.add('nav-action-visible','has-tooltip--bottom');
@@ -1314,6 +1326,7 @@ function _syncNavActionMirrors(){
       sidebar.insertBefore(mirror,anchor||null);
     }else{
       mirror.innerHTML=source.innerHTML;
+      _stripInlineEventHandlers(mirror);
     }
     mirror._navActionSource=source;
     const label=source.getAttribute('data-tooltip')||source.getAttribute('aria-label')||'';

--- a/static/ui.js
+++ b/static/ui.js
@@ -1290,12 +1290,50 @@ function _dashboardBrowserUrl(status){
   const displayHost=browserHost.includes(':')&&!browserHost.startsWith('[')?'['+browserHost+']':browserHost;
   return source.protocol+'//'+displayHost+':'+status.port;
 }
+function _syncNavActionMirrors(){
+  const rail=document.querySelector('.rail');
+  const sidebar=document.querySelector('.sidebar-nav');
+  if(!rail||!sidebar)return;
+  const sources=Array.from(rail.querySelectorAll('.nav-tab:not([data-panel]):not([data-dashboard-link])')).filter(source=>source.id);
+  const mirrors=Array.from(sidebar.querySelectorAll('[data-nav-action-mirror]'));
+  const sourceIds=new Set(sources.map(source=>source.id));
+  mirrors.forEach(mirror=>{
+    if(!sourceIds.has(mirror.getAttribute('data-nav-action-mirror')))mirror.remove();
+  });
+  sources.forEach(source=>{
+    source.classList.add('nav-action-visible');
+    let mirror=mirrors.find(el=>el.getAttribute('data-nav-action-mirror')===source.id);
+    if(!mirror){
+      mirror=source.cloneNode(true);
+      mirror.id=source.id+'Mobile';
+      mirror.classList.remove('rail-btn');
+      mirror.classList.add('nav-action-visible','has-tooltip--bottom');
+      mirror.setAttribute('data-nav-action-mirror',source.id);
+      mirror.addEventListener('click',e=>{e.preventDefault();if(mirror._navActionSource)mirror._navActionSource.click();});
+      const anchor=sidebar.querySelector('.dashboard-link,[data-dashboard-link]')||sidebar.querySelector('[data-panel="logs"]');
+      sidebar.insertBefore(mirror,anchor||null);
+    }else{
+      mirror.innerHTML=source.innerHTML;
+    }
+    mirror._navActionSource=source;
+    const label=source.getAttribute('data-tooltip')||source.getAttribute('aria-label')||'';
+    if(label)mirror.setAttribute('data-label',label);
+  });
+}
+function _initNavActionMirrors(){
+  _syncNavActionMirrors();
+  const rail=document.querySelector('.rail');
+  if(rail&&window.MutationObserver)new MutationObserver(_syncNavActionMirrors).observe(rail,{childList:true});
+}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_initNavActionMirrors,{once:true});
+else _initNavActionMirrors();
 function _applyDashboardStatus(status){
   const running=!!(status&&status.running);
   const url=running?_dashboardBrowserUrl(status):'';
   const warning=running&&!_dashboardIsBrowserLoopback()?t('dashboard_loopback_warning'):'';
   document.querySelectorAll('[data-dashboard-link]').forEach(btn=>{
     btn.classList.toggle('dashboard-link-visible',running);
+    btn.classList.toggle('nav-action-visible',running);
     btn.style.display=running?'':'none';
     btn.dataset.dashboardUrl=url;
     const tipText=warning||t('tab_dashboard');

--- a/static/ui.js
+++ b/static/ui.js
@@ -1312,16 +1312,29 @@ function _syncNavActionMirrors(){
     if(!sourceIds.has(mirror.getAttribute('data-nav-action-mirror')))mirror.remove();
   });
   sources.forEach(source=>{
-    source.classList.add('nav-action-visible');
+    const sourceVisible=(()=>{
+      if(source.hidden||source.getAttribute('aria-hidden')==='true')return false;
+      if(source.classList.contains('nav-tab-hidden'))return false;
+      if(source.style&&(source.style.display==='none'||source.style.visibility==='hidden'))return false;
+      if(typeof window!=='undefined'&&typeof window.getComputedStyle==='function'){
+        const computed=window.getComputedStyle(source);
+        if(computed&&(computed.display==='none'||computed.visibility==='hidden'))return false;
+      }
+      return true;
+    })();
     let mirror=mirrors.find(el=>el.getAttribute('data-nav-action-mirror')===source.id);
     if(!mirror){
       mirror=source.cloneNode(true);
       _stripInlineEventHandlers(mirror);
       mirror.id=source.id+'Mobile';
       mirror.classList.remove('rail-btn');
-      mirror.classList.add('nav-action-visible','has-tooltip--bottom');
+      mirror.classList.add('has-tooltip--bottom');
       mirror.setAttribute('data-nav-action-mirror',source.id);
-      mirror.addEventListener('click',e=>{e.preventDefault();if(mirror._navActionSource)mirror._navActionSource.click();});
+      mirror.addEventListener('click',e=>{
+        e.preventDefault();
+        if(mirror._navActionSource)mirror._navActionSource.click();
+        if(typeof closeMobileSidebar==='function')closeMobileSidebar();
+      });
       const anchor=sidebar.querySelector('.dashboard-link,[data-dashboard-link]')||sidebar.querySelector('[data-panel="logs"]');
       sidebar.insertBefore(mirror,anchor||null);
     }else{
@@ -1329,6 +1342,7 @@ function _syncNavActionMirrors(){
       _stripInlineEventHandlers(mirror);
     }
     mirror._navActionSource=source;
+    mirror.classList.toggle('nav-action-visible',sourceVisible);
     const label=source.getAttribute('data-tooltip')||source.getAttribute('aria-label')||'';
     if(label)mirror.setAttribute('data-label',label);
   });
@@ -1336,7 +1350,12 @@ function _syncNavActionMirrors(){
 function _initNavActionMirrors(){
   _syncNavActionMirrors();
   const rail=document.querySelector('.rail');
-  if(rail&&window.MutationObserver)new MutationObserver(_syncNavActionMirrors).observe(rail,{childList:true});
+  if(rail&&window.MutationObserver)new MutationObserver(_syncNavActionMirrors).observe(rail,{
+    childList:true,
+    subtree:true,
+    attributes:true,
+    attributeFilter:['class','style','hidden','aria-hidden','data-tooltip','aria-label'],
+  });
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_initNavActionMirrors,{once:true});
 else _initNavActionMirrors();

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -385,7 +385,7 @@ def test_dashboard_settings_controls_live_in_system_panel():
 
 
 def test_dashboard_frontend_uses_browser_url_without_requiring_probe_port():
-    match = re.search(r"function _dashboardBrowserUrl\(status\).*?\n}\nfunction _applyDashboardStatus", UI_JS, re.DOTALL)
+    match = re.search(r"function _dashboardBrowserUrl\(status\).*?\n}\nfunction _syncNavActionMirrors", UI_JS, re.DOTALL)
     assert match is not None
     helper = match.group(0)
     assert "status.browser_url||status.url" in helper
@@ -393,7 +393,7 @@ def test_dashboard_frontend_uses_browser_url_without_requiring_probe_port():
     assert helper.index("status.browser_url||status.url") < helper.index("!status.port")
 
 
-def test_mobile_dashboard_link_is_scoped_hidden_in_narrow_viewport_css():
+def test_mobile_dashboard_link_uses_shared_visible_action_class():
     match = re.search(
         r"@media\(max-width:640px\)\{([\s\S]*?)\n\s*}\s*\n\s*@media \(hover:none\)",
         STYLE_CSS,
@@ -401,11 +401,169 @@ def test_mobile_dashboard_link_is_scoped_hidden_in_narrow_viewport_css():
     )
     assert match is not None
     mobile_css = match.group(1)
-    assert re.search(
-        r"\.sidebar-nav\s+\.dashboard-link,\s*\.sidebar-nav\s+\.dashboard-link\.dashboard-link-visible\s*\{\s*display\s*:\s*none\s*!important\s*;\s*}",
-        mobile_css,
-        re.DOTALL,
+    assert re.search(r"\.dashboard-link-visible,\s*\.nav-action-visible\{display:flex!important;\}", STYLE_CSS)
+    assert ".sidebar-nav .dashboard-link:not(.nav-action-visible){display:none!important;}" in mobile_css
+    assert ".sidebar-nav .dashboard-link.dashboard-link-visible{display:none!important;}" not in mobile_css
+    assert ".sidebar-nav .dashboard-link:not(.dashboard-link-visible){display:none!important;}" not in mobile_css
+
+
+@requires_node
+def test_extension_rail_actions_are_mirrored_to_mobile_nav():
+    driver = textwrap.dedent(
+        """\
+        const fs = require('fs');
+        const src = fs.readFileSync(process.argv[2], 'utf8');
+
+        function extractFn(name) {
+          const start = src.indexOf(`function ${name}(`);
+          if (start < 0) throw new Error(`${name}() not found`);
+          let i = src.indexOf('{', start);
+          let depth = 0;
+          for (; i < src.length; i++) {
+            if (src[i] === '{') depth += 1;
+            if (src[i] === '}') {
+              depth -= 1;
+              if (depth === 0) return src.slice(start, i + 1);
+            }
+          }
+          throw new Error(`could not extract ${name}`);
+        }
+
+        class El {
+          constructor(tag) {
+            this.tagName = tag;
+            this.children = [];
+            this._attrs = {};
+            this.dataset = {};
+            this.innerHTML = '';
+            this.id = '';
+            this.parentNode = null;
+            this._handlers = {};
+            this.classList = {
+              _set: new Set(),
+              add: (...classes) => classes.forEach(c => this.classList._set.add(c)),
+              remove: (...classes) => classes.forEach(c => this.classList._set.delete(c)),
+              contains: c => this.classList._set.has(c),
+            };
+          }
+          appendChild(child) { child.parentNode = this; this.children.push(child); return child; }
+          insertBefore(child, anchor) {
+            const idx = anchor ? this.children.indexOf(anchor) : -1;
+            child.parentNode = this;
+            if (idx >= 0) this.children.splice(idx, 0, child);
+            else this.children.push(child);
+            return child;
+          }
+          remove() {
+            if (!this.parentNode) return;
+            const idx = this.parentNode.children.indexOf(this);
+            if (idx >= 0) this.parentNode.children.splice(idx, 1);
+            this.parentNode = null;
+          }
+          setAttribute(name, value) {
+            this._attrs[name] = String(value);
+            if (name.startsWith('data-')) this.dataset[name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = String(value);
+          }
+          getAttribute(name) { return Object.prototype.hasOwnProperty.call(this._attrs, name) ? this._attrs[name] : null; }
+          hasAttribute(name) { return Object.prototype.hasOwnProperty.call(this._attrs, name); }
+          addEventListener(name, fn) { this._handlers[name] = fn; }
+          click() { if (this._handlers.click) this._handlers.click({ preventDefault() {} }); }
+          cloneNode() {
+            const clone = new El(this.tagName);
+            clone.id = this.id;
+            clone.innerHTML = this.innerHTML;
+            this.classList._set.forEach(c => clone.classList.add(c));
+            Object.entries(this._attrs).forEach(([k, v]) => clone.setAttribute(k, v));
+            return clone;
+          }
+          querySelectorAll(sel) {
+            if (sel === '.nav-tab:not([data-panel]):not([data-dashboard-link])') {
+              return this.children.filter(el => el.classList.contains('nav-tab') && !el.hasAttribute('data-panel') && !el.hasAttribute('data-dashboard-link'));
+            }
+            if (sel === '[data-nav-action-mirror]') {
+              return this.children.filter(el => el.hasAttribute('data-nav-action-mirror'));
+            }
+            return [];
+          }
+          querySelector(sel) {
+            if (sel.startsWith('[data-nav-action-mirror="')) {
+              const id = sel.slice(25, -2);
+              return this.children.find(el => el.getAttribute('data-nav-action-mirror') === id) || null;
+            }
+            if (sel === '.dashboard-link,[data-dashboard-link]') return this.children.find(el => el.classList.contains('dashboard-link') || el.hasAttribute('data-dashboard-link')) || null;
+            if (sel === '[data-panel="logs"]') return this.children.find(el => el.getAttribute('data-panel') === 'logs') || null;
+            return null;
+          }
+        }
+
+        const rail = new El('nav');
+        const sidebar = new El('div');
+        const source = new El('button');
+        const dashboard = new El('button');
+        let clicked = 0;
+        source.id = 'hwxThemeCreatorRailBtn';
+        source.classList.add('rail-btn', 'nav-tab', 'has-tooltip');
+        source.setAttribute('data-tooltip', 'Theme Creator');
+        source.innerHTML = '<svg></svg>';
+        source.click = () => { clicked += 1; };
+        dashboard.classList.add('dashboard-link');
+        sidebar.appendChild(dashboard);
+        let observerCallback = null;
+        let observedRail = null;
+
+        global.document = {
+          readyState: 'complete',
+          querySelector(sel) {
+            if (sel === '.rail') return rail;
+            if (sel === '.sidebar-nav') return sidebar;
+            return null;
+          },
+        };
+        global.window = {};
+        global.MutationObserver = window.MutationObserver = class {
+          constructor(callback) { observerCallback = callback; }
+          observe(target) { observedRail = target; }
+        };
+
+        const helpers = Function(extractFn('_syncNavActionMirrors') + '\\n' + extractFn('_initNavActionMirrors') + '; return { _initNavActionMirrors };')();
+        helpers._initNavActionMirrors();
+        rail.appendChild(source);
+        observerCallback();
+        const mirror = sidebar.children.find(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn');
+        mirror.click();
+        const mirrorBeforeDashboard = sidebar.children[0] === mirror;
+        source.remove();
+        observerCallback();
+        console.log(JSON.stringify({
+          observerArmed: observedRail === rail,
+          sourceVisible: source.classList.contains('nav-action-visible'),
+          mirrorVisible: mirror.classList.contains('nav-action-visible'),
+          mirrorRailClass: mirror.classList.contains('rail-btn'),
+          mirrorLabel: mirror.getAttribute('data-label'),
+          mirrorBeforeDashboard,
+          mirrorRemoved: !sidebar.children.some(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn'),
+          clicked,
+        }));
+        """
     )
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(driver)
+        path = handle.name
+    try:
+        result = subprocess.run([NODE, path, str(UI_PATH)], text=True, capture_output=True, timeout=15, check=True)
+        out = json.loads(result.stdout)
+    finally:
+        pathlib.Path(path).unlink(missing_ok=True)
+    assert out == {
+        "observerArmed": True,
+        "sourceVisible": True,
+        "mirrorVisible": True,
+        "mirrorRailClass": False,
+        "mirrorLabel": "Theme Creator",
+        "mirrorBeforeDashboard": True,
+        "mirrorRemoved": True,
+        "clicked": 1,
+    }
 
 
 def test_desktop_dashboard_link_button_stays_in_desktop_nav():
@@ -431,6 +589,7 @@ def test_dashboard_dropdown_save_resyncs_chip_state():
     assert out["statusCalls"] >= 1
     assert all(
         "dashboard-link-visible" not in state["classes"]
+        and "nav-action-visible" not in state["classes"]
         and state["display"] == "none"
         for state in out["buttonStates"]
     )
@@ -448,6 +607,7 @@ def test_dashboard_chip_save_keeps_buttons_refreshed():
     assert out["statusCalls"] >= 1
     assert all(
         "dashboard-link-visible" in state["classes"]
+        and "nav-action-visible" in state["classes"]
         and state["display"] != "none"
         for state in out["buttonStates"]
     )
@@ -471,6 +631,7 @@ def test_stale_dashboard_load_does_not_overwrite_newer_save():
     assert out["statusCalls"] == 1
     assert all(
         "dashboard-link-visible" in state["classes"]
+        and "nav-action-visible" in state["classes"]
         and state["display"] != "none"
         for state in out["buttonStates"]
     )

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -437,6 +437,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
             this.dataset = {};
             this.innerHTML = '';
             this.id = '';
+            this.onclick = null;
             this.parentNode = null;
             this._handlers = {};
             this.classList = {
@@ -464,6 +465,11 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
             this._attrs[name] = String(value);
             if (name.startsWith('data-')) this.dataset[name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = String(value);
           }
+          removeAttribute(name) {
+            delete this._attrs[name];
+            if (name.startsWith('data-')) delete this.dataset[name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase())];
+          }
+          get attributes() { return Object.entries(this._attrs).map(([name, value]) => ({ name, value })); }
           getAttribute(name) { return Object.prototype.hasOwnProperty.call(this._attrs, name) ? this._attrs[name] : null; }
           hasAttribute(name) { return Object.prototype.hasOwnProperty.call(this._attrs, name); }
           addEventListener(name, fn) { this._handlers[name] = fn; }
@@ -472,6 +478,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
             const clone = new El(this.tagName);
             clone.id = this.id;
             clone.innerHTML = this.innerHTML;
+            clone.onclick = this.onclick;
             this.classList._set.forEach(c => clone.classList.add(c));
             Object.entries(this._attrs).forEach(([k, v]) => clone.setAttribute(k, v));
             return clone;
@@ -504,6 +511,8 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         source.id = 'hwxThemeCreatorRailBtn';
         source.classList.add('rail-btn', 'nav-tab', 'has-tooltip');
         source.setAttribute('data-tooltip', 'Theme Creator');
+        source.setAttribute('onclick', 'clicked += 100;');
+        source.onclick = () => { clicked += 100; };
         source.innerHTML = '<svg></svg>';
         source.click = () => { clicked += 1; };
         dashboard.classList.add('dashboard-link');
@@ -525,7 +534,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
           observe(target) { observedRail = target; }
         };
 
-        const helpers = Function(extractFn('_syncNavActionMirrors') + '\\n' + extractFn('_initNavActionMirrors') + '; return { _initNavActionMirrors };')();
+        const helpers = Function(extractFn('_stripInlineEventHandlers') + '\\n' + extractFn('_syncNavActionMirrors') + '\\n' + extractFn('_initNavActionMirrors') + '; return { _initNavActionMirrors };')();
         helpers._initNavActionMirrors();
         rail.appendChild(source);
         observerCallback();
@@ -540,6 +549,8 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
           mirrorVisible: mirror.classList.contains('nav-action-visible'),
           mirrorRailClass: mirror.classList.contains('rail-btn'),
           mirrorLabel: mirror.getAttribute('data-label'),
+          mirrorOnclickAttribute: mirror.getAttribute('onclick'),
+          mirrorOnclickProperty: mirror.onclick === null,
           mirrorBeforeDashboard,
           mirrorRemoved: !sidebar.children.some(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn'),
           clicked,
@@ -560,6 +571,8 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         "mirrorVisible": True,
         "mirrorRailClass": False,
         "mirrorLabel": "Theme Creator",
+        "mirrorOnclickAttribute": None,
+        "mirrorOnclickProperty": True,
         "mirrorBeforeDashboard": True,
         "mirrorRemoved": True,
         "clicked": 1,

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -402,7 +402,8 @@ def test_mobile_dashboard_link_uses_shared_visible_action_class():
     assert match is not None
     mobile_css = match.group(1)
     assert re.search(r"\.dashboard-link-visible,\s*\.nav-action-visible\{display:flex!important;\}", STYLE_CSS)
-    assert ".sidebar-nav .dashboard-link:not(.nav-action-visible){display:none!important;}" in mobile_css
+    assert ".sidebar-nav .dashboard-link:not(.nav-action-visible)" in mobile_css
+    assert ".sidebar-nav [data-nav-action-mirror]:not(.nav-action-visible){display:none!important;}" in mobile_css
     assert ".sidebar-nav .dashboard-link.dashboard-link-visible{display:none!important;}" not in mobile_css
     assert ".sidebar-nav .dashboard-link:not(.dashboard-link-visible){display:none!important;}" not in mobile_css
 
@@ -445,6 +446,19 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
               add: (...classes) => classes.forEach(c => this.classList._set.add(c)),
               remove: (...classes) => classes.forEach(c => this.classList._set.delete(c)),
               contains: c => this.classList._set.has(c),
+              toggle: (cls, force) => {
+                if (force === undefined) {
+                  if (this.classList._set.has(cls)) {
+                    this.classList._set.delete(cls);
+                    return false;
+                  }
+                  this.classList._set.add(cls);
+                  return true;
+                }
+                if (force) this.classList._set.add(cls);
+                else this.classList._set.delete(cls);
+                return !!force;
+              },
             };
           }
           appendChild(child) { child.parentNode = this; this.children.push(child); return child; }
@@ -508,6 +522,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         const source = new El('button');
         const dashboard = new El('button');
         let clicked = 0;
+        let sidebarClosed = 0;
         source.id = 'hwxThemeCreatorRailBtn';
         source.classList.add('rail-btn', 'nav-tab', 'has-tooltip');
         source.setAttribute('data-tooltip', 'Theme Creator');
@@ -519,6 +534,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         sidebar.appendChild(dashboard);
         let observerCallback = null;
         let observedRail = null;
+        let observedOptions = null;
 
         global.document = {
           readyState: 'complete',
@@ -528,10 +544,18 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
             return null;
           },
         };
-        global.window = {};
+        global.closeMobileSidebar = () => { sidebarClosed += 1; };
+        global.window = {
+          getComputedStyle(el) {
+            return {
+              display: el.hidden || (el.style && el.style.display === 'none') ? 'none' : '',
+              visibility: (el.style && el.style.visibility) || '',
+            };
+          },
+        };
         global.MutationObserver = window.MutationObserver = class {
           constructor(callback) { observerCallback = callback; }
-          observe(target) { observedRail = target; }
+          observe(target, options) { observedRail = target; observedOptions = options; }
         };
 
         const helpers = Function(extractFn('_stripInlineEventHandlers') + '\\n' + extractFn('_syncNavActionMirrors') + '\\n' + extractFn('_initNavActionMirrors') + '; return { _initNavActionMirrors };')();
@@ -539,14 +563,22 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         rail.appendChild(source);
         observerCallback();
         const mirror = sidebar.children.find(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn');
+        source.hidden = true;
+        observerCallback();
+        const mirrorHiddenWhenSourceHidden = !mirror.classList.contains('nav-action-visible');
+        source.hidden = false;
+        observerCallback();
         mirror.click();
         const mirrorBeforeDashboard = sidebar.children[0] === mirror;
         source.remove();
         observerCallback();
         console.log(JSON.stringify({
           observerArmed: observedRail === rail,
+          observerAttributes: !!(observedOptions && observedOptions.attributes),
+          observerSubtree: !!(observedOptions && observedOptions.subtree),
           sourceVisible: source.classList.contains('nav-action-visible'),
           mirrorVisible: mirror.classList.contains('nav-action-visible'),
+          mirrorHiddenWhenSourceHidden,
           mirrorRailClass: mirror.classList.contains('rail-btn'),
           mirrorLabel: mirror.getAttribute('data-label'),
           mirrorOnclickAttribute: mirror.getAttribute('onclick'),
@@ -554,6 +586,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
           mirrorBeforeDashboard,
           mirrorRemoved: !sidebar.children.some(el => el.getAttribute('data-nav-action-mirror') === 'hwxThemeCreatorRailBtn'),
           clicked,
+          sidebarClosed,
         }));
         """
     )
@@ -567,8 +600,11 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         pathlib.Path(path).unlink(missing_ok=True)
     assert out == {
         "observerArmed": True,
-        "sourceVisible": True,
+        "observerAttributes": True,
+        "observerSubtree": True,
+        "sourceVisible": False,
         "mirrorVisible": True,
+        "mirrorHiddenWhenSourceHidden": True,
         "mirrorRailClass": False,
         "mirrorLabel": "Theme Creator",
         "mirrorOnclickAttribute": None,
@@ -576,6 +612,7 @@ def test_extension_rail_actions_are_mirrored_to_mobile_nav():
         "mirrorBeforeDashboard": True,
         "mirrorRemoved": True,
         "clicked": 1,
+        "sidebarClosed": 1,
     }
 
 


### PR DESCRIPTION
## Thinking Path

- The dashboard link already has a runtime visible state, but the narrow sidebar breakpoint overrides that state with `display:none!important`.
- The same sidebar nav surface is where dashboard-style extension actions need to remain reachable, so the fix makes “visible nav action” a shared state instead of another breakpoint exception.
- Theme Creator currently adds a rail-only action, so core needs a small shared mirror for rail actions that do not already have a mobile/sidebar counterpart.
- The regression belongs with the existing dashboard link UI tests, which currently assert the broken mobile CSS contract.

## What Changed

- `static/style.css`: replaces the narrow breakpoint hide override with a shared visible nav-action rule that can win consistently across rail and sidebar layouts.
- `static/ui.js`: keeps the existing dashboard visible class, toggles the shared nav-action visible class from the dashboard status path, and reconciles rail-only extension action mirrors into the mobile sidebar while delegating clicks back to the current source button.
- `tests/test_dashboard_link_ui.py`: inverts the mobile CSS regression, extends the dashboard status driver, and adds a Theme Creator-shaped rail action harness that proves the mobile mirror stays visible, clickable, and removed when its source disappears.

## Why It Matters

Dashboard and dashboard-style extension actions stay reachable in the narrow navigation layout. Future nav actions can opt into the same visibility state instead of duplicating breakpoint-specific display rules.

## Verification

```text
pytest tests/test_dashboard_link_ui.py -v --timeout=60
npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/**/*.js"
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5583.

## Model Used

GPT-5 via Codex CLI
