### PR TITLE
fix(chat): contain streaming code block layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2309,7 +2309,7 @@
   .msg-body > h4:first-child,.msg-body > h5:first-child,.msg-body > h6:first-child{margin-top:0;}
   .msg-body strong{color:var(--strong);font-weight:600;}.msg-body em{color:var(--em);font-style:italic;}
   .msg-body code{font-family:"SF Mono","Fira Code",ui-monospace,monospace;font-size:var(--message-code-font-size);background:var(--code-inline-bg);padding:1px 5px;border-radius:4px;color:var(--code-text);}
-  .msg-body pre{background:var(--code-bg);border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;margin:10px 0;}
+  .msg-body pre{background:var(--code-bg);border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;contain:content;margin:10px 0;}
   .msg-body pre code{background:none;padding:0;border-radius:0;color:var(--pre-text);font-size:var(--message-pre-code-font-size);line-height:1.6;}
   .msg-body pre.md-source-block,.preview-md pre.md-source-block{white-space:pre-wrap;overflow-x:hidden;overflow-wrap:anywhere;}
   .msg-body pre.md-source-block code,.preview-md pre.md-source-block code{display:block;white-space:inherit;overflow-wrap:anywhere;word-break:break-word;}

--- a/tests/test_issue5760_code_block_containment.py
+++ b/tests/test_issue5760_code_block_containment.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import re
+
+
+REPO = Path(__file__).resolve().parent.parent
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _base_msg_body_pre_rule() -> str:
+    match = re.search(r"(^|\n)\s*\.msg-body pre\{([^}]*)\}", STYLE_CSS)
+    assert match, "base .msg-body pre rule not found in style.css"
+    return match.group(2)
+
+
+def test_msg_body_pre_containment_contract():
+    rule = _base_msg_body_pre_rule()
+    assert "overflow-x:auto" in rule, ".msg-body pre must keep horizontal scrolling"
+    assert "contain:content" in rule, ".msg-body pre must add contain: content"
+
+
+def test_msg_body_pre_avoids_strict_containment():
+    rule = _base_msg_body_pre_rule()
+    assert "contain:strict" not in rule, ".msg-body pre must not use contain: strict"


### PR DESCRIPTION
## Thinking Path

- The live issue is streaming layout, not Prism highlighting, because Prism runs after message finalization.
- The narrowest boundary is the code block, where the growing markdown block should isolate its own layout.
- `contain: content` keeps the block from disturbing adjacent fade spans without the clipping risk of strict containment.

## What Changed

- `static/style.css`: add content containment to assistant message code blocks while preserving horizontal scrolling.
- `tests/test_issue5760_code_block_containment.py`: cover the CSS contract for containment, scrolling, and avoiding strict containment.

## Why It Matters

Long streamed code blocks should stay inside their message while the fade animation is active. This keeps the fix local to code-block layout instead of changing markdown streaming or syntax highlighting.

## Verification

Focused CSS contract coverage checks the rule shape; rendered layout proof covers the visual surface.

## Upstream

Closes #5760.

## Model Used

GPT-5.5
