### PR TITLE
fix(#5954): refresh the reasoning chip after empty boot hydration

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -3474,6 +3474,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       else if(typeof syncModelChip==='function') syncModelChip();
     }
     if(S.session) syncTopbar();
+    else if(typeof syncReasoningChip==='function') syncReasoningChip();
   }).catch(e=>{
     window._modelDropdownReady=null;
     throw e;

--- a/tests/test_issue5954_empty_boot_reasoning_chip.py
+++ b/tests/test_issue5954_empty_boot_reasoning_chip.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for boot behavior checks")
+
+
+def _boot_completion_branch() -> str:
+    source = Path("static/boot.js").read_text(encoding="utf-8")
+    marker = "    if(S.session) syncTopbar();"
+    start = source.index(marker)
+    end = source.index("\n  }).catch(e=>", start)
+    return source[start:end]
+
+
+def _run_boot_branch() -> list[dict[str, int | str | None]]:
+    branch = _boot_completion_branch()
+    script = f"""
+const branch = {json.dumps(branch)};
+function run(session) {{
+  const S = {{session}};
+  let syncTopbarCalls = 0;
+  let syncReasoningChipCalls = 0;
+  function syncTopbar() {{ syncTopbarCalls += 1; }}
+  function syncReasoningChip() {{ syncReasoningChipCalls += 1; }}
+  eval(branch);
+  return {{session: session ? 'present' : null, syncTopbarCalls, syncReasoningChipCalls}};
+}}
+console.log(JSON.stringify([run(null), run({{id: 'session'}})]));
+"""
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_boot_hydration_refreshes_chip_only_without_a_session():
+    assert _run_boot_branch() == [
+        {"session": None, "syncTopbarCalls": 0, "syncReasoningChipCalls": 1},
+        {"session": "present", "syncTopbarCalls": 1, "syncReasoningChipCalls": 0},
+    ]

--- a/tests/test_issue5954_empty_boot_reasoning_chip.py
+++ b/tests/test_issue5954_empty_boot_reasoning_chip.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for boot 
 
 
 def _boot_completion_branch() -> str:
-    source = Path("static/boot.js").read_text(encoding="utf-8")
+    source = (Path(__file__).resolve().parents[1] / "static" / "boot.js").read_text(encoding="utf-8")
     marker = "    if(S.session) syncTopbar();"
     start = source.index(marker)
     end = source.index("\n  }).catch(e=>", start)


### PR DESCRIPTION

## Thinking Path

- The boot model-hydration path already chooses the right default model, but it only refreshes the topbar when a session is present.
- Empty normal boot therefore misses the same reasoning-chip refresh that every later model change already runs.
- The fix is the issue's preapproved no-session branch, added at the existing hydration completion seam without changing the active-session path.

## What Changed

- `static/boot.js`: refresh the reasoning chip after boot model hydration when no session is active.
- `tests/test_issue5954_empty_boot_reasoning_chip.py`: add a behavioral boot harness that proves the no-session branch refreshes the chip while the session branch stays on `syncTopbar()`.

## Why It Matters

Users on a fresh boot see the reasoning chip for the hydrated default model immediately, instead of waiting for a later interaction to repair the chip state.

## Verification

Focused boot-harness and frontend regression tests cover the empty-boot branch and the unchanged session branch, and runtime ESLint covers the touched JavaScript.

## Upstream

Closes #5954.

## Model Used

GPT 5.5 via Codex CLI