### PR TITLE
test: stabilize cross-platform WebUI suite

### DIFF
--- a/tests/test_issue3368_model_prefix_shadowing.py
+++ b/tests/test_issue3368_model_prefix_shadowing.py
@@ -40,6 +40,11 @@ NODE = shutil.which("node")
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
+@pytest.fixture(scope="module")
+def commands_src() -> str:
+    return COMMANDS_JS_PATH.read_text(encoding="utf-8")
+
+
 # ── driver for _findModelInDropdown (ui.js) ─────────────────────────────────
 
 _FIND_DRIVER = r"""
@@ -302,12 +307,7 @@ class TestDidYouMeanToastAssembly:
     And no_model_match already ends with an opening quote, so cmdModel must close
     with `${args}"`, not `"${args}"` (which doubled the quote)."""
 
-    @pytest.fixture(scope="class")
-    def commands_src(self):
-        import pathlib
-        root = pathlib.Path(__file__).resolve().parents[1]
-        return (root / "static" / "commands.js").read_text(encoding="utf-8")
-
+    # Uses the module-scoped commands_src fixture above.
     def test_toast_passes_suggestion_as_t_argument(self, commands_src):
         assert "t('model_did_you_mean', suggestion)" in commands_src, (
             "cmdModel must pass the suggestion into t() so the template fills in "
@@ -342,12 +342,7 @@ class TestSlashQualifiedVersionedNoSnap:
     no-match/'did you mean?' toast. The cross-provider direct update is gated on
     `!versionedNoSnap` so genuinely-off-catalog providers (no near variant) still work."""
 
-    @pytest.fixture(scope="class")
-    def commands_src(self):
-        import pathlib
-        root = pathlib.Path(__file__).resolve().parents[1]
-        return (root / "static" / "commands.js").read_text(encoding="utf-8")
-
+    # Uses the module-scoped commands_src fixture above.
     def test_cross_provider_direct_update_gated_on_versioned_no_snap(self, commands_src):
         # The guard variable is computed from the version check + a near suggestion.
         assert "_looksLikeVersionedModel(bare)" in commands_src
@@ -470,12 +465,7 @@ class TestCmdModelFullCatalogWiring:
     """Source-level guards: cmdModel must build candidates from the catalog and
     inject the option before selecting, so an extras-only winner is honored."""
 
-    @pytest.fixture(scope="class")
-    def commands_src(self):
-        import pathlib
-        root = pathlib.Path(__file__).resolve().parents[1]
-        return (root / "static" / "commands.js").read_text(encoding="utf-8")
-
+    # Uses the module-scoped commands_src fixture above.
     def test_builds_candidates_from_catalog_groups(self, commands_src):
         assert "_buildModelCandidates(sel,modelsData&&modelsData.groups)" in commands_src
 

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -20,6 +20,37 @@ from tests.conftest import requires_agent_modules
 TEST_BASE = f"http://127.0.0.1:{os.environ.get('HERMES_WEBUI_TEST_PORT', '8788')}"
 
 
+def _read_static_file(name: str) -> str:
+    return (pathlib.Path(__file__).resolve().parents[1] / "static" / name).read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.fixture(scope="module")
+def commands_js():
+    return _read_static_file("commands.js")
+
+
+@pytest.fixture(scope="module")
+def messages_js():
+    return _read_static_file("messages.js")
+
+
+@pytest.fixture(scope="module")
+def index_html():
+    return _read_static_file("index.html")
+
+
+@pytest.fixture(scope="module")
+def style_css():
+    return _read_static_file("style.css")
+
+
+@pytest.fixture(scope="module")
+def i18n_js():
+    return _read_static_file("i18n.js")
+
+
 def _get(path, expect_ok=True):
     import urllib.request, urllib.error
     try:
@@ -132,11 +163,6 @@ class TestYoloEndpointPost:
 class TestYoloCommandRegistration:
     """/yolo slash command should be registered in commands.js."""
 
-    @pytest.fixture(scope="class")
-    def commands_js(self):
-        with open("static/commands.js", "r", encoding="utf-8") as f:
-            return f.read()
-
     def test_yolo_command_in_array(self, commands_js):
         assert "'yolo'" in commands_js or '"yolo"' in commands_js
 
@@ -152,11 +178,6 @@ class TestYoloCommandRegistration:
 
 class TestYoloBusySendPath:
     """/yolo should be recognized by the busy-send command intercept."""
-
-    @pytest.fixture(scope="class")
-    def messages_js(self):
-        with open("static/messages.js", "r", encoding="utf-8") as f:
-            return f.read()
 
     def test_yolo_in_busy_send_allowlist(self, messages_js):
         send_idx = messages_js.find("async function send(")
@@ -186,11 +207,6 @@ class TestYoloBusySendPath:
 class TestYoloPillHTML:
     """YOLO pill element should exist in index.html."""
 
-    @pytest.fixture(scope="class")
-    def index_html(self):
-        with open("static/index.html", "r", encoding="utf-8") as f:
-            return f.read()
-
     def test_yolo_pill_element_exists(self, index_html):
         assert 'id="yoloPill"' in index_html
 
@@ -208,11 +224,6 @@ class TestYoloPillHTML:
 
 class TestYoloCSS:
     """YOLO-related CSS classes should exist."""
-
-    @pytest.fixture(scope="class")
-    def style_css(self):
-        with open("static/style.css", "r", encoding="utf-8") as f:
-            return f.read()
 
     def test_yolo_pill_class(self, style_css):
         assert ".yolo-pill{" in style_css or ".yolo-pill {" in style_css
@@ -239,11 +250,6 @@ class TestYoloI18n:
     ]
 
     LOCALES = ["en", "ru", "es", "de", "zh", "ko"]
-
-    @pytest.fixture(scope="class")
-    def i18n_js(self):
-        with open("static/i18n.js", "r", encoding="utf-8") as f:
-            return f.read()
 
     @pytest.mark.parametrize("locale", LOCALES)
     def test_locale_has_all_yolo_keys(self, i18n_js, locale):

--- a/tests/test_profile_skills_stats.py
+++ b/tests/test_profile_skills_stats.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 import yaml
 from api import profiles
@@ -25,11 +26,12 @@ def test_get_profile_skills_stats(tmp_path):
     # Setup skills directory with:
     # 1 compatible & enabled skill ("alpha")
     # 1 compatible & disabled skill ("beta")
-    # 1 incompatible skill ("gamma" - macos only on linux test run)
+    # 1 incompatible skill ("gamma" is explicitly tagged for another OS)
     profile_home = tmp_path / "auditor"
     _write_skill(profile_home, "alpha")
     _write_skill(profile_home, "beta")
-    _write_skill(profile_home, "gamma", platforms=["macos"])
+    incompatible_platform = "linux" if sys.platform == "darwin" else "macos"
+    _write_skill(profile_home, "gamma", platforms=[incompatible_platform])
     _write_config(profile_home, ["beta"])
 
     # Explicitly clear the stats cache to ensure we compute fresh


### PR DESCRIPTION
## Summary
- make profile skill-statistics coverage choose an actually incompatible platform on macOS
- remove eight Pytest class-scoped instance-fixture deprecation warnings by using state-free module fixtures

The OpenRouter hermetic test fix that originally overlapped with this branch landed upstream while this PR was in progress, so it was intentionally dropped during rebase.

## Verification
- `12836 passed, 22 skipped, 1 xfailed, 2 xpassed, 16 subtests passed`
- `npm run lint:runtime`
- focused YOLO and model-prefix test files passed

No production runtime code changed.