### PR TITLE
Release Batch C: hidden-tab poll + SSE write-deadline + rate-limit map bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 ### Fixed
 
+- **The dashboard status poll now pauses while the browser tab is hidden.** The Insights/dashboard status poll kept firing on a backgrounded tab; it now skips unforced polls while `document.hidden` and does one catch-up fetch on re-show (sibling of the hidden-tab session-poll pause). Forced init/save/resume fetches are unaffected. Thanks @ai-ag2026. (#5840)
+
+- **A slow or stuck client can no longer pin the session-events invalidation stream.** The session-events SSE stream now arms a write deadline after headers and before subscription, so a client that stops reading is torn down (and unsubscribed in `finally`) instead of holding the stream open indefinitely. A healthy slow-but-alive client is unaffected. Thanks @ai-ag2026. (#5841)
+
+- **The per-client rate-limit maps are now bounded.** The client rate-limit tracking maps grew unbounded over long uptimes; a sweep now prunes keys whose newest timestamp is older than the live window (under the existing locks), so a key still inside its window is never evicted (no rate-limit bypass). Part of the long-uptime stability work. Thanks @ai-ag2026. (#5842)
+
 - **Steering a live *gateway-owned* run no longer errors and drops your message.** When you steered a stream backed by a gateway run (which has no process-local agent in `SESSION_AGENT_CACHE`), the old path showed a misleading "No agent cached for this session" toast and lost the text you'd typed. WebUI now detects the live gateway run and queues your steer as the next turn on that session (snapshotting model/provider/profile first), updates the queue badge, clears the composer draft, and shows a "Steer queued for next turn" notice — without cancelling the active stream. This is the gateway sibling of the existing local-agent queued-steer fallback. Thanks @rodboev. (#5823, #5585)
 
 - **CORS preflight (`OPTIONS`) responses are now framed with `Content-Length: 0`.** Under HTTP/1.1 keep-alive the preflight `200` was sent with no `Content-Length`, so a browser/proxy/curl client read the body until connection close (RFC 7230 §3.3.3) — a keep-alive preflight would hang to the 30s timeout and couldn't reuse the connection. The handler now emits `Content-Length: 0` before `end_headers()`; status stays `200` and CORS headers are unchanged. Thanks @ai-ag2026. (#5828)

--- a/api/routes.py
+++ b/api/routes.py
@@ -5565,11 +5565,30 @@ def _embedded_terminal_gate_allows(handler) -> bool:
     return _onboarding_gate_allows(handler)
 
 
+# Above this many distinct client keys, sweep out entries whose timestamps have
+# all aged past the window on the next update. Behind a reverse proxy the map
+# holds a single key (the proxy IP) and never trips this; a directly-exposed
+# deployment would otherwise keep one entry forever for every IP that ever hit
+# the endpoint, since a key is only revisited when that same IP calls again.
+_RATE_LIMIT_MAP_SWEEP_THRESHOLD = 4096
+
+
+def _prune_stale_rate_limit_keys(mapping: dict, cutoff: float) -> None:
+    """Drop keys whose newest timestamp has aged out of the window. Caller holds
+    the map's lock. Size-gated so the common (few-key) path stays O(1)."""
+    if len(mapping) <= _RATE_LIMIT_MAP_SWEEP_THRESHOLD:
+        return
+    stale = [k for k, ts in mapping.items() if not ts or ts[-1] < cutoff]
+    for k in stale:
+        del mapping[k]
+
+
 def _csp_report_rate_limited(handler, *, now: float | None = None) -> bool:
     now = time.time() if now is None else now
     key = _client_ip_for_rate_limit(handler)
     cutoff = now - _CSP_REPORT_RATE_LIMIT_WINDOW_SECONDS
     with _CSP_REPORT_RATE_LIMIT_LOCK:
+        _prune_stale_rate_limit_keys(_CSP_REPORT_RATE_LIMIT, cutoff)
         timestamps = [ts for ts in _CSP_REPORT_RATE_LIMIT.get(key, []) if ts >= cutoff]
         if len(timestamps) >= _CSP_REPORT_RATE_LIMIT_MAX:
             _CSP_REPORT_RATE_LIMIT[key] = timestamps
@@ -5584,6 +5603,7 @@ def _client_event_rate_limited(handler, *, now: float | None = None) -> bool:
     key = _client_ip_for_rate_limit(handler)
     cutoff = now - _CLIENT_EVENT_RATE_LIMIT_WINDOW_SECONDS
     with _CLIENT_EVENT_RATE_LIMIT_LOCK:
+        _prune_stale_rate_limit_keys(_CLIENT_EVENT_RATE_LIMIT, cutoff)
         timestamps = [ts for ts in _CLIENT_EVENT_RATE_LIMIT.get(key, []) if ts >= cutoff]
         if len(timestamps) >= _CLIENT_EVENT_RATE_LIMIT_MAX:
             _CLIENT_EVENT_RATE_LIMIT[key] = timestamps
@@ -16642,6 +16662,7 @@ def _handle_session_events_stream(handler):
     # #3103: see _handle_gateway_sse_stream — `Connection: close` causes
     # EventSource reconnect storms in browsers on long-lived SSE.
     end_sse_headers(handler)
+    _sse_set_write_deadline(handler)  # Defect A: slow tab can't pin this thread
 
     q = subscribe_session_events()
     try:

--- a/static/ui.js
+++ b/static/ui.js
@@ -1795,6 +1795,14 @@ function _applyDashboardStatus(status){
 }
 async function refreshDashboardStatus(force=false){
   const now=Date.now();
+  // Skip the interval-driven poll while the tab is hidden: the 60s interval
+  // equals the cache TTL, so every background tick was a real /api/dashboard/status
+  // fetch that never hit the cache — a needless wakeup on a tab nobody is
+  // looking at (battery/CPU, #2476). Forced calls (settings save, init, the
+  // visibilitychange catch-up) still run. A visible tab keeps its live status.
+  if(!force&&typeof document!=='undefined'&&document.hidden){
+    return _dashboardStatusCache;
+  }
   if(!force&&_dashboardStatusCache&&(now-_dashboardStatusFetchedAt)<DASHBOARD_STATUS_TTL_MS){
     _applyDashboardStatus(_dashboardStatusCache);
     return _dashboardStatusCache;
@@ -1860,6 +1868,13 @@ function _initDashboardLinkProbe(){
   loadDashboardSettings();
   refreshDashboardStatus(true);
   setInterval(refreshDashboardStatus,DASHBOARD_STATUS_TTL_MS);
+  // Catch up once when the tab becomes visible again, since the interval poll
+  // was skipped while hidden and its cache is now stale.
+  if(typeof document!=='undefined'&&typeof document.addEventListener==='function'){
+    document.addEventListener('visibilitychange',()=>{
+      if(!document.hidden) refreshDashboardStatus(true);
+    });
+  }
 }
 if(document.readyState==='complete'){
   _initDashboardLinkProbe();

--- a/tests/test_dashboard_poll_visibility.py
+++ b/tests/test_dashboard_poll_visibility.py
@@ -1,0 +1,104 @@
+"""Regression test — the dashboard status poll is skipped while the tab is hidden.
+
+`_initDashboardLinkProbe` sets `setInterval(refreshDashboardStatus, 60000)`, and
+the interval equals `DASHBOARD_STATUS_TTL_MS`, so every background tick was a
+real `/api/dashboard/status` fetch that never hit the cache — a needless wakeup
+on a tab nobody is looking at. It was the only frontend poll without a
+`document.hidden` guard (the gateway / streaming / hidden-stream polls all skip
+while hidden, #4704/#2476).
+
+`refreshDashboardStatus` now short-circuits an unforced call while hidden, and
+`_initDashboardLinkProbe` refreshes once on `visibilitychange` back to visible.
+Forced calls (settings save, init, the catch-up) still run.
+"""
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+
+import pytest
+
+REPO = pathlib.Path(__file__).parent.parent
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+requires_node = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def test_guard_and_catchup_present():
+    # Guard lives inside refreshDashboardStatus (keeps the setInterval anchor).
+    assert "setInterval(refreshDashboardStatus,DASHBOARD_STATUS_TTL_MS)" in UI_JS
+    assert "if(!force&&typeof document!=='undefined'&&document.hidden){" in UI_JS
+    assert "visibilitychange" in UI_JS
+
+
+_DRIVER = textwrap.dedent(
+    """\
+    const fs = require('fs');
+    function extractFn(src, name) {
+      const markers = [`async function ${name}(`, `function ${name}(`];
+      let start = -1;
+      for (const m of markers) { start = src.indexOf(m); if (start >= 0) break; }
+      if (start < 0) throw new Error(`${name}() not found`);
+      let i = src.indexOf('{', start), depth = 0, s = null, esc = false, lc = false, bc = false;
+      for (; i < src.length; i++) {
+        const ch = src[i], nx = src[i + 1] || '';
+        if (lc) { if (ch === '\\n') lc = false; continue; }
+        if (bc) { if (ch === '*' && nx === '/') bc = false; continue; }
+        if (s) { if (esc) esc = false; else if (ch === '\\\\') esc = true; else if (ch === s) s = null; continue; }
+        if (ch === '/' && nx === '/') { lc = true; continue; }
+        if (ch === '/' && nx === '*') { bc = true; continue; }
+        if (ch === '\\'' || ch === '"' || ch === '`') { s = ch; continue; }
+        if (ch === '{') depth += 1;
+        if (ch === '}') { depth -= 1; if (depth === 0) return src.slice(start, i + 1); }
+      }
+      throw new Error(`could not extract ${name}`);
+    }
+
+    const uiSrc = fs.readFileSync(process.argv[2], 'utf8');
+    const hidden = process.argv[3] === 'hidden';
+    let fetches = 0;
+    global.document = { hidden };
+    global._dashboardStatusCache = null;
+    global._dashboardStatusFetchedAt = 0;
+    global.DASHBOARD_STATUS_TTL_MS = 60000;
+    global._applyDashboardStatus = () => {};
+    global.api = (url) => { if (String(url) === '/api/dashboard/status') fetches += 1; return Promise.resolve({ running: true }); };
+    eval(extractFn(uiSrc, 'refreshDashboardStatus'));
+
+    (async () => {
+      // Unforced call (what the interval does).
+      await refreshDashboardStatus();
+      // Forced call always runs regardless of visibility.
+      await refreshDashboardStatus(true);
+      console.log(JSON.stringify({ fetches }));
+    })();
+    """
+)
+
+
+def _run(hidden):
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+        f.write(_DRIVER)
+        driver = f.name
+    out = subprocess.run(
+        [NODE, driver, str(REPO / "static" / "ui.js"), "hidden" if hidden else "visible"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    import json
+    return json.loads(out.stdout.strip())
+
+
+@requires_node
+def test_hidden_tab_skips_unforced_poll_but_forced_still_runs():
+    r = _run(hidden=True)
+    # Only the forced call fetched; the unforced (interval) call was skipped.
+    assert r["fetches"] == 1, "hidden tab should skip the unforced poll"
+
+
+@requires_node
+def test_visible_tab_polls_normally():
+    r = _run(hidden=False)
+    # Both the unforced and forced calls fetched while visible.
+    assert r["fetches"] == 2, "visible tab should poll on both calls"

--- a/tests/test_optionz_liveview_perf.py
+++ b/tests/test_optionz_liveview_perf.py
@@ -226,11 +226,25 @@ def test_sse_write_timeout_drops_slow_subscriber():
 def test_all_sse_endpoints_set_write_deadline():
     src = (REPO_ROOT / "api" / "routes.py").read_text()
     assert "_sse_set_write_deadline" in src
-    # Every SSE handler must arm the deadline. Count call sites — there are
-    # 6 long-lived SSE endpoints (chat-stream, terminal, gateway, approval,
-    # clarify, session).
-    assert src.count("_sse_set_write_deadline(handler") >= 6, (
-        "all 6 SSE endpoints must arm the write deadline"
+    # Every long-lived SSE handler must arm the deadline. Call sites: chat-stream,
+    # terminal, gateway, approval, clarify, session-list, and the session-events
+    # invalidation stream (the last was previously the only one missing it).
+    assert src.count("_sse_set_write_deadline(handler") >= 7, (
+        "every long-lived SSE endpoint must arm the write deadline"
+    )
+
+
+def test_session_events_stream_arms_write_deadline():
+    """The session-events invalidation SSE handler must arm the write deadline
+    like every other long-lived SSE endpoint — otherwise a slow/backgrounded tab
+    can pin its handler thread for up to the 30s connection timeout instead of
+    the tunable deadline."""
+    src = (REPO_ROOT / "api" / "routes.py").read_text()
+    start = src.index("def _handle_session_events_stream(")
+    end = src.index("\ndef ", start)
+    body = src[start:end]
+    assert "_sse_set_write_deadline(handler)" in body, (
+        "_handle_session_events_stream must call _sse_set_write_deadline"
     )
 
 

--- a/tests/test_rate_limit_map_prune.py
+++ b/tests/test_rate_limit_map_prune.py
@@ -1,0 +1,69 @@
+"""Regression test — the client rate-limit maps don't grow without bound.
+
+`_csp_report_rate_limited` / `_client_event_rate_limited` key a timestamp list
+by client IP and always re-store `[now]` for the calling key, so a key is only
+ever revisited when that same IP calls again. An IP that hits the endpoint once
+and never returns left its entry in the map forever. Behind a reverse proxy the
+map holds a single key (the proxy IP), but a directly-exposed deployment would
+accumulate one entry per distinct IP.
+
+The functions now sweep keys whose newest timestamp has aged past the window,
+size-gated so the common few-key path stays O(1).
+"""
+import api.routes as routes
+
+
+def test_prune_drops_only_fully_stale_keys(monkeypatch):
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAP_SWEEP_THRESHOLD", 2)
+    now = 1_000_000.0
+    window = 60.0
+    cutoff = now - window
+    mapping = {
+        "stale-1": [now - 120.0],            # aged out
+        "stale-2": [now - 90.0, now - 61.0],  # newest still older than cutoff
+        "fresh": [now - 10.0],                # within window
+        "empty": [],                          # degenerate, drop
+    }
+
+    routes._prune_stale_rate_limit_keys(mapping, cutoff)
+
+    assert set(mapping) == {"fresh"}, "prune must keep only keys active in the window"
+
+
+def test_prune_is_size_gated_noop_below_threshold(monkeypatch):
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAP_SWEEP_THRESHOLD", 100)
+    mapping = {"stale": [0.0], "also-stale": [1.0]}
+    routes._prune_stale_rate_limit_keys(mapping, cutoff=1_000_000.0)
+    # Under the threshold nothing is swept — keeps the hot path O(1).
+    assert set(mapping) == {"stale", "also-stale"}
+
+
+def test_map_bounded_across_many_one_shot_ips(monkeypatch):
+    """End-to-end: many distinct IPs each calling once must not grow the map
+    without bound once it crosses the sweep threshold."""
+    routes._CSP_REPORT_RATE_LIMIT.clear()
+    monkeypatch.setattr(routes, "_RATE_LIMIT_MAP_SWEEP_THRESHOLD", 50)
+
+    base = 2_000_000.0
+    # 200 distinct IPs, each a single hit far enough apart that older ones age out.
+    for i in range(200):
+        # Advance time by 2s per IP so the first entries fall outside the 60s window.
+        routes._csp_report_rate_limited(
+            _ip_handler(f"198.51.100.{i % 256}.{i}"), now=base + i * 2.0
+        )
+
+    # Without the sweep this would hold ~200 keys; with it, only the recent window.
+    assert len(routes._CSP_REPORT_RATE_LIMIT) <= 60, (
+        f"rate-limit map grew unbounded: {len(routes._CSP_REPORT_RATE_LIMIT)} keys"
+    )
+    routes._CSP_REPORT_RATE_LIMIT.clear()
+
+
+class _IpHandler:
+    def __init__(self, ip):
+        self.client_address = (ip, 12345)
+        self.headers = {}
+
+
+def _ip_handler(ip):
+    return _IpHandler(ip)


### PR DESCRIPTION
Phase 2 low-risk backend/perf batch (concentric sweep, on top of exp-v0.52.8). Three independent contributor fixes from the ai-ag2026 long-uptime reliability cluster, each byte-identical to its PR head, Codex SAFE-TO-SHIP, full regression + own tests green.

## Included
- **#5840** (@ai-ag2026) — `static/ui.js`: skip the dashboard status poll while the tab is hidden; one catch-up fetch on re-show. Behavior/perf only (forced init/save/resume polls unaffected, nothing renders differently).
- **#5841** (@ai-ag2026) — `api/routes.py`: arm a write deadline on the session-events invalidation SSE so a stuck client is torn down (unsubscribed in `finally`) instead of pinning the stream.
- **#5842** (@ai-ag2026) — `api/routes.py`: bound the client rate-limit maps by sweeping stale keys (keys still inside their live window are never evicted → no rate-limit bypass).

## Gate
- Each PR's contribution byte-identical to its head; #5841 + #5842 apply to disjoint `routes.py` regions (clean, no conflict).
- Codex advisor: **SAFE TO SHIP** (all three line-verified; no regression; locks intact; poll gate resumes correctly).
- Tests: 33 own + 720 regression (dashboard/sse/rate-limit/poll/liveview) pass; `node -c` + py ast + runtime lint clean.

Closes #5840, closes #5841, closes #5842.
