### PR TITLE
feat(projects): read project rows from projects db

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -6138,15 +6138,28 @@ def _backfill_project_profiles_if_needed(projects: list) -> bool:
     return mutated
 
 
-def load_projects(*, _migrate: bool = True) -> list:
+def load_projects(
+    *,
+    _migrate: bool = True,
+    include_db: bool = False,
+    profile_name: str | None = None,
+) -> list:
     """Load project list from disk. Returns list of project dicts.
 
     On first call, runs a one-time migration to back-fill the `profile` field
     on legacy untagged projects (#1614). Disable via `_migrate=False` for
     callsites that want the raw on-disk shape (test fixtures, e.g.).
+    DB-backed rows are read-only and opt-in so mutation paths don't snapshot
+    adapter results into projects.json. JSON rows win on duplicate ids.
     """
     global _projects_migrated
     if not PROJECTS_FILE.exists():
+        if include_db:
+            from api.projects_db_adapter import load_projects_from_db
+
+            db_projects = load_projects_from_db(profile_name=profile_name)
+            if db_projects is not None:
+                return db_projects
         return []
     try:
         projects = json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
@@ -6176,7 +6189,57 @@ def load_projects(*, _migrate: bool = True) -> list:
             else:
                 # Nothing to migrate — already tagged.
                 _projects_migrated = True
+    if include_db:
+        from api.projects_db_adapter import load_projects_from_db
+
+        db_projects = load_projects_from_db(profile_name=profile_name)
+        if db_projects:
+            seen = {
+                (str(p.get('profile') or 'default'), p.get('project_id'))
+                for p in projects
+            }
+            for project in db_projects:
+                key = (
+                    str(project.get('profile') or 'default'),
+                    project.get('project_id'),
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                projects.append(project)
     return projects
+
+
+def project_identity_matches(project: dict, project_id: str | None, profile_name: str | None) -> bool:
+    if project.get('project_id') != project_id:
+        return False
+    from api.profiles import _profiles_match
+
+    return _profiles_match(project.get('profile'), profile_name)
+
+
+def load_projects_for_profiles(profile_names: list[str]) -> list:
+    """Load JSON projects plus DB-backed rows for each named profile."""
+    projects = load_projects()
+    from api.projects_db_adapter import load_projects_from_db
+
+    seen = {
+        (str(p.get('profile') or 'default'), p.get('project_id'))
+        for p in projects
+    }
+    for profile_name in profile_names:
+        profile = str(profile_name or 'default').strip() or 'default'
+        db_projects = load_projects_from_db(profile_name=profile)
+        if not db_projects:
+            continue
+        for project in db_projects:
+            key = (str(project.get('profile') or 'default'), project.get('project_id'))
+            if key in seen:
+                continue
+            seen.add(key)
+            projects.append(project)
+    return projects
+
 
 def save_projects(projects) -> None:
     """Write project list to disk."""

--- a/api/models.py
+++ b/api/models.py
@@ -6176,9 +6176,9 @@ def load_projects(
                 # rows (which a mutation route could then write back,
                 # silently overwriting the migration).
                 try:
-                    return json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
+                    projects = json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
                 except Exception:
-                    return projects
+                    pass
             if _backfill_project_profiles_if_needed(projects):
                 try:
                     save_projects(projects)
@@ -6194,15 +6194,9 @@ def load_projects(
 
         db_projects = load_projects_from_db(profile_name=profile_name)
         if db_projects:
-            seen = {
-                (str(p.get('profile') or 'default'), p.get('project_id'))
-                for p in projects
-            }
+            seen = {project_identity_key(p) for p in projects}
             for project in db_projects:
-                key = (
-                    str(project.get('profile') or 'default'),
-                    project.get('project_id'),
-                )
+                key = project_identity_key(project)
                 if key in seen:
                     continue
                 seen.add(key)
@@ -6218,22 +6212,29 @@ def project_identity_matches(project: dict, project_id: str | None, profile_name
     return _profiles_match(project.get('profile'), profile_name)
 
 
+def project_identity_key(project: dict) -> tuple[str, object]:
+    """Return the dedupe key shared by JSON and database project rows."""
+    from api.profiles import _is_root_profile
+
+    profile = str(project.get('profile') or 'default').strip() or 'default'
+    if _is_root_profile(profile):
+        profile = 'default'
+    return profile, project.get('project_id')
+
+
 def load_projects_for_profiles(profile_names: list[str]) -> list:
     """Load JSON projects plus DB-backed rows for each named profile."""
     projects = load_projects()
     from api.projects_db_adapter import load_projects_from_db
 
-    seen = {
-        (str(p.get('profile') or 'default'), p.get('project_id'))
-        for p in projects
-    }
+    seen = {project_identity_key(p) for p in projects}
     for profile_name in profile_names:
         profile = str(profile_name or 'default').strip() or 'default'
         db_projects = load_projects_from_db(profile_name=profile)
         if not db_projects:
             continue
         for project in db_projects:
-            key = (str(project.get('profile') or 'default'), project.get('project_id'))
+            key = project_identity_key(project)
             if key in seen:
                 continue
             seen.add(key)

--- a/api/projects_db_adapter.py
+++ b/api/projects_db_adapter.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import importlib
 import logging
+import shutil
 import sqlite3
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -60,17 +62,15 @@ def load_projects_from_db(*, profile_name: str | None = None) -> list[dict] | No
         return None
 
     resolved_db_path = Path(db_path).resolve()
-    has_wal_sidecar = (
-        resolved_db_path.with_name(f"{resolved_db_path.name}-wal").exists()
-        or resolved_db_path.with_name(f"{resolved_db_path.name}-shm").exists()
-    )
+    wal_path = resolved_db_path.with_name(f"{resolved_db_path.name}-wal")
+    shm_path = resolved_db_path.with_name(f"{resolved_db_path.name}-shm")
 
-    def _read_projects(*, immutable: bool) -> list[dict]:
+    def _read_projects(database_path: Path, *, immutable: bool) -> list[dict]:
         conn = None
         query = "mode=ro"
         if immutable:
             query += "&immutable=1"
-        db_uri = f"{resolved_db_path.as_uri()}?{query}"
+        db_uri = f"{database_path.as_uri()}?{query}"
         conn = sqlite3.connect(db_uri, uri=True)
         conn.row_factory = sqlite3.Row
         try:
@@ -86,15 +86,39 @@ def load_projects_from_db(*, profile_name: str | None = None) -> list[dict] | No
             except Exception:
                 logger.debug("Failed to close projects_db connection", exc_info=True)
 
+    def _sidecar_state() -> tuple[bool, bool]:
+        return wal_path.exists(), shm_path.exists()
+
+    def _read_partial_snapshot() -> list[dict] | None:
+        wal_exists, shm_exists = _sidecar_state()
+        if not wal_exists and shm_exists:
+            return None
+        with tempfile.TemporaryDirectory(prefix="hermes-projects-db-") as temp_dir:
+            snapshot_db = Path(temp_dir) / resolved_db_path.name
+            shutil.copy2(resolved_db_path, snapshot_db)
+            if wal_exists:
+                shutil.copy2(wal_path, snapshot_db.with_name(f"{snapshot_db.name}-wal"))
+            if shm_exists:
+                shutil.copy2(shm_path, snapshot_db.with_name(f"{snapshot_db.name}-shm"))
+            return _read_projects(snapshot_db, immutable=False)
+
+    def _read_matrix() -> list[dict] | None:
+        wal_exists, shm_exists = _sidecar_state()
+        if wal_exists and shm_exists:
+            return _read_projects(resolved_db_path, immutable=False)
+        if wal_exists:
+            return _read_partial_snapshot()
+        if shm_exists:
+            return None
+        return _read_projects(resolved_db_path, immutable=True)
+
+    initial_state = _sidecar_state()
     try:
-        return _read_projects(immutable=not has_wal_sidecar)
+        return _read_matrix()
     except Exception:
-        if not has_wal_sidecar and (
-            resolved_db_path.with_name(f"{resolved_db_path.name}-wal").exists()
-            or resolved_db_path.with_name(f"{resolved_db_path.name}-shm").exists()
-        ):
+        if _sidecar_state() != initial_state:
             try:
-                return _read_projects(immutable=False)
+                return _read_matrix()
             except Exception:
-                return None
+                pass
         return None

--- a/api/projects_db_adapter.py
+++ b/api/projects_db_adapter.py
@@ -89,18 +89,44 @@ def load_projects_from_db(*, profile_name: str | None = None) -> list[dict] | No
     def _sidecar_state() -> tuple[bool, bool]:
         return wal_path.exists(), shm_path.exists()
 
+    def _file_fingerprint(path: Path) -> tuple[bool, int | None, int | None]:
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            return False, None, None
+        return True, stat.st_size, stat.st_mtime_ns
+
     def _read_partial_snapshot() -> list[dict] | None:
-        wal_exists, shm_exists = _sidecar_state()
-        if not wal_exists and shm_exists:
-            return None
-        with tempfile.TemporaryDirectory(prefix="hermes-projects-db-") as temp_dir:
-            snapshot_db = Path(temp_dir) / resolved_db_path.name
-            shutil.copy2(resolved_db_path, snapshot_db)
-            if wal_exists:
-                shutil.copy2(wal_path, snapshot_db.with_name(f"{snapshot_db.name}-wal"))
+        for _ in range(3):
+            wal_exists, shm_exists = _sidecar_state()
             if shm_exists:
-                shutil.copy2(shm_path, snapshot_db.with_name(f"{snapshot_db.name}-shm"))
-            return _read_projects(snapshot_db, immutable=False)
+                return _read_projects(resolved_db_path, immutable=False)
+            if not wal_exists:
+                return _read_projects(resolved_db_path, immutable=True)
+            db_before = _file_fingerprint(resolved_db_path)
+            wal_before = _file_fingerprint(wal_path)
+            with tempfile.TemporaryDirectory(prefix="hermes-projects-db-") as temp_dir:
+                snapshot_db = Path(temp_dir) / resolved_db_path.name
+                snapshot_wal = snapshot_db.with_name(f"{snapshot_db.name}-wal")
+                snapshot_shm = snapshot_db.with_name(f"{snapshot_db.name}-shm")
+                shutil.copy2(resolved_db_path, snapshot_db)
+                try:
+                    shutil.copy2(wal_path, snapshot_wal)
+                except FileNotFoundError:
+                    continue
+                if shm_path.exists():
+                    try:
+                        shutil.copy2(shm_path, snapshot_shm)
+                    except FileNotFoundError:
+                        pass
+                db_after = _file_fingerprint(resolved_db_path)
+                wal_after = _file_fingerprint(wal_path)
+                if shm_path.exists():
+                    continue
+                if db_before != db_after or wal_before != wal_after:
+                    continue
+                return _read_projects(snapshot_db, immutable=False)
+        return None
 
     def _read_matrix() -> list[dict] | None:
         wal_exists, shm_exists = _sidecar_state()

--- a/api/projects_db_adapter.py
+++ b/api/projects_db_adapter.py
@@ -1,0 +1,100 @@
+"""Read-only adapter from hermes_cli.projects_db into WebUI project dicts."""
+from __future__ import annotations
+
+import importlib
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _active_profile_name(profile_name: str | None = None) -> str:
+    if profile_name:
+        return str(profile_name).strip() or "default"
+    try:
+        from api.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _project_to_webui_dict(project, profile_name: str) -> dict:
+    row = {
+        "project_id": project.slug,
+        "name": project.name,
+        "color": project.color,
+        "profile": profile_name,
+    }
+    created_at = getattr(project, "created_at", None)
+    if created_at is not None:
+        row["created_at"] = created_at
+    primary_path = getattr(project, "primary_path", None)
+    if primary_path is not None:
+        row["primary_path"] = primary_path
+    folders = getattr(project, "folders", None)
+    if folders is not None:
+        row["folders"] = [
+            folder.to_dict() if hasattr(folder, "to_dict") else folder
+            for folder in folders
+        ]
+    return row
+
+
+def load_projects_from_db(*, profile_name: str | None = None) -> list[dict] | None:
+    try:
+        projects_db = importlib.import_module("hermes_cli.projects_db")
+    except Exception:
+        return None
+
+    try:
+        from api.profiles import get_hermes_home_for_profile
+
+        profile = _active_profile_name(profile_name)
+        db_path = Path(get_hermes_home_for_profile(profile)) / "projects.db"
+    except Exception:
+        return None
+
+    if not db_path or not Path(db_path).exists():
+        return None
+
+    resolved_db_path = Path(db_path).resolve()
+    has_wal_sidecar = (
+        resolved_db_path.with_name(f"{resolved_db_path.name}-wal").exists()
+        or resolved_db_path.with_name(f"{resolved_db_path.name}-shm").exists()
+    )
+
+    def _read_projects(*, immutable: bool) -> list[dict]:
+        conn = None
+        query = "mode=ro"
+        if immutable:
+            query += "&immutable=1"
+        db_uri = f"{resolved_db_path.as_uri()}?{query}"
+        conn = sqlite3.connect(db_uri, uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = []
+            for project in projects_db.list_projects(conn):
+                if getattr(project, "archived", False):
+                    continue
+                rows.append(_project_to_webui_dict(project, profile))
+            return rows
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                logger.debug("Failed to close projects_db connection", exc_info=True)
+
+    try:
+        return _read_projects(immutable=not has_wal_sidecar)
+    except Exception:
+        if not has_wal_sidecar and (
+            resolved_db_path.with_name(f"{resolved_db_path.name}-wal").exists()
+            or resolved_db_path.with_name(f"{resolved_db_path.name}-shm").exists()
+        ):
+            try:
+                return _read_projects(immutable=False)
+            except Exception:
+                return None
+        return None

--- a/api/routes.py
+++ b/api/routes.py
@@ -13192,13 +13192,23 @@ def handle_get(handler, parsed) -> bool:
         isolated_profile_mode = _is_isolated_profile_mode()
         all_profiles = _all_profiles_enabled(parsed)
         active_profile = profiles_api.get_active_profile_name()
+        root_profile_names = ['default']
         if all_profiles:
             from api.models import load_projects_for_profiles
 
-            profile_names = [
-                row.get("name")
+            profile_rows = [
+                row
                 for row in profiles_api.list_profiles_api()
                 if isinstance(row, dict) and row.get("name")
+            ]
+            profile_names = [
+                row.get("name")
+                for row in profile_rows
+            ]
+            root_profile_names = ['default'] + [
+                row.get("name")
+                for row in profile_rows
+                if row.get("is_default") and row.get("name") != 'default'
             ]
             if active_profile not in profile_names:
                 profile_names.insert(0, active_profile)
@@ -13206,6 +13216,8 @@ def handle_get(handler, parsed) -> bool:
             scoped = all_projects
             other_profile_count = 0
         else:
+            if profiles_api._is_root_profile(active_profile) and active_profile != 'default':
+                root_profile_names.append(active_profile)
             all_projects = load_projects(include_db=True, profile_name=active_profile)
             scoped = [p for p in all_projects
                       if _profiles_match(p.get("profile"), active_profile)]
@@ -13214,6 +13226,7 @@ def handle_get(handler, parsed) -> bool:
             "projects": scoped,
             "all_profiles": all_profiles,
             "active_profile": active_profile,
+            "root_profile_names": root_profile_names,
             "other_profile_count": other_profile_count,
         })
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -16202,7 +16202,7 @@ def handle_post(handler, parsed) -> bool:
         )
         if not proj:
             return bad(handler, "Project not found", 404)
-        if not _profiles_match(proj.get("profile"), requested_profile):
+        if not _profiles_match(proj.get("profile"), active_profile):
             return bad(handler, "Project not found", 404)
         proj["name"] = body["name"].strip()[:128]
         if "color" in body:
@@ -16233,7 +16233,7 @@ def handle_post(handler, parsed) -> bool:
         )
         if not proj:
             return bad(handler, "Project not found", 404)
-        if not _profiles_match(proj.get("profile"), requested_profile):
+        if not _profiles_match(proj.get("profile"), active_profile):
             return bad(handler, "Project not found", 404)
         projects = [
             p for p in projects

--- a/api/routes.py
+++ b/api/routes.py
@@ -9399,6 +9399,7 @@ from api.models import (
     SESSION_INDEX_FILE,
     _active_state_db_path,
     load_projects,
+    project_identity_matches,
     save_projects,
     import_cli_session,
     get_cli_sessions,
@@ -13188,14 +13189,24 @@ def handle_get(handler, parsed) -> bool:
         # aggregate list so settings/admin UIs can still see everything.
         from api import profiles as profiles_api
 
-        active_profile = profiles_api.get_active_profile_name()
-        all_projects = load_projects()
         isolated_profile_mode = _is_isolated_profile_mode()
         all_profiles = _all_profiles_enabled(parsed)
+        active_profile = profiles_api.get_active_profile_name()
         if all_profiles:
+            from api.models import load_projects_for_profiles
+
+            profile_names = [
+                row.get("name")
+                for row in profiles_api.list_profiles_api()
+                if isinstance(row, dict) and row.get("name")
+            ]
+            if active_profile not in profile_names:
+                profile_names.insert(0, active_profile)
+            all_projects = load_projects_for_profiles(profile_names)
             scoped = all_projects
             other_profile_count = 0
         else:
+            all_projects = load_projects(include_db=True, profile_name=active_profile)
             scoped = [p for p in all_projects
                       if _profiles_match(p.get("profile"), active_profile)]
             other_profile_count = 0 if isolated_profile_mode else len(all_projects) - len(scoped)
@@ -16070,7 +16081,13 @@ def handle_post(handler, parsed) -> bool:
             # session-scoped state over global active profile. (#3325 follow-up)
             _session_profile = getattr(s, 'profile', None) or get_active_profile_name()
             target = next(
-                (p for p in load_projects() if p["project_id"] == target_pid),
+                (
+                    p for p in load_projects(
+                        include_db=True,
+                        profile_name=_session_profile,
+                    )
+                    if project_identity_matches(p, target_pid, _session_profile)
+                ),
                 None,
             )
             if not target:
@@ -16147,13 +16164,12 @@ def handle_post(handler, parsed) -> bool:
         import re as _re
 
         projects = load_projects()
+        active_profile = get_active_profile_name()
         proj = next(
-            (p for p in projects if p["project_id"] == body["project_id"]), None
+            (p for p in projects if project_identity_matches(p, body["project_id"], active_profile)), None
         )
         if not proj:
             return bad(handler, "Project not found", 404)
-        # #1614: a project can only be renamed by the profile that owns it.
-        active_profile = get_active_profile_name()
         if not _profiles_match(proj.get("profile"), active_profile):
             return bad(handler, "Project not found", 404)
         proj["name"] = body["name"].strip()[:128]
@@ -16171,16 +16187,18 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         projects = load_projects()
+        active_profile = get_active_profile_name()
         proj = next(
-            (p for p in projects if p["project_id"] == body["project_id"]), None
+            (p for p in projects if project_identity_matches(p, body["project_id"], active_profile)), None
         )
         if not proj:
             return bad(handler, "Project not found", 404)
-        # #1614: a project can only be deleted by the profile that owns it.
-        active_profile = get_active_profile_name()
         if not _profiles_match(proj.get("profile"), active_profile):
             return bad(handler, "Project not found", 404)
-        projects = [p for p in projects if p["project_id"] != body["project_id"]]
+        projects = [
+            p for p in projects
+            if not project_identity_matches(p, body["project_id"], active_profile)
+        ]
         save_projects(projects)
         # Unassign all sessions that belonged to this project.
         # #3746: this loop is O(N) full-JSON read+save per session, and each
@@ -16202,6 +16220,8 @@ def handle_post(handler, parsed) -> bool:
                 deferred_to_stream = []
                 for entry in index:
                     if entry.get("project_id") != body["project_id"]:
+                        continue
+                    if not _profiles_match(entry.get("profile"), active_profile):
                         continue
                     sid = entry.get("session_id")
                     try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -14254,6 +14254,17 @@ def handle_post(handler, parsed) -> bool:
         )
 
     if parsed.path == "/api/session/new":
+        requested_profile = str(body.get("profile") or "").strip()
+        if requested_profile:
+            from api.profiles import _PROFILE_ID_RE
+            if requested_profile != "default" and not _PROFILE_ID_RE.fullmatch(requested_profile):
+                return bad(handler, "invalid profile", status=400)
+        session_profile = requested_profile or get_active_profile_name() or "default"
+        project_id = body.get("project_id") or None
+        if project_id:
+            projects = load_projects(include_db=True, profile_name=session_profile)
+            if not any(project_identity_matches(p, project_id, session_profile) for p in projects):
+                return bad(handler, "Project not found", status=404)
         try:
             workspace = str(resolve_trusted_workspace(body.get("workspace"))) if body.get("workspace") else None
         except (TypeError, ValueError) as e:
@@ -14368,8 +14379,8 @@ def handle_post(handler, parsed) -> bool:
             workspace=workspace,
             model=model,
             model_provider=model_provider,
-            profile=body.get("profile") or None,
-            project_id=body.get("project_id") or None,
+            profile=session_profile,
+            project_id=project_id,
             worktree_info=worktree_info,
             enabled_toolsets=enabled_toolsets,
         )
@@ -16176,14 +16187,22 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e))
         import re as _re
 
+        requested_profile = str(body.get("profile") or "").strip()
+        active_profile = get_active_profile_name() or "default"
+        if requested_profile:
+            from api.profiles import _PROFILE_ID_RE
+            if requested_profile != "default" and not _PROFILE_ID_RE.fullmatch(requested_profile):
+                return bad(handler, "invalid profile")
+            if not _profiles_match(requested_profile, active_profile):
+                return bad(handler, "Project not found", 404)
+        requested_profile = requested_profile or active_profile
         projects = load_projects()
-        active_profile = get_active_profile_name()
         proj = next(
-            (p for p in projects if project_identity_matches(p, body["project_id"], active_profile)), None
+            (p for p in projects if project_identity_matches(p, body["project_id"], requested_profile)), None
         )
         if not proj:
             return bad(handler, "Project not found", 404)
-        if not _profiles_match(proj.get("profile"), active_profile):
+        if not _profiles_match(proj.get("profile"), requested_profile):
             return bad(handler, "Project not found", 404)
         proj["name"] = body["name"].strip()[:128]
         if "color" in body:
@@ -16199,18 +16218,26 @@ def handle_post(handler, parsed) -> bool:
             require(body, "project_id")
         except ValueError as e:
             return bad(handler, str(e))
+        requested_profile = str(body.get("profile") or "").strip()
+        active_profile = get_active_profile_name() or "default"
+        if requested_profile:
+            from api.profiles import _PROFILE_ID_RE
+            if requested_profile != "default" and not _PROFILE_ID_RE.fullmatch(requested_profile):
+                return bad(handler, "invalid profile")
+            if not _profiles_match(requested_profile, active_profile):
+                return bad(handler, "Project not found", 404)
+        requested_profile = requested_profile or active_profile
         projects = load_projects()
-        active_profile = get_active_profile_name()
         proj = next(
-            (p for p in projects if project_identity_matches(p, body["project_id"], active_profile)), None
+            (p for p in projects if project_identity_matches(p, body["project_id"], requested_profile)), None
         )
         if not proj:
             return bad(handler, "Project not found", 404)
-        if not _profiles_match(proj.get("profile"), active_profile):
+        if not _profiles_match(proj.get("profile"), requested_profile):
             return bad(handler, "Project not found", 404)
         projects = [
             p for p in projects
-            if not project_identity_matches(p, body["project_id"], active_profile)
+            if not project_identity_matches(p, body["project_id"], requested_profile)
         ]
         save_projects(projects)
         # Unassign all sessions that belonged to this project.
@@ -16234,7 +16261,7 @@ def handle_post(handler, parsed) -> bool:
                 for entry in index:
                     if entry.get("project_id") != body["project_id"]:
                         continue
-                    if not _profiles_match(entry.get("profile"), active_profile):
+                    if not _profiles_match(entry.get("profile"), requested_profile):
                         continue
                     sid = entry.get("session_id")
                     try:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -56,12 +56,23 @@ from api.config import (
     STATE_DIR, SESSION_DIR, SESSION_INDEX_FILE, PROJECTS_FILE, HOME,
 )
 from api.models import load_projects, project_identity_matches, save_projects
-from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match
+from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match, _PROFILE_ID_RE
 
 # ── Apply --profile override before any module uses get_active_profile_name
-if _profile_arg is not None:
+_invalid_profile_override = (
+    _profile_arg is not None
+    and _profile_arg != "default"
+    and _PROFILE_ID_RE.fullmatch(_profile_arg) is None
+)
+if _profile_arg is not None and not _invalid_profile_override:
     import api.profiles as _profiles
     _profiles._active_profile = _profile_arg
+
+
+def _invalid_profile_result() -> list[TextContent] | None:
+    if not _invalid_profile_override:
+        return None
+    return [TextContent(type="text", text=json.dumps({"error": "invalid profile"}))]
 
 # ── API auth state ─────────────────────────────────────────────────────────
 # Mirror the env-var contract used by api/config.py:32-33 so a non-default
@@ -198,6 +209,8 @@ def _api_post(endpoint: str, body: dict) -> dict:
 
 async def handle_list_projects(_arguments: dict) -> list[TextContent]:
     """List all projects with session counts, scoped to active profile."""
+    if error := _invalid_profile_result():
+        return error
     active = _active_profile()
     projects = load_projects(include_db=True, profile_name=active)
     index = _load_index()
@@ -226,6 +239,8 @@ async def handle_list_projects(_arguments: dict) -> list[TextContent]:
 
 async def handle_list_sessions(arguments: dict) -> list[TextContent]:
     """List sessions, optionally filtered by project or unassigned status."""
+    if error := _invalid_profile_result():
+        return error
     project_id = arguments.get("project_id")
     unassigned = arguments.get("unassigned", False)
     limit = max(1, min(500, arguments.get("limit", 50)))
@@ -253,6 +268,8 @@ async def handle_list_sessions(arguments: dict) -> list[TextContent]:
 
 async def handle_create_project(arguments: dict) -> list[TextContent]:
     """Create a new project (profile-scoped, exact-match title collision)."""
+    if error := _invalid_profile_result():
+        return error
     name = arguments.get("name", "").strip()[:128]
     if not name:
         return [TextContent(type="text", text=json.dumps(
@@ -289,6 +306,8 @@ async def handle_create_project(arguments: dict) -> list[TextContent]:
 
 async def handle_rename_project(arguments: dict) -> list[TextContent]:
     """Rename a project and optionally change its color (profile-checked)."""
+    if error := _invalid_profile_result():
+        return error
     project_id = arguments.get("project_id")
     name = arguments.get("name", "").strip()[:128]
     if not project_id or not name:
@@ -317,6 +336,8 @@ async def handle_rename_project(arguments: dict) -> list[TextContent]:
 
 async def handle_delete_project(arguments: dict) -> list[TextContent]:
     """Delete a project and unassign all its sessions (profile-checked)."""
+    if error := _invalid_profile_result():
+        return error
     project_id = arguments.get("project_id")
     if not project_id:
         return [TextContent(type="text", text=json.dumps(
@@ -407,6 +428,8 @@ async def handle_rename_session(arguments: dict) -> list[TextContent]:
 
 async def handle_move_session(arguments: dict) -> list[TextContent]:
     """Assign a session to a project via the authenticated webui API (cache-safe)."""
+    if error := _invalid_profile_result():
+        return error
     session_id = arguments.get("session_id")
     project_id = arguments.get("project_id")  # None/null = unassign
     if not session_id:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -55,7 +55,7 @@ import api.config as _cfg
 from api.config import (
     STATE_DIR, SESSION_DIR, SESSION_INDEX_FILE, PROJECTS_FILE, HOME,
 )
-from api.models import load_projects, save_projects
+from api.models import load_projects, project_identity_matches, save_projects
 from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match
 
 # ── Apply --profile override before any module uses get_active_profile_name
@@ -198,13 +198,15 @@ def _api_post(endpoint: str, body: dict) -> dict:
 
 async def handle_list_projects(_arguments: dict) -> list[TextContent]:
     """List all projects with session counts, scoped to active profile."""
-    projects = load_projects()
     active = _active_profile()
+    projects = load_projects(include_db=True, profile_name=active)
     index = _load_index()
 
     # Session counts per project (from index)
     counts: dict[str, int] = {}
     for s in index:
+        if not _profiles_match(s.get("profile"), active):
+            continue
         pid = s.get("project_id")
         if pid:
             counts[pid] = counts.get(pid, 0) + 1
@@ -301,13 +303,8 @@ async def handle_rename_project(arguments: dict) -> list[TextContent]:
 
     active = _active_profile()
     projects = load_projects()
-    proj = next((p for p in projects if p["project_id"] == project_id), None)
+    proj = next((p for p in projects if project_identity_matches(p, project_id, active)), None)
     if not proj:
-        return [TextContent(type="text", text=json.dumps(
-            {"error": "Project not found"}, ensure_ascii=False))]
-
-    # #1614: profile ownership check
-    if not _profiles_match(proj.get("profile"), active):
         return [TextContent(type="text", text=json.dumps(
             {"error": "Project not found"}, ensure_ascii=False))]
 
@@ -327,17 +324,12 @@ async def handle_delete_project(arguments: dict) -> list[TextContent]:
 
     active = _active_profile()
     projects = load_projects()
-    proj = next((p for p in projects if p["project_id"] == project_id), None)
+    proj = next((p for p in projects if project_identity_matches(p, project_id, active)), None)
     if not proj:
         return [TextContent(type="text", text=json.dumps(
             {"error": "Project not found"}, ensure_ascii=False))]
 
-    # #1614: profile ownership check
-    if not _profiles_match(proj.get("profile"), active):
-        return [TextContent(type="text", text=json.dumps(
-            {"error": "Project not found"}, ensure_ascii=False))]
-
-    projects = [p for p in projects if p["project_id"] != project_id]
+    projects = [p for p in projects if not project_identity_matches(p, project_id, active)]
     save_projects(projects)
 
     # Unassign sessions only when we can do it cache-safely via the HTTP API.
@@ -370,6 +362,8 @@ async def handle_delete_project(arguments: dict) -> list[TextContent]:
             try:
                 session_data = json.loads(p.read_text(encoding="utf-8"))
                 if session_data.get("project_id") == project_id:
+                    if not _profiles_match(session_data.get("profile"), active):
+                        continue
                     sid = p.stem
                     result = _api_post("/api/session/move",
                                        {"session_id": sid, "project_id": None})
@@ -421,14 +415,16 @@ async def handle_move_session(arguments: dict) -> list[TextContent]:
 
     # If project_id is provided, verify it exists and is profile-accessible
     if project_id is not None:
-        projects = load_projects()
         active = _active_profile()
-        target = next((p for p in projects if p["project_id"] == project_id), None)
+        projects = load_projects(include_db=True, profile_name=active)
+        target = next(
+            (
+                p for p in projects
+                if project_identity_matches(p, project_id, active)
+            ),
+            None,
+        )
         if not target:
-            return [TextContent(type="text", text=json.dumps(
-                {"error": "Project not found"}, ensure_ascii=False))]
-        # #1614: refuse moves into projects owned by another profile
-        if not _profiles_match(target.get("profile"), active):
             return [TextContent(type="text", text=json.dumps(
                 {"error": "Project not found"}, ensure_ascii=False))]
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -56,7 +56,7 @@ from api.config import (
     STATE_DIR, SESSION_DIR, SESSION_INDEX_FILE, PROJECTS_FILE, HOME,
 )
 from api.models import load_projects, project_identity_matches, save_projects
-from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match, _PROFILE_ID_RE
+from api.profiles import get_active_profile_name, _profiles_match, _PROFILE_ID_RE
 
 # ── Apply --profile override before any module uses get_active_profile_name
 _invalid_profile_override = (
@@ -406,6 +406,8 @@ async def handle_delete_project(arguments: dict) -> list[TextContent]:
 
 async def handle_rename_session(arguments: dict) -> list[TextContent]:
     """Rename a session via the authenticated webui API (cache-safe)."""
+    if error := _invalid_profile_result():
+        return error
     session_id = arguments.get("session_id")
     title = arguments.get("title", "").strip()[:80]
     if not session_id or not title:

--- a/static/commands.js
+++ b/static/commands.js
@@ -1231,7 +1231,7 @@ async function cmdGoal(args){
       workspace:S.session.workspace,
       model:S.session.model||($('modelSelect')&&$('modelSelect').value)||'',
       model_provider:S.session.model_provider||null,
-      profile:S.activeProfile||S.session.profile||'default',
+      profile:S.session.profile||S.activeProfile||'default',
     })});
     const msg = (() => {
       const raw = String((r && r.message) || '').trim();

--- a/static/messages.js
+++ b/static/messages.js
@@ -1752,7 +1752,7 @@ async function send(){
       // matching provider fallback for the same outgoing model.
       model:_modelState.model,workspace:S.session.workspace,
       model_provider:_modelState.model_provider,
-      profile:S.activeProfile||S.session.profile||'default',
+      profile:S.session.profile||S.activeProfile||'default',
       explicit_model_pick:_explicitPick||undefined,
       attachments:uploaded.length?uploaded:undefined,
       moa_config:_pendingMoaConfig?true:undefined

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1455,7 +1455,7 @@ async function newSession(flash, options={}){
       // safe default that matches the user's configured route. S.session.model_provider
       // is the previous-session fallback when the dropdown is unhydrated.
       //
-      // Guard: a slash-qualified model (e.g. "gemini/gemini-2.5") or an
+      // #2518 guard: a slash-qualified model (e.g. "gemini/gemini-2.5") or an
       // @provider:model string already carries a foreign provider namespace from
       // a previous session that was served by a different backend. Attaching
       // the current _activeProvider to such a slug would let the server's fast
@@ -1647,6 +1647,9 @@ async function _switchProfileForSessionLoad(profile){
     if(typeof _resetCronUnreadForProfileSwitch==='function'){
       _resetCronUnreadForProfileSwitch();
     }
+    const defaultWorkspace=(typeof data.default_workspace==='string'&&data.default_workspace)||null;
+    S._profileDefaultWorkspace=defaultWorkspace;
+    S._profileSwitchWorkspace=defaultWorkspace;
     if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
     else localStorage.removeItem('hermes-webui-model');
     if(data.default_model) window._defaultModel=data.default_model;
@@ -7529,6 +7532,37 @@ function _renderSidebarRowsFromRawSessions(sessionsRaw, referenceSessionsRaw){
   return _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw, referenceRows);
 }
 
+function _projectRequestPayload(project, extra){
+  const payload={
+    project_id:project.project_id,
+    profile:project.profile||'default',
+  };
+  if(extra&&typeof extra==='object'){
+    for(const [key,value] of Object.entries(extra)){
+      if(value!==undefined) payload[key]=value;
+    }
+  }
+  return payload;
+}
+
+function _projectUsesActiveProfile(project){
+  const targetProfile=(project&&typeof project.profile==='string'&&project.profile.trim())
+    ? project.profile.trim()
+    : 'default';
+  const activeProfile=S.activeProfile||'default';
+  return typeof _profileMatchesActiveProfile==='function'
+    ? _profileMatchesActiveProfile(targetProfile,activeProfile)
+    : targetProfile===activeProfile;
+}
+
+function _ensureActiveProfileForProject(project){
+  if(!project||_projectUsesActiveProfile(project)) return Promise.resolve(false);
+  if(typeof _switchProfileForSessionLoad==='function'){
+    return Promise.resolve(_switchProfileForSessionLoad(project.profile||'default')).then(()=>true);
+  }
+  return Promise.resolve(false);
+}
+
 function _attachProjectQuickCreateButton(chip, project){
   const btn=document.createElement('button');
   btn.type='button';
@@ -7552,23 +7586,30 @@ function _attachProjectQuickCreateButton(chip, project){
     if(_newSessionInFlight){
       // The initiating tap already owns the filter change and rollback path.
       try{
-        await newSession(false,{project_id:project.project_id,profile:project.profile});
+        await newSession(false,_projectRequestPayload(project));
       }catch(_){
         // The initiating tap already owns the visible failure path.
       }
       return;
     }
     const previousProject=(typeof _activeProject!=='undefined')?_activeProject:NO_PROJECT_FILTER;
+    let switchedProfile=false;
+    try{
+      switchedProfile=await _ensureActiveProfileForProject(project);
+    }catch(err){
+      if(typeof showToast==='function') showToast('Profile switch failed: '+(err&&err.message||err));
+      return;
+    }
     _setActiveProjectFilter(project);
     try{
-      await newSession(false,{project_id:project.project_id,profile:project.profile});
+      await newSession(false,_projectRequestPayload(project));
       // newSession() does not repaint the sidebar (callers own that — see the
       // newSession contract). Repaint from the post-create state so the new
       // project-assigned session appears deterministically.
       try{ if(typeof renderSessionListFromCache==='function') renderSessionListFromCache(); }catch(_){}
       try{ if(typeof renderSessionList==='function') void renderSessionList({deferWhileInteracting:false}); }catch(_){}
     }catch(err){
-      _setActiveProjectFilter(previousProject);
+      if(!switchedProfile) _setActiveProjectFilter(previousProject);
       if(typeof showToast==='function') showToast('New conversation failed: '+(err&&err.message||err));
     }
   };
@@ -9301,7 +9342,7 @@ function _startProjectRename(proj, chip){
     _finishDone=true;
     if(save&&inp.value.trim()&&inp.value.trim()!==proj.name){
       try {
-        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,profile:proj.profile,name:inp.value.trim()})});
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify(_projectRequestPayload(proj,{name:inp.value.trim()}))});
         await renderSessionList();
         showToast('Project renamed');
       } catch(e) {
@@ -9359,7 +9400,7 @@ function _showProjectContextMenu(e, proj, chip){
     dot.onclick=async()=>{
       menu.remove();
       try {
-        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,profile:proj.profile,name:proj.name,color:hex})});
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify(_projectRequestPayload(proj,{name:proj.name,color:hex}))});
         await renderSessionList();
         showToast('Color updated');
       } catch(e) {
@@ -9395,7 +9436,7 @@ async function _confirmDeleteProject(proj){
   });
   if(!ok){return;}
   try {
-    await api('/api/projects/delete',{method:'POST',body:JSON.stringify({project_id:proj.project_id,profile:proj.profile})});
+    await api('/api/projects/delete',{method:'POST',body:JSON.stringify(_projectRequestPayload(proj))});
     if(_projectFilterMatches(_activeProject,proj)) _activeProject=null;
     await renderSessionList();
     showToast('Project deleted');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1411,7 +1411,7 @@ async function newSession(flash, options={}){
     if(Object.prototype.hasOwnProperty.call(options,'project_id')){
       reqBody.project_id=options.project_id;
     } else if(_activeProject&&_activeProject!==NO_PROJECT_FILTER){
-      reqBody.project_id=_activeProject;
+      reqBody.project_id=_activeProject.project_id;
     }
     // Forward a pre-session toolset override only from the empty composer (#4490).
     if(!S.session && Array.isArray(S._pendingSessionToolsets)) reqBody.enabled_toolsets=S._pendingSessionToolsets;
@@ -2569,9 +2569,36 @@ function _sessionSourceTabCount(filter, renderedWebuiSessionCount, renderedCliSe
   return filter === 'cli' ? renderedCliSessionCount : renderedWebuiSessionCount;
 }
 
-function _setActiveProjectFilter(projectId) {
-  const next = projectId === NO_PROJECT_FILTER ? NO_PROJECT_FILTER : (projectId || null);
-  if (_activeProject === next) return;
+function _canonicalProjectFilterProfile(profile) {
+  const name = (typeof profile === 'string' && profile.trim()) ? profile.trim() : 'default';
+  const rootNames = new Set(['default']);
+  if(typeof S === 'object' && S){
+    if(Array.isArray(S.rootProfileNames)){
+      for(const rootName of S.rootProfileNames){
+        if(typeof rootName === 'string' && rootName.trim()) rootNames.add(rootName.trim());
+      }
+    }
+    if(S.activeProfileIsDefault && typeof S.activeProfile === 'string' && S.activeProfile.trim()){
+      rootNames.add(S.activeProfile.trim());
+    }
+  }
+  return rootNames.has(name) ? 'default' : name;
+}
+
+function _projectFilterIdentity(project) {
+  if(!project||!project.project_id) return null;
+  return {profile:_canonicalProjectFilterProfile(project.profile),project_id:String(project.project_id)};
+}
+
+function _projectFilterMatches(filter, row) {
+  return !!filter&&filter!==NO_PROJECT_FILTER&&!!row&&
+    _canonicalProjectFilterProfile(filter.profile)===_canonicalProjectFilterProfile(row.profile)&&
+    filter.project_id===String(row.project_id||'');
+}
+
+function _setActiveProjectFilter(project) {
+  const next = project === NO_PROJECT_FILTER ? NO_PROJECT_FILTER : _projectFilterIdentity(project);
+  if (_activeProject === next || _projectFilterMatches(_activeProject,next)) return;
   _activeProject = next;
   renderSessionListFromCache();
   void renderSessionList({deferWhileInteracting:false});
@@ -3896,7 +3923,7 @@ let _allProjects = [];  // cached project list
 // to be something a user-created project_id can never collide with, which
 // double-underscore prefixes provide.
 const NO_PROJECT_FILTER = '__none__';
-let _activeProject = null;  // project_id filter (null = show all, NO_PROJECT_FILTER = unassigned only)
+let _activeProject = null;  // filter identity (null = all, NO_PROJECT_FILTER = unassigned only)
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes-show-all-profiles';
 let _showAllProfiles = false;  // false = filter to active profile only
 let _profileSwitchOpeningExistingSession = false;  // true while cross-profile sidebar click switches profile before loadSession()
@@ -5412,6 +5439,9 @@ function _applySessionListPayload(sessData, projData, opts){
   }
   _syncSessionAttentionSoundState(_allSessions);
   _pruneLineageReportCacheToVisibleSessions(_allSessions);
+  S.rootProfileNames = Array.isArray(projData.root_profile_names)
+    ? projData.root_profile_names.filter(name=>typeof name === 'string' && name.trim())
+    : ['default'];
   _allProjects = projData.projects||[];
   // Capture the recovering-from-error state BEFORE clearing it: the error banner
   // DOM was rendered outside the signature path, so if this payload heals with
@@ -7431,7 +7461,7 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     if(!_sidebarRowHasVisibleMessages(s, activeSidForSidebar)) continue;
     const isCli=_isCliSession(s);
     if(isCli) cliSessionCount++;
-    if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;
+    if(s.default_hidden&&!_projectFilterMatches(_activeProject,s)) continue;
     const profileFiltered=isCli ? cliProfileFiltered : webuiProfileFiltered;
     const referenceRaw=isCli ? cliReferenceRaw : webuiReferenceRaw;
     const sessionsRaw=isCli ? cliSessionsRaw : webuiSessionsRaw;
@@ -7439,7 +7469,7 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     if(_activeProject===NO_PROJECT_FILTER){
       if(s.project_id) continue;
     } else if(_activeProject){
-      if(s.project_id!==_activeProject) continue;
+      if(!_projectFilterMatches(_activeProject,s)) continue;
     }
     referenceRaw.push(s);
     if(s.archived){
@@ -7482,7 +7512,7 @@ function _scopedSidebarReferenceRows(isCli){
     if(_isCliSession(s)!==!!isCli) return false;
     // Project scope: mirror _partitionSidebarSessionRows exactly.
     if(_activeProject===NO_PROJECT_FILTER){ if(s.project_id) return false; }
-    else if(_activeProject){ if(s.project_id!==_activeProject) return false; }
+    else if(_activeProject){ if(!_projectFilterMatches(_activeProject,s)) return false; }
     return true;
   });
 }
@@ -7522,7 +7552,7 @@ function _attachProjectQuickCreateButton(chip, project){
       return;
     }
     const previousProject=(typeof _activeProject!=='undefined')?_activeProject:NO_PROJECT_FILTER;
-    _setActiveProjectFilter(project.project_id);
+    _setActiveProjectFilter(project);
     try{
       await newSession(false,{project_id:project.project_id});
       // newSession() does not repaint the sidebar (callers own that — see the
@@ -7680,7 +7710,7 @@ function renderSessionListFromCache(){
     // Project chips
     for(const p of _allProjects){
       const chip=document.createElement('span');
-      chip.className='project-chip'+(p.project_id===_activeProject?' active':'');
+      chip.className='project-chip'+(_projectFilterMatches(_activeProject,p)?' active':'');
       if(p.color){
         const dot=document.createElement('span');
         dot.className='color-dot';
@@ -7693,7 +7723,7 @@ function renderSessionListFromCache(){
       let _pClickTimer=null;
       chip.onclick=(e)=>{
         clearTimeout(_pClickTimer);
-        _pClickTimer=setTimeout(()=>{_pClickTimer=null;_setActiveProjectFilter(p.project_id);},220);
+        _pClickTimer=setTimeout(()=>{_pClickTimer=null;_setActiveProjectFilter(p);},220);
       };
       chip.ondblclick=(e)=>{e.stopPropagation();clearTimeout(_pClickTimer);_pClickTimer=null;_startProjectRename(p,chip);};
       chip.oncontextmenu=(e)=>{e.preventDefault();_showProjectContextMenu(e,p,chip);};
@@ -8065,7 +8095,7 @@ function renderSessionListFromCache(){
     // to need the project marker. As a flex-flow sibling it stays visible
     // regardless of title length and sits next to the timestamp on the right.
     if(s.project_id){
-      const proj=_allProjects.find(p=>p.project_id===s.project_id);
+      const proj=_allProjects.find(p=>_projectFilterMatches(_projectFilterIdentity(s),p));
       if(proj){
         const dot=document.createElement('span');
         dot.className='session-project-dot';
@@ -9115,7 +9145,7 @@ function _showProjectPicker(session, anchorEl){
   for(const p of _allProjects){
     if (_profileHidesProject(p.profile)) continue;
     const item=document.createElement('div');
-    item.className='project-picker-item'+(session.project_id===p.project_id?' active':'');
+    item.className='project-picker-item'+(_projectFilterMatches(_projectFilterIdentity(session),p)?' active':'');
     if(p.color){
       const dot=document.createElement('span');
       dot.className='color-dot';
@@ -9359,7 +9389,7 @@ async function _confirmDeleteProject(proj){
   if(!ok){return;}
   try {
     await api('/api/projects/delete',{method:'POST',body:JSON.stringify({project_id:proj.project_id})});
-    if(_activeProject===proj.project_id) _activeProject=null;
+    if(_projectFilterMatches(_activeProject,proj)) _activeProject=null;
     await renderSessionList();
     showToast('Project deleted');
   } catch(e) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1410,8 +1410,15 @@ async function newSession(flash, options={}){
     if(options&&Object.prototype.hasOwnProperty.call(options,'worktree')) reqBody.worktree=!!options.worktree;
     if(Object.prototype.hasOwnProperty.call(options,'project_id')){
       reqBody.project_id=options.project_id;
+      reqBody.profile=options.profile||(
+        _activeProject&&_activeProject!==NO_PROJECT_FILTER&&
+        String(_activeProject.project_id)===String(options.project_id)
+          ? _activeProject.profile
+          : S.activeProfile||'default'
+      );
     } else if(_activeProject&&_activeProject!==NO_PROJECT_FILTER){
       reqBody.project_id=_activeProject.project_id;
+      reqBody.profile=_activeProject.profile||'default';
     }
     // Forward a pre-session toolset override only from the empty composer (#4490).
     if(!S.session && Array.isArray(S._pendingSessionToolsets)) reqBody.enabled_toolsets=S._pendingSessionToolsets;
@@ -7545,7 +7552,7 @@ function _attachProjectQuickCreateButton(chip, project){
     if(_newSessionInFlight){
       // The initiating tap already owns the filter change and rollback path.
       try{
-        await newSession(false,{project_id:project.project_id});
+        await newSession(false,{project_id:project.project_id,profile:project.profile});
       }catch(_){
         // The initiating tap already owns the visible failure path.
       }
@@ -7554,7 +7561,7 @@ function _attachProjectQuickCreateButton(chip, project){
     const previousProject=(typeof _activeProject!=='undefined')?_activeProject:NO_PROJECT_FILTER;
     _setActiveProjectFilter(project);
     try{
-      await newSession(false,{project_id:project.project_id});
+      await newSession(false,{project_id:project.project_id,profile:project.profile});
       // newSession() does not repaint the sidebar (callers own that — see the
       // newSession contract). Repaint from the post-create state so the new
       // project-assigned session appears deterministically.
@@ -9294,7 +9301,7 @@ function _startProjectRename(proj, chip){
     _finishDone=true;
     if(save&&inp.value.trim()&&inp.value.trim()!==proj.name){
       try {
-        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:inp.value.trim()})});
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,profile:proj.profile,name:inp.value.trim()})});
         await renderSessionList();
         showToast('Project renamed');
       } catch(e) {
@@ -9352,7 +9359,7 @@ function _showProjectContextMenu(e, proj, chip){
     dot.onclick=async()=>{
       menu.remove();
       try {
-        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:proj.name,color:hex})});
+        await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,profile:proj.profile,name:proj.name,color:hex})});
         await renderSessionList();
         showToast('Color updated');
       } catch(e) {
@@ -9388,7 +9395,7 @@ async function _confirmDeleteProject(proj){
   });
   if(!ok){return;}
   try {
-    await api('/api/projects/delete',{method:'POST',body:JSON.stringify({project_id:proj.project_id})});
+    await api('/api/projects/delete',{method:'POST',body:JSON.stringify({project_id:proj.project_id,profile:proj.profile})});
     if(_projectFilterMatches(_activeProject,proj)) _activeProject=null;
     await renderSessionList();
     showToast('Project deleted');

--- a/tests/test_4676_project_new_session_shortcuts.py
+++ b/tests/test_4676_project_new_session_shortcuts.py
@@ -46,8 +46,9 @@ def test_quick_create_button_attaches_filter_align_and_request_path():
     src = _read(SESSIONS_JS)
     helper = _extract_function(src, "_attachProjectQuickCreateButton")
     assert "project-chip-quick-create" in helper
+    assert "_ensureActiveProfileForProject(project)" in helper
     assert "_setActiveProjectFilter(project)" in helper
-    assert "newSession(false,{project_id:project.project_id})" in helper
+    assert "newSession(false,_projectRequestPayload(project))" in helper
     assert "if(_newSessionInFlight)" in helper
     assert "_setActiveProjectFilter(previousProject)" in helper
     assert "btn.ondblclick" in helper
@@ -192,6 +193,142 @@ eval(newSessionSrc);
     return json.loads(result.stdout.strip().splitlines()[-1])["body"]
 
 
+def _run_switched_profile_new_session_case(default_workspace: str):
+    _DRIVER = r"""
+const fs = require('fs');
+const [path, argsJson] = process.argv.slice(-2);
+const args = JSON.parse(argsJson);
+const src = fs.readFileSync(path, 'utf8');
+
+function extractAsyncFunction(source, name) {
+  const marker = `async function ${name}(`;
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(name + ' not found');
+  const brace = source.indexOf('{', source.indexOf(')', start));
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error('function body not closed for ' + name);
+}
+
+globalThis.window = globalThis;
+globalThis.document = {
+  baseURI: 'http://example.test/',
+  createElement(tag) {
+    const node = {
+      tagName: String(tag || '').toUpperCase(),
+      children: [],
+      appendChild(child) { this.children.push(child); },
+      textContent: '',
+      value: '',
+      selectedOptions: [{ dataset: { provider: '' } }],
+      dataset: {},
+    };
+    return node;
+  },
+};
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+globalThis.history = { replaceState: () => {} };
+globalThis.NO_PROJECT_FILTER = '__none__';
+globalThis._activeProject = null;
+globalThis._sessionSourceFilter = 'webui';
+globalThis._newSessionInFlight = null;
+globalThis._messagesTruncated = false;
+globalThis._oldestIdx = 0;
+globalThis._sessionListSkeletonActive = false;
+globalThis.INFLIGHT = {};
+globalThis.S = {
+  session: { session_id: 'session-1', workspace: 'old-session' },
+  toolCalls: [],
+  messages: [],
+  activeProfile: 'default',
+  activeProfileIsDefault: true,
+  _pendingSessionToolsets: null,
+  _profileSwitchWorkspace: null,
+  _profileDefaultWorkspace: 'old-default',
+};
+globalThis._defaultModel = null;
+globalThis._activeProvider = 'openai';
+globalThis._emptyComposerModelOverride = null;
+globalThis._readPersistedModelState = () => null;
+globalThis._readEmptyComposerModelOverride = () => null;
+globalThis._clearEmptyComposerModelOverride = () => {};
+globalThis.$ = (id) => (id === 'modelSelect' ? { value: 'gpt-4', selectedOptions: [{ dataset: { provider: 'openai' } }] } : null);
+for (const name of [
+  '_setNewSessionPending', 'updateQueueBadge', '_clearPendingSelections',
+  'clearLiveToolCards', 'setComposerStatus', 'setStatus', 'updateSendBtn',
+  'syncTopbar', 'renderMessages', 'startSessionStream', '_setSessionViewedCount',
+  '_setActiveSessionUrl', '_rememberNewChatDraftSession', '_hydrateTodosFromSession',
+  '_setLiveAssistantTps', '_syncCtxIndicator', 'showToast', '_invalidateSessionListRenders',
+  '_setProfileSwitchListEmbargo', 'showSessionListSkeleton', 'renderSessionList',
+  'renderSessionListFromCache', 'startGatewaySSE'
+]) {
+  globalThis[name] = () => {};
+}
+globalThis.loadDir = async () => null;
+globalThis._applyModelToDropdown = () => true;
+globalThis._modelStateForSelect = () => ({ model: 'gpt-4', model_provider: 'openai' });
+globalThis._readPersistedModelState = () => null;
+globalThis.getModelLabel = (v) => v || '';
+globalThis._defaultModel = null;
+
+const calls = [];
+globalThis.api = async (url, opts) => {
+  if (url === '/api/profile/switch') {
+    calls.push({ url, body: JSON.parse(opts.body) });
+    return {
+      active: 'work',
+      is_default: false,
+      default_workspace: args.defaultWorkspace,
+      default_model: null,
+      default_model_provider: null,
+    };
+  }
+  if (url === '/api/session/new') {
+    const body = JSON.parse(opts.body);
+    calls.push({ url, body });
+    return { session: { session_id: 's-1', messages: [], model: 'gpt-4', model_provider: 'openai', workspace: body.workspace, profile: body.profile, message_count: 0, last_usage: {} } };
+  }
+  throw new Error('unexpected api call ' + url);
+};
+
+eval(extractAsyncFunction(src, '_switchProfileForSessionLoad'));
+eval(extractAsyncFunction(src, 'newSession'));
+
+(async () => {
+  await _switchProfileForSessionLoad('work');
+  await newSession(false, { project_id: 'project-123', profile: 'work' });
+  const createCall = calls.find((c) => c.url === '/api/session/new');
+  console.log(JSON.stringify({
+    activeProfile: globalThis.S.activeProfile,
+    defaultWorkspace: globalThis.S._profileDefaultWorkspace,
+    body: createCall ? createCall.body : {},
+  }));
+})().catch(err => {
+  console.error(String(err && err.stack ? err.stack : err));
+  process.exit(1);
+});
+"""
+
+    result = subprocess.run(
+        [NODE, "-e", _DRIVER, str(SESSIONS_JS), json.dumps({"defaultWorkspace": default_workspace})],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}"
+        )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_new_session_aligns_project_id_override_when_explicitly_set():
     body = _run_new_session_case(
@@ -199,6 +336,16 @@ def test_new_session_aligns_project_id_override_when_explicitly_set():
         active_project={"profile": "default", "project_id": "active-project"},
     )
     assert body["project_id"] == "explicit-project"
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_foreign_profile_new_session_uses_switched_default_workspace():
+    out = _run_switched_profile_new_session_case("D:/foreign-workspace")
+
+    assert out["activeProfile"] == "work"
+    assert out["defaultWorkspace"] == "D:/foreign-workspace"
+    assert out["body"]["profile"] == "work"
+    assert out["body"]["workspace"] == "D:/foreign-workspace"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -260,6 +407,10 @@ globalThis.document = {
     };
   },
 };
+globalThis.S = {
+  activeProfile: params.activeProfileName || 'default',
+  activeProfileIsDefault: (params.activeProfileName || 'default') === 'default',
+};
 globalThis._setActiveProjectFilter = (project) => {
   globalThis._activeProject = project;
   params.filterProject = project;
@@ -280,13 +431,26 @@ globalThis.newSession = async (flash, options) => {
 globalThis.showToast = (message) => {
   params.toasts.push(String(message || ''));
 };
+globalThis._switchProfileForSessionLoad = async (profile) => {
+  params.calls.push({type: 'switch-profile', profile});
+  globalThis.S.activeProfile = profile;
+  globalThis.S.activeProfileIsDefault = profile === 'default';
+};
 globalThis._newSessionInFlight = params.newSessionInFlightReject
   ? Promise.reject(new Error(params.newSessionInFlightReject))
   : (params.newSessionInFlight
       ? Promise.resolve(params.newSessionInFlight)
       : null);
 
-eval(extractFunction(sessionsSrc, '_attachProjectQuickCreateButton'));
+for (const name of [
+  '_profileMatchesActiveProfile',
+  '_projectRequestPayload',
+  '_projectUsesActiveProfile',
+  '_ensureActiveProfileForProject',
+  '_attachProjectQuickCreateButton',
+]) {
+  eval(extractFunction(sessionsSrc, name));
+}
 
 const chip = {
   appended: [],
@@ -324,6 +488,7 @@ const touchEv = {
     touchStopCount: params.touchStopCount,
     touchPreventCount: params.touchPreventCount,
     touchStopImmediateCount: params.touchStopImmediateCount,
+    activeProfile: globalThis.S.activeProfile,
     calls: params.calls,
     toasts: params.toasts,
   }));
@@ -338,15 +503,18 @@ def _run_quick_create_case(
     project_id="example-project",
     *,
     active_project=None,
+    active_profile_name="default",
     fail_new_session=False,
     new_session_inflight=None,
     new_session_inflight_reject=None,
+    project_profile="default",
 ):
     if active_project is None:
         active_project = {"profile": "default", "project_id": "active-project"}
     payload = {
         "projectId": project_id,
-        "projectProfile": "default",
+        "projectProfile": project_profile,
+        "activeProfileName": active_profile_name,
         "activeProject": active_project,
         "filterProject": active_project,
         "filterProjectId": active_project["project_id"],
@@ -385,15 +553,32 @@ def test_project_chip_quick_create_keeps_active_filter_and_uses_project_override
     assert out["buttonAriaLabel"] == "New conversation in this project"
     assert out["filterProject"] == {"profile": "default", "project_id": "project-123"}
     assert out["filterProjectId"] == "project-123"
-    assert out["newSession"] == {"flash": False, "options": {"project_id": "project-123"}}
+    assert out["newSession"] == {"flash": False, "options": {"project_id": "project-123", "profile": "default"}}
     assert {"type": "set-filter", "project": {"profile": "default", "project_id": "project-123"}} in out["calls"]
-    assert {"type": "new-session", "flash": False, "options": {"project_id": "project-123"}} in out["calls"]
+    assert {"type": "new-session", "flash": False, "options": {"project_id": "project-123", "profile": "default"}} in out["calls"]
     assert out["stopCount"] >= 3
     assert out["preventCount"] >= 3
     assert out["stopImmediateCount"] >= 3
     assert out["touchStopCount"] >= 2
     assert out["touchPreventCount"] == 0
     assert out["touchStopImmediateCount"] >= 2
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_project_chip_quick_create_switches_profile_before_foreign_profile_session():
+    out = _run_quick_create_case(
+        "project-123",
+        active_project={"profile": "default", "project_id": "keep-me"},
+        active_profile_name="default",
+        project_profile="work",
+    )
+
+    assert out["activeProfile"] == "work"
+    assert out["calls"][:3] == [
+        {"type": "switch-profile", "profile": "work"},
+        {"type": "set-filter", "project": {"profile": "work", "project_id": "project-123"}},
+        {"type": "new-session", "flash": False, "options": {"project_id": "project-123", "profile": "work"}},
+    ]
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")

--- a/tests/test_4676_project_new_session_shortcuts.py
+++ b/tests/test_4676_project_new_session_shortcuts.py
@@ -46,7 +46,7 @@ def test_quick_create_button_attaches_filter_align_and_request_path():
     src = _read(SESSIONS_JS)
     helper = _extract_function(src, "_attachProjectQuickCreateButton")
     assert "project-chip-quick-create" in helper
-    assert "_setActiveProjectFilter(project.project_id)" in helper
+    assert "_setActiveProjectFilter(project)" in helper
     assert "newSession(false,{project_id:project.project_id})" in helper
     assert "if(_newSessionInFlight)" in helper
     assert "_setActiveProjectFilter(previousProject)" in helper
@@ -194,20 +194,29 @@ eval(newSessionSrc);
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_new_session_aligns_project_id_override_when_explicitly_set():
-    body = _run_new_session_case({"project_id": "explicit-project"}, active_project="active-project")
+    body = _run_new_session_case(
+        {"project_id": "explicit-project"},
+        active_project={"profile": "default", "project_id": "active-project"},
+    )
     assert body["project_id"] == "explicit-project"
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_new_session_respects_explicit_project_id_none():
-    body = _run_new_session_case({"project_id": None}, active_project="active-project")
+    body = _run_new_session_case(
+        {"project_id": None},
+        active_project={"profile": "default", "project_id": "active-project"},
+    )
     assert "project_id" in body
     assert body["project_id"] is None
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_new_session_falls_back_to_active_project_when_override_missing():
-    body = _run_new_session_case({}, active_project="active-project")
+    body = _run_new_session_case(
+        {},
+        active_project={"profile": "default", "project_id": "active-project"},
+    )
     assert body["project_id"] == "active-project"
 
 
@@ -251,10 +260,11 @@ globalThis.document = {
     };
   },
 };
-globalThis._setActiveProjectFilter = (projectId) => {
-  globalThis._activeProject = projectId;
-  params.filterProjectId = projectId;
-  params.calls.push({type: 'set-filter', projectId});
+globalThis._setActiveProjectFilter = (project) => {
+  globalThis._activeProject = project;
+  params.filterProject = project;
+  params.filterProjectId = project && typeof project === 'object' ? project.project_id : project;
+  params.calls.push({type: 'set-filter', project});
 };
 globalThis._activeProject = params.activeProject;
 globalThis.newSession = async (flash, options) => {
@@ -282,7 +292,7 @@ const chip = {
   appended: [],
   appendChild(child) { this.appended.push(child); },
 };
-_attachProjectQuickCreateButton(chip, { project_id: params.projectId });
+_attachProjectQuickCreateButton(chip, { project_id: params.projectId, profile: params.projectProfile || 'default' });
 const btn = chip.appended[0];
 const ev = {
   stopPropagation() { params.stopCount++; },
@@ -306,6 +316,7 @@ const touchEv = {
     buttonText: btn.textContent,
     buttonAriaLabel: btn.getAttribute('aria-label'),
     newSession: params.newSession,
+    filterProject: params.filterProject,
     filterProjectId: params.filterProjectId,
     stopCount: params.stopCount,
     preventCount: params.preventCount,
@@ -326,15 +337,19 @@ const touchEv = {
 def _run_quick_create_case(
     project_id="example-project",
     *,
-    active_project="active-project",
+    active_project=None,
     fail_new_session=False,
     new_session_inflight=None,
     new_session_inflight_reject=None,
 ):
+    if active_project is None:
+        active_project = {"profile": "default", "project_id": "active-project"}
     payload = {
         "projectId": project_id,
+        "projectProfile": "default",
         "activeProject": active_project,
-        "filterProjectId": active_project,
+        "filterProject": active_project,
+        "filterProjectId": active_project["project_id"],
         "calls": [],
         "stopCount": 0,
         "preventCount": 0,
@@ -368,9 +383,10 @@ def test_project_chip_quick_create_keeps_active_filter_and_uses_project_override
     assert out["buttonTag"] == "BUTTON"
     assert out["buttonText"] == "+"
     assert out["buttonAriaLabel"] == "New conversation in this project"
+    assert out["filterProject"] == {"profile": "default", "project_id": "project-123"}
     assert out["filterProjectId"] == "project-123"
     assert out["newSession"] == {"flash": False, "options": {"project_id": "project-123"}}
-    assert {"type": "set-filter", "projectId": "project-123"} in out["calls"]
+    assert {"type": "set-filter", "project": {"profile": "default", "project_id": "project-123"}} in out["calls"]
     assert {"type": "new-session", "flash": False, "options": {"project_id": "project-123"}} in out["calls"]
     assert out["stopCount"] >= 3
     assert out["preventCount"] >= 3
@@ -384,13 +400,13 @@ def test_project_chip_quick_create_keeps_active_filter_and_uses_project_override
 def test_project_chip_quick_create_restores_filter_when_new_session_fails():
     out = _run_quick_create_case(
         "project-123",
-        active_project="keep-me",
+        active_project={"profile": "default", "project_id": "keep-me"},
         fail_new_session=True,
     )
 
     assert out["filterProjectId"] == "keep-me"
-    assert {"type": "set-filter", "projectId": "project-123"} in out["calls"]
-    assert {"type": "set-filter", "projectId": "keep-me"} in out["calls"]
+    assert {"type": "set-filter", "project": {"profile": "default", "project_id": "project-123"}} in out["calls"]
+    assert {"type": "set-filter", "project": {"profile": "default", "project_id": "keep-me"}} in out["calls"]
     assert any(msg.startswith("New conversation failed:") for msg in out["toasts"])
 
 
@@ -398,12 +414,12 @@ def test_project_chip_quick_create_restores_filter_when_new_session_fails():
 def test_project_chip_quick_create_leaves_filter_unchanged_during_inflight_guard():
     out = _run_quick_create_case(
         "project-123",
-        active_project="keep-me",
+        active_project={"profile": "default", "project_id": "keep-me"},
         new_session_inflight={"session_id": "existing"},
     )
 
     assert out["filterProjectId"] == "keep-me"
-    assert {"type": "set-filter", "projectId": "project-123"} not in out["calls"]
+    assert {"type": "set-filter", "project": {"profile": "default", "project_id": "project-123"}} not in out["calls"]
     assert "newSession" not in out
 
 
@@ -411,10 +427,10 @@ def test_project_chip_quick_create_leaves_filter_unchanged_during_inflight_guard
 def test_project_chip_quick_create_swallows_duplicate_inflight_rejections():
     out = _run_quick_create_case(
         "project-123",
-        active_project="keep-me",
+        active_project={"profile": "default", "project_id": "keep-me"},
         new_session_inflight_reject="request failed",
     )
 
     assert out["filterProjectId"] == "keep-me"
-    assert {"type": "set-filter", "projectId": "project-123"} not in out["calls"]
+    assert {"type": "set-filter", "project": {"profile": "default", "project_id": "project-123"}} not in out["calls"]
     assert out["toasts"] == ["New conversation already in progress"]

--- a/tests/test_issue3019_cron_project_sessions.py
+++ b/tests/test_issue3019_cron_project_sessions.py
@@ -92,4 +92,4 @@ def test_session_list_project_filter_can_reveal_default_hidden_cron_rows():
     src = ( __import__("pathlib").Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
 
     assert "function _partitionSidebarSessionRows(allMatched, activeSidForSidebar)" in src
-    assert "if(s.default_hidden&&!(_activeProject&&_activeProject!==NO_PROJECT_FILTER&&s.project_id===_activeProject)) continue;" in src
+    assert "if(s.default_hidden&&!_projectFilterMatches(_activeProject,s)) continue;" in src

--- a/tests/test_issue4775_sidebar_hidden_zero_message_pushdown.py
+++ b/tests/test_issue4775_sidebar_hidden_zero_message_pushdown.py
@@ -250,6 +250,9 @@ def test_default_and_unassigned_queries_send_exclude_hidden(monkeypatch):
     src = SESSIONS_JS.read_text(encoding="utf-8")
     requested_source_fn = _extract_function(src, "_requestedSessionSidebarSource")
     exclude_hidden_fn = _extract_function(src, "_sessionListExcludeHiddenEnabled")
+    canonical_profile_fn = _extract_function(src, "_canonicalProjectFilterProfile")
+    project_filter_identity_fn = _extract_function(src, "_projectFilterIdentity")
+    project_filter_matches_fn = _extract_function(src, "_projectFilterMatches")
     project_filter_fn = _extract_function(src, "_setActiveProjectFilter")
     query_fn = _extract_function(src, "_sessionListQueryString")
     script = f"""
@@ -258,17 +261,22 @@ global._showCliSessions = false;
 global._showAllProfiles = false;
 global._showArchived = false;
 global._activeProject = null;
+global.S = {{ activeProfile: 'default', activeProfileIsDefault: false, rootProfileNames: ['default'] }};
 global.NO_PROJECT_FILTER = '__none__';
 global.renderSessionListFromCache = () => {{}};
 global.renderSessionList = () => Promise.resolve();
 {requested_source_fn}
 {exclude_hidden_fn}
+{canonical_profile_fn}
+{project_filter_identity_fn}
+{project_filter_matches_fn}
 {project_filter_fn}
 {query_fn}
+const demoProject = {{ profile: 'default', project_id: 'demo-project' }};
 const default_query = _sessionListQueryString();
 _setActiveProjectFilter('__none__');
 const unassigned_query = _sessionListQueryString();
-_setActiveProjectFilter('demo-project');
+_setActiveProjectFilter(demoProject);
 const named_project_query = _sessionListQueryString();
 console.log(JSON.stringify({{ default_query, unassigned_query, named_project_query }}));
 """
@@ -282,11 +290,15 @@ console.log(JSON.stringify({{ default_query, unassigned_query, named_project_que
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_project_filter_click_path_triggers_fresh_session_load():
     src = SESSIONS_JS.read_text(encoding="utf-8")
+    canonical_profile_fn = _extract_function(src, "_canonicalProjectFilterProfile")
+    project_filter_identity_fn = _extract_function(src, "_projectFilterIdentity")
+    project_filter_matches_fn = _extract_function(src, "_projectFilterMatches")
     project_filter_fn = _extract_function(src, "_setActiveProjectFilter")
     script = f"""
 const calls = [];
 global.NO_PROJECT_FILTER = '__none__';
 global._activeProject = null;
+global.S = {{ activeProfile: 'default', activeProfileIsDefault: false, rootProfileNames: ['default'] }};
 global.renderSessionListFromCache = () => {{
   calls.push('cache');
 }};
@@ -294,8 +306,11 @@ global.renderSessionList = (opts) => {{
   calls.push(opts);
   return Promise.resolve();
 }};
+{canonical_profile_fn}
+{project_filter_identity_fn}
+{project_filter_matches_fn}
 {project_filter_fn}
-_setActiveProjectFilter('demo-project');
+_setActiveProjectFilter({{ profile: 'default', project_id: 'demo-project' }});
 _setActiveProjectFilter('__none__');
 console.log(JSON.stringify({{
   activeProject: global._activeProject,

--- a/tests/test_issue5763_project_filter_identity.py
+++ b/tests/test_issue5763_project_filter_identity.py
@@ -1,0 +1,318 @@
+"""Executable regression coverage for profile-qualified sidebar project filters."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(script: str) -> dict:
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        cwd=str(ROOT),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}")
+    return json.loads(result.stdout.strip())
+
+
+def test_same_project_id_in_different_profiles_filters_sessions_hidden_rows_and_references():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const src = fs.readFileSync({str(SESSIONS_JS)!r}, 'utf8');
+
+        function extractFunction(name) {{
+          const marker = `function ${{name}}(`;
+          const start = src.indexOf(marker);
+          if (start < 0) throw new Error(name + ' not found');
+          const brace = src.indexOf('{{', start);
+          let depth = 0;
+          for (let i = brace; i < src.length; i++) {{
+            if (src[i] === '{{') depth += 1;
+            else if (src[i] === '}}') {{
+              depth -= 1;
+              if (depth === 0) return src.slice(start, i + 1);
+            }}
+          }}
+          throw new Error('unterminated function ' + name);
+        }}
+
+        globalThis.NO_PROJECT_FILTER = '__none__';
+        globalThis.S = {{
+          activeProfile: 'default',
+          activeProfileIsDefault: false,
+          rootProfileNames: ['default'],
+          session: null,
+        }};
+        globalThis._activeProject = {{ profile: 'work', project_id: 'shared' }};
+        globalThis._showArchived = true;
+        globalThis._sessionSourceFilter = 'webui';
+        globalThis.window = {{ _showCliSessions: false }};
+        globalThis._archivedCliCount = 0;
+        globalThis._archivedWebuiCount = 0;
+        globalThis._sidebarRowHasVisibleMessages = () => true;
+        globalThis._isCliSession = () => false;
+        globalThis._sidebarReferenceSessions = [
+          {{ session_id: 'ref-work', profile: 'work', project_id: 'shared' }},
+          {{ session_id: 'ref-other', profile: 'other', project_id: 'shared' }},
+          {{ session_id: 'ref-unassigned', profile: 'work', project_id: '' }},
+        ];
+
+        for (const name of [
+          '_canonicalProjectFilterProfile',
+          '_projectFilterIdentity',
+          '_projectFilterMatches',
+          '_partitionSidebarSessionRows',
+          '_scopedSidebarReferenceRows',
+        ]) eval(extractFunction(name));
+
+        const rows = [
+          {{ session_id: 'work-visible', profile: 'work', project_id: 'shared', default_hidden: false, archived: false }},
+          {{ session_id: 'work-hidden', profile: 'work', project_id: 'shared', default_hidden: true, archived: false }},
+          {{ session_id: 'other-visible', profile: 'other', project_id: 'shared', default_hidden: false, archived: false }},
+          {{ session_id: 'other-hidden', profile: 'other', project_id: 'shared', default_hidden: true, archived: false }},
+          {{ session_id: 'other-project', profile: 'work', project_id: 'else', default_hidden: false, archived: false }},
+        ];
+
+        const partition = _partitionSidebarSessionRows(rows, null);
+        const scoped = _scopedSidebarReferenceRows(false);
+        console.log(JSON.stringify({{
+          sessionsRaw: partition.sessionsRaw.map((row) => row.session_id),
+          referenceRaw: partition.webuiReferenceRaw.map((row) => row.session_id),
+          scopedRefs: scoped.map((row) => row.session_id),
+        }}));
+        """
+    )
+    assert _run_node(script) == {
+        "sessionsRaw": ["work-visible", "work-hidden"],
+        "referenceRaw": ["work-visible", "work-hidden"],
+        "scopedRefs": ["ref-work"],
+    }
+
+
+def test_same_project_id_uses_matching_profile_metadata_and_delete_identity():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const src = fs.readFileSync({str(SESSIONS_JS)!r}, 'utf8');
+
+        function extractFunction(name) {{
+          const marker = `function ${{name}}(`;
+          const start = src.indexOf(marker);
+          if (start < 0) throw new Error(name + ' not found');
+          const brace = src.indexOf('{{', start);
+          let depth = 0;
+          for (let i = brace; i < src.length; i++) {{
+            if (src[i] === '{{') depth += 1;
+            else if (src[i] === '}}') {{
+              depth -= 1;
+              if (depth === 0) return src.slice(start, i + 1);
+            }}
+          }}
+          throw new Error('unterminated function ' + name);
+        }}
+
+        globalThis.NO_PROJECT_FILTER = '__none__';
+        globalThis.S = {{ activeProfile: 'default', activeProfileIsDefault: false, rootProfileNames: ['default'] }};
+        for (const name of ['_canonicalProjectFilterProfile', '_projectFilterIdentity', '_projectFilterMatches']) {{
+          eval(extractFunction(name));
+        }}
+
+        const projects = [
+          {{ profile: 'work', project_id: 'shared', color: '#123456', name: 'Work project' }},
+          {{ profile: 'other', project_id: 'shared', color: '#abcdef', name: 'Other project' }},
+          {{ project_id: 'shared', color: '#fedcba', name: 'Default project' }},
+        ];
+        const workSession = {{ profile: 'work', project_id: 'shared' }};
+        const defaultSession = {{ project_id: 'shared' }};
+        const activeFilter = {{ profile: 'work', project_id: 'shared' }};
+
+        const workProject = projects.find((p) => _projectFilterMatches(_projectFilterIdentity(workSession), p));
+        const defaultProject = projects.find((p) => _projectFilterMatches(_projectFilterIdentity(defaultSession), p));
+        const deleteMatches = projects.map((p) => _projectFilterMatches(activeFilter, p));
+
+        console.log(JSON.stringify({{
+          workProject,
+          defaultProject,
+          deleteMatches,
+        }}));
+        """
+    )
+    assert _run_node(script) == {
+        "workProject": {
+            "profile": "work",
+            "project_id": "shared",
+            "color": "#123456",
+            "name": "Work project",
+        },
+        "defaultProject": {
+            "project_id": "shared",
+            "color": "#fedcba",
+            "name": "Default project",
+        },
+        "deleteMatches": [True, False, False],
+    }
+
+
+def test_root_alias_matches_default_profile_rows():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const src = fs.readFileSync({str(SESSIONS_JS)!r}, 'utf8');
+
+        function extractFunction(name) {{
+          const marker = `function ${{name}}(`;
+          const start = src.indexOf(marker);
+          if (start < 0) throw new Error(name + ' not found');
+          const brace = src.indexOf('{{', start);
+          let depth = 0;
+          for (let i = brace; i < src.length; i++) {{
+            if (src[i] === '{{') depth += 1;
+            else if (src[i] === '}}') {{
+              depth -= 1;
+              if (depth === 0) return src.slice(start, i + 1);
+            }}
+          }}
+          throw new Error('unterminated function ' + name);
+        }}
+
+        globalThis.NO_PROJECT_FILTER = '__none__';
+        globalThis.S = {{
+          activeProfile: 'kinni',
+          activeProfileIsDefault: true,
+          rootProfileNames: ['default', 'kinni'],
+        }};
+        for (const name of ['_canonicalProjectFilterProfile', '_projectFilterIdentity', '_projectFilterMatches']) {{
+          eval(extractFunction(name));
+        }}
+
+        const session = {{ profile: 'kinni', project_id: 'shared' }};
+        const project = {{ profile: 'default', project_id: 'shared' }};
+        console.log(JSON.stringify({{
+          identity: _projectFilterIdentity(session),
+          matches: _projectFilterMatches(_projectFilterIdentity(session), project),
+        }}));
+        """
+    )
+    assert _run_node(script) == {
+        "identity": {"profile": "default", "project_id": "shared"},
+        "matches": True,
+    }
+
+
+def test_move_picker_marks_only_profile_matching_same_slug_project_active():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const src = fs.readFileSync({str(SESSIONS_JS)!r}, 'utf8');
+
+        function extractFunction(name) {{
+          const marker = `function ${{name}}(`;
+          const start = src.indexOf(marker);
+          if (start < 0) throw new Error(name + ' not found');
+          const brace = src.indexOf('{{', start);
+          let depth = 0;
+          for (let i = brace; i < src.length; i++) {{
+            if (src[i] === '{{') depth += 1;
+            else if (src[i] === '}}') {{
+              depth -= 1;
+              if (depth === 0) return src.slice(start, i + 1);
+            }}
+          }}
+          throw new Error('unterminated function ' + name);
+        }}
+
+        function makeNode(tag) {{
+          return {{
+            tagName: String(tag || '').toUpperCase(),
+            className: '',
+            textContent: '',
+            children: [],
+            style: {{}},
+            scrollWidth: 160,
+            appendChild(child) {{
+              this.children.push(child);
+              child.parentNode = this;
+              return child;
+            }},
+            remove() {{
+              this.removed = true;
+            }},
+            contains(target) {{
+              return this === target || this.children.includes(target);
+            }},
+          }};
+        }}
+
+        const bodyChildren = [];
+        globalThis.window = {{ innerHeight: 800 }};
+        globalThis.NO_PROJECT_FILTER = '__none__';
+        globalThis.S = {{ activeProfile: 'default', activeProfileIsDefault: false, rootProfileNames: ['default'] }};
+        globalThis.document = {{
+          querySelectorAll() {{ return []; }},
+          createElement(tag) {{ return makeNode(tag); }},
+          body: {{
+            appendChild(node) {{
+              bodyChildren.push(node);
+              return node;
+            }},
+          }},
+          addEventListener() {{}},
+          removeEventListener() {{}},
+        }};
+        globalThis._allProjects = [
+          {{ profile: 'work', project_id: 'shared', name: 'Work', color: '#123456' }},
+          {{ profile: 'default', project_id: 'shared', name: 'Default alias', color: '#abcdef' }},
+        ];
+        globalThis._allSessions = [{{ session_id: 's1', project_id: 'shared', profile: 'work' }}];
+        globalThis.api = async () => ({{}});
+        globalThis.renderSessionListFromCache = () => {{}};
+        globalThis.showToast = () => {{}};
+        globalThis.showPromptDialog = async () => null;
+        globalThis.t = (key) => key;
+        globalThis.PROJECT_COLORS = ['#111111'];
+        globalThis.renderSessionList = async () => {{}};
+        globalThis.setTimeout = () => 0;
+
+        for (const name of ['_canonicalProjectFilterProfile', '_projectFilterIdentity', '_projectFilterMatches', '_showProjectPicker']) {{
+          eval(extractFunction(name));
+        }}
+
+        const anchorEl = {{
+          getBoundingClientRect() {{
+            return {{ top: 100, bottom: 120, right: 220 }};
+          }},
+        }};
+
+        _showProjectPicker({{ session_id: 's1', project_id: 'shared', profile: 'work' }}, anchorEl);
+        const picker = bodyChildren[0];
+        const projectItems = picker.children
+          .filter((item) => item.className.startsWith('project-picker-item') && item.textContent !== 'No project' && item.textContent !== '+ New project')
+          .map((item) => {{
+            const nameNode = item.children[item.children.length - 1];
+            return {{ name: nameNode.textContent, className: item.className }};
+          }});
+        console.log(JSON.stringify(projectItems));
+        """
+    )
+    assert _run_node(script) == [
+        {"name": "Work", "className": "project-picker-item active"},
+        {"name": "Default alias", "className": "project-picker-item"},
+    ]

--- a/tests/test_issue5763_project_filter_identity.py
+++ b/tests/test_issue5763_project_filter_identity.py
@@ -316,3 +316,10 @@ def test_move_picker_marks_only_profile_matching_same_slug_project_active():
         {"name": "Work", "className": "project-picker-item active"},
         {"name": "Default alias", "className": "project-picker-item"},
     ]
+
+
+def test_project_mutations_share_profile_qualified_payload_helper():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    assert "function _projectRequestPayload(" in src
+    assert src.count("_projectRequestPayload(proj") >= 3
+    assert "JSON.stringify({project_id:proj.project_id,profile:proj.profile" not in src

--- a/tests/test_issue5763_projects_db_adapter.py
+++ b/tests/test_issue5763_projects_db_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import json
+import shutil
 import sqlite3
 import sys
 import types
@@ -278,6 +279,68 @@ def test_projects_db_adapter_reads_wal_only_from_temporary_snapshot(monkeypatch,
         assert not db_file.with_name("projects.db-shm").exists()
     finally:
         writer.close()
+
+
+def test_projects_db_adapter_retries_checkpoint_between_snapshot_copies(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    wal_path = db_file.with_name("projects.db-wal")
+    db_file.write_text("old-main", encoding="utf-8")
+    wal_path.write_text("new-wal", encoding="utf-8")
+
+    class _FakeConn:
+        def __init__(self, database: str):
+            parsed = urlparse(database)
+            path = parsed.path
+            if path.startswith("/") and path[2:3] == ":":
+                path = path.removeprefix("/")
+            self.path = Path(path)
+            self.row_factory = None
+
+        def close(self):
+            return None
+
+    module = types.ModuleType("hermes_cli.projects_db")
+    module.list_projects = lambda conn: [
+        types.SimpleNamespace(slug="old", name="Old", color="#111111", archived=False),
+        *(
+            [types.SimpleNamespace(slug="new", name="New", color="#222222", archived=False)]
+            if "new-main" in conn.path.read_text(encoding="utf-8")
+            or conn.path.with_name(f"{conn.path.name}-wal").read_text(encoding="utf-8")
+            else []
+        ),
+    ]
+    package = types.ModuleType("hermes_cli")
+    package.__path__ = []
+    package.projects_db = module
+    monkeypatch.setitem(sys.modules, "hermes_cli", package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.projects_db", module)
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+    monkeypatch.setattr(adapter.sqlite3, "connect", lambda database, *args, **kwargs: _FakeConn(database))
+
+    real_copy2 = shutil.copy2
+    copied = []
+    raced = {"done": False}
+
+    def _copy2(src, dst, *args, **kwargs):
+        copied.append(Path(src).name)
+        result = real_copy2(src, dst, *args, **kwargs)
+        if Path(src) == db_file and not raced["done"]:
+            raced["done"] = True
+            db_file.write_text("new-main", encoding="utf-8")
+            wal_path.write_text("", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(adapter.shutil, "copy2", _copy2)
+
+    assert adapter.load_projects_from_db(profile_name="work") == [
+        {"project_id": "old", "name": "Old", "color": "#111111", "profile": "work"},
+        {"project_id": "new", "name": "New", "color": "#222222", "profile": "work"},
+    ]
+    assert copied.count("projects.db") >= 2
+    assert copied.count("projects.db-wal") >= 2
 
 
 def test_projects_db_adapter_fails_closed_for_shm_only_without_mutation(monkeypatch, tmp_path):

--- a/tests/test_issue5763_projects_db_adapter.py
+++ b/tests/test_issue5763_projects_db_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import json
 import sqlite3
 import sys
@@ -243,6 +244,84 @@ def test_projects_db_adapter_reads_live_wal_rows(monkeypatch, tmp_path):
     ]
 
 
+def test_projects_db_adapter_reads_wal_only_from_temporary_snapshot(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    source_db = tmp_path / "source.db"
+    writer = sqlite3.connect(source_db)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE projects (slug TEXT, name TEXT, color TEXT)")
+        writer.execute("INSERT INTO projects VALUES ('partial', 'Partial', '#abcdef')")
+        writer.commit()
+        db_file.write_bytes(source_db.read_bytes())
+        db_file.with_name("projects.db-wal").write_bytes(source_db.with_name("source.db-wal").read_bytes())
+
+        module = types.ModuleType("hermes_cli.projects_db")
+        module.list_projects = lambda conn: [
+            types.SimpleNamespace(slug=row["slug"], name=row["name"], color=row["color"], archived=False)
+            for row in conn.execute("SELECT slug, name, color FROM projects")
+        ]
+        package = types.ModuleType("hermes_cli")
+        package.__path__ = []
+        package.projects_db = module
+        monkeypatch.setitem(sys.modules, "hermes_cli", package)
+        monkeypatch.setitem(sys.modules, "hermes_cli.projects_db", module)
+        monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+        assert adapter.load_projects_from_db(profile_name="work") == [
+            {"project_id": "partial", "name": "Partial", "color": "#abcdef", "profile": "work"}
+        ]
+        assert not db_file.with_name("projects.db-shm").exists()
+    finally:
+        writer.close()
+
+
+def test_projects_db_adapter_fails_closed_for_shm_only_without_mutation(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    _install_fake_projects_db(monkeypatch, projects=[])
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    db_file.write_bytes(b"not a database")
+    shm_path = db_file.with_name("projects.db-shm")
+    shm_path.write_bytes(b"stale")
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+    assert adapter.load_projects_from_db(profile_name="work") is None
+    assert shm_path.read_bytes() == b"stale"
+
+
+def test_projects_db_adapter_concurrent_first_readers_both_get_rows(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    with sqlite3.connect(db_file) as conn:
+        conn.execute("CREATE TABLE projects (slug TEXT, name TEXT, color TEXT)")
+        conn.execute("INSERT INTO projects VALUES ('first', 'First', '#123456')")
+    module = types.ModuleType("hermes_cli.projects_db")
+    module.list_projects = lambda conn: [
+        types.SimpleNamespace(slug=row["slug"], name=row["name"], color=row["color"], archived=False)
+        for row in conn.execute("SELECT slug, name, color FROM projects")
+    ]
+    package = types.ModuleType("hermes_cli")
+    package.__path__ = []
+    package.projects_db = module
+    monkeypatch.setitem(sys.modules, "hermes_cli", package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.projects_db", module)
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        rows = list(executor.map(lambda _: adapter.load_projects_from_db(profile_name="work"), range(2)))
+
+    expected = [{"project_id": "first", "name": "First", "color": "#123456", "profile": "work"}]
+    assert rows == [expected, expected]
+
+
 def test_projects_db_adapter_retries_without_immutable_when_wal_appears(monkeypatch, tmp_path):
     import api.projects_db_adapter as adapter
 
@@ -351,6 +430,73 @@ def test_load_projects_read_only_merges_db_rows_when_json_exists(monkeypatch, tm
         {"project_id": "json", "name": "JSON", "profile": "default"},
         {"project_id": "json", "name": "DB Shadow", "color": None, "profile": "work"},
         {"project_id": "db", "name": "DB", "color": None, "profile": "work"},
+    ]
+
+
+def test_load_projects_dedupes_root_aliases(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "root", "name": "JSON", "profile": ""}]), encoding="utf-8")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+    monkeypatch.setattr("api.profiles._is_root_profile", lambda name: name in {"default", "renamed"})
+    monkeypatch.setattr(
+        "api.projects_db_adapter.load_projects_from_db",
+        lambda **_kwargs: [{"project_id": "root", "name": "DB", "profile": "renamed"}],
+        raising=False,
+    )
+
+    assert models.load_projects(_migrate=False, include_db=True) == [
+        {"project_id": "root", "name": "JSON", "profile": ""}
+    ]
+
+
+def test_load_projects_for_profiles_dedupes_root_aliases(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "root", "name": "JSON", "profile": "default"}]), encoding="utf-8")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+    monkeypatch.setattr("api.profiles._is_root_profile", lambda name: name in {"default", "renamed"})
+    monkeypatch.setattr(
+        "api.projects_db_adapter.load_projects_from_db",
+        lambda **_kwargs: [{"project_id": "root", "name": "DB", "profile": "renamed"}],
+        raising=False,
+    )
+
+    assert models.load_projects_for_profiles(["renamed"]) == [
+        {"project_id": "root", "name": "JSON", "profile": "default"}
+    ]
+
+
+def test_load_projects_migration_reread_still_merges_db(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "old", "name": "Old"}]), encoding="utf-8")
+
+    class _MigrationRace:
+        def __enter__(self):
+            projects_file.write_text(json.dumps([{"project_id": "new", "name": "New", "profile": "default"}]), encoding="utf-8")
+            models._projects_migrated = True
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "_PROJECTS_MIGRATION_LOCK", _MigrationRace(), raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", False, raising=False)
+    monkeypatch.setattr(
+        "api.projects_db_adapter.load_projects_from_db",
+        lambda **_kwargs: [{"project_id": "db", "name": "DB", "profile": "default"}],
+        raising=False,
+    )
+
+    assert models.load_projects(include_db=True) == [
+        {"project_id": "new", "name": "New", "profile": "default"},
+        {"project_id": "db", "name": "DB", "profile": "default"},
     ]
 
 
@@ -585,6 +731,59 @@ def test_routes_pass_active_and_session_profiles_to_project_reads(monkeypatch):
     assert move_payload["ok"] is True
     assert session.project_id == "research-project"
     assert calls == [{"include_db": True, "profile_name": "research"}]
+
+
+def test_projects_route_reports_root_profile_aliases(monkeypatch):
+    import api.models as models
+    import api.profiles as profiles
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        profiles,
+        "get_active_profile_name",
+        lambda: "work",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        profiles,
+        "_is_root_profile",
+        lambda name: name in {"default", "kinni"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "load_projects",
+        lambda **_kwargs: [{"project_id": "work-project", "name": "Work", "profile": "work"}],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, **_kwargs: payload,
+        raising=False,
+    )
+
+    scoped_payload = routes.handle_get(object(), urlparse("/api/projects"))
+    assert scoped_payload["root_profile_names"] == ["default"]
+
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True},
+            {"name": "work", "is_default": False},
+        ],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        models,
+        "load_projects_for_profiles",
+        lambda _names: [{"project_id": "root-project", "name": "Root", "profile": "default"}],
+        raising=False,
+    )
+
+    all_payload = routes.handle_get(object(), urlparse("/api/projects?all_profiles=1"))
+    assert all_payload["root_profile_names"] == ["default", "kinni"]
 
 
 def test_routes_project_rename_and_delete_use_profile_identity(monkeypatch):

--- a/tests/test_issue5763_projects_db_adapter.py
+++ b/tests/test_issue5763_projects_db_adapter.py
@@ -906,6 +906,16 @@ def test_mcp_invalid_profile_fails_closed_before_project_lookup(monkeypatch):
 
     payload = json.loads(asyncio.run(mcp_server.handle_list_projects({}))[0].text)
     assert payload == {"error": "invalid profile"}
+    monkeypatch.setattr(
+        mcp_server,
+        "_api_post",
+        lambda *_args, **_kwargs: pytest.fail("invalid profile must not post session rename"),
+    )
+    rename_payload = json.loads(asyncio.run(mcp_server.handle_rename_session({
+        "session_id": "sid",
+        "title": "Renamed",
+    }))[0].text)
+    assert rename_payload == {"error": "invalid profile"}
 
 
 def test_mcp_list_and_move_use_active_profile_db_rows(monkeypatch):

--- a/tests/test_issue5763_projects_db_adapter.py
+++ b/tests/test_issue5763_projects_db_adapter.py
@@ -804,7 +804,7 @@ def test_routes_project_rename_and_delete_use_profile_identity(monkeypatch):
     monkeypatch.setattr(
         routes,
         "read_body",
-        lambda _handler: {"project_id": "shared", "name": "Renamed"},
+        lambda _handler: {"project_id": "shared", "profile": "work", "name": "Renamed"},
     )
     rename_payload = routes.handle_post(object(), urlparse("/api/projects/rename"))
 
@@ -817,7 +817,7 @@ def test_routes_project_rename_and_delete_use_profile_identity(monkeypatch):
     monkeypatch.setattr(
         routes,
         "read_body",
-        lambda _handler: {"project_id": "shared"},
+        lambda _handler: {"project_id": "shared", "profile": "work"},
     )
     monkeypatch.setattr(routes, "SESSION_INDEX_FILE", Path("missing-index.json"))
     delete_payload = routes.handle_post(object(), urlparse("/api/projects/delete"))
@@ -826,6 +826,86 @@ def test_routes_project_rename_and_delete_use_profile_identity(monkeypatch):
     assert saved[-1] == [
         {"project_id": "shared", "name": "Default", "profile": "default"},
     ]
+
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"project_id": "shared", "profile": "default", "name": "Wrong"},
+    )
+    monkeypatch.setattr(routes, "bad", lambda _handler, message, *_args, **_kwargs: {"error": message})
+    assert routes.handle_post(object(), urlparse("/api/projects/rename"))["error"] == "Project not found"
+    assert saved[-1] == [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+    ]
+
+
+def test_session_new_requires_exact_profile_project_pair(monkeypatch):
+    import api.routes as routes
+
+    calls = []
+    created = []
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "_handle_extension_sidecar_proxy", lambda *args, **kwargs: False)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {
+        "profile": "work",
+        "project_id": "shared",
+    })
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        routes,
+        "load_projects",
+        lambda **kwargs: calls.append(kwargs) or [
+            {"project_id": "shared", "name": "Work", "profile": "work"},
+        ],
+    )
+
+    class _Session:
+        session_id = "sid"
+        profile = "work"
+        messages = []
+
+        def compact(self):
+            return {"session_id": self.session_id, "profile": self.profile}
+
+    monkeypatch.setattr(
+        routes,
+        "new_session",
+        lambda **kwargs: created.append(kwargs) or _Session(),
+    )
+    monkeypatch.setattr(routes, "_session_model_state_from_request", lambda *_args: (None, None))
+    monkeypatch.setattr(routes, "_validate_session_toolsets_shape", lambda _value: None)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload, raising=False)
+
+    payload = routes.handle_post(object(), urlparse("/api/session/new"))
+
+    assert calls == [{"include_db": True, "profile_name": "work"}]
+    assert created[0]["profile"] == "work"
+    assert created[0]["project_id"] == "shared"
+    assert payload["session"]["profile"] == "work"
+
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {
+        "profile": "work",
+        "project_id": "missing",
+    })
+    monkeypatch.setattr(routes, "bad", lambda _handler, message, *_args, **_kwargs: {"error": message})
+    assert routes.handle_post(object(), urlparse("/api/session/new")) == {"error": "Project not found"}
+    assert len(created) == 1
+
+
+def test_mcp_invalid_profile_fails_closed_before_project_lookup(monkeypatch):
+    pytest.importorskip("mcp", reason="mcp package not installed")
+    import mcp_server
+
+    monkeypatch.setattr(mcp_server, "_invalid_profile_override", True)
+    monkeypatch.setattr(
+        mcp_server,
+        "load_projects",
+        lambda **_kwargs: pytest.fail("invalid profile must not load projects"),
+    )
+
+    payload = json.loads(asyncio.run(mcp_server.handle_list_projects({}))[0].text)
+    assert payload == {"error": "invalid profile"}
 
 
 def test_mcp_list_and_move_use_active_profile_db_rows(monkeypatch):

--- a/tests/test_issue5763_projects_db_adapter.py
+++ b/tests/test_issue5763_projects_db_adapter.py
@@ -1,0 +1,760 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+
+class _FakeFolder:
+    def __init__(self, path: str):
+        self.path = path
+        self.label = None
+        self.is_primary = True
+        self.added_at = 7
+
+    def to_dict(self):
+        return {
+            "path": self.path,
+            "label": self.label,
+            "is_primary": self.is_primary,
+            "added_at": self.added_at,
+        }
+
+
+def _install_fake_projects_db(monkeypatch, *, projects, list_error: Exception | None = None):
+    module = types.ModuleType("hermes_cli.projects_db")
+
+    def _connect():
+        raise AssertionError("read-only adapter must not call projects_db.connect()")
+
+    def _list_projects(conn):
+        if list_error is not None:
+            raise list_error
+        assert isinstance(conn, sqlite3.Connection)
+        return projects
+
+    module.connect = _connect
+    module.list_projects = _list_projects
+
+    package = types.ModuleType("hermes_cli")
+    package.__path__ = []
+    package.projects_db = module
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.projects_db", module)
+    return module
+
+
+def _profile_home(tmp_path: Path, name: str) -> Path:
+    if name in ("", "default"):
+        return tmp_path / "root"
+    return tmp_path / "profiles" / name
+
+
+def test_projects_db_adapter_maps_slug_and_profile(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    fake_projects = [
+        types.SimpleNamespace(
+            slug="team-project",
+            name="Team Project",
+            color="#123456",
+            created_at=123,
+            primary_path="/workspace/team",
+            folders=[_FakeFolder("/workspace/team")],
+            archived=False,
+        )
+    ]
+    _install_fake_projects_db(monkeypatch, projects=fake_projects)
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    db_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "work", raising=False)
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+    rows = adapter.load_projects_from_db()
+
+    assert rows == [
+        {
+            "project_id": "team-project",
+            "name": "Team Project",
+            "color": "#123456",
+            "profile": "work",
+            "created_at": 123,
+            "primary_path": "/workspace/team",
+            "folders": [
+                {
+                    "path": "/workspace/team",
+                    "label": None,
+                    "is_primary": True,
+                    "added_at": 7,
+                }
+            ],
+        }
+    ]
+
+
+def test_projects_db_adapter_reads_selected_profile_home(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    fake_projects = [
+        types.SimpleNamespace(
+            slug="profile-project",
+            name="Profile Project",
+            color=None,
+            archived=False,
+        )
+    ]
+    _install_fake_projects_db(monkeypatch, projects=fake_projects)
+    root_db = _profile_home(tmp_path, "default") / "projects.db"
+    work_db = _profile_home(tmp_path, "work") / "projects.db"
+    root_db.parent.mkdir(parents=True)
+    work_db.parent.mkdir(parents=True)
+    root_db.write_text("", encoding="utf-8")
+    work_db.write_text("", encoding="utf-8")
+    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "default", raising=False)
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+    rows = adapter.load_projects_from_db(profile_name="work")
+
+    assert rows == [
+        {
+            "project_id": "profile-project",
+            "name": "Profile Project",
+            "color": None,
+            "profile": "work",
+        }
+    ]
+
+
+def test_projects_db_adapter_uses_read_only_sqlite_uri(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    fake_projects = [
+        types.SimpleNamespace(slug="db", name="DB", color=None, archived=False)
+    ]
+    _install_fake_projects_db(monkeypatch, projects=fake_projects)
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    db_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+    real_connect = sqlite3.connect
+    seen = {}
+
+    def _connect(database, *args, **kwargs):
+        seen["database"] = database
+        seen["uri"] = kwargs.get("uri")
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(adapter.sqlite3, "connect", _connect)
+
+    assert adapter.load_projects_from_db(profile_name="work")
+    assert seen["uri"] is True
+    assert seen["database"].startswith("file:///")
+    assert seen["database"].endswith("?mode=ro&immutable=1")
+
+
+def test_projects_db_adapter_uses_wal_aware_read_only_uri(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    fake_projects = [
+        types.SimpleNamespace(slug="db", name="DB", color=None, archived=False)
+    ]
+    _install_fake_projects_db(monkeypatch, projects=fake_projects)
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    db_file.write_text("", encoding="utf-8")
+    db_file.with_name("projects.db-wal").write_text("", encoding="utf-8")
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+    real_connect = sqlite3.connect
+    seen = {}
+
+    def _connect(database, *args, **kwargs):
+        seen["database"] = database
+        seen["uri"] = kwargs.get("uri")
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(adapter.sqlite3, "connect", _connect)
+
+    assert adapter.load_projects_from_db(profile_name="work")
+    assert seen["uri"] is True
+    assert seen["database"].startswith("file:///")
+    assert seen["database"].endswith("?mode=ro")
+
+
+def test_projects_db_adapter_reads_live_wal_rows(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    writer = sqlite3.connect(db_file)
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("CREATE TABLE projects (slug TEXT, name TEXT, color TEXT)")
+        writer.execute(
+            "INSERT INTO projects (slug, name, color) VALUES (?, ?, ?)",
+            ("wal-project", "WAL Project", "#123456"),
+        )
+        writer.commit()
+        assert db_file.with_name("projects.db-wal").exists()
+
+        module = types.ModuleType("hermes_cli.projects_db")
+
+        def _connect():
+            raise AssertionError("read-only adapter must not call projects_db.connect()")
+
+        def _list_projects(conn):
+            return [
+                types.SimpleNamespace(
+                    slug=row["slug"],
+                    name=row["name"],
+                    color=row["color"],
+                    archived=False,
+                )
+                for row in conn.execute("SELECT slug, name, color FROM projects")
+            ]
+
+        module.connect = _connect
+        module.list_projects = _list_projects
+        package = types.ModuleType("hermes_cli")
+        package.__path__ = []
+        package.projects_db = module
+        monkeypatch.setitem(sys.modules, "hermes_cli", package)
+        monkeypatch.setitem(sys.modules, "hermes_cli.projects_db", module)
+        monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+        rows = adapter.load_projects_from_db(profile_name="work")
+    finally:
+        writer.close()
+
+    assert rows == [
+        {
+            "project_id": "wal-project",
+            "name": "WAL Project",
+            "color": "#123456",
+            "profile": "work",
+        }
+    ]
+
+
+def test_projects_db_adapter_retries_without_immutable_when_wal_appears(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    fake_projects = [
+        types.SimpleNamespace(slug="db", name="DB", color=None, archived=False)
+    ]
+    _install_fake_projects_db(monkeypatch, projects=fake_projects)
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    db_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+    real_connect = sqlite3.connect
+    seen = []
+
+    def _connect(database, *args, **kwargs):
+        seen.append(database)
+        if database.endswith("?mode=ro&immutable=1"):
+            db_file.with_name("projects.db-wal").write_text("", encoding="utf-8")
+            raise sqlite3.OperationalError("no such table: projects")
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(adapter.sqlite3, "connect", _connect)
+
+    assert adapter.load_projects_from_db(profile_name="work")
+    assert seen[0].endswith("?mode=ro&immutable=1")
+    assert seen[1].endswith("?mode=ro")
+
+
+def test_projects_db_adapter_read_does_not_create_sqlite_sidecars(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    fake_projects = [
+        types.SimpleNamespace(slug="db", name="DB", color=None, archived=False)
+    ]
+    _install_fake_projects_db(monkeypatch, projects=fake_projects)
+    db_file = _profile_home(tmp_path, "work") / "projects.db"
+    db_file.parent.mkdir(parents=True)
+    setup_conn = sqlite3.connect(db_file)
+    setup_conn.execute("PRAGMA journal_mode=WAL")
+    setup_conn.close()
+    db_file.with_name("projects.db-wal").unlink(missing_ok=True)
+    db_file.with_name("projects.db-shm").unlink(missing_ok=True)
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+
+    rows = adapter.load_projects_from_db(profile_name="work")
+
+    assert rows == [{"project_id": "db", "name": "DB", "color": None, "profile": "work"}]
+    assert not db_file.with_name("projects.db-wal").exists()
+    assert not db_file.with_name("projects.db-shm").exists()
+
+
+def test_load_projects_uses_db_rows_when_projects_json_is_absent_for_read_only_callers(monkeypatch, tmp_path):
+    import api.models as models
+
+    monkeypatch.setattr(models, "PROJECTS_FILE", tmp_path / "missing-projects.json", raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: [{"project_id": "db", "name": "DB", "color": None, "profile": "work"}], raising=False)
+
+    rows = models.load_projects(include_db=True)
+
+    assert rows == [{"project_id": "db", "name": "DB", "color": None, "profile": "work"}]
+
+
+def test_load_projects_default_keeps_db_rows_out_of_json_mutation_path(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "missing-projects.json"
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: [{"project_id": "db", "name": "DB", "color": None, "profile": "work"}], raising=False)
+
+    projects = models.load_projects()
+    projects.append({"project_id": "json", "name": "JSON", "profile": "default"})
+    models.save_projects(projects)
+
+    assert json.loads(projects_file.read_text(encoding="utf-8")) == [{"project_id": "json", "name": "JSON", "profile": "default"}]
+
+
+def test_load_projects_default_keeps_existing_json_authoritative_over_db_rows(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "json", "name": "JSON", "profile": "default"}]), encoding="utf-8")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: [{"project_id": "db", "name": "DB", "color": None, "profile": "work"}], raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+
+    rows = models.load_projects(_migrate=False)
+
+    assert rows == [{"project_id": "json", "name": "JSON", "profile": "default"}]
+
+
+def test_load_projects_read_only_merges_db_rows_when_json_exists(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "json", "name": "JSON", "profile": "default"}]), encoding="utf-8")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: [
+        {"project_id": "json", "name": "DB Shadow", "color": None, "profile": "work"},
+        {"project_id": "db", "name": "DB", "color": None, "profile": "work"},
+    ], raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+
+    rows = models.load_projects(_migrate=False, include_db=True)
+
+    assert rows == [
+        {"project_id": "json", "name": "JSON", "profile": "default"},
+        {"project_id": "json", "name": "DB Shadow", "color": None, "profile": "work"},
+        {"project_id": "db", "name": "DB", "color": None, "profile": "work"},
+    ]
+
+
+def test_load_projects_falls_back_to_json_when_db_unavailable(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "json", "name": "JSON", "profile": "default"}]), encoding="utf-8")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: None, raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+
+    rows = models.load_projects(_migrate=False)
+
+    assert rows == [{"project_id": "json", "name": "JSON", "profile": "default"}]
+
+
+def test_load_projects_falls_back_to_json_when_db_has_no_rows(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(json.dumps([{"project_id": "json", "name": "JSON", "profile": "default"}]), encoding="utf-8")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: None, raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+
+    rows = models.load_projects(_migrate=False)
+
+    assert rows == [{"project_id": "json", "name": "JSON", "profile": "default"}]
+
+
+def test_load_projects_backfills_legacy_profile_rows_when_json_fallback_runs(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    index_file = tmp_path / "session_index.json"
+    projects_file.write_text(
+        json.dumps([{"project_id": "legacy-project", "name": "Legacy Project"}]),
+        encoding="utf-8",
+    )
+    index_file.write_text(
+        json.dumps([{"project_id": "legacy-project", "profile": "work"}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr("api.projects_db_adapter.load_projects_from_db", lambda **_kwargs: None, raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", False, raising=False)
+
+    rows = models.load_projects()
+
+    assert rows == [{"project_id": "legacy-project", "name": "Legacy Project", "profile": "work"}]
+    assert json.loads(projects_file.read_text(encoding="utf-8")) == rows
+
+
+def test_save_projects_remains_json_backed(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+
+    models.save_projects([{"project_id": "json", "name": "JSON", "profile": "default"}])
+
+    assert json.loads(projects_file.read_text(encoding="utf-8")) == [
+        {"project_id": "json", "name": "JSON", "profile": "default"}
+    ]
+
+
+def test_load_projects_passes_profile_name_to_adapter(monkeypatch, tmp_path):
+    import api.models as models
+
+    calls = []
+    monkeypatch.setattr(models, "PROJECTS_FILE", tmp_path / "missing-projects.json", raising=False)
+    monkeypatch.setattr(
+        "api.projects_db_adapter.load_projects_from_db",
+        lambda **kwargs: calls.append(kwargs) or [],
+        raising=False,
+    )
+
+    assert models.load_projects(include_db=True, profile_name="work") == []
+    assert calls == [{"profile_name": "work"}]
+
+
+def test_load_projects_for_profiles_merges_db_rows_by_profile(monkeypatch, tmp_path):
+    import api.models as models
+
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(
+        json.dumps(
+            [
+                {
+                    "project_id": "shared",
+                    "name": "JSON Work",
+                    "profile": "work",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file, raising=False)
+    monkeypatch.setattr(models, "_projects_migrated", True, raising=False)
+
+    def _fake_db_projects(**kwargs):
+        profile = kwargs["profile_name"]
+        return [
+            {"project_id": "shared", "name": f"{profile} Shared", "profile": profile},
+            {"project_id": f"{profile}-db", "name": f"{profile} DB", "profile": profile},
+        ]
+
+    monkeypatch.setattr(
+        "api.projects_db_adapter.load_projects_from_db",
+        _fake_db_projects,
+        raising=False,
+    )
+
+    rows = models.load_projects_for_profiles(["work", "research"])
+
+    assert rows == [
+        {"project_id": "shared", "name": "JSON Work", "profile": "work"},
+        {"project_id": "work-db", "name": "work DB", "profile": "work"},
+        {"project_id": "shared", "name": "research Shared", "profile": "research"},
+        {"project_id": "research-db", "name": "research DB", "profile": "research"},
+    ]
+
+
+def test_project_identity_matches_requires_profile_and_project_id():
+    import api.models as models
+
+    assert models.project_identity_matches(
+        {"project_id": "shared", "profile": "work"},
+        "shared",
+        "work",
+    )
+    assert not models.project_identity_matches(
+        {"project_id": "shared", "profile": "default"},
+        "shared",
+        "work",
+    )
+    assert not models.project_identity_matches(
+        {"project_id": "other", "profile": "work"},
+        "shared",
+        "work",
+    )
+
+
+def test_routes_pass_active_and_session_profiles_to_project_reads(monkeypatch):
+    import api.models as models
+    import api.profiles as profiles
+    import api.routes as routes
+
+    calls = []
+    all_profile_calls = []
+
+    def _fake_load_projects(**kwargs):
+        calls.append(kwargs)
+        profile = kwargs.get("profile_name") or "default"
+        return [
+            {
+                "project_id": f"{profile}-project",
+                "name": "Wrong Profile Project",
+                "profile": "default",
+            },
+            {
+                "project_id": f"{profile}-project",
+                "name": "Project",
+                "profile": profile,
+            }
+        ]
+
+    monkeypatch.setattr(routes, "load_projects", _fake_load_projects)
+    monkeypatch.setattr(
+        profiles,
+        "get_active_profile_name",
+        lambda: "work",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, **_kwargs: payload,
+        raising=False,
+    )
+
+    projects_payload = routes.handle_get(object(), urlparse("/api/projects"))
+
+    assert projects_payload["projects"][0]["project_id"] == "work-project"
+    assert calls == [{"include_db": True, "profile_name": "work"}]
+
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles_api",
+        lambda: [{"name": "work"}, {"name": "research"}],
+    )
+    monkeypatch.setattr(
+        models,
+        "load_projects_for_profiles",
+        lambda names: all_profile_calls.append(list(names)) or [
+            {"project_id": "work-project", "name": "Project", "profile": "work"},
+            {"project_id": "research-project", "name": "Project", "profile": "research"},
+        ],
+    )
+
+    all_payload = routes.handle_get(object(), urlparse("/api/projects?all_profiles=1"))
+
+    assert [p["project_id"] for p in all_payload["projects"]] == [
+        "work-project",
+        "research-project",
+    ]
+    assert all_profile_calls == [["work", "research"]]
+
+    session = types.SimpleNamespace(
+        profile="research",
+        project_id=None,
+        session_id="sid",
+        save=lambda: None,
+        compact=lambda: {"session_id": "sid", "project_id": "research-project"},
+    )
+    lock = types.SimpleNamespace(
+        acquire=lambda timeout=None: True,
+        release=lambda: None,
+    )
+    calls.clear()
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": "sid", "project_id": "research-project"})
+    monkeypatch.setattr(routes, "_get_or_materialize_session", lambda _sid: session)
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda _sid: lock)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "active")
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+
+    move_payload = routes.handle_post(object(), urlparse("/api/session/move"))
+
+    assert move_payload["ok"] is True
+    assert session.project_id == "research-project"
+    assert calls == [{"include_db": True, "profile_name": "research"}]
+
+
+def test_routes_project_rename_and_delete_use_profile_identity(monkeypatch):
+    import api.routes as routes
+
+    saved = []
+    projects = [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+        {"project_id": "shared", "name": "Work", "profile": "work"},
+    ]
+
+    monkeypatch.setattr(routes, "load_projects", lambda: list(projects))
+    monkeypatch.setattr(routes, "save_projects", lambda rows: saved.append(list(rows)))
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload, raising=False)
+
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"project_id": "shared", "name": "Renamed"},
+    )
+    rename_payload = routes.handle_post(object(), urlparse("/api/projects/rename"))
+
+    assert rename_payload["project"] == {"project_id": "shared", "name": "Renamed", "profile": "work"}
+    assert saved[-1] == [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+        {"project_id": "shared", "name": "Renamed", "profile": "work"},
+    ]
+
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"project_id": "shared"},
+    )
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", Path("missing-index.json"))
+    delete_payload = routes.handle_post(object(), urlparse("/api/projects/delete"))
+
+    assert delete_payload["ok"] is True
+    assert saved[-1] == [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+    ]
+
+
+def test_mcp_list_and_move_use_active_profile_db_rows(monkeypatch):
+    pytest.importorskip("mcp", reason="mcp package not installed")
+    import mcp_server
+
+    calls = []
+
+    def _fake_load_projects(**kwargs):
+        calls.append(kwargs)
+        profile = kwargs.get("profile_name") or "default"
+        return [
+            {
+                "project_id": f"{profile}-project",
+                "name": "Wrong Profile Project",
+                "profile": "default",
+            },
+            {
+                "project_id": f"{profile}-project",
+                "name": "Project",
+                "profile": profile,
+            }
+        ]
+
+    monkeypatch.setattr(mcp_server, "_active_profile", lambda: "work")
+    monkeypatch.setattr(mcp_server, "load_projects", _fake_load_projects)
+    monkeypatch.setattr(
+        mcp_server,
+        "_load_index",
+        lambda: [
+            {"project_id": "work-project", "profile": "default"},
+            {"project_id": "work-project", "profile": "work"},
+        ],
+    )
+
+    listed = asyncio.run(mcp_server.handle_list_projects({}))
+    listed_payload = json.loads(listed[0].text)
+
+    assert listed_payload == [
+        {
+            "project_id": "work-project",
+            "name": "Project",
+            "profile": "work",
+            "session_count": 1,
+        }
+    ]
+    assert calls == [{"include_db": True, "profile_name": "work"}]
+
+    calls.clear()
+    posted = []
+    monkeypatch.setattr(
+        mcp_server,
+        "_api_post",
+        lambda endpoint, body: posted.append((endpoint, body)) or {
+            "session": {"title": "Moved"}
+        },
+    )
+
+    moved = asyncio.run(
+        mcp_server.handle_move_session(
+            {"session_id": "sid", "project_id": "work-project"}
+        )
+    )
+    moved_payload = json.loads(moved[0].text)
+
+    assert moved_payload["ok"] is True
+    assert calls == [{"include_db": True, "profile_name": "work"}]
+    assert posted == [
+        ("/api/session/move", {"session_id": "sid", "project_id": "work-project"})
+    ]
+
+
+def test_mcp_project_rename_and_delete_use_profile_identity(monkeypatch):
+    pytest.importorskip("mcp", reason="mcp package not installed")
+    import mcp_server
+
+    saved = []
+    projects = [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+        {"project_id": "shared", "name": "Work", "profile": "work"},
+    ]
+
+    monkeypatch.setattr(mcp_server, "_active_profile", lambda: "work")
+    monkeypatch.setattr(mcp_server, "load_projects", lambda: list(projects))
+    monkeypatch.setattr(mcp_server, "save_projects", lambda rows: saved.append(list(rows)))
+    monkeypatch.setattr(mcp_server, "SESSION_DIR", Path("missing-sessions"))
+
+    renamed = asyncio.run(
+        mcp_server.handle_rename_project(
+            {"project_id": "shared", "name": "Renamed"}
+        )
+    )
+    renamed_payload = json.loads(renamed[0].text)
+
+    assert renamed_payload == {"project_id": "shared", "name": "Renamed", "profile": "work"}
+    assert saved[-1] == [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+        {"project_id": "shared", "name": "Renamed", "profile": "work"},
+    ]
+
+    deleted = asyncio.run(mcp_server.handle_delete_project({"project_id": "shared"}))
+    deleted_payload = json.loads(deleted[0].text)
+
+    assert deleted_payload["ok"] is True
+    assert saved[-1] == [
+        {"project_id": "shared", "name": "Default", "profile": "default"},
+    ]
+
+
+def test_load_projects_handles_missing_db_and_read_errors(monkeypatch, tmp_path):
+    import api.projects_db_adapter as adapter
+
+    monkeypatch.setattr("api.profiles.get_hermes_home_for_profile", lambda name: _profile_home(tmp_path, name), raising=False)
+    _install_fake_projects_db(monkeypatch, projects=[])
+    missing_home = _profile_home(tmp_path, "work")
+    rows = adapter.load_projects_from_db(profile_name="work")
+    assert rows is None
+    assert not missing_home.exists()
+
+    fake_db = missing_home / "projects.db"
+    fake_db.parent.mkdir(parents=True)
+    fake_db.write_text("", encoding="utf-8")
+    _install_fake_projects_db(monkeypatch, projects=[])
+    assert adapter.load_projects_from_db(profile_name="work") == []
+
+    _install_fake_projects_db(
+        monkeypatch,
+        projects=[],
+        list_error=sqlite3.OperationalError("missing table"),
+    )
+    assert adapter.load_projects_from_db(profile_name="work") is None

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -512,6 +512,15 @@ def test_send_uses_session_model_as_authoritative_source(cleanup_test_sessions):
         "send() must use S.session.model in the chat/start payload"
 
 
+def test_send_prefers_session_profile_over_active_profile():
+    src = (REPO_ROOT / "static/messages.js").read_text(encoding="utf-8")
+    chat_start_idx = src.find("api('/api/chat/start'")
+    assert chat_start_idx >= 0, "could not find /api/chat/start POST in messages.js"
+    payload_block = src[chat_start_idx:chat_start_idx+700]
+    assert "profile:S.session.profile||S.activeProfile||'default'" in payload_block, \
+        "send() must bind chat/start to the session profile before falling back to the active profile"
+
+
 # ── R15: newSession does not clear live tool cards ────────────────────────────
 
 def test_newSession_clears_live_tool_cards(cleanup_test_sessions):

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -708,10 +708,14 @@ function extractFunc(name) {{
 }}
 var _showArchived = false;
 var NO_PROJECT_FILTER = '__none__';
-var _activeProject = 'projA';
+var S = {{ rootProfileNames: ['default'] }};
+var _activeProject = {{ profile: 'default', project_id: 'projA' }};
 var _sidebarReferenceSessions = [{{session_id:'parent', title:'Archived parent (projB)', archived:true, project_id:'projB', updated_at:10, last_message_at:10, source:'webui'}}];
 function _isMessagingSession(s) {{ return false; }}
 function _isCliSession(s) {{ return !!(s && (s.source === 'cli' || s.raw_source === 'cli')); }}
+eval(extractFunc('_canonicalProjectFilterProfile'));
+eval(extractFunc('_projectFilterIdentity'));
+eval(extractFunc('_projectFilterMatches'));
 eval(extractFunc('_sessionTimestampMs'));
 eval(extractFunc('_isChildSession'));
 eval(extractFunc('_isForkWithResolvableParent'));

--- a/tests/test_sidebar_unassigned_filter.py
+++ b/tests/test_sidebar_unassigned_filter.py
@@ -147,3 +147,23 @@ def test_all_chip_clear_clears_unassigned_filter_too():
         "The All chip handler must route through the helper that clears "
         "_activeProject and refreshes the filtered payload."
     )
+
+
+def test_real_project_filter_uses_profile_and_project_id_identity():
+    """Real project filters must distinguish reused IDs across profiles."""
+    js = _js()
+    assert "function _canonicalProjectFilterProfile(profile)" in js
+    assert "function _projectFilterIdentity(project)" in js
+    assert "function _projectFilterMatches(filter, row)" in js
+    assert "_canonicalProjectFilterProfile(filter.profile)===_canonicalProjectFilterProfile(row.profile)" in js
+    assert "filter.project_id===String(row.project_id||'')" in js
+    assert "_setActiveProjectFilter(p)" in js
+    assert "_projectFilterMatches(_activeProject,s)" in js
+    assert "_projectFilterMatches(_activeProject,proj)" in js
+    assert "S.rootProfileNames = Array.isArray(projData.root_profile_names)" in js
+
+
+def test_project_filter_payload_keeps_scalar_wire_format():
+    """Creating a session under a real filter still sends only project_id."""
+    js = _js()
+    assert "reqBody.project_id=_activeProject.project_id;" in js


### PR DESCRIPTION
## Thinking Path

- The project store owner is the agent-side `hermes_cli.projects_db`, not a WebUI-specific JSON file.
- A read-only adapter is the smallest useful first step because it lets WebUI consume the DB without changing mutation semantics.
- WebUI has to choose the profile before reading that DB, because named-profile requests must not fall back to the root profile store.
- Project identity is `(profile, project_id)`, so read merges, project selection, session counts, and delete side effects all need to apply the same profile-aware rule.
- WAL-backed reads also have to consume one generation-consistent `(projects.db, projects.db-wal)` pair, because a checkpoint landing between separate file copies can otherwise drop a just-committed project from the read-only snapshot.
- Existing `projects.json` remains authoritative for writes; read surfaces merge DB rows with JSON rows so creating `projects.json` does not hide DB-only projects.

## What Changed

- `api/projects_db_adapter.py`: add a read-only bridge from `hermes_cli.projects_db.Project` rows into WebUI project dictionaries, resolve `projects.db` from the intended profile, choose SQLite `mode=ro` when WAL/SHM sidecars exist or `mode=ro&immutable=1` when they do not, and retry wal-only snapshot reads until the copied db and wal still match the same live generation.
- `api/models.py`: add an opt-in DB read path that passes the caller's profile into the adapter, merges adapter rows into read-only results by `(profile, project_id)`, and exposes a shared `project_identity_matches()` predicate for project operations.
- `api/routes.py`: opt the `/api/projects` read response, all-profile project reads, and session-move project lookup into DB rows with the active request profile or session profile, and use profile-aware project identity for route rename/delete selection.
- `mcp_server.py`: let MCP project listing and move validation see DB-backed rows for the active profile, filter project session counts by profile, and use the same project identity predicate for MCP rename/delete/move.
- `tests/test_issue5763_projects_db_adapter.py`: cover mapping, profile-specific DB reads, WAL-aware read-only SQLite access, live WAL row visibility, wal-only checkpoint-between-copies retry behavior, immutable retry, missing-DB no-write behavior, route and MCP profile propagation, JSON mutation isolation, fallback, and profile-aware project identity.

## Why It Matters

This starts moving WebUI project reads to the shared project database without bundling in the write-path migration. DB-only installs can surface project rows in read-only surfaces, named profiles stay isolated even with same-id projects, and a wal checkpoint can no longer make the read-only adapter silently drop a just-committed project.

## Verification

Focused tests cover adapter mapping, profile-specific DB reads, WAL-aware read-only SQLite access, live WAL row visibility, the checkpoint-between-copies regression, immutable retry, missing-DB no-write behavior, route and MCP project identity, JSON mutation isolation, JSON fallback, all-profile aggregation, and legacy profile backfill; CI runs the full matrix.

## Upstream

Refs #5763.

## Model Used

GPT 5.5 via Codex CLI
