### PR TITLE
Live Stream: Show compression recovery from session state

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -13814,7 +13814,10 @@ function renderMessages(options){
       const summary=m.provider_details_label||'Provider details';
       bodyHtml += `<details class="provider-error-details"><summary>${esc(String(summary))}</summary><pre><code>${esc(String(m.provider_details))}</code></pre></details>`;
     }
-    const recoveryHtml=(!isUser&&m._compressionRecovery) ? _compressionRecoveryHtml(m._compressionRecovery, (S.session&&S.session.session_id)||'') : '';
+    const recoveryPayload=(!isUser&&m._compressionRecovery)
+      ? m._compressionRecovery
+      : (!isUser&&isLastAssistant&&isTurnFinalAssistant&&typeof _activeCompressionRecoveryPayload==='function' ? _activeCompressionRecoveryPayload() : null);
+    const recoveryHtml=recoveryPayload ? _compressionRecoveryHtml(recoveryPayload, (S.session&&S.session.session_id)||'') : '';
     if(recoveryHtml) bodyHtml += recoveryHtml;
     const statusHtml = (!isUser&&m._statusCard) ? _statusCardHtml(m._statusCard) : '';
     const isEditableUser=isUser&&rawIdx===lastUserRawIdx;

--- a/tests/test_compression_recovery_action.py
+++ b/tests/test_compression_recovery_action.py
@@ -431,6 +431,19 @@ def test_compression_recovery_ui_wires_card_action_and_send_intercept():
     assert "_compressionRecovery:recovery||undefined" in messages
 
 
+def test_compression_recovery_ui_renders_session_level_recovery_on_terminal_message():
+    ui = (ROOT / "static/ui.js").read_text(encoding="utf-8")
+    start = ui.index("const recoveryPayload=(!isUser&&m._compressionRecovery)")
+    end = ui.index("const statusHtml", start)
+    body = ui[start:end]
+
+    assert "? m._compressionRecovery" in body
+    assert "_activeCompressionRecoveryPayload()" in body
+    assert "isLastAssistant&&isTurnFinalAssistant" in body
+    assert "typeof _activeCompressionRecoveryPayload==='function'" in body
+    assert body.index("m._compressionRecovery") < body.index("_activeCompressionRecoveryPayload()")
+
+
 def test_compression_recovery_ui_skips_message_fallback_after_session_clear():
     ui = (ROOT / "static/ui.js").read_text(encoding="utf-8")
     start = ui.index("function _activeCompressionRecoveryPayload(){")


### PR DESCRIPTION
## Thinking Path

#5538 shipped the first #4685 recovery path: compression-exhausted sessions recommend a focused continuation child session, and generic `continue` prompts are intercepted. That depends on users seeing the recovery card. The normal SSE path stores `_compressionRecovery` on the terminal assistant message, but rebuilt or legacy sessions can still expose the active recovery payload at `session.compression_recovery` without a message marker. In that state the send box can block generic continuation while the visible card/action is missing.

Touched contract family: Live-to-final / compression recovery state. Evidence used: #4685 shipped recovery payload semantics, `compression_recovery` session payload, and the render path in `static/ui.js`.

## What Changed

- Keep message-level `_compressionRecovery` as the preferred source for the recovery card.
- When the active session still has `compression_exhausted` recovery state but the message marker is absent, render the existing recovery card on the last assistant terminal message.
- Gate that fallback to `isLastAssistant && isTurnFinalAssistant` so active session-level recovery does not add cards to historical assistant turns.
- Guard the helper lookup for partial `renderMessages()` harnesses that do not load the full UI module.
- Add a focused regression test for the session-level fallback.

## Why It Matters

Without this fallback, a recovered/rebuilt compression-exhausted session can enter an inconsistent UX: the app knows recovery is required and intercepts generic `continue`, but the user does not get the visible "Start focused continuation" action. This keeps #4685's shipped first slice usable when session-level state survives but message-level display metadata is missing.

Release-note-ready wording: show the focused continuation recovery card when a compression-exhausted session only has session-level recovery metadata.

UI evidence: this does not introduce a new visual state; it reuses the existing compression recovery card and changes only when that existing card appears. The new regression guards the missing-card state.

## Verification

- `node --check static/ui.js`
- `./scripts/test.sh tests/test_compression_recovery_action.py -q` -> `16 passed`
- `./scripts/test.sh tests/test_compression_recovery_action.py tests/test_auto_compression_terminal_failure.py -q` -> `30 passed`
- `./scripts/test.sh tests/test_anchor_fallback_ownership.py::test_render_messages_keeps_anchor_owned_turn_out_of_legacy_activity_rebuilds -q` -> `1 passed`

## Risks / Follow-ups

- This PR intentionally does not add new recovery choices or change continuation-session creation. #4685 remains open for richer recovery UX and policy work.
- The fallback is intentionally limited to the last assistant terminal message to avoid duplicate recovery cards on historical turns.

## Model Used

AI-assisted. Provider: OpenAI. Model: GPT-5 Codex. Notable tool use: local shell, focused repo tests, GitHub CLI.