### PR TITLE
fix(workspace): render local images referenced in .md files

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -4548,7 +4548,7 @@ async function _openWikiBrowser() {
       const data = await api('/api/wiki/page?path=' + encodeURIComponent(path));
       if (typeof renderMarkdownPreviewContent === 'function') {
         contentEl.innerHTML = '<button onclick="window._wikiBrowserBack()" style="margin-bottom:10px;background:none;border:1px solid var(--border);border-radius:4px;padding:3px 10px;cursor:pointer;font-size:12px;color:var(--text);">&#8592; Back</button><div id="wikiBrowserMd"></div>';
-        renderMarkdownPreviewContent({content: data.content, el: document.getElementById('wikiBrowserMd')});
+        renderMarkdownPreviewContent({content: data.content, el: document.getElementById('wikiBrowserMd'), baseDir: path});
       } else {
         contentEl.innerHTML = '<button onclick="window._wikiBrowserBack()" style="margin-bottom:10px;background:none;border:1px solid var(--border);border-radius:4px;padding:3px 10px;cursor:pointer;font-size:12px;color:var(--text);">&#8592; Back</button><pre style="white-space:pre-wrap;word-break:break-word;font-size:12px;margin:0;">' + esc(data.content) + '</pre>';
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -6771,7 +6771,9 @@ function renderMd(raw){
     // backticks stays protected as a \x00C token and is never rendered as <img>.
     // Must run before _code_stash restore and before _link_stash so the image
     // is not consumed by the [label](url) link regex.
-    t=t.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|\/api\/file\/raw\?|file:\/\/)[^\)]+)\)/g,(_,alt,url)=>`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+    t=t.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|\/api\/file\/raw\?|file:\/\/)[^\)]+)\)/g,(_,alt,url)=>{
+      return `<img src="${_markdownImgSrc(url)}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`;
+    });
     // Stash rendered <img> tags so autolink never matches URLs inside src=
     const _img_stash=[];
     t=t.replace(/(<img\b[^>]*>)/g,m=>{_img_stash.push(m);return `\x00G${_img_stash.length-1}\x00`;});
@@ -6913,7 +6915,7 @@ function renderMd(raw){
   // #487: Outer image pass — handles ![alt](url) in plain paragraphs (outside tables/lists).
   // Runs AFTER the table pass (images in table cells are handled by inlineMd() above).
   // Runs BEFORE the outer [label](url) link pass so the image is not consumed as a plain link.
-  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|\/api\/file\/raw\?|file:\/\/)[^\)]+)\)/g,(_,alt,url)=>`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|\/api\/file\/raw\?|file:\/\/)[^\)]+)\)/g,(_,alt,url)=>`<img src="${_markdownImgSrc(url)}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
   // Outer link pass for labeled links in plain paragraphs (outside table cells).
   // Runs AFTER the table pass so table cells are processed by inlineMd() only.
   // Stash existing <a> tags first to avoid re-linking already-linked URLs.
@@ -6934,6 +6936,13 @@ function renderMd(raw){
   const SAFE_TAGS=/^<\/?(?:strong|em|del|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td|hr|blockquote|p|br|a|div|span|img)([\s>]|$)/i;
   function _safeAttrValue(v){
     return String(v||'').replace(/&quot;/g,'"').replace(/&#39;/g,"'").replace(/&amp;/g,'&').trim();
+  }
+  // #5933 F3: Build a CSP-safe <img src> from a markdown image URL.
+  // file:// URLs are routed through /api/media (same rewrite as _markdownHref
+  // applies to file:// links) because CSP img-src has no file: scheme — a raw
+  // file:// src would be silently blocked by the browser.
+  function _markdownImgSrc(raw){
+    return _markdownHref(raw).replace(/"/g,'%22');
   }
   function _markdownHref(raw){
     const href=String(raw||'').replace(/"/g,'%22');

--- a/static/ui.js
+++ b/static/ui.js
@@ -6771,7 +6771,7 @@ function renderMd(raw){
     // backticks stays protected as a \x00C token and is never rendered as <img>.
     // Must run before _code_stash restore and before _link_stash so the image
     // is not consumed by the [label](url) link regex.
-    t=t.replace(/!\[([^\]]*)\]\((https?:\/\/[^\)]+)\)/g,(_,alt,url)=>`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+    t=t.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|\/api\/file\/raw\?|file:\/\/)[^\)]+)\)/g,(_,alt,url)=>`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
     // Stash rendered <img> tags so autolink never matches URLs inside src=
     const _img_stash=[];
     t=t.replace(/(<img\b[^>]*>)/g,m=>{_img_stash.push(m);return `\x00G${_img_stash.length-1}\x00`;});
@@ -6913,7 +6913,7 @@ function renderMd(raw){
   // #487: Outer image pass — handles ![alt](url) in plain paragraphs (outside tables/lists).
   // Runs AFTER the table pass (images in table cells are handled by inlineMd() above).
   // Runs BEFORE the outer [label](url) link pass so the image is not consumed as a plain link.
-  s=s.replace(/!\[([^\]]*)\]\((https?:\/\/[^\)]+)\)/g,(_,alt,url)=>`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|\/api\/file\/raw\?|file:\/\/)[^\)]+)\)/g,(_,alt,url)=>`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
   // Outer link pass for labeled links in plain paragraphs (outside table cells).
   // Runs AFTER the table pass so table cells are processed by inlineMd() only.
   // Stash existing <a> tags first to avoid re-linking already-linked URLs.
@@ -7006,7 +7006,8 @@ function renderMd(raw){
     if(/^(javascript|data|vbscript):/i.test(compact)) return false;
     if(/^https?:\/\//i.test(raw)) return true;
     if(/^(mailto:|tel:|message:)/i.test(raw)) return true;
-    if(img && /^api\//i.test(raw)) return true;
+    // #5933: allow /api/file/raw?… (workspace image preview) and file:// URLs
+    if(img && (/^api\//i.test(raw) || /^\/api\//i.test(raw) || /^file:\/\//i.test(raw))) return true;
     if(!img && (/^api\//i.test(raw) || /^#/.test(raw) || _isInternalSessionHref(raw))) return true;
     return false;
   }

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -849,9 +849,27 @@ function setLargeMarkdownForceRenderVisible(visible){
 }
 
 function renderMarkdownPreviewContent(data){
+  // #5933: resolve relative image paths to /api/file/raw?… API URLs so
+  // images referenced in the markdown (e.g. ![alt](./img.png)) render inline
+  // in the workspace preview rather than showing broken links.
+  let content = data.content;
+  if (_previewCurrentPath && S.session) {
+    const dirPath = _previewCurrentPath.includes('/')
+      ? _previewCurrentPath.substring(0, _previewCurrentPath.lastIndexOf('/') + 1)
+      : '';
+    content = content.replace(
+      /!\[([^\]]*)\]\((?!https?:\/\/|\/api\/|file:\/\/)([^\)]+)\)/g,
+      (_, alt, relPath) => {
+        const resolvedPath = _normalizeWorkspaceRelPath(dirPath + relPath);
+        const sessionId = encodeURIComponent(S.session.session_id);
+        const apiUrl = `/api/file/raw?session_id=${sessionId}&path=${encodeURIComponent(resolvedPath)}&inline=1`;
+        return `![${alt}](${apiUrl})`;
+      }
+    );
+  }
   const target=data&&data.el?data.el:$('previewMd');
   if(!data||!data.el) showPreview('md');
-  target.innerHTML=renderMd(data.content);
+  target.innerHTML=renderMd(content);
   requestAnimationFrame(()=>{if(typeof renderKatexBlocks==='function')renderKatexBlocks();});
 }
 

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -853,11 +853,23 @@ function renderMarkdownPreviewContent(data){
   // images referenced in the markdown (e.g. ![alt](./img.png)) render inline
   // in the workspace preview rather than showing broken links.
   let content = data.content;
-  if (_previewCurrentPath && S.session) {
-    const dirPath = _previewCurrentPath.includes('/')
-      ? _previewCurrentPath.substring(0, _previewCurrentPath.lastIndexOf('/') + 1)
+  // basePath: the directory to resolve relative image paths against. Prefer
+  // an explicit data.baseDir (e.g. from the wiki browser, which has no
+  // _previewCurrentPath context) and fall back to _previewCurrentPath.
+  // Using a stale _previewCurrentPath for non-previewMd targets would resolve
+  // images against the wrong directory (#5933 F2).
+  const basePathSrc = (data && data.baseDir) ? data.baseDir : _previewCurrentPath;
+  if (basePathSrc && S.session) {
+    const dirPath = basePathSrc.includes('/')
+      ? basePathSrc.substring(0, basePathSrc.lastIndexOf('/') + 1)
       : '';
-    content = content.replace(
+    // Stash fenced code blocks and inline-code spans BEFORE the image rewrite
+    // so ![alt](./img.png) inside `code` or ```fences``` is NOT rewritten —
+    // renderMd would otherwise render an <img> inside <code> (#5933 F1).
+    const _codeStash=[];
+    let work=content.replace(/```[^\n`]*\n[\s\S]*?\n```/g,m=>{_codeStash.push(m);return '\x00K'+(_codeStash.length-1)+'\x00';});
+    work=work.replace(/`[^`\n]+`/g,m=>{_codeStash.push(m);return '\x00K'+(_codeStash.length-1)+'\x00';});
+    work=work.replace(
       /!\[([^\]]*)\]\((?!https?:\/\/|\/api\/|file:\/\/)([^\)]+)\)/g,
       (_, alt, relPath) => {
         const resolvedPath = _normalizeWorkspaceRelPath(dirPath + relPath);
@@ -866,6 +878,7 @@ function renderMarkdownPreviewContent(data){
         return `![${alt}](${apiUrl})`;
       }
     );
+    content=work.replace(/\x00K(\d+)\x00/g,(_,i)=>_codeStash[+i]);
   }
   const target=data&&data.el?data.el:$('previewMd');
   if(!data||!data.el) showPreview('md');

--- a/tests/test_issue2823_large_markdown_preview.py
+++ b/tests/test_issue2823_large_markdown_preview.py
@@ -55,7 +55,7 @@ def test_markdown_render_helper_runs_render_md_and_katex():
     helper = WORKSPACE_JS[start:end]
 
     target_pos = helper.find("const target=data&&data.el?data.el:$('previewMd')")
-    render_pos = helper.find("target.innerHTML=renderMd(data.content)")
+    render_pos = helper.find("target.innerHTML=renderMd(content)")
     katex_pos = helper.rfind("renderKatexBlocks")
     assert target_pos != -1, "Helper must honor an explicit markdown render target"
     assert "if(!data||!data.el) showPreview('md')" in helper

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -368,20 +368,20 @@ def test_workspace_calls_render_katex_after_preview():
 
 
 def test_workspace_renders_katex_after_file_open():
-    """workspace.js renderKatexBlocks call must come after the renderMd(data.content) assignment."""
-    preview_md_pos = WORKSPACE_JS.find("renderMd(data.content)")
+    """workspace.js renderKatexBlocks call must come after the renderMd(content) assignment."""
+    preview_md_pos = WORKSPACE_JS.find("renderMd(content)")
     # Use the actual call string (not a stray regex match on 'M' characters)
     katex_call_str = "renderKatexBlocks==='function'"
     katex_call_pos = WORKSPACE_JS.find(katex_call_str)
-    assert preview_md_pos != -1, "renderMd(data.content) not found in workspace.js"
+    assert preview_md_pos != -1, "renderMd(content) not found in workspace.js"
     assert katex_call_pos != -1, (
         "renderKatexBlocks guard (typeof renderKatexBlocks==='function') not found in workspace.js"
     )
-    # The call after 'renderMd(data.content)' — find the LAST occurrence
+    # The call after 'renderMd(content)' — find the LAST occurrence
     # (there may be an earlier one in the save path at line ~153)
     last_katex_pos = WORKSPACE_JS.rfind(katex_call_str)
     assert last_katex_pos > preview_md_pos, (
-        "renderKatexBlocks must be called AFTER renderMd(data.content) in workspace.js "
+        "renderKatexBlocks must be called AFTER renderMd(content) in workspace.js "
         f"(renderMd at {preview_md_pos}, last renderKatexBlocks at {last_katex_pos})"
     )
 

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -789,3 +789,55 @@ class TestBareFileUrlMediaRendering:
         # Labeled anchors keep the normal link path (routed to /api/media as a link,
         # not auto-loaded as an <img>).
         assert "<img" not in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #5933: Markdown image syntax ![alt](url) must render <img> for more URL
+# schemes than just https?://.  The workspace .md preview pre-resolves relative
+# image paths to /api/file/raw?… API URLs, and file:// URLs also appear in
+# user-authored markdown.  Before the fix the inlineMd image regex only matched
+# https?:// so those images showed up as broken links.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMarkdownImageSchemeCoverage:
+    """![alt](url) must produce <img> for /api/file/raw and file:// URLs too."""
+
+    def test_api_file_raw_url_renders_as_img(self, driver_path):
+        out = _render(driver_path, "![chart](/api/file/raw?session_id=abc&path=images%2Fchart.png&inline=1)")
+        assert "<img" in out and "msg-media-img" in out, (
+            f"/api/file/raw?… image must render as <img>: {out!r}"
+        )
+        # HTML sanitizer escapes & → &amp; in attribute values (correct behaviour)
+        assert 'src="/api/file/raw?session_id=abc&amp;path=images%2Fchart.png&amp;inline=1"' in out
+        assert 'alt="chart"' in out
+
+    def test_file_scheme_url_renders_as_img(self, driver_path):
+        out = _render(driver_path, "![screenshot](file:///tmp/shot.png)")
+        assert "<img" in out and "msg-media-img" in out, (
+            f"file:// image must render as <img>: {out!r}"
+        )
+        assert 'src="file:///tmp/shot.png"' in out
+        assert 'alt="screenshot"' in out
+
+    def test_https_url_still_renders_as_img(self, driver_path):
+        """Regression guard: the existing https?:// match must still work."""
+        out = _render(driver_path, "![capy](https://example.com/capy.png)")
+        assert "<img" in out and "msg-media-img" in out
+        assert 'src="https://example.com/capy.png"' in out
+
+    def test_image_inside_code_fence_stays_literal(self, driver_path):
+        """Images inside fenced code must NOT be rendered — fence stash protects them."""
+        out = _render(driver_path, "```\n![alt](./image.png)\n```")
+        assert "<img" not in out
+        assert "![alt](./image.png)" in out or "!&#91;alt&#93;" in out, (
+            f"Image inside code fence must stay literal: {out!r}"
+        )
+
+    def test_image_inside_inline_code_stays_literal(self, driver_path):
+        """Images inside backtick code spans must NOT be rendered — code stash protects them."""
+        out = _render(driver_path, "Run `![alt](./image.png)` now")
+        assert "<img" not in out
+        assert "<code>" in out, (
+            f"Image inside inline code must stay literal: {out!r}"
+        )

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -813,12 +813,22 @@ class TestMarkdownImageSchemeCoverage:
         assert 'alt="chart"' in out
 
     def test_file_scheme_url_renders_as_img(self, driver_path):
+        """![alt](file:///path) must route through /api/media (like file:// links)
+        because the CSP img-src directive has no file: scheme — a raw file:// src
+        would be blocked by the browser.  The established _markdownHref rewrite
+        for file:// links uses api/media?path=…&inline=1; images must do the same.
+        """
         out = _render(driver_path, "![screenshot](file:///tmp/shot.png)")
         assert "<img" in out and "msg-media-img" in out, (
             f"file:// image must render as <img>: {out!r}"
         )
-        assert 'src="file:///tmp/shot.png"' in out
-        assert 'alt="screenshot"' in out
+        assert "api/media?path=" in out, (
+            f"file:// image src must be rewritten to /api/media (CSP-safe): {out!r}"
+        )
+        assert "file://" not in out, (
+            f"file:// must not appear in rendered img src (blocked by CSP): {out!r}"
+        )
+        assert "alt=\"screenshot\"" in out
 
     def test_https_url_still_renders_as_img(self, driver_path):
         """Regression guard: the existing https?:// match must still work."""

--- a/tests/test_workspace_md_preview_preprocessing.py
+++ b/tests/test_workspace_md_preview_preprocessing.py
@@ -182,6 +182,74 @@ class TestPreprocessingSkipsInlineCode:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Maintainer review feedback (nesquena-hermes, PR #5935):
+# "There is no test for the triple-backtick fenced block case, even though
+# that's the path with its own dedicated regex (the more failure-prone of the
+# two). Fenced blocks are also the common way docs show a markdown image
+# example."
+#
+# These tests lock down fenced-block image syntax against the preprocessing
+# rewrite, paralleling the inline-code tests above.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPreprocessingSkipsFencedCode:
+    """Preprocessing must not rewrite images inside triple-backtick fenced blocks."""
+
+    def test_fenced_block_image_not_rewritten(self, driver_path):
+        """![alt](./img.png) inside a ```md fence must stay literal."""
+        md = "```md\n![alt](./img.png)\n```"
+        out = _render_preview(driver_path, md)
+        assert "/api/file/raw" not in out, (
+            f"Fenced image path must stay literal, not rewritten to /api/file/raw: {out!r}"
+        )
+        assert "./img.png" in out, (
+            f"Relative path inside fenced block must be preserved verbatim: {out!r}"
+        )
+
+    def test_fenced_block_image_no_img_tag(self, driver_path):
+        """An image inside a fenced block must NOT produce an <img> tag."""
+        md = "```md\n![alt](./img.png)\n```"
+        out = _render_preview(driver_path, md)
+        assert "<img" not in out, (
+            f"Image inside fenced block must NOT be rendered as <img>: {out!r}"
+        )
+
+    def test_fenced_block_preserves_multiple_images(self, driver_path):
+        """Multiple image refs inside a fenced block must all stay literal."""
+        md = "```md\n![first](./a.png)\n![second](./b.png)\n```"
+        out = _render_preview(driver_path, md)
+        assert "/api/file/raw" not in out
+        assert "./a.png" in out
+        assert "./b.png" in out
+
+    def test_mixed_fenced_block_and_real_image(self, driver_path):
+        """Fenced example stays literal while a real sibling image renders.
+
+        This is the mixed case the maintainer requested: proves the stash
+        restores correctly and the real image outside the fence still renders.
+        """
+        md = (
+            "```md\n"
+            "![example](./img.png)\n"
+            "```\n"
+            "\n"
+            "![real](./real.png)"
+        )
+        out = _render_preview(driver_path, md)
+        # Real image outside fence must render
+        assert "<img" in out
+        assert "/api/file/raw" in out
+        assert "msg-media-img" in out
+        # The fenced example path must stay literal (not rewritten)
+        assert "path=img.png" not in out.replace("path=real.png", ""), (
+            f"Fenced image must not be rewritten, but found /api/file/raw for it: {out!r}"
+        )
+        assert "./img.png" in out, (
+            f"Fenced example path must be preserved verbatim: {out!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # F5: exercise the preprocessing step itself (relative path resolution).
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_workspace_md_preview_preprocessing.py
+++ b/tests/test_workspace_md_preview_preprocessing.py
@@ -1,0 +1,297 @@
+"""Behavioural tests for renderMarkdownPreviewContent preprocessing (#5933).
+
+These tests drive the ACTUAL renderMd() from static/ui.js together with the
+image-path preprocessing extracted from static/workspace.js via node, so the
+full pipeline (preprocessing → renderMd) is exercised end-to-end.
+
+They close the gap noted in R1 finding F5: the existing
+TestMarkdownImageSchemeCoverage only feeds pre-resolved /api/file/raw URLs
+straight into renderMd, so it never tests the preprocessing step that rewrites
+relative ``![alt](./img.png)`` paths.  They also guard F1: image syntax inside
+inline-code spans must NOT be rewritten by the preprocessing pass (otherwise
+renderMd renders an <img> inside <code>).
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+WORKSPACE_JS_PATH = REPO_ROOT / "static" / "workspace.js"
+
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+
+// ── Load renderMd and helpers from ui.js ──────────────────────────────────
+const uiSrc = fs.readFileSync(process.argv[2], 'utf8');
+global.window = {};
+global.document = { createElement: () => ({ innerHTML: '', textContent: '' }), baseURI: 'http://localhost/app/' };
+function _sessionUrlForSid(sid) { return '/app/session/' + encodeURIComponent(String(sid || '')); }
+const esc = s => String(s ?? '').replace(/[&<>"]/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const _IMAGE_EXTS=/\.(png|jpg|jpeg|gif|webp|bmp|ico|avif)$/i;
+const _SVG_EXTS=/\.svg$/i;
+const _AUDIO_EXTS=/\.(mp3|ogg|wav|m4a|aac|flac|wma|opus|webm)$/i;
+const _VIDEO_EXTS=/\.(mp4|webm|mkv|mov|avi|ogv|m4v)$/i;
+
+function extractFunc(src, name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc(uiSrc, '_matchBacktickFenceLine'));
+eval(extractFunc(uiSrc, '_isBacktickFenceClose'));
+eval(extractFunc(uiSrc, 'renderMd'));
+
+// ── Load renderMarkdownPreviewContent from workspace.js ──────────────────
+// It references globals (_previewCurrentPath, S, _normalizeWorkspaceRelPath,
+// showPreview, $) which we stub here. renderMd is already defined above.
+const wsSrc = fs.readFileSync(process.argv[3], 'utf8');
+global._normalizeWorkspaceRelPath = function(p){
+  return String(p||'').replace(/\/+/g,'/').replace(/^\.\//,'');
+};
+global.showPreview = function(){};
+global.$ = function(id){ return { innerHTML: '' }; };
+global.requestAnimationFrame = function(fn){ if(typeof fn==='function') fn(); };
+// _previewCurrentPath and S are set per-test via stdin preamble.
+eval(extractFunc(wsSrc, 'renderMarkdownPreviewContent'));
+
+// Read test payload from stdin: lines of "KEY=VALUE" preamble, then "---",
+// then the markdown content body.
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => {
+  const sep = buf.indexOf('\n---\n');
+  let preamble, body;
+  if (sep >= 0) {
+    preamble = buf.slice(0, sep);
+    body = buf.slice(sep + 5);
+  } else {
+    preamble = '';
+    body = buf;
+  }
+  // Apply preamble
+  for (const line of preamble.split('\n')) {
+    const m = line.match(/^(\w+)=(.*)$/);
+    if (!m) continue;
+    if (m[1] === 'previewCurrentPath') global._previewCurrentPath = m[2];
+    else if (m[1] === 'sessionId') global.S = { session: { session_id: m[2] } };
+  }
+  // renderMarkdownPreviewContent renders into target.innerHTML.
+  // We capture the result by giving it a fake element.
+  const captureEl = { innerHTML: '' };
+  // Parse extra data.* fields from preamble (baseDir=…).
+  const data = { content: body, el: captureEl };
+  for (const line of preamble.split('\n')) {
+    const m = line.match(/^data\.(\w+)=(.*)$/);
+    if (m) data[m[1]] = m[2];
+  }
+  renderMarkdownPreviewContent(data);
+  process.stdout.write(captureEl.innerHTML);
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("ws_md_preview_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _render_preview(driver_path, markdown, *, preview_current_path="notes/note.md",
+                    session_id="test-sid", base_dir=None):
+    """Run renderMarkdownPreviewContent (preprocessing + renderMd) and return HTML."""
+    lines = [f"previewCurrentPath={preview_current_path}", f"sessionId={session_id}"]
+    if base_dir is not None:
+        lines.append(f"data.baseDir={base_dir}")
+    payload = "\n".join(lines) + "\n---\n" + markdown
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), str(WORKSPACE_JS_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return result.stdout
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F1: image syntax inside inline-code spans must NOT be rewritten by the
+# preprocessing pass.  Before the fix the regex matched ![alt](./img.png)
+# inside backticks, rewrote it to /api/file/raw?…, and renderMd's inlineMd
+# image pass then rendered <img> inside <code>.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPreprocessingSkipsInlineCode:
+    """Preprocessing must not rewrite images inside backtick code spans."""
+
+    def test_inline_code_image_not_rewritten(self, driver_path):
+        """`![alt](./img.png)` inside backticks must stay literal text in <code>."""
+        out = _render_preview(driver_path, "Run `![alt](./img.png)` now")
+        assert "<img" not in out, (
+            f"Image syntax inside inline code must NOT be rendered as <img>: {out!r}"
+        )
+        assert "<code>" in out
+
+    def test_inline_code_image_preserves_relative_path(self, driver_path):
+        """The relative path inside inline code must be preserved verbatim."""
+        out = _render_preview(driver_path, "See `![alt](./img.png)` here")
+        assert "./img.png" in out, (
+            f"Relative path inside inline code must be preserved: {out!r}"
+        )
+        assert "/api/file/raw" not in out or "api/file/raw" not in out.split("<code>")[1].split("</code>")[0], (
+            f"Path inside inline code must not be rewritten to /api/file/raw: {out!r}"
+        )
+
+    def test_real_image_outside_code_still_rewritten(self, driver_path):
+        """A real image outside backticks must still be rewritten and rendered."""
+        out = _render_preview(driver_path, "![real](./real.png)")
+        assert "<img" in out
+        assert "/api/file/raw" in out
+        assert "msg-media-img" in out
+
+    def test_mixed_inline_code_and_real_image(self, driver_path):
+        """Code image stays literal while a sibling real image renders."""
+        md = "Code: `![alt](./img.png)` and real ![real](./real.png)."
+        out = _render_preview(driver_path, md)
+        # Real image rendered
+        assert "<img" in out
+        assert "/api/file/raw" in out
+        # But the code span must not contain an <img>
+        assert "<code><img" not in out, (
+            f"<img> must not appear inside <code>: {out!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F5: exercise the preprocessing step itself (relative path resolution).
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPreprocessingResolvesRelativePaths:
+    """The preprocessing resolves relative image paths against the preview dir."""
+
+    def test_relative_image_in_subdirectory(self, driver_path):
+        """![alt](./img.png) with preview path notes/note.md → notes/img.png."""
+        out = _render_preview(driver_path, "![pic](./pic.png)",
+                              preview_current_path="notes/note.md")
+        assert "<img" in out
+        assert "path=notes%2Fpic.png" in out or "path=notes%2F.%2Fpic.png" in out
+
+    def test_relative_image_in_root(self, driver_path):
+        """![alt](img.png) with preview path note.md → img.png (no dir prefix)."""
+        out = _render_preview(driver_path, "![pic](pic.png)",
+                              preview_current_path="note.md")
+        assert "<img" in out
+        assert "path=pic.png" in out
+
+    def test_https_image_not_rewritten(self, driver_path):
+        """https:// images must pass through unchanged."""
+        out = _render_preview(driver_path, "![x](https://example.com/x.png)")
+        assert "<img" in out
+        assert 'src="https://example.com/x.png"' in out
+        assert "/api/file/raw" not in out
+
+    def test_already_api_url_not_double_rewritten(self, driver_path):
+        """/api/file/raw URLs must not be rewritten again."""
+        url = "/api/file/raw?session_id=abc&path=x.png&inline=1"
+        out = _render_preview(driver_path, f"![x]({url})")
+        assert "<img" in out
+        # Should not be double-rewritten
+        assert out.count("/api/file/raw") == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F2: wiki browser must pass baseDir via data, not rely on stale
+# _previewCurrentPath.  renderMarkdownPreviewContent must honor an explicit
+# data.baseDir for path resolution, even when _previewCurrentPath is unset or
+# points to an unrelated file.
+# ─────────────────────────────────────────────────────────────────────────────
+
+PANELS_JS_PATH = REPO_ROOT / "static" / "panels.js"
+
+
+class TestPreviewBaseDirOverride:
+    """renderMarkdownPreviewContent must honor data.baseDir for path resolution."""
+
+    def test_basedir_resolves_when_preview_path_unset(self, driver_path):
+        """When _previewCurrentPath is empty, data.baseDir must still resolve images.
+
+        This is the wiki browser case: _previewCurrentPath may be empty or stale
+        because the user navigated the wiki, not the workspace file tree.
+        """
+        out = _render_preview(
+            driver_path,
+            "![pic](./pic.png)",
+            preview_current_path="",
+            base_dir="wiki/page.md",
+        )
+        assert "<img" in out, (
+            f"data.baseDir must resolve images even when _previewCurrentPath is empty: {out!r}"
+        )
+        assert "/api/file/raw" in out
+        assert "path=wiki%2Fpic.png" in out or "path=wiki%2F.%2Fpic.png" in out
+
+    def test_basedir_overrides_stale_preview_path(self, driver_path):
+        """data.baseDir must win over a stale _previewCurrentPath.
+
+        Without the fix, a stale _previewCurrentPath (from the last-previewed
+        workspace file) would resolve wiki images against the wrong directory.
+        """
+        out = _render_preview(
+            driver_path,
+            "![pic](./pic.png)",
+            preview_current_path="unrelated/other.md",
+            base_dir="wiki/page.md",
+        )
+        assert "<img" in out
+        # Must resolve against baseDir (wiki/), NOT _previewCurrentPath (unrelated/)
+        assert "path=wiki%2Fpic.png" in out or "path=wiki%2F.%2Fpic.png" in out
+        assert "unrelated" not in out, (
+            f"Stale _previewCurrentPath must NOT be used when data.baseDir is set: {out!r}"
+        )
+
+    def test_no_basedir_falls_back_to_preview_path(self, driver_path):
+        """Without data.baseDir, _previewCurrentPath is used (backwards compat)."""
+        out = _render_preview(
+            driver_path,
+            "![pic](./pic.png)",
+            preview_current_path="fallback/note.md",
+        )
+        assert "<img" in out
+        assert "path=fallback%2Fpic.png" in out or "path=fallback%2F.%2Fpic.png" in out
+
+
+class TestWikiBrowserPassesBaseDir:
+    """The wiki browser caller in panels.js must pass baseDir=path to
+    renderMarkdownPreviewContent so images resolve against the wiki page's
+    directory, not a stale _previewCurrentPath (#5933 F2)."""
+
+    def test_wiki_open_page_passes_basedir(self):
+        """panels.js _wikiBrowserOpenPage must pass baseDir to renderMarkdownPreviewContent."""
+        src = PANELS_JS_PATH.read_text(encoding="utf-8")
+        # Locate the _wikiBrowserOpenPage call to renderMarkdownPreviewContent.
+        marker = "renderMarkdownPreviewContent({content: data.content, el: document.getElementById('wikiBrowserMd')})"
+        assert marker not in src, (
+            "wiki browser must pass baseDir — found bare renderMarkdownPreviewContent call without baseDir"
+        )
+        # The call must now include baseDir: path (or baseDir:path).
+        assert "baseDir" in src, "wiki browser must pass baseDir to renderMarkdownPreviewContent"
+


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI renders `.md` workspace files in a preview panel via `renderMarkdownPreviewContent` → `renderMd`
- Images referenced with relative paths like `![alt](./img.png)` showed as broken links in the preview
- Root cause had three layers: (1) the `renderMd` image regex only matched `https?://` so pre-resolved `/api/file/raw?…` URLs and `file://` URLs were dropped; (2) `_isSafeUrl` denied `/api/…` (absolute) and `file://` for `<img>` src, stripping them; (3) `renderMarkdownPreviewContent` had no relative-path resolution at all
- A first round of review (R1) found five issues: image syntax inside inline-code spans was being rewritten by a preprocessing lookahead (F1); the wiki browser didn't pass its file path so images resolved against a stale `_previewCurrentPath` (F2); `file://` image src would be blocked by CSP `img-src` (no `file:` scheme) so it must route through `/api/media` like `file://` links do (F3); two existing tests asserted the old `renderMd(data.content)` call string and regressed (F4); the preprocessing step itself was untested (F5)
- This PR fixes the original bug and all five R1 findings

## What Changed

**`static/workspace.js` — `renderMarkdownPreviewContent`**
- Added a preprocessing pass that resolves relative image paths (`./img.png`, `subdir/img.png`) to `/api/file/raw?session_id=…&path=…&inline=1` API URLs using the markdown file's directory as base, before calling `renderMd`
- `basePathSrc` prefers an explicit `data.baseDir` (used by the wiki browser, which has no `_previewCurrentPath` context) and falls back to `_previewCurrentPath` — fixes F2 (stale path for wiki)
- Fenced code blocks (` ``` `) and inline-code spans (`` ` ``) are stashed **before** the image rewrite so `![alt](./img.png)` inside code is NOT rewritten and stays literal text — fixes F1

**`static/panels.js` — wiki browser**
- `_openWikiBrowser` now passes `baseDir: path` to `renderMarkdownPreviewContent` so images in wiki pages resolve against the wiki page's directory, not a stale `_previewCurrentPath` — fixes F2

**`static/ui.js` — `renderMd`**
- Extended the image regex in both the inner `inlineMd` pass and the outer paragraph pass to match `/api/file/raw?…` and `file://` URLs alongside existing `https?://` (previously only `https?://` matched, so pre-resolved API URLs and `file://` were silently dropped)
- New `_markdownImgSrc(raw)` helper routes `file://` image src through `/api/media` (same rewrite `_markdownHref` applies to `file://` links) because CSP `img-src` has no `file:` scheme — a raw `file://` src would be silently blocked by the browser — fixes F3
- `_isSafeUrl` allowlist updated to permit `/api/…` (absolute paths) and `file://` for image tags (previously only `api/` relative was allowed for images)

**Tests**
- `tests/test_renderer_js_behaviour.py` — added `TestMarkdownImageSchemeCoverage` (5 tests): `/api/file/raw?…` renders as `<img>`, `file://` routes through `/api/media`, HTTPS regression guard, images in code fences stay literal, images in inline code stay literal
- `tests/test_workspace_md_preview_preprocessing.py` — new file (297 lines, 12 tests): drives the real `renderMd` + the extracted preprocessing via a node driver, covering F1 (inline-code protection), F2 (`data.baseDir` override + wiki-browser caller check), and F5 (relative-path resolution, HTTPS passthrough, no double-rewrite of already-API URLs)
- `tests/test_issue347.py`, `tests/test_issue2823_large_markdown_preview.py` — updated assertions from `renderMd(data.content)` to `renderMd(content)` to match the new local variable introduced by the preprocessing pass — fixes F4

## Why It Matters

Users browsing `.md` files in the Workspace panel (and wiki pages) now see inline images render correctly instead of broken-link icons. The fix is CSP-safe (`file://` is routed through `/api/media`, never emitted as a raw `file:` src) and preserves the existing protection that image syntax inside code spans/fences stays literal text. Path traversal is still blocked by the existing `_normalizeWorkspaceRelPath` on the client and `safe_resolve` on the server.

## Verification

```
# Focused suite (touched files + new tests)
$ ./scripts/test.sh tests/test_workspace_md_preview_preprocessing.py tests/test_renderer_js_behaviour.py tests/test_issue347.py tests/test_issue2823_large_markdown_preview.py
121 passed in 6.66s

# Full suite (run by parent verification task t_828bb29d)
$ ./scripts/test.sh
12685 passed, 109 skipped, 1 failed in 461.80s
# The single failure is test_issue4756 — a pre-existing flaky concurrency race that
# passes in isolation (4.77s) and has zero file overlap with this PR's changes.

# Diff scope
$ git diff upstream/master...HEAD --stat
 static/panels.js                                 |   2 +-
 static/ui.js                                     |  16 +-
 static/workspace.js                              | 33 ++-
 tests/test_issue2823_large_markdown_preview.py   |   2 +-
 tests/test_issue347.py                           |  10 +-
 tests/test_renderer_js_behaviour.py              |  62 +++++
 tests/test_workspace_md_preview_preprocessing.py | 297 +++++++++++++++++++++
 7 files changed, 411 insertions(+), 11 deletions(-)
```

Manual/behavioural coverage (via the node test driver, no live browser needed): relative image in a subdirectory resolves to `notes/img.png`; relative image at root resolves to `img.png`; HTTPS images pass through unchanged; already-API URLs are not double-rewritten; `data.baseDir` resolves images when `_previewCurrentPath` is empty and overrides a stale `_previewCurrentPath`; image syntax inside inline code and fenced code stays literal.

## Risks / Follow-ups

- **LOW, non-blocking** — `data:`, `mailto:`, `tel:` URL schemes in image syntax (`![alt](data:image/png;base64,…)`) are mangled by the preprocessing lookahead into broken `/api/file/raw` requests. No security impact: the server's `safe_resolve` blocks the mangled path (it becomes `notes/data:image/png;base64,…` under the workspace root → 404, no traversal). The base behaviour also didn't render `data:` as `<img>`. An optional future fix could widen the lookahead to `(?!https?://|/api/|file://|[a-z][a-z0-9+.-]*:)` to skip any scheme-prefixed URL.
- No new dependencies, no build step, no framework — matches the project's vanilla JS + Python constraints.

## Release-Note Wording

> Workspace `.md` preview: images referenced with relative paths (`![alt](./img.png)`) now render inline. The `renderMd` image pass now matches `/api/file/raw?…` and `file://` URLs (not just `https?://`), and `renderMarkdownPreviewContent` pre-resolves relative image paths against the markdown file's directory. `file://` image src is routed through `/api/media` to stay CSP-safe. Wiki browser images now resolve against the wiki page's directory. Image syntax inside inline code and fenced code stays literal.

## AI Usage Disclosure

This change was produced with assistance from **Hermes Agent** (by Nous Research), model **xopglm52** via OpenRouter, using Kanban board coordination and terminal/file tools. The implementation followed a strict TDD cycle; two adversarial code-review passes (R1 audit + R2 re-review) were performed by the same agent profile before delivery.

Closes #5933
