### PR TITLE
fix: teach the WebUI ephemeral system prompt that redacted credential values are intentional masking

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -636,6 +636,7 @@ WebUI progress guidance:
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.
+- Password, API-key, token, and secret fields are automatically redacted by the system. Treat masked values as intentional redaction, not placeholder text or user input errors, and do not tell the user a stored credential is wrong based on a masked value alone.
 - Final visible assistant replies must be clear, user-facing, and in the user's language, not private planning notes.
 - Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need script", "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
 - For direct answers or very short tasks, skip progress updates and answer normally.

--- a/tests/test_issue5871_redaction_awareness_prompt.py
+++ b/tests/test_issue5871_redaction_awareness_prompt.py
@@ -1,0 +1,47 @@
+"""Product-semantics coverage for WebUI credential-masking guidance (#5871)."""
+
+import re
+
+from api.streaming import _WEBUI_PROGRESS_PROMPT, _webui_ephemeral_system_prompt
+
+
+def _redaction_guidance() -> str:
+    return next(
+        line for line in _WEBUI_PROGRESS_PROMPT.splitlines()
+        if "automatically redacted" in line
+    )
+
+
+def test_progress_prompt_explains_intentional_credential_redaction():
+    guidance = _redaction_guidance()
+
+    assert "Password, API-key, token, and secret fields" in guidance
+    assert "intentional redaction" in guidance
+    assert "not placeholder text or user input errors" in guidance
+    assert "do not tell the user a stored credential is wrong" in guidance
+    assert "masked value alone" in guidance
+
+
+def test_redaction_guidance_flows_into_ephemeral_system_prompt():
+    prompt = _webui_ephemeral_system_prompt(
+        "Use a concise tone.",
+        surface_context={"source": "webui"},
+    )
+
+    assert _redaction_guidance() in prompt
+
+
+def test_progress_prompt_retains_secret_leak_prevention_guidance():
+    assert (
+        "Do not reveal hidden reasoning, chain-of-thought, private scratchpads, "
+        "secrets, raw logs, or long tool output."
+    ) in _WEBUI_PROGRESS_PROMPT
+
+
+def test_redaction_guidance_does_not_teach_concrete_key_or_mask_formats():
+    guidance = _redaction_guidance()
+
+    assert "***" not in guidance
+    assert "..." not in guidance
+    assert not re.search(r"\b(?:sk-|ghp_|github_pat_|xox[baprs]-|AKIA)\S+", guidance)
+    assert not re.search(r"\b[A-Za-z0-9_-]{24,}\b", guidance)


### PR DESCRIPTION
## Thinking Path
Users were being told their stored credentials were wrong when the values were actually fine. The WebUI and the agent redact secrets before the model sees them (`***`, `sk-abc...xyz1`), but nothing in the model-facing prompt says that masking exists, so the model reads a masked value as a placeholder or a user mistake. The collaborator review on #5871 confirmed the failure end to end and endorsed Option A, a masking-awareness bullet in `_WEBUI_PROGRESS_PROMPT`, as the WebUI-side stopgap while the durable Option B fix belongs in the upstream agent repo.

## What Changed
One bullet added to `_WEBUI_PROGRESS_PROMPT` in `api/streaming.py`, placed next to the existing "Do not reveal ... secrets" line so leak-prevention and interpretation guidance sit together. It tells the model that password/API-key/token/secret fields are automatically redacted, that masked values are intentional redaction rather than placeholder text or input errors, and that it must not tell a user a stored credential is wrong based on a masked value alone. Per the maintainer's wording note, it does not enumerate what real key shapes look like.

## Why It Matters
This closes a confirmed real-user failure (`VITE_DEFAULT_API_KEY=***` being flagged as a broken credential) at the layer the maintainer scoped for this repo. The prompt flows into the model through `agent.ephemeral_system_prompt = _webui_ephemeral_system_prompt(...)`, so every WebUI session picks it up.

## Verification
`tests/test_issue5871_redaction_awareness_prompt.py` follows the repo's `tests/test_issue<NNNN>_*.py` convention: it asserts the guidance bullet is present in `_WEBUI_PROGRESS_PROMPT` and that it flows into the assembled ephemeral prompt. Ran with pytest; both tests pass.

## Risks
Low. The change is a single prompt bullet; no code paths change. The main risk is prompt-length creep, which one line does not meaningfully affect.

## Contract Routing
Touches the WebUI ephemeral-prompt contract family (model-facing progress guidance in `api/streaming.py`); no changes to `docs/CONTRACTS.md` schemas themselves.

## Model Used
AI was used for assistance.

Refs #5871 (covers the WebUI-side Option A; the durable Option B fix needs an upstream change in the agent repo)
