### PR TITLE
Release: clearInterval (not clearTimeout) for login connectivity retry (#5801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **The login page's connectivity retry timer is now cleared correctly.** The retry poller is started with `setInterval` but was cleared with `clearTimeout`, so once the server came back the interval kept firing (a zombie timer) instead of stopping and reloading once. It now uses `clearInterval`. Thanks @ai-ag2026. (#5801)
+
 - **A background wakeup no longer eats the assistant reply that preceded it.** When a background-process wakeup prompt arrived after an assistant response, the response could disappear from the interactive transcript (it remained in the DB and export). Background wakeups now render as their own distinct "Background wakeup" status row aligned to the message rail — with attachment support — leaving the prior reply intact. Thanks @Isla-Liu. (#5766)
 
 - **Service-tier (fast-mode) support is now derived from the agent's model metadata instead of a hardcoded list.** The service-tier control appears for a model only when the agent reports it supports the fast tier, so newly-supported models light up automatically and unsupported ones don't show a dead control. Falls back safely (no control) when the metadata is absent. Thanks @starship-s. (#5762, #4536)

--- a/static/login.js
+++ b/static/login.js
@@ -175,7 +175,7 @@ document.addEventListener('DOMContentLoaded', function () {
             // Server is reachable — if we were in retry mode, reload so the
             // page reflects the correct auth state (expired session, etc.).
             if (retryTimer !== null) {
-              clearTimeout(retryTimer);
+              clearInterval(retryTimer);
               retryTimer = null;
               window.location.reload();
             }


### PR DESCRIPTION
Ships #5801 (@ai-ag2026) — login retry poller (setInterval) was cleared with clearTimeout, leaving a zombie interval; now uses clearInterval. Codex SAFE + full suite 12,300/0. Closes #5801.