### PR TITLE
fix: preserve bounded transcript windows across session lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -281,20 +281,23 @@ the correct display payload: a session may already be loaded through the paginat
 `/api/session?msg_limit=...` contract, especially when transcript virtualization is
 disabled.
 
-When the browser's current session is truncated, `sessions.js` requests a bounded
+When the browser's current session is truncated, `sessions.js` requests its loaded
 settled window from the same `/api/session` endpoint before applying the terminal
-snapshot. The server remains authoritative for visible-row counting, tool-result
-carry-through, `_messages_offset`, and activity-scene hydration. `messages.js` merges
-that bounded window with the terminal metadata and preserves the existing pagination
-cursor. SSE recovery uses the same path.
+snapshot. Windows within the server-advertised `msg_limit` ceiling stay bounded. A
+larger loaded window omits `msg_limit` and fetches the authoritative transcript rather
+than accepting a clamped response that would discard older loaded rows. The server
+remains authoritative for visible-row counting, tool-result carry-through,
+`_messages_offset`, and activity-scene hydration. `messages.js` merges that replacement
+window with the terminal metadata and preserves the existing pagination cursor. SSE
+recovery uses the same path.
 
 The terminal paths do not promote `_messageRenderWindowSize` to the full transcript.
 Explicit history actions such as loading older messages, session-start navigation,
 and export may still request or render the full session. Edit/regenerate targets
 already visible in a paginated window keep the server-facing absolute `keep_count`
 but slice only the loaded local window; they do not expand the transcript merely to
-submit the mutation. Reconnect/refresh recovery also requests a bounded window. If a
-bounded refresh fails, the browser keeps its bounded in-flight/local transcript
+submit the mutation. Reconnect/refresh recovery also preserves the loaded window
+width. If a refresh fails, the browser keeps its bounded in-flight/local transcript
 rather than replacing it with the full SSE payload. This keeps the visible transcript
 and pagination state coherent without changing the experimental virtualization
 preference or the Agent repository.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1141,6 +1141,11 @@ terminal payload.
 
 Same-session force refreshes (metadata reconciliation and SSE recovery) keep the
 existing per-session SSE subscription alive while the bounded window is fetched.
+Reconnect recovery also derives its request limit from the currently displayed
+bounded window when no force-reload hint exists, so an expanded 90-row view does
+not collapse back to the initial 30-row tail. Completion follow intent is
+re-evaluated after the bounded fetch and pane-ownership check, so a reader who
+scrolls upward while that request is pending is not pulled back to the bottom.
 The browser shares the active load promise with duplicate same-session callers.
 Mutation refreshes from `/undo` and `/retry`, plus same-session `session-updated`
 events, queue at most one bounded follow-up after that promise settles; an event

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1141,10 +1141,15 @@ terminal payload.
 
 Same-session force refreshes (metadata reconciliation and SSE recovery) keep the
 existing per-session SSE subscription alive while the bounded window is fetched.
-The browser also ignores a recovery frame while another session load owns the
-pane. This avoids creating an artificial subscribe gap that can repeatedly
-re-enter recovery for a large settled session, and prevents a stale event from
-hijacking a user-initiated session switch.
+The browser shares the active load promise with duplicate same-session callers.
+Mutation refreshes from `/undo` and `/retry`, plus same-session `session-updated`
+events, queue at most one bounded follow-up after that promise settles; an event
+follow-up is skipped when the active load already reached its reported message
+count. Events for a different session remain suppressed while navigation owns the
+pane. This avoids an artificial subscribe gap that can repeatedly re-enter
+recovery for a large settled session, prevents a stale event from hijacking a
+user-initiated session switch, and keeps mutation callers from continuing against
+an unfinished transcript refresh.
 
 ### Sprint 1 (March 30, 2026): Bug Fixes, Arch Foundations, First Tests
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -299,6 +299,13 @@ rather than replacing it with the full SSE payload. This keeps the visible trans
 and pagination state coherent without changing the experimental virtualization
 preference or the Agent repository.
 
+Session mutations that shrink a transcript, including WebUI `/undo` and `/retry`,
+reuse the same bounded same-session reload path after the server-side mutation. They
+must not issue an unbounded follow-up `GET /api/session` or manually replace
+`S.messages`, because that would promote a long session back into a full browser DOM
+and discard its pagination cursor. Older-message paging updates the canonical session
+count and refreshes the top-bar `loaded of total` metadata after each window change.
+
 Fallback sync endpoint: POST /api/chat still exists and holds the connection open until
 the agent finishes. The frontend never uses it but it can be useful for debugging.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -273,6 +273,29 @@ block. If the browser disconnects mid-stream, the daemon thread runs to completi
 then cleans up. The queue fills and the put_nowait() calls fail silently (queue.Full
 is caught).
 
+#### 4.3.1 Settled transcript windowing
+
+The SSE `done` payload is intentionally a full terminal snapshot so the browser can
+reconcile canonical session metadata, usage, and the completed turn. It is not always
+the correct display payload: a session may already be loaded through the paginated
+`/api/session?msg_limit=...` contract, especially when transcript virtualization is
+disabled.
+
+When the browser's current session is truncated, `sessions.js` requests a bounded
+settled window from the same `/api/session` endpoint before applying the terminal
+snapshot. The server remains authoritative for visible-row counting, tool-result
+carry-through, `_messages_offset`, and activity-scene hydration. `messages.js` merges
+that bounded window with the terminal metadata and preserves the existing pagination
+cursor. SSE recovery uses the same path.
+
+The terminal paths do not promote `_messageRenderWindowSize` to the full transcript.
+Explicit history actions such as loading older messages, session-start navigation,
+export, edit, and regenerate may still request or render the full session. If the
+bounded refresh fails, the browser keeps its bounded in-flight/local transcript rather
+than replacing it with the full SSE payload. This keeps the visible transcript and
+the pagination state coherent without changing the experimental virtualization
+preference or the Agent repository.
+
 Fallback sync endpoint: POST /api/chat still exists and holds the connection open until
 the agent finishes. The frontend never uses it but it can be useful for debugging.
 
@@ -1092,6 +1115,17 @@ Resolution: Phase B replaces with thread-local or explicit parameter passing.
 
 This section records what was actually built and changed in each sprint. It is the
 permanent history of the codebase. Update it at the end of every sprint.
+
+### July 2026: Bounded Settled Transcript Windows
+
+The WebUI's terminal `done` event carries a full session snapshot, but the browser
+now preserves an already-paginated session window when applying that snapshot. It
+refreshes the canonical bounded tail through `/api/session?msg_limit=...`, retaining
+server-owned offsets, tool-result rows, activity metadata, and the newly completed
+turn without rendering thousands of older messages after every completion. SSE error
+and `stream_end` recovery use the same bounded request. Explicit history-loading
+actions remain unchanged, and a failed refresh keeps the bounded local/in-flight view
+instead of promoting the full terminal payload.
 
 ### Sprint 1 (March 30, 2026): Bug Fixes, Arch Foundations, First Tests
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -290,10 +290,13 @@ cursor. SSE recovery uses the same path.
 
 The terminal paths do not promote `_messageRenderWindowSize` to the full transcript.
 Explicit history actions such as loading older messages, session-start navigation,
-export, edit, and regenerate may still request or render the full session. If the
-bounded refresh fails, the browser keeps its bounded in-flight/local transcript rather
-than replacing it with the full SSE payload. This keeps the visible transcript and
-the pagination state coherent without changing the experimental virtualization
+and export may still request or render the full session. Edit/regenerate targets
+already visible in a paginated window keep the server-facing absolute `keep_count`
+but slice only the loaded local window; they do not expand the transcript merely to
+submit the mutation. Reconnect/refresh recovery also requests a bounded window. If a
+bounded refresh fails, the browser keeps its bounded in-flight/local transcript
+rather than replacing it with the full SSE payload. This keeps the visible transcript
+and pagination state coherent without changing the experimental virtualization
 preference or the Agent repository.
 
 Fallback sync endpoint: POST /api/chat still exists and holds the connection open until
@@ -1122,10 +1125,19 @@ The WebUI's terminal `done` event carries a full session snapshot, but the brows
 now preserves an already-paginated session window when applying that snapshot. It
 refreshes the canonical bounded tail through `/api/session?msg_limit=...`, retaining
 server-owned offsets, tool-result rows, activity metadata, and the newly completed
-turn without rendering thousands of older messages after every completion. SSE error
-and `stream_end` recovery use the same bounded request. Explicit history-loading
-actions remain unchanged, and a failed refresh keeps the bounded local/in-flight view
-instead of promoting the full terminal payload.
+turn without rendering thousands of older messages after every completion. SSE error,
+`stream_end`, and reconnect recovery use the same bounded request. Editing or
+regenerating a visible message uses the absolute server keep-count while trimming
+only the local window. Explicit history-loading actions remain unchanged, and a
+failed refresh keeps the bounded local/in-flight view instead of promoting the full
+terminal payload.
+
+Same-session force refreshes (metadata reconciliation and SSE recovery) keep the
+existing per-session SSE subscription alive while the bounded window is fetched.
+The browser also ignores a recovery frame while another session load owns the
+pane. This avoids creating an artificial subscribe gap that can repeatedly
+re-enter recovery for a large settled session, and prevents a stale event from
+hijacking a user-initiated session switch.
 
 ### Sprint 1 (March 30, 2026): Bug Fixes, Arch Foundations, First Tests
 

--- a/static/commands.js
+++ b/static/commands.js
@@ -1696,7 +1696,7 @@ async function cmdRetry(){
     const r=await api('/api/session/retry',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry'});
+    await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry',skipExtHooks:true});
     if(!S.session||S.session.session_id!==activeSid)return;
     $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();
     // Re-arm the single-shot explicit-pick marker from the captured non-default
@@ -1715,7 +1715,7 @@ async function cmdUndo(){
     const r=await api('/api/session/undo',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo'});
+    await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo',skipExtHooks:true});
     if(!S.session||S.session.session_id!==activeSid)return;
     showToast(`↩ ${t('undid_n_messages')} ${r.removed_count} ${t('undid_messages_suffix')}`);
   }catch(e){showToast(t('undo_failed')+e.message);}

--- a/static/commands.js
+++ b/static/commands.js
@@ -1696,11 +1696,8 @@ async function cmdRetry(){
     const r=await api('/api/session/retry',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    // #5924 SILENT-race guard: a session switch during the GET await must not let
-    // this recovery apply session A's intent to whatever session is now visible.
+    await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry'});
     if(!S.session||S.session.session_id!==activeSid)return;
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
     $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();
     // Re-arm the single-shot explicit-pick marker from the captured non-default
     // pick — but only if it's still safe at fire time (session unchanged, current
@@ -1718,8 +1715,8 @@ async function cmdUndo(){
     const r=await api('/api/session/undo',{method:'POST',body:JSON.stringify({session_id:activeSid})});
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
-    const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
+    await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo'});
+    if(!S.session||S.session.session_id!==activeSid)return;
     showToast(`↩ ${t('undid_n_messages')} ${r.removed_count} ${t('undid_messages_suffix')}`);
   }catch(e){showToast(t('undo_failed')+e.message);}
 }

--- a/static/messages.js
+++ b/static/messages.js
@@ -5817,7 +5817,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             ? _settledDoneInflightSnapshot.toolCalls
             : (Array.isArray(S.toolCalls)?S.toolCalls.map(tc=>({...tc})):[]);
           try{
-            _settledDoneWindow=await _fetchSettledSessionMessageWindow(activeSid,completedSession);
+            _settledDoneWindow=await _fetchSettledSessionMessageWindow(completedSid,completedSession);
           }catch(_settledWindowError){
             _settledDoneWindowFailed=true;
             if(typeof console!=='undefined'&&console.warn){

--- a/static/messages.js
+++ b/static/messages.js
@@ -2183,12 +2183,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     stopClarifyPolling();
     hideClarifyCard(true, reason||'terminal');
   }
-  function _clearOwnerInflightState(){
-    if(_isActiveSession() && S.activeStreamId!==streamId) return;
+  function _clearOwnerInflightState(options){
+    if(_isActiveSession() && S.activeStreamId!==streamId) return false;
     delete INFLIGHT[activeSid];
     clearInflightState(activeSid);
     _clearActivePaneInflightIfOwner();
-    _resumeSessionStreamAfterLiveChat(activeSid);
+    if(!(options&&options.deferSessionStreamResume)){
+      _resumeSessionStreamAfterLiveChat(activeSid);
+    }
+    return true;
   }
   function _isMarkerOnlyAssistantMessage(m){
     if(!m||m.role!=='assistant') return false;
@@ -5796,7 +5799,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               : [],
           }
           : null;
-        _clearOwnerInflightState();
+        let _deferredOwnerSessionStreamResume=false;
+        try{
+        _deferredOwnerSessionStreamResume=_clearOwnerInflightState({deferSessionStreamResume:true});
         if(typeof _markSessionCompletedInList==='function'){
           _markSessionCompletedInList(completedSession, activeSid);
         }
@@ -6052,6 +6057,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           liveDisplayText:typeof _streamDisplay==='function'?_streamDisplay():assistantText,
         });
         sendBrowserNotification('Response complete',_completionPreview||'Task finished',{forceHidden:_wasEverBackgrounded,sid:activeSid});
+        }finally{
+          if(_deferredOwnerSessionStreamResume){
+            _resumeSessionStreamAfterLiveChat(completedSid);
+          }
+        }
       };
       if(_shouldUseLiveProseFade()&&assistantBody){
         _cancelAnimationFramePendingStreamRender();

--- a/static/messages.js
+++ b/static/messages.js
@@ -7566,6 +7566,27 @@ function _resumeSessionStreamAfterLiveChat(sid) {
   }, 0);
 }
 
+function _queueSessionUpdatedRefresh(sid, serverCount) {
+  const loadingSid=(typeof _loadingSessionId!=='undefined') ? _loadingSessionId : null;
+  // A load for another session owns the pane transition; an event from the
+  // session being left must remain suppressed. A load for this same session is
+  // different: loadSession() will await/coalesce it and schedule one bounded
+  // follow-up if the active request did not reach serverCount.
+  if(loadingSid&&loadingSid!==sid) return false;
+  const localCount=(S.session&&S.session.session_id===sid&&Number.isFinite(Number(S.session.message_count)))
+    ? Number(S.session.message_count)
+    : (Array.isArray(S.messages)?S.messages.length:0);
+  if(!Number.isFinite(serverCount)||serverCount<=localCount) return false;
+  if(typeof loadSession!=='function') return false;
+  void loadSession(sid,{
+    force:true,
+    externalRefreshReason:'session-updated',
+    keepStaleUntilLoaded:true,
+    minimumMessageCount:serverCount,
+  });
+  return true;
+}
+
 function startSessionStream(sid) {
   if (!sid) return;
   // Already on this session? No-op (loadSession is a no-op when re-selecting
@@ -7668,21 +7689,7 @@ function startSessionStream(sid) {
           : (S.session && S.session.session_id === sid);
         if (!isCurrent) return;
         if (S.activeStreamId) return;
-        // Do not let a recovery event start a second load while a navigation or
-        // same-session refresh already owns the pane. In particular, a
-        // cross-session click must not be hijacked by a stale event from the
-        // long session that was just on screen.
-        if (typeof _loadingSessionId !== 'undefined' && _loadingSessionId) return;
-        // Re-check against our CURRENT known count — a concurrent load may have
-        // already caught us up between the server's emit and now.
-        const localCount = (S.session && S.session.session_id === sid && Number.isFinite(Number(S.session.message_count)))
-          ? Number(S.session.message_count)
-          : (Array.isArray(S.messages) ? S.messages.length : 0);
-        const serverCount = Number(d.message_count);
-        if (!Number.isFinite(serverCount) || serverCount <= localCount) return;
-        if (typeof loadSession === 'function') {
-          void loadSession(sid, {force: true, externalRefreshReason: 'session-updated', keepStaleUntilLoaded: true});
-        }
+        _queueSessionUpdatedRefresh(sid, Number(d.message_count));
       } catch (_) {}
     });
     // ── Defect B: live-view of server-initiated (Option Z) turns ──────────

--- a/static/messages.js
+++ b/static/messages.js
@@ -6594,7 +6594,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     try{
       const restoreUrl=typeof _settledSessionMessageWindowUrl==='function'
-        ? _settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true})
+        ? _settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true,forceBounded:true})
         : `/api/session?session_id=${encodeURIComponent(activeSid)}`;
       const data=await api(restoreUrl);
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
@@ -7668,6 +7668,11 @@ function startSessionStream(sid) {
           : (S.session && S.session.session_id === sid);
         if (!isCurrent) return;
         if (S.activeStreamId) return;
+        // Do not let a recovery event start a second load while a navigation or
+        // same-session refresh already owns the pane. In particular, a
+        // cross-session click must not be hijacked by a stale event from the
+        // long session that was just on screen.
+        if (typeof _loadingSessionId !== 'undefined' && _loadingSessionId) return;
         // Re-check against our CURRENT known count — a concurrent load may have
         // already caught us up between the server's emit and now.
         const localCount = (S.session && S.session.session_id === sid && Number.isFinite(Number(S.session.message_count)))

--- a/static/messages.js
+++ b/static/messages.js
@@ -5830,10 +5830,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             }
           }
         }
-        // The bounded refresh awaits a second session request. Do not let a
-        // session switch during that await project the completed old stream
-        // into the newly selected pane.
-        if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;
+        // The bounded refresh awaits a second session request. Pane identity
+        // alone is not enough here: a new chat stream can take ownership of the
+        // same session while the old stream is settling. Only the exact
+        // registered owner may install terminal state or clear activeStreamId.
+        if(isActiveSession){
+          const _settledLiveOwner=LIVE_STREAMS[activeSid];
+          const _settlementStillOwnsPane=
+            _isSessionCurrentPane(activeSid)&&
+            S.activeStreamId===streamId&&
+            !!(_settledLiveOwner&&_settledLiveOwner.streamId===streamId&&_settledLiveOwner.source===source);
+          if(!_settlementStillOwnsPane) isActiveSession=false;
+        }
         // The bounded window fetch above can take long enough for the reader
         // to scroll away from the tail. Re-evaluate follow intent only after
         // the await and pane-ownership check; a pre-fetch snapshot would yank

--- a/static/messages.js
+++ b/static/messages.js
@@ -5737,7 +5737,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _cancelThrottledSnapshotTimer();
       const _doneData=JSON.parse(e.data);
       const _doneEvent=e;
-      const _finishDone=()=>{
+      const _finishDone=async()=>{
         // Bug A fix: cancel any pending rAF and mark stream finalized before
         // the DOM is settled by renderMessages, so no trailing token/reasoning rAF
         // can reintroduce a stale thinking card or duplicate content.
@@ -5767,7 +5767,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         },_doneEvent);
         _scheduleAnchorRegistryCleanup();
         _clearAnchorProseIncrementalNode();
-        const isActiveSession=_isSessionCurrentPane(activeSid);
+        let isActiveSession=_isSessionCurrentPane(activeSid);
         const isSessionViewed=_isSessionActivelyViewed(activeSid);
         const completedSession=d.session||{session_id:activeSid};
         const completedSid=completedSession.session_id||activeSid;
@@ -5786,6 +5786,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           _markSessionCompletionUnread(completedSid, completedMessageCount);
         }
         if(isSessionViewed) _markSessionViewed(completedSid, completedMessageCount);
+        const _settledDoneInflightSnapshot=isActiveSession&&INFLIGHT[activeSid]
+          ? {
+            messages:Array.isArray(INFLIGHT[activeSid].messages)
+              ? INFLIGHT[activeSid].messages.map(m=>({...m}))
+              : [],
+            toolCalls:Array.isArray(INFLIGHT[activeSid].toolCalls)
+              ? INFLIGHT[activeSid].toolCalls.map(tc=>({...tc}))
+              : [],
+          }
+          : null;
         _clearOwnerInflightState();
         if(typeof _markSessionCompletedInList==='function'){
           _markSessionCompletedInList(completedSession, activeSid);
@@ -5796,6 +5806,32 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           ? _shouldFollowMessagesOnDomReplace()
           : (typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(1200)));
         const _settledStreamId=isActiveSession?(S.activeStreamId||(d&&d.stream_id)||''):'';
+        let _settledDoneWindow=null;
+        let _settledDoneWindowFailed=false;
+        let _settledDoneFallbackMessages=null;
+        let _settledDoneFallbackToolCalls=null;
+        const _settledDoneWasTruncated=!!(typeof _messagesTruncated!=='undefined'&&_messagesTruncated);
+        const _settledDonePriorOldestIdx=(typeof _oldestIdx!=='undefined')?(_oldestIdx||0):0;
+        if(isActiveSession&&_settledDoneWasTruncated&&typeof _fetchSettledSessionMessageWindow==='function'){
+          _settledDoneFallbackMessages=Array.isArray(_settledDoneInflightSnapshot&&_settledDoneInflightSnapshot.messages)
+            ? _settledDoneInflightSnapshot.messages
+            : (Array.isArray(S.messages)?S.messages.map(m=>({...m})):[]);
+          _settledDoneFallbackToolCalls=Array.isArray(_settledDoneInflightSnapshot&&_settledDoneInflightSnapshot.toolCalls)
+            ? _settledDoneInflightSnapshot.toolCalls
+            : (Array.isArray(S.toolCalls)?S.toolCalls.map(tc=>({...tc})):[]);
+          try{
+            _settledDoneWindow=await _fetchSettledSessionMessageWindow(activeSid,completedSession);
+          }catch(_settledWindowError){
+            _settledDoneWindowFailed=true;
+            if(typeof console!=='undefined'&&console.warn){
+              console.warn('settled session window refresh failed; keeping bounded local transcript',_settledWindowError);
+            }
+          }
+        }
+        // The bounded refresh awaits a second session request. Do not let a
+        // session switch during that await project the completed old stream
+        // into the newly selected pane.
+        if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;
         if(isActiveSession){
           S.activeStreamId=null;
         }
@@ -5810,9 +5846,29 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const _prevCost=(S.session&&S.session.estimated_cost)||0;
           const _prevCacheRead=(S.session&&S.session.cache_read_tokens)||0;
           const _prevCacheWrite=(S.session&&S.session.cache_write_tokens)||0;
-          S.session=d.session;S.messages=_carryForwardEphemeralTurnFields(S.messages||[], d.session.messages||[]);if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!d.session._messages_truncated;
-          // #4720: reset _oldestIdx (full-load symmetry; keeps the #4613 anchor aligned).
-          if(typeof _oldestIdx!=='undefined')_oldestIdx=d.session._messages_offset||0;
+          const _settledSession=_settledDoneWindow
+            ? {..._settledDoneWindow,...d.session}
+            : (_settledDoneWindowFailed
+              ? {...d.session,messages:_settledDoneFallbackMessages||[],tool_calls:_settledDoneFallbackToolCalls||[],_messages_truncated:true,_messages_offset:_settledDonePriorOldestIdx}
+              : d.session);
+          if(_settledDoneWindow){
+            _settledSession.messages=_settledDoneWindow.messages||[];
+            _settledSession.tool_calls=_settledDoneWindow.tool_calls||[];
+            _settledSession._messages_truncated=!!_settledDoneWindow._messages_truncated;
+            _settledSession._messages_offset=_settledDoneWindow._messages_offset||0;
+          }
+          S.session=_settledSession;
+          S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _settledSession.messages||[]);
+          if(typeof _messagesTruncated!=='undefined'){
+            _messagesTruncated=_settledDoneWasTruncated
+              ? (_settledDoneWindowFailed||!!_settledSession._messages_truncated)
+              : !!_settledSession._messages_truncated;
+          }
+          if(typeof _oldestIdx!=='undefined'){
+            _oldestIdx=_settledDoneWasTruncated
+              ? (_settledDoneWindowFailed?_settledDonePriorOldestIdx:(_settledSession._messages_offset||0))
+              : (_settledSession._messages_offset||0);
+          }
           S.messages=_filterRecoveryControlMessages(S.messages || []);
           if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
           if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();
@@ -5902,9 +5958,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
             return hasTc||hasPartialTc||hasTu;
           });
-          if(!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length){
-            S.toolCalls=d.session.tool_calls.map(tc=>tc);
-            S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);
+          if(!hasMessageToolMetadata&&_settledSession.tool_calls&&_settledSession.tool_calls.length){
+            S.toolCalls=_settledSession.tool_calls.map(tc=>tc);
+            S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(_settledSession.tool_calls);
           } else {
             if(hasMessageToolMetadata) S._settledLiveToolMetadata=S.toolCalls.map(tc=>({...tc,done:true}));
             S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map(tc=>({...tc,done:true}));
@@ -5934,11 +5990,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           // delivered the final messages and tool calls.
           if(typeof window!=='undefined') window._streamJustFinished=true;
           setTimeout(()=>{ if(typeof window!=='undefined') window._streamJustFinished=false; }, 5000);
-          // Expand render window to cover all messages so the done render
-          // doesn't hide Activity behind a tiny window (winSize=50).
-          if(typeof _messageRenderableMessageCount==='function'&&typeof _messageRenderWindowSize!=='undefined'){
-            _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
-          }
           // #4650 review: the agent turn that just completed may have changed
           // server-side reasoning config (e.g. a `/reasoning <level>` slash
           // command writes agent.reasoning_effort) WITHOUT changing the model/
@@ -6542,7 +6593,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       return returnStatus?'stale':false;
     }
     try{
-      const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+      const restoreUrl=typeof _settledSessionMessageWindowUrl==='function'
+        ? _settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true})
+        : `/api/session?session_id=${encodeURIComponent(activeSid)}`;
+      const data=await api(restoreUrl);
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
       // we were awaiting the network roundtrip, bail out — done already settled.
       if(_streamFinalized) return returnStatus?'restored':true;
@@ -6596,6 +6650,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           ? [..._stagedMessages,..._currentVisibleMessages.slice(_stagedMessages.length)]
           : _stagedMessages;
         S.messages=_filterRecoveryControlMessages(_resolvedMessages || []);
+        if(typeof _messagesTruncated!=='undefined') _messagesTruncated=!!session._messages_truncated;
+        if(typeof _oldestIdx!=='undefined') _oldestIdx=session._messages_offset||0;
         _attachProjectedAnchorSceneToLastAssistant(S.messages);
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
         if(S.session&&S.session.session_id){
@@ -6622,10 +6678,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           S.toolCalls=[];
         }
         if(isSessionViewed) _markSessionViewed(completedSid, session.message_count ?? S.messages.length);
-        // Expand render window so the settled render doesn't hide Activity.
-        if(typeof _messageRenderableMessageCount==='function'&&typeof _messageRenderWindowSize!=='undefined'){
-          _messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize==='function'?_currentMessageRenderWindowSize():50, _messageRenderableMessageCount());
-        }
         syncTopbar();renderMessages({preserveScroll:true});
       }
       if(_isActiveSession()) _queueDrainSid=activeSid;

--- a/static/messages.js
+++ b/static/messages.js
@@ -5802,9 +5802,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         _clearApprovalForOwner();
         _clearClarifyForOwner('terminal');
-        const shouldFollowOnDone=isActiveSession&&((typeof _shouldFollowMessagesOnDomReplace==='function')
-          ? _shouldFollowMessagesOnDomReplace()
-          : (typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(1200)));
         const _settledStreamId=isActiveSession?(S.activeStreamId||(d&&d.stream_id)||''):'';
         let _settledDoneWindow=null;
         let _settledDoneWindowFailed=false;
@@ -5832,6 +5829,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // session switch during that await project the completed old stream
         // into the newly selected pane.
         if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;
+        // The bounded window fetch above can take long enough for the reader
+        // to scroll away from the tail. Re-evaluate follow intent only after
+        // the await and pane-ownership check; a pre-fetch snapshot would yank
+        // a reader back to the bottom after they deliberately scrolled up.
+        const shouldFollowOnDone=isActiveSession&&((typeof _shouldFollowMessagesOnDomReplace==='function')
+          ? _shouldFollowMessagesOnDomReplace()
+          : (typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(1200)));
         if(isActiveSession){
           S.activeStreamId=null;
         }
@@ -6011,7 +6015,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(typeof _disarmKeepSettledWorklogOpen==='function') _disarmKeepSettledWorklogOpen();
           if(typeof _renderMessagesWithScrollSnapshot==='function') _renderMessagesWithScrollSnapshot();
           else renderMessages({preserveScroll:true});
-          if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
+          if(typeof _followSettledDoneIfStillPinned==='function') _followSettledDoneIfStillPinned();
+          else if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
           if(typeof noteWorkspaceMutationsFromToolCalls==='function') noteWorkspaceMutationsFromToolCalls(S.toolCalls);
           loadDir('.', { preservePreview: true });
           // TTS auto-read: speak the last assistant response if enabled (#499)
@@ -7585,6 +7590,13 @@ function _queueSessionUpdatedRefresh(sid, serverCount) {
     minimumMessageCount:serverCount,
   });
   return true;
+}
+
+function _followSettledDoneIfStillPinned(){
+  const shouldFollow=(typeof _shouldFollowMessagesOnDomReplace==='function')
+    ? _shouldFollowMessagesOnDomReplace()
+    : (typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(1200));
+  if(shouldFollow&&typeof scrollToBottom==='function') scrollToBottom();
 }
 
 function startSessionStream(sid) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -24,6 +24,113 @@ let _loadingSessionId = null;
 // concurrent loads can still race and overwrite each other unless we compare
 // the generation token as well.
 let _loadSessionGeneration = 0;
+// The generation token protects shared state from stale continuations, while
+// this promise coordinates callers that target the same session. A caller that
+// arrives during an active same-session refresh must not continue on an already
+// resolved `return;` path.
+let _activeSessionLoad = null;
+
+function _canonicalSessionLoadId(sid, opts) {
+  if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){
+    const resolvedSid=_resolveSessionIdFromSidebarLineage(sid);
+    if(resolvedSid&&resolvedSid!==sid) return resolvedSid;
+  }
+  return sid;
+}
+
+function _sessionLoadNeedsFollowUp(opts) {
+  const reason=String(opts&&opts.externalRefreshReason||'');
+  return reason==='retry'||reason==='undo'||reason==='session-updated';
+}
+
+function _sessionLoadCurrentMessageCount(sid) {
+  if(typeof S==='undefined'||!S.session||S.session.session_id!==sid) return null;
+  const count=Number(S.session.message_count);
+  return Number.isFinite(count)?count:null;
+}
+
+function _startSessionLoad(sid, opts) {
+  const promise=_loadSessionOnce(sid, opts||{});
+  const entry={
+    sid,
+    promise,
+    followUpPromise:null,
+    followUpOptions:null,
+    followUpRequiresMutation:false,
+    minimumMessageCount:Number(opts&&opts.minimumMessageCount),
+  };
+  _activeSessionLoad=entry;
+  const clearActive=()=>{
+    if(_activeSessionLoad===entry) _activeSessionLoad=null;
+  };
+  // Use both handlers so a failed load cannot leave a stale coordinator entry,
+  // and do not create an unhandled rejected promise from `.finally()`.
+  promise.then(clearActive,clearActive);
+  return promise;
+}
+
+function _runQueuedSessionLoad(sid, entry) {
+  if(typeof S==='undefined'||!S.session||S.session.session_id!==sid) return;
+  if(!entry.followUpRequiresMutation){
+    const minimum=entry.minimumMessageCount;
+    const current=_sessionLoadCurrentMessageCount(sid);
+    if(Number.isFinite(minimum)&&current!==null&&current>=minimum) return;
+  }
+  const opts={...(entry.followUpOptions||{}),_forceNew:true};
+  if(Number.isFinite(entry.minimumMessageCount)){
+    opts.minimumMessageCount=entry.minimumMessageCount;
+  }
+  return _startSessionLoad(sid,opts);
+}
+
+function _queueSessionLoadAfterActive(sid, opts, entry) {
+  const reason=String(opts&&opts.externalRefreshReason||'');
+  const minimum=Number(opts&&opts.minimumMessageCount);
+  if(Number.isFinite(minimum)){
+    const current=Number(entry.minimumMessageCount);
+    entry.minimumMessageCount=Number.isFinite(current)
+      ? Math.max(current,minimum)
+      : minimum;
+  }
+  if(reason==='retry'||reason==='undo'){
+    entry.followUpRequiresMutation=true;
+    entry.followUpOptions={...opts};
+  }else if(!entry.followUpOptions){
+    entry.followUpOptions={...opts};
+  }
+  if(!entry.followUpPromise){
+    entry.followUpPromise=entry.promise.then(
+      ()=>_runQueuedSessionLoad(sid,entry),
+      ()=>_runQueuedSessionLoad(sid,entry)
+    );
+  }
+  return entry.followUpPromise;
+}
+
+function loadSession(sid) {
+  const opts=arguments[1]||{};
+  sid=_canonicalSessionLoadId(sid,opts);
+  // Extension pre-open hooks belong to the public coordinator, not the
+  // execution core. This keeps coalesced, profile-retry, and continuation
+  // loads from notifying extensions more than once for one navigation.
+  if(!opts.skipExtHooks && !opts._preloadNotified && typeof _hermesNotifySessionOpen==='function'){
+    const preResult=_hermesNotifySessionOpen(sid,null,{preload:true,opts});
+    if(preResult&&preResult.cancel===true) return;
+  }
+  const forceReload=!!opts.force;
+  const currentSid=typeof S!=='undefined'&&S.session ? S.session.session_id : null;
+  const activeLoad=_activeSessionLoad;
+  if(!opts._forceNew&&activeLoad&&activeLoad.sid===sid){
+    if(forceReload&&currentSid===sid){
+      return _sessionLoadNeedsFollowUp(opts)
+        ? _queueSessionLoadAfterActive(sid,opts,activeLoad)
+        : activeLoad.promise;
+    }
+    if(!forceReload&&currentSid===sid) return activeLoad.promise;
+  }
+  return _startSessionLoad(sid,opts);
+}
+
 // #3306: Snapshot of S.messages captured by loadSession() right before it
 // clears them on a force-reload of the active session. Consumed by
 // _ensureMessagesLoaded() when calling _carryForwardEphemeralTurnFields so
@@ -1666,32 +1773,11 @@ async function _switchProfileForSessionLoad(profile){
   }
 }
 
-async function loadSession(sid){
+async function _loadSessionOnce(sid){
   const opts = arguments[1] || {};
-  // Resolve canonical lineage SID BEFORE both the direct and sidebar preload
-  // notifications so extensions always see the canonical session id, not the
-  // raw sidebar click id (which may differ after lineage folding).
-  if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){
-    const resolvedSid=_resolveSessionIdFromSidebarLineage(sid);
-    if(resolvedSid&&resolvedSid!==sid) sid=resolvedSid;
-  }
-  // Extension pre-open hook — fires once per sidebar click, not on every call.
-  // _openSidebarSession passes _preloadNotified:true so the hook isn't re-fired
-  // when loadSession runs the actual navigation inside it.
-  if(!opts.skipExtHooks && !opts._preloadNotified && typeof _hermesNotifySessionOpen==='function'){
-    var _preResult=_hermesNotifySessionOpen(sid, null, {preload:true, opts:opts});
-    if(_preResult&&_preResult.cancel===true){
-      return;
-    }
-  }
   const forceReload = !!opts.force;
   const currentSid = S.session ? S.session.session_id : null;
   const sameSessionForceReload = forceReload && currentSid===sid;
-  // A recovery event or a second refresh may arrive while the first
-  // same-session reload is still fetching its bounded window. It cannot add
-  // any information and would supersede the active generation, so let the
-  // existing owner finish instead of starting another destructive reload.
-  if(sameSessionForceReload&&_loadingSessionId===sid) return;
   // Clicking the already-open session in the sidebar is a no-op. Reloading it
   // tears down active pane state and can reset the long-session scroll window
   // to the top even though the user did not navigate anywhere. Explicit
@@ -1851,7 +1937,7 @@ async function loadSession(sid){
           return;
         }
         if (_isCurrentLoad()) _loadingSessionId = null;
-        return loadSession(sid,{...opts,skipProfileResolve:true,force:true,_preloadNotified:true});
+        return _loadSessionOnce(sid,{...opts,skipProfileResolve:true,force:true});
       }catch(switchErr){
         e=switchErr;
       }
@@ -1962,8 +2048,8 @@ async function loadSession(sid){
   // cross-profile continuation can't poison restore state with an unusable id.
   const continuationSid=(data.session&&data.session.continuation_session_id)||'';
   if(continuationSid&&continuationSid!==sid&&!opts.skipContinuationResolve){
-    _loadingSessionId=null;
-    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true,_preloadNotified:true});
+    if (_isCurrentLoad()) _loadingSessionId=null;
+    return _loadSessionOnce(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
   }
   S.session=data.session;
   if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3142,12 +3142,12 @@ function _settledSessionMessageWindowLimit(nextSession, options){
   if(typeof _messagesTruncated==='undefined'||(!_messagesTruncated&&!forceBounded)) return null;
   const loadedRenderableCount=_currentLoadedRenderableMessageCount();
   const loadedMessageCount=Array.isArray(S.messages)?S.messages.length:0;
-  // A recovery request can run before the normal paginated load has established
-  // _messagesTruncated. Do not let an already-full local transcript turn that
-  // recovery request back into a full server reload.
-  const loadedWindow=forceBounded&&!_messagesTruncated
-    ? 0
-    : Math.max(0,loadedRenderableCount);
+  // A populated non-truncated pane is already complete. Even force-bounded
+  // recovery must preserve that contract; requesting the default tail would
+  // replace the complete pane with 30 rows. An empty pre-load recovery may still
+  // reserve the normal initial window below.
+  if(!_messagesTruncated&&(loadedRenderableCount>0||loadedMessageCount>0)) return null;
+  const loadedWindow=Math.max(0,loadedRenderableCount);
   const priorMessageCount=Math.max(
     0,
     Number(S.session&&S.session.message_count)||loadedMessageCount
@@ -3166,10 +3166,24 @@ function _settledSessionMessageWindowLimit(nextSession, options){
   );
 }
 
-function _settledSessionMessageWindowUrl(sid, nextSession, options){
+function _sessionMessageReloadUrl(sid, requestedLimit){
   const base=`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`;
+  const numericLimit=Number(requestedLimit);
+  const boundedLimit=Number.isFinite(numericLimit)&&numericLimit>0&&numericLimit<=_msgLimitMax
+    ? Math.floor(numericLimit)
+    : null;
+  // A replace-oriented request above the server ceiling would be clamped and
+  // silently discard already-loaded older rows. Omitting msg_limit asks for the
+  // authoritative full transcript instead. The same omission also preserves a
+  // fully loaded, non-truncated pane instead of collapsing it to the default 30.
+  return boundedLimit===null
+    ? base
+    : `${base}&msg_limit=${encodeURIComponent(boundedLimit)}&expand_renderable=1`;
+}
+
+function _settledSessionMessageWindowUrl(sid, nextSession, options){
   const limit=_settledSessionMessageWindowLimit(nextSession,options);
-  return limit===null?base:`${base}&msg_limit=${encodeURIComponent(limit)}`;
+  return _sessionMessageReloadUrl(sid,limit);
 }
 
 async function _fetchSettledSessionMessageWindow(sid, nextSession, options){
@@ -3226,16 +3240,14 @@ function _messageReloadLimitForSession(sid){
       );
     }
   }
-  // Recovery callers such as refreshSession() do not pass through the
-  // same-session force-reload path, so they have no captured hint. Preserve
-  // the currently displayed bounded window in that case instead of silently
-  // collapsing an expanded view back to the initial tail.
-  // Keep the policy in _settledSessionMessageWindowLimit so every bounded
-  // session fetch uses the same visible-row accounting.
-  const boundedLimit=typeof _settledSessionMessageWindowLimit==='function'
-    ? _settledSessionMessageWindowLimit(null,{forceBounded:true})
-    : null;
-  return boundedLimit===null ? _INITIAL_MSG_LIMIT : boundedLimit;
+  const loadedRenderableCount=_currentLoadedRenderableMessageCount();
+  const loadedMessageCount=Array.isArray(S.messages)?S.messages.length:0;
+  // An empty pane is an initial/cold load and should use the default tail.
+  if(loadedRenderableCount<=0&&loadedMessageCount<=0) return _INITIAL_MSG_LIMIT;
+  // A populated non-truncated pane is already complete. Recovery must omit
+  // msg_limit so replacing S.messages cannot collapse it to the default tail.
+  if(!_messagesTruncated) return null;
+  return _settledSessionMessageWindowLimit(null);
 }
 
 function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){
@@ -3297,16 +3309,11 @@ async function _ensureMessagesLoaded(sid, opts) {
   // window exceeds the ceiling, fall back to the bare full-transcript request
   // (no msg_limit / no expand_renderable) so a same-session refresh never drops
   // already-loaded older rows (Codex gate #6154, silent row-loss).
-  const boundedReloadLimit = (reloadLimit && reloadLimit <= _msgLimitMax) ? reloadLimit : null;
-  const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';
-  // Older frontends used expand_renderable=1 to request visible-row expansion.
-  // The server now counts msg_limit by visible transcript rows by default; keep
-  // the flag for compatibility with mixed-version deployments.
-  const expandParam = boundedReloadLimit ? '&expand_renderable=1' : '';
+  const reloadUrl=_sessionMessageReloadUrl(sid,reloadLimit);
   let data;
   try {
     data = await api(
-      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}${expandParam}`,
+      reloadUrl,
       {timeoutMs:120000}
     );
   } finally {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3209,13 +3209,21 @@ function _messageReloadLimitForSession(sid){
   const hint=_sameSessionForceReloadHint;
   if(hint&&hint.session_id===sid){
     const loadedRenderableCount=Math.max(0,Number(hint.loaded_renderable_count)||0);
+    // S.messages also contains hidden role:"tool" rows. `msg_limit` is a
+    // renderable-row budget, so raw array length must never widen a mutation
+    // reload window (a 30-row view with 30 tool rows would otherwise request
+    // 60 visible rows on /undo or /retry).
     const loadedMessageCount=Math.max(0,Number(hint.loaded_message_count)||0);
     if(loadedRenderableCount>0 || loadedMessageCount>0){
       if(!hint.truncated) return null;
       const previousMessageCount=Math.max(0,Number(hint.message_count)||0);
       const currentMessageCount=Math.max(0,Number(S.session&&S.session.session_id===sid&&S.session.message_count)||0);
       const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);
-      return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);
+      return Math.max(
+        _INITIAL_MSG_LIMIT,
+        loadedRenderableCount,
+        loadedRenderableCount+appendedMessageCount
+      );
     }
   }
   // Recovery callers such as refreshSession() do not pass through the

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -24,6 +24,10 @@ let _loadingSessionId = null;
 // concurrent loads can still race and overwrite each other unless we compare
 // the generation token as well.
 let _loadSessionGeneration = 0;
+// Tracks user-visible load intent separately from request generations. A queued
+// same-session follow-up belongs to the intent that created its active load and
+// must not start after a newer cross-session navigation has taken ownership.
+let _sessionLoadIntentGeneration = 0;
 // The generation token protects shared state from stale continuations, while
 // this promise coordinates callers that target the same session. A caller that
 // arrives during an active same-session refresh must not continue on an already
@@ -49,11 +53,12 @@ function _sessionLoadCurrentMessageCount(sid) {
   return Number.isFinite(count)?count:null;
 }
 
-function _startSessionLoad(sid, opts) {
+function _startSessionLoad(sid, opts, intentGeneration) {
   const promise=_loadSessionOnce(sid, opts||{});
   const entry={
     sid,
     promise,
+    intentGeneration,
     followUpPromise:null,
     followUpOptions:null,
     followUpRequiresMutation:false,
@@ -70,6 +75,7 @@ function _startSessionLoad(sid, opts) {
 }
 
 function _runQueuedSessionLoad(sid, entry) {
+  if(entry.intentGeneration!==_sessionLoadIntentGeneration) return;
   if(typeof S==='undefined'||!S.session||S.session.session_id!==sid) return;
   if(!entry.followUpRequiresMutation){
     const minimum=entry.minimumMessageCount;
@@ -80,7 +86,7 @@ function _runQueuedSessionLoad(sid, entry) {
   if(Number.isFinite(entry.minimumMessageCount)){
     opts.minimumMessageCount=entry.minimumMessageCount;
   }
-  return _startSessionLoad(sid,opts);
+  return _startSessionLoad(sid,opts,entry.intentGeneration);
 }
 
 function _queueSessionLoadAfterActive(sid, opts, entry) {
@@ -128,7 +134,7 @@ function loadSession(sid) {
     }
     if(!forceReload&&currentSid===sid) return activeLoad.promise;
   }
-  return _startSessionLoad(sid,opts);
+  return _startSessionLoad(sid,opts,++_sessionLoadIntentGeneration);
 }
 
 // #3306: Snapshot of S.messages captured by loadSession() right before it

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3789,7 +3789,16 @@ async function _loadOlderMessages() {
       olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
       nextMessages = [...olderMsgs, ...S.messages];
     }
-    if (!olderMsgs.length) { _messagesTruncated = !!responseSession._messages_truncated; return; }
+    if (!olderMsgs.length) {
+      _messagesTruncated = !!responseSession._messages_truncated;
+      _oldestIdx = responseSession._messages_offset || 0;
+      const serverMessageCount = Number(responseSession.message_count);
+      if (S.session && S.session.session_id === sid && Number.isFinite(serverMessageCount)) {
+        S.session.message_count = serverMessageCount;
+      }
+      if (typeof syncTopbar === 'function') syncTopbar();
+      return;
+    }
     // Replace with the larger tail window and preserve scroll as if older
     // messages were prepended. When the suffix check fails, nextMessages
     // already encodes the legacy prepend fallback so the visible behavior
@@ -3828,7 +3837,12 @@ async function _loadOlderMessages() {
     _messageRenderWindowSize=_currentMessageRenderWindowSize()+Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT);
     _messagesTruncated = !!responseSession._messages_truncated;
     _oldestIdx = responseSession._messages_offset || 0;
+    const serverMessageCount = Number(responseSession.message_count);
+    if (S.session && S.session.session_id === sid && Number.isFinite(serverMessageCount)) {
+      S.session.message_count = serverMessageCount;
+    }
     renderMessages({ preserveScroll: true });
+    if (typeof syncTopbar === 'function') syncTopbar();
     if (container) {
       // Prepending older messages must not teleport the reader. Anchor to the
       // first visible rendered row and restore that row's top offset after the

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3032,6 +3032,54 @@ function _currentLoadedRenderableMessageCount(){
   return count;
 }
 
+// Settled SSE payloads intentionally carry the full transcript, but the
+// browser may currently be showing only a paginated tail. Keep terminal
+// settlement on the same server-owned window contract as initial loads and
+// older-message paging instead of promoting a truncated pane to full history.
+// The caller supplies the next session metadata when it is available so the
+// newly completed turn has room in the requested window. Recovery paths do
+// not have that metadata before their first request and reserve one normal
+// page as a conservative completion allowance.
+function _settledSessionMessageWindowLimit(nextSession, options){
+  if(typeof _messagesTruncated==='undefined'||!_messagesTruncated) return null;
+  const loadedRenderableCount=_currentLoadedRenderableMessageCount();
+  const loadedMessageCount=Array.isArray(S.messages)?S.messages.length:0;
+  const loadedWindow=Math.max(0,loadedRenderableCount);
+  const priorMessageCount=Math.max(
+    0,
+    Number(S.session&&S.session.message_count)||loadedMessageCount
+  );
+  const nextMessageCount=Math.max(
+    priorMessageCount,
+    Number(nextSession&&nextSession.message_count)||priorMessageCount
+  );
+  const appendedRawCount=Math.max(0,nextMessageCount-priorMessageCount);
+  const recoveryAllowance=options&&options.reserveNewTurn?_INITIAL_MSG_LIMIT:0;
+  return Math.max(
+    _INITIAL_MSG_LIMIT,
+    loadedWindow,
+    loadedWindow+appendedRawCount,
+    loadedWindow+recoveryAllowance
+  );
+}
+
+function _settledSessionMessageWindowUrl(sid, nextSession, options){
+  const base=`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`;
+  const limit=_settledSessionMessageWindowLimit(nextSession,options);
+  return limit===null?base:`${base}&msg_limit=${encodeURIComponent(limit)}`;
+}
+
+async function _fetchSettledSessionMessageWindow(sid, nextSession, options){
+  const limit=_settledSessionMessageWindowLimit(nextSession,options);
+  if(limit===null) return null;
+  const data=await api(
+    _settledSessionMessageWindowUrl(sid,nextSession,options),
+    {timeoutMs:120000}
+  );
+  if(!data||!data.session) throw new Error('Settled session window unavailable');
+  return data.session;
+}
+
 function _captureSameSessionForceReloadHint(sid){
   const loadedRenderableCount=_currentLoadedRenderableMessageCount();
   const loadedMessageCount=Array.isArray(S.messages)?S.messages.length:0;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1687,6 +1687,11 @@ async function loadSession(sid){
   const forceReload = !!opts.force;
   const currentSid = S.session ? S.session.session_id : null;
   const sameSessionForceReload = forceReload && currentSid===sid;
+  // A recovery event or a second refresh may arrive while the first
+  // same-session reload is still fetching its bounded window. It cannot add
+  // any information and would supersede the active generation, so let the
+  // existing owner finish instead of starting another destructive reload.
+  if(sameSessionForceReload&&_loadingSessionId===sid) return;
   // Clicking the already-open session in the sidebar is a no-op. Reloading it
   // tears down active pane state and can reset the long-session scroll window
   // to the top even though the user did not navigate anywhere. Explicit
@@ -1724,7 +1729,13 @@ async function loadSession(sid){
     _scrollPinned = true;
   }
   stopApprovalPolling();hideApprovalCard(forceReload);
-  if(typeof stopSessionStream==='function') stopSessionStream();
+  // A same-session force reload is a transcript refresh, not a navigation.
+  // Keep the healthy per-session SSE subscription alive while the metadata and
+  // bounded message window are fetched. Tearing it down here creates an
+  // artificial subscribe gap; the server can then emit its recovery event,
+  // which re-enters loadSession() and repeats the cycle for large sessions.
+  // Cross-session navigation still closes the old session's stream.
+  if(!sameSessionForceReload&&typeof stopSessionStream==='function') stopSessionStream();
   _yoloEnabled=false;_updateYoloPill();
   if(typeof stopClarifyPolling==='function') stopClarifyPolling();
   if(typeof hideClarifyCard==='function') hideClarifyCard(forceReload, forceReload?'external-refresh':'dismissed');
@@ -3041,10 +3052,16 @@ function _currentLoadedRenderableMessageCount(){
 // not have that metadata before their first request and reserve one normal
 // page as a conservative completion allowance.
 function _settledSessionMessageWindowLimit(nextSession, options){
-  if(typeof _messagesTruncated==='undefined'||!_messagesTruncated) return null;
+  const forceBounded=!!(options&&options.forceBounded);
+  if(typeof _messagesTruncated==='undefined'||(!_messagesTruncated&&!forceBounded)) return null;
   const loadedRenderableCount=_currentLoadedRenderableMessageCount();
   const loadedMessageCount=Array.isArray(S.messages)?S.messages.length:0;
-  const loadedWindow=Math.max(0,loadedRenderableCount);
+  // A recovery request can run before the normal paginated load has established
+  // _messagesTruncated. Do not let an already-full local transcript turn that
+  // recovery request back into a full server reload.
+  const loadedWindow=forceBounded&&!_messagesTruncated
+    ? 0
+    : Math.max(0,loadedRenderableCount);
   const priorMessageCount=Math.max(
     0,
     Number(S.session&&S.session.message_count)||loadedMessageCount

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3218,7 +3218,16 @@ function _messageReloadLimitForSession(sid){
       return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);
     }
   }
-  return _INITIAL_MSG_LIMIT;
+  // Recovery callers such as refreshSession() do not pass through the
+  // same-session force-reload path, so they have no captured hint. Preserve
+  // the currently displayed bounded window in that case instead of silently
+  // collapsing an expanded view back to the initial tail.
+  // Keep the policy in _settledSessionMessageWindowLimit so every bounded
+  // session fetch uses the same visible-row accounting.
+  const boundedLimit=typeof _settledSessionMessageWindowLimit==='function'
+    ? _settledSessionMessageWindowLimit(null,{forceBounded:true})
+    : null;
+  return boundedLimit===null ? _INITIAL_MSG_LIMIT : boundedLimit;
 }
 
 function _syncToolCallsForLoadedMessages(messages, sessionToolCalls){

--- a/static/ui.js
+++ b/static/ui.js
@@ -9573,8 +9573,9 @@ async function refreshSession() {
     const pendingMsg=getPendingSessionMessage(data.session,S.messages);
     if(pendingMsg) S.messages.push(pendingMsg);
     S.activeStreamId=data.session.active_stream_id||null;
-
+    S.session._modelResolutionDeferred=true;
     syncTopbar(); _renderMessagesWithScrollSnapshot();
+    if(typeof _resolveSessionModelForDisplaySoon==='function') _resolveSessionModelForDisplaySoon(sid);
     showToast('Conversation refreshed');
   } catch(e) { setStatus('Refresh failed: ' + e.message); }
 }
@@ -18252,11 +18253,11 @@ function autoResizeTextarea(ta) {
 async function submitEdit(msgIdx, newText) {
   if(!S.session || S.busy) return;
   const initialSid = S.session.session_id;
-  const loadedWindowOffset = Math.max(0, Number(_oldestIdx)||0);
-  const loadedWindowTruncated = !!(
+  const initialWindowOffset = Math.max(0, Number(_oldestIdx)||0);
+  const initialWindowTruncated = !!(
     typeof _messagesTruncated !== 'undefined' &&
     _messagesTruncated &&
-    loadedWindowOffset > 0
+    initialWindowOffset > 0
   );
   const absoluteKeepCount = _oldestIdx + msgIdx;
   // #5924: capture the deliberate-pick signal up front (pre-network), scoped to
@@ -18268,7 +18269,7 @@ async function submitEdit(msgIdx, newText) {
   // already contains everything needed to calculate the absolute keep_count.
   // Full history is still used for non-paginated/legacy states where the local
   // index cannot be safely translated into an absolute coordinate.
-  if(!loadedWindowTruncated&&typeof _ensureAllMessagesLoaded==='function'){
+  if(!initialWindowTruncated&&typeof _ensureAllMessagesLoaded==='function'){
     await _ensureAllMessagesLoaded();
   }
   if(!S.session || S.session.session_id !== initialSid) return;
@@ -18278,9 +18279,15 @@ async function submitEdit(msgIdx, newText) {
       keep_count: absoluteKeepCount
     })});
     if(!S.session || S.session.session_id !== initialSid) return;
+    const currentWindowOffset=Math.max(0,Number(_oldestIdx)||0);
+    const currentWindowTruncated=!!(
+      typeof _messagesTruncated!=='undefined'&&
+      _messagesTruncated&&
+      currentWindowOffset>0
+    );
     S.messages = S.messages.slice(
       0,
-      _loadedMessageSliceEndForKeepCount(absoluteKeepCount, loadedWindowOffset, loadedWindowTruncated)
+      _loadedMessageSliceEndForKeepCount(absoluteKeepCount,currentWindowOffset,currentWindowTruncated)
     );
     renderMessages();
     $('msg').value = newText;
@@ -18298,11 +18305,11 @@ async function regenerateResponse(btn) {
   const row = btn.closest('[data-msg-idx]');
   if(!row) return;
   const assistantIdx = parseInt(row.dataset.msgIdx, 10);
-  const loadedWindowOffset = Math.max(0, Number(_oldestIdx)||0);
-  const loadedWindowTruncated = !!(
+  const initialWindowOffset = Math.max(0, Number(_oldestIdx)||0);
+  const initialWindowTruncated = !!(
     typeof _messagesTruncated !== 'undefined' &&
     _messagesTruncated &&
-    loadedWindowOffset > 0
+    initialWindowOffset > 0
   );
   const absoluteKeepCount = _oldestIdx + assistantIdx;
   const initialSid = S.session.session_id;
@@ -18312,7 +18319,7 @@ async function regenerateResponse(btn) {
     if(m && m.role === 'user') { lastUserText = msgContent(m); break; }
   }
   if(!lastUserText) return;
-  if(!loadedWindowTruncated&&typeof _ensureAllMessagesLoaded==='function'){
+  if(!initialWindowTruncated&&typeof _ensureAllMessagesLoaded==='function'){
     await _ensureAllMessagesLoaded();
   }
   if(!S.session || S.session.session_id !== initialSid) return;
@@ -18322,9 +18329,15 @@ async function regenerateResponse(btn) {
       keep_count: absoluteKeepCount
     })});
     if(!S.session || S.session.session_id !== initialSid) return;
+    const currentWindowOffset=Math.max(0,Number(_oldestIdx)||0);
+    const currentWindowTruncated=!!(
+      typeof _messagesTruncated!=='undefined'&&
+      _messagesTruncated&&
+      currentWindowOffset>0
+    );
     S.messages = S.messages.slice(
       0,
-      _loadedMessageSliceEndForKeepCount(absoluteKeepCount, loadedWindowOffset, loadedWindowTruncated)
+      _loadedMessageSliceEndForKeepCount(absoluteKeepCount,currentWindowOffset,currentWindowTruncated)
     );
     renderMessages();
     $('msg').value = lastUserText;

--- a/static/ui.js
+++ b/static/ui.js
@@ -9554,19 +9554,22 @@ async function refreshSession() {
   if (!S.session) return;
   try {
     // Reconnect/refresh is a recovery path, not an explicit history export.
-    // Keep it on the bounded session window so a long transcript cannot turn a
-    // transient network recovery into a full DOM/markdown rebuild.
+    // Preserve the loaded session window. The shared URL policy keeps ordinary
+    // truncated windows bounded, but omits msg_limit when a server clamp would
+    // otherwise replace the pane with fewer rows than are already loaded.
     const sid=S.session.session_id;
-    const refreshLimit=(typeof _messageReloadLimitForSession==='function'
+    const refreshLimit=typeof _messageReloadLimitForSession==='function'
       ? _messageReloadLimitForSession(sid)
-      : 30)||30;
-    const data = await api(
-      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${encodeURIComponent(Math.max(30,Number(refreshLimit)||30))}&expand_renderable=1`
-    );
+      : 30;
+    const refreshUrl=typeof _sessionMessageReloadUrl==='function'
+      ? _sessionMessageReloadUrl(sid,refreshLimit)
+      : `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`;
+    const data = await api(refreshUrl);
     S.session = data.session;
     S.messages = data.session.messages || [];
     _messagesTruncated = !!data.session._messages_truncated;
     _oldestIdx = data.session._messages_offset || 0;
+    if(typeof _msgLimitMax!=='undefined') _msgLimitMax=data.session._msg_limit_max||_MSG_LIMIT_MAX;
     const pendingMsg=getPendingSessionMessage(data.session,S.messages);
     if(pendingMsg) S.messages.push(pendingMsg);
     S.activeStreamId=data.session.active_stream_id||null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -9553,7 +9553,16 @@ async function refreshSession() {
   dismissReconnect();
   if (!S.session) return;
   try {
-    const data = await api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}`);
+    // Reconnect/refresh is a recovery path, not an explicit history export.
+    // Keep it on the bounded session window so a long transcript cannot turn a
+    // transient network recovery into a full DOM/markdown rebuild.
+    const sid=S.session.session_id;
+    const refreshLimit=(typeof _messageReloadLimitForSession==='function'
+      ? _messageReloadLimitForSession(sid)
+      : 30)||30;
+    const data = await api(
+      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${encodeURIComponent(Math.max(30,Number(refreshLimit)||30))}&expand_renderable=1`
+    );
     S.session = data.session;
     S.messages = data.session.messages || [];
     _messagesTruncated = !!data.session._messages_truncated;
@@ -18175,6 +18184,17 @@ function ensureLiveWorklogShell(){
 
 // ── Edit + Regenerate ──
 
+// Edit/regenerate targets are rendered from the current message window, but the
+// truncate API expects an absolute position in the server transcript.  When the
+// current window starts at _oldestIdx, convert the absolute keep count back to a
+// local slice end after truncation instead of loading the entire history merely
+// to make Array#slice use the same coordinate system.
+function _loadedMessageSliceEndForKeepCount(absoluteKeepCount, windowOffset, windowTruncated){
+  const absolute=Math.max(0,Number(absoluteKeepCount)||0);
+  const offset=Math.max(0,Number(windowOffset)||0);
+  return windowTruncated?Math.max(0,absolute-offset):absolute;
+}
+
 function editMessage(btn) {
   if(S.busy) return;
   const row = btn.closest('[data-msg-idx]');
@@ -18229,13 +18249,23 @@ function autoResizeTextarea(ta) {
 async function submitEdit(msgIdx, newText) {
   if(!S.session || S.busy) return;
   const initialSid = S.session.session_id;
+  const loadedWindowOffset = Math.max(0, Number(_oldestIdx)||0);
+  const loadedWindowTruncated = !!(
+    typeof _messagesTruncated !== 'undefined' &&
+    _messagesTruncated &&
+    loadedWindowOffset > 0
+  );
   const absoluteKeepCount = _oldestIdx + msgIdx;
   // #5924: capture the deliberate-pick signal up front (pre-network), scoped to
   // initialSid — a non-default session model (vs profile default), which is
   // inference-free and survives the failed send's marker consumption. See
   // _deliberateSessionModelPick. null → no re-arm → server resolution runs.
   const _recoveryPick=_deliberateSessionModelPick(initialSid);
-  if(typeof _ensureAllMessagesLoaded==='function'){
+  // The target row is necessarily inside S.messages, so a truncated window
+  // already contains everything needed to calculate the absolute keep_count.
+  // Full history is still used for non-paginated/legacy states where the local
+  // index cannot be safely translated into an absolute coordinate.
+  if(!loadedWindowTruncated&&typeof _ensureAllMessagesLoaded==='function'){
     await _ensureAllMessagesLoaded();
   }
   if(!S.session || S.session.session_id !== initialSid) return;
@@ -18244,11 +18274,11 @@ async function submitEdit(msgIdx, newText) {
       session_id: initialSid,
       keep_count: absoluteKeepCount
     })});
-    // #5924 SILENT-race guard: a session switch during the truncate await must not
-    // let this recovery apply session A's intent (truncate/re-arm/send) to the
-    // newly-visible session.
     if(!S.session || S.session.session_id !== initialSid) return;
-    S.messages = S.messages.slice(0, absoluteKeepCount);
+    S.messages = S.messages.slice(
+      0,
+      _loadedMessageSliceEndForKeepCount(absoluteKeepCount, loadedWindowOffset, loadedWindowTruncated)
+    );
     renderMessages();
     $('msg').value = newText;
     // #5924 (Facet 1 + Facet 4): edit-resubmit is a recovery send. Re-arm the
@@ -18265,6 +18295,12 @@ async function regenerateResponse(btn) {
   const row = btn.closest('[data-msg-idx]');
   if(!row) return;
   const assistantIdx = parseInt(row.dataset.msgIdx, 10);
+  const loadedWindowOffset = Math.max(0, Number(_oldestIdx)||0);
+  const loadedWindowTruncated = !!(
+    typeof _messagesTruncated !== 'undefined' &&
+    _messagesTruncated &&
+    loadedWindowOffset > 0
+  );
   const absoluteKeepCount = _oldestIdx + assistantIdx;
   const initialSid = S.session.session_id;
   let lastUserText = '';
@@ -18273,7 +18309,7 @@ async function regenerateResponse(btn) {
     if(m && m.role === 'user') { lastUserText = msgContent(m); break; }
   }
   if(!lastUserText) return;
-  if(typeof _ensureAllMessagesLoaded==='function'){
+  if(!loadedWindowTruncated&&typeof _ensureAllMessagesLoaded==='function'){
     await _ensureAllMessagesLoaded();
   }
   if(!S.session || S.session.session_id !== initialSid) return;
@@ -18282,7 +18318,11 @@ async function regenerateResponse(btn) {
       session_id: initialSid,
       keep_count: absoluteKeepCount
     })});
-    S.messages = S.messages.slice(0, absoluteKeepCount);
+    if(!S.session || S.session.session_id !== initialSid) return;
+    S.messages = S.messages.slice(
+      0,
+      _loadedMessageSliceEndForKeepCount(absoluteKeepCount, loadedWindowOffset, loadedWindowTruncated)
+    );
     renderMessages();
     $('msg').value = lastUserText;
     await send();

--- a/tests/test_1694_prompt_ownership.py
+++ b/tests/test_1694_prompt_ownership.py
@@ -96,7 +96,7 @@ def test_polling_empty_state_clears_only_the_owner_prompt():
 
 
 def test_load_session_rerenders_cached_prompt_for_new_active_session():
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     assert "_renderPendingPromptsForActiveSession();" in body
 
 

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -49,7 +49,7 @@ def _function_body(name: str) -> str:
 def test_terminal_handlers_use_session_owned_cleanup_helpers():
     """Patch #1694 should centralize terminal cleanup behind owner-aware helpers."""
     attach_body = _function_body("attachLiveStream")
-    assert "function _clearOwnerInflightState()" in attach_body
+    assert "function _clearOwnerInflightState(options)" in attach_body
     owner_helper = _function_body("_clearOwnerInflightState")
     assert "delete INFLIGHT[activeSid]" in owner_helper
     assert "clearInflightState(activeSid)" in owner_helper
@@ -63,7 +63,9 @@ def test_terminal_handlers_use_session_owned_cleanup_helpers():
 def test_done_event_does_not_clear_active_pane_for_background_session():
     """A background done event may clear its owner marker, not the active pane."""
     body = _event_body("done")
-    assert "_clearOwnerInflightState();" in body
+    attach_body = _function_body("attachLiveStream")
+    assert "_clearOwnerInflightState({deferSessionStreamResume:true});" in body
+    assert "_resumeSessionStreamAfterLiveChat(completedSid);" in attach_body
     assert "clearInflight();clearInflightState(activeSid)" not in body
     assert "delete INFLIGHT[activeSid];\n      clearInflight();" not in body
     assert "renderSessionList();setBusy(false)" not in body

--- a/tests/test_active_empty_session_sidebar.py
+++ b/tests/test_active_empty_session_sidebar.py
@@ -17,7 +17,7 @@ def test_active_empty_session_is_injected_into_sidebar_rows():
 
 
 def test_new_session_switches_sidebar_back_to_webui_source():
-    new_session = SESSIONS_JS[SESSIONS_JS.index("async function newSession"):SESSIONS_JS.index("async function loadSession")]
+    new_session = SESSIONS_JS[SESSIONS_JS.index("async function newSession"):SESSIONS_JS.index("async function _loadSessionOnce")]
     assert "if(_sessionSourceFilter==='cli') _sessionSourceFilter='webui';" in new_session
 
 

--- a/tests/test_api_timeout.py
+++ b/tests/test_api_timeout.py
@@ -225,11 +225,12 @@ def test_session_message_loads_keep_explicit_longer_timeouts():
     """Large state.db installs can take longer than the generic 30s API timeout."""
     src = _source(SESSIONS_JS)
     assert (
-        "api(\n"
-        "      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0${reloadLimitParam}${expandParam}`,\n"
+        "data = await api(\n"
+        "      reloadUrl,\n"
         "      {timeoutMs:120000}\n"
         "    )"
     ) in src
+    assert "const reloadUrl=_sessionMessageReloadUrl(sid,reloadLimit);" in src
     # _loadOlderMessages now picks between two strategies (tail-growth vs
     # msg_before paging) via a useBeforePaging ternary, but both keep the long
     # timeoutMs:120000. Assert each URL + timeout survives in the source.

--- a/tests/test_bg_task_complete_loadsession_stream_restart.py
+++ b/tests/test_bg_task_complete_loadsession_stream_restart.py
@@ -42,10 +42,10 @@ def _read_sessions_js() -> str:
 
 
 def _load_session_body() -> str:
-    """Return the source slice of ``async function loadSession(`` start →
+    """Return the source slice of the async load core start →
     next top-level ``function`` / ``async function`` declaration."""
     js = _read_sessions_js()
-    start = js.index("async function loadSession(")
+    start = js.index("async function _loadSessionOnce(")
     rest = js[start + 1 :]
     m = re.search(r"\n(async function |function )", rest)
     end = start + 1 + (m.start() if m else len(rest))

--- a/tests/test_bounded_session_mutations_frontend.py
+++ b/tests/test_bounded_session_mutations_frontend.py
@@ -46,3 +46,7 @@ def test_older_message_window_refreshes_canonical_count_and_topbar():
     no_older_idx = fn.index("if (!olderMsgs.length)")
     assert no_older_idx < fn.index(sync, no_older_idx) < fn.index("return;", no_older_idx)
     assert fn.index("renderMessages({ preserveScroll: true });") < fn.rindex(sync)
+
+
+def test_duplicate_same_session_force_reload_is_coalesced():
+    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" in SESSIONS_JS

--- a/tests/test_bounded_session_mutations_frontend.py
+++ b/tests/test_bounded_session_mutations_frontend.py
@@ -16,8 +16,8 @@ def test_undo_and_retry_use_bounded_session_reload():
     retry = _function_block(COMMANDS_JS, "async function cmdRetry()", "async function cmdUndo()")
     undo = _function_block(COMMANDS_JS, "async function cmdUndo()", "async function undoLastExchange()")
 
-    assert "await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry'});" in retry
-    assert "await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo'});" in undo
+    assert "await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry',skipExtHooks:true});" in retry
+    assert "await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo',skipExtHooks:true});" in undo
     assert "await send();" in retry
 
     for block in (retry, undo):

--- a/tests/test_bounded_session_mutations_frontend.py
+++ b/tests/test_bounded_session_mutations_frontend.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS_JS = (ROOT / "static" / "commands.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_block(source, declaration, next_declaration):
+    start = source.index(declaration)
+    end = source.index(next_declaration, start + len(declaration))
+    return source[start:end]
+
+
+def test_undo_and_retry_use_bounded_session_reload():
+    retry = _function_block(COMMANDS_JS, "async function cmdRetry()", "async function cmdUndo()")
+    undo = _function_block(COMMANDS_JS, "async function cmdUndo()", "async function undoLastExchange()")
+
+    assert "loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry'});" in retry
+    assert "loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo'});" in undo
+    assert "await send();" in retry
+
+    for block in (retry, undo):
+        assert "api('/api/session?session_id='+encodeURIComponent(activeSid))" not in block
+        assert "S.messages=data.session.messages||[]" not in block
+        assert "clearLiveToolCards" not in block
+        assert "renderMessages()" not in block
+        assert "_messagesTruncated=false" not in block
+
+
+def test_older_message_window_refreshes_canonical_count_and_topbar():
+    fn = _function_block(
+        SESSIONS_JS,
+        "async function _loadOlderMessages()",
+        "// Ensure the full message history is loaded",
+    )
+
+    assert "const serverMessageCount = Number(responseSession.message_count);" in fn
+    assert "S.session.message_count = serverMessageCount;" in fn
+    assert "if (typeof syncTopbar === 'function') syncTopbar();" in fn
+
+    # Both the normal prepend and the already-at-the-end path must refresh the
+    # header; otherwise it remains stuck at the initial 30-message window.
+    sync = "if (typeof syncTopbar === 'function') syncTopbar();"
+    assert fn.count(sync) == 2
+    no_older_idx = fn.index("if (!olderMsgs.length)")
+    assert no_older_idx < fn.index(sync, no_older_idx) < fn.index("return;", no_older_idx)
+    assert fn.index("renderMessages({ preserveScroll: true });") < fn.rindex(sync)

--- a/tests/test_bounded_session_mutations_frontend.py
+++ b/tests/test_bounded_session_mutations_frontend.py
@@ -49,4 +49,7 @@ def test_older_message_window_refreshes_canonical_count_and_topbar():
 
 
 def test_duplicate_same_session_force_reload_is_coalesced():
-    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" in SESSIONS_JS
+    assert "const activeLoad=_activeSessionLoad;" in SESSIONS_JS
+    assert "_queueSessionLoadAfterActive(sid,opts,activeLoad)" in SESSIONS_JS
+    assert "return activeLoad.promise;" in SESSIONS_JS
+    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" not in SESSIONS_JS

--- a/tests/test_bounded_session_mutations_frontend.py
+++ b/tests/test_bounded_session_mutations_frontend.py
@@ -16,8 +16,8 @@ def test_undo_and_retry_use_bounded_session_reload():
     retry = _function_block(COMMANDS_JS, "async function cmdRetry()", "async function cmdUndo()")
     undo = _function_block(COMMANDS_JS, "async function cmdUndo()", "async function undoLastExchange()")
 
-    assert "loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry'});" in retry
-    assert "loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo'});" in undo
+    assert "await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'retry'});" in retry
+    assert "await loadSession(activeSid,{force:true,keepStaleUntilLoaded:true,externalRefreshReason:'undo'});" in undo
     assert "await send();" in retry
 
     for block in (retry, undo):

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -518,25 +518,25 @@ async function runStaleRejectedIdleCatch() {
   globalThis.apiHost = apiHost;
   globalThis.api = apiHost.api;
 
-  S.session = { session_id: 'sid-atlas', message_count: 0 };
+  S.session = { session_id: 'sid-beacon', message_count: 0 };
 
   const calls = {
-    firstMeta: apiHost.enqueue(buildMessageUrl('sid-atlas', 0)),
-    firstMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1)),
+    firstMeta: apiHost.enqueue(buildMessageUrl('sid-beacon', 0)),
+    firstMsgs: apiHost.enqueue(buildMessageUrl('sid-beacon', 1)),
     secondMeta: apiHost.enqueue(buildMessageUrl('sid-atlas', 0)),
     secondMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1)),
   };
 
-  const first = loadSession('sid-atlas', { force: true });
-  calls.firstMeta._resolve(API_ATLAS_META);
+  const first = loadSession('sid-beacon', { force: true });
+  calls.firstMeta._resolve(API_BEACON_META);
 
   // Ensure the first load has entered the messages fetch and owns the pending API
-  // call before the superseding same-session load begins.
+  // call before the superseding cross-session load begins.
   await waitForQueued(apiHost, calls.firstMsgs.url);
 
   const second = loadSession('sid-atlas', { force: true });
 
-  // The stale first request rejects while the second newer request is in flight.
+  // The stale Beacon request rejects while the newer Atlas request is in flight.
   calls.firstMsgs._reject(new Error('owner lost while load was in-flight'));
   calls.secondMeta._resolve(API_ATLAS_RELOAD_META);
   calls.secondMsgs._resolve(API_ATLAS_RELOAD_MSGS);
@@ -544,7 +544,7 @@ async function runStaleRejectedIdleCatch() {
   await Promise.all([first, second]);
 
   return {
-    scenario: 'stale-idle-catch',
+    scenario: 'stale-cross-session-catch',
     finalSid: S.session && S.session.session_id,
     messages: snapshotState().messages,
     toolCalls: snapshotState().toolCalls,
@@ -663,17 +663,25 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
     _assert_atlas_wins(observed, label="observed-idle-cross-session-ordering")
     assert observed["toastCalls"] == [], "stale Beacon return in idle-path race should not show toast"
 
-    # 3) Stale rejected idle-branch catch must be ownership-guarded and not mutate shared pane.
+    # 3) A rejected stale cross-session idle-branch load must be ownership-guarded
+    #    and must not mutate the newly active pane.
+    assert stale["finalSid"] == "sid-atlas", "stale rejection must leave Atlas active"
     assert stale["messages"] == ["reloaded-active-transcript"], "stale catch must not keep stale transcript"
     assert stale["toolCalls"] == [{"name": "tool-atlas-new", "done": True}], "stale catch must not overwrite tool state"
     assert stale["truncated"] is True and stale["oldestIdx"] == 33, "active owner should install latest metadata"
-    assert stale["msgInner"] == "INIT_LOADING", (
+    assert "Failed to load messages" not in stale["msgInner"], (
         "stale reject from superseded load must not write failure placeholder"
+    )
+    assert "Loading conversation..." in stale["msgInner"], (
+        "the active cross-session load may retain its loading placeholder"
     )
     assert stale["toastCalls"] == [], "stale reject must not surface toast for superseded load"
     assert stale["apiCalls"].count(
+        "/api/session?session_id=sid-beacon&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1"
+    ) == 1, "stale Beacon transcript should be attempted once"
+    assert stale["apiCalls"].count(
         "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1"
-    ) == 2, "both old and active loads should have attempted message fetch"
+    ) == 1, "active Atlas transcript should be attempted once"
 
     assert cross["loadingSid"] is None, "load marker should be cleared after successful completion"
     assert stale["loadingSid"] is None, "load marker should be cleared after stale reject + re-owner completion"

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -238,6 +238,7 @@ function createEnvironment() {
   globalThis._activeSessionLoad = null;
   globalThis._loadingOlder = false;
   globalThis._loadSessionGeneration = 0;
+  globalThis._sessionLoadIntentGeneration = 0;
   globalThis._pendingCarryForwardSnapshot = null;
   globalThis._messagesTruncated = false;
   globalThis._oldestIdx = 0;
@@ -668,12 +669,66 @@ async function runSameSessionMutationRefreshQueue() {
   };
 }
 
+async function runQueuedMutationSupersededByNavigation() {
+  createEnvironment();
+  S.session = { session_id: 'sid-atlas', message_count: 21 };
+  const apiCalls = [];
+  let resolveAtlasMessages;
+  let resolveBeaconMeta;
+  const atlasMessagesPending = new Promise((resolve) => { resolveAtlasMessages = resolve; });
+  const beaconMetaPending = new Promise((resolve) => { resolveBeaconMeta = resolve; });
+  let atlasMetaCalls = 0;
+  globalThis.api = async (url) => {
+    const value = String(url);
+    apiCalls.push(value);
+    if (value === buildMessageUrl('sid-atlas', 0)) {
+      atlasMetaCalls += 1;
+      return atlasMetaCalls === 1 ? API_ATLAS_META : API_ATLAS_RELOAD_META;
+    }
+    if (value === buildMessageUrl('sid-atlas', 1)) {
+      return atlasMetaCalls === 1 ? atlasMessagesPending : API_ATLAS_RELOAD_MSGS;
+    }
+    if (value === buildMessageUrl('sid-beacon', 0)) return beaconMetaPending;
+    if (value === buildMessageUrl('sid-beacon', 1)) return API_BEACON_MSGS;
+    throw new Error('Unexpected API call: ' + value);
+  };
+
+  const active = loadSession('sid-atlas', {
+    force: true,
+    keepStaleUntilLoaded: true,
+    externalRefreshReason: 'external-refresh',
+  });
+  while (!apiCalls.includes(buildMessageUrl('sid-atlas', 1))) await Promise.resolve();
+
+  const queued = loadSession('sid-atlas', {
+    force: true,
+    keepStaleUntilLoaded: true,
+    externalRefreshReason: 'undo',
+  });
+  const navigation = loadSession('sid-beacon', { force: true });
+  while (!apiCalls.includes(buildMessageUrl('sid-beacon', 0))) await Promise.resolve();
+
+  resolveAtlasMessages(API_ATLAS_MSGS);
+  await active;
+  resolveBeaconMeta(API_BEACON_META);
+  await Promise.all([queued, navigation]);
+
+  return {
+    apiCalls,
+    atlasMetaCalls,
+    finalSid: S.session && S.session.session_id,
+    messages: snapshotState().messages,
+    loadingGeneration: snapshotState().loadingGeneration,
+  };
+}
+
 async function runAll() {
   return {
     crossSessionOrdering: await runCrossSessionOrdering(),
     observedIdleCrossSessionOrdering: await runObservedIdleCrossSessionOrdering(),
     staleIdleCatch: await runStaleRejectedIdleCatch(),
     sameSessionMutationQueue: await runSameSessionMutationRefreshQueue(),
+    queuedMutationVsNavigation: await runQueuedMutationSupersededByNavigation(),
   };
 }
 
@@ -761,6 +816,7 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
     stale = body["staleIdleCatch"]
     observed = body["observedIdleCrossSessionOrdering"]
     mutation_queue = body["sameSessionMutationQueue"]
+    queued_vs_navigation = body["queuedMutationVsNavigation"]
 
     def _assert_atlas_wins(session_result, *, label):
         assert session_result["finalSid"] == "sid-atlas", f"{label}: stale overlap should end on Atlas session"
@@ -855,3 +911,9 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
     ], "queued mutation refresh should run exactly one bounded follow-up load"
     assert mutation_queue["finalSid"] == "sid-atlas"
     assert mutation_queue["messages"] == ["after-mutation-transcript"]
+
+    assert queued_vs_navigation["atlasMetaCalls"] == 1, (
+        "a queued Atlas mutation refresh must be abandoned after newer Beacon navigation intent"
+    )
+    assert queued_vs_navigation["finalSid"] == "sid-beacon"
+    assert queued_vs_navigation["messages"] == ["stale-beacon-transcript"]

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -103,6 +103,7 @@ LOAD_SESSION_COORDINATION_SRC = "\n\n".join(
         "_startSessionLoad",
         "_runQueuedSessionLoad",
         "_queueSessionLoadAfterActive",
+        "_sessionMessageReloadUrl",
     )
 )
 

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -21,6 +21,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 SESSIONS_SRC = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_SRC = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 
@@ -88,9 +89,22 @@ def _extract_function(source: str, name: str) -> str:
 
 
 LOAD_SESSION_SRC = _extract_function(SESSIONS_SRC, "loadSession")
+LOAD_SESSION_ONCE_SRC = _extract_function(SESSIONS_SRC, "_loadSessionOnce")
 ENSURE_MESSAGES_LOADED_SRC = _extract_function(SESSIONS_SRC, "_ensureMessagesLoaded")
 INFLIGHT_HAS_VISIBLE_STATE_SRC = _extract_function(SESSIONS_SRC, "_inflightHasVisibleLiveState")
 SELECT_LIVE_RECOVERY_INFLIGHT_SRC = _extract_function(SESSIONS_SRC, "_selectLiveRecoveryInflight")
+SESSION_UPDATED_HELPER_SRC = _extract_function(MESSAGES_SRC, "_queueSessionUpdatedRefresh")
+LOAD_SESSION_COORDINATION_SRC = "\n\n".join(
+    _extract_function(SESSIONS_SRC, name)
+    for name in (
+        "_canonicalSessionLoadId",
+        "_sessionLoadNeedsFollowUp",
+        "_sessionLoadCurrentMessageCount",
+        "_startSessionLoad",
+        "_runQueuedSessionLoad",
+        "_queueSessionLoadAfterActive",
+    )
+)
 
 
 def _normalise_ws(s: str) -> str:
@@ -98,7 +112,7 @@ def _normalise_ws(s: str) -> str:
 
 
 def test_loadsession_has_generation_token_and_forwards_to_ensure_messages_loaded():
-    body = LOAD_SESSION_SRC
+    body = LOAD_SESSION_ONCE_SRC
     assert "_loadSessionGeneration" in body, (
         "loadSession() must use a global generation counter so superseded loads "
         "can be rejected by continuation ownership checks"
@@ -122,9 +136,26 @@ def test_loadsession_has_generation_token_and_forwards_to_ensure_messages_loaded
         "loadSession() must pass generation into _ensureMessagesLoaded() for stale-owner checks"
     )
     assert (
-        "showToast('Failed to load session" in LOAD_SESSION_SRC
-        or "showToast('Failed to load conversation messages" in LOAD_SESSION_SRC
+        "showToast('Failed to load session" in LOAD_SESSION_ONCE_SRC
+        or "showToast('Failed to load conversation messages" in LOAD_SESSION_ONCE_SRC
     ), "loadSession() should preserve toast-based failure paths"
+
+
+def test_same_session_reload_callers_wait_or_queue_a_follow_up():
+    body = LOAD_SESSION_SRC
+    assert "const activeLoad=_activeSessionLoad;" in body
+    assert "return _sessionLoadNeedsFollowUp(opts)" in body
+    assert "_queueSessionLoadAfterActive(sid,opts,activeLoad)" in body
+    assert "return activeLoad.promise" in body
+    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" not in SESSIONS_SRC
+
+
+def test_session_updated_refresh_preserves_cross_session_suppression_and_queues_same_session():
+    body = SESSION_UPDATED_HELPER_SRC
+    assert "if(loadingSid&&loadingSid!==sid) return false;" in body
+    assert "externalRefreshReason:'session-updated'" in body
+    assert "minimumMessageCount:serverCount" in body
+    assert "_queueSessionUpdatedRefresh(sid, Number(d.message_count));" in MESSAGES_SRC
 
 
 def test_ensure_messages_loaded_ownership_guard_pre_and_post_await():
@@ -203,6 +234,7 @@ function createEnvironment() {
     activeStreamId: null,
   };
   globalThis._loadingSessionId = null;
+  globalThis._activeSessionLoad = null;
   globalThis._loadingOlder = false;
   globalThis._loadSessionGeneration = 0;
   globalThis._pendingCarryForwardSnapshot = null;
@@ -348,8 +380,11 @@ let toastCalls = [];
 // Source under test
 __INFLIGHT_HAS_VISIBLE_STATE_SRC__
 __SELECT_LIVE_RECOVERY_INFLIGHT_SRC__
+__LOAD_SESSION_COORDINATION_SRC__
 __LOAD_SESSION_SRC__
+__LOAD_SESSION_ONCE_SRC__
 __ENSURE_MESSAGES_LOADED_SRC__
+__SESSION_UPDATED_HELPER_SRC__
 
 async function waitForQueued(apiHost, url) {
   const target = String(url);
@@ -559,11 +594,85 @@ async function runStaleRejectedIdleCatch() {
   };
 }
 
+async function runSameSessionMutationRefreshQueue() {
+  createEnvironment();
+  S.session = { session_id: 'sid-atlas', message_count: 21 };
+  const apiHost = makeHarness();
+  globalThis.apiHost = apiHost;
+  globalThis.api = apiHost.api;
+
+  const afterMutationMeta = {
+    session: { ...API_ATLAS_META.session, message_count: 22 },
+  };
+  const afterMutationMsgs = {
+    session: {
+      ...API_ATLAS_MSGS.session,
+      message_count: 22,
+      messages: [{ role: 'assistant', content: 'after-mutation-transcript' }],
+    },
+  };
+  const calls = {
+    firstMeta: apiHost.enqueue(buildMessageUrl('sid-atlas', 0)),
+    firstMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1)),
+    secondMeta: apiHost.enqueue(buildMessageUrl('sid-atlas', 0)),
+    secondMsgs: apiHost.enqueue(buildMessageUrl('sid-atlas', 1)),
+  };
+
+  const first = loadSession('sid-atlas', {
+    force: true,
+    keepStaleUntilLoaded: true,
+    externalRefreshReason: 'external-refresh',
+  });
+  await waitForQueued(apiHost, calls.firstMeta.url);
+  calls.firstMeta._resolve(API_ATLAS_META);
+  await waitForQueued(apiHost, calls.firstMsgs.url);
+
+  let duplicateSettled = false;
+  const duplicate = loadSession('sid-atlas', {
+    force: true,
+    keepStaleUntilLoaded: true,
+    externalRefreshReason: 'external-refresh',
+  });
+  duplicate.then(() => { duplicateSettled = true; });
+  await Promise.resolve();
+  const duplicateSettledBeforeFirst = duplicateSettled;
+
+  const eventQueued = _queueSessionUpdatedRefresh('sid-atlas', 22);
+  let secondSettled = false;
+  const second = loadSession('sid-atlas', {
+    force: true,
+    keepStaleUntilLoaded: true,
+    externalRefreshReason: 'undo',
+  });
+  second.then(() => { secondSettled = true; });
+  await Promise.resolve();
+  const secondSettledBeforeFirst = secondSettled;
+
+  calls.firstMsgs._resolve(API_ATLAS_MSGS);
+  await first;
+  await duplicate;
+  await waitForQueued(apiHost, calls.secondMeta.url);
+  calls.secondMeta._resolve(afterMutationMeta);
+  await waitForQueued(apiHost, calls.secondMsgs.url);
+  calls.secondMsgs._resolve(afterMutationMsgs);
+  await second;
+
+  return {
+    eventQueued,
+    duplicateSettledBeforeFirst,
+    secondSettledBeforeFirst,
+    apiCalls: apiHost.apiCalls.slice(),
+    finalSid: S.session && S.session.session_id,
+    messages: snapshotState().messages,
+  };
+}
+
 async function runAll() {
   return {
     crossSessionOrdering: await runCrossSessionOrdering(),
     observedIdleCrossSessionOrdering: await runObservedIdleCrossSessionOrdering(),
     staleIdleCatch: await runStaleRejectedIdleCatch(),
+    sameSessionMutationQueue: await runSameSessionMutationRefreshQueue(),
   };
 }
 
@@ -592,6 +701,44 @@ def _run_node(script: str) -> dict:
     return json.loads(output_lines[-1])
 
 
+_SESSION_UPDATED_HELPER_NODE_TEMPLATE = r'''
+globalThis.S = {
+  session: { session_id: 'sid-atlas', message_count: 10 },
+  messages: [],
+};
+globalThis._loadingSessionId = 'sid-atlas';
+const calls = [];
+globalThis.loadSession = (sid, opts) => {
+  calls.push({ sid, opts });
+  return Promise.resolve();
+};
+__SESSION_UPDATED_HELPER_SRC__
+
+const sameSessionQueued = _queueSessionUpdatedRefresh('sid-atlas', 11);
+globalThis._loadingSessionId = 'sid-beacon';
+const crossSessionSuppressed = _queueSessionUpdatedRefresh('sid-atlas', 12);
+globalThis._loadingSessionId = 'sid-atlas';
+S.session.message_count = 11;
+const alreadyCaughtUp = _queueSessionUpdatedRefresh('sid-atlas', 11);
+console.log(JSON.stringify({ sameSessionQueued, crossSessionSuppressed, alreadyCaughtUp, calls }));
+'''
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_session_updated_helper_routes_same_session_events_safely():
+    body = _run_node(
+        _SESSION_UPDATED_HELPER_NODE_TEMPLATE.replace(
+            "__SESSION_UPDATED_HELPER_SRC__", SESSION_UPDATED_HELPER_SRC
+        )
+    )
+    assert body["sameSessionQueued"] is True
+    assert body["crossSessionSuppressed"] is False
+    assert body["alreadyCaughtUp"] is False
+    assert len(body["calls"]) == 1
+    assert body["calls"][0]["sid"] == "sid-atlas"
+    assert body["calls"][0]["opts"]["minimumMessageCount"] == 11
+
+
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
     script = (
@@ -601,14 +748,18 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
         .replace(
             "__SELECT_LIVE_RECOVERY_INFLIGHT_SRC__", SELECT_LIVE_RECOVERY_INFLIGHT_SRC
         )
+        .replace("__LOAD_SESSION_COORDINATION_SRC__", LOAD_SESSION_COORDINATION_SRC)
         .replace("__LOAD_SESSION_SRC__", LOAD_SESSION_SRC)
+        .replace("__LOAD_SESSION_ONCE_SRC__", LOAD_SESSION_ONCE_SRC)
         .replace("__ENSURE_MESSAGES_LOADED_SRC__", ENSURE_MESSAGES_LOADED_SRC)
+        .replace("__SESSION_UPDATED_HELPER_SRC__", SESSION_UPDATED_HELPER_SRC)
     )
     body = _run_node(script)
 
     cross = body["crossSessionOrdering"]
     stale = body["staleIdleCatch"]
     observed = body["observedIdleCrossSessionOrdering"]
+    mutation_queue = body["sameSessionMutationQueue"]
 
     def _assert_atlas_wins(session_result, *, label):
         assert session_result["finalSid"] == "sid-atlas", f"{label}: stale overlap should end on Atlas session"
@@ -685,3 +836,21 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
 
     assert cross["loadingSid"] is None, "load marker should be cleared after successful completion"
     assert stale["loadingSid"] is None, "load marker should be cleared after stale reject + re-owner completion"
+
+    assert mutation_queue["secondSettledBeforeFirst"] is False, (
+        "a same-session mutation refresh must remain pending until the active load settles"
+    )
+    assert mutation_queue["duplicateSettledBeforeFirst"] is False, (
+        "a same-session duplicate refresh must await the active load"
+    )
+    assert mutation_queue["eventQueued"] is True, (
+        "a same-session session-updated event must join the active load and queue a follow-up"
+    )
+    assert mutation_queue["apiCalls"] == [
+        "/api/session?session_id=sid-atlas&messages=0&resolve_model=0",
+        "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1",
+        "/api/session?session_id=sid-atlas&messages=0&resolve_model=0",
+        "/api/session?session_id=sid-atlas&messages=1&resolve_model=0&msg_limit=2&expand_renderable=1",
+    ], "queued mutation refresh should run exactly one bounded follow-up load"
+    assert mutation_queue["finalSid"] == "sid-atlas"
+    assert mutation_queue["messages"] == ["after-mutation-transcript"]

--- a/tests/test_extension_session_hooks.py
+++ b/tests/test_extension_session_hooks.py
@@ -15,6 +15,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+COMMANDS_JS = (REPO / "static" / "commands.js").read_text(encoding="utf-8")
 
 
 def _extract_block(src, signature):
@@ -310,6 +311,7 @@ def test_load_session_coordinator_honors_preload_veto_and_bridge_flag(tmp_path):
         + textwrap.dedent("""
             var S={session:null};
             var _activeSessionLoad=null;
+            var _sessionLoadIntentGeneration=0;
             var starts=[];
             var notifications=[];
             function _resolveSessionIdFromSidebarLineage(sid){return sid==='alias'?'canonical':sid;}
@@ -330,6 +332,70 @@ def test_load_session_coordinator_honors_preload_veto_and_bridge_flag(tmp_path):
     assert data["notifications"] == [{"sid": "canonical", "preload": True}]
     assert len(data["starts"]) == 1
     assert data["starts"][0]["sid"] == "canonical"
+
+
+def test_retry_and_undo_internal_reload_bypasses_preload_veto(tmp_path):
+    body = (
+        _extract_block(SESSIONS_JS, "function _canonicalSessionLoadId(sid, opts)")
+        + "\n"
+        + _extract_block(SESSIONS_JS, "function loadSession(sid)")
+        + "\n"
+        + _extract_block(COMMANDS_JS, "async function cmdRetry()")
+        + "\n"
+        + _extract_block(COMMANDS_JS, "async function cmdUndo()")
+        + textwrap.dedent("""
+            var S={session:{session_id:'active',is_cli_session:false}};
+            var _activeSessionLoad=null;
+            var _sessionLoadIntentGeneration=0;
+            var starts=[];
+            var notifications=[];
+            var mutations=[];
+            var sends=0;
+            var input={value:''};
+            function _resolveSessionIdFromSidebarLineage(sid){return sid;}
+            function _hermesNotifySessionOpen(sid,data,opts){
+              notifications.push({sid:sid,preload:!!opts.preload});
+              return {cancel:true};
+            }
+            function _startSessionLoad(sid,opts,intentGeneration){
+              starts.push({sid:sid,opts:opts,intentGeneration:intentGeneration});
+              return Promise.resolve(sid);
+            }
+            function _sessionLoadNeedsFollowUp(){return false;}
+            function _queueSessionLoadAfterActive(){throw new Error('unexpected queue');}
+            function _deliberateSessionModelPick(){return null;}
+            function _reArmRecoveryPick(){}
+            function autoResize(){}
+            function send(){sends+=1;return Promise.resolve();}
+            function showToast(){}
+            function t(value){return value;}
+            function $(id){return id==='msg'?input:null;}
+            async function api(url){
+              mutations.push(url);
+              if(url==='/api/session/retry') return {last_user_text:'retry-user'};
+              if(url==='/api/session/undo') return {removed_count:2};
+              throw new Error('unexpected api '+url);
+            }
+            (async()=>{
+              await cmdRetry();
+              await cmdUndo();
+              process.stdout.write(JSON.stringify({
+                starts:starts,notifications:notifications,mutations:mutations,
+                sends:sends,input:input.value
+              }));
+            })().catch(error=>{console.error(error.stack||error);process.exit(1);});
+        """)
+    )
+    data = json.loads(_run_in_tmp(tmp_path, body))
+    assert data["mutations"] == ["/api/session/retry", "/api/session/undo"]
+    assert data["notifications"] == []
+    assert len(data["starts"]) == 2
+    assert [entry["opts"]["externalRefreshReason"] for entry in data["starts"]] == [
+        "retry",
+        "undo",
+    ]
+    assert all(entry["opts"]["skipExtHooks"] is True for entry in data["starts"])
+    assert data["sends"] == 1
 
 
 def test_preload_veto_only_on_preload_phase():

--- a/tests/test_extension_session_hooks.py
+++ b/tests/test_extension_session_hooks.py
@@ -294,10 +294,42 @@ class TestHookRegistration:
 
 
 def test_canonical_sid_resolved_before_preload_notification():
-    body = _extract_block(SESSIONS_JS, "async function loadSession(sid)")
-    idx_resolve = body.index("_resolveSessionIdFromSidebarLineage")
+    canonical = _extract_block(SESSIONS_JS, "function _canonicalSessionLoadId(sid, opts)")
+    body = _extract_block(SESSIONS_JS, "function loadSession(sid)")
+    assert "_resolveSessionIdFromSidebarLineage" in canonical
+    idx_resolve = body.index("_canonicalSessionLoadId")
     idx_preload = body.index("_hermesNotifySessionOpen")
     assert idx_resolve < idx_preload
+
+
+def test_load_session_coordinator_honors_preload_veto_and_bridge_flag(tmp_path):
+    body = (
+        _extract_block(SESSIONS_JS, "function _canonicalSessionLoadId(sid, opts)")
+        + "\n"
+        + _extract_block(SESSIONS_JS, "function loadSession(sid)")
+        + textwrap.dedent("""
+            var S={session:null};
+            var _activeSessionLoad=null;
+            var starts=[];
+            var notifications=[];
+            function _resolveSessionIdFromSidebarLineage(sid){return sid==='alias'?'canonical':sid;}
+            function _hermesNotifySessionOpen(sid,data,opts){
+              notifications.push({sid:sid,preload:!!opts.preload});
+              return {cancel:true};
+            }
+            function _startSessionLoad(sid,opts){starts.push({sid:sid,opts:opts});return Promise.resolve(sid);}
+            function _sessionLoadNeedsFollowUp(){return false;}
+            function _queueSessionLoadAfterActive(){throw new Error('unexpected queue');}
+
+            loadSession('alias',{});
+            loadSession('alias',{_preloadNotified:true});
+            process.stdout.write(JSON.stringify({notifications:notifications,starts:starts}));
+        """)
+    )
+    data = json.loads(_run_in_tmp(tmp_path, body))
+    assert data["notifications"] == [{"sid": "canonical", "preload": True}]
+    assert len(data["starts"]) == 1
+    assert data["starts"][0]["sid"] == "canonical"
 
 
 def test_preload_veto_only_on_preload_phase():
@@ -305,11 +337,12 @@ def test_preload_veto_only_on_preload_phase():
     assert "opts.preload" in body
 
 
-def test_continuation_retry_carries_preload_notified_flag():
-    body = _extract_block(SESSIONS_JS, "async function loadSession(sid)")
+def test_continuation_retry_stays_inside_execution_core():
+    body = _extract_block(SESSIONS_JS, "async function _loadSessionOnce(sid)")
     idx_cont = body.index("continuationSid=")
     cont_branch = body[idx_cont:idx_cont + 400]
-    assert "_preloadNotified:true" in cont_branch
+    assert "return _loadSessionOnce(continuationSid" in cont_branch
+    assert "return loadSession(continuationSid" not in cont_branch
 
 
 def test_bridge_flag_passed_by_sidebar_open():
@@ -363,10 +396,10 @@ def test_no_early_closemobilesidebar_before_sidebar_open():
     )
 
 
-def test_cross_profile_retry_carries_preload_notified():
-    """Cross-profile retry must pass _preloadNotified:true so the pre-hook
-    doesn't re-fire after destructive side-effects already ran."""
-    body = _extract_block(SESSIONS_JS, "async function loadSession(sid)")
+def test_cross_profile_retry_stays_inside_execution_core():
+    """Cross-profile retry must not re-enter the preload coordinator."""
+    body = _extract_block(SESSIONS_JS, "async function _loadSessionOnce(sid)")
     idx_profile = body.index("skipProfileResolve:true")
-    profile_branch = body[idx_profile:idx_profile + 200]
-    assert "_preloadNotified:true" in profile_branch
+    profile_branch = body[max(0, idx_profile - 100):idx_profile + 200]
+    assert "return _loadSessionOnce(sid" in profile_branch
+    assert "return loadSession(sid" not in profile_branch

--- a/tests/test_gateway_sse_reconnect_dedupe.py
+++ b/tests/test_gateway_sse_reconnect_dedupe.py
@@ -129,7 +129,7 @@ if(!_isDuplicateGatewaySessionSnapshot([null, {session_id:'web-2', session_sourc
 def test_load_session_persists_only_after_metadata_loads():
     """Do not overwrite the last good localStorage sid before /api/session succeeds."""
     src = _read(SESSIONS_JS)
-    load = _block(src, "async function loadSession(sid)", "function _mergePendingSessionMessage")
+    load = _block(src, "async function _loadSessionOnce(sid)", "function _mergePendingSessionMessage")
     api_pos = load.index("data = await api(`/api/session")
     persist_pos = load.index("localStorage.setItem('hermes-webui-session',S.session.session_id)")
 

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -138,7 +138,7 @@ def test_attach_live_stream_different_stream_still_reopens_transport():
 
 def test_load_session_reattach_path_uses_attach_live_stream_for_running_sessions():
     """The session switch-back path should still route through attachLiveStream()."""
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     # Anchor without the `const`/`let` keyword: the declaration was widened to
     # `let` so the race-guard can re-read activeStreamId after the awaited
     # message load (#5248). The invariant this test pins — the snapshot is taken
@@ -165,7 +165,7 @@ def test_load_session_same_sid_noop_does_not_mask_pending_switch_back():
     ownership). If a different sid is loading, the guard must not short-circuit
     so pending switch-back keeps progressing.
     """
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     compact = re.sub(r"\s+", "", body)
     # The same-session no-op now opens a block so re-selecting the already-open
     # session can clear a stale unread dot before returning (#4946). The
@@ -193,7 +193,7 @@ def test_load_session_preserves_existing_worklog_content_without_destructive_fal
     the destructive fallback must not call clearLiveToolCards() and rebuild a blank
     Running shell over the preserved timeline.
     """
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     content_pos = body.find("const hasCurrentWorklogContent=")
     clear_pos = body.find("clearLiveToolCards();", content_pos)
     assert content_pos != -1
@@ -274,7 +274,7 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
     `INFLIGHT[sid].reattach && activeStreamId` gate is enough — this test
     pins the gate's shape so future refactors don't drop the flag check.
     """
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence): #3899
     # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would grab
     # the wrong one. rfind = the substantive restore branch.
@@ -303,7 +303,7 @@ def test_load_session_attaches_sse_before_auxiliary_work():
     before attachLiveStream(), because any synchronous failure in those paths
     would otherwise leave the backend stream active with no browser subscriber.
     """
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     active_branch = body[body.find("if(activeStreamId){") : body.find("}else{", body.find("if(activeStreamId){"))]
     active_attach = active_branch.find("attachLiveStream(sid, activeStreamId")
     assert active_attach != -1
@@ -853,7 +853,7 @@ assert.strictEqual(inflight.toolCalls[0].activitySegmentSeq, 1);
 
 
 def test_load_session_rebuilds_live_tail_before_snapshot_fallback():
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     ensure_pos = body.find("_ensureInflightLiveAssistantMessage(INFLIGHT[sid]);")
     inflight_pos = body.find("const inflightMessages=_projectInflightMessagesForActivityBursts(INFLIGHT[sid]);")
     prepare_pos = body.find("const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);")
@@ -875,7 +875,7 @@ def test_load_session_prefers_structured_inflight_state_over_live_turn_snapshot(
     per-burst live tail, old snapshots can alternately erase progress text and
     leave Activity groups piled at the bottom of the turn.
     """
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     structured_pos = body.find("const hasStructuredLiveState=!!(INFLIGHT[sid]&&(")
     restore_pos = body.find("restoreLiveTurnHtmlForSession(sid)")
     fallback_pos = body.find("if(!restoredLiveTurn){", restore_pos)
@@ -896,7 +896,7 @@ def test_load_session_prefers_structured_inflight_state_over_live_turn_snapshot(
 
 def test_load_session_restores_worklog_shell_before_reattach_replay():
     """Reattaching before replay/new SSE should not leave the active stream blank."""
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     fallback_pos = body.find("if(!restoredLiveTurn){")
     assert fallback_pos != -1, "loadSession must have a live-turn fallback branch"
     refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid);", fallback_pos)
@@ -920,7 +920,7 @@ def test_restore_succeeded_reconnect_replays_tool_cards():
     """When reconnect replay succeeds in restoring the live turn HTML, tool cards
     are still repainted from the persisted live-call list instead of waiting for a
     future SSE event to reintroduce them."""
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
     reattach_pos = body.find("if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function')")
     restore_pos = body.find("restoreLiveTurnHtmlForSession", reattach_pos if reattach_pos != -1 else 0)
@@ -951,7 +951,7 @@ def test_restore_succeeded_reconnect_skips_unkeyed_restored_tool_duplicates():
     duplicate, so the restore-success reconnect path should only replay unkeyed
     tools when the restored turn has no visible tool rows to preserve.
     """
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
     restore_replay_pos = body.find("if(restoredLiveTurn&&didReconnect){")
     fallback_pos = body.find("if(!restoredLiveTurn){", restore_replay_pos)
@@ -1009,7 +1009,7 @@ assert.deepStrictEqual(
 
 
 def test_load_session_does_not_advance_replay_cursor_from_session_journal_summary():
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     assert "INFLIGHT[sid].lastRunJournalSeq=journalSeq;" not in body
     assert "const journalSeq=_runJournalSeqFromSession(S.session);" not in body
     assert "function _runJournalSeqFromSession" not in SESSIONS_JS
@@ -1017,7 +1017,7 @@ def test_load_session_does_not_advance_replay_cursor_from_session_journal_summar
 
 def test_session_switch_reattach_discards_tail_cache_for_full_journal_replay():
     close_body = _function_body(MESSAGES_JS, "closeLiveStream")
-    load_body = _function_body(SESSIONS_JS, "loadSession")
+    load_body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     compact_body = _function_body(UI_JS, "_compactInflightState")
 
     assert "INFLIGHT[sessionId].journalReplayFromStart=true" in close_body
@@ -1036,7 +1036,7 @@ def test_load_session_discards_cursor_only_inflight_before_reattach():
     lastRunJournalSeq cursor but lost visible INFLIGHT content, reattaching from
     that cursor makes the session look blank after switching away and back.
     """
-    load_body = _function_body(SESSIONS_JS, "loadSession")
+    load_body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     helper_start = SESSIONS_JS.index("function _inflightHasVisibleLiveState")
     helper_body = SESSIONS_JS[
         helper_start : SESSIONS_JS.index("function _rememberRenderedSessionSnapshot", helper_start)

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -1165,7 +1165,7 @@ assert.strictEqual(inflight.lastRunJournalEventId, 'run-a:7');
     result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
 
-    load_body = _function_body(SESSIONS_JS, "loadSession")
+    load_body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     attach_body = _function_body(MESSAGES_JS, "attachLiveStream")
     close_body = _function_body(MESSAGES_JS, "closeLiveStream")
     compact_body = _function_body(UI_JS, "_compactInflightState")

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -84,7 +84,7 @@ def test_cached_render_path_uses_same_scroll_policy_as_fresh_render():
 
 
 def test_session_switch_and_idle_session_load_keep_default_bottom_pin_behavior():
-    load_session = _function_body(SESSIONS_JS, "loadSession")
+    load_session = _function_body(SESSIONS_JS, "_loadSessionOnce")
     idle_branch = load_session[load_session.index("}else{\n      S.busy=false;") : load_session.index("// Sync context usage indicator")]
 
     # #3326: the idle branch now renders with a CONDITIONAL preserveScroll —

--- a/tests/test_issue2655_frontend.py
+++ b/tests/test_issue2655_frontend.py
@@ -24,7 +24,7 @@ def test_workspace_artifacts_tab_collects_session_files_and_previews_them():
     assert "panel.dataset.activeTab = _workspacePanelActiveTab" in WORKSPACE_JS
     assert "renderSessionArtifacts();" in SESSIONS_JS
     assert "typeof scheduleRenderSessionArtifacts==='function'" in MESSAGES_JS
-    assert "S.toolCalls=d.session.tool_calls.map" in MESSAGES_JS
+    assert "S.toolCalls=_settledSession.tool_calls.map" in MESSAGES_JS
     assert ".workspace-artifact-item" in STYLE_CSS
 
 

--- a/tests/test_issue3306_loadsession_carry_forward.py
+++ b/tests/test_issue3306_loadsession_carry_forward.py
@@ -31,7 +31,7 @@ def _function_body(start_marker: str, end_marker: str) -> str:
 
 def _load_session_clear_block() -> str:
     """The if(currentSid!==sid||forceReload){...} block in loadSession()."""
-    start = SESSIONS_JS.index("async function loadSession(sid)")
+    start = SESSIONS_JS.index("async function _loadSessionOnce(sid)")
     clear_start = SESSIONS_JS.index("if (currentSid !== sid || forceReload) {", start)
     clear_end = SESSIONS_JS.index("// Phase 1: Load metadata only", clear_start)
     return SESSIONS_JS[clear_start:clear_end]

--- a/tests/test_issue3479_ios_stream_scroll_jump.py
+++ b/tests/test_issue3479_ios_stream_scroll_jump.py
@@ -133,7 +133,7 @@ def test_scroll_snapshot_restore_reinstates_unpinned_state_when_reader_is_mid_an
 
 
 def test_same_session_force_refresh_does_not_reset_scroll_direction_tracker():
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     compact = _compact(body)
 
     assert "constcurrentSid=S.session?S.session.session_id:null;" in compact

--- a/tests/test_issue4490_presession_toolsets.py
+++ b/tests/test_issue4490_presession_toolsets.py
@@ -116,7 +116,7 @@ def test_load_existing_session_clears_staged_toolsets():
     loadSession() assigns S.session=data.session on the success path; the staged
     value is cleared there so a subsequent New Chat does not inherit it (#4490).
     """
-    body = _function_body(SESSIONS_JS, "async function loadSession")
+    body = _function_body(SESSIONS_JS, "async function _loadSessionOnce")
     compact = body.replace(" ", "")
     assign = compact.index("S.session=data.session")
     # The clear must accompany the real-session assignment, not only the create path.

--- a/tests/test_issue4720_done_scroll_jump_first_message.py
+++ b/tests/test_issue4720_done_scroll_jump_first_message.py
@@ -27,7 +27,7 @@ def _compact(text: str) -> str:
 def test_done_handler_uses_canonical_settled_window_offset():
     """The done handler must use the server-owned bounded window when needed."""
     compact = _compact(MESSAGES_JS)
-    assert "_settledDoneWindow=await_fetchSettledSessionMessageWindow(activeSid,completedSession)" in compact, (
+    assert "_settledDoneWindow=await_fetchSettledSessionMessageWindow(completedSid,completedSession)" in compact, (
         "done handler should refresh a canonical bounded window for paginated sessions"
     )
     assert "_messagesTruncated=_settledDoneWasTruncated" in compact, (

--- a/tests/test_issue4720_done_scroll_jump_first_message.py
+++ b/tests/test_issue4720_done_scroll_jump_first_message.py
@@ -1,16 +1,16 @@
 """Regression for #4720: transcript jumps to the first message after completion.
 
-Root cause: the `done` SSE handler in static/messages.js replaced the transcript
-with the full payload and updated `_messagesTruncated`, but did NOT reset
-`_oldestIdx` from `d.session._messages_offset` the way the canonical full-load
-paths do (sessions.js `_ensureMessagesLoaded`, ui.js `loadSession`). The #4613
-scroll restore keys on an absolute index (`sessionIdx = _oldestIdx + rawIdx`);
-leaving `_oldestIdx` stale after a truncated initial load desynchronized that
-anchor once the done handler expands the render window to all messages, so the
-viewport jumped to the first message on every completion.
+Root cause: the `done` SSE handler replaced a paginated transcript with the
+full settled payload and then expanded the render window to all messages. The
+#4613 scroll restore keys on an absolute index (`sessionIdx = _oldestIdx +
+rawIdx`), so the terminal path must consume the canonical paginated window's
+`_messages_offset` instead of treating the full SSE payload as the display
+window. Otherwise a long completion can both render the entire history and
+desynchronize the viewport anchor.
 
-These tests assert the one-line symmetry fix is present in the done handler and
-that it behaves correctly (full payload -> offset 0; explicit offset honored).
+These tests assert that the done handler uses the bounded settled-window path
+and that its offset bookkeeping remains correct for both bounded and fully
+loaded sessions.
 """
 
 import subprocess
@@ -24,51 +24,43 @@ def _compact(text: str) -> str:
     return "".join(text.split())
 
 
-def test_done_handler_resets_oldest_idx_from_payload_offset():
-    """The done handler must reset _oldestIdx alongside _messagesTruncated."""
+def test_done_handler_uses_canonical_settled_window_offset():
+    """The done handler must use the server-owned bounded window when needed."""
     compact = _compact(MESSAGES_JS)
-    # The truncated flag and the offset reset must be wired off the SAME done
-    # payload (d.session), mirroring sessions.js / ui.js full-load paths.
-    assert "_messagesTruncated=!!d.session._messages_truncated" in compact, (
-        "done handler should still set _messagesTruncated from the done payload"
+    assert "_settledDoneWindow=await_fetchSettledSessionMessageWindow(activeSid,completedSession)" in compact, (
+        "done handler should refresh a canonical bounded window for paginated sessions"
     )
-    assert "_oldestIdx=d.session._messages_offset||0" in compact, (
-        "#4720: done handler must reset _oldestIdx from the done payload offset "
-        "so the absolute scroll anchor stays valid after the render-window expansion"
+    assert "_messagesTruncated=_settledDoneWasTruncated" in compact, (
+        "done handler should preserve the prior pagination state when the SSE "
+        "payload itself is intentionally full"
+    )
+    assert "_oldestIdx=_settledDoneWasTruncated" in compact
+    assert "_messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize" not in compact, (
+        "done settlement must not promote a paginated transcript to a full render window"
     )
 
 
-def test_done_handler_oldest_idx_reset_is_guarded_and_ordered_before_filter():
-    """Reset must be typeof-guarded and happen before the messages are re-filtered/rendered."""
+def test_done_handler_offset_is_applied_before_filter_and_render():
+    """The canonical offset must be applied before the transcript is filtered/rendered."""
     compact = _compact(MESSAGES_JS)
-    assert "if(typeof_oldestIdx!=='undefined')_oldestIdx=d.session._messages_offset||0" in compact, (
-        "_oldestIdx reset should be typeof-guarded like _messagesTruncated"
-    )
-    # The reset must precede _filterRecoveryControlMessages (which precedes the
-    # done-path renderMessages), so the anchor coordinate system is correct when
-    # the transcript is rebuilt.
-    reset_idx = compact.index("_oldestIdx=d.session._messages_offset||0")
+    assert "_oldestIdx=_settledDoneWasTruncated?" in compact
+    reset_idx = compact.index("_oldestIdx=_settledDoneWasTruncated?")
     filter_idx = compact.index("S.messages=_filterRecoveryControlMessages")
     assert reset_idx < filter_idx, (
-        "_oldestIdx must be reset before the done-path re-filter/render"
+        "_oldestIdx must be updated before the done-path re-filter/render"
     )
 
 
-def test_oldest_idx_reset_matches_full_load_offset_semantics():
-    """Execute the reset expression to confirm offset semantics (full payload -> 0)."""
+def test_settled_window_offset_semantics():
+    """A bounded response uses its offset; a full response uses zero."""
     script = """
 const assert = require('assert');
-function applyReset(doneSession) {
-  let _oldestIdx = 7;  // stale value from a truncated initial load
-  // mirror the done-handler line exactly:
-  if (typeof _oldestIdx !== 'undefined') _oldestIdx = doneSession._messages_offset || 0;
-  return _oldestIdx;
+function applyOffset(wasTruncated, failed, settledSession, priorOffset) {
+  if (wasTruncated) return failed ? priorOffset : (settledSession._messages_offset || 0);
+  return settledSession._messages_offset || 0;
 }
-// Full transcript payload (no offset field) -> reset to 0.
-assert.strictEqual(applyReset({ messages: [1, 2, 3] }), 0);
-// Explicit zero offset -> 0.
-assert.strictEqual(applyReset({ _messages_offset: 0 }), 0);
-// Explicit non-zero offset is honored (defensive; current done payload is full).
-assert.strictEqual(applyReset({ _messages_offset: 12 }), 12);
+assert.strictEqual(applyOffset(true, false, { _messages_offset: 970 }, 900), 970);
+assert.strictEqual(applyOffset(true, true, {}, 900), 900);
+assert.strictEqual(applyOffset(false, false, {}, 900), 0);
 """
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -671,7 +671,7 @@ def test_populate_model_dropdown_accepts_session_visit_freshness_and_guards_stal
 
 
 def test_load_session_schedules_session_visit_model_refresh_before_message_load():
-    body = _extract_function_body(_read_static("sessions.js"), "async function loadSession(")
+    body = _extract_function_body(_read_static("sessions.js"), "async function _loadSessionOnce(")
 
     assign_idx = body.index("S.session=data.session")
     message_load_idx = body.index("await _ensureMessagesLoaded(sid", assign_idx)
@@ -695,7 +695,7 @@ def test_session_visit_model_refresh_is_deferred_until_after_first_paint():
     sessions = _read_static("sessions.js")
     defer_helper = _extract_function_body(sessions, "function _afterSessionFirstPaint(")
     side_effect_helper = _extract_function_body(sessions, "function _deferSessionSideEffect(")
-    load_body = _extract_function_body(sessions, "async function loadSession(")
+    load_body = _extract_function_body(sessions, "async function _loadSessionOnce(")
 
     assert "requestAnimationFrame(()=>requestAnimationFrame(run))" in defer_helper
     assert "requestIdleCallback(invoke,{timeout:1500})" in defer_helper

--- a/tests/test_issue5177_hidden_tab_blank_gap.py
+++ b/tests/test_issue5177_hidden_tab_blank_gap.py
@@ -40,10 +40,10 @@ def _compact(text: str) -> str:
 
 
 def _load_session_block(compact: str) -> str:
-    """Slice from the start of ``async function loadSession`` to the matching
+    """Slice from the start of the async load core to the matching
     close brace, using brace counting so future code growth in the function
     cannot push assertions out of a fixed window."""
-    marker = "asyncfunctionloadSession(sid){"
+    marker = "asyncfunction_loadSessionOnce(sid){"
     start = compact.find(marker)
     assert start != -1, "expected the loadSession definition"
     i = start + len(marker) - 1  # position of the opening brace

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -518,7 +518,7 @@ def test_focus_visibility_return_marks_active_session_viewed_and_clears_marker()
 
 
 def test_completion_unread_clears_only_when_session_is_opened():
-    load_idx = SESSIONS_JS.find("async function loadSession(sid")
+    load_idx = SESSIONS_JS.find("async function _loadSessionOnce(sid")
     assert load_idx != -1, "loadSession not found"
     load_block = SESSIONS_JS[load_idx:SESSIONS_JS.find("function _resolveSessionModelForDisplaySoon", load_idx)]
 

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -91,7 +91,7 @@ def test_done_event_updates_sidebar_cache_immediately_after_completion_marker():
     done_block = _done_block()
 
     marker_idx = done_block.find("_markSessionCompletionUnread(completedSid")
-    cleanup_idx = done_block.find("_clearOwnerInflightState();")
+    cleanup_idx = done_block.find("_clearOwnerInflightState({deferSessionStreamResume:true});")
     if cleanup_idx == -1:
         cleanup_idx = done_block.find("delete INFLIGHT[activeSid];")
     cache_idx = done_block.find("_markSessionCompletedInList(completedSession, activeSid);")

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -434,10 +434,10 @@ def test_active_done_marks_viewed_without_setting_unread_marker():
 def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     done_block = _done_block()
 
-    active_const_idx = done_block.find("const isActiveSession=_isSessionCurrentPane(activeSid);")
+    active_const_idx = done_block.find("let isActiveSession=_isSessionCurrentPane(activeSid);")
     viewed_const_idx = done_block.find("const isSessionViewed=_isSessionActivelyViewed(activeSid);")
     active_guard_idx = done_block.find("if(isActiveSession){", viewed_const_idx)
-    session_update_idx = done_block.find("S.session=d.session", active_guard_idx)
+    session_update_idx = done_block.find("S.session=_settledSession", active_guard_idx)
     render_idx = done_block.find("renderMessages(", active_guard_idx)
     load_dir_idx = done_block.find("preservePreview", active_guard_idx)
     mark_viewed_idx = done_block.find("if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx)
@@ -445,7 +445,7 @@ def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     assert active_const_idx != -1, "done handler must compute active/current pane separately"
     assert viewed_const_idx != -1, "done handler must still compute visible/focused read state"
     assert active_const_idx < viewed_const_idx
-    assert session_update_idx != -1, "active hidden completion must still refresh S.session"
+    assert session_update_idx != -1, "active hidden completion must still refresh the settled S.session"
     assert render_idx != -1, "active hidden completion must still render the final assistant response"
     assert load_dir_idx != -1, "active hidden completion must keep normal active-session finalization"
     assert mark_viewed_idx != -1, "read-state write must stay gated by visible/focused viewing"

--- a/tests/test_issue_edit_regenerate_absolute_keep_count.py
+++ b/tests/test_issue_edit_regenerate_absolute_keep_count.py
@@ -1,6 +1,7 @@
 """Regression: edit/regenerate use absolute keep_count (#2184 pattern)."""
 
 import re
+import json
 import subprocess
 from pathlib import Path
 
@@ -50,8 +51,8 @@ def test_truncated_edit_and_regenerate_do_not_force_full_reload():
     """A visible paginated target can be truncated without loading all history."""
     for name in ("submitEdit", "regenerateResponse"):
         body = "".join(_function_body(UI_JS, name).split())
-        assert "if(!loadedWindowTruncated&&typeof_ensureAllMessagesLoaded==='function')" in body
-        assert "_loadedMessageSliceEndForKeepCount(absoluteKeepCount,loadedWindowOffset,loadedWindowTruncated)" in body
+        assert "if(!initialWindowTruncated&&typeof_ensureAllMessagesLoaded==='function')" in body
+        assert "_loadedMessageSliceEndForKeepCount(absoluteKeepCount,currentWindowOffset,currentWindowTruncated)" in body
 
 
 def test_loaded_window_slice_end_preserves_absolute_keep_count_semantics():
@@ -65,3 +66,63 @@ assert.strictEqual(_loadedMessageSliceEndForKeepCount(103, 0, false), 103);
 assert.strictEqual(_loadedMessageSliceEndForKeepCount(0, 70, true), 0);
 """
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
+def _run_pagination_race(function_name: str) -> dict:
+    helper = _function_body(UI_JS, "_loadedMessageSliceEndForKeepCount")
+    mutation = _function_body(UI_JS, function_name)
+    invocation = (
+        "submitEdit(20, 'replacement')"
+        if function_name == "submitEdit"
+        else "regenerateResponse({closest:()=>({dataset:{msgIdx:'20'}})})"
+    )
+    script = f"""
+const makeMessages=(start,end)=>Array.from({{length:end-start}},(_,i)=>{{
+  const absolute=start+i;
+  return {{role:absolute%2===0?'assistant':'user',content:'abs-'+absolute}};
+}});
+const S={{session:{{session_id:'sid-race'}},busy:false,messages:makeMessages(70,100)}};
+let _oldestIdx=70;
+let _messagesTruncated=true;
+let resolveTruncate;
+const truncatePending=new Promise(resolve=>{{resolveTruncate=resolve;}});
+const calls=[];
+async function api(url,opts){{calls.push({{url,opts}});return truncatePending;}}
+function _ensureAllMessagesLoaded(){{throw new Error('truncated window must not full-load');}}
+function _deliberateSessionModelPick(){{return null;}}
+function _reArmRecoveryPick(){{}}
+function renderMessages(){{}}
+function msgContent(message){{return String(message&&message.content||'');}}
+function setStatus(message){{throw new Error(message);}}
+function send(){{return Promise.resolve();}}
+const input={{value:''}};
+function $(id){{return id==='msg'?input:null;}}
+{helper}
+{mutation}
+(async()=>{{
+  const pending={invocation};
+  await Promise.resolve();
+  S.messages=makeMessages(40,100);
+  _oldestIdx=40;
+  _messagesTruncated=true;
+  resolveTruncate({{ok:true}});
+  await pending;
+  process.stdout.write(JSON.stringify({{
+    keepCount:JSON.parse(calls[0].opts.body).keep_count,
+    rows:S.messages.map(message=>message.content),
+    input:input.value,
+  }}));
+}})().catch(error=>{{console.error(error.stack||error);process.exit(1);}});
+"""
+    completed = subprocess.run(
+        ["node", "-e", script], check=False, capture_output=True, text=True
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def test_edit_and_regenerate_slice_from_current_window_after_truncate_await():
+    for function_name in ("submitEdit", "regenerateResponse"):
+        result = _run_pagination_race(function_name)
+        assert result["keepCount"] == 90
+        assert result["rows"] == [f"abs-{absolute}" for absolute in range(40, 90)]

--- a/tests/test_issue_edit_regenerate_absolute_keep_count.py
+++ b/tests/test_issue_edit_regenerate_absolute_keep_count.py
@@ -1,6 +1,7 @@
 """Regression: edit/regenerate use absolute keep_count (#2184 pattern)."""
 
 import re
+import subprocess
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -9,7 +10,10 @@ UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 
 def _function_body(src: str, name: str) -> str:
     needle_async = f"async function {name}"
-    start = src.index(needle_async)
+    needle_sync = f"function {name}"
+    start = src.find(needle_async)
+    if start < 0:
+        start = src.index(needle_sync)
     brace = src.index("{", start)
     depth = 0
     for i in range(brace, len(src)):
@@ -40,3 +44,24 @@ def test_submit_edit_captures_absolute_before_await():
     assert cap
     first_await = re.search(r"\bawait\b", body)
     assert first_await and cap.start() < first_await.start()
+
+
+def test_truncated_edit_and_regenerate_do_not_force_full_reload():
+    """A visible paginated target can be truncated without loading all history."""
+    for name in ("submitEdit", "regenerateResponse"):
+        body = "".join(_function_body(UI_JS, name).split())
+        assert "if(!loadedWindowTruncated&&typeof_ensureAllMessagesLoaded==='function')" in body
+        assert "_loadedMessageSliceEndForKeepCount(absoluteKeepCount,loadedWindowOffset,loadedWindowTruncated)" in body
+
+
+def test_loaded_window_slice_end_preserves_absolute_keep_count_semantics():
+    """Translate only the local array slice; the API keep_count stays absolute."""
+    helper = _function_body(UI_JS, "_loadedMessageSliceEndForKeepCount")
+    script = f"""
+const assert = require('assert');
+{helper}
+assert.strictEqual(_loadedMessageSliceEndForKeepCount(103, 70, true), 33);
+assert.strictEqual(_loadedMessageSliceEndForKeepCount(103, 0, false), 103);
+assert.strictEqual(_loadedMessageSliceEndForKeepCount(0, 70, true), 0);
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -19,7 +19,7 @@ def _btn_new_chat_handler() -> str:
 
 
 def _load_session_clear_block() -> str:
-    start = SESSIONS_JS.find("async function loadSession(")
+    start = SESSIONS_JS.find("async function _loadSessionOnce(")
     clear_start = SESSIONS_JS.find("if (currentSid !== sid || forceReload) {", start)
     clear_end = SESSIONS_JS.find("// Phase 1: Load metadata only", clear_start)
     assert start != -1, "loadSession not found"
@@ -29,7 +29,7 @@ def _load_session_clear_block() -> str:
 
 def test_new_session_remembers_regular_empty_session_id():
     start = SESSIONS_JS.find("async function newSession(")
-    end = SESSIONS_JS.find("async function loadSession(", start)
+    end = SESSIONS_JS.find("async function _loadSessionOnce(", start)
     assert start != -1 and end != -1, "newSession block not found"
     body = SESSIONS_JS[start:end]
     assign_idx = body.find("S.session=data.session")

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -140,7 +140,7 @@ def test_reattach_normalizes_live_activity_group_placement_by_burst_anchor():
 def test_done_handler_preserves_live_tool_burst_metadata_for_settled_render():
     assert "function _mergeSettledToolCallsWithLiveMetadata(rawCalls)" in MESSAGES_JS
     assert "activityBurstId" in MESSAGES_JS
-    assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);" in MESSAGES_JS
+    assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(_settledSession.tool_calls);" in MESSAGES_JS
     assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);" in MESSAGES_JS
 
 

--- a/tests/test_mobile_reload_compression_recovery.py
+++ b/tests/test_mobile_reload_compression_recovery.py
@@ -46,10 +46,10 @@ def test_load_session_follows_backend_continuation_hint():
     restore state with an unusable id — #2980 hardening).
     """
     src = SESSIONS_JS.read_text(encoding="utf-8")
-    load_session = _function_block(src, "async function loadSession")
+    load_session = _function_block(src, "async function _loadSessionOnce")
 
     assert "continuation_session_id" in load_session
-    assert "loadSession(continuationSid" in load_session
+    assert "_loadSessionOnce(continuationSid" in load_session
     assert "skipContinuationResolve" in load_session
     # The re-entrant follow must pass skipContinuationResolve:true to prevent recursion.
     assert "skipContinuationResolve:true" in load_session

--- a/tests/test_model_selection_refresh_persistence.py
+++ b/tests/test_model_selection_refresh_persistence.py
@@ -42,7 +42,7 @@ def test_model_selection_records_pending_state_before_async_session_update():
 
 def test_load_session_applies_pending_model_before_first_topbar_sync():
     """Reload should project the pending selection before server old metadata wins."""
-    body = _body_between(SESSIONS_JS, "async function loadSession", "activeStreamId=S.session.active_stream_id")
+    body = _body_between(SESSIONS_JS, "async function _loadSessionOnce", "activeStreamId=S.session.active_stream_id")
 
     apply_idx = body.index("_applyPendingSessionModelForSession")
     sync_idx = body.index("syncTopbar()")

--- a/tests/test_optionz_liveview_perf.py
+++ b/tests/test_optionz_liveview_perf.py
@@ -732,11 +732,16 @@ def test_frontend_subscribes_with_known_count_and_handles_session_updated():
     knc_ix = ss_src.index("_knownCount")
     knc_src = ss_src[knc_ix:knc_ix + 400]
     assert "S.messages.length" not in knc_src
-    # (b) the session-updated listener routes through the swap-in-place path.
+    # (b) the session-updated listener routes through the coordinator helper,
+    # whose load options own the swap-in-place path.
     su_ix = js.index("addEventListener('session-updated'")
     su_src = js[su_ix:su_ix + 1800]
-    assert "keepStaleUntilLoaded: true" in su_src or "keepStaleUntilLoaded:true" in su_src
-    assert "loadSession(" in su_src
+    assert "_queueSessionUpdatedRefresh(sid, Number(d.message_count));" in su_src
+    helper_ix = js.index("function _queueSessionUpdatedRefresh(sid, serverCount)")
+    helper_end = js.index("function startSessionStream", helper_ix)
+    helper_src = js[helper_ix:helper_end]
+    assert "keepStaleUntilLoaded:true" in helper_src
+    assert "minimumMessageCount:serverCount" in helper_src
     # Idle-only: must bail when a live turn is rendering (that path owns its own
     # message updates) and when the session isn't the one on screen.
     assert "S.activeStreamId" in su_src

--- a/tests/test_optionz_liveview_perf.py
+++ b/tests/test_optionz_liveview_perf.py
@@ -734,7 +734,7 @@ def test_frontend_subscribes_with_known_count_and_handles_session_updated():
     assert "S.messages.length" not in knc_src
     # (b) the session-updated listener routes through the swap-in-place path.
     su_ix = js.index("addEventListener('session-updated'")
-    su_src = js[su_ix:su_ix + 1400]
+    su_src = js[su_ix:su_ix + 1800]
     assert "keepStaleUntilLoaded: true" in su_src or "keepStaleUntilLoaded:true" in su_src
     assert "loadSession(" in su_src
     # Idle-only: must bail when a live turn is rendering (that path owns its own
@@ -774,4 +774,3 @@ def test_loadsession_idle_cleanup_does_not_clobber_concurrent_live_stream():
     assert reread_ix != -1 and branch_ix != -1 and reread_ix < branch_ix, (
         "race-guard re-read must precede the attach/idle branch"
     )
-

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -440,12 +440,14 @@ class TestMessagePaginationFrontend:
         fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
         fn_body = SESSIONS_JS[fn_start:fn_end]
 
-        assert "msg_limit=" in fn_body, (
-            "_ensureMessagesLoaded should include msg_limit parameter in the API call"
+        assert "_sessionMessageReloadUrl(sid,reloadLimit)" in fn_body, (
+            "_ensureMessagesLoaded should route requests through the shared reload URL policy"
         )
         assert "_INITIAL_MSG_LIMIT" in fn_body, (
             "_ensureMessagesLoaded should use _INITIAL_MSG_LIMIT constant"
         )
+        assert "function _sessionMessageReloadUrl(sid, requestedLimit)" in SESSIONS_JS
+        assert "&msg_limit=${encodeURIComponent(boundedLimit)}&expand_renderable=1" in SESSIONS_JS
 
     def test_truncation_tracking(self):
         """_messagesTruncated must be set from the server response."""

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -868,7 +868,7 @@ class TestFrontendWiring:
         )
         upload_body = ui[ui.index("async function uploadPendingFiles") :]
         sessions = (Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
-        load_body = _source_between(sessions, "async function loadSession", "\nfunction _isMessagingSession")
+        load_body = _source_between(sessions, "async function _loadSessionOnce", "\nfunction _isMessagingSession")
         assert "_uploadPendingFilesSyncProgressForSession(sid)" in load_body
         assert "_uploadPendingFilesProgressBySession.set(owner,{percent:clamped})" in progress_helper
         assert "function _uploadPendingFilesSyncProgressForSession" in progress_helper

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -578,7 +578,7 @@ def test_queue_card_cross_session_helper_used_only_for_session_change(cleanup_te
     not on same-session navigation/force-reload code paths.
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
-    load_start = src.find("async function loadSession(sid){")
+    load_start = src.find("async function _loadSessionOnce(sid){")
     assert load_start >= 0
     load_end = src.find("  // Sync context usage indicator from session data", load_start)
     load_body = src[load_start:load_end]

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -405,7 +405,7 @@ def test_run_journal_cursor_tracks_every_long_task_timeline_event():
 def test_server_runtime_journal_snapshot_restores_structured_inflight_state():
     helper_pos = SESSIONS_SRC.index("function _serverLiveSnapshotToolId")
     helper_block = SESSIONS_SRC[helper_pos : helper_pos + 3600]
-    load_pos = SESSIONS_SRC.index("async function loadSession")
+    load_pos = SESSIONS_SRC.index("async function _loadSessionOnce")
     load_end = SESSIONS_SRC.index("// ── Handoff hint logic", load_pos)
     load_block = SESSIONS_SRC[load_pos:load_end]
 

--- a/tests/test_session_channel_option_x.py
+++ b/tests/test_session_channel_option_x.py
@@ -938,7 +938,7 @@ def test_load_session_rearms_stream_on_every_early_return():
     # Isolate the loadSession body. Widened window: the #4946 visit-ack helpers
     # added inside loadSession pushed the fetch-error catch's stream restart past
     # the old 14000-char cutoff.
-    fn_ix = js.index("async function loadSession(")
+    fn_ix = js.index("async function _loadSessionOnce(")
     body = js[fn_ix:fn_ix + 16000]
 
     # The unconditional teardown must still be there (this is what creates the

--- a/tests/test_session_model_resolution_on_load.py
+++ b/tests/test_session_model_resolution_on_load.py
@@ -30,7 +30,7 @@ def _extract_function(src: str, signature: str) -> str:
 
 
 def test_load_session_initial_metadata_request_defers_model_resolution_until_after_state_assignment():
-    body = _extract_function(SESSIONS_JS, "async function loadSession(sid")
+    body = _extract_function(SESSIONS_JS, "async function _loadSessionOnce(sid")
     fast_metadata_fetch = "messages=0&resolve_model=0"
     deferred_metadata_fetch = "messages=0&resolve_model=1"
     assignment = "S.session=data.session"

--- a/tests/test_session_msg_limit_ceiling.py
+++ b/tests/test_session_msg_limit_ceiling.py
@@ -93,5 +93,6 @@ def test_frontend_declares_live_ceiling_at_module_scope_with_fallback():
 
 def test_frontend_reload_width_paths_read_the_live_ceiling():
     """Both reload-width decisions read the live `_msgLimitMax`, not the mirror."""
-    assert "reloadLimit <= _msgLimitMax" in _SESSIONS_JS       # _ensureMessagesLoaded
-    assert "requestedLimit >= _msgLimitMax" in _SESSIONS_JS    # _loadOlderMessages
+    assert "numericLimit>0&&numericLimit<=_msgLimitMax" in _SESSIONS_JS  # shared URL policy
+    assert "_sessionMessageReloadUrl(sid,reloadLimit)" in _SESSIONS_JS   # _ensureMessagesLoaded
+    assert "requestedLimit >= _msgLimitMax" in _SESSIONS_JS              # _loadOlderMessages

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -11,8 +11,8 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     # #3018 inserted a carry-forward of ephemeral per-turn fields into both the
     # completion (_finishDone) and settled-restore assignments; match the new shapes.
     completion_marker = re.compile(
-        r"S\.session=d\.session;\s*"
-        r"S\.messages=_carryForwardEphemeralTurnFields\(S\.messages\|\|\[\], d\.session\.messages\|\|\[\]\);"
+        r"S\.session=_settledSession;\s*"
+        r"S\.messages=_carryForwardEphemeralTurnFields\(S\.messages\|\|\[\], _settledSession\.messages\|\|\[\]\);"
     )
     settled_marker = "S.session=session;\n        const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);"
 
@@ -27,8 +27,8 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     # stale-prefix guard before the tab-state sync, so keep the assertion local
     # to the handler while widening the slice enough to cover the new helper
     # state and the unchanged localStorage/update-url writes.
-    completion_block = MESSAGES_JS[completion_pos : completion_pos + 1000]
-    settled_block = MESSAGES_JS[settled_pos : settled_pos + 1800]
+    completion_block = MESSAGES_JS[completion_pos : completion_pos + 1600]
+    settled_block = MESSAGES_JS[settled_pos : settled_pos + 2600]
 
     for block in (completion_block, settled_block):
         assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block

--- a/tests/test_session_switch_busy_race.py
+++ b/tests/test_session_switch_busy_race.py
@@ -33,7 +33,7 @@ def _function_body(src: str, signature: str) -> str:
 
 
 def test_loadSession_clears_busy_before_async_message_load_when_server_idle():
-    body = _function_body(SESSIONS_SRC, "async function loadSession(")
+    body = _function_body(SESSIONS_SRC, "async function _loadSessionOnce(")
 
     idle_reset = body.find("if(!activeStreamId){")
     assert idle_reset != -1, "loadSession must gate idle cleanup on missing active_stream_id"
@@ -50,7 +50,7 @@ def test_loadSession_clears_busy_before_async_message_load_when_server_idle():
 
 
 def test_loadSession_snapshots_live_turn_before_wiping_message_pane():
-    body = _function_body(SESSIONS_SRC, "async function loadSession(")
+    body = _function_body(SESSIONS_SRC, "async function _loadSessionOnce(")
 
     snap_pos = body.find("snapshotLiveTurnHtmlForSession(currentSid)")
     # Anchor on the actual loading-placeholder marker (unique), not the
@@ -63,7 +63,7 @@ def test_loadSession_snapshots_live_turn_before_wiping_message_pane():
 
 
 def test_loadSession_restores_live_turn_on_active_stream_return_path():
-    body = _function_body(SESSIONS_SRC, "async function loadSession(")
+    body = _function_body(SESSIONS_SRC, "async function _loadSessionOnce(")
 
     # The restore that actually fires on switch-back is the Phase 2a path: after
     # loadInflightState() rehydrates INFLIGHT for an active stream, the streaming

--- a/tests/test_session_unread_dot_on_visit.py
+++ b/tests/test_session_unread_dot_on_visit.py
@@ -36,7 +36,7 @@ SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 
 
 def _load_session_block() -> str:
-    start = SESSIONS_JS.index("async function loadSession(sid")
+    start = SESSIONS_JS.index("async function _loadSessionOnce(sid")
     end = SESSIONS_JS.index("function _resolveSessionModelForDisplaySoon", start)
     return SESSIONS_JS[start:end]
 

--- a/tests/test_session_unread_dot_on_visit.py
+++ b/tests/test_session_unread_dot_on_visit.py
@@ -361,6 +361,10 @@ let S = {{ session: {{ session_id: 'open', message_count: 0 }}, messages: [], la
 // Stubs for the incidental side effects _ensureMessagesLoaded touches.
 function _clearSameSessionForceReloadHint() {{}}
 function _messageReloadLimitForSession() {{ return 0; }}
+function _sessionMessageReloadUrl(sid, limit) {{
+  const base=`/api/session?session_id=${{encodeURIComponent(sid)}}&messages=1&resolve_model=0`;
+  return limit>0?`${{base}}&msg_limit=${{limit}}&expand_renderable=1`:base;
+}}
 function _syncToolCallsForLoadedMessages() {{}}
 function clearLiveToolCards() {{}}
 

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -1,0 +1,143 @@
+"""Focused regression tests for bounded settled-session message windows."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for settled-window runtime tests")
+
+
+def _node_driver(body: str) -> dict:
+    result = subprocess.run(
+        [NODE, "-e", body, str(REPO / "static" / "sessions.js")],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip())
+
+
+_EXTRACT = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[1], 'utf8');
+function extractFunction(name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  let start = -1;
+  for (const marker of markers) {
+    start = src.indexOf(marker);
+    if (start >= 0) break;
+  }
+  if (start < 0) throw new Error(`missing ${name}`);
+  const brace = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = brace; i < src.length; i += 1) {
+    if (src[i] === '{') depth += 1;
+    else if (src[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unterminated ${name}`);
+}
+"""
+
+
+def test_settled_window_limit_preserves_loaded_width_and_turn_allowance():
+    outcome = _node_driver(
+        _EXTRACT
+        + r"""
+const _INITIAL_MSG_LIMIT = 30;
+let _messagesTruncated = true;
+let loadedRenderable = 30;
+const S = {
+  messages: Array.from({length: 30}, () => ({role: 'user'})),
+  session: {message_count: 100},
+};
+function _currentLoadedRenderableMessageCount() { return loadedRenderable; }
+eval(extractFunction('_settledSessionMessageWindowLimit'));
+const results = [
+  _settledSessionMessageWindowLimit({message_count: 103}, {}),
+  _settledSessionMessageWindowLimit(null, {reserveNewTurn: true}),
+];
+_messagesTruncated = false;
+results.push(_settledSessionMessageWindowLimit({message_count: 1000}, {}));
+_messagesTruncated = true;
+loadedRenderable = 80;
+S.messages = Array.from({length: 80}, () => ({role: 'user'}));
+S.session.message_count = 200;
+results.push(_settledSessionMessageWindowLimit({message_count: 205}, {}));
+console.log(JSON.stringify(results));
+"""
+    )
+
+    assert outcome == [33, 60, None, 85]
+
+
+def test_settled_window_fetch_uses_canonical_session_pagination():
+    outcome = _node_driver(
+        _EXTRACT
+        + r"""
+const _INITIAL_MSG_LIMIT = 30;
+let _messagesTruncated = true;
+let loadedRenderable = 30;
+const S = {
+  messages: Array.from({length: 30}, () => ({role: 'user'})),
+  session: {message_count: 100},
+};
+function _currentLoadedRenderableMessageCount() { return loadedRenderable; }
+const calls = [];
+async function api(url, options) {
+  calls.push({url, options});
+  return {session: {_messages_truncated: true, _messages_offset: 70, messages: []}};
+}
+eval(extractFunction('_settledSessionMessageWindowLimit'));
+eval(extractFunction('_settledSessionMessageWindowUrl'));
+eval(extractFunction('_fetchSettledSessionMessageWindow'));
+(async()=>{
+  const bounded = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 103}, {});
+  _messagesTruncated = false;
+  const full = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 1000}, {});
+  console.log(JSON.stringify({bounded, full, calls}));
+})().catch(err=>{ console.error(err.stack || err); process.exit(1); });
+"""
+    )
+
+    assert outcome["bounded"]["_messages_offset"] == 70
+    assert outcome["full"] is None
+    assert len(outcome["calls"]) == 1
+    assert "session_id=sid-1&messages=1&resolve_model=0&msg_limit=33" in outcome["calls"][0]["url"]
+    assert outcome["calls"][0]["options"] == {"timeoutMs": 120000}
+
+
+def test_done_and_recovery_paths_do_not_expand_the_render_window():
+    compact = "".join(MESSAGES_JS.split())
+    assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in compact
+    assert "_settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true})" in compact
+    assert "_messagesTruncated=!!session._messages_truncated" in compact
+    assert "_messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize" not in compact
+
+    done_start = MESSAGES_JS.index("source.addEventListener('done'")
+    done_end = MESSAGES_JS.index("source.addEventListener('stream_end'", done_start)
+    done_body = MESSAGES_JS[done_start:done_end]
+    assert done_body.index("const _settledDoneInflightSnapshot") < done_body.index("_clearOwnerInflightState()")
+    refresh_idx = done_body.index("await _fetchSettledSessionMessageWindow")
+    ownership_idx = done_body.index("if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;")
+    assert refresh_idx < ownership_idx < done_body.index("S.session=_settledSession")
+
+
+def test_settled_window_helpers_and_cross_module_callers_are_present():
+    assert "function _settledSessionMessageWindowLimit" in SESSIONS_JS
+    assert "async function _fetchSettledSessionMessageWindow" in SESSIONS_JS
+    assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in MESSAGES_JS

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -11,6 +11,7 @@ import pytest
 REPO = Path(__file__).resolve().parents[1]
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 NODE = shutil.which("node")
 
 pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for settled-window runtime tests")
@@ -106,25 +107,29 @@ eval(extractFunction('_settledSessionMessageWindowLimit'));
 eval(extractFunction('_settledSessionMessageWindowUrl'));
 eval(extractFunction('_fetchSettledSessionMessageWindow'));
 (async()=>{
-  const bounded = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 103}, {});
-  _messagesTruncated = false;
-  const full = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 1000}, {});
-  console.log(JSON.stringify({bounded, full, calls}));
+const bounded = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 103}, {});
+_messagesTruncated = false;
+const full = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 1000}, {});
+const forced = await _fetchSettledSessionMessageWindow('sid-1', null, {reserveNewTurn: true, forceBounded: true});
+console.log(JSON.stringify({bounded, full, forced, calls}));
 })().catch(err=>{ console.error(err.stack || err); process.exit(1); });
 """
     )
 
     assert outcome["bounded"]["_messages_offset"] == 70
     assert outcome["full"] is None
-    assert len(outcome["calls"]) == 1
+    assert outcome["forced"]["_messages_offset"] == 70
+    assert len(outcome["calls"]) == 2
     assert "session_id=sid-1&messages=1&resolve_model=0&msg_limit=33" in outcome["calls"][0]["url"]
+    assert "session_id=sid-1&messages=1&resolve_model=0&msg_limit=30" in outcome["calls"][1]["url"]
     assert outcome["calls"][0]["options"] == {"timeoutMs": 120000}
+    assert outcome["calls"][1]["options"] == {"timeoutMs": 120000}
 
 
 def test_done_and_recovery_paths_do_not_expand_the_render_window():
     compact = "".join(MESSAGES_JS.split())
     assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in compact
-    assert "_settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true})" in compact
+    assert "_settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true,forceBounded:true})" in compact
     assert "_messagesTruncated=!!session._messages_truncated" in compact
     assert "_messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize" not in compact
 
@@ -141,3 +146,12 @@ def test_settled_window_helpers_and_cross_module_callers_are_present():
     assert "function _settledSessionMessageWindowLimit" in SESSIONS_JS
     assert "async function _fetchSettledSessionMessageWindow" in SESSIONS_JS
     assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in MESSAGES_JS
+
+
+def test_reconnect_refresh_uses_a_bounded_session_window():
+    start = UI_JS.index("async function refreshSession()")
+    end = UI_JS.index("// ── Update banner", start)
+    body = "".join(UI_JS[start:end].split())
+    assert "_messageReloadLimitForSession(sid)" in body
+    assert "messages=1&resolve_model=0&msg_limit=${encodeURIComponent" in body
+    assert "api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}`)" not in body

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -43,7 +43,20 @@ function extractFunction(name) {
     if (start >= 0) break;
   }
   if (start < 0) throw new Error(`missing ${name}`);
-  const brace = src.indexOf('{', start);
+  const params = src.indexOf('(', start);
+  let paramDepth = 0;
+  let brace = -1;
+  for (let i = params; i < src.length; i += 1) {
+    if (src[i] === '(') paramDepth += 1;
+    else if (src[i] === ')') {
+      paramDepth -= 1;
+      if (paramDepth === 0) {
+        brace = src.indexOf('{', i + 1);
+        break;
+      }
+    }
+  }
+  if (brace < 0) throw new Error(`missing body for ${name}`);
   let depth = 0;
   for (let i = brace; i < src.length; i += 1) {
     if (src[i] === '{') depth += 1;
@@ -275,39 +288,333 @@ def test_done_defers_session_stream_resume_until_after_async_settlement():
     assert "finally" in done_body[idle_idx:resume_idx]
 
 
-def test_deferred_owner_cleanup_waits_for_settlement_before_resuming_continuation():
-    outcome = _node_driver(
+def _done_continuation_stream_harness(settlement_mode: str) -> dict:
+    assert settlement_mode in {"success", "rejection"}
+    return _node_driver(
         _EXTRACT
-        + r"""
-const activeSid='parent-session';
-const streamId='stream-1';
-const S={session:{session_id:activeSid},activeStreamId:streamId};
-const INFLIGHT={[activeSid]:{messages:[]}};
-const resumes=[];
-function _isActiveSession(){return S.session&&S.session.session_id===activeSid;}
-function clearInflightState(){}
-function _clearActivePaneInflightIfOwner(){S.activeStreamId=null;}
-function _resumeSessionStreamAfterLiveChat(sid){resumes.push(sid);}
-eval(extractFunction('_clearOwnerInflightState'));
+        + rf"""
+const path = require('path');
+const uiSrc = fs.readFileSync(path.join(path.dirname(process.argv[1]), 'ui.js'), 'utf8');
+function extractFrom(source, name) {{
+  const markers = [`async function ${{name}}(`, `function ${{name}}(`];
+  let start = -1;
+  for (const marker of markers) {{
+    start = source.indexOf(marker);
+    if (start >= 0) break;
+  }}
+  if (start < 0) throw new Error(`missing ${{name}}`);
+  const params = source.indexOf('(', start);
+  let paramDepth = 0;
+  let brace = -1;
+  for (let i = params; i < source.length; i += 1) {{
+    if (source[i] === '(') paramDepth += 1;
+    else if (source[i] === ')') {{
+      paramDepth -= 1;
+      if (paramDepth === 0) {{
+        brace = source.indexOf('{{', i + 1);
+        break;
+      }}
+    }}
+  }}
+  if (brace < 0) throw new Error(`missing body for ${{name}}`);
+  let depth = 0;
+  for (let i = brace; i < source.length; i += 1) {{
+    if (source[i] === '{{') depth += 1;
+    else if (source[i] === '}}') {{
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }}
+  }}
+  throw new Error(`unterminated ${{name}}`);
+}}
+
+const parentSid = 'parent-session';
+const continuationSid = 'continuation-session';
+const streamId = 'stream-1';
+const fallbackMessages = [
+  {{role:'user', content:'bounded question'}},
+  {{role:'assistant', content:'bounded local answer', _live:true}},
+];
+const fallbackToolCalls = [{{id:'local-tool', name:'read_file', done:true}}];
+const settledMessages = [
+  {{role:'user', content:'settled question'}},
+  {{role:'assistant', content:'settled authoritative answer'}},
+];
+const settledToolCalls = [{{id:'settled-tool', name:'read_file', done:true}}];
+
+const storage = new Map([
+  ['hermes-webui-inflight', JSON.stringify({{sid:parentSid,streamId,ts:1}})],
+  ['hermes-webui-inflight-state', JSON.stringify({{[parentSid]:{{streamId}}}})],
+]);
+global.localStorage = {{
+  getItem:key=>storage.has(key)?storage.get(key):null,
+  setItem:(key,value)=>storage.set(key,String(value)),
+  removeItem:key=>storage.delete(key),
+}};
+global.location = {{href:'http://example.test/', pathname:'/', search:''}};
+global.history = {{replaceState:()=>{{}}}};
+global.document = {{
+  hidden:false,
+  visibilityState:'visible',
+  baseURI:'http://example.test/',
+  addEventListener:()=>{{}},
+  removeEventListener:()=>{{}},
+  querySelector:()=>null,
+  hasFocus:()=>true,
+}};
+global.window = global;
+window.location = global.location;
+window._compressionUi = null;
+window._streamJustFinished = false;
+
+const S = global.S = {{
+  session:{{session_id:parentSid,message_count:90,pending_started_at:1}},
+  messages:fallbackMessages.map(message=>({{...message}})),
+  toolCalls:fallbackToolCalls.map(tool=>({{...tool}})),
+  activeStreamId:streamId,
+  activeProfile:'default',
+  busy:true,
+  todos:[],
+}};
+const INFLIGHT = global.INFLIGHT = {{
+  [parentSid]:{{
+    messages:fallbackMessages.map(message=>({{...message}})),
+    toolCalls:fallbackToolCalls.map(tool=>({{...tool}})),
+    uploaded:[],
+  }},
+}};
+const LIVE_STREAMS = global.LIVE_STREAMS = {{}};
+const _STREAM_WAS_HIDDEN = global._STREAM_WAS_HIDDEN = {{}};
+const _STREAM_NOTIFICATION_BACKGROUND = global._STREAM_NOTIFICATION_BACKGROUND = {{}};
+const _desktopBackgroundedForNotifications = false;
+let _messagesTruncated = true;
+let _oldestIdx = 60;
+let _loadingSessionId = null;
+let _queueDrainSid = null;
+let _approvalSessionId = null;
+let _clarifySessionId = null;
+let _sessionEventSource = null;
+let _sessionStreamSessionId = null;
+let _sessionStreamReconnectTimer = null;
+let _sessionStreamHiddenSid = null;
+let _sessionStreamHiddenPollTimer = null;
+let _sessionStreamHiddenPollSid = null;
+let _sessionStreamHiddenPollFalseStreamId = null;
+let _sessionStreamHiddenPollFalseCount = 0;
+const _SESSION_STREAM_HIDDEN_POLL_MAX_FALSE = 3;
+const INFLIGHT_KEY = 'hermes-webui-inflight';
+const INFLIGHT_STATE_KEY = 'hermes-webui-inflight-state';
+
+class FakeEventSource {{
+  static instances = [];
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSED = 2;
+  constructor(url) {{
+    this.url = String(url);
+    this.listeners = Object.create(null);
+    this.readyState = FakeEventSource.OPEN;
+    FakeEventSource.instances.push(this);
+  }}
+  addEventListener(name, fn) {{
+    (this.listeners[name] || (this.listeners[name] = [])).push(fn);
+  }}
+  emit(name, data) {{
+    for (const fn of this.listeners[name] || []) fn({{data:JSON.stringify(data),lastEventId:''}});
+  }}
+  close() {{ this.readyState = FakeEventSource.CLOSED; }}
+}}
+global.EventSource = FakeEventSource;
+
+const noops = [
+  '_resetStreamScrollFollow','ensureLiveWorklogShell','resetTurnWorkspaceMutations',
+  'snapshotLiveTurnHtmlForSession','_clearLiveRunStatusTimer','hideLiveRunStatus',
+  'saveInflightState','_setSessionViewedCount','_markSessionViewed','_markSessionCompletionUnread',
+  '_clearSessionCompletionUnread','_markSessionCompletedInList','_clearApprovalPendingForSession',
+  '_clearClarifyPendingForSession','stopApprovalPolling','hideApprovalCard','stopClarifyPolling',
+  'hideClarifyCard','finalizeThinkingCard','_cancelAnimationFramePendingStreamRender',
+  '_streamFadeCleanupReduceMotionListener','_smdEndParser','_flushReasoningToAnchor',
+  '_applyToAnchor','_scheduleAnchorRegistryCleanup','_clearAnchorProseIncrementalNode',
+  '_hydrateTodosFromSession','clearVisibleMessageRowCache','_setActiveSessionUrl',
+  '_attachProjectedAnchorSceneToLastAssistant','renderSessionArtifacts','clearLiveToolCards',
+  'removeThinking','syncTopbar','renderMessages','_followSettledDoneIfStillPinned',
+  'noteWorkspaceMutationsFromToolCalls','loadDir','renderSessionList','playNotificationSound',
+  'sendBrowserNotification','setComposerStatus','setStatus','setBusy','updateQueueBadge',
+  'trackBackgroundError','_stopHiddenActiveStreamPoll','_startHiddenActiveStreamPoll',
+];
+for (const name of noops) global[name] = ()=>{{}};
+global.$ = ()=>null;
+global.msgContent = message=>String(message&&message.content||'');
+global._isPreservedCompressionTaskListMarkerOnlyText = ()=>false;
+global._replaceMarkerOnlyAssistantWithStreamError = ()=>false;
+global._filterRecoveryControlMessages = messages=>messages;
+global._carryForwardEphemeralTurnFields = (_oldMessages,newMessages)=>newMessages;
+global._splitThinkFromContent = (content,reasoning)=>({{content,reasoning}});
+global._mergeSettledToolCallsWithLiveMetadata = calls=>calls;
+global._shouldUseLiveProseFade = ()=>false;
+global._isMessagePaneNearBottom = ()=>true;
+global._shouldFollowMessagesOnDomReplace = ()=>false;
+global._isDocumentVisibleAndFocused = ()=>true;
+global._completionNotificationPreviewText = ()=>'';
+global._shouldForceCompletionNotification = ()=>false;
+global._chatPayloadModelState = ()=>({{model:'model',model_provider:'provider'}});
+global._apiUrl = value=>value;
+global._readInflightStateMap = ()=>{{
+  try {{ return JSON.parse(localStorage.getItem(INFLIGHT_STATE_KEY)||'{{}}'); }}
+  catch (_) {{ return {{}}; }}
+}};
+global._isSessionCurrentPane = sid=>!!(sid&&S.session&&S.session.session_id===sid);
+global._isSessionActivelyViewed = sid=>global._isSessionCurrentPane(sid);
+global._clearStreamHidden = (sid,ownerStreamId)=>{{
+  const entry=_STREAM_WAS_HIDDEN[sid];
+  if(entry&&(!ownerStreamId||!entry.streamId||entry.streamId===ownerStreamId)) delete _STREAM_WAS_HIDDEN[sid];
+}};
+global._clearStreamNotificationBackground = (sid,ownerStreamId)=>{{
+  const entry=_STREAM_NOTIFICATION_BACKGROUND[sid];
+  if(entry&&(!ownerStreamId||!entry.streamId||entry.streamId===ownerStreamId)) delete _STREAM_NOTIFICATION_BACKGROUND[sid];
+}};
+global._bindStreamHiddenTracker = ()=>{{}};
+global._runJournalReplayParams = ()=>'';
+global._extractInlineThinkingFromContent = (content,reasoning)=>({{content:String(content||''),reasoning:String(reasoning||'')}});
+global._syncCtxIndicator = ()=>{{}};
+global._mergeUsageForCtxIndicator = (usage,fallback)=>({{...fallback,...usage}});
 
 let resolveSettlement;
-const settlement=new Promise(resolve=>{resolveSettlement=resolve;});
-(async()=>{
-  const ownsDeferredResume=_clearOwnerInflightState({deferSessionStreamResume:true});
-  const whilePending=resumes.slice();
-  resolveSettlement();
-  await settlement;
-  if(ownsDeferredResume) _resumeSessionStreamAfterLiveChat('continuation-session');
-  console.log(JSON.stringify({whilePending,afterSettlement:resumes,ownsDeferredResume}));
-})().catch(err=>{console.error(err.stack||err);process.exit(1);});
+let rejectSettlement;
+let fetchCalls = [];
+const settlement = new Promise((resolve,reject)=>{{
+  resolveSettlement=resolve;
+  rejectSettlement=reject;
+}});
+global._fetchSettledSessionMessageWindow = (sid,session)=>{{
+  fetchCalls.push({{sid,sessionId:session&&session.session_id}});
+  return settlement;
+}};
+
+for (const name of ['clearInflightState','clearInflight']) eval(extractFrom(uiSrc,name));
+for (const name of [
+  'closeLiveStream','closeOtherLiveStreams','attachLiveStream',
+  '_chatStreamActiveForSession','_suspendSessionStreamForLiveChat',
+  '_resumeSessionStreamAfterLiveChat','stopSessionStream','startSessionStream',
+]) eval(extractFunction(name));
+
+const flush = () => new Promise(resolve=>setTimeout(resolve,0));
+const sessionSources = () => FakeEventSource.instances.filter(source=>source.url.includes('api/session/stream'));
+const chatSources = () => FakeEventSource.instances.filter(source=>source.url.includes('api/chat/stream'));
+
+(async()=>{{
+  attachLiveStream(parentSid,streamId);
+  await flush();
+  const parentSource=chatSources()[0];
+  if(!parentSource) throw new Error('production attachLiveStream did not create the parent chat EventSource');
+  parentSource.emit('done',{{
+    stream_id:streamId,
+    status:'completed',
+    session:{{
+      session_id:continuationSid,
+      message_count:92,
+      messages:[{{role:'assistant',content:'terminal snapshot'}}],
+      tool_calls:[],
+      _messages_truncated:true,
+      _messages_offset:61,
+    }},
+  }});
+  await Promise.resolve();
+  await flush();
+  const pending={{
+    fetchCalls:fetchCalls.slice(),
+    sessionSources:sessionSources().map(source=>source.url),
+    sessionId:S.session&&S.session.session_id,
+    activeStreamId:S.activeStreamId,
+    parentInflightPresent:Object.prototype.hasOwnProperty.call(INFLIGHT,parentSid),
+  }};
+
+  if ({json.dumps(settlement_mode)} === 'success') {{
+    resolveSettlement({{
+      session_id:continuationSid,
+      message_count:92,
+      messages:settledMessages.map(message=>({{...message}})),
+      tool_calls:settledToolCalls.map(tool=>({{...tool}})),
+      _messages_truncated:true,
+      _messages_offset:62,
+    }});
+  }} else {{
+    rejectSettlement(new Error('settled window unavailable'));
+  }}
+  await flush();
+  await flush();
+  const afterFirstResume=sessionSources().map(source=>source.url);
+  await flush();
+
+  console.log(JSON.stringify({{
+    mode:{json.dumps(settlement_mode)},
+    pending,
+    final:{{
+      sessionId:S.session&&S.session.session_id,
+      messages:S.messages,
+      toolCalls:S.toolCalls,
+      activeStreamId:S.activeStreamId,
+      parentInflightPresent:Object.prototype.hasOwnProperty.call(INFLIGHT,parentSid),
+      messagesTruncated:_messagesTruncated,
+      oldestIdx:_oldestIdx,
+      sessionSources:sessionSources().map(source=>source.url),
+      afterFirstResume,
+      sessionStreamSessionId:_sessionStreamSessionId,
+      sessionEventSourceUrl:_sessionEventSource&&_sessionEventSource.url,
+      chatSourceCount:chatSources().length,
+    }},
+  }}));
+}})().catch(error=>{{console.error(error.stack||error);process.exit(1);}});
 """,
         REPO / "static" / "messages.js",
     )
-    assert outcome == {
-        "whilePending": [],
-        "afterSettlement": ["continuation-session"],
-        "ownsDeferredResume": True,
+
+
+@pytest.mark.parametrize("settlement_mode", ["success", "rejection"])
+def test_done_restarts_continuation_session_stream_after_settlement(settlement_mode):
+    outcome = _done_continuation_stream_harness(settlement_mode)
+
+    assert outcome["pending"] == {
+        "fetchCalls": [
+            {"sid": "continuation-session", "sessionId": "continuation-session"}
+        ],
+        "sessionSources": [],
+        "sessionId": "parent-session",
+        "activeStreamId": "stream-1",
+        "parentInflightPresent": False,
     }
+
+    final = outcome["final"]
+    assert final["sessionId"] == "continuation-session"
+    assert final["activeStreamId"] is None
+    assert final["parentInflightPresent"] is False
+    assert final["messagesTruncated"] is True
+    assert final["sessionStreamSessionId"] == "continuation-session"
+    assert len(final["sessionSources"]) == 1
+    assert final["afterFirstResume"] == final["sessionSources"]
+    assert "session_id=continuation-session" in final["sessionSources"][0]
+    assert final["sessionEventSourceUrl"] == final["sessionSources"][0]
+    assert final["chatSourceCount"] == 1
+
+    if settlement_mode == "success":
+        assert [(message["role"], message["content"]) for message in final["messages"]] == [
+            ("user", "settled question"),
+            ("assistant", "settled authoritative answer"),
+        ]
+        assert final["toolCalls"] == [
+            {"id": "settled-tool", "name": "read_file", "done": True}
+        ]
+        assert final["oldestIdx"] == 62
+    else:
+        assert [(message["role"], message["content"]) for message in final["messages"]] == [
+            ("user", "bounded question"),
+            ("assistant", "bounded local answer"),
+        ]
+        assert final["messages"][1]["_live"] is True
+        assert final["toolCalls"] == [
+            {"id": "local-tool", "name": "read_file", "done": True}
+        ]
+        assert final["oldestIdx"] == 60
 
 
 def test_settled_window_helpers_and_cross_module_callers_are_present():

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -155,9 +155,91 @@ console.log(JSON.stringify({
     assert outcome == {"expanded": 90, "initial": 30}
 
 
+def test_mutation_reload_uses_renderable_width_not_hidden_tool_rows():
+    outcome = _node_driver(
+        _EXTRACT
+        + r"""
+const _INITIAL_MSG_LIMIT = 30;
+let _messagesTruncated = true;
+let _sameSessionForceReloadHint = null;
+let loadedRenderable = 30;
+const S = {
+  messages: [
+    ...Array.from({length: 30}, () => ({role: 'assistant', content: 'visible'})),
+    ...Array.from({length: 30}, () => ({role: 'tool', content: 'hidden'})),
+  ],
+  session: {session_id: 'sid-1', message_count: 300},
+};
+function _currentLoadedRenderableMessageCount() { return loadedRenderable; }
+eval(extractFunction('_captureSameSessionForceReloadHint'));
+eval(extractFunction('_messageReloadLimitForSession'));
+_captureSameSessionForceReloadHint('sid-1');
+const beforeUndo = _messageReloadLimitForSession('sid-1');
+S.session.message_count = 299;
+const afterUndo = _messageReloadLimitForSession('sid-1');
+console.log(JSON.stringify({beforeUndo, afterUndo}));
+"""
+    )
+
+    assert outcome == {"beforeUndo": 30, "afterUndo": 30}
+
+
+def test_rotated_done_window_uses_continuation_session_data():
+    compact = "".join(MESSAGES_JS.split())
+    done_start = MESSAGES_JS.index("source.addEventListener('done'")
+    done_end = MESSAGES_JS.index("source.addEventListener('stream_end'", done_start)
+    done_body = "".join(MESSAGES_JS[done_start:done_end].split())
+    completed_sid_idx = done_body.index("constcompletedSid=completedSession.session_id||activeSid;")
+    fetch_idx = done_body.index("_settledDoneWindow=await_fetchSettledSessionMessageWindow")
+    assert completed_sid_idx < fetch_idx
+    assert "_settledDoneWindow=await_fetchSettledSessionMessageWindow(completedSid,completedSession)" in compact
+    assert "_settledDoneWindow=await_fetchSettledSessionMessageWindow(activeSid,completedSession)" not in done_body
+
+    outcome = _node_driver(
+        r"""
+const activeSid = 'parent-session';
+const completedSession = {session_id: 'continuation-session', message_count: 101};
+const completedSid = completedSession.session_id || activeSid;
+const windows = {
+  'parent-session': {
+    messages: [{role: 'assistant', content: 'STALE PARENT WINDOW'}],
+    tool_calls: [{id: 'parent-tool'}],
+    _messages_truncated: true,
+    _messages_offset: 70,
+  },
+  'continuation-session': {
+    messages: [{role: 'assistant', content: 'FINAL ANSWER'}],
+    tool_calls: [{id: 'continuation-tool'}],
+    _messages_truncated: true,
+    _messages_offset: 70,
+  },
+};
+async function _fetchSettledSessionMessageWindow(sid) {
+  return windows[sid];
+}
+(async()=>{
+  const _settledDoneWindow = await _fetchSettledSessionMessageWindow(completedSid, completedSession);
+  const settled = {
+    session_id: completedSid,
+    messages: _settledDoneWindow.messages,
+    tool_calls: _settledDoneWindow.tool_calls,
+    _messages_offset: _settledDoneWindow._messages_offset,
+  };
+  console.log(JSON.stringify(settled));
+})().catch(err=>{ console.error(err.stack || err); process.exit(1); });
+"""
+    )
+    assert outcome == {
+        "session_id": "continuation-session",
+        "messages": [{"role": "assistant", "content": "FINAL ANSWER"}],
+        "tool_calls": [{"id": "continuation-tool"}],
+        "_messages_offset": 70,
+    }
+
+
 def test_done_and_recovery_paths_do_not_expand_the_render_window():
     compact = "".join(MESSAGES_JS.split())
-    assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in compact
+    assert "_fetchSettledSessionMessageWindow(completedSid,completedSession)" in compact
     assert "_settledSessionMessageWindowUrl(activeSid,null,{reserveNewTurn:true,forceBounded:true})" in compact
     assert "_messagesTruncated=!!session._messages_truncated" in compact
     assert "_messageRenderWindowSize=Math.max(typeof _currentMessageRenderWindowSize" not in compact
@@ -174,7 +256,7 @@ def test_done_and_recovery_paths_do_not_expand_the_render_window():
 def test_settled_window_helpers_and_cross_module_callers_are_present():
     assert "function _settledSessionMessageWindowLimit" in SESSIONS_JS
     assert "async function _fetchSettledSessionMessageWindow" in SESSIONS_JS
-    assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in MESSAGES_JS
+    assert "_fetchSettledSessionMessageWindow(completedSid,completedSession)" in MESSAGES_JS
 
 
 def test_reconnect_refresh_uses_a_bounded_session_window():

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -17,9 +17,11 @@ NODE = shutil.which("node")
 pytestmark = pytest.mark.skipif(NODE is None, reason="node is required for settled-window runtime tests")
 
 
-def _node_driver(body: str) -> dict:
+def _node_driver(body: str, source: Path | None = None) -> dict:
+    assert NODE is not None
+    source = source or (REPO / "static" / "sessions.js")
     result = subprocess.run(
-        [NODE, "-e", body, str(REPO / "static" / "sessions.js")],
+        [NODE, "-e", body, str(source)],
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -91,6 +93,8 @@ def test_settled_window_fetch_uses_canonical_session_pagination():
         _EXTRACT
         + r"""
 const _INITIAL_MSG_LIMIT = 30;
+const _MSG_LIMIT_MAX = 500;
+let _msgLimitMax = _MSG_LIMIT_MAX;
 let _messagesTruncated = true;
 let loadedRenderable = 30;
 const S = {
@@ -104,6 +108,7 @@ async function api(url, options) {
   return {session: {_messages_truncated: true, _messages_offset: 70, messages: []}};
 }
 eval(extractFunction('_settledSessionMessageWindowLimit'));
+eval(extractFunction('_sessionMessageReloadUrl'));
 eval(extractFunction('_settledSessionMessageWindowUrl'));
 eval(extractFunction('_fetchSettledSessionMessageWindow'));
 (async()=>{
@@ -111,19 +116,24 @@ const bounded = await _fetchSettledSessionMessageWindow('sid-1', {message_count:
 _messagesTruncated = false;
 const full = await _fetchSettledSessionMessageWindow('sid-1', {message_count: 1000}, {});
 const forced = await _fetchSettledSessionMessageWindow('sid-1', null, {reserveNewTurn: true, forceBounded: true});
-console.log(JSON.stringify({bounded, full, forced, calls}));
+const fullRecoveryUrl = _settledSessionMessageWindowUrl('sid-1', null, {reserveNewTurn: true, forceBounded: true});
+_messagesTruncated = true;
+loadedRenderable = 600;
+S.messages = Array.from({length: 600}, () => ({role: 'user'}));
+const aboveCeilingRecoveryUrl = _settledSessionMessageWindowUrl('sid-1', null, {reserveNewTurn: true, forceBounded: true});
+console.log(JSON.stringify({bounded, full, forced, fullRecoveryUrl, aboveCeilingRecoveryUrl, calls}));
 })().catch(err=>{ console.error(err.stack || err); process.exit(1); });
 """
     )
 
     assert outcome["bounded"]["_messages_offset"] == 70
     assert outcome["full"] is None
-    assert outcome["forced"]["_messages_offset"] == 70
-    assert len(outcome["calls"]) == 2
-    assert "session_id=sid-1&messages=1&resolve_model=0&msg_limit=33" in outcome["calls"][0]["url"]
-    assert "session_id=sid-1&messages=1&resolve_model=0&msg_limit=30" in outcome["calls"][1]["url"]
+    assert outcome["forced"] is None
+    assert "msg_limit=" not in outcome["fullRecoveryUrl"]
+    assert "msg_limit=" not in outcome["aboveCeilingRecoveryUrl"]
+    assert len(outcome["calls"]) == 1
+    assert "session_id=sid-1&messages=1&resolve_model=0&msg_limit=33&expand_renderable=1" in outcome["calls"][0]["url"]
     assert outcome["calls"][0]["options"] == {"timeoutMs": 120000}
-    assert outcome["calls"][1]["options"] == {"timeoutMs": 120000}
 
 
 def test_reload_limit_preserves_expanded_window_without_force_reload_hint():
@@ -247,10 +257,57 @@ def test_done_and_recovery_paths_do_not_expand_the_render_window():
     done_start = MESSAGES_JS.index("source.addEventListener('done'")
     done_end = MESSAGES_JS.index("source.addEventListener('stream_end'", done_start)
     done_body = MESSAGES_JS[done_start:done_end]
-    assert done_body.index("const _settledDoneInflightSnapshot") < done_body.index("_clearOwnerInflightState()")
+    assert done_body.index("const _settledDoneInflightSnapshot") < done_body.index("_clearOwnerInflightState({deferSessionStreamResume:true})")
     refresh_idx = done_body.index("await _fetchSettledSessionMessageWindow")
     ownership_idx = done_body.index("if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;")
     assert refresh_idx < ownership_idx < done_body.index("S.session=_settledSession")
+
+
+def test_done_defers_session_stream_resume_until_after_async_settlement():
+    done_start = MESSAGES_JS.index("source.addEventListener('done'")
+    done_end = MESSAGES_JS.index("source.addEventListener('stream_end'", done_start)
+    done_body = MESSAGES_JS[done_start:done_end]
+    clear_idx = done_body.index("_clearOwnerInflightState({deferSessionStreamResume:true})")
+    fetch_idx = done_body.index("await _fetchSettledSessionMessageWindow")
+    idle_idx = done_body.index("_setActivePaneIdleIfOwner()")
+    resume_idx = done_body.rindex("_resumeSessionStreamAfterLiveChat(completedSid)")
+    assert clear_idx < fetch_idx < idle_idx < resume_idx
+    assert "finally" in done_body[idle_idx:resume_idx]
+
+
+def test_deferred_owner_cleanup_waits_for_settlement_before_resuming_continuation():
+    outcome = _node_driver(
+        _EXTRACT
+        + r"""
+const activeSid='parent-session';
+const streamId='stream-1';
+const S={session:{session_id:activeSid},activeStreamId:streamId};
+const INFLIGHT={[activeSid]:{messages:[]}};
+const resumes=[];
+function _isActiveSession(){return S.session&&S.session.session_id===activeSid;}
+function clearInflightState(){}
+function _clearActivePaneInflightIfOwner(){S.activeStreamId=null;}
+function _resumeSessionStreamAfterLiveChat(sid){resumes.push(sid);}
+eval(extractFunction('_clearOwnerInflightState'));
+
+let resolveSettlement;
+const settlement=new Promise(resolve=>{resolveSettlement=resolve;});
+(async()=>{
+  const ownsDeferredResume=_clearOwnerInflightState({deferSessionStreamResume:true});
+  const whilePending=resumes.slice();
+  resolveSettlement();
+  await settlement;
+  if(ownsDeferredResume) _resumeSessionStreamAfterLiveChat('continuation-session');
+  console.log(JSON.stringify({whilePending,afterSettlement:resumes,ownsDeferredResume}));
+})().catch(err=>{console.error(err.stack||err);process.exit(1);});
+""",
+        REPO / "static" / "messages.js",
+    )
+    assert outcome == {
+        "whilePending": [],
+        "afterSettlement": ["continuation-session"],
+        "ownsDeferredResume": True,
+    }
 
 
 def test_settled_window_helpers_and_cross_module_callers_are_present():
@@ -264,5 +321,5 @@ def test_reconnect_refresh_uses_a_bounded_session_window():
     end = UI_JS.index("// ── Update banner", start)
     body = "".join(UI_JS[start:end].split())
     assert "_messageReloadLimitForSession(sid)" in body
-    assert "messages=1&resolve_model=0&msg_limit=${encodeURIComponent" in body
+    assert "_sessionMessageReloadUrl(sid,refreshLimit)" in body
     assert "api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}`)" not in body

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -272,7 +272,9 @@ def test_done_and_recovery_paths_do_not_expand_the_render_window():
     done_body = MESSAGES_JS[done_start:done_end]
     assert done_body.index("const _settledDoneInflightSnapshot") < done_body.index("_clearOwnerInflightState({deferSessionStreamResume:true})")
     refresh_idx = done_body.index("await _fetchSettledSessionMessageWindow")
-    ownership_idx = done_body.index("if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;")
+    ownership_idx = done_body.index("const _settlementStillOwnsPane=")
+    assert "S.activeStreamId===streamId" in done_body[ownership_idx:]
+    assert "_settledLiveOwner.streamId===streamId" in done_body[ownership_idx:]
     assert refresh_idx < ownership_idx < done_body.index("S.session=_settledSession")
 
 
@@ -288,7 +290,9 @@ def test_done_defers_session_stream_resume_until_after_async_settlement():
     assert "finally" in done_body[idle_idx:resume_idx]
 
 
-def _done_continuation_stream_harness(settlement_mode: str) -> dict:
+def _done_continuation_stream_harness(
+    settlement_mode: str, *, replace_owner_while_pending: bool = False
+) -> dict:
     assert settlement_mode in {"success", "rejection"}
     return _node_driver(
         _EXTRACT
@@ -331,6 +335,9 @@ function extractFrom(source, name) {{
 const parentSid = 'parent-session';
 const continuationSid = 'continuation-session';
 const streamId = 'stream-1';
+const replacementStreamId = 'stream-new';
+const replaceOwnerWhilePending = {json.dumps(replace_owner_while_pending)};
+const completedSid = replaceOwnerWhilePending ? parentSid : continuationSid;
 const fallbackMessages = [
   {{role:'user', content:'bounded question'}},
   {{role:'assistant', content:'bounded local answer', _live:true}},
@@ -511,7 +518,7 @@ const chatSources = () => FakeEventSource.instances.filter(source=>source.url.in
     stream_id:streamId,
     status:'completed',
     session:{{
-      session_id:continuationSid,
+      session_id:completedSid,
       message_count:92,
       messages:[{{role:'assistant',content:'terminal snapshot'}}],
       tool_calls:[],
@@ -529,9 +536,18 @@ const chatSources = () => FakeEventSource.instances.filter(source=>source.url.in
     parentInflightPresent:Object.prototype.hasOwnProperty.call(INFLIGHT,parentSid),
   }};
 
+  if (replaceOwnerWhilePending) {{
+    S.messages=[{{role:'assistant',content:'new owner live transcript',_live:true}}];
+    S.toolCalls=[{{id:'new-owner-tool',name:'terminal',done:false}}];
+    S.activeStreamId=replacementStreamId;
+    S.busy=true;
+    attachLiveStream(parentSid,replacementStreamId);
+    await flush();
+  }}
+
   if ({json.dumps(settlement_mode)} === 'success') {{
     resolveSettlement({{
-      session_id:continuationSid,
+      session_id:completedSid,
       message_count:92,
       messages:settledMessages.map(message=>({{...message}})),
       tool_calls:settledToolCalls.map(tool=>({{...tool}})),
@@ -562,6 +578,7 @@ const chatSources = () => FakeEventSource.instances.filter(source=>source.url.in
       sessionStreamSessionId:_sessionStreamSessionId,
       sessionEventSourceUrl:_sessionEventSource&&_sessionEventSource.url,
       chatSourceCount:chatSources().length,
+      liveStreamId:LIVE_STREAMS[parentSid]&&LIVE_STREAMS[parentSid].streamId,
     }},
   }}));
 }})().catch(error=>{{console.error(error.stack||error);process.exit(1);}});
@@ -615,6 +632,26 @@ def test_done_restarts_continuation_session_stream_after_settlement(settlement_m
             {"id": "local-tool", "name": "read_file", "done": True}
         ]
         assert final["oldestIdx"] == 60
+
+
+@pytest.mark.parametrize("settlement_mode", ["success", "rejection"])
+def test_old_done_settlement_preserves_newer_same_session_stream_owner(settlement_mode):
+    outcome = _done_continuation_stream_harness(
+        settlement_mode, replace_owner_while_pending=True
+    )
+
+    final = outcome["final"]
+    assert final["sessionId"] == "parent-session"
+    assert final["activeStreamId"] == "stream-new"
+    assert final["liveStreamId"] == "stream-new"
+    assert final["chatSourceCount"] == 2
+    assert final["sessionSources"] == []
+    assert [(message["role"], message["content"]) for message in final["messages"]] == [
+        ("assistant", "new owner live transcript")
+    ]
+    assert final["toolCalls"] == [
+        {"id": "new-owner-tool", "name": "terminal", "done": False}
+    ]
 
 
 def test_settled_window_helpers_and_cross_module_callers_are_present():

--- a/tests/test_settled_session_window.py
+++ b/tests/test_settled_session_window.py
@@ -126,6 +126,35 @@ console.log(JSON.stringify({bounded, full, forced, calls}));
     assert outcome["calls"][1]["options"] == {"timeoutMs": 120000}
 
 
+def test_reload_limit_preserves_expanded_window_without_force_reload_hint():
+    outcome = _node_driver(
+        _EXTRACT
+        + r"""
+const _INITIAL_MSG_LIMIT = 30;
+let _messagesTruncated = true;
+let _sameSessionForceReloadHint = null;
+let loadedRenderable = 90;
+const S = {
+  messages: Array.from({length: 90}, () => ({role: 'user'})),
+  session: {session_id: 'sid-1', message_count: 300},
+};
+function _currentLoadedRenderableMessageCount() { return loadedRenderable; }
+eval(extractFunction('_settledSessionMessageWindowLimit'));
+eval(extractFunction('_messageReloadLimitForSession'));
+console.log(JSON.stringify({
+  expanded: _messageReloadLimitForSession('sid-1'),
+  initial: (() => {
+    loadedRenderable = 30;
+    S.messages = Array.from({length: 30}, () => ({role: 'user'}));
+    return _messageReloadLimitForSession('sid-1');
+  })(),
+}));
+"""
+    )
+
+    assert outcome == {"expanded": 90, "initial": 30}
+
+
 def test_done_and_recovery_paths_do_not_expand_the_render_window():
     compact = "".join(MESSAGES_JS.split())
     assert "_fetchSettledSessionMessageWindow(activeSid,completedSession)" in compact

--- a/tests/test_sprint9.py
+++ b/tests/test_sprint9.py
@@ -42,7 +42,8 @@ def test_workspace_js_served(cleanup_test_sessions):
 def test_sessions_js_served(cleanup_test_sessions):
     src = get_text("/static/sessions.js")
     assert "async function newSession(" in src
-    assert "async function loadSession(" in src
+    assert "function loadSession(sid)" in src
+    assert "async function _loadSessionOnce(" in src
     assert "async function renderSessionList(" in src
 
 def test_messages_js_served(cleanup_test_sessions):

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -584,7 +584,7 @@ class TestDoneEventSmd:
         assert fn, "'done' handler not found"
         done_before_render = fn[:fn.index("renderMessages({preserveScroll:true})")]
         assert "const hasMessageToolMetadata=S.messages.some" in done_before_render
-        assert "!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length" in done_before_render
+        assert "!hasMessageToolMetadata&&_settledSession.tool_calls&&_settledSession.tool_calls.length" in done_before_render
         assert "S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map" in done_before_render
 
 

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -22,12 +22,16 @@ Tests are static (regex / AST-level) — no browser required.
 import pathlib
 import re
 import json
+import shutil
 import subprocess
+
+import pytest
 
 REPO = pathlib.Path(__file__).parent.parent
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+NODE = shutil.which("node")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -557,6 +561,55 @@ class TestDoneEventSmd:
             "Done follow capture must include a near-bottom DOM check, not only "
             "the possibly-stale _scrollPinned flag."
         )
+
+    def test_done_follow_decision_is_revalidated_after_bounded_fetch(self):
+        """Completion must not carry pre-fetch follow intent across the await."""
+        fn = self.get_fn()
+        assert fn, "'done' handler not found"
+        fetch_idx = fn.index("await _fetchSettledSessionMessageWindow")
+        ownership_idx = fn.index("if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;")
+        decision_idx = fn.index("const shouldFollowOnDone", ownership_idx)
+        render_idx = fn.index("renderMessages({preserveScroll:true})", decision_idx)
+        helper_idx = fn.index("_followSettledDoneIfStillPinned();", render_idx)
+        assert fetch_idx < ownership_idx < decision_idx < render_idx < helper_idx
+
+    @pytest.mark.skipif(NODE is None, reason="node is required for follow-intent runtime tests")
+    def test_done_follow_helper_uses_live_intent_after_fetch(self):
+        helper = extract_fn(MESSAGES_JS, "_followSettledDoneIfStillPinned")
+        script = f"""
+{helper}
+let follow = true;
+let scrollCalls = 0;
+let release;
+function _shouldFollowMessagesOnDomReplace() {{ return follow; }}
+function scrollToBottom() {{ scrollCalls += 1; }}
+async function run() {{
+  const pending = new Promise(resolve => {{ release = resolve; }});
+  const completion = (async () => {{
+    await pending;
+    _followSettledDoneIfStillPinned();
+  }})();
+  release();
+  follow = false;
+  await completion;
+  const afterReaderScrolledUp = scrollCalls;
+  follow = true;
+  _followSettledDoneIfStillPinned();
+  console.log(JSON.stringify({{afterReaderScrolledUp, finalScrollCalls: scrollCalls}}));
+}}
+run().catch(err => {{ console.error(err.stack || err); process.exit(1); }});
+"""
+        result = subprocess.run(
+            [NODE, "-e", script],
+            cwd=str(REPO),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        outcome = json.loads(result.stdout.strip())
+        assert outcome == {"afterReaderScrolledUp": 0, "finalScrollCalls": 1}
 
     def test_dom_replace_follow_threshold_is_not_broad_reader_zone(self):
         """Completion must not snap readers who scrolled slightly up mid-stream.

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -567,7 +567,7 @@ class TestDoneEventSmd:
         fn = self.get_fn()
         assert fn, "'done' handler not found"
         fetch_idx = fn.index("await _fetchSettledSessionMessageWindow")
-        ownership_idx = fn.index("if(isActiveSession&&!_isSessionCurrentPane(activeSid)) isActiveSession=false;")
+        ownership_idx = fn.index("const _settlementStillOwnsPane=", fetch_idx)
         decision_idx = fn.index("const shouldFollowOnDone", ownership_idx)
         render_idx = fn.index("renderMessages({preserveScroll:true})", decision_idx)
         helper_idx = fn.index("_followSettledDoneIfStillPinned();", render_idx)

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -25,7 +25,9 @@ def _scroll_listener_block() -> str:
 
 
 def test_clicking_current_session_is_noop_before_load_session_side_effects():
-    load_session = _function_body(SESSIONS_JS, "async function loadSession")
+    # The public loadSession() wrapper now coordinates same-session callers;
+    # the navigation/no-op side effects live in its async core.
+    load_session = _function_body(SESSIONS_JS, "async function _loadSessionOnce")
 
     current_idx = load_session.index("const currentSid = S.session ? S.session.session_id : null")
     noop_idx = load_session.index("if(currentSid===sid && !forceReload) return")
@@ -127,7 +129,7 @@ def test_external_active_refresh_defers_while_reader_is_manually_unpinned():
 
 
 def test_session_switch_clears_deferred_active_refresh_reason():
-    load = _function_body(SESSIONS_JS, "async function loadSession")
+    load = _function_body(SESSIONS_JS, "async function _loadSessionOnce")
     assert "function _clearDeferredActiveSessionExternalRefresh()" in SESSIONS_JS
     assert "_deferredActiveSessionExternalRefreshReason = '';" in SESSIONS_JS
     assert "if (currentSid !== sid) {\n    _clearDeferredActiveSessionExternalRefresh();\n  }" in load

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -447,7 +447,8 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     assert "function _messageReloadLimitForSession(sid)" in SESSIONS_JS
     assert "if(!hint.truncated) return null;" in SESSIONS_JS
     assert "const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);" in SESSIONS_JS
-    assert "return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);" in SESSIONS_JS
+    assert "loadedRenderableCount+appendedMessageCount" in SESSIONS_JS
+    assert "loadedMessageCount+appendedMessageCount" not in SESSIONS_JS
     assert "const reloadLimit = _messageReloadLimitForSession(sid);" in SESSIONS_JS
     # The width hint is applied only when it stays within the server msg_limit
     # ceiling; an over-ceiling hint would be clamped by the backend and could

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -46,6 +46,27 @@ def test_load_session_supports_force_reload_for_external_refresh():
     assert "loadSession(sid, {force:true" in SESSIONS_JS
 
 
+def test_same_session_force_reload_does_not_restart_healthy_session_stream():
+    """Refreshing a long transcript must not manufacture an SSE recovery gap."""
+    body = _function_body(SESSIONS_JS, "loadSession")
+    assert "const sameSessionForceReload = forceReload && currentSid===sid;" in body
+    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" in body
+    assert "if(!sameSessionForceReload&&typeof stopSessionStream==='function') stopSessionStream();" in body
+
+
+def test_session_updated_recovery_does_not_hijack_an_inflight_navigation():
+    """A stale session event must not restart the session being left."""
+    # The per-session listener lives in messages.js; keep this assertion here
+    # with the other active-session reconciliation contracts because it guards
+    # the loadSession ownership state shared by both modules.
+    messages = Path("static/messages.js").read_text(encoding="utf-8")
+    event_start = messages.index("addEventListener('session-updated'")
+    event_body = messages[event_start : event_start + 1800]
+    guard = "if (typeof _loadingSessionId !== 'undefined' && _loadingSessionId) return;"
+    assert guard in event_body
+    assert event_body.index(guard) < event_body.index("loadSession(")
+
+
 def test_active_session_external_refresh_uses_metadata_then_force_reload():
     assert "function ensureActiveSessionExternalRefreshPoll()" in SESSIONS_JS
     assert "async function refreshActiveSessionIfExternallyUpdated(reason)" in SESSIONS_JS

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -77,12 +77,14 @@ def test_manual_refresh_never_replaces_a_loaded_window_with_a_smaller_clamped_ta
         let loadedRenderable=0;
         const S={{session:null,messages:[],activeStreamId:null}};
         const calls=[];
+        const resolveCalls=[];
         function _currentLoadedRenderableMessageCount(){{return loadedRenderable;}}
         function dismissReconnect(){{}}
         function getPendingSessionMessage(){{return null;}}
         function syncTopbar(){{}}
         function _renderMessagesWithScrollSnapshot(){{}}
         function showToast(){{}}
+        function _resolveSessionModelForDisplaySoon(sid){{resolveCalls.push(sid);}}
         function setStatus(message){{throw new Error(message);}}
         const window={{_restartingForUpdate:false}};
         const location={{reload(){{throw new Error('unexpected page reload');}}}};
@@ -108,7 +110,7 @@ def test_manual_refresh_never_replaces_a_loaded_window_with_a_smaller_clamped_ta
           S.session={{session_id:'sid-'+count,message_count:count}};
           S.messages=Array.from({{length:count}},(_,i)=>({{role:'assistant',content:String(i)}}));
           await refreshSession();
-          return {{url:calls[calls.length-1],rows:S.messages.length}};
+          return {{url:calls[calls.length-1],rows:S.messages.length,resolveSid:resolveCalls[resolveCalls.length-1]}};
         }}
         (async()=>{{
           const full=await runCase(100,false);
@@ -120,8 +122,97 @@ def test_manual_refresh_never_replaces_a_loaded_window_with_a_smaller_clamped_ta
     out = _run_node(script)
     assert "msg_limit=" not in out["full"]["url"]
     assert out["full"]["rows"] == 100
+    assert out["full"]["resolveSid"] == "sid-100"
     assert "msg_limit=" not in out["aboveCeiling"]["url"]
     assert out["aboveCeiling"]["rows"] == 600
+    assert out["aboveCeiling"]["resolveSid"] == "sid-600"
+
+
+def test_manual_refresh_defers_model_hydration_and_ignores_stale_resolution():
+    refresh = _function_body(UI_JS, "refreshSession")
+    resolver = _function_body(SESSIONS_JS, "_resolveSessionModelForDisplaySoon")
+    script = textwrap.dedent(
+        f"""
+        let _messagesTruncated=false;
+        let _oldestIdx=0;
+        const _MSG_LIMIT_MAX=500;
+        let _msgLimitMax=500;
+        const S={{session:null,messages:[],activeStreamId:null,lastUsage:null}};
+        const deferred=[];
+        const apiCalls=[];
+        let resolveHydration;
+        function _deferSessionSideEffect(sid,fn){{deferred.push({{sid,fn}});return Promise.resolve();}}
+        function _messageReloadLimitForSession(){{return 30;}}
+        function _sessionMessageReloadUrl(sid){{return `/api/session?session_id=${{sid}}&messages=1&resolve_model=0`;}}
+        function dismissReconnect(){{}}
+        function getPendingSessionMessage(){{return null;}}
+        function syncTopbar(){{}}
+        function _renderMessagesWithScrollSnapshot(){{}}
+        function showToast(){{}}
+        function setStatus(message){{throw new Error(message);}}
+        function _syncCtxIndicator(){{}}
+        const window={{_restartingForUpdate:false}};
+        const location={{reload(){{throw new Error('unexpected page reload');}}}};
+        async function api(url){{
+          apiCalls.push(String(url));
+          if(String(url).includes('resolve_model=0')) return {{session:{{
+            session_id:S.session.session_id,model:'fast-alias',model_provider:'alias-provider',
+            messages:[],_messages_truncated:false,_messages_offset:0,
+          }}}};
+          if(String(url).includes('resolve_model=1')){{
+            return new Promise(resolve=>{{resolveHydration=resolve;}});
+          }}
+          throw new Error('unexpected url '+url);
+        }}
+        {resolver}
+        {refresh}
+        (async()=>{{
+          S.session={{session_id:'sid-hydrate'}};
+          await refreshSession();
+          const aliasAfterRefresh=S.session.model;
+          const deferredBeforeHydration=S.session._modelResolutionDeferred;
+          const hydration=deferred.shift().fn();
+          resolveHydration({{session:{{
+            session_id:'sid-hydrate',model:'resolved-model',model_provider:'resolved-provider',
+            context_length:128000,threshold_tokens:100000,last_prompt_tokens:100,
+          }}}});
+          await hydration;
+          const hydrated={{
+            model:S.session.model,
+            provider:S.session.model_provider,
+            deferred:S.session._modelResolutionDeferred,
+          }};
+
+          S.session={{session_id:'sid-stale'}};
+          await refreshSession();
+          const staleHydration=deferred.shift().fn();
+          S.session={{session_id:'sid-newer',model:'newer-model',model_provider:'newer-provider'}};
+          resolveHydration({{session:{{
+            session_id:'sid-stale',model:'stale-resolved',model_provider:'stale-provider',
+          }}}});
+          await staleHydration;
+          process.stdout.write(JSON.stringify({{
+            aliasAfterRefresh,deferredBeforeHydration,hydrated,
+            final:{{sid:S.session.session_id,model:S.session.model,provider:S.session.model_provider}},
+            apiCalls,
+          }}));
+        }})().catch(error=>{{console.error(error.stack||error);process.exit(1);}});
+        """
+    )
+    out = _run_node(script)
+    assert out["aliasAfterRefresh"] == "fast-alias"
+    assert out["deferredBeforeHydration"] is True
+    assert out["hydrated"] == {
+        "model": "resolved-model",
+        "provider": "resolved-provider",
+        "deferred": False,
+    }
+    assert out["final"] == {
+        "sid": "sid-newer",
+        "model": "newer-model",
+        "provider": "newer-provider",
+    }
+    assert sum("resolve_model=1" in url for url in out["apiCalls"]) == 2
 
 
 def test_session_updated_recovery_does_not_hijack_an_inflight_navigation():

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -39,18 +39,19 @@ def _run_node(script: str) -> dict:
 
 
 def test_load_session_supports_force_reload_for_external_refresh():
-    assert "async function loadSession(sid)" in SESSIONS_JS
+    assert "function loadSession(sid)" in SESSIONS_JS
+    assert "async function _loadSessionOnce(sid)" in SESSIONS_JS
     assert "const opts = arguments[1] || {};" in SESSIONS_JS
     assert "const forceReload = !!opts.force" in SESSIONS_JS
-    assert "if(currentSid===sid && !forceReload) return;" in SESSIONS_JS
+    assert "_activeSessionLoad" in SESSIONS_JS
     assert "loadSession(sid, {force:true" in SESSIONS_JS
 
 
 def test_same_session_force_reload_does_not_restart_healthy_session_stream():
     """Refreshing a long transcript must not manufacture an SSE recovery gap."""
-    body = _function_body(SESSIONS_JS, "loadSession")
+    body = _function_body(SESSIONS_JS, "_loadSessionOnce")
     assert "const sameSessionForceReload = forceReload && currentSid===sid;" in body
-    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" in body
+    assert "if(sameSessionForceReload&&_loadingSessionId===sid) return;" not in body
     assert "if(!sameSessionForceReload&&typeof stopSessionStream==='function') stopSessionStream();" in body
 
 
@@ -62,9 +63,9 @@ def test_session_updated_recovery_does_not_hijack_an_inflight_navigation():
     messages = Path("static/messages.js").read_text(encoding="utf-8")
     event_start = messages.index("addEventListener('session-updated'")
     event_body = messages[event_start : event_start + 1800]
-    guard = "if (typeof _loadingSessionId !== 'undefined' && _loadingSessionId) return;"
-    assert guard in event_body
-    assert event_body.index(guard) < event_body.index("loadSession(")
+    assert "function _queueSessionUpdatedRefresh(sid, serverCount)" in messages
+    assert "if(loadingSid&&loadingSid!==sid) return false;" in messages
+    assert "_queueSessionUpdatedRefresh(sid, Number(d.message_count));" in event_body
 
 
 def test_active_session_external_refresh_uses_metadata_then_force_reload():
@@ -458,7 +459,7 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     assert "const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';" in SESSIONS_JS
     assert "if (_ownsLoad()) _clearSameSessionForceReloadHint(sid);" in SESSIONS_JS
 
-    load_start = SESSIONS_JS.index("async function loadSession(sid)")
+    load_start = SESSIONS_JS.index("async function _loadSessionOnce(sid)")
     load_end = SESSIONS_JS.index("// ── Handoff hint logic", load_start)
     load_body = SESSIONS_JS[load_start:load_end]
     capture_pos = load_body.index("if (sameSessionForceReload) _captureSameSessionForceReloadHint(sid);")

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -55,6 +55,75 @@ def test_same_session_force_reload_does_not_restart_healthy_session_stream():
     assert "if(!sameSessionForceReload&&typeof stopSessionStream==='function') stopSessionStream();" in body
 
 
+def test_manual_refresh_never_replaces_a_loaded_window_with_a_smaller_clamped_tail():
+    """Full and above-ceiling panes must use an unbounded replacement request."""
+    functions = "\n\n".join(
+        _function_body(SESSIONS_JS, name)
+        for name in (
+            "_settledSessionMessageWindowLimit",
+            "_messageReloadLimitForSession",
+            "_sessionMessageReloadUrl",
+        )
+    )
+    refresh = _function_body(UI_JS, "refreshSession")
+    script = textwrap.dedent(
+        f"""
+        const _INITIAL_MSG_LIMIT=30;
+        const _MSG_LIMIT_MAX=500;
+        let _msgLimitMax=500;
+        let _sameSessionForceReloadHint=null;
+        let _messagesTruncated=false;
+        let _oldestIdx=0;
+        let loadedRenderable=0;
+        const S={{session:null,messages:[],activeStreamId:null}};
+        const calls=[];
+        function _currentLoadedRenderableMessageCount(){{return loadedRenderable;}}
+        function dismissReconnect(){{}}
+        function getPendingSessionMessage(){{return null;}}
+        function syncTopbar(){{}}
+        function _renderMessagesWithScrollSnapshot(){{}}
+        function showToast(){{}}
+        function setStatus(message){{throw new Error(message);}}
+        const window={{_restartingForUpdate:false}};
+        const location={{reload(){{throw new Error('unexpected page reload');}}}};
+        async function api(url){{
+          calls.push(String(url));
+          const match=String(url).match(/[?&]msg_limit=(\\d+)/);
+          const requested=match?Number(match[1]):loadedRenderable;
+          const returned=match?Math.min(requested,_msgLimitMax):loadedRenderable;
+          return {{session:{{
+            session_id:S.session.session_id,
+            message_count:loadedRenderable,
+            messages:Array.from({{length:returned}},(_,i)=>({{role:'assistant',content:String(i)}})),
+            _messages_truncated:returned<loadedRenderable,
+            _messages_offset:loadedRenderable-returned,
+            _msg_limit_max:_msgLimitMax,
+          }}}};
+        }}
+        {functions}
+        {refresh}
+        async function runCase(count,truncated){{
+          loadedRenderable=count;
+          _messagesTruncated=truncated;
+          S.session={{session_id:'sid-'+count,message_count:count}};
+          S.messages=Array.from({{length:count}},(_,i)=>({{role:'assistant',content:String(i)}}));
+          await refreshSession();
+          return {{url:calls[calls.length-1],rows:S.messages.length}};
+        }}
+        (async()=>{{
+          const full=await runCase(100,false);
+          const aboveCeiling=await runCase(600,true);
+          process.stdout.write(JSON.stringify({{full,aboveCeiling}}));
+        }})().catch(err=>{{console.error(err.stack||err);process.exit(1);}});
+        """
+    )
+    out = _run_node(script)
+    assert "msg_limit=" not in out["full"]["url"]
+    assert out["full"]["rows"] == 100
+    assert "msg_limit=" not in out["aboveCeiling"]["url"]
+    assert out["aboveCeiling"]["rows"] == 600
+
+
 def test_session_updated_recovery_does_not_hijack_an_inflight_navigation():
     """A stale session event must not restart the session being left."""
     # The per-session listener lives in messages.js; keep this assertion here
@@ -456,9 +525,9 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     # full-transcript path (#6152/#6154 ceiling; Codex gate silent row-loss fix).
     # #6177: the ceiling is now read from /api/session metadata into _msgLimitMax
     # (module-scope let, default _MSG_LIMIT_MAX) instead of the mirrored const.
-    assert "const boundedReloadLimit = (reloadLimit && reloadLimit <= _msgLimitMax) ? reloadLimit : null;" in SESSIONS_JS
-    assert "const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';" in SESSIONS_JS
-    assert "if (_ownsLoad()) _clearSameSessionForceReloadHint(sid);" in SESSIONS_JS
+    assert "function _sessionMessageReloadUrl(sid, requestedLimit)" in SESSIONS_JS
+    assert "numericLimit>0&&numericLimit<=_msgLimitMax" in SESSIONS_JS
+    assert "return boundedLimit===null" in SESSIONS_JS
 
     load_start = SESSIONS_JS.index("async function _loadSessionOnce(sid)")
     load_end = SESSIONS_JS.index("// ── Handoff hint logic", load_start)


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI supports long-running conversations that can contain thousands of messages.
- The browser normally displays a bounded transcript window for responsive session switching.
- Several lifecycle paths could still replace that bounded window with the complete transcript.
- This PR applies the bounded-window contract consistently across settlement, recovery, editing, retry, undo, and pagination.

## What Changed

- Keep settled SSE `done`, `stream_end`, reconnect, and error-recovery paths bounded.
- Prevent full terminal session snapshots from replacing a paginated browser transcript.
- Preserve same-session SSE ownership during force reloads.
- Ignore stale or re-entrant session recovery events during an active session load.
- Keep edit and regenerate operations bounded when their target is already visible.
- Route `/retry` and `/undo` through the canonical bounded session reload path.
- Preserve the existing transcript while a bounded post-mutation refresh completes.
- Update the canonical message count and top-bar metadata after loading older messages.
- Add focused regression tests and document the session-windowing behavior.

## Why It Matters

Long conversations could be fully loaded and rendered during normal lifecycle operations, producing:

- complete transcript dumps;
- visible flickering;
- long loading delays;
- difficult session switching;
- unnecessary DOM replacement for edit, retry, and undo.

The browser now keeps a bounded visible window while preserving the correct server-side message coordinate, pagination state, and total message count.

## Verification

**Focused automated verification:**

- 40 passed:
  `tests/test_bounded_session_mutations_frontend.py`
  `tests/test_topbar_lazy_message_count.py`
  `tests/test_parallel_session_switch.py`
- 19 passed:
  `tests/test_cmd_idle_fallback.py`
  `tests/test_older_history_viewport_preservation.py`
- JavaScript syntax checks passed for `commands.js`, `sessions.js`, and `ui.js`.
- Ruff passed for the new regression test.
- `git diff --check` passed.

**Manual UI verification covered with a session of 1500 messages:**

- edit/regenerate;
- stream completion;
- retry;
- undo;
- moving between sessions.
- loading messages automatically on scroll up

## Risks / Follow-ups

- Explicit full-history actions such as export or jump-to-session-start remain capable of loading the full transcript.
- Existing `loaded of total` top-bar semantics are preserved.
- No backend, Hermes Agent, or state.db changes are included.
- No new dependencies, framework, bundler, or build step is introduced.

## Contract Routing

- Contract family: session transcript windowing, recovery/replay, and session metadata.
- References: `docs/CONTRACTS.md` and `ARCHITECTURE.md`.
- Contract change: none intentional; lifecycle operations now consistently follow the existing bounded transcript contract.

## Model Used

Provider: OpenAI, Model: Codex - GPT-5.6 Luna Max, Human super vision and review