### PR TITLE
fix(reasoning): stop date-stamped Claude 3.0 ids from surfacing reasoning-effort controls

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3142,8 +3142,13 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
     if normalized in {"o1", "o3", "o4"} or normalized.startswith(("o1-", "o3-", "o4-")):
         return True
     if "claude" in token_set or normalized.startswith("claude"):
-        # Restrict to Claude 4+ or Claude 3.7+ (exclude Claude 3.0/3.5)
-        match = re.search(r"claude.*?(\d+)(?:\D+(\d+))?", normalized)
+        # Restrict to Claude 4+ or Claude 3.7+ (exclude Claude 3.0/3.5).
+        # The minor group is capped at 1-2 digits with a (?!\d) guard so a
+        # trailing date stamp is NOT captured as a minor version — otherwise a
+        # bare, date-stamped Claude 3.0 id ("claude-3-opus-20240229") would read
+        # minor=20240229 and wrongly satisfy the 3.7+ gate. (Same date-stamp
+        # defense _is_pre_adaptive_anthropic already uses.)
+        match = re.search(r"claude.*?(\d+)(?:\D+(\d{1,2})(?!\d))?", normalized)
         if match:
             major = int(match.group(1))
             minor = int(match.group(2)) if match.group(2) else 0

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -417,3 +417,34 @@ def test_max_only_offered_in_ui_when_actually_supported():
     assert "max" not in cfg.resolve_model_reasoning_efforts("claude-sonnet-4-5", provider_id="anthropic")
     assert "max" not in cfg.resolve_model_reasoning_efforts("gpt-5.1", provider_id="openai")
     assert "max" not in cfg.resolve_model_reasoning_efforts("gemini-3-pro", provider_id="gemini")
+
+
+def test_datestamped_claude3_not_reasoning_capable_heuristic():
+    # A bare, date-stamped Claude 3.0 id must NOT be treated as reasoning-capable
+    # by the heuristic. The minor-version capture previously used `(\d+)`, which
+    # swallowed the 8-digit date stamp ("...-20240229") as the minor version so
+    # `major==3 and minor>=7` wrongly matched — surfacing reasoning-effort
+    # controls for models that don't support them. Claude 3.0/3.5 have no
+    # extended-thinking support; only 3.7+ (and 4.x) do.
+    for model in (
+        "claude-3-opus-20240229",
+        "claude-3-sonnet-20240229",
+        "claude-3-haiku-20240307",
+        "claude-3-opus",
+        "claude-3-5-sonnet-20241022",
+    ):
+        assert cfg._candidate_supports_reasoning(model) is False, (
+            f"{model} must not be reasoning-capable (Claude 3.0/3.5 excluded)"
+        )
+    # 3.7+ and 4.x (including date-stamped builds) stay reasoning-capable.
+    for model in (
+        "claude-3-7-sonnet",
+        "claude-3-7-sonnet-20250219",
+        "claude-sonnet-4-5",
+        "claude-opus-4-20250514",
+        "claude-opus-4.6",
+    ):
+        assert cfg._candidate_supports_reasoning(model) is True, (
+            f"{model} must remain reasoning-capable"
+        )
+


### PR DESCRIPTION
## Summary

`_candidate_supports_reasoning()` in `api/config.py` — the heuristic that decides whether a model exposes reasoning-effort controls when models.dev / hermes_cli metadata is unavailable — misclassifies **bare, date-stamped Claude 3.0 model ids** (e.g. `claude-3-opus-20240229`) as reasoning-capable. Its own contract says *"Restrict to Claude 4+ or Claude 3.7+ (exclude Claude 3.0/3.5)"*, so this is a self-contradiction.

## Root cause

```python
# api/config.py  (_candidate_supports_reasoning, Claude branch)
match = re.search(r"claude.*?(\d+)(?:\D+(\d+))?", normalized)
if match:
    major = int(match.group(1))
    minor = int(match.group(2)) if match.group(2) else 0
    if major >= 4 or (major == 3 and minor >= 7):
        return True
```

The minor-version group `(\d+)` is unbounded, so when a Claude 3.0 id carries a **date stamp and no real minor version** the regex captures the 8-digit date as the "minor":

- `claude-3-opus-20240229` → `major=3, minor=20240229` → `minor >= 7` → **True** (wrong)
- `claude-3-5-sonnet-20241022` → `major=3, minor=5` → False (correct — a real minor "5" sits before the date)

So the *older* Claude 3.0 Opus/Sonnet/Haiku wrongly get reasoning controls while the *newer* Claude 3.5 correctly does not — a clear inconsistency. For a bare anthropic id (no `anthropic/` prefix), `_heuristic_reasoning_efforts()` falls straight through to this gate, so `resolve_model_reasoning_efforts()` returns `[minimal, low, medium, high, xhigh]` for Claude 3 Opus and the UI shows effort options the model rejects.

## Fix

Cap the minor group to 1–2 digits with a `(?!\d)` guard so a trailing date stamp is never read as a minor version — the exact date-stamp defense `_is_pre_adaptive_anthropic()` already uses (`"A date-stamp (>=6 digits) is NOT a minor version"`):

```python
match = re.search(r"claude.*?(\d+)(?:\D+(\d{1,2})(?!\d))?", normalized)
```

One-line regex change plus a focused regression test.

## Correctness

| model id | expected | before | after |
|---|---|---|---|
| `claude-3-opus-20240229` | False | **True** | False |
| `claude-3-sonnet-20240229` | False | **True** | False |
| `claude-3-haiku-20240307` | False | **True** | False |
| `claude-3-opus` | False | False | False |
| `claude-3-5-sonnet-20241022` | False | False | False |
| `claude-3-7-sonnet` | True | True | True |
| `claude-3-7-sonnet-20250219` | True | True | True |
| `claude-sonnet-4-5` | True | True | True |
| `claude-opus-4-20250514` | True | True | True |
| `claude-opus-4.6` | True | True | True |

The existing `test_max_effort_degrades_to_xhigh_for_pre_adaptive_anthropic` (which lists `claude-3-opus-20240229`) is unaffected: its `max -> xhigh` result comes from the ceiling path (`_is_pre_adaptive_anthropic` + `_filter_reasoning_efforts_for_provider`), which is independent of this heuristic and still degrades regardless of the now-empty supported list.

## Verification

- Extracted the real `_candidate_supports_reasoning` regex and ran it under Python 3.11 against the table above: **before = 3 mismatches, after = 0**. (verified by executing the extracted function locally; full `api.config` import not run in this environment)
- Fix mirrors the established `\d{1,2}` + `(?!\d)` date-stamp guard already present in `_is_pre_adaptive_anthropic`.
