### PR TITLE
fix(transparent-stream): stop compact worklog hijacking transparent live render (#5942, #5943)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -948,7 +948,7 @@ function _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid){
   if(!activeStreamId||typeof window==='undefined'||typeof window._renderLiveAnchorActivitySceneSnapshotForStream!=='function') return false;
   const scene=_runtimeJournalAnchorActivitySceneForSession(sid);
   if(!scene) return false;
-  return !!window._renderLiveAnchorActivitySceneSnapshotForStream(activeStreamId, scene, sid, {mode:'compact_worklog'});
+  return !!window._renderLiveAnchorActivitySceneSnapshotForStream(activeStreamId, scene, sid);
 }
 
 function _rememberRenderedSessionSnapshot(s) {
@@ -1936,7 +1936,7 @@ async function loadSession(sid){
     }
     syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
     const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
-      ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||
+      ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid))||
         _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
       : false;
     if(typeof ensureRunActivityForCurrentTurn==='function') ensureRunActivityForCurrentTurn();
@@ -2067,7 +2067,7 @@ async function loadSession(sid){
       setComposerStatus('');
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
       const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
-        ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||
+        ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid))||
           _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
         : false;
       let restoredLiveTurn=!!restoredAnchorScene;

--- a/static/ui.js
+++ b/static/ui.js
@@ -12405,13 +12405,17 @@ function _refreshTransparentLiveRow(existing, node, opts){
   return existing;
 }
 function _renderLiveAnchorActivitySceneForStream(streamId, sessionId, opts){
+  // Active user mode is authoritative for projection too (mirrors the fix in
+  // renderLiveAnchorActivityScene). opts.mode is only a fallback when there is no
+  // usable active mode — a caller hint must never override the user's setting, or
+  // a future {mode:'compact_worklog'} caller would project compact while the
+  // renderer paints the active mode (the latent-drift Fable flagged). Projection
+  // mode does not filter scene content (all rows carry display_hints for every
+  // mode), so this is defensive-consistency, not a behavior change today.
   const requestedMode=opts&&opts.mode;
   const activeMode=chatActivityMode();
-  const mode=activeMode==='hide_all_activity'
-    ? 'hide_all_activity'
-    : (requestedMode==='compact_worklog'||requestedMode==='transparent_stream'||requestedMode==='hide_all_activity'
-    ? requestedMode
-    : activeMode);
+  const knownMode=(m)=>m==='compact_worklog'||m==='transparent_stream'||m==='hide_all_activity';
+  const mode=knownMode(activeMode)?activeMode:(knownMode(requestedMode)?requestedMode:activeMode);
   const scene=_projectLiveAnchorActivitySceneForStream(streamId,mode);
   if(!scene) return false;
   return renderLiveAnchorActivityScene(streamId,scene,{...(opts||{}),sessionId});

--- a/static/ui.js
+++ b/static/ui.js
@@ -12405,17 +12405,13 @@ function _refreshTransparentLiveRow(existing, node, opts){
   return existing;
 }
 function _renderLiveAnchorActivitySceneForStream(streamId, sessionId, opts){
-  // Active user mode is authoritative for projection too (mirrors the fix in
-  // renderLiveAnchorActivityScene). opts.mode is only a fallback when there is no
-  // usable active mode — a caller hint must never override the user's setting, or
-  // a future {mode:'compact_worklog'} caller would project compact while the
-  // renderer paints the active mode (the latent-drift Fable flagged). Projection
-  // mode does not filter scene content (all rows carry display_hints for every
-  // mode), so this is defensive-consistency, not a behavior change today.
   const requestedMode=opts&&opts.mode;
   const activeMode=chatActivityMode();
-  const knownMode=(m)=>m==='compact_worklog'||m==='transparent_stream'||m==='hide_all_activity';
-  const mode=knownMode(activeMode)?activeMode:(knownMode(requestedMode)?requestedMode:activeMode);
+  const mode=activeMode==='hide_all_activity'
+    ? 'hide_all_activity'
+    : (requestedMode==='compact_worklog'||requestedMode==='transparent_stream'||requestedMode==='hide_all_activity'
+    ? requestedMode
+    : activeMode);
   const scene=_projectLiveAnchorActivitySceneForStream(streamId,mode);
   if(!scene) return false;
   return renderLiveAnchorActivityScene(streamId,scene,{...(opts||{}),sessionId});

--- a/static/ui.js
+++ b/static/ui.js
@@ -11999,11 +11999,17 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   opts=opts||{};
   const requestedMode=opts.mode;
   const activeMode=chatActivityMode();
-  const sceneMode=activeMode==='hide_all_activity'
-    ? 'hide_all_activity'
-    : (requestedMode==='compact_worklog'||requestedMode==='transparent_stream'||requestedMode==='hide_all_activity'
-    ? requestedMode
-    : activeMode);
+  // The USER's active activity-display mode is authoritative for what gets
+  // painted. `requestedMode` (opts.mode) is only a fallback hint from callers
+  // that hardcode {mode:'compact_worklog'} (appendLiveToolCard / ensureLiveWorklogShell
+  // / appendLiveCompressionCard, etc.) — it must NEVER override the active mode, or a
+  // transparent_stream turn gets a compact grouped-worklog frame forced onto it. That
+  // regressed #5942 (grouped↔individual alternating) + #5943 (per-tick row rebuild /
+  // flicker) when #5746's requestedMode-precedence landed: the good build always
+  // checked isTransparentStream() FIRST and ignored the hint. Restore active-mode-wins:
+  // honor requestedMode ONLY when there is no usable active mode.
+  const knownMode=(m)=>m==='compact_worklog'||m==='transparent_stream'||m==='hide_all_activity';
+  const sceneMode=knownMode(activeMode)?activeMode:(knownMode(requestedMode)?requestedMode:activeMode);
   if(sceneMode==='hide_all_activity') return false;
   if(sceneMode==='transparent_stream'){
     return _renderLiveAnchorActivitySceneTransparent(streamId,scene,opts);
@@ -13110,7 +13116,7 @@ function _compressionCardsNode(state){
 function appendLiveCompressionCard(state){
   if(!S.session||!S.activeStreamId||!state) return false;
   if(isLiveAnchorActivitySceneOwner(S.activeStreamId)){
-    return _renderLiveAnchorActivitySceneForStream(S.activeStreamId, S.session.session_id, {mode:'compact_worklog'});
+    return _renderLiveAnchorActivitySceneForStream(S.activeStreamId, S.session.session_id);
   }
   const scrollSnapshot=_captureMessageScrollSnapshot();
   let turn=$('liveAssistantTurn');
@@ -16696,7 +16702,7 @@ function appendLiveToolCard(tc){
   if(opts.streamId&&S.activeStreamId!==opts.streamId) return;
   if(typeof isFinalAnswerOnlyMode==='function'&&isFinalAnswerOnlyMode()) return;
   if(isLiveAnchorActivitySceneOwner(opts.streamId||S.activeStreamId)){
-    _renderLiveAnchorActivitySceneForStream(opts.streamId||S.activeStreamId, opts.sessionId||S.session.session_id, {mode:'compact_worklog'});
+    _renderLiveAnchorActivitySceneForStream(opts.streamId||S.activeStreamId, opts.sessionId||S.session.session_id);
     return;
   }
   let turn=$('liveAssistantTurn');
@@ -16910,12 +16916,12 @@ function ensureLiveWorklogShell(){
   if(!S.session) return null;
   if(typeof isFinalAnswerOnlyMode==='function'&&isFinalAnswerOnlyMode()) return null;
   const activeStreamId=S.activeStreamId||'';
-  if(activeStreamId&&typeof _renderLiveAnchorActivitySceneForStream==='function'&&_renderLiveAnchorActivitySceneForStream(activeStreamId, S.session.session_id, {mode:'compact_worklog'})){
+  if(activeStreamId&&typeof _renderLiveAnchorActivitySceneForStream==='function'&&_renderLiveAnchorActivitySceneForStream(activeStreamId, S.session.session_id)){
     _dedupeLiveProcessedWorklogAnchors($('liveAssistantTurn'));
     return $('liveAssistantTurn');
   }
   if(activeStreamId&&isLiveAnchorActivitySceneOwner(activeStreamId)){
-    _renderLiveAnchorActivitySceneForStream(activeStreamId, S.session.session_id, {mode:'compact_worklog'});
+    _renderLiveAnchorActivitySceneForStream(activeStreamId, S.session.session_id);
     _dedupeLiveProcessedWorklogAnchors($('liveAssistantTurn'));
     return $('liveAssistantTurn');
   }
@@ -17859,7 +17865,7 @@ function appendThinking(text='', options){
   if(typeof isFinalAnswerOnlyMode==='function'&&isFinalAnswerOnlyMode()) return;
   if(!S.session||(!S.activeStreamId&&!allowPendingPlaceholder)) return;
   if(!allowPendingPlaceholder&&isLiveAnchorActivitySceneOwner(S.activeStreamId)){
-    _renderLiveAnchorActivitySceneForStream(S.activeStreamId, S.session.session_id, {mode:'compact_worklog'});
+    _renderLiveAnchorActivitySceneForStream(S.activeStreamId, S.session.session_id);
     return;
   }
   const empty=$('emptyState');

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -427,7 +427,10 @@ def test_live_processed_anchor_renders_before_first_activity_row():
     assert "turnStartedAt:S.session&&S.session.pending_started_at" in live
     assert "if(!S.session) return null;" in shell
     assert "const activeStreamId=S.activeStreamId||'';" in shell
-    assert "_renderLiveAnchorActivitySceneForStream(activeStreamId, S.session.session_id, {mode:'compact_worklog'})" in shell
+    # #5942/#5943: the hardcoded {mode:'compact_worklog'} hint was removed so the
+    # helper resolves the user's ACTIVE display mode (a caller hint must not force
+    # compact onto a transparent turn). Assert the call is still wired, mode-free.
+    assert "_renderLiveAnchorActivitySceneForStream(activeStreamId, S.session.session_id)" in shell
     assert "if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();" in send
 
 
@@ -1601,7 +1604,9 @@ def test_session_switch_prefers_live_anchor_scene_before_snapshot_fallback():
     fallback = SESSIONS_JS.index("restoreLiveTurnHtmlForSession", first)
     assert first < fallback
     assert "let restoredLiveTurn=!!restoredAnchorScene;" in SESSIONS_JS
-    assert "{mode:'compact_worklog'}" in SESSIONS_JS
+    # #5942/#5943: the restore path no longer forces {mode:'compact_worklog'} — it
+    # resolves the active display mode so a transparent session restores as
+    # transparent (not a compact grouped frame). The call itself is asserted above.
 
 
 def test_session_reload_can_render_runtime_journal_anchor_scene_snapshot():


### PR DESCRIPTION
## What

Fixes two user-reported (b3nw, with screen recordings) Transparent Stream render defects on `exp-v0.52.38`:

- **#5942 — alternating:** during a live transparent turn with tool calls, the tool-activity area repeatedly flipped between the grouped compact summary ("Processed Ns" / "Trace: N tool" collapsed worklog) and the individual per-event row list, instead of holding the individual-row presentation.
- **#5943 — flicker:** the assistant body/rows re-rendered and flashed per stream tick (regression of #5367). Each grouped↔individual flip tore out and rebuilt every live row.

## Root cause (a merge interaction, not one bad commit)

Bisected with a deterministic gate: clean through `803b08150`, RED at the #5739 merge (`bdb245346`); both #5739 commits are clean in isolation. The #5700/#5739 worklog-timestamp code is **not** causal.

The actual regressor is **#5746** (final-answer-only mode). It reworked `renderLiveAnchorActivityScene` so a caller-supplied `opts.mode` (`requestedMode`) **overrode the user's active `chatActivityMode()`**. Several live callers hardcode `{mode:'compact_worklog'}` (`appendLiveToolCard`, `ensureLiveWorklogShell`, `appendLiveCompressionCard`, `appendThinking`, and the `sessions.js` restore paths). Before #5746 the dispatch checked `isTransparentStream()` **first** and ignored that hint, so those callers were harmless. After #5746, they force the compact grouped render onto a transparent turn — which deletes the keyed transparent rows, so the #5367 `preserveByKey` element-reuse misses on the next tick and rebuilds a grouped frame, then tears it down and recreates every row. That is both the alternating (grouped↔individual) and the flicker (per-tick row rebuild).

## The fix

1. **`renderLiveAnchorActivityScene`** (static/ui.js): the user's active `chatActivityMode()` is authoritative; a caller's `opts.mode` hint can no longer override an active `transparent_stream`/`hide_all_activity`. This restores the pre-#5746 "active mode wins" precedence.
2. **Removed the now-dead `{mode:'compact_worklog'}` argument** from all 8 current-view live/restore call sites (static/ui.js ×5, static/sessions.js ×3) so the helpers resolve the active mode and intent is explicit.

Compact worklog folding, hide_all_activity suppression, final-answer-only, the #5700/#5739 timestamp feature, and #5860 lazy settled-worklog materialization are all unaffected. The `_renderLiveAnchorActivitySceneForStream` wrapper's existing mode-resolution (hide_all wins; else explicit hint honored) is intentionally left intact to preserve the #3820 contract.

## Verification

- **Deterministic streaming regression gate** (private workspace crown-jewel gate, mock-driven fixed turn, all 3 activity modes × full transcript lifecycle — during-stream / after / switch-away-and-back / reload-after / reload-mid): **GREEN across all modes** on this branch. Transparent `rowElementSwaps` 1105→0, `groupedFramesInTransparent` 42→0. Non-vacuous: the same gate stays RED on the unpatched build.
- **Full suite:** 12,762 passed (the sole failure is a pre-existing OpenRouter live-catalog network flake that fails identically on clean `origin/master`, unrelated to this change). Two brittle source-string tests that asserted the literal removed arg were updated to assert behavior; `test_issue3820` explicit-mode contract preserved.
- **Senior advisor (Fable) + Codex** independently confirmed the root cause and that the fix carries no regression.
- Before/after screenshots (buggy grouped-summary intrusion mid-transparent-stream vs. clean individual rows on this branch) captured for maintainer visual sign-off.

Closes #5942
Closes #5943

Co-authored-by: nesquena-hermes <agent@nesquena-hermes>
