### PR TITLE
[security] fix(models): stop credentialed live-model redirects

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1258,6 +1258,26 @@ def _get_anthropic_fallback_env_vars() -> tuple[str, ...]:
         return fallback
 
 
+_AGENT_CREDENTIAL_ENV_NAMES_BY_PROVIDER = {
+    "anthropic": _get_anthropic_fallback_env_vars(),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "gmi": ("GMI_API_KEY",),
+    "lmstudio": ("LM_API_KEY", "LMSTUDIO_API_KEY"),
+    "minimax": ("MINIMAX_API_KEY",),
+    "mistralai": ("MISTRAL_API_KEY",),
+    "nvidia": ("NVIDIA_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "openai-api": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "stepfun": ("STEPFUN_API_KEY",),
+    "xai": ("XAI_API_KEY",),
+    "zai": ("ZAI_API_KEY", "GLM_API_KEY"),
+}
+
+_AGENT_ALWAYS_SKIP_PROVIDER_MODEL_IDS_PROVIDERS = frozenset({"copilot", "copilot-acp", "nous"})
+
+
 def _resolve_provider_alias(name: str) -> str:
     """Return the canonical provider slug for *name*.
 
@@ -5637,19 +5657,10 @@ def _configured_provider_api_key_for_live_probe(provider_id: str) -> str:
             if key:
                 return key
 
-    env_names_by_provider = {
-        "anthropic": _get_anthropic_fallback_env_vars(),
-        "deepseek": ("DEEPSEEK_API_KEY",),
-        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-        "lmstudio": ("LM_API_KEY", "LMSTUDIO_API_KEY"),
-        "minimax": ("MINIMAX_API_KEY",),
-        "mistralai": ("MISTRAL_API_KEY",),
-        "nvidia": ("NVIDIA_API_KEY",),
-        "openrouter": ("OPENROUTER_API_KEY",),
-        "xai": ("XAI_API_KEY",),
-        "zai": ("ZAI_API_KEY", "GLM_API_KEY"),
-    }
-    for env_name in env_names_by_provider.get(provider, ()):  # pragma: no branch - tiny tuple
+    for env_name in _AGENT_CREDENTIAL_ENV_NAMES_BY_PROVIDER.get(
+        provider,
+        (),
+    ):  # pragma: no branch - tiny tuple
         key = str(os.getenv(env_name) or "").strip()
         if key:
             return key
@@ -5670,7 +5681,10 @@ def _read_live_provider_model_ids(provider_id: str) -> list[str]:
     if not pid:
         return []
     resolved_pid = _resolve_provider_alias(pid)
-    if resolved_pid == "copilot" or _configured_provider_api_key_for_live_probe(resolved_pid):
+    if (
+        resolved_pid in _AGENT_ALWAYS_SKIP_PROVIDER_MODEL_IDS_PROVIDERS
+        or _configured_provider_api_key_for_live_probe(resolved_pid)
+    ):
         # Credentialed provider_model_ids() calls live endpoints inside
         # hermes_cli, where WebUI cannot enforce no-redirect transport. Fall
         # back to WebUI-owned static/direct discovery unless the probe is known

--- a/api/config.py
+++ b/api/config.py
@@ -3288,15 +3288,34 @@ def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     """urllib redirect handler that refuses to follow any redirect.
 
-    Used by the LM Studio reasoning probe so a 3xx from the probe URL can never
-    forward the ``Authorization`` header (the configured LM Studio key) to a
-    redirected, possibly attacker-controlled host. ``redirect_request``
-    returning ``None`` makes urllib raise the original 3xx as an ``HTTPError``,
-    which the probe swallows. (#3837 security review)
+    Used by credentialed model probes so a 3xx from the probe URL can never
+    forward the ``Authorization`` header to a redirected, possibly
+    attacker-controlled host. ``redirect_request`` returning ``None`` makes
+    urllib raise the original 3xx as an ``HTTPError``, which callers swallow and
+    treat as an unavailable live catalog. (#3837 security review)
     """
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
+
+
+def _credentialed_json_get_no_redirect(
+    url: str,
+    headers: dict[str, str],
+    *,
+    timeout: float,
+):
+    """Fetch credentialed model-discovery JSON without following redirects.
+
+    ``urllib.request.urlopen`` follows redirects and can re-send request headers
+    such as ``Authorization`` to the redirect target. All WebUI-owned model
+    discovery paths that attach provider credentials should use this helper so a
+    3xx fails closed while preserving urllib's default proxy handling.
+    """
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    with opener.open(request, timeout=timeout) as response:  # nosec B310
+        return json.loads(response.read().decode("utf-8", errors="replace"))
 
 
 def _get_lmstudio_reasoning_probe_api_key() -> str | None:
@@ -5599,6 +5618,44 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
     )
 
 
+def _configured_provider_api_key_for_live_probe(provider_id: str) -> str:
+    """Return a visible provider credential that would make live probes credentialed."""
+    provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
+    if not provider:
+        return ""
+
+    provider_cfg = _get_provider_cfg(provider)
+    key = str(provider_cfg.get("api_key") or "").strip()
+    if key:
+        return key
+
+    model_cfg = cfg.get("model") or {}
+    if isinstance(model_cfg, dict):
+        active_provider = _resolve_provider_alias(str(model_cfg.get("provider") or "").strip().lower())
+        if active_provider == provider:
+            key = str(model_cfg.get("api_key") or "").strip()
+            if key:
+                return key
+
+    env_names_by_provider = {
+        "anthropic": _get_anthropic_fallback_env_vars(),
+        "deepseek": ("DEEPSEEK_API_KEY",),
+        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "lmstudio": ("LM_API_KEY", "LMSTUDIO_API_KEY"),
+        "minimax": ("MINIMAX_API_KEY",),
+        "mistralai": ("MISTRAL_API_KEY",),
+        "nvidia": ("NVIDIA_API_KEY",),
+        "openrouter": ("OPENROUTER_API_KEY",),
+        "xai": ("XAI_API_KEY",),
+        "zai": ("ZAI_API_KEY", "GLM_API_KEY"),
+    }
+    for env_name in env_names_by_provider.get(provider, ()):  # pragma: no branch - tiny tuple
+        key = str(os.getenv(env_name) or "").strip()
+        if key:
+            return key
+    return ""
+
+
 def _read_live_provider_model_ids(provider_id: str) -> list[str]:
     """Return live model IDs from Hermes CLI for a provider, or [] on failure.
 
@@ -5611,6 +5668,13 @@ def _read_live_provider_model_ids(provider_id: str) -> list[str]:
     """
     pid = str(provider_id or "").strip()
     if not pid:
+        return []
+    resolved_pid = _resolve_provider_alias(pid)
+    if resolved_pid == "copilot" or _configured_provider_api_key_for_live_probe(resolved_pid):
+        # Credentialed provider_model_ids() calls live endpoints inside
+        # hermes_cli, where WebUI cannot enforce no-redirect transport. Fall
+        # back to WebUI-owned static/direct discovery unless the probe is known
+        # to be keyless.
         return []
     try:
         from hermes_cli.models import provider_model_ids as _provider_model_ids
@@ -6303,7 +6367,6 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             try:
                 import ipaddress
                 import urllib.error
-                import urllib.request
                 import socket
 
                 endpoint_url = _models_endpoint_for_base_url(base)
@@ -6342,12 +6405,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     except socket.gaierror:
                         pass
 
-                req = urllib.request.Request(endpoint_url, method="GET")
-                req.add_header("User-Agent", "OpenAI/Python 1.0")
-                for k, v in headers.items():
-                    req.add_header(k, v)
-                with urllib.request.urlopen(req, timeout=CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS) as response:  # nosec B310
-                    data = json.loads(response.read().decode("utf-8"))
+                headers = {"User-Agent": "OpenAI/Python 1.0", **headers}
+                data = _credentialed_json_get_no_redirect(
+                    endpoint_url,
+                    headers,
+                    timeout=CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS,
+                )
                 return _extract_model_entries_from_payload(data, provider), None
             except urllib.error.HTTPError as exc:
                 error = _custom_endpoint_error(provider, exc, code=getattr(exc, "code", None))
@@ -6951,10 +7014,7 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                                 headers["Authorization"] = f"Bearer {lm_api_key}"
                             endpoint = (lm_base_url + "/models").rstrip("/")
                             try:
-                                import urllib.request as _urlreq
-                                req = _urlreq.Request(endpoint, method="GET", headers=headers)
-                                with _urlreq.urlopen(req, timeout=5) as resp:
-                                    lm_data = json.loads(resp.read().decode())
+                                lm_data = _credentialed_json_get_no_redirect(endpoint, headers, timeout=5)
                                 for m in (lm_data.get("data") or []):
                                     if isinstance(m, dict):
                                         mid = str(m.get("id") or "").strip()

--- a/api/routes.py
+++ b/api/routes.py
@@ -18224,6 +18224,25 @@ def _handle_clarify_inject(handler, parsed):
     return j(handler, {"error": "session_id required"}, status=400)
 
 
+def _credentialed_json_get_no_redirect(url: str, headers: dict[str, str], *, timeout: float):
+    """Fetch JSON for credentialed provider probes without following redirects.
+
+    ``urllib.request.urlopen`` preserves request headers across redirects.  Model
+    discovery attaches provider credentials, so a 3xx from the configured models
+    endpoint must fail closed instead of forwarding ``Authorization`` to the
+    redirect target.
+    """
+
+    class _NoRedirectProviderProbeHandler(HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    req = Request(url, headers=headers)
+    opener = build_opener(ProxyHandler({}), _NoRedirectProviderProbeHandler())
+    with opener.open(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
 def _handle_live_models(handler, parsed):
     """Return the live model list for a provider.
 
@@ -18405,13 +18424,11 @@ def _handle_live_models(handler, parsed):
                         else:
                             _models_url = f"{_ep}/v1/models"
                         
-                        _req = urllib.request.Request(
+                        _body = _credentialed_json_get_no_redirect(
                             _models_url,
-                            headers={"Authorization": f"Bearer {_api_key}"},
+                            {"Authorization": f"Bearer {_api_key}"},
+                            timeout=CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS,
                         )
-                        
-                        with urllib.request.urlopen(_req, timeout=CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS) as _resp:
-                            _body = json.loads(_resp.read())
                         
                         # Parse response: {"data": [{"id": "model1", ...}, ...]}
                         if isinstance(_body, dict):
@@ -18471,12 +18488,11 @@ def _handle_live_models(handler, parsed):
                             if _active_provider == provider:
                                 _key = _model_cfg.get("api_key")
                     if _key:
-                        _req = urllib.request.Request(
+                        _body = _credentialed_json_get_no_redirect(
                             f"{_ep}/models",
-                            headers={"Authorization": f"Bearer {_key}"},
+                            {"Authorization": f"Bearer {_key}"},
+                            timeout=8,
                         )
-                        with urllib.request.urlopen(_req, timeout=8) as _resp:
-                            _body = json.loads(_resp.read())
                         ids = [m.get("id", "") for m in _body.get("data", []) if m.get("id")]
                         logger.debug("Live-fetched %d models from %s /v1/models", len(ids), provider)
                 except Exception as _fetch_err:

--- a/api/routes.py
+++ b/api/routes.py
@@ -18238,7 +18238,7 @@ def _credentialed_json_get_no_redirect(url: str, headers: dict[str, str], *, tim
             return None
 
     req = Request(url, headers=headers)
-    opener = build_opener(ProxyHandler({}), _NoRedirectProviderProbeHandler())
+    opener = build_opener(_NoRedirectProviderProbeHandler())
     with opener.open(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -18265,18 +18265,29 @@ def _configured_provider_api_key_for_live_probe(provider: str, cfg: dict) -> str
             if key:
                 return key
 
-    env_names_by_provider = {
-        "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
-        "deepseek": ("DEEPSEEK_API_KEY",),
-        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-        "minimax": ("MINIMAX_API_KEY",),
-        "mistralai": ("MISTRAL_API_KEY",),
-        "nvidia": ("NVIDIA_API_KEY",),
-        "openrouter": ("OPENROUTER_API_KEY",),
-        "xai": ("XAI_API_KEY",),
-        "zai": ("ZAI_API_KEY", "GLM_API_KEY"),
-    }
-    for env_name in env_names_by_provider.get(provider, ()):  # pragma: no branch - tiny tuple
+    try:
+        from api.config import _AGENT_CREDENTIAL_ENV_NAMES_BY_PROVIDER
+    except Exception:
+        _AGENT_CREDENTIAL_ENV_NAMES_BY_PROVIDER = {
+            "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+            "deepseek": ("DEEPSEEK_API_KEY",),
+            "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+            "gmi": ("GMI_API_KEY",),
+            "lmstudio": ("LM_API_KEY", "LMSTUDIO_API_KEY"),
+            "minimax": ("MINIMAX_API_KEY",),
+            "mistralai": ("MISTRAL_API_KEY",),
+            "nvidia": ("NVIDIA_API_KEY",),
+            "openai": ("OPENAI_API_KEY",),
+            "openai-api": ("OPENAI_API_KEY",),
+            "openrouter": ("OPENROUTER_API_KEY",),
+            "stepfun": ("STEPFUN_API_KEY",),
+            "xai": ("XAI_API_KEY",),
+            "zai": ("ZAI_API_KEY", "GLM_API_KEY"),
+        }
+    for env_name in _AGENT_CREDENTIAL_ENV_NAMES_BY_PROVIDER.get(
+        provider,
+        (),
+    ):  # pragma: no branch - tiny tuple
         key = str(os.getenv(env_name) or "").strip()
         if key:
             return key
@@ -18285,9 +18296,14 @@ def _configured_provider_api_key_for_live_probe(provider: str, cfg: dict) -> str
 
 def _should_skip_agent_provider_model_ids(provider: str, cfg: dict) -> bool:
     """Avoid agent live probes when they may attach credentials we cannot redirect-harden."""
-    if provider == "copilot":
-        # Copilot discovery is OAuth-backed inside hermes_cli; WebUI cannot wrap
-        # those urllib calls with a no-redirect opener, so fall back locally.
+    try:
+        from api.config import _AGENT_ALWAYS_SKIP_PROVIDER_MODEL_IDS_PROVIDERS
+    except Exception:
+        _AGENT_ALWAYS_SKIP_PROVIDER_MODEL_IDS_PROVIDERS = frozenset({"copilot", "copilot-acp", "nous"})
+    if provider in _AGENT_ALWAYS_SKIP_PROVIDER_MODEL_IDS_PROVIDERS:
+        # These providers can resolve OAuth/token-pool credentials inside
+        # hermes_cli; WebUI cannot wrap those urllib calls with a no-redirect
+        # opener, so fall back locally.
         return True
     return bool(_configured_provider_api_key_for_live_probe(provider, cfg))
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -18243,6 +18243,55 @@ def _credentialed_json_get_no_redirect(url: str, headers: dict[str, str], *, tim
         return json.loads(resp.read())
 
 
+def _configured_provider_api_key_for_live_probe(provider: str, cfg: dict) -> str:
+    """Return a configured key for provider live discovery, if WebUI can see one."""
+    providers_cfg = cfg.get("providers") or {}
+    provider_cfg = providers_cfg.get(provider, {}) if isinstance(providers_cfg, dict) else {}
+    if isinstance(provider_cfg, dict):
+        key = str(provider_cfg.get("api_key") or "").strip()
+        if key:
+            return key
+
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        try:
+            from api.config import _resolve_provider_alias as _resolve_live_provider_alias
+
+            active_provider = _resolve_live_provider_alias(str(model_cfg.get("provider") or "").strip().lower())
+        except Exception:
+            active_provider = str(model_cfg.get("provider") or "").strip().lower()
+        if active_provider == provider:
+            key = str(model_cfg.get("api_key") or "").strip()
+            if key:
+                return key
+
+    env_names_by_provider = {
+        "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        "deepseek": ("DEEPSEEK_API_KEY",),
+        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "minimax": ("MINIMAX_API_KEY",),
+        "mistralai": ("MISTRAL_API_KEY",),
+        "nvidia": ("NVIDIA_API_KEY",),
+        "openrouter": ("OPENROUTER_API_KEY",),
+        "xai": ("XAI_API_KEY",),
+        "zai": ("ZAI_API_KEY", "GLM_API_KEY"),
+    }
+    for env_name in env_names_by_provider.get(provider, ()):  # pragma: no branch - tiny tuple
+        key = str(os.getenv(env_name) or "").strip()
+        if key:
+            return key
+    return ""
+
+
+def _should_skip_agent_provider_model_ids(provider: str, cfg: dict) -> bool:
+    """Avoid agent live probes when they may attach credentials we cannot redirect-harden."""
+    if provider == "copilot":
+        # Copilot discovery is OAuth-backed inside hermes_cli; WebUI cannot wrap
+        # those urllib calls with a no-redirect opener, so fall back locally.
+        return True
+    return bool(_configured_provider_api_key_for_live_probe(provider, cfg))
+
+
 def _handle_live_models(handler, parsed):
     """Return the live model list for a provider.
 
@@ -18293,19 +18342,20 @@ def _handle_live_models(handler, parsed):
         # Delegate to the agent's live-fetch + fallback resolver.
         # provider_model_ids() tries live endpoints first and falls back to
         # the static _PROVIDER_MODELS list — it never raises.
-        try:
-            import sys as _sys
-            import os as _os
-            _agent_dir = _os.path.join(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))),
-                                       "..", "..", ".hermes", "hermes-agent")
-            _agent_dir = _os.path.normpath(_agent_dir)
-            if _agent_dir not in _sys.path:
-                _sys.path.insert(0, _agent_dir)
-            from hermes_cli.models import provider_model_ids as _pmi
-            ids = _pmi(provider)
-        except Exception as _import_err:
-            logger.debug("provider_model_ids import failed for %s: %s", provider, _import_err)
-            ids = []
+        ids = []
+        if not _should_skip_agent_provider_model_ids(provider, cfg):
+            try:
+                import sys as _sys
+                import os as _os
+                _agent_dir = _os.path.join(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))),
+                                           "..", "..", ".hermes", "hermes-agent")
+                _agent_dir = _os.path.normpath(_agent_dir)
+                if _agent_dir not in _sys.path:
+                    _sys.path.insert(0, _agent_dir)
+                from hermes_cli.models import provider_model_ids as _pmi
+                ids = _pmi(provider)
+            except Exception as _import_err:
+                logger.debug("provider_model_ids import failed for %s: %s", provider, _import_err)
 
         if not ids:
             custom_provider_entry = None

--- a/tests/test_byok_model_dropdown.py
+++ b/tests/test_byok_model_dropdown.py
@@ -328,30 +328,17 @@ class TestLiveModelsCustomProviderFallback:
 
     def test_named_custom_live_fetch_uses_matching_entry_endpoint(self, monkeypatch):
         """custom:<slug> live fetch must use that entry, not the active model config."""
-        import json
-        import urllib.request
-
         requests = []
 
-        class Response:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def read(self):
-                return json.dumps({"data": [{"id": "right-live-model"}]}).encode("utf-8")
-
-        def fake_urlopen(req, timeout=None):
+        def fake_credentialed_json_get_no_redirect(url, headers, *, timeout):
             requests.append(
                 {
-                    "url": req.full_url,
-                    "authorization": req.headers.get("Authorization"),
+                    "url": url,
+                    "authorization": headers.get("Authorization"),
                     "timeout": timeout,
                 }
             )
-            return Response()
+            return {"data": [{"id": "right-live-model"}]}
 
         cfg = {
             "model": {
@@ -372,7 +359,9 @@ class TestLiveModelsCustomProviderFallback:
                 },
             ],
         }
-        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        import api.routes as r
+
+        monkeypatch.setattr(r, "_credentialed_json_get_no_redirect", fake_credentialed_json_get_no_redirect)
 
         resp = self._call_live_models(monkeypatch, cfg, "custom:rightcode-codex")
 
@@ -387,15 +376,13 @@ class TestLiveModelsCustomProviderFallback:
 
     def test_standard_provider_live_fetch_does_not_reuse_active_provider_key(self, monkeypatch):
         """A requested provider must not receive another provider's top-level key."""
-        import urllib.request
-
         requests = []
 
-        def fake_urlopen(req, timeout=None):
+        def fake_credentialed_json_get_no_redirect(url, headers, *, timeout):
             requests.append(
                 {
-                    "url": req.full_url,
-                    "authorization": req.headers.get("Authorization"),
+                    "url": url,
+                    "authorization": headers.get("Authorization"),
                     "timeout": timeout,
                 }
             )
@@ -408,7 +395,9 @@ class TestLiveModelsCustomProviderFallback:
             },
             "providers": {"mistralai": {}},
         }
-        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        import api.routes as r
+
+        monkeypatch.setattr(r, "_credentialed_json_get_no_redirect", fake_credentialed_json_get_no_redirect)
 
         resp = self._call_live_models(monkeypatch, cfg, "mistralai")
 
@@ -418,30 +407,17 @@ class TestLiveModelsCustomProviderFallback:
 
     def test_standard_provider_live_fetch_can_use_matching_top_level_key(self, monkeypatch):
         """The active provider's top-level key remains valid for that same provider."""
-        import json
-        import urllib.request
-
         requests = []
 
-        class Response:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def read(self):
-                return json.dumps({"data": [{"id": "mistral-live-model"}]}).encode("utf-8")
-
-        def fake_urlopen(req, timeout=None):
+        def fake_credentialed_json_get_no_redirect(url, headers, *, timeout):
             requests.append(
                 {
-                    "url": req.full_url,
-                    "authorization": req.headers.get("Authorization"),
+                    "url": url,
+                    "authorization": headers.get("Authorization"),
                     "timeout": timeout,
                 }
             )
-            return Response()
+            return {"data": [{"id": "mistral-live-model"}]}
 
         cfg = {
             "model": {
@@ -450,7 +426,9 @@ class TestLiveModelsCustomProviderFallback:
             },
             "providers": {"mistralai": {}},
         }
-        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        import api.routes as r
+
+        monkeypatch.setattr(r, "_credentialed_json_get_no_redirect", fake_credentialed_json_get_no_redirect)
 
         resp = self._call_live_models(monkeypatch, cfg, "mistralai")
 
@@ -465,30 +443,17 @@ class TestLiveModelsCustomProviderFallback:
 
     def test_standard_provider_live_fetch_allows_matching_active_provider_alias(self, monkeypatch):
         """Alias-equivalent active providers should still count as the same provider."""
-        import json
-        import urllib.request
-
         requests = []
 
-        class Response:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def read(self):
-                return json.dumps({"data": [{"id": "zai-live-model"}]}).encode("utf-8")
-
-        def fake_urlopen(req, timeout=None):
+        def fake_credentialed_json_get_no_redirect(url, headers, *, timeout):
             requests.append(
                 {
-                    "url": req.full_url,
-                    "authorization": req.headers.get("Authorization"),
+                    "url": url,
+                    "authorization": headers.get("Authorization"),
                     "timeout": timeout,
                 }
             )
-            return Response()
+            return {"data": [{"id": "zai-live-model"}]}
 
         cfg = {
             "model": {
@@ -500,7 +465,7 @@ class TestLiveModelsCustomProviderFallback:
         import api.config as c
         import api.routes as r
 
-        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(r, "_credentialed_json_get_no_redirect", fake_credentialed_json_get_no_redirect)
         monkeypatch.setattr(c, "get_config", lambda: cfg)
         monkeypatch.setattr(r, "j", lambda _handler, payload, **_kw: payload)
         self._install_provider_model_ids(monkeypatch, lambda _p: [])

--- a/tests/test_issue1527_lmstudio_base_url_classification.py
+++ b/tests/test_issue1527_lmstudio_base_url_classification.py
@@ -79,6 +79,14 @@ def _write_config(tmp_path, monkeypatch, text: str) -> None:
 
 
 def _mock_model_discovery(monkeypatch, model_ids: list[str], resolved_ip: str) -> None:
+    def _fake_credentialed_json_get_no_redirect(*_args, **_kwargs):
+        return {"data": [{"id": mid} for mid in model_ids]}
+
+    monkeypatch.setattr(
+        config,
+        "_credentialed_json_get_no_redirect",
+        _fake_credentialed_json_get_no_redirect,
+    )
     monkeypatch.setattr(
         urllib.request,
         "urlopen",

--- a/tests/test_issue2513_custom_provider_remote_models.py
+++ b/tests/test_issue2513_custom_provider_remote_models.py
@@ -1,50 +1,29 @@
-import json
-import urllib.request
-
 from api import config
 
 
 def test_custom_provider_model_field_does_not_block_remote_catalog(monkeypatch, tmp_path):
     """custom_providers[].model is sticky metadata, not the whole picker catalog."""
 
-    class FakeResponse:
-        def __init__(self, payload):
-            self.payload = payload
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def read(self):
-            return json.dumps(self.payload).encode("utf-8")
-
     calls = []
 
-    def fake_urlopen(req, timeout=10):
-        url = getattr(req, "full_url", str(req))
+    def fake_get(url, headers, *, timeout):
         calls.append(url)
         if "alpha.example" in url:
-            return FakeResponse(
-                {
-                    "data": [
-                        {"id": "alpha/sticky", "name": "Alpha Sticky"},
-                        {"id": "alpha/remote", "name": "Alpha Remote"},
-                    ]
-                }
-            )
+            return {
+                "data": [
+                    {"id": "alpha/sticky", "name": "Alpha Sticky"},
+                    {"id": "alpha/remote", "name": "Alpha Remote"},
+                ]
+            }
         if "beta.example" in url:
-            return FakeResponse(
-                {
-                    "models": [
-                        {"id": "beta/remote", "name": "Beta Remote"},
-                    ]
-                }
-            )
+            return {
+                "models": [
+                    {"id": "beta/remote", "name": "Beta Remote"},
+                ]
+            }
         raise AssertionError(f"unexpected urlopen: {url}")
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", fake_get)
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
     monkeypatch.setattr(config, "_get_auth_store_path", lambda: tmp_path / "auth.json")
 

--- a/tests/test_issue2540_models_endpoint_error.py
+++ b/tests/test_issue2540_models_endpoint_error.py
@@ -1,5 +1,4 @@
 import urllib.error
-import urllib.request
 from email.message import Message
 
 from api import config
@@ -12,6 +11,7 @@ class _ConfigState:
         self.old_cache = config._available_models_cache
         self.old_cache_ts = config._available_models_cache_ts
         self.old_cache_fp = config._available_models_cache_source_fingerprint
+        self.old_cache_build_in_progress = config._cache_build_in_progress
         self.old_live_budget = config._LIVE_REBUILD_BUDGET_SECONDS
         config._cfg_mtime = 0.0
         config._available_models_cache = None
@@ -21,6 +21,7 @@ class _ConfigState:
         # provider-catalog budget fallback. Force the synchronous rebuild path
         # so slower Python 3.11 shards cannot fall onto the global 4s fallback
         # and mask the endpoint-specific error contract under test.
+        config._cache_build_in_progress = False
         config._LIVE_REBUILD_BUDGET_SECONDS = 0.0
         return self
 
@@ -30,6 +31,7 @@ class _ConfigState:
         config._available_models_cache = self.old_cache
         config._available_models_cache_ts = self.old_cache_ts
         config._available_models_cache_source_fingerprint = self.old_cache_fp
+        config._cache_build_in_progress = self.old_cache_build_in_progress
         config._LIVE_REBUILD_BUDGET_SECONDS = self.old_live_budget
         return False
 
@@ -50,29 +52,48 @@ def _configure_named_custom_provider(tmp_path, monkeypatch, *, model=None):
         "fallback_providers": [],
         "custom_providers": [entry],
     }
+    try:
+        config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+    except Exception:
+        config._cfg_mtime = 0.0
+    config._cfg_path = config._get_config_path()
 
 
 def _groups_by_provider(data):
     return {group["provider_id"]: group for group in data["groups"]}
 
 
+def _get_available_models_for_endpoint_test():
+    data = config.get_available_models(force_refresh=True)
+    if "custom:broken-proxy" not in _groups_by_provider(data):
+        # Some preceding catalog tests can leave an out-of-band bounded rebuild
+        # publishing to the process-wide in-memory cache. Force one clean sync
+        # rebuild after clearing any late-published result so these endpoint
+        # error-shaping tests remain order-independent.
+        config.invalidate_models_cache()
+        data = config.get_available_models(force_refresh=True)
+    return data
+
+
 def test_named_custom_provider_models_endpoint_401_surfaces_error(monkeypatch, tmp_path):
-    def fake_urlopen(req, timeout=10):
+    def fake_models_endpoint(_url, _headers, *, timeout):
         raise urllib.error.HTTPError(
-            getattr(req, "full_url", "https://broken.example/v1/models"),
+            "https://broken.example/v1/models",
             401,
             "Unauthorized",
             hdrs=Message(),
             fp=None,
         )
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", fake_models_endpoint)
 
     with _ConfigState():
         _configure_named_custom_provider(tmp_path, monkeypatch, model="broken/manual")
-        data = config.get_available_models()
+        data = _get_available_models_for_endpoint_test()
 
-    group = _groups_by_provider(data)["custom:broken-proxy"]
+    groups = _groups_by_provider(data)
+    assert "custom:broken-proxy" in groups, groups
+    group = groups["custom:broken-proxy"]
     error = group["models_endpoint_error"]
     assert error["kind"] == "auth"
     assert error["code"] == 401
@@ -82,14 +103,14 @@ def test_named_custom_provider_models_endpoint_401_surfaces_error(monkeypatch, t
 
 
 def test_named_custom_provider_models_endpoint_network_error_surfaces_empty_group(monkeypatch, tmp_path):
-    def fake_urlopen(req, timeout=10):
+    def fake_models_endpoint(_url, _headers, *, timeout):
         raise urllib.error.URLError("connection refused")
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", fake_models_endpoint)
 
     with _ConfigState():
         _configure_named_custom_provider(tmp_path, monkeypatch)
-        data = config.get_available_models()
+        data = _get_available_models_for_endpoint_test()
 
     group = _groups_by_provider(data)["custom:broken-proxy"]
     assert group["models"] == []
@@ -99,20 +120,20 @@ def test_named_custom_provider_models_endpoint_network_error_surfaces_empty_grou
 
 
 def test_named_custom_provider_models_endpoint_5xx_preserves_status(monkeypatch, tmp_path):
-    def fake_urlopen(req, timeout=10):
+    def fake_models_endpoint(_url, _headers, *, timeout):
         raise urllib.error.HTTPError(
-            getattr(req, "full_url", "https://broken.example/v1/models"),
+            "https://broken.example/v1/models",
             502,
             "Bad Gateway",
             hdrs=Message(),
             fp=None,
         )
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", fake_models_endpoint)
 
     with _ConfigState():
         _configure_named_custom_provider(tmp_path, monkeypatch, model="broken/manual")
-        data = config.get_available_models()
+        data = _get_available_models_for_endpoint_test()
 
     error = _groups_by_provider(data)["custom:broken-proxy"]["models_endpoint_error"]
     assert error["kind"] == "http"
@@ -122,22 +143,18 @@ def test_named_custom_provider_models_endpoint_5xx_preserves_status(monkeypatch,
 def test_named_custom_provider_models_endpoint_network_error_uses_short_timeout(monkeypatch, tmp_path):
     observed_timeouts = []
 
-    def fake_urlopen(req, timeout=10):
-        # Only record timeouts for the broken-proxy custom endpoint — unrelated
-        # background probes (Copilot token fetch, OpenRouter free-tier discovery, etc.)
-        # also call urlopen during get_available_models() and would otherwise pollute
-        # the assertion. The contract we're pinning: the broken-proxy /v1/models call
-        # uses CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS, not the urllib default 10.
-        full_url = getattr(req, "full_url", "")
-        if "broken.example" in str(full_url):
+    def fake_models_endpoint(url, _headers, *, timeout):
+        # The contract we're pinning: the broken-proxy /v1/models call uses
+        # CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS, not the urllib default 10.
+        if "broken.example" in str(url):
             observed_timeouts.append(timeout)
         raise urllib.error.URLError("timed out")
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", fake_models_endpoint)
 
     with _ConfigState():
         _configure_named_custom_provider(tmp_path, monkeypatch)
-        data = config.get_available_models()
+        data = _get_available_models_for_endpoint_test()
 
     group = _groups_by_provider(data)["custom:broken-proxy"]
     assert group["models"] == []

--- a/tests/test_live_models_ttl_cache.py
+++ b/tests/test_live_models_ttl_cache.py
@@ -18,6 +18,8 @@ def _patch_live_models_basics(monkeypatch, routes, profile="default"):
     import api.config as config
     import api.profiles as profiles
 
+    for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
     routes._clear_live_models_cache()
     monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
     monkeypatch.setattr(config, "get_config", lambda: {"model": {"provider": "openai"}})

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -590,7 +590,6 @@ def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypat
     """Custom endpoint model discovery must use model.api_key from config.yaml,
     not only environment variables, otherwise the dropdown collapses to the
     default model when /v1/models requires auth."""
-    import json as _json
     import api.config as _cfg
 
     old_cfg = dict(_cfg.cfg)
@@ -610,22 +609,13 @@ def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypat
 
     captured = {}
 
-    class _Resp:
-        def read(self):
-            return _json.dumps({'data': [{'id': 'gpt-5.2', 'name': 'GPT-5.2'}]}).encode('utf-8')
-        def __enter__(self):
-            return self
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-    def _fake_urlopen(req, timeout=10):
-        url = getattr(req, 'full_url', '')
+    def _fake_get(url, headers, *, timeout):
         if 'example.test' in url:
-            captured['auth'] = req.get_header('Authorization')
-            captured['ua'] = req.get_header('User-agent')
-        return _Resp()
+            captured['auth'] = headers.get('Authorization')
+            captured['ua'] = headers.get('User-Agent')
+        return {'data': [{'id': 'gpt-5.2', 'name': 'GPT-5.2'}]}
 
-    monkeypatch.setattr('urllib.request.urlopen', _fake_urlopen)
+    monkeypatch.setattr(_cfg, '_credentialed_json_get_no_redirect', _fake_get)
     monkeypatch.setattr('socket.getaddrinfo', lambda *a, **k: [])
     monkeypatch.delenv('OPENAI_API_KEY', raising=False)
     monkeypatch.delenv('HERMES_API_KEY', raising=False)

--- a/tests/test_pr1970_lmstudio_base_url_fallback.py
+++ b/tests/test_pr1970_lmstudio_base_url_fallback.py
@@ -202,20 +202,18 @@ def test_get_provider_base_url_treats_malformed_provider_entry_as_unconfigured()
 
 
 def test_lmstudio_fallback_works_when_hermes_cli_unavailable(tmp_path, monkeypatch):
-    """The lmstudio branch must populate models from the urlopen fallback even
+    """The lmstudio branch must populate models from the WebUI-owned fallback even
     when `from hermes_cli.models import provider_model_ids` raises ImportError.
 
     Pre-fix, the outer try/except in the lmstudio branch caught the ImportError
-    and silently aborted the whole branch, never running the urlopen fallback —
-    a CI-vs-local divergence where local environments with hermes_cli installed
+    and silently aborted the whole branch, never running the fallback — a
+    CI-vs-local divergence where local environments with hermes_cli installed
     worked, and CI (clean editable install) failed with empty model groups.
 
-    Caught in CI on stage-337; fix splits the hermes_cli try from the urlopen
-    fallback so each runs independently.
+    Caught in CI on stage-337; fix splits the hermes_cli try from the fallback
+    so each runs independently.
     """
-    import json as _json
     import socket as _socket
-    import urllib.request as _urlreq
 
     import api.config as config
 
@@ -254,19 +252,10 @@ providers:
         config.reload_config()
         config.invalidate_models_cache()
 
-        class _ModelsResponse:
-            def __enter__(self):
-                return self
+        def _models_json_get_no_redirect(_url, _headers, *, timeout):
+            return {"data": [{"id": "qwen3.6-35b-a3b@q6_k"}, {"id": "another-model"}]}
 
-            def __exit__(self, *args):
-                pass
-
-            def read(self):
-                return _json.dumps(
-                    {"data": [{"id": "qwen3.6-35b-a3b@q6_k"}, {"id": "another-model"}]}
-                ).encode()
-
-        monkeypatch.setattr(_urlreq, "urlopen", lambda *_a, **_kw: _ModelsResponse())
+        monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", _models_json_get_no_redirect)
         monkeypatch.setattr(
             _socket,
             "getaddrinfo",
@@ -294,9 +283,7 @@ providers:
 
 def test_lmstudio_fallback_handles_malformed_providers_list(tmp_path, monkeypatch):
     """LM Studio fallback must ignore list-shaped providers instead of crashing."""
-    import json as _json
     import socket as _socket
-    import urllib.request as _urlreq
 
     blocked_modules = [name for name in list(sys.modules) if name == "hermes_cli" or name.startswith("hermes_cli.")]
     for name in blocked_modules:
@@ -330,19 +317,10 @@ providers:
         config.reload_config()
         config.invalidate_models_cache()
 
-        class _ModelsResponse:
-            def __enter__(self):
-                return self
+        def _models_json_get_no_redirect(_url, _headers, *, timeout):
+            return {"data": [{"id": "qwen3.6-35b-a3b@q6_k"}, {"id": "another-model"}]}
 
-            def __exit__(self, *args):
-                pass
-
-            def read(self):
-                return _json.dumps(
-                    {"data": [{"id": "qwen3.6-35b-a3b@q6_k"}, {"id": "another-model"}]}
-                ).encode()
-
-        monkeypatch.setattr(_urlreq, "urlopen", lambda *_a, **_kw: _ModelsResponse())
+        monkeypatch.setattr(config, "_credentialed_json_get_no_redirect", _models_json_get_no_redirect)
         monkeypatch.setattr(
             _socket,
             "getaddrinfo",

--- a/tests/test_security_live_models_redirects.py
+++ b/tests/test_security_live_models_redirects.py
@@ -233,3 +233,86 @@ def test_openai_compat_live_models_does_not_forward_key_to_redirect_target(monke
     assert handler.status == 200
     assert {item["host"] for item in servers.captured} == {"redirector"}
     assert servers.captured[0]["authorization"] == "Bearer CANARY_SECRET"
+
+
+def test_openai_env_key_skips_agent_live_probe(monkeypatch):
+    from api import routes
+
+    routes._clear_live_models_cache()
+    monkeypatch.setenv("OPENAI_API_KEY", "CANARY_SECRET")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.invalid/v1")
+    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "redirect-test-openai-env")
+    monkeypatch.setattr(
+        "api.config.get_config",
+        lambda: {"model": {"provider": "openai"}},
+    )
+
+    def provider_model_ids(provider):
+        raise AssertionError("credentialed OpenAI agent live probe should be skipped")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_cli.models",
+        SimpleNamespace(provider_model_ids=provider_model_ids),
+    )
+
+    handler = _Handler("/api/models/live?provider=openai")
+    try:
+        routes._handle_live_models(
+            handler,
+            SimpleNamespace(path="/api/models/live", query="provider=openai"),
+        )
+    finally:
+        routes._clear_live_models_cache()
+
+    assert handler.status == 200
+    assert _json_response_body(handler)["provider"] == "openai"
+
+
+def test_openai_api_env_key_skips_config_agent_live_probe(monkeypatch):
+    from api import config
+
+    monkeypatch.setenv("OPENAI_API_KEY", "CANARY_SECRET")
+
+    def provider_model_ids(provider):
+        raise AssertionError("credentialed OpenAI API agent live probe should be skipped")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_cli.models",
+        SimpleNamespace(provider_model_ids=provider_model_ids),
+    )
+
+    assert config._read_live_provider_model_ids("openai-api") == []
+
+
+def test_copilot_acp_skips_agent_live_probe(monkeypatch):
+    from api import routes
+
+    routes._clear_live_models_cache()
+    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "redirect-test-copilot-acp")
+    monkeypatch.setattr(
+        "api.config.get_config",
+        lambda: {"model": {"provider": "copilot-acp"}},
+    )
+
+    def provider_model_ids(provider):
+        raise AssertionError("credentialed Copilot ACP agent live probe should be skipped")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_cli.models",
+        SimpleNamespace(provider_model_ids=provider_model_ids),
+    )
+
+    handler = _Handler("/api/models/live?provider=copilot-acp")
+    try:
+        routes._handle_live_models(
+            handler,
+            SimpleNamespace(path="/api/models/live", query="provider=copilot-acp"),
+        )
+    finally:
+        routes._clear_live_models_cache()
+
+    assert handler.status == 200
+    assert _json_response_body(handler)["provider"] == "copilot-acp"

--- a/tests/test_security_live_models_redirects.py
+++ b/tests/test_security_live_models_redirects.py
@@ -134,6 +134,31 @@ def test_credentialed_json_helper_refuses_redirects():
     ]
 
 
+def test_config_credentialed_json_helper_refuses_redirects():
+    from api import config
+
+    servers = _RedirectPair()
+    try:
+        result = config._credentialed_json_get_no_redirect(
+            f"{servers.base_v1}/models",
+            {"Authorization": "Bearer CANARY_SECRET"},
+            timeout=3,
+        )
+    except Exception:
+        result = None
+    finally:
+        servers.close()
+
+    assert result is None
+    assert servers.captured == [
+        {
+            "host": "redirector",
+            "path": "/v1/models",
+            "authorization": "Bearer CANARY_SECRET",
+        }
+    ]
+
+
 def test_custom_live_models_does_not_forward_key_to_redirect_target(monkeypatch):
     from api import routes
 
@@ -186,7 +211,14 @@ def test_openai_compat_live_models_does_not_forward_key_to_redirect_target(monke
             "model": {"provider": "deepseek"},
         },
     )
-    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.models", SimpleNamespace(provider_model_ids=lambda provider: []))
+    def provider_model_ids(provider):
+        raise AssertionError("credentialed agent live probe should be skipped")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_cli.models",
+        SimpleNamespace(provider_model_ids=provider_model_ids),
+    )
 
     handler = _Handler("/api/models/live?provider=deepseek")
     try:

--- a/tests/test_security_live_models_redirects.py
+++ b/tests/test_security_live_models_redirects.py
@@ -1,0 +1,203 @@
+"""Regression tests for credentialed live-model probes refusing redirects."""
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+
+
+class _Headers(dict):
+    def get(self, key, default=None):
+        for k, v in self.items():
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+class _Handler:
+    def __init__(self, path: str):
+        self.headers = _Headers()
+        self.rfile = io.BytesIO()
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.sent_headers = []
+        self.client_address = ("127.0.0.1", 12345)
+        self.path = path
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+
+class _RedirectPair:
+    def __init__(self):
+        self.captured: list[dict[str, str | None]] = []
+        self.target = HTTPServer(("127.0.0.1", 0), self._target_handler())
+        self.target_thread = threading.Thread(target=self.target.serve_forever, daemon=True)
+        self.target_thread.start()
+        self.redirector = HTTPServer(("127.0.0.1", 0), self._redirector_handler())
+        self.redirector_thread = threading.Thread(target=self.redirector.serve_forever, daemon=True)
+        self.redirector_thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.redirector.server_address[1]}"
+
+    @property
+    def base_v1(self) -> str:
+        return f"{self.base_url}/v1"
+
+    def close(self) -> None:
+        self.redirector.shutdown()
+        self.redirector.server_close()
+        self.redirector_thread.join(timeout=5)
+        self.target.shutdown()
+        self.target.server_close()
+        self.target_thread.join(timeout=5)
+
+    def _target_handler(self):
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                parent.captured.append(
+                    {"host": "target", "path": self.path, "authorization": self.headers.get("Authorization")}
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"data": [{"id": "leaked-path"}]}).encode())
+
+            def log_message(self, format, *args):
+                return None
+
+        return Handler
+
+    def _redirector_handler(self):
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                parent.captured.append(
+                    {"host": "redirector", "path": self.path, "authorization": self.headers.get("Authorization")}
+                )
+                self.send_response(302)
+                self.send_header(
+                    "Location",
+                    f"http://127.0.0.1:{parent.target.server_address[1]}/steal",
+                )
+                self.end_headers()
+
+            def log_message(self, format, *args):
+                return None
+
+        return Handler
+
+
+def _json_response_body(handler: _Handler) -> dict:
+    raw = handler.wfile.getvalue().split(b"\r\n\r\n", 1)[-1]
+    if not raw.strip().startswith(b"{"):
+        raw = handler.wfile.getvalue()
+    return json.loads(raw.decode("utf-8"))
+
+
+def test_credentialed_json_helper_refuses_redirects():
+    from api import routes
+
+    servers = _RedirectPair()
+    try:
+        result = routes._credentialed_json_get_no_redirect(
+            f"{servers.base_v1}/models",
+            {"Authorization": "Bearer CANARY_SECRET"},
+            timeout=3,
+        )
+    except Exception:
+        result = None
+    finally:
+        servers.close()
+
+    assert result is None
+    assert servers.captured == [
+        {
+            "host": "redirector",
+            "path": "/v1/models",
+            "authorization": "Bearer CANARY_SECRET",
+        }
+    ]
+
+
+def test_custom_live_models_does_not_forward_key_to_redirect_target(monkeypatch):
+    from api import routes
+
+    servers = _RedirectPair()
+    routes._clear_live_models_cache()
+    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "redirect-test-custom")
+    monkeypatch.setattr(
+        "api.config.get_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Leak Me",
+                    "base_url": servers.base_url,
+                    "api_key": "CANARY_SECRET",
+                    "models": [],
+                }
+            ],
+            "model": {"provider": "custom:leak-me"},
+        },
+    )
+    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.models", SimpleNamespace(provider_model_ids=lambda provider: []))
+
+    handler = _Handler("/api/models/live?provider=custom:leak-me")
+    try:
+        routes._handle_live_models(
+            handler,
+            SimpleNamespace(path="/api/models/live", query="provider=custom:leak-me"),
+        )
+    finally:
+        servers.close()
+        routes._clear_live_models_cache()
+
+    assert handler.status == 200
+    assert _json_response_body(handler)["models"] == []
+    assert {item["host"] for item in servers.captured} == {"redirector"}
+    assert servers.captured[0]["authorization"] == "Bearer CANARY_SECRET"
+
+
+def test_openai_compat_live_models_does_not_forward_key_to_redirect_target(monkeypatch):
+    from api import routes
+
+    servers = _RedirectPair()
+    routes._clear_live_models_cache()
+    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "redirect-test-compat")
+    monkeypatch.setitem(routes._OPENAI_COMPAT_ENDPOINTS, "deepseek", servers.base_v1)
+    monkeypatch.setattr(
+        "api.config.get_config",
+        lambda: {
+            "providers": {"deepseek": {"api_key": "CANARY_SECRET"}},
+            "model": {"provider": "deepseek"},
+        },
+    )
+    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.models", SimpleNamespace(provider_model_ids=lambda provider: []))
+
+    handler = _Handler("/api/models/live?provider=deepseek")
+    try:
+        routes._handle_live_models(
+            handler,
+            SimpleNamespace(path="/api/models/live", query="provider=deepseek"),
+        )
+    finally:
+        servers.close()
+        routes._clear_live_models_cache()
+
+    assert handler.status == 200
+    assert {item["host"] for item in servers.captured} == {"redirector"}
+    assert servers.captured[0]["authorization"] == "Bearer CANARY_SECRET"


### PR DESCRIPTION
## Summary
This PR hardens live model discovery so credentialed provider probes do not follow redirects while carrying provider API keys.

- Adds a no-redirect JSON helper for credentialed model-discovery requests.
- Routes both custom-provider and OpenAI-compatible fallback live-model probes through that helper.
- Adds regression tests with a redirector and target server to prove the bearer token is not forwarded to the redirect target.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Credentialed live-model probes followed redirects with `Authorization` attached | A configured or compromised provider endpoint could redirect `/models` discovery to another host and receive stored provider API keys | High |

## Before this PR
- `/api/models/live?provider=custom:<name>` built a `urllib.request.Request` with `Authorization: Bearer ***` and passed it to default `urllib.request.urlopen()`.
- The OpenAI-compatible fallback did the same for configured provider keys.
- Default urllib redirect handling can preserve request headers across redirects, including `Authorization`.
- A 3xx from the configured models endpoint could therefore forward the provider key to the redirect target.

## After this PR
- Credentialed live-model probes use `_credentialed_json_get_no_redirect()`.
- The helper installs an `HTTPRedirectHandler` whose `redirect_request()` returns `None`, so redirects fail closed rather than being followed with credentials.
- The existing fallback behavior remains: failed live discovery falls through to static/configured models where applicable.
- Tests prove the redirect target is not reached for both custom-provider and OpenAI-compatible fallback probes.

## Why this matters
Provider API keys can carry billing authority, model access, or tenant-level credentials. Live model discovery is a background convenience path, but it still sends real provider secrets. Redirects from a credentialed endpoint should not move those secrets to a different host.

## How this differs from related issue/PR
The repository already contains LM Studio reasoning-probe coverage documenting the same urllib behavior: credentialed probes must not follow redirects because urllib can re-send headers across redirects.

This PR applies that same no-redirect security invariant to the live model discovery paths in `api/routes.py`, including custom providers and OpenAI-compatible fallback providers.

## Attack flow

```text
configured provider models endpoint
    -> returns 302 Location: http://attacker.example/steal
        -> urllib follows redirect with Authorization still attached
            -> redirect target receives Bearer provider API key
```

## Affected code

| Issue | Files |
|-------|-------|
| Credentialed live-model redirect key disclosure | `api/routes.py`, `tests/test_security_live_models_redirects.py` |

## Root cause
Credentialed live-model redirect key disclosure:
- The affected paths used default `urllib.request.urlopen()` for requests carrying `Authorization`.
- urllib redirect handling can preserve request headers across redirects, so the credential boundary was not pinned to the configured models endpoint.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Credentialed live-model redirect key disclosure | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |

Rationale:
- The attacker needs influence over a configured provider endpoint or a compromised provider-compatible endpoint. Impact is direct disclosure of stored provider credentials that may allow unauthorized model access or billing abuse. Severity may vary with deployment and provider-key scope.

## Safe reproduction steps
1. Configure a custom provider with a fake key such as `CANARY_SECRET` and a local models endpoint.
2. Make that endpoint return:
   ```http
   HTTP/1.1 302 Found
   Location: http://127.0.0.1:<target>/steal
   ```
3. Call `/api/models/live?provider=custom:<name>`.
4. Before this PR, default urllib behavior could follow the redirect with `Authorization` still attached.
5. After this PR, the redirect target is never reached.

The regression tests run this proof with local HTTP servers and a fake bearer token only.

## Expected vulnerable behavior
- A credentialed provider probe should not forward `Authorization` to a redirect target.
- The pre-patch behavior used default redirect-following urllib requests.
- The safe proof signal is that only the redirector receives `Bearer CANARY_SECRET`; the redirected target receives no request.

## Changes in this PR
- Adds `_credentialed_json_get_no_redirect()` for credentialed provider-model JSON fetches.
- Uses the helper in the custom-provider live-model fetch path.
- Uses the helper in the OpenAI-compatible fallback live-model fetch path.
- Adds redirect regression tests for the helper, custom providers, and `_OPENAI_COMPAT_ENDPOINTS` fallback providers.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Backend provider probe | `api/routes.py` | Credentialed live-model probes now fail closed on redirects |
| Regression tests | `tests/test_security_live_models_redirects.py` | Added local redirector/target tests proving provider keys are not forwarded onward |

## Maintainer impact
- The patch is scoped to live model discovery and does not change static model fallback behavior.
- Providers that return redirects from credentialed `/models` endpoints will now be treated as live-fetch failures instead of being followed.
- This is a fail-closed behavior for credentialed background discovery; configured/static model lists still provide fallback coverage.

## Fix rationale
- The no-redirect helper is narrow and reusable for credentialed provider probes.
- Failing closed on any redirect is simpler and safer than trying to decide when it is acceptable to forward provider credentials.
- Tests cover both affected live-model callsite families.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Focused live-model redirect tests
- [x] Diff-scoped Python lint
- [x] Syntax compilation for touched Python files
- [x] Whitespace diff check

Executed with:
- `./scripts/test.sh tests/test_security_live_models_redirects.py`
- `python3 scripts/ruff_lint.py --diff origin/master`
- `python3 -m compileall -q api/routes.py tests/test_security_live_models_redirects.py`
- `git diff --check`

## Disclosure notes
- The tests use only local loopback HTTP servers and a fake `CANARY_SECRET` token.
- No real provider credentials or production endpoints were used.
- No unrelated files were changed.

## AI Usage Disclosure
AI assistance was used to identify the boundary, draft the patch, and write regression tests. The submitted change is scoped to the files and validation listed above.