### PR TITLE
fix(session): ignore inactive compacted state rows in context replay

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -6143,6 +6143,7 @@ def get_state_db_session_messages(
     stitch_continuations: bool = False,
     profile=None,
     since_timestamp=None,
+    include_inactive: bool = False,
 ) -> list:
     """Read messages for a Hermes session from state.db.
 
@@ -6158,6 +6159,13 @@ def get_state_db_session_messages(
     raw state.db scan to rows at or after a sidecar-derived timestamp floor while
     preserving the caller's normal merge/window logic.  Full-history callers must
     leave it unset.
+
+    When the messages table exposes an ``active`` column, inactive rows are
+    compacted/archived history and are intentionally excluded by default. WebUI
+    reconciliation feeds this reader straight into the next model context; pulling
+    ``active=0`` archive rows back in resurrects pre-compaction history and can
+    make every later turn re-trigger compression. Pass ``include_inactive=True``
+    only for explicit recovery/audit views.
     """
     try:
         import sqlite3
@@ -6249,11 +6257,15 @@ def get_state_db_session_messages(
                 if since_ts is not None:
                     since_clause = " AND (timestamp IS NULL OR timestamp >= ?)"
                     params.append(since_ts)
+            active_clause = ""
+            if 'active' in available and not include_inactive:
+                active_clause = " AND (active IS NULL OR active != 0)"
             cur.execute(f"""
                 SELECT {', '.join(selected)}, session_id
                 FROM messages
                 WHERE session_id IN ({placeholders})
                 {since_clause}
+                {active_clause}
                 ORDER BY timestamp ASC, id ASC
             """, params)
             msgs = []

--- a/tests/test_state_db_active_filter.py
+++ b/tests/test_state_db_active_filter.py
@@ -1,0 +1,77 @@
+import sqlite3
+
+import api.models as models
+from api.models import Session, get_state_db_session_messages, reconciled_state_db_messages_for_session
+
+
+def _make_state_db(path):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT,
+            content TEXT,
+            timestamp REAL,
+            active INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO messages (session_id, role, content, timestamp, active) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("sid", "user", "archived prompt", 1.0, 0),
+            ("sid", "assistant", "archived answer", 2.0, 0),
+            ("sid", "assistant", "compacted summary", 3.0, 1),
+            ("sid", "user", "live follow-up", 4.0, 1),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_state_db_reader_excludes_inactive_compaction_archive_by_default(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _make_state_db(db)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+
+    messages = get_state_db_session_messages("sid")
+
+    assert [m["content"] for m in messages] == ["compacted summary", "live follow-up"]
+
+
+def test_state_db_reader_can_include_inactive_for_explicit_recovery(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _make_state_db(db)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+
+    messages = get_state_db_session_messages("sid", include_inactive=True)
+
+    assert [m["content"] for m in messages] == [
+        "archived prompt",
+        "archived answer",
+        "compacted summary",
+        "live follow-up",
+    ]
+
+
+def test_reconciled_context_does_not_resurrect_inactive_archive_rows(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _make_state_db(db)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: db)
+
+    session = Session(
+        session_id="sid",
+        messages=[{"role": "user", "content": "full display transcript"}],
+        context_messages=[{"role": "assistant", "content": "compacted summary", "timestamp": 3.0}],
+    )
+
+    state_messages = get_state_db_session_messages("sid")
+    reconciled = reconciled_state_db_messages_for_session(
+        session,
+        prefer_context=True,
+        state_messages=state_messages,
+    )
+
+    assert [m["content"] for m in reconciled] == ["compacted summary", "live follow-up"]


### PR DESCRIPTION
## Summary

- Filter inactive (`active=0`) rows out of `get_state_db_session_messages()` by default when the `messages.active` column exists.
- Add an explicit `include_inactive=True` escape hatch for recovery/audit callers that need archived rows.
- Add regression coverage proving compacted archive rows are not reconciled back into the next model-facing context.

## Why

In-place context compaction archives old `state.db` message rows by marking them inactive. WebUI's normal state-db reader fed those archived rows back into `reconciled_state_db_messages_for_session(..., prefer_context=True)`, so the next turn could resurrect pre-compaction history and trigger compression again.

This is the same stale state-db replay class discussed in #4249 / #4685 and related to the closed #4069 attempt, but this patch fixes the concrete schema-level source: inactive archive rows should not be part of the normal active transcript read.

Refs #4249
Refs #4685
Refs #2361

## Verification

- `./scripts/test.sh tests/test_state_db_active_filter.py -q` → 3 passed
- `./scripts/test.sh tests/test_state_db_active_filter.py tests/test_webui_state_db_context_reconciliation.py -q` → 7 passed
- `./.venv/bin/python -m py_compile api/models.py`

## Risks / Follow-ups

- Default behavior changes only for schemas with a `messages.active` column. Legacy schemas without that column keep the existing query shape.
- Explicit recovery/audit views can opt into archived rows with `include_inactive=True`.

## Model Used

OpenAI GPT-5.5 via Hermes Agent, with terminal/file tools for diagnosis, patching, and verification.
