### PR TITLE
Refresh reasoning chip after empty boot hydration

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -3474,6 +3474,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       else if(typeof syncModelChip==='function') syncModelChip();
     }
     if(S.session) syncTopbar();
+    else if(typeof syncReasoningChip==='function') syncReasoningChip();
   }).catch(e=>{
     window._modelDropdownReady=null;
     throw e;

--- a/tests/test_issue1103_reasoning_chip_visibility.py
+++ b/tests/test_issue1103_reasoning_chip_visibility.py
@@ -110,6 +110,24 @@ def test_syncReasoningChip_called_on_model_change():
         "syncReasoningChip() must run after S.session.model is updated"
 
 
+def test_model_dropdown_hydration_refreshes_reasoning_chip_without_session():
+    """Fresh boot must refresh reasoning after the default model is hydrated."""
+    with open("static/boot.js") as f:
+        src = f.read()
+    start = src.index("const _hydrateModelDropdown=")
+    end = src.index("const _startModelDropdown=", start)
+    block = src[start:end]
+
+    assert "if(S.session) syncTopbar();" in block, \
+        "active-session hydration must continue to refresh the full top bar"
+    assert "else if(typeof syncReasoningChip==='function') syncReasoningChip();" in block, \
+        "empty-session hydration must refresh reasoning for the hydrated default model"
+    assert block.count("syncTopbar()") == 1, \
+        "active-session hydration must refresh the top bar exactly once"
+    assert block.count("syncReasoningChip()") == 1, \
+        "empty-session hydration must refresh the reasoning chip exactly once"
+
+
 def test_selectModelFromDropdown_defers_reasoning_sync_to_onchange():
     """Custom model dropdown must not fetch reasoning before session state updates."""
     with open("static/ui.js") as f:


### PR DESCRIPTION
## Thinking Path

Model-dropdown hydration already refreshed the complete top bar when an active session existed. On a normal empty boot, however, the hydrated profile/default model could change without refreshing the reasoning-effort chip, leaving the chip stale until another UI action occurred.

## What Changed

- Refresh `syncReasoningChip()` after model-dropdown hydration when there is no active session.
- Preserve the existing `syncTopbar()` path when a session exists.
- Add a regression assertion covering the empty-session refresh and ensuring each branch fires only once.

## Why It Matters

The reasoning-effort chip now reflects the model selected during fresh boot hydration instead of displaying stale or unset state.

Fixes #5954.

## Verification

- `./scripts/test.sh tests/test_issue1103_reasoning_chip_visibility.py tests/test_5021_boot_model_redirect_budget.py tests/test_session_metadata_fast_path.py -v` — 26 passed.
- `python -m ruff check tests/test_issue1103_reasoning_chip_visibility.py` — passed.
- `node --check static/boot.js` — passed.
- `git diff --check` — passed.
- Full `./scripts/test.sh` was attempted on Windows and exceeded the 10-minute local execution window without emitting a test failure; the upstream Linux CI matrix remains the authoritative full-suite gate.

## Risks / Follow-ups

Low risk. This changes only the post-hydration refresh branch and does not alter model selection, persistence, API behavior, or visual layout. No screenshot is included because the fix corrects boot-time state synchronization without changing the rendered design.

## Model Used

OpenAI Codex with GPT-5.6 Sol. Repository search, targeted regression testing, JavaScript syntax checking, and the project test runner were used. The contributor reviewed and verified the final diff.
