### PR TITLE
fix(server): frame OPTIONS preflight with Content-Length: 0

### DIFF
--- a/server.py
+++ b/server.py
@@ -439,6 +439,9 @@ class Handler(BaseHTTPRequestHandler):
         self._req_t0 = time.time()
         self.send_response(200)
         apply_cors_preflight_headers(self)
+        # Frame the empty preflight: without Content-Length an HTTP/1.1 keep-alive
+        # 200 is read-until-close, hanging the client until the 30s timeout.
+        self.send_header("Content-Length", "0")
         self.end_headers()
 
     def do_DELETE(self) -> None:

--- a/tests/test_options_content_length.py
+++ b/tests/test_options_content_length.py
@@ -1,0 +1,77 @@
+"""Regression test — the CORS preflight (OPTIONS) 200 must be framed.
+
+`Handler.do_OPTIONS` answered every preflight with `send_response(200)` +
+CORS headers + `end_headers()` but no `Content-Length`. The class runs
+`protocol_version = "HTTP/1.1"` (keep-alive on), and its own docstring states
+"every response must declare framing". An unframed 200 is "read body until the
+connection closes" (RFC 7230 §3.3.3), so a keep-alive client issuing a preflight
+(browser CORS for an allowlisted cross-origin front-end, curl, a proxy, a
+monitor) blocks reading a body that never arrives until the 30s connection
+timeout — and can't reuse the connection.
+
+This pins that the preflight now carries `Content-Length: 0`, sent before
+`end_headers()` (so it lands among the emitted headers), mirroring the framing
+every other bodyless response in the server already sets. The CORS-header policy
+itself (which Origins are echoed) is unchanged and covered separately.
+"""
+class _FakeHeaders(dict):
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+
+class _OptionsHandler:
+    """Captures the send_response / send_header / end_headers sequence."""
+
+    def __init__(self, headers=None):
+        self.headers = _FakeHeaders(headers or {})
+        self.client_address = ("127.0.0.1", 12345)
+        self.status = None
+        self.order = []
+
+    def send_response(self, status):
+        self.status = status
+        self.order.append(("status", status, None))
+
+    def send_header(self, key, value):
+        self.order.append(("hdr", key.lower(), value))
+
+    def end_headers(self):
+        self.order.append(("end", None, None))
+
+
+def _run_options(headers=None):
+    import server
+
+    handler = _OptionsHandler(headers)
+    server.Handler.do_OPTIONS(handler)
+    return handler
+
+
+def test_options_sets_content_length_zero():
+    handler = _run_options()
+    assert handler.status == 200
+    header_map = {k: v for kind, k, v in handler.order if kind == "hdr"}
+    assert header_map.get("content-length") == "0", (
+        "OPTIONS preflight 200 must be framed with Content-Length: 0"
+    )
+
+
+def test_options_content_length_precedes_end_headers():
+    """Framing must land before end_headers() to be emitted at all."""
+    handler = _run_options()
+    end_idx = next(i for i, e in enumerate(handler.order) if e[0] == "end")
+    header_names = [k for kind, k, _ in handler.order[:end_idx] if kind == "hdr"]
+    assert "content-length" in header_names
+
+
+def test_options_framed_even_for_allowlisted_origin(monkeypatch):
+    """The framing is unconditional — a preflight that DOES emit CORS headers
+    (allowlisted origin) must still be framed, not just the no-origin case."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes, "_check_same_origin_browser_request", lambda handler: True
+    )
+    handler = _run_options({"Origin": "https://app.example"})
+    header_map = {k: v for kind, k, v in handler.order if kind == "hdr"}
+    assert header_map.get("content-length") == "0"


### PR DESCRIPTION
## Summary
`Handler.do_OPTIONS` answers every CORS preflight with `send_response(200)` + CORS headers + `end_headers()` but never sets `Content-Length`.

## Why
The handler runs `protocol_version = "HTTP/1.1"` (keep-alive on), and its own class docstring states *"every response must declare framing."* An unframed `200` is *read-body-until-connection-close* (RFC 7230 §3.3.3), so a keep-alive client issuing a preflight — a browser CORS check for an allowlisted cross-origin front-end (`HERMES_WEBUI_ALLOWED_ORIGINS`), `curl`, a reverse proxy, a monitor — blocks reading a body that never arrives until the 30s connection timeout, and cannot reuse the connection.

This is the same framing gap the passkey-login 200 fix closed, on the OPTIONS path. The fix mirrors it: send `Content-Length: 0` before `end_headers()`. Status stays `200` (no behavior change for clients that already tolerated the gap), and the CORS-header policy is untouched.

## Validation
- `./scripts/test.sh tests/test_options_content_length.py tests/test_cors_preflight_allowlist.py tests/test_passkey_login_content_length.py -q` → 17 passed
- New regression `tests/test_options_content_length.py`: asserts the preflight 200 carries `Content-Length: 0`, that it is emitted before `end_headers()`, and that the framing is unconditional (also present for an allowlisted cross-origin preflight that emits CORS headers).
- `python3 scripts/ruff_lint.py --diff origin/master` → no new violations

## Notes
Complementary to (not conflicting with) #5531's credentialed-CORS work — that PR changes which headers `apply_cors_preflight_headers` emits; this changes only the response framing in `do_OPTIONS`.