### PR TITLE
feat: add GPT (ChatGPT 2025 redesign) skin

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2267,6 +2267,7 @@ const _SKINS=[
   {name:'Sisyphus', colors:['#A78BFA','#8B5CF6','#7C3AED']},
   {name:'Charizard',colors:['#FB923C','#F97316','#EA580C']},
   {name:'Sienna',   colors:['#D97757','#C06A49','#9A523A']},
+  {name:'GPT',      colors:['#10a37f','#059669','#19c37d']},
   {name:'Catppuccin',colors:['#CBA6F7','#B4BEFE','#8839EF']},
   {name:'Hepburn',   colors:['#c6246a','#ec5597','#f2abca']},
   {name:'Nous',     colors:['#4682B4','#3A6E9A','#2C5F88']},

--- a/static/style.css
+++ b/static/style.css
@@ -1044,6 +1044,96 @@
   :root[data-skin="geist-contrast"] textarea#msg{scrollbar-width:none;overflow-y:auto;}
   :root[data-skin="geist-contrast"] textarea#msg::-webkit-scrollbar{display:none;}
 
+  /* ── Skin: GPT (ChatGPT 2025 redesign) ──
+     Full palette matched to the latest ChatGPT UI design system.
+     Light: crisp white surfaces, gray-100 sidebar, OpenAI green accent.
+     Dark: #212121 canvas, #171717 sidebar, OpenAI green accent. */
+  :root[data-skin="gpt"]{
+    color-scheme:light;
+    --bg:#ffffff;--sidebar:#f3f4f6;--surface:#ffffff;
+    --surface-subtle:#f9fafb;--surface-subtle-hover:#f3f4f6;
+    --main-bg:#ffffff;--topbar-bg:rgba(255,255,255,.92);
+    --border:#e5e7eb;--border2:#d1d5db;
+    --border-subtle:#e5e7eb;--border-muted:#d1d5db;
+    --text:#111827;--strong:#030712;--muted:#6b7280;--em:#4b5563;
+    --accent:#10a37f;--accent-hover:#059669;
+    --accent-bg:rgba(16,163,127,.10);--accent-bg-strong:rgba(16,163,127,.18);
+    --accent-text:#047857;
+    --blue:#10a37f;--gold:#10a37f;
+    --focus-ring:rgba(16,163,127,.30);--focus-glow:rgba(16,163,127,.08);
+    --input-bg:rgba(0,0,0,.03);--hover-bg:rgba(0,0,0,.05);
+    --code-bg:#f7f8fa;--code-inline-bg:rgba(0,0,0,.06);
+    --code-text:#374151;--pre-text:#111827;
+    --error:#ef4444;--success:#10a37f;--warning:#f59e0b;--info:#3b82f6;
+    --user-bubble-bg:#f3f4f6;--user-bubble-border:#e5e7eb;
+    --user-bubble-text:#111827;--user-bubble-placeholder:#6b7280;
+    --user-selection-bg:rgba(16,163,127,.22);--user-selection-text:#030712;
+    --radius-sm:6px;--radius-md:8px;--radius-card:10px;--radius-lg:12px;
+    --font-ui:"Segoe UI",-apple-system,BlinkMacSystemFont,Inter,system-ui,sans-serif;
+    font-family:var(--font-ui);
+  }
+  :root.dark[data-skin="gpt"]{
+    color-scheme:dark;
+    --bg:#212121;--sidebar:#171717;--surface:#2a2a2a;
+    --surface-subtle:rgba(255,255,255,.025);
+    --surface-subtle-hover:rgba(255,255,255,.045);
+    --main-bg:#212121;--topbar-bg:rgba(23,23,23,.92);
+    --border:#333333;--border2:rgba(255,255,255,.15);
+    --border-subtle:rgba(255,255,255,.07);
+    --border-muted:rgba(255,255,255,.12);
+    --text:#ececec;--strong:#f5f5f5;--muted:#a0a0a0;--em:#d4d4d4;
+    --accent:#10a37f;--accent-hover:#19c37d;
+    --accent-bg:rgba(16,163,127,.15);--accent-bg-strong:rgba(16,163,127,.25);
+    --accent-text:#19c37d;
+    --blue:#10a37f;--gold:#10a37f;
+    --focus-ring:rgba(16,163,127,.40);--focus-glow:rgba(16,163,127,.12);
+    --input-bg:rgba(255,255,255,.04);--hover-bg:rgba(255,255,255,.06);
+    --code-bg:#1a1a1a;--code-inline-bg:rgba(255,255,255,.08);
+    --code-text:#d4d4d4;--pre-text:#ececec;
+    --error:#ef4444;--success:#10a37f;--warning:#f59e0b;--info:#3b82f6;
+    --user-bubble-bg:#2f2f2f;--user-bubble-border:#3a3a3a;
+    --user-bubble-text:#f5f5f5;--user-bubble-placeholder:#a0a0a0;
+    --user-selection-bg:rgba(16,163,127,.25);--user-selection-text:#f5f5f5;
+  }
+  :root[data-skin="gpt"],
+  :root[data-skin="gpt"] body{font-family:var(--font-ui)!important;font-weight:400;letter-spacing:0;background:var(--bg);-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-rendering:optimizeLegibility;}
+  :root[data-skin="gpt"] .rail,
+  :root[data-skin="gpt"] .sidebar,
+  :root[data-skin="gpt"] .rightpanel,
+  :root[data-skin="gpt"] .topbar,
+  :root[data-skin="gpt"] .composer-wrap{background:var(--sidebar)!important;border-color:var(--border)!important;box-shadow:none!important;}
+  :root[data-skin="gpt"] .main,
+  :root[data-skin="gpt"] .chat,
+  :root[data-skin="gpt"] .panel-view{background:var(--bg)!important;}
+  :root[data-skin="gpt"] .session-item{border-radius:8px;font-size:13px;line-height:1.45;}
+  :root[data-skin="gpt"] .session-meta{font-size:11px;}
+  :root[data-skin="gpt"] .session-item.active{
+    position:relative;border:1px solid var(--border2)!important;
+    background:var(--surface-subtle-hover)!important;
+  }
+  :root[data-skin="gpt"] .session-item.active::before{
+    content:"";position:absolute;left:6px;top:10px;bottom:10px;
+    width:2px;border-radius:999px;background:var(--accent);
+  }
+  :root[data-skin="gpt"] .welcome-prompt{padding:24px 28px;margin:8px 0;}
+  :root[data-skin="gpt"] .welcome-prompt .prompt-action{
+    background:var(--surface)!important;border:1px solid var(--border)!important;
+    border-radius:8px;padding:12px 16px;font-size:13px;line-height:1.45;
+    transition:border-color .15s,background .15s;
+  }
+  :root[data-skin="gpt"] .welcome-prompt .prompt-action:hover{
+    border-color:var(--accent)!important;
+    background:var(--accent-bg)!important;
+  }
+  :root[data-skin="gpt"] .composer-wrap{
+    border-radius:var(--radius-md);border:1px solid var(--border)!important;
+    background:var(--surface)!important;margin:0 12px 12px;padding:4px;
+  }
+  :root[data-skin="gpt"] .composer-wrap.has-focus{
+    border-color:var(--accent)!important;
+    box-shadow:0 0 0 2px var(--focus-glow);
+  }
+
   /* ── Skin: Zeus ──
      OLED-near-black skin: replaces the default dark-blue/navy surfaces with warm
      near-blacks while keeping the gold accent unchanged. Borders are gold-tinted

--- a/tests/test_gpt_skin.py
+++ b/tests/test_gpt_skin.py
@@ -1,0 +1,45 @@
+"""Tests for GPT skin — ChatGPT 2025 redesign palette."""
+import re
+
+def test_gpt_skin_css_block():
+    """The :root[data-skin=\"gpt\"] block must be present with expected tokens."""
+    with open("static/style.css", encoding="utf-8") as f:
+        css = f.read()
+
+    m = re.search(r':root\[data-skin="gpt"\]\s*\{([^}]+)\}', css, re.DOTALL)
+    assert m, "Missing :root[data-skin=\"gpt\"] block"
+
+    block = m.group(1)
+    assert "--bg:#ffffff" in block
+    assert "--sidebar:#f3f4f6" in block
+    assert "--accent:#10a37f" in block
+    assert "--accent-text:#047857" in block
+    assert "--text:#111827" in block
+    assert "--font-ui:\"Segoe UI\"" in block
+
+
+def test_gpt_skin_dark_block():
+    """The :root.dark[data-skin=\"gpt\"] block must be present."""
+    with open("static/style.css", encoding="utf-8") as f:
+        css = f.read()
+
+    m = re.search(r':root\.dark\[data-skin="gpt"\]\s*\{([^}]+)\}', css, re.DOTALL)
+    assert m, "Missing :root.dark[data-skin=\"gpt\"] block"
+
+    block = m.group(1)
+    assert "--bg:#212121" in block
+    assert "--sidebar:#171717" in block
+    assert "--accent:#10a37f" in block
+    assert "--accent-text:#19c37d" in block
+    assert "color-scheme:dark" in block
+
+
+def test_gpt_skin_in_boot_js():
+    """The _SKINS array in boot.js must include the GPT entry."""
+    with open("static/boot.js", encoding="utf-8") as f:
+        js = f.read()
+
+    assert "'GPT'" in js or '"GPT"' in js, "Missing GPT entry in _SKINS"
+    assert "#10a37f" in js, "Expected GPT accent color #10a37f"
+    assert "#059669" in js, "Expected GPT hover color #059669"
+    assert "#19c37d" in js, "Expected GPT dark accent #19c37d"


### PR DESCRIPTION
Adds GPT (ChatGPT 2025 redesign) skin.

## Changed files
- `static/boot.js`: GPT entry in _SKINS
- `static/style.css`: Full palette light + dark blocks
- `tests/test_gpt_skin.py`: 3 assertion tests

## Palette
| Token | Light | Dark |
|-------|-------|------|
| --bg | #ffffff | #212121 |
| --sidebar | #f3f4f6 | #171717 |
| --accent | #10a37f | #10a37f |
| --accent-text | #047857 | #19c37d |