### PR TITLE
Release: cap StreamChannel offline replay buffer (#5788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- **A dropped SSE connection can no longer grow the offline replay buffer without bound.** When a stream disconnected without being cancelled, the per-`StreamChannel` offline replay buffer grew for the whole turn (a per-abandoned-turn memory risk). It's now a bounded `deque` (drop-oldest); the reconnect tail is intact and any dropped frames are recovered through the run-journal `last_event_id` replay path (the client requests journal replay on reconnect; the server enforces journal gap coverage before draining the tail). Thanks @ai-ag2026. (#5788, #4633)
+
 - **The embedded terminal no longer leaks a file descriptor, reader thread, and shell process on exit.** When the terminal client disconnected or the shell exited, the PTY fd, its reader thread, and the shell process were left dangling — accumulating over a long uptime (part of the #4633 long-uptime-crash family). Teardown now closes the fd once, stops the reader thread, and reaps the shell on both the client-exit and shell-exit paths. Thanks @ai-ag2026. (#5835, #4633)
 
 - **Atomic JSON writers now `fsync` before rename, and the discoverability temp write is thread-safe.** The OAuth, passkeys, and session-discoverability stores wrote via temp-file → `os.replace` but without an `fsync`, so a crash right after the rename could still surface a partially-flushed file; they now flush → `fsync` → replace (matching the settings/config atomic-write hardening). The discoverability temp file also now uses a thread-specific name so concurrent writers can't collide. Thanks @ai-ag2026. (#5843)

--- a/api/config.py
+++ b/api/config.py
@@ -7863,10 +7863,39 @@ class StreamChannel:
     of them instead of being consumed destructively by a single queue reader.
     """
 
+    # Cap on the offline replay buffer (drop-oldest). While no tab is subscribed,
+    # put_nowait() buffers the stream tail so a first/reconnecting subscriber can
+    # catch up. But a client that disconnects without cancelling leaves the turn
+    # running with zero subscribers, so an unbounded buffer here grows for the
+    # WHOLE turn (a busy turn emits thousands of coalesced token frames) — an OOM
+    # risk per abandoned turn (#4633). Bounding to the most recent N frames keeps
+    # a reconnecting tab's needed *tail* intact; older dropped frames stay
+    # recoverable via the run journal by last_event_id. 8192 is generous enough
+    # to hold a long multi-tool turn's backlog while capping worst-case memory to
+    # a fixed number of small (event, data, id) tuples — deliberately far above
+    # SessionChannel's per-subscriber maxsize of 16 (that queue drops on a *slow*
+    # reader; this buffer must survive a legitimate reconnect gap).
+    _OFFLINE_BUFFER_MAXLEN = 8192
+
     def __init__(self):
         self._lock = threading.Lock()
         self._subscribers: list[queue.Queue] = []
-        self._offline_buffer: list[tuple[str, object]] = []
+        self._offline_buffer: collections.deque = collections.deque(
+            maxlen=self._OFFLINE_BUFFER_MAXLEN
+        )
+        # Frames evicted at the cap from the CURRENT buffer content. Scoped to
+        # the buffer, NOT to an attach cycle: it resets exactly when the buffer
+        # itself is cleared (first live broadcast), never on subscribe/
+        # unsubscribe alone — a drain is a non-destructive copy, so after a
+        # transient attach the buffer is STILL truncated and reporting 0 would
+        # hand the next subscriber a silently-holed tail. Whether a given
+        # reconnect actually NEEDS the evicted frames is decided server-side
+        # against offline_first_event_id (its cursor may sit inside the
+        # retained tail). Also gates the one-shot eviction log.
+        self._offline_dropped = 0
+        # Cumulative evictions over the channel's lifetime, never reset — for ops
+        # visibility via diagnostic_snapshot().
+        self._offline_dropped_total = 0
         self._last_event_id: str | None = None
 
     def subscribe(self) -> queue.Queue:
@@ -7883,8 +7912,19 @@ class StreamChannel:
             # is safe. Per Opus advisor on stage-292.
             for item in self._offline_buffer:
                 q.put_nowait(item)
+            first = self._offline_buffer[0] if self._offline_buffer else None
             snapshot = {
                 "offline_buffered_events": len(self._offline_buffer),
+                # Surface eviction so the SSE handler can tell the tail it is
+                # about to drain may be truncated (older frames were dropped at
+                # the cap) and must be proven contiguous before streaming.
+                "offline_dropped_events": self._offline_dropped,
+                # Event id of the oldest retained frame: the handler needs run-
+                # journal coverage only for (client cursor → this frame); a
+                # cursor already inside the retained tail needs no journal.
+                "offline_first_event_id": (
+                    first[2] if first is not None and len(first) >= 3 else None
+                ),
                 "last_event_id": self._last_event_id,
             }
             self._subscribers.append(q)
@@ -7911,9 +7951,27 @@ class StreamChannel:
                 self._last_event_id = event_id
             subscribers = list(self._subscribers)
             if not subscribers:
+                # deque(maxlen) evicts the oldest frame automatically when full.
+                # Log once on the first eviction (debug: an abandoned/disconnected
+                # turn is expected to hit this) and keep a running dropped count
+                # for diagnostics.
+                if len(self._offline_buffer) >= self._OFFLINE_BUFFER_MAXLEN:
+                    if self._offline_dropped == 0:  # first eviction this cycle
+                        logger.debug(
+                            "StreamChannel offline buffer full (cap=%d); dropping "
+                            "oldest frames while no subscriber is connected",
+                            self._OFFLINE_BUFFER_MAXLEN,
+                        )
+                    self._offline_dropped += 1
+                    self._offline_dropped_total += 1
                 self._offline_buffer.append(item)
                 return
+            # A subscriber is live: events now broadcast directly, so the offline
+            # tail is drained. Reset the per-cycle eviction count (which also
+            # re-arms the one-shot log) so the NEXT disconnect/overflow cycle
+            # reports and logs its own truncation, not a stale carry-over.
             self._offline_buffer.clear()
+            self._offline_dropped = 0
         for q in subscribers:
             q.put_nowait(item)
 
@@ -7923,6 +7981,9 @@ class StreamChannel:
             return {
                 "subscriber_count": len(self._subscribers),
                 "offline_buffered_events": len(self._offline_buffer),
+                # Cumulative over the channel lifetime (ops visibility), vs. the
+                # per-cycle count subscribe_with_snapshot() reports for truncation.
+                "offline_dropped_events": self._offline_dropped_total,
             }
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -16221,6 +16221,185 @@ def _run_journal_same_run_seq(event_id: str | None, stream_id: str) -> int | Non
     return event_seq
 
 
+def _run_journal_covers_offline_gap(
+    stream_id: str, after_seq: int | None, cutoff_seq: int | None
+) -> bool:
+    """Return True when the run journal PROVABLY backfills a dropped-frame gap.
+
+    When StreamChannel evicted frames from its offline buffer
+    (``offline_dropped_events > 0``), draining the retained tail to a
+    reconnecting client is only safe if the journal replay actually covers
+    everything from the client's cursor (*after_seq*, ``None`` = start of run)
+    through the snapshot cutoff — journal seqs are assigned contiguously from 1,
+    so coverage means every seq in ``(after_seq, cutoff_seq]`` is present. A
+    missing journal, a journal that stops short of the cutoff, or a window with
+    malformed/dropped lines all mean the evicted frames are unrecoverable here
+    and the caller must signal recovery instead of streaming tail-only.
+
+    ``cutoff_seq is None`` (the channel never saw a same-run journaled event id)
+    counts as not covered: nothing can be proven against an unknown cutoff.
+    """
+    if cutoff_seq is None:
+        return False
+    floor = max(0, int(after_seq)) if after_seq is not None else 0
+    if floor >= cutoff_seq:
+        # Client cursor is already at/past everything the buffer ever held.
+        return True
+    try:
+        summary = find_run_summary(stream_id)
+        if not summary:
+            return False
+        journal = read_run_events(
+            str(summary.get("session_id") or ""),
+            stream_id,
+            after_seq=floor,
+            max_seq=cutoff_seq,
+        )
+    except Exception:
+        logger.debug(
+            "Run journal coverage check failed for stream %s", stream_id, exc_info=True
+        )
+        return False
+    cutoff = int(cutoff_seq)
+    seqs = set()
+    for entry in journal.get("events") or []:
+        try:
+            seq = int(entry.get("seq") or 0)
+        except (TypeError, ValueError):
+            continue
+        if floor < seq <= cutoff:
+            seqs.add(seq)
+    # Seqs are unique and bounded to the window, so full coverage means one
+    # distinct seq per slot — no need to materialize the whole range.
+    return len(seqs) == cutoff - floor
+
+
+def _sse_replay_run_journal_gap_checked(
+    handler, qs: dict, stream_id: str, stream_snapshot: dict
+) -> tuple[bool, int | None]:
+    """Journal-replay for a reconnecting client, enforcing offline-gap coverage.
+
+    Returns ``(gap_recovered, replay_cutoff_seq)``. When the channel evicted
+    frames from its offline buffer (``offline_dropped_events > 0`` in the
+    subscribe snapshot) and the run journal cannot PROVE it backfills the gap
+    (see ``_run_journal_covers_offline_gap``), a recovery_control apperror has
+    been emitted and the caller must return instead of draining the retained
+    tail (``gap_recovered=True``).
+    """
+    if not (
+        qs.get("replay", [""])[0]
+        or qs.get("after_seq", [None])[0] not in (None, "")
+        or qs.get("after_event_id", [None])[0]
+    ):
+        return False, None
+    try:
+        offline_dropped = int(stream_snapshot.get("offline_dropped_events") or 0)
+    except (TypeError, ValueError):
+        offline_dropped = 0
+    snapshot_cutoff_seq = _run_journal_same_run_seq(
+        str(stream_snapshot.get("last_event_id") or ""),
+        stream_id,
+    )
+    after_seq = _parse_run_journal_after_seq(qs, stream_id)
+    # The subscribe snapshot already queued the retained offline tail, which
+    # covers [first buffered frame → snapshot cutoff] by itself. The journal
+    # only has to bridge (client cursor → first buffered frame) — and the
+    # replay/dedup cutoff must stop there too, or the drain loop's
+    # `seq <= replay_cutoff_seq` filter would eat queued frames the journal
+    # never emitted. Without a parseable first-frame id (empty buffer, foreign
+    # run, unjournaled head frame) fall back to the full (cursor → cutoff]
+    # window as before.
+    replay_max_seq = snapshot_cutoff_seq
+    first_buffered_seq = _run_journal_same_run_seq(
+        str(stream_snapshot.get("offline_first_event_id") or ""),
+        stream_id,
+    )
+    if first_buffered_seq is not None:
+        replay_max_seq = first_buffered_seq - 1
+        if snapshot_cutoff_seq is not None:
+            replay_max_seq = min(replay_max_seq, snapshot_cutoff_seq)
+    covered = offline_dropped <= 0 or _run_journal_covers_offline_gap(
+        stream_id, after_seq, replay_max_seq
+    )
+    replay_cutoff_seq = None
+    replay_failed = False
+    if covered:
+        try:
+            if _replay_run_journal(
+                handler,
+                stream_id,
+                after_seq,
+                max_seq=replay_max_seq,
+                include_stale=False,
+            ):
+                replay_cutoff_seq = replay_max_seq
+        except _CLIENT_DISCONNECT_ERRORS:
+            raise
+        except Exception:
+            replay_failed = True
+            logger.debug("Failed to replay active run journal for stream %s", stream_id, exc_info=True)
+    if offline_dropped > 0 and (not covered or replay_failed):
+        _sse_offline_gap_recovery(handler, stream_id, offline_dropped)
+        return True, None
+    # Two distinct dedup bounds feed the drain loop's `seq <=` filter: frames
+    # the journal replay just emitted (replay_cutoff_seq, capped at the buffer
+    # head so queued frames the journal never sent survive) AND frames the
+    # client already holds per its own cursor. A cursor at/inside the retained
+    # tail (after_seq >= first buffered frame) would otherwise get the queued
+    # copy of frames it already rendered — a double-render, since this filter
+    # is the only dedup for replayed streams.
+    if after_seq is not None:
+        cursor_bound = after_seq
+        if snapshot_cutoff_seq is not None:
+            # A legitimate cursor can never exceed the channel's last known
+            # frame; clamping keeps a bogus/corrupt cursor from filtering the
+            # queued terminal frame and pinning the loop on heartbeats.
+            cursor_bound = min(cursor_bound, snapshot_cutoff_seq)
+        replay_cutoff_seq = (
+            cursor_bound
+            if replay_cutoff_seq is None
+            else max(replay_cutoff_seq, cursor_bound)
+        )
+    return False, replay_cutoff_seq
+
+
+def _sse_offline_gap_recovery(handler, stream_id: str, offline_dropped: int) -> None:
+    """Signal an unrecoverable replay gap instead of streaming tail-only.
+
+    Frames were evicted from the channel's capped offline buffer and the run
+    journal cannot prove it backfills (client cursor → snapshot cutoff]:
+    draining the retained tail would render a silent transcript hole that ends
+    in a normal ``stream_end``. Emit the established ``recovery_control``
+    apperror (same client contract as ``run_journal.stale_interrupted_event``)
+    so the tab restores the transcript from persisted session state instead.
+    """
+    # The client only acts on the recovery signal when the payload names its
+    # session (eventMatchesCurrent), so fall back to the journal summary when
+    # the pre-worker owner registration is already gone.
+    try:
+        session_id = stream_owner_session_id(stream_id) or ""
+        if not session_id:
+            session_id = str((find_run_summary(stream_id) or {}).get("session_id") or "")
+    except Exception:
+        session_id = ""
+    _sse(
+        handler,
+        "apperror",
+        {
+            "type": "interrupted",
+            "recovery_control": True,
+            "message": (
+                "The live stream's replay buffer overflowed while no tab was "
+                "attached and the run journal cannot backfill the dropped frames."
+            ),
+            "hint": "The transcript was restored to the last saved state.",
+            "session_id": session_id,
+            "stream_id": stream_id,
+            "offline_dropped_events": offline_dropped,
+        },
+    )
+
+
 def _runner_stream_cursor_from_query(qs: dict) -> str | None:
     cursor = str(qs.get("cursor", [""])[0] or "").strip()
     if cursor:
@@ -16352,27 +16531,13 @@ def _handle_sse_stream(handler, parsed):
     handler.send_header("Connection", "close")
     end_sse_headers(handler)
     _sse_set_write_deadline(handler)  # Defect A: slow tab can't pin this thread
-    replay_cutoff_seq = None
-    if qs.get("replay", [""])[0] or qs.get("after_seq", [None])[0] not in (None, "") or qs.get("after_event_id", [None])[0]:
-        snapshot_cutoff_seq = _run_journal_same_run_seq(
-            str(stream_snapshot.get("last_event_id") or ""),
-            stream_id,
-        )
-        try:
-            replayed = _replay_run_journal(
-                handler,
-                stream_id,
-                _parse_run_journal_after_seq(qs, stream_id),
-                max_seq=snapshot_cutoff_seq,
-                include_stale=False,
-            )
-            if replayed:
-                replay_cutoff_seq = snapshot_cutoff_seq
-        except _CLIENT_DISCONNECT_ERRORS:
-            raise
-        except Exception:
-            logger.debug("Failed to replay active run journal for stream %s", stream_id, exc_info=True)
+    # Replay shares the drain loop's try/finally so every exit path unsubscribes.
     try:
+        gap_recovered, replay_cutoff_seq = _sse_replay_run_journal_gap_checked(
+            handler, qs, stream_id, stream_snapshot
+        )
+        if gap_recovered:
+            return True
         while True:
             try:
                 item = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)

--- a/static/messages.js
+++ b/static/messages.js
@@ -5874,7 +5874,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
             if(st&&st.active){
               setComposerStatus('Reconnected');
-              _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+              _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
               return;
             }
             if(st&&st.replay_available){

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -168,6 +168,25 @@ def test_attention_events_use_distinct_sound_from_completion():
     assert "Notification sound failed" not in attention_body
 
 
+def test_active_reconnect_uses_run_journal_replay_cursor():
+    """Active-stream reconnects must send replay cursor params too.
+
+    Once StreamChannel's offline buffer drops old frames, a still-active stream
+    can only backfill the dropped gap from the run journal.  Reconnecting without
+    replay/after_seq/after_event_id silently resumes at the retained tail and
+    loses the older gap.
+    """
+    body = _event_body("error")
+    active_status_idx = body.find("if(st&&st.active)")
+    replay_status_idx = body.find("if(st&&st.replay_available)")
+    assert active_status_idx != -1, "active reconnect branch not found"
+    assert replay_status_idx != -1, "replay reconnect branch not found"
+    active_block = body[active_status_idx:replay_status_idx]
+    assert "${_runJournalReplayParams()}" in active_block
+    assert "after_seq" in _function_body("_runJournalReplayParams")
+    assert "after_event_id" in _function_body("_runJournalReplayParams")
+
+
 def test_attach_live_stream_registers_one_source_per_session_stream():
     """Reconnect/compaction paths must not stack same-stream EventSources.
 

--- a/tests/test_stream_offline_buffer_cap.py
+++ b/tests/test_stream_offline_buffer_cap.py
@@ -1,0 +1,207 @@
+"""
+Regression tests for #4633 — StreamChannel's offline replay buffer is capped.
+
+While no browser tab is subscribed, ``StreamChannel.put_nowait`` buffers each
+SSE event so a first/reconnecting subscriber can replay the stream tail. A
+client that disconnects WITHOUT cancelling leaves the turn running with zero
+subscribers, and the buffer used to be an unbounded ``list`` — it grew for the
+whole turn (a busy turn emits thousands of coalesced token frames), an OOM risk
+per abandoned turn.
+
+The buffer is now a ``collections.deque(maxlen=_OFFLINE_BUFFER_MAXLEN)`` that
+evicts the OLDEST frame when full (a reconnecting tab needs the tail; older
+frames stay recoverable via the run journal by ``last_event_id``). The broadcast
+path when a subscriber IS attached is unchanged.
+"""
+import logging
+
+from api.config import StreamChannel, create_stream_channel
+
+
+def test_offline_buffer_capped_and_drops_oldest():
+    """put without a subscriber past the cap keeps len <= N and evicts oldest."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    total = n + 500
+    for i in range(total):
+        ch.put_nowait(("token", i, f"id{i}"))
+
+    snap = ch.diagnostic_snapshot()
+    assert snap["offline_buffered_events"] == n
+    assert snap["offline_dropped_events"] == 500
+    # The oldest 500 frames were evicted; the newest tail is retained.
+    assert list(ch._offline_buffer)[0] == ("token", 500, "id500")
+    assert list(ch._offline_buffer)[-1] == ("token", total - 1, f"id{total - 1}")
+
+
+def test_reconnecting_subscriber_replays_capped_tail():
+    """A subscriber attaching after overflow receives exactly the retained tail."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    for i in range(n + 100):
+        ch.put_nowait(("token", i, f"id{i}"))
+
+    q, snapshot = ch.subscribe_with_snapshot()
+    assert snapshot["offline_buffered_events"] == n
+    drained = []
+    while not q.empty():
+        drained.append(q.get_nowait())
+    assert len(drained) == n
+    assert drained[0][1] == 100          # oldest 100 dropped
+    assert drained[-1][1] == n + 100 - 1  # newest retained
+
+
+def test_last_event_id_tracks_newest_after_eviction():
+    """The last_event_id contract is unaffected by buffer eviction."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    for i in range(n + 10):
+        ch.put_nowait(("token", i, f"id{i}"))
+    assert ch._last_event_id == f"id{n + 10 - 1}"
+
+
+def test_under_cap_buffers_all_and_drops_none():
+    """Below the cap the buffer behaves exactly as before (no drops)."""
+    ch = create_stream_channel()
+    for i in range(10):
+        ch.put_nowait(("token", i))
+    snap = ch.diagnostic_snapshot()
+    assert snap["offline_buffered_events"] == 10
+    assert snap["offline_dropped_events"] == 0
+
+
+def test_subscribed_path_unbuffered_and_broadcasts():
+    """With a subscriber attached, events broadcast directly and don't buffer."""
+    ch = create_stream_channel()
+    sub = ch.subscribe()
+    ch.put_nowait(("token", "x", "idx"))
+    assert ch.diagnostic_snapshot()["offline_buffered_events"] == 0
+    assert sub.get_nowait() == ("token", "x", "idx")
+
+
+def test_reconnect_snapshot_exposes_dropped_count():
+    """A reconnecting subscriber can detect a truncated replay tail: the snapshot
+    carries offline_dropped_events so it can fall back to the run journal."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    for i in range(n + 7):
+        ch.put_nowait(("token", i, f"id{i}"))
+    _q, snapshot = ch.subscribe_with_snapshot()
+    assert snapshot["offline_dropped_events"] == 7
+    assert snapshot["last_event_id"] == f"id{n + 7 - 1}"
+
+
+def test_snapshot_dropped_count_is_per_cycle_not_carried_over():
+    """The snapshot truncation signal must be PER disconnect cycle: a subscriber
+    arriving during a later CLEAN cycle must see 0, not a stale cumulative
+    carry-over from an earlier overflow (which would be a false 'truncated'
+    positive). The cumulative total lives in diagnostic_snapshot for ops."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    # cycle 1: overflow
+    for i in range(n + 5):
+        ch.put_nowait(("token", i))
+    # reconnect drains the buffer and resets the per-cycle count
+    q = ch.subscribe()
+    ch.put_nowait(("token", "live"))
+    ch.unsubscribe(q)
+    # cycle 2: CLEAN (well under the cap, no eviction)
+    for i in range(10):
+        ch.put_nowait(("token", ("c2", i)))
+    _q2, snapshot = ch.subscribe_with_snapshot()
+    assert snapshot["offline_dropped_events"] == 0, (
+        "reconnect snapshot carried over a cumulative drop count (false positive)"
+    )
+    # cumulative total is still visible to ops
+    assert ch.diagnostic_snapshot()["offline_dropped_events"] == 5
+
+
+def test_eviction_logs_once_per_disconnect_cycle(caplog):
+    """The one-shot eviction debug log must fire again after a reconnect cycle,
+    not stay silenced forever by the cumulative counter (which stays cumulative
+    for diagnostics)."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+
+    def overflow(extra):
+        for i in range(n + extra):
+            ch.put_nowait(("token", i))
+
+    with caplog.at_level(logging.DEBUG, logger="api.config"):
+        # cycle 1 (no subscriber) → one log
+        overflow(3)
+        assert caplog.text.count("offline buffer full") == 1
+        # a subscriber drains the buffer → resets the per-cycle log guard
+        q = ch.subscribe()
+        ch.put_nowait(("token", "live"))
+        ch.unsubscribe(q)
+        # cycle 2 → logs again (was previously silenced by the cumulative gate)
+        overflow(2)
+        assert caplog.text.count("offline buffer full") == 2
+
+    # cumulative dropped counter is preserved across cycles (not reset)
+    assert ch.diagnostic_snapshot()["offline_dropped_events"] == 5
+
+
+def test_transient_attach_does_not_silence_truncation_signal():
+    """The drop signal is scoped to the BUFFER, not to an attach cycle.
+
+    A subscribe drain is a non-destructive copy: after a transient attach
+    (drain + detach with no live frame in between) the buffer is STILL the
+    same truncated tail, so the next subscriber MUST still see
+    offline_dropped_events > 0 — resetting it at unsubscribe would hand that
+    subscriber a silently-holed replay marked clean (the exact regression this
+    PR exists to prevent). Whether the reconnect actually NEEDS the evicted
+    frames is decided server-side against offline_first_event_id.
+    """
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    for i in range(n + 25):
+        ch.put_nowait(("token", i, f"id{i}"))
+
+    # Transient attach: drains a copy, detaches before any live frame.
+    q, snapshot = ch.subscribe_with_snapshot()
+    assert snapshot["offline_dropped_events"] == 25
+    ch.unsubscribe(q)
+
+    # The buffer content did not change, so neither may the signal.
+    q2, snapshot2 = ch.subscribe_with_snapshot()
+    assert snapshot2["offline_dropped_events"] == 25
+    assert snapshot2["offline_first_event_id"] == "id25"
+    head = q2.get_nowait()
+    assert head[2] == "id25"  # replay head really is the post-eviction frame
+    ch.unsubscribe(q2)
+
+    # A live broadcast clears buffer AND signal together (the only reset
+    # point): the next disconnect cycle starts clean.
+    q3 = ch.subscribe()
+    ch.put_nowait(("token", "live", f"id{n + 25}"))
+    ch.unsubscribe(q3)
+    _q4, snapshot4 = ch.subscribe_with_snapshot()
+    assert snapshot4["offline_dropped_events"] == 0
+    ch.unsubscribe(_q4)
+    # Cumulative ops counter is never reset.
+    assert ch.diagnostic_snapshot()["offline_dropped_events"] == 25
+
+
+def test_snapshot_exposes_first_buffered_event_id():
+    """The SSE handler bounds its journal-coverage window at the first retained
+    frame — the snapshot must expose that frame's event id (None when the
+    buffer is empty or the head frame carries no id)."""
+    ch = create_stream_channel()
+    _q, empty_snapshot = ch.subscribe_with_snapshot()
+    assert empty_snapshot["offline_first_event_id"] is None
+    ch.unsubscribe(_q)
+
+    ch2 = create_stream_channel()
+    ch2.put_nowait(("token", "a", "run:41"))
+    ch2.put_nowait(("token", "b", "run:42"))
+    _q2, snapshot = ch2.subscribe_with_snapshot()
+    assert snapshot["offline_first_event_id"] == "run:41"
+    ch2.unsubscribe(_q2)
+
+    # 2-tuple (id-less) head frames degrade to None, not an IndexError.
+    ch3 = create_stream_channel()
+    ch3.put_nowait(("token", "no-id"))
+    _q3, snapshot3 = ch3.subscribe_with_snapshot()
+    assert snapshot3["offline_first_event_id"] is None

--- a/tests/test_stream_offline_gap_recovery.py
+++ b/tests/test_stream_offline_gap_recovery.py
@@ -1,0 +1,406 @@
+"""
+Regression tests for #4633/#5788 — the SSE handler must ENFORCE run-journal
+coverage before draining a truncated offline tail.
+
+``StreamChannel.subscribe_with_snapshot()`` reports ``offline_dropped_events``
+when the capped offline buffer evicted frames during a disconnect gap. The
+retained tail is only safe to drain when the run journal provably backfills
+everything from the client's replay cursor through the snapshot cutoff —
+otherwise the browser would render later frames plus a normal ``stream_end``
+with a silent transcript hole in the middle (the journal being missing,
+incomplete, or unreadable leaves the evicted frames unrecoverable).
+
+Enforcement contract pinned here:
+
+* dropped > 0 and the journal does NOT cover the gap → emit the established
+  ``apperror`` + ``recovery_control: true`` event (same client contract as
+  ``run_journal.stale_interrupted_event`` — the tab restores the transcript
+  from persisted state) and do NOT stream the tail.
+* dropped > 0 and the journal DOES cover the gap → replay + tail as before.
+* a client cursor already at/past the snapshot cutoff has no gap to cover —
+  no recovery even when the journal is missing.
+* the retained tail itself covers [first buffered frame → cutoff]: the journal
+  only has to bridge (cursor → first buffered frame), a cursor already inside
+  the retained range needs no journal at all, and the replay/dedup cutoff stops
+  at the bridge so queued frames the journal never emitted are not skipped.
+"""
+import io
+import json
+import queue
+from urllib.parse import urlparse
+
+import api.routes as routes
+
+
+class _Handler:
+    def __init__(self):
+        self.wfile = io.BytesIO()
+
+    def send_response(self, _code):
+        pass
+
+    def send_header(self, _name, _value):
+        pass
+
+    def end_headers(self):
+        pass
+
+
+class _FakeStream:
+    def __init__(self, snapshot, items):
+        self.q = queue.Queue()
+        for item in items:
+            self.q.put_nowait(item)
+        self._snapshot = dict(snapshot)
+        self.unsubscribed = False
+
+    def subscribe_with_snapshot(self):
+        return self.q, dict(self._snapshot)
+
+    def unsubscribe(self, q):
+        self.unsubscribed = q is self.q
+
+
+def _run_handler(monkeypatch, stream, query):
+    handler = _Handler()
+    previous_streams = dict(routes.STREAMS)
+    routes.STREAMS.clear()
+    routes.STREAMS["run_1"] = stream
+    try:
+        routes._handle_sse_stream(handler, urlparse(f"/api/chat/stream?{query}"))
+    finally:
+        routes.STREAMS.clear()
+        routes.STREAMS.update(previous_streams)
+    return handler.wfile.getvalue().decode("utf-8")
+
+
+def _sse_payloads(body, event):
+    """Extract parsed data payloads for all SSE frames of the given event."""
+    payloads = []
+    lines = body.splitlines()
+    for i, line in enumerate(lines):
+        if line == f"event: {event}" and i + 1 < len(lines):
+            data = lines[i + 1]
+            assert data.startswith("data: ")
+            payloads.append(json.loads(data[len("data: "):]))
+    return payloads
+
+
+def _journal_events(lo, hi, run_id="run_1"):
+    return [
+        {
+            "event": "token",
+            "payload": {"text": f"journal-{seq}"},
+            "event_id": f"{run_id}:{seq}",
+            "seq": seq,
+        }
+        for seq in range(lo, hi + 1)
+    ]
+
+
+def test_dropped_frames_without_journal_emit_recovery_not_tail(monkeypatch):
+    """Missing journal + evicted frames → recovery_control apperror, no tail."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:9000",
+            "offline_buffered_events": 2,
+            "offline_dropped_events": 25,
+            "offline_first_event_id": "run_1:8999",
+        },
+        [
+            ("token", {"text": "tail-frame"}, "run_1:8999"),
+            ("stream_end", {}, "run_1:9000"),
+        ],
+    )
+    monkeypatch.setattr(routes, "find_run_summary", lambda _sid: None)
+    monkeypatch.setattr(routes, "stream_owner_session_id", lambda _sid: "session_1")
+
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=100")
+
+    payloads = _sse_payloads(body, "apperror")
+    assert len(payloads) == 1
+    assert payloads[0]["recovery_control"] is True
+    assert payloads[0]["type"] == "interrupted"
+    assert payloads[0]["session_id"] == "session_1"
+    assert payloads[0]["stream_id"] == "run_1"
+    assert payloads[0]["offline_dropped_events"] == 25
+    # The truncated tail must NOT be drained: no silent hole + stream_end.
+    assert "tail-frame" not in body
+    assert "event: stream_end" not in body
+    # Every exit path returns the queue to the channel.
+    assert stream.unsubscribed is True
+
+
+def test_dropped_frames_with_full_journal_coverage_stream_normally(monkeypatch):
+    """Journal covers (cursor → cutoff] → replay + tail drain, no recovery."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:105",
+            "offline_buffered_events": 2,
+            "offline_dropped_events": 25,
+            "offline_first_event_id": "run_1:106",
+        },
+        [
+            ("token", {"text": "tail-frame"}, "run_1:106"),
+            ("stream_end", {}, "run_1:107"),
+        ],
+    )
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda sid: {"session_id": "session_1", "run_id": sid, "terminal": False},
+    )
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        lambda _session_id, run_id, after_seq=None, max_seq=None: {
+            "events": _journal_events(101, 105, run_id=run_id)
+        },
+    )
+
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=100")
+
+    assert _sse_payloads(body, "apperror") == []
+    assert "journal-101" in body and "journal-105" in body
+    assert "tail-frame" in body
+    assert "event: stream_end" in body
+    assert stream.unsubscribed is True
+
+
+def test_incomplete_journal_coverage_emits_recovery(monkeypatch):
+    """A journal that stops short of the snapshot cutoff is NOT coverage."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:105",
+            "offline_buffered_events": 2,
+            "offline_dropped_events": 25,
+            "offline_first_event_id": "run_1:106",
+        },
+        [
+            ("token", {"text": "tail-frame"}, "run_1:106"),
+            ("stream_end", {}, "run_1:107"),
+        ],
+    )
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda sid: {"session_id": "session_1", "run_id": sid, "terminal": False},
+    )
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        # Journal lost its newest entries: stops at 103 < cutoff 105.
+        lambda _session_id, run_id, after_seq=None, max_seq=None: {
+            "events": _journal_events(101, 103, run_id=run_id)
+        },
+    )
+    monkeypatch.setattr(routes, "stream_owner_session_id", lambda _sid: "session_1")
+
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=100")
+
+    payloads = _sse_payloads(body, "apperror")
+    assert len(payloads) == 1
+    assert payloads[0]["recovery_control"] is True
+    assert "tail-frame" not in body
+    assert stream.unsubscribed is True
+
+
+def test_cursor_at_cutoff_has_no_gap_and_streams_tail(monkeypatch):
+    """A client already at/past the snapshot cutoff missed nothing the buffer
+    ever held — no recovery even when the journal is missing entirely."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:105",
+            "offline_buffered_events": 2,
+            "offline_dropped_events": 25,
+            "offline_first_event_id": "run_1:106",
+        },
+        [
+            ("token", {"text": "tail-frame"}, "run_1:106"),
+            ("stream_end", {}, "run_1:107"),
+        ],
+    )
+    monkeypatch.setattr(routes, "find_run_summary", lambda _sid: None)
+
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=105")
+
+    assert _sse_payloads(body, "apperror") == []
+    assert "tail-frame" in body
+    assert "event: stream_end" in body
+    assert stream.unsubscribed is True
+
+
+def test_coverage_helper_rejects_mid_window_holes(monkeypatch):
+    """Endpoint checks are not enough: a malformed/dropped line INSIDE the
+    window (journal seqs are contiguous by construction) must fail coverage."""
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda sid: {"session_id": "session_1", "run_id": sid, "terminal": False},
+    )
+    events = [e for e in _journal_events(101, 105) if e["seq"] != 103]
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        lambda _session_id, _run_id, after_seq=None, max_seq=None: {"events": events},
+    )
+    assert routes._run_journal_covers_offline_gap("run_1", 100, 105) is False
+
+
+def test_coverage_helper_requires_known_cutoff():
+    """Without a same-run journaled cutoff nothing can be proven → not covered."""
+    assert routes._run_journal_covers_offline_gap("run_1", 100, None) is False
+
+
+def test_cursor_inside_retained_tail_needs_no_journal(monkeypatch):
+    """A reconnect whose cursor already sits inside the retained buffer range
+    is contiguous from the queue alone — no journal required, no recovery,
+    even though frames were evicted before the retained head (they are all
+    ≤ the client's cursor)."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:9000",
+            "offline_buffered_events": 2,
+            "offline_dropped_events": 25,
+            "offline_first_event_id": "run_1:8999",
+        },
+        [
+            ("token", {"text": "tail-frame"}, "run_1:8999"),
+            ("stream_end", {}, "run_1:9000"),
+        ],
+    )
+    monkeypatch.setattr(routes, "find_run_summary", lambda _sid: None)
+
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=8998")
+
+    assert _sse_payloads(body, "apperror") == []
+    assert "tail-frame" in body
+    assert "event: stream_end" in body
+    assert stream.unsubscribed is True
+
+
+def test_replay_cutoff_stops_at_buffer_head_so_dedup_keeps_queued_frames(monkeypatch):
+    """The journal only bridges (cursor → first buffered frame); the dedup
+    cutoff must stop there too. With the cutoff at the snapshot's last_event_id
+    the drain loop's `seq <= replay_cutoff_seq` filter would silently skip the
+    queued frames the journal never emitted — a hole certified as covered."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:105",
+            "offline_buffered_events": 3,
+            "offline_dropped_events": 25,
+            "offline_first_event_id": "run_1:103",
+        },
+        [
+            ("token", {"text": "buffered-103"}, "run_1:103"),
+            ("token", {"text": "buffered-104"}, "run_1:104"),
+            ("token", {"text": "buffered-105"}, "run_1:105"),
+            ("stream_end", {}, "run_1:106"),
+        ],
+    )
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda sid: {"session_id": "session_1", "run_id": sid, "terminal": False},
+    )
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        # The journal only holds the bridge (100 → 102]; 103.. live in the buffer.
+        lambda _session_id, run_id, after_seq=None, max_seq=None: {
+            "events": _journal_events(101, 102, run_id=run_id)
+        },
+    )
+
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=100")
+
+    assert _sse_payloads(body, "apperror") == []
+    assert "journal-101" in body and "journal-102" in body
+    # The queued frames past the bridge must all survive the dedup filter.
+    assert "buffered-103" in body
+    assert "buffered-104" in body
+    assert "buffered-105" in body
+    assert "event: stream_end" in body
+    assert stream.unsubscribed is True
+
+
+def test_cursor_past_buffer_head_does_not_double_render_queued_frames(monkeypatch):
+    """A cursor AT/INSIDE the retained tail (after_seq >= first buffered frame)
+    must not receive the queued copy of frames it already rendered.
+
+    The journal-emission bound (buffer head) and the client-cursor bound are
+    two DIFFERENT dedup cutoffs: collapsing them onto the buffer head would
+    re-stream [head, cursor] from the queue — a visible double-render, since
+    the drain loop's `seq <=` filter is the only dedup for replayed streams
+    (the client does not de-duplicate token frames itself)."""
+    stream = _FakeStream(
+        {
+            "last_event_id": "run_1:105",
+            "offline_buffered_events": 3,
+            "offline_dropped_events": 0,
+            "offline_first_event_id": "run_1:103",
+        },
+        [
+            ("token", {"text": "buffered-103"}, "run_1:103"),
+            ("token", {"text": "buffered-104"}, "run_1:104"),
+            ("token", {"text": "buffered-105"}, "run_1:105"),
+            ("stream_end", {}, "run_1:106"),
+        ],
+    )
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda sid: {"session_id": "session_1", "run_id": sid, "terminal": False},
+    )
+    all_events = _journal_events(101, 105)
+
+    def _filtering_read(_session_id, _run_id, after_seq=None, max_seq=None):
+        # Mirror the real read_run_events window filters.
+        events = [
+            e
+            for e in all_events
+            if (after_seq is None or e["seq"] > after_seq)
+            and (max_seq is None or e["seq"] <= max_seq)
+        ]
+        return {"events": events}
+
+    monkeypatch.setattr(routes, "read_run_events", _filtering_read)
+
+    # Client already rendered up to 104 (e.g. tab flap after a partial drain).
+    body = _run_handler(monkeypatch, stream, "stream_id=run_1&replay=1&after_seq=104")
+
+    assert _sse_payloads(body, "apperror") == []
+    assert "buffered-103" not in body
+    assert "buffered-104" not in body
+    assert "buffered-105" in body
+    assert "event: stream_end" in body
+    assert stream.unsubscribed is True
+
+
+def test_bogus_cursor_is_clamped_so_terminal_frame_survives(monkeypatch):
+    """The client-cursor dedup bound is clamped at the snapshot cutoff.
+
+    A legitimate cursor can never exceed the channel's last known frame; an
+    out-of-range one (corrupt client state) must not raise the dedup cutoff
+    past the queued terminal frame — the drain loop's `seq <=` skip runs
+    BEFORE its terminal break, so a filtered stream_end would pin the loop on
+    heartbeats until the write deadline."""
+    from urllib.parse import parse_qs
+
+    monkeypatch.setattr(routes, "find_run_summary", lambda _sid: None)
+    handler = _Handler()
+    handled, cutoff = routes._sse_replay_run_journal_gap_checked(
+        handler,
+        parse_qs("stream_id=run_1&replay=1&after_seq=999"),
+        "run_1",
+        {
+            "last_event_id": "run_1:105",
+            "offline_buffered_events": 3,
+            "offline_dropped_events": 0,
+            "offline_first_event_id": "run_1:103",
+        },
+    )
+    assert handled is False
+    # Clamped to the cutoff (105): the queued stream_end (seq 106) passes the
+    # drain loop's dedup filter and terminates the connection.
+    assert cutoff == 105

--- a/tests/test_webui_runtime_diagnostics.py
+++ b/tests/test_webui_runtime_diagnostics.py
@@ -9,6 +9,7 @@ def test_stream_channel_exposes_buffer_and_subscriber_counts():
     assert channel.diagnostic_snapshot() == {
         "subscriber_count": 0,
         "offline_buffered_events": 1,
+        "offline_dropped_events": 0,
     }
 
     subscriber = channel.subscribe()


### PR DESCRIPTION
Ships **#5788** (@ai-ag2026) — cap StreamChannel offline replay buffer (#4633).

## What
When an SSE stream disconnected without being cancelled, the per-`StreamChannel` offline replay buffer grew for the whole turn (per-abandoned-turn memory risk). It's now a bounded `deque(maxlen)` drop-oldest. The reconnect tail is intact; dropped frames are recovered via the run-journal `last_event_id` replay path.

## Gate (deep-review round)
- Byte-identical to PR head `8492e3ecbc` (patch-id match).
- Codex advisor: **SAFE TO SHIP** — traced the disconnect→reconnect cycle end-to-end and verified dropped frames ARE journal-recovered: client requests journal replay on reconnect (`static/messages.js:5877`), server enforces journal gap coverage + emits `recovery_control` before draining the tail (`api/routes.py:16257`), client transcript-restores (`static/messages.js:5770`). The unused `offline_dropped_events` counter is benign observability, not data-loss.
- Tests: 20 own + 1106 regression (stream/offline/reconnect/journal) green.

Closes #5788.
