### PR TITLE
feat(profile): support profile query deep links

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -3179,17 +3179,18 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     try{
       if(profileIntent.valid){
         if(typeof switchToProfile==='function'){
-          await switchToProfile(profileIntent.name);
-          _profileSwitchCompleted=true;
-          _profileSwitchChangedProfile=(S.activeProfile||'default')!==_profileSwitchProfileBefore||!!S.activeProfileIsDefault!==_profileSwitchIsDefaultBefore;
+          _profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;
+          if(_profileSwitchCompleted){
+            _profileSwitchChangedProfile=(S.activeProfile||'default')!==_profileSwitchProfileBefore||!!S.activeProfileIsDefault!==_profileSwitchIsDefaultBefore;
+            if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
+          }
         }
       }else{
         console.warn('[boot] ignored invalid profile query', profileIntent.name);
+        if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
       }
     }catch(e){
       console.warn('[boot] profile query switch failed', e);
-    }finally{
-      if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
     }
   }
   // Fetch available models without blocking session restore. The static HTML

--- a/static/boot.js
+++ b/static/boot.js
@@ -1849,6 +1849,7 @@ $('modelSelect').onchange=async()=>{
   const modelState=(typeof _modelStateForSelect==='function')
     ? _modelStateForSelect($('modelSelect'),selectedModel)
     : {model:selectedModel,model_provider:null};
+  if(typeof clearProfileTransitionReasoningContext==='function') clearProfileTransitionReasoningContext();
   if(typeof closeModelDropdown==='function') closeModelDropdown();
   if(typeof _writePersistedModelState==='function') _writePersistedModelState(modelState.model,modelState.model_provider);
   else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
@@ -3167,8 +3168,6 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
   const titleLabel=$('titlebarProfileLabel');
   if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
-  // Initialize reasoning chip on boot (fixes #1103: chip hidden until session load)
-  if(typeof fetchReasoningChip==='function') fetchReasoningChip();
   const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;
   const _savedLocalBeforeProfileSwitch=localStorage.getItem('hermes-webui-session');
   const _profileSwitchProfileBefore=S.activeProfile||'default';
@@ -3193,6 +3192,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       console.warn('[boot] profile query switch failed', e);
     }
   }
+  if(typeof fetchReasoningChip==='function'&&(!_profileSwitchCompleted||!_profileSwitchChangedProfile)) fetchReasoningChip();
   // Fetch available models without blocking session restore. The static HTML
   // options are enough for first paint; the dynamic provider list can settle
   // after the saved session is visible.

--- a/static/boot.js
+++ b/static/boot.js
@@ -122,6 +122,9 @@ function _prefillHasDraftText(prefillIntent){
 function _rootPrefillNeedsFreshComposer(urlSession, savedLocal, prefillIntent){
   return !urlSession&&!!savedLocal&&_prefillHasDraftText(prefillIntent);
 }
+function _profileQueryBlocksSavedLocalRestore(profileIntent, urlSession){
+  return !!(profileIntent&&profileIntent.hasParam&&profileIntent.valid&&!urlSession);
+}
 async function _applyComposerPrefillOnBoot(prefillIntent){
   if(!prefillIntent||!prefillIntent.hasText) return;
   const msg=(typeof $==='function')?$('msg'):document.getElementById('msg');
@@ -3164,6 +3167,31 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
   const titleLabel=$('titlebarProfileLabel');
   if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
+  // Initialize reasoning chip on boot (fixes #1103: chip hidden until session load)
+  if(typeof fetchReasoningChip==='function') fetchReasoningChip();
+  const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;
+  const _savedLocalBeforeProfileSwitch=localStorage.getItem('hermes-webui-session');
+  const _profileSwitchProfileBefore=S.activeProfile||'default';
+  const _profileSwitchIsDefaultBefore=!!S.activeProfileIsDefault;
+  let _profileSwitchCompleted=false;
+  let _profileSwitchChangedProfile=false;
+  if(profileIntent&&profileIntent.hasParam){
+    try{
+      if(profileIntent.valid){
+        if(typeof switchToProfile==='function'){
+          await switchToProfile(profileIntent.name);
+          _profileSwitchCompleted=true;
+          _profileSwitchChangedProfile=(S.activeProfile||'default')!==_profileSwitchProfileBefore||!!S.activeProfileIsDefault!==_profileSwitchIsDefaultBefore;
+        }
+      }else{
+        console.warn('[boot] ignored invalid profile query', profileIntent.name);
+      }
+    }catch(e){
+      console.warn('[boot] profile query switch failed', e);
+    }finally{
+      if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();
+    }
+  }
   // Fetch available models without blocking session restore. The static HTML
   // options are enough for first paint; the dynamic provider list can settle
   // after the saved session is visible.
@@ -3256,8 +3284,6 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   // re-run when the browser restores the page from bfcache.
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
   if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
-  // Initialize reasoning chip on boot (fixes #1103 — chip hidden until session load)
-  if(typeof fetchReasoningChip==='function') fetchReasoningChip();
   if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
   const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
   const pwaLaunchAction=(window.HermesPWA&&typeof window.HermesPWA.launchAction==='function')
@@ -3277,6 +3303,12 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       S._bootReady=true;
       syncTopbar();syncWorkspacePanelState();await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);if(typeof startGatewaySSE==='function')startGatewaySSE();return;
     }catch(e){console.warn('[pwa] new-chat launch action failed', e);}
+  }
+  const _profileQueryBlocksSavedLocal=_profileQueryBlocksSavedLocalRestore(profileIntent, urlSession);
+  if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){
+    try{
+      if(localStorage.getItem('hermes-webui-session')===_savedLocalBeforeProfileSwitch) localStorage.removeItem('hermes-webui-session');
+    }catch(_){}
   }
   const savedLocal=localStorage.getItem('hermes-webui-session');
   const saved=urlSession||savedLocal;

--- a/static/panels.js
+++ b/static/panels.js
@@ -6828,7 +6828,7 @@ async function switchToProfile(name) {
   // already on this profile, so paths like activateCurrentProfile() (which
   // doesn't pre-check) can't flash a skeleton→restore for a click that changes
   // nothing. (#4662 Opus gate)
-  if (name && name === S.activeProfile) return;
+  if (name && name === S.activeProfile) return true;
   S._pendingSessionToolsets=null;
   // Profile switches are per-client cookie/TLS scoped, so a running stream in
   // the current session can safely continue while this tab moves to another
@@ -6909,7 +6909,7 @@ async function switchToProfile(name) {
     // the single source of truth for switch failure and is gated on _switchGen, so the
     // error surfaces ONLY when the CURRENT switch genuinely fails (@rodboev review, #4662).
     const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }), timeoutToast: false });
-    if (_switchGen !== _profileSwitchGeneration) return;
+    if (_switchGen !== _profileSwitchGeneration) return false;
     S.activeProfile = data.active || name;
     S.activeProfileIsDefault = !!data.is_default;
     const targetActiveProfile = S.activeProfile || 'default';
@@ -7026,7 +7026,7 @@ async function switchToProfile(name) {
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
       await renderSessionList();
-      if (_switchGen !== _profileSwitchGeneration) return;
+      if (_switchGen !== _profileSwitchGeneration) return false;
       if (workspaceVisible && typeof clearWorkspaceTreeSkeleton === 'function') clearWorkspaceTreeSkeleton();
       showToast(t('profile_switched', name));
     } else if (sessionInProgress) {
@@ -7034,7 +7034,7 @@ async function switchToProfile(name) {
       // Start a new session for the new profile so nothing gets cross-tagged.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
       await newSession(false, {awaitWorkspaceLoad: workspaceVisible});
-      if (_switchGen !== _profileSwitchGeneration) return;
+      if (_switchGen !== _profileSwitchGeneration) return false;
       // Keep topbar chips (workspace/profile) in sync after creating the
       // new profile-scoped session.
       syncTopbar();
@@ -7048,7 +7048,7 @@ async function switchToProfile(name) {
       // the superseded switch would clear the newer switch's workspace skeleton
       // and pop a stale toast. Mirrors the no-messages branch guard below.
       // (@rodboev/greptile review, #4662)
-      if (_switchGen !== _profileSwitchGeneration) return;
+      if (_switchGen !== _profileSwitchGeneration) return false;
       if (typeof _openProfileSwitchSessionBrowser === 'function') _openProfileSwitchSessionBrowser();
       // Safety net: if the new session has no workspace, newSession() won't have
       // painted the file tree — clear the up-front skeleton so it can't strand
@@ -7089,6 +7089,7 @@ async function switchToProfile(name) {
 
     await _profileSwitchPanelLoad();
     _refreshProfileSwitchBackground(_switchGen);
+    return true;
 
   } catch (e) {
     // Revert the optimistic name update on error
@@ -7115,6 +7116,7 @@ async function switchToProfile(name) {
         clearWorkspaceTreeSkeleton();
       }
     }
+    return false;
   } finally {
     // Always remove loading indicator regardless of success or failure
     if (_switchGen === _profileSwitchGeneration && _chip) { _chip.classList.remove('switching'); _chip.disabled = false; }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6925,13 +6925,6 @@ async function switchToProfile(name) {
         sessionInProgress = true;
       }
     }
-    // #4650 review: a profile switch can change agent.reasoning_effort (and other
-    // reasoning inputs like base_url) WITHOUT changing the default model/provider,
-    // which is all the reasoning-chip cache key tracks. Force exactly one reasoning
-    // refetch for the new profile so the chip reflects the new profile's effort
-    // (the syncTopbar() calls below route through syncReasoningChip()).
-    if (typeof _lastReasoningFetchKey !== 'undefined') _lastReasoningFetchKey = null;
-
     // Reconnect the gateway SSE to the NEW profile's watcher. The backend watcher
     // registry is now profile-keyed (#3629), but this tab's existing EventSource is
     // still subscribed to the PREVIOUS profile's watcher — and the probe-based
@@ -6994,6 +6987,9 @@ async function switchToProfile(name) {
     // model patch above (don't touch a session about to be replaced).
     if (S.session && !sessionInProgress) {
       S.session.profile = data.active || name;
+    }
+    if (typeof refreshProfileTransitionReasoningChip === 'function') {
+      refreshProfileTransitionReasoningChip(data.default_model, data.default_model_provider);
     }
 
     // ── Apply workspace ────────────────────────────────────────────────────

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3609,11 +3609,38 @@ function _composerPrefillIntentFromLocation(){
     };
   }catch(_e){return empty;}
 }
+function _profileQueryIntentFromLocation(){
+  const empty={hasParam:false,valid:false,name:''};
+  if(typeof window==='undefined'||!window.location) return empty;
+  try{
+    const qs=new URLSearchParams(window.location.search||'');
+    if(!qs.has('profile')) return empty;
+    const name=String(qs.get('profile')||'');
+    return {
+      hasParam:true,
+      valid:/^[a-z0-9][a-z0-9_-]{0,63}$/.test(name),
+      name
+    };
+  }catch(_e){return empty;}
+}
+function _consumeProfileQueryParamFromLocation(){
+  if(typeof window==='undefined'||!window.location||!window.history||typeof window.history.replaceState!=='function') return;
+  try{
+    const current=new URL(window.location.href);
+    const before=current.searchParams.toString();
+    current.searchParams.delete('profile');
+    const after=current.searchParams.toString();
+    if(after===before) return;
+    const next=current.pathname+(after?`?${after}`:'')+(current.hash||'');
+    window.history.replaceState(window.history.state||null,'',next);
+  }catch(_e){}
+}
 function _consumeComposerPrefillParamsFromLocation(){
   if(typeof window==='undefined'||!window.location||!window.history||typeof window.history.replaceState!=='function') return;
   try{
     const current=new URL(window.location.href);
     const before=current.searchParams.toString();
+    current.searchParams.delete('profile');
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');
@@ -3638,6 +3665,7 @@ function _sessionUrlForSid(sid){
     const current=new URL(window.location.href);
     current.searchParams.delete('session');
     current.searchParams.delete('session_id');
+    current.searchParams.delete('profile');
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1325,6 +1325,9 @@ async function _switchProfileForSessionLoad(profile){
     else localStorage.removeItem('hermes-webui-model');
     if(data.default_model) window._defaultModel=data.default_model;
     if(data.default_model_provider) window._activeProvider=data.default_model_provider;
+    if(typeof refreshProfileTransitionReasoningChip==='function'){
+      refreshProfileTransitionReasoningChip(data.default_model,data.default_model_provider);
+    }
     if(typeof startGatewaySSE==='function') startGatewaySSE();
     if(typeof syncTopbar==='function') syncTopbar();
     if(typeof _setProfileSwitchListEmbargo==='function') _setProfileSwitchListEmbargo(false);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3643,7 +3643,6 @@ function _consumeComposerPrefillParamsFromLocation(){
   try{
     const current=new URL(window.location.href);
     const before=current.searchParams.toString();
-    current.searchParams.delete('profile');
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');
@@ -3668,7 +3667,6 @@ function _sessionUrlForSid(sid){
     const current=new URL(window.location.href);
     current.searchParams.delete('session');
     current.searchParams.delete('session_id');
-    current.searchParams.delete('profile');
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');

--- a/static/ui.js
+++ b/static/ui.js
@@ -4493,6 +4493,10 @@ function refreshProfileTransitionReasoningChip(model, provider){
   fetchReasoningChip(params.size?'?'+params.toString():undefined);
 }
 
+function clearProfileTransitionReasoningContext(){
+  _profileTransitionReasoningContext=null;
+}
+
 function syncReasoningChip(){
   // #4650: syncTopbar() calls this on every routine UI refresh, and during
   // streaming those fire at high frequency. Before a9ce2889 this served the

--- a/static/ui.js
+++ b/static/ui.js
@@ -4343,6 +4343,7 @@ if(document.readyState==='loading'){
 // ── Reasoning effort chip ────────────────────────────────────────────────────
 let _currentReasoningEffort=null;
 let _currentReasoningEffortsSupported=null;
+let _profileTransitionReasoningContext=null;
 
 function _normalizeReasoningEffort(eff){
   return String(eff||'').trim().toLowerCase();
@@ -4360,6 +4361,14 @@ function _formatReasoningEffortLabel(effort){
 }
 
 function _reasoningEffortContext(){
+  const transition=_profileTransitionReasoningContext;
+  const session=S&&S.session;
+  if(transition&&(!session||session.profile!==transition.profile)){
+    const ctx={};
+    if(transition.model) ctx.model=transition.model;
+    if(transition.provider) ctx.provider=transition.provider;
+    return ctx;
+  }
   const sel=$('modelSelect');
   const model=(S&&S.session&&S.session.model)||(sel&&sel.value)||'';
   let provider=(S&&S.session&&S.session.model_provider)||'';
@@ -4449,11 +4458,11 @@ let _lastReasoningFetchKey=null;
 // a different agent.reasoning_effort) — #4650 review.
 let _reasoningFetchSeq=0;
 
-function fetchReasoningChip(){
+function fetchReasoningChip(keyOverride){
   // Set the cache key OPTIMISTICALLY before the request so rapid routine syncs
   // while this GET is in flight short-circuit instead of re-dispatching (that
   // in-flight window is exactly where the #4650 storm lived).
-  const key=_reasoningEffortQuery();
+  const key=keyOverride===undefined?_reasoningEffortQuery():keyOverride;
   const seq=++_reasoningFetchSeq;
   _lastReasoningFetchKey=key;
   api('/api/reasoning'+key).then(function(st){
@@ -4469,6 +4478,19 @@ function fetchReasoningChip(){
     _lastReasoningFetchKey=null;
     _applyReasoningChip('', {supported_efforts:[]});
   });
+}
+
+function refreshProfileTransitionReasoningChip(model, provider){
+  _profileTransitionReasoningContext={profile:(S&&S.activeProfile)||'default',model,provider};
+  _currentReasoningEffort=null;
+  _currentReasoningEffortsSupported=null;
+  _lastReasoningFetchKey=null;
+  ++_reasoningFetchSeq;
+  _applyReasoningChip('', {supported_efforts:[]});
+  const params=new URLSearchParams();
+  if(model) params.set('model',model);
+  if(provider) params.set('provider',provider);
+  fetchReasoningChip(params.size?'?'+params.toString():undefined);
 }
 
 function syncReasoningChip(){

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -1,0 +1,487 @@
+"""Regression tests for #5682 profile query boot switching."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+BOOT_JS_PATH = REPO_ROOT / "static" / "boot.js"
+SESSIONS_JS = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+BOOT_JS = BOOT_JS_PATH.read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> str:
+    result = subprocess.run(
+        [NODE],
+        input=source,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
+
+
+def _node_prelude() -> str:
+    return f"""
+const sessionsSrc = {SESSIONS_JS!r};
+const bootSrc = {BOOT_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('(?:async\\\\s+)?function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function evalSession(name) {{
+  globalThis[name] = (0, eval)('(' + extractFunc(sessionsSrc, name) + ')');
+}}
+function evalBoot(name) {{
+  globalThis[name] = (0, eval)('(' + extractFunc(bootSrc, name) + ')');
+}}
+"""
+
+
+def test_valid_profile_query_switches_before_restore_and_cleans_url():
+    source = _node_prelude() + """
+function applyUrl(rel) {
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.window = {
+  location: {},
+  history: {
+    state: { from: 'test' },
+    calls: [],
+    replaceState(state, title, url) {
+      this.calls.push({ state, title, url });
+      this.state = state;
+      applyUrl(url);
+    }
+  }
+};
+global.document = { baseURI: 'https://example.test/app/' };
+console.warn = (...args) => { throw new Error('unexpected warn: ' + args.join(' ')); };
+applyUrl('/app/?profile=vops&q=hello&prompt=hi&send=1&keep=1#frag');
+global.localStorage = {
+  store: { 'hermes-webui-session': 'saved-local' },
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  },
+  setItem(key, value) {
+    this.store[key] = String(value);
+  },
+  removeItem(key) {
+    delete this.store[key];
+  }
+};
+evalSession('_profileQueryIntentFromLocation');
+evalSession('_consumeProfileQueryParamFromLocation');
+evalSession('_consumeComposerPrefillParamsFromLocation');
+evalSession('_sessionUrlForSid');
+evalBoot('_profileQueryBlocksSavedLocalRestore');
+const intent = _profileQueryIntentFromLocation();
+global.S = { activeProfile: 'default', activeProfileIsDefault: true };
+const switched = [];
+global.switchToProfile = async (name) => {
+  switched.push(name);
+  S.activeProfile = name;
+  S.activeProfileIsDefault = false;
+  localStorage.setItem('hermes-webui-session', 'fresh-local');
+};
+(async () => {
+  const promoted = _sessionUrlForSid('abc 123');
+  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  const profileSwitchProfileBefore = S.activeProfile || 'default';
+  const profileSwitchIsDefaultBefore = !!S.activeProfileIsDefault;
+  let profileSwitchCompleted = false;
+  let profileSwitchChangedProfile = false;
+  if (intent && intent.hasParam) {
+    try {
+      if (intent.valid) {
+        if (typeof switchToProfile === 'function') {
+          await switchToProfile(intent.name);
+          profileSwitchCompleted = true;
+          profileSwitchChangedProfile = (S.activeProfile || 'default') !== profileSwitchProfileBefore || !!S.activeProfileIsDefault !== profileSwitchIsDefaultBefore;
+        }
+      } else {
+        console.warn('[boot] ignored invalid profile query', intent.name);
+      }
+    } catch (e) {
+      console.warn('[boot] profile query switch failed', e);
+    } finally {
+      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+    }
+  }
+  const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
+  if (blocksSavedLocal && profileSwitchCompleted && profileSwitchChangedProfile && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  const savedLocalAfterSuppress = localStorage.getItem('hermes-webui-session');
+  const savedLocalAfterReload = localStorage.getItem('hermes-webui-session');
+  const keepsExplicitSession = _profileQueryBlocksSavedLocalRestore(intent, 'session-123');
+  const afterProfile = window.location.pathname + window.location.search + window.location.hash;
+  _consumeComposerPrefillParamsFromLocation();
+  const afterPrefill = window.location.pathname + window.location.search + window.location.hash;
+  const profilePos = bootSrc.indexOf("const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;");
+  const renderPos = bootSrc.indexOf("await renderSessionList();", profilePos);
+  const savedPos = bootSrc.indexOf("const saved=urlSession||savedLocal;", profilePos);
+  const loadPos = bootSrc.indexOf("await loadSession(saved, {preserveActiveInput:true});", profilePos);
+  const consumePos = bootSrc.indexOf("if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();", profilePos);
+  const completedPos = bootSrc.indexOf("_profileSwitchCompleted=true;", profilePos);
+  const changedPos = bootSrc.indexOf("_profileSwitchChangedProfile=", completedPos);
+  const cleanupGuardPos = bootSrc.indexOf("if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){", profilePos);
+  const fetchPos = bootSrc.indexOf("fetchReasoningChip()");
+  console.log(JSON.stringify({ intent, switched, promoted, afterProfile, afterPrefill, historyCalls: window.history.calls, profilePos, renderPos, savedPos, loadPos, consumePos, completedPos, changedPos, cleanupGuardPos, fetchPos, savedLocalBefore, savedLocalAfterSuppress, savedLocalAfterReload, blocksSavedLocal, keepsExplicitSession }));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["intent"] == {"hasParam": True, "valid": True, "name": "vops"}
+    assert payload["switched"] == ["vops"]
+    assert payload["promoted"] == "/app/session/abc%20123?keep=1#frag"
+    assert payload["afterProfile"] == "/app/?q=hello&prompt=hi&send=1&keep=1#frag"
+    assert payload["afterPrefill"] == "/app/?keep=1#frag"
+    assert payload["historyCalls"][0]["url"] == "/app/?q=hello&prompt=hi&send=1&keep=1#frag"
+    assert payload["historyCalls"][1]["url"] == "/app/?keep=1#frag"
+    assert payload["profilePos"] >= 0
+    assert payload["renderPos"] > payload["profilePos"]
+    assert payload["savedPos"] > payload["profilePos"]
+    assert payload["loadPos"] > payload["savedPos"]
+    assert payload["consumePos"] > payload["profilePos"]
+    assert payload["completedPos"] > payload["profilePos"]
+    assert payload["changedPos"] > payload["completedPos"]
+    assert payload["cleanupGuardPos"] > payload["consumePos"]
+    assert payload["fetchPos"] < payload["profilePos"]
+    assert payload["savedLocalBefore"] == "saved-local"
+    assert payload["savedLocalAfterSuppress"] == "fresh-local"
+    assert payload["savedLocalAfterReload"] == "fresh-local"
+    assert payload["blocksSavedLocal"] is True
+    assert payload["keepsExplicitSession"] is False
+
+
+def test_noop_profile_query_switch_keeps_saved_local_state():
+    source = _node_prelude() + """
+function applyUrl(rel) {
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.window = {
+  location: {},
+  history: {
+    state: { from: 'test' },
+    calls: [],
+    replaceState(state, title, url) {
+      this.calls.push({ state, title, url });
+      this.state = state;
+      applyUrl(url);
+    }
+  }
+};
+global.document = { baseURI: 'https://example.test/app/' };
+applyUrl('/app/?profile=default&q=hello&keep=1#frag');
+global.S = { activeProfile: 'default', activeProfileIsDefault: true };
+global.localStorage = {
+  store: { 'hermes-webui-session': 'saved-local' },
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  },
+  removeItem(key) {
+    delete this.store[key];
+  }
+};
+evalSession('_profileQueryIntentFromLocation');
+evalSession('_consumeProfileQueryParamFromLocation');
+evalBoot('_profileQueryBlocksSavedLocalRestore');
+const intent = _profileQueryIntentFromLocation();
+global.switchToProfile = async () => {};
+(async () => {
+  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  const profileSwitchProfileBefore = S.activeProfile || 'default';
+  const profileSwitchIsDefaultBefore = !!S.activeProfileIsDefault;
+  let profileSwitchCompleted = false;
+  let profileSwitchChangedProfile = false;
+  if (intent && intent.hasParam) {
+    try {
+      if (intent.valid) {
+        if (typeof switchToProfile === 'function') {
+          await switchToProfile(intent.name);
+          profileSwitchCompleted = true;
+          profileSwitchChangedProfile = (S.activeProfile || 'default') !== profileSwitchProfileBefore || !!S.activeProfileIsDefault !== profileSwitchIsDefaultBefore;
+        }
+      } else {
+        console.warn('[boot] ignored invalid profile query', intent.name);
+      }
+    } catch (e) {
+      console.warn('[boot] profile query switch failed', e);
+    } finally {
+      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+    }
+  }
+  const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
+  if (blocksSavedLocal && profileSwitchCompleted && profileSwitchChangedProfile && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  const cleanupGuardPos = bootSrc.indexOf("if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){", bootSrc.indexOf("const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;"));
+  console.log(JSON.stringify({
+    intent,
+    blocksSavedLocal,
+    profileSwitchCompleted,
+    profileSwitchChangedProfile,
+    savedLocalBefore,
+    savedLocalAfter: localStorage.getItem('hermes-webui-session'),
+    cleanupGuardPos,
+  }));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["intent"] == {"hasParam": True, "valid": True, "name": "default"}
+    assert payload["blocksSavedLocal"] is True
+    assert payload["profileSwitchCompleted"] is True
+    assert payload["profileSwitchChangedProfile"] is False
+    assert payload["savedLocalBefore"] == "saved-local"
+    assert payload["savedLocalAfter"] == "saved-local"
+    assert payload["cleanupGuardPos"] >= 0
+
+
+def test_failed_profile_query_switch_keeps_saved_local_state():
+    source = _node_prelude() + """
+function applyUrl(rel) {
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.window = {
+  location: {},
+  history: {
+    state: null,
+    calls: [],
+    replaceState(state, title, url) {
+      this.calls.push({ state, title, url });
+      this.state = state;
+      applyUrl(url);
+    }
+  }
+};
+global.document = { baseURI: 'https://example.test/app/' };
+const warns = [];
+console.warn = (...args) => { warns.push(args.map(String)); };
+applyUrl('/app/?profile=vops&q=hello&keep=1#frag');
+global.localStorage = {
+  store: { 'hermes-webui-session': 'saved-local' },
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  },
+  removeItem(key) {
+    delete this.store[key];
+  }
+};
+evalSession('_profileQueryIntentFromLocation');
+evalSession('_consumeProfileQueryParamFromLocation');
+evalBoot('_profileQueryBlocksSavedLocalRestore');
+const intent = _profileQueryIntentFromLocation();
+global.switchToProfile = async () => { throw new Error('boom'); };
+(async () => {
+  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  let profileSwitchCompleted = false;
+  if (intent && intent.hasParam) {
+    try {
+      if (intent.valid) {
+        if (typeof switchToProfile === 'function') {
+          await switchToProfile(intent.name);
+          profileSwitchCompleted = true;
+        }
+      } else {
+        console.warn('[boot] ignored invalid profile query', intent.name);
+      }
+    } catch (e) {
+      console.warn('[boot] profile query switch failed', e);
+    } finally {
+      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+    }
+  }
+  const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
+  if (blocksSavedLocal && profileSwitchCompleted && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  console.log(JSON.stringify({
+    blocksSavedLocal,
+    profileSwitchCompleted,
+    savedLocalAfter: localStorage.getItem('hermes-webui-session'),
+    url: window.location.pathname + window.location.search + window.location.hash,
+    warns,
+  }));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["blocksSavedLocal"] is True
+    assert payload["profileSwitchCompleted"] is False
+    assert payload["savedLocalAfter"] == "saved-local"
+    assert payload["url"] == "/app/?q=hello&keep=1#frag"
+    assert payload["warns"] == [["[boot] profile query switch failed", "Error: boom"]]
+
+
+def test_invalid_profile_query_warns_and_skips_switch():
+    source = _node_prelude() + """
+function applyUrl(rel) {
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.window = {
+  location: {},
+  history: {
+    state: null,
+    calls: [],
+    replaceState(state, title, url) {
+      this.calls.push({ state, title, url });
+      this.state = state;
+      applyUrl(url);
+    }
+  }
+};
+global.document = { baseURI: 'https://example.test/app/' };
+const warns = [];
+console.warn = (...args) => { warns.push(args); };
+applyUrl('/app/?profile=../bad&q=hello&keep=1#frag');
+evalSession('_profileQueryIntentFromLocation');
+evalSession('_consumeProfileQueryParamFromLocation');
+const intent = _profileQueryIntentFromLocation();
+const switched = [];
+global.switchToProfile = async (name) => { switched.push(name); };
+(async () => {
+  if (intent && intent.hasParam) {
+    try {
+      if (intent.valid) {
+        if (typeof switchToProfile === 'function') await switchToProfile(intent.name);
+      } else {
+        console.warn('[boot] ignored invalid profile query', intent.name);
+      }
+    } catch (e) {
+      console.warn('[boot] profile query switch failed', e);
+    } finally {
+      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+    }
+  }
+  console.log(JSON.stringify({
+    intent,
+    switched,
+    warns,
+    url: window.location.pathname + window.location.search + window.location.hash,
+    historyCalls: window.history.calls,
+  }));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["intent"] == {"hasParam": True, "valid": False, "name": "../bad"}
+    assert payload["switched"] == []
+    assert payload["warns"] == [["[boot] ignored invalid profile query", "../bad"]]
+    assert payload["url"] == "/app/?q=hello&keep=1#frag"
+    assert payload["historyCalls"] == [{"state": None, "title": "", "url": "/app/?q=hello&keep=1#frag"}]
+
+
+def test_prefill_cleanup_still_strips_q_prompt_and_send():
+    source = _node_prelude() + """
+function applyUrl(rel) {
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.window = {
+  location: {},
+  history: {
+    state: null,
+    calls: [],
+    replaceState(state, title, url) {
+      this.calls.push({ state, title, url });
+      this.state = state;
+      applyUrl(url);
+    }
+  }
+};
+global.document = { baseURI: 'https://example.test/app/' };
+applyUrl('/app/?q=hello&prompt=hi&send=1&keep=1#frag');
+evalSession('_consumeComposerPrefillParamsFromLocation');
+_consumeComposerPrefillParamsFromLocation();
+console.log(JSON.stringify({
+  url: window.location.pathname + window.location.search + window.location.hash,
+  historyCalls: window.history.calls,
+}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["url"] == "/app/?keep=1#frag"
+    assert payload["historyCalls"] == [{"state": None, "title": "", "url": "/app/?keep=1#frag"}]
+
+
+def test_profile_query_blocks_only_implicit_saved_local_restore():
+    source = _node_prelude() + """
+evalBoot('_profileQueryBlocksSavedLocalRestore');
+global.localStorage = {
+  store: { 'hermes-webui-session': 'saved-local' },
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  },
+  setItem(key, value) {
+    this.store[key] = String(value);
+  },
+  removeItem(key) {
+    delete this.store[key];
+  }
+};
+const validProfile = { hasParam: true, valid: true };
+const invalidProfile = { hasParam: true, valid: false };
+const blocksImplicit = _profileQueryBlocksSavedLocalRestore(validProfile, null);
+if (blocksImplicit) localStorage.removeItem('hermes-webui-session');
+const implicitAfter = localStorage.getItem('hermes-webui-session');
+localStorage.setItem('hermes-webui-session', 'saved-local');
+const allowsExplicit = _profileQueryBlocksSavedLocalRestore(validProfile, 'session-123');
+if (allowsExplicit) localStorage.removeItem('hermes-webui-session');
+const explicitAfter = localStorage.getItem('hermes-webui-session');
+console.log(JSON.stringify({
+  blocksImplicit,
+  allowsExplicit,
+  ignoresInvalid: _profileQueryBlocksSavedLocalRestore(invalidProfile, null),
+  implicitAfter,
+  explicitAfter,
+}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload == {
+        "blocksImplicit": True,
+        "allowsExplicit": False,
+        "ignoresInvalid": False,
+        "implicitAfter": None,
+        "explicitAfter": "saved-local",
+    }

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -9,8 +9,12 @@ import pytest
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
 BOOT_JS_PATH = REPO_ROOT / "static" / "boot.js"
+PANELS_JS_PATH = REPO_ROOT / "static" / "panels.js"
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
 SESSIONS_JS = SESSIONS_JS_PATH.read_text(encoding="utf-8")
 BOOT_JS = BOOT_JS_PATH.read_text(encoding="utf-8")
+PANELS_JS = PANELS_JS_PATH.read_text(encoding="utf-8")
+UI_JS = UI_JS_PATH.read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -485,3 +489,182 @@ console.log(JSON.stringify({
         "implicitAfter": None,
         "explicitAfter": "saved-local",
     }
+
+
+def test_profile_transition_reasoning_refresh_hides_stale_chip_until_destination_resolves():
+    source = f"""
+const uiSrc = {UI_JS!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = uiSrc.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = uiSrc.indexOf('{{', start), depth = 1; i++;
+  while (depth > 0 && i < uiSrc.length) {{
+    if (uiSrc[i] === '{{') depth++;
+    else if (uiSrc[i] === '}}') depth--;
+    i++;
+  }}
+  return uiSrc.slice(start, i);
+}}
+function makeEl() {{
+  return {{
+    style: {{}}, classList: {{ toggle(){{}}, add(){{}}, remove(){{}} }},
+    setAttribute(){{}}, querySelectorAll(){{ return []; }},
+  }};
+}}
+const els = {{
+  composerReasoningWrap: makeEl(), composerReasoningLabel: makeEl(),
+  composerReasoningChip: makeEl(), composerMobileReasoningAction: makeEl(),
+}};
+global.$ = id => els[id] || null;
+global.S = {{ session: {{ model: 'gpt-5', model_provider: 'openai' }} }};
+global._highlightReasoningOption = () => {{}};
+global._applyReasoningOptions = () => {{}};
+global._reasoningEffortQuery = () => '?model=gpt-5';
+const pending = [];
+let calls = 0;
+global.api = () => {{
+  calls++;
+  return {{ then(ok) {{ pending.push(ok); return {{ catch() {{}} }}; }} }};
+}};
+var _currentReasoningEffort = 'low';
+var _currentReasoningEffortsSupported = ['low', 'high'];
+var _lastReasoningFetchKey = '?model=gpt-5';
+var _reasoningFetchSeq = 7;
+eval(extractFunc('_normalizeReasoningEffort'));
+eval(extractFunc('_formatReasoningEffortLabel'));
+eval(extractFunc('_applyReasoningChip'));
+eval(extractFunc('fetchReasoningChip'));
+eval(extractFunc('refreshProfileTransitionReasoningChip'));
+fetchReasoningChip();
+refreshProfileTransitionReasoningChip();
+const beforeDestination = {{
+  effort: _currentReasoningEffort,
+  cachedKey: _lastReasoningFetchKey,
+  wrapDisplay: els.composerReasoningWrap.style.display,
+  calls,
+}};
+pending[0]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
+const afterPreviousResponse = {{ effort: _currentReasoningEffort, wrapDisplay: els.composerReasoningWrap.style.display }};
+pending[1]({{ reasoning_effort: 'high', supported_efforts: ['low', 'high'] }});
+console.log(JSON.stringify({{ beforeDestination, afterPreviousResponse, afterDestination: _currentReasoningEffort, calls }}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["beforeDestination"] == {
+        "effort": "",
+        "cachedKey": "?model=gpt-5",
+        "wrapDisplay": "none",
+        "calls": 2,
+    }
+    assert payload["afterPreviousResponse"] == {"effort": "", "wrapDisplay": "none"}
+    assert payload["afterDestination"] == "high"
+    assert payload["calls"] == 2
+    assert "refreshProfileTransitionReasoningChip" in PANELS_JS
+    assert PANELS_JS.index("refreshProfileTransitionReasoningChip") > PANELS_JS.index("S.activeProfile = data.active || name")
+    background = PANELS_JS[PANELS_JS.index("function _refreshProfileSwitchBackground"):PANELS_JS.index("async function loadProfilesPanel")]
+    for refresh in (
+        "_ensureComposerControlVisibilityState",
+        "_setComposerControlOrder",
+        "_renderComposerControlChips",
+        "_renderComposerSituationalControlChips",
+        "_applyComposerFooterVisibilitySettings",
+        "_applyTitlebarProfileVisibility",
+    ):
+        assert refresh in background
+
+
+def test_profile_transitions_fetch_destination_reasoning_after_hiding_stale_chip():
+    source = f"""
+const uiSrc = {UI_JS!r};
+const panelsSrc = {PANELS_JS!r};
+const sessionsSrc = {SESSIONS_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('(?:async\\\\s+)?function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start), depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function makeEl() {{ return {{ style: {{}}, disabled: false, classList: {{ add(){{}}, remove(){{}}, toggle(){{}} }}, setAttribute(){{}}, querySelectorAll(){{ return []; }} }}; }}
+const els = {{ composerReasoningWrap: makeEl(), composerReasoningLabel: makeEl(), composerReasoningChip: makeEl(), composerMobileReasoningAction: makeEl() }};
+global.$ = id => els[id] || null;
+global.window = {{}};
+global.document = {{ title: '' }};
+global.localStorage = {{ removeItem(){{}} }};
+global.S = {{ activeProfile: 'default', activeProfileIsDefault: true, session: null, messages: [] }};
+global._highlightReasoningOption = () => {{}};
+global._applyReasoningOptions = () => {{}};
+global._applyModelToDropdown = model => model;
+global._modelStateForSelect = (_, model) => ({{ model, model_provider: 'openai' }});
+global.renderSessionList = async () => {{}};
+global.startGatewaySSE = () => {{}};
+global.showToast = () => {{}};
+global.t = value => value;
+global.assistantDisplayName = () => 'Hermes';
+global._profileSwitchPanelLoad = async () => {{}};
+global._refreshProfileSwitchBackground = () => {{}};
+var _profileSwitchGeneration = 0;
+var _skillsData = null, _workspaceList = null;
+var _currentReasoningEffort = 'low';
+var _currentReasoningEffortsSupported = ['low', 'high'];
+var _profileTransitionReasoningContext = null;
+var _lastReasoningFetchKey = null;
+var _reasoningFetchSeq = 0;
+eval(extractFunc(uiSrc, '_normalizeReasoningEffort'));
+eval(extractFunc(uiSrc, '_formatReasoningEffortLabel'));
+eval(extractFunc(uiSrc, '_reasoningEffortContext'));
+eval(extractFunc(uiSrc, '_reasoningEffortQuery'));
+eval(extractFunc(uiSrc, '_applyReasoningChip'));
+eval(extractFunc(uiSrc, 'fetchReasoningChip'));
+eval(extractFunc(uiSrc, 'refreshProfileTransitionReasoningChip'));
+eval(extractFunc(uiSrc, 'syncTopbar'));
+eval(extractFunc(panelsSrc, 'switchToProfile'));
+eval(extractFunc(sessionsSrc, '_switchProfileForSessionLoad'));
+const pending = [];
+const reasoningUrls = [];
+global.api = (url) => {{
+  if (url === '/api/profile/switch') return Promise.resolve({{ active: 'vops', is_default: false, default_model: 'gpt-high', default_model_provider: 'openai' }});
+  if (url.startsWith('/api/reasoning')) {{
+    reasoningUrls.push(url);
+    return {{ then(ok) {{ pending.push(ok); return {{ catch() {{}} }}; }} }};
+  }}
+  throw new Error('unexpected API ' + url);
+}};
+fetchReasoningChip();
+(async () => {{
+  await switchToProfile('vops');
+  const blankBoot = {{ hidden: els.composerReasoningWrap.style.display, urls: reasoningUrls.slice() }};
+  pending[0]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
+  const blankBootAfterOld = _currentReasoningEffort;
+  pending[1]({{ reasoning_effort: 'high', supported_efforts: ['low', 'high'] }});
+  const blankBootAfterNew = _currentReasoningEffort;
+  S.activeProfile = 'default'; S.activeProfileIsDefault = true;
+  S.session = {{ model: 'old-model', model_provider: 'old-provider', profile: 'default' }};
+  _currentReasoningEffort = 'low'; _currentReasoningEffortsSupported = ['low', 'high']; _profileTransitionReasoningContext = null; _lastReasoningFetchKey = null;
+  fetchReasoningChip();
+  await _switchProfileForSessionLoad('vops');
+  const directLoad = {{ hidden: els.composerReasoningWrap.style.display, urls: reasoningUrls.slice(2) }};
+  pending[2]({{ reasoning_effort: 'low', supported_efforts: ['low', 'high'] }});
+  const directLoadAfterOld = _currentReasoningEffort;
+  pending[3]({{ reasoning_effort: 'high', supported_efforts: ['low', 'high'] }});
+  console.log(JSON.stringify({{ blankBoot, blankBootAfterOld, blankBootAfterNew, directLoad, directLoadAfterOld, directLoadAfterNew: _currentReasoningEffort }}));
+}})().catch(err => {{ console.error(err); process.exit(1); }});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["blankBoot"] == {
+        "hidden": "none",
+        "urls": ["/api/reasoning", "/api/reasoning?model=gpt-high&provider=openai"],
+    }
+    assert payload["blankBootAfterOld"] == ""
+    assert payload["blankBootAfterNew"] == "high"
+    assert payload["directLoad"] == {
+        "hidden": "none",
+        "urls": ["/api/reasoning?model=old-model&provider=old-provider", "/api/reasoning?model=gpt-high&provider=openai"],
+    }
+    assert payload["directLoadAfterOld"] == ""
+    assert payload["directLoadAfterNew"] == "high"

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -110,9 +110,9 @@ global.switchToProfile = async (name) => {
   S.activeProfile = name;
   S.activeProfileIsDefault = false;
   localStorage.setItem('hermes-webui-session', 'fresh-local');
+  return true;
 };
 (async () => {
-  const promoted = _sessionUrlForSid('abc 123');
   const savedLocalBefore = localStorage.getItem('hermes-webui-session');
   const profileSwitchProfileBefore = S.activeProfile || 'default';
   const profileSwitchIsDefaultBefore = !!S.activeProfileIsDefault;
@@ -122,17 +122,17 @@ global.switchToProfile = async (name) => {
     try {
       if (intent.valid) {
         if (typeof switchToProfile === 'function') {
-          await switchToProfile(intent.name);
-          profileSwitchCompleted = true;
-          profileSwitchChangedProfile = (S.activeProfile || 'default') !== profileSwitchProfileBefore || !!S.activeProfileIsDefault !== profileSwitchIsDefaultBefore;
+          profileSwitchCompleted = await switchToProfile(intent.name) === true;
+          if (profileSwitchCompleted) {
+            profileSwitchChangedProfile = (S.activeProfile || 'default') !== profileSwitchProfileBefore || !!S.activeProfileIsDefault !== profileSwitchIsDefaultBefore;
+            if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+          }
         }
       } else {
         console.warn('[boot] ignored invalid profile query', intent.name);
       }
     } catch (e) {
       console.warn('[boot] profile query switch failed', e);
-    } finally {
-      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
@@ -141,6 +141,7 @@ global.switchToProfile = async (name) => {
   const savedLocalAfterReload = localStorage.getItem('hermes-webui-session');
   const keepsExplicitSession = _profileQueryBlocksSavedLocalRestore(intent, 'session-123');
   const afterProfile = window.location.pathname + window.location.search + window.location.hash;
+  const promoted = _sessionUrlForSid('abc 123');
   _consumeComposerPrefillParamsFromLocation();
   const afterPrefill = window.location.pathname + window.location.search + window.location.hash;
   const profilePos = bootSrc.indexOf("const profileIntent=(typeof _profileQueryIntentFromLocation==='function')?_profileQueryIntentFromLocation():null;");
@@ -148,7 +149,7 @@ global.switchToProfile = async (name) => {
   const savedPos = bootSrc.indexOf("const saved=urlSession||savedLocal;", profilePos);
   const loadPos = bootSrc.indexOf("await loadSession(saved, {preserveActiveInput:true});", profilePos);
   const consumePos = bootSrc.indexOf("if(typeof _consumeProfileQueryParamFromLocation==='function') _consumeProfileQueryParamFromLocation();", profilePos);
-  const completedPos = bootSrc.indexOf("_profileSwitchCompleted=true;", profilePos);
+  const completedPos = bootSrc.indexOf("_profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;", profilePos);
   const changedPos = bootSrc.indexOf("_profileSwitchChangedProfile=", completedPos);
   const cleanupGuardPos = bootSrc.indexOf("if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){", profilePos);
   const fetchPos = bootSrc.indexOf("fetchReasoningChip()");
@@ -217,9 +218,11 @@ global.localStorage = {
 };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
+evalSession('_consumeComposerPrefillParamsFromLocation');
+evalSession('_sessionUrlForSid');
 evalBoot('_profileQueryBlocksSavedLocalRestore');
 const intent = _profileQueryIntentFromLocation();
-global.switchToProfile = async () => {};
+global.switchToProfile = async () => true;
 (async () => {
   const savedLocalBefore = localStorage.getItem('hermes-webui-session');
   const profileSwitchProfileBefore = S.activeProfile || 'default';
@@ -230,17 +233,17 @@ global.switchToProfile = async () => {};
     try {
       if (intent.valid) {
         if (typeof switchToProfile === 'function') {
-          await switchToProfile(intent.name);
-          profileSwitchCompleted = true;
-          profileSwitchChangedProfile = (S.activeProfile || 'default') !== profileSwitchProfileBefore || !!S.activeProfileIsDefault !== profileSwitchIsDefaultBefore;
+          profileSwitchCompleted = await switchToProfile(intent.name) === true;
+          if (profileSwitchCompleted) {
+            profileSwitchChangedProfile = (S.activeProfile || 'default') !== profileSwitchProfileBefore || !!S.activeProfileIsDefault !== profileSwitchIsDefaultBefore;
+            if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+          }
         }
       } else {
         console.warn('[boot] ignored invalid profile query', intent.name);
       }
     } catch (e) {
       console.warn('[boot] profile query switch failed', e);
-    } finally {
-      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
@@ -306,6 +309,8 @@ global.localStorage = {
 };
 evalSession('_profileQueryIntentFromLocation');
 evalSession('_consumeProfileQueryParamFromLocation');
+evalSession('_consumeComposerPrefillParamsFromLocation');
+evalSession('_sessionUrlForSid');
 evalBoot('_profileQueryBlocksSavedLocalRestore');
 const intent = _profileQueryIntentFromLocation();
 global.switchToProfile = async () => { throw new Error('boom'); };
@@ -316,25 +321,30 @@ global.switchToProfile = async () => { throw new Error('boom'); };
     try {
       if (intent.valid) {
         if (typeof switchToProfile === 'function') {
-          await switchToProfile(intent.name);
-          profileSwitchCompleted = true;
+          profileSwitchCompleted = await switchToProfile(intent.name) === true;
+          if (profileSwitchCompleted && typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
         }
       } else {
         console.warn('[boot] ignored invalid profile query', intent.name);
+        if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
       }
     } catch (e) {
       console.warn('[boot] profile query switch failed', e);
-    } finally {
-      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
     }
   }
   const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
   if (blocksSavedLocal && profileSwitchCompleted && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  const afterBoot = window.location.pathname + window.location.search + window.location.hash;
+  _consumeComposerPrefillParamsFromLocation();
+  const afterPrefill = window.location.pathname + window.location.search + window.location.hash;
+  const promoted = _sessionUrlForSid('abc 123');
   console.log(JSON.stringify({
     blocksSavedLocal,
     profileSwitchCompleted,
     savedLocalAfter: localStorage.getItem('hermes-webui-session'),
-    url: window.location.pathname + window.location.search + window.location.hash,
+    afterBoot,
+    afterPrefill,
+    promoted,
     warns,
   }));
 })().catch(err => {
@@ -346,8 +356,91 @@ global.switchToProfile = async () => { throw new Error('boom'); };
     assert payload["blocksSavedLocal"] is True
     assert payload["profileSwitchCompleted"] is False
     assert payload["savedLocalAfter"] == "saved-local"
-    assert payload["url"] == "/app/?q=hello&keep=1#frag"
+    assert payload["afterBoot"] == "/app/?profile=vops&q=hello&keep=1#frag"
+    assert payload["afterPrefill"] == "/app/?profile=vops&keep=1#frag"
+    assert payload["promoted"] == "/app/session/abc%20123?profile=vops&keep=1#frag"
     assert payload["warns"] == [["[boot] profile query switch failed", "Error: boom"]]
+
+
+def test_unsuccessful_profile_query_result_keeps_retry_url_without_warning():
+    source = _node_prelude() + """
+function applyUrl(rel) {
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}
+global.window = {
+  location: {},
+  history: {
+    state: null,
+    calls: [],
+    replaceState(state, title, url) {
+      this.calls.push({ state, title, url });
+      this.state = state;
+      applyUrl(url);
+    }
+  }
+};
+global.document = { baseURI: 'https://example.test/app/' };
+const warns = [];
+console.warn = (...args) => { warns.push(args.map(String)); };
+applyUrl('/app/?profile=vops&q=hello&keep=1#frag');
+global.localStorage = {
+  store: { 'hermes-webui-session': 'saved-local' },
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  },
+  removeItem(key) {
+    delete this.store[key];
+  }
+};
+evalSession('_profileQueryIntentFromLocation');
+evalSession('_consumeProfileQueryParamFromLocation');
+evalBoot('_profileQueryBlocksSavedLocalRestore');
+const intent = _profileQueryIntentFromLocation();
+global.switchToProfile = async () => false;
+(async () => {
+  const savedLocalBefore = localStorage.getItem('hermes-webui-session');
+  let profileSwitchCompleted = false;
+  if (intent && intent.hasParam) {
+    try {
+      if (intent.valid) {
+        if (typeof switchToProfile === 'function') {
+          profileSwitchCompleted = await switchToProfile(intent.name) === true;
+          if (profileSwitchCompleted && typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+        }
+      } else {
+        console.warn('[boot] ignored invalid profile query', intent.name);
+        if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
+      }
+    } catch (e) {
+      console.warn('[boot] profile query switch failed', e);
+    }
+  }
+  const blocksSavedLocal = _profileQueryBlocksSavedLocalRestore(intent, null);
+  if (blocksSavedLocal && profileSwitchCompleted && localStorage.getItem('hermes-webui-session') === savedLocalBefore) localStorage.removeItem('hermes-webui-session');
+  console.log(JSON.stringify({
+    blocksSavedLocal,
+    profileSwitchCompleted,
+    savedLocalAfter: localStorage.getItem('hermes-webui-session'),
+    url: window.location.pathname + window.location.search + window.location.hash,
+    historyCalls: window.history.calls,
+    warns,
+  }));
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["blocksSavedLocal"] is True
+    assert payload["profileSwitchCompleted"] is False
+    assert payload["savedLocalAfter"] == "saved-local"
+    assert payload["url"] == "/app/?profile=vops&q=hello&keep=1#frag"
+    assert payload["historyCalls"] == []
+    assert payload["warns"] == []
 
 
 def test_invalid_profile_query_warns_and_skips_switch():
@@ -387,11 +480,10 @@ global.switchToProfile = async (name) => { switched.push(name); };
         if (typeof switchToProfile === 'function') await switchToProfile(intent.name);
       } else {
         console.warn('[boot] ignored invalid profile query', intent.name);
+        if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
       }
     } catch (e) {
       console.warn('[boot] profile query switch failed', e);
-    } finally {
-      if (typeof _consumeProfileQueryParamFromLocation === 'function') _consumeProfileQueryParamFromLocation();
     }
   }
   console.log(JSON.stringify({

--- a/tests/test_5682_profile_query_switch.py
+++ b/tests/test_5682_profile_query_switch.py
@@ -152,8 +152,8 @@ global.switchToProfile = async (name) => {
   const completedPos = bootSrc.indexOf("_profileSwitchCompleted=await switchToProfile(profileIntent.name)===true;", profilePos);
   const changedPos = bootSrc.indexOf("_profileSwitchChangedProfile=", completedPos);
   const cleanupGuardPos = bootSrc.indexOf("if(_profileQueryBlocksSavedLocal&&_profileSwitchCompleted&&_profileSwitchChangedProfile){", profilePos);
-  const fetchPos = bootSrc.indexOf("fetchReasoningChip()");
-  console.log(JSON.stringify({ intent, switched, promoted, afterProfile, afterPrefill, historyCalls: window.history.calls, profilePos, renderPos, savedPos, loadPos, consumePos, completedPos, changedPos, cleanupGuardPos, fetchPos, savedLocalBefore, savedLocalAfterSuppress, savedLocalAfterReload, blocksSavedLocal, keepsExplicitSession }));
+  const initialReasoningFetchPos = bootSrc.indexOf("if(typeof fetchReasoningChip==='function'&&(!_profileSwitchCompleted||!_profileSwitchChangedProfile)) fetchReasoningChip();", profilePos);
+  console.log(JSON.stringify({ intent, switched, promoted, afterProfile, afterPrefill, historyCalls: window.history.calls, profilePos, renderPos, savedPos, loadPos, consumePos, completedPos, changedPos, cleanupGuardPos, initialReasoningFetchPos, savedLocalBefore, savedLocalAfterSuppress, savedLocalAfterReload, blocksSavedLocal, keepsExplicitSession }));
 })().catch(err => {
   console.error(err);
   process.exit(1);
@@ -175,7 +175,7 @@ global.switchToProfile = async (name) => {
     assert payload["completedPos"] > payload["profilePos"]
     assert payload["changedPos"] > payload["completedPos"]
     assert payload["cleanupGuardPos"] > payload["consumePos"]
-    assert payload["fetchPos"] < payload["profilePos"]
+    assert payload["initialReasoningFetchPos"] > payload["completedPos"]
     assert payload["savedLocalBefore"] == "saved-local"
     assert payload["savedLocalAfterSuppress"] == "fresh-local"
     assert payload["savedLocalAfterReload"] == "fresh-local"
@@ -760,3 +760,73 @@ fetchReasoningChip();
     }
     assert payload["directLoadAfterOld"] == ""
     assert payload["directLoadAfterNew"] == "high"
+
+
+def test_blank_profile_transition_context_clears_before_explicit_model_change():
+    source = f"""
+const uiSrc = {UI_JS!r};
+const bootSrc = {BOOT_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('(?:async\\\\s+)?function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start), depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function makeEl() {{ return {{ style: {{}}, classList: {{ toggle(){{}} }}, setAttribute(){{}}, querySelectorAll(){{ return []; }} }}; }}
+const els = {{
+  modelSelect: {{ value: 'claude-sonnet' }},
+  composerReasoningWrap: makeEl(),
+  composerReasoningLabel: makeEl(),
+  composerReasoningChip: makeEl(),
+  composerMobileReasoningAction: makeEl()
+}};
+global.$ = id => els[id] || null;
+global.S = {{ activeProfile: 'vops', session: null }};
+global._highlightReasoningOption = () => {{}};
+global._applyReasoningOptions = () => {{}};
+global._modelStateForSelect = (_, model) => ({{ model, model_provider: 'anthropic' }});
+var _currentReasoningEffort = 'high';
+var _currentReasoningEffortsSupported = ['low', 'high'];
+var _profileTransitionReasoningContext = {{ profile: 'vops', model: 'gpt-high', provider: 'openai' }};
+var _lastReasoningFetchKey = '?model=gpt-high&provider=openai';
+var _reasoningFetchSeq = 1;
+const urls = [];
+global.api = (url) => {{
+  urls.push(url);
+  return Promise.resolve({{ reasoning_effort: 'medium', supported_efforts: ['medium'] }});
+}};
+eval(extractFunc(uiSrc, '_normalizeReasoningEffort'));
+eval(extractFunc(uiSrc, '_formatReasoningEffortLabel'));
+eval(extractFunc(uiSrc, '_reasoningEffortContext'));
+eval(extractFunc(uiSrc, '_reasoningEffortQuery'));
+eval(extractFunc(uiSrc, '_applyReasoningChip'));
+eval(extractFunc(uiSrc, 'fetchReasoningChip'));
+eval(extractFunc(uiSrc, 'refreshProfileTransitionReasoningChip'));
+eval(extractFunc(uiSrc, 'clearProfileTransitionReasoningContext'));
+eval(extractFunc(uiSrc, 'syncReasoningChip'));
+clearProfileTransitionReasoningContext();
+syncReasoningChip();
+const handler = bootSrc.slice(bootSrc.indexOf("$('modelSelect').onchange=async()=>"), bootSrc.indexOf("$('msg').addEventListener", bootSrc.indexOf("$('modelSelect').onchange=async()=>")));
+const clearPos = handler.indexOf("clearProfileTransitionReasoningContext");
+const rememberBlankPos = handler.indexOf("_rememberEmptyComposerModelOverride");
+const noSessionSyncPos = handler.indexOf("syncReasoningChip()", rememberBlankPos);
+console.log(JSON.stringify({{
+  urls,
+  context: _profileTransitionReasoningContext,
+  lastKey: _lastReasoningFetchKey,
+  clearPos,
+  noSessionSyncPos
+}}));
+"""
+    payload = json.loads(_run_node(source))
+    assert payload["urls"] == ["/api/reasoning?model=claude-sonnet&provider=anthropic"]
+    assert payload["context"] is None
+    assert payload["lastKey"] == "?model=claude-sonnet&provider=anthropic"
+    assert payload["clearPos"] >= 0
+    assert payload["clearPos"] < payload["noSessionSyncPos"]

--- a/tests/test_issue1103_reasoning_chip_visibility.py
+++ b/tests/test_issue1103_reasoning_chip_visibility.py
@@ -16,12 +16,9 @@ def test_boot_call_before_session_load():
     """fetchReasoningChip() should be called before session load in boot sequence."""
     with open("static/boot.js") as f:
         src = f.read()
-    # Find the boot session load; URL-anchored tabs may prefer a URL session id
-    # before falling back to the stored session id.
-    boot_marker = "localStorage.getItem('hermes-webui-session')"
+    boot_marker = "await loadSession(saved, {preserveActiveInput:true});"
     boot_pos = src.index(boot_marker)
-    fetch_pos = src.index("fetchReasoningChip()")
-    # fetchReasoningChip must be called just before the saved session load
+    fetch_pos = src.index("fetchReasoningChip()", src.index("_profileQueryIntentFromLocation"))
     assert fetch_pos < boot_pos, \
         "fetchReasoningChip() should be called before saved session load in boot.js"
 

--- a/tests/test_issue1103_reasoning_chip_visibility.py
+++ b/tests/test_issue1103_reasoning_chip_visibility.py
@@ -60,12 +60,12 @@ def test_ui_js_passes_model_context_to_reasoning_api():
     # the query into a local `key` first (for the in-flight storm + stale-success
     # guards), so accept either the inlined form or the captured-key form — both
     # pass _reasoningEffortQuery()'s output to the endpoint.
-    fetch_match = re.search(r"function fetchReasoningChip\(\)\{(.+?)\n\}", src, re.DOTALL)
+    fetch_match = re.search(r"function fetchReasoningChip\([^)]*\)\{(.+?)\n\}", src, re.DOTALL)
     assert fetch_match, "fetchReasoningChip function must exist"
     fetch_body = fetch_match.group(1)
     inlined = "api('/api/reasoning'+_reasoningEffortQuery())" in src
     captured = (
-        re.search(r"const\s+key\s*=\s*_reasoningEffortQuery\(\)", fetch_body)
+        "_reasoningEffortQuery()" in fetch_body
         and "api('/api/reasoning'+key)" in fetch_body
     )
     assert inlined or captured, (
@@ -79,7 +79,7 @@ def test_fetchReasoningChip_calls_apply():
     with open("static/ui.js") as f:
         src = f.read()
     # Find fetchReasoningChip function
-    func_match = re.search(r"function fetchReasoningChip\(\)\{(.+?)\}", src, re.DOTALL)
+    func_match = re.search(r"function fetchReasoningChip\([^)]*\)\{(.+?)\}", src, re.DOTALL)
     assert func_match, "fetchReasoningChip function must exist"
     func_body = func_match.group(1)
     assert "_applyReasoningChip" in func_body, \

--- a/tests/test_issue4650_reasoning_chip_no_storm.py
+++ b/tests/test_issue4650_reasoning_chip_no_storm.py
@@ -81,6 +81,7 @@ function extractFunc(name) {
 // declare them in this eval scope so the extracted functions can see them.
 var _currentReasoningEffort = null;
 var _currentReasoningEffortsSupported = null;
+var _profileTransitionReasoningContext = null;
 var _lastReasoningFetchKey = null;
 var _reasoningFetchSeq = 0;
 

--- a/tests/test_issue4662_profile_switch_skeleton_static.py
+++ b/tests/test_issue4662_profile_switch_skeleton_static.py
@@ -56,7 +56,7 @@ class TestSwitchWiring:
         # (Codex gate #4662). The skeletons shown up front already provide the
         # immediate cross-surface feedback.
         body = _switch_body()
-        guard = "if (_switchGen !== _profileSwitchGeneration) return;"
+        guard = "if (_switchGen !== _profileSwitchGeneration) return false;"
         # In the non-sessionInProgress branch, the loadDir('.') call must come
         # after an occurrence of the guard.
         dir_idx = body.index("const dirLoad = loadDir('.');")
@@ -88,7 +88,7 @@ class TestSwitchWiring:
         body = _switch_body()
         head = body[: _show_session_skeleton_call_idx(body)]
         assert "name === S.activeProfile" in head, "missing no-op self-switch early-return"
-        assert "return;" in head
+        assert "return true;" in head
 
     def test_dismisses_rename_and_menu_before_skeleton(self):
         # Opus gate #4662: renderSessionListFromCache() early-returns while
@@ -128,7 +128,7 @@ class TestSwitchWiring:
         # rapid second switch could have its workspace skeleton cleared / a stale
         # toast popped by the slower earlier switch. Mirror the no-messages guard.
         body = _switch_body()
-        guard = "if (_switchGen !== _profileSwitchGeneration) return;"
+        guard = "if (_switchGen !== _profileSwitchGeneration) return false;"
         # Inside the sessionInProgress branch: locate its "await renderSessionList()"
         # then the profile_switched_new_conversation toast; a guard must sit between.
         new_toast_idx = body.index("profile_switched_new_conversation")

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1443,7 +1443,7 @@ def test_reasoning_chip_updates_desktop_and_mobile_controls():
     """Reasoning chip sync should keep both footer and mobile overflow labels current."""
     ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
     chip_start = ui_js.index("function _applyReasoningChip(eff)")
-    chip_end = ui_js.index("function fetchReasoningChip()", chip_start)
+    chip_end = ui_js.index("function fetchReasoningChip(", chip_start)
     chip_body = ui_js[chip_start:chip_end]
     for expected in (
         "composerReasoningWrap",

--- a/tests/test_reasoning_chip_js_behaviour.py
+++ b/tests/test_reasoning_chip_js_behaviour.py
@@ -68,6 +68,7 @@ global.document = {
 };
 global.$ = id => els[id] || null;
 global.api = () => ({ then: () => ({ catch: () => {} }), catch: () => {} });
+var _profileTransitionReasoningContext = null;
 
 function extractFunc(name) {
   const re = new RegExp('function\\s+' + name + '\\s*\\(');


### PR DESCRIPTION
## Thinking Path

- A profile query is boot intent, so it has to run before the saved-session and sidebar restore branches.
- The backend and frontend already have a per-tab profile switch path, but boot needs an explicit success result before it can safely consume retryable URL intent.
- Composer prefill stays on its existing late path because `q`, `prompt`, and `send` write into the booted composer, and it no longer owns `profile` cleanup.

## What Changed

- `static/sessions.js`: adds profile-query intent and cleanup helpers using the same profile id shape as the backend, and keeps generic prefill/session URL rewrites from deleting pending profile intent.
- `static/boot.js`: consumes a valid profile query only after the switch reports success, preserves retryable `?profile=` on failed switches, and keeps composer prefill finalization late.
- `static/panels.js`: gives `switchToProfile()` a success result so boot can distinguish completed, no-op, superseded, and failed switches.
- `static/ui.js`: refreshes profile-scoped reasoning state through the shared profile transition path.
- `tests/test_5682_profile_query_switch.py`: covers valid, invalid, no-op active-profile, thrown failure, handled failure, retry-preserving URL rewrites, reasoning refresh, cleanup, and ordering behavior.

## Why It Matters

Bookmarks, alerts, QR codes, and shared workspace URLs can land a tab directly in the intended profile without first painting the previous profile. If a transient profile switch failure happens, refresh keeps retrying the intended profile instead of silently restoring the old profile with the query gone.

## Verification

Focused tests cover profile-query switching, active-profile no-op preservation, invalid-name fallback, failed-switch retry preservation, saved-session behavior, URL cleanup, profile-switch UX, parallel-switch behavior, reasoning refresh, and existing composer prefill preservation; CI runs the full matrix on 3.11, 3.12, and 3.13.

## Upstream

Closes #5682. The ordering follows the maintainer's boot caveat in https://github.com/nesquena/hermes-webui/issues/5682#issuecomment-4894668407.

## Model Used

GPT 5.5 via Codex CLI
