### PR TITLE
fix: focus composer after URL prefill

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -130,6 +130,7 @@ async function _applyComposerPrefillOnBoot(prefillIntent){
   msg.value=text;
   if(typeof autoResize==='function') autoResize();
   else if(typeof updateSendBtn==='function') updateSendBtn();
+  if(typeof msg.focus==='function') msg.focus();
 }
 async function _finalizeComposerPrefillOnBoot(prefillIntent){
   if(prefillIntent&&prefillIntent.hasParams&&typeof _consumeComposerPrefillParamsFromLocation==='function'){

--- a/tests/test_4961_url_query_prefill.py
+++ b/tests/test_4961_url_query_prefill.py
@@ -185,8 +185,8 @@ def test_apply_prefill_updates_composer_without_autosending():
     source = _node_prelude() + """
 (async () => {
   evalBoot('_applyComposerPrefillOnBoot');
-  const counts = { autoResize: 0, updateSendBtn: 0, send: 0 };
-  const msg = { value: '' };
+  const counts = { autoResize: 0, updateSendBtn: 0, focus: 0, send: 0 };
+  const msg = { value: '', focus() { counts.focus++; } };
   global.document = {
     getElementById(id) {
       return id === 'msg' ? msg : null;
@@ -207,7 +207,7 @@ def test_apply_prefill_updates_composer_without_autosending():
 });
 """
     payload = json.loads(_run_node(source))
-    assert payload["counts"] == {"autoResize": 1, "updateSendBtn": 1, "send": 0}
+    assert payload["counts"] == {"autoResize": 1, "updateSendBtn": 1, "focus": 2, "send": 0}
     assert payload["value"] == "second pass"
 
 


### PR DESCRIPTION
## Thinking Path
- URL-prefill already waits until the composer is rendered, writes the draft, and refreshes composer controls.
- It stopped one step short: keyboard focus remained elsewhere, so Enter could not submit the prefilled prompt.
- This keeps the existing non-destructive prefill flow and focuses only after non-empty prefill is applied.

## What Changed
- Focus `#msg` after boot applies a non-empty URL prefill.
- Extend the existing #4961 Node regression to prove focus is called for populated drafts and never auto-sends.

## Why It Matters
Browser-search and launcher deep links can now be opened and submitted with Enter immediately, without an extra click.

## Verification
- `./scripts/test.sh tests/test_4961_url_query_prefill.py` — 7 passed
- `./scripts/test.sh tests/test_static_js_runtime_lint.py` — 1 passed
- `npm run lint:runtime` — passed
- `git diff --check` — passed
- Visual layout is unchanged; focused browser E2E/screenshot evidence was not captured locally because no headless browser runtime is installed. CI browser smoke remains the runtime gate.

## Risks / Follow-ups
- Scope is limited to non-empty boot prefill. It does not auto-send, change URL cleanup, or affect ordinary page loads.
- Release note: URL-prefilled composer links now focus the message box so Enter submits immediately.

## Model Used
OpenAI `gpt-5.6-terra` via Hermes Agent; targeted repository inspection, Node-backed regression tests, ESLint runtime guard, and GitHub API tooling.

Closes #5884
