### PR TITLE
Release exp-v0.52.37: context-selection counter reset (#5929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **Context chips restart at "Context 1" after you clear them.** The selection counter used to only ever increment, so clearing all context chips (or switching sessions) and selecting new text started at "Context N+1" instead of "Context 1". The counter now resets whenever the last chip is removed and on clear-all / session switch, so chip numbering starts fresh each time. Thanks @akay64. (#5929)
+
 - **The agent no longer tells you a stored credential is "wrong" when it's just masked.** Secrets are redacted (`***`, `sk-abc…xyz1`) before the model sees them, but nothing told the model that masking was intentional — so it sometimes read a masked API key or password and reported it as a typo or a placeholder. The WebUI progress-guidance prompt now explains that redacted credential fields are deliberate masking, so the agent stops flagging correctly-stored secrets as errors. Thanks @mvanhorn. (#5927, #5871)
 
 - **Stale "unread" dot no longer lingers on a session after you open it.** Visiting a session now clears its sidebar unread indicator across the paths that previously left it stuck — the same-session reselect, the metadata-arrival ack, and the post-message-load re-sync — while a completion that lands in a genuinely hidden/background tab correctly stays unread. It also stops a phantom unread/streaming indicator from appearing when you switch from a busy session to an idle one (the idle session's streaming flags are now reset from its own metadata before the sidebar repaint, instead of inheriting the previous session's busy state). Thanks @neaucode-bot. (#5917, #4946)

--- a/static/messages.js
+++ b/static/messages.js
@@ -910,10 +910,12 @@ function _addNamedContextBlock(text){
 
 function _removeNamedContextBlock(id){
   _pendingSelections=_pendingSelections.filter(s=>s.id!==id);
+  if(!_pendingSelections.length)_selectionIdCounter=0;
   _renderSelectionChips();
 }
 
 function _clearPendingSelections(){
+  _selectionIdCounter=0;
   if(!_pendingSelections.length)return false;
   _pendingSelections=[];
   _renderSelectionChips();

--- a/tests/test_issue2543_named_context_session_switch.py
+++ b/tests/test_issue2543_named_context_session_switch.py
@@ -34,3 +34,24 @@ def test_newsession_clears_pending_named_context():
     assert "window._clearPendingSelections()" in head, (
         "newSession() must clear pending named context blocks before replacing S.session"
     )
+
+
+def test_selection_id_counter_resets_when_all_chips_cleared():
+    # #5929: the module-level _selectionIdCounter only ever incremented, so
+    # clearing all context chips and selecting again started at "Context N+1"
+    # instead of "Context 1". It must reset to 0 when the last chip is removed
+    # AND on _clearPendingSelections (clear-all / session switch).
+    remove_fn = MESSAGES_JS[
+        MESSAGES_JS.index("function _removeNamedContextBlock(id){"):
+        MESSAGES_JS.index("function _clearPendingSelections(){")
+    ]
+    assert "if(!_pendingSelections.length)_selectionIdCounter=0;" in remove_fn, (
+        "_removeNamedContextBlock must reset _selectionIdCounter to 0 once the "
+        "last chip is removed so the next selection restarts at Context 1"
+    )
+    clear_fn = MESSAGES_JS[MESSAGES_JS.index("function _clearPendingSelections(){"):]
+    clear_fn = clear_fn[:clear_fn.index("\n}") + 2]
+    assert "_selectionIdCounter=0;" in clear_fn, (
+        "_clearPendingSelections must reset _selectionIdCounter to 0 (clear-all "
+        "and session-switch path) so context chip numbering restarts at 1"
+    )


### PR DESCRIPTION
Ships **#5929** to the experimental channel: context chips restart at "Context 1" after clear.

## What ships
The `_selectionIdCounter` (labels context chips "Context 1", "Context 2"…) only ever incremented, so clearing all chips (or switching sessions) and selecting new text started at "Context N+1". It now resets to 0 when the last chip is removed and on clear-all / session switch, so numbering restarts fresh.

## Gate
SAFE TO SHIP — +2 lines, provably safe: the reset only fires when `_pendingSelections` is empty, so no id collision is possible. Actual-function Node probe confirmed unique ids after partial removal, last-chip removal, clear-all, and empty early-return. No regression to id assignment, chip render, or the #2543 session-switch clear path. I added a maintainer regression test (asserts both reset points), preserving @akay64 attribution. UI-adjacent-behavior reliability class — overnight-eligible.

## Attribution
Original fix by @akay64 (Co-authored-by). (Closes #5929)

## Verification
Staged full suite: 12,767 passed (the single test_static_asset_resolver diff is the known untagged-stage git-describe version artifact — resolves on tag). Tags exp-v0.52.37.
