### PR TITLE
Release exp-v0.52.51: refresh reasoning chip after empty boot (#5967, #5954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- **The reasoning-effort chip is correct right after an empty startup.** On a normal boot with no active session restored, the top-bar reasoning chip wasn't refreshed for the hydrated default model, so it could show a stale value until you changed the model. It now refreshes on empty boot too. Thanks @rodboev. (#5967, #5954)
+
 - **Transparent Stream no longer bloats memory (or freezes the tab) on long tool-heavy chats.** With Transparent Stream enabled, opening a conversation with many prompts built a DOM node for every activity event of every past turn at load and eagerly rendered each tool row's full detail body — a long reasoning-heavy history could balloon to multiple GB and lock up the tab. Settled tool rows now render header-only and build their detail on first expand (identical to the old view once opened), and a turn with a very large number of steps shows its most recent 30 behind a "Show N earlier steps" control. Live turns are unchanged. Thanks @curtisszmania-cytocync for the report. (#5974, #5966)
 
 - **Dictation no longer wipes text you already typed.** When you typed part of a prompt and then used the microphone (server-side transcription / MediaRecorder path), the recognized text replaced your typed prefix instead of being appended to it. Dictation now appends to whatever is already in the composer, so you can type a partial sentence and dictate the rest. A Settings toggle lets you opt back into the old replace behavior. Thanks @Kopamed. (#5895)

--- a/static/boot.js
+++ b/static/boot.js
@@ -3529,6 +3529,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       else if(typeof syncModelChip==='function') syncModelChip();
     }
     if(S.session) syncTopbar();
+    else if(typeof syncReasoningChip==='function') syncReasoningChip();
   }).catch(e=>{
     window._modelDropdownReady=null;
     throw e;

--- a/tests/test_issue5954_empty_boot_reasoning_chip.py
+++ b/tests/test_issue5954_empty_boot_reasoning_chip.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for boot behavior checks")
+
+
+def _boot_completion_branch() -> str:
+    source = Path("static/boot.js").read_text(encoding="utf-8")
+    marker = "    if(S.session) syncTopbar();"
+    start = source.index(marker)
+    end = source.index("\n  }).catch(e=>", start)
+    return source[start:end]
+
+
+def _run_boot_branch() -> list[dict[str, int | str | None]]:
+    branch = _boot_completion_branch()
+    script = f"""
+const branch = {json.dumps(branch)};
+function run(session) {{
+  const S = {{session}};
+  let syncTopbarCalls = 0;
+  let syncReasoningChipCalls = 0;
+  function syncTopbar() {{ syncTopbarCalls += 1; }}
+  function syncReasoningChip() {{ syncReasoningChipCalls += 1; }}
+  eval(branch);
+  return {{session: session ? 'present' : null, syncTopbarCalls, syncReasoningChipCalls}};
+}}
+console.log(JSON.stringify([run(null), run({{id: 'session'}})]));
+"""
+    result = subprocess.run(
+        [NODE, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_boot_hydration_refreshes_chip_only_without_a_session():
+    assert _run_boot_branch() == [
+        {"session": None, "syncTopbarCalls": 0, "syncReasoningChipCalls": 1},
+        {"session": "present", "syncTopbarCalls": 1, "syncReasoningChipCalls": 0},
+    ]

--- a/tests/test_issue5954_empty_boot_reasoning_chip.py
+++ b/tests/test_issue5954_empty_boot_reasoning_chip.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for boot 
 
 
 def _boot_completion_branch() -> str:
-    source = Path("static/boot.js").read_text(encoding="utf-8")
+    source = (Path(__file__).resolve().parents[1] / "static" / "boot.js").read_text(encoding="utf-8")
     marker = "    if(S.session) syncTopbar();"
     start = source.index(marker)
     end = source.index("\n  }).catch(e=>", start)


### PR DESCRIPTION
Release exp-v0.52.51 — reasoning chip refresh after empty boot (#5967, closes #5954, rodboev).

Empty normal boot (no session restored) missed the reasoning-chip refresh that with-session boots + later model changes run, so the chip showed a stale value for the hydrated default. Adds the maintainer-preapproved no-session else-branch → syncReasoningChip(). This closes the #5954 follow-up filed during the boot-path batch.

Gate: Codex SAFE (else-branch fires only when !S.session + typeof-guarded; with-session syncTopbar path preserved; saved-session brief no-session branch safe via dedup+sequence-guard; 46 tests). Tiny +1-line boot.js change + test.
