### PR TITLE
Archive delegated subagent sessions with parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ If an AI assistant is helping with install, reinstall, bootstrap, provider setup
 - Create, rename, duplicate, delete, search by title and message content
 - Session actions via `⋯` dropdown per session — pin, move to project, archive, duplicate, delete
 - Pin/star sessions to the top of the sidebar (gold indicator)
-- Archive sessions (hide without deleting, toggle to show)
+- Archive sessions (hide without deleting, toggle to show); archiving a parent conversation also archives its direct delegated subagent sessions, and restoring it restores that group
 - Session projects -- named groups with colors for organizing sessions
 - Session tags -- add #tag to titles for colored chips and click-to-filter
 - Grouped by Today / Yesterday / Earlier in the sidebar (collapsible date groups)

--- a/api/routes.py
+++ b/api/routes.py
@@ -15568,6 +15568,10 @@ def handle_post(handler, parsed) -> bool:
                     model=cli_meta.get("model") or "unknown",
                     created_at=cli_meta.get("created_at"),
                     updated_at=cli_meta.get("updated_at"),
+                    # Messaging sessions are state.db-backed. Carry their
+                    # recorded owner into the sidecar so archive group sync
+                    # cannot confuse a named profile with root/default.
+                    profile=cli_meta.get("profile") or get_active_profile_name() or "default",
                 )
                 s.is_cli_session = is_cli_session_row(cli_meta)
                 s.source_tag = cli_meta.get("source_tag")
@@ -15606,14 +15610,45 @@ def handle_post(handler, parsed) -> bool:
                 s.session_key = cli_meta.get("session_key")
                 s.platform = cli_meta.get("platform")
         with _get_session_agent_lock(sid):
-            s.archived = bool(body.get("archived", True))
+            archived = bool(body.get("archived", True))
+            # A profile-less sidecar is canonically a legacy root/default
+            # session (see api.profiles._profiles_match). Persist that explicit
+            # owner before state-db work; request/ambient profile is not evidence
+            # of ownership and must not select the synchronization target.
+            session_profile = getattr(s, "profile", None) or "default"
+            s.profile = session_profile
+            s.archived = archived
             s.save(touch_updated_at=False)
+            try:
+                from api.state_sync import sync_session_archive_group
+
+                # Delegated children remain read-only in WebUI. A parent archive
+                # is the sole group operation: this transaction mirrors the
+                # parent's reversible archive flag to direct state.db children
+                # whose source is exactly ``subagent``.
+                subagent_archive_synced, subagent_child_ids = sync_session_archive_group(
+                    getattr(s, "session_id", sid),
+                    archived,
+                    profile=session_profile,
+                )
+            except Exception:
+                subagent_archive_synced, subagent_child_ids = False, []
+                logger.debug("Failed to sync session archive group to state.db", exc_info=True)
         publish_session_list_changed(
             "session_archive",
             profile=getattr(s, "profile", None),
             session_id=getattr(s, "session_id", sid),
         )
-        return j(handler, {"ok": True, "session": s.compact(), **_worktree_retained_payload(s)})
+        return j(
+            handler,
+            {
+                "ok": True,
+                "session": s.compact(),
+                "subagent_archive_synced": subagent_archive_synced,
+                "subagent_child_count": len(subagent_child_ids),
+                **_worktree_retained_payload(s),
+            },
+        )
 
     # ── Session move to project (POST) ──
     if parsed.path == "/api/session/move":

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -195,3 +195,65 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
             db.close()
         except Exception:
             logger.debug("Failed to close state.db")
+
+
+def sync_session_archive_group(
+    parent_session_id: str,
+    archived: bool,
+    profile: Optional[str] = None,
+) -> tuple[bool, list[str]]:
+    """Synchronize a parent's archive state with direct delegated children.
+
+    A delegated child remains view-only in WebUI: callers may not mutate a child
+    session by its own ID. The parent archive operation is the one exception,
+    scoped narrowly to state.db rows whose exact ``parent_session_id`` matches
+    and whose Agent-owned source is exactly ``subagent``. The parent row and its
+    eligible children are written through one ``SessionDB._execute_write`` call,
+    so competing archive/restore requests cannot leave the group split inside
+    state.db.
+
+    Returns ``(synced, child_ids)``. ``synced=False`` distinguishes an unavailable
+    or failed parent state-db write from a successful group write with no children.
+    The caller still owns the WebUI JSON sidecar mutation and must surface that
+    distinction to the client.
+    """
+    if not parent_session_id:
+        return False, []
+    db = _get_state_db(profile=profile)
+    if not db:
+        return False, []
+    try:
+        def _set_group_archive_state(conn):
+            parent = conn.execute(
+                "UPDATE sessions SET archived = ? WHERE id = ?",
+                (int(bool(archived)), parent_session_id),
+            )
+            if parent.rowcount != 1:
+                raise LookupError(f"state.db parent session not found: {parent_session_id}")
+            rows = conn.execute(
+                """
+                SELECT id
+                FROM sessions
+                WHERE parent_session_id = ?
+                  AND source = 'subagent'
+                ORDER BY id
+                """,
+                (parent_session_id,),
+            ).fetchall()
+            child_ids = [str(row[0]) for row in rows if row and row[0]]
+            if child_ids:
+                conn.executemany(
+                    "UPDATE sessions SET archived = ? WHERE id = ?",
+                    [(int(bool(archived)), child_id) for child_id in child_ids],
+                )
+            return child_ids
+
+        return True, list(db._execute_write(_set_group_archive_state) or [])
+    except Exception:
+        logger.debug("Failed to sync parent/subagent archive group to state.db", exc_info=True)
+        return False, []
+    finally:
+        try:
+            db.close()
+        except Exception:
+            logger.debug("Failed to close state.db")

--- a/tests/test_issue2057_worktree_ui_static.py
+++ b/tests/test_issue2057_worktree_ui_static.py
@@ -67,7 +67,13 @@ def test_worktree_archive_delete_api_responses_are_explicit():
     assert "def _worktree_retained_payload_for_session_id(sid: str)" in src
     assert '"worktree_retained": True' in src
     assert '{"ok": True, **worktree_retained}' in src
-    assert '{"ok": True, "session": s.compact(), **_worktree_retained_payload(s)}' in src
+    archive_start = src.index('if parsed.path == "/api/session/archive":')
+    archive_end = src.index('if parsed.path == "/api/session/move":', archive_start)
+    archive_handler = src[archive_start:archive_end]
+    assert '"session": s.compact()' in archive_handler
+    assert '"subagent_archive_synced": subagent_archive_synced' in archive_handler
+    assert '"subagent_child_count": len(subagent_child_ids)' in archive_handler
+    assert "**_worktree_retained_payload(s)" in archive_handler
 
 
 def test_remove_worktree_ui_does_not_force_unsafe_status_by_default():

--- a/tests/test_session_archive_subagents.py
+++ b/tests/test_session_archive_subagents.py
@@ -1,0 +1,332 @@
+"""Regression coverage for parent-initiated subagent session archiving.
+
+Delegated children remain view-only. The only permitted mutation is a parent
+conversation's archive/restore operation, scoped to its direct
+``source='subagent'`` state.db children.
+"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = ROOT / "api" / "routes.py"
+README = ROOT / "README.md"
+
+
+def _state_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            parent_session_id TEXT,
+            source TEXT,
+            archived INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO sessions (id, parent_session_id, source, archived) VALUES (?, ?, ?, ?)",
+        [
+            ("parent", None, "webui", 0),
+            ("child-one", "parent", "subagent", 0),
+            ("child-two", "parent", "subagent", 0),
+            ("case-variant", "parent", "SubAgent", 0),
+            ("non-subagent", "parent", "cli", 0),
+            ("grandchild", "child-one", "subagent", 0),
+            ("other-child", "other-parent", "subagent", 0),
+        ],
+    )
+    conn.commit()
+    return conn
+
+
+class _FakeSessionDb:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+        self.closed = False
+
+    def _execute_write(self, callback):
+        result = callback(self.conn)
+        self.conn.commit()
+        return result
+
+    def close(self):
+        self.closed = True
+
+
+def _archived_rows(conn: sqlite3.Connection) -> dict[str, int]:
+    return dict(conn.execute("SELECT id, archived FROM sessions"))
+
+
+def test_parent_archive_updates_only_direct_exact_subagent_children(monkeypatch):
+    """The parent-only capability must not make children individually writable."""
+    from api import state_sync
+
+    conn = _state_db()
+    db = _FakeSessionDb(conn)
+    monkeypatch.setattr(state_sync, "_get_state_db", lambda profile=None: db)
+
+    synced, child_ids = state_sync.sync_session_archive_group(
+        "parent", True, profile="default"
+    )
+
+    assert synced is True
+    assert child_ids == ["child-one", "child-two"]
+    assert _archived_rows(conn) == {
+        "parent": 1,
+        "child-one": 1,
+        "child-two": 1,
+        "case-variant": 0,
+        "non-subagent": 0,
+        "grandchild": 0,
+        "other-child": 0,
+    }
+    assert db.closed is True
+
+
+def test_parent_restore_reverses_the_same_direct_subagent_group(monkeypatch):
+    from api import state_sync
+
+    conn = _state_db()
+    db = _FakeSessionDb(conn)
+    monkeypatch.setattr(state_sync, "_get_state_db", lambda profile=None: db)
+
+    state_sync.sync_session_archive_group("parent", True, profile="default")
+    synced, child_ids = state_sync.sync_session_archive_group(
+        "parent", False, profile="default"
+    )
+
+    assert synced is True
+    assert child_ids == ["child-one", "child-two"]
+    assert _archived_rows(conn) == {
+        "parent": 0,
+        "child-one": 0,
+        "child-two": 0,
+        "case-variant": 0,
+        "non-subagent": 0,
+        "grandchild": 0,
+        "other-child": 0,
+    }
+
+
+def test_parent_with_no_subagents_reports_successful_zero_child_group(monkeypatch):
+    from api import state_sync
+
+    conn = _state_db()
+    conn.execute("DELETE FROM sessions WHERE parent_session_id = 'parent'")
+    conn.commit()
+    db = _FakeSessionDb(conn)
+    monkeypatch.setattr(state_sync, "_get_state_db", lambda profile=None: db)
+
+    assert state_sync.sync_session_archive_group("parent", True, profile="default") == (
+        True,
+        [],
+    )
+    assert _archived_rows(conn)["parent"] == 1
+    assert db.closed is True
+
+
+def test_missing_parent_fails_before_any_child_mutation(monkeypatch):
+    """A failed parent write must not archive children on its own."""
+    from api import state_sync
+
+    conn = _state_db()
+    conn.execute("DELETE FROM sessions WHERE id = 'parent'")
+    conn.commit()
+    db = _FakeSessionDb(conn)
+    monkeypatch.setattr(state_sync, "_get_state_db", lambda profile=None: db)
+
+    assert state_sync.sync_session_archive_group("parent", True, profile="default") == (
+        False,
+        [],
+    )
+    assert _archived_rows(conn)["child-one"] == 0
+    assert _archived_rows(conn)["child-two"] == 0
+    assert db.closed is True
+
+
+def test_archive_route_assigns_default_to_legacy_profile_before_state_sync(monkeypatch):
+    """A profile-less legacy sidecar canonically belongs to root/default."""
+    from api import routes, state_sync
+    from api.models import Session
+
+    sid = "archive-profile-fallback"
+    session = Session(
+        session_id=sid,
+        workspace=".",
+        messages=[{"role": "user", "content": "preserve me"}],
+        profile=None,
+    )
+    saved_profiles = []
+    sync_call = {}
+    response = {}
+
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *args, **kwargs: True)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda value: False)
+    monkeypatch.setattr(routes, "get_session", lambda value, **kwargs: session)
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "maiko")
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda value: nullcontext())
+    monkeypatch.setattr(
+        session,
+        "save",
+        lambda touch_updated_at=False: saved_profiles.append(session.profile),
+    )
+    monkeypatch.setattr(
+        state_sync,
+        "sync_session_archive_group",
+        lambda parent_session_id, archived, profile: (
+            sync_call.update(
+                parent_session_id=parent_session_id,
+                archived=archived,
+                profile=profile,
+            )
+            or (True, [])
+        ),
+    )
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda handler: {"session_id": sid, "archived": True},
+    )
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "_worktree_retained_payload", lambda value: {})
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda handler, payload, status=200, extra_headers=None: (
+            response.update(payload=payload, status=status) or True
+        ),
+    )
+
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+    assert session.profile == "default"
+    assert saved_profiles == ["default"]
+    assert sync_call == {
+        "parent_session_id": sid,
+        "archived": True,
+        "profile": "default",
+    }
+    assert response["status"] == 200
+    assert response["payload"]["subagent_archive_synced"] is True
+
+
+def test_archive_messaging_parent_uses_metadata_profile_for_group_sync(monkeypatch):
+    """Messaging fallback must not redirect a named-profile group to default."""
+    from api import routes, state_sync
+
+    parent_id = "messaging-parent"
+    child_id = "messaging-child"
+
+    def profile_group_db():
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                parent_session_id TEXT,
+                source TEXT,
+                archived INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO sessions (id, parent_session_id, source, archived) VALUES (?, ?, ?, ?)",
+            [
+                (parent_id, None, "telegram", 0),
+                (child_id, parent_id, "subagent", 0),
+            ],
+        )
+        conn.commit()
+        return conn
+
+    named_conn = profile_group_db()
+    default_conn = profile_group_db()
+    dbs = {
+        "maiko": _FakeSessionDb(named_conn),
+        "default": _FakeSessionDb(default_conn),
+    }
+    opened_profiles = []
+    created_profiles = []
+    cli_meta = {
+        "profile": "maiko",
+        "title": "Messaging parent",
+        "source": "telegram",
+    }
+
+    class MaterializedMessagingSession:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.profile = kwargs.get("profile")
+            self.archived = False
+            created_profiles.append(self.profile)
+
+        def save(self, touch_updated_at=False):
+            pass
+
+        def compact(self):
+            return {"session_id": self.session_id, "archived": self.archived}
+
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *args, **kwargs: True)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda value: False)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda value, **kwargs: (_ for _ in ()).throw(KeyError(value)),
+    )
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda value: cli_meta)
+    monkeypatch.setattr(routes, "_is_messaging_session_record", lambda value: True)
+    monkeypatch.setattr(routes, "Session", MaterializedMessagingSession)
+    monkeypatch.setattr(routes, "get_active_profile_name", lambda: "wrong-active-profile")
+    monkeypatch.setattr(routes, "get_last_workspace", lambda: ".")
+    monkeypatch.setattr(routes, "is_cli_session_row", lambda value: True)
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda value: nullcontext())
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda handler: {"session_id": parent_id, "archived": True},
+    )
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "_worktree_retained_payload", lambda value: {})
+    monkeypatch.setattr(routes, "j", lambda handler, payload, **kwargs: True)
+    monkeypatch.setattr(
+        state_sync,
+        "_get_state_db",
+        lambda profile=None: (opened_profiles.append(profile) or dbs[profile]),
+    )
+
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+    assert created_profiles == ["maiko"]
+    assert opened_profiles == ["maiko"]
+    assert _archived_rows(named_conn) == {parent_id: 1, child_id: 1}
+    assert _archived_rows(default_conn) == {parent_id: 0, child_id: 0}
+
+    cli_meta["profile"] = "default"
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/archive")) is True
+    assert created_profiles == ["maiko", "default"]
+    assert opened_profiles == ["maiko", "default"]
+    assert _archived_rows(named_conn) == {parent_id: 1, child_id: 1}
+    assert _archived_rows(default_conn) == {parent_id: 1, child_id: 1}
+
+
+def test_archive_route_preserves_readonly_child_boundary_and_reports_group_state():
+    """The public archive flow must use the parent-only group operation."""
+    route = ROUTES_PY.read_text(encoding="utf-8")
+    route_start = route.index('if parsed.path == "/api/session/archive":')
+    route_end = route.index('if parsed.path == "/api/session/move":', route_start)
+    archive_route = route[route_start:route_end]
+
+    assert "_session_is_subagent_view_only(sid)" in archive_route
+    assert "sync_session_archive_group(" in archive_route
+    assert '"subagent_archive_synced"' in archive_route
+    assert '"subagent_child_count"' in archive_route
+    assert archive_route.index("_session_is_subagent_view_only(sid)") < archive_route.index(
+        "sync_session_archive_group("
+    )
+    assert "direct delegated subagent sessions" in README.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Archive or restore a parent WebUI conversation together with its direct delegated `source='subagent'` state.db children.
- Preserve child view-only protections: direct child archive requests remain rejected.
- Update the parent state-db row and eligible children in one `SessionDB._execute_write` transaction, scoped by exact `parent_session_id` and exact source.
- Return `subagent_archive_synced` and `subagent_child_count` so sync failure is distinguishable from an empty child group.

## Verification
- `./scripts/test.sh tests/test_session_archive_subagents.py tests/test_5307_subagent_child_transcript.py tests/test_session_action_menu_regression.py tests/test_sprint14.py -q` — 30 passed
- `node --check static/sessions.js`
- `.venv/bin/python -m py_compile api/state_sync.py api/routes.py`
- Independent specification and integration review completed.
- Live end-to-end verification: parent archive updated exactly two direct subagent children, left a non-subagent control unchanged, restore reversed the group, and a direct child archive request returned the existing 400 view-only refusal.
