### PR TITLE
fix: reset context selection counter on clear and session switch

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -910,10 +910,12 @@ function _addNamedContextBlock(text){
 
 function _removeNamedContextBlock(id){
   _pendingSelections=_pendingSelections.filter(s=>s.id!==id);
+  if(!_pendingSelections.length)_selectionIdCounter=0;
   _renderSelectionChips();
 }
 
 function _clearPendingSelections(){
+  _selectionIdCounter=0;
   if(!_pendingSelections.length)return false;
   _pendingSelections=[];
   _renderSelectionChips();


### PR DESCRIPTION
The context selection counter (`_selectionIdCounter`) is a module-level variable in `messages.js` that persists for the lifetime of the SPA session. It only ever increments — never resets — causing two related bugs:

1. **Within a session:** selecting text for context adds chips numbered "Context 1", "Context 2"… "Context N". Clearing all chips and selecting again starts at "Context N+1" instead of "Context 1".

2. **Across sessions (New Chat or sidebar switch):** since the SPA never unloads, the counter carries between conversations. A session with 10 context chips leaves the counter at 10, and the next session starts at "Context 11" instead of "Context 1".

### Root cause

`_selectionIdCounter` (initialized to `0` at module scope) is incremented in `_addNamedContextBlock()` to produce unique chip IDs. Three state-clearing paths exist — `_clearPendingSelections()` (bulk clear, called on New Chat and sidebar session switch), `_removeNamedContextBlock()` (individual chip removal via ✕), and the internal guard in `_clearPendingSelections()` that bails early when the pending array is already empty — and none of them reset the counter.

### Fix (2 additions)

1. **`_clearPendingSelections()`** — moved `_selectionIdCounter = 0` to the top of the function, **before** the empty-array guard. This ensures the counter resets on every call: manual clear-all, flush-to-composer, post-send cleanup, New Chat, and sidebar session switch — regardless of whether `_pendingSelections` already had items.

2. **`_removeNamedContextBlock()`** — added `if(!_pendingSelections.length)_selectionIdCounter=0;` so removing the last individual chip also resets the counter.

### Before/After

| Action | Before | After |
|--------|--------|-------|
| Select "Context 1", clear all, select again | "Context 2" | "Context 1" |
| Select 10 times, New Chat, select again | "Context 11" | "Context 1" |
| Remove last chip individually, select again | "Context N+1" | "Context 1" |