### PR TITLE
continue cron replies in a writable fork

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1128,6 +1128,7 @@ if(typeof document!=='undefined'){
 // setBusy(true) is only called after the first await inside send().
 let _sendInProgress = false;
 let _sendInProgressSid = null;  // session_id of the in-flight send
+let _branchHandoffInProgress = false;
 const _sessionTitleProvisionalBySid = new Map();
 // Agent commands that are safe to execute directly in the WebUI even though
 // their canonical command is registered on the backend (for example
@@ -1304,6 +1305,7 @@ async function send(){
   // If a send is already in-flight (e.g. queue drain), re-queue the message
   // instead of silently dropping it.
   if (_sendInProgress) {
+    if(typeof _branchHandoffInProgress!=='undefined'&&_branchHandoffInProgress) return;
     const _text=_composerTextWithPendingSelections().trim();
     // Use the in-flight session's sid, not the currently viewed session,
     // so the queued message goes to the chat that owns the active stream.
@@ -1356,13 +1358,11 @@ async function send(){
   if(S.busy||compressionRunning){
     if(text||S.pendingFiles.length){
       if(!S.session){await newSession();await renderSessionList();}
-      // Busy-control slash commands must be intercepted HERE, before the
-      // defaultMessageMode routing block, so the user can always type /steer, /interrupt,
-      // /queue, /terminal, /goal, or /yolo while the agent is running and have
-      // them execute immediately.
-      // Without this intercept they fall through to the queue and execute after
-      // the current turn ends — by which point there is no active stream and
-      // cmdSteer / cmdInterrupt say "No active task to stop."
+      if(typeof _isReadOnlySession==='function'&&_isReadOnlySession(S.session)){
+        if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
+        return;
+      }
+      // Intercept explicit busy commands before the default mode dispatch.
       if(text.startsWith('/')&&!literalSlash){
         const _pc=typeof parseCommand==='function'&&parseCommand(text);
         if(_pc&&['steer','interrupt','queue','terminal','goal','yolo'].includes(_pc.name)){
@@ -1413,22 +1413,18 @@ async function send(){
     }
     return;
   }
-  if(S.session&&(S.session.read_only||S.session.is_read_only)){
-    if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
-    return;
-  }
   let _slashDisplayTextOverride=null;
   let _pendingMoaConfig=null;
-  // Slash command intercept -- local commands handled without agent round-trip.
-  // We push the user message BEFORE running the handler for echo-worthy
-  // commands so chat order is correct: some handlers (e.g. cmdHelp) push
-  // their assistant response synchronously.  If we pushed AFTER, S.messages
-  // would be [assistant, user] and the chat would show the response above
-  // the user's own input — reverse chronological order (#840 ordering bug).
+  // Slash command intercept -- echoing commands optimistically push the user
+  // turn before sync handlers, and false opt-out rolls that push back.
   if(text.startsWith('/')&&!S.pendingFiles.length&&!literalSlash){
     const _parsedCmd=parseCommand(text);
     const _cmd=_parsedCmd?COMMANDS.find(c=>c.name===_parsedCmd.name):null;
     if(_cmd){
+      if(_parsedCmd.name!=='branch'&&S.session&&(S.session.read_only||S.session.is_read_only)){
+        if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
+        return;
+      }
       let _pushedUser=false;
       if(!_cmd.noEcho){
         if(!S.session){await newSession();await renderSessionList();}
@@ -1448,6 +1444,10 @@ async function send(){
       }
     }
     if(_parsedCmd&&!_cmd){
+      if(_parsedCmd.name!=='branch'&&S.session&&(S.session.read_only||S.session.is_read_only)){
+        if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
+        return;
+      }
       if(_parsedCmd.name==='pet'){
         if(!S.session){await newSession();await renderSessionList();}
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
@@ -1556,6 +1556,66 @@ async function send(){
           $('msg').value='';autoResize();hideCmdDropdown();return;
         }
       }
+    }
+  }
+  if(S.session&&(S.session.read_only||S.session.is_read_only)){
+    if(typeof _isBranchableReadOnlySession!=='function'||!_isBranchableReadOnlySession(S.session)){
+      if(typeof showToast==='function') showToast('Read-only imported sessions cannot be modified.',3000);
+      return;
+    }
+    const _branchSourceSid=S.session.session_id;
+    const _branchText=text;
+    const _branchFiles=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
+    const _branchModelState=_chatPayloadModelState();
+    const _branchProfile=S.activeProfile||S.session.profile||'default';
+    const _branchComposer=$('msg');
+    const _branchComposerReadOnly=!!(_branchComposer&&_branchComposer.readOnly);
+    const _branchComposerDisabled=!!(_branchComposer&&_branchComposer.disabled);
+    const _restoreBranchComposerState=()=>{
+      if(!_branchComposer) return;
+      _branchComposer.readOnly=_branchComposerReadOnly;
+      _branchComposer.disabled=_branchComposerDisabled;
+      if(typeof updateSendBtn==='function') updateSendBtn();
+    };
+    if(_branchComposer){
+      _branchComposer.readOnly=true;
+      _branchComposer.disabled=true;
+    }
+    _branchHandoffInProgress=true;
+    if(typeof updateSendBtn==='function') updateSendBtn();
+    let _branchChildSid=null;
+    try{
+      const _branchData=await api('/api/session/branch',{method:'POST',body:JSON.stringify({session_id:_branchSourceSid})});
+      if(!_branchData||!_branchData.session_id) throw new Error('Fork response did not include a session id.');
+      _branchChildSid=_branchData.session_id;
+      $('msg').value='';
+      S.pendingFiles=[];
+      if(typeof autoResize==='function') autoResize();
+      if(typeof renderTray==='function') renderTray();
+      await loadSession(_branchChildSid,{throwOnMessageLoadFailure:true});
+      if(!S.session||S.session.session_id!==_branchChildSid) throw new Error('Fork load did not activate the writable child.');
+      if(S.session){
+        S.session.model=_branchModelState.model;
+        S.session.model_provider=_branchModelState.model_provider;
+        S.session.profile=_branchProfile;
+      }
+      S.activeProfile=_branchProfile;
+      S.pendingFiles=[..._branchFiles];
+      $('msg').value=_branchText;
+      if(typeof autoResize==='function') autoResize();
+      if(typeof renderTray==='function') renderTray();
+      _restoreBranchComposerState();
+      _branchHandoffInProgress=false;
+      if(typeof showToast==='function') showToast(t('branch_forked'));
+    }catch(_branchError){
+      _branchHandoffInProgress=false;
+      const _restoreSid=(S.session&&S.session.session_id===_branchChildSid)
+        ? _branchChildSid
+        : _branchSourceSid;
+      _restoreComposerDraftAfterFailedSend(_branchText,_branchFiles,_restoreSid);
+      _restoreBranchComposerState();
+      if(typeof showToast==='function') showToast(t('branch_failed')+(_branchError&&_branchError.message||_branchError));
+      return;
     }
   }
   if(!S.session){await newSession();await renderSessionList();}

--- a/static/messages.js
+++ b/static/messages.js
@@ -1592,7 +1592,7 @@ async function send(){
       S.pendingFiles=[];
       if(typeof autoResize==='function') autoResize();
       if(typeof renderTray==='function') renderTray();
-      await loadSession(_branchChildSid,{throwOnMessageLoadFailure:true});
+      await loadSession(_branchChildSid,{throwOnMessageLoadFailure:true,internalBranchHandoff:true});
       if(!S.session||S.session.session_id!==_branchChildSid) throw new Error('Fork load did not activate the writable child.');
       if(S.session){
         S.session.model=_branchModelState.model;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1671,6 +1671,7 @@ async function loadSession(sid){
   // Resolve canonical lineage SID BEFORE both the direct and sidebar preload
   // notifications so extensions always see the canonical session id, not the
   // raw sidebar click id (which may differ after lineage folding).
+  const _throwOnMessageLoadFailure=!!opts.throwOnMessageLoadFailure;
   if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){
     const resolvedSid=_resolveSessionIdFromSidebarLineage(sid);
     if(resolvedSid&&resolvedSid!==sid) sid=resolvedSid;
@@ -2232,6 +2233,7 @@ async function loadSession(sid){
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
       if (_isCurrentLoad()) _loadingSessionId = null;
+      if(_throwOnMessageLoadFailure) throw new Error('Failed to load conversation messages');
       return;
     }
     // Stale? A newer loadSession() call has already started (#1060).
@@ -2496,12 +2498,10 @@ function _isReadOnlySession(session) {
 
 function _isBranchableReadOnlySession(session) {
   if (!_isReadOnlySession(session)) return false;
-  const sources = [
-    session && session.source_tag,
-    session && session.raw_source,
-    session && session.source,
-  ].map(v => String(v || '').trim().toLowerCase());
-  return sources.includes('cron');
+  const sourceKind = String(
+    (session && (session.source_tag || session.raw_source || session.source)) || ''
+  ).trim().toLowerCase();
+  return sourceKind === 'cron';
 }
 
 function _sourceKeyForSession(session) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1671,6 +1671,8 @@ async function loadSession(sid){
   // Resolve canonical lineage SID BEFORE both the direct and sidebar preload
   // notifications so extensions always see the canonical session id, not the
   // raw sidebar click id (which may differ after lineage folding).
+  const _internalBranchHandoff=!!opts.internalBranchHandoff;
+  if(typeof _branchHandoffInProgress!=='undefined'&&_branchHandoffInProgress&&!_internalBranchHandoff) return;
   const _throwOnMessageLoadFailure=!!opts.throwOnMessageLoadFailure;
   if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){
     const resolvedSid=_resolveSessionIdFromSidebarLineage(sid);

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -137,12 +137,18 @@ def _send_harness(body: str) -> str:
     cmd_branch = _extract_async_function(commands_source, "cmdBranch")
     is_read_only = _extract_function(session_source, "_isReadOnlySession")
     is_branchable_read_only = _extract_function(session_source, "_isBranchableReadOnlySession")
+    real_load_session = _extract_async_function(session_source, "loadSession").replace(
+        "async function loadSession(",
+        "async function _realLoadSession(",
+        1,
+    )
     return _run_node(
         "\n".join([
             "const calls = [];",
             "const toasts = [];",
             "const loadedSessions = [];",
             "const restoreCalls = [];",
+            "const draftSaveCalls = [];",
             "let S = null;",
             "const composer = { value: 'What changed since yesterday?', dispatchEvent() {} };",
             "const document = { querySelector: () => null };",
@@ -163,6 +169,7 @@ def _send_harness(body: str) -> str:
             "const _composerTextWithPendingSelections = () => composer.value;",
             "const _pendingSelections = [];",
             "const _clearPendingSelections = () => {};",
+            "const _saveComposerDraftNow = (sid, text, files) => { draftSaveCalls.push({ sid, text, files: [...files] }); return Promise.resolve(); };",
             "const parseCommand = (text) => { const [name, ...rest] = text.slice(1).trim().split(/\\s+/); return { name, args: rest.join(' ') }; };",
             "const shouldInterceptCompressionRecoveryContinuation = () => false;",
             "const isCompressionUiRunning = () => false;",
@@ -171,7 +178,10 @@ def _send_harness(body: str) -> str:
             "const uploadPendingFiles = async ({ files }) => files.map(file => ({ name: file.name, path: file.name }));",
             "const setBusy = (busy) => { S.busy = busy; };",
             "let api = async (url, opts) => { const body = JSON.parse(opts.body); calls.push({ url, body }); if(url === '/api/session/branch') return { session_id: 'forked-session' }; return { stream_id: 'stream-1' }; };",
-            "let loadSession = async (sid) => { loadedSessions.push(sid); S.session = { session_id: sid, workspace: '/tmp', model: 'child-default', model_provider: 'child-provider', profile: 'child-profile' }; };",
+            "let _branchHandoffInProgress = false;",
+            real_load_session,
+            "let useRealLoadSession = false;",
+            "let loadSession = async (sid, opts = {}) => { if(opts.internalBranchHandoff || !useRealLoadSession){ loadedSessions.push(sid); S.session = { session_id: sid, workspace: '/tmp', model: 'child-default', model_provider: 'child-provider', profile: 'child-profile' }; return; } return await _realLoadSession(sid, opts); };",
             "const ensureLiveWorklogShell = () => {};",
             "const clearLiveToolCards = () => {};",
             "const appendThinking = () => {};",
@@ -840,7 +850,7 @@ def test_send_requests_strict_fork_load_failure_from_load_session():
         "console.log(JSON.stringify({ loadOptions, loadedSessions, calls }));"
     )
     payload = json.loads(result)
-    assert payload["loadOptions"] == {"throwOnMessageLoadFailure": True}
+    assert payload["loadOptions"] == {"throwOnMessageLoadFailure": True, "internalBranchHandoff": True}
     assert payload["loadedSessions"] == ["forked-session"]
     assert [call["url"] for call in payload["calls"]] == ["/api/session/branch", "/api/chat/start"]
 
@@ -952,25 +962,39 @@ def test_send_restores_payload_to_visible_child_when_fork_load_fails_after_activ
     assert payload["session"]["session_id"] == "forked-session"
 
 
-def test_send_restores_payload_to_source_when_unrelated_session_becomes_active_during_fork_load():
+def test_send_blocks_unrelated_session_load_during_branch_handoff():
     result = _send_harness(
-        "loadSession = async () => { "
-        "  S.session = { session_id: 'manual-session', workspace: '/tmp', model: 'manual-model', model_provider: 'manual-provider', profile: 'manual-profile' }; "
+        "let resolveBranch; const loadAttempts = []; "
+        "useRealLoadSession = true; "
+        "const originalLoadSession = loadSession; "
+        "loadSession = async (sid, opts = {}) => { loadAttempts.push({ sid, opts }); return await originalLoadSession(sid, opts); }; "
+        "api = async (url, opts) => { const body = JSON.parse(opts.body); calls.push({ url, body }); "
+        "  if(url === '/api/session/branch') return await new Promise(resolve => { resolveBranch = resolve; }); "
+        "  return { stream_id: 'stream-1' }; "
         "}; "
-        "await send(); "
-        "console.log(JSON.stringify({ calls, toasts, composer: composer.value, files: S.pendingFiles, restoreCalls, session: S.session }));"
+        "const first = send(); await Promise.resolve(); await loadSession('manual-session'); "
+        "const during = { session: S.session.session_id, composer: composer.value, files: [...S.pendingFiles], draftSaveCalls: [...draftSaveCalls], loadedSessions: [...loadedSessions] }; "
+        "resolveBranch({ session_id: 'forked-session' }); await first; "
+        "console.log(JSON.stringify({ calls, loadAttempts, during, session: S.session, loadedSessions, draftSaveCalls }));"
     )
     payload = json.loads(result)
-    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
-    assert payload["toasts"][0][0] == "Fork failed: Fork load did not activate the writable child."
-    assert payload["composer"] == "What changed since yesterday?"
-    assert payload["files"] == [{"name": "notes.txt"}]
-    assert payload["restoreCalls"] == [{
-        "text": "What changed since yesterday?",
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch", "/api/chat/start"]
+    assert [attempt["sid"] for attempt in payload["loadAttempts"]] == ["manual-session", "forked-session"]
+    assert payload["loadAttempts"][0]["opts"] == {}
+    assert payload["loadAttempts"][1]["opts"] == {
+        "throwOnMessageLoadFailure": True,
+        "internalBranchHandoff": True,
+    }
+    assert payload["during"] == {
+        "session": "daily-summary",
+        "composer": "What changed since yesterday?",
         "files": [{"name": "notes.txt"}],
-        "sid": "daily-summary",
-    }]
-    assert payload["session"]["session_id"] == "manual-session"
+        "draftSaveCalls": [],
+        "loadedSessions": [],
+    }
+    assert payload["draftSaveCalls"] == []
+    assert payload["loadedSessions"] == ["forked-session"]
+    assert payload["session"]["session_id"] == "forked-session"
 
 
 def test_send_restores_payload_when_fork_load_does_not_activate_child():

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -26,6 +26,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 COMMANDS_JS = ROOT / "static" / "commands.js"
 SESSIONS_JS = ROOT / "static" / "sessions.js"
+MESSAGES_JS = ROOT / "static" / "messages.js"
 NODE = shutil.which("node")
 
 
@@ -124,6 +125,95 @@ def _commands_harness(body: str) -> str:
             "  console.error(err && err.stack ? err.stack : String(err));",
             "  process.exit(1);",
             "});",
+        ])
+    )
+
+
+def _send_harness(body: str) -> str:
+    source = MESSAGES_JS.read_text(encoding="utf-8")
+    commands_source = COMMANDS_JS.read_text(encoding="utf-8")
+    session_source = SESSIONS_JS.read_text(encoding="utf-8")
+    send = _extract_async_function(source, "send")
+    cmd_branch = _extract_async_function(commands_source, "cmdBranch")
+    is_read_only = _extract_function(session_source, "_isReadOnlySession")
+    is_branchable_read_only = _extract_function(session_source, "_isBranchableReadOnlySession")
+    return _run_node(
+        "\n".join([
+            "const calls = [];",
+            "const toasts = [];",
+            "const loadedSessions = [];",
+            "const restoreCalls = [];",
+            "let S = null;",
+            "const composer = { value: 'What changed since yesterday?', dispatchEvent() {} };",
+            "const document = { querySelector: () => null };",
+            "const window = { _defaultMessageMode: 'queue', _defaultModel: '', _activeProvider: null };",
+            "const $ = (id) => id === 'msg' ? composer : null;",
+            "const t = (key) => ({ branch_forked: 'Forked into new session', branch_failed: 'Fork failed: ' }[key] || key);",
+            "const showToast = (...args) => toasts.push(args);",
+            "const renderTray = () => {};",
+            "const autoResize = () => {};",
+            "const hideCmdDropdown = () => {};",
+            "const renderMessages = () => {};",
+            "const updateSendBtn = () => {};",
+            "const renderSessionList = async () => {};",
+            "const _ensureAllMessagesLoaded = async () => {};",
+            "const _clearComposerDraft = () => Promise.resolve();",
+            "const _restoreComposerDraftAfterFailedSend = (text, files, sid) => { restoreCalls.push({ text, files: [...files], sid }); composer.value = text; S.pendingFiles = [...files]; };",
+            "const _flushSelectionBlocksToComposer = () => {};",
+            "const _composerTextWithPendingSelections = () => composer.value;",
+            "const _pendingSelections = [];",
+            "const _clearPendingSelections = () => {};",
+            "const parseCommand = (text) => { const [name, ...rest] = text.slice(1).trim().split(/\\s+/); return { name, args: rest.join(' ') }; };",
+            "const shouldInterceptCompressionRecoveryContinuation = () => false;",
+            "const isCompressionUiRunning = () => false;",
+            "const _clearStaleBusyStateBeforeSend = () => false;",
+            "const _chatPayloadModelState = () => ({ model: S.session.model || 'default-model', model_provider: S.session.model_provider || null });",
+            "const uploadPendingFiles = async ({ files }) => files.map(file => ({ name: file.name, path: file.name }));",
+            "const setBusy = (busy) => { S.busy = busy; };",
+            "let api = async (url, opts) => { const body = JSON.parse(opts.body); calls.push({ url, body }); if(url === '/api/session/branch') return { session_id: 'forked-session' }; return { stream_id: 'stream-1' }; };",
+            "let loadSession = async (sid) => { loadedSessions.push(sid); S.session = { session_id: sid, workspace: '/tmp', model: 'child-default', model_provider: 'child-provider', profile: 'child-profile' }; };",
+            "const ensureLiveWorklogShell = () => {};",
+            "const clearLiveToolCards = () => {};",
+            "const appendThinking = () => {};",
+            "const upsertActiveSessionForLocalTurn = () => {};",
+            "const renderSessionListFromCache = () => {};",
+            "const startApprovalPolling = () => {};",
+            "const startClarifyPolling = () => {};",
+            "const _fetchYoloState = () => {};",
+            "const applySessionTitleUpdate = () => {};",
+            "const saveInflightState = () => {};",
+            "const _runOptionalPreStartUiStep = (_label, fn) => { try { fn(); } catch (_) {} };",
+            "const _runOptionalPostStartUiStep = (_label, fn) => { try { fn(); } catch (_) {} };",
+            "const _readPendingSessionModel = () => null;",
+            "const _clearPendingSessionModel = () => {};",
+            "let _forcedSkillDirectivePending = null;",
+            "const _clearComposerAfterQueuedSelectionSend = () => { composer.value = ''; };",
+            "const _defaultMessageMode = 'queue';",
+            "const COMMANDS = [];",
+            "const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set();",
+            "const INFLIGHT = {};",
+            "let _sendInProgress = false;",
+            "let _sendInProgressSid = null;",
+            "const cancelStream = async () => {};",
+            "const stopApprovalPolling = () => {};",
+            "const stopClarifyPolling = () => {};",
+            "const hideApprovalCard = () => {};",
+            "const hideClarifyCard = () => {};",
+            "const removeThinking = () => {};",
+            "const clearOptimisticSessionStreaming = () => {};",
+            "const attachLiveStream = () => {};",
+            "const queueSessionMessage = () => {};",
+            "const updateQueueBadge = () => {};",
+            "const setComposerStatus = () => {};",
+            "const _isOffline = false;",
+            is_read_only,
+            is_branchable_read_only,
+            cmd_branch,
+            send,
+            "(async () => {",
+            "S = { session: { session_id: 'daily-summary', raw_source: 'cron', read_only: true, model: 'chosen-model', model_provider: 'chosen-provider', workspace: '/tmp', profile: 'chosen-profile' }, busy: false, pendingFiles: [{ name: 'notes.txt' }], messages: [], activeProfile: 'chosen-profile', toolCalls: [] };",
+            body,
+            "})().catch((err) => { console.error(err && err.stack ? err.stack : String(err)); process.exit(1); });",
         ])
     )
 
@@ -572,9 +662,8 @@ def test_branchable_read_only_helper_accepts_cron_sources():
     """Read-only cron sessions should be forkable follow-up sources."""
     src = _read('static/sessions.js')
     assert "function _isBranchableReadOnlySession(session)" in src
-    assert "session && session.source_tag" in src
-    assert "session && session.raw_source" in src
-    assert "sources.includes('cron')" in src
+    assert "session.source_tag || session.raw_source || session.source" in src
+    assert "sourceKind === 'cron'" in src
     assert "sid.startsWith('cron_')" not in src
     assert "sid.startsWith('cron-')" not in src
 
@@ -678,6 +767,242 @@ def test_forkFromMessage_preserves_absolute_keep_count_for_writable_sessions():
     assert payload["ensureCalls"] == 2, "writable forkFromMessage should preserve both message-load calls"
     assert payload["loadedSessions"] == ["forked-session"]
     assert payload["renderCalls"] == 1
+
+
+def test_send_branches_read_only_cron_session_and_continues_original_message():
+    result = _send_harness(
+        "await send(); console.log(JSON.stringify({ calls, loadedSessions, toasts, session: S.session, composer: composer.value }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch", "/api/chat/start"]
+    assert payload["loadedSessions"] == ["forked-session"]
+    assert payload["calls"][1]["body"]["session_id"] == "forked-session"
+    assert payload["calls"][1]["body"]["message"].startswith("What changed since yesterday?")
+    assert payload["toasts"][0][0] == "Forked into new session"
+
+
+def test_send_branch_command_on_read_only_cron_session_branches_only_once():
+    result = _send_harness(
+        "composer.value = '/branch'; "
+        "S.pendingFiles = []; "
+        "COMMANDS.push({ name: 'branch', fn: cmdBranch, noEcho: true }); "
+        "await send(); "
+        "console.log(JSON.stringify({ calls, loadedSessions, toasts, session: S.session, composer: composer.value }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
+    assert payload["loadedSessions"] == ["forked-session"]
+    assert payload["session"]["session_id"] == "forked-session"
+    assert payload["composer"] == ""
+
+
+def test_send_non_branch_slash_command_on_read_only_cron_session_stays_blocked():
+    result = _send_harness(
+        "composer.value = '/help'; "
+        "S.pendingFiles = []; "
+        "COMMANDS.push({ name: 'help', fn: () => {}, noEcho: false }); "
+        "await send(); "
+        "console.log(JSON.stringify({ calls, toasts, messages: S.messages, composer: composer.value }));"
+    )
+    payload = json.loads(result)
+    assert payload["calls"] == []
+    assert payload["toasts"][0][0] == "Read-only imported sessions cannot be modified."
+    assert payload["messages"] == []
+    assert payload["composer"] == "/help"
+
+
+def test_send_busy_non_branch_slash_command_on_read_only_cron_session_stays_blocked():
+    result = _send_harness(
+        "composer.value = '/queue hold this'; "
+        "S.busy = true; "
+        "S.activeStreamId = 'stream-1'; "
+        "const busyCalls = []; "
+        "COMMANDS.push({ name: 'queue', fn: (args) => { busyCalls.push(args); }, noEcho: true }); "
+        "await send(); "
+        "console.log(JSON.stringify({ calls, busyCalls, toasts, composer: composer.value }));"
+    )
+    payload = json.loads(result)
+    assert payload["calls"] == []
+    assert payload["busyCalls"] == []
+    assert payload["toasts"][0][0] == "Read-only imported sessions cannot be modified."
+    assert payload["composer"] == "/queue hold this"
+
+
+def test_send_requests_strict_fork_load_failure_from_load_session():
+    result = _send_harness(
+        "let loadOptions = null; "
+        "loadSession = async (sid, opts) => { "
+        "  loadOptions = opts; "
+        "  loadedSessions.push(sid); "
+        "  S.session = { session_id: sid, workspace: '/tmp', model: 'child-default', model_provider: 'child-provider', profile: 'child-profile' }; "
+        "}; "
+        "await send(); "
+        "console.log(JSON.stringify({ loadOptions, loadedSessions, calls }));"
+    )
+    payload = json.loads(result)
+    assert payload["loadOptions"] == {"throwOnMessageLoadFailure": True}
+    assert payload["loadedSessions"] == ["forked-session"]
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch", "/api/chat/start"]
+
+
+def test_send_non_cron_read_only_session_stays_blocked():
+    result = _send_harness(
+        "S.session.raw_source = 'messaging'; await send(); console.log(JSON.stringify({ calls, toasts, composer: composer.value }));"
+    )
+    payload = json.loads(result)
+    assert payload["calls"] == []
+    assert payload["toasts"][0][0] == "Read-only imported sessions cannot be modified."
+    assert payload["composer"] == "What changed since yesterday?"
+
+
+def test_send_cron_prefixed_non_cron_read_only_session_stays_blocked():
+    result = _send_harness(
+        "S.session.session_id = 'cron_spoof_messaging'; S.session.raw_source = 'messaging'; await send(); console.log(JSON.stringify({ calls, toasts }));"
+    )
+    payload = json.loads(result)
+    assert payload["calls"] == []
+    assert payload["toasts"][0][0] == "Read-only imported sessions cannot be modified."
+
+
+def test_send_conflicting_source_precedence_stays_blocked():
+    result = _send_harness(
+        "S.session.source_tag = 'messaging'; S.session.raw_source = 'cron'; await send(); console.log(JSON.stringify({ calls, toasts }));"
+    )
+    payload = json.loads(result)
+    assert payload["calls"] == []
+    assert payload["toasts"][0][0] == "Read-only imported sessions cannot be modified."
+
+
+def test_send_preserves_files_model_provider_and_profile_across_branch_handoff():
+    result = _send_harness(
+        "await send(); console.log(JSON.stringify({ start: calls.find(call => call.url === '/api/chat/start'), session: S.session, files: S.pendingFiles }));"
+    )
+    payload = json.loads(result)
+    start = payload["start"]["body"]
+    assert [attachment["name"] for attachment in start["attachments"]] == ["notes.txt"]
+    assert start["model"] == "chosen-model"
+    assert start["model_provider"] == "chosen-provider"
+    assert start["profile"] == "chosen-profile"
+    assert payload["session"]["model"] == "chosen-model"
+    assert payload["session"]["model_provider"] == "chosen-provider"
+    assert payload["session"]["profile"] == "chosen-profile"
+
+
+def test_send_clears_source_draft_before_branch_load_observes_it():
+    result = _send_harness(
+        "let branchLoadSnapshot = null; "
+        "loadSession = async (sid) => { "
+        "  branchLoadSnapshot = { sid, composer: composer.value, files: [...S.pendingFiles] }; "
+        "  loadedSessions.push(sid); "
+        "  S.session = { session_id: sid, workspace: '/tmp', model: 'child-default', model_provider: 'child-provider', profile: 'child-profile' }; "
+        "}; "
+        "await send(); "
+        "console.log(JSON.stringify({ branchLoadSnapshot, start: calls.find(call => call.url === '/api/chat/start'), composer: composer.value, files: S.pendingFiles }));"
+    )
+    payload = json.loads(result)
+    assert payload["branchLoadSnapshot"] == {
+        "sid": "forked-session",
+        "composer": "",
+        "files": [],
+    }
+    assert payload["start"]["body"]["message"].startswith("What changed since yesterday?")
+    assert [attachment["name"] for attachment in payload["start"]["body"]["attachments"]] == ["notes.txt"]
+    assert payload["composer"] == ""
+    assert payload["files"] == []
+
+
+def test_send_restores_payload_when_branch_response_lacks_session_id():
+    result = _send_harness(
+        "api = async (url, opts) => { const body = JSON.parse(opts.body); calls.push({ url, body }); if(url === '/api/session/branch') return {}; return { stream_id: 'stream-1' }; }; await send(); console.log(JSON.stringify({ calls, toasts, composer: composer.value, files: S.pendingFiles }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
+    assert payload["toasts"][0][0].startswith("Fork failed: ")
+    assert payload["composer"] == "What changed since yesterday?"
+    assert payload["files"] == [{"name": "notes.txt"}]
+
+
+def test_send_restores_payload_when_fork_load_fails():
+    result = _send_harness(
+        "loadSession = async () => { throw new Error('load failed'); }; await send(); console.log(JSON.stringify({ calls, toasts, composer: composer.value, files: S.pendingFiles }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
+    assert payload["toasts"][0][0] == "Fork failed: load failed"
+    assert payload["composer"] == "What changed since yesterday?"
+    assert payload["files"] == [{"name": "notes.txt"}]
+
+
+def test_send_restores_payload_to_visible_child_when_fork_load_fails_after_activation():
+    result = _send_harness(
+        "loadSession = async (sid) => { loadedSessions.push(sid); S.session = { session_id: sid, workspace: '/tmp', model: 'child-default', model_provider: 'child-provider', profile: 'child-profile' }; throw new Error('Failed to load conversation messages'); }; "
+        "await send(); "
+        "console.log(JSON.stringify({ calls, toasts, composer: composer.value, files: S.pendingFiles, restoreCalls, session: S.session }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
+    assert payload["toasts"][0][0] == "Fork failed: Failed to load conversation messages"
+    assert payload["composer"] == "What changed since yesterday?"
+    assert payload["files"] == [{"name": "notes.txt"}]
+    assert payload["restoreCalls"] == [{
+        "text": "What changed since yesterday?",
+        "files": [{"name": "notes.txt"}],
+        "sid": "forked-session",
+    }]
+    assert payload["session"]["session_id"] == "forked-session"
+
+
+def test_send_restores_payload_to_source_when_unrelated_session_becomes_active_during_fork_load():
+    result = _send_harness(
+        "loadSession = async () => { "
+        "  S.session = { session_id: 'manual-session', workspace: '/tmp', model: 'manual-model', model_provider: 'manual-provider', profile: 'manual-profile' }; "
+        "}; "
+        "await send(); "
+        "console.log(JSON.stringify({ calls, toasts, composer: composer.value, files: S.pendingFiles, restoreCalls, session: S.session }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
+    assert payload["toasts"][0][0] == "Fork failed: Fork load did not activate the writable child."
+    assert payload["composer"] == "What changed since yesterday?"
+    assert payload["files"] == [{"name": "notes.txt"}]
+    assert payload["restoreCalls"] == [{
+        "text": "What changed since yesterday?",
+        "files": [{"name": "notes.txt"}],
+        "sid": "daily-summary",
+    }]
+    assert payload["session"]["session_id"] == "manual-session"
+
+
+def test_send_restores_payload_when_fork_load_does_not_activate_child():
+    result = _send_harness(
+        "loadSession = async () => {}; await send(); console.log(JSON.stringify({ calls, toasts, composer: composer.value, files: S.pendingFiles }));"
+    )
+    payload = json.loads(result)
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch"]
+    assert payload["toasts"][0][0] == "Fork failed: Fork load did not activate the writable child."
+    assert payload["composer"] == "What changed since yesterday?"
+    assert payload["files"] == [{"name": "notes.txt"}]
+
+
+def test_send_ignores_second_submit_during_branch_handoff():
+    result = _send_harness(
+        "let resolveBranch; api = async (url, opts) => { const body = JSON.parse(opts.body); calls.push({ url, body }); if(url === '/api/session/branch') return await new Promise(resolve => { resolveBranch = resolve; }); return { stream_id: 'stream-1' }; }; const first = send(); await Promise.resolve(); const branchDisabledDuringWait = composer.disabled && composer.readOnly; await send(); resolveBranch({ session_id: 'forked-session' }); await first; console.log(JSON.stringify({ calls, branchDisabledDuringWait, loadedSessions }));"
+    )
+    payload = json.loads(result)
+    assert payload["branchDisabledDuringWait"] is True
+    assert [call["url"] for call in payload["calls"]] == ["/api/session/branch", "/api/chat/start"]
+    assert payload["loadedSessions"] == ["forked-session"]
+
+
+def test_busy_read_only_cron_send_does_not_auto_branch():
+    result = _send_harness(
+        "S.busy = true; S.activeStreamId = 'stream-1'; await send(); console.log(JSON.stringify({ calls, toasts, composer: composer.value, queued: S.pendingFiles }));"
+    )
+    payload = json.loads(result)
+    assert payload["calls"] == []
+    assert payload["toasts"][0][0] == "Read-only imported sessions cannot be modified."
+    assert payload["composer"] == "What changed since yesterday?"
+    assert payload["queued"] == [{"name": "notes.txt"}]
 
 
 # ── Frontend: sidebar parent indicator ────────────────────────────────────────

--- a/tests/test_issue5936_cron_reply.py
+++ b/tests/test_issue5936_cron_reply.py
@@ -1,0 +1,218 @@
+"""DOM harness for the cron-reply fork handoff."""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests._layout_helpers import assert_layout_sane, assert_no_raw_i18n_keys
+from tests.test_465_session_branching import (
+    MESSAGES_JS,
+    SESSIONS_JS,
+    _extract_async_function,
+    _extract_function,
+)
+
+
+_BROWSER_ARGS = ["--no-sandbox", "--disable-dev-shm-usage"]
+
+
+def _page_html() -> str:
+    return """\
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { margin: 0; font: 16px sans-serif; background: #111827; color: #f9fafb; }
+    .layout { min-height: 100vh; display: flex; flex-direction: column; }
+    main { flex: 1; max-width: 960px; margin: 0 auto; padding: 24px; width: 100%; box-sizing: border-box; }
+    .session-meta { margin-bottom: 16px; font-size: 14px; opacity: 0.85; }
+    #msg { width: 100%; box-sizing: border-box; min-height: 96px; padding: 12px; border-radius: 10px; border: 1px solid #374151; background: #0f172a; color: inherit; }
+    .actions { display: flex; gap: 12px; margin-top: 12px; align-items: center; }
+    #send { padding: 10px 18px; border: 0; border-radius: 10px; background: #2563eb; color: white; cursor: pointer; }
+    #toast { min-height: 24px; color: #bfdbfe; }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <main>
+      <div class="session-meta">Active session: <span id="activeSession">daily-summary</span></div>
+      <textarea id="msg">What changed since yesterday?</textarea>
+      <div class="actions">
+        <button id="send" type="button">Send</button>
+        <div id="toast" aria-live="polite"></div>
+      </div>
+    </main>
+  </div>
+</body>
+</html>
+"""
+
+
+def test_read_only_cron_send_forks_and_delivers_follow_up(tmp_path):
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception:
+        pytest.skip("playwright is unavailable; run the headed browser proof in CI")
+
+    send_source = _extract_async_function(
+        MESSAGES_JS.read_text(encoding="utf-8"), "send"
+    )
+    is_read_only_source = _extract_function(
+        SESSIONS_JS.read_text(encoding="utf-8"), "_isReadOnlySession"
+    )
+    is_branchable_source = _extract_function(
+        SESSIONS_JS.read_text(encoding="utf-8"), "_isBranchableReadOnlySession"
+    )
+    artifact = tmp_path / "webui5936-after.png"
+    export_path = os.environ.get("PR_SWEEP_ARTIFACT_PATH")
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True, args=_BROWSER_ARGS)
+        page = browser.new_page(viewport={"width": 1280, "height": 720})
+        page.set_content(_page_html())
+        page.evaluate(
+            """
+            ([sendSource, isReadOnlySource, isBranchableSource]) => {
+              window.__calls = [];
+              window.__toasts = [];
+              window.__loadedSessions = [];
+              window.__chatStarts = [];
+              window.$ = (id) => document.getElementById(id);
+              window.t = (key) => ({
+                branch_forked: 'Forked into new session',
+                branch_failed: 'Fork failed: ',
+              }[key] || key);
+              window.showToast = (msg) => {
+                document.getElementById('toast').textContent = msg;
+                window.__toasts.push(msg);
+              };
+              window.renderTray = () => {};
+              window.autoResize = () => {};
+              window.renderMessages = () => {};
+              window.updateSendBtn = () => {};
+              window.renderSessionList = async () => {};
+              window._clearComposerDraft = () => Promise.resolve();
+              window._restoreComposerDraftAfterFailedSend = (text, files) => {
+                document.getElementById('msg').value = text;
+                S.pendingFiles = [...files];
+              };
+              window._flushSelectionBlocksToComposer = () => {};
+              window._composerTextWithPendingSelections = () => document.getElementById('msg').value;
+              window._pendingSelections = [];
+              window._clearPendingSelections = () => {};
+              window.shouldInterceptCompressionRecoveryContinuation = () => false;
+              window.isCompressionUiRunning = () => false;
+              window._clearStaleBusyStateBeforeSend = () => false;
+              window._chatPayloadModelState = () => ({
+                model: S.session.model || 'default-model',
+                model_provider: S.session.model_provider || null,
+              });
+              window.uploadPendingFiles = async ({ files }) => files.map((file) => ({
+                name: file.name,
+                path: file.name,
+              }));
+              window.setBusy = (busy) => { S.busy = busy; };
+              window.api = async (url, opts) => {
+                const body = JSON.parse(opts.body);
+                window.__calls.push({ url, body });
+                if (url === '/api/session/branch') {
+                  return { session_id: 'forked-session' };
+                }
+                window.__chatStarts.push(body);
+                return { stream_id: 'stream-1' };
+              };
+              window.loadSession = async (sid) => {
+                window.__loadedSessions.push(sid);
+                S.session = {
+                  session_id: sid,
+                  workspace: '/tmp',
+                  model: 'child-default',
+                  model_provider: 'child-provider',
+                  profile: 'child-profile',
+                };
+                document.getElementById('activeSession').textContent = sid;
+              };
+              window.ensureLiveWorklogShell = () => {};
+              window.clearLiveToolCards = () => {};
+              window.appendThinking = () => {};
+              window.upsertActiveSessionForLocalTurn = () => {};
+              window.renderSessionListFromCache = () => {};
+              window.startApprovalPolling = () => {};
+              window.startClarifyPolling = () => {};
+              window._fetchYoloState = () => {};
+              window.applySessionTitleUpdate = () => {};
+              window.saveInflightState = () => {};
+              window._readPendingSessionModel = () => null;
+              window._clearPendingSessionModel = () => {};
+              window._forcedSkillDirectivePending = null;
+              window._clearComposerAfterQueuedSelectionSend = () => {};
+              window._defaultMessageMode = 'queue';
+              window.COMMANDS = [];
+              window.INFLIGHT = {};
+              window._sendInProgress = false;
+              window._sendInProgressSid = null;
+              window.cancelStream = async () => {};
+              window.stopApprovalPolling = () => {};
+              window.stopClarifyPolling = () => {};
+              window.hideApprovalCard = () => {};
+              window.hideClarifyCard = () => {};
+              window.removeThinking = () => {};
+              window.clearOptimisticSessionStreaming = () => {};
+              window.queueSessionMessage = () => {};
+              window.updateQueueBadge = () => {};
+              window.setComposerStatus = () => {};
+              window._isOffline = false;
+              window.S = {
+                session: {
+                  session_id: 'daily-summary',
+                  raw_source: 'cron',
+                  read_only: true,
+                  model: 'chosen-model',
+                  model_provider: 'chosen-provider',
+                  workspace: '/tmp',
+                  profile: 'chosen-profile',
+                },
+                busy: false,
+                pendingFiles: [{ name: 'notes.txt' }],
+                messages: [],
+                activeProfile: 'chosen-profile',
+                toolCalls: [],
+              };
+              eval(isReadOnlySource);
+              eval(isBranchableSource);
+              eval(sendSource);
+              document.getElementById('send').addEventListener('click', () => send());
+            }
+            """,
+            [send_source, is_read_only_source, is_branchable_source],
+        )
+        page.locator("#send").click()
+        page.wait_for_function(
+            """
+            () => document.getElementById('activeSession').textContent === 'forked-session'
+            """
+        )
+        assert page.locator("#toast").text_content() == "Forked into new session"
+        calls = page.evaluate("window.__calls")
+        assert [call["url"] for call in calls] == [
+            "/api/session/branch",
+            "/api/chat/start",
+        ]
+        assert calls[1]["body"]["session_id"] == "forked-session"
+        assert calls[1]["body"]["message"].startswith("What changed since yesterday?")
+        assert "[Attached files: notes.txt]" in calls[1]["body"]["message"]
+        assert_layout_sane(
+            page,
+            scope_selector=".layout > main",
+            checks=["overlap", "clip", "container-escape", "raw-string"],
+        )
+        assert_no_raw_i18n_keys(page, scope_selector=".layout > main")
+        page.screenshot(path=str(artifact), full_page=True)
+        browser.close()
+    if export_path:
+        export_artifact = Path(export_path)
+        export_artifact.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(artifact, export_artifact)


### PR DESCRIPTION
## Thinking Path

- Cron briefings render in the sidebar, but replying to one still hits `static/messages.js:1416` and dead-ends on `Read-only imported sessions cannot be modified.`. The user can read the brief but never ask a follow-up from the normal composer.
- The repo already decided cron is "read but branch": `_isBranchableReadOnlySession` (`static/sessions.js:2259`) unlocks `/branch`, `forkFromMessage`, and the message-hover fork button, and the backend already permits branching a canonical cron read-only source through `/api/session/branch` while 403-ing every other read-only source. The composer send path was simply the one consumer that never adopted that shared authority.
- Rather than relax the direct-claim denylist, the fix routes the composer's first reply through the same fork-to-continue boundary: detect a branchable read-only cron session, branch it once, load the writable fork, and continue the original submit with the same text, files, model, and profile.
- The maintainer follow-up found one more lifecycle edge: while that branch handoff is pending, an unrelated session switch must not slip into `loadSession()` and save or clear the wrong draft. The handoff now owns navigation until the child activates, so external session loads are serialized for that short window.
- This follows the fork-to-continue precedent shipped in [#5555](https://github.com/nesquena/hermes-webui/pull/5555) and the 2026-07-11 collaborator guidance on [#5936](https://github.com/nesquena/hermes-webui/issues/5936#issuecomment-4947845057), instead of widening the direct claim gate while `attach_to_session` is still unavailable there.

## What Changed

- `static/messages.js`: branchable read-only cron sessions now auto-fork through `/api/session/branch`, load the returned writable child, and continue the submit with the captured text, pending files, model, model provider, and profile. The child load is marked as the one handoff-owned navigation call.
- `static/sessions.js`: `loadSession()` now returns before any session-switch side effects when the cron branch handoff is active, unless the caller is that marked child load.
- `tests/test_465_session_branching.py`: extended the browserless branching harness to cover the new composer send path, the non-cron and spoof-id negative cases, slash `/branch` single-branch preservation, payload preservation, source-draft isolation during fork load, late post-activation fork-load failure recovery, busy-path invariance, and the pending-branch session-switch race.
- `tests/test_issue5936_cron_reply.py`: added a targeted browser proof for the visible handoff from a read-only cron transcript into its writable fork.

## Why It Matters

Users can finally reply to a cron briefing inline without copy-paste. The follow-up seamlessly continues in a fresh writable fork off the read-only brief, while the cron transcript itself stays immutable and unrelated session drafts stay protected during the handoff.

## Verification

Focused branching-harness tests cover the cron branch-then-continue send, the non-cron and spoof-id negative paths, slash `/branch` single-branch preservation, payload preservation, source-draft isolation during fork load, the pending-branch cross-session draft race, and late post-activation fork-load failure recovery; a targeted browser proof covers the visible fork handoff; CI runs the full matrix on 3.11/3.12/3.13.

## Upstream

Closes #5936.

## Model Used

GPT 5.5 via Codex CLI