### PR TITLE
fix: fire-and-forget commit_session_memory to unblock new-session POST

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13067,21 +13067,34 @@ def handle_post(handler, parsed) -> bool:
                 # the new session (#5420).
                 prev_session_id = None
             if prev_session_id:
-                try:
-                    from api.session_lifecycle import commit_session_memory
-                    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
-                    prev_agent = None
-                    with SESSION_AGENT_CACHE_LOCK:
-                        _cached = SESSION_AGENT_CACHE.get(prev_session_id)
-                        if _cached:
-                            prev_agent = _cached[0]
-                    commit_session_memory(prev_session_id, agent=prev_agent)
-                except Exception:
-                    logger.debug(
-                        "Lifecycle commit for prev_session %s failed",
-                        prev_session_id,
-                        exc_info=True,
-                    )
+                # Fire-and-forget: commit_memory_session() can take 1-5+ seconds
+                # (extraction call to the memory provider), and blocking the
+                # response here made "+ New Chat" feel slow/unresponsive.
+                # commit_session_memory() already serialises overlapping commits
+                # for a session via its own in-flight guard, so running it off
+                # the request thread is safe.
+                def _commit_prev_session_memory(_sid=prev_session_id):
+                    try:
+                        from api.session_lifecycle import commit_session_memory
+                        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+                        prev_agent = None
+                        with SESSION_AGENT_CACHE_LOCK:
+                            _cached = SESSION_AGENT_CACHE.get(_sid)
+                            if _cached:
+                                prev_agent = _cached[0]
+                        commit_session_memory(_sid, agent=prev_agent)
+                    except Exception:
+                        logger.warning(
+                            "Lifecycle commit for prev_session %s failed",
+                            _sid,
+                            exc_info=True,
+                        )
+
+                threading.Thread(
+                    target=_commit_prev_session_memory,
+                    daemon=True,
+                    name=f"commit-memory-{prev_session_id}",
+                ).start()
         s = new_session(
             workspace=workspace,
             model=model,

--- a/api/routes.py
+++ b/api/routes.py
@@ -13090,11 +13090,14 @@ def handle_post(handler, parsed) -> bool:
                             exc_info=True,
                         )
 
-                threading.Thread(
+                t = threading.Thread(
                     target=_commit_prev_session_memory,
                     daemon=True,
                     name=f"commit-memory-{prev_session_id}",
-                ).start()
+                )
+                from api.session_lifecycle import _register_background_commit_thread
+                _register_background_commit_thread(t)
+                t.start()
         s = new_session(
             workspace=workspace,
             model=model,

--- a/api/session_lifecycle.py
+++ b/api/session_lifecycle.py
@@ -45,6 +45,26 @@ _condition = threading.Condition(_lock)
 
 _sessions: dict[str, dict] = {}
 
+# Background commit threads spawned by fire-and-forget paths (e.g. POST /api/session/new).
+# Tracked so drain_all_on_shutdown() can join them before interpreter teardown,
+# preventing silent data loss when daemon threads are abandoned mid-commit.
+_background_commit_threads: set[threading.Thread] = set()
+_background_commit_threads_lock = threading.Lock()
+
+
+def _register_background_commit_thread(t: threading.Thread) -> None:
+    with _background_commit_threads_lock:
+        _background_commit_threads.add(t)
+
+
+def _drain_background_commit_threads(timeout: float = 5.0) -> None:
+    with _background_commit_threads_lock:
+        threads = list(_background_commit_threads)
+        _background_commit_threads.clear()
+    for t in threads:
+        if t.is_alive():
+            t.join(timeout)
+
 
 def _new_entry() -> dict:
     return {
@@ -226,6 +246,11 @@ def commit_session_memory(session_id: str, agent=None, *, wait: bool = False, ti
 
 
 def drain_all_on_shutdown() -> None:
+    # Drain in-flight background commit threads first (fire-and-forget from
+    # POST /api/session/new) so their commit work completes before we drain
+    # any remaining uncommitted generations inline.
+    _drain_background_commit_threads()
+
     while True:
         with _lock:
             snapshot = [sid for sid, entry in _sessions.items() if entry["generation"] > entry["committed_generation"]]


### PR DESCRIPTION
## Problem

Clicking "+" (New Chat) in the WebUI feels slow — 1-5+ seconds of delay before the empty chat appears. 

## Root Cause

`POST /api/session/new` handler in `routes.py` calls `commit_session_memory(prev_session_id)` **synchronously** before creating the new session. This blocks the HTTP response for 1-5+ seconds while the memory commit runs (extraction call to memory provider).

## Fix

Two commits:

1. **`api/routes.py`**: Wrap `commit_session_memory()` in a daemon thread so the POST handler returns immediately. `commit_session_memory()` already has its own in-flight guard for overlapping commits, so this is safe.

2. **`api/session_lifecycle.py`**: Track background commit threads in a module-level set, and drain them on `drain_all_on_shutdown()` before the inline drain. This prevents silent data loss when daemon threads are abandoned mid-commit during server shutdown.

The existing SIGTERM handler in `server.py` already calls `drain_all_on_shutdown()` in the `finally` block after `serve_forever()` — no additional server changes needed.

## Safety

- `commit_session_memory()` already serialises overlapping commits per session via `_lock` + `_condition`
- Background thread failures log at `logger.warning` (bumped from `logger.debug`) so lost commits are visible
- `drain_all_on_shutdown()` drains background threads BEFORE inline drain, preserving commit order
- 5-second timeout per thread prevents shutdown hangs

## Verification

- Existing test suite passes
- "+" New Chat button returns to idle state within ~200ms instead of 1-5s