### PR TITLE
feat(tts): add MiniMax TTS engine (server proxy + extension)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -17103,6 +17103,164 @@ def _handle_tts(handler, parsed):
             pass
         return True
 
+    # ── MiniMax TTS ────────────────────────────────────────────────────
+    if engine == "minimax":
+        api_key = os.getenv("MINIMAX_API_KEY", "").strip()
+        if not api_key:
+            try:
+                from api.onboarding import _load_env_file
+                from api.profiles import get_active_hermes_home
+                api_key = _load_env_file(get_active_hermes_home() / ".env").get("MINIMAX_API_KEY", "")
+            except Exception:
+                pass
+        if not api_key:
+            from api.helpers import bad as _bad
+            return _bad(handler, "MINIMAX_API_KEY not configured", 503)
+
+        # Resolve config: tts.minimax.{model, voice_id, speed, vol, pitch}
+        # Default voice: English_expressive_narrator — verified to exist on
+        # MiniMax's platform as of 2026-07-07. (English_Exciting_Actor appears
+        # in MiniMax's docs as a sample but returns "voice id not exist".)
+        mm_model = "speech-2.8-hd"
+        mm_voice = "English_expressive_narrator"
+        mm_speed = 1
+        mm_vol = 1
+        mm_pitch = 0
+        try:
+            from api.config import get_config
+            tts_cfg = (get_config() or {}).get("tts", {})
+            if isinstance(tts_cfg, dict):
+                mm_cfg = tts_cfg.get("minimax", {})
+                if isinstance(mm_cfg, dict):
+                    mm_model = mm_cfg.get("model") or mm_model
+                    cfg_voice = mm_cfg.get("voice_id")
+                    if isinstance(cfg_voice, str) and cfg_voice.strip():
+                        mm_voice = cfg_voice.strip()
+                    try:
+                        mm_speed = float(mm_cfg.get("speed", mm_speed))
+                    except (TypeError, ValueError):
+                        pass
+                    try:
+                        mm_vol = float(mm_cfg.get("vol", mm_vol))
+                    except (TypeError, ValueError):
+                        pass
+                    try:
+                        mm_pitch = float(mm_cfg.get("pitch", mm_pitch))
+                    except (TypeError, ValueError):
+                        pass
+        except Exception:
+            pass  # fall through to defaults
+
+        # Per-utterance voice override from the request body (set by the
+        # extension's synthesize() when opts.voice_id is supplied).
+        req_voice = (data.get("voice_id") or "").strip()
+        if req_voice:
+            # Defense-in-depth: only allow safe identifier characters so a
+            # tampered voice_id can't smuggle JSON into the upstream payload.
+            if not re.fullmatch(r'[A-Za-z0-9_\-]{1,64}', req_voice):
+                from api.helpers import bad as _bad
+                return _bad(handler, "invalid voice_id", 400)
+            mm_voice = req_voice
+
+        # Clamp voice settings to MiniMax's documented ranges.
+        try:
+            mm_speed = max(0.5, min(2.0, float(mm_speed)))
+        except (TypeError, ValueError):
+            mm_speed = 1
+        try:
+            mm_vol = max(0.0, min(10.0, float(mm_vol)))
+        except (TypeError, ValueError):
+            mm_vol = 1
+        try:
+            mm_pitch = max(-12.0, min(12.0, float(mm_pitch)))
+        except (TypeError, ValueError):
+            mm_pitch = 0
+
+        url = "https://api.minimax.io/v1/t2a_v2"
+        req_body = json.dumps({
+            "model": mm_model,
+            "text": text,
+            "stream": False,
+            "language_boost": "auto",
+            "output_format": "hex",
+            "voice_setting": {
+                "voice_id": mm_voice,
+                "speed": mm_speed,
+                "vol": mm_vol,
+                "pitch": int(mm_pitch),
+            },
+            "audio_setting": {
+                "sample_rate": 32000,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1,
+            },
+        }).encode("utf-8")
+
+        req = Request(url, data=req_body, headers={
+            "Authorization": "Bearer " + api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        })
+
+        try:
+            with _tts_open(req, timeout=30, opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectTtsHandler())) as resp:
+                raw = resp.read()
+        except ValueError:
+            logger.warning("MiniMax TTS rejected an invalid upstream response", exc_info=True)
+            from api.helpers import bad as _bad
+            return _bad(handler, "MiniMax TTS generation failed", 502)
+        except Exception:
+            logger.exception("MiniMax TTS generation failed")
+            from api.helpers import bad as _bad
+            return _bad(handler, "MiniMax TTS generation failed", 500)
+
+        # MiniMax returns JSON with hex-encoded audio in data.audio. Parse it,
+        # then validate the upstream actually succeeded (base_resp.status_code).
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except Exception:
+            logger.exception("MiniMax TTS returned non-JSON body")
+            from api.helpers import bad as _bad
+            return _bad(handler, "MiniMax TTS generation failed", 502)
+
+        base_resp = payload.get("base_resp") or {}
+        if base_resp.get("status_code") not in (0, None):
+            logger.warning(
+                "MiniMax TTS upstream returned error: %s",
+                base_resp.get("status_msg") or base_resp,
+            )
+            from api.helpers import bad as _bad
+            return _bad(
+                handler,
+                "MiniMax TTS rejected the request: " + str(base_resp.get("status_msg") or "unknown"),
+                502,
+            )
+
+        data_obj = payload.get("data") or {}
+        audio_hex = data_obj.get("audio")
+        if not isinstance(audio_hex, str) or not audio_hex:
+            from api.helpers import bad as _bad
+            return _bad(handler, "MiniMax TTS returned empty audio", 502)
+
+        try:
+            audio_data = bytes.fromhex(audio_hex)
+        except ValueError:
+            logger.exception("MiniMax TTS returned non-hex audio payload")
+            from api.helpers import bad as _bad
+            return _bad(handler, "MiniMax TTS returned invalid audio", 502)
+
+        handler.send_response(200)
+        handler.send_header("Content-Type", "audio/mpeg")
+        handler.send_header("Cache-Control", "no-store")
+        handler.send_header("Content-Length", str(len(audio_data)))
+        handler.end_headers()
+        try:
+            handler.wfile.write(audio_data)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        return True
+
     # ── Edge TTS ────────────────────────────────────────────────────────
     allowed = {
         "zh-CN-XiaoxiaoNeural", "zh-CN-XiaoyiNeural", "zh-CN-YunxiNeural",

--- a/static/extensions/minimax-tts.js
+++ b/static/extensions/minimax-tts.js
@@ -7,7 +7,7 @@
 //
 // v1 surface:
 //   - engine: 'minimax'  (registered here)
-//   - default voice: English_Exciting_Actor (configurable via tts.minimax.voice_id)
+//   - default voice: English_expressive_narrator (configurable via tts.minimax.voice_id)
 //   - audio: mp3, 32 kHz mono, ~128 kbps (MiniMax defaults)
 //   - streaming: NOT YET — every utterance is one POST + one audio buffer.
 //     v2 will reuse the Edge/voice-mode chunking infra to speak sentence-by-sentence
@@ -20,7 +20,7 @@
     }
     var ok = window.registerHermesTtsEngine({
       id: 'minimax',
-      label: 'MiniMax (Exciting Actor)',
+      label: 'MiniMax',
       synthesize: async function synthesize(text, opts) {
         if (!text || typeof text !== 'string') {
           throw new Error('MiniMax TTS: text is required');

--- a/static/extensions/minimax-tts.js
+++ b/static/extensions/minimax-tts.js
@@ -1,0 +1,75 @@
+// MiniMax TTS engine for hermes-webui (v1, non-streaming).
+//
+// Registers via window.registerHermesTtsEngine — see static/boot.js for the
+// contract. synthesize(text, opts) returns Promise<ArrayBuffer>. The actual
+// HTTP call to MiniMax is proxied server-side by /api/tts so the
+// MINIMAX_API_KEY stays off the browser.
+//
+// v1 surface:
+//   - engine: 'minimax'  (registered here)
+//   - default voice: English_Exciting_Actor (configurable via tts.minimax.voice_id)
+//   - audio: mp3, 32 kHz mono, ~128 kbps (MiniMax defaults)
+//   - streaming: NOT YET — every utterance is one POST + one audio buffer.
+//     v2 will reuse the Edge/voice-mode chunking infra to speak sentence-by-sentence
+//     as Hermes streams tokens.
+(function () {
+  function _register() {
+    if (typeof window.registerHermesTtsEngine !== 'function') {
+      console.warn('[MiniMax TTS] registerHermesTtsEngine not defined yet — engine will NOT register. Load order is broken.');
+      return false;
+    }
+    var ok = window.registerHermesTtsEngine({
+      id: 'minimax',
+      label: 'MiniMax (Exciting Actor)',
+      synthesize: async function synthesize(text, opts) {
+        if (!text || typeof text !== 'string') {
+          throw new Error('MiniMax TTS: text is required');
+        }
+        var body = { engine: 'minimax', text: text };
+        // Optional per-utterance override; falls back to server-side tts.minimax.voice_id.
+        if (opts && typeof opts.voice_id === 'string' && opts.voice_id) {
+          body.voice_id = opts.voice_id;
+        }
+        var resp = await fetch('/api/tts', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+          var detail = '';
+          try {
+            var j = await resp.json();
+            detail = (j && j.error) ? ': ' + j.error : '';
+          } catch (_e) { /* ignore */ }
+          throw new Error('MiniMax TTS failed (' + resp.status + ')' + detail);
+        }
+        return await resp.arrayBuffer();
+      },
+    });
+    if (ok) {
+      console.info('[MiniMax TTS] engine registered.');
+    } else {
+      console.warn('[MiniMax TTS] engine registration was rejected (likely a reserved id or invalid id).');
+    }
+    return ok;
+  }
+
+  // Try immediately (works when this script loads AFTER boot.js, which
+  // is the normal ordering — boot.js defines window.registerHermesTtsEngine).
+  if (!_register()) {
+    // Fallback: defer until boot.js has had a chance to define the API.
+    // If we still fail after a few seconds, give up with a clear error so
+    // the user can see what went wrong instead of silent failure.
+    var attempts = 0;
+    var interval = setInterval(function () {
+      attempts++;
+      if (_register()) {
+        clearInterval(interval);
+      } else if (attempts >= 20) {
+        clearInterval(interval);
+        console.error('[MiniMax TTS] gave up after 10s — boot.js never defined registerHermesTtsEngine. Check script load order in index.html.');
+      }
+    }, 500);
+  }
+})();

--- a/static/index.html
+++ b/static/index.html
@@ -1721,6 +1721,7 @@
 <script src="static/panels.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/onboarding.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/boot.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/extensions/minimax-tts.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/outline.js?v=__WEBUI_VERSION__" defer></script>
 
 <!-- Kanban: create/rename board modal — used for both flows. -->

--- a/static/panels.js
+++ b/static/panels.js
@@ -9241,6 +9241,56 @@ async function loadSettingsPanel(){
         ttsVoiceSel.innerHTML='<option value="">Hermy — ElevenLabs (server-configured)</option>';
       } else if(engine==='openai'){
         ttsVoiceSel.innerHTML='<option value="">OpenAI voice (server-configured)</option>';
+      } else if(engine==='minimax'){
+        // MiniMax TTS voices — VERIFIED to exist on the platform as of
+        // 2026-07-07. Many voice IDs that appear in MiniMax's marketing
+        // docs (e.g. English_Exciting_Actor) return "voice id not exist"
+        // from the API. The four below all returned 200 with real audio.
+        // See the full MiniMax voice catalog:
+        // https://platform.minimax.io/faq/system-voice-id
+        const mmVoices=[
+          {value:'English_expressive_narrator',label:'Expressive Narrator (English, Male, storytelling) — DEFAULT'},
+          {value:'English_Graceful_Lady',label:'Graceful Lady (English, Female, warm)'},
+          {value:'English_Trustworth_Man',label:'Trustworthy Man (English, Male, calm)'},
+          {value:'English_Diligent_Man',label:'Diligent Man (English, Male, steady)'},
+          {value:'English_Comedian',label:'Comedian (English, Male, playful)'},
+          {value:'English_Cute_Girl',label:'Cute Girl (English, Female, bright)'},
+        ];
+        ttsVoiceSel.innerHTML='<option value="">Server default (English_expressive_narrator)</option>';
+        mmVoices.forEach(v=>{
+          const opt=document.createElement('option');
+          opt.value=v.value;opt.textContent=v.label;
+          if(v.value===current) opt.selected=true;
+          ttsVoiceSel.appendChild(opt);
+        });
+      } else if(typeof window._hermesTtsIsRegistered==='function' && window._hermesTtsIsRegistered(engine)
+                &&typeof window._hermesTtsEngineVoices==='function'){
+        // Any other extension-registered engine can supply its own voice list
+        // via window._hermesTtsEngineVoices(engine) -> [{value,label}, ...].
+        // Falls through to the Browser list below if the engine didn't implement it.
+        const extVoices=window._hermesTtsEngineVoices(engine);
+        if(Array.isArray(extVoices)&&extVoices.length){
+          ttsVoiceSel.innerHTML='<option value="">Server default</option>';
+          extVoices.forEach(v=>{
+            const opt=document.createElement('option');
+            opt.value=v.value;opt.textContent=v.label;
+            if(v.value===current) opt.selected=true;
+            ttsVoiceSel.appendChild(opt);
+          });
+          return;
+        }
+        if(!('speechSynthesis' in window)){
+          ttsVoiceSel.innerHTML='<option value="">Speech synthesis not available</option>';
+          return;
+        }
+        const voices=speechSynthesis.getVoices();
+        ttsVoiceSel.innerHTML='<option value="">Default system voice</option>';
+        voices.forEach(v=>{
+          const opt=document.createElement('option');
+          opt.value=v.name;opt.textContent=v.name+(v.lang?' ('+v.lang+')':'');
+          if(v.name===current) opt.selected=true;
+          ttsVoiceSel.appendChild(opt);
+        });
       } else if(engine==='edge'){
         const edgeVoices=[
           {value:'zh-CN-XiaoxiaoNeural',label:'Xiaoxiao (Chinese, Female)'},

--- a/static/ui.js
+++ b/static/ui.js
@@ -8252,8 +8252,13 @@ function autoReadLastAssistant(){
   // registered-engine branch in speakMessage() so auto-read honors the selection.
   if(typeof window._hermesTtsIsRegistered==='function' && window._hermesTtsIsRegistered(engine)){
     _ttsSpeaking=true;
+    // The voice dropdown stores its value in localStorage 'hermes-tts-voice'.
+    // We pass it to the extension as BOTH 'voice' (legacy/speaking-friendly) and
+    // 'voice_id' (our MiniMax engine's preferred key), so any registered engine
+    // can pick whichever it expects. Empty string means "use server default".
     const _opts={
       voice: localStorage.getItem('hermes-tts-voice')||'',
+      voice_id: localStorage.getItem('hermes-tts-voice')||'',
       rate: parseFloat(localStorage.getItem('hermes-tts-rate')),
       pitch: parseFloat(localStorage.getItem('hermes-tts-pitch')),
     };

--- a/tests/test_minimax_tts_endpoint.py
+++ b/tests/test_minimax_tts_endpoint.py
@@ -1,0 +1,318 @@
+"""Coverage for the MiniMax TTS engine on the /api/tts endpoint.
+
+Exercises the engine routing + guard rails of _handle_tts's minimax branch
+in-process via a fake handler. The happy path mocks routes._tts_open so no
+real MiniMax network call is made; the rejection paths (missing key, bad
+voice_id, upstream error, non-hex audio) bail before / after the call
+deterministically.
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+import api.routes as routes
+
+
+class _FakeHandler:
+    def __init__(self, body: bytes, command: str = "POST", headers=None, client="9.9.9.9"):
+        self.command = command
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.headers = headers or {}
+        self.headers.setdefault("Content-Length", str(len(body)))
+        self.client_address = (client, 12345)
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        try:
+            return json.loads(self.wfile.getvalue().decode("utf-8"))
+        except Exception:
+            return None
+
+
+def _post(body_dict, **kw):
+    return _FakeHandler(json.dumps(body_dict).encode(), **kw)
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    # Auth + limiter sit before the engine branch; pin them off/clean so these
+    # assertions are deterministic regardless of suite order.
+    import api.auth as _auth
+    monkeypatch.setattr(_auth, "is_auth_enabled", lambda: False)
+    monkeypatch.setattr(routes, "is_auth_enabled", lambda: False, raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_TRUST_FORWARDED_FOR", raising=False)
+    if hasattr(routes._handle_tts, "_tts_limiter"):
+        del routes._handle_tts._tts_limiter
+    yield
+    if hasattr(routes._handle_tts, "_tts_limiter"):
+        del routes._handle_tts._tts_limiter
+
+
+def test_minimax_missing_key_returns_503(monkeypatch, tmp_path):
+    """No MINIMAX_API_KEY (env or .env) → 503, no network call."""
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    import api.profiles as profiles
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    h = _post({"text": "hello", "engine": "minimax"}, client="9.9.9.1")
+    routes._handle_tts(h, None)
+    assert h.status == 503
+    assert "MINIMAX_API_KEY" in (h.payload() or {}).get("error", "")
+
+
+def test_minimax_rejects_unsafe_voice_id_in_request(monkeypatch):
+    """A voice_id containing JSON-smuggling characters → 400 before any call."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("MiniMax upstream called")
+
+    monkeypatch.setattr(routes, "_tts_open", _fail_if_called)
+    h = _post(
+        {"text": "hello", "engine": "minimax", "voice_id": 'evil","injected":1'},
+        client="9.9.9.2",
+    )
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "voice_id" in (h.payload() or {}).get("error", "")
+
+
+def test_minimax_overlong_text_rejected_before_engine(monkeypatch):
+    """The shared 5000-char cap applies to the minimax engine too (no call)."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("MiniMax upstream called")
+
+    monkeypatch.setattr(routes, "_tts_open", _fail_if_called)
+    h = _post({"text": "x" * 5001, "engine": "minimax"}, client="9.9.9.3")
+    routes._handle_tts(h, None)
+    assert h.status == 400
+    assert "too long" in (h.payload() or {}).get("error", "")
+
+
+def test_minimax_happy_path_decodes_hex_and_streams_mp3(monkeypatch):
+    """With a key + valid config, the branch hits MiniMax, hex-decodes
+    data.audio, and returns audio/mpeg with Content-Length matching the
+    decoded byte count."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+    import api.config as _cfg
+    monkeypatch.setattr(_cfg, "get_config", lambda: {
+        "tts": {"minimax": {"model": "speech-2.8-hd", "voice_id": "English_expressive_narrator"}}
+    })
+
+    # MP3 frames start with either an ID3 tag or 0xFFEx sync. Use ID3 + payload
+    # so the test would fail loudly if hex decoding or frame assembly broke.
+    real_audio = b"ID3\x03\x00" + b"\x00" * 16 + b"\xff\xfb\x90\x00" + b"\x00" * 32
+    audio_hex = real_audio.hex()
+
+    upstream_payload = json.dumps({
+        "data": {"audio": audio_hex, "status": 2},
+        "extra_info": {"audio_length": 11124, "audio_size": len(real_audio)},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }).encode("utf-8")
+
+    captured = {}
+
+    class _Resp:
+        def __init__(self):
+            self._chunks = [upstream_payload, b""]
+            self._i = 0
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
+        captured["url"] = req.full_url
+        captured["authorization"] = req.get_header("Authorization")
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp()
+
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
+
+    h = _post({"text": "hello world", "engine": "minimax"}, client="9.9.9.4")
+    routes._handle_tts(h, None)
+
+    assert h.status == 200
+    assert h.sent_headers.get("Content-Type") == "audio/mpeg"
+    assert h.sent_headers.get("Content-Length") == str(len(real_audio))
+    assert h.wfile.getvalue() == real_audio
+    # Confirm we hit the right URL with the right auth and voice.
+    assert captured["url"] == "https://api.minimax.io/v1/t2a_v2"
+    assert captured["authorization"] == "Bearer sk-minimax-test"
+    assert captured["body"]["voice_setting"]["voice_id"] == "English_expressive_narrator"
+    assert captured["body"]["model"] == "speech-2.8-hd"
+    assert captured["body"]["stream"] is False
+    assert captured["body"]["output_format"] == "hex"
+
+
+def test_minimax_upstream_error_status_returns_502(monkeypatch):
+    """base_resp.status_code != 0 → 502 with the upstream message surfaced."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+
+    upstream_payload = json.dumps({
+        "data": {},
+        "base_resp": {"status_code": 1002, "status_msg": "invalid voice_id"},
+    }).encode("utf-8")
+
+    class _Resp:
+        def __init__(self):
+            self._chunks = [upstream_payload, b""]
+            self._i = 0
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(routes, "_tts_open", lambda *a, **kw: _Resp())
+    h = _post({"text": "hello", "engine": "minimax"}, client="9.9.9.5")
+    routes._handle_tts(h, None)
+    assert h.status == 502
+    err = (h.payload() or {}).get("error", "")
+    assert "invalid voice_id" in err
+
+
+def test_minimax_non_hex_audio_returns_502(monkeypatch):
+    """data.audio that's not valid hex → 502."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+
+    upstream_payload = json.dumps({
+        "data": {"audio": "not-actually-hex-zzzz", "status": 2},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }).encode("utf-8")
+
+    class _Resp:
+        def __init__(self):
+            self._chunks = [upstream_payload, b""]
+            self._i = 0
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(routes, "_tts_open", lambda *a, **kw: _Resp())
+    h = _post({"text": "hello", "engine": "minimax"}, client="9.9.9.6")
+    routes._handle_tts(h, None)
+    assert h.status == 502
+    err = (h.payload() or {}).get("error", "")
+    assert "invalid audio" in err
+
+
+def test_minimax_default_voice_is_known_good(monkeypatch):
+    """Regression guard: the hardcoded default voice (used when no
+    tts.minimax.voice_id is set) must be one that actually exists on
+    MiniMax's platform. English_Exciting_Actor appears in MiniMax's
+    docs as a sample but returns 'voice id not exist' (status_code 2054)
+    from the API. The current default is English_expressive_narrator,
+    which was verified to return audio on 2026-07-07.
+    """
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+    # Empty config — exercises the hardcoded default.
+    import api.config as _cfg
+    monkeypatch.setattr(_cfg, "get_config", lambda: {"tts": {"minimax": {}}})
+
+    captured = {}
+    audio_hex = b"ID3ok".hex()
+
+    class _Resp:
+        def __init__(self):
+            self._chunks = [
+                json.dumps({
+                    "data": {"audio": audio_hex, "status": 2},
+                    "base_resp": {"status_code": 0, "status_msg": "success"},
+                }).encode("utf-8"),
+                b"",
+            ]
+            self._i = 0
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp()
+
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
+    h = _post({"text": "hello", "engine": "minimax"}, client="9.9.9.8")
+    routes._handle_tts(h, None)
+    assert h.status == 200
+    # If you ever change the default, first verify the new voice_id
+    # actually works against the real MiniMax API (curl test) and
+    # then update this assertion + the dropdown in panels.js.
+    assert captured["body"]["voice_setting"]["voice_id"] == "English_expressive_narrator"
+
+
+def test_minimax_per_request_voice_id_overrides_config(monkeypatch):
+    """When synthesize() passes voice_id in opts, it shows up in the request body."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "sk-minimax-test")
+    import api.config as _cfg
+    monkeypatch.setattr(_cfg, "get_config", lambda: {
+        "tts": {"minimax": {"voice_id": "English_Graceful_Lady"}}
+    })
+    captured = {}
+    audio_hex = b"ID3hi".hex()
+
+    class _Resp:
+        def __init__(self):
+            self._chunks = [
+                json.dumps({
+                    "data": {"audio": audio_hex, "status": 2},
+                    "base_resp": {"status_code": 0, "status_msg": "success"},
+                }).encode("utf-8"),
+                b"",
+            ]
+            self._i = 0
+        def read(self, n=-1):
+            c = self._chunks[self._i] if self._i < len(self._chunks) else b""
+            self._i += 1
+            return c
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_tts_open(req, timeout=30, opener_factory=None, **_kw):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp()
+
+    monkeypatch.setattr(routes, "_tts_open", _fake_tts_open)
+
+    h = _post(
+        {"text": "hello", "engine": "minimax", "voice_id": "English_Cute_Girl"},
+        client="9.9.9.7",
+    )
+    routes._handle_tts(h, None)
+
+    assert h.status == 200
+    assert captured["body"]["voice_setting"]["voice_id"] == "English_Cute_Girl"


### PR DESCRIPTION
## Thinking Path

- MiniMax is already a supported LLM provider in Hermes/Hermes WebUI, but there is no MiniMax TTS engine, so users who already have `MINIMAX_API_KEY` configured for chat can't use it for voice.
- The repo's supported way to add a TTS engine without touching core playback plumbing is `window.registerHermesTtsEngine` (documented in `docs/EXTENSIONS.md`, "Registering a custom TTS engine"), which already handles selection, the dropdown option, and the `<audio>` playback lifecycle for any engine that returns audio bytes.
- Calling MiniMax's `t2a_v2` API directly from the browser would put `MINIMAX_API_KEY` in client JS, so the actual HTTP call needs to live server-side.
- This PR adds a `minimax` branch to the existing `/api/tts` proxy (same shape as the existing Edge/ElevenLabs/OpenAI branches in `api/routes.py`) and a small client extension that registers the engine and calls that proxy.
- Opening as a draft first (per "Path 2: Bigger Changes" in `CONTRIBUTING.md`) to align on the design — in particular the extension-vs-core placement described below — before polishing further.

## What Changed

- `api/routes.py`: new `engine == "minimax"` branch in `_handle_tts`. Reads `MINIMAX_API_KEY` from env or the active Hermes home `.env`, reads `tts.minimax.{model,voice_id,speed,vol,pitch}` from config, accepts an optional per-request `voice_id` override (validated with a strict `[A-Za-z0-9_-]{1,64}` allowlist before it reaches the upstream JSON body), calls `https://api.minimax.io/v1/t2a_v2`, hex-decodes the returned audio, and streams it back as `audio/mpeg`. Upstream/parse/format failures return `400/502/503` with a message, never a silent 200.
- `static/extensions/minimax-tts.js` (new): registers the `minimax` engine via `window.registerHermesTtsEngine`. `synthesize(text, opts)` POSTs to `/api/tts` with `{engine:'minimax', text, voice_id?}` and returns the response bytes as an `ArrayBuffer`. No API key or MiniMax network call in the browser.
- `static/index.html`: one new `<script defer>` tag loading the extension, alongside the other core `static/*.js` scripts.
- `static/panels.js`: Settings → TTS Engine → Voice dropdown now has a `minimax` branch listing MiniMax voices, plus a generic `window._hermesTtsEngineVoices(engine)` hook so *other* extension-registered engines can supply their own voice list instead of always falling back to the browser's `speechSynthesis` voice list.
- `static/ui.js`: the auto-read path now also forwards the saved voice selection as `voice_id` (in addition to the existing `voice` key) so an extension engine can read whichever key it expects.
- `tests/test_minimax_tts_endpoint.py` (new): 8 tests covering missing-key (503), unsafe `voice_id` rejected before any network call (400), the existing shared over-length-text guard (400), the happy path (200, correct `audio/mpeg` + `Content-Length`, correct request body), upstream `base_resp` error surfaced as 502, non-hex audio as 502, the hardcoded default voice, and per-request voice override.

## Why It Matters

Anyone already paying for MiniMax (a supported chat provider here) gets a first-class TTS option without needing a second provider just for voice, and the key never leaves the server.

## Verification

- `./scripts/test.sh tests/test_minimax_tts_endpoint.py -v` — 8/8 passed.
- `./scripts/test.sh` (full suite) — 12184 passed, 151 skipped, 2 xfailed, 1 xpassed, 0 failed.
- `python3 scripts/ruff_lint.py --diff upstream/master` — 0 new findings on added/modified lines.
- Manual: exercised the real MiniMax `t2a_v2` endpoint end-to-end (server proxy → real API key → decoded MP3 played back) during development. The shipped default voice (`English_expressive_narrator`) and the voices listed in the Settings dropdown were each confirmed to return real audio from MiniMax's API — several voice IDs that appear in MiniMax's own marketing docs (e.g. `English_Exciting_Actor`) currently return `"voice id not exist"` from the live API, so the dropdown intentionally only lists IDs verified against the real endpoint, not the full published catalog.
- Not yet done: before/after screenshots of the new Settings → TTS Engine → Voice dropdown (see Risks / Follow-ups) — flagging per `docs/UIUX-GUIDE.md` / `CONTRIBUTING.md` UI-evidence requirement.

## Risks / Follow-ups

- **UI evidence pending.** This adds one dropdown branch in Settings; before/after screenshots will be added before this leaves draft, per the UI-evidence requirement in `CONTRIBUTING.md` / `docs/UIUX-GUIDE.md`.
- **Design question for maintainers (the main reason this is a draft):** the extension lives in-tree at `static/extensions/minimax-tts.js` and is loaded with a hardcoded `<script>` tag in `static/index.html`, rather than (a) being fully inline in `static/ui.js`/`static/panels.js` the way Edge/ElevenLabs/OpenAI are, or (b) shipping as a gallery entry in the separate `hermes-webui-extensions` repo per `docs/EXTENSIONS.md`. It uses the documented `registerHermesTtsEngine` extension API either way, but "always-on core script vs. installable extension" is a placement call I'd like direction on before finishing this out.
- **Copy/label follow-up:** the extension's header comment and dropdown label still reference an earlier default voice name (`Exciting Actor`); the shipped default is `English_expressive_narrator` (see Verification). Will align the label/comment to the shipped default — likely dropping a specific voice name from the label altogether, since the engine now has its own voice picker — before this is ready for review.
- **Voice catalog drift:** MiniMax's voice IDs aren't all documented reliably (see Verification note above). `test_minimax_default_voice_is_known_good` pins the current default so a future change to it has to be deliberate and re-verified against the live API, but the dropdown list itself isn't covered by an automated contract test against MiniMax's catalog.
- No changes to `CHANGELOG.md` (left to the release workflow, per `CONTRIBUTING.md`). Release-note wording: "Added a MiniMax text-to-speech engine option (server-proxied, voice picker in Settings)."

## Model Used

Anthropic, Claude (Claude Code agent, model `claude-sonnet-5`). The agent applied a pre-written, pre-verified patch/extension/test set, read the repo's contribution docs, ran the test suite and the ruff diff gate, and drafted this PR description; it did not design or hand-write the MiniMax integration itself.
