### PR TITLE
fix(session): ACP adapter sessions are invisible in both sidebar buckets

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -53,6 +53,7 @@ CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
 CLI_MIN_UNTITLED_USER_MESSAGE_COUNT = 2
 
 SOURCE_LABELS = {
+    'acp': 'ACP',
     'api_server': 'API',
     'cli': 'CLI',
     'cron': 'Cron',
@@ -81,7 +82,12 @@ def normalize_agent_session_source(raw_source: str | None) -> dict:
 
     if raw == 'webui':
         session_source = 'webui'
-    elif raw in {'cli', 'tui'}:
+    elif raw in {'acp', 'cli', 'tui'}:
+        # 'acp' (Agent Client Protocol adapter — Zed, external device bridges)
+        # is a local interactive agent client like the CLI/TUI: its sessions
+        # live only in state.db, so classifying it 'other' would leave them
+        # invisible in both sidebar buckets (webui skips the state.db
+        # projection; cli keeps only CLI-classified rows).
         session_source = 'cli'
     elif raw in MESSAGING_SOURCES:
         session_source = 'messaging'
@@ -231,10 +237,10 @@ def is_cli_session_row(row: dict) -> bool:
     if source in {"external_agent", "external-agent"}:
         return True
     if (
-        source_tag in {"cli", "tui"}
-        or raw_source in {"cli", "tui"}
-        or source_name in {"cli", "tui"}
-        or source_label in {"cli", "tui"}
+        source_tag in {"acp", "cli", "tui"}
+        or raw_source in {"acp", "cli", "tui"}
+        or source_name in {"acp", "cli", "tui"}
+        or source_label in {"acp", "cli", "tui"}
     ):
         return True
 
@@ -270,12 +276,15 @@ def is_cli_session_row_visible(row: dict) -> bool:
     ):
         return True
 
-    if "tui" in {
+    if {"tui", "acp"} & {
         _normalize_source_name(row.get("source")),
         _normalize_source_name(row.get("source_tag")),
         _normalize_source_name(row.get("raw_source")),
         _normalize_source_name(row.get("source_label")),
     }:
+        # Like TUI rows, ACP sessions are always genuinely user-interactive
+        # (an external agent client drove them), never framework-generated
+        # metadata — keep ended/untitled ones visible.
         return True
 
     if _has_cli_lineage(row):

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -276,16 +276,20 @@ def is_cli_session_row_visible(row: dict) -> bool:
     ):
         return True
 
-    if {"tui", "acp"} & {
+    interactive_sources = {
         _normalize_source_name(row.get("source")),
         _normalize_source_name(row.get("source_tag")),
         _normalize_source_name(row.get("raw_source")),
         _normalize_source_name(row.get("source_label")),
-    }:
-        # Like TUI rows, ACP sessions are always genuinely user-interactive
-        # (an external agent client drove them), never framework-generated
-        # metadata — keep ended/untitled ones visible.
+    }
+    if "tui" in interactive_sources:
         return True
+    if "acp" in interactive_sources:
+        # Like TUI rows, user-driven ACP sessions stay visible even when
+        # ended/untitled. Unlike TUI, an ACP connection can record only
+        # assistant/tool/system rows (e.g. a replayed or aborted turn), so
+        # require at least one user turn before surfacing the row.
+        return _count_user_turns(row) > 0
 
     if _has_cli_lineage(row):
         return True

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2282,7 +2282,7 @@ function _isCliSession(session) {
     || session.source_label
     || ''
   ).toLowerCase();
-  if (raw === 'cli' || raw === 'tui') return true;
+  if (raw === 'cli' || raw === 'tui' || raw === 'acp') return true;
   // If messaging-like, don't classify as legacy CLI even when is_cli_session is true.
   if (_isMessagingSession(session)) return false;
   return session.is_cli_session === true;

--- a/tests/test_acp_session_sidebar_visibility.py
+++ b/tests/test_acp_session_sidebar_visibility.py
@@ -69,6 +69,26 @@ def test_empty_acp_row_stays_hidden():
     assert is_cli_session_row_visible({**row, **normalize_agent_session_source('acp')}) is False
 
 
+def test_acp_row_without_user_turns_stays_hidden():
+    """An ACP row holding only assistant/tool/system messages is not user-driven.
+
+    A replayed or aborted turn can leave an ended ACP connection with a
+    positive message_count but zero user turns — it must not surface in the
+    sidebar (Greptile review on #5939).
+    """
+    row = {
+        'id': 'acp-no-user-turns',
+        'source': 'acp',
+        'title': 'Replayed segment',
+        'message_count': 3,
+        'actual_message_count': 3,
+        'actual_user_message_count': 0,
+        'ended_at': 1751000000.0,
+        'end_reason': 'client_disconnect',
+    }
+    assert is_cli_session_row_visible({**row, **normalize_agent_session_source('acp')}) is False
+
+
 # --- state.db projection (mirrors tests/test_issue3586_cli_session_source_label.py) ---
 
 def _make_state_db(path, sessions):

--- a/tests/test_acp_session_sidebar_visibility.py
+++ b/tests/test_acp_session_sidebar_visibility.py
@@ -1,0 +1,157 @@
+"""ACP-sourced state.db sessions must be visible in the sidebar.
+
+The gateway's ACP adapter (Agent Client Protocol — Zed, external device
+bridges such as a Rabbit R1) persists sessions to state.db with
+``source='acp'``. Before this fix, 'acp' normalised to session_source
+'other', which fell through BOTH sidebar buckets:
+
+- ``sidebar_source=webui`` skips the state.db projection entirely, and an
+  ACP session has no WebUI sidecar, so it never appeared there.
+- ``sidebar_source=cli`` keeps only CLI-classified rows
+  (``_is_cli_session_for_settings``), which dropped 'other' rows.
+
+ACP is a local interactive agent client like the CLI/TUI, so it is now
+classified into the CLI family.
+"""
+
+import sqlite3
+import time
+import unittest.mock
+
+import api.models as models
+from api.agent_sessions import (
+    is_cli_session_row,
+    is_cli_session_row_visible,
+    normalize_agent_session_source,
+)
+
+
+def test_acp_normalizes_to_cli_family():
+    meta = normalize_agent_session_source('acp')
+    assert meta['session_source'] == 'cli'
+    assert meta['raw_source'] == 'acp'
+    assert meta['source_label'] == 'ACP'
+
+
+def test_acp_row_is_cli_classified():
+    row = {'id': 'e91ffb31-654c-4b62-9ca1-6ecc16423899', 'source': 'acp'}
+    assert is_cli_session_row({**row, **normalize_agent_session_source('acp')}) is True
+    # Raw rows (no prior normalization) must classify the same way — several
+    # callers pass sidecar/state rows that only carry source metadata.
+    assert is_cli_session_row(row) is True
+
+
+def test_acp_row_with_messages_stays_visible_even_when_ended():
+    """Ended/untitled ACP rows are user-driven conversations, never framework noise."""
+    row = {
+        'id': 'acp-ended',
+        'source': 'acp',
+        'title': 'Acp Session',  # default-shaped title
+        'message_count': 4,
+        'actual_message_count': 4,
+        'actual_user_message_count': 1,  # below CLI_MIN_UNTITLED_USER_MESSAGE_COUNT
+        'ended_at': 1751000000.0,
+        'end_reason': 'client_disconnect',
+    }
+    assert is_cli_session_row_visible({**row, **normalize_agent_session_source('acp')}) is True
+
+
+def test_empty_acp_row_stays_hidden():
+    """Zero-message ACP rows (connect/reconnect stubs) must not clutter the sidebar."""
+    row = {
+        'id': 'acp-empty',
+        'source': 'acp',
+        'title': None,
+        'message_count': 0,
+        'actual_message_count': 0,
+        'actual_user_message_count': 0,
+    }
+    assert is_cli_session_row_visible({**row, **normalize_agent_session_source('acp')}) is False
+
+
+# --- state.db projection (mirrors tests/test_issue3586_cli_session_source_label.py) ---
+
+def _make_state_db(path, sessions):
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            session_source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE INDEX idx_sessions_started ON sessions(started_at);
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+        """
+    )
+    base = time.time() - len(sessions)
+    for i, sess in enumerate(sessions):
+        sid = sess['id']
+        started = base + i
+        conn.execute(
+            """
+            INSERT INTO sessions
+            (id, source, session_source, title, model, started_at, message_count,
+             parent_session_id, ended_at, end_reason)
+            VALUES (?, ?, NULL, ?, 'deepseek/deepseek-chat', ?, 2, NULL, NULL, NULL)
+            """,
+            (sid, sess['source'], sess.get('title', sid), started),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'user', 'hello', ?)",
+            (f"msg_{sid}_0", sid, started),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'user', 'follow-up', ?)",
+            (f"msg_{sid}_1", sid, started + 0.1),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'assistant', 'hi', ?)",
+            (f"msg_{sid}_2", sid, started + 0.2),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _call_uncached(tmp_path, sessions):
+    db = tmp_path / 'state.db'
+    _make_state_db(db, sessions)
+    with (
+        unittest.mock.patch('api.models.get_claude_code_sessions', return_value=[]),
+        unittest.mock.patch('api.models.ensure_cron_project', return_value='cron-project-id'),
+    ):
+        return models._load_cli_sessions_uncached(tmp_path, db, None)
+
+
+def test_acp_session_appears_in_projection_as_cli(tmp_path):
+    """An ACP state.db row must surface in the sidebar projection, CLI-classified."""
+    sessions = [
+        {
+            'id': 'e91ffb31-654c-4b62-9ca1-6ecc16423899',
+            'source': 'acp',
+            'title': 'Raumanalyse mit Schimmelfleck-Beurteilung',
+        },
+    ]
+    results = _call_uncached(tmp_path, sessions)
+    row = next(
+        (s for s in results if s['session_id'] == 'e91ffb31-654c-4b62-9ca1-6ecc16423899'),
+        None,
+    )
+    assert row is not None, "acp session should appear in the sidebar projection"
+    assert row['is_cli_session'] is True
+    assert row['session_source'] == 'cli'
+    assert row['source_label'] == 'ACP'


### PR DESCRIPTION
## Summary

Sessions created by the Hermes gateway's **ACP adapter** (Agent Client Protocol — Zed, external device bridges) are persisted to `state.db` with `source='acp'`, but the WebUI sidebar never shows them. `normalize_agent_session_source('acp')` classifies them as `'other'`, which falls through **both** sidebar buckets:

- `sidebar_source=webui` skips the state.db projection entirely (`load_cli_sessions = … and sidebar_source != "webui"`), and ACP rows have no WebUI sidecar to surface through `all_sessions()`.
- `sidebar_source=cli` loads the projection but `_filter_sidebar_source` keeps only CLI-classified rows (`_is_cli_session_for_settings`), dropping `'other'`.

Because the rows never render, they can also never be clicked/imported — the conversations are completely invisible in WebUI.

This PR classifies `acp` into the CLI family, mirroring `tui` (a local interactive agent client):

- `api/agent_sessions.py`: `SOURCE_LABELS['acp'] = 'ACP'`; `normalize_agent_session_source` maps `acp` → `session_source='cli'`; `is_cli_session_row` recognises the raw source; `is_cli_session_row_visible` keeps ended/untitled ACP rows visible (they are always user-driven, never framework-generated metadata).
- `static/sessions.js`: `_isCliSession` accepts `raw === 'acp'`.

Deliberately unchanged:
- **Claim policy** (`_is_claimable_cli_source`): ACP stays claimable like CLI/TUI, per the documented "future local agent sources" allowance. A claimed ACP session continues under the same state.db session id, so an ACP client that later resumes replays the WebUI turns too — same hybrid semantics as CLI sessions.
- Zero-message ACP connect/reconnect stubs stay hidden via the existing `message_count` guard in `is_cli_session_row_visible`.
- The `tui` lineage-tip title special-case in `_collapse_session_lineage_for_sidebar` (compression-segment naming) is TUI-specific and not extended.

## Validation

```
$ python -m pytest tests/test_acp_session_sidebar_visibility.py -q
5 passed

$ python -m pytest tests/test_acp_session_sidebar_visibility.py \
    tests/test_issue4766_sidebar_source_pushdown.py \
    tests/test_issue3586_cli_session_source_label.py \
    tests/test_issue2351_cli_session_source_filter.py \
    tests/test_sidebar_session_partition.py tests/test_sidebar_tab_visibility.py \
    tests/test_issue2453_agent_source_boundary.py \
    tests/test_chat_start_claim_cli_session.py \
    tests/test_issue3603_external_session_import_gate.py \
    tests/test_gateway_sync.py -q
178 passed
```

Verified live against a real gateway ACP session (a Rabbit R1 device bridge): before the fix, `GET /api/sessions?sidebar_source=cli` returned only `source='cli'` rows and the ACP session was absent from both buckets; after the fix it appears at the top of the CLI tab labelled **ACP**, its empty reconnect stubs stay hidden, and `POST /api/session/import_cli` materialises it with all 15 messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
