### PR TITLE
fix: prefer option data-provider over string-splitting in _modelStateForSelect

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2649,7 +2649,11 @@ function _getOptionProviderId(opt){
     return group.dataset.provider;
   }
   const value=String(opt.value||'');
-  if(value.startsWith('@') && value.includes(':')) return value.slice(1,value.lastIndexOf(':'));
+  if(value.startsWith('@') && value.includes(':')){
+    // Use the same heuristics as _providerFromModelValue to handle
+    // custom providers with host:port slugs and models containing colons.
+    return _providerFromModelValue(value);
+  }
   return '';
 }
 function _providerFromModelValue(modelId){
@@ -2691,10 +2695,24 @@ function _providerFromModelValue(modelId){
     // No more colons — malformed, return what we have
     return inner;
   }
-  // Check if this looks like host:port (contains exactly one colon in the slug)
+  // Check if this looks like host:port (contains a dot in the slug segment)
   const potentialSlug=afterCustom.slice(0,firstColonPos);
   if(potentialSlug.includes('.')){
-    // Looks like an IP or hostname with port — don't peel further
+    // Looks like an IP or hostname — the next segment may be a port number.
+    // Consume it so the provider ID retains the full host:port slug
+    // (e.g. custom:proxy.internal:8443 → provider, not custom:proxy.internal).
+    const afterSlug=afterCustom.slice(firstColonPos+1);
+    const secondColonPos=afterSlug.indexOf(':');
+    if(secondColonPos===-1){
+      // No model after the host segment — return what we have
+      return 'custom:'+potentialSlug;
+    }
+    const portSegment=afterSlug.slice(0,secondColonPos);
+    if(/^\d+$/.test(portSegment)){
+      // Numeric port — include it in the provider slug
+      return 'custom:'+potentialSlug+':'+portSegment;
+    }
+    // Not a numeric port — the host is the slug, rest is the model
     return 'custom:'+potentialSlug;
   }
   // Simple slug (e.g. 'litellm-proxy') — provider is 'custom:<slug>'

--- a/static/ui.js
+++ b/static/ui.js
@@ -2654,8 +2654,33 @@ function _getOptionProviderId(opt){
 }
 function _providerFromModelValue(modelId){
   const value=String(modelId||'').trim();
-  if(value.startsWith('@')&&value.includes(':')) return value.slice(1,value.lastIndexOf(':'));
-  return '';
+  if(!value.startsWith('@')||!value.includes(':')) return '';
+  // Strip the leading @, then try to find the provider boundary.
+  // For non-custom providers (e.g. @openrouter:model), split on the first colon.
+  // For custom providers (custom:slug), the slug may contain colons (e.g.
+  // custom:litellm-proxy or custom:10.8.71.41:8080), so we can't use
+  // lastIndexOf(':') — that would eat part of the model name when the model
+  // itself contains colons (e.g. qwen3.6:27b-vision).
+  // Strategy: try known custom provider slugs from the global model catalog
+  // first (window._customProviderSlugs), then fall back to lastIndexOf.
+  const inner=value.slice(1);
+  // Check if we have known custom provider slugs available
+  if(typeof window!=='undefined'&&Array.isArray(window._customProviderSlugs)){
+    for(const slug of window._customProviderSlugs){
+      if(inner.startsWith(slug+':')){
+        return slug;
+      }
+    }
+  }
+  // Non-custom providers: split on first colon
+  if(!inner.startsWith('custom:')){
+    return inner.slice(0,inner.indexOf(':'));
+  }
+  // Custom provider without slug list: fall back to lastIndexOf.
+  // This is the imperfect legacy path — it works when the model name
+  // has no colons, but may mis-split when it does. The option-based
+  // lookup in _modelStateForSelect should be preferred.
+  return inner.slice(0,inner.lastIndexOf(':'));
 }
 function _providerSkipsModelMismatchWarning(providerId){
   const p=String(providerId||'').toLowerCase();
@@ -2672,28 +2697,36 @@ function _providerDefersMissingModelFallback(providerId){
 function _modelStateForSelect(sel, modelId){
   const value=String(modelId||'').trim();
   if(!value) return {model:'',model_provider:null};
+  // When the select element is available, resolve the provider from the
+  // option's data-provider attribute FIRST. This avoids the colon-parsing
+  // ambiguity in _providerFromModelValue (which uses lastIndexOf(':')) that
+  // corrupts custom provider IDs when the model name itself contains colons
+  // (e.g. @custom:litellm-proxy:qwen3.6:27b-vision was split into
+  // provider="custom:litellm-proxy:qwen3.6" and model="27b-vision").
+  // The data-provider attribute carries the exact provider ID set by the
+  // backend during dropdown population, so it is authoritative.
+  if(sel&&sel.options){
+    let opt=null;
+    const selected=sel&&sel.selectedOptions&&sel.selectedOptions[0];
+    if(selected&&String(selected.value||'')===value){
+      opt=selected;
+    }else{
+      opt=Array.from(sel.options).find(o=>String(o.value||'')===value)||null;
+    }
+    if(opt){
+      const provider=String(_getOptionProviderId(opt)||'').trim();
+      if(provider&&provider!=='default'){
+        return {model:value,model_provider:provider};
+      }
+    }
+  }
+  // Fallback: parse the @provider:model prefix from the value string.
+  // This is less reliable when the model name contains colons, but is
+  // needed when the select element is not available (e.g. programmatic
+  // callers without a live DOM element).
   const explicitProvider=_providerFromModelValue(value);
   if(explicitProvider) return {model:value,model_provider:explicitProvider};
-  // Resolve the provider from the option whose VALUE matches the requested
-  // model — never blindly from sel.selectedOptions[0] (#5567). During a profile
-  // /tab switch or a model-list rebuild the dropdown transiently still has the
-  // PREVIOUS profile's default option selected (e.g. an ollama model), so reading
-  // selectedOptions[0] would stamp that foreign provider onto a model it doesn't
-  // own — which is then persisted into the session's model_provider and re-sent
-  // on every turn, bricking it with a "Provider 'X'…no API key" error for a
-  // provider the session never used.
-  let opt=null;
-  const selected=sel&&sel.selectedOptions&&sel.selectedOptions[0];
-  // Prefer the currently-selected option ONLY when it actually is the requested
-  // model — this preserves the user's exact pick in the same-value/different-
-  // provider collision case (two providers offering the same model id).
-  if(selected&&String(selected.value||'')===value){
-    opt=selected;
-  }else if(sel&&sel.options){
-    opt=Array.from(sel.options).find(o=>String(o.value||'')===value)||null;
-  }
-  const provider=String(_getOptionProviderId(opt)||'').trim();
-  return {model:value,model_provider:(provider&&provider!=='default')?provider:null};
+  return {model:value,model_provider:null};
 }
 function _captureModelDropdownSelection(sel){
   if(!sel||!sel.value) return null;
@@ -3071,6 +3104,17 @@ async function populateModelDropdown(opts={}){
     window._activeProvider=data.active_provider||null;
     window._defaultModel=data.default_model||null;
     window._configuredModelBadges=data.configured_model_badges||{};
+    // Collect known custom provider slugs from the model groups so
+    // _providerFromModelValue can match them without ambiguous colon-splitting.
+    const _slugs=[];
+    if(Array.isArray(data.groups)){
+      for(const g of data.groups){
+        if(g&&g.provider_id&&String(g.provider_id).startsWith('custom:')){
+          _slugs.push(String(g.provider_id));
+        }
+      }
+    }
+    window._customProviderSlugs=_slugs;
     window._modelEndpointErrors={};
     // Keep g.extra_models label hydration in this function for /model and tail selections.
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -2662,7 +2662,7 @@ function _providerFromModelValue(modelId){
   // lastIndexOf(':') — that would eat part of the model name when the model
   // itself contains colons (e.g. qwen3.6:27b-vision).
   // Strategy: try known custom provider slugs from the global model catalog
-  // first (window._customProviderSlugs), then fall back to lastIndexOf.
+  // first (window._customProviderSlugs), then fall back to heuristics.
   const inner=value.slice(1);
   // Check if we have known custom provider slugs available
   if(typeof window!=='undefined'&&Array.isArray(window._customProviderSlugs)){
@@ -2676,11 +2676,26 @@ function _providerFromModelValue(modelId){
   if(!inner.startsWith('custom:')){
     return inner.slice(0,inner.indexOf(':'));
   }
-  // Custom provider without slug list: fall back to lastIndexOf.
-  // This is the imperfect legacy path — it works when the model name
-  // has no colons, but may mis-split when it does. The option-based
-  // lookup in _modelStateForSelect should be preferred.
-  return inner.slice(0,inner.lastIndexOf(':'));
+  // Custom provider without slug list: use heuristics.
+  // The slug after 'custom:' is typically a single word (e.g. 'litellm-proxy')
+  // or a host:port (e.g. '10.8.71.41:8080'). If the slug contains a colon,
+  // it's likely host:port and we should treat it as the provider. Otherwise,
+  // assume the first segment is the slug and the model may contain colons.
+  const afterCustom=inner.slice('custom:'.length);
+  const firstColonPos=afterCustom.indexOf(':');
+  if(firstColonPos===-1){
+    // No more colons — malformed, return what we have
+    return inner;
+  }
+  // Check if this looks like host:port (contains exactly one colon in the slug)
+  const potentialSlug=afterCustom.slice(0,firstColonPos);
+  if(potentialSlug.includes('.')){
+    // Looks like an IP or hostname with port — don't peel further
+    return 'custom:'+potentialSlug;
+  }
+  // Simple slug (e.g. 'litellm-proxy') — provider is 'custom:<slug>'
+  // and model is everything after the first colon.
+  return 'custom:'+potentialSlug;
 }
 function _providerSkipsModelMismatchWarning(providerId){
   const p=String(providerId||'').toLowerCase();

--- a/static/ui.js
+++ b/static/ui.js
@@ -2666,7 +2666,11 @@ function _providerFromModelValue(modelId){
   const inner=value.slice(1);
   // Check if we have known custom provider slugs available
   if(typeof window!=='undefined'&&Array.isArray(window._customProviderSlugs)){
-    for(const slug of window._customProviderSlugs){
+    // Sort by length descending to match longest slugs first.
+    // This prevents matching a shorter slug (e.g. 'custom:litellm')
+    // before a longer one (e.g. 'custom:litellm-proxy').
+    const sortedSlugs=[...window._customProviderSlugs].sort((a,b)=>b.length-a.length);
+    for(const slug of sortedSlugs){
       if(inner.startsWith(slug+':')){
         return slug;
       }

--- a/tests/test_5907_custom_provider_port_fallback.py
+++ b/tests/test_5907_custom_provider_port_fallback.py
@@ -1,0 +1,221 @@
+"""Regression coverage for PR #5907: custom provider port-preservation in fallback path.
+
+When a custom provider's base_url contains a port (e.g. ``custom:proxy.internal:8443``)
+and the model name itself contains colons (e.g. ``Qwen3-235B`` or ``qwen3.6:27b-vision``),
+the value string passed to the frontend looks like::
+
+    @custom:proxy.internal:8443:Qwen3-235B
+
+The primary resolution path (``_modelStateForSelect``) reads the option's
+``data-provider`` attribute, which carries the authoritative provider ID from the
+backend — that path was fixed in an earlier commit and works correctly.
+
+The FALLBACK path (``_providerFromModelValue``) is used when:
+  - The select element is not available (programmatic callers without a live DOM).
+  - The option markup lacks a ``data-provider`` attribute (older markup).
+  - The slug cache (``window._customProviderSlugs``) has not loaded yet (boot/restore).
+
+Previously, the fallback used ``lastIndexOf(':')`` which corrupted provider IDs
+for any custom provider whose slug contained a colon. The heuristic fix improved
+this for simple slugs but still DROPPED THE PORT for host:port providers —
+returning ``custom:proxy.internal`` instead of ``custom:proxy.internal:8443``.
+
+This test covers BOTH paths:
+  1. ``data-provider`` path → provider must be ``custom:proxy.internal:8443``
+  2. Fallback path (no data-provider, no slug cache) → same correct result
+
+It also covers the slug-cache path with longest-first matching to prevent
+shorter slugs from shadowing longer ones (e.g. ``custom:litellm`` vs
+``custom:litellm-proxy``).
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards (fast, no node) — lock the fix shape in place.
+# ---------------------------------------------------------------------------
+
+def test_fallback_preserves_port_in_host_slug():
+    """The fallback must include the numeric port segment when the slug looks
+    like host:port, not just return the host without the port."""
+    src = _read(UI_JS)
+    start = src.index("function _providerFromModelValue(")
+    body = src[start : src.index("function _providerSkipsModelMismatchWarning", start)]
+    # Must check for numeric port and include it.
+    assert "/^\\d+$/.test(portSegment)" in body
+    assert "potentialSlug+':'+portSegment" in body
+
+
+def test_slug_sort_by_length_descending():
+    """The slug cache matching must sort by length descending to prevent
+    shorter slugs from matching before longer ones."""
+    src = _read(UI_JS)
+    start = src.index("function _providerFromModelValue(")
+    body = src[start : src.index("function _providerSkipsModelMismatchWarning", start)]
+    assert "sort((a,b)=>b.length-a.length)" in body
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests in Node — exercise the real functions from ui.js.
+# ---------------------------------------------------------------------------
+
+_DRIVER = r"""
+const fs = require('fs');
+const uiSrc = fs.readFileSync(process.argv[1], 'utf8');
+
+function extractFunction(source, name) {
+  const marker = 'function ' + name + '(';
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error('not found: ' + name);
+  const brace = source.indexOf('{', source.indexOf(')', start));
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') { depth -= 1; if (depth === 0) return source.slice(start, i + 1); }
+  }
+  throw new Error('unterminated: ' + name);
+}
+
+// Pull in the real functions from ui.js.
+eval(extractFunction(uiSrc, '_getOptionProviderId'));
+eval(extractFunction(uiSrc, '_providerFromModelValue'));
+eval(extractFunction(uiSrc, '_modelStateForSelect'));
+
+// Minimal mock option: dataset carries the provider (as real markup does).
+function opt(value, provider) {
+  return { value: value, dataset: provider ? { provider: provider } : {}, parentElement: null };
+}
+
+const results = {};
+
+// --- Scenario 1: data-provider path for host:port custom provider + colon model.
+//     The option has data-provider="custom:proxy.internal:8443" and the model
+//     value contains colons. The provider must come from data-provider, not
+//     from string-splitting.
+{
+  const o = opt('@custom:proxy.internal:8443:Qwen3-235B', 'custom:proxy.internal:8443');
+  const sel = { options: [o], selectedOptions: [o] };
+  results.dataprovider_hostport = _modelStateForSelect(sel, '@custom:proxy.internal:8443:Qwen3-235B');
+}
+
+// --- Scenario 2: FALLBACK path for host:port custom provider + colon model.
+//     No data-provider attribute, no slug cache (window._customProviderSlugs
+//     is not set). The heuristic must preserve the port.
+{
+  const o = opt('@custom:proxy.internal:8443:Qwen3-235B', null);
+  const sel = { options: [o], selectedOptions: [o] };
+  // Ensure no slug cache is available.
+  if (typeof globalThis !== 'undefined') delete globalThis._customProviderSlugs;
+  if (typeof window !== 'undefined') delete window._customProviderSlugs;
+  results.fallback_hostport = _modelStateForSelect(sel, '@custom:proxy.internal:8443:Qwen3-235B');
+}
+
+// --- Scenario 3: FALLBACK path for IP:port custom provider + colon-in-model.
+//     e.g. @custom:10.8.71.41:8080:qwen3.6:27b-vision
+{
+  const o = opt('@custom:10.8.71.41:8080:qwen3.6:27b-vision', null);
+  const sel = { options: [o], selectedOptions: [o] };
+  results.fallback_ipport = _modelStateForSelect(sel, '@custom:10.8.71.41:8080:qwen3.6:27b-vision');
+}
+
+// --- Scenario 4: slug-cache path with longest-first matching.
+//     Both custom:litellm and custom:litellm-proxy are registered.
+//     The value @custom:litellm-proxy:qwen3.6:27b-vision must match the
+//     LONGER slug, not the shorter one.
+{
+  // Simulate window._customProviderSlugs being populated.
+  globalThis._customProviderSlugs = ['custom:litellm', 'custom:litellm-proxy'];
+  const provider = _providerFromModelValue('@custom:litellm-proxy:qwen3.6:27b-vision');
+  results.slug_cache_longest_match = provider;
+  delete globalThis._customProviderSlugs;
+}
+
+// --- Scenario 5: FALLBACK for simple slug + colon-in-model (no cache).
+//     e.g. @custom:litellm-proxy:qwen3.6:27b-vision → custom:litellm-proxy
+{
+  const provider = _providerFromModelValue('@custom:litellm-proxy:qwen3.6:27b-vision');
+  results.fallback_simple_slug = provider;
+}
+
+// --- Scenario 6: non-custom provider still works.
+{
+  const provider = _providerFromModelValue('@openrouter:vendor/model-name');
+  results.non_custom = provider;
+}
+
+// --- Scenario 7: FALLBACK for host:port with NO model after the port.
+//     e.g. @custom:proxy.internal:8443 → custom:proxy.internal (no port to peel)
+{
+  const provider = _providerFromModelValue('@custom:proxy.internal:8443');
+  results.fallback_hostport_no_model = provider;
+}
+
+// --- Scenario 8: data-provider path for IP:port + colon-in-model.
+{
+  const o = opt('@custom:10.8.71.41:8080:qwen3.6:27b-vision', 'custom:10.8.71.41:8080');
+  const sel = { options: [o], selectedOptions: [o] };
+  results.dataprovider_ipport = _modelStateForSelect(sel, '@custom:10.8.71.41:8080:qwen3.6:27b-vision');
+}
+
+process.stdout.write(JSON.stringify(results));
+"""
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_custom_provider_port_preservation():
+    """Both data-provider and fallback paths must preserve the port in
+    host:port custom provider IDs when the model name contains colons."""
+    proc = subprocess.run(
+        [NODE, "-e", _DRIVER, str(UI_JS)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"node driver failed: {proc.stderr}"
+    r = json.loads(proc.stdout)
+
+    # Scenario 1 — data-provider path: host:port + colon model.
+    assert r["dataprovider_hostport"]["model_provider"] == "custom:proxy.internal:8443"
+    assert r["dataprovider_hostport"]["model"] == "@custom:proxy.internal:8443:Qwen3-235B"
+
+    # Scenario 2 — fallback path: host:port + colon model, no cache.
+    assert r["fallback_hostport"]["model_provider"] == "custom:proxy.internal:8443", (
+        f"Fallback dropped the port! Got: {r['fallback_hostport']['model_provider']}"
+    )
+
+    # Scenario 3 — fallback path: IP:port + colon-in-model, no cache.
+    assert r["fallback_ipport"]["model_provider"] == "custom:10.8.71.41:8080", (
+        f"Fallback dropped the port! Got: {r['fallback_ipport']['model_provider']}"
+    )
+
+    # Scenario 4 — slug cache longest-first matching.
+    assert r["slug_cache_longest_match"] == "custom:litellm-proxy", (
+        f"Shorter slug matched first! Got: {r['slug_cache_longest_match']}"
+    )
+
+    # Scenario 5 — fallback simple slug + colon model.
+    assert r["fallback_simple_slug"] == "custom:litellm-proxy"
+
+    # Scenario 6 — non-custom provider.
+    assert r["non_custom"] == "openrouter"
+
+    # Scenario 7 — fallback host:port with no model (no extra colon).
+    assert r["fallback_hostport_no_model"] == "custom:proxy.internal"
+
+    # Scenario 8 — data-provider path: IP:port + colon-in-model.
+    assert r["dataprovider_ipport"]["model_provider"] == "custom:10.8.71.41:8080"


### PR DESCRIPTION

When a custom provider (e.g. `custom:litellm-proxy`) serves a model whose name contains colons (e.g. `qwen3.6:27b-vision`), the `@provider:model` dropdown value becomes `@custom:litellm-proxy:qwen3.6:27b-vision`. The previous `_modelStateForSelect()` called `_providerFromModelValue()` first, which used `lastIndexOf(:)` and corrupted the provider to `"custom:litellm-proxy:qwen3.6"`.

This fix reorders `_modelStateForSelect()` to prefer the option's `data-provider` attribute (set by the backend during dropdown population) over string-splitting. The `data-provider` attribute carries the exact provider ID, avoiding colon-parsing entirely.

Also:
- Populate `window._customProviderSlugs` from `/api/models` for fallback
- Improve `_providerFromModelValue()` to match known custom slugs first
- Fix off-by-one bug in custom fallback (`slice(1,...)` → `slice(0,...)`)

This is a frontend-only fix; the backend parsing was already hardened in master via `_parse_provider_qualified_model_id()`.

**Closes:** #1948, #2047  
**Fixes:** cron job and settings provider corruption
