### PR TITLE
fix(#5940): classify gateway terminal provider errors instead of generic empty turns

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -638,6 +638,9 @@ def _run_gateway_chat_streaming(
     def put_gateway_event(event, data):
         if cancel_event.is_set() and not success_writeback_committed and event not in ("cancel", "error", "apperror"):
             return
+        if event == "apperror" and isinstance(data, dict):
+            data = data.copy()
+            data.setdefault("session_id", session_id)
         event_id = None
         if run_journal is not None:
             try:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -44,6 +44,19 @@ _WEBUI_GATEWAY_API_KEY_ENV = "HERMES_WEBUI_GATEWAY_API_KEY"
 _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
+
+def _gateway_provider_error_payload(message: str) -> dict | None:
+    from api.streaming import _classify_provider_error, _provider_error_payload
+
+    classification = _classify_provider_error(message)
+    if classification["type"] == "error":
+        return None
+    return _provider_error_payload(
+        message,
+        classification["type"],
+        classification.get("hint", ""),
+    )
+
 # Total byte-silence budget (seconds) for the gateway SSE socket, applied via
 # ``urlopen(timeout=...)``. A stream that emits ANY byte within the window never
 # trips it, so a genuinely alive (if slow) token stream is untouched; only more
@@ -515,6 +528,8 @@ def _run_gateway_runs_api_streaming(
                 sse_event = "message"
                 continue
             if payload_event == "run.completed":
+                if payload.get("error"):
+                    raise RuntimeError(str(payload["error"]))
                 output = str(payload.get("output") or "")
                 if output and not final_text:
                     final_text = output
@@ -647,6 +662,7 @@ def _run_gateway_chat_streaming(
 
     s = None
     final_text = ""
+    terminal_error = ""
     usage = {"input_tokens": 0, "output_tokens": 0, "estimated_cost": 0}
     try:
         s = get_session(session_id)
@@ -728,7 +744,8 @@ def _run_gateway_chat_streaming(
                     session=s,
                 )
             except Exception as exc:
-                put_gateway_event("apperror", {
+                error_payload = _gateway_provider_error_payload(str(exc))
+                put_gateway_event("apperror", error_payload or {
                     "label": "Gateway runs API error",
                     "type": "gateway_runs_error",
                     "message": str(exc)[:400],
@@ -879,6 +896,8 @@ def _run_gateway_chat_streaming(
                         sse_event = "message"
                         continue
                     last_payload = payload
+                    if payload.get("error"):
+                        terminal_error = str(payload["error"])
                     reasoning_delta = _gateway_sse_reasoning_delta(payload)
                     if reasoning_delta:
                         if stream_id in STREAM_REASONING_TEXT:
@@ -894,6 +913,11 @@ def _run_gateway_chat_streaming(
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
         assistant_text = final_text.strip()
         if not assistant_text:
+            if terminal_error:
+                error_payload = _gateway_provider_error_payload(terminal_error)
+                if error_payload:
+                    put_gateway_event("apperror", error_payload)
+                    return
             put_gateway_event("apperror", {
                 "label": "Gateway returned no response",
                 "type": "gateway_empty_response",

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -556,6 +556,63 @@ def _run_gateway_runs_api_streaming(
     return final_text, usage
 
 
+def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, model_provider, terminal_error):
+    from api.streaming import (
+        _classify_provider_error,
+        _materialize_pending_user_turn_before_error,
+        _provider_error_payload,
+        _session_payload_with_full_messages,
+        _snapshot_and_append_partial_on_error,
+    )
+
+    with _get_session_agent_lock(session_id):
+        session = get_session(session_id)
+        if not _stream_writeback_is_current(session, stream_id):
+            return None
+        error_classification = _classify_provider_error(terminal_error)
+        error_payload = _provider_error_payload(
+            terminal_error,
+            error_classification["type"],
+            error_classification.get("hint", ""),
+        )
+        _materialize_pending_user_turn_before_error(session)
+        session.active_stream_id = None
+        session.pending_user_message = None
+        session.pending_attachments = []
+        session.pending_started_at = None
+        session.pending_user_source = None
+        try:
+            _snapshot_and_append_partial_on_error(session, stream_id)
+        except Exception:
+            logger.debug("Failed to snapshot gateway partials on terminal error", exc_info=True)
+        error_message = {
+            "role": "assistant",
+            "content": (
+                f"**{error_classification['label']}:** "
+                f"{error_payload.get('message') or error_classification['label']}"
+            ) + (f"\n\n*{error_payload['hint']}*" if error_payload.get("hint") else ""),
+            "timestamp": int(time.time()),
+            "_error": True,
+        }
+        if error_payload.get("details"):
+            error_message["provider_details"] = error_payload["details"]
+        if not isinstance(session.messages, list):
+            session.messages = []
+        session.messages.append(error_message)
+        session.workspace = str(workspace)
+        session.model = model
+        session.model_provider = model_provider
+        try:
+            session.save()
+        except Exception:
+            logger.debug("Failed to persist gateway terminal error settlement", exc_info=True)
+        error_payload["session"] = redact_session_data(
+            _session_payload_with_full_messages(session, tool_calls=[])
+        )
+        error_payload["session_id"] = session.session_id
+        return error_payload
+
+
 def _stream_writeback_is_current(session: Any, stream_id: str) -> bool:
     return bool(stream_id and getattr(session, "active_stream_id", None) == stream_id)
 
@@ -745,13 +802,17 @@ def _run_gateway_chat_streaming(
                     session=s,
                 )
             except Exception as exc:
-                error_payload = _gateway_provider_error_payload(str(exc))
-                put_gateway_event("apperror", error_payload or {
-                    "label": "Gateway runs API error",
-                    "type": "gateway_runs_error",
-                    "message": str(exc)[:400],
-                    "hint": "Check that the Hermes Gateway runs API (/v1/runs) is available.",
-                })
+                error_payload = _settle_gateway_terminal_error(
+                    session_id,
+                    stream_id,
+                    workspace,
+                    model,
+                    model_provider,
+                    str(exc),
+                )
+                if error_payload is None:
+                    return
+                put_gateway_event("apperror", error_payload)
                 return
             if final_text is None:
                 return
@@ -914,7 +975,17 @@ def _run_gateway_chat_streaming(
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
         assistant_text = final_text.strip()
         if terminal_error:
-            put_gateway_event("apperror", _gateway_provider_error_payload(terminal_error))
+            error_payload = _settle_gateway_terminal_error(
+                session_id,
+                stream_id,
+                workspace,
+                model,
+                model_provider,
+                terminal_error,
+            )
+            if error_payload is None:
+                return
+            put_gateway_event("apperror", error_payload)
             return
         if not assistant_text:
             put_gateway_event("apperror", {

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -45,12 +45,10 @@ _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
 
-def _gateway_provider_error_payload(message: str) -> dict | None:
+def _gateway_provider_error_payload(message: str) -> dict:
     from api.streaming import _classify_provider_error, _provider_error_payload
 
     classification = _classify_provider_error(message)
-    if classification["type"] == "error":
-        return None
     return _provider_error_payload(
         message,
         classification["type"],
@@ -912,12 +910,10 @@ def _run_gateway_chat_streaming(
                     usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
         assistant_text = final_text.strip()
+        if terminal_error:
+            put_gateway_event("apperror", _gateway_provider_error_payload(terminal_error))
+            return
         if not assistant_text:
-            if terminal_error:
-                error_payload = _gateway_provider_error_payload(terminal_error)
-                if error_payload:
-                    put_gateway_event("apperror", error_payload)
-                    return
             put_gateway_event("apperror", {
                 "label": "Gateway returned no response",
                 "type": "gateway_empty_response",

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -45,16 +45,6 @@ _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
 
-def _gateway_provider_error_payload(message: str) -> dict:
-    from api.streaming import _classify_provider_error, _provider_error_payload
-
-    classification = _classify_provider_error(message)
-    return _provider_error_payload(
-        message,
-        classification["type"],
-        classification.get("hint", ""),
-    )
-
 # Total byte-silence budget (seconds) for the gateway SSE socket, applied via
 # ``urlopen(timeout=...)``. A stream that emits ANY byte within the window never
 # trips it, so a genuinely alive (if slow) token stream is untouched; only more

--- a/api/models.py
+++ b/api/models.py
@@ -801,19 +801,26 @@ def _append_recovered_turn_to_context(session, recovered: dict) -> None:
     context_messages = getattr(session, 'context_messages', None)
     if not isinstance(context_messages, list) or not context_messages:
         return
-    role = str(recovered.get('role') or '')
-    recovered_text = " ".join(str(recovered.get('content') or '').split())
+    recovered_text = _normalize_journal_recovery_text(recovered.get('content'))
     if not recovered_text and not recovered.get('tool_call_id') and not recovered.get('tool_calls'):
         return
     if recovered_text:
-        for existing in reversed(context_messages[-8:]):
-            if not isinstance(existing, dict) or existing.get('role') != role:
-                continue
-            existing_text = " ".join(str(existing.get('content') or '').split())
-            if existing_text == recovered_text:
+        if recovered.get('role') == 'user':
+            if _message_matches_pending_checkpoint(
+                context_messages[-1] if context_messages else None,
+                recovered.get('content'),
+                recovered.get('timestamp'),
+                recovered.get('_source'),
+                recovered.get('attachments'),
+            ):
                 return
-    context_entry = {k: v for k, v in recovered.items() if k != 'timestamp'}
-    context_messages.append(context_entry)
+        else:
+            for existing in reversed(context_messages[-8:]):
+                if not isinstance(existing, dict) or existing.get('role') != recovered.get('role'):
+                    continue
+                if _normalize_journal_recovery_text(existing.get('content')) == recovered_text:
+                    return
+    context_messages.append(dict(recovered))
 
 
 def _append_recovered_pending_turn(session, *, timestamp: int | None = None) -> dict | None:
@@ -2159,6 +2166,41 @@ def _normalize_journal_recovery_text(value) -> str:
     return " ".join(str(value or "").split())
 
 
+def _message_matches_pending_checkpoint(message, pending_text, timestamp, source, attachments):
+    if not isinstance(message, dict) or message.get('role') != 'user':
+        return False
+    try:
+        message_timestamp = int(message.get('timestamp'))
+        expected_timestamp = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    return (
+        _normalize_journal_recovery_text(message.get('content'))
+        == _normalize_journal_recovery_text(pending_text)
+        and message_timestamp == expected_timestamp
+        and (message.get('_source') or 'webui') == (source or 'webui')
+        and list(message.get('attachments') or []) == list(attachments or [])
+    )
+
+
+def _message_matches_pending_text(message, pending_text):
+    if not isinstance(message, dict) or message.get('role') != 'user':
+        return False
+    return (
+        _normalize_journal_recovery_text(message.get('content'))
+        == _normalize_journal_recovery_text(pending_text)
+    )
+
+
+def _latest_user_matches_pending_text(messages, pending_text):
+    if not isinstance(messages, list) or not pending_text:
+        return False
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get('role') == 'user':
+            return _message_matches_pending_text(message, pending_text)
+    return False
+
+
 def _partial_message_signature(message: dict) -> tuple:
     """Return a stable identity for partial assistant markers recovered on load."""
     if not isinstance(message, dict):
@@ -2855,21 +2897,24 @@ def _apply_core_sync_or_error_marker(
     # prompt submitted just before a server restart, so materialize it before
     # clearing runtime stream state.
     if len(session.messages) != 0:
-        _pending_text = " ".join(str(session.pending_user_message or "").split())
-        _already_checkpointed = False
-        if _pending_text and session.messages:
-            for _last_msg in reversed(session.messages):
-                if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
-                    _last_text = " ".join(str(_last_msg.get('content') or "").split())
-                    _already_checkpointed = _last_text == _pending_text
-                    break
         _recovered_ts = int(time.time())
         if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
             _recovered_ts = int(session.pending_started_at)
+        _already_checkpointed = _message_matches_pending_checkpoint(
+            session.messages[-1],
+            session.pending_user_message,
+            _recovered_ts,
+            session.pending_user_source,
+            session.pending_attachments,
+        )
+        _tail_user_already_checkpointed = _already_checkpointed or _message_matches_pending_text(
+            session.messages[-1],
+            session.pending_user_message,
+        )
         _stream_id = stream_id_for_recheck or session.active_stream_id
         _pending_started_at = session.pending_started_at
         if _run_journal_terminal_state(session, _stream_id) == 'completed':
-            if not _already_checkpointed:
+            if not (_already_checkpointed or _latest_user_matches_pending_text(session.messages, session.pending_user_message)):
                 _append_recovered_pending_turn(session, timestamp=_recovered_ts)
             _append_journaled_partial_output(
                 session,
@@ -2888,14 +2933,18 @@ def _apply_core_sync_or_error_marker(
                 _stream_id,
             )
             return True
-        if not _already_checkpointed:
+        if not _tail_user_already_checkpointed:
             _append_recovered_pending_turn(session, timestamp=_recovered_ts)
         else:
             recovered = {
                 'role': 'user',
                 'content': session.pending_user_message,
+                'timestamp': _recovered_ts,
                 '_recovered': True,
             }
+            pending_source = getattr(session, 'pending_user_source', None)
+            if pending_source and pending_source != 'webui':
+                recovered['_source'] = pending_source
             if session.pending_attachments:
                 recovered['attachments'] = list(session.pending_attachments)
             _append_recovered_turn_to_context(session, recovered)
@@ -2936,21 +2985,25 @@ def _apply_core_sync_or_error_marker(
                 if core.get(field) is not None:
                     setattr(session, field, core[field])
             _pending_text = _normalize_journal_recovery_text(session.pending_user_message)
-            _already_checkpointed = False
-            if _pending_text and session.messages:
-                for _last_msg in reversed(session.messages):
-                    if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
-                        _last_text = _normalize_journal_recovery_text(_last_msg.get('content'))
-                        _already_checkpointed = _last_text == _pending_text
-                        break
+            _recovered_ts = int(time.time())
+            if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
+                _recovered_ts = int(session.pending_started_at)
+            _already_checkpointed = _message_matches_pending_checkpoint(
+                session.messages[-1] if session.messages else None,
+                session.pending_user_message,
+                _recovered_ts,
+                session.pending_user_source,
+                session.pending_attachments,
+            )
+            _tail_user_already_checkpointed = _already_checkpointed or _message_matches_pending_text(
+                session.messages[-1] if session.messages else None,
+                session.pending_user_message,
+            )
             if (
                 _pending_text
-                and not _already_checkpointed
+                and not _tail_user_already_checkpointed
                 and _run_journal_has_visible_output(session, _stream_id)
             ):
-                _recovered_ts = int(time.time())
-                if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
-                    _recovered_ts = int(session.pending_started_at)
                 _append_recovered_pending_turn(session, timestamp=_recovered_ts)
             recovered_output = _append_journaled_partial_output(
                 session,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6001,30 +6001,43 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     pending_text = str(getattr(session, 'pending_user_message', None) or '')
     if not pending_text:
         return False
-    normalized_pending = " ".join(pending_text.split())
-    if normalized_pending:
-        for existing in reversed(list(getattr(session, 'messages', None) or [])[-8:]):
-            if not isinstance(existing, dict) or existing.get('role') != 'user':
-                continue
-            existing_text = " ".join(str(existing.get('content') or '').split())
-            if existing_text == normalized_pending:
-                return False
     recovered_ts = int(time.time())
     pending_started_at = getattr(session, 'pending_started_at', None)
     if isinstance(pending_started_at, (int, float)) and pending_started_at > 0:
         recovered_ts = int(pending_started_at)
+    pending_source = getattr(session, 'pending_user_source', None) or 'webui'
+    pending_attachments = list(getattr(session, 'pending_attachments', None) or [])
+
+    def is_exact_checkpoint(messages):
+        if not isinstance(messages, list) or not messages:
+            return False
+        existing = messages[-1]
+        if not isinstance(existing, dict) or existing.get('role') != 'user':
+            return False
+        existing_source = existing.get('_source') or 'webui'
+        try:
+            existing_ts = int(existing.get('timestamp'))
+        except (TypeError, ValueError):
+            return False
+        return (
+            _normalize_user_text(existing.get('content')) == _normalize_user_text(pending_text)
+            and existing_ts == recovered_ts
+            and existing_source == pending_source
+            and list(existing.get('attachments') or []) == pending_attachments
+        )
+
+    if is_exact_checkpoint(getattr(session, 'messages', None)):
+        return False
     recovered = {
         'role': 'user',
         'content': pending_text,
         'timestamp': recovered_ts,
         '_recovered': True,
     }
-    pending_source = getattr(session, 'pending_user_source', None)
-    if pending_source and pending_source != 'webui':
+    if pending_source != 'webui':
         recovered['_source'] = pending_source
-    pending_attachments = getattr(session, 'pending_attachments', None)
     if pending_attachments:
-        recovered['attachments'] = list(pending_attachments)
+        recovered['attachments'] = pending_attachments
     session.messages.append(recovered)
     # Mirror to context_messages so the _recovered flag survives the state.db
     # round-trip (#4283).  state.db has no _recovered column, so without this
@@ -6035,14 +6048,8 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     # Placing the mirror here (rather than in _persist_cancelled_turn) covers
     # all three callers: cancel, provider-error, and exception paths.
     ctx = getattr(session, 'context_messages', None)
-    if isinstance(ctx, list) and ctx:
-        rec_text = " ".join(str(recovered.get('content') or '').split())
-        if not any(
-            isinstance(e, dict) and e.get('role') == 'user'
-            and " ".join(str(e.get('content') or '').split()) == rec_text
-            for e in ctx[-8:]
-        ):
-            ctx.append({k: v for k, v in recovered.items() if k != 'timestamp'})
+    if isinstance(ctx, list) and ctx and not is_exact_checkpoint(ctx):
+        ctx.append(dict(recovered))
     # The new user turn is now committed to messages (#3831): advance a positive
     # truncation watermark left over from a prior retry/undo/edit so that
     # merge_session_messages_append_only() still filters out replaced pre-edit

--- a/tests/test_issue1361_cancel_data_loss.py
+++ b/tests/test_issue1361_cancel_data_loss.py
@@ -402,9 +402,16 @@ def test_stream_error_pending_materialization_does_not_duplicate_eager_checkpoin
         pending_msg="please restart the WebUI",
         messages=[
             {"role": "assistant", "content": "previous answer"},
-            {"role": "user", "content": "please restart the WebUI"},
+            {
+                "role": "user",
+                "content": "[Workspace::v1: C:\\repo]\nplease   restart the WebUI",
+                "timestamp": 1778098700,
+                "attachments": [{"name": "screen.png"}],
+            },
         ],
     )
+    s.pending_started_at = 1778098700.0
+    s.pending_attachments = [{"name": "screen.png"}]
 
     appended = _materialize_pending_user_turn_before_error(s)
 

--- a/tests/test_issue4283_recovered_context_replay.py
+++ b/tests/test_issue4283_recovered_context_replay.py
@@ -264,7 +264,7 @@ class _DummySession:
         self.context_messages = context_messages
         self.pending_user_message = pending_msg
         self.pending_attachments = []
-        self.pending_started_at = None
+        self.pending_started_at = 1778098700.0
         self.active_stream_id = "stream-test"
         self.truncation_watermark = None
         self.path = ""
@@ -293,6 +293,7 @@ def test_materialize_mirrors_recovered_user_to_context_messages():
     ctx_users = [m for m in s.context_messages if m.get("role") == "user"]
     assert any(m.get("_recovered") for m in ctx_users)
     assert any("restart the gateway" in m.get("content", "") for m in ctx_users)
+    assert any(m.get("timestamp") == 1778098700 for m in ctx_users)
 
 
 def test_materialize_does_not_duplicate_context_messages():

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -547,6 +547,75 @@ class TestEmptyMessagesGuard:
         assert s.pending_user_message is None
         assert s.active_stream_id is None
 
+    def test_repeated_pending_prompt_uses_current_checkpoint_identity(self, hermes_home, monkeypatch):
+        """Historical identical text must not suppress the current pending turn."""
+        s = _make_session(
+            messages=[
+                {"role": "user", "content": "repeat this", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+                {"role": "assistant", "content": "Earlier answer"},
+            ],
+            context_messages=[
+                {"role": "user", "content": "repeat this", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+                {"role": "assistant", "content": "Earlier answer"},
+            ],
+        )
+        s.pending_user_message = "repeat this"
+        s.pending_started_at = 222.0
+        s.pending_attachments = [{"name": "current.png"}]
+        s.active_stream_id = "stream_1"
+        lock = config._get_session_agent_lock(s.session_id)
+
+        with lock:
+            core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
+            result = _apply_core_sync_or_error_marker(
+                s, core_path, stream_id_for_recheck="stream_1",
+            )
+
+        assert result is True
+        users = [m for m in s.messages if m.get("role") == "user"]
+        assert len(users) == 2
+        assert users[-1]["timestamp"] == 222
+        assert users[-1]["attachments"] == [{"name": "current.png"}]
+        context_users = [m for m in s.context_messages if m.get("role") == "user"]
+        assert len(context_users) == 2
+        assert context_users[-1]["timestamp"] == 222
+        assert context_users[-1]["attachments"] == [{"name": "current.png"}]
+
+    def test_recovered_assistant_context_row_still_deduplicates(self):
+        s = _make_session(
+            context_messages=[{"role": "assistant", "content": "Recovered answer"}],
+        )
+        recovered = {
+            "role": "assistant",
+            "content": "Recovered answer",
+            "timestamp": 222,
+        }
+
+        models._append_recovered_turn_to_context(s, recovered)
+
+        assert s.context_messages == [{"role": "assistant", "content": "Recovered answer"}]
+
+    def test_recovered_user_context_row_requires_tail_checkpoint(self):
+        s = _make_session(
+            context_messages=[
+                {"role": "user", "content": "repeat this", "timestamp": 222, "attachments": [{"name": "same.png"}]},
+                {"role": "assistant", "content": "Earlier answer"},
+            ],
+        )
+        recovered = {
+            "role": "user",
+            "content": "repeat this",
+            "timestamp": 222,
+            "attachments": [{"name": "same.png"}],
+            "_recovered": True,
+        }
+
+        models._append_recovered_turn_to_context(s, recovered)
+
+        context_users = [m for m in s.context_messages if m.get("role") == "user"]
+        assert len(context_users) == 2
+        assert context_users[-1]["timestamp"] == 222
+
     def test_bails_when_pending_user_message_none(self, hermes_home, monkeypatch):
         """If pending_user_message is None, repair bails out."""
         s = _make_session(messages=[])

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -433,6 +433,7 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     apperrors = [item[1] for item in events if item[0] == "apperror"]
     assert apperrors
     assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+    assert apperrors[-1]["session_id"] == s.session_id
 
     response_error[0] = ""
     empty_stream_id = "stream-gateway-empty-response-test"
@@ -455,6 +456,7 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     )
     empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
     assert empty_errors[-1]["type"] == "gateway_empty_response"
+    assert empty_errors[-1]["session_id"] == s.session_id
 
     response_error[0] = "Gateway provider failed without a known classification"
     unknown_stream_id = "stream-gateway-unknown-terminal-error-test"
@@ -1370,6 +1372,7 @@ def test_gateway_runs_api_classifies_terminal_provider_error():
             )
         apperrors = [item[1] for item in events if item[0] == "apperror"]
         assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+        assert apperrors[-1]["session_id"] == "sess-runs-terminal-error"
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -375,6 +375,85 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert all(len(item) == 3 and item[2] for item in events)
 
 
+def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp_path, monkeypatch):
+    """Gateway terminal errors must survive an empty assistant stream."""
+    from unittest.mock import MagicMock
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    error_text = (
+        'HTTP 400: {"detail":"Invalid Request: Invalid model format or no credentials '
+        'for provider: <redacted>"}'
+    )
+    response_error = [error_text]
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            if response_error[0]:
+                yield f'data: {{"error":{json.dumps(response_error[0])}}}\n\n'.encode()
+            yield b"data: [DONE]\n\n"
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    events = []
+    channel = MagicMock()
+    channel.put_nowait = lambda item: events.append(item)
+    s = new_session()
+    stream_id = "stream-gateway-terminal-provider-error-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    apperrors = [item[1] for item in events if item[0] == "apperror"]
+    assert apperrors
+    assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+
+    response_error[0] = ""
+    empty_stream_id = "stream-gateway-empty-response-test"
+    s = new_session()
+    s.active_stream_id = empty_stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    empty_events = []
+    empty_channel = MagicMock()
+    empty_channel.put_nowait = lambda item: empty_events.append(item)
+    STREAMS[empty_stream_id] = empty_channel
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        empty_stream_id,
+        [],
+    )
+    empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
+    assert empty_errors[-1]["type"] == "gateway_empty_response"
+
+
 def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
@@ -1185,6 +1264,62 @@ def test_gateway_runs_api_body_includes_session_id():
                 )
         assert "/v1/runs" in captured["url"]
         assert captured["body"]["session_id"] == "sess-stable-uuid"
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
+
+def test_gateway_runs_api_classifies_terminal_provider_error():
+    from unittest.mock import MagicMock, patch
+
+    from api.config import STREAMS, STREAMS_LOCK
+    from api.gateway_chat import _run_gateway_chat_streaming
+
+    error_text = "HTTP 400: Invalid model format or no credentials for provider"
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+    stream_id = "sid-runs-terminal-provider-error"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    call_count = [0]
+
+    def fake_urlopen(req, *, timeout=None):
+        call_count[0] += 1
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        if call_count[0] == 1:
+            resp.read = lambda sz=65536: b'{"run_id":"run_error"}'
+        else:
+            resp.__iter__ = lambda s: iter([
+                b'event: run.failed\n',
+                f'data: {{"error":{json.dumps(error_text)}}}\n'.encode(),
+            ])
+        return resp
+
+    try:
+        with patch.dict("os.environ", {
+            "HERMES_WEBUI_CHAT_BACKEND": "gateway",
+            "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1",
+            "HERMES_WEBUI_GATEWAY_BASE_URL": "http://gateway.local",
+        }, clear=True), \
+             patch("api.gateway_chat.gateway_supports_approval", return_value=True), \
+             patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("api.gateway_chat.get_session", return_value=MagicMock(
+                 active_stream_id=stream_id, workspace="/tmp", profile=None,
+                 context_messages=[], messages=[],
+             )):
+            _run_gateway_chat_streaming(
+                session_id="sess-runs-terminal-error",
+                msg_text="hi",
+                model="test",
+                workspace="/tmp",
+                stream_id=stream_id,
+            )
+        apperrors = [item[1] for item in events if item[0] == "apperror"]
+        assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -417,7 +417,16 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     stream_id = "stream-gateway-terminal-provider-error-test"
     s.active_stream_id = stream_id
     s.pending_user_message = "Say hello"
-    s.pending_attachments = []
+    s.pending_started_at = 222
+    s.pending_attachments = [{"name": "current.png"}]
+    s.messages = [
+        {"role": "user", "content": "Say hello", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
+    s.context_messages = [
+        {"role": "user", "content": "Say hello", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
     s.save()
     STREAMS[stream_id] = channel
 
@@ -434,6 +443,16 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     assert apperrors
     assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
     assert apperrors[-1]["session_id"] == s.session_id
+    saved = models.get_session(s.session_id)
+    user_messages = [m for m in saved.messages if m.get("role") == "user"]
+    assert len(user_messages) == 2
+    assert user_messages[-1]["timestamp"] == 222
+    assert user_messages[-1]["attachments"] == [{"name": "current.png"}]
+    context_users = [m for m in saved.context_messages if m.get("role") == "user"]
+    assert len(context_users) == 2
+    assert context_users[-1]["timestamp"] == 222
+    assert context_users[-1]["attachments"] == [{"name": "current.png"}]
+    assert saved.messages[-1].get("_error") is True
 
     response_error[0] = ""
     empty_stream_id = "stream-gateway-empty-response-test"

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -398,7 +398,10 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
             return False
 
         def __iter__(self):
-            if response_error[0]:
+            if response_error[0] == "partial":
+                yield b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'
+                yield f'data: {{"error":{json.dumps(error_text)}}}\n\n'.encode()
+            elif response_error[0]:
                 yield f'data: {{"error":{json.dumps(response_error[0])}}}\n\n'.encode()
             yield b"data: [DONE]\n\n"
 
@@ -452,6 +455,53 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     )
     empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
     assert empty_errors[-1]["type"] == "gateway_empty_response"
+
+    response_error[0] = "Gateway provider failed without a known classification"
+    unknown_stream_id = "stream-gateway-unknown-terminal-error-test"
+    s = new_session()
+    s.active_stream_id = unknown_stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    unknown_events = []
+    unknown_channel = MagicMock()
+    unknown_channel.put_nowait = lambda item: unknown_events.append(item)
+    STREAMS[unknown_stream_id] = unknown_channel
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        unknown_stream_id,
+        [],
+    )
+    unknown_errors = [item[1] for item in unknown_events if item[0] == "apperror"]
+    assert unknown_errors[-1]["type"] == "error"
+    assert "Gateway provider failed" in unknown_errors[-1]["message"]
+
+    response_error[0] = "partial"
+    partial_stream_id = "stream-gateway-partial-terminal-error-test"
+    s = new_session()
+    s.active_stream_id = partial_stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    partial_events = []
+    partial_channel = MagicMock()
+    partial_channel.put_nowait = lambda item: partial_events.append(item)
+    STREAMS[partial_stream_id] = partial_channel
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        partial_stream_id,
+        [],
+    )
+    partial_errors = [item[1] for item in partial_events if item[0] == "apperror"]
+    assert partial_errors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+    saved = models.get_session(s.session_id)
+    assert not any(message.get("role") == "assistant" for message in saved.messages)
 
 
 def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -503,7 +503,89 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     partial_errors = [item[1] for item in partial_events if item[0] == "apperror"]
     assert partial_errors[-1]["type"] in {"model_not_found", "auth_mismatch"}
     saved = models.get_session(s.session_id)
-    assert not any(message.get("role") == "assistant" for message in saved.messages)
+    assert [message.get("role") for message in saved.messages[-3:]] == ["user", "assistant", "assistant"]
+    partial_message = saved.messages[-2]
+    assert partial_message.get("_partial") is True
+    assert partial_message["content"] == "partial"
+    error_message = saved.messages[-1]
+    assert error_message.get("_error") is True
+    assert "Invalid Request" in error_message.get("provider_details", "")
+    payload_messages = partial_errors[-1]["session"]["messages"]
+    assert payload_messages[-2]["_partial"] is True
+    assert payload_messages[-2]["content"] == "partial"
+    assert payload_messages[-1]["_error"] is True
+
+
+def test_gateway_chat_worker_persists_reasoning_and_tool_state_on_terminal_error(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    error_text = (
+        'HTTP 400: {"detail":"Invalid Request: Invalid model format or no credentials '
+        'for provider: <redacted>"}'
+    )
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"part"}}]}\n\n'
+            yield b'event: hermes.tool.progress\n'
+            yield b'data: {"tool":"terminal","label":"terminal: pytest","toolCallId":"call-1","status":"running","arguments":{}}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"text":"Preview reasoning"}\n\n'
+            yield f'data: {{"error":{json.dumps(error_text)}}}\n\n'.encode()
+            yield b"data: [DONE]\n\n"
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    events = []
+    channel = MagicMock()
+    channel.put_nowait = lambda item: events.append(item)
+    s = new_session()
+    stream_id = "stream-gateway-terminal-reasoning-tool-error-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    partial_message = saved.messages[-2]
+    assert partial_message.get("_partial") is True
+    assert partial_message["content"] == "part"
+    assert partial_message["reasoning"] == "Preview reasoning"
+    assert partial_message["_partial_tool_calls"] == [{
+        "name": "terminal",
+        "args": {},
+        "done": False,
+        "tid": "call-1",
+    }]
+    apperrors = [item[1] for item in events if item[0] == "apperror"]
+    assert apperrors[-1]["session"]["messages"][-2]["reasoning"] == "Preview reasoning"
+    assert apperrors[-1]["session"]["messages"][-2]["_partial_tool_calls"][0]["name"] == "terminal"
+    assert apperrors[-1]["session"]["messages"][-1]["_error"] is True
 
 
 def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):
@@ -1321,13 +1403,18 @@ def test_gateway_runs_api_body_includes_session_id():
             STREAMS.pop(stream_id, None)
 
 
-def test_gateway_runs_api_classifies_terminal_provider_error():
+def test_gateway_runs_api_classifies_terminal_provider_error(tmp_path, monkeypatch):
     from unittest.mock import MagicMock, patch
 
     from api.config import STREAMS, STREAMS_LOCK
     from api.gateway_chat import _run_gateway_chat_streaming
 
     error_text = "HTTP 400: Invalid model format or no credentials for provider"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
     events = []
     q = MagicMock()
     q.put_nowait = lambda item: events.append(item)
@@ -1352,19 +1439,20 @@ def test_gateway_runs_api_classifies_terminal_provider_error():
         return resp
 
     try:
+        s = new_session()
+        s.active_stream_id = stream_id
+        s.pending_user_message = "hi"
+        s.pending_attachments = []
+        s.save()
         with patch.dict("os.environ", {
             "HERMES_WEBUI_CHAT_BACKEND": "gateway",
             "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1",
             "HERMES_WEBUI_GATEWAY_BASE_URL": "http://gateway.local",
         }, clear=True), \
              patch("api.gateway_chat.gateway_supports_approval", return_value=True), \
-             patch("urllib.request.urlopen", side_effect=fake_urlopen), \
-             patch("api.gateway_chat.get_session", return_value=MagicMock(
-                 active_stream_id=stream_id, workspace="/tmp", profile=None,
-                 context_messages=[], messages=[],
-             )):
+             patch("urllib.request.urlopen", side_effect=fake_urlopen):
             _run_gateway_chat_streaming(
-                session_id="sess-runs-terminal-error",
+                session_id=s.session_id,
                 msg_text="hi",
                 model="test",
                 workspace="/tmp",
@@ -1372,7 +1460,11 @@ def test_gateway_runs_api_classifies_terminal_provider_error():
             )
         apperrors = [item[1] for item in events if item[0] == "apperror"]
         assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
-        assert apperrors[-1]["session_id"] == "sess-runs-terminal-error"
+        assert apperrors[-1]["session_id"] == s.session_id
+        saved = models.get_session(s.session_id)
+        assert [message.get("role") for message in saved.messages[-2:]] == ["user", "assistant"]
+        assert saved.messages[-1]["_error"] is True
+        assert apperrors[-1]["session"]["messages"][-1]["_error"] is True
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)


### PR DESCRIPTION
pr_title: fix(#5940): classify gateway terminal provider errors instead of generic empty turns

## Thinking Path

- The reported HTTP 400 is already classified correctly in the current in-process path, so the original `no_response` symptom is not live there anymore.
- The remaining live drop is in gateway terminal-error settlement, where both the legacy terminal-error branch and the runs-API failure path emitted `apperror` before they settled the in-flight turn into session state.
- After durable settlement landed, the last reload regression was repeated-prompt recovery: pending-turn repair still deduped by historical content, so an earlier identical prompt could suppress the current failed turn in both the shared streaming materializer and stale-pending repair.
- The fix keeps the shared provider-error classifier as the single authority, routes both gateway variants through one settlement helper, and narrows pending-turn recovery dedupe to exact current-turn checkpoints before the final `apperror`.
- Both terminal-error callers still enter that helper without holding the non-reentrant per-session lock, so the settlement order stays single-acquisition through `save()` and releases before teardown cleanup reacquires it.

## What Changed

- `api/gateway_chat.py`: add `_settle_gateway_terminal_error()` and route both the legacy terminal-error branch and the runs-API failure path through the same local-stream settlement helpers before emitting `apperror`, then keep the gateway path on the shared classifier and payload builder directly with no unused adapter seam.
- `api/streaming.py`: make `_materialize_pending_user_turn_before_error()` dedupe only an exact current-tail checkpoint, then mirror the full recovered checkpoint into `context_messages` so a repeated prompt no longer disappears on gateway terminal-error reload.
- `api/models.py`: apply the same exact-checkpoint rule to stale-pending repair and recovered-context mirroring, so cache-miss and core-sync recovery stop treating a historical repeated prompt as the current checkpoint.
- `tests/test_webui_gateway_chat_backend.py`, `tests/test_session_sidecar_repair.py`, and the focused recovery regressions: prove both the gateway reload path and stale-pending repair keep the current repeated prompt, its attachments, and the recovered terminal/error context instead of collapsing onto historical text.

## Why It Matters

The actionable gateway error now survives a page reload with the failed turn intact, even when the user repeats an earlier prompt with the same text, while genuine empty turns and the in-process fallbacks keep their current behavior.

## Verification

Focused gateway and recovery regressions cover legacy and runs-API terminal-error settlement, repeated-prompt reload and stale-repair preservation, preserved partial reasoning/tool state, the true empty-turn fallback, the existing in-process provider-error behavior, and the unchanged lock ordering through the shared settlement path; CI runs the full matrix.

## Upstream

Closes #5940.

## Model Used

GPT 5.5 via Codex CLI
