### PR TITLE
fix(chat): stabilize mobile layout across session switches

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1606,7 +1606,7 @@ async function loadSession(sid){
     const profileMismatch=_sessionProfileMismatchFromError(e);
     if(profileMismatch && profileMismatch.profile && !opts.skipProfileResolve){
       if (!_isCurrentLoad()) {
-        if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
+        if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());
         _rearmActiveSessionStream();
         return;
       }
@@ -1619,7 +1619,7 @@ async function loadSession(sid){
         // before clearing _loadingSessionId or retrying so the stale
         // continuation can't hijack the UI back to the old target.
         if (!_isCurrentLoad()) {
-          if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
+          if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());
           _rearmActiveSessionStream();
           return;
         }
@@ -1638,7 +1638,7 @@ async function loadSession(sid){
     // load, re-arm the active session's stream and bail before any DOM mutation
     // or self-heal.
     if (!_isCurrentLoad()) {
-      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
+      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());
       _rearmActiveSessionStream();
       return;
     }
@@ -1677,7 +1677,7 @@ async function loadSession(sid){
       }
     }
     _clearSameSessionForceReloadHint(sid);
-    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());
     // Capture whether this failure self-healed away the current session (a
     // 404 on the *current* session whose sidecar was deleted server-side).
     // In that case there is no live session left to stream for, so we must
@@ -1713,7 +1713,7 @@ async function loadSession(sid){
   // send users to empty state after re-login (#4028 follow-up).
   if (!data) {
     _clearSameSessionForceReloadHint(sid);
-    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());
     if (_isCurrentLoad()) _loadingSessionId = null;
     // #2971: re-arm the still-displayed session's stream (defensive — harmless
     // if the 401 redirect is already tearing the page down). Idempotent.
@@ -2015,7 +2015,7 @@ async function loadSession(sid){
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
-      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
+      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());
       if (_isCurrentLoad()) _loadingSessionId = null;
       return;
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1606,7 +1606,7 @@ async function loadSession(sid){
     const profileMismatch=_sessionProfileMismatchFromError(e);
     if(profileMismatch && profileMismatch.profile && !opts.skipProfileResolve){
       if (!_isCurrentLoad()) {
-        if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
+        if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
         _rearmActiveSessionStream();
         return;
       }
@@ -1619,7 +1619,7 @@ async function loadSession(sid){
         // before clearing _loadingSessionId or retrying so the stale
         // continuation can't hijack the UI back to the old target.
         if (!_isCurrentLoad()) {
-          if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
+          if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
           _rearmActiveSessionStream();
           return;
         }
@@ -1638,7 +1638,7 @@ async function loadSession(sid){
     // load, re-arm the active session's stream and bail before any DOM mutation
     // or self-heal.
     if (!_isCurrentLoad()) {
-      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
+      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
       _rearmActiveSessionStream();
       return;
     }
@@ -1677,7 +1677,7 @@ async function loadSession(sid){
       }
     }
     _clearSameSessionForceReloadHint(sid);
-    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
     // Capture whether this failure self-healed away the current session (a
     // 404 on the *current* session whose sidecar was deleted server-side).
     // In that case there is no live session left to stream for, so we must
@@ -1713,7 +1713,7 @@ async function loadSession(sid){
   // send users to empty state after re-login (#4028 follow-up).
   if (!data) {
     _clearSameSessionForceReloadHint(sid);
-    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
     if (_isCurrentLoad()) _loadingSessionId = null;
     // #2971: re-arm the still-displayed session's stream (defensive — harmless
     // if the 401 redirect is already tearing the page down). Idempotent.
@@ -1775,7 +1775,7 @@ async function loadSession(sid){
     _clearDeferredActiveSessionExternalRefresh();
   }
   if (currentSid !== sid && typeof window !== 'undefined' && typeof window._beginSessionSwitchLayoutStabilization === 'function') {
-    try { window._beginSessionSwitchLayoutStabilization(sid); } catch (_) {}
+    try { window._beginSessionSwitchLayoutStabilization(sid, _loadGeneration); } catch (_) {}
   }
   if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
     try { window._resetScrollDirectionTracker(); } catch (_) {}
@@ -2015,7 +2015,7 @@ async function loadSession(sid){
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
-      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
+      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization(_loadGeneration);
       if (_isCurrentLoad()) _loadingSessionId = null;
       return;
     }
@@ -2076,7 +2076,7 @@ async function loadSession(sid){
       setComposerStatus('');
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
       if(currentSid!==sid&&typeof window!=='undefined'&&typeof window._settleSessionSwitchLayoutStabilization==='function'){
-        window._settleSessionSwitchLayoutStabilization(sid);
+        window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);
       }
       const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
         ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||
@@ -2104,7 +2104,7 @@ async function loadSession(sid){
       updateQueueBadge(sid);
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
       if(currentSid!==sid&&typeof window!=='undefined'&&typeof window._settleSessionSwitchLayoutStabilization==='function'){
-        window._settleSessionSwitchLayoutStabilization(sid);
+        window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);
       }
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       // Workspace refresh is guarded by session id inside loadDir(); keep it

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1504,6 +1504,16 @@ async function loadSession(sid){
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   const _loadGeneration = ++_loadSessionGeneration;
   const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration;
+  // Retire the session-switch stabilization THIS load armed, generation-gated
+  // and non-forced: it only clears if the live stabilization is still ours, so a
+  // stale continuation can't tear down a newer owner. Called on every post-begin
+  // stale return so an abandoned generation that exits before a successor opens
+  // its own stabilization can't leave `session-switch-layout-stabilizing` armed.
+  const _retireOwnStabilization = () => {
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function'){
+      try { window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, false); } catch (_) {}
+    }
+  };
   _loadingSessionId = sid;
   if(currentSid!==sid&&typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
   // Reset scroll state for fresh session navigation — the reader expects to
@@ -1914,12 +1924,14 @@ async function loadSession(sid){
       await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
     } catch(e) {
       if (!_isCurrentLoad()) {
+        _retireOwnStabilization();
         _rearmActiveSessionStream();
         return;
       }
       S.messages=inflightMessages;
     }
     if (!_isCurrentLoad()) {
+      _retireOwnStabilization();
       _rearmActiveSessionStream();
       return;
     }
@@ -1955,7 +1967,7 @@ async function loadSession(sid){
     let didReconnect=false;
     if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
       INFLIGHT[sid].reattach=false;
-      if (!_isCurrentLoad()) return;
+      if (!_isCurrentLoad()) { _retireOwnStabilization(); return; }
       didReconnect=true;
       attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
     }
@@ -2031,6 +2043,7 @@ async function loadSession(sid){
       await _ensureMessagesLoaded(sid, {force:_keepStaleUntilLoaded, loadGeneration:_loadGeneration});
     } catch (e) {
       if (!_isCurrentLoad()) {
+        _retireOwnStabilization();
         _rearmActiveSessionStream();
         return;
       }
@@ -2048,7 +2061,7 @@ async function loadSession(sid){
       return;
     }
     // Stale? A newer loadSession() call has already started (#1060).
-    if (!_isCurrentLoad()) return;
+    if (!_isCurrentLoad()) { _retireOwnStabilization(); return; }
 
     // Restore any queued message that survived page refresh or tab restore.
     if(typeof queueSessionMessage==='function'){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1483,6 +1483,14 @@ async function loadSession(sid){
     // Re-selecting the already-open session is a no-op for transcript/scroll, but
     // it is still a *visit*: clear a stale sidebar unread dot (e.g. one a
     // background completion left on the open, unfocused pane) before returning.
+    // It is ALSO an authoritative same-SID load: if a just-abandoned switch left
+    // stabilization armed (rapid A→B→A where the B load never became current and
+    // its stale return was gated out by a newer generation), force-retire it now
+    // so `session-switch-layout-stabilizing` can't stay permanently armed and
+    // silently disable mobile user-row virtualization for the rest of the tab.
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function'){
+      try { window._endSessionSwitchLayoutStabilization(undefined, undefined, true); } catch (_) {}
+    }
     if(_sessionVisitHasUnreadState(sid)){
       _acknowledgeSessionVisit(
         sid,

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1776,6 +1776,15 @@ async function loadSession(sid){
   }
   if (currentSid !== sid && typeof window !== 'undefined' && typeof window._beginSessionSwitchLayoutStabilization === 'function') {
     try { window._beginSessionSwitchLayoutStabilization(sid, _loadGeneration); } catch (_) {}
+  } else if (sameSessionForceReload && typeof window !== 'undefined' && typeof window._endSessionSwitchLayoutStabilization === 'function') {
+    // A same-session force reload does NOT open a new stabilization (the
+    // currentSid===sid gate above skips _begin), but it IS the authoritative
+    // current load. If an older cross-session load left stabilization active
+    // (e.g. its async settle is still pending when the user force-reloads the
+    // same session), nothing else would retire it and the transcript could stay
+    // forced-visible / min-height-pinned. Force-retire + invalidate it now so
+    // the reload starts from a clean layout state.
+    try { window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, true); } catch (_) {}
   }
   if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
     try { window._resetScrollDirectionTracker(); } catch (_) {}
@@ -1992,6 +2001,17 @@ async function loadSession(sid){
     startApprovalPolling(sid);
     if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
     if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
+    // Settle session-switch stabilization for the INFLIGHT streaming-restore
+    // path. This branch renders + reattaches the live stream and then returns
+    // without falling through to the idle/attach settle below, so without this
+    // the stabilization opened at _begin (currentSid!==sid) would never be
+    // released (begin=1 / settle=0 / end=0) — leaving the transcript
+    // forced-visible / min-height-pinned for the rest of the session. Pass the
+    // streaming flag: the live turn keeps growing, so we must not arm the
+    // ResizeObserver (it would chase the stream and never settle).
+    if(currentSid!==sid&&typeof window!=='undefined'&&typeof window._settleSessionSwitchLayoutStabilization==='function'){
+      window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration, true);
+    }
   }else{
     // Phase 2b: Idle session — load full messages lazily for rendering.
     // _ensureMessagesLoaded is idempotent; it skips if S.messages already populated.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1769,6 +1769,9 @@ async function loadSession(sid){
   if (currentSid !== sid) {
     _clearDeferredActiveSessionExternalRefresh();
   }
+  if (currentSid !== sid && typeof window !== 'undefined' && typeof window._beginSessionSwitchLayoutStabilization === 'function') {
+    try { window._beginSessionSwitchLayoutStabilization(sid); } catch (_) {}
+  }
   if (currentSid !== sid && typeof window !== 'undefined' && typeof window._resetScrollDirectionTracker === 'function') {
     try { window._resetScrollDirectionTracker(); } catch (_) {}
   }
@@ -2066,6 +2069,9 @@ async function loadSession(sid){
       setStatus('');
       setComposerStatus('');
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+      if(currentSid!==sid&&typeof window!=='undefined'&&typeof window._settleSessionSwitchLayoutStabilization==='function'){
+        window._settleSessionSwitchLayoutStabilization(sid);
+      }
       const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
         ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||
           _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
@@ -2091,6 +2097,9 @@ async function loadSession(sid){
       setComposerStatus('');
       updateQueueBadge(sid);
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+      if(currentSid!==sid&&typeof window!=='undefined'&&typeof window._settleSessionSwitchLayoutStabilization==='function'){
+        window._settleSessionSwitchLayoutStabilization(sid);
+      }
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       // Workspace refresh is guarded by session id inside loadDir(); keep it
       // after the transcript's first paint so chat switching is not competing

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1606,6 +1606,7 @@ async function loadSession(sid){
     const profileMismatch=_sessionProfileMismatchFromError(e);
     if(profileMismatch && profileMismatch.profile && !opts.skipProfileResolve){
       if (!_isCurrentLoad()) {
+        if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
         _rearmActiveSessionStream();
         return;
       }
@@ -1618,6 +1619,7 @@ async function loadSession(sid){
         // before clearing _loadingSessionId or retrying so the stale
         // continuation can't hijack the UI back to the old target.
         if (!_isCurrentLoad()) {
+          if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
           _rearmActiveSessionStream();
           return;
         }
@@ -1636,6 +1638,7 @@ async function loadSession(sid){
     // load, re-arm the active session's stream and bail before any DOM mutation
     // or self-heal.
     if (!_isCurrentLoad()) {
+      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
       _rearmActiveSessionStream();
       return;
     }
@@ -1674,6 +1677,7 @@ async function loadSession(sid){
       }
     }
     _clearSameSessionForceReloadHint(sid);
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
     // Capture whether this failure self-healed away the current session (a
     // 404 on the *current* session whose sidecar was deleted server-side).
     // In that case there is no live session left to stream for, so we must
@@ -1709,6 +1713,7 @@ async function loadSession(sid){
   // send users to empty state after re-login (#4028 follow-up).
   if (!data) {
     _clearSameSessionForceReloadHint(sid);
+    if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
     if (_isCurrentLoad()) _loadingSessionId = null;
     // #2971: re-arm the still-displayed session's stream (defensive — harmless
     // if the 401 redirect is already tearing the page down). Idempotent.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2076,7 +2076,7 @@ async function loadSession(sid){
       setComposerStatus('');
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
       if(currentSid!==sid&&typeof window!=='undefined'&&typeof window._settleSessionSwitchLayoutStabilization==='function'){
-        window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);
+        window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration, true);
       }
       const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
         ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid, {mode:'compact_worklog'}))||

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2010,6 +2010,7 @@ async function loadSession(sid){
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
+      if(typeof window!=='undefined'&&typeof window._endSessionSwitchLayoutStabilization==='function') window._endSessionSwitchLayoutStabilization();
       if (_isCurrentLoad()) _loadingSessionId = null;
       return;
     }

--- a/static/style.css
+++ b/static/style.css
@@ -5857,6 +5857,11 @@ main.main > #mainPlugin{display:none;}
      the existing "some rows must stay fully rendered" opt-out pattern for
      #liveAssistantTurn below. */
   .msg-row[data-role="user"] { content-visibility: auto; contain-intrinsic-size: auto 96px; contain: layout style; }
+  /* A fresh session switch must establish the incoming transcript's real row
+     geometry before content-visibility starts skipping off-screen user rows.
+     Otherwise the landing frame can shrink repeatedly as remembered intrinsic
+     sizes settle, producing a visible jump even though scrollTop follows dH. */
+  .messages.session-switch-layout-stabilizing .msg-row[data-role="user"] { content-visibility: visible; }
   .msg-row { contain: layout style; }
   /* Keep the LIVE streaming turn fully rendered while a response streams. The
      live turn is always id="liveAssistantTurn" (assigned on every render path:

--- a/static/ui.js
+++ b/static/ui.js
@@ -5132,6 +5132,11 @@ let _sessionSwitchLayoutLoadGeneration=null;
 let _sessionSwitchLayoutStabilizationToken=0;
 let _sessionSwitchLayoutStabilizationTimer=0;
 let _sessionSwitchLayoutStabilizationObserver=null;
+// Absolute-cap watchdog: force-retires stabilization even if a post-process
+// waiter (a never-settling fetch/preview) never releases its pending marker, so
+// the `session-switch-layout-stabilizing` class can't stay armed forever and
+// silently disable mobile user-row virtualization.
+let _sessionSwitchLayoutWatchdogTimer=0;
 let _sessionSwitchLayoutPostProcessPending=0;
 let _sessionSwitchLayoutSettleRequested=false;
 let _liveAnchorScrollRebuildGeneration=0;
@@ -5148,6 +5153,8 @@ function _endSessionSwitchLayoutStabilization(loadGeneration,token,force){
   if(token!==undefined&&token!==_sessionSwitchLayoutStabilizationToken) return;
   clearTimeout(_sessionSwitchLayoutStabilizationTimer);
   _sessionSwitchLayoutStabilizationTimer=0;
+  clearTimeout(_sessionSwitchLayoutWatchdogTimer);
+  _sessionSwitchLayoutWatchdogTimer=0;
   if(_sessionSwitchLayoutStabilizationObserver){
     _sessionSwitchLayoutStabilizationObserver.disconnect();
     _sessionSwitchLayoutStabilizationObserver=null;
@@ -5227,6 +5234,20 @@ function _settleSessionSwitchLayoutStabilization(sid,loadGeneration,streaming){
     _sessionSwitchLayoutStabilizationObserver.observe(observed);
   }
   _scheduleSessionSwitchLayoutQuietCheck(token,sid,loadGeneration);
+  // Independent absolute-cap watchdog. The quiet-check is event-driven and waits
+  // on _sessionSwitchLayoutPostProcessPending, so a single async processor that
+  // never resolves (a hung fetch / preview that neither renders nor errors)
+  // would keep pending>0 and leave stabilization armed for the whole tab. Arm a
+  // bounded fallback that force-retires this exact token after the cap even if a
+  // waiter never releases. Re-armed on each settle; cleared by _end.
+  clearTimeout(_sessionSwitchLayoutWatchdogTimer);
+  _sessionSwitchLayoutWatchdogTimer=setTimeout(()=>{
+    if(token!==_sessionSwitchLayoutStabilizationToken) return;
+    // Force-retire regardless of pending count; a still-pending waiter here is a
+    // stuck processor, not live geometry. token match guarantees we only clear
+    // the stabilization this settle owns.
+    _endSessionSwitchLayoutStabilization(loadGeneration,token,true);
+  },15000);
 }
 if(typeof window!=='undefined'){
   window._beginSessionSwitchLayoutStabilization=_beginSessionSwitchLayoutStabilization;

--- a/static/ui.js
+++ b/static/ui.js
@@ -5128,16 +5128,29 @@ let _nearBottomCount=0;
 let _lastScrollTop=null;
 let _lastMessageClientHeight=null;   // #4702: track scroller height to ignore iOS portrait toolbar-settle reflows (a clientHeight increase fires a scroll event with decreased scrollTop that is NOT a user scroll)
 let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutStabilizationToken=0;
 let _sessionSwitchLayoutStabilizationTimer=0;
-function _endSessionSwitchLayoutStabilization(){
+let _sessionSwitchLayoutStabilizationObserver=null;
+let _sessionSwitchLayoutPostProcessPending=0;
+let _sessionSwitchLayoutSettleRequested=false;
+let _liveAnchorScrollRebuildGeneration=0;
+function _endSessionSwitchLayoutStabilization(token){
+  if(token!==undefined&&token!==_sessionSwitchLayoutStabilizationToken) return;
   clearTimeout(_sessionSwitchLayoutStabilizationTimer);
   _sessionSwitchLayoutStabilizationTimer=0;
+  if(_sessionSwitchLayoutStabilizationObserver){
+    _sessionSwitchLayoutStabilizationObserver.disconnect();
+    _sessionSwitchLayoutStabilizationObserver=null;
+  }
+  _sessionSwitchLayoutPostProcessPending=0;
+  _sessionSwitchLayoutSettleRequested=false;
   _sessionSwitchLayoutStabilizationSid='';
   const el=$('messages');
   if(el&&el.classList) el.classList.remove('session-switch-layout-stabilizing');
 }
 function _beginSessionSwitchLayoutStabilization(sid){
   _endSessionSwitchLayoutStabilization();
+  ++_sessionSwitchLayoutStabilizationToken;
   _bottomSettleToken++;
   if(_settleRO){ _settleRO.disconnect(); _settleRO=null; }
   clearTimeout(_settleTimer);
@@ -5145,33 +5158,60 @@ function _beginSessionSwitchLayoutStabilization(sid){
   cancelAnimationFrame(_settleRAF);
   _programmaticScroll=false;
   _sessionSwitchLayoutStabilizationSid=String(sid||'');
+  _sessionSwitchLayoutPostProcessPending=0;
+  _sessionSwitchLayoutSettleRequested=false;
   const el=$('messages');
   if(el&&el.classList) el.classList.add('session-switch-layout-stabilizing');
-  // Failure/stale-load fallback. The loading placeholder has no user rows, so
-  // keeping this class while a slow metadata/message fetch is in flight is cheap.
-  // The normal render path replaces this long fallback with a short settle timer.
-  _sessionSwitchLayoutStabilizationTimer=setTimeout(_endSessionSwitchLayoutStabilization,15000);
+}
+function _finishSessionSwitchLayoutStabilization(token,sid){
+  if(token!==_sessionSwitchLayoutStabilizationToken||String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
+  _endSessionSwitchLayoutStabilization(token);
+  requestAnimationFrame(()=>{
+    if(token!==_sessionSwitchLayoutStabilizationToken) return;
+    if(!_messageUserUnpinned&&_scrollPinned&&typeof scrollToBottom==='function') scrollToBottom();
+  });
+}
+function _scheduleSessionSwitchLayoutQuietCheck(token,sid){
+  clearTimeout(_sessionSwitchLayoutStabilizationTimer);
+  _sessionSwitchLayoutStabilizationTimer=setTimeout(()=>{
+    if(token!==_sessionSwitchLayoutStabilizationToken||!_sessionSwitchLayoutSettleRequested) return;
+    if(_sessionSwitchLayoutPostProcessPending>0) return;
+    _finishSessionSwitchLayoutStabilization(token,sid);
+  },300);
+}
+function _beginSessionSwitchLayoutPostProcess(){
+  if(!_sessionSwitchLayoutSettleRequested||!_sessionSwitchLayoutStabilizationSid) return null;
+  const marker={token:_sessionSwitchLayoutStabilizationToken,sid:_sessionSwitchLayoutStabilizationSid};
+  _sessionSwitchLayoutPostProcessPending++;
+  clearTimeout(_sessionSwitchLayoutStabilizationTimer);
+  return marker;
+}
+function _endSessionSwitchLayoutPostProcess(marker){
+  if(!marker||marker.token!==_sessionSwitchLayoutStabilizationToken||marker.sid!==_sessionSwitchLayoutStabilizationSid) return;
+  _sessionSwitchLayoutPostProcessPending=Math.max(0,_sessionSwitchLayoutPostProcessPending-1);
+  if(_sessionSwitchLayoutPostProcessPending===0) _scheduleSessionSwitchLayoutQuietCheck(marker.token,marker.sid);
 }
 function _settleSessionSwitchLayoutStabilization(sid){
   if(!_sessionSwitchLayoutStabilizationSid||String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
   const el=$('messages');
   if(!el){ _endSessionSwitchLayoutStabilization(); return; }
-  clearTimeout(_sessionSwitchLayoutStabilizationTimer);
-  // The incoming rows, post-processing, and content-visibility intrinsic sizes can
-  // keep changing for hundreds of milliseconds after renderMessages returns. Hold
-  // real row layout through that window, then expose content-visibility once and
-  // re-anchor against the final geometry. Two rAFs were empirically too short.
-  _sessionSwitchLayoutStabilizationTimer=setTimeout(()=>{
-    if(String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
-    _endSessionSwitchLayoutStabilization();
-    requestAnimationFrame(()=>{
-      if(!_messageUserUnpinned&&_scrollPinned&&typeof scrollToBottom==='function') scrollToBottom();
+  const token=_sessionSwitchLayoutStabilizationToken;
+  _sessionSwitchLayoutSettleRequested=true;
+  if(typeof ResizeObserver==='function'){
+    if(_sessionSwitchLayoutStabilizationObserver) _sessionSwitchLayoutStabilizationObserver.disconnect();
+    const observed=document.getElementById('msgInner')||el;
+    _sessionSwitchLayoutStabilizationObserver=new ResizeObserver(()=>{
+      if(token!==_sessionSwitchLayoutStabilizationToken) return;
+      _scheduleSessionSwitchLayoutQuietCheck(token,sid);
     });
-  },1200);
+    _sessionSwitchLayoutStabilizationObserver.observe(observed);
+  }
+  _scheduleSessionSwitchLayoutQuietCheck(token,sid);
 }
 if(typeof window!=='undefined'){
   window._beginSessionSwitchLayoutStabilization=_beginSessionSwitchLayoutStabilization;
   window._settleSessionSwitchLayoutStabilization=_settleSessionSwitchLayoutStabilization;
+  window._endSessionSwitchLayoutStabilization=_endSessionSwitchLayoutStabilization;
 }
 
 // Sticky-unpin model (#3343 supersedes #3330's proximity re-pin): once the user
@@ -12004,6 +12044,12 @@ function _projectLiveAnchorActivitySceneForStream(streamId, mode){
     return null;
   }
 }
+function _nextLiveAnchorScrollRebuildGuard(){
+  return {generation:++_liveAnchorScrollRebuildGeneration,sessionId:String(S.session&&S.session.session_id||'')};
+}
+function _liveAnchorScrollRebuildGuardCurrent(guard){
+  return !!(guard&&guard.generation===_liveAnchorScrollRebuildGeneration&&String(S.session&&S.session.session_id||'')===guard.sessionId);
+}
 function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
   const messagesEl=$('messages');
   if(!messagesEl||!scrollSnapshot) return {readerAwayFromBottom:false,release:null};
@@ -12079,6 +12125,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
     : null;
   const scrollSnapshot=_captureMessageScrollSnapshot();
   const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);
+  const scrollRebuildIdentity=(typeof _nextLiveAnchorScrollRebuildGuard==='function')?_nextLiveAnchorScrollRebuildGuard():null;
   blocks.querySelectorAll('[data-anchor-scene-owner="1"],[data-anchor-scene-row="1"]').forEach(el=>el.remove());
   blocks.querySelectorAll('.live-worklog[data-live-worklog-shell="1"],.tool-worklog-group[data-live-tool-call-group="1"],.tool-call-group[data-live-tool-call-group="1"],.tool-card-row[data-live-tid]:not(.transparent-event-row),.agent-activity-thinking[data-live-thinking="1"],.interim-collapse-toggle').forEach(el=>el.remove());
   blocks.querySelectorAll('[data-live-assistant="1"]').forEach(el=>{
@@ -12111,6 +12158,7 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
       // SAME callback reads the pre-release geometry and lands one frame early.
       // Restore on the following frame after released geometry is measurable.
       requestAnimationFrame(()=>{
+        if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
         if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
       });
     });
@@ -12140,6 +12188,7 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   if(!blocks) return false;
   const scrollSnapshot=_captureMessageScrollSnapshot();
   const scrollRebuildGuard=_prepareLiveAnchorScrollRebuildGuard(scrollSnapshot);
+  const scrollRebuildIdentity=(typeof _nextLiveAnchorScrollRebuildGuard==='function')?_nextLiveAnchorScrollRebuildGuard():null;
   const activeStreamId = String(streamId || S.activeStreamId || '');
   const activeSessionId = String(S.session && S.session.session_id || '');
   const preserveByKey = new Map();
@@ -12224,6 +12273,7 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
     requestAnimationFrame(()=>{
       scrollRebuildGuard.release();
       requestAnimationFrame(()=>{
+        if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
         if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
       });
     });
@@ -17126,12 +17176,14 @@ async function regenerateResponse(btn) {
 // it) in the same suppression so the browser layer cannot re-anchor during the
 // async settle window. Desktop rests at `none`, so this is a no-op there.
 function _postProcessWithAnchorSuppression(container){
+  const sessionSwitchPostProcess=_beginSessionSwitchLayoutPostProcess();
   const scroller=$('messages');
   const release=(scroller&&typeof _suppressBrowserOverflowAnchor==='function')
     ? _suppressBrowserOverflowAnchor(scroller) : null;
   try{
     postProcessRenderedMessages(container);
   }finally{
+    _endSessionSwitchLayoutPostProcess(sessionSwitchPostProcess);
     // Hold suppression across ONE more frame so late media/layout reflow
     // (image decode, katex/mermaid measure) cannot re-anchor either, then let
     // _suppressBrowserOverflowAnchor's own rAF-deferred restore run.

--- a/static/ui.js
+++ b/static/ui.js
@@ -5199,13 +5199,21 @@ function _endSessionSwitchLayoutPostProcess(marker){
   _sessionSwitchLayoutPostProcessPending=Math.max(0,_sessionSwitchLayoutPostProcessPending-1);
   if(_sessionSwitchLayoutPostProcessPending===0) _scheduleSessionSwitchLayoutQuietCheck(marker.token,marker.sid,marker.loadGeneration);
 }
-function _settleSessionSwitchLayoutStabilization(sid,loadGeneration){
+function _settleSessionSwitchLayoutStabilization(sid,loadGeneration,streaming){
   if(!_sessionSwitchLayoutStabilizationSid||String(sid||'')!==_sessionSwitchLayoutStabilizationSid||loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
   const el=$('messages');
   if(!el){ _endSessionSwitchLayoutStabilization(); return; }
   const token=_sessionSwitchLayoutStabilizationToken;
   _sessionSwitchLayoutSettleRequested=true;
-  if(typeof ResizeObserver==='function'){
+  // Skip the ResizeObserver arm when switching INTO an actively-streaming
+  // session. The live turn grows continuously there, so the observer would keep
+  // firing and the quiet-check would never reach zero-pending until the stream
+  // pauses — leaving content-visibility forced on every user row for the whole
+  // stream duration and temporarily disabling #5637's off-screen-skip win. The
+  // stream's own scroll handling already owns geometry during streaming, so a
+  // single quiet-check that still waits on any pending async post-processing is
+  // enough; stabilization settles promptly instead of trailing the stream.
+  if(!streaming&&typeof ResizeObserver==='function'){
     if(_sessionSwitchLayoutStabilizationObserver) _sessionSwitchLayoutStabilizationObserver.disconnect();
     const observed=document.getElementById('msgInner')||el;
     _sessionSwitchLayoutStabilizationObserver=new ResizeObserver(()=>{

--- a/static/ui.js
+++ b/static/ui.js
@@ -12161,6 +12161,13 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
+      // Guard the release itself: a newer rebuild (B) may have installed its own
+      // min-height guard before this older callback (A) runs. A's release()
+      // would restore the value A saved and tear down B's active guard, causing
+      // an intermediate height collapse and viewport movement. Only release when
+      // we still own the current guard; otherwise B owns it and will restore the
+      // true original via its own dataset-backed release.
+      if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
       scrollRebuildGuard.release();
       // Releasing the temporary min-height changes layout. Restoring in this
       // SAME callback reads the pre-release geometry and lands one frame early.
@@ -12279,6 +12286,13 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
+      // Guard the release itself: a newer rebuild may have installed its own
+      // min-height guard before this older callback runs. Releasing here would
+      // restore this callback's saved value and tear down the newer guard,
+      // collapsing height and moving the viewport. Only release when we still
+      // own the current guard; otherwise the newer rebuild restores the true
+      // original via its own dataset-backed release.
+      if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
       scrollRebuildGuard.release();
       requestAnimationFrame(()=>{
         if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;

--- a/static/ui.js
+++ b/static/ui.js
@@ -5135,8 +5135,12 @@ let _sessionSwitchLayoutStabilizationObserver=null;
 let _sessionSwitchLayoutPostProcessPending=0;
 let _sessionSwitchLayoutSettleRequested=false;
 let _liveAnchorScrollRebuildGeneration=0;
-function _endSessionSwitchLayoutStabilization(loadGeneration,token){
-  if(loadGeneration!==undefined&&loadGeneration!==null&&loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
+function _endSessionSwitchLayoutStabilization(loadGeneration,token,force){
+  // `force` lets the authoritative current load retire stabilization owned by
+  // an older load it superseded (e.g. a forced reload of the incoming session
+  // that skipped _begin because currentSid===sid). Stale continuations pass
+  // force=false and stay gated on generation so they can't clear newer state.
+  if(!force&&loadGeneration!==undefined&&loadGeneration!==null&&loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
   if(token!==undefined&&token!==_sessionSwitchLayoutStabilizationToken) return;
   clearTimeout(_sessionSwitchLayoutStabilizationTimer);
   _sessionSwitchLayoutStabilizationTimer=0;
@@ -17290,7 +17294,15 @@ function initTreeViews(container){
         // Note: if CDN load fails, s.onerror does NOT call back —
         // the wrap stays un-initialised (raw view only), which is safe.
         wrap.removeAttribute('data-tree-init');
-        _loadJsyamlThen(initTreeViews);
+        // Hold session-switch stabilization across the async js-yaml fetch +
+        // the deferred re-run that builds the tree view. Without this the quiet
+        // timer can expire before the tree DOM is inserted, so the later
+        // insertion could shift the transcript after the final correction.
+        const yamlMarker=_beginSessionSwitchLayoutPostProcess();
+        _loadJsyamlThen(()=>{
+          try{ initTreeViews(container); }
+          finally{ if(yamlMarker) _endSessionSwitchLayoutPostProcess(yamlMarker); }
+        });
         return;
       }
     }
@@ -17664,6 +17676,13 @@ function loadPdfInline(container){
     const mediaSessionId=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)?String(S.session.session_id):'';
     const publicMediaUrl='api/media?path='+encodeURIComponent(path);
     const mediaUrl=publicMediaUrl+(mediaSessionId?'&session_id='+encodeURIComponent(mediaSessionId):'');
+    // Hold session-switch stabilization until the PDF fetch + full page render
+    // finish (or the load times out / errors). PDF work spans fetch → parse →
+    // sequential per-page canvas render, easily exceeding the quiet window, so
+    // the marker must live until the last page settles, not launch.
+    const marker=_beginSessionSwitchLayoutPostProcess();
+    let markerReleased=false;
+    const releaseMarker=()=>{ if(marker&&!markerReleased){ markerReleased=true; _endSessionSwitchLayoutPostProcess(marker); } };
     const loadPdf=(pdfjsLib)=>{
       fetch(mediaUrl)
         .then(r=>{if(!r.ok) throw new Error(r.status); return r.arrayBuffer();})
@@ -17671,12 +17690,13 @@ function loadPdfInline(container){
           if(buf.byteLength>PDF_MAX_SIZE){
             const dlUrl=publicMediaUrl+'&download=1';
             el.outerHTML=`<div class="pdf-preview-fallback"><a class="msg-media-link" href="${dlUrl}" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('pdf_too_large')}</span></div>`;
+            releaseMarker();
             return;
           }
           return pdfjsLib.getDocument({data:buf, isEvalSupported:false}).promise;
         })
         .then(pdf=>{
-          if(!pdf) return;
+          if(!pdf) { releaseMarker(); return; }
           const dlUrl=publicMediaUrl+'&download=1';
           const total=pdf.numPages;
           const pagesLabel=total>1?` · ${total} pages`:'';
@@ -17699,7 +17719,7 @@ function loadPdfInline(container){
           // page can't silently halt the preview or surface an unhandled
           // promise rejection (renderPage runs outside the outer .catch chain).
           const renderPage=(i)=>{
-            if(i>n) return;
+            if(i>n) { releaseMarker(); return; }
             pdf.getPage(i).then(page=>{
               const canvas=document.createElement('canvas');
               const scale=1.5;
@@ -17718,6 +17738,7 @@ function loadPdfInline(container){
         .catch(()=>{
           const dlUrl=publicMediaUrl+'&download=1';
           el.outerHTML=`<div class="pdf-preview-fallback"><a class="msg-media-link" href="${dlUrl}" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('pdf_error')}</span></div>`;
+          releaseMarker();
         });
     };
     if(_pdfjsReady){
@@ -17740,6 +17761,7 @@ function loadPdfInline(container){
           if(el.parentNode){
             el.outerHTML=`<div class="pdf-preview-fallback"><a class="msg-media-link" href="${dlUrl}" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('pdf_error')}</span></div>`;
           }
+          releaseMarker();
         }
       },15000);
     } else {

--- a/static/ui.js
+++ b/static/ui.js
@@ -5135,6 +5135,10 @@ let _sessionSwitchLayoutStabilizationObserver=null;
 let _sessionSwitchLayoutPostProcessPending=0;
 let _sessionSwitchLayoutSettleRequested=false;
 let _liveAnchorScrollRebuildGeneration=0;
+// Cleanup ownership for the live-anchor min-height guard, tracked separately
+// from the render/session generation so a no-guard rebuild can't strand
+// min-height set (see _prepareLiveAnchorScrollRebuildGuard).
+let _liveAnchorMinHeightGuardOwner=0;
 function _endSessionSwitchLayoutStabilization(loadGeneration,token,force){
   // `force` lets the authoritative current load retire stabilization owned by
   // an older load it superseded (e.g. a forced reload of the incoming session
@@ -12094,9 +12098,26 @@ function _prepareLiveAnchorScrollRebuildGuard(scrollSnapshot){
   }
   const guardHeight=Math.max(messagesEl.scrollHeight,Number(scrollSnapshot.scrollHeight)||0);
   if(guardHeight>0) msgInner.style.minHeight=`${guardHeight}px`;
+  // Min-height cleanup ownership is tracked SEPARATELY from the render/session
+  // generation. Every rebuild advances the render generation (used to guard the
+  // stale-snapshot restore), but only a rebuild that actually installs a
+  // min-height guard takes cleanup ownership. This lets the release closure
+  // decide correctly in both overlap cases:
+  //   - A newer rebuild that installs its OWN guard bumps the owner, so the
+  //     older release no-ops (the newer one will restore the true original) —
+  //     no torn-down active guard.
+  //   - A newer rebuild that installs NO guard (reader re-pinned / session
+  //     switch) leaves the owner untouched, so THIS release still runs and
+  //     min-height can never be stranded set (the no-successor leak).
+  const guardOwnerToken=++_liveAnchorMinHeightGuardOwner;
+  let released=false;
   return {
     readerAwayFromBottom:true,
     release:()=>{
+      // Only the current cleanup owner may restore. If a newer guard superseded
+      // us, it owns min-height now and will release its own value.
+      if(released||guardOwnerToken!==_liveAnchorMinHeightGuardOwner) return;
+      released=true;
       msgInner.style.minHeight=previousMinHeight;
       if(msgInner.dataset&&msgInner.dataset[guardPreviousKey]===previousMinHeight){
         delete msgInner.dataset[guardPreviousKey];
@@ -12169,13 +12190,12 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
-      // Guard the release itself: a newer rebuild (B) may have installed its own
-      // min-height guard before this older callback (A) runs. A's release()
-      // would restore the value A saved and tear down B's active guard, causing
-      // an intermediate height collapse and viewport movement. Only release when
-      // we still own the current guard; otherwise B owns it and will restore the
-      // true original via its own dataset-backed release.
-      if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
+      // release() is self-owning: it restores min-height only if THIS guard is
+      // still the cleanup owner (a newer guard-installing rebuild bumps the
+      // owner and releases its own value; a newer no-guard rebuild leaves us the
+      // owner so we still release). So call it unconditionally here — gating it
+      // on the render generation would strand min-height set when a no-guard
+      // successor advanced the generation without taking cleanup ownership.
       scrollRebuildGuard.release();
       // Releasing the temporary min-height changes layout. Restoring in this
       // SAME callback reads the pre-release geometry and lands one frame early.
@@ -12294,13 +12314,11 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
-      // Guard the release itself: a newer rebuild may have installed its own
-      // min-height guard before this older callback runs. Releasing here would
-      // restore this callback's saved value and tear down the newer guard,
-      // collapsing height and moving the viewport. Only release when we still
-      // own the current guard; otherwise the newer rebuild restores the true
-      // original via its own dataset-backed release.
-      if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
+      // release() is self-owning (see renderLiveAnchorActivityScene): it restores
+      // min-height only when THIS guard is still the cleanup owner, so call it
+      // unconditionally. Gating on the render generation would strand min-height
+      // set when a no-guard successor advanced the generation without taking
+      // cleanup ownership.
       scrollRebuildGuard.release();
       requestAnimationFrame(()=>{
         if(scrollRebuildIdentity&&typeof _liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)) return;
@@ -17765,29 +17783,38 @@ function loadPdfInline(container){
     };
     if(_pdfjsReady){
       loadPdf(window._pdfjsLib);
-    } else if(!_pdfjsLoading){
-      _pdfjsLoading=true;
-      const _pdfSrc='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.min.mjs';
-      const _pdfWorker='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.worker.min.mjs';
-      const _pdfBlob=new Blob([`import*as p from'${_pdfSrc}';p.GlobalWorkerOptions.workerSrc='${_pdfWorker}';window._pdfjsLib=p;window._pdfjsReady=true;window.dispatchEvent(new Event('pdfjs-ready'));`],{type:'application/javascript'});
-      const s=document.createElement('script');
-      s.type='module';
-      const _pdfBlobUrl=URL.createObjectURL(_pdfBlob);
-      s.src=_pdfBlobUrl;
-      s.onload=()=>URL.revokeObjectURL(_pdfBlobUrl);
-      document.head.appendChild(s);
-      window.addEventListener('pdfjs-ready',()=>{ _pdfjsReady=true; loadPdf(window._pdfjsLib); },{once:true});
-      setTimeout(()=>{
-        if(!_pdfjsReady){
-          const dlUrl=publicMediaUrl+'&download=1';
-          if(el.parentNode){
-            el.outerHTML=`<div class="pdf-preview-fallback"><a class="msg-media-link" href="${dlUrl}" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('pdf_error')}</span></div>`;
-          }
-          releaseMarker();
-        }
-      },15000);
     } else {
-      window.addEventListener('pdfjs-ready',()=>{ loadPdf(window._pdfjsLib); },{once:true});
+      // pdfjs is loaded once and shared across every PDF in the render. Kick off
+      // the loader on the first PDF that needs it, but give EVERY waiting PDF —
+      // not just the loader owner — its own pdfjs-ready listener AND its own
+      // bounded timeout that releases THIS el's stabilization marker. Otherwise
+      // a shared loader failure (CDN blocked) fires the owner's timeout only,
+      // stranding every other waiter's marker so stabilization never settles.
+      if(!_pdfjsLoading){
+        _pdfjsLoading=true;
+        const _pdfSrc='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.min.mjs';
+        const _pdfWorker='https://cdn.jsdelivr.net/npm/pdfjs-dist@4.9.155/build/pdf.worker.min.mjs';
+        const _pdfBlob=new Blob([`import*as p from'${_pdfSrc}';p.GlobalWorkerOptions.workerSrc='${_pdfWorker}';window._pdfjsLib=p;window._pdfjsReady=true;window.dispatchEvent(new Event('pdfjs-ready'));`],{type:'application/javascript'});
+        const s=document.createElement('script');
+        s.type='module';
+        const _pdfBlobUrl=URL.createObjectURL(_pdfBlob);
+        s.src=_pdfBlobUrl;
+        s.onload=()=>URL.revokeObjectURL(_pdfBlobUrl);
+        s.onerror=()=>{ _pdfjsLoading=false; };
+        document.head.appendChild(s);
+      }
+      window.addEventListener('pdfjs-ready',()=>{ _pdfjsReady=true; loadPdf(window._pdfjsLib); },{once:true});
+      // Per-el bounded cleanup: if pdfjs is still not ready after the cap, render
+      // this el's fallback (once) and release this el's marker so a stalled or
+      // failed shared loader can't leave stabilization pending indefinitely.
+      setTimeout(()=>{
+        if(_pdfjsReady||_pdfMkDone) return;
+        const dlUrl=publicMediaUrl+'&download=1';
+        if(el.parentNode){
+          el.outerHTML=`<div class="pdf-preview-fallback"><a class="msg-media-link" href="${dlUrl}" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('pdf_error')}</span></div>`;
+        }
+        releaseMarker();
+      },15000);
     }
   });
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -5128,13 +5128,15 @@ let _nearBottomCount=0;
 let _lastScrollTop=null;
 let _lastMessageClientHeight=null;   // #4702: track scroller height to ignore iOS portrait toolbar-settle reflows (a clientHeight increase fires a scroll event with decreased scrollTop that is NOT a user scroll)
 let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutLoadGeneration=null;
 let _sessionSwitchLayoutStabilizationToken=0;
 let _sessionSwitchLayoutStabilizationTimer=0;
 let _sessionSwitchLayoutStabilizationObserver=null;
 let _sessionSwitchLayoutPostProcessPending=0;
 let _sessionSwitchLayoutSettleRequested=false;
 let _liveAnchorScrollRebuildGeneration=0;
-function _endSessionSwitchLayoutStabilization(token){
+function _endSessionSwitchLayoutStabilization(loadGeneration,token){
+  if(loadGeneration!==undefined&&loadGeneration!==null&&loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
   if(token!==undefined&&token!==_sessionSwitchLayoutStabilizationToken) return;
   clearTimeout(_sessionSwitchLayoutStabilizationTimer);
   _sessionSwitchLayoutStabilizationTimer=0;
@@ -5145,10 +5147,11 @@ function _endSessionSwitchLayoutStabilization(token){
   _sessionSwitchLayoutPostProcessPending=0;
   _sessionSwitchLayoutSettleRequested=false;
   _sessionSwitchLayoutStabilizationSid='';
+  _sessionSwitchLayoutLoadGeneration=null;
   const el=$('messages');
   if(el&&el.classList) el.classList.remove('session-switch-layout-stabilizing');
 }
-function _beginSessionSwitchLayoutStabilization(sid){
+function _beginSessionSwitchLayoutStabilization(sid,loadGeneration){
   _endSessionSwitchLayoutStabilization();
   ++_sessionSwitchLayoutStabilizationToken;
   _bottomSettleToken++;
@@ -5158,41 +5161,42 @@ function _beginSessionSwitchLayoutStabilization(sid){
   cancelAnimationFrame(_settleRAF);
   _programmaticScroll=false;
   _sessionSwitchLayoutStabilizationSid=String(sid||'');
+  _sessionSwitchLayoutLoadGeneration=(loadGeneration===undefined?null:loadGeneration);
   _sessionSwitchLayoutPostProcessPending=0;
   _sessionSwitchLayoutSettleRequested=false;
   const el=$('messages');
   if(el&&el.classList) el.classList.add('session-switch-layout-stabilizing');
 }
-function _finishSessionSwitchLayoutStabilization(token,sid){
-  if(token!==_sessionSwitchLayoutStabilizationToken||String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
-  _endSessionSwitchLayoutStabilization(token);
+function _finishSessionSwitchLayoutStabilization(token,sid,loadGeneration){
+  if(token!==_sessionSwitchLayoutStabilizationToken||String(sid||'')!==_sessionSwitchLayoutStabilizationSid||loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
+  _endSessionSwitchLayoutStabilization(loadGeneration,token);
   requestAnimationFrame(()=>{
     if(token!==_sessionSwitchLayoutStabilizationToken) return;
     if(!_messageUserUnpinned&&_scrollPinned&&typeof scrollToBottom==='function') scrollToBottom();
   });
 }
-function _scheduleSessionSwitchLayoutQuietCheck(token,sid){
+function _scheduleSessionSwitchLayoutQuietCheck(token,sid,loadGeneration){
   clearTimeout(_sessionSwitchLayoutStabilizationTimer);
   _sessionSwitchLayoutStabilizationTimer=setTimeout(()=>{
     if(token!==_sessionSwitchLayoutStabilizationToken||!_sessionSwitchLayoutSettleRequested) return;
     if(_sessionSwitchLayoutPostProcessPending>0) return;
-    _finishSessionSwitchLayoutStabilization(token,sid);
+    _finishSessionSwitchLayoutStabilization(token,sid,loadGeneration);
   },300);
 }
 function _beginSessionSwitchLayoutPostProcess(){
   if(!_sessionSwitchLayoutSettleRequested||!_sessionSwitchLayoutStabilizationSid) return null;
-  const marker={token:_sessionSwitchLayoutStabilizationToken,sid:_sessionSwitchLayoutStabilizationSid};
+  const marker={token:_sessionSwitchLayoutStabilizationToken,sid:_sessionSwitchLayoutStabilizationSid,loadGeneration:_sessionSwitchLayoutLoadGeneration};
   _sessionSwitchLayoutPostProcessPending++;
   clearTimeout(_sessionSwitchLayoutStabilizationTimer);
   return marker;
 }
 function _endSessionSwitchLayoutPostProcess(marker){
-  if(!marker||marker.token!==_sessionSwitchLayoutStabilizationToken||marker.sid!==_sessionSwitchLayoutStabilizationSid) return;
+  if(!marker||marker.token!==_sessionSwitchLayoutStabilizationToken||marker.sid!==_sessionSwitchLayoutStabilizationSid||marker.loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
   _sessionSwitchLayoutPostProcessPending=Math.max(0,_sessionSwitchLayoutPostProcessPending-1);
-  if(_sessionSwitchLayoutPostProcessPending===0) _scheduleSessionSwitchLayoutQuietCheck(marker.token,marker.sid);
+  if(_sessionSwitchLayoutPostProcessPending===0) _scheduleSessionSwitchLayoutQuietCheck(marker.token,marker.sid,marker.loadGeneration);
 }
-function _settleSessionSwitchLayoutStabilization(sid){
-  if(!_sessionSwitchLayoutStabilizationSid||String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
+function _settleSessionSwitchLayoutStabilization(sid,loadGeneration){
+  if(!_sessionSwitchLayoutStabilizationSid||String(sid||'')!==_sessionSwitchLayoutStabilizationSid||loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;
   const el=$('messages');
   if(!el){ _endSessionSwitchLayoutStabilization(); return; }
   const token=_sessionSwitchLayoutStabilizationToken;
@@ -5202,11 +5206,11 @@ function _settleSessionSwitchLayoutStabilization(sid){
     const observed=document.getElementById('msgInner')||el;
     _sessionSwitchLayoutStabilizationObserver=new ResizeObserver(()=>{
       if(token!==_sessionSwitchLayoutStabilizationToken) return;
-      _scheduleSessionSwitchLayoutQuietCheck(token,sid);
+      _scheduleSessionSwitchLayoutQuietCheck(token,sid,loadGeneration);
     });
     _sessionSwitchLayoutStabilizationObserver.observe(observed);
   }
-  _scheduleSessionSwitchLayoutQuietCheck(token,sid);
+  _scheduleSessionSwitchLayoutQuietCheck(token,sid,loadGeneration);
 }
 if(typeof window!=='undefined'){
   window._beginSessionSwitchLayoutStabilization=_beginSessionSwitchLayoutStabilization;
@@ -17433,7 +17437,8 @@ function loadDiffInline(container){
   root.querySelectorAll('.diff-inline-load:not([data-loaded])').forEach(el=>{
     el.setAttribute('data-loaded','1');
     const path=el.dataset.path;
-    fetch('api/media?path='+encodeURIComponent(path))
+    const marker=_beginSessionSwitchLayoutPostProcess();
+    const task=fetch('api/media?path='+encodeURIComponent(path))
       .then(r=>{if(!r.ok) throw new Error(r.status);return r.text();})
       .then(text=>{
         if(text.length>DIFF_MAX_SIZE){
@@ -17452,6 +17457,7 @@ function loadDiffInline(container){
       .catch(()=>{
         el.outerHTML=`<div class="diff-inline-error">${esc(path.split('/').pop())}<br><span style="color:var(--muted);font-size:12px">${t('diff_error')}</span></div>`;
       });
+    if(marker) task.finally(()=>_endSessionSwitchLayoutPostProcess(marker));
   });
 }
 
@@ -17505,7 +17511,8 @@ function loadCsvInline(container){
     const path=el.dataset.path;
     const mediaUrl=_csvMediaUrl(path);
     const downloadUrl=_csvMediaUrl(path,{download:true});
-    fetch(mediaUrl)
+    const marker=_beginSessionSwitchLayoutPostProcess();
+    const task=fetch(mediaUrl)
       .then(r=>{if(!r.ok) throw new Error(r.status);return r.text();})
       .then(text=>{
         const preview=buildCsvTablePreview(path, text, downloadUrl);
@@ -17514,6 +17521,7 @@ function loadCsvInline(container){
       .catch(()=>{
         el.outerHTML=_csvPreviewErrorHtml(path, 'csv_error');
       });
+    if(marker) task.finally(()=>_endSessionSwitchLayoutPostProcess(marker));
   });
 }
 
@@ -17523,7 +17531,8 @@ function loadExcalidrawInline(container){
   root.querySelectorAll('.excalidraw-inline-load:not([data-loaded])').forEach(el=>{
     el.setAttribute('data-loaded','1');
     const path=el.dataset.path;
-    fetch('api/media?path='+encodeURIComponent(path))
+    const marker=_beginSessionSwitchLayoutPostProcess();
+    const task=fetch('api/media?path='+encodeURIComponent(path))
       .then(r=>{if(!r.ok) throw new Error(r.status);return r.text();})
       .then(text=>{
         if(text.length>EXCALIDRAW_MAX_SIZE){
@@ -17555,6 +17564,7 @@ function loadExcalidrawInline(container){
       .catch(()=>{
         el.outerHTML=`<div class="diff-inline-error">${esc(path.split('/').pop())}<br><span style="color:var(--muted);font-size:12px">${t('excalidraw_error')}</span></div>`;
       });
+    if(marker) task.finally(()=>_endSessionSwitchLayoutPostProcess(marker));
   });
 }
 
@@ -17749,7 +17759,8 @@ function loadHtmlInline(container){
     const mediaSessionId=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)?String(S.session.session_id):'';
     const publicMediaUrl='api/media?path='+encodeURIComponent(path);
     const mediaUrl=publicMediaUrl+(mediaSessionId?'&session_id='+encodeURIComponent(mediaSessionId):'');
-    fetch(mediaUrl)
+    const marker=_beginSessionSwitchLayoutPostProcess();
+    const task=fetch(mediaUrl)
       .then(r=>{if(!r.ok) throw new Error(r.status); return r.text();})
       .then(html=>{
         if(html.length>HTML_MAX_SIZE){
@@ -17765,6 +17776,7 @@ function loadHtmlInline(container){
         const dlUrl=publicMediaUrl+'&download=1';
         el.outerHTML=`<div class="html-preview-fallback"><a class="msg-media-link" href="${dlUrl}" download="${esc(fname)}">📎 ${esc(fname)}</a><br><span style="color:var(--muted);font-size:12px">${t('html_error')}</span></div>`;
       });
+    if(marker) task.finally(()=>_endSessionSwitchLayoutPostProcess(marker));
   });
 }
 
@@ -17794,7 +17806,8 @@ function renderMermaidBlocks(container){
     }
     return;
   }
-  blocks.forEach(async(block)=>{
+  const marker=_beginSessionSwitchLayoutPostProcess();
+  const tasks=Array.from(blocks).map(async(block)=>{
     block.dataset.rendered='true';
     const code=block.textContent;
     const id=block.dataset.mermaidId||('m-'+Math.random().toString(36).slice(2));
@@ -17816,6 +17829,7 @@ function renderMermaidBlocks(container){
       block.innerHTML=`<div class="pre-header">mermaid</div><pre><code>${esc(code)}</code></pre>`;
     }
   });
+  if(marker) Promise.allSettled(tasks).finally(()=>_endSessionSwitchLayoutPostProcess(marker));
 }
 
 let _katexLoading=false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -5127,6 +5127,53 @@ function _deferClearProgrammaticScroll(ms){clearTimeout(_programmaticScrollReset
 let _nearBottomCount=0;
 let _lastScrollTop=null;
 let _lastMessageClientHeight=null;   // #4702: track scroller height to ignore iOS portrait toolbar-settle reflows (a clientHeight increase fires a scroll event with decreased scrollTop that is NOT a user scroll)
+let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutStabilizationTimer=0;
+function _endSessionSwitchLayoutStabilization(){
+  clearTimeout(_sessionSwitchLayoutStabilizationTimer);
+  _sessionSwitchLayoutStabilizationTimer=0;
+  _sessionSwitchLayoutStabilizationSid='';
+  const el=$('messages');
+  if(el&&el.classList) el.classList.remove('session-switch-layout-stabilizing');
+}
+function _beginSessionSwitchLayoutStabilization(sid){
+  _endSessionSwitchLayoutStabilization();
+  _bottomSettleToken++;
+  if(_settleRO){ _settleRO.disconnect(); _settleRO=null; }
+  clearTimeout(_settleTimer);
+  clearTimeout(_settleFinalTimer);
+  cancelAnimationFrame(_settleRAF);
+  _programmaticScroll=false;
+  _sessionSwitchLayoutStabilizationSid=String(sid||'');
+  const el=$('messages');
+  if(el&&el.classList) el.classList.add('session-switch-layout-stabilizing');
+  // Failure/stale-load fallback. The loading placeholder has no user rows, so
+  // keeping this class while a slow metadata/message fetch is in flight is cheap.
+  // The normal render path replaces this long fallback with a short settle timer.
+  _sessionSwitchLayoutStabilizationTimer=setTimeout(_endSessionSwitchLayoutStabilization,15000);
+}
+function _settleSessionSwitchLayoutStabilization(sid){
+  if(!_sessionSwitchLayoutStabilizationSid||String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
+  const el=$('messages');
+  if(!el){ _endSessionSwitchLayoutStabilization(); return; }
+  clearTimeout(_sessionSwitchLayoutStabilizationTimer);
+  // The incoming rows, post-processing, and content-visibility intrinsic sizes can
+  // keep changing for hundreds of milliseconds after renderMessages returns. Hold
+  // real row layout through that window, then expose content-visibility once and
+  // re-anchor against the final geometry. Two rAFs were empirically too short.
+  _sessionSwitchLayoutStabilizationTimer=setTimeout(()=>{
+    if(String(sid||'')!==_sessionSwitchLayoutStabilizationSid) return;
+    _endSessionSwitchLayoutStabilization();
+    requestAnimationFrame(()=>{
+      if(!_messageUserUnpinned&&_scrollPinned&&typeof scrollToBottom==='function') scrollToBottom();
+    });
+  },1200);
+}
+if(typeof window!=='undefined'){
+  window._beginSessionSwitchLayoutStabilization=_beginSessionSwitchLayoutStabilization;
+  window._settleSessionSwitchLayoutStabilization=_settleSessionSwitchLayoutStabilization;
+}
+
 // Sticky-unpin model (#3343 supersedes #3330's proximity re-pin): once the user
 // scrolls up, streaming stops auto-following until they return to the bottom or
 // click ↓. The upward-intent TIMEOUT mechanism (_lastMessageUpwardIntentMs /
@@ -12060,10 +12107,12 @@ function renderLiveAnchorActivityScene(streamId, scene, opts){
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
       scrollRebuildGuard.release();
-      // Only re-restore the unpinned snapshot if the reader is STILL unpinned at
-      // rAF time. If they re-pinned between guard-engage and this frame, the
-      // stale re-restore would yank them back off the bottom (Opus gate finding).
-      if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+      // Releasing the temporary min-height changes layout. Restoring in this
+      // SAME callback reads the pre-release geometry and lands one frame early.
+      // Restore on the following frame after released geometry is measurable.
+      requestAnimationFrame(()=>{
+        if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+      });
     });
   }
   if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();
@@ -12174,7 +12223,9 @@ function _renderLiveAnchorActivitySceneTransparent(streamId, scene, opts){
   if(scrollRebuildGuard&&scrollRebuildGuard.release){
     requestAnimationFrame(()=>{
       scrollRebuildGuard.release();
-      if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+      requestAnimationFrame(()=>{
+        if(_messageUserUnpinned) _restoreMessageScrollSnapshotSameFrame(scrollSnapshot);
+      });
     });
   }
   if(!scrollRebuildGuard.readerAwayFromBottom&&typeof scrollIfPinned==='function') scrollIfPinned();

--- a/static/ui.js
+++ b/static/ui.js
@@ -17233,18 +17233,23 @@ function highlightCode(container) {
   }
 }
 
-// Lazy load js-yaml for YAML tree view support
+// Lazy load js-yaml for YAML tree view support.
+// onSettle (optional) fires exactly once when this call reaches a terminal
+// state — after cb on success, OR on CDN/script failure — so callers holding a
+// resource (e.g. a session-switch stabilization marker) can always release it,
+// even when the loader never invokes cb because the script failed to load.
 let _jsyamlLoading=false;
-function _loadJsyamlThen(cb){
-  if(typeof jsyaml!=='undefined'){ cb(); return; }
-  if(_jsyamlLoading){ setTimeout(()=>_loadJsyamlThen(cb),100); return; }
+function _loadJsyamlThen(cb,onSettle){
+  const settle=(typeof onSettle==='function')?onSettle:null;
+  if(typeof jsyaml!=='undefined'){ try{ cb(); } finally{ if(settle) settle(); } return; }
+  if(_jsyamlLoading){ setTimeout(()=>_loadJsyamlThen(cb,onSettle),100); return; }
   _jsyamlLoading=true;
   const s=document.createElement('script');
   s.src='static/vendor/js-yaml/4.1.0/js-yaml.min.js';
   s.integrity='sha384-+pxiN6T7yvpryuJmE1gM9PX7yQit15auDb+ZwwvJOd/4be2Cie5/IuVXgQb/S9du';
   s.crossOrigin='anonymous';
-  s.onload=()=>{ _jsyamlLoading=false; cb(); };
-  s.onerror=()=>{ _jsyamlLoading=false; }; // CDN blocked, fall back to raw
+  s.onload=()=>{ _jsyamlLoading=false; try{ cb(); } finally{ if(settle) settle(); } };
+  s.onerror=()=>{ _jsyamlLoading=false; if(settle) settle(); }; // CDN blocked, fall back to raw
   document.head.appendChild(s);
 }
 
@@ -17291,18 +17296,16 @@ function initTreeViews(container){
         try{ parsed=jsyaml.load(rawText); }catch(e){ parseFailed=true; }
       }else{
         // Defer: remove init marker so we retry after load.
-        // Note: if CDN load fails, s.onerror does NOT call back —
-        // the wrap stays un-initialised (raw view only), which is safe.
         wrap.removeAttribute('data-tree-init');
         // Hold session-switch stabilization across the async js-yaml fetch +
-        // the deferred re-run that builds the tree view. Without this the quiet
-        // timer can expire before the tree DOM is inserted, so the later
-        // insertion could shift the transcript after the final correction.
+        // the deferred re-run that builds the tree view. Release the marker on
+        // settle (success OR CDN failure) so a blocked load can't leave the
+        // pending count above zero and wedge the quiet check permanently.
         const yamlMarker=_beginSessionSwitchLayoutPostProcess();
-        _loadJsyamlThen(()=>{
-          try{ initTreeViews(container); }
-          finally{ if(yamlMarker) _endSessionSwitchLayoutPostProcess(yamlMarker); }
-        });
+        _loadJsyamlThen(
+          ()=>initTreeViews(container),
+          ()=>{ if(yamlMarker) _endSessionSwitchLayoutPostProcess(yamlMarker); }
+        );
         return;
       }
     }
@@ -17676,13 +17679,10 @@ function loadPdfInline(container){
     const mediaSessionId=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)?String(S.session.session_id):'';
     const publicMediaUrl='api/media?path='+encodeURIComponent(path);
     const mediaUrl=publicMediaUrl+(mediaSessionId?'&session_id='+encodeURIComponent(mediaSessionId):'');
-    // Hold session-switch stabilization until the PDF fetch + full page render
-    // finish (or the load times out / errors). PDF work spans fetch → parse →
-    // sequential per-page canvas render, easily exceeding the quiet window, so
-    // the marker must live until the last page settles, not launch.
-    const marker=_beginSessionSwitchLayoutPostProcess();
-    let markerReleased=false;
-    const releaseMarker=()=>{ if(marker&&!markerReleased){ markerReleased=true; _endSessionSwitchLayoutPostProcess(marker); } };
+    // Hold session-switch stabilization until the async PDF fetch + full page
+    // render settle (or time out / error); released once at every exit below.
+    const _pdfMk=_beginSessionSwitchLayoutPostProcess(); let _pdfMkDone=false;
+    const releaseMarker=()=>{ if(_pdfMk&&!_pdfMkDone){ _pdfMkDone=true; _endSessionSwitchLayoutPostProcess(_pdfMk); } };
     const loadPdf=(pdfjsLib)=>{
       fetch(mediaUrl)
         .then(r=>{if(!r.ok) throw new Error(r.status); return r.arrayBuffer();})

--- a/tests/test_issue3993_session_load_self_heal.py
+++ b/tests/test_issue3993_session_load_self_heal.py
@@ -96,6 +96,8 @@ def test_stale_load_guard_present_before_self_heal():
     # And before the 404 inline clear too.
     assert block.index(guard) < block.index("localStorage.removeItem('hermes-webui-session')"), \
         "stale-load guard must precede the 404 inline self-heal"
-    # It re-arms the active stream rather than leaving it torn down.
-    guard_tail = block[block.index(guard): block.index(guard) + 120]
+    # It re-arms the active stream rather than leaving it torn down. (The guard
+    # body may also release session-switch layout stabilization before re-arming,
+    # so allow a wider tail than the bare re-arm call.)
+    guard_tail = block[block.index(guard): block.index(guard) + 320]
     assert "_rearmActiveSessionStream()" in guard_tail

--- a/tests/test_issue4295_midstream_scroll_anchor.py
+++ b/tests/test_issue4295_midstream_scroll_anchor.py
@@ -122,6 +122,7 @@ const messages = {{
   clientHeight: 600,
 }};
 const inner = {{ style: {{ minHeight: '' }}, dataset: {{}} }};
+let _liveAnchorMinHeightGuardOwner = 0;
 function $(id) {{
   if (id === 'messages') return messages;
   if (id === 'msgInner') return inner;
@@ -157,8 +158,13 @@ const nestedGuard = _prepareLiveAnchorScrollRebuildGuard(nestedSnapshot);
 assert.strictEqual(nestedGuard.readerAwayFromBottom, true);
 assert.strictEqual(inner.style.minHeight, '5200px');
 assert.strictEqual(inner.dataset.liveAnchorScrollGuardPreviousMinHeight, '');
+// Ownership model: the nested (newer) guard took cleanup ownership, so the
+// older guard's release must NO-OP — it can no longer tear down the newer
+// guard's min-height (the frozen-layout leak class). Height stays pinned at the
+// newer guard's value until the OWNER releases.
 guard.release();
-assert.strictEqual(inner.style.minHeight, '');
+assert.strictEqual(inner.style.minHeight, '5200px');
+// The current owner's release restores the original and clears the dataset.
 nestedGuard.release();
 assert.strictEqual(inner.style.minHeight, '');
 assert.strictEqual(Object.prototype.hasOwnProperty.call(inner.dataset, 'liveAnchorScrollGuardPreviousMinHeight'), false);

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -128,7 +128,7 @@ class TestLoadPdfInlineFunction:
     def test_fallback_on_error(self):
         ui = _read_js('ui.js')
         idx = ui.find('function loadPdfInline')
-        body = ui[idx:idx + 4000]  # was 3000 — loadPdfInline grew with the per-page render loop + truncation notice
+        body = ui[idx:idx + 4200]  # grows with loadPdfInline: per-page render loop, truncation notice, and the session-switch stabilization pending marker
         assert 'pdf_error' in body, 'Must show error fallback on failure'
         assert 'pdf_download' in body or 'download=' in body, 'Error fallback must include download link'
 
@@ -204,7 +204,7 @@ class TestLoadHtmlInlineFunction:
     def test_pdf_fetch_url_includes_session_id_for_session_media_artifacts(self):
         ui = _read_js('ui.js')
         idx = ui.find('function loadPdfInline')
-        body = ui[idx:idx + 1200]
+        body = ui[idx:idx + 1400]  # window grows with the session-switch stabilization pending marker at the top of loadPdfInline
         assert 'const mediaSessionId=' in body
         assert "'&session_id='+encodeURIComponent(mediaSessionId)" in body
         assert 'fetch(mediaUrl)' in body

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -189,6 +189,78 @@ def test_same_session_force_reload_force_retires_prior_stabilization():
     assert "window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, true);" in load
 
 
+def test_every_post_begin_stale_return_retires_its_own_generation():
+    """After _begin arms the class, every reachable stale return in the INFLIGHT
+    and idle branches must retire the generation it armed (generation-gated,
+    non-forced) — otherwise an abandoned load that exits before a successor opens
+    its own stabilization leaves the class armed with no settle/watchdog owner.
+    A shared per-load helper (_retireOwnStabilization) does the gated retire.
+    """
+    load = _function_body(SESSIONS_JS, "loadSession")
+    # The helper is generation-gated and non-forced.
+    assert "const _retireOwnStabilization = () => {" in load
+    assert "window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, false);" in load
+    # Restrict to the post-begin region (after the _begin call) and require the
+    # retire on every stale return there. The 5 flagged exits: INFLIGHT reject,
+    # INFLIGHT success, reconnect pre-attach guard, idle reject, idle success.
+    post_begin = load[load.index("window._beginSessionSwitchLayoutStabilization(sid, _loadGeneration);"):]
+    assert post_begin.count("_retireOwnStabilization();") == 5, \
+        "all 5 post-begin stale returns must retire their own generation"
+    # Each retire must sit on a stale-load exit (immediately paired with a bail).
+    assert "_retireOwnStabilization();\n        _rearmActiveSessionStream();" in post_begin
+    assert "if (!_isCurrentLoad()) { _retireOwnStabilization(); return; }" in post_begin
+
+
+def test_stale_generation_cannot_clear_newer_armed_generation():
+    """Behavioral: the generation-gated retire an abandoned load performs must
+    NOT clear a newer owner's armed stabilization, but MUST clear its own when it
+    is still the live owner. Drives the real _begin/_end helpers.
+    """
+    fns = "\n".join(_function_body(UI_JS, n) for n in (
+        "_endSessionSwitchLayoutStabilization",
+        "_beginSessionSwitchLayoutStabilization",
+    ))
+    script = f"""
+const assert=require('assert');
+let _classes=new Set();
+const el={{classList:{{add:c=>_classes.add(c),remove:c=>_classes.delete(c),contains:c=>_classes.has(c)}}}};
+function $(id){{return id==='messages'?el:null;}}
+const document={{getElementById:()=>null}};
+global.setTimeout=()=>0; global.clearTimeout=()=>{{}};
+global.requestAnimationFrame=()=>0; global.cancelAnimationFrame=()=>{{}};
+let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutLoadGeneration=null;
+let _sessionSwitchLayoutStabilizationToken=0;
+let _sessionSwitchLayoutStabilizationTimer=0;
+let _sessionSwitchLayoutStabilizationObserver=null;
+let _sessionSwitchLayoutWatchdogTimer=0;
+let _sessionSwitchLayoutPostProcessPending=0;
+let _sessionSwitchLayoutSettleRequested=false;
+let _bottomSettleToken=0,_settleRO=null,_settleTimer=0,_settleFinalTimer=0,_settleRAF=0,_programmaticScroll=false;
+{fns}
+// Simulate the per-load gated retire (non-forced, own generation).
+function retire(gen){{ _endSessionSwitchLayoutStabilization(gen, undefined, false); }}
+
+// Case 1: abandoned owner with NO successor -> its own retire clears the class.
+_beginSessionSwitchLayoutStabilization('A', 1);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true);
+retire(1); // load gen 1 exits stale, no newer begin happened
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), false, 'abandoned owner retires itself');
+assert.strictEqual(_sessionSwitchLayoutLoadGeneration, null);
+
+// Case 2: a newer owner armed; an OLDER stale generation must NOT clear it.
+_beginSessionSwitchLayoutStabilization('B', 2);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true);
+retire(1); // stale gen 1 tries to retire after gen 2 became the owner
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true, 'stale gen cannot clear newer owner');
+assert.strictEqual(_sessionSwitchLayoutLoadGeneration, 2);
+// The true owner can still retire.
+retire(2);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), false, 'current owner retires');
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
 def test_authoritative_same_sid_load_force_retires_armed_stabilization():
     """Rapid A→B→A→B: a same-SID non-force load re-selecting the already-open
     session (the early-return no-op) is still the authoritative current load. If
@@ -282,6 +354,72 @@ assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true, 'sti
 advance(15000);
 assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), false, 'watchdog force-retired the stuck stabilization');
 assert.strictEqual(_sessionSwitchLayoutStabilizationSid, '', 'state cleared');
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
+def test_watchdog_retires_when_real_diff_producer_fetch_never_resolves():
+    """Real-producer wiring: loadDiffInline registers a session-switch pending
+    marker and releases it from its fetch promise's .finally. If the fetch never
+    resolves (a hung media endpoint), the marker never releases and the
+    quiet-check can't settle — so the independent watchdog must still retire the
+    class. Drives the REAL loadDiffInline against a fetch that never settles.
+    """
+    fns = "\n".join(_function_body(UI_JS, n) for n in (
+        "_endSessionSwitchLayoutStabilization",
+        "_beginSessionSwitchLayoutStabilization",
+        "_finishSessionSwitchLayoutStabilization",
+        "_scheduleSessionSwitchLayoutQuietCheck",
+        "_beginSessionSwitchLayoutPostProcess",
+        "_endSessionSwitchLayoutPostProcess",
+        "_settleSessionSwitchLayoutStabilization",
+        "loadDiffInline",
+    ))
+    script = f"""
+const assert=require('assert');
+let _now=0; const _timers=[];
+global.setTimeout=(fn,ms)=>{{const id={{fn,at:_now+(ms||0),cancelled:false}};_timers.push(id);return id;}};
+global.clearTimeout=(id)=>{{if(id&&typeof id==='object')id.cancelled=true;}};
+global.requestAnimationFrame=(fn)=>{{_timers.push({{fn,at:_now,cancelled:false}});return 0;}};
+global.cancelAnimationFrame=()=>{{}};
+function advance(ms){{_now+=ms;let ran=true;while(ran){{ran=false;_timers.slice().sort((a,b)=>a.at-b.at).forEach(t=>{{if(!t.cancelled&&t.at<=_now){{t.cancelled=true;ran=true;t.fn();}}}});}}}}
+let _classes=new Set();
+const messagesEl={{classList:{{add:c=>_classes.add(c),remove:c=>_classes.delete(c),contains:c=>_classes.has(c)}}}};
+function $(id){{return id==='messages'?messagesEl:null;}}
+const document={{getElementById:()=>null}};
+let _scrollPinned=false,_messageUserUnpinned=true;
+function scrollToBottom(){{}}
+function esc(s){{return String(s);}}
+function t(k){{return k;}}
+// A fetch that NEVER resolves (hung media endpoint).
+global.fetch=()=>new Promise(()=>{{}});
+// A single diff element pending inline load.
+let _diffAttrs={{}};
+const diffEl={{
+  dataset:{{path:'/x/y.diff'}},
+  setAttribute:(k,v)=>{{_diffAttrs[k]=v;}},
+  getAttribute:k=>_diffAttrs[k],
+}};
+const container={{querySelectorAll:sel=>sel.includes('diff-inline-load')?[diffEl]:[]}};
+let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutLoadGeneration=null;
+let _sessionSwitchLayoutStabilizationToken=0;
+let _sessionSwitchLayoutStabilizationTimer=0;
+let _sessionSwitchLayoutStabilizationObserver=null;
+let _sessionSwitchLayoutWatchdogTimer=0;
+let _sessionSwitchLayoutPostProcessPending=0;
+let _sessionSwitchLayoutSettleRequested=false;
+let _bottomSettleToken=0,_settleRO=null,_settleTimer=0,_settleFinalTimer=0,_settleRAF=0,_programmaticScroll=false;
+{fns}
+_beginSessionSwitchLayoutStabilization('sidA', 1);
+_settleSessionSwitchLayoutStabilization('sidA', 1, false);
+// Real producer registers its own pending marker via _beginSessionSwitchLayoutPostProcess.
+loadDiffInline(container);
+assert.strictEqual(_sessionSwitchLayoutPostProcessPending, 1, 'diff producer registered a pending marker');
+advance(1000);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true, 'still armed while the hung fetch keeps pending>0');
+advance(15000);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), false, 'watchdog retired despite the never-resolving diff fetch');
 """
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -154,3 +154,50 @@ def test_touch_css_forces_real_user_row_layout_only_during_switch():
     assert selector in STYLE_CSS
     media = STYLE_CSS[STYLE_CSS.index("@media (pointer: coarse)"):]
     assert media.index(".msg-row[data-role=\"user\"] { content-visibility: auto;") < media.index(selector)
+
+
+def test_current_load_can_force_retire_superseded_stabilization():
+    """A superseding current load must be able to retire stabilization owned by
+    the load it replaced (a forced reload that skipped _begin because
+    currentSid===sid), while a stale continuation must stay gated by generation.
+    The end helper takes a `force` flag, and every sessions.js cleanup passes
+    `_isCurrentLoad()` so only the authoritative current load forces the retire.
+    """
+    end = _function_body(UI_JS, "_endSessionSwitchLayoutStabilization")
+    # Signature carries the force flag and the generation gate is bypassed only
+    # when force is truthy.
+    assert "function _endSessionSwitchLayoutStabilization(loadGeneration,token,force)" in end
+    assert "if(!force&&loadGeneration!==undefined&&loadGeneration!==null&&loadGeneration!==_sessionSwitchLayoutLoadGeneration) return;" in end
+    # Mutation guard: removing the !force bypass would let a stale continuation
+    # clear newer state (the very bug the finding describes).
+    assert "!force&&" in end
+    # Every sessions.js cleanup passes its ownership decision as the force arg.
+    calls = SESSIONS_JS.count(
+        "window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, _isCurrentLoad());"
+    )
+    assert calls == 6, f"expected 6 ownership-aware cleanups, found {calls}"
+    assert "window._endSessionSwitchLayoutStabilization(_loadGeneration);" not in SESSIONS_JS
+
+
+def test_async_pdf_and_yaml_processors_hold_pending_marker_until_completion():
+    """PDF rendering and the deferred js-yaml tree-view build are asynchronous
+    past postProcessRenderedMessages() returning. Both must register a
+    session-switch pending marker and release it only on real completion, so the
+    quiet timer cannot expire before their final DOM insertion.
+    """
+    pdf = _function_body(UI_JS, "loadPdfInline")
+    assert "_beginSessionSwitchLayoutPostProcess()" in pdf
+    assert "releaseMarker" in pdf
+    # Marker is released, not just on launch: the render-complete branch (i>n),
+    # the too-large branch, the no-pdf branch, the error catch, and the pdfjs
+    # load timeout all release it.
+    assert pdf.count("releaseMarker()") >= 4
+    # Idempotent release guard so double-release can't corrupt the pending count.
+    assert "markerReleased" in pdf
+
+    tree = _function_body(UI_JS, "initTreeViews")
+    # The deferred js-yaml path holds a marker across the async lib load + the
+    # re-run that inserts the tree DOM, releasing it from the deferred callback.
+    assert "_beginSessionSwitchLayoutPostProcess()" in tree
+    assert "_loadJsyamlThen(" in tree
+    assert "_endSessionSwitchLayoutPostProcess(yamlMarker)" in tree

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -40,6 +40,7 @@ def test_session_switch_stabilization_behavior_and_mutation_sensitivity():
     script = f"""
 const assert=require('assert');
 let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutLoadGeneration=null;
 let _sessionSwitchLayoutStabilizationToken=0;
 let _sessionSwitchLayoutStabilizationTimer=0;
 let _sessionSwitchLayoutStabilizationObserver=null;
@@ -68,16 +69,16 @@ function cancelAnimationFrame(){{}}
 function setTimeout(fn){{timers.push(fn);return timers.length;}}
 function clearTimeout(){{}}
 {functions}
-_beginSessionSwitchLayoutStabilization('incoming');
+_beginSessionSwitchLayoutStabilization('incoming',1);
 assert(classes.has('session-switch-layout-stabilizing'));
-_settleSessionSwitchLayoutStabilization('incoming');
+_settleSessionSwitchLayoutStabilization('incoming',1);
 timers.at(-1)();
 while(raf.length) raf.shift()();
 assert(!classes.has('session-switch-layout-stabilizing'));
 assert.strictEqual(bottomCalls,1);
-_beginSessionSwitchLayoutStabilization('incoming-2');
+_beginSessionSwitchLayoutStabilization('incoming-2',2);
 _messageUserUnpinned=true;
-_settleSessionSwitchLayoutStabilization('incoming-2');
+_settleSessionSwitchLayoutStabilization('incoming-2',2);
 timers.at(-1)();
 while(raf.length) raf.shift()();
 assert.strictEqual(bottomCalls,1);
@@ -100,9 +101,9 @@ console.log(JSON.stringify({{bottomCalls,hasClass:classes.has('session-switch-la
 
 def test_session_switch_wires_begin_before_reset_and_settle_after_both_render_branches():
     load = _function_body(SESSIONS_JS, "loadSession")
-    begin = "window._beginSessionSwitchLayoutStabilization(sid);"
+    begin = "window._beginSessionSwitchLayoutStabilization(sid, _loadGeneration);"
     reset = "window._resetScrollDirectionTracker();"
-    settle = "window._settleSessionSwitchLayoutStabilization(sid);"
+    settle = "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);"
     assert begin in load
     assert load.index(begin) < load.index(reset)
     assert load.count(settle) == 2

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -193,11 +193,17 @@ def test_async_pdf_and_yaml_processors_hold_pending_marker_until_completion():
     # load timeout all release it.
     assert pdf.count("releaseMarker()") >= 4
     # Idempotent release guard so double-release can't corrupt the pending count.
-    assert "markerReleased" in pdf
+    assert "_pdfMkDone" in pdf
 
     tree = _function_body(UI_JS, "initTreeViews")
     # The deferred js-yaml path holds a marker across the async lib load + the
-    # re-run that inserts the tree DOM, releasing it from the deferred callback.
+    # re-run that inserts the tree DOM, releasing it from the settle callback so
+    # a CDN failure (onerror, which never invokes cb) still clears the pending
+    # count instead of wedging the quiet check forever.
     assert "_beginSessionSwitchLayoutPostProcess()" in tree
     assert "_loadJsyamlThen(" in tree
     assert "_endSessionSwitchLayoutPostProcess(yamlMarker)" in tree
+    # The loader must invoke the settle callback on BOTH success and failure.
+    loader = _function_body(UI_JS, "_loadJsyamlThen")
+    assert "s.onerror=()=>{ _jsyamlLoading=false; if(settle) settle(); }" in loader
+    assert "s.onload=()=>{ _jsyamlLoading=false; try{ cb(); } finally{ if(settle) settle(); } }" in loader

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -1,0 +1,121 @@
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    m = re.search(rf"function\s+{re.escape(name)}\b", src)
+    assert m, f"{name} not found"
+    start = src.index("{", m.end())
+    depth = 0
+    for i in range(start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[m.start(): i + 1]
+    raise AssertionError(f"unterminated {name}")
+
+
+def test_session_switch_stabilization_behavior_and_mutation_sensitivity():
+    functions = "\n".join(
+        _function_body(UI_JS, name)
+        for name in (
+            "_endSessionSwitchLayoutStabilization",
+            "_beginSessionSwitchLayoutStabilization",
+            "_settleSessionSwitchLayoutStabilization",
+        )
+    )
+    script = f"""
+const assert=require('assert');
+let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutStabilizationTimer=0;
+let _messageUserUnpinned=false;
+let _scrollPinned=true;
+let _bottomSettleToken=0;
+let _settleRO=null;
+let _settleTimer=0;
+let _settleFinalTimer=0;
+let _settleRAF=0;
+let _programmaticScroll=true;
+let bottomCalls=0;
+let raf=[];
+let timers=[];
+const classes=new Set();
+const el={{classList:{{add:x=>classes.add(x),remove:x=>classes.delete(x)}}}};
+function $(id){{return id==='messages'?el:null;}}
+function scrollToBottom(){{bottomCalls++;}}
+function requestAnimationFrame(fn){{raf.push(fn);return raf.length;}}
+function cancelAnimationFrame(){{}}
+function setTimeout(fn){{timers.push(fn);return timers.length;}}
+function clearTimeout(){{}}
+{functions}
+_beginSessionSwitchLayoutStabilization('incoming');
+assert(classes.has('session-switch-layout-stabilizing'));
+_settleSessionSwitchLayoutStabilization('incoming');
+timers.at(-1)();
+while(raf.length) raf.shift()();
+assert(!classes.has('session-switch-layout-stabilizing'));
+assert.strictEqual(bottomCalls,1);
+_beginSessionSwitchLayoutStabilization('incoming-2');
+_messageUserUnpinned=true;
+_settleSessionSwitchLayoutStabilization('incoming-2');
+timers.at(-1)();
+while(raf.length) raf.shift()();
+assert.strictEqual(bottomCalls,1);
+console.log(JSON.stringify({{bottomCalls,hasClass:classes.has('session-switch-layout-stabilizing')}}));
+"""
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"bottomCalls": 1, "hasClass": False}
+
+    # Mutation: removing the CSS class add must make the same behavior test fail.
+    mutated = functions.replace(
+        "if(el&&el.classList) el.classList.add('session-switch-layout-stabilizing');",
+        "// mutation: class add removed",
+    )
+    mutated_result = subprocess.run(
+        ["node", "-e", script.replace(functions, mutated)], capture_output=True, text=True
+    )
+    assert mutated_result.returncode != 0
+
+
+def test_session_switch_wires_begin_before_reset_and_settle_after_both_render_branches():
+    load = _function_body(SESSIONS_JS, "loadSession")
+    begin = "window._beginSessionSwitchLayoutStabilization(sid);"
+    reset = "window._resetScrollDirectionTracker();"
+    settle = "window._settleSessionSwitchLayoutStabilization(sid);"
+    assert begin in load
+    assert load.index(begin) < load.index(reset)
+    assert load.count(settle) == 2
+    for marker in (
+        "if(activeStreamId){",
+        "}else{\n      S.busy=false;",
+    ):
+        branch = load[load.index(marker):]
+        assert branch.index("renderMessages(") < branch.index(settle)
+
+
+def test_live_anchor_scroll_guard_restores_after_release_layout_frame():
+    for name in ("renderLiveAnchorActivityScene", "_renderLiveAnchorActivitySceneTransparent"):
+        body = _function_body(UI_JS, name)
+        compact = re.sub(r"\s+", "", body)
+        release = "scrollRebuildGuard.release();"
+        nested = "requestAnimationFrame(()=>{if(_messageUserUnpinned)_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);});"
+        assert release in compact
+        assert nested in compact
+        assert compact.index(release) < compact.index(nested)
+
+
+def test_touch_css_forces_real_user_row_layout_only_during_switch():
+    selector = ".messages.session-switch-layout-stabilizing .msg-row[data-role=\"user\"] { content-visibility: visible; }"
+    assert selector in STYLE_CSS
+    media = STYLE_CSS[STYLE_CSS.index("@media (pointer: coarse)"):]
+    assert media.index(".msg-row[data-role=\"user\"] { content-visibility: auto;") < media.index(selector)

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -44,6 +44,7 @@ let _sessionSwitchLayoutLoadGeneration=null;
 let _sessionSwitchLayoutStabilizationToken=0;
 let _sessionSwitchLayoutStabilizationTimer=0;
 let _sessionSwitchLayoutStabilizationObserver=null;
+let _sessionSwitchLayoutWatchdogTimer=0;
 let _sessionSwitchLayoutPostProcessPending=0;
 let _sessionSwitchLayoutSettleRequested=false;
 let _messageUserUnpinned=false;
@@ -72,14 +73,16 @@ function clearTimeout(){{}}
 _beginSessionSwitchLayoutStabilization('incoming',1);
 assert(classes.has('session-switch-layout-stabilizing'));
 _settleSessionSwitchLayoutStabilization('incoming',1);
-timers.at(-1)();
+// settle schedules the quiet-check THEN arms the watchdog, so the quiet-check
+// is the second-to-last timer. Fire it (not the watchdog) to settle normally.
+timers.at(-2)();
 while(raf.length) raf.shift()();
 assert(!classes.has('session-switch-layout-stabilizing'));
 assert.strictEqual(bottomCalls,1);
 _beginSessionSwitchLayoutStabilization('incoming-2',2);
 _messageUserUnpinned=true;
 _settleSessionSwitchLayoutStabilization('incoming-2',2);
-timers.at(-1)();
+timers.at(-2)();
 while(raf.length) raf.shift()();
 assert.strictEqual(bottomCalls,1);
 console.log(JSON.stringify({{bottomCalls,hasClass:classes.has('session-switch-layout-stabilizing')}}));
@@ -184,6 +187,103 @@ def test_same_session_force_reload_force_retires_prior_stabilization():
     # The else-branch of the _begin gate handles same-session force reload.
     assert "} else if (sameSessionForceReload && typeof window !== 'undefined' && typeof window._endSessionSwitchLayoutStabilization === 'function') {" in load
     assert "window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, true);" in load
+
+
+def test_authoritative_same_sid_load_force_retires_armed_stabilization():
+    """Rapid A→B→A→B: a same-SID non-force load re-selecting the already-open
+    session (the early-return no-op) is still the authoritative current load. If
+    an abandoned switch left stabilization armed (a B load that never became
+    current and whose stale return was gated out by a newer generation), this
+    path must force-retire it — otherwise `session-switch-layout-stabilizing`
+    stays armed forever and silently disables mobile user-row virtualization.
+    """
+    load = _function_body(SESSIONS_JS, "loadSession")
+    early = load[load.index("if(currentSid===sid && !forceReload"):load.index("return;\n  }\n")]
+    assert "window._endSessionSwitchLayoutStabilization(undefined, undefined, true);" in early, \
+        "authoritative same-SID re-select must force-retire any armed stabilization"
+
+
+def test_settle_arms_bounded_watchdog_that_force_retires_stuck_processor():
+    """The quiet-check waits on the pending-work count, so a single async
+    processor that never resolves keeps pending>0 and leaves stabilization armed
+    for the whole tab. _settle must arm an INDEPENDENT absolute-cap watchdog that
+    force-retires the owning token after a bound even when a waiter never
+    releases. It's cleared on _end so a normal settle doesn't fire it late.
+    """
+    settle = _function_body(UI_JS, "_settleSessionSwitchLayoutStabilization")
+    end = _function_body(UI_JS, "_endSessionSwitchLayoutStabilization")
+    assert "_sessionSwitchLayoutWatchdogTimer=setTimeout(" in settle
+    # Watchdog force-retires (force=true) the exact token/generation it armed for.
+    assert "_endSessionSwitchLayoutStabilization(loadGeneration,token,true);" in settle
+    assert ",15000);" in settle
+    # Token guard so a stale watchdog can't clear a newer stabilization.
+    assert "if(token!==_sessionSwitchLayoutStabilizationToken) return;" in settle
+    # Cleared by _end so a completed settle never fires the watchdog afterward.
+    assert "clearTimeout(_sessionSwitchLayoutWatchdogTimer);" in end
+    assert UI_JS.count("let _sessionSwitchLayoutWatchdogTimer=0;") == 1
+
+
+def test_watchdog_retires_stabilization_when_processor_never_resolves():
+    """Behavioral: drive the real begin/settle/postprocess/end helpers with a
+    pending marker that NEVER releases, advance a fake clock past the cap, and
+    assert the stabilizing class is removed anyway (the silent-leak the
+    maintainer flagged). Uses node with a controllable timer queue.
+    """
+    fns = "\n".join(_function_body(UI_JS, n) for n in (
+        "_endSessionSwitchLayoutStabilization",
+        "_beginSessionSwitchLayoutStabilization",
+        "_finishSessionSwitchLayoutStabilization",
+        "_scheduleSessionSwitchLayoutQuietCheck",
+        "_beginSessionSwitchLayoutPostProcess",
+        "_endSessionSwitchLayoutPostProcess",
+        "_settleSessionSwitchLayoutStabilization",
+    ))
+    script = f"""
+const assert=require('assert');
+// Controllable clock: collect timers, fire by advancing a virtual now.
+let _now=0; const _timers=[];
+global.setTimeout=(fn,ms)=>{{const id={{fn,at:_now+(ms||0),cancelled:false}};_timers.push(id);return id;}};
+global.clearTimeout=(id)=>{{if(id&&typeof id==='object')id.cancelled=true;}};
+global.requestAnimationFrame=(fn)=>{{_timers.push({{fn,at:_now,cancelled:false}});return 0;}};
+global.cancelAnimationFrame=()=>{{}};
+function advance(ms){{_now+=ms;let ran=true;while(ran){{ran=false;_timers.slice().sort((a,b)=>a.at-b.at).forEach(t=>{{if(!t.cancelled&&t.at<=_now){{t.cancelled=true;ran=true;t.fn();}}}});}}}}
+// Minimal DOM: a messages element whose classList tracks the stabilizing class.
+let _classes=new Set();
+const messagesEl={{classList:{{add:c=>_classes.add(c),remove:c=>_classes.delete(c),contains:c=>_classes.has(c)}}}};
+function $(id){{return id==='messages'?messagesEl:null;}}
+function document_getElementById(){{return null;}}
+const document={{getElementById:()=>null}};
+let _scrollPinned=false,_messageUserUnpinned=true;
+function scrollToBottom(){{}}
+// Stabilization state globals.
+let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutLoadGeneration=null;
+let _sessionSwitchLayoutStabilizationToken=0;
+let _sessionSwitchLayoutStabilizationTimer=0;
+let _sessionSwitchLayoutStabilizationObserver=null;
+let _sessionSwitchLayoutWatchdogTimer=0;
+let _sessionSwitchLayoutPostProcessPending=0;
+let _sessionSwitchLayoutSettleRequested=false;
+let _bottomSettleToken=0,_settleRO=null,_settleTimer=0,_settleFinalTimer=0,_settleRAF=0,_programmaticScroll=false;
+// No ResizeObserver in this harness -> settle takes the non-observer path.
+{fns}
+// Switch INTO a session (idle path, observer would arm but is absent here).
+_beginSessionSwitchLayoutStabilization('sidA', 1);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true, 'armed on begin');
+_settleSessionSwitchLayoutStabilization('sidA', 1, false);
+// Register a post-process waiter that NEVER releases (hung fetch).
+const marker=_beginSessionSwitchLayoutPostProcess();
+assert.ok(marker, 'pending marker registered');
+assert.strictEqual(_sessionSwitchLayoutPostProcessPending, 1);
+// Advance past the quiet window: pending>0 so the quiet-check must NOT settle.
+advance(1000);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), true, 'still armed while pending>0');
+// Advance past the watchdog cap: it must force-retire despite the stuck waiter.
+advance(15000);
+assert.strictEqual(_classes.has('session-switch-layout-stabilizing'), false, 'watchdog force-retired the stuck stabilization');
+assert.strictEqual(_sessionSwitchLayoutStabilizationSid, '', 'state cleared');
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
 
 
 def test_session_switch_has_no_fixed_load_expiry_and_postprocess_is_event_driven():

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -30,13 +30,21 @@ def test_session_switch_stabilization_behavior_and_mutation_sensitivity():
         for name in (
             "_endSessionSwitchLayoutStabilization",
             "_beginSessionSwitchLayoutStabilization",
+            "_finishSessionSwitchLayoutStabilization",
+            "_scheduleSessionSwitchLayoutQuietCheck",
+            "_beginSessionSwitchLayoutPostProcess",
+            "_endSessionSwitchLayoutPostProcess",
             "_settleSessionSwitchLayoutStabilization",
         )
     )
     script = f"""
 const assert=require('assert');
 let _sessionSwitchLayoutStabilizationSid='';
+let _sessionSwitchLayoutStabilizationToken=0;
 let _sessionSwitchLayoutStabilizationTimer=0;
+let _sessionSwitchLayoutStabilizationObserver=null;
+let _sessionSwitchLayoutPostProcessPending=0;
+let _sessionSwitchLayoutSettleRequested=false;
 let _messageUserUnpinned=false;
 let _scrollPinned=true;
 let _bottomSettleToken=0;
@@ -49,8 +57,11 @@ let bottomCalls=0;
 let raf=[];
 let timers=[];
 const classes=new Set();
+const inner={{}};
 const el={{classList:{{add:x=>classes.add(x),remove:x=>classes.delete(x)}}}};
-function $(id){{return id==='messages'?el:null;}}
+function $(id){{return id==='messages'?el:(id==='msgInner'?inner:null);}}
+const document={{getElementById:id=>id==='msgInner'?inner:null}};
+class ResizeObserver{{constructor(cb){{this.cb=cb;}}observe(){{}}disconnect(){{}}}}
 function scrollToBottom(){{bottomCalls++;}}
 function requestAnimationFrame(fn){{raf.push(fn);return raf.length;}}
 function cancelAnimationFrame(){{}}
@@ -108,10 +119,33 @@ def test_live_anchor_scroll_guard_restores_after_release_layout_frame():
         body = _function_body(UI_JS, name)
         compact = re.sub(r"\s+", "", body)
         release = "scrollRebuildGuard.release();"
-        nested = "requestAnimationFrame(()=>{if(_messageUserUnpinned)_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);});"
+        nested = "requestAnimationFrame(()=>{if(scrollRebuildIdentity&&typeof_liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;if(_messageUserUnpinned)_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);});"
         assert release in compact
         assert nested in compact
         assert compact.index(release) < compact.index(nested)
+
+
+def test_session_switch_has_no_fixed_load_expiry_and_postprocess_is_event_driven():
+    begin = _function_body(UI_JS, "_beginSessionSwitchLayoutStabilization")
+    settle = _function_body(UI_JS, "_settleSessionSwitchLayoutStabilization")
+    quiet = _function_body(UI_JS, "_scheduleSessionSwitchLayoutQuietCheck")
+    post = _function_body(UI_JS, "_postProcessWithAnchorSuppression")
+    assert "15000" not in begin
+    assert "ResizeObserver" in settle
+    assert "_sessionSwitchLayoutPostProcessPending>0" in quiet
+    assert "_beginSessionSwitchLayoutPostProcess()" in post
+    assert "_endSessionSwitchLayoutPostProcess(sessionSwitchPostProcess)" in post
+
+
+def test_live_anchor_delayed_restore_is_generation_and_session_guarded():
+    guard = _function_body(UI_JS, "_liveAnchorScrollRebuildGuardCurrent")
+    assert "_liveAnchorScrollRebuildGeneration" in guard
+    assert "S.session.session_id" in guard
+    for name in ("renderLiveAnchorActivityScene", "_renderLiveAnchorActivitySceneTransparent"):
+        body = _function_body(UI_JS, name)
+        guarded_identity = "const scrollRebuildIdentity=(typeof _nextLiveAnchorScrollRebuildGuard==='function')?_nextLiveAnchorScrollRebuildGuard():null;"
+        assert guarded_identity in body
+        assert "_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)" in body
 
 
 def test_touch_css_forces_real_user_row_layout_only_during_switch():

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -109,7 +109,9 @@ def test_session_switch_wires_begin_before_reset_and_settle_after_both_render_br
     settle_idle = "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);"
     assert begin in load
     assert load.index(begin) < load.index(reset)
-    assert load.count(settle_streaming) == 1
+    # Two streaming settles now: the INFLIGHT streaming-restore branch and the
+    # post-await activeStreamId attach branch. Both opt out of the observer.
+    assert load.count(settle_streaming) == 2
     assert load.count(settle_idle) == 1
     for marker, settle in (
         ("if(activeStreamId){", settle_streaming),
@@ -124,15 +126,64 @@ def test_live_anchor_scroll_guard_restores_after_release_layout_frame():
         body = _function_body(UI_JS, name)
         compact = re.sub(r"\s+", "", body)
         release = "scrollRebuildGuard.release();"
-        # The release() call must itself be gated on still owning the guard, so a
-        # superseded older callback cannot restore its stale min-height and tear
-        # down a newer rebuild's active guard.
-        guarded_release = "if(scrollRebuildIdentity&&typeof_liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;scrollRebuildGuard.release();"
-        assert guarded_release in compact, f"{name}: release() must be identity-gated"
-        nested = "requestAnimationFrame(()=>{if(scrollRebuildIdentity&&typeof_liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;if(_messageUserUnpinned)_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);});"
+        # release() must be called UNCONDITIONALLY here (not gated on the render
+        # generation). Ownership is enforced INSIDE release() via a separate
+        # min-height cleanup owner token, so gating the call on the render
+        # generation would strand min-height set whenever a no-guard successor
+        # advanced the generation without taking cleanup ownership (the leak the
+        # maintainer flagged). The following-frame snapshot restore stays gated.
         assert release in compact
+        gated_release = "_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;scrollRebuildGuard.release();"
+        assert gated_release not in compact, f"{name}: release() must NOT be render-generation gated"
+        nested = "requestAnimationFrame(()=>{if(scrollRebuildIdentity&&typeof_liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;if(_messageUserUnpinned)_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);});"
         assert nested in compact
         assert compact.index(release) < compact.index(nested)
+
+
+def test_min_height_guard_release_ownership_survives_no_guard_successor():
+    """The min-height cleanup guard must own its release via a token tracked
+    SEPARATELY from the render/session generation. Every rebuild advances the
+    render generation, but only a guard-installing rebuild takes cleanup
+    ownership — so a later no-guard rebuild (reader re-pinned / session switch)
+    can't invalidate an older release and strand msgInner.style.minHeight set
+    (the permanent-frozen-layout leak, which could regress desktop too).
+    """
+    prep = _function_body(UI_JS, "_prepareLiveAnchorScrollRebuildGuard")
+    # A dedicated owner counter, distinct from _liveAnchorScrollRebuildGeneration.
+    assert "_liveAnchorMinHeightGuardOwner" in prep
+    assert "const guardOwnerToken=++_liveAnchorMinHeightGuardOwner;" in prep
+    # release() no-ops unless THIS guard is still the current cleanup owner.
+    assert "if(released||guardOwnerToken!==_liveAnchorMinHeightGuardOwner) return;" in prep
+    # Only a guard-installing prepare bumps the owner: the early no-guard returns
+    # must happen BEFORE the owner is taken.
+    assert prep.index("return {readerAwayFromBottom:false,release:null};") < prep.index("++_liveAnchorMinHeightGuardOwner")
+    assert prep.index("return {readerAwayFromBottom:true,release:null};") < prep.index("++_liveAnchorMinHeightGuardOwner")
+    # The owner global is declared once.
+    assert UI_JS.count("let _liveAnchorMinHeightGuardOwner=0;") == 1
+
+
+def test_inflight_streaming_restore_settles_stabilization():
+    """The INFLIGHT streaming-restore branch renders + reattaches and returns
+    without falling through to the idle/attach settle, so it must settle
+    stabilization itself (with the streaming flag) — otherwise begin=1/settle=0/
+    end=0 leaves the transcript forced-visible for the whole session.
+    """
+    load = _function_body(SESSIONS_JS, "loadSession")
+    inflight = load[load.index("if(INFLIGHT[sid]){"):load.index("}else{\n    // Phase 2b")]
+    assert "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration, true);" in inflight, \
+        "INFLIGHT streaming-restore branch must settle with the streaming flag"
+
+
+def test_same_session_force_reload_force_retires_prior_stabilization():
+    """A same-session force reload skips _begin (currentSid===sid) but is the
+    authoritative current load, so it must force-retire + invalidate any prior
+    stabilization left active by an older cross-session load, or the transcript
+    can stay forced-visible / min-height-pinned.
+    """
+    load = _function_body(SESSIONS_JS, "loadSession")
+    # The else-branch of the _begin gate handles same-session force reload.
+    assert "} else if (sameSessionForceReload && typeof window !== 'undefined' && typeof window._endSessionSwitchLayoutStabilization === 'function') {" in load
+    assert "window._endSessionSwitchLayoutStabilization(_loadGeneration, undefined, true);" in load
 
 
 def test_session_switch_has_no_fixed_load_expiry_and_postprocess_is_event_driven():
@@ -227,10 +278,6 @@ def test_async_pdf_and_yaml_processors_hold_pending_marker_until_completion():
     assert "_pdfMkDone" in pdf
 
     tree = _function_body(UI_JS, "initTreeViews")
-    # The deferred js-yaml path holds a marker across the async lib load + the
-    # re-run that inserts the tree DOM, releasing it from the settle callback so
-    # a CDN failure (onerror, which never invokes cb) still clears the pending
-    # count instead of wedging the quiet check forever.
     assert "_beginSessionSwitchLayoutPostProcess()" in tree
     assert "_loadJsyamlThen(" in tree
     assert "_endSessionSwitchLayoutPostProcess(yamlMarker)" in tree
@@ -238,3 +285,29 @@ def test_async_pdf_and_yaml_processors_hold_pending_marker_until_completion():
     loader = _function_body(UI_JS, "_loadJsyamlThen")
     assert "s.onerror=()=>{ _jsyamlLoading=false; if(settle) settle(); }" in loader
     assert "s.onload=()=>{ _jsyamlLoading=false; try{ cb(); } finally{ if(settle) settle(); } }" in loader
+
+
+def test_multi_pdf_shared_loader_failure_releases_every_waiter():
+    """pdfjs is loaded once and shared. When two PDFs are pending and the shared
+    loader fails/stalls, EVERY waiter must release its own marker — not just the
+    loader owner — or a blocked CDN strands the other waiters' markers and
+    stabilization never settles. The fix gives each waiting el its own bounded
+    timeout (outside the `!_pdfjsLoading` owner block) that releases its own
+    marker, plus an onerror reset so a failed load doesn't wedge _pdfjsLoading.
+    """
+    pdf = _function_body(UI_JS, "loadPdfInline")
+    compact = re.sub(r"\s+", "", pdf)
+    # The per-el timeout must live in the shared else-branch, NOT nested inside
+    # the `if(!_pdfjsLoading)` owner-only block. Assert the timeout guard + its
+    # release are present and reference the per-el done flag (so it runs for
+    # every waiter, and no-ops if the el already settled).
+    assert "if(_pdfjsReady||_pdfMkDone)return;" in compact, \
+        "each waiting PDF must have its own bounded cleanup timeout"
+    # The owner block resets _pdfjsLoading on script error so a failed shared
+    # load can be retried and doesn't permanently block future PDFs.
+    assert "s.onerror=()=>{_pdfjsLoading=false;};" in compact
+    # The pdfjs-ready listener is registered for every waiter (outside the owner
+    # block), so a late success still renders all pending PDFs.
+    owner_block = pdf[pdf.index("if(!_pdfjsLoading){"):pdf.index("window.addEventListener('pdfjs-ready'")]
+    assert "setTimeout(" not in owner_block, \
+        "the bounded cleanup timeout must be per-el (outside the loader-owner block)"

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -103,13 +103,17 @@ def test_session_switch_wires_begin_before_reset_and_settle_after_both_render_br
     load = _function_body(SESSIONS_JS, "loadSession")
     begin = "window._beginSessionSwitchLayoutStabilization(sid, _loadGeneration);"
     reset = "window._resetScrollDirectionTracker();"
-    settle = "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);"
+    # The streaming branch opts out of the ResizeObserver (third arg `true`); the
+    # idle branch keeps the default. Both still settle after their render.
+    settle_streaming = "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration, true);"
+    settle_idle = "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);"
     assert begin in load
     assert load.index(begin) < load.index(reset)
-    assert load.count(settle) == 2
-    for marker in (
-        "if(activeStreamId){",
-        "}else{\n      S.busy=false;",
+    assert load.count(settle_streaming) == 1
+    assert load.count(settle_idle) == 1
+    for marker, settle in (
+        ("if(activeStreamId){", settle_streaming),
+        ("}else{\n      S.busy=false;", settle_idle),
     ):
         branch = load[load.index(marker):]
         assert branch.index("renderMessages(") < branch.index(settle)
@@ -152,6 +156,28 @@ def test_live_anchor_delayed_restore_is_generation_and_session_guarded():
         guarded_identity = "const scrollRebuildIdentity=(typeof _nextLiveAnchorScrollRebuildGuard==='function')?_nextLiveAnchorScrollRebuildGuard():null;"
         assert guarded_identity in body
         assert "_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity)" in body
+
+
+def test_settle_skips_observer_when_switching_into_streaming_session():
+    """Switching INTO an actively-streaming session must not arm the
+    ResizeObserver: the live turn grows continuously, so the observer would keep
+    firing and the quiet-check would never reach zero-pending until the stream
+    pauses, leaving content-visibility forced on every user row for the whole
+    stream (temporarily undoing #5637). The streaming call site passes the flag;
+    the idle branch does not (observer still arms for a static transcript).
+    """
+    settle = _function_body(UI_JS, "_settleSessionSwitchLayoutStabilization")
+    assert "function _settleSessionSwitchLayoutStabilization(sid,loadGeneration,streaming)" in settle
+    # The observer arm is gated on NOT streaming. Mutation guard: dropping the
+    # !streaming term would re-arm the observer during streaming (the bug).
+    assert "if(!streaming&&typeof ResizeObserver==='function')" in settle
+    # The streaming loadSession branch opts out of the observer; the idle branch
+    # keeps the default (no third arg).
+    assert "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration, true);" in SESSIONS_JS
+    assert "window._settleSessionSwitchLayoutStabilization(sid, _loadGeneration);" in SESSIONS_JS
+    # A single quiet-check is still scheduled so stabilization settles (waiting on
+    # any pending async post-processing) even without the observer.
+    assert "_scheduleSessionSwitchLayoutQuietCheck(token,sid,loadGeneration);" in settle
 
 
 def test_touch_css_forces_real_user_row_layout_only_during_switch():

--- a/tests/test_session_switch_layout_stabilization.py
+++ b/tests/test_session_switch_layout_stabilization.py
@@ -120,6 +120,11 @@ def test_live_anchor_scroll_guard_restores_after_release_layout_frame():
         body = _function_body(UI_JS, name)
         compact = re.sub(r"\s+", "", body)
         release = "scrollRebuildGuard.release();"
+        # The release() call must itself be gated on still owning the guard, so a
+        # superseded older callback cannot restore its stale min-height and tear
+        # down a newer rebuild's active guard.
+        guarded_release = "if(scrollRebuildIdentity&&typeof_liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;scrollRebuildGuard.release();"
+        assert guarded_release in compact, f"{name}: release() must be identity-gated"
         nested = "requestAnimationFrame(()=>{if(scrollRebuildIdentity&&typeof_liveAnchorScrollRebuildGuardCurrent==='function'&&!_liveAnchorScrollRebuildGuardCurrent(scrollRebuildIdentity))return;if(_messageUserUnpinned)_restoreMessageScrollSnapshotSameFrame(scrollSnapshot);});"
         assert release in compact
         assert nested in compact


### PR DESCRIPTION
## Problem

On touch layouts, switching into a conversation can expose several transient geometry changes before the transcript settles. Off-screen user rows use `content-visibility:auto`; while their intrinsic sizes are being resolved, `scrollHeight` can change in several steps. Even when `scrollTop` follows most of that change, a stable visible row can still move noticeably.

A second instance of the same geometry-ordering problem exists during live Activity rebuilds: the temporary `min-height` guard was released and the viewport snapshot was restored in the same animation-frame callback. That restore could read geometry from before the release had completed layout.

## Fix

- Add a short, session-scoped layout stabilization phase for real session switches.
- While it is active, force user rows to `content-visibility:visible` so the incoming transcript establishes real geometry before the optimization is re-enabled.
- Cancel any bottom-settle observer/timers inherited from the previous session.
- Keep the stabilization active through post-processing, then remove it after a measured settle window and re-anchor once against final geometry.
- Restore unpinned viewport snapshots one frame after releasing the live Activity `min-height` guard, not in the same callback.
- Cover both idle and active-stream session-switch render paths.

This preserves the existing product contract: a real session switch still lands at the latest messages. It does not preserve a stale reading position from the previous session.

## Relationship to earlier scroll fixes

- This does not reintroduce the closed min-height approach from #5722, which held the outgoing session's height and could strand a taller incoming session mid-transcript.
- It does not change the stale-anchor refusal or user-row intrinsic-height cache behavior from the #5637 follow-ups.
- It is complementary to those fixes: it stabilizes incoming row geometry during the switch and corrects the release/restore ordering in live Activity rebuilds.

## Verification

- New behavior tests execute the real stabilization helpers and include a mutation check proving that removing the CSS-class arm fails the test.
- Structural tests require begin-before-reset and settle-after-render in both switch branches.
- Structural tests require live Activity snapshot restore to run in the frame after guard release.
- Focused scroll, Android, session-switch, Activity, Transparent Stream, and intrinsic-height suites: `144 passed`.
- Syntax checks: `node --check static/ui.js` and `node --check static/sessions.js`.
- Mobile Chromium session-switch sampling showed no upward movement across the landing sequence and finished at the final bottom geometry.
