### PR TITLE
fix(#3874): auto-refresh sidebar session list after new session creation

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1242,7 +1242,8 @@ async function newSession(flash, options={}){
       const _dirP=loadDir('.');
       if(_dirP&&typeof _dirP.catch==='function') _dirP.catch(()=>{});
     }
-    // don't call renderSessionList here - callers do it when needed
+    // Refresh sidebar to include the newly created session (#3874).
+    if(typeof refreshSessionList==='function'){Promise.resolve(refreshSessionList('new-session')).catch(()=>{})}
   })();
   try{
     return await _newSessionInFlight;


### PR DESCRIPTION
Fixes #3874

## Problem
When a new local session is created from within the WebUI, the sidebar session list does not auto-refresh to include it. The `newSession()` function had a comment saying "don't call renderSessionList here - callers do it when needed" but not all callers followed through, leaving the sidebar stale in several code paths.

## Fix
Added a `refreshSessionList('new-session')` call at the end of `newSession()` so the sidebar refreshes automatically whenever a new session is created, regardless of which caller invoked it. The `refreshSessionList` function has built-in deduplication (in-flight/pending-request queue) so callers that already trigger their own refresh won't cause double-fetches.

## Changes
- `static/sessions.js`: 2 insertions, 1 deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)