### PR TITLE
fix(#5637): bump contain-intrinsic-size fallback from 1px to 400px on .msg-row

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5729,7 +5729,7 @@ main.main > #mainPlugin{display:none;}
    enough to avoid scrollHeight recalculation jumps that kill flick-scroll
    momentum on iOS. */
 @media (pointer: coarse) {
-  .msg-row { content-visibility: auto; contain-intrinsic-size: auto 1px; contain: layout style; }
+  .msg-row { content-visibility: auto; contain-intrinsic-size: auto 400px; contain: layout style; }
   /* Keep the LIVE streaming turn fully rendered while a response streams. The
      live turn is always id="liveAssistantTurn" (assigned on every render path:
      Compact Worklog, Transparent Stream, restored-live, etc.), but ONLY the


### PR DESCRIPTION
## Problem

On touch devices (Android Chrome), scrolling history while a reply streams causes the viewport to jump back toward the top. Root cause: `contain-intrinsic-size: auto 1px` on `.msg-row` under `@media (pointer: coarse)` collapses scrollHeight by tens of thousands of px when off-screen rows haven't been measured, forcing the browser to clamp scrollTop.

From the real-device instrumentation in #5637:
```
SHRINK  scrollHeight 53316 -> 1569   rows 275 -> 276   ATCLAMP
JUMP    dTop -51859  dH -51747       JS=none
```

The DOM is NOT wiped — rows stay high (275+). Only the CSS-driven reserved off-screen height collapses.

## Fix

Bump `contain-intrinsic-size` fallback from `1px` to `400px` — a reasonable per-row estimate that prevents destructive scrollHeight collapse while preserving the WKWebView streaming performance benefit from #5541.

## Diff

`static/style.css`: 1 line changed (1 insertion, 1 deletion).

Fixes #5637.