### PR TITLE
fix(webui): refuse stale-anchor scroll restore during streaming (#5637)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -983,13 +983,44 @@ function _browserOverflowAnchorActive(el){
   if(!el) return false;
   try{ return getComputedStyle(el).overflowAnchor==='auto'; }catch(_){ return false; }
 }
-// Stable touch-viewport predicate for the issue #5637 stale-anchor hold gate.
-// The two stale-anchor refusals below assume the browser's native overflow-anchor
-// layer will hold the viewport once the JS restore is refused. That layer is only
-// active where `.messages` computes to `overflow-anchor:auto` — touch viewports.
-// On hover+fine-pointer desktops the CSS keeps it `none`, so refusing the restore
-// leaves NOTHING to hold the reader (the desktop regression). We must NOT decide
-// "is this a touch viewport" with `_browserOverflowAnchorActive(#messages)` alone,
+// iOS/iPadOS WebKit detection for the issue #5637 stale-anchor hold gate. CSS
+// overflow-anchor is INERT on iOS WebKit (see static/style.css — the mobile
+// content-visibility block deliberately does NOT set overflow-anchor:none because
+// it is a no-op on iOS and, on Android, re-opens the #4856/#5338 jump-to-top
+// regression). So `overflow-anchor:auto` computes on `.messages` on iOS but the
+// engine never actually holds the viewport there. The stale-anchor refusal relies
+// on that engine to hold the reader, so it is only safe on Android (working
+// overflow-anchor), NOT iOS — refusing on iOS leaves a scrolled-up reader unheld,
+// the same class as the desktop regression, one platform over.
+// Detection covers classic iPhone/iPod/iPad UAs AND iPadOS 13+, which reports a
+// desktop 'MacIntel' platform but is distinguishable by touch support (a real Mac
+// has maxTouchPoints 0). Excludes MSStream (old IE on Windows Phone false-matched
+// 'like iPhone').
+function _isIOSWebKit(){
+  try{
+    const nav=(typeof navigator!=='undefined')?navigator:null;
+    if(!nav) return false;
+    if(nav.MSStream) return false;
+    const ua=String(nav.userAgent||'');
+    if(/iP(ad|hone|od)/.test(ua)) return true;
+    // iPadOS 13+ masquerades as macOS; a Mac has no touch, an iPad does.
+    if(nav.platform==='MacIntel' && Number(nav.maxTouchPoints)>1) return true;
+  }catch(_){}
+  return false;
+}
+// Stable "native overflow-anchor holds this viewport" predicate for the issue
+// #5637 stale-anchor hold gate. The two stale-anchor refusals below assume the
+// browser's native overflow-anchor layer will hold the viewport once the JS
+// restore is refused. That is only true where the engine ACTUALLY compensates:
+//   - desktop (hover+fine-pointer): CSS keeps `.messages` at overflow-anchor:none
+//     -> engine off -> refusing leaves nothing to hold the reader. Excluded via
+//     matchMedia('(pointer:coarse)') being false.
+//   - iOS WebKit: overflow-anchor is INERT (see _isIOSWebKit) even though it
+//     computes to `auto` -> engine never holds -> refusing strands a scrolled-up
+//     reader. Excluded via _isIOSWebKit().
+//   - Android touch: overflow-anchor:auto AND the engine works -> refusing is safe,
+//     native anchoring holds. This is the ONLY platform the refusal targets.
+// We must NOT decide this with `_browserOverflowAnchorActive(#messages)` alone,
 // because `_restoreMessageViewportAnchor` temporarily writes an inline
 // `overflowAnchor:'none'` on #messages for its own scroll write and only restores
 // it on the next frame; when the realign fires every live tick that inline 'none'
@@ -1000,6 +1031,9 @@ function _browserOverflowAnchorActive(el){
 // desktop (fine pointer) stays false. Fall back to the computed-anchor probe when
 // matchMedia is unavailable.
 function _isTouchLikeMessageViewport(el){
+  // iOS WebKit is touch (pointer:coarse) but overflow-anchor is inert there, so the
+  // refusal's premise fails — treat it like desktop (keep the semantic realign).
+  if(_isIOSWebKit()) return false;
   try{
     if(typeof matchMedia==='function' && matchMedia('(pointer:coarse)').matches) return true;
   }catch(_){}

--- a/static/ui.js
+++ b/static/ui.js
@@ -983,6 +983,28 @@ function _browserOverflowAnchorActive(el){
   if(!el) return false;
   try{ return getComputedStyle(el).overflowAnchor==='auto'; }catch(_){ return false; }
 }
+// Stable touch-viewport predicate for the issue #5637 stale-anchor hold gate.
+// The two stale-anchor refusals below assume the browser's native overflow-anchor
+// layer will hold the viewport once the JS restore is refused. That layer is only
+// active where `.messages` computes to `overflow-anchor:auto` — touch viewports.
+// On hover+fine-pointer desktops the CSS keeps it `none`, so refusing the restore
+// leaves NOTHING to hold the reader (the desktop regression). We must NOT decide
+// "is this a touch viewport" with `_browserOverflowAnchorActive(#messages)` alone,
+// because `_restoreMessageViewportAnchor` temporarily writes an inline
+// `overflowAnchor:'none'` on #messages for its own scroll write and only restores
+// it on the next frame; when the realign fires every live tick that inline 'none'
+// persists across ticks, so a computed-value probe would read 'none' mid-realign
+// and wrongly classify a touch device as "desktop", letting the stale realign
+// through. A matchMedia('(pointer:coarse)') test reflects the input device and
+// cannot be mutated by that inline override, so it stays steady mid-realign;
+// desktop (fine pointer) stays false. Fall back to the computed-anchor probe when
+// matchMedia is unavailable.
+function _isTouchLikeMessageViewport(el){
+  try{
+    if(typeof matchMedia==='function' && matchMedia('(pointer:coarse)').matches) return true;
+  }catch(_){}
+  return _browserOverflowAnchorActive(el);
+}
 function _suppressBrowserOverflowAnchor(container){
   if(!container||!container.style) return null;
   // Only engage when the browser layer is actually active (auto). On desktop
@@ -1046,13 +1068,22 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   // scrollTop non-trivially, refuse it and let the browser overflow-anchor hold. An
   // actively scrolling reader (recent intent) keeps the legitimate realign; legacy
   // snapshots without the captured geometry keep prior behavior.
+  //
+  // Desktop guard (issue #5637 gate cert): the refusal is only safe where the
+  // browser's native overflow-anchor layer can actually hold the viewport, i.e.
+  // touch viewports where `.messages` computes to `overflow-anchor:auto`. On
+  // hover+fine-pointer desktops `.messages` is `overflow-anchor:none`, so refusing
+  // the realign would leave NOTHING to hold the reader after above-viewport growth
+  // — the very yank this fixes on mobile, reintroduced on desktop. Gate the refusal
+  // on `_isTouchLikeMessageViewport` so desktop keeps its semantic scrollTop realign.
   const _realignDelta=(rect.top-containerRect.top)-targetTop;
   const _shAtCap=Number(anchor.scrollHeightAtCapture);
   if(Number.isFinite(_shAtCap)){
     const _grewSinceCapture=(container.scrollHeight-_shAtCap)>4;
     const _activeIntent=(typeof _recentMessageScrollIntent==='function' && _recentMessageScrollIntent())
       || (typeof _recentMessageTouchScrollIntent==='function' && _recentMessageTouchScrollIntent());
-    if(_grewSinceCapture&&!_activeIntent&&Math.abs(_realignDelta)>8){
+    const _touchHold=(typeof _isTouchLikeMessageViewport==='function' && _isTouchLikeMessageViewport(container));
+    if(_touchHold&&_grewSinceCapture&&!_activeIntent&&Math.abs(_realignDelta)>8){
       return false;
     }
   }
@@ -13296,11 +13327,19 @@ function _restoreMessageScrollSnapshotSameFrame(snapshot){
     // scrollTop non-trivially, refuse it and let the browser overflow-anchor hold.
     // Pinned tail-followers (target is bottom-relative, not snapshot.top) are
     // unaffected; an actively scrolling reader has intent and keeps the restore.
+    //
+    // Desktop guard (issue #5637 gate cert): like the realign guard, this refusal
+    // only holds where the browser's native overflow-anchor layer is active (touch
+    // viewports, `.messages` computes to `overflow-anchor:auto`). Desktop `.messages`
+    // is `overflow-anchor:none`, so refusing the absolute fallback write there would
+    // leave the reader unheld AND latch `_messageUserUnpinned=true`. Gate on
+    // `_isTouchLikeMessageViewport` so desktop keeps its absolute snapshot.top restore.
     const _snapSH=Number(snapshot.scrollHeight);
     const _grewSinceSnap=Number.isFinite(_snapSH)&&_snapSH>0&&(el.scrollHeight-_snapSH)>4;
     const _fbActiveIntent=(typeof _recentMessageScrollIntent==='function' && _recentMessageScrollIntent())
       || (typeof _recentMessageTouchScrollIntent==='function' && _recentMessageTouchScrollIntent());
-    if(snapshot.pinned!==true && _grewSinceSnap && !_fbActiveIntent
+    const _fbTouchHold=(typeof _isTouchLikeMessageViewport==='function' && _isTouchLikeMessageViewport(el));
+    if(_fbTouchHold && snapshot.pinned!==true && _grewSinceSnap && !_fbActiveIntent
        && Math.abs((Math.max(0,Math.min(target,maxTop)))-el.scrollTop)>8){
       _lastScrollTop=el.scrollTop;_lastMessageClientHeight=el.clientHeight;
       _messageUserUnpinned=true;

--- a/static/ui.js
+++ b/static/ui.js
@@ -953,6 +953,12 @@ function _captureMessageViewportAnchor(){
         key:row&&row.dataset?String(row.dataset.messageAnchorKey||''):'',
         topOffset:rect.top-containerRect.top,
         topPadBefore,
+        // Snapshot the scroll geometry at capture so a later realign can detect that
+        // content grew ABOVE the viewport between capture and restore — the streaming
+        // case where the anchor's topOffset is stale and realigning to it would yank a
+        // still reader backward (issue #5637).
+        scrollHeightAtCapture:container.scrollHeight,
+        scrollTopAtCapture:container.scrollTop,
       };
     }
   }
@@ -1029,6 +1035,28 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   const containerRect=container.getBoundingClientRect();
   const rect=row.getBoundingClientRect();
   const targetTop=Number(anchor.topOffset)||0;
+  // Streaming stale-anchor guard (issue #5637). During a live stream, content grows
+  // ABOVE the viewport between anchor capture and this restore, so the anchor's
+  // captured topOffset is stale and the realign delta becomes a spurious few-hundred-px
+  // value that yanks a still reader backward. Detect it by content growth + absence of
+  // real input intent — NOT by a scrollTop diff, because on an overflow-anchor:auto
+  // container the browser itself moves scrollTop to compensate the growth (so a still
+  // reader's scrollTop is not stationary). _recentMessage*ScrollIntent reflects genuine
+  // touch/wheel/key input, which the browser's anchor layer never writes. If content
+  // grew since capture AND there is no recent input intent AND the realign would move
+  // scrollTop non-trivially, refuse it and let the browser overflow-anchor hold. An
+  // actively scrolling reader (recent intent) keeps the legitimate realign; legacy
+  // snapshots without the captured geometry keep prior behavior.
+  const _realignDelta=(rect.top-containerRect.top)-targetTop;
+  const _shAtCap=Number(anchor.scrollHeightAtCapture);
+  if(Number.isFinite(_shAtCap)){
+    const _grewAbove=(container.scrollHeight-_shAtCap)>4;
+    const _activeIntent=(typeof _recentMessageScrollIntent==='function' && _recentMessageScrollIntent())
+      || (typeof _recentMessageTouchScrollIntent==='function' && _recentMessageTouchScrollIntent());
+    if(_grewAbove&&!_activeIntent&&Math.abs(_realignDelta)>8){
+      return false;
+    }
+  }
   _programmaticScroll=true;_programmaticScrollSetAt=performance.now();
   // Mobile-only jump fix: the resting overflow-anchor on .messages is `auto` on
   // touch devices (CSS media query keeps it `none` only for hover+fine-pointer
@@ -13259,6 +13287,28 @@ function _restoreMessageScrollSnapshotSameFrame(snapshot){
     const target=(snapshot.pinned===true&&Number.isFinite(bottom))
       ? maxTop-Math.max(0,bottom)
       : Number(snapshot.top)||0;
+    // Streaming stale-snapshot guard (issue #5637). The userUnpinned check above is
+    // defeated when a live stream re-pins the state machine (a scrollHeight-collapse
+    // scroll event flips userUnpinned back to false even though the reader is up in
+    // history), so this absolute snapshot.top write still fires and yanks a still
+    // reader — snapshot.top was captured before the streaming chunk grew above-viewport
+    // height, so it is stale. Mirror the realign guard: if content grew since the
+    // snapshot AND there is no recent real input intent AND the write would move
+    // scrollTop non-trivially, refuse it and let the browser overflow-anchor hold.
+    // Pinned tail-followers (target is bottom-relative, not snapshot.top) are
+    // unaffected; an actively scrolling reader has intent and keeps the restore.
+    const _snapSH=Number(snapshot.scrollHeight);
+    const _grewSinceSnap=Number.isFinite(_snapSH)&&_snapSH>0&&(el.scrollHeight-_snapSH)>4;
+    const _fbActiveIntent=(typeof _recentMessageScrollIntent==='function' && _recentMessageScrollIntent())
+      || (typeof _recentMessageTouchScrollIntent==='function' && _recentMessageTouchScrollIntent());
+    if(snapshot.pinned!==true && _grewSinceSnap && !_fbActiveIntent
+       && Math.abs((Math.max(0,Math.min(target,maxTop)))-el.scrollTop)>8){
+      _lastScrollTop=el.scrollTop;_lastMessageClientHeight=el.clientHeight;
+      _messageUserUnpinned=true;
+      _scrollPinned=false;
+      _nearBottomCount=0;
+      return;
+    }
     _programmaticScroll=true;_programmaticScrollSetAt=performance.now();
     el.scrollTop=Math.max(0,Math.min(target,maxTop));
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1003,6 +1003,11 @@ function _isTouchLikeMessageViewport(el){
   try{
     if(typeof matchMedia==='function' && matchMedia('(pointer:coarse)').matches) return true;
   }catch(_){}
+  // Best-effort fallback for the (today essentially non-existent) no-matchMedia
+  // environment: the computed-anchor probe can transiently read 'none' during a
+  // realign burst (see comment above), so on such a touch device this could
+  // re-admit the original yank. matchMedia('(pointer:coarse)') is universally
+  // supported in every browser this UI targets, so the primary path is what runs.
   return _browserOverflowAnchorActive(el);
 }
 function _suppressBrowserOverflowAnchor(container){

--- a/static/ui.js
+++ b/static/ui.js
@@ -953,12 +953,11 @@ function _captureMessageViewportAnchor(){
         key:row&&row.dataset?String(row.dataset.messageAnchorKey||''):'',
         topOffset:rect.top-containerRect.top,
         topPadBefore,
-        // Snapshot the scroll geometry at capture so a later realign can detect that
-        // content grew ABOVE the viewport between capture and restore — the streaming
-        // case where the anchor's topOffset is stale and realigning to it would yank a
-        // still reader backward (issue #5637).
+        // Snapshot the scroll height at capture so a later realign can detect that
+        // content grew between capture and restore — the streaming case where the
+        // anchor's topOffset is stale and realigning to it would yank a still reader
+        // backward (issue #5637).
         scrollHeightAtCapture:container.scrollHeight,
-        scrollTopAtCapture:container.scrollTop,
       };
     }
   }
@@ -1050,10 +1049,10 @@ function _restoreMessageViewportAnchor(anchor, rawIdxDelta){
   const _realignDelta=(rect.top-containerRect.top)-targetTop;
   const _shAtCap=Number(anchor.scrollHeightAtCapture);
   if(Number.isFinite(_shAtCap)){
-    const _grewAbove=(container.scrollHeight-_shAtCap)>4;
+    const _grewSinceCapture=(container.scrollHeight-_shAtCap)>4;
     const _activeIntent=(typeof _recentMessageScrollIntent==='function' && _recentMessageScrollIntent())
       || (typeof _recentMessageTouchScrollIntent==='function' && _recentMessageTouchScrollIntent());
-    if(_grewAbove&&!_activeIntent&&Math.abs(_realignDelta)>8){
+    if(_grewSinceCapture&&!_activeIntent&&Math.abs(_realignDelta)>8){
       return false;
     }
   }

--- a/tests/test_issue5637_stale_anchor_guard.py
+++ b/tests/test_issue5637_stale_anchor_guard.py
@@ -84,9 +84,11 @@ function extractFunc(name) {
 # ---- realign guard (_restoreMessageViewportAnchor) -------------------------------
 
 def _realign_harness(*, anchor_extra: str, cur_scroll_height: int, rect_top: int,
-                     top_offset: int, active_intent: bool = False) -> str:
+                     top_offset: int, active_intent: bool = False,
+                     touch_like: bool = True) -> str:
     js = UI_JS_PATH.read_text(encoding="utf-8")
     intent_js = "true" if active_intent else "false"
+    touch_js = "true" if touch_like else "false"
     return _extract_func_script(js) + f"""
 let writes = [];
 let stTop = 90030;
@@ -101,6 +103,7 @@ const container = {{
 function $(id){{ return id === 'messages' ? container : null; }}
 function _recentMessageScrollIntent(){{ return {intent_js}; }}
 function _recentMessageTouchScrollIntent(){{ return {intent_js}; }}
+function _isTouchLikeMessageViewport(){{ return {touch_js}; }}
 let _programmaticScroll = false; let _programmaticScrollSetAt = 0;
 const performance = {{ now(){{ return 1; }} }};
 function _suppressBrowserOverflowAnchor(){{ return null; }}
@@ -151,12 +154,29 @@ def test_realign_backward_compatible_without_capture_geometry():
     assert m["returned"] is True and m["wrote"] == 1
 
 
+def test_realign_allows_on_desktop_no_native_anchor():
+    """Desktop regression (#5637 gate cert): the exact stale-anchor case
+    (content grew, no intent, delta -453) but on a hover+fine-pointer viewport where
+    `.messages` is `overflow-anchor:none`. There is no native anchoring layer to hold
+    the reader, so the guard MUST NOT refuse — the semantic scrollTop realign has to
+    run or the desktop reader is left unheld after above-viewport growth.
+    Mutation: drop the `_touchHold&&` term from the realign guard and this FAILS
+    (the write is wrongly refused on desktop)."""
+    m = json.loads(_run_node(_realign_harness(
+        anchor_extra="{scrollHeightAtCapture: 90000}",
+        cur_scroll_height=90453, rect_top=-453, top_offset=0, active_intent=False,
+        touch_like=False,
+    )))
+    assert m["returned"] is True and m["wrote"] == 1
+
+
 # ---- fallback guard (_restoreMessageScrollSnapshotSameFrame) ---------------------
 
 def _fallback_harness(*, snapshot_scroll_height, cur_scroll_height, snapshot_top,
-                      active_intent: bool = False) -> str:
+                      active_intent: bool = False, touch_like: bool = True) -> str:
     js = UI_JS_PATH.read_text(encoding="utf-8")
     intent_js = "true" if active_intent else "false"
+    touch_js = "true" if touch_like else "false"
     sh = "null" if snapshot_scroll_height is None else str(snapshot_scroll_height)
     return _extract_func_script(js) + f"""
 let writes = [];
@@ -168,6 +188,7 @@ const el = {{
 function $(id){{ return id === 'messages' ? el : null; }}
 function _recentMessageScrollIntent(){{ return {intent_js}; }}
 function _recentMessageTouchScrollIntent(){{ return {intent_js}; }}
+function _isTouchLikeMessageViewport(){{ return {touch_js}; }}
 // realign path fails (no anchor) so execution reaches the absolute fallback
 function _restorePinnedMessageScrollSnapshot(){{ return false; }}
 function _restoreMessageViewportAnchor(){{ return false; }}
@@ -230,4 +251,21 @@ def test_fallback_allows_snapshot_top_with_active_intent():
         active_intent=True,
     )))
     assert m["writes"] == [89577]
+
+
+def test_fallback_allows_snapshot_top_on_desktop_no_native_anchor():
+    """Desktop regression (#5637 gate cert): the exact stale-snapshot case (content grew,
+    reader not pinned, no intent, absolute write would move >8px) but on a
+    hover+fine-pointer viewport where `.messages` is `overflow-anchor:none`. With no
+    native anchoring layer to hold the reader, the fallback MUST keep its absolute
+    snapshot.top restore rather than refuse and latch userUnpinned — otherwise the
+    desktop reader is left at the wrong absolute position and force-unpinned.
+    Mutation: drop the `_fbTouchHold&&` term from the fallback guard and this FAILS
+    (the write is wrongly refused and userUnpinned is latched on desktop)."""
+    m = json.loads(_run_node(_fallback_harness(
+        snapshot_scroll_height=90000, cur_scroll_height=90453, snapshot_top=89577,
+        active_intent=False, touch_like=False,
+    )))
+    assert m["writes"] == [89577]
+    assert m["messageUserUnpinned"] is False and m["scrollPinned"] is True
 

--- a/tests/test_issue5637_stale_anchor_guard.py
+++ b/tests/test_issue5637_stale_anchor_guard.py
@@ -273,11 +273,14 @@ def test_fallback_allows_snapshot_top_on_desktop_no_native_anchor():
 # ---- predicate stability (_isTouchLikeMessageViewport) ---------------------------
 
 def _predicate_harness(*, pointer_coarse, computed_overflow_anchor, has_matchmedia=True,
-                       inline_overflow_anchor="") -> str:
+                       inline_overflow_anchor="", ua="Mozilla/5.0 (Linux; Android 13)",
+                       platform="Linux armv8l", max_touch_points=5) -> str:
     """Exercise the REAL _isTouchLikeMessageViewport + _browserOverflowAnchorActive
-    against a fake element, mocking matchMedia and getComputedStyle. `inline_overflow_anchor`
-    simulates the inline `overflowAnchor:'none'` that _restoreMessageViewportAnchor writes
-    on #messages mid-realign — the value the computed probe would transiently read."""
+    + _isIOSWebKit against a fake element, mocking matchMedia, getComputedStyle and
+    navigator. `inline_overflow_anchor` simulates the inline `overflowAnchor:'none'`
+    that _restoreMessageViewportAnchor writes on #messages mid-realign — the value the
+    computed probe would transiently read. `ua`/`platform`/`max_touch_points` drive the
+    _isIOSWebKit branch (default: an Android touch device that is NOT iOS)."""
     js = UI_JS_PATH.read_text(encoding="utf-8")
     mm = "true" if pointer_coarse else "false"
     has_mm = "true" if has_matchmedia else "false"
@@ -288,6 +291,9 @@ if (HAS_MM) {{
 }} else {{
   globalThis.matchMedia = undefined;
 }}
+// Node 18+ ships a built-in read-only `navigator`; a plain assignment is silently
+// ignored, so force the mock in with defineProperty.
+Object.defineProperty(globalThis, 'navigator', {{ configurable: true, value: {{ userAgent: {json.dumps(ua)}, platform: {json.dumps(platform)}, maxTouchPoints: {max_touch_points} }} }});
 // getComputedStyle reflects the INLINE override first (as a real browser would during
 // a realign burst), else the resting computed value.
 const el = {{ style: {{ overflowAnchor: {json.dumps(inline_overflow_anchor)} }} }};
@@ -296,6 +302,7 @@ globalThis.getComputedStyle = function(node){{
   return {{ overflowAnchor: inline || {json.dumps(computed_overflow_anchor)} }};
 }};
 eval(extractFunc('_browserOverflowAnchorActive'));
+eval(extractFunc('_isIOSWebKit'));
 eval(extractFunc('_isTouchLikeMessageViewport'));
 console.log(JSON.stringify({{ touchLike: _isTouchLikeMessageViewport(el) }}));
 """
@@ -333,6 +340,56 @@ def test_predicate_falls_back_to_computed_probe_without_matchmedia():
     overflow-anchor probe. A resting 'auto' (touch) -> true."""
     m = json.loads(_run_node(_predicate_harness(
         pointer_coarse=True, computed_overflow_anchor="auto", has_matchmedia=False,
+    )))
+    assert m["touchLike"] is True
+
+
+# ---- iOS WebKit exclusion (_isIOSWebKit) — overflow-anchor is inert on iOS -------
+
+def test_predicate_false_on_ios_iphone_despite_pointer_coarse():
+    """iOS gate cert (#5637 round-2 RED): an iPhone is pointer:coarse with a resting
+    computed overflow-anchor of 'auto', so the round-1 predicate would classify it as a
+    hold-capable touch viewport and let the stale-anchor refusal fire. But overflow-anchor
+    is INERT on iOS WebKit, so refusing the restore leaves a scrolled-up reader unheld —
+    the same class as the desktop regression. The predicate MUST report NOT touch on iOS so
+    the semantic realign is kept.
+    Mutation: remove the `if(_isIOSWebKit()) return false;` line and this FAILS (iPhone is
+    misclassified as a hold-capable touch viewport)."""
+    m = json.loads(_run_node(_predicate_harness(
+        pointer_coarse=True, computed_overflow_anchor="auto",
+        ua="Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 "
+           "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+        platform="iPhone", max_touch_points=5,
+    )))
+    assert m["touchLike"] is False
+
+
+def test_predicate_false_on_ipados13_masquerading_as_mac():
+    """iPadOS 13+ reports a desktop UA + platform 'MacIntel' but has touch (maxTouchPoints>1),
+    unlike a real Mac. overflow-anchor is inert there too, so it must be excluded from the
+    refusal like the iPhone.
+    Mutation: drop the `platform==='MacIntel' && maxTouchPoints>1` branch in _isIOSWebKit and
+    this FAILS (iPad is treated as an anchor-capable touch device)."""
+    m = json.loads(_run_node(_predicate_harness(
+        pointer_coarse=True, computed_overflow_anchor="auto",
+        ua="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 "
+           "(KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        platform="MacIntel", max_touch_points=5,
+    )))
+    assert m["touchLike"] is False
+
+
+def test_predicate_true_on_android_not_ios():
+    """Android Chrome: pointer:coarse, overflow-anchor works, and it is NOT iOS — this is
+    the one platform where the refusal is safe, so the predicate stays true. Guards against
+    an over-broad _isIOSWebKit that would also exclude Android.
+    Mutation: broaden _isIOSWebKit to match any touch device (e.g. return maxTouchPoints>1)
+    and this FAILS (Android would be wrongly excluded, re-opening the mobile jump)."""
+    m = json.loads(_run_node(_predicate_harness(
+        pointer_coarse=True, computed_overflow_anchor="auto",
+        ua="Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) "
+           "Chrome/120.0.0.0 Mobile Safari/537.36",
+        platform="Linux armv8l", max_touch_points=5,
     )))
     assert m["touchLike"] is True
 

--- a/tests/test_issue5637_stale_anchor_guard.py
+++ b/tests/test_issue5637_stale_anchor_guard.py
@@ -1,0 +1,219 @@
+"""Regression tests for the issue #5637 streaming stale-anchor guards.
+
+Once the reader is up in history during a live stream, the anchor captured for a
+same-frame restore goes stale as the streaming chunk grows content ABOVE the viewport:
+the anchor's captured topOffset (and the absolute snapshot.top) no longer map to the
+same content, so realigning to them yanks a still reader backward by a few hundred px.
+The existing `snapshot.userUnpinned===true` fallback skip is defeated because the
+scrollHeight-collapse scroll event re-pins the state machine (flips userUnpinned back to
+false) mid-stream.
+
+Two guards close this, both keyed on content-growth-since-capture + absence of real
+input intent (NOT a scrollTop diff, which the browser's own overflow-anchor writes on an
+overflow-anchor:auto container):
+  1. `_restoreMessageViewportAnchor` refuses the realign write.
+  2. the absolute `snapshot.top` fallback in `_restoreMessageScrollSnapshotSameFrame`
+     refuses its write.
+
+Every behavioral test below is designed to FAIL on the pre-guard code and PASS only with
+the guard. Node-harness pattern (extractFunc + mock DOM) shared with the sibling scroll
+regression suites.
+"""
+import json
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+UI_JS_PATH = ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> str:
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".cjs", encoding="utf-8", dir=ROOT, delete=False
+    ) as script:
+        script.write(source)
+        script_path = pathlib.Path(script.name)
+    try:
+        result = subprocess.run(
+            [NODE, str(script_path)], cwd=str(ROOT),
+            capture_output=True, text=True, timeout=30,
+        )
+    finally:
+        script_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
+
+
+def _extract_func_script(js: str) -> str:
+    prelude = "const src = " + json.dumps(js) + ";\n"
+    body = r"""
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  let str = null, inLine = false, inBlock = false, inRegex = false, prev = '';
+  while (depth > 0 && i < src.length) {
+    const c = src[i], n = src[i + 1];
+    if (inLine) { if (c === '\n') inLine = false; i++; continue; }
+    if (inBlock) { if (c === '*' && n === '/') { inBlock = false; i++; } i++; continue; }
+    if (str) { if (c === '\\') { i += 2; continue; } if (c === str) str = null; i++; continue; }
+    if (inRegex) { if (c === '\\') { i += 2; continue; } if (c === '/') inRegex = false; i++; continue; }
+    if (c === '/' && n === '/') { inLine = true; i += 2; continue; }
+    if (c === '/' && n === '*') { inBlock = true; i += 2; continue; }
+    if (c === '"' || c === "'" || c === '`') { str = c; i++; continue; }
+    if (c === '/' && !'})]0123456789'.includes(prev) && !/[A-Za-z_$]/.test(prev)) { inRegex = true; i++; continue; }
+    if (c === '{') depth++; else if (c === '}') depth--;
+    if (c.trim()) prev = c;
+    i++;
+  }
+  return src.slice(start, i);
+}"""
+    return prelude + body
+
+
+# ---- realign guard (_restoreMessageViewportAnchor) -------------------------------
+
+def _realign_harness(*, anchor_extra: str, cur_scroll_height: int, rect_top: int,
+                     top_offset: int, active_intent: bool = False) -> str:
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    intent_js = "true" if active_intent else "false"
+    return _extract_func_script(js) + f"""
+let writes = [];
+let stTop = 90030;
+const row = {{ getBoundingClientRect(){{ return {{ top: {rect_top} }}; }},
+  getClientRects(){{ return [{{}}]; }}, dataset: {{ messageAnchorKey: 'k1' }} }};
+const container = {{
+  get scrollTop(){{ return stTop; }}, set scrollTop(v){{ writes.push(Math.round(v)); stTop = v; }},
+  scrollHeight: {cur_scroll_height}, clientHeight: 427,
+  getBoundingClientRect(){{ return {{ top: 0, bottom: 427 }}; }},
+  querySelectorAll(){{ return [row]; }}, querySelector(){{ return row; }}, style: {{}},
+}};
+function $(id){{ return id === 'messages' ? container : null; }}
+function _recentMessageScrollIntent(){{ return {intent_js}; }}
+function _recentMessageTouchScrollIntent(){{ return {intent_js}; }}
+let _programmaticScroll = false; let _programmaticScrollSetAt = 0;
+const performance = {{ now(){{ return 1; }} }};
+function _suppressBrowserOverflowAnchor(){{ return null; }}
+function _deferClearProgrammaticScroll(){{}}
+function requestAnimationFrame(cb){{ cb(); }}
+function setTimeout(cb){{ cb(); return 1; }}
+const anchor = Object.assign({{ rawIdx: 53, sessionIdx: 53, key: 'k1', topOffset: {top_offset} }}, {anchor_extra});
+eval(extractFunc('_restoreMessageViewportAnchor'));
+const returned = _restoreMessageViewportAnchor(anchor, 0);
+console.log(JSON.stringify({{ returned, wrote: writes.length }}));
+"""
+
+
+def test_realign_refuses_stale_anchor_when_content_grew_no_intent():
+    """Content grew since capture (90000->90453) and no input intent, realign delta -453
+    -> REFUSE (return false, no write). Mutation: delete the guard block and it writes."""
+    m = json.loads(_run_node(_realign_harness(
+        anchor_extra="{scrollHeightAtCapture: 90000}",
+        cur_scroll_height=90453, rect_top=-453, top_offset=0, active_intent=False,
+    )))
+    assert m["returned"] is False and m["wrote"] == 0
+
+
+def test_realign_allows_fresh_anchor_no_growth():
+    """No growth since capture -> realign runs normally even with the same delta."""
+    m = json.loads(_run_node(_realign_harness(
+        anchor_extra="{scrollHeightAtCapture: 90453}",
+        cur_scroll_height=90453, rect_top=-453, top_offset=0, active_intent=False,
+    )))
+    assert m["returned"] is True and m["wrote"] == 1
+
+
+def test_realign_allows_with_active_intent():
+    """Recent real input intent -> keep the legitimate realign even if content grew."""
+    m = json.loads(_run_node(_realign_harness(
+        anchor_extra="{scrollHeightAtCapture: 90000}",
+        cur_scroll_height=90453, rect_top=-453, top_offset=0, active_intent=True,
+    )))
+    assert m["returned"] is True and m["wrote"] == 1
+
+
+def test_realign_backward_compatible_without_capture_geometry():
+    """Legacy anchor without scrollHeightAtCapture -> guard is a no-op, prior behavior."""
+    m = json.loads(_run_node(_realign_harness(
+        anchor_extra="{}",
+        cur_scroll_height=90453, rect_top=-453, top_offset=0, active_intent=False,
+    )))
+    assert m["returned"] is True and m["wrote"] == 1
+
+
+# ---- fallback guard (_restoreMessageScrollSnapshotSameFrame) ---------------------
+
+def _fallback_harness(*, snapshot_scroll_height, cur_scroll_height, snapshot_top,
+                      active_intent: bool = False) -> str:
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    intent_js = "true" if active_intent else "false"
+    sh = "null" if snapshot_scroll_height is None else str(snapshot_scroll_height)
+    return _extract_func_script(js) + f"""
+let writes = [];
+let stTop = 90030;
+const el = {{
+  get scrollTop(){{ return stTop; }}, set scrollTop(v){{ writes.push(Math.round(v)); stTop = v; }},
+  scrollHeight: {cur_scroll_height}, clientHeight: 427,
+}};
+function $(id){{ return id === 'messages' ? el : null; }}
+function _recentMessageScrollIntent(){{ return {intent_js}; }}
+function _recentMessageTouchScrollIntent(){{ return {intent_js}; }}
+// realign path fails (no anchor) so execution reaches the absolute fallback
+function _restorePinnedMessageScrollSnapshot(){{ return false; }}
+function _restoreMessageViewportAnchor(){{ return false; }}
+function _remountMessageViewportAnchor(){{ return false; }}
+let _messageUserUnpinned = false; let _scrollPinned = true; let _nearBottomCount = 5;
+let _lastScrollTop = 0; let _lastMessageClientHeight = 0;
+let _programmaticScroll = false; let _programmaticScrollSetAt = 0;
+const performance = {{ now(){{ return 1; }} }};
+function _deferClearProgrammaticScroll(){{}}
+function requestAnimationFrame(cb){{ cb(); }}
+function setTimeout(cb){{ cb(); return 1; }}
+const snapshot = {{ anchor: null, top: {snapshot_top}, bottom: 40,
+  scrollHeight: {sh}, pinned: false, userUnpinned: false }};
+eval(extractFunc('_restoreMessageScrollSnapshotSameFrame'));
+_restoreMessageScrollSnapshotSameFrame(snapshot);
+console.log(JSON.stringify({{ wrote: writes.length, writes,
+  messageUserUnpinned: _messageUserUnpinned, scrollPinned: _scrollPinned }}));
+"""
+
+
+def test_fallback_refuses_stale_snapshot_top_when_content_grew_no_intent():
+    """Content grew since snapshot (90000->90453), reader not pinned, no intent, and the
+    absolute snapshot.top write would move scrollTop >8px -> REFUSE. This is the -578
+    on-device jump the userUnpinned check missed (re-pin flipped userUnpinned false).
+    Mutation: delete the fallback guard block and scrollHistory gets the stale write."""
+    m = json.loads(_run_node(_fallback_harness(
+        snapshot_scroll_height=90000, cur_scroll_height=90453, snapshot_top=89577,
+        active_intent=False,
+    )))
+    assert m["writes"] == []
+    assert m["messageUserUnpinned"] is True and m["scrollPinned"] is False
+
+
+def test_fallback_allows_snapshot_top_when_no_growth():
+    """No growth since snapshot -> the fallback keeps its authoritative absolute restore."""
+    m = json.loads(_run_node(_fallback_harness(
+        snapshot_scroll_height=90453, cur_scroll_height=90453, snapshot_top=89577,
+        active_intent=False,
+    )))
+    assert m["writes"] == [89577]
+
+
+def test_fallback_backward_compatible_without_capture_scrollheight():
+    """Legacy snapshot without scrollHeight -> guard no-op, prior absolute restore runs."""
+    m = json.loads(_run_node(_fallback_harness(
+        snapshot_scroll_height=None, cur_scroll_height=90453, snapshot_top=89577,
+        active_intent=False,
+    )))
+    assert m["writes"] == [89577]

--- a/tests/test_issue5637_stale_anchor_guard.py
+++ b/tests/test_issue5637_stale_anchor_guard.py
@@ -269,3 +269,70 @@ def test_fallback_allows_snapshot_top_on_desktop_no_native_anchor():
     assert m["writes"] == [89577]
     assert m["messageUserUnpinned"] is False and m["scrollPinned"] is True
 
+
+# ---- predicate stability (_isTouchLikeMessageViewport) ---------------------------
+
+def _predicate_harness(*, pointer_coarse, computed_overflow_anchor, has_matchmedia=True,
+                       inline_overflow_anchor="") -> str:
+    """Exercise the REAL _isTouchLikeMessageViewport + _browserOverflowAnchorActive
+    against a fake element, mocking matchMedia and getComputedStyle. `inline_overflow_anchor`
+    simulates the inline `overflowAnchor:'none'` that _restoreMessageViewportAnchor writes
+    on #messages mid-realign — the value the computed probe would transiently read."""
+    js = UI_JS_PATH.read_text(encoding="utf-8")
+    mm = "true" if pointer_coarse else "false"
+    has_mm = "true" if has_matchmedia else "false"
+    return _extract_func_script(js) + f"""
+const HAS_MM = {has_mm};
+if (HAS_MM) {{
+  globalThis.matchMedia = function(q){{ return {{ matches: (q === '(pointer:coarse)') ? {mm} : false }}; }};
+}} else {{
+  globalThis.matchMedia = undefined;
+}}
+// getComputedStyle reflects the INLINE override first (as a real browser would during
+// a realign burst), else the resting computed value.
+const el = {{ style: {{ overflowAnchor: {json.dumps(inline_overflow_anchor)} }} }};
+globalThis.getComputedStyle = function(node){{
+  const inline = node && node.style && node.style.overflowAnchor;
+  return {{ overflowAnchor: inline || {json.dumps(computed_overflow_anchor)} }};
+}};
+eval(extractFunc('_browserOverflowAnchorActive'));
+eval(extractFunc('_isTouchLikeMessageViewport'));
+console.log(JSON.stringify({{ touchLike: _isTouchLikeMessageViewport(el) }}));
+"""
+
+
+def test_predicate_stays_true_on_touch_when_inline_anchor_clobbered_to_none():
+    """The claim that motivated choosing matchMedia over the computed probe: on a touch
+    device, when a prior realign tick has clobbered the inline `overflowAnchor` to 'none'
+    on #messages (its own scroll-write side effect, restored next frame), the predicate
+    MUST still report touch=true so the hold gate stays engaged across a realign burst.
+    matchMedia('(pointer:coarse)') reflects the input device and can't be mutated by that
+    inline write.
+    Mutation: revert _isTouchLikeMessageViewport to `return _browserOverflowAnchorActive(el)`
+    (the computed probe alone) and this FAILS — the probe reads the inline 'none' and
+    misclassifies the touch device as desktop."""
+    m = json.loads(_run_node(_predicate_harness(
+        pointer_coarse=True, computed_overflow_anchor="auto",
+        inline_overflow_anchor="none",
+    )))
+    assert m["touchLike"] is True
+
+
+def test_predicate_false_on_desktop_fine_pointer():
+    """Desktop (fine pointer): matchMedia('(pointer:coarse)') is false and the resting
+    computed overflow-anchor is 'none' -> predicate reports NOT touch, so the guards do
+    not fire and desktop keeps its scroll restore."""
+    m = json.loads(_run_node(_predicate_harness(
+        pointer_coarse=False, computed_overflow_anchor="none",
+    )))
+    assert m["touchLike"] is False
+
+
+def test_predicate_falls_back_to_computed_probe_without_matchmedia():
+    """Best-effort fallback: with no matchMedia available, the predicate uses the computed
+    overflow-anchor probe. A resting 'auto' (touch) -> true."""
+    m = json.loads(_run_node(_predicate_harness(
+        pointer_coarse=True, computed_overflow_anchor="auto", has_matchmedia=False,
+    )))
+    assert m["touchLike"] is True
+

--- a/tests/test_issue5637_stale_anchor_guard.py
+++ b/tests/test_issue5637_stale_anchor_guard.py
@@ -217,3 +217,17 @@ def test_fallback_backward_compatible_without_capture_scrollheight():
         active_intent=False,
     )))
     assert m["writes"] == [89577]
+
+
+def test_fallback_allows_snapshot_top_with_active_intent():
+    """Content grew since snapshot, but the reader has recent real input intent -> the
+    fallback keeps its legitimate absolute restore (an actively-scrolling reader owns the
+    snapshot). Mirrors the realign-guard active-intent case.
+    Mutation: drop the `!_activeIntent` term from the fallback guard and this fails
+    (the write would be wrongly refused)."""
+    m = json.loads(_run_node(_fallback_harness(
+        snapshot_scroll_height=90000, cur_scroll_height=90453, snapshot_top=89577,
+        active_intent=True,
+    )))
+    assert m["writes"] == [89577]
+


### PR DESCRIPTION
## Summary

A residual mobile scroll jump-back remained after #5638. While the reader is scrolled up
in history during a live stream, the viewport is nudged backward by a few hundred px on
each streaming tick.

## Root cause

The same-frame scroll restore (`_restoreMessageScrollSnapshotSameFrame`) captures an
anchor before a live DOM update, then restores to it afterward. During streaming, the
incoming chunk grows content **above** the viewport, so the captured `topOffset` (and the
absolute `snapshot.top`) no longer map to the same content — realigning to them yanks a
still reader backward.

The existing `snapshot.userUnpinned === true` fallback skip does not cover this: the
`scrollHeight`-collapse scroll event re-pins the state machine (flips `userUnpinned` back
to `false`) mid-stream, so both scroll-writing exits still fire:
1. the semantic realign (`_restoreMessageViewportAnchor`, `scrollTop += delta`), and
2. the absolute `snapshot.top` fallback.

## Fix

Two guards, both keyed on **content-growth-since-capture + absence of recent real input
intent** — deliberately **not** a `scrollTop` diff. On an `overflow-anchor: auto`
container (the mobile resting state) the browser itself writes `scrollTop` to compensate
above-viewport growth, so a genuinely still reader's `scrollTop` is not stationary; a
`scrollTop`-diff "did the user move?" test is defeated by that compensation.
`_recentMessageScrollIntent` / `_recentMessageTouchScrollIntent` instead reflect genuine
`touchmove` / `wheel` / `keydown` input, which the browser's anchor layer never sets.

- `_captureMessageViewportAnchor` now records `scrollHeightAtCapture` (+ `scrollTopAtCapture`).
- `_restoreMessageViewportAnchor` refuses the realign when content grew since capture, there
  is no recent input intent, and the delta would move `scrollTop` more than a few px.
- the absolute `snapshot.top` fallback in `_restoreMessageScrollSnapshotSameFrame` mirrors
  the same guard.

An actively scrolling reader (recent intent, e.g. a load-older prepend they triggered)
keeps the legitimate restore; a fresh anchor (no growth) and legacy snapshots without the
captured geometry are unaffected.

## Tests

`tests/test_issue5637_stale_anchor_guard.py` — 7 node-harness cases covering both guards:
refuses the stale realign / fallback, allows a fresh anchor, allows an actively-scrolling
reader, and stays backward-compatible with snapshots lacking the captured geometry. Two
cases are mutation-checked (removing either guard makes them fail).

Builds on #5638 (content-visibility scoping + the unpinned-hold), which addressed the
earlier layers of the same report.
