### PR TITLE
fix(model-picker): prevent cross-profile provider dropdown contamination

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2570,8 +2570,17 @@ function _modelStateForSelect(sel, modelId){
   if(!value) return {model:'',model_provider:null};
   const explicitProvider=_providerFromModelValue(value);
   if(explicitProvider) return {model:value,model_provider:explicitProvider};
-  const opt=sel&&sel.selectedOptions&&sel.selectedOptions[0];
-  const provider=String(_getOptionProviderId(opt)||'').trim();
+  let opt=null;
+  if(sel&&sel.options){
+    opt=Array.from(sel.options).find(o=>o.value===value);
+  }
+  if(!opt){
+    const currentOpt=sel&&sel.selectedOptions&&sel.selectedOptions[0];
+    if(currentOpt&&currentOpt.value===value){
+      opt=currentOpt;
+    }
+  }
+  const provider=String((opt&&_getOptionProviderId(opt))||'').trim();
   return {model:value,model_provider:(provider&&provider!=='default')?provider:null};
 }
 function _captureModelDropdownSelection(sel){

--- a/tests/test_chat_start_provider_fallback.py
+++ b/tests/test_chat_start_provider_fallback.py
@@ -215,6 +215,24 @@ def test_model_state_reads_live_custom_provider_from_option_metadata(driver_path
     assert state == {"model": "llama-3.3-custom", "model_provider": "custom:lab"}
 
 
+@node_test
+def test_model_state_does_not_use_unrelated_selected_option_provider(driver_path):
+    # If the requested model is not in the options and differs from the currently
+    # selected option, it should return model_provider = null instead of the selected option's provider.
+    state = _run_model_state_helper(driver_path, {
+        "model": "kilo/minimax/minimax-m3",
+        "initialValue": "qwen3.6:27b-mlx",
+        "options": [{
+            "provider": "ollama",
+            "optionProvider": "ollama",
+            "value": "qwen3.6:27b-mlx",
+        }],
+    })
+
+    assert state == {"model": "kilo/minimax/minimax-m3", "model_provider": None}
+
+
+
 def test_live_custom_models_are_tagged_with_provider_metadata():
     ui_src = UI_JS_PATH.read_text(encoding="utf-8")
     start = ui_src.index("function _addLiveModelsToSelect")


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI maintains profile-isolated workspaces, configurations, and session model selections.
- Setting up a new session or composer turn queries the dropdown state resolver `_modelStateForSelect` to extract the active model and provider.
- The bug was that `_modelStateForSelect` fell back to retrieving the provider from the active DOM selection (`sel.selectedOptions[0]`) even when queried for a model ID different from the currently selected one.
- On profile switches or cold session boots, the dropdown momentarily holds the previous profile's default model (e.g., `qwen3.6:27b-mlx` / provider `ollama`).
- This caused custom provider models (like `kilo/minimax/minimax-m3`) to resolve with the provider `"ollama"`, poisoning the session configuration file and causing the backend worker thread to crash with a `RuntimeError` due to missing `OLLAMA_API_KEY` credentials in the active profile.
- This PR fixes the dropdown query to search `sel.options` for the option matching the target model value, and only fall back to the active selected option if its value actually matches the queried model ID.

Closes #5567 

## What Changed
- **`static/ui.js`**: Patched `_modelStateForSelect` to locate the option by value from the dropdown options list instead of assuming `selectedOptions[0]` is correct.
- **`tests/test_chat_start_provider_fallback.py`**: Added `test_model_state_does_not_use_unrelated_selected_option_provider` to verify that resolving the provider of a model not currently present in the picker returns `null` instead of stealing the selected option's provider.

## Why It Matters
- Prevents cross-profile/cross-model provider contamination and intermittent agent initialization failures (`RuntimeError` on missing API keys) when switching between profiles with distinct provider configurations.

## Verification
- Verified that all model resolution, picker, and fallback tests (152 tests total) pass locally using `uv run pytest`.

## Risks / Follow-ups
- None. The fix preserves the fallback to `selectedOptions[0]` only when the requested model matches the selected option's value.

## AI Usage Disclosure
- **Provider**: Google
- **Model**: Antigravity (Gemini 3.5 Flash)
- **Notable mode/tool use**: Git worktree checkout, targeted code replacement, local node eslint, and pytest verification.
