### PR TITLE
Release: handle terminal output EventSource transport errors (#5786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **The embedded terminal now recovers from a dropped connection instead of silently freezing.** A transport-level failure on the terminal's output stream (session expired, gateway restarted, network drop) fired an EventSource `error` with no handler, so the terminal froze with no feedback. It now shows a "connection lost, reconnecting…" / "disconnected" line, lets the browser auto-reconnect a recoverable connection, and tears down a permanently-closed one so a restart can reconnect — notifying once per outage so a flapping connection can't flood the pane. Thanks @ai-ag2026. (#5786)
+
 - **The OpenCode Go model picker now lists the current flat-rate catalog.** The static `opencode-go` model snapshot was stale; it's been re-synced from the public opencode.ai/go docs + models endpoint (adds MiniMax M3, Kimi K2.7 Code, GLM-5.2, Qwen 3.7 Max/Plus, and more), keeping preview/free-only Zen models out of the Go picker. Thanks @ai-ag2026. (#5761)
 
 - **The background-task completion drain thread can no longer spin at 100% CPU when the process registry is (re)initializing.** If the registry didn't yet expose its `completion_queue`, the drain loop's broad `except Exception: continue` swallowed the `AttributeError` and immediately retried with no delay — a hot loop. The loop now reads the queue defensively (`getattr(..., None)`) and backs off on the stop event when it's missing, catches `queue.Empty` separately as the normal idle path, and logs (no longer silently swallows) any unexpected queue error before backing off. No delivery latency is added — real completions are still drained on the 1 Hz blocking `get`. Thanks @ai-ag2026. (#5782, #2476, #4633)

--- a/static/terminal.js
+++ b/static/terminal.js
@@ -431,6 +431,34 @@ function _connectTerminalOutput(){
     try{if(source&&source.readyState!==2)source.close();}catch(_){}
     TERMINAL_UI.source=null;
   });
+  // A successful (re)connect clears the notify latch so the NEXT outage notifies
+  // again — "once per outage", not "once per source lifetime". Without this, a
+  // source that errors, auto-reconnects, then drops a second time would stay
+  // silent (guard already true, not CLOSED) — the exact freeze this handler
+  // prevents.
+  source.addEventListener('open',()=>{
+    if(TERMINAL_UI.source!==source)return;
+    source._terminalErrNotified=false;
+  });
+  // Transport-level failures (session expired, gateway killed, network drop)
+  // fire 'error' rather than a terminal_* event; without this the terminal froze
+  // with no feedback and no telemetry. Let the browser auto-reconnect a merely
+  // CONNECTING source (no manual loop/backoff), but surface a permanently CLOSED
+  // one and tear it down so a restart can reconnect. Notify once per outage so a
+  // flapping connection can't flood the pane or telemetry.
+  source.addEventListener('error',()=>{
+    if(TERMINAL_UI.source!==source)return;
+    const closed=source.readyState===EventSource.CLOSED;
+    if(closed||!source._terminalErrNotified){
+      source._terminalErrNotified=true;
+      if(typeof recordClientSSEError==='function')recordClientSSEError('terminal',{ready_state:source?source.readyState:null,reason:'terminal EventSource.onerror'});
+      if(TERMINAL_UI.term)TERMINAL_UI.term.writeln('\r\n[terminal '+(closed?'disconnected':'connection lost, reconnecting…')+']\r\n');
+    }
+    if(closed){
+      try{if(source&&source.readyState!==2)source.close();}catch(_){}
+      TERMINAL_UI.source=null;
+    }
+  });
 }
 
 async function _startComposerTerminal(restart=false){


### PR DESCRIPTION
Ships #5786 (@ai-ag2026) — embedded terminal recovers from a dropped output stream (shows status, auto-reconnects recoverable, tears down closed, once-per-outage notify) instead of silently freezing. JS syntax clean + full suite green on current master (frontend-only, 28 LOC additive). Trusted-gate ship per Nathan (low visual risk). Closes #5786.