### PR TITLE
Release: contain streaming code block layout (#5770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **A wide or tall code block in the chat no longer thrashes the surrounding layout while a reply streams.** Code blocks now use CSS `contain: content`, so a growing/overflowing `<pre>` is isolated to its own rounded container (with its own horizontal scroll) instead of reflowing the message column during streaming. Thanks @rodboev. (#5770, #5760)
+
 - **Workspace switcher is now navigable with a screen reader.** The workspace switcher exposes proper roles/labels and announces the "New Chat" workspace state transiently, and the closed workspace dropdown is kept out of screen-reader navigation so it isn't read while collapsed. Visual layout and click/keyboard behavior are unchanged. Thanks @rodboev. (#5721, #5671)
 
 - **A background child stream no longer bumps its parent session to the top of the sidebar.** When a child (branched/background) stream was active, its activity re-sorted the parent session's sidebar time-bucket, yanking the parent around while you were working elsewhere. The sidebar sort no longer keys the parent's bucket off child-stream activity, so parents stay put. Thanks @rodboev. (#5729, #5699)

--- a/static/style.css
+++ b/static/style.css
@@ -2310,7 +2310,7 @@
   .msg-body > h4:first-child,.msg-body > h5:first-child,.msg-body > h6:first-child{margin-top:0;}
   .msg-body strong{color:var(--strong);font-weight:600;}.msg-body em{color:var(--em);font-style:italic;}
   .msg-body code{font-family:"SF Mono","Fira Code",ui-monospace,monospace;font-size:var(--message-code-font-size);background:var(--code-inline-bg);padding:1px 5px;border-radius:4px;color:var(--code-text);}
-  .msg-body pre{background:var(--code-bg);border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;margin:10px 0;}
+  .msg-body pre{background:var(--code-bg);border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;contain:content;margin:10px 0;}
   .msg-body pre code{background:none;padding:0;border-radius:0;color:var(--pre-text);font-size:var(--message-pre-code-font-size);line-height:1.6;}
   .msg-body pre.md-source-block,.preview-md pre.md-source-block{white-space:pre-wrap;overflow-x:hidden;overflow-wrap:anywhere;}
   .msg-body pre.md-source-block code,.preview-md pre.md-source-block code{display:block;white-space:inherit;overflow-wrap:anywhere;word-break:break-word;}

--- a/tests/test_issue5760_code_block_containment.py
+++ b/tests/test_issue5760_code_block_containment.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import re
+
+
+REPO = Path(__file__).resolve().parent.parent
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _base_msg_body_pre_rule() -> str:
+    match = re.search(r"(^|\n)\s*\.msg-body pre\{([^}]*)\}", STYLE_CSS)
+    assert match, "base .msg-body pre rule not found in style.css"
+    return match.group(2)
+
+
+def test_msg_body_pre_containment_contract():
+    rule = _base_msg_body_pre_rule()
+    assert "overflow-x:auto" in rule, ".msg-body pre must keep horizontal scrolling"
+    assert "contain:content" in rule, ".msg-body pre must add contain: content"
+
+
+def test_msg_body_pre_avoids_strict_containment():
+    rule = _base_msg_body_pre_rule()
+    assert "contain:strict" not in rule, ".msg-body pre must not use contain: strict"


### PR DESCRIPTION
Ships #5770 (@rodboev) — code blocks use CSS contain:content so a wide/tall streaming code block stays isolated to its own scroll container instead of thrashing the message column. Screenshot-approved by Nathan + full suite 12,292/0 on current master. Closes #5770, #5760.