### PR TITLE
fix(routes): bound the client rate-limit maps by sweeping stale keys

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5565,11 +5565,30 @@ def _embedded_terminal_gate_allows(handler) -> bool:
     return _onboarding_gate_allows(handler)
 
 
+# Above this many distinct client keys, sweep out entries whose timestamps have
+# all aged past the window on the next update. Behind a reverse proxy the map
+# holds a single key (the proxy IP) and never trips this; a directly-exposed
+# deployment would otherwise keep one entry forever for every IP that ever hit
+# the endpoint, since a key is only revisited when that same IP calls again.
+_RATE_LIMIT_MAP_SWEEP_THRESHOLD = 4096
+
+
+def _prune_stale_rate_limit_keys(mapping: dict, cutoff: float) -> None:
+    """Drop keys whose newest timestamp has aged out of the window. Caller holds
+    the map's lock. Size-gated so the common (few-key) path stays O(1)."""
+    if len(mapping) <= _RATE_LIMIT_MAP_SWEEP_THRESHOLD:
+        return
+    stale = [k for k, ts in mapping.items() if not ts or ts[-1] < cutoff]
+    for k in stale:
+        del mapping[k]
+
+
 def _csp_report_rate_limited(handler, *, now: float | None = None) -> bool:
     now = time.time() if now is None else now
     key = _client_ip_for_rate_limit(handler)
     cutoff = now - _CSP_REPORT_RATE_LIMIT_WINDOW_SECONDS
     with _CSP_REPORT_RATE_LIMIT_LOCK:
+        _prune_stale_rate_limit_keys(_CSP_REPORT_RATE_LIMIT, cutoff)
         timestamps = [ts for ts in _CSP_REPORT_RATE_LIMIT.get(key, []) if ts >= cutoff]
         if len(timestamps) >= _CSP_REPORT_RATE_LIMIT_MAX:
             _CSP_REPORT_RATE_LIMIT[key] = timestamps
@@ -5584,6 +5603,7 @@ def _client_event_rate_limited(handler, *, now: float | None = None) -> bool:
     key = _client_ip_for_rate_limit(handler)
     cutoff = now - _CLIENT_EVENT_RATE_LIMIT_WINDOW_SECONDS
     with _CLIENT_EVENT_RATE_LIMIT_LOCK:
+        _prune_stale_rate_limit_keys(_CLIENT_EVENT_RATE_LIMIT, cutoff)
         timestamps = [ts for ts in _CLIENT_EVENT_RATE_LIMIT.get(key, []) if ts >= cutoff]
         if len(timestamps) >= _CLIENT_EVENT_RATE_LIMIT_MAX:
             _CLIENT_EVENT_RATE_LIMIT[key] = timestamps

--- a/tests/test_rate_limit_map_prune.py
+++ b/tests/test_rate_limit_map_prune.py
@@ -1,0 +1,69 @@
+"""Regression test — the client rate-limit maps don't grow without bound.
+
+`_csp_report_rate_limited` / `_client_event_rate_limited` key a timestamp list
+by client IP and always re-store `[now]` for the calling key, so a key is only
+ever revisited when that same IP calls again. An IP that hits the endpoint once
+and never returns left its entry in the map forever. Behind a reverse proxy the
+map holds a single key (the proxy IP), but a directly-exposed deployment would
+accumulate one entry per distinct IP.
+
+The functions now sweep keys whose newest timestamp has aged past the window,
+size-gated so the common few-key path stays O(1).
+"""
+import api.routes as routes
+
+
+def test_prune_drops_only_fully_stale_keys(monkeypatch):
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAP_SWEEP_THRESHOLD", 2)
+    now = 1_000_000.0
+    window = 60.0
+    cutoff = now - window
+    mapping = {
+        "stale-1": [now - 120.0],            # aged out
+        "stale-2": [now - 90.0, now - 61.0],  # newest still older than cutoff
+        "fresh": [now - 10.0],                # within window
+        "empty": [],                          # degenerate, drop
+    }
+
+    routes._prune_stale_rate_limit_keys(mapping, cutoff)
+
+    assert set(mapping) == {"fresh"}, "prune must keep only keys active in the window"
+
+
+def test_prune_is_size_gated_noop_below_threshold(monkeypatch):
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAP_SWEEP_THRESHOLD", 100)
+    mapping = {"stale": [0.0], "also-stale": [1.0]}
+    routes._prune_stale_rate_limit_keys(mapping, cutoff=1_000_000.0)
+    # Under the threshold nothing is swept — keeps the hot path O(1).
+    assert set(mapping) == {"stale", "also-stale"}
+
+
+def test_map_bounded_across_many_one_shot_ips(monkeypatch):
+    """End-to-end: many distinct IPs each calling once must not grow the map
+    without bound once it crosses the sweep threshold."""
+    routes._CSP_REPORT_RATE_LIMIT.clear()
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAP_SWEEP_THRESHOLD", 50)
+
+    base = 2_000_000.0
+    # 200 distinct IPs, each a single hit far enough apart that older ones age out.
+    for i in range(200):
+        # Advance time by 2s per IP so the first entries fall outside the 60s window.
+        routes._csp_report_rate_limited(
+            _ip_handler(f"198.51.100.{i % 256}.{i}"), now=base + i * 2.0
+        )
+
+    # Without the sweep this would hold ~200 keys; with it, only the recent window.
+    assert len(routes._CSP_REPORT_RATE_LIMIT) <= 60, (
+        f"rate-limit map grew unbounded: {len(routes._CSP_REPORT_RATE_LIMIT)} keys"
+    )
+    routes._CSP_REPORT_RATE_LIMIT.clear()
+
+
+class _IpHandler:
+    def __init__(self, ip):
+        self.client_address = (ip, 12345)
+        self.headers = {}
+
+
+def _ip_handler(ip):
+    return _IpHandler(ip)


### PR DESCRIPTION
## Summary
`_csp_report_rate_limited` and `_client_event_rate_limited` key a timestamp list by client IP and only ever revisit a key when that same IP calls again. An IP that hits the endpoint once and never returns leaves its entry in the map forever.

## Why
Behind a reverse proxy the map holds a single key (the proxy IP) — no growth. But a directly-exposed deployment accumulates one entry per distinct IP that ever hit `/api/csp-report` or the client-event endpoint, unbounded over uptime.

## Fix
Both functions now call `_prune_stale_rate_limit_keys` under the existing lock, dropping keys whose newest timestamp has aged past the 60s window. It's **size-gated** at 4096 keys, so the common few-key path (proxy, LAN) stays O(1) and only a genuinely large map pays the sweep.

The per-key `Lock` maps flagged in the same audit (`_OP_LOCKS`, `_OAUTH_START_LOCKS`, `_SKILLS_STATS_LOCKS`, `_JOURNAL_RETRY_LOCKS`) are **intentionally not touched**: evicting a `Lock` that another thread may hold or re-create via `setdefault` would break mutual exclusion, and they lack a "this key is gone forever" signal to gate eviction on (unlike `run_journal`'s delete path). Left as-is deliberately.

## Validation
- New `tests/test_rate_limit_map_prune.py`: prune keeps only in-window keys and drops fully-stale/empty ones; is a no-op below the threshold (hot path stays O(1)); and an end-to-end check that 200 one-shot IPs keep the map bounded.
- Existing `tests/test_issue1909_csp_report_only.py` still green (rate-limiting behavior unchanged).
- `./scripts/test.sh tests/test_rate_limit_map_prune.py tests/test_issue1909_csp_report_only.py` → 9 passed; `ruff` clean.