### PR TITLE
fix(streaming): drop empty tool_calls arrays before API send

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4025,6 +4025,10 @@ def _sanitize_messages_for_api(
                 # Orphaned tool result — skip to avoid 400 from strict providers.
                 continue
         sanitized = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS}
+        # Drop empty tool_calls — strict providers (DeepSeek, newer OpenAI)
+        # reject tool_calls: [] with HTTP 400 even when no orphaned calls exist.
+        if 'tool_calls' in sanitized and not sanitized['tool_calls']:
+            del sanitized['tool_calls']
         # Provider-aware reasoning_content stripping from model-facing history.
         # Historical assistant reasoning_content is stripped only when the user
         # explicitly requests strip mode or auto mode identifies a local/generic
@@ -4136,6 +4140,8 @@ def _api_safe_message_positions(messages):
             if not tid or tid not in valid_tool_call_ids:
                 continue
         sanitized = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS}
+        if 'tool_calls' in sanitized and not sanitized['tool_calls']:
+            del sanitized['tool_calls']
         if is_recovered:
             sanitized['_recovered'] = True  # temporary marker — stripped before return
         if 'content' in sanitized:


### PR DESCRIPTION
## Problem

Strict providers (DeepSeek v4, newer OpenAI) reject messages with `tool_calls: []` as HTTP 400:

> Invalid 'messages[120].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.

`_sanitize_messages_for_api()` (PR #542 / 9220a87) already strips orphaned `role: tool` messages whose `tool_call_id` cannot be linked to a preceding assistant, but it does not handle the case where an **assistant message itself** carries an empty `tool_calls` array.

This happens when a stored message has `tool_calls: []` (not `None`, not missing — literally an empty JSON array) and the dict comprehension copies it verbatim into the sanitized output.

## Fix

After the dict comprehension in both sanitize paths (`_sanitize_messages_for_api` and `_api_safe_message_positions`), check if `tool_calls` exists and is falsy (empty list) — if so, delete it from the sanitized dict entirely so the outbound request is compliant with the spec.

## Testing

- Normal histories with real tool_calls are completely unaffected
- Histories containing an empty `tool_calls: []` now have it stripped before the API call, preventing the 400

Fixes the WebUI-side gap that surfaces when using strict providers (DeepSeek, newer OpenAI-compat endpoints).