### PR TITLE
fix(tests): sync on subscriber count in multitab SSE test (#5628)

### DIFF
--- a/tests/test_issue_1584_multitab_sse.py
+++ b/tests/test_issue_1584_multitab_sse.py
@@ -1,5 +1,6 @@
 import io
 import threading
+import time
 from types import SimpleNamespace
 
 from api.config import STREAMS, STREAMS_LOCK, create_stream_channel
@@ -63,6 +64,28 @@ def test_same_stream_in_two_tabs_receives_identical_token_sequence():
     try:
         for thread in threads:
             thread.start()
+
+        # Wait until BOTH tabs have actually subscribed before producing any
+        # events. StreamChannel.put_nowait() buffers events in _offline_buffer
+        # only while there are ZERO subscribers, and clears that buffer the
+        # moment the first subscriber attaches and it broadcasts live. If we
+        # put tokens in the window after tab A subscribes but before tab B
+        # does, tab B subscribes to an already-cleared buffer, never receives
+        # stream_end, and hangs -> thread.join times out (the ~20% timing flake
+        # on slow CI runners, issue #5628). Synchronize on the real subscriber
+        # count so the test is deterministic regardless of thread-start timing.
+        deadline = time.monotonic() + 5.0
+        subscribed = 0
+        while time.monotonic() < deadline:
+            with stream._lock:
+                subscribed = len(stream._subscribers)
+            if subscribed >= len(handlers):
+                break
+            time.sleep(0.005)
+        else:
+            raise AssertionError(
+                f"only {subscribed}/{len(handlers)} tabs subscribed before timeout"
+            )
 
         stream.put_nowait(("token", {"text": "H"}))
         stream.put_nowait(("token", {"text": "allo"}))


### PR DESCRIPTION
## Summary
Fixes the ~20% timing flake in `test_issue_1584_multitab_sse.py::test_same_stream_in_two_tabs_receives_identical_token_sequence` (issue #5628) that intermittently red-fails **3.11 shard-4** on CI and has been blocking the PR gate queue (seen on #5624/#5560/#5653).

## Root cause
The test starts both SSE-handler threads then **immediately** `put_nowait`s the tokens + `stream_end` without waiting for both threads to actually **subscribe**. `StreamChannel.put_nowait()` buffers events in `_offline_buffer` only while there are **zero** subscribers, and **clears that buffer the moment the first subscriber attaches** and broadcasts live. So if the producer puts events in the window *after* tab A subscribes but *before* tab B does, tab B subscribes to an already-cleared buffer, never receives `stream_end`, hangs, and `thread.join(timeout=1)` → `assert not thread.is_alive()` fails ("every tab should finish the same SSE stream"). On slow/contended CI runners (3.11 shard-4) tab B's subscribe reliably lags past the puts.

## Fix (test-only)
Before producing events, poll (bounded 5s, 5ms sleep) until `len(stream._subscribers) == len(handlers)` under `stream._lock`, else raise a clear assertion. Delivery is now deterministic regardless of thread-start timing.

**No production change.** The orphan-on-buffer-clear is a test-synchronization artifact, not a production risk: real tab reconnect mid-stream uses `{reconnecting:true}` + run-journal replay (sessions.js:1716/1840, messages.js:4536/6296, routes.py:16058 server-side active replay), a different mechanism that correctly replays the tail.

## Verification
- Original test: **flakes 2/30** under CPU contention (reproduces the CI failure).
- Fixed test: **30/30** under the same contention; 10/10 unloaded.
- Full suite: **12178 passed, 0 failed**.

Fixes #5628