### PR TITLE
ci(#5658): install Playwright in pytest CI so browser tests run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Office parsers stay optional at runtime; CI installs them explicitly for the workspace preview tests.
-          pip install "pyyaml>=6.0" pytest pytest-timeout pytest-asyncio pytest-shard python-docx openpyxl python-pptx
+          pip install "pyyaml>=6.0" pytest pytest-timeout pytest-asyncio pytest-shard python-docx openpyxl python-pptx playwright
           # ruff is installed so tests/test_ruff_forward_lint.py runs its E9/F821
           # tree-clean assertions in-suite (mirrors how eslint is available for
           # tests/test_static_js_runtime_lint.py). If install fails the test
@@ -116,6 +116,19 @@ jobs:
           # wheel not yet available, etc.), tests/test_mcp_server.py uses
           # importorskip and the matrix stays green.
           pip install mcp || echo "mcp install failed — test_mcp_server.py will importorskip"
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pip show playwright | grep '^Version:' | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        run: python -m playwright install --with-deps chromium
 
       - name: Run tests (shard ${{ matrix.shard }} of 5)
         run: pytest tests/ -v --timeout=60 --shard-id=${{ matrix.shard }} --num-shards=5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
         run: python -m playwright install --with-deps chromium


### PR DESCRIPTION

## Thinking Path

- The #5250 hit-test guards its real-Chromium assertion with a skip when `playwright.sync_api` fails to import, and the pytest CI job never installs `playwright`, so that guard has been silently swallowing the only real-browser test in the suite on every CI run.
- `browser-smoke.yml` already proves the install pattern works in this exact runner image (unpinned `playwright` + `python -m playwright install --with-deps chromium`), so the fix mirrors that into the pytest job rather than building something new.
- The pytest matrix is 3 Python versions x 5 shards. Browser binaries don't depend on the Python version, so the cache key uses only the runner OS and the resolved Playwright version, keeping the whole matrix on one shared cache entry.

## What Changed

- `.github/workflows/tests.yml`: added `playwright` to the test job's pip install line, then inserted three steps before `Run tests`: read the installed Playwright version, restore/cache `~/.cache/ms-playwright` keyed on OS + that version, then run `python -m playwright install --with-deps chromium` (same command `browser-smoke.yml` uses).

## Why It Matters

Browser-backed regression tests now actually execute in CI instead of silently skipping. Every future test following the existing #5250 idiom (real Chromium, skip-guard for local convenience) will have CI teeth from day one.

## Verification

```
pytest tests/test_issue5250_settings_search_dropdown_escape.py -v --timeout=60
```

Full-suite CI context, not a required local check unless requested: `pytest tests/ -v --timeout=60`. The definitive check is this PR's own CI run: the #5250 test should report PASSED on its shard instead of SKIPPED.

## Upstream

Closes #5658.

## Model Used

Claude Opus 4.6 via Claude Code CLI

