### PR TITLE
fix(voice): keep dictation listening through pauses and prevent screen sleep (#4732)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -650,6 +650,17 @@ function _micToastKeyForRecognitionError(error){
   let _micPointerDown=false;
   let _micStartSeq=0;
   const _micHoldThresholdMs=300;
+  let _wakeLock=null;
+
+  async function _acquireWakeLock(){
+    if(_wakeLock) return;
+    try{ _wakeLock=await navigator.wakeLock.request('screen');
+      _wakeLock.addEventListener('release',()=>{ _wakeLock=null; }); }catch(_){ _wakeLock=null; }
+  }
+
+  async function _releaseWakeLock(){
+    if(_wakeLock){ try{ await _wakeLock.release(); }catch(_){} _wakeLock=null; }
+  }
 
   function _setButtonTooltipAndKey(btn, key){
     const text = t(key);
@@ -662,6 +673,13 @@ function _micToastKeyForRecognitionError(error){
     }
   }
 
+  // Re-acquire wake lock when the page becomes visible while recording (#4732)
+  if(typeof document!=='undefined'){
+    document.addEventListener('visibilitychange',()=>{
+      if(!document.hidden&&_isRecording) _acquireWakeLock();
+    });
+  }
+
   function _setRecording(on){
     window._micActive=on;
     btn.classList.toggle('recording',on);
@@ -670,7 +688,7 @@ function _micToastKeyForRecognitionError(error){
     _setButtonTooltipAndKey(btn, on ? (_rawAudioMode ? 'voice_recording_active' : 'voice_dictate_active') : (_rawAudioMode ? 'voice_send_raw' : 'voice_dictate'));
     status.style.display=on?'':'none';
     if(statusText) statusText.textContent=on?'Listening':'Listening';
-    if(!on){ _finalText=''; _prefix=''; }
+    if(on){ _acquireWakeLock(); }else{ _releaseWakeLock(); _finalText=''; _prefix=''; }
   }
 
   function _updateMicTooltip(){
@@ -796,7 +814,7 @@ function _micToastKeyForRecognitionError(error){
   function _ensureSpeechRecognition(){
     if(!SpeechRecognition) return null;
     const sr=recognition||new SpeechRecognition();
-    sr.continuous=false;
+    sr.continuous=true;
     sr.interimResults=true;
     sr.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -688,7 +688,8 @@ function _micToastKeyForRecognitionError(error){
     _setButtonTooltipAndKey(btn, on ? (_rawAudioMode ? 'voice_recording_active' : 'voice_dictate_active') : (_rawAudioMode ? 'voice_send_raw' : 'voice_dictate'));
     status.style.display=on?'':'none';
     if(statusText) statusText.textContent=on?'Listening':'Listening';
-    if(on){ _acquireWakeLock(); }else{ _releaseWakeLock(); _finalText=''; _prefix=''; }
+    if(!on){ _finalText=''; _prefix=''; }
+    if(on){ _acquireWakeLock(); } else { _releaseWakeLock(); }
   }
 
   function _updateMicTooltip(){
@@ -833,6 +834,7 @@ function _micToastKeyForRecognitionError(error){
     };
 
     sr.onend=()=>{
+      _isRecording=false;
       const committed=_finalText
         ? (_prefix&&!_prefix.endsWith(' ')&&!_prefix.endsWith('\n')
             ? _prefix+' '+_finalText.trimStart()


### PR DESCRIPTION
## Summary

Fixes #4732 — mobile dictation stops on thinking pauses and lacks wake lock.

## Changes

### 1. SpeechRecognition.continuous=true
The browser's Web Speech API was configured with `continuous=false`, which causes the recognizer to terminate after detecting an end-of-speech pause. On mobile, this means any natural thinking pause ends the dictation session. Setting `continuous=true` keeps the recognizer listening until the user explicitly stops.

### 2. Screen Wake Lock
Added Screen Wake Lock support to prevent the device from sleeping during dictation on mobile:
- `_acquireWakeLock()` — requests a screen wake lock when recording starts
- `_releaseWakeLock()` — releases the wake lock when recording stops
- Visibility change handler — re-acquires wake lock when the page returns to foreground while recording
- Graceful degradation — silently ignores if the Wake Lock API is unavailable

## Diff
- `static/boot.js`: +20 / -2 lines

Closes #4732