### PR TITLE
Release exp-v0.52.41: dedupe pending prompts across compaction boundary (#5920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- **A pending prompt no longer renders twice across a context-compaction boundary.** On reload / reattach to an active turn, a synthetic `[CONTEXT COMPACTION]` marker (a user-role row that isn't a real submitted turn) placed after your prompt was treated as the latest user message, so the tail scan missed the actual prompt right before it and rendered the same pending prompt twice. The session-load and refresh/reconnect tail scans now skip compaction markers when locating the current user message, while completed assistant rows stay hard boundaries so genuinely-repeated prompts still render. Thanks @starship-s. (#5920)
+
 - **Sessions from Zed and other ACP (Agent Client Protocol) clients now show up in the sidebar.** An ACP-adapter session persists to the agent database with source `acp`, which was classified as `other` and fell through both sidebar buckets — so those conversations were completely invisible and unclickable. ACP sessions are now grouped with the CLI/TUI family (labelled "ACP"), with the same zero-message / ended-connection hiding rules as other interactive agent sessions. Thanks @ai-ag2026. (#5939)
 
 - **Date-stamped legacy Claude 3.0 model ids no longer show reasoning-effort controls they don't support.** The capability check read an 8-digit date suffix (e.g. `claude-3-opus-20240229`) as the model's minor version, so a bare date-stamped Claude 3.0 id wrongly qualified as reasoning-capable. The minor-version match is now bounded (mirroring the existing date-stamp defense), so date-stamped Claude 3.0 ids correctly hide reasoning-effort options while Claude 3.7 / 4.x / adaptive keep them. Thanks @nankingjing. (#5934)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3013,7 +3013,11 @@ function _currentTailUserMessage(messages){
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
-    if(String(msg.role||'')==='user') return msg;
+    if(String(msg.role||'')==='user'){
+      // Compaction rows are synthetic user-role markers, not submitted turns.
+      if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      return msg;
+    }
     if(msg._live||String(msg.role||'')==='tool') continue;
     return null;
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -9845,7 +9845,11 @@ function _pendingCurrentTailUserMessage(messages){
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
-    if(String(msg.role||'')==='user') return msg;
+    if(String(msg.role||'')==='user'){
+      // Compaction rows are synthetic user-role markers, not submitted turns.
+      if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      return msg;
+    }
     if(msg._live||String(msg.role||'')==='tool') continue;
     return null;
   }

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -80,6 +80,9 @@ def _run_current_turn_scope_probe() -> dict:
     helpers = "\n".join(
         [
             _function_body(UI_SRC, "function _stripWorkspaceDisplayPrefix"),
+            _function_body(UI_SRC, "function msgContent"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
             _function_body(SESSIONS_SRC, "function _messageComparableText"),
             _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
             _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
@@ -128,6 +131,35 @@ const inflightWithCurrent = _mergeInflightTailMessages(
   [{{role:'user', content:{json.dumps(prompt)}, _ts:3}}, liveAssistant]
 );
 
+const compaction = {{
+  role:'user',
+  content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.',
+  _ts:3.5,
+}};
+const compactionBase = [historical, historicalAnswer, optimisticCurrent, compaction];
+const compactionCandidate = {{role:'user', content:{json.dumps(prompt)}, _ts:3}};
+const compactionCurrentTail = _currentTailUserMessage(compactionBase);
+const compactionTailDuplicate = _hasCurrentTailUserDuplicate(compactionBase, compactionCandidate);
+const compactionMerged = _mergeInflightTailMessages(
+  compactionBase,
+  [compactionCandidate, liveAssistant]
+);
+const insertedAfterCompaction = _mergePendingSessionMessage(pendingSession, compactionMerged);
+const compactionPromptCount = compactionMerged.filter(
+  m=>m&&m.role==='user'&&m._ts===3&&_normalizeUserTranscriptText(m.content)==={json.dumps(prompt)}
+).length;
+const compactionMarkerRetained = compactionMerged.some(m=>_isContextCompactionMessage(m));
+const compactionLiveAssistantRetained = compactionMerged.some(
+  m=>m&&m.role==='assistant'&&m._live&&m.content==='working'
+);
+const completedBoundaryDedupe = _hasCurrentTailUserDuplicate(
+  [historical, historicalAnswer, compaction],
+  {{role:'user', content:{json.dumps(prompt)}, _ts:3}}
+);
+const distinctCompletedTurnPromptCount = inflightAfterHistory.filter(
+  m=>m&&m.role==='user'&&_normalizeUserTranscriptText(m.content)==={json.dumps(prompt)}
+).length;
+
 process.stdout.write(JSON.stringify({{
   insertedAfterHistory,
   pendingAfterHistoryRoles: pendingAfterHistory.map(m=>m.role),
@@ -137,6 +169,14 @@ process.stdout.write(JSON.stringify({{
   pendingWithCurrentRoles: pendingWithCurrent.map(m=>m.role),
   inflightAfterHistoryRoles: inflightAfterHistory.map(m=>m.role),
   inflightWithCurrentRoles: inflightWithCurrent.map(m=>m.role),
+  insertedAfterCompaction,
+  compactionCurrentTailContent: compactionCurrentTail&&compactionCurrentTail.content,
+  compactionTailDuplicate,
+  compactionPromptCount,
+  compactionMarkerRetained,
+  compactionLiveAssistantRetained,
+  completedBoundaryDedupe,
+  distinctCompletedTurnPromptCount,
 }}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -157,6 +197,8 @@ def _run_pending_session_message_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
             _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
             _function_body(UI_SRC, "function getPendingSessionMessage"),
         ]
     )
@@ -168,8 +210,24 @@ const historicalWorkspace = {{role:'user', content:{json.dumps(historical_worksp
 const historicalAnswer = {{role:'assistant', content:'done', _ts:2}};
 const currentTail = {{role:'user', content:prompt, _ts:3}};
 const currentWorkspaceTail = {{role:'user', content:{json.dumps(current_workspace_prompt)}, _ts:3}};
+const currentTailForCompaction = {{role:'user', content:prompt, _ts:3}};
 const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4}};
 const attachments = [{{name:'note.txt', path:'note.txt', mime:'text/plain'}}];
+const compactionMarker = {{
+  role:'user',
+  content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.',
+  _ts:3.5,
+}};
+const repeatedPromptTurnOne = {{role:'user', content:prompt, _ts:1}};
+const repeatedPromptAnswerOne = {{role:'assistant', content:'done', _ts:2}};
+const repeatedPromptTurnTwo = {{role:'user', content:prompt, _ts:3}};
+const repeatedPromptAnswerTwo = {{role:'assistant', content:'done', _ts:4}};
+const repeatedCompletedBase = [
+  repeatedPromptTurnOne,
+  repeatedPromptAnswerOne,
+  repeatedPromptTurnTwo,
+  repeatedPromptAnswerTwo,
+];
 
 const fromHistoricalSameText = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:3}},
@@ -196,6 +254,21 @@ const differentTailResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4}},
   [historical, historicalAnswer, {{role:'user', content:'different prompt', _ts:3}}]
 );
+const compactionTailResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:4, pending_attachments:attachments}},
+  [historical, historicalAnswer, currentTailForCompaction, compactionMarker]
+);
+const repeatedCompletedResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:5}},
+  repeatedCompletedBase
+);
+const repeatedCompletedMessages = repeatedCompletedResult
+  ? [...repeatedCompletedBase, repeatedCompletedResult]
+  : repeatedCompletedBase;
+const repeatedCompletedPromptCount = repeatedCompletedMessages.filter(
+  m=>m&&m.role==='user'&&_normalizeUserTranscriptText(m.content)===prompt
+).length;
+const compactionCurrentTail = _pendingCurrentTailUserMessage([historical, historicalAnswer, currentTailForCompaction, compactionMarker]);
 
 process.stdout.write(JSON.stringify({{
   historicalSameTextSurvives: !!fromHistoricalSameText && fromHistoricalSameText.content===prompt && fromHistoricalSameText._pending===true,
@@ -205,6 +278,12 @@ process.stdout.write(JSON.stringify({{
   workspaceCurrentTailDedupe: workspaceCurrentResult===null,
   liveAfterCurrentTailDedupe: liveAfterCurrentResult===null,
   differentCurrentTailSurvives: !!differentTailResult && differentTailResult.content===prompt && differentTailResult._pending===true,
+  compactionBoundaryDedupe: compactionTailResult===null,
+  compactionBoundaryCurrentTail: compactionCurrentTail&&compactionCurrentTail.role==='user'&&compactionCurrentTail.content===prompt,
+  compactionCurrentTailAttachmentsCopied: Array.isArray(currentTailForCompaction.attachments) && currentTailForCompaction.attachments[0].name==='note.txt',
+  repeatedCompletedPromptsRemainValid: repeatedCompletedPromptCount===3,
+  isContextCompactionText: _isContextCompactionText(compactionMarker.content),
+  isContextCompactionMessage: _isContextCompactionMessage(compactionMarker),
 }}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -385,6 +464,15 @@ def test_user_turn_dedupe_is_scoped_to_current_turn_by_behavior():
     assert result["inflightAfterHistoryRoles"] == ["user", "assistant", "user", "assistant"]
     assert result["inflightWithCurrentRoles"] == ["user", "assistant", "user", "assistant"]
 
+    assert result["insertedAfterCompaction"] is False
+    assert result["compactionCurrentTailContent"] == "[Workspace::v1: /tmp/current]\nrepeat me"
+    assert result["compactionTailDuplicate"] is True
+    assert result["compactionPromptCount"] == 1
+    assert result["compactionMarkerRetained"] is True
+    assert result["compactionLiveAssistantRetained"] is True
+    assert result["completedBoundaryDedupe"] is False
+    assert result["distinctCompletedTurnPromptCount"] == 2
+
 
 def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     """Deferred active reload must not hide a current repeat prompt.
@@ -404,6 +492,12 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["workspaceCurrentTailDedupe"] is True
     assert result["liveAfterCurrentTailDedupe"] is True
     assert result["differentCurrentTailSurvives"] is True
+    assert result["compactionBoundaryDedupe"] is True
+    assert result["compactionBoundaryCurrentTail"] is True
+    assert result["compactionCurrentTailAttachmentsCopied"] is True
+    assert result["repeatedCompletedPromptsRemainValid"] is True
+    assert result["isContextCompactionText"] is True
+    assert result["isContextCompactionMessage"] is True
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():


### PR DESCRIPTION
## Release exp-v0.52.41

### #5920 — fix(chat): dedupe pending prompts across compaction (starship-s)
On reload / reattach to an active turn, a synthetic `[CONTEXT COMPACTION]` marker (a user-role row that isn't a real submitted turn) placed after your prompt was treated as the latest user message, so the tail scan missed the actual prompt right before it → the same pending prompt rendered twice across the compaction boundary. The fix adds an identical guard to `_currentTailUserMessage` (sessions.js) and `_pendingCurrentTailUserMessage` (ui.js): skip compaction markers (via the pre-existing `_isContextCompactionMessage`, `typeof`-guarded) when scanning for the current user turn; completed assistant rows stay hard boundaries so genuinely-repeated prompts still render.

**Gate (crown-jewel chat-render):**
- **Rebased onto current master** (the branch predated the #5946 stream fix, which made the raw PR head trip the stream gate RED on the OLD exp-v0.52.38 regression — a stale-base artifact, not the PR's bug).
- **Stream-regression-gate: GREEN across all 3 modes** on the rebased head (transparent `rowElementSwaps` 0, no alternating, no flicker, full lifecycle).
- Minimal +104 (2 prod files, 4 guard lines + a node-backed regression test covering the compaction-skip + verifying legit repeated prompts still render).

**Channel:** experimental (`exp-v0.52.41`). Original author @starship-s (rebased by maintainer).
