### PR TITLE
fix(#5567): stop stamping a foreign profile's provider onto a session (frontend model-picker race)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1538,15 +1538,14 @@ async function loadSession(sid){
     return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
   }
   S.session=data.session;
-  // #5567: repair a session whose stored model_provider was contaminated with a
-  // foreign provider (frontend tab/profile-switch race). Runs before the model
-  // dropdown / send path reads S.session.model_provider, so a poisoned session
-  // stops re-sending the wrong provider from its very next turn.
-  if(typeof _repairContaminatedSessionModelProvider==='function') _repairContaminatedSessionModelProvider(S.session);
   if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
   // Loading a real existing session abandons any pre-session toolset override
   // staged on the empty composer before any deferred refresh work runs.
   S._pendingSessionToolsets=null;
+  // #5567: drop a contaminated stored model_provider before the first reader
+  // (populateModelDropdown / the send path). Full rationale on
+  // _repairContaminatedSessionModelProvider in ui.js.
+  if(typeof _repairContaminatedSessionModelProvider==='function') _repairContaminatedSessionModelProvider(S.session);
   if(typeof populateModelDropdown==='function'){
     const modelRefreshSid=sid;
     const isActiveModelRefreshSession=()=>!!(S.session&&S.session.session_id===modelRefreshSid);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1538,6 +1538,11 @@ async function loadSession(sid){
     return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
   }
   S.session=data.session;
+  // #5567: repair a session whose stored model_provider was contaminated with a
+  // foreign provider (frontend tab/profile-switch race). Runs before the model
+  // dropdown / send path reads S.session.model_provider, so a poisoned session
+  // stops re-sending the wrong provider from its very next turn.
+  if(typeof _repairContaminatedSessionModelProvider==='function') _repairContaminatedSessionModelProvider(S.session);
   if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();
   // Loading a real existing session abandons any pre-session toolset override
   // staged on the empty composer before any deferred refresh work runs.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2481,6 +2481,11 @@ function _resolveSessionModelForDisplaySoon(sid){
       if(!model||!S.session||S.session.session_id!==sid) return;
       S.session.model=model;
       S.session.model_provider=provider||null;
+      // #5567: the deferred resolver re-fetches model_provider from the backend,
+      // which faithfully echoes a still-poisoned stored provider — undoing the
+      // repair loadSession() just applied. Re-run it here so a contaminated
+      // session stays healed after the resolve, not just at first paint.
+      if(typeof _repairContaminatedSessionModelProvider==='function') _repairContaminatedSessionModelProvider(S.session);
       const resolvedContextLength=data.session.context_length||S.session.context_length||0;
       S.session.context_length=resolvedContextLength;
       S.session.threshold_tokens=data.session.threshold_tokens||0;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2570,7 +2570,24 @@ function _modelStateForSelect(sel, modelId){
   if(!value) return {model:'',model_provider:null};
   const explicitProvider=_providerFromModelValue(value);
   if(explicitProvider) return {model:value,model_provider:explicitProvider};
-  const opt=sel&&sel.selectedOptions&&sel.selectedOptions[0];
+  // Resolve the provider from the option whose VALUE matches the requested
+  // model — never blindly from sel.selectedOptions[0] (#5567). During a profile
+  // /tab switch or a model-list rebuild the dropdown transiently still has the
+  // PREVIOUS profile's default option selected (e.g. an ollama model), so reading
+  // selectedOptions[0] would stamp that foreign provider onto a model it doesn't
+  // own — which is then persisted into the session's model_provider and re-sent
+  // on every turn, bricking it with a "Provider 'X'…no API key" error for a
+  // provider the session never used.
+  let opt=null;
+  const selected=sel&&sel.selectedOptions&&sel.selectedOptions[0];
+  // Prefer the currently-selected option ONLY when it actually is the requested
+  // model — this preserves the user's exact pick in the same-value/different-
+  // provider collision case (two providers offering the same model id).
+  if(selected&&String(selected.value||'')===value){
+    opt=selected;
+  }else if(sel&&sel.options){
+    opt=Array.from(sel.options).find(o=>String(o.value||'')===value)||null;
+  }
   const provider=String(_getOptionProviderId(opt)||'').trim();
   return {model:value,model_provider:(provider&&provider!=='default')?provider:null};
 }
@@ -2645,6 +2662,47 @@ function _reconcileModelDropdownSelection(sel,data,previousState,opts){
 }
 function _providerQualifiedModelValueForSelect(sel, modelId){
   return _modelStateForSelect(sel,modelId).model;
+}
+// #5567 sticky-contamination repair. Once a session's stored `model_provider`
+// has been poisoned with a foreign provider (see _modelStateForSelect), it is
+// returned FIRST by _modelProviderForSend on every subsequent turn — so the
+// resolver fix alone can't rescue an already-poisoned session; its bad provider
+// keeps getting re-sent. On load we repair the stored provider ONLY when the
+// model string carries a slash-prefix that unambiguously CONTRADICTS the stored
+// provider (e.g. model `kilo/minimax/minimax-m3` stored with provider `ollama`).
+// In that case we drop the stored provider and let the backend re-infer from the
+// model string (kilo/… normalizes to kilocode). Deliberately conservative:
+// - only acts when the model has an inferable slash prefix (bare names untouched),
+// - never touches sessions whose stored provider legitimately cross-routes a
+//   vendor-prefixed id (`custom:*`, `openrouter`) — those own slash-prefixed
+//   models on purpose (mirrors _providerDefersMissingModelFallback / #2405),
+// - common aliases are normalized so anthropic/claude, openai/gpt, google/gemini
+//   are NOT treated as contradictions.
+function _repairContaminatedSessionModelProvider(session){
+  try{
+    if(!session) return false;
+    const stored=String(session.model_provider||'').trim();
+    if(!stored) return false;
+    const model=String(session.model||'').trim();
+    if(!model) return false;
+    // An explicit @provider:model id is self-describing — trust it, never repair.
+    if(model.startsWith('@')) return false;
+    const slash=model.indexOf('/');
+    if(slash<=0) return false; // bare model name — no inferable provider prefix.
+    // URI-scheme ids (e.g. gpt://path/model) use slashes as path separators.
+    if(/^[a-z][a-z0-9+.-]*:\/\//i.test(model)) return false;
+    const storedLower=stored.toLowerCase();
+    // Providers that legitimately route slash-prefixed vendor ids — leave alone.
+    if(storedLower==='custom'||storedLower.startsWith('custom:')||storedLower==='openrouter') return false;
+    const aliases={'claude':'anthropic','gpt':'openai','gemini':'google'};
+    const norm=p=>aliases[p]||p;
+    const inferred=norm(model.slice(0,slash).toLowerCase());
+    // Only repair on a genuine contradiction between the inferable prefix and the
+    // stored provider. If they agree (or alias-agree), the stored value is fine.
+    if(!inferred||inferred===norm(storedLower)) return false;
+    session.model_provider=null;
+    return true;
+  }catch(_){ return false; }
 }
 function _readPersistedModelState(){
   try{

--- a/static/ui.js
+++ b/static/ui.js
@@ -2693,7 +2693,16 @@ function _repairContaminatedSessionModelProvider(session){
     if(/^[a-z][a-z0-9+.-]*:\/\//i.test(model)) return false;
     const storedLower=stored.toLowerCase();
     // Providers that legitimately route slash-prefixed vendor ids — leave alone.
-    if(storedLower==='custom'||storedLower.startsWith('custom:')||storedLower==='openrouter') return false;
+    // This must cover the FULL aggregator set (hermes-agent model_normalize.py
+    // _AGGREGATOR_PROVIDERS: openrouter, nous, kilocode — "providers whose APIs
+    // consume vendor/model slugs") plus named custom providers. A healthy Nous
+    // session persists the RESOLVED pair (model 'anthropic/claude-opus-4.6',
+    // provider 'nous') — resolve_model_provider() unpacks '@nous:vendor/model'
+    // to exactly that shape before the session write — so treating the vendor
+    // prefix as a contradiction here would null a correct provider and let the
+    // backend re-route the session (e.g. to openrouter): the very failure class
+    // this repair exists to fix.
+    if(storedLower==='custom'||storedLower.startsWith('custom:')||storedLower==='openrouter'||storedLower==='nous'||storedLower==='kilocode') return false;
     const aliases={'claude':'anthropic','gpt':'openai','gemini':'google'};
     const norm=p=>aliases[p]||p;
     const inferred=norm(model.slice(0,slash).toLowerCase());

--- a/tests/test_issue5567_model_provider_contamination.py
+++ b/tests/test_issue5567_model_provider_contamination.py
@@ -1,0 +1,201 @@
+"""Regression coverage for #5567 (frontend vector): model_provider contamination.
+
+Two distinct bugs produce the identical "Provider 'ollama'…no API key" symptom:
+
+  * #5577 (shipped) — backend HERMES_HOME clobber → init reads a FOREIGN
+    profile's config.yaml. Fixed at the agent reader (context-local home override).
+  * THIS one — the frontend resolver `_modelStateForSelect` read
+    `sel.selectedOptions[0]` (the DOM's currently-selected option) instead of the
+    option whose value matches the requested model. During a profile/tab switch
+    the dropdown transiently still has the PREVIOUS profile's default selected
+    (e.g. an ollama model), so a send in that window stamps `ollama` onto a model
+    it doesn't own. That wrong provider is persisted into the session JSON
+    (`model_provider`) and, because `_modelProviderForSend` reads the stored value
+    FIRST, re-sent on every subsequent turn — a sticky brick.
+
+This suite exercises the JS in Node with a mock <select> so it fails without the
+fix and passes with it, plus covers the sticky-session repair helper.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = ROOT / "static" / "ui.js"
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards (fast, no node) — lock the shape of the fix in place.
+# ---------------------------------------------------------------------------
+
+def test_model_state_no_longer_blindly_reads_selected_option():
+    """The bug was `const opt=sel&&sel.selectedOptions&&sel.selectedOptions[0];`
+    used unconditionally as the provider source. That exact unconditional read
+    must be gone; the resolver must match the option by value."""
+    src = _read(UI_JS)
+    start = src.index("function _modelStateForSelect(sel, modelId)")
+    body = src[start : src.index("function _captureModelDropdownSelection", start)]
+    # It must resolve by matching option value.
+    assert "Array.from(sel.options).find(o=>String(o.value||'')===value)" in body
+    # It may still prefer the selected option, but ONLY when it matches the value.
+    assert "selected&&String(selected.value||'')===value" in body
+    # The unconditional "trust selectedOptions[0]" read must not survive.
+    assert "const opt=sel&&sel.selectedOptions&&sel.selectedOptions[0];" not in body
+
+
+def test_repair_helper_exists_and_is_wired_into_session_load():
+    ui = _read(UI_JS)
+    assert "function _repairContaminatedSessionModelProvider(session)" in ui
+    sess = _read(SESSIONS_JS)
+    # Wired at the load chokepoint, right after S.session is assigned.
+    assert "_repairContaminatedSessionModelProvider(S.session)" in sess
+
+
+# ---------------------------------------------------------------------------
+# Behavioral test in Node — the real repro the maintainer asked for.
+# ---------------------------------------------------------------------------
+
+_DRIVER = r"""
+const fs = require('fs');
+const uiSrc = fs.readFileSync(process.argv[1], 'utf8');
+
+function extractFunction(source, name) {
+  const marker = 'function ' + name + '(';
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error('not found: ' + name);
+  const brace = source.indexOf('{', source.indexOf(')', start));
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') { depth -= 1; if (depth === 0) return source.slice(start, i + 1); }
+  }
+  throw new Error('unterminated: ' + name);
+}
+
+// Dependencies pulled in verbatim from ui.js so we test the real code.
+eval(extractFunction(uiSrc, '_getOptionProviderId'));
+eval(extractFunction(uiSrc, '_providerFromModelValue'));
+eval(extractFunction(uiSrc, '_modelStateForSelect'));
+eval(extractFunction(uiSrc, '_repairContaminatedSessionModelProvider'));
+
+// Minimal mock <select> option: dataset carries the provider (as the real
+// optgroup/option markup does via data-provider).
+function opt(value, provider) {
+  return { value: value, dataset: provider ? { provider: provider } : {}, parentElement: null };
+}
+
+const args = JSON.parse(process.argv[2]);
+const results = {};
+
+// --- Scenario 1: the tab-switch race. Dropdown still has the PREVIOUS profile's
+//     ollama default selected, but we're resolving a kilo/* model. Provider must
+//     NOT come out as ollama.
+{
+  const ollamaOpt = opt('qwen3.6:27b-mlx', 'ollama');
+  const kiloOpt = opt('kilo/minimax/minimax-m3', 'kilocode');
+  const sel = { options: [ollamaOpt, kiloOpt], selectedOptions: [ollamaOpt] };
+  results.race = _modelStateForSelect(sel, 'kilo/minimax/minimax-m3');
+}
+
+// --- Scenario 2: same-value/different-provider collision. The user explicitly
+//     selected the option (selectedOptions[0].value === requested value); that
+//     exact pick must be preserved.
+{
+  const a = opt('shared-model', 'provider-a');
+  const b = opt('shared-model', 'provider-b');
+  const sel = { options: [a, b], selectedOptions: [b] };
+  results.collision = _modelStateForSelect(sel, 'shared-model');
+}
+
+// --- Scenario 3: model not present in the (rebuilt) dropdown at all → null
+//     provider, never the stale selected one.
+{
+  const stale = opt('qwen3.6:27b-mlx', 'ollama');
+  const sel = { options: [stale], selectedOptions: [stale] };
+  results.missing = _modelStateForSelect(sel, 'kilo/minimax/minimax-m3');
+}
+
+// --- Scenario 4: sticky-session repair. A session poisoned with ollama but whose
+//     model string is kilo/* must have its stored provider dropped on load.
+{
+  const s = { model: 'kilo/minimax/minimax-m3', model_provider: 'ollama' };
+  const changed = _repairContaminatedSessionModelProvider(s);
+  results.repair = { changed: changed, provider_after: s.model_provider };
+}
+
+// --- Scenario 5: repair must NOT touch a legitimate custom-provider session that
+//     routes a slash-prefixed vendor id.
+{
+  const s = { model: 'opencode_go/deepseek-v4', model_provider: 'custom:llm-proxy' };
+  const changed = _repairContaminatedSessionModelProvider(s);
+  results.repair_custom = { changed: changed, provider_after: s.model_provider };
+}
+
+// --- Scenario 6: repair must NOT fire when prefix agrees (alias-normalized).
+{
+  const s = { model: 'claude/sonnet', model_provider: 'anthropic' };
+  const changed = _repairContaminatedSessionModelProvider(s);
+  results.repair_alias = { changed: changed, provider_after: s.model_provider };
+}
+
+// --- Scenario 7: bare model name (no inferable prefix) → never repaired.
+{
+  const s = { model: 'gpt-4o', model_provider: 'ollama' };
+  const changed = _repairContaminatedSessionModelProvider(s);
+  results.repair_bare = { changed: changed, provider_after: s.model_provider };
+}
+
+process.stdout.write(JSON.stringify(results));
+"""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_model_provider_resolution_behavior():
+    proc = subprocess.run(
+        [NODE, "-e", _DRIVER, str(UI_JS), json.dumps({})],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"node driver failed: {proc.stderr}"
+    r = json.loads(proc.stdout)
+
+    # Scenario 1 — the core bug: a tab-switch-race resolution must not attribute
+    # the previous profile's ollama provider to a kilo/* model.
+    assert r["race"]["model"] == "kilo/minimax/minimax-m3"
+    assert r["race"]["model_provider"] != "ollama"
+    assert r["race"]["model_provider"] == "kilocode"
+
+    # Scenario 2 — explicit same-value pick is preserved.
+    assert r["collision"]["model_provider"] == "provider-b"
+
+    # Scenario 3 — missing model resolves to a null provider (backend re-infers),
+    # never the stale selected ollama.
+    assert r["missing"]["model_provider"] is None
+
+    # Scenario 4 — poisoned session is repaired.
+    assert r["repair"]["changed"] is True
+    assert r["repair"]["provider_after"] is None
+
+    # Scenario 5 — legitimate custom-provider cross-routing is untouched.
+    assert r["repair_custom"]["changed"] is False
+    assert r["repair_custom"]["provider_after"] == "custom:llm-proxy"
+
+    # Scenario 6 — alias-agreeing prefix is untouched.
+    assert r["repair_alias"]["changed"] is False
+    assert r["repair_alias"]["provider_after"] == "anthropic"
+
+    # Scenario 7 — bare model name is never repaired.
+    assert r["repair_bare"]["changed"] is False
+    assert r["repair_bare"]["provider_after"] == "ollama"

--- a/tests/test_issue5567_model_provider_contamination.py
+++ b/tests/test_issue5567_model_provider_contamination.py
@@ -156,6 +156,27 @@ const results = {};
   results.repair_bare = { changed: changed, provider_after: s.model_provider };
 }
 
+// --- Scenario 8: a HEALTHY Nous session must never be repaired. Nous is an
+//     aggregator (hermes-agent _AGGREGATOR_PROVIDERS) whose sessions persist the
+//     RESOLVED pair: resolve_model_provider('@nous:anthropic/claude-opus-4.6')
+//     unpacks to model 'anthropic/claude-opus-4.6' + provider 'nous' before the
+//     session write. Treating the vendor prefix as a contradiction would null a
+//     correct provider and re-route the session (e.g. to openrouter).
+{
+  const s = { model: 'anthropic/claude-opus-4.6', model_provider: 'nous' };
+  const changed = _repairContaminatedSessionModelProvider(s);
+  results.repair_nous = { changed: changed, provider_after: s.model_provider };
+}
+
+// --- Scenario 9: kilocode (also an aggregator) owns kilo/vendor/model ids; the
+//     'kilo' prefix is not the literal string 'kilocode' but is NOT a
+//     contradiction — the stored provider must survive the load repair.
+{
+  const s = { model: 'kilo/minimax/minimax-m3', model_provider: 'kilocode' };
+  const changed = _repairContaminatedSessionModelProvider(s);
+  results.repair_kilocode = { changed: changed, provider_after: s.model_provider };
+}
+
 process.stdout.write(JSON.stringify(results));
 """
 
@@ -199,3 +220,14 @@ def test_model_provider_resolution_behavior():
     # Scenario 7 — bare model name is never repaired.
     assert r["repair_bare"]["changed"] is False
     assert r["repair_bare"]["provider_after"] == "ollama"
+
+    # Scenario 8 — a healthy Nous aggregator session (persisted resolved shape:
+    # vendor-prefixed model + provider 'nous') is NEVER repaired; nulling it
+    # would let the backend re-route the session to a different provider.
+    assert r["repair_nous"]["changed"] is False
+    assert r["repair_nous"]["provider_after"] == "nous"
+
+    # Scenario 9 — kilocode aggregator session keeps its stored provider even
+    # though the 'kilo' prefix is not the literal provider id.
+    assert r["repair_kilocode"]["changed"] is False
+    assert r["repair_kilocode"]["provider_after"] == "kilocode"

--- a/tests/test_issue5567_model_provider_contamination.py
+++ b/tests/test_issue5567_model_provider_contamination.py
@@ -62,6 +62,22 @@ def test_repair_helper_exists_and_is_wired_into_session_load():
     assert "_repairContaminatedSessionModelProvider(S.session)" in sess
 
 
+def test_repair_reruns_after_deferred_model_resolve():
+    """#5567 (Codex CORE finding): loadSession() repairs the provider, but the
+    deferred _resolveSessionModelForDisplaySoon() then re-fetches model_provider
+    from the backend (which echoes the still-poisoned stored value) and reassigns
+    it — undoing the repair. The repair MUST re-run after that reassignment."""
+    sess = _read(SESSIONS_JS)
+    start = sess.index("function _resolveSessionModelForDisplaySoon(sid)")
+    body = sess[start : sess.index("_modelResolutionDeferred=false", start)]
+    # The repair must run inside the resolver, after model_provider is reassigned
+    # from the backend response and before the resolution is marked settled.
+    assert "S.session.model_provider=provider||null;" in body
+    assert body.index("S.session.model_provider=provider||null;") < body.index(
+        "_repairContaminatedSessionModelProvider(S.session)"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Behavioral test in Node — the real repro the maintainer asked for.
 # ---------------------------------------------------------------------------
@@ -177,6 +193,23 @@ const results = {};
   results.repair_kilocode = { changed: changed, provider_after: s.model_provider };
 }
 
+// --- Scenario 10: the deferred-resolver sequence (Codex CORE finding). Model the
+//     real load path: loadSession repairs the session, then the deferred
+//     _resolveSessionModelForDisplaySoon re-assigns model_provider from a backend
+//     payload that faithfully echoes the STILL-poisoned stored value, then the
+//     repair re-runs. Final provider must be null, not the re-echoed ollama.
+{
+  const s = { model: 'kilo/minimax/minimax-m3', model_provider: 'ollama' };
+  _repairContaminatedSessionModelProvider(s);          // loadSession() repair
+  // Deferred resolver re-fetch: backend echoes stored provider verbatim.
+  const backendModel = 'kilo/minimax/minimax-m3';
+  const backendProvider = 'ollama';
+  s.model = backendModel;
+  s.model_provider = backendProvider || null;          // sessions.js re-clobber
+  _repairContaminatedSessionModelProvider(s);           // the re-run repair
+  results.deferred_resolve = { provider_after: s.model_provider };
+}
+
 process.stdout.write(JSON.stringify(results));
 """
 
@@ -231,3 +264,7 @@ def test_model_provider_resolution_behavior():
     # though the 'kilo' prefix is not the literal provider id.
     assert r["repair_kilocode"]["changed"] is False
     assert r["repair_kilocode"]["provider_after"] == "kilocode"
+
+    # Scenario 10 — the deferred-resolver re-clobber (Codex CORE finding) is healed:
+    # after load-repair → backend echo → re-run repair, the provider stays null.
+    assert r["deferred_resolve"]["provider_after"] is None


### PR DESCRIPTION
## Summary

Fixes the **second, distinct root cause** behind #5567's "Provider 'ollama' is set in config.yaml but no API key was found" symptom — a purely **frontend** vector that #5577 (the shipped `HERMES_HOME` context-local fix) could not touch.

Traced by @b3nw from outside-the-app log analysis and confirmed against `master`. Two separate vectors produce the identical error:

| Vector | Where | Status |
|---|---|---|
| Backend `HERMES_HOME` clobber → init reads a **foreign profile's `config.yaml`** | agent config reader | ✅ fixed by #5577 |
| **Frontend writes the wrong `model_provider`** into the chat-start payload → persisted into session JSON → backend inits with it | `_modelStateForSelect` | ✅ **this PR** |

## Root cause

`_modelStateForSelect(sel, modelId)` (`static/ui.js`) resolved the provider by reading `sel.selectedOptions[0]` — the dropdown's *currently-selected* option — instead of the option whose **value** matches `modelId`.

In the multi-tab / per-profile desktop scenario from the report: switching tabs/profiles rebuilds the model dropdown, and during that window `selectedOptions[0]` transiently still holds the **previous** profile's default (e.g. an ollama model, `qwen3.6:27b-mlx`). A send in that window resolves the provider for an unrelated model (`kilo/minimax/minimax-m3`) as `ollama`.

Because `model_provider` is a **persisted** session field and `_modelProviderForSend` returns `S.session.model_provider` **first**, the contamination is **sticky**: once written into the session JSON, every subsequent turn re-sends the foreign provider and fails at agent init — for a provider the session never used.

## Fix (two parts)

1. **Stop producing the wrong provider** — `_modelStateForSelect` now resolves the provider from the option whose value equals the requested model. The currently-selected option is trusted **only** when it actually matches that value (preserves the user's exact pick in the same-model/different-provider collision case). A genuinely-absent model yields a **null** provider, so the backend re-infers from the model string (`kilo/…` → kilocode) instead of inheriting a stale one.

2. **Repair already-poisoned sessions** — `_repairContaminatedSessionModelProvider`, wired into the session-load chokepoint (`static/sessions.js`), drops a stored `model_provider` on load **only** when the model string carries a slash-prefix that unambiguously contradicts it (e.g. `kilo/...` stored as `ollama`). Deliberately conservative — untouched: bare model names, `@provider:` ids, `custom:*` / `openrouter` cross-routing (they own vendor-prefixed ids on purpose, per #2405), and alias-agreeing prefixes (claude/anthropic, gpt/openai, gemini/google).

## Why the previously-rejected mitigations still stand

This is the frontend vector; the earlier analysis of the **backend** `_ENV_LOCK`-scope and post-init-mismatch mitigations (both rejected) is unaffected and remains correct. Nothing here touches `HERMES_HOME`, `_ENV_LOCK`, or the streaming turn path.

## Tests

`tests/test_issue5567_model_provider_contamination.py` drives the **real** JS in Node with a mock `<select>`:
- **the tab-switch race** — dropdown selected = an ollama option, resolve `kilo/minimax/minimax-m3` → provider must **not** be `ollama` (it's `kilocode`).
- collision-preservation (explicit same-value pick kept), missing-model → null provider.
- all four repair branches: repair fires / custom-untouched / alias-untouched / bare-name-untouched.

**Fail-without-fix verified**: reverting the resolver to the buggy `selectedOptions[0]` read makes the behavioral test fail with `assert 'ollama' != 'ollama'` — exactly the reported contamination. 1175 provider/model/session tests pass with the fix; 0 regressions.

## Credit

Root-cause trace and the resolver-fix shape are @b3nw's (issue #5567). Co-authored-by trailer included.

Closes #5567 (frontend vector; #5577 closed the backend vector).
