### PR TITLE
fix(settings): write settings.json atomically to survive mid-write crashes

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8668,6 +8668,64 @@ _SETTINGS_WRITE_VERSION = 0
 _SETTINGS_WRITE_LOCK = __import__("threading").Lock()
 
 
+def _atomic_write_settings_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically (temp file + fsync + os.replace).
+
+    ``settings.json`` was rewritten with a plain ``Path.write_text``, which
+    truncates the file in place: a crash or full disk mid-write leaves it
+    truncated/empty, so the next start loses every persisted setting (theme,
+    workspace, tab order, and the login ``password_hash``). Writing to a
+    sibling temp file, fsyncing, then ``os.replace`` keeps the old contents
+    intact until the rename commits the new ones in one step.  Mirrors the
+    tempfile+fsync+os.replace pattern already used by
+    ``webui_session_db.WebUIJsonSessionDB._atomic_write``.
+
+    The existing file's mode is carried onto the replacement: ``os.replace``
+    swaps in the temp file's inode, and a plain ``open`` respects the umask
+    (typically 0644), so without this an operator-hardened ``settings.json``
+    (chmod 0600 because it holds the password hash) would be silently loosened
+    on the next save.  New files fall back to the umask-adjusted default.
+
+    A symlinked target is written through to its referent (same follow-through
+    as the ``Path.write_text`` this replaces), rather than replacing the link
+    itself with a regular file.
+    """
+    path = Path(path)
+    write_path = path.resolve(strict=False) if path.is_symlink() else path
+    tmp = write_path.with_name(
+        f".{write_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
+    try:
+        mode = os.stat(write_path).st_mode & 0o777
+    except FileNotFoundError:
+        mode = 0o666 & ~_current_umask()
+    try:
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, write_path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _current_umask() -> int:
+    """Read the process umask without leaving it changed.
+
+    ``os.umask`` has no read-only form (it sets and returns the prior value),
+    so we set-then-restore. Called only on the new-``settings.json`` path, which
+    is rare; the tiny set-to-0 window is acceptable here (unlike a per-write
+    hot path).
+    """
+    umask = os.umask(0)
+    os.umask(umask)
+    return umask
+
+
 def _coerce_provider_cost_budget(value: Any) -> float | None:
     """Normalize a monthly budget to the persisted two-decimal representation."""
     try:
@@ -8827,9 +8885,9 @@ def save_settings(settings: dict) -> dict:
     effective_persisted_speech_keys.update(applied_speech_keys)
     persisted = _settings_payload_for_write(current, effective_persisted_speech_keys)
     SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SETTINGS_FILE.write_text(
+    _atomic_write_settings_text(
+        SETTINGS_FILE,
         json.dumps(persisted, ensure_ascii=False, indent=2),
-        encoding="utf-8",
     )
     global _SETTINGS_WRITE_VERSION
     with _SETTINGS_WRITE_LOCK:
@@ -8870,7 +8928,8 @@ if _settings_file_exists:
             startup_persisted_speech_keys = _extract_persisted_speech_keys(
                 _read_raw_settings_file()
             )
-            SETTINGS_FILE.write_text(
+            _atomic_write_settings_text(
+                SETTINGS_FILE,
                 json.dumps(
                     _settings_payload_for_write(
                         _startup_settings, startup_persisted_speech_keys
@@ -8878,7 +8937,6 @@ if _settings_file_exists:
                     ensure_ascii=False,
                     indent=2,
                 ),
-                encoding="utf-8",
             )
         except Exception:
             pass

--- a/tests/test_atomic_settings_writes.py
+++ b/tests/test_atomic_settings_writes.py
@@ -1,0 +1,109 @@
+"""Regression tests — settings.json is written atomically.
+
+`save_settings` (and the startup default-workspace rewrite) persisted
+`settings.json` via a plain `Path.write_text`, which truncates the file in
+place.  A crash / full disk / power loss mid-write leaves it truncated or
+empty, so the next start loses every persisted setting — theme, workspace,
+tab order, and the login `password_hash` (losing the hash also silently
+disables auth, but the data-loss regression is the point here).
+
+The write now goes through `_atomic_write_settings_text`: temp file in the
+same dir, fsync, `os.replace`.  A failure before the rename leaves the
+ORIGINAL file byte-for-byte intact.  These pin the helper directly (success,
+mode preservation, crash-safety, symlink write-through) so a refactor can't
+reintroduce the truncating plain write.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from api.config import _atomic_write_settings_text
+
+
+def test_replaces_contents(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    target.write_text('{"theme": "old"}', encoding="utf-8")
+
+    _atomic_write_settings_text(target, '{"theme": "new"}')
+
+    assert target.read_text(encoding="utf-8") == '{"theme": "new"}'
+    # No temp debris after a clean write.
+    assert [p.name for p in tmp_path.iterdir()] == ["settings.json"]
+
+
+def test_creates_new_file(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    _atomic_write_settings_text(target, '{"created": true}')
+    assert target.read_text(encoding="utf-8") == '{"created": true}'
+
+
+def test_preserves_hardened_mode(tmp_path: Path) -> None:
+    """A 0600 settings.json (operator-hardened because it holds the password
+    hash) must not be loosened to 0644 by the atomic replace."""
+    target = tmp_path / "settings.json"
+    target.write_text('{"password_hash": "x"}', encoding="utf-8")
+    os.chmod(target, 0o600)
+
+    _atomic_write_settings_text(target, '{"password_hash": "y"}')
+
+    assert (os.stat(target).st_mode & 0o777) == 0o600
+
+
+def test_failed_replace_leaves_original_intact(tmp_path: Path, monkeypatch) -> None:
+    target = tmp_path / "settings.json"
+    original = '{"theme": "keep-me"}'
+    target.write_text(original, encoding="utf-8")
+
+    def _boom(src, dst):
+        raise RuntimeError("simulated crash before rename commits")
+
+    monkeypatch.setattr(os, "replace", _boom)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        _atomic_write_settings_text(target, '{"theme": "half-written"}')
+
+    assert target.read_text(encoding="utf-8") == original
+    # Temp file cleaned up, not left as debris.
+    assert [p.name for p in tmp_path.iterdir()] == ["settings.json"]
+
+
+def test_writes_through_symlink(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    link_dir = tmp_path / "link"
+    real_dir.mkdir()
+    link_dir.mkdir()
+    target = real_dir / "settings.json"
+    link = link_dir / "settings.json"
+    target.write_text('{"theme": "old"}', encoding="utf-8")
+    link.symlink_to(target)
+
+    _atomic_write_settings_text(link, '{"theme": "new"}')
+
+    # The link stays a link; the referent got the new contents.
+    assert link.is_symlink()
+    assert target.read_text(encoding="utf-8") == '{"theme": "new"}'
+    assert [p.name for p in link_dir.iterdir()] == ["settings.json"]
+
+
+def test_save_settings_uses_atomic_writer(tmp_path: Path, monkeypatch) -> None:
+    """End-to-end: save_settings must route through the atomic writer, not a
+    bare write_text (which a future edit could reintroduce)."""
+    import api.config as config
+
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", settings_file)
+
+    calls = []
+    real = config._atomic_write_settings_text
+
+    def _spy(path, text):
+        calls.append(Path(path))
+        return real(path, text)
+
+    monkeypatch.setattr(config, "_atomic_write_settings_text", _spy)
+
+    config.save_settings({"theme": "dark"})
+
+    assert settings_file in calls, "save_settings must use the atomic writer"
+    assert settings_file.exists()


### PR DESCRIPTION
## Summary
`save_settings` (and the startup default-workspace rewrite) persisted `settings.json` via a plain `Path.write_text`, which truncates the file in place.

## Why
A crash / full disk / power loss between the truncate and the full write leaves `settings.json` truncated or empty. The next start then loses **every** persisted setting — theme, workspace, tab order, and the login `password_hash`. (Losing the hash also silently drops back to no-auth, but the data-loss regression is the point here; the fail-open angle is tracked separately.)

## Fix
Both writes now go through a new `_atomic_write_settings_text`: write to a sibling temp file, `flush` + `os.fsync`, then `os.replace` into place, with a `finally` temp-cleanup. Because `os.replace` is atomic, a failure anywhere before the rename leaves the original file byte-for-byte intact. Mirrors the tempfile+fsync+os.replace pattern already used by `webui_session_db.WebUIJsonSessionDB._atomic_write`.

Two behavior-neutrality details:
- **Mode preserved** — `os.replace` swaps in the temp inode (a plain `open` respects the umask, ~0644), so the existing file's mode is copied onto the replacement. Without it, an operator-hardened `settings.json` (chmod 0600 because it holds the password hash) would be silently loosened on the next save.
- **Symlink write-through** — a symlinked target is written through to its referent rather than replaced with a regular file (matching `Path.write_text`'s follow semantics).

## Validation
- `./scripts/test.sh tests/test_atomic_settings_writes.py -q` → 6 passed
- New `tests/test_atomic_settings_writes.py`: replace-contents, new-file, 0600 mode preservation, failed-`os.replace` leaves original intact + no temp debris, symlink write-through, and an end-to-end check that `save_settings` routes through the atomic writer.
- Existing settings suite unaffected: `pytest tests/test_*settings*.py tests/test_auth_settings_safety.py` → 180 passed, 1 skipped
- `python3 scripts/ruff_lint.py --diff origin/master` → no new violations

## Notes
Independent of #5797 — that PR makes `config.yaml` writes atomic via `api/paths.py`; this covers a different file (`settings.json`) with a self-contained helper, so the two do not conflict.