### PR TITLE
Draft: Capy Spaces widget API slice

### DIFF
--- a/.hermes/plans/capy-spaces-space-agent-parity.md
+++ b/.hermes/plans/capy-spaces-space-agent-parity.md
@@ -1,0 +1,862 @@
+# Capy Spaces: Space Agent Feature-Parity Architecture Plan
+
+Created: 2026-04-27 23:28 CDT  
+Research targets:
+- Space Agent checkout: `/tmp/space-agent` at `1289793`
+- Hermes WebUI checkout: `/Users/bschmidy10/hermes-webui` at `5720fa5`
+- Hermes Agent checkout: `/Users/bschmidy10/.hermes/hermes-agent` at `e403379b`
+
+## Executive Summary
+
+Space Agent is a browser-first agent runtime: a thick client-side app shell where an onscreen agent can inspect and mutate a user-owned “space” made of YAML-backed widget definitions, customware layers, browser surfaces, skills, prompt extensions, and file-backed state. Its server is intentionally thin: authentication, file routing, proxying, shared-data integrity, runtime params, optional Git history, sharing, and packaged desktop hosting.
+
+Capy/Hermes should not directly clone Space Agent’s trust model or generated-browser-JavaScript execution loop. The best implementation is a native **Capy Spaces** layer inside Hermes WebUI backed by Hermes Agent primitives:
+
+1. Hermes Agent remains the authoritative tool/runtime engine.
+2. Hermes WebUI becomes the visual workspace/canvas host.
+3. A new `spaces` backend module stores structured space/widget/app state under profile-aware WebUI state or workspace-local `.capy/spaces/` roots.
+4. Widgets are declarative, sandboxed, versioned artifacts, not arbitrary unbounded same-origin JS by default.
+5. Agents create and edit spaces via first-class Hermes tools/APIs, not via raw browser eval.
+6. Space Agent’s best UX ideas — spaces, widgets, browser panels, skills, imports/exports, sharing, current-space prompt context, onboarding, and local history — are replicated using safer Capy-native interfaces.
+
+The end goal is **functional parity plus a stronger architecture**: a user can ask Capy to create a dashboard/workspace, add live widgets, browse websites, inspect/modify files, generate reports, manage memory/skills/cron jobs, package/share a space, roll back changes, and continue across Telegram/WebUI/local sessions.
+
+### Demo-Video Parity Covenant
+
+After reviewing the Space Agent demo video (`https://www.youtube.com/watch?v=F3ZzNgf-R7Y`, 46:51), the concrete parity bar is no longer abstract “spaces and widgets.” Capy Spaces must be able to reproduce the full demo arc on Brendan’s Mac Studio before we claim Space Agent-level parity:
+
+1. Blank-space prompt → weather answer → persistent weather widget.
+2. Prebuilt/generated prices, charts, news, and daily dashboards.
+3. Browser games and canvas/WebAudio interactions with correct focus isolation.
+4. A real notes app with folders, rename, WYSIWYG editing, markdown mode, copy/paste, images, and attachments.
+5. Camera/surveillance dashboards with explicit URL/network permission handling.
+6. Local-agent/service dashboards: API chat widget plus embedded browser UI for another local app/agent.
+7. Browser-surface control where Capy and the user cooperate on the same live page, including captcha/login handoff.
+8. Research harness widgets where the UI can send prompts back to Capy, Capy browses/researches, and widgets update planning/source/notes/summary live.
+9. Agent-patched widget features such as “add export to PDF” without losing persistence or rollback.
+10. Trello-style Kanban board with persistent cards/columns and direct manipulation.
+11. Stock chart widgets using browser-origin or approved backend data fetches with robust error states.
+12. Iterative repair of imperfect generated UI, e.g. the demo’s broken first snake game attempt, with focused keyboard capture and safe rerendering.
+13. Music/sequencer/piano-roll widgets using WebAudio, persisted patterns, resize/rerender cleanup, and explicit audio permissions.
+14. Provider/local-model setup equivalent to Space Agent’s OpenRouter/local-inference panel, mapped to Hermes profiles, LM Studio, and existing provider settings rather than widget-stored raw secrets.
+15. Big Bang first-run onboarding space that shows off and teaches the workflow.
+16. Time travel/Git rollback for every space/widget/module mutation.
+17. Safe admin/recovery mode that still works if generated UI breaks the normal Spaces route.
+
+Do not promise “perfect” one-shot generation. Space Agent itself showed an initial broken snake game. The parity target is stronger: **Capy can create, inspect, patch, persist, visually verify, roll back, and recover every demo class safely.**
+
+## Research Findings
+
+### Space Agent: Core Mechanics
+
+Inspected Space Agent docs and code show these major subsystems:
+
+- `app/L0/_all/mod/_core/spaces/`
+  - Main spaces canvas.
+  - Persists under authenticated user app files: `~/spaces/<spaceId>/`.
+  - `space.yaml` stores manifest, metadata, agent instructions, layout, minimized widgets, timestamps.
+  - `widgets/<widgetId>.yaml` stores widget definitions, preferred YAML schema, dimensions, metadata, and a `renderer` function source string.
+  - `data/`, `assets/`, `scripts/` store widget-owned data/files/modules.
+  - Runtime namespaces: `space.current.*` and `space.spaces.*` expose CRUD, widget read/patch/render/reload/layout/share helpers.
+  - Prompt extensions add compact available-space/current-widget/current-space context.
+  - It has a staged workflow: list/read/patch/see widgets instead of dumping source into history.
+
+- `app/L0/_all/mod/_core/onscreen_agent/`
+  - Floating browser-overlay agent surface.
+  - Stores config in `~/conf/onscreen-agent.yaml`, UI state in browser storage, history in `~/hist/onscreen-agent.json`.
+  - Builds prompts from firmware prompt + examples + live history + transient runtime sections.
+  - Uses context tags (`space:open`, `browser:open`, etc.) to gate skill eligibility and auto-loading.
+  - Executes browser-side JavaScript through a `_____javascript` protocol.
+  - Provides seams for prompt extension, API request preparation, execution validation, and message processing.
+
+- `app/L0/_all/mod/_core/skillset/`
+  - Browser-side SKILL.md catalog and helper JS modules.
+  - Skills have frontmatter metadata for `when`, `loaded`, and `placement`.
+  - Skills can auto-load into system/transient prompt areas based on live tags.
+
+- `server/`
+  - Thin local infrastructure runtime.
+  - Request flow: API preflight, `/api/proxy`, `/api/<endpoint>`, `/mod/...`, app-file routes, then page shells.
+  - Owns auth/session, customware path resolution, optional Git history, quotas, proxy, temporary ZIP artifacts, hosted share clones, runtime params, cluster state.
+  - Space Agent consciously keeps browser/app logic out of the backend unless security/data integrity requires backend ownership.
+
+Key Space Agent parity features:
+
+| Capability | Space Agent implementation | Capy target |
+|---|---|---|
+| Visual spaces | Routed canvas with movable/resizable widgets | WebUI canvas route/panel with `CapySpace` model |
+| Widget persistence | YAML widget files with JS renderer strings | JSON/YAML widget specs with typed renderers; JS only in sandbox |
+| Agent editing | Browser-side JS runtime APIs | Hermes tools + WebUI APIs + explicit tool progress |
+| Skills | Browser SKILL.md catalog by context tags | Reuse Hermes skills + optional space-local skills |
+| Prompt context | Current space instructions + compact widget transients | Inject structured space context into `AIAgent.run_conversation` system/context |
+| Web/browser widgets | `<x-browser>` surfaces registered with runtime | Embed Browser/CDP surfaces through backend-managed browser sessions |
+| File/data storage | `~/spaces/<id>/data|assets|scripts` | Workspace-local `.capy/spaces/<id>/...` or WebUI state dir |
+| Share/export | ZIP export/import and optional hosted sharing | ZIP/export/import first; hosted later |
+| Rollback/history | Optional writable-layer Git history | Hermes checkpoint manager + workspace Git + space revision log |
+| Desktop host | Electron packaging/native host | Keep WebUI/PWA first; optional native host later |
+
+### Capy/Hermes/WebUI: Existing Extension Points
+
+Current WebUI already has several native hooks that make Capy Spaces feasible without a rewrite:
+
+- Profile-aware state paths in `api/config.py`
+  - `STATE_DIR`, `WORKSPACES_FILE`, `SESSION_DIR`, `SETTINGS_FILE`, profile-aware config loading.
+- Workspace backend in `api/workspace.py`
+  - Profile-aware workspace list and last workspace.
+  - Trusted workspace root validation.
+  - Blocks system roots and permits safe home/default/saved workspace roots.
+  - File operations already tied to workspace trust.
+- Routing in `api/routes.py`
+  - Existing endpoints: `/api/workspaces`, `/api/workspaces/suggest`, `/api/workspaces/add`, `/api/workspaces/remove`, `/api/workspaces/rename`.
+  - File APIs: `/api/file`, `/api/file/save`, `/api/file/raw`, `/api/list`, create/delete/rename directory endpoints.
+  - Chat endpoints: `/api/chat/start`, `/api/chat`, `/api/chat/steer`.
+  - Approval/clarify endpoints already bridge tool-side prompts back to WebUI.
+- Streaming integration in `api/streaming.py`
+  - Creates/reuses `AIAgent` with `platform='webui'`, `enabled_toolsets`, callbacks, session DB, and stable session id.
+  - Sets `TERMINAL_CWD`, `HERMES_EXEC_ASK`, `HERMES_SESSION_KEY`, and profile-aware `HERMES_HOME` for tool execution.
+  - Prepends workspace context to every user message and system message.
+  - Provides SSE events for tokens, reasoning, tools, approvals, clarifications, done/error, and metering.
+  - Has `SESSION_AGENT_CACHE` reuse, stream cancel, steer, and periodic session checkpointing.
+- Frontend in `static/`
+  - `messages.js` already starts agent runs and attaches SSE streams.
+  - `workspace.js` already has a file tree, previews, sandboxed HTML iframe preview, raw-file URLs, edit/save, git badge.
+  - `index.html` is the main insertion point for panels/routes.
+- Hermes Agent core:
+  - Tool registry is self-registering in `tools/registry.py` and `model_tools.py`.
+  - Toolsets are declared in `toolsets.py`; WebUI resolves toolsets from config.
+  - Filesystem checkpointing exists in `tools/checkpoint_manager.py` as shadow Git repos under `~/.hermes/checkpoints`, automatically around mutating file operations when enabled.
+  - Skills, memory, session search, cron, browser/CDP, terminal, file, patch, image, TTS, delegation, and messaging are already first-class tools.
+  - Gateway sessions persist Telegram/WebUI context and transcripts, providing a bridge between chat surfaces.
+
+## Product Definition: Capy Spaces
+
+A **Capy Space** is a durable, visual, agent-editable workspace object containing:
+
+- A manifest: title, icon, description, instructions, created/updated timestamps, owner/profile/workspace binding, version.
+- A canvas layout: camera, grid, widget positions/sizes/minimized state.
+- Widgets: typed cards/panels with declarative config, renderer type, data bindings, permissions, and revision history.
+- Assets/data: files generated or consumed by widgets.
+- Skills/context: space-local instructions and optional reusable helpers.
+- Browser surfaces: controlled browser panels that can be inspected/interacted with by Hermes browser tools.
+- Widget-to-agent events: buttons/forms inside a widget can submit scoped prompts back to the active Capy session, with explicit event metadata and user-visible progress.
+- First-run/demo templates: curated Big Bang, research, dashboard, browser-control, Kanban, game, and music templates used both for onboarding and regression tests.
+- Tool permissions: a capability envelope limiting which Hermes tools a space/widget may invoke.
+- History/checkpoints: revisions and rollback points for all space mutations.
+- Recovery metadata: enough information to disable a bad widget/module or open safe mode without rendering untrusted content.
+- Export/import package: portable ZIP/tarball with manifest, widgets, assets, and optional redacted session transcript.
+
+Capy Spaces should be addressable from:
+
+- WebUI route/panel: visual canvas and side inspector.
+- Telegram: links/previews and commands like “open the Daily Ops space”, “add this to the research dashboard”.
+- Hermes Agent tools: `space_list`, `space_create`, `space_upsert_widget`, etc.
+- Filesystem: workspace-local `.capy/spaces/<space_id>/` for project-bound spaces.
+
+## Target Architecture
+
+### 1. Storage Layer
+
+Add a new WebUI backend module:
+
+- `api/spaces.py`
+- State location, configurable:
+  - Default: profile state dir: `{profile_home}/webui_state/spaces/`
+  - Project-bound option: `<workspace>/.capy/spaces/`
+- Recommended layout:
+
+```text
+spaces/
+  index.json
+  <space_id>/
+    space.yaml
+    widgets/
+      <widget_id>.yaml
+    data/
+    assets/
+    scripts/
+    revisions/
+      <timestamp>-<event>.json
+    thumbnails/
+      thumbnail.webp
+```
+
+Canonical `space.yaml` schema:
+
+```yaml
+schema: capy.space.v1
+id: daily-ops
+workspace: /Users/bschmidy10/workspace/example
+profile: default
+title: Daily Ops
+icon: dashboard
+color: '#6aa6ff'
+description: Operational dashboard
+agent_instructions: |
+  Keep widgets compact. Prefer patches over rewrites.
+created_at: '2026-04-27T23:28:00-05:00'
+updated_at: '2026-04-27T23:28:00-05:00'
+layout:
+  columns: 24
+  camera: {x: 0, y: 0, zoom: 1}
+  widgets:
+    news: {col: 0, row: 0, cols: 8, rows: 5, minimized: false}
+permissions:
+  toolsets: [web, file, browser]
+  network: allowlist
+  domains: []
+```
+
+Canonical widget schema:
+
+```yaml
+schema: capy.widget.v1
+id: news
+name: News Brief
+kind: markdown | chart | table | browser | html | react | script | terminal | image | custom
+cols: 8
+rows: 5
+metadata: {}
+permissions:
+  toolsets: [web]
+  network: inherit
+source:
+  type: declarative
+  spec: {}
+renderer:
+  type: markdown-template
+  body: |
+    # Today
+    {{summary}}
+data:
+  refresh: manual | interval | agent
+  bindings: []
+```
+
+Design rule: declarative renderers first; same-origin arbitrary JS never as default.
+
+### 2. Backend API Layer
+
+Add endpoints in `api/routes.py` delegating to `api/spaces.py`:
+
+- `GET /api/spaces?workspace=<path>`
+- `POST /api/spaces/create`
+- `POST /api/spaces/update`
+- `POST /api/spaces/delete`
+- `POST /api/spaces/duplicate`
+- `GET /api/spaces/get?id=<space_id>&workspace=<path>`
+- `POST /api/spaces/widget/upsert`
+- `POST /api/spaces/widget/patch`
+- `POST /api/spaces/widget/delete`
+- `POST /api/spaces/widget/event` — widget-to-agent event bridge, e.g. research form submit or “refresh this card”.
+- `POST /api/spaces/layout/save`
+- `POST /api/spaces/export`
+- `POST /api/spaces/import`
+- `GET /api/spaces/asset/raw?...`
+- `POST /api/spaces/browser/create|navigate|snapshot|click|type|close` — active browser-surface bridge, backed by Hermes browser/CDP where available.
+- `POST /api/spaces/checkpoint`
+- `POST /api/spaces/rollback`
+- `POST /api/spaces/recovery/disable-widget`
+- `POST /api/spaces/recovery/disable-module`
+- `POST /api/spaces/templates/install` — install Big Bang/demo templates into a new or existing space.
+
+Implementation rules:
+
+- Reuse `resolve_trusted_workspace()` from `api/workspace.py` for all workspace-bound paths.
+- Never accept arbitrary absolute paths inside widget specs without resolving against the space root.
+- Validate widget schemas before writing.
+- Atomic writes only.
+- Maintain `index.json` as cache, but rebuild from manifests if corrupt.
+- Store a revision event for every mutation.
+- Optionally call Hermes checkpoint manager for project-local `.capy/spaces` writes.
+
+### 3. Hermes Tool Layer
+
+Add a Hermes Agent tool module:
+
+- `tools/spaces_tool.py`
+
+Toolset:
+
+- Add `spaces` to `toolsets.py`.
+- Include it in WebUI default toolset only after API stabilizes, or gate behind config `webui.spaces.enabled` initially.
+
+Tools:
+
+- `space_list(workspace?)`
+- `space_get(space_id, include_widgets=false)`
+- `space_create(title?, workspace?, instructions?)`
+- `space_update(space_id, fields)`
+- `space_delete(space_id)`
+- `space_export(space_id)`
+- `space_import(path_or_upload)`
+- `space_widget_list(space_id)`
+- `space_widget_read(space_id, widget_id)`
+- `space_widget_upsert(space_id, widget)`
+- `space_widget_patch(space_id, widget_id, edits|fields)`
+- `space_widget_delete(space_id, widget_id)`
+- `space_widget_event(space_id, widget_id, event_name, payload)`
+- `space_layout_save(space_id, layout)`
+- `space_browser_create(space_id, url, widget_id?)`
+- `space_browser_snapshot(space_id, browser_id)`
+- `space_browser_click(space_id, browser_id, ref)`
+- `space_browser_type(space_id, browser_id, ref, text)`
+- `space_checkpoint(space_id, reason)`
+- `space_rollback(space_id, revision)`
+- `space_recovery_disable(space_id, target_type, target_id, reason)`
+- `space_demo_run(name)` for scripted parity smoke tests, not normal user workflows.
+
+Reasoning: Space Agent exposes browser runtime APIs. Capy should expose model-visible tools backed by server-side validation. The model can still use browser automation for visual inspection, but persistent mutations go through typed tools.
+
+### 4. Prompt and Context Integration
+
+Modify `api/streaming.py` around workspace context construction to include space context when a session has `active_space_id`:
+
+- Add fields to WebUI `Session` model:
+  - `active_space_id`
+  - `active_space_title`
+  - optional `space_context_version`
+- On `/api/chat/start`, accept `space_id` and store it on the session.
+- Add compact system section:
+
+```text
+## Active Capy Space
+id: daily-ops
+title: Daily Ops
+workspace: /absolute/path
+instructions:
+...
+widgets (id|name|kind|cols|rows|status):
+news|News Brief|markdown|8|5|ok
+...
+Use Capy space tools for space/widget mutations. Prefer read+patch for existing widgets.
+```
+
+- Do not inject full widget source by default.
+- Add a transient-like short section in the user message only when the active space changed.
+- Add a skill `capy-spaces` under Hermes skills with workflow rules:
+  - list/read before patching
+  - use widget IDs
+  - patch, don’t rewrite, unless broad change
+  - verify renderer/schema after writes
+  - use screenshots/browser tools for visual checks
+
+### 5. Frontend UI Layer
+
+Add files:
+
+- `static/spaces.js`
+- `static/spaces.css`
+- Add panel/route entry in `static/index.html` and any panel router module.
+
+UI components:
+
+- Spaces dashboard/list.
+- Canvas route with grid/camera pan/zoom.
+- Widget cards with title, reload, resize, move, minimize, delete.
+- Space metadata popover: title, icon/color, instructions.
+- Widget inspector/editor: source/spec, metadata, permissions, data files.
+- Chat-to-space bridge: composer includes active `space_id`; empty canvas examples submit prompts.
+- Widget-to-agent bridge: widget buttons/forms can submit scoped prompts/events through `/api/spaces/widget/event`; frontend shows the originating widget, payload summary, active session, and progress events.
+- First-run Big Bang space: seeded onboarding space with special instructions and reset action.
+- Demo parity gallery: weather, research harness, browser-control, Kanban, stock chart, snake, sequencer, and notes examples as installable templates and regression fixtures.
+- Import/export/share modal.
+- Revision history/rollback panel.
+- Safe recovery route: static/minimal `/spaces/recovery` or equivalent panel that does not render generated widgets and can disable widgets/modules, inspect files, run rollback, and launch a repair prompt.
+- Browser widget renderer using sandboxed iframe or backend-managed browser session.
+
+Rendering strategy by widget `kind`:
+
+- `markdown`: sanitized markdown using existing renderer.
+- `table/chart`: declarative JSON rendered by trusted built-in JS.
+- `image`: raw asset URL.
+- `browser`: WebUI-managed browser/CDP surface, not generic iframe.
+- `html`: sandboxed iframe with strict flags; no parent access.
+- `script/custom`: disabled by default, requires explicit trust and sandbox isolation.
+
+Security defaults:
+
+- Widget iframes use sandbox without `allow-same-origin` unless a specific trusted mode is enabled.
+- No widget can call WebUI APIs with ambient cookies from inside sandbox by default; API access goes through a narrow postMessage bridge with per-widget capability tokens.
+- Capabilities declared in widget manifest and enforced server-side.
+
+### 6. Runtime Bridge / Widget Capability Model
+
+Create a small browser runtime object for trusted built-in widgets only:
+
+```js
+window.capySpaces = {
+  current: {
+    id, widgetList(), readWidget(id), requestPatch(...)
+  },
+  widgets: {
+    requestData(widgetId, request),
+    saveData(widgetId, path, content),
+  },
+  agent: {
+    submitPrompt(text, {spaceId, widgetId})
+  }
+}
+```
+
+For sandboxed widgets, expose a postMessage bridge:
+
+- `capy:ready`
+- `capy:data:get`
+- `capy:data:put`
+- `capy:asset:url`
+- `capy:agent:prompt`
+- `capy:resize`
+
+Bridge validates:
+
+- origin/frame id
+- widget id
+- requested action
+- permissions from widget manifest
+- path containment under widget data/assets root
+
+### 7. Browser Surface Integration
+
+Space Agent’s `<x-browser>` is powerful because the agent can inspect/control browser surfaces. Capy can do better by reusing Hermes browser/CDP tooling:
+
+- Add widget kind `browser` with fields:
+
+```yaml
+kind: browser
+browser:
+  url: https://example.com
+  controls: true
+  tool_access: inspect | interact | full
+```
+
+- Backend creates/associates a browser session/surface id.
+- Frontend renders an iframe/stream/screenshot/controlled browser view depending on backend support.
+- Hermes tools map `browser_*` calls to the active browser surface when prompt context indicates a browser widget is selected.
+- The visual UI exposes numeric/ref IDs returned by browser snapshots, matching current Hermes browser tools.
+
+### 8. Versioning and Rollback
+
+Use two layers:
+
+1. Space-level revision log in `revisions/` for semantic changes.
+2. Hermes checkpoint manager or workspace Git for filesystem-level rollback.
+
+Revision event example:
+
+```json
+{
+  "id": "20260427T232811Z-widget-upsert-news",
+  "type": "widget.upsert",
+  "actor": "agent:webui-session:<sid>",
+  "before_hash": "...",
+  "after_hash": "...",
+  "summary": "Created News Brief widget"
+}
+```
+
+Expose rollback UI and tool:
+
+- Preview diff.
+- Roll back one widget, full space manifest, or whole space tree.
+- Never roll back files outside the space root.
+
+### 9. Sharing and Import/Export
+
+Phase 1:
+
+- Local ZIP export/import only.
+- Manifest includes `capy_space_export_version`.
+- Import sanitizes IDs and paths.
+- Import can create new space or replace current space with confirmation.
+- Secrets redaction scan on export: `.env`, API-key-like fields, provider config, auth cookies, session IDs.
+
+Phase 2:
+
+- Signed local share link within WebUI.
+- Optional hosted share receiver later.
+- For Telegram: send `MEDIA:/path/to/space.zip` plus preview image.
+
+### 10. Desktop/PWA Strategy
+
+Do not start with Electron. Capy already runs as WebUI + Telegram + launchd on Mac Studio. The better path:
+
+1. Make WebUI Spaces excellent.
+2. Add PWA installability and visible macOS browser launch support.
+3. Add optional native host only if a feature truly requires native windows, global shortcuts, or OS integration.
+
+## Full Feature-Parity Milestones
+
+Sequencing rule from the video review: **do not enable powerful generated/script widgets, local-service dashboards, or agent-created modules for normal use until rollback and safe recovery exist.** Space Agent can rely on admin mode after a broken UI; Capy Spaces needs the same escape hatch before we expose similar power.
+
+### Phase 0 — Safety and foundations
+
+- Create `api/spaces.py` with schema validation, atomic writes, and path containment.
+- Add tests for workspace trust, path traversal, malformed manifests, corrupt indexes.
+- Add feature flag `webui.spaces.enabled`.
+- Add `static/spaces.js/css` shell hidden behind flag.
+- Add a minimal safe recovery route/panel that lists spaces and can disable an entire space without rendering generated widget content.
+- Add revision-event IDs from the first write path, even if full diff UI comes later.
+
+Acceptance:
+
+- Can create/list/read/delete spaces through API.
+- Cannot write outside trusted workspace or profile state dir.
+- Corrupt space files fail soft.
+- Safe recovery route opens when Spaces is enabled and does not execute widget code.
+
+### Phase 1 — Basic Spaces UI
+
+- Spaces list dashboard.
+- Canvas grid with pan, move, resize, minimize, remove.
+- Metadata editor.
+- Empty-space onboarding prompts.
+- First-run Big Bang template with special `agent_instructions`, reset action, and sample non-secret demo widgets.
+- Active `space_id` attached to chat starts.
+
+Acceptance:
+
+- User can create a space in WebUI and persist layout.
+- Chat sessions know active space in prompt context.
+- A fresh WebUI profile can install/open the Big Bang space and then reset it.
+
+### Phase 2 — Typed Widgets
+
+- Implement `markdown`, `table`, `chart`, `image`, `html` renderers.
+- Implement widget CRUD APIs and tools.
+- Implement widget inspector and source/spec editor.
+- Add renderer validation and sandboxing.
+- Add built-in declarative templates for the video’s first wave: weather, prices/chart/news dashboard, Kanban, stock chart, and markdown report.
+
+Acceptance:
+
+- Capy can create a dashboard with multiple widgets via tools.
+- Widgets survive reload.
+- Existing widget edits use read+patch and do not dump full source into prompt by default.
+- From a blank space, “what is the weather in Prague?” can remain a chat answer, then “show it to me in a widget” creates a persistent widget.
+- Stock/news/chart widgets show useful blocked/rate-limited/error states rather than silent failure.
+
+### Phase 3 — Agent-Native Space Tools
+
+- Add `tools/spaces_tool.py` and `spaces` toolset.
+- Add `capy-spaces` Hermes skill.
+- Inject active-space prompt context in `api/streaming.py`.
+- Stream space mutation events to frontend as live cards.
+
+Acceptance:
+
+- From WebUI or Telegram, user can ask “create a daily research dashboard” and Capy creates a space/widgets using tools.
+- Tool calls are visible, reversible, and scoped.
+
+### Phase 4 — Data/Assets/Scripts
+
+- Add per-space `data/`, `assets/`, optional `scripts/` APIs.
+- Add postMessage bridge for sandboxed widgets.
+- Add `/api/spaces/widget/event` and frontend event UI so widget controls can submit scoped prompts back to the active Capy session.
+- Add widget refresh controls and interval scheduler.
+- Add data binding helpers for web fetch/file read/tool result input.
+
+Acceptance:
+
+- Widgets can store local data/assets safely.
+- Widget refreshes do not require rewriting the widget definition.
+- Research harness demo works: input widget submits a research prompt, Capy updates planning/source/notes/summary, stores markdown output, and can patch in PDF export.
+- Notes-app demo can persist at least folders, note files, markdown/rich-text mode state, images/assets, and rename operations.
+
+### Phase 5 — Browser Widgets
+
+- Add browser widget kind and surface registry.
+- Integrate Hermes browser snapshot/click/type/navigate APIs with selected browser widget.
+- Add visual browser controls.
+- Add visible-user co-control: if the user clicks/types/login-solves a captcha in the browser widget, the next agent snapshot reflects that state.
+- Add local-service dashboard pattern for Agent Zero/Hermes/WebUI-style services: explicit allowlist, API connector widget, and browser panel widget.
+
+Acceptance:
+
+- User can ask Capy to open a site inside a space and interact with it.
+- Agent can inspect/control the browser widget through existing browser tools.
+- Demo-equivalent “check another local agent/app settings for updates” works against a controlled local test service.
+
+### Phase 6 — Revision History and Rollback
+
+- Add revision log APIs and UI.
+- Integrate Hermes checkpoint manager for filesystem-level safety.
+- Add diff/preview and rollback.
+- Expand safe recovery route into an admin/recovery mode: static UI, file browser for `.capy/spaces`, disable-widget/module actions, rollback action, and “ask Capy to repair this space” prompt that runs without rendering the broken widgets.
+
+Acceptance:
+
+- Every agent mutation has a revision event.
+- User can roll back a widget or full space.
+- A deliberately broken widget can be disabled from recovery mode and the normal Spaces route loads afterward.
+
+### Phase 7 — Import/Export/Share
+
+- Add ZIP export/import.
+- Add thumbnail generation.
+- Add Telegram send/share integration.
+- Add optional hosted share only after threat model review.
+
+Acceptance:
+
+- Spaces are portable without leaking credentials.
+- Imported spaces cannot escape their destination root.
+
+### Phase 8 — Advanced Parity
+
+- Space-local skills/instructions.
+- Multi-space search.
+- Templates/presets gallery.
+- Widgets backed by cron jobs or scheduled refresh.
+- Collaboration/multi-user locking if WebUI auth/team mode is enabled.
+- Optional native/PWA polish.
+
+### Phase 9 — Video Demo Parity Hardening
+
+Build and keep a scripted/manual demo suite that reproduces the video examples end-to-end. This phase is not “new product scope”; it is the proof that the previous phases achieved the vision.
+
+Required fixtures/demos:
+
+1. `demo_weather_widget`
+2. `demo_daily_dashboard`
+3. `demo_notes_app`
+4. `demo_camera_dashboard`
+5. `demo_local_agent_control_dashboard`
+6. `demo_browser_cocontrol_google_or_test_site`
+7. `demo_research_harness_pdf_export`
+8. `demo_kanban_board`
+9. `demo_stock_chart`
+10. `demo_snake_iterative_repair`
+11. `demo_step_sequencer_piano_roll`
+12. `demo_big_bang_onboarding`
+13. `demo_time_travel_restore`
+14. `demo_safe_admin_recovery`
+
+Acceptance:
+
+- Every demo can be launched from the templates/gallery or scripted smoke command.
+- Every demo survives browser reload and WebUI restart.
+- Every demo has at least one rollback point.
+- Generated/advanced widgets run in sandboxed or explicitly trusted mode with visible permissions.
+- Video parity is not marked complete until this suite passes on Brendan’s Mac Studio.
+
+## File-Level Implementation Plan
+
+### Hermes WebUI
+
+Create:
+
+- `api/spaces.py`
+- `static/spaces.js`
+- `static/spaces.css`
+- `tests/test_spaces_api.py`
+- `tests/test_spaces_security.py`
+- `tests/test_spaces_rendering.py` if frontend tests exist or can be added.
+- `tests/test_spaces_recovery.py`
+- `tests/test_spaces_demo_parity.py` for backend/template smoke coverage of video fixtures.
+- `tests/fixtures/spaces_demo_parity/` with sanitized template fixtures for weather, research, Kanban, stock, notes, browser-control, snake, sequencer, Big Bang, rollback, and recovery.
+
+Modify:
+
+- `api/routes.py`
+  - Add spaces endpoints.
+  - Add `space_id` propagation in `/api/chat/start`.
+- `api/models.py`
+  - Add active space fields to `Session` serialization/compact/load/save.
+- `api/streaming.py`
+  - Add active space context to system prompt.
+  - Emit space events if the active session mutates spaces.
+- `api/workspace.py`
+  - Reuse existing trust helpers; avoid duplicating path logic.
+- `static/index.html`
+  - Add Spaces panel, canvas containers, modals.
+- Add static safe recovery route/panel entry that avoids generated widget render paths.
+- `static/messages.js`
+  - Include `space_id` in chat start body.
+  - Render space mutation SSE/tool cards if needed.
+- `static/workspace.js`
+  - Link file tree and spaces assets/data views.
+- Service worker cache list if new static files need caching.
+
+### Hermes Agent
+
+Create:
+
+- `tools/spaces_tool.py`
+- `skills/software-development/capy-spaces` or user skill `capy-spaces` if not in repo.
+
+Modify:
+
+- `toolsets.py`
+  - Add `spaces` toolset.
+- Potentially `model_tools.py` only if registry discovery is insufficient; current registry should discover a new self-registering tool file automatically.
+- Docs/tests for tool schemas.
+
+### Optional Later
+
+- Gateway link previews for Telegram space cards.
+- PWA manifest enhancements.
+- Hosted sharing service.
+
+## Security Model
+
+Threats:
+
+1. Generated widget code exfiltrates cookies/session/API keys.
+2. Widget archive import writes outside destination.
+3. Browser widget becomes arbitrary same-origin control surface.
+4. Agent overwrites project files unintentionally.
+5. Shared/exported spaces leak secrets.
+6. Long-running widget scripts degrade WebUI performance.
+
+Controls:
+
+- Declarative widgets by default.
+- Sandbox iframe with no same-origin access for HTML/script widgets.
+- postMessage bridge with per-widget capability tokens.
+- Server-side path containment and schema validation.
+- No ambient WebUI API access from widget frames.
+- Toolset-scoped permissions at space and widget level.
+- Approval prompts for dangerous tools remain in WebUI/Telegram.
+- Export redaction and denylist for secret files.
+- Timeouts/resource budgets for widget refresh and script execution.
+- Revision log plus checkpoint rollback.
+
+Do not port directly from Space Agent:
+
+- Same-origin model-generated `renderer` JS as default.
+- Browser-side unrestricted execution protocol as persistence mechanism.
+- Blind CORS/proxy expansion without allowlist/rate limits.
+- Hosted share before local ZIP import/export is robust.
+
+## Testing Strategy
+
+Backend unit tests:
+
+- Create/list/read/update/delete spaces.
+- Widget upsert/patch/delete.
+- Layout save.
+- Import/export roundtrip.
+- Path traversal rejection: `../`, symlinks, absolute asset paths.
+- Corrupt YAML/JSON handling.
+- Revision log creation.
+- Workspace trust boundaries.
+
+Hermes tool tests:
+
+- Tool schemas validate.
+- Tools call WebUI spaces API or shared storage correctly.
+- Tool outputs stay compact.
+- Patch rejects ambiguous or full-rewrite edits unless explicit.
+
+Frontend tests/manual QA:
+
+- Canvas interactions: pan/move/resize/minimize/delete.
+- Space metadata saves.
+- Widget renderer sandbox cannot access parent/cookies/localStorage.
+- Chat from active space includes `space_id`.
+- Visual browser widget lifecycle.
+
+End-to-end scenarios:
+
+1. “Create a daily news dashboard.”
+2. “Add a web browser widget for GitHub and summarize this repo.”
+3. “Turn this markdown file into a report widget.”
+4. “Patch the chart widget to use a 7-day range.”
+5. “Export this space and send it to me on Telegram.”
+6. “Roll back the last widget change.”
+
+Video-demo parity suite:
+
+1. `demo_weather_widget`: blank space → chat answer → persistent widget → reload verification.
+2. `demo_notes_app`: folders, rename, rich-text/markdown modes, image/attachment persistence.
+3. `demo_camera_dashboard`: approved public stream URLs render; private/local URLs require explicit approval/allowlist.
+4. `demo_local_agent_control_dashboard`: API connector + embedded browser panel against a controlled local test service.
+5. `demo_browser_cocontrol`: user and Capy both interact with one browser panel; element references update after user interaction.
+6. `demo_research_harness_pdf_export`: widget-origin prompt triggers research progress, markdown artifact, and PDF/print export patch.
+7. `demo_kanban_board`: persistent cards/columns, rename/edit/drag behaviors.
+8. `demo_stock_chart`: Nvidia/Apple/Alphabet chart or mocked market-data adapter with blocked-source error handling.
+9. `demo_snake_iterative_repair`: first broken/focused-keyboard regression plus patch/reload verification.
+10. `demo_step_sequencer_piano_roll`: WebAudio permission, pattern persistence, resize cleanup.
+11. `demo_big_bang_onboarding`: first-run install, reset, and space-specific instructions.
+12. `demo_time_travel_restore`: roll back last widget edit and restore present state if supported.
+13. `demo_safe_admin_recovery`: broken widget cannot prevent recovery route from loading and disabling it.
+
+Completion rule: Capy Spaces is not “Space Agent demo parity complete” until the above suite passes locally on the Mac Studio and at least the critical security tests pass in CI/local pytest.
+
+## Update Compatibility Contract
+
+Capy Spaces must remain durable across future Hermes WebUI and Hermes Agent updates. Treat this as a compatibility contract for every implementation PR and every upstream rebase/update.
+
+1. **Optional by default during rollout**
+   - Gate Capy Spaces behind a feature flag such as `HERMES_WEBUI_SPACES_ENABLED=1` until the foundation is stable.
+   - WebUI must still boot and normal chat/workspace flows must still work if Spaces is disabled or if Spaces initialization fails.
+
+2. **Isolated subsystem, minimal core edits**
+   - Prefer new files (`api/spaces.py`, `static/spaces.js`, `static/spaces.css`, `tests/test_spaces_*.py`) over broad edits to existing chat, streaming, workspace, or session modules.
+   - Existing WebUI files should receive only narrow route-registration, session-field, and navigation-hook changes.
+   - Avoid monkeypatching global WebUI behavior.
+
+3. **Backward-compatible session/data model**
+   - `Session.active_space_id` must be optional and safe for old sessions that do not contain it.
+   - Space files must include `schema_version`; loaders must tolerate missing/older fields and report migration needs without crashing.
+   - Mutations must create revision-event IDs from the first implementation slice so future migrations and rollback tools have stable history anchors.
+
+4. **Hermes Agent as stable backend dependency**
+   - Avoid Hermes Agent core changes until a stable WebUI Spaces foundation exists.
+   - When Hermes Agent integration becomes necessary, use public/stable primitives first: tools, toolsets, workspace cwd, checkpoint manager, browser tools, file tools, skills, memory, and gateway/session context.
+   - Any required Hermes Agent change must be small, tested, profile-safe, and upstream-friendly.
+
+5. **Compatibility tests are mandatory**
+   - Every Spaces PR must add/update pytest coverage for the new behavior.
+   - Every WebUI/Hermes update or rebase must run the full WebUI suite plus Spaces-focused tests:
+     ```bash
+     python3 -m pytest tests -q
+     python3 -m pytest tests/test_spaces*.py -q
+     ```
+   - Baseline before Spaces implementation: `2785 passed`, `8 subtests passed`, `1 warning` locally on Brendan's Mac Studio.
+
+6. **Safe failure and recovery**
+   - The safe recovery route/panel must not render generated widgets.
+   - If a future update breaks widget rendering, the user must still be able to list spaces, disable widgets, export data, and roll back/recover through safe mode.
+
+7. **Upstream rebase workflow**
+   - Keep Capy Spaces in Brendan's fork/feature branches until upstreamed or stabilized.
+   - For updates: fetch upstream, rebase/merge, run compatibility tests, then restart WebUI only after tests pass.
+   - If compatibility breaks, fix the adapter/isolated Spaces layer rather than changing unrelated WebUI or Hermes Agent behavior.
+
+## Migration Strategy
+
+No direct migration from Space Agent data is required initially. If later useful:
+
+- Build `space-agent-import` adapter that reads Space Agent ZIPs:
+  - Map `space.yaml` fields to `capy.space.v1`.
+  - Convert widget YAML into Capy widget schemas.
+  - Treat JS renderer strings as untrusted `html/script` widgets requiring explicit enablement.
+  - Preserve `assets/`, `data/`, and `scripts/` under import root.
+  - Add import warnings for unsupported APIs such as `space.current.*` calls.
+
+## Recommended First PR
+
+Implement Phase 0 + a thin Phase 1 skeleton:
+
+1. `api/spaces.py` with storage and validation.
+2. Routes for list/create/read/update/delete.
+3. `Session.active_space_id` field.
+4. Minimal `static/spaces.js/css` page showing spaces and empty canvas.
+5. Minimal safe recovery route that does not render widgets.
+6. Revision-event ID creation on each mutation.
+7. Tests for path safety, CRUD, recovery route, and revision-event creation.
+8. Feature flag off by default or dev-only.
+
+This gives a safe spine that future widget/tool/browser/share work can attach to without reworking the data model.
+
+## Open Design Questions
+
+- Should default storage be profile state or workspace-local `.capy/spaces/`? Recommendation: support both; default to workspace-local for project spaces, profile state for global/personal spaces.
+- Should Space tools call WebUI API over HTTP or import shared Python storage functions directly? Recommendation: shared Python functions for in-process WebUI; HTTP adapter later for remote/gateway contexts.
+- How should Telegram open/render spaces? Recommendation: send link to WebUI route plus static thumbnail; later add Telegram-native summaries.
+- Which JS widget mode is acceptable? Recommendation: declarative first; sandboxed HTML second; trusted JS only behind explicit per-space setting.
+
+## Final Recommendation
+
+Build **Capy Spaces** as a Capy-native visual workspace system, not a repository clone. Use Space Agent as a UX and feature blueprint, but map it onto Hermes’ existing strengths: typed tools, approval flow, skills, memory, session search, gateway persistence, checkpoints, browser/CDP tools, and WebUI streaming. This path reaches full functional parity while avoiding Space Agent’s highest-risk assumption: letting browser-side generated JavaScript be the primary operating substrate.

--- a/.hermes/plans/capy-spaces-video-demo-parity-checklist.md
+++ b/.hermes/plans/capy-spaces-video-demo-parity-checklist.md
@@ -1,0 +1,76 @@
+# Capy Spaces — Space Agent Demo Video Parity Checklist
+
+Video reviewed: https://www.youtube.com/watch?v=F3ZzNgf-R7Y  
+Transcript duration: 46:51  
+Created: 2026-04-27
+
+## Bottom line
+
+The demo does **not** introduce a new product direction beyond the existing Capy Spaces plan. It does clarify the exact parity bar:
+
+- Capy Spaces needs a persistent visual workspace/canvas.
+- The agent must create and update widgets from natural language.
+- Widgets must be able to cooperate through shared per-space data/files.
+- Browser panels must be first-class, inspectable, and jointly controllable by user + agent.
+- Space-specific instructions must influence the agent.
+- UI widgets must be persistent and reconstructible after reload.
+- Git/checkpoint rollback and a safe recovery/admin surface are not optional.
+
+I cannot honestly claim these examples would work **perfectly today**, because Capy Spaces is still a plan, not an implemented subsystem. I can say they are all architecturally feasible in Capy/Hermes, and the target architecture should be adjusted to explicitly test each demo example before declaring Space Agent parity.
+
+## Demo examples observed
+
+| Timestamp | Space Agent demo example | What happened | Capy Spaces parity status | Required Capy capability |
+|---|---|---|---|---|
+| 02:18 | Prebuilt prices/charts/news/daily dashboards | Host says Space Agent can render prices, charts, news, dashboards. | Feasible, should be first-class. | Declarative chart/table/news widgets, web fetch/proxy, scheduled/manual refresh. |
+| 02:25 | Browser games | Host says it can render and play games in the browser. | Feasible with sandboxed interactive widgets. | Canvas/HTML widget renderer, keyboard focus isolation, event cleanup, sandbox policies. |
+| 03:31 | Weather in Prague, then “show it to me in a widget” | Agent first replies in chat, then creates weather widget. | Must be Phase 1 acceptance test. | Chat-to-widget action, weather fetch, declarative widget, persistence. |
+| 06:58 | Notes app | Agent-created app with folder list, rename, WYSIWYG editing, markdown view, copy/paste, images, attachments. | Feasible but not MVP; medium/high complexity. | Multi-widget app pattern, shared per-space data store, file/asset APIs, rich-text editor widget, attachment handling. |
+| 09:59 | Surveillance dashboard | Agent creates dashboard of public/home camera streams. | Feasible with caveats. | Stream/image/video widgets, URL validation, mixed content/CORS handling, explicit permission for private camera URLs. |
+| 11:25 | Agent Zero control dashboard | Space has Agent Zero API chat widget plus embedded full Agent Zero web UI browser panel. | Feasible in Capy with stronger existing primitives. | API connector widget, browser panel widget, secret storage, local service allowlist, browser-control bridge. |
+| 12:05 | Agent checks Agent Zero settings/update through browser UI | Agent controls embedded browser using element transcription and click commands. | Feasible; Capy already has browser/CDP tooling, but needs WebUI-embedded browser-surface bridge. | Browser surface registry, accessibility/snapshot extraction, `click_ref/type_ref` actions, transient page context. |
+| 16:48 | Research harness | Agent-created UI with research input/output widgets and space instructions. UI can send message back to agent. | Core Capy Spaces target. | Widget-to-agent event channel, space-specific system instructions, progress-updating widgets, file output. |
+| 17:27 | Claude Mythos research run | UI-triggered agent browses web, updates planning/source gathering/notes/summary, creates markdown research output. | Feasible; Hermes is strong here. | Research workflow widget, browser/search tools, markdown artifact persistence, streaming status updates. |
+| 18:51 | Add export-to-PDF button | Agent patches existing research output UI, adds formatting/tables/links and native print/PDF flow. | Feasible; should be a Phase 2 test. | Widget patching, print/PDF export, DOM-safe formatting, revision rollback. |
+| 20:59 | Trello-style colorful Kanban board | Agent creates a kanban board, cards/columns, rename behavior. | Feasible; good standard demo. | Drag/drop widgets or internal widget state, persistent JSON state, card editing, layout constraints. |
+| 22:11 | Stock graph for Nvidia/Apple/Alphabet | Agent creates stock chart; likely uses Yahoo Finance or browser-side fetch. | Feasible with caveats around data APIs/rate limits. | Chart widget, market-data adapter/proxy, browser-origin fetch fallback, error states. |
+| 23:19 | Snake game | First attempt broken; agent is prompted with bug report and fixes it. | Feasible; important to include because “perfect” one-shot is not guaranteed. | Interactive canvas widget, keyboard focus scoping, iterative patch/debug flow, rollback. |
+| 26:05 | Step sequencer / mini synth | Multi-widget audio UI with sequencer, sound controls, guitar free-play. | Feasible but advanced/browser-specific. | WebAudio widget permission model, persisted patterns, keyboard/mouse handling, audio cleanup. |
+| 26:52 | Add piano roll | Agent patches/extends music UI with piano roll; alignment fixed by resizing. | Feasible, should be later-stage demo. | Widget patching, responsive layout testing, resize/rerender hooks. |
+| 28:14 | Local inference panel | Download/load/test HuggingFace model in browser/runtime. | Partly different in Capy. Capy already uses LM Studio/local providers; browser-side HF inference is optional, not necessary for parity. | Provider settings UI, LM Studio integration, optional browser-local inference if desired. |
+| 29:53 | Agent-created modules | Agent can create per-user/per-group/global modules beyond spaces. | Feasible but should be controlled and not MVP. | Module/plugin system, signed/approved extensions, capability scopes, recovery mode. |
+| 41:27 | User + agent cooperate on same browser page, e.g. Google | Agent navigates; user can also interact manually. | Feasible and aligned with Brendan’s visible-browser preference. | Visible browser/CDP bridge, shared control state, captcha/login handoff. |
+| 41:48 | Fresh guest setup/API key flow | New user enters OpenRouter key and starts. | Capy equivalent should use existing Hermes model/provider config, not raw widget-stored keys. | Settings UI, secret handling, provider validation. |
+| 42:42 | Big Bang first-run space | First new-user space has special onboarding instructions and shows off. | Feasible; recommended. | Seeded onboarding space, space instructions, sample widgets. |
+| 43:25 | Time travel | User/group dirs are Git repos; can travel back two hours, return to present, or revert changes. | Required for safe parity. | Hermes checkpoint manager + Git snapshots, per-space revision history, restore UI. |
+| 44:18 | Admin/recovery mode | Static firmware admin split view survives broken UI and can run agent/files/time travel/module manager. | Required before allowing powerful self-modification. | Safe-mode route outside generated content, file browser, rollback, repair-agent prompt, module disable switch. |
+
+## Acceptance criteria before saying “every demo works perfectly”
+
+Capy Spaces should not claim full video parity until these are demonstrably true on Brendan’s Mac Studio:
+
+1. Weather widget demo passes from a blank space.
+2. Notes app demo supports create/edit/rename/folders/markdown/rich text/image/file attachment persistence.
+3. Camera/dashboard demo can render allowed stream URLs and rejects unsafe/private URLs unless approved.
+4. Agent Zero/local-service dashboard works against a local test service with API + browser panel.
+5. Embedded browser panel supports user+agent co-control and element-reference actions.
+6. Research harness supports widget-to-agent triggers, live progress updates, markdown artifact, and PDF export.
+7. Kanban demo supports persistent cards/columns and drag/edit interactions.
+8. Stock chart demo renders real market data with useful error handling when sources block/rate-limit.
+9. Snake demo supports focused keyboard capture only and iterative repair.
+10. Music/sequencer/piano-roll demo supports WebAudio, persistence, resize/rerender cleanup.
+11. Onboarding Big Bang space exists and can be reset.
+12. Time travel/rollback works after every widget/module edit.
+13. Safe admin/recovery route can fix or disable broken spaces/widgets/modules.
+14. All examples run after reload and survive WebUI restart.
+15. All generated/patched UI has tests or golden smoke scripts.
+
+## Design implications for the main plan
+
+Add or emphasize these in `capy-spaces-space-agent-parity.md`:
+
+- Treat browser-surface control as a core primitive, not a later nice-to-have.
+- Add widget-to-agent events early; the research harness depends on this.
+- Add a safe admin/recovery route before arbitrary advanced widgets or modules.
+- Include a demo-parity test suite with fixtures named after the video examples.
+- Avoid promising “perfect” one-shot generation; Space Agent itself showed a broken snake first attempt. The real parity target is fast iterative repair with persistence and rollback.

--- a/api/models.py
+++ b/api/models.py
@@ -1071,6 +1071,7 @@ class Session:
                  pending_started_at=None,
                  pending_user_source: str=None,
                  context_messages=None,
+                 active_space_id=None,
                  compression_anchor_visible_idx=None,
                  compression_anchor_message_key=None,
                  compression_anchor_summary=None,
@@ -1126,6 +1127,7 @@ class Session:
         self.pending_started_at = pending_started_at
         self.pending_user_source = pending_user_source
         self.context_messages = context_messages if isinstance(context_messages, list) else []
+        self.active_space_id = active_space_id
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
         self.compression_anchor_summary = compression_anchor_summary
@@ -1216,6 +1218,7 @@ class Session:
             'cache_read_tokens', 'cache_write_tokens',
             'personality', 'active_stream_id',
             'pending_user_message', 'pending_attachments', 'pending_started_at', 'pending_user_source',
+            'active_space_id',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
             'compression_anchor_summary', 'pre_compression_snapshot',
             'context_engine', 'compression_anchor_engine', 'compression_anchor_mode',
@@ -1495,6 +1498,7 @@ class Session:
             'cache_write_tokens': self.cache_write_tokens,
             'cache_hit_percent': prompt_cache_hit_percent(self.cache_read_tokens, self.input_tokens),
             'personality': self.personality,
+            'active_space_id': self.active_space_id,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,
             'compression_anchor_summary': self.compression_anchor_summary,

--- a/api/routes.py
+++ b/api/routes.py
@@ -12279,6 +12279,28 @@ def handle_get(handler, parsed) -> bool:
             },
         )
 
+    if parsed.path == "/api/spaces":
+        from api import spaces as capy_spaces
+        if not capy_spaces.spaces_enabled():
+            return j(handler, {"enabled": False, "spaces": []})
+        return j(handler, {"enabled": True, "spaces": capy_spaces.list_spaces()})
+
+    if parsed.path == "/api/spaces/recovery":
+        from api import spaces as capy_spaces
+        return j(handler, capy_spaces.recovery_snapshot())
+
+    if parsed.path == "/api/spaces/get":
+        from api import spaces as capy_spaces
+        space_id = parse_qs(parsed.query).get("space_id", [""])[0]
+        if not space_id:
+            return bad(handler, "Missing space_id")
+        try:
+            return j(handler, {"space": capy_spaces.read_space(space_id)})
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Space not found", 404)
+
     if parsed.path == "/api/workspaces/suggest":
         qs = parse_qs(parsed.query)
         prefix = qs.get("prefix", [""])[0]
@@ -14311,6 +14333,61 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/workspaces/reorder":
         return _handle_workspace_reorder(handler, body)
+
+    # ── Capy Spaces foundation (POST) ──
+    if parsed.path == "/api/spaces/create":
+        from api import spaces as capy_spaces
+        try:
+            return j(handler, {"space": capy_spaces.create_space(body)})
+        except RuntimeError as e:
+            return bad(handler, str(e), 403)
+        except (ValueError, FileExistsError) as e:
+            return bad(handler, str(e))
+
+    if parsed.path == "/api/spaces/update":
+        from api import spaces as capy_spaces
+        space_id = body.get("space_id")
+        if not space_id:
+            return bad(handler, "Missing space_id")
+        try:
+            return j(handler, {"space": capy_spaces.update_space(space_id, body.get("updates") or body)})
+        except RuntimeError as e:
+            return bad(handler, str(e), 403)
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Space not found", 404)
+
+    if parsed.path == "/api/spaces/delete":
+        from api import spaces as capy_spaces
+        space_id = body.get("space_id")
+        if not space_id:
+            return bad(handler, "Missing space_id")
+        try:
+            return j(handler, capy_spaces.delete_space(space_id))
+        except RuntimeError as e:
+            return bad(handler, str(e), 403)
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Space not found", 404)
+
+    if parsed.path == "/api/spaces/activate":
+        from api import spaces as capy_spaces
+        space_id = body.get("space_id")
+        session_id = body.get("session_id")
+        if not space_id or not session_id:
+            return bad(handler, "Missing space_id or session_id")
+        try:
+            capy_spaces.read_space(space_id)
+            s = get_session(session_id)
+            s.active_space_id = capy_spaces.validate_space_id(space_id)
+            s.save()
+            return j(handler, {"ok": True, "session": s.compact() | {"messages": s.messages}})
+        except ValueError as e:
+            return bad(handler, str(e))
+        except (FileNotFoundError, KeyError):
+            return bad(handler, "Space or session not found", 404)
 
     # ── Approval (POST) ──
     if parsed.path == "/api/approval/respond":

--- a/api/routes.py
+++ b/api/routes.py
@@ -12303,6 +12303,36 @@ def handle_get(handler, parsed) -> bool:
         except FileNotFoundError:
             return bad(handler, "Space not found", 404)
 
+    if parsed.path == "/api/spaces/widgets":
+        from api import spaces as capy_spaces
+        if not capy_spaces.spaces_enabled():
+            return bad(handler, "Capy Spaces is disabled", 403)
+        space_id = parse_qs(parsed.query).get("space_id", [""])[0]
+        if not space_id:
+            return bad(handler, "Missing space_id")
+        try:
+            return j(handler, {"widgets": capy_spaces.list_widgets(space_id)})
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Space not found", 404)
+
+    if parsed.path == "/api/spaces/widget":
+        from api import spaces as capy_spaces
+        if not capy_spaces.spaces_enabled():
+            return bad(handler, "Capy Spaces is disabled", 403)
+        qs = parse_qs(parsed.query)
+        space_id = qs.get("space_id", [""])[0]
+        widget_id = qs.get("widget_id", [""])[0]
+        if not space_id or not widget_id:
+            return bad(handler, "Missing space_id or widget_id")
+        try:
+            return j(handler, {"widget": capy_spaces.read_widget(space_id, widget_id)})
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Widget not found", 404)
+
     if parsed.path == "/api/workspaces/suggest":
         qs = parse_qs(parsed.query)
         prefix = qs.get("prefix", [""])[0]
@@ -14373,6 +14403,36 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e))
         except FileNotFoundError:
             return bad(handler, "Space not found", 404)
+
+    if parsed.path == "/api/spaces/widget/upsert":
+        from api import spaces as capy_spaces
+        space_id = body.get("space_id")
+        widget = body.get("widget")
+        if not space_id:
+            return bad(handler, "Missing space_id")
+        try:
+            return j(handler, capy_spaces.upsert_widget(space_id, widget))
+        except RuntimeError as e:
+            return bad(handler, str(e), 403)
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Space not found", 404)
+
+    if parsed.path == "/api/spaces/widget/delete":
+        from api import spaces as capy_spaces
+        space_id = body.get("space_id")
+        widget_id = body.get("widget_id")
+        if not space_id or not widget_id:
+            return bad(handler, "Missing space_id or widget_id")
+        try:
+            return j(handler, capy_spaces.delete_widget(space_id, widget_id))
+        except RuntimeError as e:
+            return bad(handler, str(e), 403)
+        except ValueError as e:
+            return bad(handler, str(e))
+        except FileNotFoundError:
+            return bad(handler, "Widget not found", 404)
 
     if parsed.path == "/api/spaces/activate":
         from api import spaces as capy_spaces

--- a/api/routes.py
+++ b/api/routes.py
@@ -12291,6 +12291,8 @@ def handle_get(handler, parsed) -> bool:
 
     if parsed.path == "/api/spaces/get":
         from api import spaces as capy_spaces
+        if not capy_spaces.spaces_enabled():
+            return bad(handler, "Capy Spaces is disabled", 403)
         space_id = parse_qs(parsed.query).get("space_id", [""])[0]
         if not space_id:
             return bad(handler, "Missing space_id")

--- a/api/spaces.py
+++ b/api/spaces.py
@@ -1,0 +1,235 @@
+"""Capy Spaces storage and recovery primitives.
+
+This module is intentionally isolated from chat/streaming internals so the
+Spaces foundation can survive Hermes WebUI and Hermes Agent updates. The first
+slice is storage + safe recovery only; generated widget rendering and agent
+execution arrive later behind stricter permissions.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import api.config as config
+
+SCHEMA_VERSION = 1
+_SPACE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+_TRUTHY = {"1", "true", "yes", "on", "enabled"}
+
+
+def spaces_enabled() -> bool:
+    """Return whether Capy Spaces is enabled for normal API use."""
+    return str(os.getenv("HERMES_WEBUI_SPACES_ENABLED", "")).strip().lower() in _TRUTHY
+
+
+def spaces_root() -> Path:
+    return Path(config.STATE_DIR).expanduser().resolve() / "capy-spaces"
+
+
+def manifests_dir() -> Path:
+    return spaces_root() / "spaces"
+
+
+def events_dir() -> Path:
+    return spaces_root() / "events"
+
+
+def _ensure_dirs() -> None:
+    manifests_dir().mkdir(parents=True, exist_ok=True)
+    events_dir().mkdir(parents=True, exist_ok=True)
+
+
+def _slugify(value: str) -> str:
+    value = (value or "space").strip().lower()
+    value = re.sub(r"[^a-z0-9_-]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-_")
+    return value[:64] or "space"
+
+
+def validate_space_id(space_id: str) -> str:
+    sid = str(space_id or "").strip()
+    if not _SPACE_ID_RE.fullmatch(sid):
+        raise ValueError("Invalid space_id")
+    return sid
+
+
+def _space_dir(space_id: str) -> Path:
+    sid = validate_space_id(space_id)
+    root = manifests_dir().resolve()
+    path = (root / sid).resolve()
+    path.relative_to(root)
+    return path
+
+
+def _manifest_path(space_id: str) -> Path:
+    return _space_dir(space_id) / "space.json"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8")
+    tmp = path.with_suffix(f".tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    try:
+        with open(tmp, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+def _record_event(space_id: str, event_type: str, details: dict[str, Any] | None = None) -> str:
+    _ensure_dirs()
+    event_id = uuid.uuid4().hex
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": event_id,
+        "event_type": event_type,
+        "space_id": space_id,
+        "created_at": time.time(),
+        "details": details or {},
+    }
+    _atomic_write_json(events_dir() / f"{event_id}.json", event)
+    return event_id
+
+
+def _write_manifest(space: dict[str, Any], event_type: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    now = time.time()
+    space.setdefault("created_at", now)
+    space["updated_at"] = now
+    event_id = _record_event(space["space_id"], event_type, details)
+    revisions = list(space.get("revision_events") or [])
+    revisions.append(event_id)
+    space["revision_events"] = revisions
+    space["revision_event_id"] = event_id
+    _atomic_write_json(_manifest_path(space["space_id"]), space)
+    return dict(space)
+
+
+def _summary(space: dict[str, Any]) -> dict[str, Any]:
+    widgets = space.get("widgets") or []
+    return {
+        "schema_version": space.get("schema_version", SCHEMA_VERSION),
+        "space_id": space.get("space_id"),
+        "name": space.get("name") or space.get("space_id"),
+        "description": space.get("description", ""),
+        "created_at": space.get("created_at"),
+        "updated_at": space.get("updated_at"),
+        "revision_event_id": space.get("revision_event_id"),
+        "widget_count": len(widgets) if isinstance(widgets, list) else 0,
+    }
+
+
+def _unique_space_id(base: str) -> str:
+    sid = validate_space_id(_slugify(base))
+    candidate = sid
+    idx = 2
+    while _manifest_path(candidate).exists():
+        suffix = f"-{idx}"
+        candidate = f"{sid[:64 - len(suffix)]}{suffix}"
+        idx += 1
+    return candidate
+
+
+def list_spaces() -> list[dict[str, Any]]:
+    if not spaces_enabled():
+        return []
+    _ensure_dirs()
+    spaces: list[dict[str, Any]] = []
+    for manifest in manifests_dir().glob("*/space.json"):
+        try:
+            spaces.append(_summary(json.loads(manifest.read_text(encoding="utf-8"))))
+        except Exception:
+            continue
+    spaces.sort(key=lambda s: s.get("updated_at") or 0, reverse=True)
+    return spaces
+
+
+def create_space(payload: dict[str, Any]) -> dict[str, Any]:
+    if not spaces_enabled():
+        raise RuntimeError("Capy Spaces is disabled")
+    _ensure_dirs()
+    name = str(payload.get("name") or "Untitled Space").strip() or "Untitled Space"
+    requested_id = payload.get("space_id")
+    space_id = validate_space_id(requested_id) if requested_id else _unique_space_id(name)
+    if _manifest_path(space_id).exists():
+        raise FileExistsError("Space already exists")
+    now = time.time()
+    space = {
+        "schema_version": SCHEMA_VERSION,
+        "space_id": space_id,
+        "name": name,
+        "description": str(payload.get("description") or ""),
+        "template": str(payload.get("template") or "blank"),
+        "created_at": now,
+        "updated_at": now,
+        "layout": payload.get("layout") if isinstance(payload.get("layout"), dict) else {},
+        "widgets": payload.get("widgets") if isinstance(payload.get("widgets"), list) else [],
+        "capabilities": payload.get("capabilities") if isinstance(payload.get("capabilities"), dict) else {},
+        "recovery": {"safe_mode_available": True},
+        "revision_events": [],
+        "revision_event_id": None,
+    }
+    return _write_manifest(space, "space.created", {"name": name})
+
+
+def read_space(space_id: str) -> dict[str, Any]:
+    path = _manifest_path(space_id)
+    if not path.exists():
+        raise FileNotFoundError("Space not found")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data.setdefault("schema_version", SCHEMA_VERSION)
+    data.setdefault("widgets", [])
+    data.setdefault("layout", {})
+    data.setdefault("revision_events", [])
+    return data
+
+
+def update_space(space_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+    if not spaces_enabled():
+        raise RuntimeError("Capy Spaces is disabled")
+    space = read_space(space_id)
+    allowed = {"name", "description", "layout", "widgets", "capabilities", "template"}
+    for key, value in (updates or {}).items():
+        if key in allowed:
+            if key == "widgets" and not isinstance(value, list):
+                raise ValueError("widgets must be a list")
+            if key in {"layout", "capabilities"} and not isinstance(value, dict):
+                raise ValueError(f"{key} must be an object")
+            space[key] = value
+    return _write_manifest(space, "space.updated", {"fields": sorted(set(updates or {}) & allowed)})
+
+
+def delete_space(space_id: str) -> dict[str, Any]:
+    if not spaces_enabled():
+        raise RuntimeError("Capy Spaces is disabled")
+    sid = validate_space_id(space_id)
+    path = _space_dir(sid)
+    if not path.exists():
+        raise FileNotFoundError("Space not found")
+    event_id = _record_event(sid, "space.deleted")
+    shutil.rmtree(path)
+    return {"deleted": True, "space_id": sid, "revision_event_id": event_id}
+
+
+def recovery_snapshot() -> dict[str, Any]:
+    """Return safe recovery metadata without rendering/returning widget code."""
+    if not spaces_enabled():
+        return {"enabled": False, "generated_widgets_rendered": False, "spaces": []}
+    _ensure_dirs()
+    return {
+        "enabled": True,
+        "schema_version": SCHEMA_VERSION,
+        "generated_widgets_rendered": False,
+        "spaces": list_spaces(),
+    }

--- a/api/spaces.py
+++ b/api/spaces.py
@@ -20,6 +20,7 @@ import api.config as config
 
 SCHEMA_VERSION = 1
 _SPACE_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+_WIDGET_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 _TRUTHY = {"1", "true", "yes", "on", "enabled"}
 
 
@@ -57,6 +58,13 @@ def validate_space_id(space_id: str) -> str:
     if not _SPACE_ID_RE.fullmatch(sid):
         raise ValueError("Invalid space_id")
     return sid
+
+
+def validate_widget_id(widget_id: str) -> str:
+    wid = str(widget_id or "").strip()
+    if not _WIDGET_ID_RE.fullmatch(wid):
+        raise ValueError("Invalid widget_id")
+    return wid
 
 
 def _space_dir(space_id: str) -> Path:
@@ -127,6 +135,16 @@ def _summary(space: dict[str, Any]) -> dict[str, Any]:
         "updated_at": space.get("updated_at"),
         "revision_event_id": space.get("revision_event_id"),
         "widget_count": len(widgets) if isinstance(widgets, list) else 0,
+    }
+
+
+def _widget_summary(widget: dict[str, Any]) -> dict[str, Any]:
+    wid = validate_widget_id(widget.get("id"))
+    title = str(widget.get("title") or widget.get("name") or wid)
+    return {
+        "id": wid,
+        "kind": str(widget.get("kind") or "custom"),
+        "title": title,
     }
 
 
@@ -220,6 +238,90 @@ def delete_space(space_id: str) -> dict[str, Any]:
     event_id = _record_event(sid, "space.deleted")
     shutil.rmtree(path)
     return {"deleted": True, "space_id": sid, "revision_event_id": event_id}
+
+
+def _widget_index(space: dict[str, Any], widget_id: str) -> int:
+    wid = validate_widget_id(widget_id)
+    widgets = space.get("widgets") or []
+    if not isinstance(widgets, list):
+        raise ValueError("widgets must be a list")
+    for idx, widget in enumerate(widgets):
+        if isinstance(widget, dict) and widget.get("id") == wid:
+            return idx
+    raise FileNotFoundError("Widget not found")
+
+
+def list_widgets(space_id: str) -> list[dict[str, Any]]:
+    if not spaces_enabled():
+        return []
+    space = read_space(space_id)
+    widgets = space.get("widgets") or []
+    if not isinstance(widgets, list):
+        raise ValueError("widgets must be a list")
+    summaries: list[dict[str, Any]] = []
+    for widget in widgets:
+        if isinstance(widget, dict):
+            summaries.append(_widget_summary(widget))
+    return summaries
+
+
+def read_widget(space_id: str, widget_id: str) -> dict[str, Any]:
+    if not spaces_enabled():
+        raise RuntimeError("Capy Spaces is disabled")
+    space = read_space(space_id)
+    idx = _widget_index(space, widget_id)
+    return dict(space["widgets"][idx])
+
+
+def upsert_widget(space_id: str, widget: dict[str, Any]) -> dict[str, Any]:
+    if not spaces_enabled():
+        raise RuntimeError("Capy Spaces is disabled")
+    if not isinstance(widget, dict):
+        raise ValueError("widget must be an object")
+    wid = validate_widget_id(widget.get("id"))
+    clean_widget = dict(widget)
+    clean_widget["id"] = wid
+    clean_widget["kind"] = str(clean_widget.get("kind") or "custom")
+    clean_widget["title"] = str(clean_widget.get("title") or clean_widget.get("name") or wid)
+
+    space = read_space(space_id)
+    widgets = space.get("widgets") or []
+    if not isinstance(widgets, list):
+        raise ValueError("widgets must be a list")
+    replaced = False
+    for idx, existing in enumerate(widgets):
+        if isinstance(existing, dict) and existing.get("id") == wid:
+            widgets[idx] = clean_widget
+            replaced = True
+            break
+    if not replaced:
+        widgets.append(clean_widget)
+    space["widgets"] = widgets
+    event_type = "widget.updated" if replaced else "widget.created"
+    saved = _write_manifest(space, event_type, {"widget_id": wid})
+    return {
+        "space_id": saved["space_id"],
+        "widget": clean_widget,
+        "revision_event_id": saved["revision_event_id"],
+    }
+
+
+def delete_widget(space_id: str, widget_id: str) -> dict[str, Any]:
+    if not spaces_enabled():
+        raise RuntimeError("Capy Spaces is disabled")
+    wid = validate_widget_id(widget_id)
+    space = read_space(space_id)
+    idx = _widget_index(space, wid)
+    widgets = list(space.get("widgets") or [])
+    widgets.pop(idx)
+    space["widgets"] = widgets
+    saved = _write_manifest(space, "widget.deleted", {"widget_id": wid})
+    return {
+        "deleted": True,
+        "space_id": saved["space_id"],
+        "widget_id": wid,
+        "revision_event_id": saved["revision_event_id"],
+    }
 
 
 def recovery_snapshot() -> dict[str, Any]:

--- a/static/index.html
+++ b/static/index.html
@@ -70,6 +70,7 @@
   }
 })()</script>
 <link rel="stylesheet" href="static/style.css?v=__WEBUI_VERSION__">
+<link rel="stylesheet" href="static/spaces.css?v=__WEBUI_VERSION__">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" integrity="sha384-LJcOxlx9IMbNXDqJ2axpfEQKkAYbFjJfhXexLfiRJhjDU81mzgkiQq8rkV0j6dVh" crossorigin="anonymous">
   <!-- KaTeX math rendering CSS (loaded eagerly from vendored assets to prevent font CSP noise) -->
   <link rel="stylesheet" href="static/vendor/katex/0.16.22/katex.min.css">
@@ -775,6 +776,15 @@
       </div>
     </div>
     </div><!-- /#mainChat -->
+    <div id="mainCapySpaces" class="main-view" aria-label="Capy Spaces">
+      <div class="main-view-header">
+        <div class="main-view-title">Capy Spaces</div>
+      </div>
+      <div class="capy-spaces-shell">
+        <div id="capySpacesRecovery" class="capy-spaces-card capy-spaces-recovery">Loading safe recovery…</div>
+        <div id="capySpacesRoot" class="capy-spaces-card">Loading Capy Spaces…</div>
+      </div>
+    </div>
     <div id="mainSkills" class="main-view">
       <div class="main-view-header">
         <div class="main-view-title" id="skillDetailTitle"></div>
@@ -1717,6 +1727,7 @@
 <script src="static/sessions.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/commands.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/messages.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/spaces.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/extension_settings.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/panels.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/onboarding.js?v=__WEBUI_VERSION__" defer></script>

--- a/static/spaces.css
+++ b/static/spaces.css
@@ -1,0 +1,29 @@
+/* Capy Spaces foundation shell. Hidden unless the feature flag/API enables it. */
+.capy-spaces-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  height: 100%;
+  overflow: auto;
+}
+
+.capy-spaces-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--panel);
+  padding: 16px;
+}
+
+.capy-spaces-card h3 {
+  margin: 0 0 8px;
+}
+
+.capy-spaces-muted {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.capy-spaces-recovery {
+  border-color: color-mix(in srgb, var(--warning, #f59e0b) 45%, var(--border));
+}

--- a/static/spaces.js
+++ b/static/spaces.js
@@ -1,0 +1,54 @@
+// Capy Spaces foundation shell.
+// The first implementation slice only exposes safe metadata and recovery state.
+(function(){
+  async function fetchSpacesJson(path){
+    const res = await fetch(path, {cache: 'no-store'});
+    if (!res.ok) throw new Error('Spaces request failed: '+res.status);
+    return res.json();
+  }
+
+  async function loadCapySpaces(){
+    const root = document.getElementById('capySpacesRoot');
+    if (!root) return;
+    try {
+      const data = await fetchSpacesJson('api/spaces');
+      if (!data.enabled) {
+        root.innerHTML = '<div class="capy-spaces-card"><h3>Capy Spaces disabled</h3><div class="capy-spaces-muted">Set HERMES_WEBUI_SPACES_ENABLED=1 to enable the foundation shell.</div></div>';
+        return;
+      }
+      const spaces = data.spaces || [];
+      root.innerHTML = '<div class="capy-spaces-card"><h3>Capy Spaces</h3><div class="capy-spaces-muted">'+spaces.length+' space(s). Widget rendering is intentionally disabled in the foundation slice.</div></div>' +
+        spaces.map(function(s){
+          return '<div class="capy-spaces-card" data-space-id="'+escapeHtml(s.space_id||'')+'"><strong>'+escapeHtml(s.name||s.space_id||'Untitled')+'</strong><div class="capy-spaces-muted">Widgets: '+(s.widget_count||0)+' · Revision: '+escapeHtml(s.revision_event_id||'none')+'</div></div>';
+        }).join('');
+    } catch (err) {
+      root.innerHTML = '<div class="capy-spaces-card"><h3>Capy Spaces unavailable</h3><div class="capy-spaces-muted">'+escapeHtml(err.message||String(err))+'</div></div>';
+    }
+  }
+
+  async function loadCapySpacesRecovery(){
+    const root = document.getElementById('capySpacesRecovery');
+    if (!root) return;
+    try {
+      const data = await fetchSpacesJson('api/spaces/recovery');
+      root.textContent = data.enabled
+        ? 'Safe recovery available. Generated widgets rendered here: '+String(!!data.generated_widgets_rendered)
+        : 'Capy Spaces recovery is disabled because Spaces are disabled.';
+    } catch (err) {
+      root.textContent = 'Safe recovery unavailable: '+(err.message||String(err));
+    }
+  }
+
+  function escapeHtml(value){
+    return String(value).replace(/[&<>'"]/g, function(ch){
+      return ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'})[ch];
+    });
+  }
+
+  window.loadCapySpaces = loadCapySpaces;
+  window.loadCapySpacesRecovery = loadCapySpacesRecovery;
+  window.addEventListener('DOMContentLoaded', function(){
+    loadCapySpaces();
+    loadCapySpacesRecovery();
+  });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -4810,6 +4810,7 @@ body.resizing .sidebar{transition:none!important;}
 .main-view{flex:1;min-height:0;min-width:0;display:flex;flex-direction:column;background:var(--bg);}
 main.main > #mainChat,
 main.main > #mainSettings,
+main.main > #mainCapySpaces,
 main.main > #mainSkills,
 main.main > #mainMemory,
 main.main > #mainTasks,
@@ -4818,8 +4819,9 @@ main.main > #mainWorkspaces,
 main.main > #mainProfiles,
 main.main > #mainInsights,
 main.main > #mainLogs{display:none;}
-main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs):not(.showing-plugin) > #mainChat{display:flex;}
+main.main:not(.showing-settings):not(.showing-capy-spaces):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs):not(.showing-plugin) > #mainChat{display:flex;}
 main.main.showing-settings > #mainSettings{display:flex;overflow-y:auto;}
+main.main.showing-capy-spaces > #mainCapySpaces{display:flex;}
 main.main.showing-skills > #mainSkills{display:flex;}
 main.main.showing-memory > #mainMemory{display:flex;}
 main.main.showing-tasks > #mainTasks{display:flex;}

--- a/tests/test_spaces_foundation.py
+++ b/tests/test_spaces_foundation.py
@@ -1,0 +1,152 @@
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_spaces(monkeypatch, tmp_path, enabled=True):
+    import api.config as config
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path / "state")
+    if enabled:
+        monkeypatch.setenv("HERMES_WEBUI_SPACES_ENABLED", "1")
+    else:
+        monkeypatch.delenv("HERMES_WEBUI_SPACES_ENABLED", raising=False)
+    import api.spaces as spaces
+    return importlib.reload(spaces)
+
+
+def test_spaces_feature_flag_disabled_is_safe(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=False)
+
+    assert spaces.spaces_enabled() is False
+    assert spaces.list_spaces() == []
+    recovery = spaces.recovery_snapshot()
+    assert recovery["enabled"] is False
+    assert recovery["generated_widgets_rendered"] is False
+
+
+def test_create_read_list_space_with_schema_version_and_revision_event(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+
+    created = spaces.create_space({"name": "Research Harness", "description": "First safe space"})
+
+    assert created["schema_version"] == 1
+    assert created["space_id"] == "research-harness"
+    assert created["name"] == "Research Harness"
+    assert created["widgets"] == []
+    assert created["revision_event_id"]
+
+    loaded = spaces.read_space("research-harness")
+    assert loaded["space_id"] == created["space_id"]
+    assert spaces.list_spaces()[0]["space_id"] == "research-harness"
+
+    event_path = spaces.events_dir() / f"{created['revision_event_id']}.json"
+    assert event_path.exists()
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    assert event["event_type"] == "space.created"
+    assert event["space_id"] == "research-harness"
+
+
+def test_space_id_validation_rejects_traversal_and_unsafe_names(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+
+    for bad_id in ["../escape", "bad/id", ".hidden", "", "a" * 80]:
+        with pytest.raises(ValueError):
+            spaces.read_space(bad_id)
+
+    with pytest.raises(ValueError):
+        spaces.create_space({"space_id": "../escape", "name": "Escape"})
+
+
+def test_update_space_creates_new_revision_event_and_preserves_widget_specs(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Demo"})
+
+    updated = spaces.update_space(
+        created["space_id"],
+        {
+            "name": "Demo Updated",
+            "widgets": [
+                {
+                    "id": "widget-1",
+                    "kind": "markdown",
+                    "title": "Unsafe renderer should not appear in recovery",
+                    "renderer": "<script>alert('bad')</script>",
+                }
+            ],
+        },
+    )
+
+    assert updated["name"] == "Demo Updated"
+    assert updated["revision_event_id"] != created["revision_event_id"]
+    assert (spaces.events_dir() / f"{updated['revision_event_id']}.json").exists()
+    assert spaces.read_space(created["space_id"])["widgets"][0]["id"] == "widget-1"
+
+
+def test_recovery_snapshot_never_returns_generated_widget_renderers(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Broken Widgets"})
+    spaces.update_space(
+        created["space_id"],
+        {"widgets": [{"id": "w1", "renderer": "<script>breakUI()</script>", "html": "<b>bad</b>"}]},
+    )
+
+    recovery = spaces.recovery_snapshot()
+    serialized = json.dumps(recovery)
+
+    assert recovery["enabled"] is True
+    assert recovery["generated_widgets_rendered"] is False
+    assert recovery["spaces"][0]["widget_count"] == 1
+    assert "breakUI" not in serialized
+    assert "<script" not in serialized
+    assert "renderer" not in serialized
+
+
+def test_delete_space_removes_manifest_but_keeps_global_revision_event(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Disposable"})
+
+    result = spaces.delete_space(created["space_id"])
+
+    assert result["deleted"] is True
+    assert result["space_id"] == created["space_id"]
+    assert result["revision_event_id"]
+    assert (spaces.events_dir() / f"{result['revision_event_id']}.json").exists()
+    with pytest.raises(FileNotFoundError):
+        spaces.read_space(created["space_id"])
+
+
+def test_session_active_space_id_is_optional_and_persists(monkeypatch, tmp_path):
+    import api.config as config
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path / "sessions")
+    config.SESSION_DIR.mkdir(parents=True, exist_ok=True)
+
+    import api.models as models
+    monkeypatch.setattr(models, "SESSION_DIR", config.SESSION_DIR)
+    models.SESSIONS.clear()
+
+    legacy = models.Session(session_id="legacy_session", workspace=str(tmp_path))
+    assert legacy.active_space_id is None
+    assert "active_space_id" in legacy.compact()
+
+    legacy.active_space_id = "research-harness"
+    legacy.save(skip_index=True)
+    loaded = models.Session.load("legacy_session")
+
+    assert loaded.active_space_id == "research-harness"
+    assert loaded.compact()["active_space_id"] == "research-harness"
+
+
+def test_spaces_routes_and_static_shell_are_registered():
+    repo = Path(__file__).resolve().parents[1]
+    routes_src = (repo / "api" / "routes.py").read_text(encoding="utf-8")
+    index_html = (repo / "static" / "index.html").read_text(encoding="utf-8")
+
+    assert '"/api/spaces"' in routes_src
+    assert '"/api/spaces/recovery"' in routes_src
+    assert '"/api/spaces/create"' in routes_src
+    assert 'static/spaces.js' in index_html
+    assert 'static/spaces.css' in index_html
+    assert 'id="mainCapySpaces"' in index_html
+    assert 'id="capySpacesRecovery"' in index_html

--- a/tests/test_spaces_foundation.py
+++ b/tests/test_spaces_foundation.py
@@ -236,3 +236,81 @@ def test_disabled_spaces_get_route_does_not_return_manifest_details(monkeypatch,
     assert status == 403
     assert "space" not in body
     assert "secret" not in json.dumps(body)
+
+
+def test_widget_upsert_list_read_and_delete_are_revisioned(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Widget Lab"})
+
+    upserted = spaces.upsert_widget(
+        created["space_id"],
+        {
+            "id": "weather",
+            "kind": "markdown",
+            "title": "Weather",
+            "renderer": "# {{temperature}}",
+            "data": {"temperature": "72F"},
+        },
+    )
+
+    assert upserted["space_id"] == created["space_id"]
+    assert upserted["widget"]["id"] == "weather"
+    assert upserted["revision_event_id"] != created["revision_event_id"]
+    assert (spaces.events_dir() / f"{upserted['revision_event_id']}.json").exists()
+
+    widgets = spaces.list_widgets(created["space_id"])
+    assert widgets == [{"id": "weather", "kind": "markdown", "title": "Weather"}]
+    assert "renderer" not in json.dumps(widgets)
+
+    full = spaces.read_widget(created["space_id"], "weather")
+    assert full["renderer"] == "# {{temperature}}"
+
+    deleted = spaces.delete_widget(created["space_id"], "weather")
+    assert deleted["deleted"] is True
+    assert deleted["revision_event_id"] != upserted["revision_event_id"]
+    assert spaces.list_widgets(created["space_id"]) == []
+
+
+def test_widget_validation_rejects_pathlike_ids_and_non_object_specs(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Widget Validation"})
+
+    for bad_id in ["../escape", "bad/id", ".hidden", "", "a" * 80]:
+        with pytest.raises(ValueError):
+            spaces.upsert_widget(created["space_id"], {"id": bad_id, "kind": "markdown"})
+
+    with pytest.raises(ValueError):
+        spaces.upsert_widget(created["space_id"], ["not", "a", "dict"])
+
+
+def test_widget_routes_upsert_list_read_and_delete(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Route Widgets"})
+    space_id = created["space_id"]
+
+    handled, status, body = _route_post(
+        "/api/spaces/widget/upsert",
+        {"space_id": space_id, "widget": {"id": "notes", "kind": "markdown", "title": "Notes"}},
+    )
+    assert handled is None
+    assert status == 200
+    assert body["widget"]["id"] == "notes"
+
+    handled, status, body = _route_get(f"/api/spaces/widgets?space_id={space_id}")
+    assert handled is None
+    assert status == 200
+    assert body["widgets"] == [{"id": "notes", "kind": "markdown", "title": "Notes"}]
+
+    handled, status, body = _route_get(f"/api/spaces/widget?space_id={space_id}&widget_id=notes")
+    assert handled is None
+    assert status == 200
+    assert body["widget"]["title"] == "Notes"
+
+    handled, status, body = _route_post(
+        "/api/spaces/widget/delete",
+        {"space_id": space_id, "widget_id": "notes"},
+    )
+    assert handled is None
+    assert status == 200
+    assert body["deleted"] is True
+    assert spaces.list_widgets(space_id) == []

--- a/tests/test_spaces_foundation.py
+++ b/tests/test_spaces_foundation.py
@@ -1,6 +1,8 @@
 import importlib
+import io
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -150,3 +152,87 @@ def test_spaces_routes_and_static_shell_are_registered():
     assert 'static/spaces.css' in index_html
     assert 'id="mainCapySpaces"' in index_html
     assert 'id="capySpacesRecovery"' in index_html
+
+
+class _RouteHandler:
+    def __init__(self, body=None):
+        raw = json.dumps(body or {}).encode("utf-8")
+        self.rfile = io.BytesIO(raw)
+        self.wfile = io.BytesIO()
+        self.headers = {
+            "Content-Length": str(len(raw)),
+            "Accept-Encoding": "",
+            "Host": "127.0.0.1:8787",
+        }
+        self.status = None
+        self.sent_headers = []
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+    def json_body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _route_get(path):
+    import api.routes as routes
+
+    handler = _RouteHandler()
+    handled = routes.handle_get(handler, urlparse(path))
+    return handled, handler.status, handler.json_body()
+
+
+def _route_post(path, body):
+    import api.routes as routes
+
+    handler = _RouteHandler(body)
+    handled = routes.handle_post(handler, urlparse(path))
+    return handled, handler.status, handler.json_body()
+
+
+def test_spaces_routes_create_list_get_and_recovery(monkeypatch, tmp_path):
+    _load_spaces(monkeypatch, tmp_path, enabled=True)
+
+    handled, status, body = _route_post("/api/spaces/create", {"name": "Route Space"})
+    assert handled is None
+    assert status == 200
+    space_id = body["space"]["space_id"]
+
+    handled, status, body = _route_get("/api/spaces")
+    assert handled is None
+    assert status == 200
+    assert body["enabled"] is True
+    assert body["spaces"][0]["space_id"] == space_id
+
+    handled, status, body = _route_get(f"/api/spaces/get?space_id={space_id}")
+    assert handled is None
+    assert status == 200
+    assert body["space"]["name"] == "Route Space"
+
+    handled, status, body = _route_get("/api/spaces/recovery")
+    assert handled is None
+    assert status == 200
+    assert body["generated_widgets_rendered"] is False
+
+
+def test_disabled_spaces_get_route_does_not_return_manifest_details(monkeypatch, tmp_path):
+    spaces = _load_spaces(monkeypatch, tmp_path, enabled=True)
+    created = spaces.create_space({"name": "Disabled Leak"})
+    spaces.update_space(
+        created["space_id"],
+        {"widgets": [{"id": "w1", "renderer": "<script>secret()</script>"}]},
+    )
+    _load_spaces(monkeypatch, tmp_path, enabled=False)
+
+    handled, status, body = _route_get(f"/api/spaces/get?space_id={created['space_id']}")
+
+    assert handled is None
+    assert status == 403
+    assert "space" not in body
+    assert "secret" not in json.dumps(body)


### PR DESCRIPTION
## Summary

Second focused Capy Spaces review slice, stacked on the current-master foundation branch from #5712.

This PR adds:

- Route behavior coverage for the Capy Spaces API.
- Widget API endpoints and helpers for Spaces widgets.
- Focused backend tests for the new route/API behavior.

Dependency:

- Builds on foundation PR: https://github.com/nesquena/hermes-webui/pull/5712
- Umbrella full-stack checkpoint remains: https://github.com/nesquena/hermes-webui/pull/5710

Note: because GitHub PR bases for upstream forks target upstream branches, this draft targets `master`; review should consider the incremental diff after #5712.

## Validation

Ran locally on branch `review/capy-spaces-widget-api-master-20260706-180629`:

```text
$ PY=/Users/bschmidy10/.hermes/hermes-agent/venv/bin/python
$ $PY -m pytest tests/test_spaces_foundation.py -q -o 'addopts='
13 passed in 3.28s

$ $PY -m py_compile api/models.py api/routes.py api/spaces.py tests/test_spaces_foundation.py
pass

$ node --check static/spaces.js
pass

$ git diff --check
pass

conflict marker scan over touched files: all 0
```

Incremental diff vs #5712 branch:

```text
api/routes.py                   |  62 +++++++++++++++
api/spaces.py                   | 102 +++++++++++++++++++++++++
tests/test_spaces_foundation.py | 164 ++++++++++++++++++++++++++++++++++++++++
3 files changed, 328 insertions(+)
```
