### PR TITLE
Release: preserve workspace file-tree scroll position (#5664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **The workspace file tree no longer jumps to the top when you expand a folder.** Every folder expand/collapse, breadcrumb navigation, refresh, and hidden-files toggle re-rendered the tree by wiping its container, which collapsed its height and made the browser reset the scroll position to the top — teleporting you away from where you were in a long tree. The scroll position is now captured before the re-render and restored after. Reported by @claw-io. (#5664, #5657)
+
 - **Self-update recovers when a `.git/index.lock` is blocking it.** If "Update Now" failed because a stale `.git/index.lock` was present (a previous git process left it behind), the WebUI gave no in-UI way out — you were stuck on an un-updatable install. The update banner now detects that specific failure, shows the exact `rm -f …/.git/index.lock` command to run on the host, and offers a "Retry update" button that re-runs the normal update once the lock is gone. The server never deletes anything under `.git` itself (fail-closed — git's lock can't be safely auto-cleared without racing), so this is purely a detect-and-guide recovery. Thanks @b3nw. (#5688, #5687)
 
 ### Internal

--- a/static/ui.js
+++ b/static/ui.js
@@ -17212,7 +17212,18 @@ if(!S._expandedDirs) S._expandedDirs=new Set();
 if(!S._dirCache) S._dirCache={};
 
 function renderFileTree(){
-  const box=$('fileTree');box.innerHTML='';
+  const box=$('fileTree');
+  // #5657: capture the scroll position before wiping the container. box.innerHTML=''
+  // detaches every row, collapsing scrollHeight so the browser clamps scrollTop to 0;
+  // without this, every expand/collapse, breadcrumb nav, refresh, and hidden-files
+  // toggle that re-runs renderFileTree() teleports the reader back to the top of a
+  // long tree. Restored only after the normal render tail below — the two early-return
+  // paths (no-workspace hides the box; empty-dir has nothing to scroll) legitimately
+  // reset. A plain scrollTop restore suffices here: expand/collapse insert/remove rows
+  // BELOW the clicked disclosure, so the clicked row keeps its offset from the top (no
+  // getBoundingClientRect anchor delta needed — that's only for prepend-above cases).
+  const prevScrollTop=box?box.scrollTop:0;
+  box.innerHTML='';
   // Cache current dir entries
   S._dirCache[S.currentDir||'.']=S.entries;
   // Show empty-state when no workspace is set or the directory is empty (#703)
@@ -17231,6 +17242,8 @@ function renderFileTree(){
     return;
   }
   _renderTreeItems(box, visibleEntries, 0);
+  // #5657: restore the pre-wipe scroll position now that the tree is tall again.
+  if(box) box.scrollTop=prevScrollTop;
 }
 
 let _wsActiveDragPath=null;

--- a/tests/test_issue5657_filetree_scroll_preserve.py
+++ b/tests/test_issue5657_filetree_scroll_preserve.py
@@ -1,0 +1,64 @@
+"""Regression coverage for #5657 — workspace file-tree preserves scroll on re-render.
+
+`renderFileTree()` clears its scroll container with ``box.innerHTML=''`` and
+rebuilds every row. That detaches the rows, collapses ``scrollHeight``, and the
+browser clamps ``scrollTop`` to 0 — so every folder expand/collapse, breadcrumb
+nav, refresh, and hidden-files toggle that re-runs the renderer teleported the
+reader to the top of a long tree.
+
+Fix: capture ``scrollTop`` before the wipe and restore it after the normal
+render tail. A plain scrollTop restore is sufficient (expand/collapse insert or
+remove rows BELOW the clicked disclosure, so the clicked row keeps its offset) —
+the reporter's getBoundingClientRect anchor sketch is deliberately NOT used, and
+the ``.file-item`` rows carry no ``data-path`` for it anyway.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _render_file_tree_body() -> str:
+    start = UI_JS.index("function renderFileTree()")
+    end = UI_JS.index("\nfunction ", start + 1)
+    return UI_JS[start:end]
+
+
+def _render_file_tree_code() -> str:
+    """Body with // comment lines stripped, so assertions anchor on real code."""
+    lines = [ln for ln in _render_file_tree_body().splitlines() if not ln.strip().startswith("//")]
+    return "\n".join(lines)
+
+
+def test_render_file_tree_captures_and_restores_scrolltop():
+    body = _render_file_tree_code()
+    # It must still wipe the container (the behavior that loses scroll)...
+    assert "box.innerHTML=''" in body or 'box.innerHTML = ""' in body
+    # ...and it must capture scrollTop BEFORE the wipe and restore it after.
+    assert "scrollTop" in body, (
+        "renderFileTree must capture + restore scrollTop around the innerHTML wipe (#5657)"
+    )
+    capture_idx = body.index("prevScrollTop=box")
+    wipe_idx = body.index("box.innerHTML=''")
+    assert capture_idx < wipe_idx, (
+        "scrollTop must be captured BEFORE box.innerHTML='' so it isn't already clamped to 0"
+    )
+    render_idx = body.index("_renderTreeItems(box")
+    restore_idx = body.rindex("box.scrollTop=")
+    assert restore_idx > render_idx, (
+        "scrollTop must be restored AFTER _renderTreeItems repaints the tree"
+    )
+
+
+def test_early_return_paths_still_reset_scroll():
+    # The no-workspace and empty-dir early returns legitimately want scroll reset
+    # (box hidden / nothing to scroll) — the restore must live on the normal tail
+    # only, i.e. AFTER _renderTreeItems, not before the early returns.
+    body = _render_file_tree_code()
+    render_idx = body.index("_renderTreeItems(box")
+    tail = body[render_idx:]
+    assert "box.scrollTop=" in tail or "box.scrollTop =" in tail, (
+        "the scrollTop restore must be on the normal render tail, after _renderTreeItems"
+    )


### PR DESCRIPTION
## Release — preserve workspace file-tree scroll position (#5664, fixes #5657)

Reliability sprint. Self-built (nesquena-hermes) from claw-io's report; **independent review: nesquena APPROVED** (end-to-end, no fixes needed) — the self-built independent-review requirement is satisfied.

- **#5664** — `renderFileTree()` cleared its scroll container with `box.innerHTML=''` and rebuilt every row, collapsing scrollHeight so the browser clamped scrollTop to 0. Every folder expand/collapse, breadcrumb nav, refresh, and hidden-files toggle teleported the reader to the top of a long tree. Fix captures `fileTree.scrollTop` before the wipe and restores it after the render tail. Plain scrollTop restore suffices (expand/collapse insert/remove rows BELOW the clicked disclosure, so the clicked row keeps its offset). +78/-1, static/ui.js + new regression test.

**Gate (all three legs per the standing rule):**
- Codex: SAFE TO SHIP — no regression; early-return paths (no-workspace/empty-dir) legitimately reset, stale scrollTop on a shorter tree clamps harmlessly.
- Fable-UX: SHIP-UX.
- nesquena: APPROVED (independent human review).
- Full suite: 12282 passed; the 1 failure is the pre-existing tls env-flake (unrelated — #5664 touches only fileTree scroll; the test passes in isolation). Pre-gates: ruff + scope-undef CLEAN, node -c OK.

Attribution: reported by @claw-io; self-built + nesquena-reviewed.
