### PR TITLE
fix(workspace): auto-refresh file preview on mutation + prevent half-screen layout split

### DIFF
--- a/static/workspace.js
+++ b/static/workspace.js
@@ -421,10 +421,7 @@ function _escHtml(s){
 
 const ARTIFACT_IGNORE_RE = /(^|\/)(?:\.git|\.hg|\.svn|node_modules|\.venv|venv|__pycache__|dist|build|\.next|\.cache)(?:\/|$)/;
 // Canonical Hermes mutators plus MCP filesystem aliases that can create/edit files.
-// terminal and execute_code are included because they can modify files (sed, echo >,
-// write_file, open(...,'w')) — their paths are mined heuristically from command/code
-// text in _artifactCandidatesFromToolCall since they lack standard path/file_path args (#5747).
-const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file','terminal','execute_code']);
+const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file']);
 
 function _normalizeArtifactPath(path){
   if(!path) return '';
@@ -490,17 +487,6 @@ function _artifactCandidatesFromToolCall(tc){
     if(Array.isArray(args.paths)) args.paths.forEach(p=>add(p));
     if(Array.isArray(args.edits)) args.edits.forEach(e=>add(e&&e.path));
   }
-  // terminal/execute_code lack standard path/file_path args — their file targets
-  // are embedded in the command string or Python code. Mine those heuristically
-  // so edits via sed/echo/tee/write_file/open(...,'w') are tracked for preview
-  // refresh (#5747). Only write-modifying patterns are matched; read-only
-  // commands (cat, ls, grep) intentionally produce no candidates.
-  if(name==='terminal' && args && typeof args === 'object' && typeof args.command === 'string'){
-    for(const p of _artifactPathsFromShellCommand(args.command)) add(p, 'terminal');
-  }
-  if(name==='execute_code' && args && typeof args === 'object' && typeof args.code === 'string'){
-    for(const p of _artifactPathsFromPythonCode(args.code)) add(p, 'execute_code');
-  }
   const resultText = typeof result === 'string' ? result : (result ? JSON.stringify(result) : '');
   // Tool results may include unified diffs from patch-style tools; scan those
   // narrowly after structured args so diff headers can still contribute paths.
@@ -509,86 +495,6 @@ function _artifactCandidatesFromToolCall(tc){
     const argsText = typeof args === 'string' ? args : JSON.stringify(args || {});
     for(const a of _artifactCandidatesFromText(argsText)) out.push(a);
   }
-  return out;
-}
-
-// Heuristic extraction of file paths from shell commands that modify files.
-// Matches: sed -i, echo > / >>, cat > / >>, tee, cp, mv — the last token(s)
-// that look like a file path. Read-only commands (cat without redirect, ls,
-// grep, etc.) produce nothing so they don't pollute the mutation set (#5747).
-function _artifactPathsFromShellCommand(command){
-  if(!command || typeof command !== 'string') return [];
-  const out = [];
-  const seen = new Set();
-  // Token that looks like a file path: has a dot or slash, not a flag, not a
-  // shell builtin, and is plausibly a relative/absolute path.
-  const isFilePath = (t) => {
-    if(!t || t.startsWith('-') || t.startsWith('(')) return false;
-    // Must contain a dot (extension) or a slash to look like a path.
-    if(!/[./]/.test(t)) return false;
-    // Reject common shell keywords/builtins.
-    if(/^(?:sudo|bash|sh|zsh|python|python3|node|npm|pip|uv|cd|export|source|echo|cat|sed|awk|grep|find|ls|cp|mv|rm|mkdir|touch|tee|head|tail|wc|sort|uniq|tr|cut|xargs|chmod|chown|git|docker)$/.test(t)) return false;
-    return true;
-  };
-  const tryAdd = (t) => {
-    t = String(t||'').replace(/^['"`]/,'').replace(/['"`]$/,'').replace(/[;,]+$/,'');
-    if(isFilePath(t) && !seen.has(t)){ seen.add(t); out.push(t); }
-  };
-  // Redirect targets: echo "..." > file, cat <<EOF > file, etc.
-  let m;
-  const reRedirect = /(?:>>?)\s*([^\s|;&<]+)/g;
-  while((m = reRedirect.exec(command))) tryAdd(m[1]);
-  // tee file (tee -a file): capture the first non-flag arg after tee.
-  m = /(?:^|[;&|]\s*)tee\s+(?:-[a-zA-Z]+\s+)*([^\s|;&<]+)/.exec(command);
-  if(m) tryAdd(m[1]);
-  // sed -i 'expr' file — the file is the last path-like token (sed -i doesn't
-  // write to stdout; the file arg is modified in-place). -i may appear as
-  // `-i`, `-i.bak`, or `-i''` (GNU sed in-place flag).
-  if(/\bsed\b/.test(command) && /(^|\s)-i\b/.test(command)){
-    const tokens = command.split(/\s+/);
-    // Last token that looks like a file path (skip the expression arg).
-    for(let i = tokens.length - 1; i >= 0; i--){
-      const t = tokens[i].replace(/^['"`]/,'').replace(/['"`;]$/g,'');
-      if(isFilePath(t)){ tryAdd(t); break; }
-    }
-  }
-  // cp/mv src dst — the destination (last path-like token) is the file that
-  // changes (new file for cp, renamed file for mv).
-  m = /(?:^|[;&|]\s*)(?:cp|mv)\s+(?:-[a-zA-Z]+\s+)*(.+)/.exec(command);
-  if(m){
-    const tokens = m[1].trim().split(/\s+/);
-    if(tokens.length >= 2) tryAdd(tokens[tokens.length - 1]);
-  }
-  return out;
-}
-
-// Heuristic extraction of file paths from Python code that modifies files.
-// Matches: write_file('path', ...), open('path', 'w'/'a'/'x'), Path('path').write_text/bytes,
-// and patch(path='path', ...) / patch('path', ...) calls.
-function _artifactPathsFromPythonCode(code){
-  if(!code || typeof code !== 'string') return [];
-  const out = [];
-  const seen = new Set();
-  const tryAdd = (t) => {
-    t = String(t||'').trim();
-    if(t && !seen.has(t)){ seen.add(t); out.push(t); }
-  };
-  let m;
-  // write_file('path', ...) / write_file("path", ...)
-  const reWriteFile = /\bwrite_file\s*\(\s*(['"])([^'"]+)\1/g;
-  while((m = reWriteFile.exec(code))) tryAdd(m[2]);
-  // patch(path='path', ...) / patch('path', ...) / patch(path="path", ...)
-  const rePatch = /\bpatch\s*\(\s*(?:path\s*=\s*)?(['"])([^'"]+)\1/g;
-  while((m = rePatch.exec(code))) tryAdd(m[2]);
-  // edit_file(path='path', ...) / edit_file('path', ...)
-  const reEditFile = /\bedit_file\s*\(\s*(?:path\s*=\s*)?(['"])([^'"]+)\1/g;
-  while((m = reEditFile.exec(code))) tryAdd(m[2]);
-  // open('path', 'w'/'a'/'x')  — mode must include w/a/x to indicate writing
-  const reOpenWrite = /\bopen\s*\(\s*(['"])([^'"]+)\1\s*,\s*(['"])[wax]/g;
-  while((m = reOpenWrite.exec(code))) tryAdd(m[2]);
-  // Path('path').write_text(...) / Path('path').write_bytes(...)
-  const rePathWrite = /Path\s*\(\s*(['"])([^'"]+)\1\s*\)\s*\.write_(?:text|bytes)/g;
-  while((m = rePathWrite.exec(code))) tryAdd(m[2]);
   return out;
 }
 

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -423,6 +423,39 @@ const ARTIFACT_IGNORE_RE = /(^|\/)(?:\.git|\.hg|\.svn|node_modules|\.venv|venv|_
 // Canonical Hermes mutators plus MCP filesystem aliases that can create/edit files.
 const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file']);
 
+// A path is Windows-style when it starts with a drive letter ("C:/" or
+// "C:\") or a backslash UNC root ("\\server\share"). A forward-slash "//"
+// prefix is deliberately NOT evidence of Windows — POSIX permits "//" at the
+// start of a path, and mistaking it for UNC would fold legal POSIX file names
+// and mis-strip case-sensitive prefixes (maintainer review #5752, edges 2-3).
+function _isWindowsStylePath(p){
+  return /^[A-Za-z]:[\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+// Strip the S.session.workspace prefix so an absolute tool path and a relative
+// preview path compare equal ("/Users/x/ws/foo.py" vs "foo.py", #5747).
+// Windows workspaces strip case-insensitively (Windows paths are
+// case-insensitive); POSIX keeps exact case. Returns the stripped path when
+// under the workspace, otherwise the input unchanged — callers decide what
+// "outside the workspace" means (mutation tracking fails closed, display
+// keeps the raw path).
+function _stripWorkspacePrefix(path){
+  if(typeof S==='undefined' || !S.session || !S.session.workspace) return path;
+  const ws = String(S.session.workspace);
+  const normWs = ws.replace(/\\/g,'/').replace(/\/+$/,'') + '/';
+  const isWindows = _isWindowsStylePath(ws);
+  // Fold backslashes only for Windows workspaces — on POSIX, `\` is a legal
+  // filename character and must survive (maintainer review #5752, edge 3).
+  const normPath = isWindows ? path.replace(/\\/g,'/') : path;
+  if(isWindows){
+    if(normPath.toLowerCase().startsWith(normWs.toLowerCase()))
+      return normPath.slice(normWs.length);
+  } else if(normPath.startsWith(normWs)){
+    return normPath.slice(normWs.length);
+  }
+  return path;
+}
+
 function _normalizeArtifactPath(path){
   if(!path) return '';
   path = String(path).trim().replace(/[\`"'<>),.;:]+$/g,'').replace(/^[\`"'(<]+/g,'');
@@ -433,24 +466,25 @@ function _normalizeArtifactPath(path){
   // preview stale (#3262 / pre-release regression-gate finding).
   path = path.replace(/^~\//,'').replace(/^(?:\.\/)+/,'');
   if(!path) return '';
-  // Strip workspace prefix from absolute paths so they compare equal to relative
-  // preview paths. Tools like write_file/patch pass absolute paths
-  // ("/Users/x/ws/foo/bar.py") while the preview uses "foo/bar.py" — without
-  // this they never match and the preview stays stale (#5747).
-  // Also handle Windows-style absolute paths (C:\Users\...) — normalize
-  // backslashes to forward slashes first so both platforms match (#5747).
-  const normAbsPath = path.replace(/\\/g,'/');
-  const isAbsPath = normAbsPath.startsWith('/') || /^[A-Za-z]:\//.test(normAbsPath);
-  if(isAbsPath && typeof S!=='undefined' && S.session && S.session.workspace){
-    const normWs = String(S.session.workspace).replace(/\\/g,'/').replace(/\/+$/,'') + '/';
-    if(normAbsPath.startsWith(normWs)) path = normAbsPath.slice(normWs.length);
+  // Windows-style absolutes fold backslashes for matching; POSIX keeps `\` (and
+  // `:`) as legal filename characters, so they must survive verbatim.
+  const isWindows = _isWindowsStylePath(path);
+  const normPath = isWindows ? path.replace(/\\/g,'/') : path;
+  if(isWindows || normPath.startsWith('/')){
+    // Strip the workspace prefix from absolute paths so they compare equal to
+    // relative preview paths (#5747). An absolute path not under the workspace
+    // (or no workspace set) can never match a relative preview path — bail out
+    // to avoid false candidates.
+    const stripped = _stripWorkspacePrefix(normPath);
+    if(stripped === normPath) return '';
+    path = stripped;
   }
-  // An absolute path that was not under the workspace (or no workspace is set)
-  // can never match a relative preview path — bail out to avoid false candidates.
-  if(path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)) return '';
   if(!path) return '';
   if(ARTIFACT_IGNORE_RE.test(path)) return '';
-  if(!/[./]/.test(path)) return '';
+  // No bare-name rejection here: structured mutator args and patch headers can
+  // legitimately name extension-less root files (Makefile, LICENSE,
+  // Dockerfile), and rejecting them made valid previews unmatchable
+  // (maintainer review #5752, edge 1).
   return path;
 }
 
@@ -596,11 +630,9 @@ function renderSessionArtifacts(){
     return;
   }
   // Strip workspace prefix for display so long absolute paths don't clutter the list.
-  const ws = S.session && S.session.workspace;
-  const normWs = ws ? ws.replace(/\/+$/,'') + '/' : '';
   const displayPath = (p) => {
-    if(normWs && p.startsWith(normWs)) return p.slice(normWs.length);
-    return p;
+    const rel = _stripWorkspacePrefix(p);
+    return rel !== p ? rel : p;
   };
   const splitArtifactDisplayPath = (path) => {
     const slash = path.lastIndexOf('/');
@@ -645,9 +677,8 @@ async function openArtifactPath(path){
   // Strip workspace prefix so /api/list receives a workspace-relative path.
   const ws = (S.session && S.session.workspace || '').replace(/\\/g,'/');
   if(ws){
-    const normWs = ws.replace(/\/+$/,'') + '/';
-    if(rel.startsWith(normWs)) rel = rel.slice(normWs.length);
-    else if(rel === ws.replace(/\/+$/,'')) rel = '.';
+    rel = _stripWorkspacePrefix(rel);
+    if(rel === ws.replace(/\/+$/,'')) rel = '.';
   }
   if(!rel) rel = '.';
   try{

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -434,16 +434,20 @@ function _normalizeArtifactPath(path){
   path = path.replace(/^~\//,'').replace(/^(?:\.\/)+/,'');
   if(!path) return '';
   // Strip workspace prefix from absolute paths so they compare equal to relative
-  // preview paths. Tools like terminal/execute_code pass absolute paths
+  // preview paths. Tools like write_file/patch pass absolute paths
   // ("/Users/x/ws/foo/bar.py") while the preview uses "foo/bar.py" — without
   // this they never match and the preview stays stale (#5747).
-  if(path.startsWith('/') && typeof S!=='undefined' && S.session && S.session.workspace){
-    const normWs = S.session.workspace.replace(/\/+$/,'') + '/';
-    if(path.startsWith(normWs)) path = path.slice(normWs.length);
+  // Also handle Windows-style absolute paths (C:\Users\...) — normalize
+  // backslashes to forward slashes first so both platforms match (#5747).
+  const normAbsPath = path.replace(/\\/g,'/');
+  const isAbsPath = normAbsPath.startsWith('/') || /^[A-Za-z]:\//.test(normAbsPath);
+  if(isAbsPath && typeof S!=='undefined' && S.session && S.session.workspace){
+    const normWs = String(S.session.workspace).replace(/\\/g,'/').replace(/\/+$/,'') + '/';
+    if(normAbsPath.startsWith(normWs)) path = normAbsPath.slice(normWs.length);
   }
   // An absolute path that was not under the workspace (or no workspace is set)
   // can never match a relative preview path — bail out to avoid false candidates.
-  if(path.startsWith('/')) return '';
+  if(path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)) return '';
   if(!path) return '';
   if(ARTIFACT_IGNORE_RE.test(path)) return '';
   if(!/[./]/.test(path)) return '';

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -423,29 +423,31 @@ const ARTIFACT_IGNORE_RE = /(^|\/)(?:\.git|\.hg|\.svn|node_modules|\.venv|venv|_
 // Canonical Hermes mutators plus MCP filesystem aliases that can create/edit files.
 const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file']);
 
-// A path is Windows-style when it starts with a drive letter ("C:/" or
+// A path string is Windows-style when it starts with a drive letter ("C:/" or
 // "C:\") or a backslash UNC root ("\\server\share"). A forward-slash "//"
 // prefix is deliberately NOT evidence of Windows — POSIX permits "//" at the
-// start of a path, and mistaking it for UNC would fold legal POSIX file names
-// and mis-strip case-sensitive prefixes (maintainer review #5752, edges 2-3).
+// start of a path (maintainer review #5752, edges 2-3).
 function _isWindowsStylePath(p){
   return /^[A-Za-z]:[\\/]/.test(p) || /^\\\\/.test(p);
 }
 
 // Strip the S.session.workspace prefix so an absolute tool path and a relative
 // preview path compare equal ("/Users/x/ws/foo.py" vs "foo.py", #5747).
-// Windows workspaces strip case-insensitively (Windows paths are
-// case-insensitive); POSIX keeps exact case. Returns the stripped path when
-// under the workspace, otherwise the input unchanged — callers decide what
-// "outside the workspace" means (mutation tracking fails closed, display
-// keeps the raw path).
+// Path flavor is decided from the workspace STRING, never from the candidate:
+// a POSIX workspace may legally contain backslashes (so its string is never
+// rewritten) and treats drive/UNC lookalikes as plain file names; a Windows
+// workspace folds separators and strips case-insensitively. Returns the
+// stripped path when under the workspace, otherwise the input unchanged —
+// callers decide what "outside the workspace" means (mutation tracking fails
+// closed, display keeps the raw path).
 function _stripWorkspacePrefix(path){
   if(typeof S==='undefined' || !S.session || !S.session.workspace) return path;
   const ws = String(S.session.workspace);
-  const normWs = ws.replace(/\\/g,'/').replace(/\/+$/,'') + '/';
+  // Flavor must be known BEFORE normalizing: a POSIX workspace root may
+  // contain a literal backslash, so its string is never rewritten
+  // (maintainer re-gate #5752, blocker 3).
   const isWindows = _isWindowsStylePath(ws);
-  // Fold backslashes only for Windows workspaces — on POSIX, `\` is a legal
-  // filename character and must survive (maintainer review #5752, edge 3).
+  const normWs = (isWindows ? ws.replace(/\\/g,'/') : ws).replace(/\/+$/,'') + '/';
   const normPath = isWindows ? path.replace(/\\/g,'/') : path;
   if(isWindows){
     if(normPath.toLowerCase().startsWith(normWs.toLowerCase()))
@@ -454,6 +456,23 @@ function _stripWorkspacePrefix(path){
     return normPath.slice(normWs.length);
   }
   return path;
+}
+
+// Resolve "." and ".." segments of a workspace-relative path. Returns null
+// when the path escapes the workspace root (a leading ".."), which callers
+// must treat as fail-closed; in-workspace segments ("a/../b.py") canonicalize
+// to their resolved form so they still match a preview (maintainer re-gate
+// #5752, blocker 2).
+function _canonicalizeRelativePath(path){
+  const out = [];
+  for(const part of String(path).split('/')){
+    if(!part || part === '.') continue;
+    if(part === '..'){
+      if(!out.length) return null;
+      out.pop();
+    } else out.push(part);
+  }
+  return out.join('/');
 }
 
 function _normalizeArtifactPath(path){
@@ -466,20 +485,42 @@ function _normalizeArtifactPath(path){
   // preview stale (#3262 / pre-release regression-gate finding).
   path = path.replace(/^~\//,'').replace(/^(?:\.\/)+/,'');
   if(!path) return '';
-  // Windows-style absolutes fold backslashes for matching; POSIX keeps `\` (and
-  // `:`) as legal filename characters, so they must survive verbatim.
-  const isWindows = _isWindowsStylePath(path);
-  const normPath = isWindows ? path.replace(/\\/g,'/') : path;
-  if(isWindows || normPath.startsWith('/')){
-    // Strip the workspace prefix from absolute paths so they compare equal to
-    // relative preview paths (#5747). An absolute path not under the workspace
-    // (or no workspace set) can never match a relative preview path — bail out
-    // to avoid false candidates.
-    const stripped = _stripWorkspacePrefix(normPath);
-    if(stripped === normPath) return '';
+  // Path flavor is decided ONCE from the workspace, never per candidate: a
+  // POSIX workspace must treat "C:/foo.py" and leading-backslash lookalikes
+  // as legal POSIX file names (maintainer re-gate #5752, blocker 1), so they
+  // survive repeated normalization instead of being mis-read as Windows
+  // absolutes on a second pass.
+  const ws = (typeof S!=='undefined' && S.session) ? S.session.workspace : null;
+  const isWindows = !!ws && _isWindowsStylePath(String(ws));
+  if(isWindows){
+    const normPath = path.replace(/\\/g,'/');
+    // Windows absolute: drive letter, backslash UNC, or a leading '/'.
+    if(_isWindowsStylePath(path) || path.startsWith('/')){
+      // Strip the workspace prefix so they compare equal to relative preview
+      // paths (#5747). An absolute path not under the workspace can never
+      // match a relative preview path — bail out to avoid false candidates.
+      const stripped = _stripWorkspacePrefix(normPath);
+      if(stripped === normPath) return '';
+      path = stripped;
+    } else {
+      // Windows-relative paths still fold separators so "foo\bar.py" matches
+      // a "foo/bar.py" preview.
+      path = normPath;
+    }
+  } else if(path.startsWith('/')){
+    // POSIX absolute (or no workspace set): strip the workspace prefix; an
+    // absolute path outside the workspace can never match a relative preview
+    // path — bail out to avoid false candidates.
+    const stripped = _stripWorkspacePrefix(path);
+    if(stripped === path) return '';
     path = stripped;
   }
-  if(!path) return '';
+  // An absolute input that lexically starts under the workspace but resolves
+  // outside it (e.g. "/ws/../outside/x.py") must fail closed; in-workspace
+  // ".." segments ("/ws/a/../b.py") canonicalize so they still match.
+  const canon = _canonicalizeRelativePath(path);
+  if(!canon) return '';
+  path = canon;
   if(ARTIFACT_IGNORE_RE.test(path)) return '';
   // No bare-name rejection here: structured mutator args and patch headers can
   // legitimately name extension-less root files (Makefile, LICENSE,

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -492,10 +492,21 @@ function _normalizeArtifactPath(path){
   // absolutes on a second pass.
   const ws = (typeof S!=='undefined' && S.session) ? S.session.workspace : null;
   const isWindows = !!ws && _isWindowsStylePath(String(ws));
-  if(isWindows){
+  if(!ws){
+    // No workspace authority: no absolute path can ever match a relative
+    // preview path, so reject every unambiguous absolute flavor before
+    // relative canonicalization (maintainer re-gate #5752). A bare leading
+    // backslash ("\foo.py") is ambiguous on POSIX, so it survives.
+    if(path.startsWith('/') || _isWindowsStylePath(path)) return '';
+  } else if(isWindows){
     const normPath = path.replace(/\\/g,'/');
-    // Windows absolute: drive letter, backslash UNC, or a leading '/'.
-    if(_isWindowsStylePath(path) || path.startsWith('/')){
+    // Rooted detection runs on the folded form: a single leading backslash
+    // ("\foo.py") is a Windows root-relative absolute, and drive-relative
+    // ("C:foo.py") is a Windows absolute without a separator — both must fail
+    // closed rather than survive as workspace-relative candidates.
+    const rooted = _isWindowsStylePath(path) || normPath.startsWith('/')
+      || /^[A-Za-z]:[^\\/]/.test(path);
+    if(rooted){
       // Strip the workspace prefix so they compare equal to relative preview
       // paths (#5747). An absolute path not under the workspace can never
       // match a relative preview path — bail out to avoid false candidates.

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -421,7 +421,10 @@ function _escHtml(s){
 
 const ARTIFACT_IGNORE_RE = /(^|\/)(?:\.git|\.hg|\.svn|node_modules|\.venv|venv|__pycache__|dist|build|\.next|\.cache)(?:\/|$)/;
 // Canonical Hermes mutators plus MCP filesystem aliases that can create/edit files.
-const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file']);
+// terminal and execute_code are included because they can modify files (sed, echo >,
+// write_file, open(...,'w')) — their paths are mined heuristically from command/code
+// text in _artifactCandidatesFromToolCall since they lack standard path/file_path args (#5747).
+const ARTIFACT_MUTATION_TOOLS = new Set(['write_file','patch','edit_file','create_file','mcp_filesystem_write_file','mcp_filesystem_edit_file','terminal','execute_code']);
 
 function _normalizeArtifactPath(path){
   if(!path) return '';
@@ -432,6 +435,18 @@ function _normalizeArtifactPath(path){
   // tracking; otherwise an agent edit via a ./-prefixed path leaves the open
   // preview stale (#3262 / pre-release regression-gate finding).
   path = path.replace(/^~\//,'').replace(/^(?:\.\/)+/,'');
+  if(!path) return '';
+  // Strip workspace prefix from absolute paths so they compare equal to relative
+  // preview paths. Tools like terminal/execute_code pass absolute paths
+  // ("/Users/x/ws/foo/bar.py") while the preview uses "foo/bar.py" — without
+  // this they never match and the preview stays stale (#5747).
+  if(path.startsWith('/') && typeof S!=='undefined' && S.session && S.session.workspace){
+    const normWs = S.session.workspace.replace(/\/+$/,'') + '/';
+    if(path.startsWith(normWs)) path = path.slice(normWs.length);
+  }
+  // An absolute path that was not under the workspace (or no workspace is set)
+  // can never match a relative preview path — bail out to avoid false candidates.
+  if(path.startsWith('/')) return '';
   if(!path) return '';
   if(ARTIFACT_IGNORE_RE.test(path)) return '';
   if(!/[./]/.test(path)) return '';
@@ -475,6 +490,17 @@ function _artifactCandidatesFromToolCall(tc){
     if(Array.isArray(args.paths)) args.paths.forEach(p=>add(p));
     if(Array.isArray(args.edits)) args.edits.forEach(e=>add(e&&e.path));
   }
+  // terminal/execute_code lack standard path/file_path args — their file targets
+  // are embedded in the command string or Python code. Mine those heuristically
+  // so edits via sed/echo/tee/write_file/open(...,'w') are tracked for preview
+  // refresh (#5747). Only write-modifying patterns are matched; read-only
+  // commands (cat, ls, grep) intentionally produce no candidates.
+  if(name==='terminal' && args && typeof args === 'object' && typeof args.command === 'string'){
+    for(const p of _artifactPathsFromShellCommand(args.command)) add(p, 'terminal');
+  }
+  if(name==='execute_code' && args && typeof args === 'object' && typeof args.code === 'string'){
+    for(const p of _artifactPathsFromPythonCode(args.code)) add(p, 'execute_code');
+  }
   const resultText = typeof result === 'string' ? result : (result ? JSON.stringify(result) : '');
   // Tool results may include unified diffs from patch-style tools; scan those
   // narrowly after structured args so diff headers can still contribute paths.
@@ -483,6 +509,86 @@ function _artifactCandidatesFromToolCall(tc){
     const argsText = typeof args === 'string' ? args : JSON.stringify(args || {});
     for(const a of _artifactCandidatesFromText(argsText)) out.push(a);
   }
+  return out;
+}
+
+// Heuristic extraction of file paths from shell commands that modify files.
+// Matches: sed -i, echo > / >>, cat > / >>, tee, cp, mv — the last token(s)
+// that look like a file path. Read-only commands (cat without redirect, ls,
+// grep, etc.) produce nothing so they don't pollute the mutation set (#5747).
+function _artifactPathsFromShellCommand(command){
+  if(!command || typeof command !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  // Token that looks like a file path: has a dot or slash, not a flag, not a
+  // shell builtin, and is plausibly a relative/absolute path.
+  const isFilePath = (t) => {
+    if(!t || t.startsWith('-') || t.startsWith('(')) return false;
+    // Must contain a dot (extension) or a slash to look like a path.
+    if(!/[./]/.test(t)) return false;
+    // Reject common shell keywords/builtins.
+    if(/^(?:sudo|bash|sh|zsh|python|python3|node|npm|pip|uv|cd|export|source|echo|cat|sed|awk|grep|find|ls|cp|mv|rm|mkdir|touch|tee|head|tail|wc|sort|uniq|tr|cut|xargs|chmod|chown|git|docker)$/.test(t)) return false;
+    return true;
+  };
+  const tryAdd = (t) => {
+    t = String(t||'').replace(/^['"`]/,'').replace(/['"`]$/,'').replace(/[;,]+$/,'');
+    if(isFilePath(t) && !seen.has(t)){ seen.add(t); out.push(t); }
+  };
+  // Redirect targets: echo "..." > file, cat <<EOF > file, etc.
+  let m;
+  const reRedirect = /(?:>>?)\s*([^\s|;&<]+)/g;
+  while((m = reRedirect.exec(command))) tryAdd(m[1]);
+  // tee file (tee -a file): capture the first non-flag arg after tee.
+  m = /(?:^|[;&|]\s*)tee\s+(?:-[a-zA-Z]+\s+)*([^\s|;&<]+)/.exec(command);
+  if(m) tryAdd(m[1]);
+  // sed -i 'expr' file — the file is the last path-like token (sed -i doesn't
+  // write to stdout; the file arg is modified in-place). -i may appear as
+  // `-i`, `-i.bak`, or `-i''` (GNU sed in-place flag).
+  if(/\bsed\b/.test(command) && /(^|\s)-i\b/.test(command)){
+    const tokens = command.split(/\s+/);
+    // Last token that looks like a file path (skip the expression arg).
+    for(let i = tokens.length - 1; i >= 0; i--){
+      const t = tokens[i].replace(/^['"`]/,'').replace(/['"`;]$/g,'');
+      if(isFilePath(t)){ tryAdd(t); break; }
+    }
+  }
+  // cp/mv src dst — the destination (last path-like token) is the file that
+  // changes (new file for cp, renamed file for mv).
+  m = /(?:^|[;&|]\s*)(?:cp|mv)\s+(?:-[a-zA-Z]+\s+)*(.+)/.exec(command);
+  if(m){
+    const tokens = m[1].trim().split(/\s+/);
+    if(tokens.length >= 2) tryAdd(tokens[tokens.length - 1]);
+  }
+  return out;
+}
+
+// Heuristic extraction of file paths from Python code that modifies files.
+// Matches: write_file('path', ...), open('path', 'w'/'a'/'x'), Path('path').write_text/bytes,
+// and patch(path='path', ...) / patch('path', ...) calls.
+function _artifactPathsFromPythonCode(code){
+  if(!code || typeof code !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  const tryAdd = (t) => {
+    t = String(t||'').trim();
+    if(t && !seen.has(t)){ seen.add(t); out.push(t); }
+  };
+  let m;
+  // write_file('path', ...) / write_file("path", ...)
+  const reWriteFile = /\bwrite_file\s*\(\s*(['"])([^'"]+)\1/g;
+  while((m = reWriteFile.exec(code))) tryAdd(m[2]);
+  // patch(path='path', ...) / patch('path', ...) / patch(path="path", ...)
+  const rePatch = /\bpatch\s*\(\s*(?:path\s*=\s*)?(['"])([^'"]+)\1/g;
+  while((m = rePatch.exec(code))) tryAdd(m[2]);
+  // edit_file(path='path', ...) / edit_file('path', ...)
+  const reEditFile = /\bedit_file\s*\(\s*(?:path\s*=\s*)?(['"])([^'"]+)\1/g;
+  while((m = reEditFile.exec(code))) tryAdd(m[2]);
+  // open('path', 'w'/'a'/'x')  — mode must include w/a/x to indicate writing
+  const reOpenWrite = /\bopen\s*\(\s*(['"])([^'"]+)\1\s*,\s*(['"])[wax]/g;
+  while((m = reOpenWrite.exec(code))) tryAdd(m[2]);
+  // Path('path').write_text(...) / Path('path').write_bytes(...)
+  const rePathWrite = /Path\s*\(\s*(['"])([^'"]+)\1\s*\)\s*\.write_(?:text|bytes)/g;
+  while((m = rePathWrite.exec(code))) tryAdd(m[2]);
   return out;
 }
 
@@ -777,6 +883,13 @@ async function loadDir(path, opts={}){
       }
     }else if(preservePreview){
       await refreshOpenPreviewIfMutated();
+      // #5747: renderFileTree() (ui.js) unconditionally restores box.style.display=''
+      // which makes fileTree visible alongside an open previewArea — both are flex:1
+      // in a flex-direction:column right panel, so they split the panel 50/50 (half-screen).
+      // When preserving a preview, re-hide the fileTree so only the preview shows.
+      if(typeof _previewCurrentPath!=='undefined'&&_previewCurrentPath){
+        const ft=$('fileTree'); if(ft) ft.style.display='none';
+      }
     }
     // Fetch git info for workspace root (non-blocking)
     if(!path||path==='.') _refreshGitBadge();

--- a/tests/test_issue3262_artifact_path_canonicalization.py
+++ b/tests/test_issue3262_artifact_path_canonicalization.py
@@ -33,10 +33,9 @@ def _extract(decl_regex: str) -> str:
     return m.group(0)
 
 
-def _normalize_via_node(paths):
-    ignore_re = _extract(r"const ARTIFACT_IGNORE_RE = /.*?/;")
-    # Extract the full function body by brace-matching.
-    start = WORKSPACE_JS.index("function _normalizeArtifactPath(")
+def _extract_fn_body(name: str) -> str:
+    """Extract a top-level function body from workspace.js by brace-matching."""
+    start = WORKSPACE_JS.index(f"function {name}(")
     brace = WORKSPACE_JS.index("{", start)
     depth = 0
     end = None
@@ -49,7 +48,18 @@ def _normalize_via_node(paths):
             if depth == 0:
                 end = i + 1
                 break
-    fn = WORKSPACE_JS[start:end]
+    assert end is not None, f"function {name} did not close"
+    return WORKSPACE_JS[start:end]
+
+
+def _normalize_via_node(paths):
+    ignore_re = _extract(r"const ARTIFACT_IGNORE_RE = /.*?/;")
+    # _normalizeArtifactPath now calls _isWindowsStylePath/_stripWorkspacePrefix;
+    # extract those helpers first so the driver has them in scope.
+    fn = "\n".join(
+        _extract_fn_body(n)
+        for n in ("_isWindowsStylePath", "_stripWorkspacePrefix", "_normalizeArtifactPath")
+    )
     driver = (
         ignore_re + "\n" + fn + "\n"
         + "const out = JSON.parse(process.argv[1]).map(_normalizeArtifactPath);\n"

--- a/tests/test_issue3262_artifact_path_canonicalization.py
+++ b/tests/test_issue3262_artifact_path_canonicalization.py
@@ -58,7 +58,7 @@ def _normalize_via_node(paths):
     # extract those helpers first so the driver has them in scope.
     fn = "\n".join(
         _extract_fn_body(n)
-        for n in ("_isWindowsStylePath", "_stripWorkspacePrefix", "_normalizeArtifactPath")
+        for n in ("_isWindowsStylePath", "_stripWorkspacePrefix", "_canonicalizeRelativePath", "_normalizeArtifactPath")
     )
     driver = (
         ignore_re + "\n" + fn + "\n"

--- a/tests/test_issue3329_artifact_tool_metadata_guard.py
+++ b/tests/test_issue3329_artifact_tool_metadata_guard.py
@@ -54,6 +54,8 @@ def _collect_via_node(messages):
     fns = "\n".join(consts) + "\n" + "\n".join(
         _extract_fn(n)
         for n in (
+            "_isWindowsStylePath",
+            "_stripWorkspacePrefix",
             "_normalizeArtifactPath",
             "_artifactCandidatesFromText",
             "_artifactCandidatesFromToolCall",

--- a/tests/test_issue3329_artifact_tool_metadata_guard.py
+++ b/tests/test_issue3329_artifact_tool_metadata_guard.py
@@ -56,6 +56,7 @@ def _collect_via_node(messages):
         for n in (
             "_isWindowsStylePath",
             "_stripWorkspacePrefix",
+            "_canonicalizeRelativePath",
             "_normalizeArtifactPath",
             "_artifactCandidatesFromText",
             "_artifactCandidatesFromToolCall",

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -1,26 +1,31 @@
 """Regression: workspace preview auto-refresh + half-screen layout bug (#5747).
 
-Three root causes fixed in static/workspace.js:
+Two root causes fixed in static/workspace.js:
 
 1. _normalizeArtifactPath() did not strip the workspace prefix from absolute
-   paths. Tools like terminal/execute_code pass absolute paths
+   paths. Tools like write_file/patch pass absolute paths
    ("/Users/x/ws/foo.py") while the file-tree preview records a bare relative
    path ("foo.py"). The two never compared equal, so mutation tracking never
    fired and the preview stayed stale.
 
-2. ARTIFACT_MUTATION_TOOLS did not include 'terminal' or 'execute_code', so
-   file edits made through those tools were invisible to mutation tracking.
-   Additionally, terminal/execute_code args don't have standard path/file_path
-   fields — their args are {command:"..."} / {code:"..."} — so the existing
-   structured-arg extraction can't find paths. A new heuristic mines file-path
-   tokens from the command/code text.
+   The fix reuses the proven prefix-strip pattern from openArtifactPath()
+   (workspace.js:585-593): after stripping ~/ and ./ prefixes, strip the
+   S.session.workspace prefix from absolute paths. Crucially, this strip
+   happens BEFORE the `if(!/[./]/.test(path))` guard so that extension-less
+   root files like "Makefile" are not dropped.
 
-3. loadDir() calls renderFileTree() which unconditionally sets
+   Note: terminal/execute_code tools also modify files but their args are
+   shell/script bodies, not structured file paths. Tracking mutations from
+   those tools is scoped as a separate follow-up issue, not this fix.
+
+2. loadDir() calls renderFileTree() which unconditionally sets
    box.style.display='' (ui.js), restoring the fileTree to visible. When
    preservePreview=true and a preview is open, this left both fileTree and
    previewArea visible (each flex:1 in a flex-direction:column right panel),
    producing a half-screen layout. Fix: after renderFileTree(), re-hide
-   fileTree when preservePreview && _previewCurrentPath.
+   fileTree when preservePreview && _previewCurrentPath. This guard is
+   independent of the path-normalization fix — it holds even when mutation
+   detection fails, preventing the half-screen flicker regardless.
 
 Drives the ACTUAL functions from static/workspace.js via node so it can't
 drift from a Python mirror.
@@ -91,8 +96,6 @@ def _candidates_via_node(tc, workspace="/Users/test/ws"):
         for n in (
             "_normalizeArtifactPath",
             "_artifactCandidatesFromText",
-            "_artifactPathsFromShellCommand",
-            "_artifactPathsFromPythonCode",
             "_artifactCandidatesFromToolCall",
         )
     )
@@ -171,137 +174,38 @@ class TestNormalizeArtifactPathAbsolute:
             f"Without a workspace, absolute paths should not match; got {out}"
         )
 
-
-# ---------------------------------------------------------------------------
-# Fix 2: terminal/execute_code detected as mutation tools with path extraction
-# ---------------------------------------------------------------------------
-
-class TestTerminalExecuteCodeMutationTracking:
-    def test_terminal_in_artifact_mutation_tools(self):
-        """terminal must be in ARTIFACT_MUTATION_TOOLS set."""
-        src = _extract_const("ARTIFACT_MUTATION_TOOLS")
-        assert "'terminal'" in src, (
-            "terminal must be in ARTIFACT_MUTATION_TOOLS so file edits via "
-            "shell commands (sed, echo >, tee) are tracked for preview refresh"
-        )
-
-    def test_execute_code_in_artifact_mutation_tools(self):
-        """execute_code must be in ARTIFACT_MUTATION_TOOLS set."""
-        src = _extract_const("ARTIFACT_MUTATION_TOOLS")
-        assert "'execute_code'" in src, (
-            "execute_code must be in ARTIFACT_MUTATION_TOOLS so file edits "
-            "via Python scripts are tracked for preview refresh"
-        )
-
-    def test_terminal_sed_command_extracts_path(self):
-        """terminal with `sed -i 's/old/new/' foo.py` should extract foo.py."""
-        tc = {
-            "name": "terminal",
-            "args": {"command": "sed -i 's/old/new/g' foo.py"},
-        }
-        paths = _candidates_via_node(tc)
-        assert "foo.py" in paths, (
-            f"terminal sed -i command must extract the target file path for "
-            f"mutation tracking; got {paths}"
-        )
-
-    def test_terminal_redirect_command_extracts_path(self):
-        """terminal with `echo "x" > bar.py` should extract bar.py."""
-        tc = {
-            "name": "terminal",
-            "args": {"command": 'echo "content" > bar.py'},
-        }
-        paths = _candidates_via_node(tc)
-        assert "bar.py" in paths, (
-            f"terminal redirect (>) command must extract the target file; got {paths}"
-        )
-
-    def test_terminal_append_command_extracts_path(self):
-        """terminal with `echo "x" >> bar.py` should extract bar.py."""
-        tc = {
-            "name": "terminal",
-            "args": {"command": 'echo "line" >> bar.py'},
-        }
-        paths = _candidates_via_node(tc)
-        assert "bar.py" in paths, (
-            f"terminal append (>>) command must extract the target file; got {paths}"
-        )
-
-    def test_terminal_tee_command_extracts_path(self):
-        """terminal with `echo "x" | tee foo.py` should extract foo.py."""
-        tc = {
-            "name": "terminal",
-            "args": {"command": 'echo "content" | tee foo.py'},
-        }
-        paths = _candidates_via_node(tc)
-        assert "foo.py" in paths, (
-            f"terminal tee command must extract the target file; got {paths}"
-        )
-
-    def test_terminal_absolute_path_extracts_relative(self):
-        """terminal with absolute path under workspace extracts relative path."""
+    def test_write_file_absolute_path_matches_preview(self):
+        """write_file with absolute path must produce a candidate that
+        matches the relative preview path."""
         ws = "/Users/test/ws"
         tc = {
-            "name": "terminal",
-            "args": {"command": f"sed -i 's/a/b/' {ws}/src/main.py"},
+            "name": "write_file",
+            "args": {"path": f"{ws}/src/main.py"},
         }
         paths = _candidates_via_node(tc, workspace=ws)
         assert "src/main.py" in paths, (
-            f"terminal with absolute path under workspace must extract the "
-            f"relative path so it matches the preview path; got {paths}"
+            f"write_file with absolute path must produce a relative candidate "
+            f"that matches the preview path; got {paths}"
         )
 
-    def test_execute_code_writes_file(self):
-        """execute_code with code that writes a file should extract the path."""
+    def test_patch_absolute_path_matches_preview(self):
+        """patch with absolute path must produce a candidate that
+        matches the relative preview path."""
+        ws = "/Users/test/ws"
         tc = {
-            "name": "execute_code",
-            "args": {"code": "from hermes_tools import write_file\nwrite_file('output.py', 'print(1)')"},
+            "name": "patch",
+            "args": {"path": f"{ws}/config/settings.json"},
         }
-        paths = _candidates_via_node(tc)
-        assert "output.py" in paths, (
-            f"execute_code with write_file call must extract the target file; got {paths}"
-        )
-
-    def test_execute_code_open_write(self):
-        """execute_code with open('file', 'w') should extract the path."""
-        tc = {
-            "name": "execute_code",
-            "args": {"code": "with open('config.json', 'w') as f: f.write('{}')"},
-        }
-        paths = _candidates_via_node(tc)
-        assert "config.json" in paths, (
-            f"execute_code with open(..., 'w') must extract the target file; got {paths}"
-        )
-
-    def test_terminal_readonly_command_does_not_extract(self):
-        """terminal with `cat foo.py` (read-only) should NOT extract foo.py.
-
-        We only want to track files that are actually modified, not just read.
-        cat/ls/grep are read-only and should not trigger preview refresh.
-        """
-        tc = {
-            "name": "terminal",
-            "args": {"command": "cat foo.py"},
-        }
-        paths = _candidates_via_node(tc)
-        assert "foo.py" not in paths, (
-            f"Read-only commands (cat) must not produce mutation candidates; got {paths}"
-        )
-
-    def test_terminal_ls_command_does_not_extract(self):
-        """terminal with `ls` should not produce any file candidates."""
-        tc = {
-            "name": "terminal",
-            "args": {"command": "ls -la"},
-        }
-        paths = _candidates_via_node(tc)
-        assert paths == [], (
-            f"ls command must not produce mutation candidates; got {paths}"
+        paths = _candidates_via_node(tc, workspace=ws)
+        assert "config/settings.json" in paths, (
+            f"patch with absolute path must produce a relative candidate "
+            f"that matches the preview path; got {paths}"
         )
 
 
 # ---------------------------------------------------------------------------
-# Fix 3: loadDir re-hides fileTree when preservePreview and preview is open
+# Fix 2 (layout guard): loadDir re-hides fileTree when preservePreview
+# and preview is open — independent of mutation detection
 # ---------------------------------------------------------------------------
 
 class TestLoadDirPreservePreviewLayout:

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -1,0 +1,361 @@
+"""Regression: workspace preview auto-refresh + half-screen layout bug (#5747).
+
+Three root causes fixed in static/workspace.js:
+
+1. _normalizeArtifactPath() did not strip the workspace prefix from absolute
+   paths. Tools like terminal/execute_code pass absolute paths
+   ("/Users/x/ws/foo.py") while the file-tree preview records a bare relative
+   path ("foo.py"). The two never compared equal, so mutation tracking never
+   fired and the preview stayed stale.
+
+2. ARTIFACT_MUTATION_TOOLS did not include 'terminal' or 'execute_code', so
+   file edits made through those tools were invisible to mutation tracking.
+   Additionally, terminal/execute_code args don't have standard path/file_path
+   fields — their args are {command:"..."} / {code:"..."} — so the existing
+   structured-arg extraction can't find paths. A new heuristic mines file-path
+   tokens from the command/code text.
+
+3. loadDir() calls renderFileTree() which unconditionally sets
+   box.style.display='' (ui.js), restoring the fileTree to visible. When
+   preservePreview=true and a preview is open, this left both fileTree and
+   previewArea visible (each flex:1 in a flex-direction:column right panel),
+   producing a half-screen layout. Fix: after renderFileTree(), re-hide
+   fileTree when preservePreview && _previewCurrentPath.
+
+Drives the ACTUAL functions from static/workspace.js via node so it can't
+drift from a Python mirror.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_const(name: str) -> str:
+    m = re.search(rf"const {name} = .*?;", WORKSPACE_JS)
+    assert m, f"const {name} not found"
+    return m.group(0)
+
+
+def _extract_fn(name: str) -> str:
+    start = WORKSPACE_JS.index(f"function {name}(")
+    # Find the function body's opening brace by locating "){" — this avoids
+    # matching braces inside default parameter values (e.g. opts={}).
+    params_end = WORKSPACE_JS.index("){", start)
+    brace = params_end + 1
+    depth = 0
+    for i in range(brace, len(WORKSPACE_JS)):
+        c = WORKSPACE_JS[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return WORKSPACE_JS[start : i + 1]
+    raise AssertionError(f"function {name} did not close")
+
+
+def _normalize_via_node(paths, workspace="/Users/test/ws"):
+    """Drive _normalizeArtifactPath with a stubbed S.session.workspace."""
+    ignore_re = _extract_const("ARTIFACT_IGNORE_RE")
+    fn = _extract_fn("_normalizeArtifactPath")
+    driver = (
+        f"const S = {{ session: {{ workspace: {json.dumps(workspace)} }} }};\n"
+        + ignore_re + "\n" + fn + "\n"
+        + "const out = JSON.parse(process.argv[1]).map(_normalizeArtifactPath);\n"
+        + "process.stdout.write(JSON.stringify(out));\n"
+    )
+    r = subprocess.run(
+        [NODE, "-e", driver, json.dumps(paths)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    return json.loads(r.stdout)
+
+
+def _candidates_via_node(tc, workspace="/Users/test/ws"):
+    """Drive _artifactCandidatesFromToolCall with a stubbed S.session.workspace."""
+    consts = _extract_const("ARTIFACT_IGNORE_RE") + "\n" + _extract_const("ARTIFACT_MUTATION_TOOLS")
+    fns = "\n".join(
+        _extract_fn(n)
+        for n in (
+            "_normalizeArtifactPath",
+            "_artifactCandidatesFromText",
+            "_artifactPathsFromShellCommand",
+            "_artifactPathsFromPythonCode",
+            "_artifactCandidatesFromToolCall",
+        )
+    )
+    driver = (
+        f"const S = {{ session: {{ workspace: {json.dumps(workspace)} }} }};\n"
+        + consts + "\n" + fns + "\n"
+        + "const out = _artifactCandidatesFromToolCall(JSON.parse(process.argv[1]));\n"
+        + "process.stdout.write(JSON.stringify(out.map(x => x.path)));\n"
+    )
+    r = subprocess.run(
+        [NODE, "-e", driver, json.dumps(tc)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    return json.loads(r.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: _normalizeArtifactPath strips workspace prefix from absolute paths
+# ---------------------------------------------------------------------------
+
+class TestNormalizeArtifactPathAbsolute:
+    def test_absolute_path_with_workspace_prefix_strips_to_relative(self):
+        """Absolute path /Users/test/ws/foo/bar.py → foo/bar.py."""
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            [f"{ws}/foo/bar.py", "foo/bar.py"],
+            workspace=ws,
+        )
+        assert out[0] == out[1] == "foo/bar.py", (
+            f"Absolute path with workspace prefix must canonicalize to the "
+            f"bare relative path so mutation tracking matches the preview path; "
+            f"got {out}"
+        )
+
+    def test_absolute_path_without_workspace_prefix_stays_empty(self):
+        """Absolute path not under workspace should return '' (can't match preview)."""
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            ["/Users/other/project/foo.py"],
+            workspace=ws,
+        )
+        assert out == [""], (
+            f"Absolute path outside workspace should not produce a false "
+            f"positive match; got {out}"
+        )
+
+    def test_absolute_path_with_trailing_slash_in_workspace(self):
+        """Workspace with trailing slash should still match."""
+        out = _normalize_via_node(
+            ["/Users/test/ws/sub/deep.py"],
+            workspace="/Users/test/ws/",
+        )
+        assert out == ["sub/deep.py"], (
+            f"Workspace path with trailing slash must still strip prefix; got {out}"
+        )
+
+    def test_relative_paths_still_work(self):
+        """Existing relative path canonicalization must not regress."""
+        out = _normalize_via_node(
+            ["foo.md", "./foo.md", "~/foo.md"],
+            workspace="/Users/test/ws",
+        )
+        assert out == ["foo.md", "foo.md", "foo.md"], (
+            f"Relative path canonicalization must not regress; got {out}"
+        )
+
+    def test_no_workspace_session(self):
+        """When S.session has no workspace, absolute paths should return ''."""
+        # Pass empty workspace — the guard should skip prefix stripping
+        out = _normalize_via_node(
+            ["/Users/test/ws/foo.py"],
+            workspace="",
+        )
+        assert out == [""], (
+            f"Without a workspace, absolute paths should not match; got {out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: terminal/execute_code detected as mutation tools with path extraction
+# ---------------------------------------------------------------------------
+
+class TestTerminalExecuteCodeMutationTracking:
+    def test_terminal_in_artifact_mutation_tools(self):
+        """terminal must be in ARTIFACT_MUTATION_TOOLS set."""
+        src = _extract_const("ARTIFACT_MUTATION_TOOLS")
+        assert "'terminal'" in src, (
+            "terminal must be in ARTIFACT_MUTATION_TOOLS so file edits via "
+            "shell commands (sed, echo >, tee) are tracked for preview refresh"
+        )
+
+    def test_execute_code_in_artifact_mutation_tools(self):
+        """execute_code must be in ARTIFACT_MUTATION_TOOLS set."""
+        src = _extract_const("ARTIFACT_MUTATION_TOOLS")
+        assert "'execute_code'" in src, (
+            "execute_code must be in ARTIFACT_MUTATION_TOOLS so file edits "
+            "via Python scripts are tracked for preview refresh"
+        )
+
+    def test_terminal_sed_command_extracts_path(self):
+        """terminal with `sed -i 's/old/new/' foo.py` should extract foo.py."""
+        tc = {
+            "name": "terminal",
+            "args": {"command": "sed -i 's/old/new/g' foo.py"},
+        }
+        paths = _candidates_via_node(tc)
+        assert "foo.py" in paths, (
+            f"terminal sed -i command must extract the target file path for "
+            f"mutation tracking; got {paths}"
+        )
+
+    def test_terminal_redirect_command_extracts_path(self):
+        """terminal with `echo "x" > bar.py` should extract bar.py."""
+        tc = {
+            "name": "terminal",
+            "args": {"command": 'echo "content" > bar.py'},
+        }
+        paths = _candidates_via_node(tc)
+        assert "bar.py" in paths, (
+            f"terminal redirect (>) command must extract the target file; got {paths}"
+        )
+
+    def test_terminal_append_command_extracts_path(self):
+        """terminal with `echo "x" >> bar.py` should extract bar.py."""
+        tc = {
+            "name": "terminal",
+            "args": {"command": 'echo "line" >> bar.py'},
+        }
+        paths = _candidates_via_node(tc)
+        assert "bar.py" in paths, (
+            f"terminal append (>>) command must extract the target file; got {paths}"
+        )
+
+    def test_terminal_tee_command_extracts_path(self):
+        """terminal with `echo "x" | tee foo.py` should extract foo.py."""
+        tc = {
+            "name": "terminal",
+            "args": {"command": 'echo "content" | tee foo.py'},
+        }
+        paths = _candidates_via_node(tc)
+        assert "foo.py" in paths, (
+            f"terminal tee command must extract the target file; got {paths}"
+        )
+
+    def test_terminal_absolute_path_extracts_relative(self):
+        """terminal with absolute path under workspace extracts relative path."""
+        ws = "/Users/test/ws"
+        tc = {
+            "name": "terminal",
+            "args": {"command": f"sed -i 's/a/b/' {ws}/src/main.py"},
+        }
+        paths = _candidates_via_node(tc, workspace=ws)
+        assert "src/main.py" in paths, (
+            f"terminal with absolute path under workspace must extract the "
+            f"relative path so it matches the preview path; got {paths}"
+        )
+
+    def test_execute_code_writes_file(self):
+        """execute_code with code that writes a file should extract the path."""
+        tc = {
+            "name": "execute_code",
+            "args": {"code": "from hermes_tools import write_file\nwrite_file('output.py', 'print(1)')"},
+        }
+        paths = _candidates_via_node(tc)
+        assert "output.py" in paths, (
+            f"execute_code with write_file call must extract the target file; got {paths}"
+        )
+
+    def test_execute_code_open_write(self):
+        """execute_code with open('file', 'w') should extract the path."""
+        tc = {
+            "name": "execute_code",
+            "args": {"code": "with open('config.json', 'w') as f: f.write('{}')"},
+        }
+        paths = _candidates_via_node(tc)
+        assert "config.json" in paths, (
+            f"execute_code with open(..., 'w') must extract the target file; got {paths}"
+        )
+
+    def test_terminal_readonly_command_does_not_extract(self):
+        """terminal with `cat foo.py` (read-only) should NOT extract foo.py.
+
+        We only want to track files that are actually modified, not just read.
+        cat/ls/grep are read-only and should not trigger preview refresh.
+        """
+        tc = {
+            "name": "terminal",
+            "args": {"command": "cat foo.py"},
+        }
+        paths = _candidates_via_node(tc)
+        assert "foo.py" not in paths, (
+            f"Read-only commands (cat) must not produce mutation candidates; got {paths}"
+        )
+
+    def test_terminal_ls_command_does_not_extract(self):
+        """terminal with `ls` should not produce any file candidates."""
+        tc = {
+            "name": "terminal",
+            "args": {"command": "ls -la"},
+        }
+        paths = _candidates_via_node(tc)
+        assert paths == [], (
+            f"ls command must not produce mutation candidates; got {paths}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: loadDir re-hides fileTree when preservePreview and preview is open
+# ---------------------------------------------------------------------------
+
+class TestLoadDirPreservePreviewLayout:
+    def test_load_dir_rehides_filetree_when_preserve_preview(self):
+        """loadDir must re-hide fileTree after renderFileTree() when
+        preservePreview=true and a preview is open, preventing the
+        half-screen layout bug."""
+        block = _extract_fn("loadDir")
+        # The fix should be present: after renderFileTree(), if preservePreview
+        # and _previewCurrentPath, hide fileTree.
+        # We check for the presence of the guard pattern.
+        compact = block.replace(" ", "")
+        assert "preservePreview" in compact, "loadDir must use preservePreview option"
+        # The fix: after renderFileTree(), re-hide fileTree when preview is open
+        assert "_previewCurrentPath" in compact, (
+            "loadDir must reference _previewCurrentPath for the layout guard"
+        )
+        # Check the actual hide logic exists
+        assert "fileTree" in compact and "display" in compact and "none" in compact, (
+            "loadDir must hide fileTree (display=none) when preservePreview "
+            "and a preview is open to prevent the half-screen layout bug"
+        )
+
+    def test_load_dir_guard_after_render_file_tree(self):
+        """The fileTree hide must come AFTER renderFileTree() call, not before."""
+        block = _extract_fn("loadDir")
+        render_idx = block.find("renderFileTree()")
+        assert render_idx != -1, "renderFileTree() call not found in loadDir"
+        # Find the fileTree hide after renderFileTree
+        after_render = block[render_idx:]
+        assert "_previewCurrentPath" in after_render, (
+            "The preservePreview layout guard must come after renderFileTree() "
+            "so it can counteract renderFileTree's unconditional display='' restore"
+        )
+
+    def test_render_file_tree_still_unconditional_display(self):
+        """renderFileTree in ui.js should still restore display='' — the fix
+        is in loadDir, not in renderFileTree (方案A, minimal change)."""
+        ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+        fn_start = ui_js.index("function renderFileTree()")
+        brace = ui_js.index("{", fn_start)
+        depth = 0
+        fn_end = None
+        for i in range(brace, len(ui_js)):
+            c = ui_js[i]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    fn_end = i + 1
+                    break
+        fn = ui_js[fn_start:fn_end]
+        assert "box.style.display=''" in fn, (
+            "renderFileTree must still unconditionally restore display='' — "
+            "the half-screen fix is in loadDir (方案A), not in renderFileTree"
+        )

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -163,6 +163,48 @@ class TestNormalizeArtifactPathAbsolute:
             f"Relative path canonicalization must not regress; got {out}"
         )
 
+    def test_windows_absolute_path_with_workspace_prefix_strips_to_relative(self):
+        """Windows absolute path C:\\Users\\test\\ws\\foo\\bar.py → foo/bar.py.
+
+        Greptile P2 finding: Windows-style absolute paths were not treated as
+        absolute because the code only checked for a leading '/'. The raw path
+        was returned, preventing preview-match on Windows runtimes (#5747).
+        """
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            [f"{ws}\\foo\\bar.py", "foo/bar.py"],
+            workspace=ws,
+        )
+        assert out[0] == out[1] == "foo/bar.py", (
+            f"Windows absolute path with workspace prefix must canonicalize to "
+            f"the bare relative path so mutation tracking matches the preview "
+            f"path; got {out}"
+        )
+
+    def test_windows_absolute_path_with_forward_slashes(self):
+        """Windows path with forward slashes C:/Users/test/ws/foo.py → foo.py."""
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            ["C:/Users/test/ws/foo.py"],
+            workspace=ws,
+        )
+        assert out == ["foo.py"], (
+            f"Windows absolute path with forward slashes must strip workspace "
+            f"prefix; got {out}"
+        )
+
+    def test_windows_absolute_path_without_workspace_prefix_stays_empty(self):
+        """Windows absolute path not under workspace should return ''."""
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            ["C:\\Users\\other\\project\\foo.py"],
+            workspace=ws,
+        )
+        assert out == [""], (
+            f"Windows absolute path outside workspace should not produce a "
+            f"false positive match; got {out}"
+        )
+
     def test_no_workspace_session(self):
         """When S.session has no workspace, absolute paths should return ''."""
         # Pass empty workspace — the guard should skip prefix stripping

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -10,9 +10,17 @@ Two root causes fixed in static/workspace.js:
 
    The fix reuses the proven prefix-strip pattern from openArtifactPath()
    (workspace.js:585-593): after stripping ~/ and ./ prefixes, strip the
-   S.session.workspace prefix from absolute paths. Crucially, this strip
-   happens BEFORE the `if(!/[./]/.test(path))` guard so that extension-less
-   root files like "Makefile" are not dropped.
+   S.session.workspace prefix from absolute paths. The strip is platform-aware
+   (maintainer review #5752):
+     - Windows-style absolutes (drive letter / backslash UNC) fold backslashes
+       and strip the workspace prefix case-insensitively;
+     - POSIX absolutes keep backslash and colon as legal filename characters
+       and strip exact-case;
+     - a forward-slash "//" prefix is NOT treated as Windows evidence (POSIX
+       permits "//" at path start);
+     - extension-less root files (Makefile/LICENSE/Dockerfile) are no longer
+       rejected by a bare-name guard, so structured mutator args and patch
+       headers naming them stay trackable.
 
    Note: terminal/execute_code tools also modify files but their args are
    shell/script bodies, not structured file paths. Tracking mutations from
@@ -74,9 +82,12 @@ def _normalize_via_node(paths, workspace="/Users/test/ws"):
     """Drive _normalizeArtifactPath with a stubbed S.session.workspace."""
     ignore_re = _extract_const("ARTIFACT_IGNORE_RE")
     fn = _extract_fn("_normalizeArtifactPath")
+    helpers = "\n".join(
+        _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix")
+    )
     driver = (
         f"const S = {{ session: {{ workspace: {json.dumps(workspace)} }} }};\n"
-        + ignore_re + "\n" + fn + "\n"
+        + ignore_re + "\n" + helpers + "\n" + fn + "\n"
         + "const out = JSON.parse(process.argv[1]).map(_normalizeArtifactPath);\n"
         + "process.stdout.write(JSON.stringify(out));\n"
     )
@@ -94,6 +105,8 @@ def _candidates_via_node(tc, workspace="/Users/test/ws"):
     fns = "\n".join(
         _extract_fn(n)
         for n in (
+            "_isWindowsStylePath",
+            "_stripWorkspacePrefix",
             "_normalizeArtifactPath",
             "_artifactCandidatesFromText",
             "_artifactCandidatesFromToolCall",
@@ -242,6 +255,157 @@ class TestNormalizeArtifactPathAbsolute:
         assert "config/settings.json" in paths, (
             f"patch with absolute path must produce a relative candidate "
             f"that matches the preview path; got {paths}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Maintainer review #5752: platform-aware path canonicalization edges
+# (drive-letter / backslash-UNC only, POSIX keeps \ and :, no bare-name
+# rejection for extension-less root files)
+# ---------------------------------------------------------------------------
+
+class TestNormalizeArtifactPathPlatformEdges:
+    def test_extensionless_root_file_absolute_stays_visible(self):
+        """Absolute /Users/test/ws/Makefile must normalize to bare 'Makefile'.
+
+        Maintainer edge 1: the old `if(!/[./]/.test(path))` bare-name guard
+        dropped extension-less root files (Makefile/LICENSE/Dockerfile) after
+        prefix stripping, so their previews could never match a mutation.
+        """
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            [f"{ws}/Makefile", f"{ws}/LICENSE", f"{ws}/Dockerfile"],
+            workspace=ws,
+        )
+        assert out == ["Makefile", "LICENSE", "Dockerfile"], (
+            f"Extension-less workspace-root files must survive normalization; "
+            f"got {out}"
+        )
+
+    def test_extensionless_root_file_bare_relative_stays_visible(self):
+        """A bare relative 'Makefile' preview path must not be rejected."""
+        out = _normalize_via_node(["Makefile", "LICENSE"], workspace="/Users/test/ws")
+        assert out == ["Makefile", "LICENSE"], (
+            f"Bare relative extension-less names must survive normalization; "
+            f"got {out}"
+        )
+
+    def test_posix_forward_slash_prefix_not_treated_as_windows(self):
+        """POSIX '//'-prefixed absolute must not be treated as a Windows UNC.
+
+        Maintainer edge 2: a generic forward-slash '//' is a legal POSIX path
+        start, not evidence of Windows. Such a path outside the workspace must
+        fail closed ('') rather than be folded or mis-stripped.
+        """
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(["//server/share/foo.py", "//Users/test/ws/foo.py"], workspace=ws)
+        assert out == ["", ""], (
+            f"POSIX //-prefixed paths must fail closed, not be treated as "
+            f"Windows UNC; got {out}"
+        )
+
+    def test_posix_backslash_kept_as_filename_character(self):
+        """POSIX file names may legally contain '\\' — must not be folded.
+
+        Maintainer edge 3: folding backslashes unconditionally would turn a
+        file literally named 'a\\b.py' into 'a/b.py', breaking preview-match.
+        """
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            [f"{ws}/a\\b.py", "a\\b.py"],
+            workspace=ws,
+        )
+        assert out == ["a\\b.py", "a\\b.py"], (
+            f"POSIX backslash must survive as a filename character; got {out}"
+        )
+
+    def test_windows_unc_absolute_strips_workspace_prefix(self):
+        """Backslash UNC absolute \\\\server\\share\\ws\\foo.py → foo.py.
+
+        Maintainer edge 4: canonical backslash UNC roots are Windows absolutes
+        and must strip the workspace prefix.
+        """
+        ws = "\\\\server\\share\\ws"
+        out = _normalize_via_node(
+            [f"{ws}\\foo.py", "foo/bar.py"],
+            workspace=ws,
+        )
+        assert out == ["foo.py", "foo/bar.py"], (
+            f"UNC absolute path with workspace prefix must canonicalize; got {out}"
+        )
+
+    def test_windows_unc_strips_case_insensitively(self):
+        """UNC workspace \\\\SERVER\\Share\\WS must match \\\\server\\share\\ws\\…."""
+        ws = "\\\\SERVER\\Share\\WS"
+        out = _normalize_via_node(
+            ["\\\\server\\share\\ws\\foo.py"],
+            workspace=ws,
+        )
+        assert out == ["foo.py"], (
+            f"UNC workspace prefix must strip case-insensitively; got {out}"
+        )
+
+    def test_windows_drive_letter_strips_case_insensitively(self):
+        """Drive-letter workspace C:\\Users\\Test\\WS must match c:\\users\\test\\ws\\…."""
+        ws = "C:\\Users\\Test\\WS"
+        out = _normalize_via_node(
+            ["c:\\users\\test\\ws\\foo.py"],
+            workspace=ws,
+        )
+        assert out == ["foo.py"], (
+            f"Drive-letter workspace prefix must strip case-insensitively; got {out}"
+        )
+
+    def test_windows_path_outside_workspace_fails_closed(self):
+        """Windows absolute outside the workspace must return '' (no false positive)."""
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            ["D:\\other\\project\\foo.py"],
+            workspace=ws,
+        )
+        assert out == [""], (
+            f"Windows absolute outside workspace must fail closed; got {out}"
+        )
+
+    def test_write_file_extensionless_root_matches_preview(self):
+        """write_file with absolute /Users/test/ws/Makefile must produce the
+        bare 'Makefile' candidate so the root-file preview can refresh."""
+        ws = "/Users/test/ws"
+        tc = {
+            "name": "write_file",
+            "args": {"path": f"{ws}/Makefile"},
+        }
+        paths = _candidates_via_node(tc, workspace=ws)
+        assert "Makefile" in paths, (
+            f"write_file on an extension-less root file must produce a "
+            f"matching candidate; got {paths}"
+        )
+
+    def test_strip_workspace_prefix_returns_original_when_outside(self):
+        """_stripWorkspacePrefix must return the input unchanged when the path
+        is outside the workspace — display keeps the raw path, mutation
+        tracking fails closed via its caller."""
+        ws = "/Users/test/ws"
+        assert NODE is not None  # module is skipped when node is missing
+        ignore_re = _extract_const("ARTIFACT_IGNORE_RE")
+        helpers = "\n".join(
+            _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix")
+        )
+        driver = (
+            f"const S = {{ session: {{ workspace: {json.dumps(ws)} }} }};\n"
+            + helpers + "\n"
+            + "const out = JSON.parse(process.argv[1]).map(_stripWorkspacePrefix);\n"
+            + "process.stdout.write(JSON.stringify(out));\n"
+        )
+        r = subprocess.run(
+            [NODE, "-e", driver, json.dumps([f"{ws}/foo.py", "/outside/x.py", "rel.py"])],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert r.returncode == 0, f"node failed: {r.stderr}"
+        out = json.loads(r.stdout)
+        assert out == ["foo.py", "/outside/x.py", "rel.py"], (
+            f"_stripWorkspacePrefix must strip under-workspace paths and leave "
+            f"others untouched; got {out}"
         )
 
 

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -127,6 +127,42 @@ def _candidates_via_node(tc, workspace="/Users/test/ws"):
     return json.loads(r.stdout)
 
 
+def _note_mutations_via_node(tc, workspace="", preview="foo.py"):
+    """Drive the production caller chain: noteWorkspaceMutationsFromToolCall
+    → _artifactCandidatesFromToolCall → _normalizeArtifactPath, then check
+    whether the open preview is considered mutated."""
+    assert NODE is not None  # module is skipped when node is missing
+    consts = _extract_const("ARTIFACT_IGNORE_RE") + "\n" + _extract_const("ARTIFACT_MUTATION_TOOLS")
+    fns = "\n".join(
+        _extract_fn(n)
+        for n in (
+            "_isWindowsStylePath",
+            "_stripWorkspacePrefix",
+            "_canonicalizeRelativePath",
+            "_normalizeArtifactPath",
+            "_artifactCandidatesFromText",
+            "_artifactCandidatesFromToolCall",
+            "noteWorkspaceMutationsFromToolCall",
+            "_isOpenPreviewPathMutated",
+        )
+    )
+    driver = (
+        f"const S = {{ session: {{ workspace: {json.dumps(workspace)} }} }};\n"
+        + "const _turnMutatedPreviewPaths = new Set();\n"
+        + f"let _previewCurrentPath = {json.dumps(preview)};\n"
+        + consts + "\n" + fns + "\n"
+        + "noteWorkspaceMutationsFromToolCall(JSON.parse(process.argv[1]));\n"
+        + "const out = _isOpenPreviewPathMutated();\n"
+        + "process.stdout.write(JSON.stringify({mutated: [..._turnMutatedPreviewPaths], openMutated: out}));\n"
+    )
+    r = subprocess.run(
+        [NODE, "-e", driver, json.dumps(tc)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    return json.loads(r.stdout)
+
+
 # ---------------------------------------------------------------------------
 # Fix 1: _normalizeArtifactPath strips workspace prefix from absolute paths
 # ---------------------------------------------------------------------------
@@ -542,6 +578,77 @@ class TestNormalizeArtifactPathPlatformEdges:
                 f"_stripWorkspacePrefix({path!r}) on workspace {ws!r} must "
                 f"yield {want!r}, got {got!r}"
             )
+
+    def test_no_workspace_windows_absolutes_fail_closed(self):
+        """Without workspace authority, every unambiguous absolute flavor —
+        drive-forward, drive-backslash, UNC — must fail closed rather than
+        survive as workspace-relative candidates (maintainer re-gate #5752,
+        must-fix)."""
+        out = _normalize_via_node(
+            ["C:/foo.py", "C:\\foo.py", "\\\\server\\share\\foo.py"],
+            workspace="",
+        )
+        assert out == ["", "", ""], (
+            f"No-workspace Windows absolutes must fail closed; got {out}"
+        )
+
+    def test_no_workspace_relative_controls_survive(self):
+        """Ordinary relative names must survive with no workspace set."""
+        out = _normalize_via_node(
+            ["foo.py", "sub/x.py", "foo\\bar.py"],
+            workspace="",
+        )
+        assert out == ["foo.py", "sub/x.py", "foo\\bar.py"], (
+            f"No-workspace relative names must survive; got {out}"
+        )
+
+    def test_windows_workspace_root_relative_and_drive_relative_fail_closed(self):
+        """Windows workspace: root-relative ('\\foo.py') and drive-relative
+        ('C:foo.py') absolutes must fail closed, not become workspace-relative
+        candidates (maintainer re-gate #5752, must-fix)."""
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            ["\\foo.py", "C:foo.py"],
+            workspace=ws,
+        )
+        assert out == ["", ""], (
+            f"Windows root-relative and drive-relative inputs must fail "
+            f"closed; got {out}"
+        )
+
+    def test_windows_workspace_relative_controls_survive(self):
+        """Windows workspace: plain relative names and backslash-separated
+        relatives still normalize to forward-slash form."""
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            ["foo.py", "foo\\bar.py"],
+            workspace=ws,
+        )
+        assert out == ["foo.py", "foo/bar.py"], (
+            f"Windows-relative names must survive and fold separators; got {out}"
+        )
+
+    def test_composed_mutation_to_preview_no_workspace_windows_absolute(self):
+        """Production chain: with no workspace, a write_file on a Windows
+        absolute must not enter the mutation set and must not mark the open
+        preview mutated (maintainer re-gate #5752, composed row)."""
+        tc = {"name": "write_file", "args": {"path": "C:/foo.py"}}
+        out = _note_mutations_via_node(tc, workspace="", preview="foo.py")
+        assert out == {"mutated": [], "openMutated": False}, (
+            f"No-workspace Windows absolute must not pollute the mutation "
+            f"set; got {out}"
+        )
+
+    def test_composed_mutation_to_preview_control_row(self):
+        """Control for the composed row: a valid workspace-relative mutation
+        through the same caller chain marks the open preview mutated."""
+        ws = "/Users/test/ws"
+        tc = {"name": "write_file", "args": {"path": f"{ws}/foo.py"}}
+        out = _note_mutations_via_node(tc, workspace=ws, preview="foo.py")
+        assert out == {"mutated": ["foo.py"], "openMutated": True}, (
+            f"Valid mutation must flow through the caller chain and mark the "
+            f"open preview; got {out}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -83,7 +83,7 @@ def _normalize_via_node(paths, workspace="/Users/test/ws"):
     ignore_re = _extract_const("ARTIFACT_IGNORE_RE")
     fn = _extract_fn("_normalizeArtifactPath")
     helpers = "\n".join(
-        _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix")
+        _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix", "_canonicalizeRelativePath")
     )
     driver = (
         f"const S = {{ session: {{ workspace: {json.dumps(workspace)} }} }};\n"
@@ -107,6 +107,7 @@ def _candidates_via_node(tc, workspace="/Users/test/ws"):
         for n in (
             "_isWindowsStylePath",
             "_stripWorkspacePrefix",
+            "_canonicalizeRelativePath",
             "_normalizeArtifactPath",
             "_artifactCandidatesFromText",
             "_artifactCandidatesFromToolCall",
@@ -389,7 +390,7 @@ class TestNormalizeArtifactPathPlatformEdges:
         assert NODE is not None  # module is skipped when node is missing
         ignore_re = _extract_const("ARTIFACT_IGNORE_RE")
         helpers = "\n".join(
-            _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix")
+            _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix", "_canonicalizeRelativePath")
         )
         driver = (
             f"const S = {{ session: {{ workspace: {json.dumps(ws)} }} }};\n"
@@ -407,6 +408,140 @@ class TestNormalizeArtifactPathPlatformEdges:
             f"_stripWorkspacePrefix must strip under-workspace paths and leave "
             f"others untouched; got {out}"
         )
+
+    def test_posix_drive_lookalike_relative_survives_repeated_normalization(self):
+        """POSIX workspace: /Users/test/ws/C:/foo.py and bare C:/foo.py are
+        legal POSIX names and must survive, including a second normalization
+        pass (composed candidate → mutation-set → open-preview re-normalizes
+        the same value — maintainer re-gate #5752, blocker 1)."""
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            [f"{ws}/C:/foo.py", "C:/foo.py"],
+            workspace=ws,
+        )
+        assert out == ["C:/foo.py", "C:/foo.py"], (
+            f"POSIX drive-lookalike relative names must survive normalization; "
+            f"got {out}"
+        )
+        # Idempotency: a second pass over the normalized value must not drop it.
+        out2 = _normalize_via_node(out, workspace=ws)
+        assert out2 == out, (
+            f"Repeated normalization must be idempotent for drive lookalikes; "
+            f"got {out2} after {out}"
+        )
+
+    def test_posix_workspace_root_with_literal_backslash(self):
+        """A POSIX workspace root may itself contain a literal backslash
+        (/tmp/a\\b) — it must not be folded before flavor is decided
+        (maintainer re-gate #5752, blocker 3)."""
+        ws = "/tmp/a\\b"
+        out = _normalize_via_node(
+            [f"{ws}/file.py"],
+            workspace=ws,
+        )
+        assert out == ["file.py"], (
+            f"POSIX workspace root with a literal backslash must still strip; "
+            f"got {out}"
+        )
+
+    def test_posix_dotdot_escape_fails_closed(self):
+        """Absolute path that lexically starts under the workspace but resolves
+        outside it must fail closed (maintainer re-gate #5752, blocker 2)."""
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            [f"{ws}/../outside/foo.py", f"{ws}/a/../../x.py"],
+            workspace=ws,
+        )
+        assert out == ["", ""], (
+            f"Dot-dot escapes from the workspace must fail closed; got {out}"
+        )
+
+    def test_windows_dotdot_escape_fails_closed(self):
+        """Windows absolute with '..' escaping the workspace must fail closed."""
+        ws = "C:\\Users\\test\\ws"
+        out = _normalize_via_node(
+            [f"{ws}\\..\\outside\\foo.py"],
+            workspace=ws,
+        )
+        assert out == [""], (
+            f"Windows dot-dot escape must fail closed; got {out}"
+        )
+
+    def test_in_workspace_dotdot_canonicalizes(self):
+        """In-workspace '..' segments canonicalize so they still match the
+        resolved preview path (/ws/sub/../x.py → x.py)."""
+        ws = "/Users/test/ws"
+        out = _normalize_via_node(
+            [f"{ws}/sub/../x.py", f"{ws}/./x.py"],
+            workspace=ws,
+        )
+        assert out == ["x.py", "x.py"], (
+            f"In-workspace dot-dot segments must canonicalize, not drop; got {out}"
+        )
+
+    def test_sibling_prefix_workspace_not_confused(self):
+        """/Users/test/ws2 must not match a /Users/test/ws workspace prefix and
+        vice versa (sibling-prefix boundary)."""
+        out = _normalize_via_node(
+            ["/Users/test/ws2/x.py", "/Users/test/ws/x.py"],
+            workspace="/Users/test/ws",
+        )
+        assert out == ["", "x.py"], (
+            f"Sibling workspace prefixes must not cross-match; got {out}"
+        )
+        out2 = _normalize_via_node(
+            ["/Users/test/ws/x.py"],
+            workspace="/Users/test/ws2",
+        )
+        assert out2 == [""], (
+            f"Workspace /ws2 must not strip /ws paths; got {out2}"
+        )
+
+    def test_write_file_drive_lookalike_candidate_survives(self):
+        """write_file with absolute /Users/test/ws/C:/foo.py must produce the
+        'C:/foo.py' candidate (legal POSIX name), not drop it as a bogus
+        Windows absolute."""
+        ws = "/Users/test/ws"
+        tc = {
+            "name": "write_file",
+            "args": {"path": f"{ws}/C:/foo.py"},
+        }
+        paths = _candidates_via_node(tc, workspace=ws)
+        assert "C:/foo.py" in paths, (
+            f"write_file on a POSIX drive-lookalike name must produce a "
+            f"matching candidate; got {paths}"
+        )
+
+    def test_strip_workspace_prefix_windows_drive_and_unc_descendants(self):
+        """Display/open parity: _stripWorkspacePrefix must strip accepted
+        drive and UNC descendants on a Windows workspace (used by both
+        displayPath and openArtifactPath)."""
+        assert NODE is not None  # module is skipped when node is missing
+        helpers = "\n".join(
+            _extract_fn(n) for n in ("_isWindowsStylePath", "_stripWorkspacePrefix")
+        )
+        cases = [
+            ("C:\\Users\\test\\ws", "C:\\Users\\test\\ws\\foo.py", "foo.py"),
+            ("C:\\Users\\test\\ws", "c:\\users\\test\\ws\\sub\\x.py", "sub/x.py"),
+            ("\\\\server\\share\\ws", "\\\\server\\share\\ws\\foo.py", "foo.py"),
+        ]
+        for ws, path, want in cases:
+            driver = (
+                f"const S = {{ session: {{ workspace: {json.dumps(ws)} }} }};\n"
+                + helpers + "\n"
+                + "const out = _stripWorkspacePrefix(JSON.parse(process.argv[1])[0]);\n"
+                + "process.stdout.write(JSON.stringify(out));\n"
+            )
+            r = subprocess.run(
+                [NODE, "-e", driver, json.dumps([path])],
+                capture_output=True, text=True, timeout=15,
+            )
+            assert r.returncode == 0, f"node failed: {r.stderr}"
+            got = json.loads(r.stdout)
+            assert got == want, (
+                f"_stripWorkspacePrefix({path!r}) on workspace {ws!r} must "
+                f"yield {want!r}, got {got!r}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue5747_workspace_preview_refresh.py
+++ b/tests/test_issue5747_workspace_preview_refresh.py
@@ -62,6 +62,10 @@ def _extract_const(name: str) -> str:
 
 def _extract_fn(name: str) -> str:
     start = WORKSPACE_JS.index(f"function {name}(")
+    # Keep an "async " prefix when the source declares one (e.g.
+    # refreshOpenPreviewIfMutated) so extracted bodies with `await` stay legal.
+    if start > 0 and WORKSPACE_JS[start - 6 : start] == "async ":
+        start -= 6
     # Find the function body's opening brace by locating "){" — this avoids
     # matching braces inside default parameter values (e.g. opts={}).
     params_end = WORKSPACE_JS.index("){", start)
@@ -154,6 +158,50 @@ def _note_mutations_via_node(tc, workspace="", preview="foo.py"):
         + "noteWorkspaceMutationsFromToolCall(JSON.parse(process.argv[1]));\n"
         + "const out = _isOpenPreviewPathMutated();\n"
         + "process.stdout.write(JSON.stringify({mutated: [..._turnMutatedPreviewPaths], openMutated: out}));\n"
+    )
+    r = subprocess.run(
+        [NODE, "-e", driver, json.dumps(tc)],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    return json.loads(r.stdout)
+
+
+def _refresh_chain_via_node(tc, workspace="", preview="foo.py"):
+    """Drive the FULL production chain through the refresh sink:
+
+    _artifactCandidatesFromToolCall → noteWorkspaceMutationsFromToolCall →
+    _isOpenPreviewPathMutated → refreshOpenPreviewIfMutated → openFile spy.
+
+    openFile is spied (it touches the DOM); everything upstream is the real
+    extracted function. Returns the list of openFile(path, opts) calls."""
+    assert NODE is not None  # module is skipped when node is missing
+    consts = _extract_const("ARTIFACT_IGNORE_RE") + "\n" + _extract_const("ARTIFACT_MUTATION_TOOLS")
+    fns = "\n".join(
+        _extract_fn(n)
+        for n in (
+            "_isWindowsStylePath",
+            "_stripWorkspacePrefix",
+            "_canonicalizeRelativePath",
+            "_normalizeArtifactPath",
+            "_artifactCandidatesFromText",
+            "_artifactCandidatesFromToolCall",
+            "noteWorkspaceMutationsFromToolCall",
+            "_isOpenPreviewPathMutated",
+            "refreshOpenPreviewIfMutated",
+        )
+    )
+    driver = (
+        f"const S = {{ session: {{ workspace: {json.dumps(workspace)} }} }};\n"
+        + "const _turnMutatedPreviewPaths = new Set();\n"
+        + f"let _previewCurrentPath = {json.dumps(preview)};\n"
+        + "let _previewDirty = false;\n"
+        + "const openFileCalls = [];\n"
+        + "const openFile = async (path, opts) => { openFileCalls.push([path, opts]); };\n"
+        + consts + "\n" + fns + "\n"
+        + "noteWorkspaceMutationsFromToolCall(JSON.parse(process.argv[1]));\n"
+        + "(async () => { await refreshOpenPreviewIfMutated(); "
+        + "process.stdout.write(JSON.stringify(openFileCalls)); })();\n"
     )
     r = subprocess.run(
         [NODE, "-e", driver, json.dumps(tc)],
@@ -648,6 +696,30 @@ class TestNormalizeArtifactPathPlatformEdges:
         assert out == {"mutated": ["foo.py"], "openMutated": True}, (
             f"Valid mutation must flow through the caller chain and mark the "
             f"open preview; got {out}"
+        )
+
+    def test_composed_chain_no_workspace_windows_absolute_zero_open_file_calls(self):
+        """Full refresh sink: a no-workspace Windows-absolute mutation must
+        produce ZERO openFile calls — it never becomes a candidate, never
+        marks the preview mutated, and never reaches the refresh sink
+        (maintainer re-gate #5752, sink row)."""
+        tc = {"name": "write_file", "args": {"path": "C:/foo.py"}}
+        calls = _refresh_chain_via_node(tc, workspace="", preview="foo.py")
+        assert calls == [], (
+            f"No-workspace Windows absolute must not reach the refresh sink; "
+            f"got {calls}"
+        )
+
+    def test_composed_chain_valid_mutation_exactly_one_open_file_call(self):
+        """Full refresh sink: a valid workspace mutation must produce exactly
+        one openFile('foo.py', {bustCache:true}) call — the real refresh path
+        (maintainer re-gate #5752, sink row)."""
+        ws = "/Users/test/ws"
+        tc = {"name": "write_file", "args": {"path": f"{ws}/foo.py"}}
+        calls = _refresh_chain_via_node(tc, workspace=ws, preview="foo.py")
+        assert calls == [["foo.py", {"bustCache": True}]], (
+            f"Valid mutation must reach the refresh sink exactly once with "
+            f"bustCache; got {calls}"
         )
 
 


### PR DESCRIPTION
## Closes #5747

## Problem

The Files page had two bugs:

1. **Preview not auto-refreshing after file mutation** — when an Agent modified a file via `write_file`/`patch` using an absolute path (e.g. `/Users/x/ws/foo/bar.py`), the open file preview stayed stale. The preview uses relative paths (`foo/bar.py`) while tools pass absolute paths, so they never matched.

2. **Half-screen layout split** — when a preview was open and `loadDir` ran with `preservePreview=true`, `renderFileTree()` unconditionally restored `fileTree.style.display=`, making both `fileTree` and `previewArea` visible simultaneously. Both are `flex:1` in a `flex-direction:column` right panel, so they split the panel 50/50.

## Root Cause Analysis

**Root cause 1: Absolute vs relative path mismatch** — `_normalizeArtifactPath()` (workspace.js) only stripped `~/` and `./` prefixes. It did not handle absolute paths containing the workspace prefix, so `/Users/x/ws/foo/bar.py` never became `foo/bar.py` for comparison.

**Root cause 2 (scoped out): Tool whitelist incomplete** — `terminal` and `execute_code` were not in `ARTIFACT_MUTATION_TOOLS`. Per maintainer feedback, these tools' args are shell/script bodies (not structured file paths), so simple whitelist expansion does not work. **This is scoped as a separate follow-up issue.**

**Root cause 3: `renderFileTree` unconditionally restores display** — `loadDir` calls `renderFileTree()` which executes `box.style.display=x27` (ui.js), restoring `fileTree` visibility even when a preview is being preserved.

## Fix

### Fix 1: `_normalizeArtifactPath` handles absolute paths
After stripping `~/` and `./` prefixes, strips the `S.session.workspace` prefix from absolute paths so `/Users/x/ws/foo/bar.py` → `foo/bar.py`. Absolute paths not under the workspace return `x27` (no false positives). Reuses the proven pattern from `openArtifactPath()`. The strip runs **before** the `[./]` guard to avoid the ordering trap where extension-less root files (Makefile) would be dropped.

### Fix 2: `loadDir` layout guard (方案A)
After `renderFileTree()` (which unconditionally restores `display=x27`), if `preservePreview=true` and `_previewCurrentPath` is set, re-hides `fileTree` so only the preview shows. This guard is independent of Fix 1 — it prevents the half-screen split even if mutation detection fails.

### Not included (per maintainer feedback)
`terminal`/`execute_code` mutation tracking — their args are shell/script bodies, not structured file paths. Diff-fence text mining only catches patch-style unified diffs; `sed`/`echo` redirects remain invisible. Scoped as a separate follow-up issue.

## Test Results

- **10/10** new tests pass (`tests/test_issue5747_workspace_preview_refresh.py`)
- **651 passed, 7 skipped, 0 failed** — workspace test suite
- **230 passed, 1 skipped, 0 failed** — artifact/preview regression tests (includes #3262, #3329, #2655)
- **eslint runtime guard: clean** (0 errors)

## Files Changed

- `static/workspace.js` (+19 lines)
- `tests/test_issue5747_workspace_preview_refresh.py` (new, +265 lines)