### PR TITLE
fix: surface agent's graceful summary on iteration-limit exhaustion (closes #5494)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1389,6 +1389,40 @@ def _agent_result_tool_limit_reached(result) -> bool:
     return False
 
 
+def _maybe_inject_max_iteration_summary_fallback(messages, result) -> list:
+    """Append the agent's graceful summary text as an assistant turn when one is missing.
+
+    When ``AIAgent`` exhausts its iteration budget, ``agent.handle_max_iterations``
+    always returns a non-empty ``final_response`` — either the model-generated
+    summary or a graceful fallback (e.g. ``"I reached the iteration limit and
+    couldn't generate a summary."``). Hermes Agent surfaces that string as the
+    final answer to the user; the WebUI, by contrast, reads only ``messages``,
+    so an empty summary (common with reasoning-only responses) left the user
+    with a bare ``tool_limit_reached`` error instead of any closure text.
+
+    When ``_tool_limit_reached`` is true and ``messages`` ends without a final
+    assistant answer, inject ``result['final_response']`` as a new assistant
+    turn so ``_mark_latest_assistant_tool_limit_status`` can attach the status
+    card in the normal flow and the user sees the same closure text as
+    hermes-agent. Returns the (possibly new) messages list; does nothing when
+    a usable assistant answer already exists or when ``result`` carries no
+    graceful fallback text.
+    """
+    if not isinstance(result, dict):
+        return list(messages or [])
+    fallback = result.get('final_response')
+    if not isinstance(fallback, str) or not fallback.strip():
+        return list(messages or [])
+    out = list(messages or [])
+    if not _session_lacks_final_assistant_answer(out):
+        return out
+    # Append a synthetic summary turn. Tag it so downstream consumers can
+    # distinguish it from model-emitted assistant turns if needed; mirrors the
+    # synthetic-scaffolding flag convention already used elsewhere (#5334).
+    out.append({"role": "assistant", "content": fallback, "_max_iteration_summary_fallback": True})
+    return out
+
+
 def _mark_latest_assistant_tool_limit_status(messages) -> bool:
     """Annotate the latest usable assistant final answer as limit-stopped."""
     for msg in reversed(list(messages or [])):
@@ -8239,6 +8273,20 @@ def _run_agent_streaming(
                         _result_messages,
                         enabled=_tool_limit_reached,
                     )
+                    # #5494 — parity with hermes-agent's handle_max_iterations() return
+                    # value. When the agent produced no usable summary assistant
+                    # message but result['final_response'] carries a graceful fallback
+                    # string, inject it as a final assistant turn so the user sees
+                    # closure text instead of a bare tool_limit_reached error. Apply
+                    # the synthesis to result['messages'] AND _result_messages so
+                    # downstream _all_result_messages checks (silent-failure detection
+                    # at #all_result_messages on the same turn) see the fallback too.
+                    if _tool_limit_reached:
+                        _result_messages = _maybe_inject_max_iteration_summary_fallback(
+                            _result_messages, result
+                        )
+                        if isinstance(result, dict) and result.get('messages') is not None:
+                            result = {**result, 'messages': _result_messages}
                     if cancel_event.is_set():
                         _finalize_cancelled_turn(s, ephemeral=False)
                         try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8278,14 +8278,18 @@ def _run_agent_streaming(
                     # message but result['final_response'] carries a graceful fallback
                     # string, inject it as a final assistant turn so the user sees
                     # closure text instead of a bare tool_limit_reached error. Apply
-                    # the synthesis to result['messages'] AND _result_messages so
+                    # the synthesis to result['messages'] AND _result_messages so the
                     # downstream _all_result_messages checks (silent-failure detection
-                    # at #all_result_messages on the same turn) see the fallback too.
+                    # at api/streaming.py:_assistant_reply_added_after_current_turn)
+                    # see the fallback too. `finalize_turn` in the agent always returns
+                    # messages as a list, but we write back unconditionally so the
+                    # contract is "if we built a result-messages list, the silent-failure
+                    # classifier reads the augmented version."
                     if _tool_limit_reached:
                         _result_messages = _maybe_inject_max_iteration_summary_fallback(
                             _result_messages, result
                         )
-                        if isinstance(result, dict) and result.get('messages') is not None:
+                        if isinstance(result, dict):
                             result = {**result, 'messages': _result_messages}
                     if cancel_event.is_set():
                         _finalize_cancelled_turn(s, ephemeral=False)

--- a/tests/test_tool_limit_terminal_state.py
+++ b/tests/test_tool_limit_terminal_state.py
@@ -280,6 +280,123 @@ def test_streaming_tool_limit_without_final_answer_emits_no_final_apperror(tmp_p
     )
 
 
+def test_streaming_tool_limit_with_fallback_final_response_surfaces_closure_text(tmp_path, monkeypatch):
+    """#5494 — when the agent produced no usable summary but returned a graceful
+    fallback string (handle_max_iterations() always returns one), inject that as a
+    final assistant turn so the user sees closure text instead of a bare error.
+    """
+    graceful = "I reached the iteration limit and couldn't generate a summary."
+    result = {
+        "turn_exit_reason": "max_iterations_reached(30/30)",
+        "final_response": graceful,
+        "messages": [
+            {"role": "user", "content": "Do the long task."},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": streaming._MAX_ITERATION_SUMMARY_REQUEST},
+        ],
+    }
+
+    events, payload = _run_streaming_with_fake_agent(tmp_path, monkeypatch, result)
+
+    # The user sees the graceful fallback, not a bare tool_limit_reached error.
+    assert not [
+        ap for ev, ap in events if ev == "apperror"
+        and ap.get("type") == "tool_limit_reached"
+    ], "expected no tool_limit_reached apperror when fallback was returned"
+    done_payloads = [payload for event, payload in events if event == "done"]
+    assert done_payloads, "expected done SSE payload"
+    assert done_payloads[-1]["terminal_state"] == "tool_limit_reached"
+
+    # Fallback text is shown as a final assistant message and is annotated
+    # with the status card so the UI can render the 'limit reached' chip.
+    assistant = payload["messages"][-1]
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] == graceful
+    assert assistant["_terminal_state"] == "tool_limit_reached"
+    assert assistant["_statusCard"]["title"] == "Tool iteration limit reached"
+    # Synthetic scaffolding turn was still dropped, even after fallback injection.
+    assert all(
+        message.get("content") != streaming._MAX_ITERATION_SUMMARY_REQUEST
+        for message in payload["messages"]
+    )
+
+
+def test_streaming_tool_limit_with_fallback_does_not_double_inject_when_assistant_exists(tmp_path, monkeypatch):
+    """#5494 — when the agent already appended a model-generated summary, the
+    fallback flow is a no-op; the existing summary is preserved as before.
+    """
+    summary = "I reached the limit; here is the summary."
+    result = {
+        "turn_exit_reason": "max_iterations_reached(30/30)",
+        "final_response": summary,
+        "messages": [
+            {"role": "user", "content": "Do the long task."},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": streaming._MAX_ITERATION_SUMMARY_REQUEST},
+            {"role": "assistant", "content": summary},
+        ],
+    }
+
+    events, payload = _run_streaming_with_fake_agent(tmp_path, monkeypatch, result)
+
+    done_payloads = [payload for event, payload in events if event == "done"]
+    assert done_payloads
+    assistant_msgs = [
+        m for m in payload["messages"]
+        if m.get("role") == "assistant" and m.get("content") == summary
+    ]
+    assert len(assistant_msgs) == 1, "fallback must not duplicate the existing summary"
+    assert assistant_msgs[0]["_terminal_state"] == "tool_limit_reached"
+
+
+def test_maybe_inject_max_iteration_summary_fallback_unit():
+    """Unit-level coverage for the injection helper."""
+    messages = [
+        {"role": "user", "content": "Do the long task."},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+    graceful = "I reached the iteration limit and couldn't generate a summary."
+    result = {"final_response": graceful}
+
+    injected = streaming._maybe_inject_max_iteration_summary_fallback(messages, result)
+
+    assert injected[-1]["role"] == "assistant"
+    assert injected[-1]["content"] == graceful
+    assert injected[-1]["_max_iteration_summary_fallback"] is True
+
+
+def test_maybe_inject_max_iteration_summary_fallback_skips_when_assistant_present():
+    messages = [
+        {"role": "user", "content": "Do the long task."},
+        {"role": "assistant", "content": "real summary"},
+    ]
+    result = {"final_response": "fallback text"}
+
+    out = streaming._maybe_inject_max_iteration_summary_fallback(messages, result)
+    assert out == messages
+
+
+def test_maybe_inject_max_iteration_summary_fallback_skips_when_no_fallback():
+    messages = [
+        {"role": "user", "content": "Do the long task."},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+    ]
+
+    out = streaming._maybe_inject_max_iteration_summary_fallback(messages, {})
+    assert out == messages
+
+    out = streaming._maybe_inject_max_iteration_summary_fallback(
+        messages, {"final_response": "   "}
+    )
+    assert out == messages
+
+    out = streaming._maybe_inject_max_iteration_summary_fallback(messages, None)
+    assert out == messages
+
+
 def test_streaming_tool_limit_terminal_failure_does_not_mark_final_answer(tmp_path, monkeypatch):
     result = {
         "status": "partial",

--- a/tests/test_tool_limit_terminal_state.py
+++ b/tests/test_tool_limit_terminal_state.py
@@ -281,9 +281,14 @@ def test_streaming_tool_limit_without_final_answer_emits_no_final_apperror(tmp_p
 
 
 def test_streaming_tool_limit_with_fallback_final_response_surfaces_closure_text(tmp_path, monkeypatch):
-    """#5494 — when the agent produced no usable summary but returned a graceful
-    fallback string (handle_max_iterations() always returns one), inject that as a
-    final assistant turn so the user sees closure text instead of a bare error.
+    """#5494 — handle_max_iterations() guarantees a non-empty ``final_response``
+    on iteration-limit exhaustion. This test pins the WebUI contract that,
+    when ``messages`` ends without a final assistant turn and ``final_response``
+    is set, the user sees that closure text instead of a bare
+    ``tool_limit_reached`` error. Serves both as a live-bug fix pin and as a
+    regression guard for the agent's "delivered final_response ⇒ assistant
+    row" invariant: if a future agent regression drops that invariant, this
+    test still passes because the WebUI honors the contract locally.
     """
     graceful = "I reached the iteration limit and couldn't generate a summary."
     result = {
@@ -300,6 +305,9 @@ def test_streaming_tool_limit_with_fallback_final_response_surfaces_closure_text
     events, payload = _run_streaming_with_fake_agent(tmp_path, monkeypatch, result)
 
     # The user sees the graceful fallback, not a bare tool_limit_reached error.
+    # Either (a) we synthesized the fallback here, or (b) the agent guarantee
+    # already added an assistant row and `_mark_latest_assistant_tool_limit_status`
+    # attached the status card. Both routes satisfy the contract.
     assert not [
         ap for ev, ap in events if ev == "apperror"
         and ap.get("type") == "tool_limit_reached"
@@ -323,8 +331,9 @@ def test_streaming_tool_limit_with_fallback_final_response_surfaces_closure_text
 
 
 def test_streaming_tool_limit_with_fallback_does_not_double_inject_when_assistant_exists(tmp_path, monkeypatch):
-    """#5494 — when the agent already appended a model-generated summary, the
-    fallback flow is a no-op; the existing summary is preserved as before.
+    """#5494 — when the agent already appended a model-generated summary
+    AND ``final_response`` carries the same text, the WebUI must not duplicate
+    the assistant turn. Pins the no-op contract on the synthesis path.
     """
     summary = "I reached the limit; here is the summary."
     result = {


### PR DESCRIPTION
# fix: surface agent's graceful summary on iteration-limit exhaustion (closes #5494)

Closes #5494.

## Thinking Path

The original issue framing conflated two independent mechanisms:
`api/goals.py::evaluate_after_turn()` (the `/goal` feature, gated to
active goals) and the `AIAgent` tool-iteration budget governed by
`agent.max_turns` (default 90), which fires inside the WebUI's
embedded `AIAgent`. The latter is the one that produces
`max_iterations_reached` and triggers `handle_max_iterations()` —
the same code path the Discord/CLI uses. A correction comment on
#5494 captures the distinction.

Inspecting the WebUI side further (`api/streaming.py`,
`api/goals.py`, `chat_completion_helpers.handle_max_iterations`),
the parity story is narrower than the issue suggested:

- The WebUI **already** surfaces the model's summary when one was
  generated. Existing tests pin this:
  `test_streaming_tool_limit_with_final_answer_persists_clean_done_state`.
- The actual residual gap is the **empty-summary** case: when the
  agent's summary call yields no usable assistant content (common
  with reasoning-only responses; `handle_max_iterations` only appends
  a message when `final_response` is non-empty:
  `agent/chat_completion_helpers.py:1462-1466`), the user sees a
  bare `tool_limit_reached` error.

Why the asymmetry: `handle_max_iterations()` always **returns** a
non-empty `final_response` (either the summary or one of several
graceful fallback strings like *"I reached the iteration limit and
couldn't generate a summary."*), and Hermes Agent surfaces that
return value as the turn's final answer. The WebUI reads only
`result['messages']`, so on empty summary it has no final assistant
turn and routes to the error path.

The minimal fix is to bridge that asymmetry: when
`max_iterations_reached` fires and `result['messages']` ends without
a usable assistant answer, synthesize a final assistant turn from
`result['final_response']`. The existing
`_mark_latest_assistant_tool_limit_status` flow then attaches the
status card exactly as it does for a real summary, and the user sees
the closure text instead of the bare error.

## What Changed

- **`api/streaming.py`** (+48):
  - New helper `_maybe_inject_max_iteration_summary_fallback(messages, result)`
    placed next to the existing tool-limit helpers. Pure: returns a
    new list, mutates nothing. Tagged with
    `_max_iteration_summary_fallback: True` so downstream consumers
    can distinguish from model-emitted turns (mirrors the synthetic
    scaffolding convention from #5334).
  - 9-line wire-up in `_run_agent_streaming` merge-result block,
    directly after the existing
    `_drop_synthetic_max_iteration_summary_requests`. Importantly,
    the wire-up writes the synthesized list back into
    `result['messages']` (immutable copy via `{**result, 'messages': …}`)
    so the downstream `_all_result_messages` detection
    (`api/streaming.py:8476`) — which reads `result['messages']`
    directly, not the local `_result_messages` — sees the fallback
    too. Without this, the silent-failure classifier would still
    flag empty summary as `apperror` because it sees no assistant
    answer in the raw result messages.

- **`tests/test_tool_limit_terminal_state.py`** (+117):
  - 2 E2E tests through `_run_streaming_with_fake_agent`:
    - fallback surfaces graceful text + status card, no
      `tool_limit_reached` apperror;
    - no double-injection when a real summary already exists.
  - 3 unit tests on the helper for the three skip conditions
    (no fallback string, blank/whitespace fallback, existing
    assistant answer) plus the no-result edge (None / non-dict).

  All 17 tests in the file pass; the 12 existing tests — including
  `test_streaming_tool_limit_without_final_answer_emits_no_final_apperror`
  (the "agent died entirely" path: no fallback AND no summary →
  apperror is correct) — continue to pass unchanged.

## Why It Matters

#5494 is filed as a parity question between hermes-agent and
hermes-webui. The investigation confirmed hermes-agent parity is
*already* in place for the common case (real summary present);
this PR closes the remaining gap (empty summary → bare error) so
the WebUI shows the same closure text a Discord/CLI user gets
when the agent's summary call comes back empty (a real failure
mode with reasoning-only models).

This unblocks maintainer response on the question
*A vs B vs C* originally posed in #5494: the
`Api-defaults-parity` direction the issue commenter favored now
ships as the default — no new config key, no behavioral switch,
mirrors hermes-agent by reusing the exact same graceful fallback
string.

## Verification

```
./scripts/test.sh \
  tests/test_tool_limit_terminal_state.py \
  tests/test_agent_max_turns_parity.py \
  tests/test_auto_compression_terminal_failure.py \
  tests/test_stable_assistant_turn_anchor_phase0.py \
  tests/test_a11y_transcript_landmarks.py \
  tests/test_webui_state_db_context_reconciliation.py \
  tests/test_run_journal.py
```

**59 passed in 6.49s**.

`./scripts/hermes-webui-pr-gate <worktree>` (post-commit,
required for WebUI PRs) passed clean:
- ruff_lint on `upstream/master`-diff: 0 findings on added/modified
  lines (7 pre-existing in file, untouched).
- Whitespace gate clean.
- No conflict markers, no local dev artifacts, b3nw Co-authored-by
  trailer present.

Manual verification (deferred, on dev/local running stack): replay
a long-running task against any reasoning-only model (Claude
extended thinking, DeepSeek v4, Codex Responses) that hits
`agent.max_turns`, confirm the UI renders the graceful fallback
text with the "Tool iteration limit reached" status card instead
of the apperror inline error.

## Risks / Follow-ups

- **Status-card display.** Tags the injected turn with
  `_max_iteration_summary_fallback: True` for future filtering.
  No frontend changes are needed for this PR — the existing
  status-card rendering path already triggers on the assistant
  message with the `_terminal_state` annotation that
  `_mark_latest_assistant_tool_limit_status` attaches.
  If maintainers prefer the fallback turn to surface without any
  status card (true parity with normal assistant turns), the change
  is one conditional — happy to follow up.
- **Goal path unchanged.** `api/goals.py::evaluate_after_turn()`
  (the `/goal` pause) is intentionally untouched; the
  correction comment on #5494 explains why it's a separate concern.
- **Configurability.** If maintainers prefer the fix behind a
  config gate (e.g. `agent.summary_on_iteration_limit`,
  defaulting on for parity), the change is trivial — wrap the
  helper call in a config read. Out of scope for this PR per the
  #5494 commenter's preference for default parity, but easy to
  add if requested.
- **No CHANGELOG entry** per the WebUI contributor convention
  (release workflow owns changelog).
- **No upstream issue/RFC text changes** beyond the
  posted correction comment on #5494 itself.

## Model Used

Authored hermes-webui/developer profile with `anthropic/opus-4.8 & kilo/minimax/minimax-m3` used.
