### PR TITLE
Live Stream: Hard prune post-compression tool context

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4220,6 +4220,9 @@ def _deduplicate_context_messages(messages):
                 msg['role'] = 'assistant'
             deduped.append(msg)
             continue
+        if _is_compressed_context_tool_result_summary_message(msg) and not msg.get('tool_call_id'):
+            deduped.append(msg)
+            continue
         key = _message_identity(msg)
         if key is not None and key in seen:
             continue
@@ -4336,6 +4339,13 @@ def _is_compressed_context_tool_result_summary(text: str) -> bool:
     return bool(separator and _POST_COMPRESSION_TOOL_RESULT_NOTE_RE.fullmatch(note.strip()))
 
 
+def _is_compressed_context_tool_result_summary_message(msg) -> bool:
+    if not isinstance(msg, dict) or msg.get('role') != 'tool':
+        return False
+    content = msg.get('content')
+    return isinstance(content, str) and _is_compressed_context_tool_result_summary(content)
+
+
 def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
     if not messages:
         return messages, 0
@@ -4346,11 +4356,12 @@ def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
         msg = messages[idx]
         if not isinstance(msg, dict) or msg.get('role') != 'tool':
             continue
-        text = _message_text(msg.get('content', ''))
-        if not text:
+        content = msg.get('content', '')
+        text = _raw_message_text(content)
+        if not text.strip():
             continue
         token_count = _rough_text_token_count(text)
-        if _is_compressed_context_tool_result_summary(text):
+        if isinstance(content, str) and _is_compressed_context_tool_result_summary(content):
             raw_tool_tokens += token_count
             continue
         remaining = max(0, budget - raw_tool_tokens)
@@ -5204,6 +5215,7 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     previous_display = [
         m for m in list(previous_display or [])
         if not _is_context_compression_marker(m)
+        and not _is_compressed_context_tool_result_summary_message(m)
     ]
     # Drop Hermes Agent internal verify-loop scaffolding (synthetic "premature
     # done" answer + the "[System: ...verification evidence...]" nudge) before
@@ -5266,6 +5278,7 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
             _message_identity(m)
             for m in previous_context
             if not _is_context_compression_marker(m)
+            and not _is_compressed_context_tool_result_summary_message(m)
         }
         _has_context_only_turns = bool(_context_id_set - _display_id_set)
         if _has_context_only_turns:
@@ -5303,7 +5316,13 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                         for _k in range(_cursor, _j):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
+                            if (
+                                _ckey is not None
+                                and _ckey not in _context_inserted
+                                and _ckey not in _display_id_set
+                                and not _is_context_compression_marker(_cmsg)
+                                and not _is_compressed_context_tool_result_summary_message(_cmsg)
+                            ):
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _context_inserted.add(_ckey)
                         # Sync multiset: decrement keys consumed by advancing
@@ -5324,7 +5343,13 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                         for _k in range(_cursor, len(context_keys)):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
+                            if (
+                                _ckey is not None
+                                and _ckey not in _context_inserted
+                                and _ckey not in _display_id_set
+                                and not _is_context_compression_marker(_cmsg)
+                                and not _is_compressed_context_tool_result_summary_message(_cmsg)
+                            ):
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _context_inserted.add(_ckey)
                         _cursor = len(context_keys)
@@ -5337,7 +5362,13 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
                 _ckey = context_keys[_cursor]
                 _cmsg = previous_context[_cursor]
                 _cursor += 1
-                if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
+                if (
+                    _ckey is not None
+                    and _ckey not in _context_inserted
+                    and _ckey not in _display_id_set
+                    and not _is_context_compression_marker(_cmsg)
+                    and not _is_compressed_context_tool_result_summary_message(_cmsg)
+                ):
                     _backfilled.append(copy.deepcopy(_cmsg))
                     _context_inserted.add(_ckey)
             if len(_backfilled) > len(previous_display):
@@ -5427,7 +5458,10 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
         candidates = candidates[:insert_at] + [current_user_msg] + candidates[insert_at:]
 
     for msg in candidates:
-        if _is_context_compression_marker(msg):
+        if (
+            _is_context_compression_marker(msg)
+            or _is_compressed_context_tool_result_summary_message(msg)
+        ):
             continue
         key = _message_identity(msg)
         is_current_user_turn = _looks_like_current_user_turn(msg, msg_text)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4269,6 +4269,113 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
     return stamped
 
 
+_POST_COMPRESSION_TOOL_RESULT_TOTAL_TOKENS = 4096
+_POST_COMPRESSION_TOOL_RESULT_MIN_SNIPPET_TOKENS = 256
+_POST_COMPRESSION_TOOL_RESULT_MARKER = "[WebUI compressed-context budget:"
+_POST_COMPRESSION_TOOL_RESULT_NOTE_RE = re.compile(
+    r"^\[WebUI compressed-context budget: omitted \d+(?: of \d+)? chars "
+    r"\(~\d+ rough tokens\) from this tool result; "
+    r"the full output remains in the visible transcript/tool log\.\]$"
+)
+_ROUGH_TOKEN_CHARS = 4
+
+
+def _positive_int_value(value, default: int = 0) -> int:
+    try:
+        parsed = int(value or 0)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _rough_text_token_count(text: str) -> int:
+    text = str(text or "")
+    if not text:
+        return 0
+    return max(1, (len(text) + (_ROUGH_TOKEN_CHARS - 1)) // _ROUGH_TOKEN_CHARS)
+
+
+def _post_compression_tool_result_budget(compressor) -> int:
+    budget = _positive_int_value(
+        getattr(compressor, 'tail_token_budget', None),
+        _POST_COMPRESSION_TOOL_RESULT_TOTAL_TOKENS,
+    )
+    threshold = _positive_int_value(getattr(compressor, 'threshold_tokens', None), 0)
+    if threshold:
+        budget = min(budget, max(512, threshold // 2))
+    return max(512, budget)
+
+
+def _compressed_context_tool_result_summary(text: str, *, original_tokens: int, keep_tokens: int) -> str:
+    text = str(text or "")
+    keep_chars = max(0, int(keep_tokens or 0) * _ROUGH_TOKEN_CHARS)
+    note_prefix = f"{_POST_COMPRESSION_TOOL_RESULT_MARKER} omitted "
+    note_suffix = (
+        f" (~{int(original_tokens or 0)} rough tokens) from this tool result; "
+        "the full output remains in the visible transcript/tool log.]"
+    )
+    if keep_chars < (_POST_COMPRESSION_TOOL_RESULT_MIN_SNIPPET_TOKENS * _ROUGH_TOKEN_CHARS):
+        return f"{note_prefix}{len(text)} chars{note_suffix}"
+    note_len_for_budget = len(f"{note_prefix}{len(text)} of {len(text)} chars{note_suffix}")
+    snippet_limit = max(0, keep_chars - note_len_for_budget - 2)
+    snippet = text[:snippet_limit].rstrip()
+    if not snippet:
+        return f"{note_prefix}{len(text)} chars{note_suffix}"
+    omitted_chars = max(0, len(text) - len(snippet))
+    note = f"{note_prefix}{omitted_chars} of {len(text)} chars{note_suffix}"
+    return f"{snippet}\n\n{note}"
+
+
+def _is_compressed_context_tool_result_summary(text: str) -> bool:
+    text = str(text or "").strip()
+    if not text:
+        return False
+    if _POST_COMPRESSION_TOOL_RESULT_NOTE_RE.fullmatch(text):
+        return True
+    _snippet, separator, note = text.rpartition("\n\n")
+    return bool(separator and _POST_COMPRESSION_TOOL_RESULT_NOTE_RE.fullmatch(note.strip()))
+
+
+def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
+    if not messages:
+        return messages, 0
+    budget = _post_compression_tool_result_budget(compressor)
+    raw_tool_tokens = 0
+    replacements = []
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if not isinstance(msg, dict) or msg.get('role') != 'tool':
+            continue
+        text = _message_text(msg.get('content', ''))
+        if not text:
+            continue
+        token_count = _rough_text_token_count(text)
+        if _is_compressed_context_tool_result_summary(text):
+            raw_tool_tokens += token_count
+            continue
+        remaining = max(0, budget - raw_tool_tokens)
+        if token_count <= remaining:
+            raw_tool_tokens += token_count
+            continue
+        replacements.append((idx, text, token_count, remaining))
+        # Once a tool row exceeds the residual budget, older tool rows should
+        # not be allowed to spend that same residual budget again.
+        raw_tool_tokens = budget
+
+    if not replacements:
+        return messages, 0
+
+    pruned = copy.deepcopy(list(messages))
+    for idx, text, token_count, keep_tokens in replacements:
+        msg = pruned[idx]
+        msg['content'] = _compressed_context_tool_result_summary(
+            text,
+            original_tokens=token_count,
+            keep_tokens=keep_tokens,
+        )
+    return pruned, len(replacements)
+
+
 def _prune_context_tool_results_after_compression(agent, context_messages):
     """Run the active compressor's cheap tool-result pruning on model context.
 
@@ -4276,28 +4383,35 @@ def _prune_context_tool_results_after_compression(agent, context_messages):
     before producing the final answer. Those completed tail tool results are
     model-facing context, but they were produced after the compression pass and
     therefore did not go through the compressor's tool-output pruning. Apply the
-    same cheap pruning once more after a confirmed compression event. This keeps
-    the visible transcript untouched while preventing the next turn from seeing
-    raw post-compression tool dumps.
+    same cheap pruning once more after a confirmed compression event, then apply
+    a WebUI hard cap to retained tool-result payloads. This keeps the visible
+    transcript untouched while preventing the next turn from seeing raw
+    post-compression tool dumps that the compressor protected as recent tail.
     """
     if not context_messages:
         return context_messages
     compressor = getattr(agent, 'context_compressor', None)
     prune = getattr(compressor, '_prune_old_tool_results', None)
-    if not callable(prune):
-        return context_messages
-    try:
-        pruned_messages, pruned_count = prune(
-            copy.deepcopy(context_messages),
-            protect_tail_count=getattr(compressor, 'protect_last_n', 20),
-            protect_tail_tokens=getattr(compressor, 'tail_token_budget', None),
-        )
-    except Exception:
-        logger.debug("post-compression context tool-result pruning failed", exc_info=True)
-        return context_messages
-    if not pruned_count:
-        return context_messages
-    return _deduplicate_context_messages(pruned_messages)
+    pruned_messages = context_messages
+    if callable(prune):
+        try:
+            candidate_messages, pruned_count = prune(
+                copy.deepcopy(context_messages),
+                protect_tail_count=getattr(compressor, 'protect_last_n', 20),
+                protect_tail_tokens=getattr(compressor, 'tail_token_budget', None),
+            )
+            if pruned_count:
+                pruned_messages = _deduplicate_context_messages(candidate_messages)
+        except Exception:
+            logger.debug("post-compression context tool-result pruning failed", exc_info=True)
+
+    hard_pruned_messages, hard_pruned_count = _hard_prune_post_compression_tool_results(
+        pruned_messages,
+        compressor=compressor,
+    )
+    if hard_pruned_count:
+        return _deduplicate_context_messages(hard_pruned_messages)
+    return pruned_messages
 
 
 def _restore_reasoning_metadata(previous_messages, updated_messages):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4274,6 +4274,7 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
 
 _POST_COMPRESSION_TOOL_RESULT_TOTAL_TOKENS = 4096
 _POST_COMPRESSION_TOOL_RESULT_MIN_SNIPPET_TOKENS = 256
+_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG = "_webui_pruned_tool_result_summary"
 _POST_COMPRESSION_TOOL_RESULT_MARKER = "[WebUI compressed-context budget:"
 _POST_COMPRESSION_TOOL_RESULT_NOTE_RE = re.compile(
     r"^\[WebUI compressed-context budget: omitted \d+(?: of \d+)? chars "
@@ -4342,8 +4343,7 @@ def _is_compressed_context_tool_result_summary(text: str) -> bool:
 def _is_compressed_context_tool_result_summary_message(msg) -> bool:
     if not isinstance(msg, dict) or msg.get('role') != 'tool':
         return False
-    content = msg.get('content')
-    return isinstance(content, str) and _is_compressed_context_tool_result_summary(content)
+    return msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is True
 
 
 def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
@@ -4361,7 +4361,7 @@ def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
         if not text.strip():
             continue
         token_count = _rough_text_token_count(text)
-        if isinstance(content, str) and _is_compressed_context_tool_result_summary(content):
+        if _is_compressed_context_tool_result_summary_message(msg):
             raw_tool_tokens += token_count
             continue
         remaining = max(0, budget - raw_tool_tokens)
@@ -4384,6 +4384,7 @@ def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
             original_tokens=token_count,
             keep_tokens=keep_tokens,
         )
+        msg[_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] = True
     return pruned, len(replacements)
 
 
@@ -4472,6 +4473,11 @@ def _restore_reasoning_metadata(previous_messages, updated_messages):
             # with their display counterpart.
             if prev_msg.get('id') is not None and cur_msg.get('id') is None:
                 cur_msg['id'] = prev_msg['id']
+            if (
+                prev_msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is True
+                and cur_msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is not True
+            ):
+                cur_msg[_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] = True
             if prev_msg.get('timestamp') and not cur_msg.get('timestamp'):
                 cur_msg['timestamp'] = prev_msg['timestamp']
             elif prev_msg.get('_ts') and not cur_msg.get('_ts') and not cur_msg.get('timestamp'):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4276,11 +4276,6 @@ _POST_COMPRESSION_TOOL_RESULT_TOTAL_TOKENS = 4096
 _POST_COMPRESSION_TOOL_RESULT_MIN_SNIPPET_TOKENS = 256
 _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG = "_webui_pruned_tool_result_summary"
 _POST_COMPRESSION_TOOL_RESULT_MARKER = "[WebUI compressed-context budget:"
-_POST_COMPRESSION_TOOL_RESULT_NOTE_RE = re.compile(
-    r"^\[WebUI compressed-context budget: omitted \d+(?: of \d+)? chars "
-    r"\(~\d+ rough tokens\) from this tool result; "
-    r"the full output remains in the visible transcript/tool log\.\]$"
-)
 _ROUGH_TOKEN_CHARS = 4
 
 
@@ -4328,16 +4323,6 @@ def _compressed_context_tool_result_summary(text: str, *, original_tokens: int, 
     omitted_chars = max(0, len(text) - len(snippet))
     note = f"{note_prefix}{omitted_chars} of {len(text)} chars{note_suffix}"
     return f"{snippet}\n\n{note}"
-
-
-def _is_compressed_context_tool_result_summary(text: str) -> bool:
-    text = str(text or "").strip()
-    if not text:
-        return False
-    if _POST_COMPRESSION_TOOL_RESULT_NOTE_RE.fullmatch(text):
-        return True
-    _snippet, separator, note = text.rpartition("\n\n")
-    return bool(separator and _POST_COMPRESSION_TOOL_RESULT_NOTE_RE.fullmatch(note.strip()))
 
 
 def _is_compressed_context_tool_result_summary_message(msg) -> bool:

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -4,6 +4,7 @@ from api.compression_anchor import visible_messages_for_anchor
 from api.models import Session
 from api.streaming import (
     _is_fallback_lifecycle_message,
+    _message_text,
     _prune_context_tool_results_after_compression,
 )
 
@@ -71,6 +72,136 @@ def test_post_compression_context_prunes_tail_tool_results_with_active_compresso
     assert compressor.calls == [{"protect_tail_count": 20, "protect_tail_tokens": 4096}]
     assert pruned[1]["content"] == "[browser_navigate] opened page (large snapshot summarized)"
     assert context_messages[1]["content"] == "x" * 5000
+
+
+def test_post_compression_context_hard_prunes_protected_tail_tool_payload():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    recent_payload = ("recent protected payload\n" * 1800) + "RECENT_TOOL_PAYLOAD_END"
+    session = Session(
+        session_id="budgetproof1",
+        title="Budget proof",
+        workspace="/tmp",
+        model="gpt-4o",
+        messages=[
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_recent"}]},
+            {"role": "tool", "tool_call_id": "call_recent", "content": recent_payload},
+            {"role": "assistant", "content": "Final answer"},
+        ],
+        context_messages=[
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_recent"}]},
+            {"role": "tool", "tool_call_id": "call_recent", "content": recent_payload},
+            {"role": "assistant", "content": "Final answer"},
+        ],
+    )
+
+    session.context_messages = _prune_context_tool_results_after_compression(
+        agent,
+        session.context_messages,
+    )
+
+    visible_tool = session.messages[1]["content"]
+    context_tool = session.context_messages[1]["content"]
+    context_tool_tokens = (len(_message_text(context_tool)) + 3) // 4
+
+    assert visible_tool == recent_payload
+    assert "RECENT_TOOL_PAYLOAD_END" in visible_tool
+    assert context_tool != recent_payload
+    assert "RECENT_TOOL_PAYLOAD_END" not in context_tool
+    assert "WebUI compressed-context budget" in context_tool
+    assert context_tool_tokens <= compressor.tail_token_budget
+
+
+def test_post_compression_context_note_only_replacement_consumes_residual_budget():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    old_small_payload = "s" * 80
+    old_oversize_payload = "h" * 2000
+    recent_payload = "r" * 4000
+    context_messages = [
+        {"role": "tool", "tool_call_id": "call_old_small", "content": old_small_payload},
+        {"role": "tool", "tool_call_id": "call_old_oversize", "content": old_oversize_payload},
+        {"role": "tool", "tool_call_id": "call_recent", "content": recent_payload},
+    ]
+
+    pruned = _prune_context_tool_results_after_compression(agent, context_messages)
+
+    assert pruned[2]["content"] == recent_payload
+    assert pruned[1]["content"] != old_oversize_payload
+    assert "WebUI compressed-context budget" in pruned[1]["content"]
+    assert pruned[0]["content"] != old_small_payload
+    assert "WebUI compressed-context budget" in pruned[0]["content"]
+    assert context_messages[0]["content"] == old_small_payload
+
+
+def test_post_compression_context_hard_prune_is_idempotent():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    context_messages = [
+        {"role": "tool", "tool_call_id": f"call_{idx}", "content": (f"tool {idx} payload\n" * 350)}
+        for idx in range(4)
+    ]
+
+    once = _prune_context_tool_results_after_compression(agent, context_messages)
+    twice = _prune_context_tool_results_after_compression(agent, once)
+
+    assert [msg["content"] for msg in twice] == [msg["content"] for msg in once]
+    assert any("WebUI compressed-context budget" in str(msg.get("content") or "") for msg in once)
+    assert context_messages[0]["content"] != once[0]["content"]
+
+
+def test_post_compression_context_raw_marker_collision_still_prunes():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    raw_payload = (
+        "tool echoed marker text: [WebUI compressed-context budget: not a generated summary]\n"
+        + ("raw collision payload\n" * 600)
+        + "RAW_COLLISION_END"
+    )
+    context_messages = [
+        {"role": "tool", "tool_call_id": "call_collision", "content": raw_payload},
+    ]
+
+    once = _prune_context_tool_results_after_compression(agent, context_messages)
+    twice = _prune_context_tool_results_after_compression(agent, once)
+
+    assert once[0]["content"] != raw_payload
+    assert "RAW_COLLISION_END" not in once[0]["content"]
+    assert "WebUI compressed-context budget" in once[0]["content"]
+    assert twice[0]["content"] == once[0]["content"]
+    assert context_messages[0]["content"] == raw_payload
 
 
 def test_auto_compression_running_sse_uses_active_session_running_card():

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from api.compression_anchor import visible_messages_for_anchor
 from api.models import Session
 from api.streaming import (
+    _compressed_context_tool_result_summary,
     _is_fallback_lifecycle_message,
+    _merge_display_messages_after_agent_result,
     _message_text,
     _prune_context_tool_results_after_compression,
 )
@@ -172,6 +174,117 @@ def test_post_compression_context_hard_prune_is_idempotent():
     assert [msg["content"] for msg in twice] == [msg["content"] for msg in once]
     assert any("WebUI compressed-context budget" in str(msg.get("content") or "") for msg in once)
     assert context_messages[0]["content"] != once[0]["content"]
+
+
+def test_post_compression_context_hard_prune_preserves_old_summary_after_new_tool_rows():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    context_messages = [
+        {"role": "tool", "tool_call_id": f"call_{idx}", "content": (f"tool {idx} payload\n" * 350)}
+        for idx in range(4)
+    ]
+
+    once = _prune_context_tool_results_after_compression(agent, context_messages)
+    old_summary = once[-1]["content"]
+    assert "\n\n[WebUI compressed-context budget:" in old_summary
+    assert f"of {len(context_messages[-1]['content'])} chars" in old_summary
+
+    with_new_tool = once + [
+        {
+            "role": "tool",
+            "tool_call_id": "call_new",
+            "content": "newer over-budget payload\n" * 700,
+        }
+    ]
+    twice = _prune_context_tool_results_after_compression(agent, with_new_tool)
+
+    assert twice[-2]["content"] == old_summary
+    assert f"of {len(context_messages[-1]['content'])} chars" in twice[-2]["content"]
+
+
+def test_post_compression_context_hard_prune_counts_raw_tool_whitespace():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    whitespace_padded_payload = ("x" + (" " * 79)) * 1000
+    context_messages = [
+        {"role": "tool", "tool_call_id": "call_padded", "content": whitespace_padded_payload},
+    ]
+
+    once = _prune_context_tool_results_after_compression(agent, context_messages)
+
+    assert once[0]["content"] != whitespace_padded_payload
+    assert "WebUI compressed-context budget" in once[0]["content"]
+    assert context_messages[0]["content"] == whitespace_padded_payload
+
+
+def test_post_compression_context_hard_prune_keeps_idless_twin_summaries():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 512
+        threshold_tokens = 1024
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    payload = "same idless payload\n" * 300
+    context_messages = [{"role": "tool", "content": payload} for _ in range(3)]
+
+    once = _prune_context_tool_results_after_compression(agent, context_messages)
+
+    assert len(once) == 3
+    assert sum("WebUI compressed-context budget" in msg["content"] for msg in once) == 3
+
+
+def test_post_compression_context_pruned_tool_summary_does_not_backfill_into_display():
+    full_tool_output = "full visible output\n" * 200
+    summary = _compressed_context_tool_result_summary(
+        full_tool_output,
+        original_tokens=(len(full_tool_output) + 3) // 4,
+        keep_tokens=0,
+    )
+    previous_display = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_big"}]},
+        {"role": "tool", "tool_call_id": "call_big", "content": full_tool_output},
+        {"role": "assistant", "content": "Final answer"},
+    ]
+    previous_context = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_big"}]},
+        {"role": "tool", "tool_call_id": "call_big", "content": summary},
+        {"role": "assistant", "content": "Final answer"},
+    ]
+    result_messages = previous_context + [
+        {"role": "user", "content": "next question"},
+        {"role": "assistant", "content": "next answer"},
+    ]
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display,
+        previous_context,
+        result_messages,
+        "next question",
+    )
+
+    merged_tool_contents = [msg["content"] for msg in merged if msg.get("role") == "tool"]
+    assert full_tool_output in merged_tool_contents
+    assert summary not in merged_tool_contents
 
 
 def test_post_compression_context_raw_marker_collision_still_prunes():

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -3,11 +3,14 @@ from pathlib import Path
 from api.compression_anchor import visible_messages_for_anchor
 from api.models import Session
 from api.streaming import (
+    _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG,
     _compressed_context_tool_result_summary,
     _is_fallback_lifecycle_message,
     _merge_display_messages_after_agent_result,
     _message_text,
     _prune_context_tool_results_after_compression,
+    _restore_reasoning_metadata,
+    _sanitize_messages_for_api,
 )
 
 
@@ -119,6 +122,7 @@ def test_post_compression_context_hard_prunes_protected_tail_tool_payload():
     assert context_tool != recent_payload
     assert "RECENT_TOOL_PAYLOAD_END" not in context_tool
     assert "WebUI compressed-context budget" in context_tool
+    assert session.context_messages[1][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
     assert context_tool_tokens <= compressor.tail_token_budget
 
 
@@ -147,8 +151,11 @@ def test_post_compression_context_note_only_replacement_consumes_residual_budget
     assert pruned[2]["content"] == recent_payload
     assert pruned[1]["content"] != old_oversize_payload
     assert "WebUI compressed-context budget" in pruned[1]["content"]
+    assert pruned[1][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
     assert pruned[0]["content"] != old_small_payload
     assert "WebUI compressed-context budget" in pruned[0]["content"]
+    assert pruned[0][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
+    assert _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG not in pruned[2]
     assert context_messages[0]["content"] == old_small_payload
 
 
@@ -173,6 +180,13 @@ def test_post_compression_context_hard_prune_is_idempotent():
 
     assert [msg["content"] for msg in twice] == [msg["content"] for msg in once]
     assert any("WebUI compressed-context budget" in str(msg.get("content") or "") for msg in once)
+    assert [
+        msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG)
+        for msg in twice
+    ] == [
+        msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG)
+        for msg in once
+    ]
     assert context_messages[0]["content"] != once[0]["content"]
 
 
@@ -195,6 +209,7 @@ def test_post_compression_context_hard_prune_preserves_old_summary_after_new_too
     once = _prune_context_tool_results_after_compression(agent, context_messages)
     old_summary = once[-1]["content"]
     assert "\n\n[WebUI compressed-context budget:" in old_summary
+    assert once[-1][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
     assert f"of {len(context_messages[-1]['content'])} chars" in old_summary
 
     with_new_tool = once + [
@@ -207,6 +222,7 @@ def test_post_compression_context_hard_prune_preserves_old_summary_after_new_too
     twice = _prune_context_tool_results_after_compression(agent, with_new_tool)
 
     assert twice[-2]["content"] == old_summary
+    assert twice[-2][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
     assert f"of {len(context_messages[-1]['content'])} chars" in twice[-2]["content"]
 
 
@@ -230,6 +246,7 @@ def test_post_compression_context_hard_prune_counts_raw_tool_whitespace():
 
     assert once[0]["content"] != whitespace_padded_payload
     assert "WebUI compressed-context budget" in once[0]["content"]
+    assert once[0][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
     assert context_messages[0]["content"] == whitespace_padded_payload
 
 
@@ -251,6 +268,7 @@ def test_post_compression_context_hard_prune_keeps_idless_twin_summaries():
 
     assert len(once) == 3
     assert sum("WebUI compressed-context budget" in msg["content"] for msg in once) == 3
+    assert sum(msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is True for msg in once) == 3
 
 
 def test_post_compression_context_pruned_tool_summary_does_not_backfill_into_display():
@@ -267,7 +285,12 @@ def test_post_compression_context_pruned_tool_summary_does_not_backfill_into_dis
     ]
     previous_context = [
         {"role": "assistant", "content": "", "tool_calls": [{"id": "call_big"}]},
-        {"role": "tool", "tool_call_id": "call_big", "content": summary},
+        {
+            "role": "tool",
+            "tool_call_id": "call_big",
+            "content": summary,
+            _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG: True,
+        },
         {"role": "assistant", "content": "Final answer"},
     ]
     result_messages = previous_context + [
@@ -313,8 +336,94 @@ def test_post_compression_context_raw_marker_collision_still_prunes():
     assert once[0]["content"] != raw_payload
     assert "RAW_COLLISION_END" not in once[0]["content"]
     assert "WebUI compressed-context budget" in once[0]["content"]
+    assert once[0][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
     assert twice[0]["content"] == once[0]["content"]
     assert context_messages[0]["content"] == raw_payload
+
+
+def test_post_compression_context_exact_note_shape_without_flag_still_prunes():
+    class NoopCompressor:
+        protect_last_n = 20
+        tail_token_budget = 1024
+        threshold_tokens = 4096
+
+        def _prune_old_tool_results(self, messages, protect_tail_count, protect_tail_tokens=None):
+            return messages, 0
+
+    compressor = NoopCompressor()
+    agent = type("Agent", (), {"context_compressor": compressor})()
+    generated_note = _compressed_context_tool_result_summary(
+        "prior generated payload",
+        original_tokens=512,
+        keep_tokens=0,
+    )
+    raw_payload = (
+        ("raw shape-collision payload\n" * 600)
+        + "RAW_SHAPE_COLLISION_END\n\n"
+        + generated_note
+    )
+    context_messages = [
+        {"role": "tool", "tool_call_id": "call_shape_collision", "content": raw_payload},
+    ]
+
+    once = _prune_context_tool_results_after_compression(agent, context_messages)
+
+    assert once[0]["content"] != raw_payload
+    assert "RAW_SHAPE_COLLISION_END" not in once[0]["content"]
+    assert once[0][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
+    assert context_messages[0]["content"] == raw_payload
+
+
+def test_post_compression_context_unflagged_note_shape_can_stay_visible():
+    visible_shape = _compressed_context_tool_result_summary(
+        "visible tool payload",
+        original_tokens=256,
+        keep_tokens=0,
+    )
+    previous_display = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_visible"}]},
+        {"role": "tool", "tool_call_id": "call_visible", "content": visible_shape},
+    ]
+    previous_context = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_visible"}]},
+        {"role": "tool", "tool_call_id": "call_visible", "content": visible_shape},
+    ]
+    result_messages = previous_context + [
+        {"role": "user", "content": "next question"},
+        {"role": "assistant", "content": "next answer"},
+    ]
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display,
+        previous_context,
+        result_messages,
+        "next question",
+    )
+
+    assert visible_shape in [msg.get("content") for msg in merged if msg.get("role") == "tool"]
+
+
+def test_post_compression_context_private_flag_restored_but_not_sent_to_provider():
+    previous_context = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_pruned"}]},
+        {
+            "role": "tool",
+            "tool_call_id": "call_pruned",
+            "content": _compressed_context_tool_result_summary(
+                "large generated payload",
+                original_tokens=512,
+                keep_tokens=0,
+            ),
+            _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG: True,
+        },
+    ]
+    api_safe = _sanitize_messages_for_api(previous_context)
+
+    assert _POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG not in api_safe[1]
+
+    restored = _restore_reasoning_metadata(previous_context, api_safe)
+
+    assert restored[1][_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] is True
 
 
 def test_auto_compression_running_sse_uses_active_session_running_card():


### PR DESCRIPTION
## Thinking Path

- #4685 tracks the gap between visible transcript preservation and model-facing compression safety for long, tool-heavy sessions.
- #4695 guarded stale state.db replay after compression, and #5538/#5655 added the safe focused-continuation recovery path.
- The remaining HER-675 evidence showed a different leak: `_prune_context_tool_results_after_compression()` can still keep a very large recent tool result because the agent compressor protects the tail.
- This PR adds a WebUI-owned final hard-pruning pass over model-facing `context_messages` only, so protected post-compression tool payloads cannot silently dominate the next prompt budget.

## Contract Routing

Task type: runtime/compression/model-context invariant.

Touched areas:
- `api.streaming._prune_context_tool_results_after_compression()`
- model-facing `session.context_messages` after automatic compression
- regression coverage in `tests/test_auto_compression_card.py`

Relevant public docs read:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `ARCHITECTURE.md`
- `TESTING.md`
- `docs/rfcs/README.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer mutated: model context / `context_messages` only. `Session.messages`, visible transcript, Worklog/history rendering, and focused-continuation recovery metadata are intentionally not pruned.

Invariant proved: after a compression event, retained tool-result payloads in `context_messages` are bounded by the compressor tail budget/default WebUI hard cap while the visible transcript remains inspectable.

## What Changed

- Kept the existing agent-compressor pruning pass when available.
- Added a deterministic WebUI hard cap for post-compression tool-result payloads in model-facing context:
  - defaults to 4096 rough tokens,
  - honors a smaller compressor `tail_token_budget`,
  - narrows further to half of `threshold_tokens` when that threshold is smaller,
  - favors recent tool output by walking tool rows from the tail backward.
- Replaces over-budget `role: tool` content in `context_messages` with a compact summary that states the full output remains in the visible transcript/tool log.
- Addressed review feedback on residual-budget accounting: once a tool row is over budget, even a note-only replacement consumes the residual budget so older tool rows cannot reuse it.
- Addressed gate feedback on idempotence: existing `[WebUI compressed-context budget:` tool summaries are preserved on repeat prune passes while still counting toward the shared rough-token budget.
- Addressed round-2 gate feedback on marker collisions: already-pruned detection now matches only WebUI's anchored generated summary-note shape, so raw oversized tool output that merely contains the marker literal is still pruned.
- Clarified snippet summary wording so the note reports omitted-of-total chars when a snippet remains.
- Added a regression that reproduces the HER-675 shape: a no-op compressor preserves a huge protected recent tool payload, WebUI prunes only `context_messages`, and `Session.messages` still contains the original full output.

## Why It Matters

Compression should preserve the UI transcript without letting raw tool dumps re-enter the next model request. This closes the budget-proof gap left after replay guards: even if a recent tool result is protected by compressor tail policy, WebUI now enforces a final model-context-only bound before the next turn can inherit that payload.

Release-note wording: After automatic context compression, WebUI now hard-prunes oversized tool-result payloads from model-facing context while keeping the full visible transcript and tool log available.

## Verification

- `./scripts/test.sh tests/test_auto_compression_card.py::test_post_compression_context_prunes_tail_tool_results_with_active_compressor tests/test_auto_compression_card.py::test_post_compression_context_hard_prunes_protected_tail_tool_payload tests/test_auto_compression_card.py::test_post_compression_context_note_only_replacement_consumes_residual_budget tests/test_auto_compression_card.py::test_post_compression_context_hard_prune_is_idempotent tests/test_auto_compression_card.py::test_post_compression_context_raw_marker_collision_still_prunes -q` -> 5 passed
- `./scripts/test.sh tests/test_auto_compression_card.py -q` -> 58 passed
- `.venv/bin/python -m py_compile api/streaming.py tests/test_auto_compression_card.py` -> passed
- `python3 scripts/ruff_lint.py --diff origin/master` -> 2 changed Python files, 0 new findings on added/modified lines
- `git diff --check origin/master` -> passed
- Aligned the PR head to gate-certified `9157897cac630eca977339b2ea0dfcca35dbc6ec`; `git diff --stat 85501acf208874d5892c57d649f9681c29f3ac3c..HEAD` produced no output, so this is tree-identical to the locally verified head.
- Refreshed the gate-passed commit onto `origin/master` `26a829c952e72b58d74ea00b206845c6db33b39b`; new PR head `d88cb2ed611c2753bcc301f312584070bcab09ba` passed the focused compression tests, the full touched test file, py_compile, diff-scoped ruff, and diff-check.

## Risks / Follow-ups

- The hard cap uses the same rough char-based budget shape as the live prompt estimate fallback, not provider-exact tokenization.
- This PR bounds tool-result payloads only; it does not attempt a full prompt-level recompression policy for non-tool messages.
- #4685 should remain open for broader recovery/diagnostics work.

## Model Used

OpenAI GPT-5 via Codex PR-aftercare agent. Notable tool use: local git, `gh`, PaperClip issue API readback, repo pytest runner, and diff-scoped ruff gate.

Refs #4685.