### PR TITLE
fix(steer): scope upload UX to owner session

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -1431,8 +1431,22 @@ function _steerOwnerIsCurrent(ownerSid){
   return !!(ownerSid&&typeof S!=='undefined'&&S.session&&S.session.session_id===ownerSid);
 }
 
+function _steerSetComposerStatusForOwner(ownerSid,text){
+  if(_steerOwnerIsCurrent(ownerSid)&&typeof setComposerStatus==='function')setComposerStatus(text);
+}
+
 function _steerRestoreText(originalMsg, explicitSteer){
   return explicitSteer?`/steer ${originalMsg}`:originalMsg;
+}
+
+function _steerIndicatorText(originalMsg, filesSnapshot){
+  const text=String(originalMsg||'').trim();
+  if(text)return text;
+  const names=(Array.isArray(filesSnapshot)?filesSnapshot:[])
+    .map(f=>f&&(f.name||f.filename||f.path||''))
+    .map(v=>String(v||'').trim())
+    .filter(Boolean);
+  return names.length?`Attached files: ${names.join(', ')}`:'Attached files';
 }
 
 async function _steerPersistDraftForOwner(ownerSid, originalMsg, explicitSteer, filesSnapshot){
@@ -1463,14 +1477,14 @@ async function _steerTextWithPendingFiles(msg, ownerSid, filesSnapshot){
   if(_steerUploadCache&&_steerUploadCache.sid===ownerSid&&_steerUploadCache.sig===sig&&Array.isArray(_steerUploadCache.paths)&&_steerUploadCache.paths.length){
     paths=_steerUploadCache.paths;
   }else{
-    if(typeof setComposerStatus==='function')setComposerStatus(t('uploading')||'Uploading…');
+    _steerSetComposerStatusForOwner(ownerSid,t('uploading')||'Uploading…');
     let uploaded=[];
     try{
       // Keep File objects staged until /api/chat/steer confirms acceptance. If
       // steer falls back, the draft and chips stay available for Queue/Interrupt.
       uploaded=await uploadPendingFiles({clearPending:false,sessionId:ownerSid,files:pendingFiles});
     }finally{
-      if(typeof setComposerStatus==='function')setComposerStatus('');
+      _steerSetComposerStatusForOwner(ownerSid,'');
     }
     paths=_steerUploadedAttachmentPaths(uploaded);
     if(paths.length) _steerUploadCache={sid:ownerSid,sig,paths};
@@ -1500,7 +1514,7 @@ async function _trySteer(msg, explicitSteer){
     }else{
       await _steerPersistDraftForOwner(ownerSid,originalMsg,explicitSteer,pendingFilesSnapshot);
     }
-    if(typeof setComposerStatus==='function')setComposerStatus('');
+    _steerSetComposerStatusForOwner(ownerSid,'');
     showToast(`${t('upload_failed')}${e&&e.message?e.message:e}`,3500);
     return false;
   }
@@ -1546,7 +1560,7 @@ async function _trySteer(msg, explicitSteer){
         const _remaining=S.pendingFiles.filter(f=>!_delivered.has(f));
         if(_remaining.length!==S.pendingFiles.length){S.pendingFiles=_remaining;if(typeof renderTray==='function')renderTray();}
       }
-      _showSteerIndicator(steerText);
+      _showSteerIndicator(_steerIndicatorText(originalMsg,pendingFilesSnapshot));
     }
     showToast(t('cmd_steer_delivered'),2500);
     return true;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1321,6 +1321,7 @@ async function loadSession(sid){
   // Mark this session as the in-flight load. Subsequent loadSession() calls
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   _loadingSessionId = sid;
+  if(currentSid!==sid&&typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
   // Reset scroll state for fresh session navigation — the reader expects to
   // land at the bottom of the new transcript, not wherever a stale unpin flag
   // from a prior session or a stray touch event during loading would place them.

--- a/static/ui.js
+++ b/static/ui.js
@@ -17563,8 +17563,49 @@ function addFiles(files){
   }
   renderTray();
 }
+const _uploadPendingFilesProgressBySession=new Map();
 function _uploadPendingFilesCurrentSession(sessionId){
   return !!(!sessionId||(S.session&&S.session.session_id===sessionId));
+}
+function _uploadPendingFilesHideProgressBar(){
+  const bar=$('uploadBar');const barWrap=$('uploadBarWrap');
+  if(!bar||!barWrap)return;
+  barWrap.classList.remove('active');
+  bar.style.width='0%';
+  if(barWrap.dataset)delete barWrap.dataset.uploadSessionId;
+}
+function _uploadPendingFilesShowProgressBar(owner,percent){
+  const bar=$('uploadBar');const barWrap=$('uploadBarWrap');
+  if(!bar||!barWrap)return;
+  if(barWrap.dataset)barWrap.dataset.uploadSessionId=owner;
+  barWrap.classList.add('active');
+  bar.style.width=`${Math.max(0,Math.min(100,Number(percent)||0))}%`;
+}
+function _uploadPendingFilesSyncProgressForSession(sessionId){
+  const owner=String(sessionId||'');
+  const state=owner?_uploadPendingFilesProgressBySession.get(owner):null;
+  if(state){_uploadPendingFilesShowProgressBar(owner,state.percent);return;}
+  _uploadPendingFilesHideProgressBar();
+}
+function _uploadPendingFilesUpdateProgress(sessionId,percent){
+  const bar=$('uploadBar');const barWrap=$('uploadBarWrap');
+  if(!bar||!barWrap)return;
+  const owner=String(sessionId||'');
+  const activeForOwner=barWrap.dataset&&barWrap.dataset.uploadSessionId===owner;
+  if(percent===null){
+    if(owner)_uploadPendingFilesProgressBySession.delete(owner);
+    if(activeForOwner){
+      _uploadPendingFilesHideProgressBar();
+    }
+    return;
+  }
+  const clamped=Math.max(0,Math.min(100,Number(percent)||0));
+  if(owner)_uploadPendingFilesProgressBySession.set(owner,{percent:clamped});
+  if(!_uploadPendingFilesCurrentSession(sessionId)){
+    if(activeForOwner)_uploadPendingFilesHideProgressBar();
+    return;
+  }
+  _uploadPendingFilesShowProgressBar(owner,clamped);
 }
 async function uploadPendingFiles(options={}){
   const opts=options||{};
@@ -17573,8 +17614,7 @@ async function uploadPendingFiles(options={}){
   if(!pendingFiles.length||!sessionId)return[];
   const clearPending=!(opts&&opts.clearPending===false);
   const names=[];let failures=0;
-  const bar=$('uploadBar');const barWrap=$('uploadBarWrap');
-  barWrap.classList.add('active');bar.style.width='0%';
+  _uploadPendingFilesUpdateProgress(sessionId,0);
   const total=pendingFiles.length;
   for(let i=0;i<total;i++){
     const f=pendingFiles[i];
@@ -17596,9 +17636,9 @@ async function uploadPendingFiles(options={}){
         names.push({name: data.filename, path: data.path, mime: data.mime, size: data.size, is_image: !!data.is_image});
       }
     }catch(e){failures++;setStatus(`\u274c ${t('upload_failed')}${f.name} \u2014 ${e.message}`);}
-    bar.style.width=`${Math.round((i+1)/total*100)}%`;
+    _uploadPendingFilesUpdateProgress(sessionId,Math.round((i+1)/total*100));
   }
-  barWrap.classList.remove('active');bar.style.width='0%';
+  _uploadPendingFilesUpdateProgress(sessionId,null);
   if(clearPending&&_uploadPendingFilesCurrentSession(sessionId)){S.pendingFiles=[];renderTray();}
   else if(typeof renderTray==='function'&&_uploadPendingFilesCurrentSession(sessionId))renderTray();
   if(failures===total&&total>0)throw new Error(t('all_uploads_failed',total));

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,9 @@
+"""Shared test helpers for static source assertions."""
+
+
+def source_between(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.find(start_marker)
+    assert start >= 0, f"{start_marker} not found"
+    end = src.find(end_marker, start)
+    assert end > start, f"{end_marker} not found after {start_marker}"
+    return src[start:end]

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -11,6 +11,8 @@ Issue: #720 (configurable busy-input behaviour)
 """
 from pathlib import Path
 
+from tests.helpers import source_between as _source_between
+
 ROOT = Path(__file__).parent.parent
 CONFIG_PY = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
 COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
@@ -20,14 +22,6 @@ BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
 PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
 I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
-
-
-def _source_between(src, start_marker, end_marker):
-    start = src.find(start_marker)
-    assert start >= 0, f"{start_marker} not found"
-    end = src.find(end_marker, start)
-    assert end > start, f"{end_marker} not found after {start_marker}"
-    return src[start:end]
 
 
 # ── Backend: setting registration + enum validation ─────────────────────

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.helpers import source_between as _source_between
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
@@ -79,14 +81,6 @@ def _captured_status(handler):
     calls = handler.send_response.call_args_list
     assert calls, "no status was sent"
     return calls[-1][0][0]
-
-
-def _source_between(src, start_marker, end_marker):
-    start = src.find(start_marker)
-    assert start >= 0, f"{start_marker} not found"
-    end = src.find(end_marker, start)
-    assert end > start, f"{end_marker} not found after {start_marker}"
-    return src[start:end]
 
 
 # ── Backend: the /api/chat/steer endpoint ─────────────────────────────────
@@ -327,6 +321,119 @@ class TestFrontendWiring:
             "post-await tray/DOM mutations must be guarded by the captured owner session"
         )
 
+    def test_file_steer_upload_status_and_indicator_are_owner_scoped(self):
+        steer_helpers = _source_between(
+            self.cmds,
+            "function _steerOwnerIsCurrent",
+            "\nasync function cmdTitle",
+        )
+        try_body = _source_between(self.cmds, "async function _trySteer(", "\nasync function cmdTitle")
+        assert "function _steerSetComposerStatusForOwner" in steer_helpers
+        assert "_steerSetComposerStatusForOwner(ownerSid,t('uploading')||'Uploading…')" in steer_helpers
+        assert "_steerSetComposerStatusForOwner(ownerSid,'')" in steer_helpers
+        assert "function _steerIndicatorText" in steer_helpers
+        assert "_showSteerIndicator(_steerIndicatorText(originalMsg,pendingFilesSnapshot))" in try_body, (
+            "visible steer indicator must use original text or a file-only display label, not attachment tool instructions"
+        )
+        assert "_showSteerIndicator(steerText)" not in try_body
+
+    def test_file_steer_indicator_omits_attachment_tool_note(self):
+        import json
+        import shutil
+        import subprocess
+        import textwrap
+
+        node = shutil.which("node")
+        if not node:  # pragma: no cover
+            pytest.skip("node not available")
+        assert node is not None
+
+        steer_src = _source_between(
+            self.cmds,
+            "function _steerUploadedAttachmentPaths",
+            "\nasync function cmdTitle",
+        )
+        script = textwrap.dedent(
+            f"""
+            const assert = require('assert');
+            let S = {{session:{{session_id:'A'}}, pendingFiles:[{{name:'a.pdf'}}]}};
+            let apiPayload = null;
+            let indicatorText = null;
+            function t(k){{return k;}}
+            function $(id){{return {{value:'', classList:{{add(){{}}, remove(){{}}}}, style:{{}}}};}}
+            function setComposerStatus(){{}}
+            function showToast(){{}}
+            function renderTray(){{}}
+            function _showSteerIndicator(text){{indicatorText = text;}}
+            function _showSteerRecovery(){{}}
+            function _clearComposerDraft(){{}}
+            async function uploadPendingFiles(){{return [{{path:'/tmp/a.pdf'}}];}}
+            async function api(url, options){{
+              assert.strictEqual(url, '/api/chat/steer');
+              apiPayload = JSON.parse(options.body);
+              return {{accepted:true}};
+            }}
+            eval({json.dumps(steer_src)});
+            (async()=>{{
+              const delivered = await _trySteer('hint', false);
+              assert.strictEqual(delivered, true);
+              assert.strictEqual(indicatorText, 'hint');
+              assert.ok(apiPayload.text.includes('[Attached files for this steer: /tmp/a.pdf]'));
+              assert.ok(!indicatorText.includes('Attached files'));
+              assert.ok(!indicatorText.includes('file tools/read_file'));
+            }})().catch(err=>{{console.error(err); process.exit(1);}});
+            """
+        )
+        subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
+
+    def test_attachment_only_steer_indicator_uses_file_label(self):
+        import json
+        import shutil
+        import subprocess
+        import textwrap
+
+        node = shutil.which("node")
+        if not node:  # pragma: no cover
+            pytest.skip("node not available")
+        assert node is not None
+
+        steer_src = _source_between(
+            self.cmds,
+            "function _steerUploadedAttachmentPaths",
+            "\nasync function cmdTitle",
+        )
+        script = textwrap.dedent(
+            f"""
+            const assert = require('assert');
+            let S = {{session:{{session_id:'A'}}, pendingFiles:[{{name:'a.pdf'}}]}};
+            let apiPayload = null;
+            let indicatorText = null;
+            function t(k){{return k;}}
+            function $(id){{return {{value:'', classList:{{add(){{}}, remove(){{}}}}, style:{{}}}};}}
+            function setComposerStatus(){{}}
+            function showToast(){{}}
+            function renderTray(){{}}
+            function _showSteerIndicator(text){{indicatorText = text;}}
+            function _showSteerRecovery(){{}}
+            function _clearComposerDraft(){{}}
+            async function uploadPendingFiles(){{return [{{path:'/tmp/a.pdf'}}];}}
+            async function api(url, options){{
+              assert.strictEqual(url, '/api/chat/steer');
+              apiPayload = JSON.parse(options.body);
+              return {{accepted:true}};
+            }}
+            eval({json.dumps(steer_src)});
+            (async()=>{{
+              const delivered = await _trySteer('', false);
+              assert.strictEqual(delivered, true);
+              assert.strictEqual(indicatorText, 'Attached files: a.pdf');
+              assert.ok(apiPayload.text.includes('[Attached files for this steer: /tmp/a.pdf]'));
+              assert.ok(!indicatorText.includes('file tools/read_file'));
+            }})().catch(err=>{{console.error(err); process.exit(1);}});
+            """
+        )
+        subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
+
     def test_file_steer_targets_captured_session_when_user_switches_mid_upload(self):
         import json
         import shutil
@@ -410,6 +517,94 @@ class TestFrontendWiring:
         assert "fd.append('session_id',sessionId)" in ui
         assert "if(clearPending&&_uploadPendingFilesCurrentSession(sessionId)){S.pendingFiles=[];renderTray();}" in ui
         assert "else if(typeof renderTray==='function'&&_uploadPendingFilesCurrentSession(sessionId))renderTray();" in ui
+
+    def test_upload_pending_files_progress_bar_is_session_scoped(self):
+        ui = (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+        progress_helper = _source_between(
+            ui,
+            "const _uploadPendingFilesProgressBySession",
+            "\nasync function uploadPendingFiles",
+        )
+        upload_body = ui[ui.index("async function uploadPendingFiles") :]
+        sessions = (Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
+        load_body = _source_between(sessions, "async function loadSession", "\nfunction _isMessagingSession")
+        assert "_uploadPendingFilesSyncProgressForSession(sid)" in load_body
+        assert "_uploadPendingFilesProgressBySession.set(owner,{percent:clamped})" in progress_helper
+        assert "function _uploadPendingFilesSyncProgressForSession" in progress_helper
+        assert "if(!_uploadPendingFilesCurrentSession(sessionId)){" in progress_helper
+        assert "barWrap.dataset.uploadSessionId=owner" in progress_helper
+        assert "activeForOwner" in progress_helper
+        assert "barWrap.classList.remove('active')" in progress_helper
+        assert "_uploadPendingFilesUpdateProgress(sessionId,0)" in upload_body
+        assert "_uploadPendingFilesUpdateProgress(sessionId,Math.round((i+1)/total*100))" in upload_body
+        assert "_uploadPendingFilesUpdateProgress(sessionId,null)" in upload_body
+        assert "barWrap.classList.add('active');bar.style.width='0%';" not in upload_body
+        assert "barWrap.classList.remove('active');bar.style.width='0%';" not in upload_body
+
+    def test_upload_progress_bar_hides_on_switch_and_reappears_on_owner_return(self):
+        import json
+        import shutil
+        import subprocess
+        import textwrap
+
+        node = shutil.which("node")
+        if not node:  # pragma: no cover
+            pytest.skip("node not available")
+        assert node is not None
+
+        ui = (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+        progress_src = _source_between(
+            ui,
+            "const _uploadPendingFilesProgressBySession",
+            "\nasync function uploadPendingFiles",
+        )
+        script = textwrap.dedent(
+            f"""
+            const assert = require('assert');
+            let S = {{session:{{session_id:'A'}}}};
+            const bar = {{style:{{width:''}}}};
+            const barWrap = {{
+              dataset: {{}},
+              active: false,
+              classList: {{
+                add(cls){{ if(cls === 'active') barWrap.active = true; }},
+                remove(cls){{ if(cls === 'active') barWrap.active = false; }},
+              }},
+            }};
+            function $(id){{
+              if(id === 'uploadBar') return bar;
+              if(id === 'uploadBarWrap') return barWrap;
+              return null;
+            }}
+            eval({json.dumps(progress_src)});
+            _uploadPendingFilesUpdateProgress('A', 0);
+            assert.strictEqual(barWrap.active, true);
+            assert.strictEqual(bar.style.width, '0%');
+            assert.strictEqual(barWrap.dataset.uploadSessionId, 'A');
+
+            S.session = {{session_id:'B'}};
+            _uploadPendingFilesSyncProgressForSession('B');
+            assert.strictEqual(barWrap.active, false);
+            assert.strictEqual(bar.style.width, '0%');
+            assert.strictEqual(barWrap.dataset.uploadSessionId, undefined);
+
+            _uploadPendingFilesUpdateProgress('A', 50);
+            assert.strictEqual(barWrap.active, false);
+            assert.strictEqual(bar.style.width, '0%');
+
+            S.session = {{session_id:'A'}};
+            _uploadPendingFilesSyncProgressForSession('A');
+            assert.strictEqual(barWrap.active, true);
+            assert.strictEqual(bar.style.width, '50%');
+            assert.strictEqual(barWrap.dataset.uploadSessionId, 'A');
+
+            _uploadPendingFilesUpdateProgress('A', null);
+            assert.strictEqual(barWrap.active, false);
+            assert.strictEqual(bar.style.width, '0%');
+            assert.strictEqual(barWrap.dataset.uploadSessionId, undefined);
+            """
+        )
+        subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
 
     def test_pending_steer_leftover_listener(self):
         """Frontend must listen for pending_steer_leftover SSE events and queue them."""


### PR DESCRIPTION
## Summary

Follow-up to Greptile feedback on #5623:

- show the visible steer indicator with the user's original text instead of the attachment-augmented agent/tool note
- scope steer upload composer status updates to the captured owner session
- scope upload progress bar DOM updates by owner session so background uploads do not flicker on a switched-to session
- move the duplicated `_source_between` test helper into `tests/helpers.py`

## Verification

- `node --check static/commands.js`
- `node --check static/ui.js`
- `python -m py_compile tests/helpers.py tests/test_real_steer.py tests/test_1062_busy_input_modes.py`
- `python -m pytest tests/test_real_steer.py tests/test_1062_busy_input_modes.py tests/test_issue1867_upload_size_preflight.py -q -o 'addopts='`
- `git diff --cached --check`
