### PR TITLE
fix(persistence): fsync atomic JSON writers; make discoverability temp thread-safe

### DIFF
--- a/api/oauth.py
+++ b/api/oauth.py
@@ -191,7 +191,10 @@ def _write_auth_json(data: dict[str, Any], auth_path: Path | None = None) -> Pat
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
     try:
-        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())  # durable before rename: no truncated auth.json on power loss
         try:
             tmp.chmod(0o600)
         except OSError as exc:

--- a/api/passkeys.py
+++ b/api/passkeys.py
@@ -72,6 +72,8 @@ def _atomic_write_json(path: Path, payload: Any) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())  # durable before rename: no zero-length passkey file on power loss
         os.chmod(tmp, 0o600)
         os.replace(tmp, path)
     except Exception:

--- a/api/session_discoverability.py
+++ b/api/session_discoverability.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import threading
 import shutil
 import sqlite3
 from collections import Counter
@@ -387,9 +388,27 @@ def audit_session_discoverability(
 
 
 def _atomic_write_json(path: Path, payload) -> None:
-    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+    # Temp name includes the thread id, not just the pid: WebUI runs a
+    # ThreadingHTTPServer, so two request threads reconciling the same _index.json
+    # would otherwise collide on one `<name>.tmp.<pid>` path and truncate each
+    # other's temp before its os.replace. fsync before the rename so a power loss
+    # can't leave a zero-length/garbage file where the durable JSON should be; a
+    # finally drops the temp if anything fails. Mode matches the prior write_text
+    # (umask default) since the plain open() respects the umask.
+    text = json.dumps(payload, ensure_ascii=False, indent=2)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _backup_file(path: Path, backup_dir: Path, backed_up: dict[Path, str]) -> str | None:
@@ -482,7 +501,7 @@ def _materialize_sidecar_from_state_db(session_dir: Path, state_db_path: Path | 
     payload = _state_db_row_to_sidecar(row)
     _backup_file(state_db_path, backup_dir, backed_up)
     session_dir.mkdir(parents=True, exist_ok=True)
-    tmp = target.with_suffix(target.suffix + f".tmp.{os.getpid()}")
+    tmp = target.with_suffix(target.suffix + f".tmp.{os.getpid()}.{threading.get_ident()}")
     tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     try:
         os.link(str(tmp), str(target))

--- a/tests/test_atomic_writer_fsync.py
+++ b/tests/test_atomic_writer_fsync.py
@@ -1,0 +1,105 @@
+"""Regression tests — atomic JSON writers fsync and use collision-safe temps.
+
+Three writers wrote to a temp file and os.replace'd it into place but never
+fsynced, so a power loss between the write and the physical flush could leave a
+zero-length/garbage file where durable JSON should be:
+  - session_discoverability._atomic_write_json (also used a pid-only temp name,
+    which collides between two request threads of the same ThreadingHTTPServer
+    process writing the same _index.json),
+  - passkeys._atomic_write_json (credentials),
+  - oauth._write_auth_json (access/refresh tokens).
+
+Each now fsyncs before the rename; session_discoverability additionally puts the
+thread id in the temp name and cleans it up on failure. These pin the fsync, the
+per-thread temp name, and that content/permissions are unchanged.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _spy_fsync(monkeypatch, module):
+    calls = []
+    real = os.fsync
+    monkeypatch.setattr(module.os, "fsync", lambda fd: (calls.append(fd), real(fd))[1])
+    return calls
+
+
+def test_session_discoverability_writer_fsyncs_and_roundtrips(tmp_path, monkeypatch):
+    import api.session_discoverability as sd
+
+    calls = _spy_fsync(monkeypatch, sd)
+    path = tmp_path / "_index.json"
+    payload = [{"session_id": "s1", "title": "Grüße 🌍"}]
+
+    sd._atomic_write_json(path, payload)
+
+    assert calls, "atomic write did not fsync before rename"
+    assert json.loads(path.read_text(encoding="utf-8")) == payload
+    assert [p.name for p in tmp_path.iterdir()] == ["_index.json"]  # no temp debris
+
+
+def test_session_discoverability_temp_name_is_thread_unique(monkeypatch):
+    """Two threads (same pid) must not collide on one temp path."""
+    import api.session_discoverability as sd
+
+    names = set()
+    real_replace = os.replace
+
+    def capture(src, dst):
+        names.add(Path(src).name)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(sd.os, "replace", capture)
+
+    import tempfile as _tf
+    d = Path(_tf.mkdtemp())
+    idents = iter([1111, 2222])
+    monkeypatch.setattr(sd.threading, "get_ident", lambda: next(idents))
+    sd._atomic_write_json(d / "_index.json", [{"a": 1}])
+    sd._atomic_write_json(d / "_index.json", [{"a": 2}])
+
+    assert len(names) == 2, f"temp names collided across threads: {names}"
+
+
+def test_session_discoverability_failed_write_leaves_no_debris(tmp_path, monkeypatch):
+    import api.session_discoverability as sd
+
+    original = tmp_path / "_index.json"
+    original.write_text('["keep"]', encoding="utf-8")
+
+    def boom(src, dst):
+        raise RuntimeError("simulated crash before rename")
+
+    monkeypatch.setattr(sd.os, "replace", boom)
+    with pytest.raises(RuntimeError):
+        sd._atomic_write_json(original, [{"new": True}])
+
+    assert original.read_text(encoding="utf-8") == '["keep"]'  # original intact
+    assert [p.name for p in tmp_path.iterdir()] == ["_index.json"]  # temp cleaned up
+
+
+def test_passkeys_writer_fsyncs_and_keeps_0600(tmp_path, monkeypatch):
+    import api.passkeys as passkeys
+
+    calls = _spy_fsync(monkeypatch, passkeys)
+    path = tmp_path / "passkeys.json"
+    passkeys._atomic_write_json(path, [{"id": "cred-1"}])
+
+    assert calls, "passkeys write did not fsync"
+    assert json.loads(path.read_text(encoding="utf-8")) == [{"id": "cred-1"}]
+    assert (os.stat(path).st_mode & 0o777) == 0o600  # owner-only preserved
+
+
+def test_oauth_writer_fsyncs_and_keeps_0600(tmp_path, monkeypatch):
+    import api.oauth as oauth
+
+    calls = _spy_fsync(monkeypatch, oauth)
+    path = tmp_path / "auth.json"
+    oauth._write_auth_json({"access_token": "x"}, auth_path=path)
+
+    assert calls, "oauth auth.json write did not fsync"
+    assert json.loads(path.read_text(encoding="utf-8")) == {"access_token": "x"}
+    assert (os.stat(path).st_mode & 0o777) == 0o600  # owner-only preserved


### PR DESCRIPTION
## Summary
Three atomic JSON writers wrote a temp file and `os.replace`'d it into place but never `fsync`'d, so a power loss between the write and the physical flush could leave a zero-length or garbage file where durable JSON should be:
- `session_discoverability._atomic_write_json` (session `_index.json`)
- `passkeys._atomic_write_json` (WebAuthn credentials)
- `oauth._write_auth_json` (OAuth access/refresh tokens)

## Fix
- Each now `flush()` + `os.fsync()` before the rename, so the rename only ever commits durable bytes.
- `session_discoverability` additionally used a **pid-only** temp name (`<name>.tmp.<pid>`). WebUI runs a `ThreadingHTTPServer`, so two request threads reconciling the same `_index.json` collided on that one path — one truncating the other's temp before its `os.replace`. The temp name now includes the thread id, and a `finally` drops the temp on failure. The in-place materialize-sidecar temp gets the same thread id.

Behavior-neutral otherwise: JSON content is unchanged, and file modes are preserved — `_index.json` keeps its umask-default mode (a plain `open()` respects the umask), and `passkeys`/`oauth` keep their explicit `0600` chmod. `providers.py` already fsynced and is left untouched.

## Validation
- New `tests/test_atomic_writer_fsync.py`: each writer fsyncs before rename and round-trips its JSON; the discoverability temp name is thread-unique (two idents → two distinct temp paths); a failed rename leaves the original intact with no temp debris; passkeys/oauth keep `0600`.
- Existing suites green: `tests/test_session_discoverability_repair.py`, `tests/test_session_discoverability_audit.py`, `tests/test_passkey_auth.py`.
- `./scripts/test.sh ...` → 33 passed; `ruff` clean.