### PR TITLE
fix(updates): Experimental channel shows installed version, not "unknown"/bare SHA, on a stable-tagged install

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -716,8 +716,17 @@ def channel_version_badge(channel=None) -> str:
     if channel is None:
         channel = _read_update_channel()
     channel = _normalize_channel(channel)
+    # NOTE: no ``--always`` here (deliberately different from _detect_webui_version).
+    # The current version is channel-INDEPENDENT — it's just what's installed. The
+    # channel only picks which tag family we compare AGAINST for updates. On a
+    # stable-tagged install (e.g. HEAD == v0.52.0) that opts into Experimental, no
+    # ``exp-v*`` tag is reachable BEHIND HEAD (the exp tags sit ahead on master), so
+    # ``--always`` would fall through to a bare SHA and render "WebUI: d4e80b45 ·
+    # Experimental" instead of the real installed version. Falling back to the
+    # channel-neutral WEBUI_VERSION keeps the badge showing "v0.52.0 · Experimental".
+    # (#5862)
     out, ok = _run_git(
-        ['describe', '--tags', '--always', '--match', _channel_tag_glob(channel)],
+        ['describe', '--tags', '--match', _channel_tag_glob(channel)],
         REPO_ROOT,
     )
     if ok and out:
@@ -756,6 +765,26 @@ def _release_gap(tags, current, latest):
     if current in tags:
         return tags.index(current)
     return 1
+
+
+def _count_channel_tags_ahead(path, channel=DEFAULT_UPDATE_CHANNEL):
+    """Count channel release tags strictly ahead of HEAD (fast-forwardable).
+
+    Used only when NO channel tag is reachable behind HEAD — the channel-scoped
+    ``describe`` returned None — e.g. a stable ``v0.52.0`` install opting into
+    Experimental (all ``exp-v*`` tags sit ahead on master). ``_release_gap`` can't
+    position HEAD in the tag list then and returns a bogus 1. ``git tag --contains
+    HEAD`` lists tags whose history includes HEAD, i.e. tags that are ahead of (or
+    on) HEAD; since HEAD carries no channel tag in this path, that count is exactly
+    the number of channel releases the install can fast-forward to. (#5862)
+    """
+    out, ok = _run_git(
+        ['tag', '--list', _channel_tag_glob(channel), '--contains', 'HEAD'],
+        path,
+    )
+    if not (ok and out):
+        return 0
+    return sum(1 for line in out.splitlines() if line.strip())
 
 
 def _head_is_past_latest_tag(path, current_tag, channel=DEFAULT_UPDATE_CHANNEL):
@@ -901,6 +930,22 @@ def _check_repo_release(path, name, channel=DEFAULT_UPDATE_CHANNEL):
     current_tag = _current_release_tag(path, channel)
     behind = _release_gap(tags, current_tag, latest_tag)
 
+    # When NO channel tag is reachable behind HEAD, _current_release_tag returns
+    # None (channel-scoped `describe --abbrev=0` fatals with "No tags can describe").
+    # This is the normal state of a stable-tagged install (HEAD == v0.52.0) opting
+    # into Experimental: every exp-v* tag sits AHEAD on master. _release_gap can't
+    # position None in the tag list and returns a bogus 1, and the display fields
+    # would carry current_version=None (rendered as "unknown"). Recover the real
+    # ahead-count and show the channel-neutral installed version as the current
+    # version — the channel only chooses the comparison tag family, not what's
+    # installed. (#5862)
+    current_version_display = current_tag
+    if current_tag is None:
+        ahead = _count_channel_tags_ahead(path, channel)
+        if ahead > 0:
+            behind = ahead
+        current_version_display = WEBUI_VERSION
+
     # If behind == 0 but HEAD has moved past the tag (e.g. the agent repo
     # keeps committing to master between tagged releases), the release check
     # would report "Up to date" even though hundreds of commits are missing.
@@ -944,13 +989,16 @@ def _check_repo_release(path, name, channel=DEFAULT_UPDATE_CHANNEL):
         'name': name,
         'behind': behind,
         # GitHub compare URLs accept tag names, and tag-to-tag links are the
-        # clearest "what changed in this release?" view for operators.
-        'current_sha': current_tag,
+        # clearest "what changed in this release?" view for operators. When no
+        # channel tag is reachable behind HEAD (#5862), current_version_display is
+        # the channel-neutral installed tag (e.g. v0.52.0) — a real tag name, so
+        # the /compare/<installed>...<latest> URL still resolves.
+        'current_sha': current_version_display,
         'latest_sha': latest_tag,
         'branch': latest_tag,
         'repo_url': remote_url,
         'release_based': True,
-        'current_version': current_tag,
+        'current_version': current_version_display,
         'latest_version': latest_tag,
         'channel': channel,
     }

--- a/tests/test_update_channels.py
+++ b/tests/test_update_channels.py
@@ -285,3 +285,87 @@ def test_clear_lock_retry_preserves_experimental_channel(tmp_path, monkeypatch):
     )
     assert result['ok'] is True
     assert result['lock_recovery']['action'] == 'no-lock-found'
+
+
+# ── Stable-tagged install opting into Experimental (#5862) ───────────────────
+#
+# b3nw's report: a plain stable install pinned on v0.52.0 that flips to the
+# Experimental channel. Unlike `channel_repo` (which tags stable and exp on the
+# SAME commits), here the stable tag PREDATES every exp-v* tag — so from HEAD ==
+# v0.52.0 there is NO exp-v* tag reachable behind HEAD. Both channel-scoped git
+# lookups then degrade: the chip `describe --always` leaks a bare SHA, and the
+# banner `describe --abbrev=0` fatals -> current_version=None -> "unknown".
+
+@pytest.fixture
+def stable_pinned_repo(tmp_path):
+    """v0.52.0 tagged first (stable only), then 3 exp-v* batches AHEAD on master.
+
+    HEAD is checked out ON v0.52.0, so no exp-v* tag is reachable behind HEAD.
+    """
+    repo = tmp_path / 'stable_pinned'
+    repo.mkdir()
+    _git(repo, 'init', '-q')
+    _git(repo, 'config', 'user.email', 't@t.co')
+    _git(repo, 'config', 'user.name', 'Test')
+    _git(repo, 'remote', 'add', 'origin', 'https://github.com/nesquena/hermes-webui.git')
+    _git(repo, 'commit', '-q', '--allow-empty', '-m', 'v0.52.0 release')
+    _git(repo, 'tag', 'v0.52.0')  # stable tag, NO exp tag on this commit
+    for i in range(1, 4):
+        _git(repo, 'commit', '-q', '--allow-empty', '-m', f'exp batch {i}')
+        _git(repo, 'tag', f'exp-v0.52.{i}')
+    _git(repo, 'checkout', '-q', 'v0.52.0')  # pin HEAD on the stable release
+    return repo
+
+
+def test_stable_pinned_current_release_tag_is_none_on_experimental(stable_pinned_repo):
+    """Precondition: the channel-scoped current-tag lookup genuinely returns None
+    (no exp-v* reachable behind a v0.52.0 HEAD). This is the trigger for #5862."""
+    assert updates._current_release_tag(stable_pinned_repo, 'experimental') is None
+    # Stable still resolves the real tag.
+    assert updates._current_release_tag(stable_pinned_repo, 'stable') == 'v0.52.0'
+
+
+def test_stable_pinned_experimental_reports_installed_version_not_unknown(stable_pinned_repo, monkeypatch):
+    """#5862: current_version must be the neutral installed tag (v0.52.0), NOT
+    None (which the UI renders as 'unknown'), and the count must be the real
+    number of exp releases ahead (3), NOT the bogus _release_gap fallback of 1."""
+    monkeypatch.setattr(updates, 'WEBUI_VERSION', 'v0.52.0')
+    info = updates._check_repo_release(stable_pinned_repo, 'webui', 'experimental')
+    assert info is not None
+    assert info['current_version'] == 'v0.52.0', 'must not be None/"unknown"'
+    assert info['current_sha'] == 'v0.52.0'
+    assert info['latest_version'] == 'exp-v0.52.3'
+    assert info['behind'] == 3, 'all 3 exp releases are ahead, not a bogus 1'
+
+
+def test_stable_pinned_stable_channel_still_up_to_date(stable_pinned_repo, monkeypatch):
+    """Sanity: the SAME install on the stable channel is up-to-date on v0.52.0
+    (the exp-v* tags ahead must not be offered as stable updates)."""
+    monkeypatch.setattr(updates, 'WEBUI_VERSION', 'v0.52.0')
+    info = updates._check_repo_release(stable_pinned_repo, 'webui', 'stable')
+    assert info is not None
+    assert info['behind'] == 0
+    assert info['current_version'] == 'v0.52.0'
+
+
+def test_channel_version_badge_no_bare_sha_on_experimental(stable_pinned_repo, monkeypatch):
+    """#5862 chip: channel_version_badge must fall back to the neutral installed
+    version, never a bare git SHA, when no channel tag is reachable."""
+    monkeypatch.setattr(updates, 'REPO_ROOT', stable_pinned_repo)
+    monkeypatch.setattr(updates, 'WEBUI_VERSION', 'v0.52.0')
+    badge = updates.channel_version_badge('experimental')
+    assert badge == 'v0.52.0', f'expected installed version, got bare SHA-ish {badge!r}'
+    # Stable channel resolves its own reachable tag directly.
+    assert updates.channel_version_badge('stable') == 'v0.52.0'
+
+
+def test_count_channel_tags_ahead(stable_pinned_repo):
+    """The ahead-count helper: 3 exp-v* tags sit ahead of a v0.52.0 HEAD.
+
+    This helper is only ever CALLED when no channel tag is reachable on/behind
+    HEAD (current_tag is None) — exactly the experimental case here, where no
+    exp-v* tag sits on the v0.52.0 commit, so `--contains HEAD` counts precisely
+    the 3 tags strictly ahead.
+    """
+    _git(stable_pinned_repo, 'checkout', '-q', 'v0.52.0')
+    assert updates._count_channel_tags_ahead(stable_pinned_repo, 'experimental') == 3


### PR DESCRIPTION
Fixes #5862.

## Problem

A plain **stable** install pinned on a `v*` tag (e.g. `v0.52.0`) that opts into the **Experimental** channel shows:

- System chip: `WebUI: d4e80b45 · Experimental` — a **bare git SHA** instead of the installed version.
- Update banner: `WebUI (unknown -> exp-v0.52.18): 1 release available` — current version renders as **`unknown`**, count is wrong.

On the stable channel the same install correctly shows `WebUI: v0.52.0 · Up to date ✓`.

Reported by @b3nw in Discord.

## Root cause

From a stable-tagged HEAD there is **no `exp-v*` tag reachable behind HEAD** — the exp tags sit *ahead* on master (the commit is an ancestor of `exp-v0.52.18`, so a fast-forward update is genuinely available). Both channel-scoped git lookups look *backward* and find nothing:

1. `channel_version_badge('experimental')` ran `git describe --tags --always --match 'exp-v*'` → `--always` falls through to a bare SHA. The `WEBUI_VERSION` fallback never fired because `ok and out` was truthy.
2. `_current_release_tag(path,'experimental')` ran `git describe --tags --abbrev=0 --match 'exp-v*'` → `fatal: No tags can describe` → `None` → `current_version: None` → UI renders `unknown` (`static/ui.js:8993`).
3. `_release_gap(tags, None, latest)` returned `1` (None isn't in the tag list) → "1 release" when the install is really 18 exp releases behind.

Verified against the live repo:
```
$ git describe --tags --always --match 'exp-v*' v0.52.0
d4e80b454                                       # chip bare SHA
$ git describe --tags --abbrev=0 --match 'exp-v*' v0.52.0
fatal: No tags can describe 'd4e80b45...'.      # banner "unknown"
$ git merge-base --is-ancestor v0.52.0 exp-v0.52.18 && echo "can ff"
can ff                                          # the update IS available
```

## Fix

The current version is **channel-independent** — it's just what's installed; the channel only picks which tag family we compare against.

- `channel_version_badge()`: drop `--always`; fall back to the channel-neutral `WEBUI_VERSION` so the chip shows `v0.52.0 · Experimental`, never a bare SHA.
- `_check_repo_release()`: when the channel-scoped `current_tag` is `None`, use `WEBUI_VERSION` for the display fields (`current_version`/`current_sha`) and count the real number of channel tags ahead of HEAD (new `_count_channel_tags_ahead` helper, `git tag --contains HEAD`) for `behind`.

Display-only — the update/apply fast-forward target was already correct.

## Tests

New `stable_pinned_repo` fixture (real git: stable tag first, exp tags ahead, HEAD pinned on the stable tag) reproducing b3nw's exact state, plus 5 assertions:

- `_current_release_tag(..., 'experimental')` is genuinely `None` (the trigger)
- banner reports `current_version == 'v0.52.0'` (not `None`/"unknown") and `behind == 3` (not a bogus 1)
- stable channel on the same install is still up-to-date on `v0.52.0`
- chip badge falls back to the installed version, never a bare SHA
- `_count_channel_tags_ahead` counts correctly

All 59 tests across `test_update_channels`, `test_version_badge`, and the two git-version-detection suites pass.

_Reported by @b3nw._