### PR TITLE
feat(#5711): add extension event subscription API

### DIFF
--- a/api/extensions.py
+++ b/api/extensions.py
@@ -669,6 +669,16 @@ def _manifest_entry_storage_owned(entry: Dict[str, object]) -> bool:
     storage = permissions.get("storage")
     return isinstance(storage, dict) and storage.get("owned") is True
 
+def _manifest_entry_runtime_permissions(entry: Dict[str, object]) -> Dict[str, object]:
+    permissions = entry.get("permissions")
+    if not isinstance(permissions, dict):
+        return {}
+    result: Dict[str, object] = {}
+    observability = permissions.get("observability")
+    if isinstance(observability, dict) and observability.get("events") is True:
+        result["observability"] = {"events": True}
+    return result
+
 def _settings_text(value: object, *, max_len: int = 160) -> str:
     if not isinstance(value, str):
         return ""
@@ -1116,25 +1126,27 @@ def _manifest_extension_state(
         if not manifest_enabled:
             manifest_disabled_ids.add(ext_id)
         settings_schema = _sanitize_settings_schema(entry)
-        extension_entries.append(
-            {
-                "id": ext_id,
-                "name": name or ext_id,
-                "manifest_enabled": manifest_enabled,
-                "user_enabled": (not user_disabled) if can_toggle else False,
-                "user_disabled": user_disabled,
-                "effective_enabled": effective_enabled,
-                "can_toggle": can_toggle,
-                "reload_required": True,
-                "storage_owned": _manifest_entry_storage_owned(entry),
-                "settings_schema": settings_schema,
-                "status": (
-                    "manifest_disabled"
-                    if not manifest_enabled
-                    else ("user_disabled" if user_disabled else "enabled")
-                ),
-            }
-        )
+        extension_entry = {
+            "id": ext_id,
+            "name": name or ext_id,
+            "manifest_enabled": manifest_enabled,
+            "user_enabled": (not user_disabled) if can_toggle else False,
+            "user_disabled": user_disabled,
+            "effective_enabled": effective_enabled,
+            "can_toggle": can_toggle,
+            "reload_required": True,
+            "storage_owned": _manifest_entry_storage_owned(entry),
+            "settings_schema": settings_schema,
+            "status": (
+                "manifest_disabled"
+                if not manifest_enabled
+                else ("user_disabled" if user_disabled else "enabled")
+            ),
+        }
+        runtime_permissions = _manifest_entry_runtime_permissions(entry)
+        if runtime_permissions:
+            extension_entry["permissions"] = runtime_permissions
+        extension_entries.append(extension_entry)
     if invalid_seen:
         _add_diagnostic_warning(diagnostics, "manifest_extension_id_invalid", "manifest:extensions")
     if duplicate_seen:
@@ -1257,14 +1269,16 @@ def _extension_runtime_entries(
         seen_ids.add(ext_id)
         if entry.get("enabled", True) is False or ext_id in disabled_ids:
             continue
-        extensions.append(
-            {
-                "id": ext_id,
-                "name": _manifest_entry_text(entry, "name") or ext_id,
-                "storage_owned": _manifest_entry_storage_owned(entry),
-                "settings_schema": _sanitize_settings_schema(entry),
-            }
-        )
+        extension_entry = {
+            "id": ext_id,
+            "name": _manifest_entry_text(entry, "name") or ext_id,
+            "storage_owned": _manifest_entry_storage_owned(entry),
+            "settings_schema": _sanitize_settings_schema(entry),
+        }
+        runtime_permissions = _manifest_entry_runtime_permissions(entry)
+        if runtime_permissions:
+            extension_entry["permissions"] = runtime_permissions
+        extensions.append(extension_entry)
     return extensions
 
 

--- a/api/extensions.py
+++ b/api/extensions.py
@@ -1282,6 +1282,39 @@ def _extension_runtime_entries(
     return extensions
 
 
+def _extension_script_owners(manifest: object, disabled_ids: Optional[Set[str]] = None) -> Dict[str, str]:
+    """Return manifest script URL to extension id ownership for runtime script tags."""
+    disabled_ids = disabled_ids or set()
+    owners: Dict[str, str] = {}
+    seen_ids: Set[str] = set()
+    for _source, _index, entry in _manifest_extension_entries(manifest):
+        raw_id = _manifest_entry_text(entry, "id")
+        if not _valid_extension_id(raw_id):
+            continue
+        ext_id = raw_id.strip()
+        if ext_id in seen_ids:
+            continue
+        seen_ids.add(ext_id)
+        if entry.get("enabled", True) is False or ext_id in disabled_ids:
+            continue
+        asset_base = str(entry.get("_asset_base", "") or "")
+        for value in _entry_asset_values(entry, "scripts"):
+            url = _manifest_asset_url(value, asset_base)
+            if url and _is_safe_asset_url(url) and url not in owners:
+                owners[url] = ext_id
+    return owners
+
+
+def _current_extension_script_owners() -> Dict[str, str]:
+    root = _extension_root()
+    if root is None:
+        return {}
+    state = _load_extension_state()
+    disabled_ids = set(state.get("disabled_extensions") or [])
+    manifest, _manifest_status = _load_manifest_with_status(root)
+    return _extension_script_owners(manifest, disabled_ids) if manifest is not None else {}
+
+
 def _read_manifest_urls_with_diagnostics(
     root: Path,
     diagnostics: Optional[Dict[str, Any]] = None,
@@ -1938,10 +1971,17 @@ def inject_extension_tags(index_html: str) -> str:
         '<link rel="stylesheet" href="{}">'.format(html.escape(url, quote=True))
         for url in config["stylesheet_urls"]
     ]
-    script_tags = [
-        '<script src="{}" defer></script>'.format(html.escape(url, quote=True))
-        for url in config["script_urls"]
-    ]
+    script_owners = _current_extension_script_owners()
+    script_tags = []
+    for url in config["script_urls"]:
+        owner = script_owners.get(url) if isinstance(script_owners, dict) else None
+        owner_attr = (
+            ' data-hermes-extension-id="{}"'.format(html.escape(owner, quote=True))
+            if owner else ""
+        )
+        script_tags.append(
+            '<script src="{}" defer{}></script>'.format(html.escape(url, quote=True), owner_attr)
+        )
     runtime_config = {
         "extensions": config.get("extensions", []),
     }

--- a/api/extensions.py
+++ b/api/extensions.py
@@ -1282,7 +1282,9 @@ def _extension_runtime_entries(
     return extensions
 
 
-def _extension_script_owners(manifest: object, disabled_ids: Optional[Set[str]] = None) -> Dict[str, str]:
+def _extension_script_owners(
+    manifest: object, disabled_ids: Optional[Set[str]] = None, asset_base: str = ""
+) -> Dict[str, str]:
     """Return manifest script URL to extension id ownership for runtime script tags."""
     disabled_ids = disabled_ids or set()
     owners: Dict[str, str] = {}
@@ -1297,7 +1299,6 @@ def _extension_script_owners(manifest: object, disabled_ids: Optional[Set[str]] 
         seen_ids.add(ext_id)
         if entry.get("enabled", True) is False or ext_id in disabled_ids:
             continue
-        asset_base = str(entry.get("_asset_base", "") or "")
         for value in _entry_asset_values(entry, "scripts"):
             url = _manifest_asset_url(value, asset_base)
             if url and _is_safe_asset_url(url) and url not in owners:
@@ -1311,8 +1312,9 @@ def _current_extension_script_owners() -> Dict[str, str]:
         return {}
     state = _load_extension_state()
     disabled_ids = set(state.get("disabled_extensions") or [])
-    manifest, _manifest_status = _load_manifest_with_status(root)
-    return _extension_script_owners(manifest, disabled_ids) if manifest is not None else {}
+    manifest, manifest_status = _load_manifest_with_status(root)
+    asset_base = str(manifest_status.get("_asset_base", "") or "")
+    return _extension_script_owners(manifest, disabled_ids, asset_base) if manifest is not None else {}
 
 
 def _read_manifest_urls_with_diagnostics(

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -493,6 +493,16 @@ Rules and guarantees:
   the default `connect-src`. Declare `permissions.network_external` honestly
   based on where it calls.
 
+## Observability events
+
+Extensions can subscribe to a read-only live event stream with `window.HermesExtensionEvents.subscribe(types, handler)`.
+
+- `types` accepts a string, an array of strings, or `null` / empty for all supported event types.
+- The handler receives cloned event objects with `type`, `timestamp`, `session_id`, and `payload`.
+- `subscribe()` returns an unsubscribe function on success.
+- Delivery requires an enabled extension manifest entry with `{"permissions":{"observability":{"events":true}}}`.
+- Phase 1 covers live stream events only. Metrics access is a separate slice.
+
 ## Extension authoring guidance
 
 Extensions share the page with the WebUI app, so they should be additive and

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -499,8 +499,9 @@ Extensions can subscribe to a read-only live event stream with `window.HermesExt
 
 - `types` accepts a string, an array of strings, or `null` / empty for all supported event types.
 - The handler receives cloned event objects with `type`, `timestamp`, `session_id`, and `payload`.
-- `subscribe()` returns an unsubscribe function on success.
-- Delivery requires an enabled extension manifest entry with `{"permissions":{"observability":{"events":true}}}`.
+- `subscribe()` returns an unsubscribe function on success, and `false` when the caller is not a manifest extension with permission.
+- Call `subscribe()` during the extension script's startup so WebUI can bind the subscriber to that manifest extension's injected script tag.
+- Delivery requires the calling enabled extension manifest entry to declare `{"permissions":{"observability":{"events":true}}}`.
 - Phase 1 covers live stream events only. Metrics access is a separate slice.
 
 ## Extension authoring guidance

--- a/static/boot.js
+++ b/static/boot.js
@@ -1201,6 +1201,74 @@ window._hermesTtsSynth=function(id, text, opts){
     });
 };
 
+// ── Extension event stream (observability subscription) ─────────────────────
+const _HERMES_EXTENSION_EVENT_TYPES=new Set(['tool','tool_complete','approval','clarify','done','stream_end','apperror','cancel']);
+const _HERMES_EXTENSION_EVENT_SUBSCRIBERS=new Set();
+function _cloneHermesExtensionEventPayload(value){
+  try{ return JSON.parse(JSON.stringify(value===undefined?{}:value)); }
+  catch(_){ return {}; }
+}
+function _hermesExtensionHasEventPermission(){
+  const cfg=window.__HERMES_EXTENSION_CONFIG__;
+  const extensions=cfg&&Array.isArray(cfg.extensions)?cfg.extensions:[];
+  for(const ext of extensions){
+    if(!ext||typeof ext!=='object') continue;
+    if(ext.enabled===false||ext.effective_enabled===false||ext.user_disabled===true||ext.manifest_enabled===false) continue;
+    if(ext.status==='user_disabled'||ext.status==='manifest_disabled') continue;
+    const observability=ext.permissions&&ext.permissions.observability;
+    if(observability&&observability.events===true) return true;
+  }
+  return false;
+}
+function _normalizeHermesExtensionEventTypes(types){
+  if(types==null) return null;
+  if(typeof types==='string'){
+    const name=types.trim();
+    if(!name) return null;
+    return _HERMES_EXTENSION_EVENT_TYPES.has(name)?new Set([name]):false;
+  }
+  if(!Array.isArray(types)) return false;
+  const out=new Set();
+  for(const type of types){
+    if(typeof type!=='string') return false;
+    const name=type.trim();
+    if(!name) continue;
+    if(!_HERMES_EXTENSION_EVENT_TYPES.has(name)) return false;
+    out.add(name);
+  }
+  return out.size?out:null;
+}
+function _publishHermesExtensionEvent(type, payload){
+  try{
+    if(!_HERMES_EXTENSION_EVENT_TYPES.has(type)) return false;
+    if(!_hermesExtensionHasEventPermission()) return false;
+    const event={
+      type:type,
+      timestamp:new Date().toISOString(),
+      session_id:(payload&&payload.session_id)||null,
+      payload:_cloneHermesExtensionEventPayload(payload||{}),
+    };
+    for(const subscriber of _HERMES_EXTENSION_EVENT_SUBSCRIBERS){
+      if(subscriber.types&&subscriber.types.size&&!subscriber.types.has(type)) continue;
+      try{ subscriber.handler(_cloneHermesExtensionEventPayload(event)); }catch(_){}
+    }
+    return true;
+  }catch(_){ return false; }
+}
+window.HermesExtensionEvents={
+  subscribe:function(types, handler){
+    try{
+      if(typeof handler!=='function') return false;
+      const normalized=_normalizeHermesExtensionEventTypes(types);
+      if(normalized===false) return false;
+      const subscriber={types:normalized,handler};
+      _HERMES_EXTENSION_EVENT_SUBSCRIBERS.add(subscriber);
+      return function(){ _HERMES_EXTENSION_EVENT_SUBSCRIBERS.delete(subscriber); };
+    }catch(_){ return false; }
+  }
+};
+window._publishHermesExtensionEvent=_publishHermesExtensionEvent;
+
 // ── Turn-based voice mode (#1333) ────────────────────────────────────────
 // Chained flow: listen → send → (agent processes) → TTS response → listen again
 (function(){

--- a/static/boot.js
+++ b/static/boot.js
@@ -1208,11 +1208,18 @@ function _cloneHermesExtensionEventPayload(value){
   try{ return JSON.parse(JSON.stringify(value===undefined?{}:value)); }
   catch(_){ return {}; }
 }
-function _hermesExtensionHasEventPermission(){
+function _currentHermesExtensionId(){
+  const script=typeof document==='undefined'?null:document.currentScript;
+  if(!script||typeof script.getAttribute!=='function') return '';
+  return String(script.getAttribute('data-hermes-extension-id')||'').trim();
+}
+function _hermesExtensionHasEventPermission(extensionId){
+  if(!extensionId) return false;
   const cfg=window.__HERMES_EXTENSION_CONFIG__;
   const extensions=cfg&&Array.isArray(cfg.extensions)?cfg.extensions:[];
   for(const ext of extensions){
     if(!ext||typeof ext!=='object') continue;
+    if(ext.id!==extensionId) continue;
     if(ext.enabled===false||ext.effective_enabled===false||ext.user_disabled===true||ext.manifest_enabled===false) continue;
     if(ext.status==='user_disabled'||ext.status==='manifest_disabled') continue;
     const observability=ext.permissions&&ext.permissions.observability;
@@ -1241,27 +1248,31 @@ function _normalizeHermesExtensionEventTypes(types){
 function _publishHermesExtensionEvent(type, payload){
   try{
     if(!_HERMES_EXTENSION_EVENT_TYPES.has(type)) return false;
-    if(!_hermesExtensionHasEventPermission()) return false;
     const event={
       type:type,
       timestamp:new Date().toISOString(),
       session_id:(payload&&payload.session_id)||null,
       payload:_cloneHermesExtensionEventPayload(payload||{}),
     };
+    let delivered=false;
     for(const subscriber of _HERMES_EXTENSION_EVENT_SUBSCRIBERS){
       if(subscriber.types&&subscriber.types.size&&!subscriber.types.has(type)) continue;
+      if(!_hermesExtensionHasEventPermission(subscriber.extensionId)) continue;
       try{ subscriber.handler(_cloneHermesExtensionEventPayload(event)); }catch(_){}
+      delivered=true;
     }
-    return true;
+    return delivered;
   }catch(_){ return false; }
 }
 window.HermesExtensionEvents={
   subscribe:function(types, handler){
     try{
       if(typeof handler!=='function') return false;
+      const extensionId=_currentHermesExtensionId();
+      if(!_hermesExtensionHasEventPermission(extensionId)) return false;
       const normalized=_normalizeHermesExtensionEventTypes(types);
       if(normalized===false) return false;
-      const subscriber={types:normalized,handler};
+      const subscriber={extensionId,types:normalized,handler};
       _HERMES_EXTENSION_EVENT_SUBSCRIBERS.add(subscriber);
       return function(){ _HERMES_EXTENSION_EVENT_SUBSCRIBERS.delete(subscriber); };
     }catch(_){ return false; }

--- a/static/messages.js
+++ b/static/messages.js
@@ -5147,6 +5147,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('approval',e=>{
       const d=JSON.parse(e.data);
+      if(_terminalStateReached||_streamFinalized) return;
+      if(d.session_id&&d.session_id!==activeSid) return;
+      if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       publishExtensionEvent('approval',d);
       _applyToAnchor('approval',d,e);
       showApprovalForSession(activeSid, d, 1);
@@ -5156,6 +5159,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('clarify',e=>{
       const d=JSON.parse(e.data);
+      if(_terminalStateReached||_streamFinalized) return;
+      if(d.session_id&&d.session_id!==activeSid) return;
+      if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       publishExtensionEvent('clarify',d);
       _applyToAnchor('clarify',d,e);
       showClarifyForSession(activeSid, d);

--- a/static/messages.js
+++ b/static/messages.js
@@ -1977,6 +1977,7 @@ function closeOtherLiveStreams(activeSid){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
+  const publishExtensionEvent=(type,d)=>{try{if(window._publishHermesExtensionEvent)window._publishHermesExtensionEvent(type,{...(d||{}),session_id:(d&&d.session_id)||activeSid,stream_id:streamId});}catch(_){}};
   // #4416: start (or, on reconnect for the SAME stream, keep) tracking whether
   // the tab was hidden during this stream so the done-notification fires for a
   // backgrounded tab. A reconnect with a different streamId re-seeds (the old
@@ -5035,6 +5036,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _completeAutomaticCompressionOnLiveProgress(activeSid);
       const tc=upsertLiveToolCall(d,'start');
       if(!tc) return;
+      publishExtensionEvent('tool',d);
       const pendingDisplayTextBeforeTool=segmentStart===0
         ? (_parseStreamState().displayText||'')
         : _stripXmlToolCalls(assistantText.slice(segmentStart));
@@ -5072,6 +5074,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const tc=upsertLiveToolCall(d,'complete');
       if(!tc) return;
       tc.is_error=!!d.is_error;
+      publishExtensionEvent('tool_complete',d);
       const pendingDisplayTextBeforeComplete=segmentStart===0
         ? (_parseStreamState().displayText||'')
         : _stripXmlToolCalls(assistantText.slice(segmentStart));
@@ -5144,6 +5147,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('approval',e=>{
       const d=JSON.parse(e.data);
+      publishExtensionEvent('approval',d);
       _applyToAnchor('approval',d,e);
       showApprovalForSession(activeSid, d, 1);
       playAttentionSound(_attentionSoundKey(activeSid,'approval',1));
@@ -5152,6 +5156,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('clarify',e=>{
       const d=JSON.parse(e.data);
+      publishExtensionEvent('clarify',d);
       _applyToAnchor('clarify',d,e);
       showClarifyForSession(activeSid, d);
       playAttentionSound(_attentionSoundKey(activeSid,'clarify',1));
@@ -5291,6 +5296,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
       _cancelThrottledSnapshotTimer();
       const _doneData=JSON.parse(e.data);
+      publishExtensionEvent('done',_doneData);
       const _doneEvent=e;
       const _finishDone=()=>{
         // Bug A fix: cancel any pending rAF and mark stream finalized before
@@ -5570,6 +5576,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
+        publishExtensionEvent('stream_end',d);
       }catch(_){}
       if(S.activeStreamId===streamId && _liveStreamEndScenePresent()){
         _scheduleStreamEndRecovery(source);
@@ -5728,6 +5735,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const continuationSid=(d.session&&d.session.session_id)||d.new_session_id||d.continuation_session_id||'';
       const eventMatchesCurrent=!!(currentSid&&(eventSid===currentSid||continuationSid===currentSid));
       if(eventMatchesCurrent){
+        publishExtensionEvent('apperror',d);
         _flushReasoningToAnchor();
         _applyToAnchor('apperror',{
           type:d.type||'error',
@@ -5961,6 +5969,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _clearClarifyForOwner('cancelled');
       let _cancelData={};
       try{ _cancelData=JSON.parse(e.data||'{}')||{}; }catch(_){ _cancelData={}; }
+      publishExtensionEvent('cancel',_cancelData);
       _flushReasoningToAnchor();
       _applyToAnchor('cancel',{
         status:_cancelData.status||_cancelData.type||'cancelled',

--- a/tests/test_extension_event_registration.py
+++ b/tests/test_extension_event_registration.py
@@ -18,7 +18,8 @@ MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 
 def test_public_event_api_present():
     assert "const _HERMES_EXTENSION_EVENT_TYPES=new Set(['tool','tool_complete','approval','clarify','done','stream_end','apperror','cancel'])" in BOOT_JS
-    assert "function _hermesExtensionHasEventPermission()" in BOOT_JS
+    assert "function _currentHermesExtensionId()" in BOOT_JS
+    assert "function _hermesExtensionHasEventPermission(extensionId)" in BOOT_JS
     assert "window.HermesExtensionEvents={" in BOOT_JS
     assert "subscribe:function(types, handler)" in BOOT_JS
     assert "window._publishHermesExtensionEvent=_publishHermesExtensionEvent" in BOOT_JS
@@ -39,6 +40,11 @@ def test_live_stream_handlers_publish_selected_events():
     for event_type in ("tool", "tool_complete", "approval", "clarify", "done", "stream_end", "apperror", "cancel"):
         assert f"publishExtensionEvent('{event_type}'" in MESSAGES_JS
     assert "publishExtensionEvent('metering'" not in MESSAGES_JS
+    for event_type in ("approval", "clarify"):
+        listener = MESSAGES_JS.index(f"source.addEventListener('{event_type}'")
+        publish = MESSAGES_JS.index(f"publishExtensionEvent('{event_type}'", listener)
+        guard = MESSAGES_JS.index("if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;", listener)
+        assert guard < publish
 
 
 def test_runtime_config_injects_observability_permission(tmp_path, monkeypatch):
@@ -66,6 +72,7 @@ def test_runtime_config_injects_observability_permission(tmp_path, monkeypatch):
     injected = inject_extension_tags("<html><head></head><body></body></html>")
 
     assert '"permissions":{"observability":{"events":true}}' in injected
+    assert 'data-hermes-extension-id="events-ok"' in injected
     assert injected.index("window.__HERMES_EXTENSION_CONFIG__") < injected.index("/extensions/events.js")
 
 
@@ -80,44 +87,57 @@ def test_subscription_behavior_and_permission_gate():
         const assert = require('assert');
         const results = {{}};
         global.window = {{}};
-        global.document = {{ getElementById: () => null }};
+        global.document = {{ currentScript: null, getElementById: () => null }};
         {region}
 
         const publish = (type, payload) => window._publishHermesExtensionEvent(type, payload);
+        const setCurrentExtension = id => {{
+          document.currentScript = id ? {{ getAttribute: name => name === 'data-hermes-extension-id' ? id : null }} : null;
+        }};
 
         results.apiPresent = !!window.HermesExtensionEvents && typeof window.HermesExtensionEvents.subscribe === 'function';
         results.badHandlerRejected = window.HermesExtensionEvents.subscribe('tool', null) === false;
         results.unknownTypeRejected = window.HermesExtensionEvents.subscribe('metering', () => {{}}) === false;
-        results.noConfigSubscribe = typeof window.HermesExtensionEvents.subscribe('tool', () => {{}}) === 'function';
+        setCurrentExtension('events-ok');
+        results.noConfigSubscribeRejected = window.HermesExtensionEvents.subscribe('tool', () => {{}}) === false;
 
         delete window.__HERMES_EXTENSION_CONFIG__;
         const noConfigEvents = [];
-        const noConfigUnsub = window.HermesExtensionEvents.subscribe('tool', event => noConfigEvents.push(event));
+        window.HermesExtensionEvents.subscribe('tool', event => noConfigEvents.push(event));
         results.noConfigPublishFalse = publish('tool', {{session_id: 'sid-no-config'}}) === false;
         results.noConfigNoDelivery = noConfigEvents.length === 0;
-        noConfigUnsub();
 
         window.__HERMES_EXTENSION_CONFIG__ = {{
           extensions: [{{
+            id: 'denied',
             effective_enabled: true,
             status: 'enabled',
             permissions: {{storage: {{owned: true}}}}
           }}]
         }};
         const deniedEvents = [];
-        const deniedUnsub = window.HermesExtensionEvents.subscribe('tool', event => deniedEvents.push(event));
+        setCurrentExtension('denied');
+        results.deniedSubscribeRejected = window.HermesExtensionEvents.subscribe('tool', event => deniedEvents.push(event)) === false;
         results.missingPermissionFalse = publish('tool', {{session_id: 'sid-denied'}}) === false;
         results.missingPermissionNoDelivery = deniedEvents.length === 0;
-        deniedUnsub();
 
         window.__HERMES_EXTENSION_CONFIG__ = {{
           extensions: [{{
+            id: 'events-ok',
             effective_enabled: true,
             status: 'enabled',
             permissions: {{observability: {{events: true}}}}
+          }}, {{
+            id: 'denied',
+            effective_enabled: true,
+            status: 'enabled',
+            permissions: {{storage: {{owned: true}}}}
           }}]
         }};
 
+        setCurrentExtension('denied');
+        results.deniedWithPermittedPeerRejected = window.HermesExtensionEvents.subscribe('tool', () => {{}}) === false;
+        setCurrentExtension('events-ok');
         const toolEvents = [];
         const arrayEvents = [];
         const allEvents = [];
@@ -183,11 +203,13 @@ def test_subscription_behavior_and_permission_gate():
     assert out["apiPresent"] is True
     assert out["badHandlerRejected"] is True
     assert out["unknownTypeRejected"] is True
-    assert out["noConfigSubscribe"] is True
+    assert out["noConfigSubscribeRejected"] is True
     assert out["noConfigPublishFalse"] is True
     assert out["noConfigNoDelivery"] is True
+    assert out["deniedSubscribeRejected"] is True
     assert out["missingPermissionFalse"] is True
     assert out["missingPermissionNoDelivery"] is True
+    assert out["deniedWithPermittedPeerRejected"] is True
     assert out["toolPublishTrue"] is True
     assert out["toolFilter"] is True
     assert out["toolTimestamp"] is True

--- a/tests/test_extension_event_registration.py
+++ b/tests/test_extension_event_registration.py
@@ -1,0 +1,203 @@
+"""Extension observability-event registration capability."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def test_public_event_api_present():
+    assert "const _HERMES_EXTENSION_EVENT_TYPES=new Set(['tool','tool_complete','approval','clarify','done','stream_end','apperror','cancel'])" in BOOT_JS
+    assert "function _hermesExtensionHasEventPermission()" in BOOT_JS
+    assert "window.HermesExtensionEvents={" in BOOT_JS
+    assert "subscribe:function(types, handler)" in BOOT_JS
+    assert "window._publishHermesExtensionEvent=_publishHermesExtensionEvent" in BOOT_JS
+
+
+def test_event_type_set_excludes_metrics():
+    start = BOOT_JS.index("const _HERMES_EXTENSION_EVENT_TYPES")
+    end = BOOT_JS.index("const _HERMES_EXTENSION_EVENT_SUBSCRIBERS")
+    block = BOOT_JS[start:end]
+    assert "metering" not in block
+    assert "tool_complete" in block
+    assert "stream_end" in block
+    assert "apperror" in block
+
+
+def test_live_stream_handlers_publish_selected_events():
+    assert "const publishExtensionEvent=(type,d)=>" in MESSAGES_JS
+    for event_type in ("tool", "tool_complete", "approval", "clarify", "done", "stream_end", "apperror", "cancel"):
+        assert f"publishExtensionEvent('{event_type}'" in MESSAGES_JS
+    assert "publishExtensionEvent('metering'" not in MESSAGES_JS
+
+
+def test_runtime_config_injects_observability_permission(tmp_path, monkeypatch):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    (root / "manifest.json").write_text(
+        """
+        {
+          "extensions": [
+            {
+              "id": "events-ok",
+              "scripts": ["events.js"],
+              "permissions": {"observability": {"events": true}}
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "manifest.json")
+
+    from api.extensions import inject_extension_tags
+
+    injected = inject_extension_tags("<html><head></head><body></body></html>")
+
+    assert '"permissions":{"observability":{"events":true}}' in injected
+    assert injected.index("window.__HERMES_EXTENSION_CONFIG__") < injected.index("/extensions/events.js")
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_subscription_behavior_and_permission_gate():
+    start = BOOT_JS.index("const _HERMES_EXTENSION_EVENT_TYPES")
+    end = BOOT_JS.index("// ── Turn-based voice mode (#1333)")
+    region = BOOT_JS[start:end]
+
+    script = textwrap.dedent(
+        f"""
+        const assert = require('assert');
+        const results = {{}};
+        global.window = {{}};
+        global.document = {{ getElementById: () => null }};
+        {region}
+
+        const publish = (type, payload) => window._publishHermesExtensionEvent(type, payload);
+
+        results.apiPresent = !!window.HermesExtensionEvents && typeof window.HermesExtensionEvents.subscribe === 'function';
+        results.badHandlerRejected = window.HermesExtensionEvents.subscribe('tool', null) === false;
+        results.unknownTypeRejected = window.HermesExtensionEvents.subscribe('metering', () => {{}}) === false;
+        results.noConfigSubscribe = typeof window.HermesExtensionEvents.subscribe('tool', () => {{}}) === 'function';
+
+        delete window.__HERMES_EXTENSION_CONFIG__;
+        const noConfigEvents = [];
+        const noConfigUnsub = window.HermesExtensionEvents.subscribe('tool', event => noConfigEvents.push(event));
+        results.noConfigPublishFalse = publish('tool', {{session_id: 'sid-no-config'}}) === false;
+        results.noConfigNoDelivery = noConfigEvents.length === 0;
+        noConfigUnsub();
+
+        window.__HERMES_EXTENSION_CONFIG__ = {{
+          extensions: [{{
+            effective_enabled: true,
+            status: 'enabled',
+            permissions: {{storage: {{owned: true}}}}
+          }}]
+        }};
+        const deniedEvents = [];
+        const deniedUnsub = window.HermesExtensionEvents.subscribe('tool', event => deniedEvents.push(event));
+        results.missingPermissionFalse = publish('tool', {{session_id: 'sid-denied'}}) === false;
+        results.missingPermissionNoDelivery = deniedEvents.length === 0;
+        deniedUnsub();
+
+        window.__HERMES_EXTENSION_CONFIG__ = {{
+          extensions: [{{
+            effective_enabled: true,
+            status: 'enabled',
+            permissions: {{observability: {{events: true}}}}
+          }}]
+        }};
+
+        const toolEvents = [];
+        const arrayEvents = [];
+        const allEvents = [];
+        const toolUnsub = window.HermesExtensionEvents.subscribe('tool', event => toolEvents.push(event));
+        const arrayUnsub = window.HermesExtensionEvents.subscribe(['tool', 'approval'], event => arrayEvents.push(event.type));
+        const allUnsub = window.HermesExtensionEvents.subscribe(null, event => allEvents.push(event.type));
+
+        results.toolPublishTrue = publish('tool', {{session_id: 'sid-1', nested: {{count: 1}}}}) === true;
+        results.toolFilter = toolEvents.length === 1 && toolEvents[0].type === 'tool';
+        results.toolTimestamp = typeof toolEvents[0].timestamp === 'string' && toolEvents[0].timestamp.length > 0;
+        results.toolSession = toolEvents[0].session_id === 'sid-1';
+        results.toolPayloadCloned = toolEvents[0].payload.nested.count === 1;
+
+        results.approvalPublishTrue = publish('approval', {{session_id: 'sid-2', nested: {{count: 2}}}}) === true;
+        results.arrayFilter = arrayEvents.join(',') === 'tool,approval';
+        results.nullFilter = allEvents.join(',') === 'tool,approval';
+
+        toolUnsub();
+        arrayUnsub();
+        allUnsub();
+
+        const cloneEvents = [];
+        window.HermesExtensionEvents.subscribe('cancel', event => {{
+          event.type = 'mutated';
+          event.payload.nested.count = 99;
+          cloneEvents.push('mutator');
+        }});
+        window.HermesExtensionEvents.subscribe('cancel', event => {{
+          cloneEvents.push({{
+            type: event.type,
+            count: event.payload.nested.count,
+            injected: event.payload.injected,
+          }});
+        }});
+        results.clonePublishTrue = publish('cancel', {{session_id: 'sid-3', nested: {{count: 1}}}}) === true;
+        results.cloneReadOnly = cloneEvents.length === 2 &&
+          cloneEvents[1].type === 'cancel' &&
+          cloneEvents[1].count === 1 &&
+          cloneEvents[1].injected === undefined;
+
+        let streamEndHits = 0;
+        const streamEndUnsub = window.HermesExtensionEvents.subscribe('stream_end', () => {{ streamEndHits += 1; }});
+        results.unsubscribeReturnsFunction = typeof streamEndUnsub === 'function';
+        results.unsubscribeBefore = publish('stream_end', {{session_id: 'sid-4'}}) === true && streamEndHits === 1;
+        streamEndUnsub();
+        publish('stream_end', {{session_id: 'sid-4'}});
+        results.unsubscribeAfter = streamEndHits === 1;
+
+        console.log(JSON.stringify(results));
+        """
+    )
+
+    proc = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"harness failed: {proc.stderr or proc.stdout}"
+    out = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    assert out["apiPresent"] is True
+    assert out["badHandlerRejected"] is True
+    assert out["unknownTypeRejected"] is True
+    assert out["noConfigSubscribe"] is True
+    assert out["noConfigPublishFalse"] is True
+    assert out["noConfigNoDelivery"] is True
+    assert out["missingPermissionFalse"] is True
+    assert out["missingPermissionNoDelivery"] is True
+    assert out["toolPublishTrue"] is True
+    assert out["toolFilter"] is True
+    assert out["toolTimestamp"] is True
+    assert out["toolSession"] is True
+    assert out["toolPayloadCloned"] is True
+    assert out["approvalPublishTrue"] is True
+    assert out["arrayFilter"] is True
+    assert out["nullFilter"] is True
+    assert out["clonePublishTrue"] is True
+    assert out["cloneReadOnly"] is True
+    assert out["unsubscribeReturnsFunction"] is True
+    assert out["unsubscribeBefore"] is True
+    assert out["unsubscribeAfter"] is True

--- a/tests/test_extension_event_registration.py
+++ b/tests/test_extension_event_registration.py
@@ -50,7 +50,9 @@ def test_live_stream_handlers_publish_selected_events():
 def test_runtime_config_injects_observability_permission(tmp_path, monkeypatch):
     root = tmp_path / "extensions"
     root.mkdir()
-    (root / "manifest.json").write_text(
+    bundle = root / "events-bundle"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(
         """
         {
           "extensions": [
@@ -65,7 +67,7 @@ def test_runtime_config_injects_observability_permission(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
-    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "manifest.json")
+    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_MANIFEST", "events-bundle/manifest.json")
 
     from api.extensions import inject_extension_tags
 
@@ -73,7 +75,7 @@ def test_runtime_config_injects_observability_permission(tmp_path, monkeypatch):
 
     assert '"permissions":{"observability":{"events":true}}' in injected
     assert 'data-hermes-extension-id="events-ok"' in injected
-    assert injected.index("window.__HERMES_EXTENSION_CONFIG__") < injected.index("/extensions/events.js")
+    assert injected.index("window.__HERMES_EXTENSION_CONFIG__") < injected.index("/extensions/events-bundle/events.js")
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not available")


### PR DESCRIPTION
## Thinking Path

- Extensions already have sanctioned APIs for skins, TTS, settings, storage, and sidecars, but live observability still requires scraping private DOM or stream internals.
- The existing live SSE handlers in `static/messages.js` are the smallest stable point to mirror typed event notifications after the current session and stream guards pass.
- Phase 1 keeps the capability read-only and permission-gated, leaving usage and cost metrics for a later accessor slice.

## What Changed

- `static/boot.js`: add `window.HermesExtensionEvents.subscribe(types, handler)` with permission-gated event delivery, type filtering, cloned payloads, and unsubscribe support.
- `api/extensions.py`: carry the sanitized observability event permission into the runtime extension config.
- `static/messages.js`: publish selected live stream milestones to the extension event API after current ownership checks.
- `tests/test_extension_event_registration.py`: cover API presence, permission gating, unsubscribe behavior, cloned payload delivery, event publisher wiring, and the Phase 1 metrics boundary.
- `docs/EXTENSIONS.md`: document the observability events permission and the read-only event API.

## Why It Matters

Insights and monitoring extensions can observe live agent/session activity through a stable core-owned contract instead of binding private selectors or internal stream implementation details.

## Verification

Focused tests cover the extension event API and stream publisher wiring; runtime JavaScript checks cover the touched frontend files, and CI runs the full matrix on 3.11/3.12/3.13.

## Upstream

Refs #5711.

## Model Used

GPT 5.5 via Codex CLI
