### PR TITLE
Release: frame passkey-login 200 with Content-Length (#5785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **Passkey login no longer risks a hung or mis-framed response on keep-alive connections.** The passkey-login success `200` was written without a `Content-Length` header, so a client on a persistent connection could wait for a body boundary that never came or mis-frame the next response. The response now sends an explicit `Content-Length` matching the body's byte length. Thanks @ai-ag2026. (#5785)
+
 - **Zero-token turns (a pre-flight cancel or setup error) no longer leak a streaming-meter session.** The streaming meter's `begin_session()` and its 1 Hz ticker were started before the outer `try`, so a raise or cancel before the first token left the `_sessions[stream_id]` entry unreclaimed (`get_stats()` only prunes sessions that emitted a token), inflating the SSE `active` count over a long-lived server. `begin_session()` + the ticker start now live inside the outer `try` so the paired `end_session()` / ticker-stop teardown in the `finally` always runs. Thanks @ai-ag2026. (#5787, #4633, #2476)
 
 - **Deleting a session now evicts its run-journal writer locks instead of leaking them.** The per-run-journal writer-lock cache (`_WRITER_LOCKS`) kept an entry after a session's journal was deleted, so the cache grew unbounded, and a later journal reusing the same path could be handed a stale lock. `delete_run_journal` now evicts that session's lock-cache entries — but only after confirming the directory was actually removed, so a Windows/permission transient that leaves files (locks still live) never has its lock wrongly dropped out from under a writer. Thanks @ai-ag2026. (#5784)

--- a/api/routes.py
+++ b/api/routes.py
@@ -15336,13 +15336,15 @@ def handle_post(handler, parsed) -> bool:
             _record_login_attempt(client_ip)
             return bad(handler, str(e), status=401)
         cookie_val = create_session()
+        body = json.dumps({"ok": True}).encode()
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
         handler.send_header("Cache-Control", "no-store")
         _security_headers(handler)
         set_auth_cookie(handler, cookie_val)
         handler.end_headers()
-        handler.wfile.write(json.dumps({"ok": True}).encode())
+        handler.wfile.write(body)
         return True
 
     if parsed.path == "/api/auth/passkey/register/options":

--- a/tests/test_passkey_login_content_length.py
+++ b/tests/test_passkey_login_content_length.py
@@ -1,0 +1,93 @@
+"""Regression test — passkey login must frame its 200 response with Content-Length.
+
+The password-login and logout handlers set a `Content-Length` header on their
+success response, but the passkey-login success block wrote the JSON body with
+no `Content-Length`. Under HTTP/1.1 keep-alive that response is unframed, so the
+browser's `fetch().json()` hangs until it times out. This test pins that the
+passkey-login 200 now carries a `Content-Length` matching the body it writes,
+mirroring the password-login block.
+"""
+import io
+import json
+from types import SimpleNamespace
+
+
+class FakeHeaders(dict):
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+class RouteFakeHandler:
+    def __init__(self):
+        self.headers = FakeHeaders({"Host": "localhost:8787", "Content-Length": "0"})
+        self.rfile = io.BytesIO(b"")
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.sent_headers = []
+        self.client_address = ("127.0.0.1", 12345)
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+
+def test_passkey_login_success_sets_content_length(monkeypatch):
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "_passkey_feature_flag_enabled", lambda: True)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "_check_login_rate", lambda ip: True)
+    # WebAuthn verification is out of scope here — make it succeed.
+    monkeypatch.setattr(passkeys, "finish_login", lambda body, handler: None)
+    monkeypatch.setattr(auth, "create_session", lambda: "sess-cookie")
+    monkeypatch.setattr(auth, "set_auth_cookie", lambda handler, cookie: None)
+
+    handler = RouteFakeHandler()
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/login"))
+
+    assert handler.status == 200
+    body = handler.wfile.getvalue()
+    assert json.loads(body) == {"ok": True}
+
+    header_map = {k.lower(): v for k, v in handler.sent_headers}
+    assert "content-length" in header_map, "passkey-login 200 must be framed"
+    assert header_map["content-length"] == str(len(body))
+
+
+def test_content_length_precedes_end_headers(monkeypatch):
+    """`set_auth_cookie` emits Set-Cookie via send_header, so every header —
+    including Content-Length — must be sent before end_headers()."""
+    import api.auth as auth
+    import api.passkeys as passkeys
+    import api.routes as routes
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(auth, "_passkey_feature_flag_enabled", lambda: True)
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "_check_login_rate", lambda ip: True)
+    monkeypatch.setattr(passkeys, "finish_login", lambda body, handler: None)
+    monkeypatch.setattr(auth, "create_session", lambda: "sess-cookie")
+    monkeypatch.setattr(auth, "set_auth_cookie",
+                        lambda handler, cookie: handler.send_header("Set-Cookie", "s=1"))
+
+    order = []
+    handler = RouteFakeHandler()
+    orig_send = handler.send_header
+    orig_end = handler.end_headers
+    handler.send_header = lambda k, v: (order.append(("hdr", k.lower())), orig_send(k, v))[1]
+    handler.end_headers = lambda: (order.append(("end", None)), orig_end())[1]
+
+    routes.handle_post(handler, SimpleNamespace(path="/api/auth/passkey/login"))
+
+    end_idx = order.index(("end", None))
+    header_names = [name for kind, name in order[:end_idx] if kind == "hdr"]
+    assert "content-length" in header_names
+    assert "set-cookie" in header_names


### PR DESCRIPTION
Ships #5785 (@ai-ag2026) — passkey-login 200 now sends Content-Length (no hang/mis-frame on keep-alive). Codex SAFE + full suite 12,278/0 on current master. Closes #5785.