### PR TITLE
fix(#5699): keep child streams from moving parent sidebar buckets

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -6214,7 +6214,6 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions, rawRefere
     const childActivitySec=Number(childActivityRaw);
     if(Number.isFinite(childActivitySec)&&childActivitySec>Number(parentRow._child_session_latest_at||0)){
       parentRow._child_session_latest_at=childActivitySec;
-      parentRow._sidebar_activity_at=Math.max(Number(parentRow.last_message_at||parentRow.updated_at||parentRow.created_at||0), childActivitySec);
     }
     const childAttention=childRow&&childRow.attention&&typeof childRow.attention==='object'?childRow.attention:null;
     if(!childAttention||!childAttention.kind||!Number.isFinite(Number(childAttention.count))||Number(childAttention.count)<=0) return;

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -1082,7 +1082,7 @@ console.log(JSON.stringify(rows));
     assert "_child_sessions" not in rows[0]
 
 
-def test_nested_fork_bubbles_latest_child_timestamp_for_sorting():
+def test_nested_fork_tracks_latest_child_without_changing_parent_bucket_timestamp():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
 const src = {js!r};
@@ -1112,15 +1112,15 @@ console.log(JSON.stringify({{row: rows[0], timestampMs: _sessionTimestampMs(rows
     result = json.loads(_run_node(source))
     row = result["row"]
     assert row["session_id"] == "parent"
-    # Keep the parent row's persisted timestamp intact, but use newest attached
-    # child/subagent activity for sidebar sorting/date grouping.
+    # Keep the parent row's persisted timestamp intact while still recording
+    # the newest attached child/subagent metadata.
     assert row["last_message_at"] == 10
     assert row["_child_session_latest_at"] == 20
-    assert row["_sidebar_activity_at"] == 20
-    assert result["timestampMs"] == 20_000
+    assert "_sidebar_activity_at" not in row
+    assert result["timestampMs"] == 10_000
 
 
-def test_hidden_archived_lineage_child_bubbles_running_state_and_activity_to_visible_parent():
+def test_hidden_archived_lineage_child_bubbles_running_state_and_latest_child_timestamp_without_changing_parent_bucket():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
 const src = {js!r};
@@ -1179,11 +1179,11 @@ console.log(JSON.stringify({{row: rows[0], count: rows.length, timestampMs: _ses
     assert "_child_sessions" not in row
     assert row["_child_session_streaming"] is True
     assert row["_child_session_latest_at"] == 30
-    assert row["_sidebar_activity_at"] == 30
-    assert result["timestampMs"] == 30_000
+    assert "_sidebar_activity_at" not in row
+    assert result["timestampMs"] == 10_000
 
 
-def test_archived_lineage_child_without_root_id_falls_back_to_parent_for_bubbling():
+def test_archived_lineage_child_without_root_id_preserves_parent_bucket_timestamp():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
 const src = {js!r};
@@ -1241,8 +1241,8 @@ console.log(JSON.stringify({{row: rows[0], count: rows.length, timestampMs: _ses
     assert "_child_sessions" not in row
     assert row["_child_session_streaming"] is True
     assert row["_child_session_latest_at"] == 30
-    assert row["_sidebar_activity_at"] == 30
-    assert result["timestampMs"] == 30_000
+    assert "_sidebar_activity_at" not in row
+    assert result["timestampMs"] == 10_000
 
 
 def test_non_archived_reference_only_lineage_row_does_not_bubble_to_visible_parent():
@@ -1308,7 +1308,7 @@ console.log(JSON.stringify({{row: rows[0], count: rows.length, timestampMs: _ses
     assert result["timestampMs"] == 10_000
 
 
-def test_stale_active_stream_id_on_hidden_archived_child_does_not_bubble_streaming_state():
+def test_stale_active_stream_id_on_hidden_archived_child_keeps_parent_bucket_and_latest_child_timestamp():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     source = f"""
 const src = {js!r};
@@ -1367,8 +1367,8 @@ console.log(JSON.stringify({{row: rows[0], count: rows.length, timestampMs: _ses
     assert "_child_sessions" not in row
     assert "_child_session_streaming" not in row
     assert row["_child_session_latest_at"] == 30
-    assert row["_sidebar_activity_at"] == 30
-    assert result["timestampMs"] == 30_000
+    assert "_sidebar_activity_at" not in row
+    assert result["timestampMs"] == 10_000
 
 
 def test_collapsed_lineage_segments_do_not_render_as_child_sessions():


### PR DESCRIPTION
## Thinking Path

- The sidebar already has the right parent timestamp fields, but child bubbling currently writes a transient child timestamp into the parent's sidebar timestamp slot.
- The maintainer narrowed the fix to the cosmetic bucket flip: keep child streaming metadata for the spinner, stop using child activity as parent recency.
- The patch removes that one derived timestamp write and updates the lineage tests to prove parent buckets stay stable.

## What Changed

- `static/sessions.js`: keeps child streaming and latest-child metadata while leaving the parent sidebar timestamp on parent-owned activity.
- `tests/test_session_lineage_collapse.py`: covers the stable parent bucket behavior and preserves hidden child spinner coverage.

## Why It Matters

Parents with active child sessions no longer jump between Today and Older as the child streams and settles. The sidebar still shows child activity through the existing spinner.

## Verification

Focused lineage tests cover parent bucket stability, child streaming preservation, and the recorded lineage variants; CI runs the full matrix on 3.11, 3.12, and 3.13.

## Upstream

Closes #5699. The scope follows the maintainer's recommendation in https://github.com/nesquena/hermes-webui/issues/5699#issuecomment-4896926699.

## Model Used

GPT 5.5 via Codex CLI
