### PR TITLE
Release: classify external_agent imports as CLI (#5846, #5831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- **Imported external-agent sessions (Claude Code, Codex) no longer show a non-zero "WebUI sessions" count with an empty list.** The server session-count classifier treated a read-only external-agent import (which carries a real title) as non-CLI — counting it under `webui_session_count` — while the client renderer filed the same row in the CLI bucket. The result was a confusing "WebUI sessions (N)" chip over an empty list, with those sessions only reachable under the CLI tab. The server now classifies `external_agent`/`external-agent` sources as CLI, matching the client, so the tab counts agree with where rows render. WebUI, messaging, and delegated-subagent sessions are unaffected. Thanks @nesquena-hermes. (#5846, #5831)
+
 - **Long tool outputs can no longer blow up the model context after a compression event.** After the conversation is compressed, the protected-tail tool-result payloads sent to the model are now hard-capped to a token budget (applied once, only after a confirmed compression). The cap operates on the model context only (a deep copy of `context_messages`) — it never removes or reorders messages (so no tool_call/tool_result pairing is broken) and never touches the visible/persisted transcript, which keeps the full tool output. Thanks @franksong2702. (#5667, #4685)
 
 - **"Copy conversation link" now copies an openable URL instead of a `session://` reference.** The copy action produced the internal `session://` reference (not openable in a browser); it now copies an absolute `origin + /session/<id>` URL — the same shape used elsewhere in the app, with tracking query params stripped. Thanks @djsavvy. (#5478)

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -219,6 +219,17 @@ def is_cli_session_row(row: dict) -> bool:
         return False
     if source == "cli":
         return True
+    # External-agent imports (Claude Code, Codex, etc.) are read-only sessions
+    # that Hermes discovers on disk and lists alongside CLI/TUI sessions. The
+    # client renderer (static/sessions.js: _isCliSession) files them in the CLI
+    # bucket via the is_cli_session fallthrough, so the server session-count
+    # classifier MUST agree — otherwise the server counts them under
+    # webui_session_count while the client renders them under CLI, and the WebUI
+    # filter shows a non-zero count with an empty list (#5831). These carry a
+    # real title, so they'd otherwise fall through to the conservative
+    # default-title gate below and be misclassified as non-CLI.
+    if source in {"external_agent", "external-agent"}:
+        return True
     if (
         source_tag in {"cli", "tui"}
         or raw_source in {"cli", "tui"}

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -257,3 +257,51 @@ def test_tui_continuation_projection_uses_latest_tip_title():
     assert projected[0]["title"] == "Podcast work #17"
     assert projected[0]["_lineage_root_id"] == "tui_parent"
     assert projected[0]["_lineage_tip_id"] == "tui_tip"
+
+
+def test_external_agent_rows_classify_as_cli_matching_client_render():
+    """Regression for #5831: external_agent (Claude Code) imports must count as CLI.
+
+    The client renderer (static/sessions.js: _isCliSession) files an
+    external_agent/claude_code row into the CLI bucket via the is_cli_session
+    fallthrough. The server session-count classifier used to return False for
+    such a row (it carries a real title, so it fell through to the conservative
+    default-title gate), counting it under webui_session_count while the client
+    rendered it under CLI. Result: the WebUI filter showed a non-zero count with
+    an empty list. Server and client must agree — external_agent is CLI.
+    """
+    from api.agent_sessions import is_cli_session_row
+
+    claude_code_row = {
+        "session_id": "claude_code_e62d0c1a6e8d55839e298973",
+        "title": "Overview of AI Capabilities",
+        "source_tag": "claude_code",
+        "raw_source": "claude_code",
+        "session_source": "external_agent",
+        "source_label": "Claude Code",
+        "is_cli_session": True,
+        "read_only": True,
+        "message_count": 225,
+    }
+    # The bug: a real-titled external_agent row was classified non-CLI.
+    assert is_cli_session_row(claude_code_row) is True
+    # Hyphenated variant is treated identically.
+    assert is_cli_session_row({**claude_code_row, "session_source": "external-agent"}) is True
+
+
+def test_external_agent_classification_does_not_overreach():
+    """The external_agent → CLI branch must not reclassify unrelated sources."""
+    from api.agent_sessions import is_cli_session_row
+
+    # Genuine WebUI session stays non-CLI (webui bucket).
+    assert is_cli_session_row(
+        {"session_source": "webui", "is_cli_session": False, "title": "My chat"}
+    ) is False
+    # Messaging session stays non-CLI.
+    assert is_cli_session_row(
+        {"session_source": "messaging", "source_tag": "telegram", "is_cli_session": True, "title": "tg"}
+    ) is False
+    # Delegated subagent (#5307) stays non-CLI / view-only.
+    assert is_cli_session_row(
+        {"session_source": "subagent", "is_cli_session": True, "title": "delegated child"}
+    ) is False


### PR DESCRIPTION
Ships **#5846** (@nesquena-hermes, self-built) — classify external_agent imports as CLI to match client render. Fixes the **#5831** brick.

## What
Imported external-agent sessions (Claude Code / Codex) showed **"WebUI sessions (N)" with an empty list**: the server session-count classifier counted them under `webui_session_count` (they carry a real title → fell through to the non-CLI default gate) while the client `_isCliSession` filed them in the CLI bucket. The server now classifies `external_agent`/`external-agent` as CLI, so counts agree with where rows render.

## Gate
- **Independent review:** @nesquena **APPROVED** on this exact head (`7693c9bf`, end-to-end review).
- **Codex: SAFE TO SHIP** — no over-capture: only the production mint site sets `external_agent` (`api/models.py:5449`); WebUI/messaging/cron/subagent exclusions precede the new branch; client already files these in the CLI bucket (`static/sessions.js:2156`); all `is_cli_session_row` callers audited, read-only mutation guards intact.
- Tests: 14 own + 180 session-classification regression green.

Closes #5846, closes #5831.
