### PR TITLE
fix(mcp): scope list config reads to active profile

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -703,6 +703,13 @@ def get_config_for_profile_home(profile_home: "Path | str | None") -> dict:
         target = Path(profile_home).expanduser()
     except Exception:
         return get_config()
+    try:
+        from api.profiles import get_active_hermes_home
+
+        if Path(get_active_hermes_home()).expanduser() == target:
+            return get_config()
+    except Exception:
+        pass
     # If the ambient resolver already points at this profile home, defer to
     # get_config() so in-memory overrides (monkeypatched cfg) are honored. This
     # MUST run before the nonexistent-home guard below: a matching ambient home

--- a/api/routes.py
+++ b/api/routes.py
@@ -2822,6 +2822,7 @@ from api.config import (
     _load_yaml_config_file,
     _save_yaml_config_file,
     reload_config,
+    get_config_for_profile_home,
     _cfg_lock,
     PENDING_BG_TASK_COMPLETIONS,
 )
@@ -24181,7 +24182,7 @@ def _mcp_tools_from_registry(server_summaries):
 
 def _handle_mcp_tools_list(handler):
     """List known MCP tools from already-available runtime inventory only."""
-    cfg = get_config()
+    cfg = get_config_for_profile_home(get_active_hermes_home())
     servers = cfg.get("mcp_servers", {})
     if not isinstance(servers, dict):
         servers = {}
@@ -24695,7 +24696,7 @@ def _handle_notes_item(handler, parsed):
 
 def _handle_mcp_servers_list(handler):
     """List configured MCP servers with safe, read-only runtime visibility."""
-    cfg = get_config()
+    cfg = get_config_for_profile_home(get_active_hermes_home())
     servers = cfg.get("mcp_servers", {})
     if not isinstance(servers, dict):
         servers = {}

--- a/tests/test_issue3294_profile_toolset_scoping.py
+++ b/tests/test_issue3294_profile_toolset_scoping.py
@@ -108,6 +108,31 @@ def test_matching_home_defers_to_get_config(_two_profiles):
     ]
 
 
+def test_active_home_with_external_config_override_defers_to_get_config(_two_profiles, monkeypatch, tmp_path):
+    """The active home still honors HERMES_CONFIG_PATH when the override lives
+    outside that home."""
+    cfg, default_home, profile_b_home = _two_profiles
+    from api import profiles
+
+    active_home = tmp_path / "active-home"
+    override_path = tmp_path / "override-dir" / "config.yaml"
+    active_home.mkdir()
+    _write_cfg(active_home, ["wrong-active-home-file"])
+    override_path.parent.mkdir()
+    import yaml
+
+    override_path.write_text(
+        yaml.safe_dump({"platform_toolsets": {"cli": ["override-config"]}}, sort_keys=False),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_CONFIG_PATH", str(override_path))
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: active_home)
+    cfg.reload_config()
+
+    same = cfg.get_config_for_profile_home(active_home)
+    assert same.get("platform_toolsets", {}).get("cli") == ["override-config"]
+
+
 def test_matching_ambient_home_that_does_not_exist_still_defers_to_get_config(_two_profiles, monkeypatch, tmp_path):
     """Regression (#4516 gate): the nonexistent-home guard must run AFTER the
     ambient-resolver short-circuit. A home that matches the ambient config path

--- a/tests/test_issue538_mcp_management.py
+++ b/tests/test_issue538_mcp_management.py
@@ -42,17 +42,33 @@ SAMPLE_MCP = {
 class TestMcpList:
     """GET /api/mcp/servers — list with masked secrets."""
 
-    @patch('api.routes.get_config')
-    def test_returns_servers_list(self, mock_cfg):
+    @patch('api.routes.get_config_for_profile_home')
+    @patch('api.routes.get_active_hermes_home')
+    def test_returns_servers_list(self, mock_home, mock_cfg):
+        mock_home.return_value = sentinel_home = object()
         mock_cfg.return_value = {'mcp_servers': SAMPLE_MCP}
         h = _make_handler()
         _handle_mcp_servers_list(h)
         assert h.send_response.called
         status = h.send_response.call_args[0][0]
         assert status == 200
+        mock_cfg.assert_called_once_with(sentinel_home)
 
-    @patch('api.routes.get_config')
-    def test_empty_config(self, mock_cfg):
+    @patch('api.routes.get_config_for_profile_home')
+    @patch('api.routes.get_active_hermes_home')
+    def test_reads_active_profile_home_for_servers(self, mock_home, mock_cfg):
+        mock_home.return_value = sentinel_home = object()
+        mock_cfg.return_value = {'mcp_servers': {'active': SAMPLE_MCP['searxng']}}
+        h = _make_handler()
+        _handle_mcp_servers_list(h)
+        payload = _json_payload(h)
+        assert [srv['name'] for srv in payload['servers']] == ['active']
+        mock_cfg.assert_called_once_with(sentinel_home)
+
+    @patch('api.routes.get_config_for_profile_home')
+    @patch('api.routes.get_active_hermes_home')
+    def test_empty_config(self, mock_home, mock_cfg):
+        mock_home.return_value = object()
         mock_cfg.return_value = {}
         h = _make_handler()
         _handle_mcp_servers_list(h)
@@ -65,8 +81,10 @@ class TestMcpList:
         assert payload['reload_required'] is True
 
     @patch('api.routes._mcp_runtime_status_by_name')
-    @patch('api.routes.get_config')
-    def test_list_payload_includes_status_tool_counts_and_safe_invalid_config(self, mock_cfg, mock_runtime):
+    @patch('api.routes.get_config_for_profile_home')
+    @patch('api.routes.get_active_hermes_home')
+    def test_list_payload_includes_status_tool_counts_and_safe_invalid_config(self, mock_home, mock_cfg, mock_runtime):
+        mock_home.return_value = object()
         mock_cfg.return_value = {
             'mcp_servers': {
                 'searxng': {'command': 'mcp-searxng', 'args': ['--port', '8888']},

--- a/tests/test_issue538_mcp_management.py
+++ b/tests/test_issue538_mcp_management.py
@@ -1,6 +1,7 @@
 """Tests for issue #538 — MCP server management API."""
 import json, pytest
 from unittest.mock import patch, MagicMock, call
+import yaml
 from api.routes import (
     _handle_mcp_servers_list,
     _handle_mcp_server_update,
@@ -140,6 +141,41 @@ class TestMcpList:
     def test_numeric_zero_enabled_flag_is_disabled(self):
         """YAML numeric false-y values should not show a disabled server as enabled."""
         assert _parse_mcp_enabled(0) is False
+
+    def test_active_home_list_reads_external_config_override_used_by_writes(self, monkeypatch, tmp_path):
+        """HERMES_CONFIG_PATH outside the active home remains the read/write authority."""
+        from api import config, profiles, routes
+
+        active_home = tmp_path / 'active-home'
+        override_path = tmp_path / 'override-dir' / 'config.yaml'
+        active_home.mkdir()
+        override_path.parent.mkdir()
+        active_home.joinpath('config.yaml').write_text(
+            yaml.safe_dump({'mcp_servers': {'wrong-home': {'command': 'wrong'}}}, sort_keys=False),
+            encoding='utf-8',
+        )
+        override_path.write_text(
+            yaml.safe_dump({'mcp_servers': {'override-srv': {'command': 'override'}}}, sort_keys=False),
+            encoding='utf-8',
+        )
+        monkeypatch.setenv('HERMES_CONFIG_PATH', str(override_path))
+        monkeypatch.setattr(profiles, 'get_active_hermes_home', lambda: active_home)
+        monkeypatch.setattr(routes, 'get_active_hermes_home', lambda: active_home)
+        monkeypatch.setattr(routes, '_mcp_runtime_status_by_name', lambda: {})
+        config.reload_config()
+
+        h = _make_handler()
+        _handle_mcp_servers_list(h)
+        payload = _json_payload(h)
+        assert [srv['name'] for srv in payload['servers']] == ['override-srv']
+
+        h = _make_handler()
+        h.command = 'PUT'
+        _handle_mcp_server_update(h, 'new-srv', {'command': 'new-command'})
+        saved = yaml.safe_load(override_path.read_text(encoding='utf-8'))
+        active_home_saved = yaml.safe_load(active_home.joinpath('config.yaml').read_text(encoding='utf-8'))
+        assert 'new-srv' in saved['mcp_servers']
+        assert 'new-srv' not in active_home_saved['mcp_servers']
 
 
 class TestMcpSave:

--- a/tests/test_issue697_mcp_tool_inventory.py
+++ b/tests/test_issue697_mcp_tool_inventory.py
@@ -29,8 +29,10 @@ def _read(relative_path: str) -> str:
 
 class TestMcpToolInventoryApi:
     @patch("api.routes._mcp_runtime_status_by_name")
-    @patch("api.routes.get_config")
-    def test_endpoint_returns_sanitized_registered_mcp_tools(self, mock_cfg, mock_runtime):
+    @patch("api.routes.get_config_for_profile_home")
+    @patch("api.routes.get_active_hermes_home")
+    def test_endpoint_returns_sanitized_registered_mcp_tools(self, mock_home, mock_cfg, mock_runtime):
+        mock_home.return_value = sentinel_home = object()
         mock_cfg.return_value = {
             "mcp_servers": {
                 "web-reader": {"url": "http://localhost:3001/mcp", "headers": {"Authorization": "Bearer secret-token"}},
@@ -72,6 +74,7 @@ class TestMcpToolInventoryApi:
             {"name": "url", "type": "string", "required": True, "description": "URL to fetch"},
             {"name": "limit", "type": "integer", "required": False, "description": "Maximum bytes"},
         ]
+        mock_cfg.assert_called_once_with(sentinel_home)
         raw = json.dumps(payload)
         assert "secret-token" not in raw
         assert "default" not in raw


### PR DESCRIPTION
## Thinking Path

- The reload fix for #5619 still left MCP list reads vulnerable to shared config-cache bleed across profiles.
- Moving the list endpoints to active-profile read plumbing fixed that direction, but the active-home path also has to preserve `HERMES_CONFIG_PATH` because MCP writes already use that override.
- The helper now treats the current active home as the ambient config source, so list reads and writes agree on the same config file while detached non-active profile reads still go straight to that profile.

## What Changed

- `api/routes.py`: read MCP server and tool configuration through the active profile home.
- `api/config.py`: keep active-home profile reads on `get_config()` so `HERMES_CONFIG_PATH` remains the read authority for override-config deployments.
- `tests/test_issue538_mcp_management.py`: cover the server-list active-profile read path and the external override read/write parity path.
- `tests/test_issue697_mcp_tool_inventory.py`: cover the tool-list active-profile read path.
- `tests/test_issue3294_profile_toolset_scoping.py`: cover active-home override handling without weakening direct reads for non-active profile homes.

## Why It Matters

Switching profiles shouldn't make the MCP UI inherit servers from whichever profile last warmed the process config cache. Override-config deployments also need a server added through MCP settings to appear in the list immediately, because both operations resolve the same config path.

## Verification

Focused tests cover MCP server management, MCP tool inventory, and active-profile config helper behavior; CI runs the full matrix.

## Upstream

Closes #5619.

## Model Used

GPT-5.5 via Codex CLI
