### PR TITLE
[security] fix(terminal): resolve forwarded client before local gate

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5547,11 +5547,19 @@ def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
         if hops:
             return hops[0]
 
-    # Do not fall back to X-Real-IP here. Some proxies pass client-supplied
-    # X-Real-IP through when X-Forwarded-For is absent, which would let a public
-    # caller choose a private client IP. Without XFF, only a same-host loopback
-    # proxy can be treated as local; non-loopback trusted proxies must include
-    # an XFF chain so the original client can be classified.
+    # Do not fall back to X-Real-IP or Forwarded here. Some proxies pass
+    # client-supplied values through when X-Forwarded-For is absent, which would
+    # let a public caller choose a private client IP. If a forwarded-client
+    # header is present but XFF is absent, fail closed instead of ignoring it and
+    # treating the loopback/private proxy hop as the client.
+    x_real_ip = str(handler.headers.get("X-Real-IP", "") or "").strip()
+    forwarded = str(handler.headers.get("Forwarded", "") or "").strip()
+    if x_real_ip or forwarded:
+        return ""
+
+    # Without any forwarded-client header, only a same-host loopback proxy can be
+    # treated as local; non-loopback trusted proxies must include an XFF chain so
+    # the original client can be classified.
     return raw_peer if peer_is_loopback else ""
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5488,24 +5488,30 @@ def _trusted_proxy_networks():
     return tuple(networks)
 
 
-def _ip_is_loopback_or_private(raw: str) -> bool:
+def _ip_address(raw: str):
     import ipaddress
 
     try:
         addr = ipaddress.ip_address(str(raw or "").strip())
     except ValueError:
-        return False
-    return bool(addr.is_loopback or addr.is_private)
+        return None
+    mapped = getattr(addr, "ipv4_mapped", None)
+    return mapped or addr
+
+
+def _ip_is_loopback(raw: str) -> bool:
+    addr = _ip_address(raw)
+    return bool(addr and addr.is_loopback)
+
+
+def _ip_is_loopback_or_private(raw: str) -> bool:
+    addr = _ip_address(raw)
+    return bool(addr and (addr.is_loopback or addr.is_private))
 
 
 def _ip_in_networks(raw: str, networks) -> bool:
-    import ipaddress
-
-    try:
-        addr = ipaddress.ip_address(str(raw or "").strip())
-    except ValueError:
-        return False
-    return any(addr in network for network in networks)
+    addr = _ip_address(raw)
+    return bool(addr and any(addr in network for network in networks))
 
 
 def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
@@ -5522,7 +5528,7 @@ def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
         return ""
 
     trusted_networks = _trusted_proxy_networks()
-    peer_is_loopback = _ip_is_loopback_or_private(raw_peer) and str(raw_peer).startswith(("127.", "::1"))
+    peer_is_loopback = _ip_is_loopback(raw_peer)
     peer_is_trusted = _ip_in_networks(raw_peer, trusted_networks) if trusted_networks else peer_is_loopback
     if not peer_is_trusted:
         return ""
@@ -5537,11 +5543,12 @@ def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
         if hops:
             return hops[0]
 
-    x_real_ip = str(handler.headers.get("X-Real-IP", "") or "").strip()
-    if x_real_ip:
-        return x_real_ip
-
-    return raw_peer
+    # Do not fall back to X-Real-IP here. Some proxies pass client-supplied
+    # X-Real-IP through when X-Forwarded-For is absent, which would let a public
+    # caller choose a private client IP. Without XFF, only a same-host loopback
+    # proxy can be treated as local; non-loopback trusted proxies must include
+    # an XFF chain so the original client can be classified.
+    return raw_peer if peer_is_loopback else ""
 
 
 def _onboarding_request_is_local(handler) -> bool:
@@ -5575,7 +5582,7 @@ def _onboarding_request_is_local(handler) -> bool:
     if not raw:
         return False
     if forwarded_present:
-        return _ip_is_loopback_or_private(raw) and str(raw).startswith(("127.", "::1"))
+        return _ip_is_loopback(raw)
     return _ip_is_loopback_or_private(raw)
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5471,39 +5471,94 @@ def _request_client_ip(handler) -> str:
     return ""
 
 
+def _trusted_proxy_networks():
+    """Return explicitly trusted reverse-proxy CIDRs for forwarded client IPs."""
+    import ipaddress
+
+    raw = os.getenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "")
+    networks = []
+    for item in raw.replace(";", ",").split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(item, strict=False))
+        except ValueError:
+            logger.warning("Ignoring invalid HERMES_WEBUI_TRUSTED_PROXY_CIDRS entry: %s", item)
+    return tuple(networks)
+
+
+def _ip_is_loopback_or_private(raw: str) -> bool:
+    import ipaddress
+
+    try:
+        addr = ipaddress.ip_address(str(raw or "").strip())
+    except ValueError:
+        return False
+    return bool(addr.is_loopback or addr.is_private)
+
+
+def _ip_in_networks(raw: str, networks) -> bool:
+    import ipaddress
+
+    try:
+        addr = ipaddress.ip_address(str(raw or "").strip())
+    except ValueError:
+        return False
+    return any(addr in network for network in networks)
+
+
+def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
+    """Resolve the original client IP from trusted forwarded headers.
+
+    ``X-Forwarded-For`` chains are ordered as ``client, proxy1, proxy2``.  The
+    previous implementation used the rightmost value, which is commonly a
+    private/loopback proxy hop and can make a public client look local.  Only
+    trust forwarded headers when the immediate socket peer is trusted, then walk
+    from right to left and return the first non-proxy hop.
+    """
+    raw_peer = _request_client_ip(handler)
+    if not raw_peer:
+        return ""
+
+    trusted_networks = _trusted_proxy_networks()
+    peer_is_loopback = _ip_is_loopback_or_private(raw_peer) and str(raw_peer).startswith(("127.", "::1"))
+    peer_is_trusted = _ip_in_networks(raw_peer, trusted_networks) if trusted_networks else peer_is_loopback
+    if not peer_is_trusted:
+        return ""
+
+    xff = str(handler.headers.get("X-Forwarded-For", "") or "").strip()
+    if xff:
+        hops = [part.strip() for part in xff.split(",") if part.strip()]
+        for hop in reversed(hops):
+            if trusted_networks and _ip_in_networks(hop, trusted_networks):
+                continue
+            return hop
+        if hops:
+            return hops[0]
+
+    x_real_ip = str(handler.headers.get("X-Real-IP", "") or "").strip()
+    if x_real_ip:
+        return x_real_ip
+
+    return raw_peer
+
+
 def _onboarding_request_is_local(handler) -> bool:
     """Return True when an unauthenticated onboarding request is local/private.
 
     Forwarded client-IP headers are ignored by default because direct clients can
     spoof them. Operators behind a trusted reverse proxy may opt in with
-    HERMES_WEBUI_TRUST_FORWARDED_FOR=1, matching the explicit forwarded-header
-    trust model used elsewhere in the server.
-
-    When forwarded headers are PRESENT but not trusted, the request arrived
-    through a proxy, so the raw socket address is the proxy's (typically
-    loopback/private) and tells us nothing about the real client's locality.
-    In that case we deny rather than fall back to the proxy socket — otherwise a
-    public client behind any reverse proxy would be treated as local. Operators
-    who front the WebUI with a trusted proxy must set
-    HERMES_WEBUI_TRUST_FORWARDED_FOR=1 (or HERMES_WEBUI_ONBOARDING_OPEN=1).
+    HERMES_WEBUI_TRUST_FORWARDED_FOR=1.  In that mode, forwarded headers are
+    honored only from a loopback proxy or a proxy listed in
+    HERMES_WEBUI_TRUSTED_PROXY_CIDRS, and the resolved client is the original
+    non-proxy hop rather than the rightmost/private proxy hop.
     """
-    import ipaddress
-
     trust_forwarded = _truthy_env("HERMES_WEBUI_TRUST_FORWARDED_FOR")
     if trust_forwarded:
-        candidates = [
-            handler.headers.get("X-Forwarded-For", "").split(",")[-1].strip(),
-            handler.headers.get("X-Real-IP", "").strip(),
-            _request_client_ip(handler),
-        ]
-        for raw in candidates:
-            if not raw:
-                continue
-            try:
-                addr = ipaddress.ip_address(raw)
-            except ValueError:
-                continue
-            return bool(addr.is_loopback or addr.is_private)
+        forwarded_client = _forwarded_client_ip_from_trusted_proxy(handler)
+        if forwarded_client:
+            return _ip_is_loopback_or_private(forwarded_client)
         return False
 
     # Untrusted forwarded headers present → the request arrived through a proxy.
@@ -5511,9 +5566,7 @@ def _onboarding_request_is_local(handler) -> bool:
     # counts as local in that case: a loopback raw socket is a genuine same-host
     # client (or a same-host proxy the operator controls), whereas a PRIVATE/LAN
     # raw socket is a separate proxy box that could be forwarding an arbitrary
-    # (public) client we can't see without trusting the header. Operators who
-    # front the WebUI with a LAN proxy must set HERMES_WEBUI_TRUST_FORWARDED_FOR=1
-    # (or HERMES_WEBUI_ONBOARDING_OPEN=1).
+    # (public) client we can't see without trusting the header.
     forwarded_present = bool(
         handler.headers.get("X-Forwarded-For", "").strip()
         or handler.headers.get("X-Real-IP", "").strip()
@@ -5521,13 +5574,9 @@ def _onboarding_request_is_local(handler) -> bool:
     raw = _request_client_ip(handler)
     if not raw:
         return False
-    try:
-        addr = ipaddress.ip_address(raw)
-    except ValueError:
-        return False
     if forwarded_present:
-        return bool(addr.is_loopback)
-    return bool(addr.is_loopback or addr.is_private)
+        return _ip_is_loopback_or_private(raw) and str(raw).startswith(("127.", "::1"))
+    return _ip_is_loopback_or_private(raw)
 
 
 def _onboarding_gate_allows(handler, auth_enabled: bool | None = None) -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -5514,6 +5514,10 @@ def _ip_in_networks(raw: str, networks) -> bool:
     return bool(addr and any(addr in network for network in networks))
 
 
+def _ip_is_trusted_proxy_hop(raw: str, trusted_networks) -> bool:
+    return _ip_is_loopback(raw) or _ip_in_networks(raw, trusted_networks)
+
+
 def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
     """Resolve the original client IP from trusted forwarded headers.
 
@@ -5529,7 +5533,7 @@ def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
 
     trusted_networks = _trusted_proxy_networks()
     peer_is_loopback = _ip_is_loopback(raw_peer)
-    peer_is_trusted = _ip_in_networks(raw_peer, trusted_networks) if trusted_networks else peer_is_loopback
+    peer_is_trusted = peer_is_loopback or _ip_in_networks(raw_peer, trusted_networks)
     if not peer_is_trusted:
         return ""
 
@@ -5537,7 +5541,7 @@ def _forwarded_client_ip_from_trusted_proxy(handler) -> str:
     if xff:
         hops = [part.strip() for part in xff.split(",") if part.strip()]
         for hop in reversed(hops):
-            if trusted_networks and _ip_in_networks(hop, trusted_networks):
+            if _ip_is_trusted_proxy_hop(hop, trusted_networks):
                 continue
             return hop
         if hops:

--- a/tests/test_cvd3_terminal_local_origin_gate.py
+++ b/tests/test_cvd3_terminal_local_origin_gate.py
@@ -51,6 +51,7 @@ def _no_auth(monkeypatch):
     monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
     monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
     monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", raising=False)
 
 
 # --------------------------------------------------------------------------
@@ -109,6 +110,60 @@ def test_terminal_gate_honors_onboarding_open_escape_hatch(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_ONBOARDING_OPEN", "1")
     handler = _Handler(client_ip="8.8.8.8", headers={})
     assert routes._embedded_terminal_gate_allows(handler) is True
+
+
+def test_terminal_gate_blocks_public_client_behind_trusted_proxy_chain(monkeypatch):
+    """Trusted XFF mode must resolve the original client, not the private proxy hop."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    handler = _Handler(
+        client_ip="10.0.0.10",
+        headers={"X-Forwarded-For": "8.8.8.8, 10.0.0.10"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == "8.8.8.8"
+    assert routes._embedded_terminal_gate_allows(handler) is False
+
+
+def test_terminal_gate_allows_private_client_behind_trusted_proxy_chain(monkeypatch):
+    """Trusted proxy mode still admits real private clients after XFF resolution."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    handler = _Handler(
+        client_ip="10.0.0.10",
+        headers={"X-Forwarded-For": "192.168.1.50, 10.0.0.10"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == "192.168.1.50"
+    assert routes._embedded_terminal_gate_allows(handler) is True
+
+
+def test_terminal_gate_does_not_trust_forwarded_header_from_unlisted_proxy(monkeypatch):
+    """Opting into XFF is not enough; the immediate proxy must also be trusted."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "192.168.0.0/16")
+
+    handler = _Handler(
+        client_ip="10.0.0.10",
+        headers={"X-Forwarded-For": "127.0.0.1"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == ""
+    assert routes._embedded_terminal_gate_allows(handler) is False
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_cvd3_terminal_local_origin_gate.py
+++ b/tests/test_cvd3_terminal_local_origin_gate.py
@@ -184,6 +184,42 @@ def test_terminal_gate_does_not_trust_x_real_ip_without_forwarded_chain(monkeypa
     assert routes._embedded_terminal_gate_allows(handler) is False
 
 
+def test_terminal_gate_blocks_public_client_with_trailing_loopback_hop(monkeypatch):
+    """Loopback proxy hops are trusted hops and must not become the resolved client."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"X-Forwarded-For": "8.8.8.8, 127.0.0.1"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == "8.8.8.8"
+    assert routes._embedded_terminal_gate_allows(handler) is False
+
+
+def test_terminal_gate_allows_loopback_proxy_when_cidrs_are_configured(monkeypatch):
+    """Configuring trusted proxy CIDRs must not stop trusting the local proxy peer."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"X-Forwarded-For": "192.168.1.50"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == "192.168.1.50"
+    assert routes._embedded_terminal_gate_allows(handler) is True
+
+
 def test_terminal_gate_allows_ipv4_mapped_loopback_proxy(monkeypatch):
     """IPv4-mapped loopback peers should be treated as loopback proxies."""
     from api import routes

--- a/tests/test_cvd3_terminal_local_origin_gate.py
+++ b/tests/test_cvd3_terminal_local_origin_gate.py
@@ -184,6 +184,41 @@ def test_terminal_gate_does_not_trust_x_real_ip_without_forwarded_chain(monkeypa
     assert routes._embedded_terminal_gate_allows(handler) is False
 
 
+def test_terminal_gate_fails_closed_on_x_real_ip_only_loopback_proxy(monkeypatch):
+    """A loopback proxy must not make an X-Real-IP-only public client look local."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"X-Real-IP": "8.8.8.8"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == ""
+    assert routes._embedded_terminal_gate_allows(handler) is False
+
+
+def test_terminal_gate_fails_closed_on_forwarded_only_loopback_proxy(monkeypatch):
+    """RFC Forwarded without XFF also indicates a proxy chain we cannot classify."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"Forwarded": "for=8.8.8.8;proto=https"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == ""
+    assert routes._embedded_terminal_gate_allows(handler) is False
+
+
 def test_terminal_gate_blocks_public_client_with_trailing_loopback_hop(monkeypatch):
     """Loopback proxy hops are trusted hops and must not become the resolved client."""
     from api import routes

--- a/tests/test_cvd3_terminal_local_origin_gate.py
+++ b/tests/test_cvd3_terminal_local_origin_gate.py
@@ -166,6 +166,42 @@ def test_terminal_gate_does_not_trust_forwarded_header_from_unlisted_proxy(monke
     assert routes._embedded_terminal_gate_allows(handler) is False
 
 
+def test_terminal_gate_does_not_trust_x_real_ip_without_forwarded_chain(monkeypatch):
+    """X-Real-IP alone may be client-controlled; trusted non-loopback proxies need XFF."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+
+    handler = _Handler(
+        client_ip="10.0.0.10",
+        headers={"X-Real-IP": "127.0.0.1"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == ""
+    assert routes._embedded_terminal_gate_allows(handler) is False
+
+
+def test_terminal_gate_allows_ipv4_mapped_loopback_proxy(monkeypatch):
+    """IPv4-mapped loopback peers should be treated as loopback proxies."""
+    from api import routes
+
+    monkeypatch.setattr("api.auth.is_auth_enabled", lambda: False)
+    monkeypatch.delenv("HERMES_WEBUI_ONBOARDING_OPEN", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.delenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", raising=False)
+
+    handler = _Handler(
+        client_ip="::ffff:127.0.0.1",
+        headers={"X-Forwarded-For": "192.168.1.50"},
+    )
+
+    assert routes._forwarded_client_ip_from_trusted_proxy(handler) == "192.168.1.50"
+    assert routes._embedded_terminal_gate_allows(handler) is True
+
+
 # --------------------------------------------------------------------------
 # Handler dispatch — the RCE-bearing endpoints refuse public clients (403)
 # without ever reaching the PTY-spawning code.

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -83,6 +83,32 @@ def test_onboarding_trusted_forwarded_for_uses_original_non_proxy_ip(monkeypatch
     assert routes._onboarding_request_is_local(handler) is False
 
 
+def test_onboarding_trusted_forwarded_for_skips_trailing_loopback_hop(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"X-Forwarded-For": "8.8.8.8, 127.0.0.1"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is False
+
+
+def test_onboarding_trusts_loopback_peer_even_when_cidrs_are_configured(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"X-Forwarded-For": "192.168.1.50"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is True
+
+
 def test_docker_env_log_obfuscates_password_and_secret_names():
     src = Path("docker_init.bash").read_text(encoding="utf-8")
     line = next(l for l in src.splitlines() if l.startswith("export ENV_OBFUSCATE_PART="))

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -109,6 +109,31 @@ def test_onboarding_trusts_loopback_peer_even_when_cidrs_are_configured(monkeypa
     assert routes._onboarding_request_is_local(handler) is True
 
 
+def test_onboarding_fails_closed_on_x_real_ip_only_loopback_proxy(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"X-Real-IP": "8.8.8.8"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is False
+
+
+def test_onboarding_fails_closed_on_forwarded_only_loopback_proxy(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    handler = _Handler(
+        client_ip="127.0.0.1",
+        headers={"Forwarded": "for=8.8.8.8;proto=https"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is False
+
+
 def test_docker_env_log_obfuscates_password_and_secret_names():
     src = Path("docker_init.bash").read_text(encoding="utf-8")
     line = next(l for l in src.splitlines() if l.startswith("export ENV_OBFUSCATE_PART="))

--- a/tests/test_security_review_fixes.py
+++ b/tests/test_security_review_fixes.py
@@ -44,25 +44,40 @@ def test_onboarding_local_gate_ignores_forwarded_ip_unless_trusted(monkeypatch):
     assert routes._onboarding_request_is_local(handler) is False
 
 
-def test_onboarding_local_gate_uses_forwarded_ip_when_explicitly_trusted(monkeypatch):
+def test_onboarding_local_gate_rejects_forwarded_ip_from_untrusted_peer(monkeypatch):
     from api import routes
 
     monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.delenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", raising=False)
     handler = _Handler(
         client_ip="8.8.8.8",
         headers={"X-Forwarded-For": "10.0.0.2", "X-Real-IP": "203.0.113.11"},
     )
 
-    assert routes._onboarding_request_is_local(handler) is True
+    assert routes._onboarding_request_is_local(handler) is False
 
 
-def test_onboarding_trusted_forwarded_for_uses_proxy_appended_rightmost_ip(monkeypatch):
+def test_onboarding_local_gate_uses_forwarded_ip_from_trusted_proxy(monkeypatch):
     from api import routes
 
     monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
     handler = _Handler(
         client_ip="10.0.0.10",
-        headers={"X-Forwarded-For": "127.0.0.1, 8.8.8.8"},
+        headers={"X-Forwarded-For": "10.0.0.2, 10.0.0.10"},
+    )
+
+    assert routes._onboarding_request_is_local(handler) is True
+
+
+def test_onboarding_trusted_forwarded_for_uses_original_non_proxy_ip(monkeypatch):
+    from api import routes
+
+    monkeypatch.setenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", "1")
+    monkeypatch.setenv("HERMES_WEBUI_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    handler = _Handler(
+        client_ip="10.0.0.10",
+        headers={"X-Forwarded-For": "8.8.8.8, 10.0.0.10"},
     )
 
     assert routes._onboarding_request_is_local(handler) is False


### PR DESCRIPTION
## Summary
This PR hardens the unauthenticated local/private gate used by the embedded-terminal endpoints when trusted forwarded headers are enabled.

- Resolves the original client from `X-Forwarded-For` instead of classifying the rightmost/private proxy hop as the client.
- Adds an explicit `HERMES_WEBUI_TRUSTED_PROXY_CIDRS` allowlist for trusted reverse proxies.
- Keeps passwordless embedded-terminal access blocked for public clients forwarded through a private proxy.
- Adds regression coverage for public-client, private-client, and unlisted-proxy XFF chains.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Trusted `X-Forwarded-For` chain used the private proxy hop for locality | A passwordless WebUI behind a trusted reverse proxy could treat a public remote client as local/private and admit embedded-terminal endpoints that drive a PTY shell | Critical for affected deployments |

## Before this PR
- `HERMES_WEBUI_TRUST_FORWARDED_FOR=1` made `_onboarding_request_is_local()` inspect the rightmost `X-Forwarded-For` value first.
- In common proxy chains such as `X-Forwarded-For: <public-client>, <private-proxy>`, the rightmost hop is the private proxy, not the original client.
- The embedded-terminal gate reuses this locality check, so a public client forwarded by a private proxy could pass the passwordless terminal gate.

## After this PR
- Forwarded headers are honored only when the immediate socket peer is loopback or listed in `HERMES_WEBUI_TRUSTED_PROXY_CIDRS`.
- The trusted chain is walked from right to left and the first non-trusted hop is classified as the client.
- A public original client remains blocked even when the proxy hop is private.
- Tests cover public-client, private-client, and spoofed/unlisted-proxy chains.

## Explicit operator choice
Secure default behavior:

```bash
# unset by default
HERMES_WEBUI_TRUST_FORWARDED_FOR=
HERMES_WEBUI_TRUSTED_PROXY_CIDRS=
```

Forwarded headers are ignored unless the operator explicitly opts in.

Trusted reverse-proxy behavior:

```bash
HERMES_WEBUI_TRUST_FORWARDED_FOR=1
HERMES_WEBUI_TRUSTED_PROXY_CIDRS=10.0.0.0/8,192.168.0.0/16
```

In this mode, the WebUI trusts forwarded client IPs only from loopback or listed proxy networks and classifies the original non-proxy hop.

## Why this matters
The embedded terminal spawns and drives a shell as the WebUI server user. When authentication is disabled, the terminal routes rely on the local/private gate as the remaining admission boundary. A trusted-proxy deployment should not classify a public user as local only because the final proxy hop is private.

## How this differs from related issue/PR
Existing terminal hardening added a local-origin gate for embedded-terminal endpoints when authentication is disabled.

This PR fixes a remaining bypass of that gate in trusted forwarded-header mode: the gate existed, but the client-IP extraction could use the proxy hop instead of the original client.

## Attack flow

```text
public remote client
    -> trusted reverse proxy adds X-Forwarded-For: public-client, private-proxy
        -> WebUI trusted-forwarded mode reads the private proxy hop as local
            -> embedded-terminal gate admits the request
                -> unauthenticated caller can reach PTY-backed terminal endpoints
```

## Affected code

| Issue | Files |
|-------|-------|
| Trusted XFF terminal locality bypass | `api/routes.py`, `tests/test_cvd3_terminal_local_origin_gate.py`, `tests/test_security_review_fixes.py` |

## Root cause
Trusted XFF terminal locality bypass:
- The previous trusted-forwarded-header branch inspected the rightmost `X-Forwarded-For` hop first.
- In normal proxy chains, that hop is commonly the private proxy, so the local/private decision could be made on the proxy rather than the original client.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Trusted XFF terminal locality bypass | 9.8 Critical for affected deployments | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` |

Rationale:
- The score assumes a passwordless WebUI exposed through a reverse proxy with `HERMES_WEBUI_TRUST_FORWARDED_FOR=1`. Under those conditions, a remote unauthenticated client can reach a PTY-backed terminal route that runs commands as the WebUI process user.

## Safe reproduction steps
1. Configure a passwordless WebUI behind a trusted reverse proxy.
2. Enable forwarded-header trust with `HERMES_WEBUI_TRUST_FORWARDED_FOR=1`.
3. Send a terminal request with a common proxy chain shape:
   ```http
   X-Forwarded-For: 8.8.8.8, 10.0.0.10
   ```
   where `10.0.0.10` is the private proxy hop.
4. Before this PR, the local/private decision could be made on `10.0.0.10`.
5. After this PR, the chain resolves to `8.8.8.8` and the terminal gate denies the request.

## Expected vulnerable behavior
- A public remote client should not be considered local because the final reverse-proxy hop is private.
- The pre-patch behavior could classify the rightmost proxy hop as local/private.
- The regression test asserts the resolved client is the public hop and terminal access is denied.

## Changes in this PR
- Adds trusted-proxy CIDR parsing through `HERMES_WEBUI_TRUSTED_PROXY_CIDRS`.
- Adds shared IP helpers for local/private and trusted-network checks.
- Resolves forwarded clients by walking `X-Forwarded-For` from right to left and stopping at the first non-trusted hop.
- Keeps forwarded headers denied when the immediate proxy is not loopback or explicitly trusted.
- Adds focused terminal-gate regression tests for proxy-chain behavior.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Backend security gate | `api/routes.py` | Trusted forwarded-header client resolution now requires a trusted proxy and resolves the original non-proxy client |
| Regression tests | `tests/test_cvd3_terminal_local_origin_gate.py`, `tests/test_security_review_fixes.py` | Added public/private/unlisted proxy chain coverage and updated forwarded-header locality expectations |

## Maintainer impact
- The patch is limited to the existing onboarding/embedded-terminal locality gate.
- Authentication-enabled deployments are unchanged because `check_auth()` still admits only authenticated sessions before terminal handlers run.
- Passwordless deployments that intentionally rely on a LAN/reverse proxy can keep forwarded-header support by listing the trusted proxy CIDRs.

## Fix rationale
- The locality decision belongs at the boundary that admits passwordless onboarding and embedded-terminal requests.
- Walking the trusted proxy chain avoids trusting a spoofable left-hand client value while also avoiding the previous rightmost-proxy classification bug.
- The regression tests pin both blocked public-client and allowed private-client behavior.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Focused terminal locality tests
- [x] Diff-scoped Python lint
- [x] Syntax compilation for touched Python files

Executed with:
- `./scripts/test.sh tests/test_cvd3_terminal_local_origin_gate.py tests/test_security_review_fixes.py`
- `python3 scripts/ruff_lint.py --diff origin/master`
- `python3 -m compileall -q api/routes.py tests/test_cvd3_terminal_local_origin_gate.py tests/test_security_review_fixes.py`
- `git diff --check`

## Disclosure notes
- Claims are bounded to passwordless deployments that explicitly enable trusted forwarded headers and expose the WebUI through a reverse proxy.
- No production systems or real credentials were used.
- No unrelated files were changed.

## AI Usage Disclosure
AI assistance was used to identify the boundary, draft the patch, and write regression tests. The submitted change is scoped to the files and validation listed above.