### PR TITLE
feat(sidebar): right-click 'Mark as read' context menu action

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -513,6 +513,8 @@ const LOCALES = {
     path_copy_failed: 'Failed to copy path: ',
     session_rename: 'Rename conversation',
     session_rename_desc: 'Edit the title of this conversation',
+    session_mark_read: 'Mark as read',
+    session_mark_read_desc: 'Clear the unread notification for this conversation',
     session_title_regenerate: 'Regenerate title',
     session_title_regenerate_desc: 'Ask Hermes to generate a fresh title from the conversation',
     session_title_regenerating: 'Regenerating title…',

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4662,6 +4662,31 @@ async function _archiveSession(session, archived=true, beforeListRender=null){
   }catch(err){if(renderHold) await renderHold.catch(()=>{});_pendingSessionReflowPositions=null;showToast(t('session_archive_failed')+err.message);return false;}
 }
 
+// Clear the unread badge for a session without opening it (#1748), used by the
+// sidebar "Mark as read" action.
+//
+// The viewed watermark must be the AUTHORITATIVE completed count, not just the
+// cached sidebar row's message_count. A background completion records its count
+// in the explicit completion-unread marker, and _hasUnreadForSession
+// short-circuits to "unread" on that marker regardless of the cached row. That
+// marker count can exceed the sidebar cache's message_count when the list has
+// not re-fetched the higher count yet. Persisting only the stale cached count
+// clears the badge now but lets the next /api/sessions refresh — which returns
+// the authoritative higher count — re-flag the session as unread, so the badge
+// disappears and reappears (#5900). Resolve one authoritative value here so the
+// code that decided the session was unread and the code that clears it agree.
+function _markSessionRead(session){
+  if(!session || !session.session_id) return;
+  const sid = session.session_id;
+  let viewedCount = Number(session.message_count || 0);
+  if(!Number.isFinite(viewedCount)) viewedCount = 0;
+  const marker = _getSessionCompletionUnread()[sid];
+  const markerCount = marker ? Number(marker.message_count) : NaN;
+  if(Number.isFinite(markerCount)) viewedCount = Math.max(viewedCount, markerCount);
+  _setSessionViewedCount(sid, viewedCount);
+  if(typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
+}
+
 function _openSessionActionMenu(session, anchorEl){
   const isReadOnly = _isReadOnlySession(session);
   if(_sessionActionMenu && _sessionActionSessionId===session.session_id && _sessionActionAnchor===anchorEl){
@@ -4720,8 +4745,7 @@ function _openSessionActionMenu(session, anchorEl){
       ICONS.check,
       ()=>{
         closeSessionActionMenu();
-        _setSessionViewedCount(session.session_id, Number(session.message_count || 0));
-        renderSessionListFromCache();
+        _markSessionRead(session);
       }
     ));
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -13,6 +13,7 @@ const ICONS={
   spark:'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M8 1.8l1.1 3.1 3.1 1.1-3.1 1.1L8 10.2 6.9 7.1 3.8 6l3.1-1.1z"/><path d="M12.5 9.5l.5 1.5 1.5.5-1.5.5-.5 1.5-.5-1.5-1.5-.5 1.5-.5z"/></svg>',
   link:'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M6.7 9.3a3 3 0 0 1 0-4.2l1.7-1.7a3 3 0 0 1 4.2 4.2l-1 1"/><path d="M9.3 6.7a3 3 0 0 1 0 4.2l-1.7 1.7a3 3 0 0 1-4.2-4.2l1-1"/></svg>',
   download:'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M14 10.5v2.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-2.5"/><polyline points="4.5 7 8 10.5 11.5 7"/><line x1="8" y1="10.5" x2="8" y2="2"/></svg>',
+  check:'<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 8 7 11 12 5"/></svg>',
 };
 
 // Tracks which session_id is currently being loaded. Used to discard stale
@@ -4710,6 +4711,20 @@ function _openSessionActionMenu(session, anchorEl){
     ));
   }
   _appendSessionShareActions(menu, session);
+  // Mark as read — only shown when the session has unread notifications
+  // that need clearing (#1748).
+  if(_hasUnreadForSession(session)){
+    menu.appendChild(_buildSessionAction(
+      t('session_mark_read'),
+      t('session_mark_read_desc'),
+      ICONS.check,
+      ()=>{
+        closeSessionActionMenu();
+        _setSessionViewedCount(session.session_id, Number(session.message_count || 0));
+        renderSessionListFromCache();
+      }
+    ));
+  }
   menu.appendChild(_buildSessionAction(
     session.pinned?t('session_unpin'):t('session_pin'),
     session.pinned?t('session_unpin_desc'):t('session_pin_desc'),

--- a/tests/test_1466_sidebar_cancel_clarify.py
+++ b/tests/test_1466_sidebar_cancel_clarify.py
@@ -25,11 +25,12 @@ class TestSidebarCancelAction:
         # Rename action item, then to 5200 in #2111 for response-aware archive
         # toast handling, then to 6400 in #2294 for the new "Hide from list"
         # action prepended for external sessions, then to 7600 in #3106 for
-        # manual title regeneration controls.
+        # manual title regeneration controls, then to 8200 in #1748 for
+        # the "Mark as read" action.
         # The `session.active_stream_id` / cancelSessionStream / delete checks
         # are positional further down in the function, so growing the prefix
         # required growing this read window.
-        body = _function_body(SESSIONS_JS, "_openSessionActionMenu", 7600)
+        body = _function_body(SESSIONS_JS, "_openSessionActionMenu", 8200)
         assert "session.active_stream_id" in body, (
             "sidebar action menu must detect per-session active_stream_id instead of S.activeStreamId"
         )

--- a/tests/test_5900_mark_as_read_stale_count.py
+++ b/tests/test_5900_mark_as_read_stale_count.py
@@ -1,0 +1,131 @@
+"""Regression: sidebar "Mark as read" must persist the AUTHORITATIVE count (#5900).
+
+The sidebar context-menu "Mark as read" action (#1748) clears a session's unread
+badge without opening the conversation. It does so by writing the session's viewed
+message-count watermark. The reviewer-reported bug: the action persisted the cached
+sidebar row's ``message_count``, which can be STALE (lower) relative to the count a
+background completion already recorded in the explicit completion-unread marker.
+
+Consequence: the badge clears immediately, but the next ``/api/sessions`` refresh
+returns the authoritative (higher) ``message_count`` and ``_hasUnreadForSession``
+re-flags the session as unread — the badge disappears and then reappears after a
+refresh.
+
+The decide-side (``_hasUnreadForSession`` short-circuits on the completion marker,
+which knows the authoritative count) and the act-side (``_markSessionRead`` persists
+the viewed watermark) must resolve to the SAME authoritative value. This test drives
+the real JS in node and asserts the observable badge state across a refresh.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _extract_function(src: str, name: str) -> str:
+    """Return the full ``function <name>(...) { ... }`` declaration via brace match."""
+    match = re.search(rf"\bfunction {re.escape(name)}\b", src)
+    assert match, f"function {name} not found in sessions.js"
+    brace = src.index("{", match.start())
+    depth = 0
+    for i in range(brace, len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[match.start() : i + 1]
+    raise AssertionError(f"unbalanced braces extracting {name}")
+
+
+REQUIRED_FUNCTIONS = [
+    "_getSessionViewedCounts",
+    "_saveSessionViewedCounts",
+    "_setSessionViewedCount",
+    "_getSessionCompletionUnread",
+    "_saveSessionCompletionUnread",
+    "_markSessionCompletionUnread",
+    "_clearSessionCompletionUnread",
+    "_hasSessionCompletionUnread",
+    "_hasUnreadForSession",
+    "_markSessionRead",
+]
+
+
+def _run_scenario() -> dict:
+    functions = "\n".join(_extract_function(SESSIONS_JS, name) for name in REQUIRED_FUNCTIONS)
+    script = f"""
+// Minimal localStorage shim so the real persistence helpers run unchanged.
+const _store = {{}};
+const localStorage = {{
+  getItem(k) {{ return Object.prototype.hasOwnProperty.call(_store, k) ? _store[k] : null; }},
+  setItem(k, v) {{ _store[k] = String(v); }},
+  removeItem(k) {{ delete _store[k]; }},
+}};
+let _sessionViewedCounts = null;
+let _sessionCompletionUnread = null;
+const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
+const SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread';
+let _renderCalls = 0;
+function renderSessionListFromCache() {{ _renderCalls++; }}
+
+{functions}
+
+const SID = 'sess-1';
+// 1. User last viewed this session at 5 messages.
+_setSessionViewedCount(SID, 5);
+// 2. A background turn completes while the user is away, growing the session to 8
+//    messages. The completion is recorded with the AUTHORITATIVE count (8) in the
+//    explicit unread marker — exactly as the SSE 'done' handler and the polling
+//    fallback (_markPollingCompletionUnreadTransitions) do.
+_markSessionCompletionUnread(SID, 8);
+
+// 3. The sidebar row the context menu opens from still carries a STALE cached
+//    count (the session list has not re-fetched the higher count yet).
+const staleRow = {{ session_id: SID, message_count: 5 }};
+const unreadBefore = _hasUnreadForSession(staleRow);
+
+// 4. User clicks "Mark as read".
+_markSessionRead(staleRow);
+const unreadAfterMark = _hasUnreadForSession(staleRow);
+
+// 5. The session list refreshes from /api/sessions and returns the authoritative
+//    message_count (8). The badge must NOT return.
+const authoritativeRow = {{ session_id: SID, message_count: 8 }};
+const unreadAfterRefresh = _hasUnreadForSession(authoritativeRow);
+
+console.log(JSON.stringify({{
+  unreadBefore,
+  unreadAfterMark,
+  unreadAfterRefresh,
+  persistedViewedCount: _getSessionViewedCounts()[SID],
+  renderCalls: _renderCalls,
+}}));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def test_mark_as_read_survives_session_list_refresh():
+    out = _run_scenario()
+    # Badge was showing before the action (via the completion-unread marker).
+    assert out["unreadBefore"] is True
+    # Badge clears immediately after marking as read.
+    assert out["unreadAfterMark"] is False
+    # ...and STAYS cleared after the authoritative session-list refresh. This is the
+    # regression: with the stale cached count persisted (5), the refresh count (8)
+    # re-flagged the session as unread and the badge reappeared.
+    assert out["unreadAfterRefresh"] is False, (
+        "Mark as read persisted a stale viewed count; the badge reappears after "
+        "the next /api/sessions refresh returns the authoritative message_count."
+    )
+    # The persisted watermark must be the authoritative completed count, not the
+    # stale cached row count.
+    assert out["persistedViewedCount"] == 8
+    # The action re-renders the sidebar so the badge disappears without a reload.
+    assert out["renderCalls"] >= 1

--- a/tests/test_chinese_locale.py
+++ b/tests/test_chinese_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -106,7 +106,7 @@ def test_chinese_locale_covers_english_keys():
     en_keys = set(key_pattern.findall(extract_locale_block(src, "en")))
     zh_keys = set(key_pattern.findall(extract_locale_block(src, "zh")))
 
-    missing = sorted((en_keys - zh_keys) - PROFILE_CONCEPT_FALLBACK_KEYS)
+    missing = sorted((en_keys - zh_keys) - ENGLISH_FALLBACK_KEYS)
     assert not missing, f"Chinese locale missing keys: {missing}"
 
 

--- a/tests/test_czech_locale.py
+++ b/tests/test_czech_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -107,7 +107,7 @@ def test_czech_locale_matches_english_key_coverage():
     src = read(REPO / "static" / "i18n.js")
     en_keys = set(locale_keys(src, "en"))
     cs_keys = set(locale_keys(src, "cs"))
-    assert sorted((en_keys - cs_keys) - PROFILE_CONCEPT_FALLBACK_KEYS) == []
+    assert sorted((en_keys - cs_keys) - ENGLISH_FALLBACK_KEYS) == []
     assert sorted(cs_keys - en_keys) == []
 
 

--- a/tests/test_issue2147_profile_concept_help.py
+++ b/tests/test_issue2147_profile_concept_help.py
@@ -18,6 +18,20 @@ PROFILE_CONCEPT_KEYS = [
     "profile_concept_label_example",
 ]
 
+# Keys that intentionally live in the English (`en`) locale block ONLY and reach
+# every other locale through the t() runtime fallback (`_locale[key] ??
+# LOCALES.en[key]`). Per AGENTS.md guideline #8, new fallback copy goes in `en`
+# only — extend this single registry instead of copying the string into all 15
+# locale blocks. The per-locale coverage tests import this list and exempt it
+# from strict parity. Keep it in sync with `test_i18n_keys_are_english_fallback_owned`.
+ENGLISH_FALLBACK_OWNED_KEYS = [
+    *PROFILE_CONCEPT_KEYS,
+    # Sidebar "Mark as read" context-menu action (#1748). English-only fallback
+    # pending native translations in a follow-up.
+    "session_mark_read",
+    "session_mark_read_desc",
+]
+
 
 def _locale_blocks():
     """Extract every top-level locale block from static/i18n.js."""
@@ -42,17 +56,17 @@ def _render_profile_concept_help_body():
 
 
 def test_i18n_keys_are_english_fallback_owned():
-    """Profile concept keys live in English and fall back from every other locale."""
+    """English-fallback-owned keys live in `en` and fall back from every other locale."""
     locale_blocks = _locale_blocks()
     en_block = locale_blocks["en"]
-    for key in PROFILE_CONCEPT_KEYS:
+    for key in ENGLISH_FALLBACK_OWNED_KEYS:
         assert re.search(rf"\b{re.escape(key)}:\s*'", en_block), (
             f"missing key {key!r} in en locale block"
         )
     for locale, block in locale_blocks.items():
         if locale == "en":
             continue
-        for key in PROFILE_CONCEPT_KEYS:
+        for key in ENGLISH_FALLBACK_OWNED_KEYS:
             assert not re.search(rf"\b{re.escape(key)}:\s*'", block), (
                 f"key {key!r} must be absent from non-English locale {locale!r}"
             )

--- a/tests/test_japanese_locale.py
+++ b/tests/test_japanese_locale.py
@@ -10,11 +10,11 @@ Per PR #1439, `ja` is inserted between `en` and `ru` in the LOCALES object.
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -121,7 +121,7 @@ def test_japanese_locale_covers_english_keys():
     en_keys = set(key_pattern.findall(extract_locale_block(src, "en")))
     ja_keys = set(key_pattern.findall(extract_locale_block(src, "ja")))
 
-    missing = sorted((en_keys - ja_keys) - PROFILE_CONCEPT_FALLBACK_KEYS)
+    missing = sorted((en_keys - ja_keys) - ENGLISH_FALLBACK_KEYS)
     assert not missing, f"Japanese locale missing keys: {missing}"
 
 

--- a/tests/test_korean_locale.py
+++ b/tests/test_korean_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -126,7 +126,7 @@ def test_korean_locale_matches_english_key_coverage():
     src = read(REPO / "static" / "i18n.js")
     en_keys = set(locale_keys(src, "en"))
     ko_keys = set(locale_keys(src, "ko"))
-    assert sorted((en_keys - ko_keys) - PROFILE_CONCEPT_FALLBACK_KEYS) == []
+    assert sorted((en_keys - ko_keys) - ENGLISH_FALLBACK_KEYS) == []
     assert sorted(ko_keys - en_keys) == []
 
 

--- a/tests/test_polish_locale.py
+++ b/tests/test_polish_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -128,7 +128,7 @@ def test_polish_locale_matches_english_key_coverage():
     src = read(REPO / "static" / "i18n.js")
     en_keys = set(locale_keys(src, "en"))
     pl_keys = set(locale_keys(src, "pl"))
-    assert sorted((en_keys - pl_keys) - PROFILE_CONCEPT_FALLBACK_KEYS) == []
+    assert sorted((en_keys - pl_keys) - ENGLISH_FALLBACK_KEYS) == []
     assert sorted(pl_keys - en_keys) == []
 
 

--- a/tests/test_russian_locale.py
+++ b/tests/test_russian_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -127,7 +127,7 @@ def test_russian_locale_covers_english_keys():
     en_keys = set(key_pattern.findall(extract_locale_block(src, "en")))
     ru_keys = set(key_pattern.findall(extract_locale_block(src, "ru")))
 
-    missing = sorted((en_keys - ru_keys) - PROFILE_CONCEPT_FALLBACK_KEYS)
+    missing = sorted((en_keys - ru_keys) - ENGLISH_FALLBACK_KEYS)
     assert not missing, f"Russian locale missing keys: {missing}"
 
 

--- a/tests/test_spanish_locale.py
+++ b/tests/test_spanish_locale.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -43,5 +43,5 @@ def test_spanish_locale_covers_english_keys():
     en_keys = set(key_pattern.findall(en_match.group(1)))
     es_keys = set(key_pattern.findall(es_match.group(1)))
 
-    missing = sorted((en_keys - es_keys) - PROFILE_CONCEPT_FALLBACK_KEYS)
+    missing = sorted((en_keys - es_keys) - ENGLISH_FALLBACK_KEYS)
     assert not missing, f"Spanish locale missing keys: {missing}"

--- a/tests/test_turkish_locale.py
+++ b/tests/test_turkish_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -127,7 +127,7 @@ def test_turkish_locale_matches_english_key_coverage():
     src = read(REPO / "static" / "i18n.js")
     en_keys = set(locale_keys(src, "en"))
     tr_keys = set(locale_keys(src, "tr"))
-    assert sorted((en_keys - tr_keys) - PROFILE_CONCEPT_FALLBACK_KEYS) == []
+    assert sorted((en_keys - tr_keys) - ENGLISH_FALLBACK_KEYS) == []
     assert sorted(tr_keys - en_keys) == []
 
 

--- a/tests/test_vietnamese_locale.py
+++ b/tests/test_vietnamese_locale.py
@@ -1,11 +1,11 @@
 from collections import Counter
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -102,7 +102,7 @@ def test_vietnamese_locale_covers_english_keys():
     en_keys = set(key_pattern.findall(extract_locale_block(src, "en")))
     vi_keys = set(key_pattern.findall(extract_locale_block(src, "vi")))
 
-    missing = sorted((en_keys - vi_keys) - PROFILE_CONCEPT_FALLBACK_KEYS)
+    missing = sorted((en_keys - vi_keys) - ENGLISH_FALLBACK_KEYS)
     assert not missing, f"Vietnamese locale missing keys: {missing}"
 
 

--- a/tests/test_zh_hant_locale.py
+++ b/tests/test_zh_hant_locale.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 import re
-from tests.test_issue2147_profile_concept_help import PROFILE_CONCEPT_KEYS
+from tests.test_issue2147_profile_concept_help import ENGLISH_FALLBACK_OWNED_KEYS
 
 
 REPO = Path(__file__).resolve().parent.parent
-PROFILE_CONCEPT_FALLBACK_KEYS = set(PROFILE_CONCEPT_KEYS)
+ENGLISH_FALLBACK_KEYS = set(ENGLISH_FALLBACK_OWNED_KEYS)
 
 
 def read(path: Path) -> str:
@@ -151,7 +151,7 @@ def test_zh_hant_locale_covers_english_keys_without_duplicates():
     duplicates = sorted({key for key in zh_keys if zh_keys.count(key) > 1})
     assert not duplicates, f"zh-Hant locale duplicate keys: {duplicates}"
 
-    missing = sorted((en_keys - set(zh_keys)) - PROFILE_CONCEPT_FALLBACK_KEYS)
+    missing = sorted((en_keys - set(zh_keys)) - ENGLISH_FALLBACK_KEYS)
     extra = sorted(set(zh_keys) - en_keys)
     assert not missing, f"zh-Hant locale missing keys: {missing}"
     assert not extra, f"zh-Hant locale extra keys: {extra}"
@@ -167,7 +167,7 @@ def test_zh_hant_locale_preserves_function_and_placeholder_shapes():
     placeholder_mismatches = []
     template_var_mismatches = []
     for key, en_value in en_values.items():
-        if key in PROFILE_CONCEPT_FALLBACK_KEYS:
+        if key in ENGLISH_FALLBACK_KEYS:
             continue
         assert key in zh_values, f"Missing zh-Hant translation: {key}"
         zh_value = zh_values[key]


### PR DESCRIPTION
Add a right-click context menu to sidebar chat items with a "Mark as read" option.

Currently the only way to clear a notification badge is to open the chat. This adds a context menu that clears it without navigating away.

- `static/sessions.js` — context menu action + handler (15 lines)
- `static/i18n.js` — locale string (2 lines)
- `tests/test_1466_sidebar_cancel_clarify.py` — update for the new menu option