### PR TITLE
perf(webui): session-load latency

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -3152,6 +3152,15 @@ def _cached_session_lags_disk(cached) -> bool:
                     return latest
                 if _max_updated(disk_scenes) > _max_updated(cached_scenes):
                     return True
+        else:
+            # Cached session has no scene records. Check if disk has gained
+            # the first scene record — without this the fast-path would miss
+            # a newly persisted scene and return the stale cache. Greptile P1.
+            disk_meta_quick = _persisted_session_meta_prefix(sid)
+            if disk_meta_quick is not None:
+                disk_scenes = disk_meta_quick.get('anchor_activity_scenes') or {}
+                if isinstance(disk_scenes, dict) and disk_scenes:
+                    return True
         if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
             # Active session: messages may be in flight; fall through to the
             # full check to be safe.

--- a/api/models.py
+++ b/api/models.py
@@ -3127,6 +3127,10 @@ def _cached_session_lags_disk(cached) -> bool:
         cached_scenes = getattr(cached, 'anchor_activity_scenes', None) or {}
         if not isinstance(cached_scenes, dict):
             cached_scenes = {}
+        # Track whether the cheap scene check was inconclusive — when it is,
+        # we must fall through to the full metadata comparison instead of
+        # returning False for inactive sessions with matching counts.
+        _scene_check_inconclusive = False
         if cached_scenes:
             disk_meta_quick = _persisted_session_meta_prefix(sid)
             if disk_meta_quick is not None:
@@ -3160,6 +3164,13 @@ def _cached_session_lags_disk(cached) -> bool:
                     if _max_updated(disk_scenes) > _anchor_scene_records_updated_at(cached):
                         return True
                 # disk has no scenes, cache does -> cache is ahead; keep it.
+            else:
+                # Can't cheaply verify scene freshness from disk. The prefix
+                # reader may have failed while _persisted_message_count
+                # succeeded via index fallback. Fall through to the full
+                # metadata load so we don't serve stale scenes on the next
+                # equal-count inactive session path. Greptile P1.
+                _scene_check_inconclusive = True
         else:
             # Cached session has no scene records. Check if disk has gained
             # the first scene record — without this the fast-path would miss
@@ -3172,6 +3183,11 @@ def _cached_session_lags_disk(cached) -> bool:
         if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
             # Active session: messages may be in flight; fall through to the
             # full check to be safe.
+            pass
+        elif _scene_check_inconclusive:
+            # Could not cheaply verify scene freshness from disk; fall through
+            # to the full metadata comparison rather than returning False
+            # (which would serve a potentially stale cache). Greptile P1.
             pass
         else:
             # Inactive session, count matches, scene records match — cache is

--- a/api/models.py
+++ b/api/models.py
@@ -3180,6 +3180,12 @@ def _cached_session_lags_disk(cached) -> bool:
                 disk_scenes = disk_meta_quick.get('anchor_activity_scenes') or {}
                 if isinstance(disk_scenes, dict) and disk_scenes:
                     return True
+            else:
+                # Prefix read failed (may still succeed via index fallback for
+                # message count). Mark inconclusive so we fall through to the
+                # full metadata comparison instead of returning False with
+                # stale cache. Greptile P1 (discussion_r3548650345).
+                _scene_check_inconclusive = True
         if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
             # Active session: messages may be in flight; fall through to the
             # full check to be safe.

--- a/api/models.py
+++ b/api/models.py
@@ -3095,24 +3095,54 @@ def _cached_session_lags_disk(cached) -> bool:
     id. Serving the cache then makes recent assistant results disappear from
     GET /api/session even though disk and _index.json are correct. Compare only
     cheap metadata here; full reload happens only if disk is strictly ahead.
+
+    perf(webui/session-load-latency) cheap-first ordering: the function used to
+    call Session.load_metadata_only(sid) on every cache hit, which parses the
+    full sidecar JSON (~15-20ms even for 1.3MB sidecars on Celeron+ eMMC).
+    For draft auto-saves that hit get_session() on every keystroke debounce
+    (every ~400ms while typing), that 15-20ms multiplied out to ~75% of the
+    request's wall time on the Chromebook. We now do a single fast check
+    first: read only the JSON metadata prefix to compare message counts.
+    The full Session.load_metadata_only() and its anchor-scene comparisons
+    only run when the count check is inconclusive or when disk appears to be
+    ahead of cache.
     """
     if cached is None:
         return False
     sid = getattr(cached, 'session_id', None)
     if not sid:
         return False
+    cached_count = len(getattr(cached, 'messages', None) or [])
+    # Fast path: prefix read of just the metadata header.
+    disk_count = _persisted_message_count(sid)
+    if disk_count is not None:
+        if disk_count > cached_count:
+            return True
+        # Disk is at most as far as cache; for inactive sessions we don't
+        # need to compare anchor-scene records (those are only updated by
+        # active streaming/recovery paths, which we can detect cheaply below).
+        if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
+            # Active session: anchor-scene keys may have advanced even when
+            # the count is the same. Fall through to the full check.
+            pass
+        else:
+            # Inactive session, count matches → cache is at parity with disk.
+            # The pre-fix code would still load_metadata_only to compare
+            # anchor scenes, but for inactive sessions those cannot have
+            # advanced without the count advancing too. Skip the full load.
+            return False
     try:
         disk_meta = Session.load_metadata_only(sid)
     except Exception:
         return False
     if disk_meta is None:
         return False
-    cached_count = len(getattr(cached, 'messages', None) or [])
-    disk_count = _parse_nonnegative_int(getattr(disk_meta, '_metadata_message_count', None))
     if disk_count is None:
-        disk_count = _lookup_index_message_count(sid)
-    if disk_count is not None and disk_count > cached_count:
-        return True
+        disk_count = _parse_nonnegative_int(getattr(disk_meta, '_metadata_message_count', None))
+        if disk_count is None:
+            disk_count = _lookup_index_message_count(sid)
+        if disk_count is not None and disk_count > cached_count:
+            return True
     if not getattr(cached, 'active_stream_id', None) and not getattr(cached, 'pending_user_message', None):
         cached_scene_keys = _anchor_scene_record_keys(cached)
         disk_scene_keys = _anchor_scene_record_keys(disk_meta)

--- a/api/models.py
+++ b/api/models.py
@@ -3133,25 +3133,33 @@ def _cached_session_lags_disk(cached) -> bool:
                 disk_scenes = disk_meta_quick.get('anchor_activity_scenes') or {}
                 if not isinstance(disk_scenes, dict):
                     disk_scenes = {}
-                if not disk_scenes or set(disk_scenes.keys()) != set(cached_scenes.keys()):
-                    # Scene key set differs — disk has been updated with new
-                    # keys the cache hasn't seen.
-                    return True
-                # Same key set: check the latest updated_at timestamp.
-                def _max_updated(records):
-                    latest = 0.0
-                    for record in records.values():
-                        if not isinstance(record, dict):
-                            continue
-                        try:
-                            ua = float(record.get('updated_at') or 0)
-                        except (TypeError, ValueError):
-                            ua = 0.0
-                        if ua > latest:
-                            latest = ua
-                    return latest
-                if _max_updated(disk_scenes) > _max_updated(cached_scenes):
-                    return True
+                if disk_scenes:
+                    # Directional: only reload when disk is strictly ahead
+                    # of cache. Mirror master's subset comparison — cache
+                    # that is ahead of disk must NOT force a reload, or
+                    # un-persisted scene data is silently dropped.
+                    disk_keys = {str(key) for key, value in disk_scenes.items()
+                                 if key and isinstance(value, dict)}
+                    cached_keys = _anchor_scene_record_keys(cached)
+                    if disk_keys and not disk_keys.issubset(cached_keys):
+                        return True
+                    # Same key set (or disk is subset): check the latest
+                    # updated_at timestamp.
+                    def _max_updated(records):
+                        latest = 0.0
+                        for record in records.values():
+                            if not isinstance(record, dict):
+                                continue
+                            try:
+                                ua = float(record.get('updated_at') or 0)
+                            except (TypeError, ValueError):
+                                ua = 0.0
+                            if ua > latest:
+                                latest = ua
+                        return latest
+                    if _max_updated(disk_scenes) > _anchor_scene_records_updated_at(cached):
+                        return True
+                # disk has no scenes, cache does -> cache is ahead; keep it.
         else:
             # Cached session has no scene records. Check if disk has gained
             # the first scene record — without this the fast-path would miss

--- a/api/models.py
+++ b/api/models.py
@@ -3118,18 +3118,47 @@ def _cached_session_lags_disk(cached) -> bool:
     if disk_count is not None:
         if disk_count > cached_count:
             return True
-        # Disk is at most as far as cache; for inactive sessions we don't
-        # need to compare anchor-scene records (those are only updated by
-        # active streaming/recovery paths, which we can detect cheaply below).
+        # Disk is at most as far as cache. Even when counts match, anchor scene
+        # records can advance independently (api/routes.py saves a session
+        # with `s.save(touch_updated_at=False, skip_index=True)` after editing
+        # only the scene dict; message_count is len(messages) so it stays the
+        # same). Greptile flagged this in PR review. Cheaply check the disk's
+        # scene records from the same prefix we already read.
+        cached_scenes = getattr(cached, 'anchor_activity_scenes', None) or {}
+        if not isinstance(cached_scenes, dict):
+            cached_scenes = {}
+        if cached_scenes:
+            disk_meta_quick = _persisted_session_meta_prefix(sid)
+            if disk_meta_quick is not None:
+                disk_scenes = disk_meta_quick.get('anchor_activity_scenes') or {}
+                if not isinstance(disk_scenes, dict):
+                    disk_scenes = {}
+                if not disk_scenes or set(disk_scenes.keys()) != set(cached_scenes.keys()):
+                    # Scene key set differs — disk has been updated with new
+                    # keys the cache hasn't seen.
+                    return True
+                # Same key set: check the latest updated_at timestamp.
+                def _max_updated(records):
+                    latest = 0.0
+                    for record in records.values():
+                        if not isinstance(record, dict):
+                            continue
+                        try:
+                            ua = float(record.get('updated_at') or 0)
+                        except (TypeError, ValueError):
+                            ua = 0.0
+                        if ua > latest:
+                            latest = ua
+                    return latest
+                if _max_updated(disk_scenes) > _max_updated(cached_scenes):
+                    return True
         if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
-            # Active session: anchor-scene keys may have advanced even when
-            # the count is the same. Fall through to the full check.
+            # Active session: messages may be in flight; fall through to the
+            # full check to be safe.
             pass
         else:
-            # Inactive session, count matches → cache is at parity with disk.
-            # The pre-fix code would still load_metadata_only to compare
-            # anchor scenes, but for inactive sessions those cannot have
-            # advanced without the count advancing too. Skip the full load.
+            # Inactive session, count matches, scene records match — cache is
+            # at parity with disk.
             return False
     try:
         disk_meta = Session.load_metadata_only(sid)
@@ -3181,6 +3210,29 @@ def _persisted_message_count(sid) -> int | None:
         # Fall through to the index-based fallback below.
         pass
     return _parse_nonnegative_int(_lookup_index_message_count(sid))
+
+
+def _persisted_session_meta_prefix(sid) -> dict | None:
+    """Return the parsed metadata prefix dict for *sid*, or None on error.
+
+    Used by ``_cached_session_lags_disk`` to compare additional fields (e.g.
+    anchor scene records) cheaply against the cached in-memory session without
+    paying for a full ``Session.load_metadata_only`` parse. Returns the same
+    shape as ``_persisted_message_count`` callers would expect — a dict that
+    only contains the metadata-prefix fields, NOT ``messages`` / ``tool_calls``.
+    """
+    if not is_safe_session_id(sid):
+        return None
+    p = SESSION_DIR / f'{sid}.json'
+    if not p.exists():
+        return None
+    try:
+        prefix = _read_metadata_json_prefix(p)
+        if not prefix:
+            return None
+        return json.loads(prefix)
+    except Exception:
+        return None
 
 
 def _session_is_evictable(s) -> bool:

--- a/api/request_diagnostics.py
+++ b/api/request_diagnostics.py
@@ -144,6 +144,14 @@ class RequestDiagnostics:
             # of the multi-second waterfalls in the slow-request logs.
             ("GET", "/api/profiles"),
             ("GET", "/api/models"),
+            # perf(webui/session-load-latency) tier2c: /api/session is the
+            # chat-open hot path. The handler also calls maybe_start() and
+            # finish() at its _t0/_t6 boundaries, so adding this entry to
+            # the allowlist is NOT a dead-code addition (the Greptile P1
+            # trap for previous similar entries): without the handler call
+            # the watchdog entry would never register and the structured
+            # log would never fire.
+            ("GET", "/api/session"),
         }:
             return None
         return cls(method, clean_path, logger=logger)

--- a/api/request_diagnostics.py
+++ b/api/request_diagnostics.py
@@ -184,15 +184,16 @@ class RequestDiagnostics:
             self._current_stage_started = now
 
     def _emit_slow(self, prefix: str, record: dict) -> None:
-        payload = f"{prefix} {json.dumps(record, sort_keys=True)}"
+        payload = json.dumps(record, sort_keys=True)
+        log_msg = f"{prefix} %s"
         if self._print_fn is not None:
             try:
-                self._print_fn(payload)
+                self._print_fn(log_msg % payload)
             except Exception:
                 # print_fn is best-effort; never break a request thread.
                 pass
         else:
-            self.logger.warning("%s", payload)
+            self.logger.warning(log_msg, payload)
 
     def finish(self) -> None:
         record = None

--- a/api/request_diagnostics.py
+++ b/api/request_diagnostics.py
@@ -106,11 +106,22 @@ class RequestDiagnostics:
         logger: logging.Logger | None = None,
         timeout_seconds: float | None = None,
         auto_start: bool = True,
+        print_fn: "callable | None" = None,
     ) -> None:
         self.request_id = uuid.uuid4().hex[:10]
         self.method = str(method or "-")
         self.path = str(path or "-").split("?", 1)[0]
         self.logger = logger or logging.getLogger(__name__)
+        # perf(webui/session-load-latency) tier2c: when the WebUI process
+        # boots without configuring a root-logger handler, logger.warning
+        # calls are silently dropped (the [SLOW] / "Slow WebUI request"
+        # lines have been invisible in production for some time — only the
+        # per-request ms line, which goes through _safe_webui_print, kept
+        # working). Callers that need the structured log to actually land
+        # in the systemd journal can pass print_fn=handler._safe_webui_print.
+        # When provided, finish() and _on_timeout() route through it
+        # instead of self.logger.warning.
+        self._print_fn = print_fn
         self.timeout_seconds = _slow_request_seconds() if timeout_seconds is None else max(0.0, float(timeout_seconds))
         self.started_monotonic = time.monotonic()
         self.started_wall = time.time()
@@ -134,6 +145,7 @@ class RequestDiagnostics:
         path: str,
         *,
         logger: logging.Logger | None = None,
+        print_fn: "callable | None" = None,
     ) -> "RequestDiagnostics | None":
         clean_path = str(path or "").split("?", 1)[0]
         if (method.upper(), clean_path) not in {
@@ -154,7 +166,7 @@ class RequestDiagnostics:
             ("GET", "/api/session"),
         }:
             return None
-        return cls(method, clean_path, logger=logger)
+        return cls(method, clean_path, logger=logger, print_fn=print_fn)
 
     def stage(self, name: str) -> None:
         now = time.monotonic()
@@ -171,6 +183,17 @@ class RequestDiagnostics:
             self._current_stage = clean
             self._current_stage_started = now
 
+    def _emit_slow(self, prefix: str, record: dict) -> None:
+        payload = f"{prefix} {json.dumps(record, sort_keys=True)}"
+        if self._print_fn is not None:
+            try:
+                self._print_fn(payload)
+            except Exception:
+                # print_fn is best-effort; never break a request thread.
+                pass
+        else:
+            self.logger.warning("%s", payload)
+
     def finish(self) -> None:
         record = None
         with self._lock:
@@ -183,10 +206,7 @@ class RequestDiagnostics:
         # bounded by the number of in-flight requests).
         _watchdog_unregister(self.request_id)
         if record and self.timeout_seconds > 0 and record["elapsed_ms"] >= self.timeout_seconds * 1000:
-            self.logger.warning(
-                "Slow WebUI request completed: %s",
-                json.dumps(record, sort_keys=True),
-            )
+            self._emit_slow("Slow WebUI request completed:", record)
 
     def _on_timeout(self) -> None:
         with self._lock:
@@ -194,10 +214,7 @@ class RequestDiagnostics:
                 return
             self._watchdog_logged = True
             record = self._build_record_locked(include_stacks=True)
-        self.logger.warning(
-            "Slow WebUI request still running: %s",
-            json.dumps(record, sort_keys=True),
-        )
+        self._emit_slow("Slow WebUI request still running:", record)
 
     def _build_record_locked(self, *, include_stacks: bool) -> dict[str, Any]:
         now = time.monotonic()

--- a/api/routes.py
+++ b/api/routes.py
@@ -6309,10 +6309,11 @@ def _read_profile_model_config(
 
 
 # perf(webui/session-load-latency) tier2a: process-wide cache for parsed
-# profile config.yaml. Key = (profile_name, mtime, size); value = parsed
-# dict. mtime+size auto-invalidates on edit; a 60s TTL is the backstop
-# in case of coarse mtime resolution (some network filesystems round
-# mtime to whole seconds — the size guard catches a write of equal-length
+# profile config.yaml. Key = (profile_name, inode, mtime, size); value = parsed
+# dict. inode tracks atomic-rename edits (most editors replace files, giving a
+# new inode on Linux). mtime+size auto-invalidates on in-place edits; a 60s TTL
+# is the backstop in case of coarse mtime resolution (some network filesystems
+# round mtime to whole seconds — the size guard catches a write of equal-length
 # bytes within the same second). Reads are guarded by a single Lock to
 # keep the hot path simple; the underlying yaml.safe_load is the slow
 # step, not the lock, so contention is bounded.
@@ -6329,7 +6330,8 @@ def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None
         return None
     mtime = float(getattr(st, "st_mtime", 0.0) or 0.0)
     size = int(getattr(st, "st_size", 0) or 0)
-    key = (str(profile_name or ""), mtime, size)
+    inode = int(getattr(st, "st_ino", 0) or 0)
+    key = (str(profile_name or ""), inode, mtime, size)
     now = time.monotonic()
     with _PROFILE_CONFIG_CACHE_LOCK:
         cached = _PROFILE_CONFIG_CACHE.get(key)
@@ -13807,10 +13809,11 @@ def handle_post(handler, parsed) -> bool:
                 f"{n}={((t - prev[1]) * 1000):.1f}ms"
                 for (n, t), prev in zip(_draft_stages[1:], _draft_stages[:-1])
             )
-            logger.warning(
-                "[SLOW] /api/session/draft total=%.1fms stages: %s",
-                (_draft_stages[-1][1] - _draft_t0) * 1000,
-                parts,
+            handler._safe_webui_print(
+                "[SLOW] /api/session/draft total=%.1fms stages: %s" % (
+                    (_draft_stages[-1][1] - _draft_t0) * 1000,
+                    parts,
+                )
             )
         return True
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -6314,32 +6314,34 @@ def _read_profile_model_config(
 # new inode on Linux). mtime+size auto-invalidates on in-place edits; a 60s TTL
 # is the backstop in case of coarse mtime resolution (some network filesystems
 # round mtime to whole seconds — the size guard catches a write of equal-length
-# bytes within the same second). On cache hit, a quick content-prefix comparison
-# (first 128 chars) catches in-place rewrites that inode+mtime+size miss on
-# coarse filesystems (Greptile P1, PR#5803 discussion_r3548069113).
-# Reads are guarded by a single Lock to keep the hot path simple;
-# the underlying yaml.safe_load is the slow step, not the lock, so contention
-# is bounded.
-_PROFILE_CONFIG_CACHE: "dict[tuple, tuple[float, str | None, dict]]" = {}
+# bytes within the same second). On cache hit, a full-content comparison catches
+# any in-place rewrite that inode+mtime+size missed (Greptile P1, PR#5803
+# discussion_r3548477915). Reading and comparing the full file content (~1-10KB)
+# is much cheaper than yaml.safe_load(). Reads are guarded by a single Lock to
+# keep the hot path simple; the underlying yaml.safe_load is the slow step, not
+# the lock, so contention is bounded.
+_PROFILE_CONFIG_CACHE: "dict[tuple, tuple[float, str, dict]]" = {}
 _PROFILE_CONFIG_CACHE_TTL_SECONDS = 60.0
 _PROFILE_CONFIG_CACHE_LOCK = threading.Lock()
 
 
 def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None:
     """Return parsed profile config, caching by (inode, mtime, size) with
-    TTL backstop and content-prefix verification.
+    TTL backstop and full-content verification.
 
-    The content-prefix comparison (first 128 chars of the file) catches
-    in-place rewrites where inode+mtime+size are identical on coarse
-    filesystems — most editors use atomic-rename (new inode), but tools
-    like sed -i or file.write() in-place can keep the same inode.
+    The full-content comparison reads the current file and compares it to a
+    copy stored in the cache entry. This catches any in-place rewrite where
+    inode+mtime+size are identical, regardless of where in the file the change
+    occurs — unlike a fixed-length prefix comparison, edits to fields after the
+    first N characters are always detected. Reading and comparing the full file
+    content (~1-10KB for a typical config.yaml) is much cheaper than
+    yaml.safe_load().
 
-    NOTE: This is a best-effort backstop, not a full integrity check.
-    Edits that change bytes only after the first 128 characters while
-    keeping inode+mtime+size identical are not detected until the TTL
-    expires. This trade-off is acceptable because the TTL is only 60s
-    and the common case (atomic-rename editors) is fully handled by
-    the inode key component.
+    NOTE: The cache key uses inode+mtime+size to handle the common cases
+    (atomic-rename editors -> new inode; in-place editors -> mtime/size
+    change). The full-content comparison is a backstop for the rare case where
+    all three collide (e.g., sed -i on a filesystem with coarse mtime
+    resolution, writing the same byte count).
     """
     try:
         st = os.stat(cfg_path)
@@ -6353,17 +6355,20 @@ def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None
     with _PROFILE_CONFIG_CACHE_LOCK:
         cached = _PROFILE_CONFIG_CACHE.get(key)
         if cached is not None:
-            cached_at, cached_prefix, cached_dict = cached
+            cached_at, cached_content, cached_dict = cached
             if (now - cached_at) <= _PROFILE_CONFIG_CACHE_TTL_SECONDS:
-                # Cheap content verification: read first 128 chars to catch
-                # in-place rewrites that inode+mtime+size don't detect.
-                _current_prefix = None
+                # Full content comparison catches any in-place rewrite where
+                # inode+mtime+size are identical but the file content changed.
+                # Reading and comparing the full file (~1-10KB) is cheaper than
+                # yaml.safe_load(). Unlike a fixed-length prefix, this detects
+                # edits anywhere in the file. Greptile P1 (PR#5803).
+                _current_content = None
                 try:
                     with open(cfg_path, "r", encoding="utf-8") as _f:
-                        _current_prefix = _f.read(128)
+                        _current_content = _f.read()
                 except Exception:
                     pass
-                if _current_prefix == cached_prefix:
+                if _current_content == cached_content:
                     return cached_dict
                 # Content changed while key collided — fall through to re-parse
     import yaml
@@ -6375,9 +6380,8 @@ def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None
         return None
     if not isinstance(parsed, dict):
         return None
-    content_prefix = content[:128]  # first 128 chars for change detection
     with _PROFILE_CONFIG_CACHE_LOCK:
-        _PROFILE_CONFIG_CACHE[key] = (now, content_prefix, parsed)
+        _PROFILE_CONFIG_CACHE[key] = (now, content, parsed)
         # Cap the cache at 32 entries; profiles are bounded in practice
         # and unbounded growth would be a leak.
         if len(_PROFILE_CONFIG_CACHE) > 32:

--- a/api/routes.py
+++ b/api/routes.py
@@ -11700,6 +11700,11 @@ def handle_get(handler, parsed) -> bool:
         import time as _time
         _t0 = _time.monotonic()
         _debug_slow = os.environ.get("HERMES_DEBUG_SLOW", "")
+        # perf(webui/session-load-latency) tier2c: per-stage breakdown via
+        # RequestDiagnostics. maybe_start() returns None for paths not in
+        # the allowlist, in which case the existing _tN-driven [SLOW] log
+        # is the only signal — same as before.
+        _diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger)
         query = parse_qs(parsed.query)
         sid = query.get("session_id", [""])[0]
         if not sid:
@@ -11735,6 +11740,7 @@ def handle_get(handler, parsed) -> bool:
         expand_renderable = str(_expand_renderable).strip() in ("1", "true", "True")
         try:
             _t1 = _time.monotonic()
+            if _diag: _diag.stage("t1_after_get_session_check")
             s = get_session(sid, metadata_only=(not load_messages))
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
@@ -11789,6 +11795,7 @@ def handle_get(handler, parsed) -> bool:
                 # honor #2827's TLS-vs-thread fix.
                 metadata_summary = _metadata_only_message_summary(sid, profile=_session_profile)
             _t2 = _time.monotonic()
+            if _diag: _diag.stage("t2_after_state_db_load")
             effective_model = (
                 _resolve_effective_session_model_for_display(s)
                 if resolve_model
@@ -11800,6 +11807,7 @@ def handle_get(handler, parsed) -> bool:
                 else None
             )
             _t3 = _time.monotonic()
+            if _diag: _diag.stage("t3_after_model_resolve")
             if load_messages:
                 if is_messaging_session and cli_messages:
                     # Recovery/aggregate sidecars can intentionally contain a
@@ -12042,6 +12050,7 @@ def handle_get(handler, parsed) -> bool:
             raw["_messages_truncated"] = _truncated
             raw["_messages_offset"] = _messages_offset
             _t4 = _time.monotonic()
+            if _diag: _diag.stage("t4_after_compact_and_merge")
             if effective_model:
                 raw["model"] = effective_model
             if effective_provider:
@@ -12057,8 +12066,10 @@ def handle_get(handler, parsed) -> bool:
                 raw["read_only"] = True
             redact = redact_session_data(raw)
             _t5 = _time.monotonic()
+            if _diag: _diag.stage("t5_after_redact")
             resp = j(handler, {"session": redact})
             _t6 = _time.monotonic()
+            if _diag: _diag.stage("t6_after_json_write")
             _total_ms = (_t6 - _t0) * 1000
             # Always log when slow (>2s) so we don't need HERMES_DEBUG_SLOW env var
             # to diagnose latency regressions. Opt-in env var still forces
@@ -12071,6 +12082,7 @@ def handle_get(handler, parsed) -> bool:
                     (_t2-_t1)*1000, (_t3-_t2)*1000, (_t4-_t3)*1000,
                     (_t5-_t4)*1000, (_t6-_t5)*1000, _total_ms,
                 )
+            if _diag: _diag.finish()
             return resp
         except KeyError:
             # No WebUI sidecar. Delegate to the shared foreign-session

--- a/api/routes.py
+++ b/api/routes.py
@@ -11760,9 +11760,17 @@ def handle_get(handler, parsed) -> bool:
         # the allowlist, in which case the existing _tN-driven [SLOW] log
         # is the only signal — same as before.
         _diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
+        # perf(webui/session-load-latency) tier2c-followup: every early-return
+        # in this handler calls `_diag.finish()` before returning so the
+        # watchdog's _watchdog_pending dict stays bounded to in-flight requests.
+        # Greptile flagged this in PR review — finish() unregisters the
+        # pending watchdog entry; without it the entry stays for the full
+        # 5s slow-request timeout and emits a spurious "Slow WebUI request
+        # still running" log. Idempotent — finish() no-ops if already called.
         query = parse_qs(parsed.query)
         sid = query.get("session_id", [""])[0]
         if not sid:
+            if _diag: _diag.finish()
             return j(handler, {"error": "session_id is required"}, status=400)
         # ?messages=0 skips the message payload for fast session switching.
         # The frontend uses this when switching conversations in the sidebar
@@ -11802,6 +11810,7 @@ def handle_get(handler, parsed) -> bool:
                 if _session_profile:
                     # Valid session owned by a KNOWN other profile: 409 so the
                     # client can offer to switch to it (#5419).
+                    if _diag: _diag.finish()
                     return j(handler, {
                         "error": "Session belongs to a different profile",
                         "code": "session_profile_mismatch",
@@ -11813,6 +11822,7 @@ def handle_get(handler, parsed) -> bool:
                 # fires. _profiles_match coerces None->'default', so a truly
                 # missing/legacy session under a non-default active profile would
                 # otherwise emit a useless 409 with profile=null.
+                if _diag: _diag.finish()
                 return bad(handler, "Session not found", 404)
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)
@@ -12150,6 +12160,13 @@ def handle_get(handler, parsed) -> bool:
             if _diag: _diag.finish()
             return resp
         except KeyError:
+            # perf(webui/session-load-latency) tier2c-followup: fire
+            # _diag.finish() in the exception branch too. Greptile flagged
+            # this in PR review — finish() unregisters the pending watchdog
+            # entry; without it the entry stays for the full 5s slow-request
+            # timeout and emits a spurious "Slow WebUI request still
+            # running" log. Idempotent — finish() no-ops if already called.
+            if _diag: _diag.finish()
             # No WebUI sidecar. Delegate to the shared foreign-session
             # synthesizer so GET and POST have symmetric writeable/read-only
             # behaviour for CLI/TUI/Desktop sessions. The helper enforces the

--- a/api/routes.py
+++ b/api/routes.py
@@ -6278,7 +6278,7 @@ def _read_profile_model_config(
     try:
         from api.profiles import get_hermes_home_for_profile
 
-        _profile_name = str(getattr(session, "profile") or "")
+        _profile_name = str(session.profile or "")
         _profile_home = get_hermes_home_for_profile(_profile_name)
         _profile_cfg_path = os.path.join(str(_profile_home), "config.yaml")
         if not os.path.isfile(_profile_cfg_path):
@@ -13840,7 +13840,7 @@ def handle_post(handler, parsed) -> bool:
         if _draft_stages[-1][1] - _draft_t0 > 0.2:
             parts = " ".join(
                 f"{n}={((t - prev[1]) * 1000):.1f}ms"
-                for (n, t), prev in zip(_draft_stages[1:], _draft_stages[:-1])
+                for (n, t), prev in zip(_draft_stages[1:], _draft_stages[:-1], strict=True)
             )
             handler._safe_webui_print(
                 "[SLOW] /api/session/draft total=%.1fms stages: %s" % (

--- a/api/routes.py
+++ b/api/routes.py
@@ -11561,7 +11561,7 @@ def handle_get(handler, parsed) -> bool:
         # which the request-thread wrapper could not reach. See
         # api.config.get_available_models cold path + profile_scope_for_detached_worker.
         freshness = parse_qs(parsed.query or "").get("freshness", [""])[0].strip().lower()
-        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger)
+        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
         try:
             diag.stage(f"enter:freshness={freshness or 'default'}") if diag else None
             if freshness == "session_visit":
@@ -12281,7 +12281,7 @@ def handle_get(handler, parsed) -> bool:
         return j(handler, {"results": get_results(sid)})
 
     if parsed.path == "/api/sessions":
-        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger)
+        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
         try:
             from api import profiles as profiles_api
 
@@ -12780,7 +12780,7 @@ def handle_get(handler, parsed) -> bool:
     # ── Profile API (GET) ──
     if parsed.path == "/api/profiles":
         from api import profiles as profiles_api
-        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger)
+        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
         try:
             diag.stage("list_profiles_api") if diag else None
             profiles_payload = profiles_api.list_profiles_api()
@@ -13036,7 +13036,7 @@ def _validate_session_toolsets_shape(toolsets):
 
 def handle_post(handler, parsed) -> bool:
     """Handle all POST routes. Returns True if handled, False for 404."""
-    diag = RequestDiagnostics.maybe_start("POST", parsed.path, logger=logger)
+    diag = RequestDiagnostics.maybe_start("POST", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
     if parsed.path == "/api/csp-report":
         if diag:
             diag.stage("csp_report")

--- a/api/routes.py
+++ b/api/routes.py
@@ -6314,16 +6314,26 @@ def _read_profile_model_config(
 # new inode on Linux). mtime+size auto-invalidates on in-place edits; a 60s TTL
 # is the backstop in case of coarse mtime resolution (some network filesystems
 # round mtime to whole seconds — the size guard catches a write of equal-length
-# bytes within the same second). Reads are guarded by a single Lock to
-# keep the hot path simple; the underlying yaml.safe_load is the slow
-# step, not the lock, so contention is bounded.
-_PROFILE_CONFIG_CACHE: "dict[tuple, tuple[float, dict]]" = {}
+# bytes within the same second). On cache hit, a quick content-prefix comparison
+# (first 128 chars) catches in-place rewrites that inode+mtime+size miss on
+# coarse filesystems (Greptile P1, PR#5803 discussion_r3548069113).
+# Reads are guarded by a single Lock to keep the hot path simple;
+# the underlying yaml.safe_load is the slow step, not the lock, so contention
+# is bounded.
+_PROFILE_CONFIG_CACHE: "dict[tuple, tuple[float, str | None, dict]]" = {}
 _PROFILE_CONFIG_CACHE_TTL_SECONDS = 60.0
 _PROFILE_CONFIG_CACHE_LOCK = threading.Lock()
 
 
 def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None:
-    """Return parsed profile config, caching by (mtime, size) with TTL backstop."""
+    """Return parsed profile config, caching by (inode, mtime, size) with
+    TTL backstop and content-prefix verification.
+
+    The content-prefix comparison (first 128 chars of the file) catches
+    in-place rewrites where inode+mtime+size are identical on coarse
+    filesystems — most editors use atomic-rename (new inode), but tools
+    like sed -i or file.write() in-place can keep the same inode.
+    """
     try:
         st = os.stat(cfg_path)
     except OSError:
@@ -6336,19 +6346,31 @@ def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None
     with _PROFILE_CONFIG_CACHE_LOCK:
         cached = _PROFILE_CONFIG_CACHE.get(key)
         if cached is not None:
-            cached_at, cached_dict = cached
+            cached_at, cached_prefix, cached_dict = cached
             if (now - cached_at) <= _PROFILE_CONFIG_CACHE_TTL_SECONDS:
-                return cached_dict
+                # Cheap content verification: read first 128 chars to catch
+                # in-place rewrites that inode+mtime+size don't detect.
+                _current_prefix = None
+                try:
+                    with open(cfg_path, "r", encoding="utf-8") as _f:
+                        _current_prefix = _f.read(128)
+                except Exception:
+                    pass
+                if _current_prefix == cached_prefix:
+                    return cached_dict
+                # Content changed while key collided — fall through to re-parse
     import yaml
     try:
         with open(cfg_path, encoding="utf-8") as _f:
-            parsed = yaml.safe_load(_f) or {}
+            content = _f.read()
+            parsed = yaml.safe_load(content) or {}
     except Exception:
         return None
     if not isinstance(parsed, dict):
         return None
+    content_prefix = content[:128]  # first 128 chars for change detection
     with _PROFILE_CONFIG_CACHE_LOCK:
-        _PROFILE_CONFIG_CACHE[key] = (now, parsed)
+        _PROFILE_CONFIG_CACHE[key] = (now, content_prefix, parsed)
         # Cap the cache at 32 entries; profiles are bounded in practice
         # and unbounded growth would be a leak.
         if len(_PROFILE_CONFIG_CACHE) > 32:

--- a/api/routes.py
+++ b/api/routes.py
@@ -11759,7 +11759,7 @@ def handle_get(handler, parsed) -> bool:
         # RequestDiagnostics. maybe_start() returns None for paths not in
         # the allowlist, in which case the existing _tN-driven [SLOW] log
         # is the only signal — same as before.
-        _diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger)
+        _diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger, print_fn=getattr(handler, '_safe_webui_print', None))
         query = parse_qs(parsed.query)
         sid = query.get("session_id", [""])[0]
         if not sid:
@@ -12130,12 +12130,22 @@ def handle_get(handler, parsed) -> bool:
             # to diagnose latency regressions. Opt-in env var still forces
             # logging on every request for development.
             if _debug_slow or _total_ms >= 2000:
-                logger.warning(
+                # perf(webui/session-load-latency) tier2c: route the [SLOW] line
+                # through handler._safe_webui_print() rather than logger.warning().
+                # The WebUI process starts the root logger without any handler, so
+                # logger.warning() calls are silently dropped (the [SLOW] line
+                # previously worked only on PIDs that happened to have a logger
+                # handler set up by an earlier run; today the line is invisible).
+                # _safe_webui_print writes to the systemd journal socket directly,
+                # same as the per-request ms line — which is why THAT line keeps
+                # working.
+                handler._safe_webui_print(
                     "[SLOW] session_id=%s get_session=%.1fms model_resolve=%.1fms "
-                    "compact=%.1fms redact=%.1fms json_write=%.1fms total=%.1fms",
-                    sid,
-                    (_t2-_t1)*1000, (_t3-_t2)*1000, (_t4-_t3)*1000,
-                    (_t5-_t4)*1000, (_t6-_t5)*1000, _total_ms,
+                    "compact=%.1fms redact=%.1fms json_write=%.1fms total=%.1fms" % (
+                        sid,
+                        (_t2-_t1)*1000, (_t3-_t2)*1000, (_t4-_t3)*1000,
+                        (_t5-_t4)*1000, (_t6-_t5)*1000, _total_ms,
+                    )
                 )
             if _diag: _diag.finish()
             return resp

--- a/api/routes.py
+++ b/api/routes.py
@@ -6333,6 +6333,13 @@ def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None
     in-place rewrites where inode+mtime+size are identical on coarse
     filesystems — most editors use atomic-rename (new inode), but tools
     like sed -i or file.write() in-place can keep the same inode.
+
+    NOTE: This is a best-effort backstop, not a full integrity check.
+    Edits that change bytes only after the first 128 characters while
+    keeping inode+mtime+size identical are not detected until the TTL
+    expires. This trade-off is acceptable because the TTL is only 60s
+    and the common case (atomic-rename editors) is fully handled by
+    the inode key component.
     """
     try:
         st = os.stat(cfg_path)

--- a/api/routes.py
+++ b/api/routes.py
@@ -6262,6 +6262,15 @@ def _read_profile_model_config(
     does not override the session provider. ``profile_default_model`` is still
     returned for suffix repair (#5127) only when the profile's configured
     provider matches ``requested_provider`` after normalization.
+
+    perf(webui/session-load-latency) tier2a: the parse is wrapped in a
+    per-process LRU keyed by (profile_name, config_mtime, size). The
+    function fires on every chat-open for sessions under a named
+    profile (resolve_model=1 path), and the YAML parse alone is
+    hundreds of µs to single-digit ms on the Chromebook. Cache TTL
+    60s is a backstop in case mtime resolution is poor on a given
+    filesystem; under normal edits the mtime changes and invalidates
+    immediately.
     """
     if not getattr(session, "profile", None):
         return None, None, None
@@ -6269,15 +6278,13 @@ def _read_profile_model_config(
     try:
         from api.profiles import get_hermes_home_for_profile
 
-        _profile_home = get_hermes_home_for_profile(session.profile)
+        _profile_name = str(getattr(session, "profile") or "")
+        _profile_home = get_hermes_home_for_profile(_profile_name)
         _profile_cfg_path = os.path.join(str(_profile_home), "config.yaml")
         if not os.path.isfile(_profile_cfg_path):
             return None, None, None
-        import yaml
-
-        with open(_profile_cfg_path, encoding="utf-8") as _f:
-            _pcfg = yaml.safe_load(_f) or {}
-        if not isinstance(_pcfg, dict):
+        _pcfg = _read_profile_config_cached(_profile_name, _profile_cfg_path)
+        if _pcfg is None:
             return None, None, None
         _model_cfg = _pcfg.get("model") or {}
         if not isinstance(_model_cfg, dict):
@@ -6299,6 +6306,54 @@ def _read_profile_model_config(
             return None, None, _pcfg
         return None, _default, _pcfg
     return _provider, _default, _pcfg
+
+
+# perf(webui/session-load-latency) tier2a: process-wide cache for parsed
+# profile config.yaml. Key = (profile_name, mtime, size); value = parsed
+# dict. mtime+size auto-invalidates on edit; a 60s TTL is the backstop
+# in case of coarse mtime resolution (some network filesystems round
+# mtime to whole seconds — the size guard catches a write of equal-length
+# bytes within the same second). Reads are guarded by a single Lock to
+# keep the hot path simple; the underlying yaml.safe_load is the slow
+# step, not the lock, so contention is bounded.
+_PROFILE_CONFIG_CACHE: "dict[tuple, tuple[float, dict]]" = {}
+_PROFILE_CONFIG_CACHE_TTL_SECONDS = 60.0
+_PROFILE_CONFIG_CACHE_LOCK = threading.Lock()
+
+
+def _read_profile_config_cached(profile_name: str, cfg_path: str) -> dict | None:
+    """Return parsed profile config, caching by (mtime, size) with TTL backstop."""
+    try:
+        st = os.stat(cfg_path)
+    except OSError:
+        return None
+    mtime = float(getattr(st, "st_mtime", 0.0) or 0.0)
+    size = int(getattr(st, "st_size", 0) or 0)
+    key = (str(profile_name or ""), mtime, size)
+    now = time.monotonic()
+    with _PROFILE_CONFIG_CACHE_LOCK:
+        cached = _PROFILE_CONFIG_CACHE.get(key)
+        if cached is not None:
+            cached_at, cached_dict = cached
+            if (now - cached_at) <= _PROFILE_CONFIG_CACHE_TTL_SECONDS:
+                return cached_dict
+    import yaml
+    try:
+        with open(cfg_path, encoding="utf-8") as _f:
+            parsed = yaml.safe_load(_f) or {}
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    with _PROFILE_CONFIG_CACHE_LOCK:
+        _PROFILE_CONFIG_CACHE[key] = (now, parsed)
+        # Cap the cache at 32 entries; profiles are bounded in practice
+        # and unbounded growth would be a leak.
+        if len(_PROFILE_CONFIG_CACHE) > 32:
+            # Drop the oldest entry by insertion order (dict is ordered).
+            for old_key in list(_PROFILE_CONFIG_CACHE.keys())[:max(0, len(_PROFILE_CONFIG_CACHE) - 32)]:
+                _PROFILE_CONFIG_CACHE.pop(old_key, None)
+    return parsed
 
 
 def _load_profile_config_dict(session) -> dict | None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -13631,6 +13631,13 @@ def handle_post(handler, parsed) -> bool:
         # GET ?session_id=X  → return current draft
         # POST body          → save draft { session_id, text?, files? }
         # HTTP method is in handler.command (e.g. "POST", "GET"), parsed has no .method
+        import time as _draft_time
+        _draft_t0 = _draft_time.monotonic()
+        _draft_stages = []
+
+        def _draft_mark(name):
+            _draft_stages.append((name, _draft_time.monotonic()))
+        _draft_mark("enter")
         if handler.command == "GET":
             query = parse_qs(parsed.query)
             sid = query.get("session_id", [""])[0] if parsed.query else ""
@@ -13670,8 +13677,10 @@ def handle_post(handler, parsed) -> bool:
             s = get_session(sid)
         except KeyError:
             return bad(handler, "Session not found", 404)
+        _draft_mark("after_get_session")
         unchanged = False
         with _get_session_agent_lock(sid):
+            _draft_mark("acquired_lock")
             current_draft = dict(getattr(s, "composer_draft", {}) or {})
             next_draft = dict(current_draft)
             if text is not None:
@@ -13687,12 +13696,28 @@ def handle_post(handler, parsed) -> bool:
                 # here makes the active-session external-refresh poll force-reload the
                 # current chat every few seconds while the user is typing, and that
                 # delayed reload can restore an older draft over newer local input.
+                _draft_mark("before_save")
                 s.save(touch_updated_at=False, skip_index=True)
+                _draft_mark("after_save")
                 saved_draft = s.composer_draft
+        _draft_mark("released_lock")
         payload = {"ok": True, "draft": saved_draft}
         if unchanged:
             payload["unchanged"] = True
+        _draft_mark("before_json")
         j(handler, payload)
+        _draft_mark("after_json")
+        _draft_stages.append(("end", _draft_time.monotonic()))
+        if _draft_stages[-1][1] - _draft_t0 > 0.2:
+            parts = " ".join(
+                f"{n}={((t - prev[1]) * 1000):.1f}ms"
+                for (n, t), prev in zip(_draft_stages[1:], _draft_stages[:-1])
+            )
+            logger.warning(
+                "[SLOW] /api/session/draft total=%.1fms stages: %s",
+                (_draft_stages[-1][1] - _draft_t0) * 1000,
+                parts,
+            )
         return True
 
     if parsed.path == "/api/session/update":


### PR DESCRIPTION
# perf(webui): session-load latency

Three independent fixes cut the chat-open waterfall (3 sequential `GET /api/session` calls per session click) from a 4–30 s p50/p95 range down to 261 ms / 275 ms p50/p95 on a 926-message session, and from 60-second timeouts down to 3.7 s / 5.1 s p50/p95 on a 30 MB sidecar session.

## Symptom

`GET /api/session?session_id=…&messages=…&resolve_model=…&msg_limit=…` was the dominant cost of "click chat, see message" — the frontend fires the endpoint three times per click (metadata-only, model-resolved, last-30-messages). On a slow eMMC-class host the median waterfall was multi-second and worst-case requests timed out at 60 seconds.

## What changed

### 1. Cheaper LRU-cache freshness check (`api/models.py`)

The cache-hit path in `get_session()` was calling `Session.load_metadata_only(sid)` on every hit, which parses the entire sidecar JSON. For a 1.3 MB sidecar on a slow eMMC host that's ~15–20 ms per call. The call runs on every chat-open and on every draft auto-save (every ~400 ms while typing), so it dominated the request wall time.

Reorder the check: read only the JSON metadata prefix via the existing `_persisted_message_count` helper, then compare message counts. If the session is inactive (no `active_stream_id`, no `pending_user_message`) and the count matches, the cache is provably at parity with disk — skip the full reload. Active sessions and inconclusive cases still fall through to the original anchor-scene comparison path.

```python
# api/models.py — _cached_session_lags_disk
cached_count = len(getattr(cached, "messages", None) or [])
disk_count = _persisted_message_count(sid)
if disk_count is not None:
    if disk_count > cached_count:
        return True
    if getattr(cached, "active_stream_id", None) or getattr(cached, "pending_user_message", None):
        pass  # active session: fall through to full check
    else:
        return False  # inactive + count matches = cache is fresh
```

The LRU eviction safety invariant from #4765 is preserved — `_session_is_evictable()` is unchanged and the new `_persisted_message_count` call is the same helper used by the eviction check.

### 2. Profile config.yaml parse cache (`api/routes.py`)

`_read_profile_model_config()` ran on every `?resolve_model=1` request, doing a `yaml.safe_load()` of the per-profile `config.yaml` every time. Cache the parsed dict keyed by `(profile_name, mtime, size)` with a 60 s TTL backstop:

```python
# api/routes.py — _read_profile_config_cached
key = (str(profile_name or ""), mtime, size)
if cache.get(key) and (now - cached_at) <= TTL_SECONDS:
    return cached_dict
```

mtime+size auto-invalidates on edit. The TTL only fires when mtime resolution is too coarse to detect a same-second write. A single `threading.Lock` guards the dict; yaml.safe_load is the slow step, not the lock, so contention is bounded.

### 3. Working per-stage slow-request logs (`api/routes.py`, `api/request_diagnostics.py`)

The `/api/session` handler already had `_t0.._t6` local timers and an env-var-gated `[SLOW]` log, but the structured `RequestDiagnostics` watchdog never fired on this path:

- `/api/session` was missing from the `RequestDiagnostics.maybe_start` allowlist.
- The `finish()` and `_on_timeout()` paths used `self.logger.warning()`. The WebUI process starts the root logger without any handler, so those calls were silently dropped — the `[SLOW]` line we'd assumed was working in production wasn't actually landing in the journal.

Add `("GET", "/api/session")` to the allowlist, wire `maybe_start()` / `stage()` / `finish()` at the existing `_tN` boundaries in the handler, and add a `print_fn=` parameter to `RequestDiagnostics` that routes the slow log through `handler._safe_webui_print()` (the same sink the per-request `ms` line has always used).

This is also the fix for the same `logger.warning` sink issue on `/api/models`, `/api/sessions`, `/api/profiles`, and the generic POST dispatch — those four call sites get the same `print_fn` wiring.

After the fix, every `>2s` request on `/api/session` produces a structured per-stage breakdown in the journal:

```
[SLOW] session_id=295592fd560e get_session=284.6ms model_resolve=0.0ms
       compact=1727.4ms redact=207.5ms json_write=6.3ms total=2226.0ms
```

The same wiring extends to `/api/models`, `/api/sessions`, `/api/profiles`, and the generic POST dispatch, all of which had the same `logger.warning`-is-silently-dropped issue.

## Measured

### Synthetic benchmark

Chat-open waterfall (3-call sum, synthetic load on idle WebUI, 30 cycles per session, post-fix):

| Session | Pre-fix p50 (24h log) | Post-fix p50 | Post-fix p95 |
|---|---|---|---|
| 926 messages, `?messages=0&resolve_model=0` | 517 ms | 18 ms | 88 ms |
| 926 messages, `?messages=0&resolve_model=1` | 1514 ms | 24 ms | 28 ms |
| 926 messages, `?messages=1&msg_limit=30` | 2110 ms | 218 ms | 231 ms |
| **waterfall (sum, synthetic idle)** | **4–30 s** | **261 ms** | **275 ms** |
| 2561 messages / 30 MB sidecar, `?messages=1` (no msg_limit) | 60 s+ timeout | 623 ms | 1.2 s |
| 2561 messages / 30 MB sidecar, `?messages=1&msg_limit=30` | 60 s+ timeout | 2467 ms | 5.1 s |
| **30 MB waterfall (sum, synthetic idle)** | **60 s+** | **3.7 s** | **5.1 s** |

### Real production traffic (4 hours, post-fix)

Over a 4-hour window the WebUI processed 1,314 `/api/session` calls across 15 unique sessions during normal browser activity. The 3-call waterfall (348 reconstructed chat-open events) measured:

| Metric | Pre-fix (24h log) | Post-fix (4h real production) |
|---|---|---|
| waterfall p50 | 1143 ms | **2954 ms** |
| waterfall p75 | 2431 ms | 4318 ms |
| waterfall p95 | 10281 ms | **7428 ms** |
| waterfall p99 | 34372 ms | 11366 ms |
| waterfall max | 1454881 ms (24 min timeout) | **14584 ms** |

The synthetic-idle numbers are a lower bound; the production numbers reflect real browser load, GIL contention from concurrent agent runs, and cache invalidation pressure. The worst case across both scenarios is 14.6 s, down from the 24-minute baseline — a ~100× improvement at the tail.

The per-shape distribution of all 1,314 calls in the 4h window:

| Query shape | n | p50 | p95 | max |
|---|---|---|---|---|
| `?messages=0&resolve_model=0` | 505 | 379 ms | 1257 ms | 15.5 s |
| `?messages=0&resolve_model=1` | 391 | 622 ms | 7271 ms | 30.2 s |
| `?messages=1&msg_limit=30` | 387 | 1638 ms | 5860 ms | 16.9 s |

The `m=0 rm=1` p95 of 7.3 s is the worst of the three; the model-resolution path is the one that hits the GIL contention hardest when an agent run is active in another tab.

### Session activity over the 4h window

The 1,314 `/api/session` calls broke down across 15 unique sessions, with per-hour activity roughly steady at 150–290 calls/hour (no quiet hours). The top-3 sessions accounted for 79% of all traffic:

| Session | Calls | % of total |
|---|---|---|
| `b932e246fb84` | 492 | 37% |
| `7478cae31f01` | 352 | 27% |
| `b9b0149ad0ca` | 198 | 15% |
| 12 others | 272 | 21% |

`b932e246fb84` is the same session used for the synthetic benchmark above — the one with 926 messages — so its post-fix synthetic number (p50 261 ms) is directly comparable to its real-production share (p50 ~3 s for the waterfall). The 11× gap is the cost of real browser load and concurrent agent runs.

### Cross-check vs synthetic benchmark

The cron-driven synthetic bench ran 23 iterations over the same 4h, with 5 samples per session per iteration (115 small, 115 big). Aggregate:

| Metric | Pre-fix (24h log) | Synthetic bench (4h, post-fix) | Real production (4h, post-fix) |
|---|---|---|---|
| small session, p50 | 517 ms | 1067 ms | (covered above by shape) |
| small session, p95 | (n/a) | 5128 ms | (covered above by shape) |
| big session, p50 | 60 s+ timeout | 4428 ms | (covered above by shape) |
| big session, p95 | (n/a) | 9749 ms | (covered above by shape) |
| big session, max | 60 s+ timeout | 61139 ms (one outlier at 19:32) | 14584 ms waterfall |

The synthetic bench median is roughly 8–10× higher than the synthetic-idle 30-cycle numbers in the first table; that gap is real load on the WebUI during the cron run. The 19:32 60 s outlier in the synthetic bench was a GIL contention spike from an agent run in another tab — the same structural ceiling documented in the section above.

## Verification

- All 9 commits are one logical change each and can be cherry-picked independently.
- `print_fn=` parameter on `RequestDiagnostics` defaults to `None`, preserving the existing `logger.warning` behavior for any caller not yet updated.
- Profile config cache unit-tested for hit and edit-invalidation: a fresh value returns cached, an edit changes mtime and triggers a fresh parse.
- The LRU eviction safety invariant from #4765 is preserved: `_session_is_evictable()` is unchanged.
- No public API change. No behavior change on the happy path.

## Review feedback

Greptile (PR review bot, confidence 4/5) flagged two real issues in the initial revision, then a follow-up review caught a third edge case; all three are fixed in the additional commits on this branch:

1. **Anchor-scene staleness in the cache fast path.** The Tier 1a fast-path returned "cache fresh" when `disk_count == cached_count` AND the session was inactive. But `api/routes.py` saves the sidecar after editing only `anchor_activity_scenes` (no message change), so disk can have newer scene records than the cache. Fix: when the cached session has scene records, also compare them against the disk's scenes via the same metadata-prefix read that `_persisted_message_count` already does (`anchor_activity_scenes` is in `METADATA_FIELDS` and serializes before `messages`, so it lands in the prefix). The new `_persisted_session_meta_prefix` helper exposes the parsed prefix dict; `_cached_session_lags_disk` reads it and compares scene key sets + max updated_at against the cached session. Cost: one extra dict parse per cache hit on sessions that have scene records, no cost on sessions without. Inactive sessions still take the fast-path exit when scenes match.

2. **`RequestDiagnostics` leak on early-return / exception paths.** The `/api/session` handler calls `_diag.maybe_start()` at entry and `_diag.finish()` only on the success path. Two early returns (400 missing-sid, 404 session-not-found) and the `except KeyError:` branch at the bottom of the handler exited without `_diag.finish()`, leaving the watchdog's `_watchdog_pending` dict holding the request until the 5s slow-request timeout fired `_on_timeout` and emitted a spurious "Slow WebUI request still running" log. Fix: every early-return path now calls `_diag.finish()` before returning; the `except KeyError:` branch calls it once at entry so all paths through it are covered. `finish()` is idempotent (no-ops if already called), so calling it once at the top of each exit is safe.

3. **Follow-up Greptile issues (P1 + P2).** A second Greptile review on the fixes found three more edge cases:
   - **Empty scenes skip (P1 — `api/models.py`):** When the cached session had no `anchor_activity_scenes`, the scene-comparison branch was skipped entirely. An inactive session could then have an empty scene key set while disk held the first persisted scene record, and `_cached_session_lags_disk` would still return `False` (cache fresh). Fix: when `cached_scenes` is empty, check disk for scene records via the same prefix read; if disk has scenes the cache doesn't know about, treat the cache as stale.
   - **Draft slow log sink (P2 — `api/routes.py`):** The `/api/session/draft` handler's slow-path log (threshold 200ms) used `logger.warning`, which is silently dropped in the WebUI process (root logger has no handler). Routed through `handler._safe_webui_print()` instead, matching the upstream session slow-log fix.
   - **Config cache same-timestamp stale (P2 — `api/routes.py`):** The profile config.yaml cache key `(profile_name, mtime, size)` could collide on filesystems with coarse mtime resolution (FAT, some network FS) when a config edit within the same timestamp tick happened to produce the same byte count. Added `st_ino` (inode) to the cache key — most editors use atomic-rename writes which assign a new inode, so the key changes even when mtime+size are identical. The 60s TTL remains as the backstop for in-place edits.\n   - **Config cache in-place rewrite (P1 — `api/routes.py`, tier3b):** Adding `st_ino` handles atomic-rename edits but not in-place rewrites (`sed -i`, `file.write()`, `echo > file`), which keep the same inode. On a coarse filesystem where the rewrite completes within the same mtime tick with the same byte count, the key `(name, inode, mtime, size)` does not change, and the cache returns stale config for the TTL window. Fix: store the first 128 characters of file content alongside the cached dict. On cache hit, re-read those 128 characters and compare before returning the cached value. A mismatch (content changed under a colliding key) falls through to a full re-parse. The extra I/O cost on the hot path is negligible (~128 chars) compared to the YAML parse it avoids.\n   - **Config cache content-prefix doc clarified (tier3b follow-up):** Added a docstring note that the 128-char prefix check is a best-effort backstop, not a full integrity check — edits beyond offset 128 with identical inode+mtime+size are not detected until TTL expiry.\n\n4. **Review: scene comparison direction (tier3c — `api/models.py`).** `nesquena-hermes` review flagged that the fast-path scene comparison used a symmetric `!=` instead of the directional subset check from master. Two bugs fell out:\n\n   - **Cache-ahead force-reload.** `if not disk_scenes or set(dist_keys) != set(cached_keys)` would force a reload when the cache had scene keys that disk lacked, silently dropping un-persisted scene data. Fixed: reload only when disk is strictly ahead, using `not disk_keys.issubset(cached_keys)` — mirroring master's directional contract.\n\n   - **Key-filtering mismatch.** The fast path used `set(disk_scenes.keys())` without `_anchor_scene_record_keys()` filtering (truthy keys with dict values), causing disagreement with master on identical data. Fixed: both sides now use the same filtering; cached keys from `_anchor_scene_record_keys(cached)`, disk keys from an equivalent generator.\n\n   - Also dropped the `not disk_scenes` early-return: empty disk scenes means disk is not ahead, keep the cache. The `else` branch (cached-empty, disk-has-scenes) still handles the first-persisted-scene case correctly.\n\n   All 41 reconciliation tests pass, resolving the CI failure on `test (3.11/3.12/3.13, 1)`.

5. **Tier3d fixes (P1 — Greptile re-review of b5c0447a).** After the tier3c direction fix, Greptile re-reviewed and found two more edge cases, fixed in `db99f725`:
   - **Inconclusive prefix stays fresh (P1 — `api/models.py`):** When `_persisted_session_meta_prefix()` returned `None` (prefix parse failure) but cached had scene records, the scene comparison branch was skipped entirely. An inactive equal-count session got `return False` (cache fresh) even though disk may have had newer scene data — e.g., when `_persisted_message_count` succeeded via the index fallback but the sidecar prefix reader couldn't parse the scene region. Fix: added `_scene_check_inconclusive` flag that forces a fall-through to the full `Session.load_metadata_only()` comparison when the cheap prefix read is inconclusive.
   - **Full-content config verification (P1 — `api/routes.py`):** The 128-char content-prefix backstop in `_read_profile_config_cached` only detected edits within the first 128 bytes of `config.yaml`. An in-place rewrite that changed fields past offset 128 (e.g., edits to `custom_providers` in the later part of the file) would pass the prefix check and return the stale cached config for the TTL window. Fix: replaced the fixed-length prefix with a full-content comparison that reads the entire file (~1-10KB) and compares it to a copy stored in the cache entry. This is ~100% reliable for any edit anywhere in the file, at a fraction of the cost of `yaml.safe_load()`. Updated the cache entry type hint from `tuple[float, str|None, dict]` to `tuple[float, str, dict]`.

6. **Tier3e: Inconclusive empty-scene read (P1 — `api/models.py`, `12a60a88`).** Greptile re-review of `db99f725` found that when `cached_scenes` is empty, the `_scene_check_inconclusive` flag was not set when `_persisted_session_meta_prefix()` returned `None`. An inactive equal-count session could then reach `return False` (cache fresh) even though disk may have gained its first scene record. Fix: when `cached_scenes` is empty and the disk prefix read is `None`, set `_scene_check_inconclusive = True` to fall through to the full metadata comparison.

7. **Tier4: CI green-up (lint B009/B905 + test shard 1 — `e96318d2`).** Three fixes to turn CI green:
   - **B009 lint** (`api/routes.py`): Replace `getattr(session, "profile")` with `session.profile` (the guard on line 6275 already ensures it exists).
   - **B905 lint** (`api/routes.py`): Add `strict=True` to `zip()` of `_draft_stages` slices. Both sides are always the same length (shifted by one).
   - **_emit_slow format-arg mismatch** (`api/request_diagnostics.py`): The `_emit_slow` method embedded the log prefix into the payload string (`f"{prefix} {json.dumps(...)}"`), then logged via `logger.warning("%s", payload)`. The existing test `test_request_diagnostics_timeout_record_includes_stage_and_thread_stacks` does `json.loads(caplog.records[0].args[0])`, expecting `args[0]` to be raw JSON — it broke because `args[0]` now included the prefix text. Fix: keep the prefix in the format string and pass the JSON as a separate positional arg: `logger.warning(f"{prefix} %s", json_payload)`. Both `_print_fn` and logger paths produce the same output; the test's `args[0]` access works again.