### PR TITLE
fix: resolve custom provider colon-parsing corruption in model selection

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2687,8 +2687,17 @@ def resolve_model_provider(model_id: str) -> tuple:
         inner = model_id[1:]
         provider_hint, bare_model = inner.rsplit(":", 1)
         if provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
-            _slug_rest = provider_hint[len("custom:"):]
-            if not _custom_slug_rest_looks_like_host_port(_slug_rest):
+            # The provider hint has too many colons — part of the model name
+            # may have been eaten by rsplit. Peel segments back until we
+            # match a known custom provider slug, or until we're down to a
+            # single "custom:<slug>" with one colon.
+            _known_slugs = _named_custom_provider_slugs(cfg)
+            while provider_hint.count(":") >= 2:
+                _slug_rest = provider_hint[len("custom:"):]
+                if _custom_slug_rest_looks_like_host_port(_slug_rest):
+                    break  # host:port slug — don't peel further
+                if provider_hint in _known_slugs:
+                    break  # matches a known custom provider — correct split
                 provider_hint, extra = provider_hint.rsplit(":", 1)
                 bare_model = f"{extra}:{bare_model}"
         elif (provider_hint not in _PROVIDER_MODELS

--- a/static/ui.js
+++ b/static/ui.js
@@ -2639,8 +2639,33 @@ function _getOptionProviderId(opt){
 }
 function _providerFromModelValue(modelId){
   const value=String(modelId||'').trim();
-  if(value.startsWith('@')&&value.includes(':')) return value.slice(1,value.lastIndexOf(':'));
-  return '';
+  if(!value.startsWith('@')||!value.includes(':')) return '';
+  // Strip the leading @, then try to find the provider boundary.
+  // For non-custom providers (e.g. @openrouter:model), split on the first colon.
+  // For custom providers (custom:slug), the slug may contain colons (e.g.
+  // custom:litellm-proxy or custom:10.8.71.41:8080), so we can't use
+  // lastIndexOf(':') — that would eat part of the model name when the model
+  // itself contains colons (e.g. qwen3.6:27b-vision).
+  // Strategy: try known custom provider slugs from the global model catalog
+  // first (window._customProviderSlugs), then fall back to lastIndexOf.
+  const inner=value.slice(1);
+  // Check if we have known custom provider slugs available
+  if(typeof window!=='undefined'&&Array.isArray(window._customProviderSlugs)){
+    for(const slug of window._customProviderSlugs){
+      if(inner.startsWith(slug+':')){
+        return slug;
+      }
+    }
+  }
+  // Non-custom providers: split on first colon
+  if(!inner.startsWith('custom:')){
+    return inner.slice(0,inner.indexOf(':'));
+  }
+  // Custom provider without slug list: fall back to lastIndexOf.
+  // This is the imperfect legacy path — it works when the model name
+  // has no colons, but may mis-split when it does. The option-based
+  // lookup in _modelStateForSelect should be preferred.
+  return inner.slice(1,inner.lastIndexOf(':'));
 }
 function _providerSkipsModelMismatchWarning(providerId){
   const p=String(providerId||'').toLowerCase();
@@ -2657,28 +2682,36 @@ function _providerDefersMissingModelFallback(providerId){
 function _modelStateForSelect(sel, modelId){
   const value=String(modelId||'').trim();
   if(!value) return {model:'',model_provider:null};
+  // When the select element is available, resolve the provider from the
+  // option's data-provider attribute FIRST. This avoids the colon-parsing
+  // ambiguity in _providerFromModelValue (which uses lastIndexOf(':')) that
+  // corrupts custom provider IDs when the model name itself contains colons
+  // (e.g. @custom:litellm-proxy:qwen3.6:27b-vision was split into
+  // provider="custom:litellm-proxy:qwen3.6" and model="27b-vision").
+  // The data-provider attribute carries the exact provider ID set by the
+  // backend during dropdown population, so it is authoritative.
+  if(sel&&sel.options){
+    let opt=null;
+    const selected=sel&&sel.selectedOptions&&sel.selectedOptions[0];
+    if(selected&&String(selected.value||'')===value){
+      opt=selected;
+    }else{
+      opt=Array.from(sel.options).find(o=>String(o.value||'')===value)||null;
+    }
+    if(opt){
+      const provider=String(_getOptionProviderId(opt)||'').trim();
+      if(provider&&provider!=='default'){
+        return {model:value,model_provider:provider};
+      }
+    }
+  }
+  // Fallback: parse the @provider:model prefix from the value string.
+  // This is less reliable when the model name contains colons, but is
+  // needed when the select element is not available (e.g. programmatic
+  // callers without a live DOM element).
   const explicitProvider=_providerFromModelValue(value);
   if(explicitProvider) return {model:value,model_provider:explicitProvider};
-  // Resolve the provider from the option whose VALUE matches the requested
-  // model — never blindly from sel.selectedOptions[0] (#5567). During a profile
-  // /tab switch or a model-list rebuild the dropdown transiently still has the
-  // PREVIOUS profile's default option selected (e.g. an ollama model), so reading
-  // selectedOptions[0] would stamp that foreign provider onto a model it doesn't
-  // own — which is then persisted into the session's model_provider and re-sent
-  // on every turn, bricking it with a "Provider 'X'…no API key" error for a
-  // provider the session never used.
-  let opt=null;
-  const selected=sel&&sel.selectedOptions&&sel.selectedOptions[0];
-  // Prefer the currently-selected option ONLY when it actually is the requested
-  // model — this preserves the user's exact pick in the same-value/different-
-  // provider collision case (two providers offering the same model id).
-  if(selected&&String(selected.value||'')===value){
-    opt=selected;
-  }else if(sel&&sel.options){
-    opt=Array.from(sel.options).find(o=>String(o.value||'')===value)||null;
-  }
-  const provider=String(_getOptionProviderId(opt)||'').trim();
-  return {model:value,model_provider:(provider&&provider!=='default')?provider:null};
+  return {model:value,model_provider:null};
 }
 function _captureModelDropdownSelection(sel){
   if(!sel||!sel.value) return null;
@@ -3056,6 +3089,17 @@ async function populateModelDropdown(opts={}){
     window._activeProvider=data.active_provider||null;
     window._defaultModel=data.default_model||null;
     window._configuredModelBadges=data.configured_model_badges||{};
+    // Collect known custom provider slugs from the model groups so
+    // _providerFromModelValue can match them without ambiguous colon-splitting.
+    const _slugs=[];
+    if(Array.isArray(data.groups)){
+      for(const g of data.groups){
+        if(g&&g.provider_id&&String(g.provider_id).startsWith('custom:')){
+          _slugs.push(String(g.provider_id));
+        }
+      }
+    }
+    window._customProviderSlugs=_slugs;
     window._modelEndpointErrors={};
     // Keep g.extra_models label hydration in this function for /model and tail selections.
 

--- a/tests/test_custom_provider_colon_model_split.py
+++ b/tests/test_custom_provider_colon_model_split.py
@@ -1,0 +1,112 @@
+"""Regression test: custom provider IDs must not eat model-name colons.
+
+When a custom provider (e.g. ``custom:litellm-proxy``) serves a model whose
+name contains colons (e.g. ``qwen3.6:27b-vision``), the ``@provider:model``
+dropdown value becomes ``@custom:litellm-proxy:qwen3.6:27b-vision``. The
+``rsplit(":", 1)`` logic in ``resolve_model_provider()`` must correctly
+separate the provider from the model, not concatenate part of the model name
+into the provider ID.
+
+This covers the colon-parsing family of bugs:
+  - #1948: custom provider ids containing host:port
+  - #2047: custom provider name with parentheses/port
+  - The ``:free`` / ``:thinking`` suffix variant
+"""
+import pytest
+from api.config import resolve_model_provider
+
+
+@pytest.fixture
+def custom_provider_cfg(monkeypatch):
+    cfg = {
+        "model": {
+            "default": "qwen3.6:27b-vision",
+            "provider": "custom:litellm-proxy",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "nokey",
+        },
+        "custom_providers": [
+            {
+                "name": "litellm-proxy",
+                "base_url": "http://localhost:8000/v1",
+                "model": "qwen3.6:27b-vision",
+            },
+        ],
+    }
+    monkeypatch.setattr("api.config.cfg", cfg)
+    return cfg
+
+
+@pytest.fixture
+def host_port_cfg(monkeypatch):
+    cfg = {
+        "model": {
+            "default": "Qwen3",
+            "provider": "custom:10.8.71.41:8080",
+            "base_url": "http://10.8.71.41:8080/v1",
+        },
+        "custom_providers": [
+            {
+                "name": "10.8.71.41:8080",
+                "base_url": "http://10.8.71.41:8080/v1",
+                "model": "Qwen3",
+            },
+        ],
+    }
+    monkeypatch.setattr("api.config.cfg", cfg)
+    return cfg
+
+
+class TestCustomProviderColonModelSplit:
+    def test_simple_model_name(self, custom_provider_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@custom:litellm-proxy:simple-model"
+        )
+        assert provider == "custom:litellm-proxy"
+        assert model == "simple-model"
+
+    def test_model_name_with_colon(self, custom_provider_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@custom:litellm-proxy:qwen3.6:27b-vision"
+        )
+        assert provider == "custom:litellm-proxy"
+        assert model == "qwen3.6:27b-vision"
+
+    def test_model_name_with_free_suffix(self, custom_provider_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@custom:litellm-proxy:qwen3.6:27b-vision:free"
+        )
+        assert provider == "custom:litellm-proxy"
+        assert model == "qwen3.6:27b-vision:free"
+
+    def test_model_name_with_nothink_suffix(self, custom_provider_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@custom:litellm-proxy:qwen3.6:27b-nothink"
+        )
+        assert provider == "custom:litellm-proxy"
+        assert model == "qwen3.6:27b-nothink"
+
+
+class TestHostPortProviderSlug:
+    def test_host_port_provider_simple_model(self, host_port_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@custom:10.8.71.41:8080:Qwen3"
+        )
+        assert provider == "custom:10.8.71.41:8080"
+        assert model == "Qwen3"
+
+
+class TestNonCustomProviders:
+    def test_openrouter_provider_qualified(self, custom_provider_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@openrouter:anthropic/claude-sonnet-4.6"
+        )
+        assert provider == "openrouter"
+        assert model == "anthropic/claude-sonnet-4.6"
+
+    def test_openrouter_free_suffix(self, custom_provider_cfg):
+        model, provider, _ = resolve_model_provider(
+            "@openrouter:tencent/hy3-preview:free"
+        )
+        assert provider == "openrouter"
+        assert model == "tencent/hy3-preview:free"


### PR DESCRIPTION

When a custom provider (e.g. `custom:litellm-proxy`) serves a model whose name contains colons (e.g. `qwen3.6:27b-vision`), the `@provider:model` dropdown value becomes `@custom:litellm-proxy:qwen3.6:27b-vision`. The `rsplit(":", 1)` logic in `resolve_model_provider()` was eating part of the model name into the provider ID, producing `"custom:litellm-proxy:qwen3.6"` and `"27b-vision"` instead of the correct split.

This fix has three parts:

1. **Frontend (`static/ui.js`)**: Reorder `_modelStateForSelect()` to prefer the option's `data-provider` attribute over string-splitting. The `data-provider` attribute carries the exact provider ID set by the backend, avoiding colon-parsing entirely. Also improve `_providerFromModelValue()` to try known custom provider slugs before falling back to `lastIndexOf`.

2. **Frontend (`static/ui.js`)**: Populate `window._customProviderSlugs` from the `/api/models` response so `_providerFromModelValue()` can match against known provider IDs when the select element is unavailable.

3. **Backend (`api/config.py`)**: Convert the single peel-back step in `resolve_model_provider()` into a loop that peels segments until the provider hint matches a known custom provider slug. This correctly handles the `:free/:thinking` suffix variant that previously over-corrected.

**Closes:** #1948, #2047  
**Fixes:** cron job provider corruption, settings provider corruption

**Tests:** All 7 new regression tests pass, plus 59 existing model/cron-related tests.
