### PR TITLE
fix(ui): scale model name, icon, and TPS badge with font-size preference

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -72,6 +72,23 @@
   :root[data-font-size="large"] .msg-body table { font-size: 14px; }
   :root[data-font-size="xlarge"] .msg-body table { font-size: 16px; }
 
+  /* Chat message role header (model name / icon / TPS / timestamp) */
+  :root[data-font-size="small"] .msg-role { font-size: 10px; }
+  :root[data-font-size="large"] .msg-role { font-size: 13px; }
+  :root[data-font-size="xlarge"] .msg-role { font-size: 15px; }
+  :root[data-font-size="small"] .role-icon { width: 18px; height: 18px; font-size: 8px; }
+  :root[data-font-size="large"] .role-icon { width: 22px; height: 22px; font-size: 10px; }
+  :root[data-font-size="xlarge"] .role-icon { width: 24px; height: 24px; font-size: 11px; }
+  :root[data-font-size="small"] .msg-role-name { font-size: 11px; }
+  :root[data-font-size="large"] .msg-role-name { font-size: 14px; }
+  :root[data-font-size="xlarge"] .msg-role-name { font-size: 16px; }
+  :root[data-font-size="small"] .msg-tps-inline { font-size: 9.5px; }
+  :root[data-font-size="large"] .msg-tps-inline { font-size: 12.5px; }
+  :root[data-font-size="xlarge"] .msg-tps-inline { font-size: 14.5px; }
+  :root[data-font-size="small"] .msg-time { font-size: 9px; }
+  :root[data-font-size="large"] .msg-time { font-size: 12px; }
+  :root[data-font-size="xlarge"] .msg-time { font-size: 14px; }
+
   /* Composer textarea (default is 16px in stylesheet) */
   :root[data-font-size="small"] #msg { font-size: 14px; }
   :root[data-font-size="large"] #msg { font-size: 18px; }
@@ -5801,6 +5818,7 @@ main.main > #mainPlugin{display:none;}
 /* Quieter, always-visible role header (smaller avatar, always-visible timestamp) */
 .msg-role { font-size: 11px; font-weight: 500; margin-bottom: 6px; opacity: .8; letter-spacing: 0; }
 .msg-role:hover { opacity: 1; }
+.msg-role-name { font-size: 12px; }
 .role-icon { width: 20px; height: 20px; font-size: 9px; }
 .msg-tps-inline {
   display: inline-flex;

--- a/static/style.css
+++ b/static/style.css
@@ -85,9 +85,9 @@
   :root[data-font-size="small"] .msg-tps-inline { font-size: 9.5px; }
   :root[data-font-size="large"] .msg-tps-inline { font-size: 12.5px; }
   :root[data-font-size="xlarge"] .msg-tps-inline { font-size: 14.5px; }
-  :root[data-font-size="small"] .msg-time { font-size: 9px; }
-  :root[data-font-size="large"] .msg-time { font-size: 12px; }
-  :root[data-font-size="xlarge"] .msg-time { font-size: 14px; }
+  :root[data-font-size="small"] .msg-role .msg-time { font-size: 9px; }
+  :root[data-font-size="large"] .msg-role .msg-time { font-size: 12px; }
+  :root[data-font-size="xlarge"] .msg-role .msg-time { font-size: 14px; }
 
   /* Composer textarea (default is 16px in stylesheet) */
   :root[data-font-size="small"] #msg { font-size: 14px; }

--- a/static/ui.js
+++ b/static/ui.js
@@ -9256,7 +9256,7 @@ function isTpsDisplayEnabled(){
 function _assistantRoleHtml(tsTitle='', tpsText=''){
   const _bn=assistantDisplayName();
   const tps=(isTpsDisplayEnabled()&&tpsText)?`<span class="msg-tps-inline" title="Tokens per second">${esc(tpsText)}</span>`:'';
-  return `<div class="msg-role assistant" ${tsTitle?`title="${esc(tsTitle)}"`:''}><div class="role-icon assistant">${esc(_bn.charAt(0).toUpperCase())}</div><span style="font-size:12px">${esc(_bn)}</span>${tps}</div>`;
+  return `<div class="msg-role assistant" ${tsTitle?`title="${esc(tsTitle)}"`:''}><div class="role-icon assistant">${esc(_bn.charAt(0).toUpperCase())}</div><span class="msg-role-name">${esc(_bn)}</span>${tps}</div>`;
 }
 function _setAssistantTurnTps(turn, tpsText=''){
   if(!turn) return;


### PR DESCRIPTION
## Summary
The `.msg-role` (model name/icon header), `.role-icon`, `.msg-role-name`, `.msg-tps-inline`, and `.msg-time` elements did not respond to the `data-font-size` attribute on `:root`, causing them to appear disproportionately small when users selected larger text sizes.

## Changes
- Adds responsive CSS rules for small/large/xlarge font-size modes so the chat role header scales proportionally alongside `.msg-body` text
- Replaces the hardcoded inline `style="font-size:12px"` on the assistant name span with a class-based rule (`.msg-role-name`) so responsive overrides can take effect

## Files Changed
- `static/style.css`: +18 lines (base style + 15 responsive rules)
- `static/ui.js`: 1 line changed (inline style to class)

Closes #5372

🤖 Generated with [Claude Code](https://claude.com/claude-code)