### PR TITLE
Release: Copy conversation link copies an openable URL (#5478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- **"Copy conversation link" now copies an openable URL instead of a `session://` reference.** The copy action produced the internal `session://` reference (not openable in a browser); it now copies an absolute `origin + /session/<id>` URL — the same shape used elsewhere in the app, with tracking query params stripped. Thanks @djsavvy. (#5478)
+
 - **The model picker now marks the active model with a "Selected" badge.** The currently-selected conversation model shows a distinct **Selected** pill (separate from the "Configured" state), and the picker opens with that model's provider group expanded and scrolled into view — so it's obvious at a glance which model is in use. Thanks @rodboev. (#5757, #5748)
 
 - **Transparent Stream no longer briefly renders a duplicate of the answer.** A live-token prose snapshot that was a strict prefix of the final answer escaped the existing dedupe guards (which only fired on near-complete matches) and rendered as a visible duplicate. A new provenance-gated guard suppresses only the ephemeral live-token accumulator row (role `prose` / kind `process_prose` / `token` source / `live-prose:*` id) when it's a strict shorter prefix of the settled answer and sits after the last tool row — so genuine intermediate narration is never suppressed. Thanks @rodboev. (#5758, #5749)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3976,7 +3976,7 @@ async function _copyTextToClipboard(text){
 async function _copySessionLink(session){
   const sid=session&&session.session_id;
   if(!sid) return;
-  const ref=_sessionInternalReferenceForSession(session);
+  const ref=(window.location.origin||'')+_sessionUrlForSid(sid);
   try{
     await _copyTextToClipboard(ref);
     showToast(t('session_link_copied'));


### PR DESCRIPTION
Ships **#5478** (@djsavvy) — Fix "Copy conversation link" to copy an openable URL, not a `session://` reference.

## What
The copy action produced the internal `session://` reference (not openable in a browser). It now copies an absolute `origin + /session/<id>` URL, matching the shape used elsewhere (messages.js), with tracking query params stripped.

## Gate
- +1/-1 in `static/sessions.js`. Verified: `_sessionUrlForSid` returns a **relative** path (`base.pathname+base.search+base.hash`), so the caller's `window.location.origin + …` prepends the origin exactly once — no double-origin. `sid` is in scope (from `session.session_id`).
- 17 copy-link/session-url regression tests green; `node -c` clean.
- Product/UX parity with major chat apps (Anchor C). Maintainer-approved.

Closes #5478.
