### PR TITLE
Release exp-v0.52.47: surface real provider error on failed turn (#5940)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- **A failed turn now shows the real provider error instead of "no response, try again".** When a turn hit a non-retryable provider error (e.g. HTTP 400 "invalid model" or a credentials problem), the WebUI showed a misleading "No response from provider — this often means a usage/rate limit was hit silently, try again in a moment" message and hid the actual, non-retryable cause. The terminal error the agent reports is now surfaced through to the turn-completion classifier, so you see an accurate, actionable message (e.g. "Model not found — check the model ID in Settings" / "Authentication failed") instead of being told to retry a request that can never succeed. The generic no-response message stays reserved for genuinely empty completions. Thanks @b3nw for the report. (#5940)
+
 - **Public-share button labels now show in the right language.** A value-level locale swap shipped the public-share strings (Share / Stop sharing / confirmation dialogs) as Russian text in the English locale and English text in the Russian locale — key-parity checks didn't catch it because the keys themselves were balanced. Both locales are restored to their correct language, with a regression test that fails if the values are ever swapped again. Thanks @DrMaks22. (#5955)
 
 - **An errored turn no longer hides the response the assistant already produced.** When a turn ended in an error, the tool calls and reasoning the assistant had already generated were auto-collapsed behind a single header above the error card, so it looked like nothing came back. That produced content now stays visible by default on an errored turn (the error card still shows); successful turns collapse their worklog exactly as before. Thanks @b3nw for the report. (#5950, #5941)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6921,18 +6921,40 @@ def _run_agent_streaming(
         except Exception:
             logger.debug("Failed to put event to queue")
 
+    # #5940: capture a terminal (non-retryable) provider error the Agent emits via
+    # its lifecycle status_callback. The Agent aborts a non-retryable API error
+    # (e.g. HTTP 400 "invalid model / no credentials") with
+    # `_emit_status("❌ Non-retryable error (HTTP <code>): <detail>")` but the run
+    # result / agent._last_error are empty for that path, so turn-completion below
+    # fell through to the misleading `no_response` "silent rate limit, try again"
+    # message. Stash the emitted terminal error here (single-element list = closure
+    # write without nonlocal) so it can seed `_last_err` and let the classifier
+    # surface the real, actionable cause (model_not_found / auth_mismatch).
+    _captured_terminal_error = [None]
+
     def _agent_status_callback(kind, message):
         """Bridge Agent lifecycle status into WebUI SSE.
 
         Passes compression events as 'compressing' events and rate-limit/fallback
         events as 'warning' events so the frontend can surface them to the user.
-        All other lifecycle messages are dropped silently.
+        Also captures a terminal non-retryable provider error (#5940) so the
+        turn-completion classifier can report the real cause instead of the
+        generic no_response fallback. All other lifecycle messages are dropped.
         """
         _message = str(message or '').strip()
         _kind = str(kind or '').strip().lower()
         if not _message:
             return
         _lower = _message.lower()
+        # #5940: a non-retryable terminal provider error the Agent aborted on. Keep
+        # the FIRST one seen this turn (the original cause; later fallback notices
+        # are handled separately below). Matched on the Agent's emitted shape.
+        if (
+            _captured_terminal_error[0] is None
+            and 'non-retryable error' in _lower
+            and 'http' in _lower
+        ):
+            _captured_terminal_error[0] = _message
         _is_compression_start = (
             _kind == 'lifecycle'
             and (
@@ -8692,6 +8714,13 @@ def _run_agent_streaming(
                     msg_text,
                 )
                 _last_err = getattr(agent, '_last_error', None) or result.get('error') or ''
+                # #5940: if the Agent aborted on a non-retryable provider error
+                # (captured from its lifecycle status_callback) but left no error on
+                # the result/agent, use the captured message so the classifier can
+                # surface the real cause (model_not_found / auth) instead of the
+                # misleading no_response "silent rate limit, try again" fallback.
+                if not _last_err and _captured_terminal_error[0]:
+                    _last_err = _captured_terminal_error[0]
                 _classification = _classify_provider_error(
                     str(_last_err) if _last_err else '',
                     _last_err,

--- a/tests/test_issue5940_terminal_error_surfaced.py
+++ b/tests/test_issue5940_terminal_error_surfaced.py
@@ -1,0 +1,80 @@
+"""Regression test for #5940 — surface the real non-retryable provider error.
+
+The Agent aborts a non-retryable API error (e.g. HTTP 400 "invalid model / no
+credentials") by emitting `❌ Non-retryable error (HTTP <code>): <detail>` through
+its lifecycle `status_callback`. The WebUI received that message but dropped it
+(only compression + fallback lifecycle messages were forwarded), and the run
+result / `agent._last_error` were empty for that abort path — so turn completion
+fell through to the misleading `no_response` "silent rate limit, try again"
+message.
+
+The fix captures the terminal error in `_agent_status_callback` and seeds
+`_last_err` with it at turn completion so `_classify_provider_error` reports the
+real, actionable cause instead of the generic fallback.
+
+Two layers are covered:
+  1. behavioral — the classifier buckets the captured message correctly;
+  2. wiring — the capture container + seed are present in the streaming source.
+"""
+from pathlib import Path
+
+from api import streaming
+
+ROOT = Path(__file__).resolve().parents[1]
+STREAMING_PY = (ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+
+
+# The exact shape the Agent emits (agent/conversation_loop.py:3780) wrapping the
+# provider's HTTP 400 detail.
+_INVALID_MODEL_MSG = (
+    "\u274c Non-retryable error (HTTP 400): HTTP 400: "
+    '{"detail":"Invalid Request: Invalid model format or no credentials for provider: x"}'
+)
+
+
+def test_captured_terminal_error_classifies_as_model_not_found_not_no_response():
+    """An 'invalid model' non-retryable error must classify as model_not_found —
+    NOT the misleading no_response 'try again in a moment' fallback."""
+    classified = streaming._classify_provider_error(
+        _INVALID_MODEL_MSG, Exception(_INVALID_MODEL_MSG)
+    )
+    assert classified["type"] == "model_not_found", classified
+    assert classified["type"] != "no_response"
+    # Actionable guidance, and NOT the "try again" retry advice.
+    assert "hermes model" in classified["hint"].lower() or "settings" in classified["hint"].lower()
+    assert "try again in a moment" not in classified["hint"].lower()
+
+
+def test_captured_credential_error_classifies_as_auth_not_no_response():
+    """A credential-problem non-retryable error surfaces as an auth issue, not
+    a silent-rate-limit no_response."""
+    msg = "\u274c Non-retryable error (HTTP 401): invalid api key for provider x"
+    classified = streaming._classify_provider_error(msg, Exception(msg))
+    assert classified["type"] == "auth_mismatch", classified
+    assert classified["type"] != "no_response"
+
+
+def test_no_response_reserved_for_genuinely_empty_completion():
+    """With no captured terminal error, an empty completion still classifies as
+    no_response (the fallback is reserved for genuine silent completions)."""
+    classified = streaming._classify_provider_error("", None, silent_failure=True)
+    assert classified["type"] == "no_response"
+
+
+def test_status_callback_captures_terminal_error():
+    """The status-callback bridge must capture a non-retryable terminal error
+    into the turn-local container (not drop it like other lifecycle messages)."""
+    assert "_captured_terminal_error = [None]" in STREAMING_PY, (
+        "the turn-local capture container must be declared before _agent_status_callback"
+    )
+    # capture condition matches the Agent's emitted 'non-retryable error (HTTP ...)' shape
+    assert "'non-retryable error' in _lower" in STREAMING_PY
+    assert "_captured_terminal_error[0] = _message" in STREAMING_PY
+
+
+def test_captured_terminal_error_seeds_last_err_on_completion():
+    """At turn completion, the captured terminal error must seed `_last_err` when
+    the agent/result carried no error — so the classifier runs on the real cause
+    instead of silent_failure=True."""
+    assert "if not _last_err and _captured_terminal_error[0]:" in STREAMING_PY
+    assert "_last_err = _captured_terminal_error[0]" in STREAMING_PY


### PR DESCRIPTION
Release exp-v0.52.47 — surface non-retryable provider error (#5940, b3nw).

Third of the b3nw errored-turn cluster. The agent emits a non-retryable terminal error (HTTP 400 invalid model / no creds) via its lifecycle status_callback, but the WebUI dropped it + the run result was empty -> misleading no_response "try again" message. Now captured in _agent_status_callback (turn-local) + seeds _last_err at completion so _classify_provider_error shows the real cause (model_not_found / auth).

Gate: Codex SAFE TO SHIP (verified turn-local scope, no _drop_replayed_assistant change, correct classification, 101 focused streaming/error tests) + stream-regression-gate GREEN all 3 modes. Self-built -> independent nesquena review appropriate.
