### PR TITLE
fix(chat): dedupe pending prompts across compaction

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2907,7 +2907,11 @@ function _currentTailUserMessage(messages){
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
-    if(String(msg.role||'')==='user') return msg;
+    if(String(msg.role||'')==='user'){
+      // Compaction rows are synthetic user-role markers, not submitted turns.
+      if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      return msg;
+    }
     if(msg._live||String(msg.role||'')==='tool') continue;
     return null;
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -9844,7 +9844,11 @@ function _pendingCurrentTailUserMessage(messages){
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
-    if(String(msg.role||'')==='user') return msg;
+    if(String(msg.role||'')==='user'){
+      // Compaction rows are synthetic user-role markers, not submitted turns.
+      if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      return msg;
+    }
     if(msg._live||String(msg.role||'')==='tool') continue;
     return null;
   }

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -80,6 +80,9 @@ def _run_current_turn_scope_probe() -> dict:
     helpers = "\n".join(
         [
             _function_body(UI_SRC, "function _stripWorkspaceDisplayPrefix"),
+            _function_body(UI_SRC, "function msgContent"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
             _function_body(SESSIONS_SRC, "function _messageComparableText"),
             _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
             _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
@@ -128,6 +131,35 @@ const inflightWithCurrent = _mergeInflightTailMessages(
   [{{role:'user', content:{json.dumps(prompt)}, _ts:3}}, liveAssistant]
 );
 
+const compaction = {{
+  role:'user',
+  content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.',
+  _ts:3.5,
+}};
+const compactionBase = [historical, historicalAnswer, optimisticCurrent, compaction];
+const compactionCandidate = {{role:'user', content:{json.dumps(prompt)}, _ts:3}};
+const compactionCurrentTail = _currentTailUserMessage(compactionBase);
+const compactionTailDuplicate = _hasCurrentTailUserDuplicate(compactionBase, compactionCandidate);
+const compactionMerged = _mergeInflightTailMessages(
+  compactionBase,
+  [compactionCandidate, liveAssistant]
+);
+const insertedAfterCompaction = _mergePendingSessionMessage(pendingSession, compactionMerged);
+const compactionPromptCount = compactionMerged.filter(
+  m=>m&&m.role==='user'&&m._ts===3&&_normalizeUserTranscriptText(m.content)==={json.dumps(prompt)}
+).length;
+const compactionMarkerRetained = compactionMerged.some(m=>_isContextCompactionMessage(m));
+const compactionLiveAssistantRetained = compactionMerged.some(
+  m=>m&&m.role==='assistant'&&m._live&&m.content==='working'
+);
+const completedBoundaryDedupe = _hasCurrentTailUserDuplicate(
+  [historical, historicalAnswer, compaction],
+  {{role:'user', content:{json.dumps(prompt)}, _ts:3}}
+);
+const distinctCompletedTurnPromptCount = inflightAfterHistory.filter(
+  m=>m&&m.role==='user'&&_normalizeUserTranscriptText(m.content)==={json.dumps(prompt)}
+).length;
+
 process.stdout.write(JSON.stringify({{
   insertedAfterHistory,
   pendingAfterHistoryRoles: pendingAfterHistory.map(m=>m.role),
@@ -137,6 +169,14 @@ process.stdout.write(JSON.stringify({{
   pendingWithCurrentRoles: pendingWithCurrent.map(m=>m.role),
   inflightAfterHistoryRoles: inflightAfterHistory.map(m=>m.role),
   inflightWithCurrentRoles: inflightWithCurrent.map(m=>m.role),
+  insertedAfterCompaction,
+  compactionCurrentTailContent: compactionCurrentTail&&compactionCurrentTail.content,
+  compactionTailDuplicate,
+  compactionPromptCount,
+  compactionMarkerRetained,
+  compactionLiveAssistantRetained,
+  completedBoundaryDedupe,
+  distinctCompletedTurnPromptCount,
 }}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -157,6 +197,8 @@ def _run_pending_session_message_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
             _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
             _function_body(UI_SRC, "function getPendingSessionMessage"),
         ]
     )
@@ -168,8 +210,24 @@ const historicalWorkspace = {{role:'user', content:{json.dumps(historical_worksp
 const historicalAnswer = {{role:'assistant', content:'done', _ts:2}};
 const currentTail = {{role:'user', content:prompt, _ts:3}};
 const currentWorkspaceTail = {{role:'user', content:{json.dumps(current_workspace_prompt)}, _ts:3}};
+const currentTailForCompaction = {{role:'user', content:prompt, _ts:3}};
 const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4}};
 const attachments = [{{name:'note.txt', path:'note.txt', mime:'text/plain'}}];
+const compactionMarker = {{
+  role:'user',
+  content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.',
+  _ts:3.5,
+}};
+const repeatedPromptTurnOne = {{role:'user', content:prompt, _ts:1}};
+const repeatedPromptAnswerOne = {{role:'assistant', content:'done', _ts:2}};
+const repeatedPromptTurnTwo = {{role:'user', content:prompt, _ts:3}};
+const repeatedPromptAnswerTwo = {{role:'assistant', content:'done', _ts:4}};
+const repeatedCompletedBase = [
+  repeatedPromptTurnOne,
+  repeatedPromptAnswerOne,
+  repeatedPromptTurnTwo,
+  repeatedPromptAnswerTwo,
+];
 
 const fromHistoricalSameText = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:3}},
@@ -196,6 +254,21 @@ const differentTailResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4}},
   [historical, historicalAnswer, {{role:'user', content:'different prompt', _ts:3}}]
 );
+const compactionTailResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:4, pending_attachments:attachments}},
+  [historical, historicalAnswer, currentTailForCompaction, compactionMarker]
+);
+const repeatedCompletedResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:5}},
+  repeatedCompletedBase
+);
+const repeatedCompletedMessages = repeatedCompletedResult
+  ? [...repeatedCompletedBase, repeatedCompletedResult]
+  : repeatedCompletedBase;
+const repeatedCompletedPromptCount = repeatedCompletedMessages.filter(
+  m=>m&&m.role==='user'&&_normalizeUserTranscriptText(m.content)===prompt
+).length;
+const compactionCurrentTail = _pendingCurrentTailUserMessage([historical, historicalAnswer, currentTailForCompaction, compactionMarker]);
 
 process.stdout.write(JSON.stringify({{
   historicalSameTextSurvives: !!fromHistoricalSameText && fromHistoricalSameText.content===prompt && fromHistoricalSameText._pending===true,
@@ -205,6 +278,12 @@ process.stdout.write(JSON.stringify({{
   workspaceCurrentTailDedupe: workspaceCurrentResult===null,
   liveAfterCurrentTailDedupe: liveAfterCurrentResult===null,
   differentCurrentTailSurvives: !!differentTailResult && differentTailResult.content===prompt && differentTailResult._pending===true,
+  compactionBoundaryDedupe: compactionTailResult===null,
+  compactionBoundaryCurrentTail: compactionCurrentTail&&compactionCurrentTail.role==='user'&&compactionCurrentTail.content===prompt,
+  compactionCurrentTailAttachmentsCopied: Array.isArray(currentTailForCompaction.attachments) && currentTailForCompaction.attachments[0].name==='note.txt',
+  repeatedCompletedPromptsRemainValid: repeatedCompletedPromptCount===3,
+  isContextCompactionText: _isContextCompactionText(compactionMarker.content),
+  isContextCompactionMessage: _isContextCompactionMessage(compactionMarker),
 }}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -385,6 +464,15 @@ def test_user_turn_dedupe_is_scoped_to_current_turn_by_behavior():
     assert result["inflightAfterHistoryRoles"] == ["user", "assistant", "user", "assistant"]
     assert result["inflightWithCurrentRoles"] == ["user", "assistant", "user", "assistant"]
 
+    assert result["insertedAfterCompaction"] is False
+    assert result["compactionCurrentTailContent"] == "[Workspace::v1: /tmp/current]\nrepeat me"
+    assert result["compactionTailDuplicate"] is True
+    assert result["compactionPromptCount"] == 1
+    assert result["compactionMarkerRetained"] is True
+    assert result["compactionLiveAssistantRetained"] is True
+    assert result["completedBoundaryDedupe"] is False
+    assert result["distinctCompletedTurnPromptCount"] == 2
+
 
 def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     """Deferred active reload must not hide a current repeat prompt.
@@ -404,6 +492,12 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["workspaceCurrentTailDedupe"] is True
     assert result["liveAfterCurrentTailDedupe"] is True
     assert result["differentCurrentTailSurvives"] is True
+    assert result["compactionBoundaryDedupe"] is True
+    assert result["compactionBoundaryCurrentTail"] is True
+    assert result["compactionCurrentTailAttachmentsCopied"] is True
+    assert result["repeatedCompletedPromptsRemainValid"] is True
+    assert result["isContextCompactionText"] is True
+    assert result["isContextCompactionMessage"] is True
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():


### PR DESCRIPTION
## Thinking Path

- Reloading or reattaching to an active turn can reconstruct the transcript from persisted messages, browser inflight state, and `pending_user_message` at the same time.
- When a synthetic context-compaction row follows the submitted user prompt, current-turn lookup treated that marker as the latest user turn and failed to recognize the prompt already present immediately before it.
- That allowed one submitted prompt to render twice even though backend persistence and model input contained it once.
- The narrow fix is to treat canonical compaction markers as transparent only while locating the active current-turn user message. Completed assistant rows remain hard boundaries, so identical text in separate completed turns is still valid.

## What Changed

- Made both session-load and refresh/reconnect current-tail scans skip canonical synthetic context-compaction rows.
- Kept live assistant and tool rows transparent while preserving completed-turn boundaries.
- Added behavior coverage for pending and inflight reconciliation, refresh-path dedupe, attachment carry-forward, marker/live-row retention, and repeated prompt text across distinct completed turns.

## Why It Matters

- Prevents duplicate user bubbles during active-stream reattachment around a compaction boundary.
- Keeps the visible transcript aligned with the single backend/model turn.
- Avoids global text deduplication, preserving legitimate repeated prompts in later turns.

## Screenshots

Before — the same pending prompt appears twice in a real isolated WebUI active-stream session (`1934×947`).

<img width="1934" height="947" alt="Before: duplicated pending prompt across a compaction boundary" src="https://raw.githubusercontent.com/starship-s/hermes-webui/13e458760126cade5497beb3a797a0705b89d5a8/evidence/compaction-pending-message-dedupe/before.png" />

After — the prompt appears once while the active Hermes worklog remains present (`1934×947`).

<img width="1934" height="947" alt="After: one pending prompt with active worklog preserved" src="https://raw.githubusercontent.com/starship-s/hermes-webui/13e458760126cade5497beb3a797a0705b89d5a8/evidence/compaction-pending-message-dedupe/after.png" />

## Verification

Targeted and related behavior coverage:

`python -m pytest -q tests/test_run_journal_frontend_static.py tests/test_issue2341_pending_user_reattach.py tests/test_inflight_stream_reuse.py tests/test_regressions.py`

Result: `111 passed, 1 skipped`

Independent broader relevant regression sweep: `461 passed`

Syntax and hygiene:

- `node --check static/ui.js`
- `node --check static/sessions.js`
- `python -m py_compile tests/test_run_journal_frontend_static.py`
- `git diff --check origin/master...HEAD`

Real-instance browser verification used the same neutral 550-message backend session, active stream, browser inflight state, viewport, and navigation sequence before and after.

## Risks / Follow-ups

- This changes frontend transcript reconciliation only; backend persistence and model input are unchanged.
- Compaction recognition continues to use the existing shared classifier used by transcript rendering.

## Model Used

- OpenAI / `gpt-5.6-sol` via Hermes Agent for diagnosis, implementation, verification, and visual validation.
- OpenAI / `gpt-5.3-codex-spark` via OpenCode for review-follow-up implementation and regression coverage.
- Anthropic / `claude-opus-4-8` (`max`) via Claude Code for independent review and final signoff.
