### PR TITLE
fix(login): clearInterval (not clearTimeout) for connectivity retry

### DIFF
--- a/static/login.js
+++ b/static/login.js
@@ -175,7 +175,7 @@ document.addEventListener('DOMContentLoaded', function () {
             // Server is reachable — if we were in retry mode, reload so the
             // page reflects the correct auth state (expired session, etc.).
             if (retryTimer !== null) {
-              clearTimeout(retryTimer);
+              clearInterval(retryTimer);
               retryTimer = null;
               window.location.reload();
             }


### PR DESCRIPTION
## Summary
One-line fix: the login connectivity-retry cleanup calls `clearInterval` on the
`setInterval` id instead of `clearTimeout`.

## Why
`checkConnectivity` in `static/login.js` schedules its retry with
`setInterval(...)` and stored the id in `retryTimer`, but cleared it with
`clearTimeout(retryTimer)`. Browsers happen to share one id space across the
timer families, so it works today by luck; `clearInterval` is the correct,
spec-matching call and won't break if that ever changes. `retryTimer` is only
ever assigned from `setInterval`, so there's no mixed-use ambiguity.

## Validation
```
node --check static/login.js
```
Trivial one-token change; no behavioural test added.

## Notes
Cosmetic/correctness cleanup — no user-visible change.
