### PR TITLE
fix(#5619): reload config cache on profile switch

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -444,6 +444,7 @@ def _apply_config_defaults(config_data: dict) -> None:
  
 def reload_config_if_stale() -> None:
     """Refresh config.yaml once for concurrent stale read paths."""
+    global cfg
     with _cfg_lock:
         try:
             config_path = _get_config_path()
@@ -454,6 +455,8 @@ def reload_config_if_stale() -> None:
         mtime_stale = current_mtime != _cfg_mtime
         if not _cfg_cache or path_changed or (mtime_stale and not _cfg_has_in_memory_overrides()):
             _refresh_config_cache(config_path)
+            if path_changed:
+                cfg = _cfg_cache
 
 
 def get_config() -> dict:
@@ -521,7 +524,7 @@ def _refresh_config_cache(config_path: Path | None = None) -> None:
     Callers must hold _cfg_lock when invoking this helper because it mutates
     shared state.
     """
-    global _cfg_mtime, _cfg_path, _cfg_fingerprint, cfg
+    global _cfg_mtime, _cfg_path, _cfg_fingerprint
     if config_path is None:
         config_path = _get_config_path()
     _cfg_cache.clear()
@@ -582,8 +585,6 @@ def _refresh_config_cache(config_path: Path | None = None) -> None:
         logger.debug("Failed to load yaml config from %s", config_path)
     _apply_config_defaults(_cfg_cache)
     _cfg_fingerprint = _fingerprint_config(_cfg_cache)
-    # A real reload retargets the legacy cfg alias to the cache for this path.
-    cfg = _cfg_cache
     # Bust the models cache so the next request sees fresh config values.
     # Only delete the disk cache when config has actually changed -- not on
     # first-ever load (when _old_cfg_mtime == 0.0, i.e. server start or

--- a/api/config.py
+++ b/api/config.py
@@ -5759,10 +5759,9 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     except OSError:
         _current_path = _get_config_path()
         _current_mtime = 0.0
-    if (
-        (_current_mtime != _cfg_mtime or _current_path != _cfg_path)
-        and not _cfg_has_in_memory_overrides()
-    ):
+    path_changed = _current_path != _cfg_path
+    mtime_stale = _current_mtime != _cfg_mtime
+    if path_changed or (mtime_stale and not _cfg_has_in_memory_overrides()):
         reload_config_if_stale()
     # ── COLD PATH helper ─────────────────────────────────────────────────────
     # Extracted so it runs inside _available_models_cache_lock (RLock) to

--- a/api/config.py
+++ b/api/config.py
@@ -521,7 +521,7 @@ def _refresh_config_cache(config_path: Path | None = None) -> None:
     Callers must hold _cfg_lock when invoking this helper because it mutates
     shared state.
     """
-    global _cfg_mtime, _cfg_path, _cfg_fingerprint
+    global _cfg_mtime, _cfg_path, _cfg_fingerprint, cfg
     if config_path is None:
         config_path = _get_config_path()
     _cfg_cache.clear()
@@ -582,6 +582,8 @@ def _refresh_config_cache(config_path: Path | None = None) -> None:
         logger.debug("Failed to load yaml config from %s", config_path)
     _apply_config_defaults(_cfg_cache)
     _cfg_fingerprint = _fingerprint_config(_cfg_cache)
+    # A real reload retargets the legacy cfg alias to the cache for this path.
+    cfg = _cfg_cache
     # Bust the models cache so the next request sees fresh config values.
     # Only delete the disk cache when config has actually changed -- not on
     # first-ever load (when _old_cfg_mtime == 0.0, i.e. server start or

--- a/api/config.py
+++ b/api/config.py
@@ -450,8 +450,9 @@ def reload_config_if_stale() -> None:
             current_mtime = config_path.stat().st_mtime
         except OSError:
             current_mtime = 0.0
-        cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
-        if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
+        path_changed = _cfg_path != config_path
+        mtime_stale = current_mtime != _cfg_mtime
+        if not _cfg_cache or path_changed or (mtime_stale and not _cfg_has_in_memory_overrides()):
             _refresh_config_cache(config_path)
 
 
@@ -462,8 +463,9 @@ def get_config() -> dict:
         current_mtime = config_path.stat().st_mtime
     except OSError:
         current_mtime = 0.0
-    cache_stale = current_mtime != _cfg_mtime or _cfg_path != config_path
-    if not _cfg_cache or (cache_stale and not _cfg_has_in_memory_overrides()):
+    path_changed = _cfg_path != config_path
+    mtime_stale = current_mtime != _cfg_mtime
+    if not _cfg_cache or path_changed or (mtime_stale and not _cfg_has_in_memory_overrides()):
         reload_config_if_stale()
     # When a test (or runtime caller) has rebound ``cfg`` to a different dict
     # via monkeypatch.setattr(config, "cfg", ...), return that override rather

--- a/tests/test_issue1106_custom_providers_models.py
+++ b/tests/test_issue1106_custom_providers_models.py
@@ -17,6 +17,7 @@ def _models_with_cfg(model_cfg=None, custom_providers=None, active_provider=None
     """
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     config.cfg.clear()
     if model_cfg:
         config.cfg["model"] = model_cfg
@@ -26,12 +27,14 @@ def _models_with_cfg(model_cfg=None, custom_providers=None, active_provider=None
         config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
     except Exception:
         config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
     try:
         return config.get_available_models()
     finally:
         config.cfg.clear()
         config.cfg.update(old_cfg)
         config._cfg_mtime = old_mtime
+        config._cfg_path = old_path
 
 
 def _all_model_ids(result):

--- a/tests/test_issue1240_generic_cli_catalog_sync.py
+++ b/tests/test_issue1240_generic_cli_catalog_sync.py
@@ -96,6 +96,7 @@ def _configure(monkeypatch, tmp_path, *, provider: str, default: str = ""):
         },
     )
     monkeypatch.setattr(config, "_cfg_mtime", 0.0)
+    monkeypatch.setattr(config, "_cfg_path", config._get_config_path(), raising=False)
     config.invalidate_models_cache()
 
 

--- a/tests/test_issue1680_codex_spark.py
+++ b/tests/test_issue1680_codex_spark.py
@@ -30,6 +30,7 @@ def _configure_codex(monkeypatch, tmp_path, default="gpt-5.3-codex-spark"):
         "fallback_providers": [],
     })
     monkeypatch.setattr(config, "_cfg_mtime", 0.0)
+    monkeypatch.setattr(config, "_cfg_path", config._get_config_path(), raising=False)
     config.invalidate_models_cache()
 
 

--- a/tests/test_issue1806_named_custom_provider_resolution.py
+++ b/tests/test_issue1806_named_custom_provider_resolution.py
@@ -28,6 +28,7 @@ def _isolate_models_cache(tmp_path, monkeypatch):
 def _with_ollama_local_config():
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     config.cfg.clear()
     config.cfg.update(
         {
@@ -51,11 +52,13 @@ def _with_ollama_local_config():
         config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
     except Exception:
         config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
 
     def restore():
         config.cfg.clear()
         config.cfg.update(old_cfg)
         config._cfg_mtime = old_mtime
+        config._cfg_path = old_path
         config.invalidate_models_cache()
 
     return restore

--- a/tests/test_issue1881_phantom_custom_groups.py
+++ b/tests/test_issue1881_phantom_custom_groups.py
@@ -59,6 +59,7 @@ def _with_ai_gateway_and_custom_provider():
     gateway also exposes."""
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     config.cfg.clear()
     config.cfg.update(
         {
@@ -81,11 +82,13 @@ def _with_ai_gateway_and_custom_provider():
         config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
     except Exception:
         config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
 
     def restore():
         config.cfg.clear()
         config.cfg.update(old_cfg)
         config._cfg_mtime = old_mtime
+        config._cfg_path = old_path
         config.invalidate_models_cache()
 
     return restore

--- a/tests/test_issue1881_phantom_custom_groups.py
+++ b/tests/test_issue1881_phantom_custom_groups.py
@@ -206,6 +206,7 @@ def test_named_custom_group_still_populates_when_active_is_custom_alias(monkeypa
 
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     config.cfg.clear()
     config.cfg.update(
         {
@@ -228,6 +229,7 @@ def test_named_custom_group_still_populates_when_active_is_custom_alias(monkeypa
         config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
     except Exception:
         config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
 
     try:
         result = config.get_available_models()
@@ -235,6 +237,7 @@ def test_named_custom_group_still_populates_when_active_is_custom_alias(monkeypa
         config.cfg.clear()
         config.cfg.update(old_cfg)
         config._cfg_mtime = old_mtime
+        config._cfg_path = old_path
 
     groups_by_id = {g["provider_id"]: g for g in result["groups"]}
     assert "custom:my-custom" in groups_by_id

--- a/tests/test_issue_neuralwatt_env_key.py
+++ b/tests/test_issue_neuralwatt_env_key.py
@@ -27,12 +27,14 @@ def _force_env_fallback(monkeypatch):
 def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
     monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
     monkeypatch.setattr("api.profiles.get_active_hermes_home", lambda: tmp_path, raising=False)
     config.cfg.clear()
     config.cfg.update(cfg)
     config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
     config.invalidate_models_cache()
     try:
         return config.get_available_models()
@@ -40,6 +42,7 @@ def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
         config.cfg.clear()
         config.cfg.update(old_cfg)
         config._cfg_mtime = old_mtime
+        config._cfg_path = old_path
         config.invalidate_models_cache()
 
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -29,17 +29,20 @@ def _force_env_fallback(monkeypatch):
 def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
     monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
     config.cfg.clear()
     config.cfg.update(cfg)
     config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
     try:
         return config.get_available_models()
     finally:
         config.cfg.clear()
         config.cfg.update(old_cfg)
         config._cfg_mtime = old_mtime
+        config._cfg_path = old_path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pr1970_lmstudio_base_url_fallback.py
+++ b/tests/test_pr1970_lmstudio_base_url_fallback.py
@@ -30,12 +30,14 @@ class _RestoreCfg:
         import copy
         self._snapshot = copy.deepcopy(config.cfg)
         self._cfg_mtime = config._cfg_mtime
+        self._cfg_path = getattr(config, "_cfg_path", None)
         return self
 
     def __exit__(self, *exc):
         config.cfg.clear()
         config.cfg.update(self._snapshot)
         config._cfg_mtime = self._cfg_mtime
+        config._cfg_path = self._cfg_path
 
 
 def _set_cfg(cfg_dict: dict):
@@ -45,6 +47,7 @@ def _set_cfg(cfg_dict: dict):
         config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
     except Exception:
         config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
 
 
 def _groups_by_provider_id(result: dict) -> dict:

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -591,6 +591,79 @@ def test_get_config_reloads_when_request_profile_changes_even_with_rebound_cfg_o
         config.cfg = orig_cfg
 
 
+def test_get_available_models_reloads_when_request_profile_changes_even_with_rebound_cfg_override(
+    tmp_path, monkeypatch
+):
+    """The models payload must follow the new profile even when cfg was rebound."""
+    monkeypatch.delenv("HERMES_CONFIG_PATH", raising=False)
+    import api.config as config
+    import api.profiles as profiles
+
+    default_home = tmp_path / ".hermes"
+    work_home = default_home / "profiles" / "work"
+    work_home.mkdir(parents=True)
+    default_home.mkdir(exist_ok=True)
+    (default_home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: gpt-5.5\n",
+        encoding="utf-8",
+    )
+    (work_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: google/gemini-3-flash-preview\n"
+        "custom_providers:\n  llamacpp:\n    api_key: work-key\n",
+        encoding="utf-8",
+    )
+    same_mtime = 1_700_000_000
+    os.utime(default_home / "config.yaml", (same_mtime, same_mtime))
+    os.utime(work_home / "config.yaml", (same_mtime, same_mtime))
+
+    monkeypatch.setattr(
+        config,
+        "_get_config_path",
+        lambda: profiles.get_active_hermes_home() / "config.yaml",
+    )
+    monkeypatch.setattr(config, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
+
+    orig_default_home = profiles._DEFAULT_HERMES_HOME
+    orig_active = profiles._active_profile
+    orig_cache = dict(config._cfg_cache)
+    orig_mtime = config._cfg_mtime
+    orig_path = getattr(config, "_cfg_path", None)
+    orig_fingerprint = getattr(config, "_cfg_fingerprint", None)
+    orig_cfg = config.cfg
+    profiles._tls.profile = None
+    try:
+        profiles._DEFAULT_HERMES_HOME = default_home
+        profiles._active_profile = "default"
+        config.reload_config()
+        config.invalidate_models_cache()
+        monkeypatch.setattr(
+            config,
+            "cfg",
+            {"model": {"provider": "stale-override", "default": "old-model"}},
+            raising=False,
+        )
+
+        profiles.set_request_profile("work")
+        assert config._get_config_path() == work_home / "config.yaml"
+        result = config.get_available_models()
+        assert result["active_provider"] == "openrouter"
+        assert result["default_model"] == "google/gemini-3-flash-preview"
+        assert config.cfg is config._cfg_cache
+    finally:
+        profiles.clear_request_profile()
+        profiles._DEFAULT_HERMES_HOME = orig_default_home
+        profiles._active_profile = orig_active
+        config._cfg_cache.clear()
+        config._cfg_cache.update(orig_cache)
+        config._cfg_mtime = orig_mtime
+        if hasattr(config, "_cfg_path"):
+            config._cfg_path = orig_path
+        if hasattr(config, "_cfg_fingerprint"):
+            config._cfg_fingerprint = orig_fingerprint
+        config.cfg = orig_cfg
+        config.invalidate_models_cache()
+
+
 def test_chat_start_retags_empty_session_to_request_profile(monkeypatch, tmp_path):
     """An empty session created under profile A can be sent under profile B after a switch."""
     import api.routes as routes

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -453,6 +453,71 @@ def test_get_config_reloads_when_request_profile_changes(tmp_path, monkeypatch):
             config._cfg_fingerprint = orig_fingerprint
 
 
+def test_get_config_reloads_when_request_profile_changes_even_with_in_memory_override(
+    tmp_path, monkeypatch
+):
+    """A pinned override on one profile must not survive a request-profile switch."""
+    monkeypatch.delenv("HERMES_CONFIG_PATH", raising=False)
+    import api.config as config
+    import api.profiles as profiles
+
+    default_home = tmp_path / ".hermes"
+    work_home = default_home / "profiles" / "work"
+    work_home.mkdir(parents=True)
+    default_home.mkdir(exist_ok=True)
+    (default_home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: gpt-5.5\n",
+        encoding="utf-8",
+    )
+    (work_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: google/gemini-3-flash-preview\n"
+        "custom_providers:\n  llamacpp:\n    api_key: work-key\n",
+        encoding="utf-8",
+    )
+    same_mtime = 1_700_000_000
+    os.utime(default_home / "config.yaml", (same_mtime, same_mtime))
+    os.utime(work_home / "config.yaml", (same_mtime, same_mtime))
+
+    monkeypatch.setattr(
+        config,
+        "_get_config_path",
+        lambda: profiles.get_active_hermes_home() / "config.yaml",
+    )
+
+    orig_default_home = profiles._DEFAULT_HERMES_HOME
+    orig_active = profiles._active_profile
+    orig_cache = dict(config._cfg_cache)
+    orig_mtime = config._cfg_mtime
+    orig_path = getattr(config, "_cfg_path", None)
+    orig_fingerprint = getattr(config, "_cfg_fingerprint", None)
+    profiles._tls.profile = None
+    try:
+        profiles._DEFAULT_HERMES_HOME = default_home
+        profiles._active_profile = "default"
+        config.reload_config()
+        config._cfg_cache["__test_override"] = "pinned-default"
+        assert config._cfg_has_in_memory_overrides() is True
+        assert config.get_config()["model"]["provider"] == "openai-codex"
+
+        profiles.set_request_profile("work")
+        assert config._get_config_path() == work_home / "config.yaml"
+        result = config.get_config()
+        assert result["model"]["provider"] == "openrouter"
+        assert result["model"]["default"] == "google/gemini-3-flash-preview"
+        assert result["custom_providers"]["llamacpp"]["api_key"] == "work-key"
+    finally:
+        profiles.clear_request_profile()
+        profiles._DEFAULT_HERMES_HOME = orig_default_home
+        profiles._active_profile = orig_active
+        config._cfg_cache.clear()
+        config._cfg_cache.update(orig_cache)
+        config._cfg_mtime = orig_mtime
+        if hasattr(config, "_cfg_path"):
+            config._cfg_path = orig_path
+        if hasattr(config, "_cfg_fingerprint"):
+            config._cfg_fingerprint = orig_fingerprint
+
+
 def test_chat_start_retags_empty_session_to_request_profile(monkeypatch, tmp_path):
     """An empty session created under profile A can be sent under profile B after a switch."""
     import api.routes as routes

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -518,6 +518,79 @@ def test_get_config_reloads_when_request_profile_changes_even_with_in_memory_ove
             config._cfg_fingerprint = orig_fingerprint
 
 
+def test_get_config_reloads_when_request_profile_changes_even_with_rebound_cfg_override(
+    tmp_path, monkeypatch
+):
+    """A rebound cfg override must not survive a request-profile switch."""
+    monkeypatch.delenv("HERMES_CONFIG_PATH", raising=False)
+    import api.config as config
+    import api.profiles as profiles
+
+    default_home = tmp_path / ".hermes"
+    work_home = default_home / "profiles" / "work"
+    work_home.mkdir(parents=True)
+    default_home.mkdir(exist_ok=True)
+    (default_home / "config.yaml").write_text(
+        "model:\n  provider: openai-codex\n  default: gpt-5.5\n",
+        encoding="utf-8",
+    )
+    (work_home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  default: google/gemini-3-flash-preview\n"
+        "custom_providers:\n  llamacpp:\n    api_key: work-key\n",
+        encoding="utf-8",
+    )
+    same_mtime = 1_700_000_000
+    os.utime(default_home / "config.yaml", (same_mtime, same_mtime))
+    os.utime(work_home / "config.yaml", (same_mtime, same_mtime))
+
+    monkeypatch.setattr(
+        config,
+        "_get_config_path",
+        lambda: profiles.get_active_hermes_home() / "config.yaml",
+    )
+
+    orig_default_home = profiles._DEFAULT_HERMES_HOME
+    orig_active = profiles._active_profile
+    orig_cache = dict(config._cfg_cache)
+    orig_mtime = config._cfg_mtime
+    orig_path = getattr(config, "_cfg_path", None)
+    orig_fingerprint = getattr(config, "_cfg_fingerprint", None)
+    orig_cfg = config.cfg
+    profiles._tls.profile = None
+    try:
+        profiles._DEFAULT_HERMES_HOME = default_home
+        profiles._active_profile = "default"
+        config.reload_config()
+        monkeypatch.setattr(
+            config,
+            "cfg",
+            {"model": {"provider": "stale-override", "default": "old-model"}},
+            raising=False,
+        )
+        assert config._cfg_has_in_memory_overrides() is True
+        assert config.get_config()["model"]["provider"] == "stale-override"
+
+        profiles.set_request_profile("work")
+        assert config._get_config_path() == work_home / "config.yaml"
+        result = config.get_config()
+        assert result["model"]["provider"] == "openrouter"
+        assert result["model"]["default"] == "google/gemini-3-flash-preview"
+        assert result["custom_providers"]["llamacpp"]["api_key"] == "work-key"
+        assert config.cfg is config._cfg_cache
+    finally:
+        profiles.clear_request_profile()
+        profiles._DEFAULT_HERMES_HOME = orig_default_home
+        profiles._active_profile = orig_active
+        config._cfg_cache.clear()
+        config._cfg_cache.update(orig_cache)
+        config._cfg_mtime = orig_mtime
+        if hasattr(config, "_cfg_path"):
+            config._cfg_path = orig_path
+        if hasattr(config, "_cfg_fingerprint"):
+            config._cfg_fingerprint = orig_fingerprint
+        config.cfg = orig_cfg
+
+
 def test_chat_start_retags_empty_session_to_request_profile(monkeypatch, tmp_path):
     """An empty session created under profile A can be sent under profile B after a switch."""
     import api.routes as routes

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -39,6 +39,7 @@ class _FakeResponse:
 def _with_config(model=None, providers=None):
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
+    old_path = getattr(config, "_cfg_path", None)
     config.cfg.clear()
     config.cfg["model"] = model or {}
     if providers is not None:
@@ -47,6 +48,8 @@ def _with_config(model=None, providers=None):
         config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
     except Exception:
         config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
+    _restore_config._old_path = old_path
     return old_cfg, old_mtime
 
 
@@ -54,6 +57,7 @@ def _restore_config(old_cfg, old_mtime):
     config.cfg.clear()
     config.cfg.update(old_cfg)
     config._cfg_mtime = old_mtime
+    config._cfg_path = getattr(_restore_config, "_old_path", None)
 
 
 def test_openrouter_quota_fetches_key_endpoint_and_sanitizes_response(monkeypatch, tmp_path):

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -49,15 +49,18 @@ def _with_config(model=None, providers=None):
     except Exception:
         config._cfg_mtime = 0.0
     config._cfg_path = config._get_config_path()
-    _restore_config._old_path = old_path
-    return old_cfg, old_mtime
+    return old_cfg, (old_mtime, old_path)
 
 
 def _restore_config(old_cfg, old_mtime):
+    if isinstance(old_mtime, tuple):
+        old_mtime, old_path = old_mtime
+    else:
+        old_path = getattr(config, "_cfg_path", None)
     config.cfg.clear()
     config.cfg.update(old_cfg)
     config._cfg_mtime = old_mtime
-    config._cfg_path = getattr(_restore_config, "_old_path", None)
+    config._cfg_path = old_path
 
 
 def test_openrouter_quota_fetches_key_endpoint_and_sanitizes_response(monkeypatch, tmp_path):

--- a/tests/test_stage302_config_override_regression.py
+++ b/tests/test_stage302_config_override_regression.py
@@ -26,6 +26,8 @@ These tests pin both prongs.
 """
 from __future__ import annotations
 
+import os
+
 import api.config as config
 
 
@@ -74,22 +76,30 @@ def test_cfg_has_in_memory_overrides_detects_in_place_mutation(monkeypatch):
         config._cfg_cache.pop("__test_key", None)
 
 
-def test_get_config_does_not_reload_when_only_in_memory_override(monkeypatch, tmp_path):
-    """A test that sets cfg + leaves disk untouched must not trigger reload."""
+def test_get_config_does_not_reload_when_only_in_memory_override_same_path_mtime_only(
+    monkeypatch, tmp_path
+):
+    """same_path cfg overrides must survive mtime-only staleness."""
+    config_path = tmp_path / "config.yaml"
+    base_mtime = 1_700_000_000.0
+    config_path.write_text(
+        "model:\n  provider: openrouter\n  default: test/model-x\n",
+        encoding="utf-8",
+    )
+    os.utime(config_path, (base_mtime, base_mtime))
+    monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
     config.reload_config()
-    # Fake a config path that will have a different mtime than what's cached
-    fake_path = tmp_path / "missing.yaml"
-    monkeypatch.setattr(config, "_get_config_path", lambda: fake_path)
 
-    # Override cfg via attr rebind.
     test_override = {
         "model": {"provider": "openai", "default": "gpt-test"},
         "providers": {},
     }
     monkeypatch.setattr(config, "cfg", test_override, raising=False)
 
-    # The path-aware reload would normally trigger reload (path changed),
-    # but the override-detection should suppress it.
+    os.utime(config_path, (base_mtime + 1.0, base_mtime + 1.0))
+
+    # The same_path mtime-only reload would normally trigger reload, but the
+    # override-detection should suppress it.
     result = config.get_config()
     assert result is test_override
     assert result["model"]["provider"] == "openai"


### PR DESCRIPTION
## Thinking Path

- `/api/providers` already enters the active request-profile scope, so the wrong catalog had to come from the shared config cache below the route layer.
- `get_config()` and `reload_config_if_stale()` were treating mtime drift and profile-path changes as one stale bucket, and `get_available_models()` still repeated that same combined guard while reading the legacy `cfg` alias directly.
- The fix now forces reloads on profile-path changes at every touched config consumer, while keeping the same-path override contract for tests and runtime callers.

## What Changed

- `api/config.py`: split config-cache staleness into `path_changed` and `mtime_stale` in `get_config()`, `reload_config_if_stale()`, and `get_available_models()`, then retarget the legacy `cfg` alias to the current cache on real reloads.
- `tests/test_profile_switch_1200.py`: add regressions for inherited overrides, rebound `cfg` overrides, and the `/api/models` payload after a request-profile switch.
- `tests/test_stage302_config_override_regression.py`: tighten the preserved contract to the explicit `same_path` boundary so the override-proof matches the intended behavior.

## Why It Matters

Named profiles stop inheriting the default profile's provider catalog, model picker payload, default model, and cloud-key state after any in-memory config mutation. Same-profile overrides still avoid unwanted reloads.

## Verification

`pytest tests/test_profile_switch_1200.py -v --timeout=60`

`pytest tests/test_stage302_config_override_regression.py -v --timeout=60`

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`.

## Upstream

Closes #5619.

Reporter evidence and maintainer root-cause analysis in https://github.com/nesquena/hermes-webui/issues/5619#issuecomment-4886270745, https://github.com/nesquena/hermes-webui/issues/5619#issuecomment-4886434302, and https://github.com/nesquena/hermes-webui/issues/5619#issuecomment-4886843401 pinned this to the shared config-cache reload gate rather than the request-profile route wrapper.

## Model Used

GPT 5.5 via Codex CLI
