### PR TITLE
fix: show dashboard link in mobile sidebar-nav (#5583)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3100,8 +3100,8 @@
     .sidebar-nav .nav-tab svg{width:20px;height:20px;}
     .sidebar-nav .nav-tab.active{background:var(--accent-bg);}
     .sidebar-nav .nav-tab.active::before{left:-4px;top:50%;bottom:auto;transform:translateY(-50%);width:3px;height:16px;border-radius:0 2px 2px 0;}
-    .sidebar-nav .dashboard-link,
-    .sidebar-nav .dashboard-link.dashboard-link-visible{display:none!important;}
+    /* Dashboard link: visible in mobile sidebar-nav when the dashboard
+       service is running (toggled via dashboard-link-visible by JS). */
     .sidebar .panel-view{height:100%;margin-left:52px;}
     .sidebar .panel-head{padding-right:52px;}
     .mobile-sidebar-close{display:inline-flex!important;position:absolute;right:4px;top:calc(4px + var(--app-titlebar-safe-top));width:44px;height:44px;z-index:4;background:var(--surface);border:1px solid var(--border);}


### PR DESCRIPTION
@
## Summary

Fixes #5583 — the Dashboard icon was invisible in the mobile sidebar-nav at viewport widths <= 640px, even when the dashboard service is running and reachable.

## Root cause

Inside `@media(max-width:640px)`, two rules were forcibly hiding `.sidebar-nav .dashboard-link` with `display:none!important`, overriding the JS-driven `dashboard-link-visible` toggle that enables the link at runtime.

## Fix

Removed the two `display:none!important` override rules. The dashboard link still defaults to hidden (inline `style="display:none"` on the HTML element) and only becomes visible when the JS `_applyDashboardStatus()` function sets `btn.style.display=""` and adds `dashboard-link-visible` after confirming the dashboard service is reachable — exactly matching the desktop-rail behaviour.

## Files changed

- `static/style.css`: 2 lines removed (the !important hide rules), replaced with a short comment.

Closes #5583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@