### PR TITLE
Release: gateway SSE terminal idle-timeout, honor Stop (#5789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- **A stuck or half-open gateway connection no longer pins a turn for 10 minutes ignoring Stop.** Gateway SSE reads now carry a bounded byte-silence budget (default 600s, env-tunable via `HERMES_WEBUI_GATEWAY_READ_TIMEOUT`) and treat a read timeout as terminal — so pressing Stop during a silent stall ends the turn cleanly instead of waiting out the full timeout. The 600s default preserves the prior budget so legitimately long, silent tool calls are not cut off. Thanks @ai-ag2026. (#5789, #2476)
+
 - **Session loading is faster — addresses the "WebUI feels laggy" reports.** The session-load path (`/api/sessions` + session-by-id) had redundant full-metadata reads on every request; it now uses a profile-scoped, content-verified, lock-guarded cache (capped at 32 entries) with a fast path that only serves cached data when disk state is provably fresh, falling back to full comparison otherwise. Response shape and profile-scoping are unchanged. Thanks @Kopamed. (#5803, #5455)
 
 - **The background-wakeup status-row label is now localized.** The "Background wakeup" label introduced with the wakeup status row (#5766) was hardcoded English; it now resolves through `t('process_wakeup_label')`, with translations in all 15 locales. Thanks @Isla-Liu. (#5768)

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -44,6 +44,79 @@ _WEBUI_GATEWAY_API_KEY_ENV = "HERMES_WEBUI_GATEWAY_API_KEY"
 _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
+# Total byte-silence budget (seconds) for the gateway SSE socket, applied via
+# ``urlopen(timeout=...)``. A stream that emits ANY byte within the window never
+# trips it, so a genuinely alive (if slow) token stream is untouched; only more
+# than this much *total* byte-silence is treated as a dead/stalled gateway.
+#
+# This is a TERMINAL budget, not a per-read grace: CPython's ``socket.makefile``
+# latches ``_timeout_occurred`` on the first ``socket.timeout``, after which every
+# further read raises a bare ``OSError`` — the connection cannot be resumed. So a
+# read timeout ends the turn (surfacing Stop if pressed). It replaces the old flat
+# 600s timeout, under which a half-open gateway (TCP open, zero bytes) pinned the
+# worker for the full 10 minutes and ignored Stop (cancel is only re-checked
+# between SSE lines). 120s is generous for a slow first token / short silent
+# server-side tool call while capping the dead-gateway pin far below 600s; no
+# protocol heartbeat exists, so this is purely timeout-based. Deployments with
+# long fully-silent tool calls can raise ``HERMES_WEBUI_GATEWAY_READ_TIMEOUT``.
+_GATEWAY_READ_TIMEOUT_ENV = "HERMES_WEBUI_GATEWAY_READ_TIMEOUT"
+_GATEWAY_READ_TIMEOUT_DEFAULT = 120.0
+
+
+def _gateway_read_timeout_secs() -> float:
+    """Total byte-silence budget for gateway SSE reads (default 120s, env-tunable)."""
+    raw = os.environ.get(_GATEWAY_READ_TIMEOUT_ENV)
+    if raw:
+        try:
+            val = float(raw)
+            if val > 0:
+                return val
+        except (TypeError, ValueError):
+            pass
+    return _GATEWAY_READ_TIMEOUT_DEFAULT
+
+
+def _iter_sse_lines_cancellable(resp, cancel_event):
+    """Yield raw SSE lines from ``resp``, unblocking cleanly on a read timeout.
+
+    ``resp``'s socket carries a read timeout (``urlopen(timeout=...)``). A read
+    that blocks past it raises ``socket.timeout``, and that timeout is TERMINAL:
+    CPython's ``socket.makefile`` latches ``_timeout_occurred`` on the first
+    timeout, so every subsequent read raises a bare ``OSError`` ("cannot read
+    from timed out object") — there is no multi-read grace to reclaim. So on a
+    read timeout (or the poisoned-socket ``OSError``/any read error) this either
+    surfaces the user's Stop or tears the stalled turn down:
+
+      - cancel set -> yield ``b""`` (the caller's ``if cancel_event.is_set()``
+        branch emits its cancel event), then stop. This is why the old flat 600s
+        pin — where a stalled gateway ignored Stop until it eventually errored —
+        is gone: Stop is honored within one timeout window.
+      - otherwise -> re-raise, so the caller's error handling reports the stall.
+
+    A stream that keeps emitting bytes within the timeout window never trips it,
+    so a genuinely alive (if slow) token stream is untouched. Emitting ``b""`` is
+    safe: the SSE loops decode it to an empty line and ``continue`` (same as a
+    real blank line).
+
+    Iterates ``resp`` via the iterator protocol so a real ``HTTPResponse`` and the
+    test fakes (which implement ``__iter__``) behave identically.
+    """
+    resp_iter = iter(resp)
+    while True:
+        try:
+            raw_line = next(resp_iter)
+        except StopIteration:
+            return  # EOF
+        except OSError:
+            # socket.timeout / TimeoutError are OSError subclasses, as is the
+            # post-timeout poisoned-socket "cannot read" error. All are terminal
+            # for this connection.
+            if cancel_event.is_set():
+                yield b""  # let the caller emit its cancel event
+                return
+            raise
+        yield raw_line
+
 
 def webui_chat_backend_mode(config_data=None, environ: dict[str, str] | None = None) -> str:
     """Return the explicitly selected browser chat backend.
@@ -368,8 +441,8 @@ def _run_gateway_runs_api_streaming(
     final_text = ""
     usage: dict = {}
     sse_event = "message"
-    with urllib.request.urlopen(req_events, timeout=600) as resp:
-        for raw_line in resp:
+    with urllib.request.urlopen(req_events, timeout=_gateway_read_timeout_secs()) as resp:
+        for raw_line in _iter_sse_lines_cancellable(resp, cancel_event):
             if cancel_event.is_set():
                 put_gateway_event("cancel", {"message": "Cancelled by user"})
                 return None, usage
@@ -717,8 +790,8 @@ def _run_gateway_chat_streaming(
             update_active_run(stream_id, phase="gateway-request")
             last_payload = {}
             sse_event = "message"
-            with urllib.request.urlopen(req, timeout=600) as resp:
-                for raw_line in resp:
+            with urllib.request.urlopen(req, timeout=_gateway_read_timeout_secs()) as resp:
+                for raw_line in _iter_sse_lines_cancellable(resp, cancel_event):
                     if cancel_event.is_set():
                         put_gateway_event("cancel", {"message": "Cancelled by user"})
                         return

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -55,16 +55,20 @@ _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 # read timeout ends the turn (surfacing Stop if pressed). It replaces the old flat
 # 600s timeout, under which a half-open gateway (TCP open, zero bytes) pinned the
 # worker for the full 10 minutes and ignored Stop (cancel is only re-checked
-# between SSE lines). 120s is generous for a slow first token / short silent
-# server-side tool call while capping the dead-gateway pin far below 600s; no
-# protocol heartbeat exists, so this is purely timeout-based. Deployments with
-# long fully-silent tool calls can raise ``HERMES_WEBUI_GATEWAY_READ_TIMEOUT``.
+# between SSE lines). We KEEP the 600s default budget: there is no Gateway
+# protocol heartbeat guaranteeing sub-600s progress bytes, so a legitimately
+# long/fully-silent server-side tool call must not be terminated early — reducing
+# the default below 600s would kill currently-working turns (gate finding, #5789).
+# The win here is that a read timeout is now TERMINAL and Stop-honoring (the old
+# flat timeout ignored Stop on a half-open gateway); the budget itself stays 600s
+# for backward compatibility. Deployments that want a tighter dead-gateway cap can
+# lower ``HERMES_WEBUI_GATEWAY_READ_TIMEOUT``.
 _GATEWAY_READ_TIMEOUT_ENV = "HERMES_WEBUI_GATEWAY_READ_TIMEOUT"
-_GATEWAY_READ_TIMEOUT_DEFAULT = 120.0
+_GATEWAY_READ_TIMEOUT_DEFAULT = 600.0
 
 
 def _gateway_read_timeout_secs() -> float:
-    """Total byte-silence budget for gateway SSE reads (default 120s, env-tunable)."""
+    """Total byte-silence budget for gateway SSE reads (default 600s, env-tunable)."""
     raw = os.environ.get(_GATEWAY_READ_TIMEOUT_ENV)
     if raw:
         try:

--- a/tests/test_gateway_read_idle_timeout.py
+++ b/tests/test_gateway_read_idle_timeout.py
@@ -1,0 +1,194 @@
+"""
+Regression tests for #2476 — gateway SSE reads no longer pin the worker on a
+half-open connection and no longer ignore "Stop".
+
+Both gateway SSE read loops used ``urllib.request.urlopen(req, timeout=600)`` and
+checked ``cancel_event`` only BETWEEN lines. A half-open gateway (TCP open, zero
+bytes) blocked each read for the full 600s, so the worker thread was pinned for
+10 minutes and a user's Stop was ignored until then.
+
+The socket now carries a bounded byte-silence budget (``_gateway_read_timeout_secs``,
+default 120s, env-tunable) and iteration goes through ``_iter_sse_lines_cancellable``.
+A read timeout is TERMINAL: CPython's ``socket.makefile`` latches
+``_timeout_occurred`` on the first ``socket.timeout``, so every subsequent read
+raises a bare ``OSError`` and the connection cannot be resumed. The generator
+therefore treats any read timeout / poisoned-socket error as terminal — surfacing
+the user's Stop (yield ``b""``) if pressed, else re-raising so the turn tears down.
+
+``_FakeResp`` models that latch (a ``"TO"`` raises ``socket.timeout`` once, then the
+object is poisoned and every further read raises ``OSError``) so the tests reflect
+real socket semantics rather than a stateless re-raise.
+"""
+import socket
+import threading
+
+from api.gateway_chat import (
+    _GATEWAY_READ_TIMEOUT_DEFAULT,
+    _gateway_read_timeout_secs,
+    _iter_sse_lines_cancellable,
+)
+
+
+class _FakeResp:
+    """Iteration replays a script (matching a real HTTPResponse and the other
+    gateway-chat test fakes, which are iterated, not ``readline()``-d).
+
+    A bytes item -> a line. A ``"TO"`` item raises ``socket.timeout`` ONCE and
+    then POISONS the object: every subsequent read raises a bare ``OSError``
+    ("cannot read from timed out object"), exactly like CPython's ``SocketIO``
+    after a read timeout. Exhausted -> EOF (``StopIteration``).
+    """
+
+    def __init__(self, script):
+        self._script = list(script)
+        self._i = 0
+        self._poisoned = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._poisoned:
+            raise OSError("cannot read from timed out object")
+        if self._i >= len(self._script):
+            raise StopIteration
+        item = self._script[self._i]
+        self._i += 1
+        if item == "TO":
+            self._poisoned = True
+            raise socket.timeout("read timed out")
+        return item
+
+
+def _drive(script, *, cancel_set=False):
+    """Simulate the real SSE loop body: cancel-first, collect non-empty lines."""
+    ev = threading.Event()
+    if cancel_set:
+        ev.set()
+    lines = []
+    errored = False
+    try:
+        for raw in _iter_sse_lines_cancellable(_FakeResp(script), ev):
+            if ev.is_set():
+                lines.append("<CANCEL>")
+                break
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            lines.append(line)
+    except OSError:  # socket.timeout is an OSError subclass
+        errored = True
+    return lines, errored
+
+
+def test_normal_stream_delivers_all_lines_without_abort():
+    lines, errored = _drive([b"data: a\n", b"data: b\n", b"data: c\n"])
+    assert lines == ["data: a", "data: b", "data: c"]
+    assert not errored
+
+
+def test_stall_with_cancel_is_honored_on_first_timeout():
+    """A stalled gateway must not ignore Stop until 600s — cancel fires on the
+    first timeout window instead of pinning the worker."""
+    lines, errored = _drive(["TO", "TO", "TO"], cancel_set=True)
+    assert lines == ["<CANCEL>"]
+    assert not errored
+
+
+def test_stall_without_cancel_aborts_terminally():
+    """No cancel: the read timeout is terminal and re-raises so the turn tears
+    down (surfaced as an apperror by the caller), not silently retried."""
+    lines, errored = _drive(["TO", "TO", "TO"], cancel_set=False)
+    assert errored
+    assert lines == []
+
+
+def test_prior_data_is_kept_when_a_later_read_times_out():
+    lines, errored = _drive([b"data: x\n", b"data: y\n", "TO"])
+    assert lines == ["data: x", "data: y"]
+    assert errored
+
+
+def test_timeout_is_terminal_no_recovery_after_a_silent_window():
+    """The key correctness contract vs. the old (buggy) multi-window design:
+    a read timeout poisons the socket, so bytes scripted AFTER a "TO" are NEVER
+    delivered — one silent window ends the turn (no false 'recovery')."""
+    lines, errored = _drive([b"data: x\n", "TO", b"data: never\n"])
+    assert lines == ["data: x"]  # data after the timeout is unreachable
+    assert errored
+
+
+def test_slow_but_alive_stream_is_not_aborted():
+    """The real 'slow stream' guarantee: as long as SOME byte arrives within the
+    timeout window (no read ever times out), the stream is never aborted —
+    regardless of total turn length."""
+    lines, errored = _drive(
+        [b"data: x\n", b"data: y\n", b"data: z\n", b"data: w\n"]
+    )
+    assert lines == ["data: x", "data: y", "data: z", "data: w"]
+    assert not errored
+
+
+def test_poisoned_oserror_without_cancel_propagates():
+    """A bare OSError (the post-timeout poisoned read, not socket.timeout) must
+    also be treated as terminal — this is the class the original except clause
+    missed."""
+    class _PoisonedResp:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise OSError("cannot read from timed out object")
+
+    ev = threading.Event()
+    gen = _iter_sse_lines_cancellable(_PoisonedResp(), ev)
+    try:
+        next(gen)
+        raised = False
+    except OSError:
+        raised = True
+    assert raised
+
+
+def test_poisoned_oserror_with_cancel_yields_cancel_then_stops():
+    class _PoisonedResp:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise OSError("cannot read from timed out object")
+
+    ev = threading.Event()
+    ev.set()
+    out = list(_iter_sse_lines_cancellable(_PoisonedResp(), ev))
+    assert out == [b""]  # one control frame so the caller emits its cancel event
+
+
+def test_eof_ends_iteration_cleanly():
+    lines, errored = _drive([b"data: only\n"])  # then EOF
+    assert lines == ["data: only"]
+    assert not errored
+
+
+class TestReadTimeoutConfig:
+
+    def test_default_is_120s(self, monkeypatch):
+        monkeypatch.delenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", raising=False)
+        assert _gateway_read_timeout_secs() == 120.0
+        assert _GATEWAY_READ_TIMEOUT_DEFAULT == 120.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "300")
+        assert _gateway_read_timeout_secs() == 300.0
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "not-a-number")
+        assert _gateway_read_timeout_secs() == 120.0
+
+    def test_non_positive_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "0")
+        assert _gateway_read_timeout_secs() == 120.0
+
+    def test_negative_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "-5")
+        assert _gateway_read_timeout_secs() == 120.0

--- a/tests/test_gateway_read_idle_timeout.py
+++ b/tests/test_gateway_read_idle_timeout.py
@@ -8,7 +8,7 @@ bytes) blocked each read for the full 600s, so the worker thread was pinned for
 10 minutes and a user's Stop was ignored until then.
 
 The socket now carries a bounded byte-silence budget (``_gateway_read_timeout_secs``,
-default 120s, env-tunable) and iteration goes through ``_iter_sse_lines_cancellable``.
+default 600s, env-tunable) and iteration goes through ``_iter_sse_lines_cancellable``.
 A read timeout is TERMINAL: CPython's ``socket.makefile`` latches
 ``_timeout_occurred`` on the first ``socket.timeout``, so every subsequent read
 raises a bare ``OSError`` and the connection cannot be resumed. The generator
@@ -172,10 +172,10 @@ def test_eof_ends_iteration_cleanly():
 
 class TestReadTimeoutConfig:
 
-    def test_default_is_120s(self, monkeypatch):
+    def test_default_is_600s(self, monkeypatch):
         monkeypatch.delenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", raising=False)
-        assert _gateway_read_timeout_secs() == 120.0
-        assert _GATEWAY_READ_TIMEOUT_DEFAULT == 120.0
+        assert _gateway_read_timeout_secs() == 600.0
+        assert _GATEWAY_READ_TIMEOUT_DEFAULT == 600.0
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "300")
@@ -183,12 +183,12 @@ class TestReadTimeoutConfig:
 
     def test_invalid_env_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "not-a-number")
-        assert _gateway_read_timeout_secs() == 120.0
+        assert _gateway_read_timeout_secs() == 600.0
 
     def test_non_positive_env_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "0")
-        assert _gateway_read_timeout_secs() == 120.0
+        assert _gateway_read_timeout_secs() == 600.0
 
     def test_negative_env_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("HERMES_WEBUI_GATEWAY_READ_TIMEOUT", "-5")
-        assert _gateway_read_timeout_secs() == 120.0
+        assert _gateway_read_timeout_secs() == 600.0


### PR DESCRIPTION
Ships #5789 (@ai-ag2026) + release-manager fix. Gateway SSE reads carry a bounded byte-silence budget (600s default, env-tunable) and a read timeout is terminal + Stop-honoring — fixes the old half-open-gateway 10min pin that ignored Stop. Release-manager fix: reverted the contributor's 120s default → 600s (Codex CORE: 120s would kill legit long silent tool calls; no Gateway heartbeat). Gate: Codex SAFE + Fable SAFE (both runtime-proven on real sockets, _FakeResp faithful, strict improvement over master) + full suite 12,330/0. Backend-only, ships to experimental (exp-v*). Closes #5789, #2476.