### PR TITLE
feat(webui): pass passive project metadata to agent

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -665,6 +665,7 @@ def _run_gateway_chat_streaming(
                 _normalize_prefill_messages_before_user_turn,
                 _public_prefill_context_status,
                 _webui_ephemeral_system_prompt,
+                _webui_project_surface_context,
             )
 
             prefill_context = _load_webui_prefill_context(cfg)
@@ -680,6 +681,7 @@ def _run_gateway_chat_streaming(
                     "session_id": session_id,
                     "profile": getattr(s, "profile", None),
                     "workspace": s.workspace if s is not None else str(workspace),
+                    **_webui_project_surface_context(s),
                 },
                 config_data=cfg,
             )

--- a/api/routes.py
+++ b/api/routes.py
@@ -21869,11 +21869,19 @@ def _handle_chat_sync(handler, body):
                 _restore_reasoning_metadata,
                 _sanitize_messages_for_api,
                 _context_messages_for_new_turn,
+                _webui_project_surface_context,
                 _workspace_context_prefix,
             )
             workspace_ctx = _workspace_context_prefix(str(s.workspace))
+            project_context = _webui_project_surface_context(s)
+            project_system_msg = "".join(
+                f"WebUI project {label}: {project_context[key]}\n"
+                for key, label in (("project_id", "ID"), ("project_name", "name"))
+                if key in project_context
+            )
             workspace_system_msg = (
                 f"Active workspace at session start: {s.workspace}\n"
+                f"{project_system_msg}"
                 "Every user message is prefixed with [Workspace::v1: /absolute/path] indicating the "
                 "workspace the user has selected in the web UI at the time they sent that message. "
                 "This tag is the single authoritative source of the active workspace and updates "

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -55,6 +55,7 @@ from api.models import (
     _evict_sessions_over_cap,
     clear_process_wakeup_pause,
     get_state_db_session_messages,
+    load_projects,
     record_process_wakeup_provider_unavailable_pause,
     reconciled_state_db_messages_for_session,
 )
@@ -667,6 +668,8 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
         ("session_id", "Session ID"),
         ("profile", "Profile"),
         ("workspace", "Workspace"),
+        ("project_id", "Project ID"),
+        ("project_name", "Project name"),
     )
     for key, label in fields:
         raw = surface_context.get(key)
@@ -674,6 +677,30 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
         if value:
             lines.append(f"- {label}: {value}")
     return "\n".join(lines)
+
+
+def _webui_project_surface_context(session) -> dict:
+    """Return passive project metadata for a WebUI session.
+
+    Project context is model-facing runtime metadata only. It deliberately
+    carries no instructions to create files, maintain dossiers, or suggest a
+    project assignment.
+    """
+    project_id = getattr(session, "project_id", None) or None
+    if not project_id:
+        return {}
+    project_name = None
+    try:
+        for project in load_projects():
+            if str(project.get("project_id") or "") == str(project_id):
+                project_name = str(project.get("name") or "").strip() or None
+                break
+    except Exception:
+        logger.debug("Failed to resolve WebUI project metadata for %s", project_id, exc_info=True)
+    context = {"project_id": str(project_id)}
+    if project_name:
+        context["project_name"] = project_name
+    return context
 
 
 def _webui_ephemeral_system_prompt(
@@ -8282,6 +8309,7 @@ def _run_agent_streaming(
                     'session_id': session_id,
                     'profile': getattr(s, 'profile', None),
                     'workspace': s.workspace,
+                    **_webui_project_surface_context(s),
                 },
                 config_data=_cfg,
             )

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -4,6 +4,7 @@ from api.streaming import (
     _normalize_prefill_messages_before_user_turn,
     _prefill_messages_with_webui_context,
     _webui_ephemeral_system_prompt,
+    _webui_project_surface_context,
 )
 
 
@@ -56,6 +57,59 @@ def test_webui_ephemeral_prompt_skips_empty_surface_fields():
     assert "Session ID:" not in prompt
     assert "Profile:" not in prompt
     assert "Workspace:" not in prompt
+
+
+def test_webui_ephemeral_prompt_includes_passive_project_metadata():
+    prompt = _webui_ephemeral_system_prompt(
+        None,
+        surface_context={
+            "source": "webui",
+            "project_id": "proj_abc123",
+            "project_name": "Initial setup",
+        },
+    )
+
+    assert "Project ID: proj_abc123" in prompt
+    assert "Project name: Initial setup" in prompt
+    assert "dossier" not in prompt.lower()
+    assert "assign the chat" not in prompt.lower()
+
+
+def test_webui_project_surface_context_resolves_assigned_project(monkeypatch):
+    import api.streaming as streaming
+
+    class Session:
+        project_id = "proj_abc123"
+
+    monkeypatch.setattr(
+        streaming,
+        "load_projects",
+        lambda: [{"project_id": "proj_abc123", "name": "Initial setup"}],
+    )
+
+    assert _webui_project_surface_context(Session()) == {
+        "project_id": "proj_abc123",
+        "project_name": "Initial setup",
+    }
+
+
+def test_webui_project_surface_context_omits_unassigned_project():
+    class Session:
+        project_id = None
+
+    assert _webui_project_surface_context(Session()) == {}
+
+
+def test_all_webui_chat_paths_forward_project_surface_context():
+    from pathlib import Path
+
+    streaming = Path("api/streaming.py").read_text(encoding="utf-8")
+    gateway = Path("api/gateway_chat.py").read_text(encoding="utf-8")
+    routes = Path("api/routes.py").read_text(encoding="utf-8")
+
+    assert "**_webui_project_surface_context(s)" in streaming
+    assert "**_webui_project_surface_context(s)" in gateway
+    assert "project_context = _webui_project_surface_context(s)" in routes
 
 
 def test_ephemeral_prompt_avoids_platform_info_when_no_config():


### PR DESCRIPTION
## Summary

Pass the assigned WebUI project's ID and display name to Hermes as passive runtime metadata.

- extends the existing ephemeral WebUI surface-context block with `Project ID` and `Project name`
- resolves the project name from the session's existing `project_id`
- covers direct streaming, gateway-backed streaming, and synchronous chat paths
- omits project fields entirely for unassigned sessions

## Scope and behavior

This is intentionally narrower than #3615. It does **not**:

- add or restore model-facing user-message prefixes
- create or maintain project dossiers
- ask the model to suggest assigning chats to projects
- change session loading, transcript reconciliation, updates, or UI behavior

The metadata is informational only. Existing project/session storage remains unchanged.

## State and prompt-cache invariants

- No persisted session or display message is mutated.
- Streaming and gateway paths use the existing per-turn `ephemeral_system_prompt` surface-context channel.
- Sync chat adds the same two passive values to its existing non-persisted system message.
- Unassigned sessions retain the current prompt shape apart from the new supported field definitions.

## Tests

- `./scripts/test.sh tests/test_issue1913_workspace_prefix_sentinel.py tests/test_workspace_display_prefix.py tests/test_notify_on_complete_webui.py tests/test_webui_surface_context.py` — 23 passed
- `./scripts/test.sh tests/test_webui_gateway_chat_backend.py tests/test_gateway_approval_legacy_path.py tests/test_gateway_approval_runs_api.py tests/test_issue1217_transcript_compaction.py` — 101 passed
- `python3 -m py_compile api/streaming.py api/gateway_chat.py api/routes.py`
- `git diff --check`

## Release note

WebUI-assigned project IDs and names are now available to Hermes as passive per-turn runtime context without changing visible or persisted chat messages.
