### PR TITLE
fix(#5749): suppress live token answer prefixes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     integration: tests that hit the live test server or external integration surface
+    reproduction: tests that execute a direct issue reproduction fixture

--- a/static/messages.js
+++ b/static/messages.js
@@ -3442,7 +3442,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(!String(row.local_id||'').startsWith('live-prose:')) return false;
     const rowTextKey=_anchorSceneTextKey(row.text);
     const finalKey=_anchorSceneTextKey(finalAnswer);
-    return !!rowTextKey&&!!finalKey&&rowTextKey.length<finalKey.length&&finalKey.startsWith(rowTextKey);
+    return !!rowTextKey&&!!finalKey&&rowTextKey.length>=80&&rowTextKey.length<finalKey.length&&finalKey.startsWith(rowTextKey);
   }
   function _anchorSceneRowTextOverlapsExisting(rowTextKey, seenTextKeys){
     if(!rowTextKey||!Array.isArray(seenTextKeys)) return false;

--- a/static/messages.js
+++ b/static/messages.js
@@ -3496,13 +3496,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const seen=new Set();
     const seenTextKeys=[];
     const projectedRows=Array.isArray(base.activity_rows)?base.activity_rows:[];
-    const rowIsLiveTokenFinalPrefix=(row,textKey)=>row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
-    const pushRow=(row)=>{
+    const orderedRows=[];
+    for(const row of projectedRows){
+      if(row&&row.role==='terminal') continue;
+      orderedRows.push(row);
+    }
+    for(let idx=turnStart+1;idx<=lastAsstIndex;idx+=1){
+      const bucket=messageRows.get(idx)||[];
+      for(const row of bucket) orderedRows.push(row);
+    }
+    for(const row of projectedRows){
+      if(row&&row.role==='terminal') orderedRows.push(row);
+    }
+    const lastNonTerminalWorkRowIndex=orderedRows.reduce((last,row,idx)=>(row&&row.role==='tool')?idx:last,-1);
+    const rowIsLiveTokenFinalPrefix=(row,textKey,finalSegmentEligible)=>finalSegmentEligible&&row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
+    const pushRow=(row,rowIndex)=>{
       if(!row||typeof row!=='object') return;
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
       if(!row||typeof row!=='object') return;
       const textKey=_anchorSceneTextKey(row.text);
-      if(rowIsLiveTokenFinalPrefix(row,textKey)) return;
+      if(rowIsLiveTokenFinalPrefix(row,textKey,rowIndex>lastNonTerminalWorkRowIndex)) return;
       const isTextual=row.role==='prose'||row.role==='thinking';
       if(isTextual&&_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)) return;
       if(isTextual&&_anchorSceneRowTextOverlapsExisting(textKey,seenTextKeys)) return;
@@ -3517,17 +3530,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         seq:rows.length,
       });
     };
-    for(const row of projectedRows){
-      if(row&&row.role==='terminal') continue;
-      pushRow(row);
-    }
-    for(let idx=turnStart+1;idx<=lastAsstIndex;idx+=1){
-      const bucket=messageRows.get(idx)||[];
-      for(const row of bucket) pushRow(row);
-    }
-    for(const row of projectedRows){
-      if(row&&row.role==='terminal') pushRow(row);
-    }
+    orderedRows.forEach((row,idx)=>pushRow(row,idx));
     const scene={
       ...base,
       version:'activity_scene_v1',

--- a/static/messages.js
+++ b/static/messages.js
@@ -3500,7 +3500,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
       if(!row||typeof row!=='object') return;
       const textKey=_anchorSceneTextKey(row.text);
-      if(row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length>=80&&textKey.length<finalKey.length&&finalKey.startsWith(textKey)) return;
       const isTextual=row.role==='prose'||row.role==='thinking';
       if(isTextual&&_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)) return;
       if(isTextual&&_anchorSceneRowTextOverlapsExisting(textKey,seenTextKeys)) return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -3496,14 +3496,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const seen=new Set();
     const seenTextKeys=[];
     const projectedRows=Array.isArray(base.activity_rows)?base.activity_rows:[];
-    const rowIsLiveTokenFinalPrefix=(row,textKey)=>row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length>=80&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
-    const rowHasNonLiveDuplicate=(row,textKey)=>projectedRows.some(other=>other&&other!==row&&other.role==='prose'&&other.kind==='process_prose'&&!(String(other.source_event_type||'')==='token'&&String(other.local_id||'').startsWith('live-prose:'))&&_anchorSceneTextKey(other.text)===textKey);
+    const rowIsLiveTokenFinalPrefix=(row,textKey)=>row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
     const pushRow=(row)=>{
       if(!row||typeof row!=='object') return;
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
       if(!row||typeof row!=='object') return;
       const textKey=_anchorSceneTextKey(row.text);
-      if(rowIsLiveTokenFinalPrefix(row,textKey)&&rowHasNonLiveDuplicate(row,textKey)) return;
+      if(rowIsLiveTokenFinalPrefix(row,textKey)) return;
       const isTextual=row.role==='prose'||row.role==='thinking';
       if(isTextual&&_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)) return;
       if(isTextual&&_anchorSceneRowTextOverlapsExisting(textKey,seenTextKeys)) return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -3434,16 +3434,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const longer=Math.max(rowTextKey.length,finalKey.length);
     return shorter>=80&&longer>0&&(shorter/longer)>=0.9;
   }
-  function _anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row, finalAnswer){
-    if(!row||typeof row!=='object') return false;
-    if(String(row.role||'')!=='prose') return false;
-    if(String(row.kind||'')!=='process_prose') return false;
-    if(String(row.source_event_type||'')!=='token') return false;
-    if(!String(row.local_id||'').startsWith('live-prose:')) return false;
-    const rowTextKey=_anchorSceneTextKey(row.text);
-    const finalKey=_anchorSceneTextKey(finalAnswer);
-    return !!rowTextKey&&!!finalKey&&rowTextKey.length>=80&&rowTextKey.length<finalKey.length&&finalKey.startsWith(rowTextKey);
-  }
   function _anchorSceneRowTextOverlapsExisting(rowTextKey, seenTextKeys){
     if(!rowTextKey||!Array.isArray(seenTextKeys)) return false;
     for(const existing of seenTextKeys){
@@ -3509,8 +3499,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!row||typeof row!=='object') return;
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
       if(!row||typeof row!=='object') return;
-      if(_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row,finalAnswer)) return;
       const textKey=_anchorSceneTextKey(row.text);
+      if(row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length>=80&&textKey.length<finalKey.length&&finalKey.startsWith(textKey)) return;
       const isTextual=row.role==='prose'||row.role==='thinking';
       if(isTextual&&_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)) return;
       if(isTextual&&_anchorSceneRowTextOverlapsExisting(textKey,seenTextKeys)) return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -3434,6 +3434,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const longer=Math.max(rowTextKey.length,finalKey.length);
     return shorter>=80&&longer>0&&(shorter/longer)>=0.9;
   }
+  function _anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row, finalAnswer){
+    if(!row||typeof row!=='object') return false;
+    if(String(row.role||'')!=='prose') return false;
+    if(String(row.kind||'')!=='process_prose') return false;
+    if(String(row.source_event_type||'')!=='token') return false;
+    if(!String(row.local_id||'').startsWith('live-prose:')) return false;
+    const rowTextKey=_anchorSceneTextKey(row.text);
+    const finalKey=_anchorSceneTextKey(finalAnswer);
+    return !!rowTextKey&&!!finalKey&&rowTextKey.length<finalKey.length&&finalKey.startsWith(rowTextKey);
+  }
   function _anchorSceneRowTextOverlapsExisting(rowTextKey, seenTextKeys){
     if(!rowTextKey||!Array.isArray(seenTextKeys)) return false;
     for(const existing of seenTextKeys){
@@ -3499,6 +3509,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!row||typeof row!=='object') return;
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
       if(!row||typeof row!=='object') return;
+      if(_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row,finalAnswer)) return;
       const textKey=_anchorSceneTextKey(row.text);
       const isTextual=row.role==='prose'||row.role==='thinking';
       if(isTextual&&_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)) return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -3495,11 +3495,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const rows=[];
     const seen=new Set();
     const seenTextKeys=[];
+    const projectedRows=Array.isArray(base.activity_rows)?base.activity_rows:[];
+    const rowIsLiveTokenFinalPrefix=(row,textKey)=>row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length>=80&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
+    const rowHasNonLiveDuplicate=(row,textKey)=>projectedRows.some(other=>other&&other!==row&&other.role==='prose'&&other.kind==='process_prose'&&!(String(other.source_event_type||'')==='token'&&String(other.local_id||'').startsWith('live-prose:'))&&_anchorSceneTextKey(other.text)===textKey);
     const pushRow=(row)=>{
       if(!row||typeof row!=='object') return;
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
       if(!row||typeof row!=='object') return;
       const textKey=_anchorSceneTextKey(row.text);
+      if(rowIsLiveTokenFinalPrefix(row,textKey)&&rowHasNonLiveDuplicate(row,textKey)) return;
       const isTextual=row.role==='prose'||row.role==='thinking';
       if(isTextual&&_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)) return;
       if(isTextual&&_anchorSceneRowTextOverlapsExisting(textKey,seenTextKeys)) return;
@@ -3514,7 +3518,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         seq:rows.length,
       });
     };
-    const projectedRows=Array.isArray(base.activity_rows)?base.activity_rows:[];
     for(const row of projectedRows){
       if(row&&row.role==='terminal') continue;
       pushRow(row);

--- a/static/ui.js
+++ b/static/ui.js
@@ -11460,7 +11460,7 @@ function _anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row, finalAnswer){
   if(!String(row.local_id||'').startsWith('live-prose:')) return false;
   const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
   const a=norm(row.text), b=norm(finalAnswer);
-  return !!a&&!!b&&a.length<b.length&&b.startsWith(a);
+  return !!a&&!!b&&a.length>=80&&a.length<b.length&&b.startsWith(a);
 }
 function _anchorSceneWorklogGroup(blocks, opts){
   if(!blocks) return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -11391,8 +11391,7 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     const text=String(row.text||'').trim();
     if(!text) return null;
     const finalAnswer=String((opts&&opts.finalAnswer)||'').trim();
-    const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
-    const rowKey=norm(text), finalKey=norm(finalAnswer);
+    if(_anchorSceneLiveTokenFinalPrefix(row,text,finalAnswer)) return null;
     if(finalAnswer&&_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)) return null;
     node=_anchorSceneNodeForRow(row,{settled});
     if(!node) return null;
@@ -11434,6 +11433,14 @@ function _anchorSceneTransparentNodeForRow(row, opts){
   if(opts&&opts.sessionId) node.setAttribute('data-session-id',String(opts.sessionId));
   if(live) node.setAttribute('data-live-stream-owned','1');
   return node;
+}
+function _anchorSceneLiveTokenFinalPrefix(row, proseText, finalAnswer){
+  if(!row||row.role!=='prose'||row.kind!=='process_prose') return false;
+  if(String(row.source_event_type||'')!=='token') return false;
+  if(!String(row.local_id||'').startsWith('live-prose:')) return false;
+  const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
+  const rowKey=norm(proseText), finalKey=norm(finalAnswer);
+  return !!(rowKey&&finalKey&&rowKey.length<finalKey.length&&finalKey.startsWith(rowKey));
 }
 // Whitespace-insensitive compare so a scene prose row that IS the final answer
 // (possibly re-wrapped) is recognized and not duplicated against the segment.

--- a/static/ui.js
+++ b/static/ui.js
@@ -11391,7 +11391,7 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     const text=String(row.text||'').trim();
     if(!text) return null;
     const finalAnswer=String((opts&&opts.finalAnswer)||'').trim();
-    if(_anchorSceneLiveTokenFinalPrefix(row,text,finalAnswer)) return null;
+    if(opts&&opts.liveTokenFinalPrefixEligible&&_anchorSceneLiveTokenFinalPrefix(row,text,finalAnswer)) return null;
     if(finalAnswer&&_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)) return null;
     node=_anchorSceneNodeForRow(row,{settled});
     if(!node) return null;
@@ -11441,6 +11441,10 @@ function _anchorSceneLiveTokenFinalPrefix(row, proseText, finalAnswer){
   const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
   const rowKey=norm(proseText), finalKey=norm(finalAnswer);
   return !!(rowKey&&finalKey&&rowKey.length<finalKey.length&&finalKey.startsWith(rowKey));
+}
+function _anchorSceneLastNonTerminalWorkRowIndex(rows){
+  if(!Array.isArray(rows)) return -1;
+  return rows.reduce((last,row,idx)=>(row&&row.role==='tool')?idx:last,-1);
 }
 // Whitespace-insensitive compare so a scene prose row that IS the final answer
 // (possibly re-wrapped) is recognized and not duplicated against the segment.
@@ -12039,6 +12043,7 @@ function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx
   const scene=message._anchor_activity_scene;
   const rows=_anchorSceneRowsForRendering(scene,{settled:true});
   if(!rows.length) return false;
+  const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);
   // The assistant segment owns the final answer; pass it so intermediate prose
   // rows render but the final-answer-duplicate prose row is suppressed.
   const finalAnswer=String(
@@ -12057,8 +12062,9 @@ function _renderSettledAnchorSceneTransparentForMessage(message, segment, rawIdx
     }
   });
   let wrote=false;
-  for(const row of rows){
-    const node=_anchorSceneTransparentNodeForRow(row,{settled:true,finalAnswer});
+  for(let idx=0;idx<rows.length;idx+=1){
+    const row=rows[idx];
+    const node=_anchorSceneTransparentNodeForRow(row,{settled:true,finalAnswer,liveTokenFinalPrefixEligible:idx>lastNonTerminalWorkRowIndex});
     if(!node) continue;
     if(segment.parentElement===blocks) blocks.insertBefore(node,segment);
     else blocks.appendChild(node);

--- a/static/ui.js
+++ b/static/ui.js
@@ -11393,7 +11393,6 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     const finalAnswer=String((opts&&opts.finalAnswer)||'').trim();
     const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
     const rowKey=norm(text), finalKey=norm(finalAnswer);
-    if(String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&rowKey&&finalKey&&rowKey.length>=80&&rowKey.length<finalKey.length&&finalKey.startsWith(rowKey)) return null;
     if(finalAnswer&&_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)) return null;
     node=_anchorSceneNodeForRow(row,{settled});
     if(!node) return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -11391,6 +11391,7 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     const text=String(row.text||'').trim();
     if(!text) return null;
     const finalAnswer=String((opts&&opts.finalAnswer)||'').trim();
+    if(_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row,finalAnswer)) return null;
     if(finalAnswer&&_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)) return null;
     node=_anchorSceneNodeForRow(row,{settled});
     if(!node) return null;
@@ -11450,6 +11451,16 @@ function _anchorSceneProseMatchesFinalAnswer(proseText, finalAnswer){
   if(!(a.startsWith(b)||b.startsWith(a))) return false;
   const shorter=Math.min(a.length,b.length), longer=Math.max(a.length,b.length);
   return shorter>=80 && (shorter/longer)>=0.9;
+}
+function _anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row, finalAnswer){
+  if(!row||typeof row!=='object') return false;
+  if(String(row.role||'')!=='prose') return false;
+  if(String(row.kind||'')!=='process_prose') return false;
+  if(String(row.source_event_type||'')!=='token') return false;
+  if(!String(row.local_id||'').startsWith('live-prose:')) return false;
+  const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
+  const a=norm(row.text), b=norm(finalAnswer);
+  return !!a&&!!b&&a.length<b.length&&b.startsWith(a);
 }
 function _anchorSceneWorklogGroup(blocks, opts){
   if(!blocks) return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -11391,7 +11391,9 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     const text=String(row.text||'').trim();
     if(!text) return null;
     const finalAnswer=String((opts&&opts.finalAnswer)||'').trim();
-    if(_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row,finalAnswer)) return null;
+    const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
+    const rowKey=norm(text), finalKey=norm(finalAnswer);
+    if(String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&rowKey&&finalKey&&rowKey.length>=80&&rowKey.length<finalKey.length&&finalKey.startsWith(rowKey)) return null;
     if(finalAnswer&&_anchorSceneProseMatchesFinalAnswer(text,finalAnswer)) return null;
     node=_anchorSceneNodeForRow(row,{settled});
     if(!node) return null;
@@ -11451,16 +11453,6 @@ function _anchorSceneProseMatchesFinalAnswer(proseText, finalAnswer){
   if(!(a.startsWith(b)||b.startsWith(a))) return false;
   const shorter=Math.min(a.length,b.length), longer=Math.max(a.length,b.length);
   return shorter>=80 && (shorter/longer)>=0.9;
-}
-function _anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix(row, finalAnswer){
-  if(!row||typeof row!=='object') return false;
-  if(String(row.role||'')!=='prose') return false;
-  if(String(row.kind||'')!=='process_prose') return false;
-  if(String(row.source_event_type||'')!=='token') return false;
-  if(!String(row.local_id||'').startsWith('live-prose:')) return false;
-  const norm=(s)=>String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
-  const a=norm(row.text), b=norm(finalAnswer);
-  return !!a&&!!b&&a.length>=80&&a.length<b.length&&b.startsWith(a);
 }
 function _anchorSceneWorklogGroup(blocks, opts){
   if(!blocks) return null;

--- a/tests/fixtures/issue5749_captured_session_prefix.json
+++ b/tests/fixtures/issue5749_captured_session_prefix.json
@@ -1,0 +1,36 @@
+{
+  "source": "Issue #5749 captured session JSON shape, redacted in the public issue body.",
+  "messages": [
+    {
+      "id": "assistant-5749",
+      "role": "assistant",
+      "content": "While reviewing the Transparent Stream replay, I found that the settled anchor scene kept a live token prose row from the final answer stream. That row was saved as progress even though it was only the beginning of the final response. On reload the renderer treated it as ordinary activity, so the reader saw the opening paragraph once above the answer and again inside the assistant message."
+    }
+  ],
+  "anchor_activity_scenes": {
+    "assistant-5749": {
+      "scene": {
+        "mode": "transparent_stream",
+        "final_answer": "While reviewing the Transparent Stream replay, I found that the settled anchor scene kept a live token prose row from the final answer stream. That row was saved as progress even though it was only the beginning of the final response. On reload the renderer treated it as ordinary activity, so the reader saw the opening paragraph once above the answer and again inside the assistant message.",
+        "lifecycle": {
+          "terminal_state": "done"
+        },
+        "identity": {
+          "source_message_refs": [
+            "assistant-5749"
+          ]
+        },
+        "activity_rows": [
+          {
+            "role": "prose",
+            "kind": "process_prose",
+            "source_event_type": "token",
+            "local_id": "live-prose:issue5749:1",
+            "text": "While reviewing the Transparent Stream replay, I found that the settled anchor scene kept a live token prose row from the final answer stream. That row was saved as progress",
+            "status": "running"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_5749_anchor_scene_client_prefix_dedupe.py
+++ b/tests/test_5749_anchor_scene_client_prefix_dedupe.py
@@ -20,10 +20,11 @@ def _function_body(src: str, name: str) -> str:
     raise AssertionError(f"{name} body not found")
 
 
-def test_settled_scene_limits_live_token_prefix_dedupe_to_duplicate_rows():
+def test_settled_scene_keys_live_token_prefix_dedupe_to_final_answer_identity():
     settle_body = _function_body(MESSAGES_JS, "_completeSettledAnchorSceneForTurn")
     final_overlap_body = _function_body(MESSAGES_JS, "_anchorSceneRowLooksLikeFinalAnswer")
 
-    assert "rowHasNonLiveDuplicate(row,textKey)" in settle_body
+    assert "rowIsLiveTokenFinalPrefix(row,textKey)" in settle_body
+    assert "rowHasNonLiveDuplicate" not in settle_body
     assert "_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)" in settle_body
     assert "(shorter/longer)>=0.9" in final_overlap_body

--- a/tests/test_5749_anchor_scene_client_prefix_dedupe.py
+++ b/tests/test_5749_anchor_scene_client_prefix_dedupe.py
@@ -20,10 +20,10 @@ def _function_body(src: str, name: str) -> str:
     raise AssertionError(f"{name} body not found")
 
 
-def test_settled_scene_uses_near_complete_overlap_for_live_token_prefix_dedupe():
+def test_settled_scene_limits_live_token_prefix_dedupe_to_duplicate_rows():
     settle_body = _function_body(MESSAGES_JS, "_completeSettledAnchorSceneForTurn")
     final_overlap_body = _function_body(MESSAGES_JS, "_anchorSceneRowLooksLikeFinalAnswer")
 
-    assert "finalKey.startsWith(textKey)) return" not in settle_body
+    assert "rowHasNonLiveDuplicate(row,textKey)" in settle_body
     assert "_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)" in settle_body
     assert "(shorter/longer)>=0.9" in final_overlap_body

--- a/tests/test_5749_anchor_scene_client_prefix_dedupe.py
+++ b/tests/test_5749_anchor_scene_client_prefix_dedupe.py
@@ -24,7 +24,18 @@ def test_settled_scene_keys_live_token_prefix_dedupe_to_final_answer_identity():
     settle_body = _function_body(MESSAGES_JS, "_completeSettledAnchorSceneForTurn")
     final_overlap_body = _function_body(MESSAGES_JS, "_anchorSceneRowLooksLikeFinalAnswer")
 
-    assert "rowIsLiveTokenFinalPrefix(row,textKey)" in settle_body
+    assert "lastNonTerminalWorkRowIndex" in settle_body
+    assert "rowIsLiveTokenFinalPrefix(row,textKey,rowIndex>lastNonTerminalWorkRowIndex)" in settle_body
     assert "rowHasNonLiveDuplicate" not in settle_body
     assert "_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)" in settle_body
     assert "(shorter/longer)>=0.9" in final_overlap_body
+
+
+def test_render_scene_passes_final_segment_eligibility_to_live_prefix_guard():
+    ui_js = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    render_body = _function_body(ui_js, "_renderSettledAnchorSceneTransparentForMessage")
+    row_body = _function_body(ui_js, "_anchorSceneTransparentNodeForRow")
+
+    assert "const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);" in render_body
+    assert "liveTokenFinalPrefixEligible:idx>lastNonTerminalWorkRowIndex" in render_body
+    assert "opts&&opts.liveTokenFinalPrefixEligible&&_anchorSceneLiveTokenFinalPrefix" in row_body

--- a/tests/test_5749_anchor_scene_client_prefix_dedupe.py
+++ b/tests/test_5749_anchor_scene_client_prefix_dedupe.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.index(marker)
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1 : idx]
+    raise AssertionError(f"{name} body not found")
+
+
+def test_settled_scene_uses_near_complete_overlap_for_live_token_prefix_dedupe():
+    settle_body = _function_body(MESSAGES_JS, "_completeSettledAnchorSceneForTurn")
+    final_overlap_body = _function_body(MESSAGES_JS, "_anchorSceneRowLooksLikeFinalAnswer")
+
+    assert "finalKey.startsWith(textKey)) return" not in settle_body
+    assert "_anchorSceneRowLooksLikeFinalAnswer(textKey,finalKey)" in settle_body
+    assert "(shorter/longer)>=0.9" in final_overlap_body

--- a/tests/test_anchor_fallback_ownership.py
+++ b/tests/test_anchor_fallback_ownership.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import tempfile
 import textwrap
 from pathlib import Path
 
@@ -45,13 +46,19 @@ def _run_node_script(script: str) -> str:
     if not node:
         pytest.skip("node executable is required for JavaScript behavior checks")
     try:
-        result = subprocess.run(
-            [node, "-e", script],
-            cwd=ROOT,
-            text=True,
-            capture_output=True,
-            timeout=10,
-        )
+        with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as handle:
+            handle.write(script)
+            script_path = handle.name
+        try:
+            result = subprocess.run(
+                [node, script_path],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+        finally:
+            Path(script_path).unlink(missing_ok=True)
     except subprocess.TimeoutExpired as exc:
         pytest.fail(
             "node behavior check timed out"
@@ -920,4 +927,5 @@ def test_anchor_settled_renderers_remain_the_primary_scene_path():
 
     assert "if(!message||!message._anchor_activity_scene||!segment) return false;" in transparent
     assert "_anchorSceneRowsForRendering(scene,{settled:true})" in transparent
-    assert "_anchorSceneTransparentNodeForRow(row,{settled:true,finalAnswer})" in transparent
+    assert "const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);" in transparent
+    assert "liveTokenFinalPrefixEligible:idx>lastNonTerminalWorkRowIndex" in transparent

--- a/tests/test_issue5367_transparent_live_row_reconcile.py
+++ b/tests/test_issue5367_transparent_live_row_reconcile.py
@@ -299,6 +299,7 @@ global._createAssistantTurn = () => turn;
 global._assistantTurnBlocks = () => turn;
 
 global._anchorSceneTransparentNodeForRow = (row) => null;
+eval(extractFunc('_anchorSceneLiveTokenFinalPrefix'));
 eval(extractFunc('_anchorSceneTransparentNodeForRow'));
 eval(extractFunc('_transparentLiveRowKey'));
 eval(extractFunc('_transparentLiveRowsCompatible'));

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -65,7 +65,7 @@ def test_issue5749_reproduction_fixture_matches_lone_live_prefix_shape():
 
 @pytest.mark.reproduction
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_issue5749_settlement_suppresses_live_token_prefix_rows(tmp_path):
+def test_issue5749_settlement_preserves_pre_tool_live_token_prefix_rows(tmp_path):
     fixture_scene, fixture_row = _issue5749_captured_scene()
     final_answer = fixture_scene["final_answer"]
     prefix_text = fixture_row["text"]
@@ -164,8 +164,10 @@ process.stdout.write(JSON.stringify({{
 """
     data = _run_node(MESSAGES_JS, script, tmp_path)
     assert data["final_answer"] == final_answer
-    assert [row["local_id"] for row in data["rows"]] == ["tool-row-1"]
-    assert data["rows"][0]["role"] == "tool"
+    assert [row["local_id"] for row in data["rows"]] == [fixture_row["local_id"], "tool-row-1"]
+    assert data["rows"][0]["text"] == prefix_text
+    assert data["rows"][0]["role"] == "prose"
+    assert data["rows"][1]["role"] == "tool"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -398,7 +400,11 @@ const liveRow = {{
   local_id: {json.dumps(fixture_row["local_id"])},
   text: {json.dumps(prefix_text)},
 }};
-const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
+const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{
+  settled: true,
+  finalAnswer: {json.dumps(final_answer)},
+  liveTokenFinalPrefixEligible: true,
+}});
 process.stdout.write(JSON.stringify({{
   liveResult: liveResult === null,
 }}));
@@ -467,11 +473,91 @@ const liveRow = {{
   local_id: 'live-prose:stream-1:near',
   text: {json.dumps(prefix_text)},
 }};
-const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
+const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{
+  settled: true,
+  finalAnswer: {json.dumps(final_answer)},
+  liveTokenFinalPrefixEligible: true,
+}});
 process.stdout.write(JSON.stringify(liveResult === null));
 """
     data = _run_node(UI_JS, script, tmp_path)
     assert data is True
+
+
+@pytest.mark.reproduction
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_render_fallback_preserves_pre_tool_live_token_prefix_rows(tmp_path):
+    fixture_scene, fixture_row = _issue5749_captured_scene()
+    final_answer = fixture_scene["final_answer"]
+    prefix_text = fixture_row["text"]
+    script = f"""
+const src = {json.dumps(UI_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+class FakeElement {{
+  constructor(tag) {{
+    this.tagName = String(tag || 'div').toUpperCase();
+    this.attributes = Object.create(null);
+    this.dataset = Object.create(null);
+  }}
+  setAttribute(name, value) {{
+    this.attributes[name] = String(value);
+    if (name.startsWith('data-')) {{
+      const key = name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      this.dataset[key] = String(value);
+    }}
+  }}
+}}
+global.window = {{}};
+global.document = {{ createElement(tag) {{ return new FakeElement(tag); }} }};
+global._anchorSceneNodeForRow = () => new FakeElement('div');
+global._decorateTransparentEventRow = node => node;
+global._anchorSceneToolCallFromRow = () => ({{}});
+global.buildToolCard = () => new FakeElement('div');
+global._thinkingActivityNode = () => new FakeElement('div');
+eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneLiveTokenFinalPrefix'));
+eval(extractFunc('_anchorSceneTransparentNodeForRow'));
+const liveRow = {{
+  role: 'prose',
+  kind: 'process_prose',
+  source_event_type: 'token',
+  local_id: {json.dumps(fixture_row["local_id"])},
+  text: {json.dumps(prefix_text)},
+}};
+const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{
+  settled: true,
+  finalAnswer: {json.dumps(final_answer)},
+  liveTokenFinalPrefixEligible: false,
+}});
+process.stdout.write(JSON.stringify({{
+  visible: !!liveResult,
+  rowId: liveResult && liveResult.attributes && liveResult.attributes['data-anchor-row-id'] || '',
+}}));
+"""
+    data = _run_node(UI_JS, script, tmp_path)
+    assert data == {"visible": True, "rowId": fixture_row["local_id"]}
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -1,0 +1,361 @@
+"""Regression tests for issue #5749 Transparent Stream prefix dedupe."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+def _run_node(src, script, tmp_path):
+    assert NODE, "node is required for issue #5749 regression tests"
+    script_path = tmp_path / "issue5749_node_script.js"
+    script_path.write_text(script, encoding="utf-8")
+    result = subprocess.run([NODE, str(script_path)], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _extract_js_function(src, name):
+    marker = f"function {name}"
+    start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    params = src.find("(", start)
+    depth = 0
+    close = -1
+    for idx in range(params, len(src)):
+        if src[idx] == "(":
+            depth += 1
+        elif src[idx] == ")":
+            depth -= 1
+            if depth == 0:
+                close = idx
+                break
+    assert close != -1, f"{name} params did not close"
+    brace = src.find("{", close)
+    depth = 0
+    for idx in range(brace, len(src)):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:idx + 1]
+    raise AssertionError(f"{name} body did not close")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_settlement_suppresses_live_token_prefix_rows(tmp_path):
+    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
+    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes"
+    script = f"""
+const src = {json.dumps(MESSAGES_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+global.window = {{
+  chatActivityMode() {{ return 'transparent_stream'; }},
+  _chatActivityDisplayMode: 'transparent_stream',
+  _transparentStream: true,
+}};
+global.S = {{ session: {{}} }};
+eval(extractFunc('_anchorSceneCleanText'));
+eval(extractFunc('_anchorSceneTextKey'));
+eval(extractFunc('_anchorSceneExistingRowKey'));
+eval(extractFunc('_anchorSceneRowHasLiveIdentity'));
+eval(extractFunc('_anchorSceneSettleLiveRunningRow'));
+eval(extractFunc('_anchorSceneRowLooksLikeFinalAnswer'));
+eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
+eval(extractFunc('_anchorSceneRowTextOverlapsExisting'));
+eval(extractFunc('_anchorSceneMessageRowsHaveThinking'));
+eval(extractFunc('_completeSettledAnchorSceneForTurn'));
+function _anchorSceneActiveMode() {{ return 'transparent_stream'; }}
+function _anchorSceneFinalAnswerText(message) {{ return message && (message.final_answer || message.content || ''); }}
+function _anchorSceneRowsByMessageIndex() {{ return new Map(); }}
+function _anchorSceneMessageRef(message) {{ return String(message && message.id || ''); }}
+function _anchorSceneTurnDurationForSettlement() {{ return 0; }}
+function _anchorSceneRowDisplayHintForMode(row, sceneMode) {{
+  const hints = row && typeof row === 'object' && row.display_hints && typeof row.display_hints === 'object' ? row.display_hints : null;
+  if (sceneMode === 'transparent_stream') return (hints && hints.transparent_stream) || 'chronological_activity';
+  if (sceneMode === 'compact_worklog') return (hints && hints.compact_worklog) || row && row.display_hint || 'activity_row';
+  return row && row.display_hint || 'activity_row';
+}}
+const messages = [
+  {{ role: 'user', content: 'Prompt', id: 'user-1' }},
+  {{ role: 'assistant', content: {json.dumps(final_answer)}, id: 'assistant-1' }},
+];
+const scene = _completeSettledAnchorSceneForTurn(messages, 1, {{
+  mode: 'transparent_stream',
+  final_answer: {json.dumps(final_answer)},
+  lifecycle: {{ terminal_state: 'done' }},
+  identity: {{ source_message_refs: ['legacy'] }},
+  activity_rows: [
+    {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'token',
+      local_id: 'live-prose:stream-1:1',
+      text: {json.dumps(prefix_text)},
+      status: 'running',
+      attachments: [{{ id: 'attachment-1' }}],
+    }},
+    {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'manual',
+      local_id: 'session-prose:stream-1:2',
+      text: {json.dumps(prefix_text)},
+      status: 'running',
+      attachments: [{{ id: 'attachment-2' }}],
+    }},
+    {{
+      role: 'tool',
+      kind: 'tool_result',
+      source_event_type: 'tool',
+      local_id: 'tool-row-1',
+      text: 'Fetched docs',
+      status: 'running',
+    }},
+  ],
+}});
+process.stdout.write(JSON.stringify({{
+  final_answer: scene.final_answer,
+  rows: scene.activity_rows.map(row => ({{
+    role: row.role,
+    kind: row.kind,
+    source_event_type: row.source_event_type,
+    local_id: row.local_id,
+    text: row.text,
+    status: row.status,
+    attachments: row.attachments || null,
+  }})),
+}}));
+"""
+    data = _run_node(MESSAGES_JS, script, tmp_path)
+    assert data["final_answer"] == final_answer
+    assert [row["local_id"] for row in data["rows"]] == ["session-prose:stream-1:2", "tool-row-1"]
+    assert data["rows"][0]["text"] == prefix_text
+    assert data["rows"][0]["attachments"] == [{"id": "attachment-2"}]
+    assert data["rows"][1]["role"] == "tool"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_render_fallback_suppresses_persisted_live_token_prefix_rows(tmp_path):
+    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
+    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes"
+    script = f"""
+const src = {json.dumps(UI_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+class FakeElement {{
+  constructor(tag) {{
+    this.tagName = String(tag || 'div').toUpperCase();
+    this.attributes = Object.create(null);
+    this.dataset = Object.create(null);
+  }}
+  setAttribute(name, value) {{
+    this.attributes[name] = String(value);
+    if (name.startsWith('data-')) {{
+      const key = name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      this.dataset[key] = String(value);
+    }}
+  }}
+}}
+global.window = {{}};
+global.document = {{ createElement(tag) {{ return new FakeElement(tag); }} }};
+global._anchorSceneNodeForRow = () => new FakeElement('div');
+global._decorateTransparentEventRow = node => node;
+global._anchorSceneToolCallFromRow = () => ({{}});
+global.buildToolCard = () => new FakeElement('div');
+global._thinkingActivityNode = () => new FakeElement('div');
+eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
+eval(extractFunc('_anchorSceneTransparentNodeForRow'));
+const liveRow = {{
+  role: 'prose',
+  kind: 'process_prose',
+  source_event_type: 'token',
+  local_id: 'live-prose:stream-1:1',
+  text: {json.dumps(prefix_text)},
+}};
+const boundaryRow = {{
+  role: 'prose',
+  kind: 'process_prose',
+  source_event_type: 'manual',
+  local_id: 'session-prose:stream-1:2',
+  text: {json.dumps(prefix_text)},
+  attachments: [{{ id: 'attachment-2' }}],
+}};
+const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
+const boundaryResult = _anchorSceneTransparentNodeForRow(boundaryRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
+process.stdout.write(JSON.stringify({{
+  liveResult: liveResult === null,
+  boundaryResult: !!boundaryResult,
+  boundaryRowId: boundaryResult && boundaryResult.attributes && boundaryResult.attributes['data-anchor-row-id'] || '',
+}}));
+"""
+    data = _run_node(UI_JS, script, tmp_path)
+    assert data["liveResult"] is True
+    assert data["boundaryResult"] is True
+    assert data["boundaryRowId"] == "session-prose:stream-1:2"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_non_live_prefix_rows_survive_mode_and_attachment_variants(tmp_path):
+    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
+    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes"
+    script = f"""
+const src = {json.dumps(UI_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+class FakeElement {{
+  constructor(tag) {{
+    this.tagName = String(tag || 'div').toUpperCase();
+    this.attributes = Object.create(null);
+    this.dataset = Object.create(null);
+  }}
+  setAttribute(name, value) {{
+    this.attributes[name] = String(value);
+    if (name.startsWith('data-')) {{
+      const key = name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      this.dataset[key] = String(value);
+    }}
+  }}
+}}
+global.window = {{}};
+global.document = {{ createElement(tag) {{ return new FakeElement(tag); }} }};
+global._anchorSceneNodeForRow = () => new FakeElement('div');
+global._decorateTransparentEventRow = node => node;
+global._anchorSceneToolCallFromRow = () => ({{}});
+global.buildToolCard = () => new FakeElement('div');
+global._thinkingActivityNode = () => new FakeElement('div');
+eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
+eval(extractFunc('_anchorSceneTransparentNodeForRow'));
+const variants = [
+  {{
+    label: 'full_dom',
+    row: {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'manual',
+      local_id: 'session-prose:stream-1:3',
+      text: {json.dumps(prefix_text)},
+      attachments: [{{ id: 'attachment-1' }}],
+    }},
+    opts: {{ settled: true, finalAnswer: {json.dumps(final_answer)} }},
+  }},
+  {{
+    label: 'virtualized',
+    row: {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'manual',
+      local_id: 'session-prose:stream-1:4',
+      text: {json.dumps(prefix_text)},
+    }},
+    opts: {{ settled: false, finalAnswer: {json.dumps(final_answer)} }},
+  }},
+  {{
+    label: 'attachments',
+    row: {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'manual',
+      local_id: 'session-prose:stream-1:5',
+      text: {json.dumps(prefix_text)},
+      attachments: [{{ id: 'attachment-2' }}],
+    }},
+    opts: {{ settled: true, finalAnswer: {json.dumps(final_answer)} }},
+  }},
+];
+const rendered = variants.map(({{
+  label,
+  row,
+  opts,
+}}) => {{
+  const node = _anchorSceneTransparentNodeForRow(row, opts);
+  return {{
+    label,
+    visible: !!node,
+    rowId: node && node.attributes && node.attributes['data-anchor-row-id'] || '',
+    attachmentCount: Array.isArray(row.attachments) ? row.attachments.length : 0,
+  }};
+}});
+process.stdout.write(JSON.stringify(rendered));
+"""
+    data = _run_node(UI_JS, script, tmp_path)
+    assert data == [
+        {"label": "full_dom", "visible": True, "rowId": "session-prose:stream-1:3", "attachmentCount": 1},
+        {"label": "virtualized", "visible": True, "rowId": "session-prose:stream-1:4", "attachmentCount": 0},
+        {"label": "attachments", "visible": True, "rowId": "session-prose:stream-1:5", "attachmentCount": 1},
+    ]

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -219,6 +219,91 @@ process.stdout.write(JSON.stringify(scene.activity_rows.map(row => row.text)));
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_long_live_progress_prefix_survives_without_settled_duplicate(tmp_path):
+    final_answer = "I checked the logs, identified the failing deterministic shard, and now I am applying the narrow render-path fix before rerunning the exact test file. The final answer continues with validation details and the pushed commit."
+    prefix_text = "I checked the logs, identified the failing deterministic shard, and now I am applying the narrow render-path fix before rerunning the exact test file."
+    script = f"""
+const src = {json.dumps(MESSAGES_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+global.window = {{
+  chatActivityMode() {{ return 'transparent_stream'; }},
+  _chatActivityDisplayMode: 'transparent_stream',
+  _transparentStream: true,
+}};
+global.S = {{ session: {{}} }};
+eval(extractFunc('_anchorSceneCleanText'));
+eval(extractFunc('_anchorSceneTextKey'));
+eval(extractFunc('_anchorSceneExistingRowKey'));
+eval(extractFunc('_anchorSceneRowHasLiveIdentity'));
+eval(extractFunc('_anchorSceneSettleLiveRunningRow'));
+eval(extractFunc('_anchorSceneRowLooksLikeFinalAnswer'));
+eval(extractFunc('_anchorSceneRowTextOverlapsExisting'));
+eval(extractFunc('_anchorSceneMessageRowsHaveThinking'));
+eval(extractFunc('_completeSettledAnchorSceneForTurn'));
+function _anchorSceneActiveMode() {{ return 'transparent_stream'; }}
+function _anchorSceneFinalAnswerText(message) {{ return message && (message.final_answer || message.content || ''); }}
+function _anchorSceneRowsByMessageIndex() {{ return new Map(); }}
+function _anchorSceneMessageRef(message) {{ return String(message && message.id || ''); }}
+function _anchorSceneTurnDurationForSettlement() {{ return 0; }}
+function _anchorSceneRowDisplayHintForMode(row, sceneMode) {{
+  const hints = row && typeof row === 'object' && row.display_hints && typeof row.display_hints === 'object' ? row.display_hints : null;
+  if (sceneMode === 'transparent_stream') return (hints && hints.transparent_stream) || 'chronological_activity';
+  if (sceneMode === 'compact_worklog') return (hints && hints.compact_worklog) || row && row.display_hint || 'activity_row';
+  return row && row.display_hint || 'activity_row';
+}}
+const messages = [
+  {{ role: 'user', content: 'Prompt', id: 'user-1' }},
+  {{ role: 'assistant', content: {json.dumps(final_answer)}, id: 'assistant-1' }},
+];
+const scene = _completeSettledAnchorSceneForTurn(messages, 1, {{
+  mode: 'transparent_stream',
+  final_answer: {json.dumps(final_answer)},
+  lifecycle: {{ terminal_state: 'done' }},
+  identity: {{ source_message_refs: ['legacy'] }},
+  activity_rows: [
+    {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'token',
+      local_id: 'live-prose:stream-long:1',
+      text: {json.dumps(prefix_text)},
+      status: 'running',
+    }},
+  ],
+}});
+process.stdout.write(JSON.stringify(scene.activity_rows.map(row => ({{
+  local_id: row.local_id,
+  text: row.text,
+  status: row.status,
+}}))));
+"""
+    data = _run_node(MESSAGES_JS, script, tmp_path)
+    assert data == [{"local_id": "live-prose:stream-long:1", "text": prefix_text, "status": "completed"}]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_render_fallback_suppresses_persisted_live_token_prefix_rows(tmp_path):
     final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
     prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -12,6 +12,9 @@ ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
+ISSUE5749_CAPTURED_SESSION = json.loads(
+    (ROOT / "tests" / "fixtures" / "issue5749_captured_session_prefix.json").read_text(encoding="utf-8")
+)
 
 
 def _run_node(src, script, tmp_path):
@@ -23,10 +26,49 @@ def _run_node(src, script, tmp_path):
     return json.loads(result.stdout)
 
 
+def _normalized_text(text):
+    return " ".join(str(text or "").split()).lower()
+
+
+def _issue5749_captured_scene():
+    scenes = ISSUE5749_CAPTURED_SESSION["anchor_activity_scenes"]
+    scene = next(iter(scenes.values()))["scene"]
+    rows = scene["activity_rows"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["role"] == "prose"
+    assert row["kind"] == "process_prose"
+    assert row["source_event_type"] == "token"
+    assert row["local_id"].startswith("live-prose:")
+    assert not any(
+        other is not row and other.get("text") == row["text"] and not str(other.get("local_id", "")).startswith("live-prose:")
+        for other in rows
+    )
+    row_key = _normalized_text(row["text"])
+    final_key = _normalized_text(scene["final_answer"])
+    assert row_key and final_key.startswith(row_key)
+    assert 0.40 <= len(row_key) / len(final_key) <= 0.45
+    return scene, row
+
+
+@pytest.mark.reproduction
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_reproduction_fixture_matches_lone_live_prefix_shape():
+    scene, row = _issue5749_captured_scene()
+    final_key = _normalized_text(scene["final_answer"])
+    row_key = _normalized_text(row["text"])
+
+    assert row_key != final_key
+    assert final_key.startswith(row_key)
+    assert scene["final_answer"] == ISSUE5749_CAPTURED_SESSION["messages"][0]["content"]
+
+
+@pytest.mark.reproduction
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_settlement_suppresses_live_token_prefix_rows(tmp_path):
-    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
-    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
+    fixture_scene, fixture_row = _issue5749_captured_scene()
+    final_answer = fixture_scene["final_answer"]
+    prefix_text = fixture_row["text"]
     script = f"""
 const src = {json.dumps(MESSAGES_JS)};
 function extractFunc(name) {{
@@ -92,19 +134,10 @@ const scene = _completeSettledAnchorSceneForTurn(messages, 1, {{
       role: 'prose',
       kind: 'process_prose',
       source_event_type: 'token',
-      local_id: 'live-prose:stream-1:1',
+      local_id: {json.dumps(fixture_row["local_id"])},
       text: {json.dumps(prefix_text)},
       status: 'running',
       attachments: [{{ id: 'attachment-1' }}],
-    }},
-    {{
-      role: 'prose',
-      kind: 'process_prose',
-      source_event_type: 'manual',
-      local_id: 'session-prose:stream-1:2',
-      text: {json.dumps(prefix_text)},
-      status: 'running',
-      attachments: [{{ id: 'attachment-2' }}],
     }},
     {{
       role: 'tool',
@@ -131,10 +164,8 @@ process.stdout.write(JSON.stringify({{
 """
     data = _run_node(MESSAGES_JS, script, tmp_path)
     assert data["final_answer"] == final_answer
-    assert [row["local_id"] for row in data["rows"]] == ["session-prose:stream-1:2", "tool-row-1"]
-    assert data["rows"][0]["text"] == prefix_text
-    assert data["rows"][0]["attachments"] == [{"id": "attachment-2"}]
-    assert data["rows"][1]["role"] == "tool"
+    assert [row["local_id"] for row in data["rows"]] == ["tool-row-1"]
+    assert data["rows"][0]["role"] == "tool"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -218,10 +249,12 @@ process.stdout.write(JSON.stringify(scene.activity_rows.map(row => row.text)));
     assert data == [prefix_text]
 
 
+@pytest.mark.reproduction
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_long_live_progress_prefix_is_suppressed_without_settled_duplicate(tmp_path):
-    final_answer = "I checked the logs, identified the failing deterministic shard, and now I am applying the narrow render-path fix before rerunning the exact test file. The final answer continues with validation details and the pushed commit."
-    prefix_text = "I checked the logs, identified the failing deterministic shard, and now I am applying the narrow render-path fix before rerunning the exact test file."
+    fixture_scene, fixture_row = _issue5749_captured_scene()
+    final_answer = fixture_scene["final_answer"]
+    prefix_text = fixture_row["text"]
     script = f"""
 const src = {json.dumps(MESSAGES_JS)};
 function extractFunc(name) {{
@@ -287,7 +320,7 @@ const scene = _completeSettledAnchorSceneForTurn(messages, 1, {{
       role: 'prose',
       kind: 'process_prose',
       source_event_type: 'token',
-      local_id: 'live-prose:stream-long:1',
+      local_id: {json.dumps(fixture_row["local_id"])},
       text: {json.dumps(prefix_text)},
       status: 'running',
     }},
@@ -303,10 +336,12 @@ process.stdout.write(JSON.stringify(scene.activity_rows.map(row => ({{
     assert data == []
 
 
+@pytest.mark.reproduction
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_render_fallback_suppresses_persisted_live_progress_prefix_rows(tmp_path):
-    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
-    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
+    fixture_scene, fixture_row = _issue5749_captured_scene()
+    final_answer = fixture_scene["final_answer"]
+    prefix_text = fixture_row["text"]
     script = f"""
 const src = {json.dumps(UI_JS)};
 function extractFunc(name) {{
@@ -360,29 +395,16 @@ const liveRow = {{
   role: 'prose',
   kind: 'process_prose',
   source_event_type: 'token',
-  local_id: 'live-prose:stream-1:1',
+  local_id: {json.dumps(fixture_row["local_id"])},
   text: {json.dumps(prefix_text)},
-}};
-const boundaryRow = {{
-  role: 'prose',
-  kind: 'process_prose',
-  source_event_type: 'manual',
-  local_id: 'session-prose:stream-1:2',
-  text: {json.dumps(prefix_text)},
-  attachments: [{{ id: 'attachment-2' }}],
 }};
 const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
-const boundaryResult = _anchorSceneTransparentNodeForRow(boundaryRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
 process.stdout.write(JSON.stringify({{
   liveResult: liveResult === null,
-  boundaryResult: !!boundaryResult,
-  boundaryRowId: boundaryResult && boundaryResult.attributes && boundaryResult.attributes['data-anchor-row-id'] || '',
 }}));
 """
     data = _run_node(UI_JS, script, tmp_path)
     assert data["liveResult"] is True
-    assert data["boundaryResult"] is True
-    assert data["boundaryRowId"] == "session-prose:stream-1:2"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -454,8 +476,9 @@ process.stdout.write(JSON.stringify(liveResult === null));
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_non_live_prefix_rows_survive_mode_and_attachment_variants(tmp_path):
-    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
-    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes"
+    fixture_scene, fixture_row = _issue5749_captured_scene()
+    final_answer = fixture_scene["final_answer"]
+    prefix_text = fixture_row["text"]
     script = f"""
 const src = {json.dumps(UI_JS)};
 function extractFunc(name) {{

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -64,7 +64,6 @@ eval(extractFunc('_anchorSceneExistingRowKey'));
 eval(extractFunc('_anchorSceneRowHasLiveIdentity'));
 eval(extractFunc('_anchorSceneSettleLiveRunningRow'));
 eval(extractFunc('_anchorSceneRowLooksLikeFinalAnswer'));
-eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
 eval(extractFunc('_anchorSceneRowTextOverlapsExisting'));
 eval(extractFunc('_anchorSceneMessageRowsHaveThinking'));
 eval(extractFunc('_completeSettledAnchorSceneForTurn'));
@@ -179,7 +178,6 @@ eval(extractFunc('_anchorSceneExistingRowKey'));
 eval(extractFunc('_anchorSceneRowHasLiveIdentity'));
 eval(extractFunc('_anchorSceneSettleLiveRunningRow'));
 eval(extractFunc('_anchorSceneRowLooksLikeFinalAnswer'));
-eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
 eval(extractFunc('_anchorSceneRowTextOverlapsExisting'));
 eval(extractFunc('_anchorSceneMessageRowsHaveThinking'));
 eval(extractFunc('_completeSettledAnchorSceneForTurn'));
@@ -271,7 +269,6 @@ global._anchorSceneToolCallFromRow = () => ({{}});
 global.buildToolCard = () => new FakeElement('div');
 global._thinkingActivityNode = () => new FakeElement('div');
 eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
-eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
 eval(extractFunc('_anchorSceneTransparentNodeForRow'));
 const liveRow = {{
   role: 'prose',
@@ -353,7 +350,6 @@ global._anchorSceneToolCallFromRow = () => ({{}});
 global.buildToolCard = () => new FakeElement('div');
 global._thinkingActivityNode = () => new FakeElement('div');
 eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
-eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
 eval(extractFunc('_anchorSceneTransparentNodeForRow'));
 const variants = [
   {{

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -304,7 +304,7 @@ process.stdout.write(JSON.stringify(scene.activity_rows.map(row => ({{
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_issue5749_render_fallback_suppresses_persisted_live_token_prefix_rows(tmp_path):
+def test_issue5749_render_fallback_preserves_persisted_live_progress_prefix_rows(tmp_path):
     final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
     prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
     script = f"""
@@ -379,9 +379,75 @@ process.stdout.write(JSON.stringify({{
 }}));
 """
     data = _run_node(UI_JS, script, tmp_path)
-    assert data["liveResult"] is True
+    assert data["liveResult"] is False
     assert data["boundaryResult"] is True
     assert data["boundaryRowId"] == "session-prose:stream-1:2"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_render_fallback_suppresses_near_complete_live_prefix_rows(tmp_path):
+    final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback now."
+    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
+    script = f"""
+const src = {json.dumps(UI_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+class FakeElement {{
+  constructor(tag) {{
+    this.tagName = String(tag || 'div').toUpperCase();
+    this.attributes = Object.create(null);
+    this.dataset = Object.create(null);
+  }}
+  setAttribute(name, value) {{
+    this.attributes[name] = String(value);
+    if (name.startsWith('data-')) {{
+      const key = name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      this.dataset[key] = String(value);
+    }}
+  }}
+}}
+global.window = {{}};
+global.document = {{ createElement(tag) {{ return new FakeElement(tag); }} }};
+global._anchorSceneNodeForRow = () => new FakeElement('div');
+global._decorateTransparentEventRow = node => node;
+global._anchorSceneToolCallFromRow = () => ({{}});
+global.buildToolCard = () => new FakeElement('div');
+global._thinkingActivityNode = () => new FakeElement('div');
+eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneTransparentNodeForRow'));
+const liveRow = {{
+  role: 'prose',
+  kind: 'process_prose',
+  source_event_type: 'token',
+  local_id: 'live-prose:stream-1:near',
+  text: {json.dumps(prefix_text)},
+}};
+const liveResult = _anchorSceneTransparentNodeForRow(liveRow, {{ settled: true, finalAnswer: {json.dumps(final_answer)} }});
+process.stdout.write(JSON.stringify(liveResult === null));
+"""
+    data = _run_node(UI_JS, script, tmp_path)
+    assert data is True
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -138,9 +138,9 @@ process.stdout.write(JSON.stringify({{
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_issue5749_short_live_token_prefix_rows_survive_settlement(tmp_path):
+def test_issue5749_distinct_live_token_prefix_rows_survive_settlement(tmp_path):
     final_answer = "The solution is to preserve short legitimate live-token prefixes while still suppressing longer duplicated final-answer spans."
-    prefix_text = "The"
+    prefix_text = "Checking context"
     script = f"""
 const src = {json.dumps(MESSAGES_JS)};
 function extractFunc(name) {{
@@ -219,7 +219,7 @@ process.stdout.write(JSON.stringify(scene.activity_rows.map(row => row.text)));
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_issue5749_long_live_progress_prefix_survives_without_settled_duplicate(tmp_path):
+def test_issue5749_long_live_progress_prefix_is_suppressed_without_settled_duplicate(tmp_path):
     final_answer = "I checked the logs, identified the failing deterministic shard, and now I am applying the narrow render-path fix before rerunning the exact test file. The final answer continues with validation details and the pushed commit."
     prefix_text = "I checked the logs, identified the failing deterministic shard, and now I am applying the narrow render-path fix before rerunning the exact test file."
     script = f"""
@@ -300,11 +300,11 @@ process.stdout.write(JSON.stringify(scene.activity_rows.map(row => ({{
 }}))));
 """
     data = _run_node(MESSAGES_JS, script, tmp_path)
-    assert data == [{"local_id": "live-prose:stream-long:1", "text": prefix_text, "status": "completed"}]
+    assert data == []
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
-def test_issue5749_render_fallback_preserves_persisted_live_progress_prefix_rows(tmp_path):
+def test_issue5749_render_fallback_suppresses_persisted_live_progress_prefix_rows(tmp_path):
     final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
     prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
     script = f"""
@@ -354,6 +354,7 @@ global._anchorSceneToolCallFromRow = () => ({{}});
 global.buildToolCard = () => new FakeElement('div');
 global._thinkingActivityNode = () => new FakeElement('div');
 eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneLiveTokenFinalPrefix'));
 eval(extractFunc('_anchorSceneTransparentNodeForRow'));
 const liveRow = {{
   role: 'prose',
@@ -379,7 +380,7 @@ process.stdout.write(JSON.stringify({{
 }}));
 """
     data = _run_node(UI_JS, script, tmp_path)
-    assert data["liveResult"] is False
+    assert data["liveResult"] is True
     assert data["boundaryResult"] is True
     assert data["boundaryRowId"] == "session-prose:stream-1:2"
 
@@ -435,6 +436,7 @@ global._anchorSceneToolCallFromRow = () => ({{}});
 global.buildToolCard = () => new FakeElement('div');
 global._thinkingActivityNode = () => new FakeElement('div');
 eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneLiveTokenFinalPrefix'));
 eval(extractFunc('_anchorSceneTransparentNodeForRow'));
 const liveRow = {{
   role: 'prose',
@@ -501,6 +503,7 @@ global._anchorSceneToolCallFromRow = () => ({{}});
 global.buildToolCard = () => new FakeElement('div');
 global._thinkingActivityNode = () => new FakeElement('div');
 eval(extractFunc('_anchorSceneProseMatchesFinalAnswer'));
+eval(extractFunc('_anchorSceneLiveTokenFinalPrefix'));
 eval(extractFunc('_anchorSceneTransparentNodeForRow'));
 const variants = [
   {{

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -26,7 +26,7 @@ def _run_node(src, script, tmp_path):
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_settlement_suppresses_live_token_prefix_rows(tmp_path):
     final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
-    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes"
+    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
     script = f"""
 const src = {json.dumps(MESSAGES_JS)};
 function extractFunc(name) {{
@@ -139,9 +139,91 @@ process.stdout.write(JSON.stringify({{
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_issue5749_short_live_token_prefix_rows_survive_settlement(tmp_path):
+    final_answer = "The solution is to preserve short legitimate live-token prefixes while still suppressing longer duplicated final-answer spans."
+    prefix_text = "The"
+    script = f"""
+const src = {json.dumps(MESSAGES_JS)};
+function extractFunc(name) {{
+  const start = src.indexOf('function ' + name);
+  if (start === -1) throw new Error(name + ' not found');
+  const params = src.indexOf('(', start);
+  let depth = 0, close = -1;
+  for (let i = params; i < src.length; i++) {{
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {{
+      depth--;
+      if (depth === 0) {{ close = i; break; }}
+    }}
+  }}
+  const brace = src.indexOf('{{', close);
+  depth = 0;
+  for (let i = brace; i < src.length; i++) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') {{
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(name + ' body did not close');
+}}
+global.window = {{
+  chatActivityMode() {{ return 'transparent_stream'; }},
+  _chatActivityDisplayMode: 'transparent_stream',
+  _transparentStream: true,
+}};
+global.S = {{ session: {{}} }};
+eval(extractFunc('_anchorSceneCleanText'));
+eval(extractFunc('_anchorSceneTextKey'));
+eval(extractFunc('_anchorSceneExistingRowKey'));
+eval(extractFunc('_anchorSceneRowHasLiveIdentity'));
+eval(extractFunc('_anchorSceneSettleLiveRunningRow'));
+eval(extractFunc('_anchorSceneRowLooksLikeFinalAnswer'));
+eval(extractFunc('_anchorSceneRowLooksLikeLiveTokenFinalAnswerPrefix'));
+eval(extractFunc('_anchorSceneRowTextOverlapsExisting'));
+eval(extractFunc('_anchorSceneMessageRowsHaveThinking'));
+eval(extractFunc('_completeSettledAnchorSceneForTurn'));
+function _anchorSceneActiveMode() {{ return 'transparent_stream'; }}
+function _anchorSceneFinalAnswerText(message) {{ return message && (message.final_answer || message.content || ''); }}
+function _anchorSceneRowsByMessageIndex() {{ return new Map(); }}
+function _anchorSceneMessageRef(message) {{ return String(message && message.id || ''); }}
+function _anchorSceneTurnDurationForSettlement() {{ return 0; }}
+function _anchorSceneRowDisplayHintForMode(row, sceneMode) {{
+  const hints = row && typeof row === 'object' && row.display_hints && typeof row.display_hints === 'object' ? row.display_hints : null;
+  if (sceneMode === 'transparent_stream') return (hints && hints.transparent_stream) || 'chronological_activity';
+  if (sceneMode === 'compact_worklog') return (hints && hints.compact_worklog) || row && row.display_hint || 'activity_row';
+  return row && row.display_hint || 'activity_row';
+}}
+const messages = [
+  {{ role: 'user', content: 'Prompt', id: 'user-1' }},
+  {{ role: 'assistant', content: {json.dumps(final_answer)}, id: 'assistant-1' }},
+];
+const scene = _completeSettledAnchorSceneForTurn(messages, 1, {{
+  mode: 'transparent_stream',
+  final_answer: {json.dumps(final_answer)},
+  lifecycle: {{ terminal_state: 'done' }},
+  identity: {{ source_message_refs: ['legacy'] }},
+  activity_rows: [
+    {{
+      role: 'prose',
+      kind: 'process_prose',
+      source_event_type: 'token',
+      local_id: 'live-prose:stream-short:1',
+      text: {json.dumps(prefix_text)},
+      status: 'running',
+    }},
+  ],
+}});
+process.stdout.write(JSON.stringify(scene.activity_rows.map(row => row.text)));
+"""
+    data = _run_node(MESSAGES_JS, script, tmp_path)
+    assert data == [prefix_text]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_render_fallback_suppresses_persisted_live_token_prefix_rows(tmp_path):
     final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."
-    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes"
+    prefix_text = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback"
     script = f"""
 const src = {json.dumps(UI_JS)};
 function extractFunc(name) {{

--- a/tests/test_issue5749_transparent_stream_prefix_dedupe.py
+++ b/tests/test_issue5749_transparent_stream_prefix_dedupe.py
@@ -23,34 +23,6 @@ def _run_node(src, script, tmp_path):
     return json.loads(result.stdout)
 
 
-def _extract_js_function(src, name):
-    marker = f"function {name}"
-    start = src.find(marker)
-    assert start != -1, f"{name} not found"
-    params = src.find("(", start)
-    depth = 0
-    close = -1
-    for idx in range(params, len(src)):
-        if src[idx] == "(":
-            depth += 1
-        elif src[idx] == ")":
-            depth -= 1
-            if depth == 0:
-                close = idx
-                break
-    assert close != -1, f"{name} params did not close"
-    brace = src.find("{", close)
-    depth = 0
-    for idx in range(brace, len(src)):
-        if src[idx] == "{":
-            depth += 1
-        elif src[idx] == "}":
-            depth -= 1
-            if depth == 0:
-                return src[start:idx + 1]
-    raise AssertionError(f"{name} body did not close")
-
-
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_issue5749_settlement_suppresses_live_token_prefix_rows(tmp_path):
     final_answer = "I found the issue and I am fixing it by deduping live-token prefixes during settlement and render fallback so Transparent Stream does not repeat the same prose row."

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -1233,6 +1233,7 @@ global._renderAnchorSceneRowsIntoWorklog=(group, rows)=>{{
 }};
 global._syncToolCallGroupSummary=()=>{{}};
 
+    eval(extractFunc('_anchorSceneLiveTokenFinalPrefix'));
     eval(extractFunc('_anchorSceneTransparentNodeForRow'));
     eval(extractFunc('renderLiveAnchorActivityScene'));
     eval(extractFunc('_transparentLiveRowKey'));

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -924,10 +924,12 @@ def test_settled_anchor_scene_preserves_live_projected_order_before_backfill():
     overlap = _function_body(MESSAGES_JS, "_anchorSceneRowTextOverlapsExisting")
 
     projected_idx = complete.index("const projectedRows=Array.isArray(base.activity_rows)?base.activity_rows:[];")
-    projected_push_idx = complete.index("for(const row of projectedRows){")
-    backfill_idx = complete.index("for(let idx=turnStart+1;idx<=lastAsstIndex;idx+=1)")
-    terminal_idx = complete.index("if(row&&row.role==='terminal') pushRow(row);", backfill_idx)
-    assert projected_idx < projected_push_idx < backfill_idx < terminal_idx
+    ordered_idx = complete.index("const orderedRows=[];", projected_idx)
+    projected_push_idx = complete.index("orderedRows.push(row);", ordered_idx)
+    backfill_idx = complete.index("for(let idx=turnStart+1;idx<=lastAsstIndex;idx+=1)", projected_push_idx)
+    terminal_idx = complete.index("if(row&&row.role==='terminal') orderedRows.push(row);", backfill_idx)
+    replay_idx = complete.index("orderedRows.forEach((row,idx)=>pushRow(row,idx));", terminal_idx)
+    assert projected_idx < ordered_idx < projected_push_idx < backfill_idx < terminal_idx < replay_idx
 
     assert "const seenTextKeys=[];" in complete
     assert "_anchorSceneRowTextOverlapsExisting(textKey,seenTextKeys)" in complete
@@ -990,7 +992,8 @@ def test_transparent_stream_renders_persisted_anchor_scene_after_reload():
     assert 'blocks.querySelectorAll(\'[data-anchor-settled-scene-row="1"],.transparent-event-row[data-anchor-scene-row="1"]\')' in transparent
     # combined fix: the final answer text is computed and threaded into the row
     # renderer so intermediate prose survives while the final-answer duplicate is dropped.
-    assert "_anchorSceneTransparentNodeForRow(row,{settled:true,finalAnswer})" in transparent
+    assert "const lastNonTerminalWorkRowIndex=_anchorSceneLastNonTerminalWorkRowIndex(rows);" in transparent
+    assert "liveTokenFinalPrefixEligible:idx>lastNonTerminalWorkRowIndex" in transparent
     assert "finalAnswer" in transparent
     assert "blocks.insertBefore(node,segment)" in transparent
     assert "_syncTransparentEventControls(turn)" in transparent


### PR DESCRIPTION
## Thinking Path

- Transparent Stream already suppresses exact and near-complete final-answer duplicates, but it intentionally preserves ordinary intermediate prose that happens to prefix a later answer.
- The duplicate in this issue has a narrower identity: a final-segment live-token `process_prose` row from the answer stream, not pre-tool or inter-tool narration.
- The fix keeps the conservative generic rule, keys candidate rows on live-token provenance, and only applies the strict-prefix suppression after the last tool row in both settlement and reload rendering.

## What Changed

- `static/messages.js`: builds the settled activity row sequence before filtering, finds the last tool row, and suppresses live-token `process_prose` rows only when they are strict prefixes in the final segment.
- `static/ui.js`: mirrors the same final-segment eligibility while rendering persisted Transparent Stream rows, so already-saved poisoned sessions stop showing the duplicate after reload while pre-tool live prose remains visible.
- `tests`: covers the captured lone final-answer residue, pre-tool live-token prefix preservation, persisted reload behavior, source-shape guards for the shared eligibility path, and the adjacent anchor-scene ownership tests.

## Why It Matters

Transparent Stream no longer repeats the start of the final answer as a separate activity row. The behavior that keeps real pre-tool and intermediate narration visible is preserved.

## Verification

Focused anchor-scene coverage exercises the captured-session-shaped reproduction fixture, settlement suppression, reload render fallback suppression, pre-tool live prose preservation, distinct live progress preservation, non-live transcript-rendering variants, source-shape guards, and the adjacent anchor ownership paths; CI runs the full matrix.

## Screenshots

Before, seeded persisted `live-prose:` prefix row renders above the final answer:

![Before](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/5758-before.png)

After, the final-segment duplicate is suppressed, the short pre-tool `live-prose:` row remains visible, and the final answer remains visible:

![After](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/5758-after.png)

## Upstream

Closes #5749. Implementation follows the maintainer sketch in https://github.com/nesquena/hermes-webui/issues/5749#issuecomment-4906104056.

## Model Used

GPT 5.5 via Codex CLI
