### PR TITLE
Guard empty live-settlement error hints

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8675,9 +8675,13 @@ def _run_agent_streaming(
                             _snapshot_and_append_partial_on_error(s, stream_id)
                         except Exception:
                             logger.debug("Failed to snapshot partials on error for %s", stream_id, exc_info=True)
+                        _error_content = (
+                            f'**{_err_label}:** {_error_payload.get("message") or _err_label}'
+                            + (f'\n\n*{_err_hint}*' if _err_hint else '')
+                        )
                         _error_message = {
                             'role': 'assistant',
-                            'content': f'**{_err_label}:** {_error_payload.get("message") or _err_label}\n\n*{_err_hint}*',
+                            'content': _error_content,
                             'timestamp': int(time.time()),
                             '_error': True,
                         }

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -455,6 +455,44 @@ def test_non_auth_silent_failure_still_uses_no_response(tmp_path, monkeypatch):
     assert saved.messages[-1]["_error"] is True
 
 
+def test_live_settlement_empty_hint_does_not_append_empty_emphasis(tmp_path, monkeypatch):
+    session = _prepare_session(
+        "empty_hint_failure",
+        "stream_empty_hint_failure",
+        pending_user_message="Please fail plainly",
+    )
+
+    class EmptyHintFailureAgent(MockAgent):
+        def run_conversation(self, **kwargs):
+            return {
+                "status": "failed",
+                "messages": list(kwargs.get("conversation_history") or []),
+                "error": "synthetic hard failure",
+            }
+
+    fake_queue = _run_stream(
+        monkeypatch,
+        session,
+        "stream_empty_hint_failure",
+        EmptyHintFailureAgent,
+        workspace=str(tmp_path),
+    )
+    saved = Session.load("empty_hint_failure")
+    assert saved is not None
+
+    events = _queue_events(fake_queue)
+    apperrors = [data for event, data in events if event == "apperror"]
+    assert apperrors, "expected apperror for generic terminal failure"
+    assert apperrors[-1]["type"] == "error"
+    assert apperrors[-1].get("hint") in (None, "")
+
+    error_content = saved.messages[-1]["content"]
+    assert saved.messages[-1]["_error"] is True
+    assert error_content == "**Error:** synthetic hard failure"
+    assert "\n\n**" not in error_content
+    assert not error_content.endswith("**")
+
+
 def test_completed_assistant_answer_with_stale_partial_flag_settles_done(tmp_path, monkeypatch):
     session = _prepare_session(
         "completed_answer_stale_partial",


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI long-running turns need honest terminal outcomes under the #3400 Live-to-Final contract.
- The exception error path already omits the markdown hint block when no hint exists.
- The live settlement path still emitted `\n\n*{hint}*` unconditionally, so an empty hint could persist as dangling markdown such as a trailing `**`.
- This PR keeps terminal classification unchanged and only makes live settlement error rendering match the already-guarded exception path.

## What Changed

- Build the live settlement `_error` message content with a conditional hint suffix.
- Added a regression that drives `_run_agent_streaming()` through a generic live terminal failure with an empty hint and asserts the saved assistant error contains no empty emphasis / dangling `**`.

## Why It Matters

Empty-hint failures should still render as clear terminal errors. They should not leave malformed markdown under the assistant turn or make a no-final failure look broken in the transcript.

## Verification

- `./scripts/test.sh tests/test_issue5121_provider_auth_terminal_error.py -q` → 17 passed
- `python3 scripts/ruff_lint.py --diff origin/master` → no new violations on added/modified lines
- `git diff --check` → clean

## Contract Routing

Task type: Live Stream terminal failure rendering
Touched areas: `api/streaming.py`, provider-auth/terminal-error regression coverage
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/live-to-final-assistant-replies.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/architecture/stable-assistant-turn-anchor-phase0.md`
Scope boundaries: no terminal classification changes, no wakeup error coalescing, no reasoning restore, no docs contract changes
Evidence needed before claiming done: live settlement empty-hint regression passes through the repo test runner

## Risks / Follow-ups

Risk is low: this only removes the hint suffix when the existing classified hint is falsy. Non-empty hints preserve the existing formatting.

Follow-ups intentionally left out of scope: background wakeup duplicate error-bubble coalescing and display-only hidden-reasoning restoration.

## Model Used

OpenAI GPT-5 Codex via the PaperClip/Codex local agent, with shell/git/GitHub CLI tool use.

Refs #3929, #3400.
