### PR TITLE
test(#1426): make OpenRouter live-fetch test hermetic (fix deterministic failure)

### DIFF
--- a/tests/test_issue1426_openrouter_free_tier_live_fetch.py
+++ b/tests/test_issue1426_openrouter_free_tier_live_fetch.py
@@ -111,9 +111,28 @@ def test_openrouter_group_uses_live_fetch_when_available(monkeypatch):
         return _FakeResponse(fake_payload)
 
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    # The OpenRouter branch does TWO live fetches:
+    #   (1) hermes_cli.models.fetch_openrouter_models() — the curated catalog.
+    #       This routes through hermes_cli's `open_credentialed_url()`, which
+    #       builds its own opener and calls `.open()`; it does NOT go through
+    #       the module-level `urllib.request.urlopen` symbol patched above.
+    #       So the monkeypatch alone leaves fetch (1) hitting the REAL network
+    #       whenever hermes_cli is installed — returning the live curated list,
+    #       which fills the visible picker cap and pushes the mocked free-tier
+    #       entries into `extra_models`. Mock fetch (1) here too so the test is
+    #       genuinely hermetic (as the module docstring promises) and the
+    #       free-tier augment path (2) is what is actually under test.
+    #   (2) the direct urllib.request.urlopen(".../v1/models") — the free-tier
+    #       augment; this one IS intercepted by the monkeypatch above.
     try:
         from hermes_cli import models as _hm
         monkeypatch.setattr(_hm, "_openrouter_catalog_cache", None, raising=False)
+        # A small curated base ("live data, not just the fallback list") so the
+        # tool-supporting paid model is present alongside the free-tier augment.
+        monkeypatch.setattr(
+            _hm, "fetch_openrouter_models",
+            lambda *a, **k: [("anthropic/claude-sonnet-4.6", "")],
+        )
     except Exception:
         pass
 
@@ -121,7 +140,16 @@ def test_openrouter_group_uses_live_fetch_when_available(monkeypatch):
     or_group = next((g for g in grouped if g.get("provider_id") == "openrouter"), None)
     assert or_group is not None, "openrouter group must be present"
 
-    model_ids = [m["id"] for m in or_group["models"]]
+    # Both `models` (visible dropdown) and `extra_models` (slash-command
+    # autocomplete / dynamic-label overflow) are picker surfaces — a free-tier
+    # entry that lands in either bucket has surfaced in the picker. Assert
+    # across both, matching the sibling fail-closed / cap tests, so a large
+    # curated base overflowing the visible cap does not flip this assertion.
+    model_ids = [
+        m["id"]
+        for bucket in ("models", "extra_models")
+        for m in or_group.get(bucket, [])
+    ]
     # Resilient to test-isolation pollution: when a sibling test mutates
     # `cfg` and triggers the openrouter-not-active branch, _apply_provider_prefix
     # adds an `@openrouter:` prefix to model IDs. Skip rather than fail — the


### PR DESCRIPTION
## Summary

Fixes a **deterministically-failing** test (not a network flake, not xdist pollution):

```
pytest "tests/test_issue1426_openrouter_free_tier_live_fetch.py::test_openrouter_group_uses_live_fetch_when_available" -p no:xdist
```

fails with:

```
assert 'minimax/minimax-m2.5:free' in ['anthropic/claude-sonnet-4.6', 'anthropic/claude-fable-5', 'anthropic/claude-opus-4.8', ...]
```

The failure reproduces in complete isolation in any environment where the `hermes_cli` agent package is **installed** and the network is **reachable** (e.g. local dev with the agent present). It passes in CI only because `hermes_cli` is absent there.

## Root cause — a gap in the test's mock, **not** a production regression

`api.config.get_available_models()` populates the OpenRouter picker group from **two** live fetches:

1. **Curated catalog** — `hermes_cli.models.fetch_openrouter_models()`. This routes through hermes_cli's `open_credentialed_url()`, which builds its **own** opener and calls `.open()`. It does **not** go through the module-level `urllib.request.urlopen` symbol the test monkeypatches.
2. **Free-tier augment** — a direct `urllib.request.urlopen("https://openrouter.ai/api/v1/models")` at `api/config.py:7110`, filtered to free-tier-only. This one **is** intercepted by the monkeypatch.

The test only patched `urllib.request.urlopen`, so fetch (1) hit the **real network** and returned ~36 live curated models. Those filled the visible picker cap (15), pushing the mocked free-tier entries (`minimax/minimax-m2.5:free`, `openrouter/elephant-alpha`) into the group's `extra_models` overflow bucket. The assertion only inspected the visible `models` bucket → failure.

In CI, `hermes_cli` is not installed, so fetch (1) raises `ImportError`, the curated base is empty, the 2–3 mocked entries fit the visible cap, and the test passes. Hence the environment-dependent behavior.

### Production is correct — proven

Free-tier models **do** surface in the real picker. Verified against production code with the test payload:

```
visible models count: 15
extra_models count: 23
minimax/minimax-m2.5:free  in VISIBLE? False   in EXTRA? True
openrouter/elephant-alpha  in VISIBLE? False   in EXTRA? True
```

Both `models` (visible dropdown) and `extra_models` (slash-command autocomplete / dynamic-label overflow) are legitimate picker surfaces. A free-tier entry landing in either has surfaced in the picker — it was only the assertion's narrow bucket choice that made this look like a regression.

## Fix (test-only, coverage intent preserved)

- **Mock fetch (1) too** — as the sibling `dedupe` / `fail-closed` tests already do — so the test is genuinely hermetic, matching this module's own docstring promise of *"without depending on real network access."* A small curated base (`anthropic/claude-sonnet-4.6`) keeps "live data, not just the fallback list" exercised.
- **Assert across both picker buckets** (`models` + `extra_models`), matching the sibling cap and fail-closed tests, so a large curated base overflowing the visible cap no longer flips the assertion.

No `pytest.skip`, no deleted assertion — the free-tier-visibility contract from #1426 is still fully asserted.

**No production code changed.** This PR touches only the test file and is independent of the separate transparent-stream fix.

## Verification

```
# target test in isolation
pytest "tests/...::test_openrouter_group_uses_live_fetch_when_available" -p no:xdist   → 1 passed

# whole file, no xdist
pytest tests/test_issue1426_openrouter_free_tier_live_fetch.py -p no:xdist            → 10 passed

# whole file, xdist (CI-like)
pytest tests/test_issue1426_openrouter_free_tier_live_fetch.py                        → 10 passed

# adjacent model-catalog suites (no regression)
pytest tests/test_live_models_ttl_cache.py \
       tests/test_issue1807_codex_provider_card_live_models.py \
       tests/test_issue1240_generic_cli_catalog_sync.py -p no:xdist                   → 10 passed
```
