### PR TITLE
perf(ui): skip the dashboard status poll while the tab is hidden

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1795,6 +1795,14 @@ function _applyDashboardStatus(status){
 }
 async function refreshDashboardStatus(force=false){
   const now=Date.now();
+  // Skip the interval-driven poll while the tab is hidden: the 60s interval
+  // equals the cache TTL, so every background tick was a real /api/dashboard/status
+  // fetch that never hit the cache — a needless wakeup on a tab nobody is
+  // looking at (battery/CPU, #2476). Forced calls (settings save, init, the
+  // visibilitychange catch-up) still run. A visible tab keeps its live status.
+  if(!force&&typeof document!=='undefined'&&document.hidden){
+    return _dashboardStatusCache;
+  }
   if(!force&&_dashboardStatusCache&&(now-_dashboardStatusFetchedAt)<DASHBOARD_STATUS_TTL_MS){
     _applyDashboardStatus(_dashboardStatusCache);
     return _dashboardStatusCache;
@@ -1860,6 +1868,13 @@ function _initDashboardLinkProbe(){
   loadDashboardSettings();
   refreshDashboardStatus(true);
   setInterval(refreshDashboardStatus,DASHBOARD_STATUS_TTL_MS);
+  // Catch up once when the tab becomes visible again, since the interval poll
+  // was skipped while hidden and its cache is now stale.
+  if(typeof document!=='undefined'&&typeof document.addEventListener==='function'){
+    document.addEventListener('visibilitychange',()=>{
+      if(!document.hidden) refreshDashboardStatus(true);
+    });
+  }
 }
 if(document.readyState==='complete'){
   _initDashboardLinkProbe();

--- a/tests/test_dashboard_poll_visibility.py
+++ b/tests/test_dashboard_poll_visibility.py
@@ -1,0 +1,104 @@
+"""Regression test — the dashboard status poll is skipped while the tab is hidden.
+
+`_initDashboardLinkProbe` sets `setInterval(refreshDashboardStatus, 60000)`, and
+the interval equals `DASHBOARD_STATUS_TTL_MS`, so every background tick was a
+real `/api/dashboard/status` fetch that never hit the cache — a needless wakeup
+on a tab nobody is looking at. It was the only frontend poll without a
+`document.hidden` guard (the gateway / streaming / hidden-stream polls all skip
+while hidden, #4704/#2476).
+
+`refreshDashboardStatus` now short-circuits an unforced call while hidden, and
+`_initDashboardLinkProbe` refreshes once on `visibilitychange` back to visible.
+Forced calls (settings save, init, the catch-up) still run.
+"""
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+
+import pytest
+
+REPO = pathlib.Path(__file__).parent.parent
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+requires_node = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def test_guard_and_catchup_present():
+    # Guard lives inside refreshDashboardStatus (keeps the setInterval anchor).
+    assert "setInterval(refreshDashboardStatus,DASHBOARD_STATUS_TTL_MS)" in UI_JS
+    assert "if(!force&&typeof document!=='undefined'&&document.hidden){" in UI_JS
+    assert "visibilitychange" in UI_JS
+
+
+_DRIVER = textwrap.dedent(
+    """\
+    const fs = require('fs');
+    function extractFn(src, name) {
+      const markers = [`async function ${name}(`, `function ${name}(`];
+      let start = -1;
+      for (const m of markers) { start = src.indexOf(m); if (start >= 0) break; }
+      if (start < 0) throw new Error(`${name}() not found`);
+      let i = src.indexOf('{', start), depth = 0, s = null, esc = false, lc = false, bc = false;
+      for (; i < src.length; i++) {
+        const ch = src[i], nx = src[i + 1] || '';
+        if (lc) { if (ch === '\\n') lc = false; continue; }
+        if (bc) { if (ch === '*' && nx === '/') bc = false; continue; }
+        if (s) { if (esc) esc = false; else if (ch === '\\\\') esc = true; else if (ch === s) s = null; continue; }
+        if (ch === '/' && nx === '/') { lc = true; continue; }
+        if (ch === '/' && nx === '*') { bc = true; continue; }
+        if (ch === '\\'' || ch === '"' || ch === '`') { s = ch; continue; }
+        if (ch === '{') depth += 1;
+        if (ch === '}') { depth -= 1; if (depth === 0) return src.slice(start, i + 1); }
+      }
+      throw new Error(`could not extract ${name}`);
+    }
+
+    const uiSrc = fs.readFileSync(process.argv[2], 'utf8');
+    const hidden = process.argv[3] === 'hidden';
+    let fetches = 0;
+    global.document = { hidden };
+    global._dashboardStatusCache = null;
+    global._dashboardStatusFetchedAt = 0;
+    global.DASHBOARD_STATUS_TTL_MS = 60000;
+    global._applyDashboardStatus = () => {};
+    global.api = (url) => { if (String(url) === '/api/dashboard/status') fetches += 1; return Promise.resolve({ running: true }); };
+    eval(extractFn(uiSrc, 'refreshDashboardStatus'));
+
+    (async () => {
+      // Unforced call (what the interval does).
+      await refreshDashboardStatus();
+      // Forced call always runs regardless of visibility.
+      await refreshDashboardStatus(true);
+      console.log(JSON.stringify({ fetches }));
+    })();
+    """
+)
+
+
+def _run(hidden):
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+        f.write(_DRIVER)
+        driver = f.name
+    out = subprocess.run(
+        [NODE, driver, str(REPO / "static" / "ui.js"), "hidden" if hidden else "visible"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    import json
+    return json.loads(out.stdout.strip())
+
+
+@requires_node
+def test_hidden_tab_skips_unforced_poll_but_forced_still_runs():
+    r = _run(hidden=True)
+    # Only the forced call fetched; the unforced (interval) call was skipped.
+    assert r["fetches"] == 1, "hidden tab should skip the unforced poll"
+
+
+@requires_node
+def test_visible_tab_polls_normally():
+    r = _run(hidden=False)
+    # Both the unforced and forced calls fetched while visible.
+    assert r["fetches"] == 2, "visible tab should poll on both calls"


### PR DESCRIPTION
## Summary
`_initDashboardLinkProbe` runs `setInterval(refreshDashboardStatus, 60000)`, and the interval equals `DASHBOARD_STATUS_TTL_MS` (60000). So on a **hidden** tab every 60s tick was a real `/api/dashboard/status` fetch that never hit the TTL cache — a needless network wakeup on a tab nobody is looking at.

## Why
It's the only frontend poll without a `document.hidden` guard — the gateway, streaming, and hidden-stream polls all skip while the tab is hidden (#4704). This is the same battery/CPU class as #2476.

## Fix
- `refreshDashboardStatus` short-circuits an **unforced** call while `document.hidden`. Forced calls (settings save, init, the catch-up) still run.
- `_initDashboardLinkProbe` refreshes once on `visibilitychange` back to visible, so the now-stale cache catches up when the user returns.

The guard lives inside `refreshDashboardStatus`, so the `setInterval(...)` call site (and its existing static-test anchor) is unchanged.

## Validation
- New `tests/test_dashboard_poll_visibility.py`: a node driver runs `refreshDashboardStatus` with `document.hidden` true/false — hidden skips the unforced poll (only the forced call fetches), visible polls on both; plus a static check for the guard + catch-up listener.
- `node --check static/ui.js` clean; existing `tests/test_dashboard_link_ui.py` still green (its mock `document` has no `hidden`, i.e. visible).
- `./scripts/test.sh tests/test_dashboard_poll_visibility.py tests/test_dashboard_link_ui.py` → 18 passed.

## Refs
#2476 (CPU/battery on idle/background tabs).