### PR TITLE
fix(sse): arm the write deadline on the session-events invalidation stream

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -16642,6 +16642,7 @@ def _handle_session_events_stream(handler):
     # #3103: see _handle_gateway_sse_stream — `Connection: close` causes
     # EventSource reconnect storms in browsers on long-lived SSE.
     end_sse_headers(handler)
+    _sse_set_write_deadline(handler)  # Defect A: slow tab can't pin this thread
 
     q = subscribe_session_events()
     try:

--- a/tests/test_optionz_liveview_perf.py
+++ b/tests/test_optionz_liveview_perf.py
@@ -226,11 +226,25 @@ def test_sse_write_timeout_drops_slow_subscriber():
 def test_all_sse_endpoints_set_write_deadline():
     src = (REPO_ROOT / "api" / "routes.py").read_text()
     assert "_sse_set_write_deadline" in src
-    # Every SSE handler must arm the deadline. Count call sites — there are
-    # 6 long-lived SSE endpoints (chat-stream, terminal, gateway, approval,
-    # clarify, session).
-    assert src.count("_sse_set_write_deadline(handler") >= 6, (
-        "all 6 SSE endpoints must arm the write deadline"
+    # Every long-lived SSE handler must arm the deadline. Call sites: chat-stream,
+    # terminal, gateway, approval, clarify, session-list, and the session-events
+    # invalidation stream (the last was previously the only one missing it).
+    assert src.count("_sse_set_write_deadline(handler") >= 7, (
+        "every long-lived SSE endpoint must arm the write deadline"
+    )
+
+
+def test_session_events_stream_arms_write_deadline():
+    """The session-events invalidation SSE handler must arm the write deadline
+    like every other long-lived SSE endpoint — otherwise a slow/backgrounded tab
+    can pin its handler thread for up to the 30s connection timeout instead of
+    the tunable deadline."""
+    src = (REPO_ROOT / "api" / "routes.py").read_text()
+    start = src.index("def _handle_session_events_stream(")
+    end = src.index("\ndef ", start)
+    body = src[start:end]
+    assert "_sse_set_write_deadline(handler)" in body, (
+        "_handle_session_events_stream must call _sse_set_write_deadline"
     )
 
 


### PR DESCRIPTION
## Summary
`_handle_session_events_stream` (the lightweight session-list invalidation SSE endpoint) was the only long-lived SSE handler that never called `_sse_set_write_deadline(handler)`.

## Why
Every other long-lived SSE handler — chat-stream, terminal, gateway, approval, clarify, session-list — arms the deadline right after `end_sse_headers`. The server runs `ThreadingHTTPServer` (one thread per connection, no pool cap), and each SSE handler holds its thread for the connection's lifetime. If a tab is slow or backgrounded its TCP receive window fills, and the next `handler.wfile.write()` / `flush()` blocks indefinitely (sockets have no write timeout by default). Without the deadline, that thread is only reclaimed by the 30s connection timeout instead of the shorter, tunable write deadline — the exact thread-exhaustion path the deadline exists to prevent.

## Fix
One line, mirroring the other six handlers: `_sse_set_write_deadline(handler)` after `end_sse_headers(handler)`.

## Validation
- `test_optionz_liveview_perf.py::test_all_sse_endpoints_set_write_deadline` bumped from ≥6 to ≥7 call sites, plus a new focused `test_session_events_stream_arms_write_deadline` that greps the handler body specifically.
- `./scripts/test.sh tests/test_optionz_liveview_perf.py tests/test_issue1623_sse_heartbeat_alignment.py` → 30 passed.
- `ruff` clean.