### PR TITLE
fix(#5641): tolerate edge whitespace in markdown table parsing

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -6148,7 +6148,7 @@ function renderMd(raw){
   // Tables: | col | col | header row followed by | --- | --- | separator then data rows
   // NOTE: table pass runs BEFORE outer link pass so [label](url) in table cells
   // is handled by inlineMd() only — prevents double-linking.
-  s=s.replace(/((?:^\|.+\|\n?)+)/gm,block=>{
+  s=s.replace(/((?:^[ \t]{0,3}\|.+\|[ \t]*\n?)+)/gm,block=>{
     const rows=block.trim().split('\n').filter(r=>r.trim());
     if(rows.length<2)return block;
     const isSep=r=>/^\|[\s|:-]+\|$/.test(r.trim());

--- a/static/ui.js
+++ b/static/ui.js
@@ -6148,7 +6148,7 @@ function renderMd(raw){
   // Tables: | col | col | header row followed by | --- | --- | separator then data rows
   // NOTE: table pass runs BEFORE outer link pass so [label](url) in table cells
   // is handled by inlineMd() only — prevents double-linking.
-  s=s.replace(/((?:^[ \t]{0,3}\|.+\|[ \t]*\n?)+)/gm,block=>{
+  s=s.replace(/((?:^ {0,3}\|.+\|[ \t]*\n?)+)/gm,block=>{
     const rows=block.trim().split('\n').filter(r=>r.trim());
     if(rows.length<2)return block;
     const isSep=r=>/^\|[\s|:-]+\|$/.test(r.trim());

--- a/tests/test_issue5641_table_whitespace.py
+++ b/tests/test_issue5641_table_whitespace.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_HELPERS_PATH = Path(__file__).with_name("test_renderer_js_behaviour.py")
+_SPEC = importlib.util.spec_from_file_location("issue5641_renderer_helpers", _HELPERS_PATH)
+_HELPERS = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_HELPERS)
+
+NODE = _HELPERS.NODE
+_render = _HELPERS._render
+driver_path = _HELPERS.driver_path
+
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "| a | b | \n|---|---|\n| 1 | 2 |",
+        "| a | b |\n|---|---| \n| 1 | 2 |",
+        " | a | b |\n |---|---|\n | 1 | 2 |",
+        "   | a | b |\n   |---|---|\n   | 1 | 2 |",
+    ],
+)
+def test_table_rows_with_edge_whitespace_still_render_as_table(driver_path, src):
+    out = _render(driver_path, src)
+    assert "<table><thead>" in out
+    assert "<td>1</td>" in out
+
+
+def test_four_space_indented_table_like_block_stays_outside_table(driver_path):
+    src = (
+        "    | a | b |\n"
+        "    |---|---|\n"
+        "    | 1 | 2 |"
+    )
+    out = _render(driver_path, src)
+    assert "<table" not in out

--- a/tests/test_issue5641_table_whitespace.py
+++ b/tests/test_issue5641_table_whitespace.py
@@ -31,6 +31,7 @@ def test_table_rows_with_edge_whitespace_still_render_as_table(driver_path, src)
     out = _render(driver_path, src)
     assert "<table><thead>" in out
     assert "<td>1</td>" in out
+    assert "<p>" not in out
 
 
 def test_four_space_indented_table_like_block_stays_outside_table(driver_path):


### PR DESCRIPTION
## Thinking Path

- The issue sits in the table-capture boundary, not in the separator or cell parsers, because `renderMd()` already trims rows after capture and only drops these inputs before they reach that logic.
- The narrow fix is to widen the capture regex just enough to accept trailing horizontal whitespace and CommonMark-style 0-3 space indentation, while keeping 4-space code-block input out of the table path.
- The proof stays behavioral by extending the existing node-driven `renderMd()` harness with the whitespace regressions and by preserving the current clean-table and inline-code pipe checks.

## What Changed

- `static/ui.js`: widened the table-block capture regex so rows with trailing horizontal whitespace, and rows indented 0-3 spaces, still enter the table parser without broadening into 4-space code-block territory.
- `tests/test_issue5641_table_whitespace.py`: added focused `renderMd()` regressions for accepted edge whitespace, explicit no-paragraph-spill assertions, and the 4-space negative boundary, while `tests/test_renderer_js_behaviour.py` remains the preservation harness for the shared renderer cases.

## Why It Matters

Structurally valid markdown tables from LLM output will render as tables instead of leaking raw pipes or dropping tbody rows just because an invisible trailing space or a small leading indent slipped into a row. The change stays scoped to the capture boundary, so the existing table parser behavior remains intact.

## Verification

- `pytest tests/test_issue5641_table_whitespace.py tests/test_renderer_js_behaviour.py -v --timeout=60`
- `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs "static/ui.js"`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5641.

## Model Used

GPT 5.5 via Codex CLI
