### PR TITLE
fix(#5311): skip live /v1/models probe for opencode-go — use curated static list only

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6925,6 +6925,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     if not raw_models:
                         if pid == "moa":
                             raw_models = _moa_preset_models_from_config(cfg)
+                        elif pid == "opencode-go":
+                            # Skip live /v1/models probe for OpenCode Go — it
+                            # returns models from the public catalog that are
+                            # not enabled on the Go tier, causing 404 when
+                            # selected. Use the curated static list only. (#5311)
+                            pass
                         else:
                             raw_models = _models_from_live_provider_ids(
                                 pid,


### PR DESCRIPTION
## Summary

OpenCode Go's `/v1/models` endpoint returns models from the full public catalog that are **not enabled on the Go tier**. Selecting any probe-only model from the dropdown causes `404 model not found` when the chat request is sent.

Fix: skip the live `/v1/models` probe for `opencode-go` and use the curated static list in `_PROVIDER_MODELS` only.

## Root Cause

At `api/config.py:6928`, the generic provider handler calls `_read_live_provider_model_ids(pid)` which queries Hermes CLI for `/v1/models`. OpenCode Go returns ~20 models, but ~6 of the newer ones (e.g. `qwen3.7-max`, `kimi-k2.7-code`, `glm-5.2`, `hy3-preview`, `mimo-v2.5-pro`, `mimo-v2.5`) are in the public catalog but not accepted by `/v1/chat/completions` on the Go plan.

The 14 hardcoded models have been stable and working.

## Change

**`api/config.py`** — add an `elif pid == "opencode-go"` guard that skips the live probe, falling through to the curated static list. 6 lines added (comment + pass).

## Why not Option 1 (validate the probe)

Option 1 (send a one-token probe for each model) would be more general but:
- Requires live API calls at every cache rebuild
- Introduces latency and potential rate-limit issues
- Doesn't fully solve the problem (models can flip between available/unavailable)
- The static list is already maintained and matches what works on the Go tier

## Verification

- `git diff --check`: clean
- Static analysis: no new errors (all existing LSP errors are pre-existing `hermes_cli.*`/`agent.*` unresolvable imports in a standalone context)
- The curated static list at `_PROVIDER_MODELS["opencode-go"]` (line 1755) is unchanged and contains only the 14 known-working models

Closes #5311