### PR TITLE
fix(chat): honor explicit model pick on post-failure recovery send (#5924)

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -1686,7 +1686,20 @@ async function cmdRetry(){
     if(!S.session||S.session.session_id!==activeSid)return;
     const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
     if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
-    $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();await send();
+    $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();
+    // #5924 (Facet 1 + Facet 4): /retry is a recovery send. The onchange
+    // explicit-pick marker is single-shot and was already consumed by an
+    // earlier send(), so re-arm it from the CURRENT selector state before this
+    // send. Otherwise explicit_model_pick goes out false and the server's
+    // compatible-model resolution re-reverts a freshly-picked cross-family
+    // model back to the failed/stale value. Re-arming every recovery send also
+    // lets a SECOND consecutive retry honor its pick (send() consumes it each time).
+    if(typeof _rememberPendingSessionModel==='function' && typeof _chatPayloadModel==='function' && S.session){
+      const _recoveryModel=_chatPayloadModel();
+      const _recoveryProvider=(typeof _chatPayloadModelProvider==='function')?_chatPayloadModelProvider(_recoveryModel):null;
+      _rememberPendingSessionModel(activeSid, _recoveryModel, _recoveryProvider);
+    }
+    await send();
   }catch(e){showToast(t('retry_failed')+e.message);}
 }
 async function cmdUndo(){

--- a/static/ui.js
+++ b/static/ui.js
@@ -17027,6 +17027,19 @@ async function submitEdit(msgIdx, newText) {
     S.messages = S.messages.slice(0, absoluteKeepCount);
     renderMessages();
     $('msg').value = newText;
+    // #5924 (Facet 1 + Facet 4): edit-resubmit is a recovery send. The
+    // onchange explicit-pick marker is single-shot and was already consumed by
+    // an earlier send(), so re-arm it from the CURRENT selector state before
+    // this send. Otherwise explicit_model_pick goes out false and the server's
+    // compatible-model resolution re-reverts a freshly-picked cross-family
+    // model back to the failed/stale value (mirrors a fresh onchange→send).
+    // Re-arming every recovery send also lets a SECOND consecutive edit honor
+    // its pick even though send() consumes the marker each time.
+    if(typeof _rememberPendingSessionModel==='function' && typeof _chatPayloadModel==='function' && S.session){
+      const _recoveryModel=_chatPayloadModel();
+      const _recoveryProvider=(typeof _chatPayloadModelProvider==='function')?_chatPayloadModelProvider(_recoveryModel):null;
+      _rememberPendingSessionModel(S.session.session_id, _recoveryModel, _recoveryProvider);
+    }
     await send();
   } catch(e) { setStatus(t('edit_failed') + e.message); }
 }

--- a/tests/test_issue5924_post_failure_recovery_model_pick.py
+++ b/tests/test_issue5924_post_failure_recovery_model_pick.py
@@ -1,0 +1,143 @@
+"""Regression coverage for #5924 — post-failure recovery must honor a fresh pick.
+
+After a provider failure the reporter (@b3nw) could not switch models: changing
+the model in the selector and then **edit-resubmit** or **/retry** re-sent the
+*failed* model, forcing a session fork to escape.
+
+Root cause (Facet 1 + Facet 4): the onchange explicit-pick marker
+(``_rememberPendingSessionModel``) is single-shot — ``send()`` consumes it once
+(``messages.js``). The two recovery paths (``submitEdit`` in ``ui.js`` and
+``cmdRetry`` in ``commands.js``) truncate and call ``send()`` directly WITHOUT
+re-arming the marker, so ``explicit_model_pick`` goes out ``false`` and the
+server's ``_resolve_compatible_session_model_state`` re-reverts a freshly-picked
+cross-family model back to the profile default.
+
+Two-layer invariant pinned here:
+  * WebUI: both recovery paths re-arm the pending explicit-pick marker from the
+    CURRENT selector state *before* ``await send()`` (so a recovery send —
+    including a SECOND consecutive one — carries ``explicit_model_pick:true``).
+  * Server: with ``explicit_model_pick=True`` the fresh cross-family pick is
+    honored (NOT reverted), and without it the stale value is still normalized
+    (the #3737/#5731 repair path must not regress).
+"""
+
+from pathlib import Path
+
+import api.routes as routes
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    needle = f"async function {name}"
+    start = src.index(needle)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function {name!r} body not found")
+
+
+# ── WebUI layer: recovery paths re-arm the marker before send() ──────────────
+
+
+def test_submit_edit_rearms_pending_pick_before_send():
+    """Edit-resubmit must re-arm the explicit-pick marker before ``await send()``."""
+    body = _function_body(UI_JS, "submitEdit")
+    assert "_rememberPendingSessionModel" in body, (
+        "submitEdit must re-arm the explicit-pick marker (#5924); otherwise the "
+        "recovery send loses explicit_model_pick and the server re-reverts the model"
+    )
+    rearm_idx = body.index("_rememberPendingSessionModel")
+    send_idx = body.rindex("await send()")
+    assert rearm_idx < send_idx, "the re-arm must happen BEFORE await send()"
+
+
+def test_cmd_retry_rearms_pending_pick_before_send():
+    """/retry must re-arm the explicit-pick marker before ``await send()``."""
+    body = _function_body(COMMANDS_JS, "cmdRetry")
+    assert "_rememberPendingSessionModel" in body, (
+        "cmdRetry must re-arm the explicit-pick marker (#5924); otherwise /retry "
+        "re-sends the failed model instead of the freshly-picked one"
+    )
+    rearm_idx = body.index("_rememberPendingSessionModel")
+    send_idx = body.rindex("await send()")
+    assert rearm_idx < send_idx, "the re-arm must happen BEFORE await send()"
+
+
+def test_recovery_rearm_reads_current_selector_state():
+    """The re-arm must source the CURRENT selector/session model, not a stale const.
+
+    Sourcing from ``_chatPayloadModel()`` is what makes a *freshly-picked* model
+    (typed into the selector after the failure) win on the recovery send.
+    """
+    for body in (_function_body(UI_JS, "submitEdit"), _function_body(COMMANDS_JS, "cmdRetry")):
+        assert "_chatPayloadModel()" in body
+        assert "_chatPayloadModelProvider(" in body
+
+
+# ── Server layer: explicit pick is honored; repair path preserved (#3737) ────
+
+
+def test_explicit_pick_honors_fresh_cross_family_model_on_recovery():
+    """The freshly-picked cross-family model survives when explicit_model_pick=True.
+
+    This is the value the re-armed marker carries into /api/chat/start on the
+    recovery send. It must NOT be reverted to the failed/profile-default model.
+    """
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "gpt-5.4-mini",  # freshly picked, cross-family vs anthropic profile
+        None,
+        profile_provider="anthropic",
+        profile_default_model="claude-sonnet-4",
+        explicit_model_pick=True,
+    )
+    assert changed is False, "an explicit recovery pick must not be reverted"
+    assert effective == "gpt-5.4-mini", "the freshly-picked model must survive"
+    assert provider == "anthropic"
+
+
+def test_second_consecutive_recovery_send_still_honors_pick():
+    """A SECOND consecutive recovery send re-arms the marker, so it stays explicit.
+
+    send() consumes the marker each time, but both recovery paths re-arm it from
+    the current selector state on every invocation — so two retries/edits in a
+    row both carry explicit_model_pick=True and both honor the pick.
+    """
+    for _ in range(2):
+        effective, provider, changed = routes._resolve_compatible_session_model_state(
+            "gpt-5.4-mini",
+            None,
+            profile_provider="anthropic",
+            profile_default_model="claude-sonnet-4",
+            explicit_model_pick=True,
+        )
+        assert changed is False
+        assert effective == "gpt-5.4-mini"
+        assert provider == "anthropic"
+
+
+def test_non_explicit_send_still_normalizes_stale_model():
+    """Guard against regressing the #3737/#5731 repair path.
+
+    Without an explicit pick (the normal 2nd+-turn continuation), a stale
+    cross-family model is still normalized to the profile default. The #5924 fix
+    only re-arms on the recovery entry points, so this path is unchanged.
+    """
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "gpt-5.4-mini",
+        None,
+        profile_provider="anthropic",
+        profile_default_model="claude-sonnet-4",
+        explicit_model_pick=False,
+    )
+    assert changed is True, "stale model must still be normalized on a plain send"
+    assert effective == "claude-sonnet-4"
+    assert provider == "anthropic"


### PR DESCRIPTION
## Summary

After a provider failure, the recovery flow ignored a freshly-picked model/provider: changing the model in the selector and then **edit-resubmit** *or* **/retry** re-sent the *failed* model, forcing the user to fork the session to escape.

This PR fixes **Facet 1** (the pick not being honored on the recovery send) and **Facet 4** (stuck model surviving fork/refresh/reselect/update — same root cause) by re-arming the explicit-pick marker on both recovery entry points.

Reported by @b3nw (Discord `#report-bugs`).

## Root cause

The frontend selector path is correct — `boot.js` `modelSelect.onchange` writes a pending explicit-pick marker via `_rememberPendingSessionModel(...)`. The problem is that **the marker is single-shot**: `send()` consumes it exactly once (`messages.js`), and neither recovery path re-arms it.

- `submitEdit()` (`static/ui.js`) truncates and calls `send()` directly.
- `cmdRetry()` (`static/commands.js`) does the same after `/api/session/retry`.

Because the marker was already consumed by an earlier send, the recovery send goes out with `explicit_model_pick:false`. The server's `_resolve_compatible_session_model_state` (`api/routes.py`) is then free to "repair" a cross-family model back toward the profile default — re-reverting to the stale/failed value. Facet 4 is the same loop: each non-explicit recovery send lets the server re-pin the persisted `model_provider`, so reselect/refresh/fork never sticks.

This is exactly the layer the maintainer's investigation comment identified: **WebUI-side, small, on the two recovery entry points** — not the server guard (which correctly honors `explicit_model_pick=True` and must keep normalizing stale models when the pick is absent, per #3737 / #5731).

## Fix

Re-arm the pending explicit-pick marker from the **current** selector/session state (`_chatPayloadModel()` / `_chatPayloadModelProvider()`) immediately before `await send()` in both `submitEdit()` and `cmdRetry()`. This makes a recovery send carry `explicit_model_pick:true`, exactly like a fresh `onchange → send`. Because the re-arm runs on *every* recovery invocation, it also survives a **second consecutive** recovery send even though `send()` consumes the marker each time.

- The normal (non-failure) send path is unchanged — no re-arm added there.
- The server-side `_resolve_compatible_session_model_state` guard is untouched; the #3737 / #2761 / #5567 / #5731 repair behavior is preserved (verified by a regression assertion that a *non-explicit* send still normalizes a stale cross-family model).

## Files changed

- `static/ui.js` — `submitEdit()` re-arms the pending pick before `await send()`.
- `static/commands.js` — `cmdRetry()` re-arms the pending pick before `await send()`.
- `tests/test_issue5924_post_failure_recovery_model_pick.py` — new regression test.

## Tests

New file `tests/test_issue5924_post_failure_recovery_model_pick.py` pins the two-layer invariant:

- **WebUI:** both `submitEdit` and `cmdRetry` re-arm the marker (from the current selector state) *before* `await send()`.
- **Server:** an explicit recovery pick is honored (not reverted); a **second consecutive** recovery send still honors it; and a **non-explicit** send still normalizes a stale model (no #3737 regression).

```
tests/test_issue5924_post_failure_recovery_model_pick.py ...... [100%]
6 passed
```

Also re-ran `tests/test_issue_edit_regenerate_absolute_keep_count.py` and `tests/test_model_selection_refresh_persistence.py` (6 passed) to confirm no regression on the touched functions.

## Scope / out-of-scope follow-ups

This is a **Facet 1 + Facet 4** fix. Deliberately out of scope (should be separate PRs):

- **Facet 2** — a clear/dismiss affordance for failed error turns (missing UI feature; error turns are pushed as plain assistant bubbles with no per-turn delete).
- **Facet 3** — "first fork after an error is a full copy": maintainer could not reproduce from `forkFromMessage`; likely a stale `_oldestIdx` / transcript-not-fully-loaded timing issue on the error turn, needs a focused repro.

Addresses #5924 (Facet 1 + Facet 4). Leaving the issue open for Facet 2 and Facet 3 above.
