### PR TITLE
fix(webui): invalidate default terminal env on backend switch (#5937)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -21841,6 +21841,25 @@ def _handle_chat_sync(handler, body):
         s.model = model
         s.model_provider = model_provider
     from api.streaming import _ENV_LOCK
+    from api.terminal_backend_isolation import (
+        TerminalBackendIsolationError,
+        acquire_turn_lease_failclosed,
+    )
+
+    # #5937/#5988 round 4: this fallback endpoint constructs a tool-capable
+    # AIAgent, so it must hold the same full-turn backend-identity lease as
+    # the streaming path — otherwise it can create/use the agent "default"
+    # env slot concurrently with (or across) a backend transition. This
+    # handler applies no profile runtime env overlay, so the effective turn
+    # environment is the process env itself (identity ignores TERMINAL_CWD,
+    # which is the only terminal key mutated below). Acquired BEFORE the
+    # _ENV_LOCK mutation, released in the turn's finally; rejections fail
+    # closed as a retryable 503 instead of running against an unverified
+    # slot.
+    try:
+        _terminal_backend_lease, _ = acquire_turn_lease_failclosed(dict(os.environ))
+    except TerminalBackendIsolationError as e:
+        return j(handler, {"error": str(e)}, status=503)
 
     with _ENV_LOCK:
         old_cwd = os.environ.get("TERMINAL_CWD")
@@ -21961,6 +21980,10 @@ def _handle_chat_sync(handler, body):
                 os.environ.pop("HERMES_SESSION_KEY", None)
             else:
                 os.environ["HERMES_SESSION_KEY"] = old_session_key
+        # Release AFTER the env restore: a waiter admitted by this release
+        # must never observe this turn's TERMINAL_* mutations. release() is
+        # idempotent (#5937).
+        _terminal_backend_lease.release()
     with _get_session_agent_lock(s.session_id):
         _result_messages = result.get("messages") or _previous_context_messages
         _next_context_messages = _restore_reasoning_metadata(

--- a/api/routes.py
+++ b/api/routes.py
@@ -21861,14 +21861,26 @@ def _handle_chat_sync(handler, body):
     except TerminalBackendIsolationError as e:
         return j(handler, {"error": str(e)}, status=503)
 
-    with _ENV_LOCK:
-        old_cwd = os.environ.get("TERMINAL_CWD")
-        os.environ["TERMINAL_CWD"] = str(workspace)
-        old_exec_ask = os.environ.get("HERMES_EXEC_ASK")
-        old_session_key = os.environ.get("HERMES_SESSION_KEY")
-        os.environ["HERMES_EXEC_ASK"] = "1"
-        os.environ["HERMES_SESSION_KEY"] = s.session_id
+    # #5988 round 5 (lease-leak): the env mutation, agent run, env restore, and
+    # lease release all live under ONE guaranteed teardown. The release is in
+    # the OUTER finally so it runs even if (a) the env MUTATION below raises
+    # before the run — previously it sat between the acquire and the protecting
+    # try, so a throw there leaked the lease with no backstop on this path — or
+    # (b) the env RESTORE raises during teardown. release() is idempotent, so
+    # this never double-frees another turn's count.
+    # Pre-bind so the restore in the finally can never NameError even if the
+    # mutation below raises before binding them.
+    old_cwd = old_exec_ask = old_session_key = None
     try:
+        with _ENV_LOCK:
+            # Capture ALL prior values before mutating any, so a set that
+            # raises still leaves an accurate restore snapshot.
+            old_cwd = os.environ.get("TERMINAL_CWD")
+            old_exec_ask = os.environ.get("HERMES_EXEC_ASK")
+            old_session_key = os.environ.get("HERMES_SESSION_KEY")
+            os.environ["TERMINAL_CWD"] = str(workspace)
+            os.environ["HERMES_EXEC_ASK"] = "1"
+            os.environ["HERMES_SESSION_KEY"] = s.session_id
         from run_agent import AIAgent
 
         with CHAT_LOCK:
@@ -21967,23 +21979,26 @@ def _handle_chat_sync(handler, body):
                 persist_user_message=msg,
             )
     finally:
-        with _ENV_LOCK:
-            if old_cwd is None:
-                os.environ.pop("TERMINAL_CWD", None)
-            else:
-                os.environ["TERMINAL_CWD"] = old_cwd
-            if old_exec_ask is None:
-                os.environ.pop("HERMES_EXEC_ASK", None)
-            else:
-                os.environ["HERMES_EXEC_ASK"] = old_exec_ask
-            if old_session_key is None:
-                os.environ.pop("HERMES_SESSION_KEY", None)
-            else:
-                os.environ["HERMES_SESSION_KEY"] = old_session_key
-        # Release AFTER the env restore: a waiter admitted by this release
-        # must never observe this turn's TERMINAL_* mutations. release() is
-        # idempotent (#5937).
-        _terminal_backend_lease.release()
+        try:
+            with _ENV_LOCK:
+                if old_cwd is None:
+                    os.environ.pop("TERMINAL_CWD", None)
+                else:
+                    os.environ["TERMINAL_CWD"] = old_cwd
+                if old_exec_ask is None:
+                    os.environ.pop("HERMES_EXEC_ASK", None)
+                else:
+                    os.environ["HERMES_EXEC_ASK"] = old_exec_ask
+                if old_session_key is None:
+                    os.environ.pop("HERMES_SESSION_KEY", None)
+                else:
+                    os.environ["HERMES_SESSION_KEY"] = old_session_key
+        finally:
+            # #5988 round 5 (lease-leak): NESTED in a finally so the release
+            # runs even if the env restore above raises. Ordered AFTER the
+            # restore so a waiter admitted by this release never observes this
+            # turn's TERMINAL_* mutations. release() is idempotent (#5937).
+            _terminal_backend_lease.release()
     with _get_session_agent_lock(s.session_id):
         _result_messages = result.get("messages") or _previous_context_messages
         _next_context_messages = _restore_reasoning_metadata(

--- a/api/routes.py
+++ b/api/routes.py
@@ -21849,15 +21849,40 @@ def _handle_chat_sync(handler, body):
     # #5937/#5988 round 4: this fallback endpoint constructs a tool-capable
     # AIAgent, so it must hold the same full-turn backend-identity lease as
     # the streaming path — otherwise it can create/use the agent "default"
-    # env slot concurrently with (or across) a backend transition. This
-    # handler applies no profile runtime env overlay, so the effective turn
-    # environment is the process env itself (identity ignores TERMINAL_CWD,
-    # which is the only terminal key mutated below). Acquired BEFORE the
-    # _ENV_LOCK mutation, released in the turn's finally; rejections fail
-    # closed as a retryable 503 instead of running against an unverified
-    # slot.
+    # env slot concurrently with (or across) a backend transition.
+    #
+    # #5988 P1 (greptile): the lease identity must come from THIS request's
+    # RESOLVED profile, not raw process-global os.environ. A concurrent
+    # streaming turn keeps its own profile's HERMES_HOME + terminal settings
+    # in os.environ for its whole run, so computing identity from the live
+    # process env would let a sync turn for a different profile calculate the
+    # streaming profile's identity, skip invalidation, and reuse its cached
+    # "default" backend. Resolve the session's profile and build the identity
+    # (and the applied turn env below) from the profile overlay, exactly like
+    # streaming — so identity reflects the backend this turn will actually use.
     try:
-        _terminal_backend_lease, _ = acquire_turn_lease_failclosed(dict(os.environ))
+        from api.profiles import (
+            filter_runtime_env_for_gateway_parity,
+            get_hermes_home_for_profile,
+            get_profile_runtime_env,
+        )
+        _chat_profile_home = str(get_hermes_home_for_profile(getattr(s, "profile", None)))
+        _chat_safe_profile_env = filter_runtime_env_for_gateway_parity(
+            get_profile_runtime_env(_chat_profile_home)
+        )
+    except ImportError:
+        _chat_profile_home = os.environ.get("HERMES_HOME", "")
+        _chat_safe_profile_env = {}
+
+    _effective_turn_env = dict(os.environ)
+    _effective_turn_env.update(_chat_safe_profile_env)
+    if _chat_profile_home:
+        _effective_turn_env["HERMES_HOME"] = _chat_profile_home
+    # Acquired BEFORE the _ENV_LOCK mutation (a differing-backend turn may
+    # block here waiting on in-flight turns; their env restore needs the lock).
+    # Released in the turn's finally; rejections fail closed as a retryable 503.
+    try:
+        _terminal_backend_lease, _ = acquire_turn_lease_failclosed(_effective_turn_env)
     except TerminalBackendIsolationError as e:
         return j(handler, {"error": str(e)}, status=503)
 
@@ -21870,14 +21895,23 @@ def _handle_chat_sync(handler, body):
     # this never double-frees another turn's count.
     # Pre-bind so the restore in the finally can never NameError even if the
     # mutation below raises before binding them.
-    old_cwd = old_exec_ask = old_session_key = None
+    old_cwd = old_exec_ask = old_session_key = old_hermes_home = None
+    _old_profile_env = {}
     try:
         with _ENV_LOCK:
             # Capture ALL prior values before mutating any, so a set that
             # raises still leaves an accurate restore snapshot.
+            _old_profile_env = {k: os.environ.get(k) for k in _chat_safe_profile_env}
             old_cwd = os.environ.get("TERMINAL_CWD")
             old_exec_ask = os.environ.get("HERMES_EXEC_ASK")
             old_session_key = os.environ.get("HERMES_SESSION_KEY")
+            old_hermes_home = os.environ.get("HERMES_HOME")
+            # Apply THIS request's resolved profile so the agent creates/uses
+            # the backend the lease identity names (#5988 P1) — not a
+            # concurrent streaming turn's leftover process env.
+            os.environ.update(_chat_safe_profile_env)
+            if _chat_profile_home:
+                os.environ["HERMES_HOME"] = _chat_profile_home
             os.environ["TERMINAL_CWD"] = str(workspace)
             os.environ["HERMES_EXEC_ASK"] = "1"
             os.environ["HERMES_SESSION_KEY"] = s.session_id
@@ -21981,6 +22015,15 @@ def _handle_chat_sync(handler, body):
     finally:
         try:
             with _ENV_LOCK:
+                for _pk, _pv in _old_profile_env.items():
+                    if _pv is None:
+                        os.environ.pop(_pk, None)
+                    else:
+                        os.environ[_pk] = _pv
+                if old_hermes_home is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = old_hermes_home
                 if old_cwd is None:
                     os.environ.pop("TERMINAL_CWD", None)
                 else:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6621,6 +6621,7 @@ def _run_agent_streaming(
     old_session_platform = None
     old_hermes_home = None
     old_profile_env = {}
+    _terminal_backend_lease = None
 
     # MCP discovery moved to AFTER the per-profile HERMES_HOME mutation below
     # (was here at v0.51.30) — the previous placement always read the default
@@ -7171,6 +7172,29 @@ def _run_agent_streaming(
         # block other concurrent sessions waiting on _ENV_LOCK (#2024).
         _prewarm_skill_tool_modules()
         _install_streaming_cronjob_profile_wrapper()
+        # #5937: multi-profile WebUI can leave an incompatible terminal env in
+        # the agent process-global "default" cache slot after a backend
+        # identity switch. Acquire a full-turn backend-identity lease BEFORE
+        # _ENV_LOCK (a differing-backend turn may block here waiting for
+        # in-flight turns, and their env restore needs _ENV_LOCK). Identity is
+        # derived from the effective turn environment — process env overlaid
+        # with this profile's runtime env, i.e. what os.environ.update below
+        # produces — not the profile env alone, so env applied by other layers
+        # is reflected. The lease is released in the turn's finally block.
+        try:
+            from api.terminal_backend_isolation import (
+                acquire_terminal_backend_turn_lease,
+            )
+            _effective_turn_env = dict(os.environ)
+            _effective_turn_env.update(_safe_profile_runtime_env)
+            _terminal_backend_lease, _ = acquire_terminal_backend_turn_lease(
+                _effective_turn_env
+            )
+        except Exception:
+            logger.warning(
+                "terminal backend isolation lease failed (#5937)",
+                exc_info=True,
+            )
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short
@@ -7185,20 +7209,9 @@ def _run_agent_streaming(
             old_session_chat_id = os.environ.get('HERMES_SESSION_CHAT_ID')
             old_hermes_home = os.environ.get('HERMES_HOME')
             os.environ.update(_safe_profile_runtime_env)
-            # #5937: multi-profile WebUI can leave a remote terminal env in the
-            # agent process-global "default" cache slot after SSH→local (or any
-            # backend identity) switch. Scoped invalidation drops only that slot
-            # when identity changes; same-backend turns still share the env.
-            try:
-                from api.terminal_backend_isolation import (
-                    maybe_invalidate_default_terminal_env,
-                )
-                maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)
-            except Exception:
-                logger.warning(
-                    "terminal backend isolation check failed (#5937)",
-                    exc_info=True,
-                )
+            # #5937: the backend-identity lease acquired above (before this
+            # lock) already invalidated the agent "default" terminal env slot
+            # if this turn's identity differs from the last committed one.
             os.environ['TERMINAL_CWD'] = str(s.workspace)
             os.environ['HERMES_EXEC_ASK'] = '1'
             os.environ['HERMES_SESSION_KEY'] = session_id
@@ -9996,6 +10009,17 @@ def _run_agent_streaming(
                 else: os.environ['HERMES_SESSION_CHAT_ID'] = old_session_chat_id
                 if old_hermes_home is None: os.environ.pop('HERMES_HOME', None)
                 else: os.environ['HERMES_HOME'] = old_hermes_home
+            # #5937: release this turn's backend-identity lease AFTER the env
+            # restore so a waiting differing-backend turn can't invalidate
+            # while this turn's environment is still nominally in effect.
+            if _terminal_backend_lease is not None:
+                try:
+                    _terminal_backend_lease.release()
+                except Exception:
+                    logger.debug(
+                        "terminal backend lease release failed (#5937)",
+                        exc_info=True,
+                    )
 
     except Exception as e:
         print('[webui] stream error:\n' + traceback.format_exc(), flush=True)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7185,6 +7185,20 @@ def _run_agent_streaming(
             old_session_chat_id = os.environ.get('HERMES_SESSION_CHAT_ID')
             old_hermes_home = os.environ.get('HERMES_HOME')
             os.environ.update(_safe_profile_runtime_env)
+            # #5937: multi-profile WebUI can leave a remote terminal env in the
+            # agent process-global "default" cache slot after SSH→local (or any
+            # backend identity) switch. Scoped invalidation drops only that slot
+            # when identity changes; same-backend turns still share the env.
+            try:
+                from api.terminal_backend_isolation import (
+                    maybe_invalidate_default_terminal_env,
+                )
+                maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)
+            except Exception:
+                logger.warning(
+                    "terminal backend isolation check failed (#5937)",
+                    exc_info=True,
+                )
             os.environ['TERMINAL_CWD'] = str(s.workspace)
             os.environ['HERMES_EXEC_ASK'] = '1'
             os.environ['HERMES_SESSION_KEY'] = session_id

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7195,6 +7195,15 @@ def _run_agent_streaming(
 
         _effective_turn_env = dict(os.environ)
         _effective_turn_env.update(_safe_profile_runtime_env)
+        # #5988 round 5: the identity must reflect THIS turn's profile, not
+        # whatever HERMES_HOME the shared process env currently carries (a
+        # prior turn's, applied to os.environ only later at the mutation
+        # below). Stamp the RESOLVED profile home so two profiles can never
+        # share a backend identity. The forwarded-secret VALUES are already
+        # present via _safe_profile_runtime_env (the profile's .env), which
+        # terminal_backend_identity() now fingerprints.
+        if _profile_home:
+            _effective_turn_env['HERMES_HOME'] = _profile_home
         _terminal_backend_lease, _ = acquire_turn_lease_failclosed(
             _effective_turn_env
         )
@@ -9994,35 +10003,41 @@ def _run_agent_streaming(
                     _unreg_clarify_notify(session_id)
                 except Exception:
                     logger.debug("Failed to unregister clarify callback")
-            with _ENV_LOCK:
-                for _key, _old_value in old_profile_env.items():
-                    if _old_value is None: os.environ.pop(_key, None)
-                    else: os.environ[_key] = _old_value
-                if old_cwd is None: os.environ.pop('TERMINAL_CWD', None)
-                else: os.environ['TERMINAL_CWD'] = old_cwd
-                if old_exec_ask is None: os.environ.pop('HERMES_EXEC_ASK', None)
-                else: os.environ['HERMES_EXEC_ASK'] = old_exec_ask
-                if old_session_key is None: os.environ.pop('HERMES_SESSION_KEY', None)
-                else: os.environ['HERMES_SESSION_KEY'] = old_session_key
-                if old_session_id is None: os.environ.pop('HERMES_SESSION_ID', None)
-                else: os.environ['HERMES_SESSION_ID'] = old_session_id
-                if old_session_platform is None: os.environ.pop('HERMES_SESSION_PLATFORM', None)
-                else: os.environ['HERMES_SESSION_PLATFORM'] = old_session_platform
-                if old_session_chat_id is None: os.environ.pop('HERMES_SESSION_CHAT_ID', None)
-                else: os.environ['HERMES_SESSION_CHAT_ID'] = old_session_chat_id
-                if old_hermes_home is None: os.environ.pop('HERMES_HOME', None)
-                else: os.environ['HERMES_HOME'] = old_hermes_home
-            # #5937: release this turn's backend-identity lease AFTER the env
-            # restore so a waiting differing-backend turn can't invalidate
-            # while this turn's environment is still nominally in effect.
-            if _terminal_backend_lease is not None:
-                try:
-                    _terminal_backend_lease.release()
-                except Exception:
-                    logger.debug(
-                        "terminal backend lease release failed (#5937)",
-                        exc_info=True,
-                    )
+            try:
+                with _ENV_LOCK:
+                    for _key, _old_value in old_profile_env.items():
+                        if _old_value is None: os.environ.pop(_key, None)
+                        else: os.environ[_key] = _old_value
+                    if old_cwd is None: os.environ.pop('TERMINAL_CWD', None)
+                    else: os.environ['TERMINAL_CWD'] = old_cwd
+                    if old_exec_ask is None: os.environ.pop('HERMES_EXEC_ASK', None)
+                    else: os.environ['HERMES_EXEC_ASK'] = old_exec_ask
+                    if old_session_key is None: os.environ.pop('HERMES_SESSION_KEY', None)
+                    else: os.environ['HERMES_SESSION_KEY'] = old_session_key
+                    if old_session_id is None: os.environ.pop('HERMES_SESSION_ID', None)
+                    else: os.environ['HERMES_SESSION_ID'] = old_session_id
+                    if old_session_platform is None: os.environ.pop('HERMES_SESSION_PLATFORM', None)
+                    else: os.environ['HERMES_SESSION_PLATFORM'] = old_session_platform
+                    if old_session_chat_id is None: os.environ.pop('HERMES_SESSION_CHAT_ID', None)
+                    else: os.environ['HERMES_SESSION_CHAT_ID'] = old_session_chat_id
+                    if old_hermes_home is None: os.environ.pop('HERMES_HOME', None)
+                    else: os.environ['HERMES_HOME'] = old_hermes_home
+            finally:
+                # #5937: release this turn's backend-identity lease AFTER the env
+                # restore so a waiting differing-backend turn can't invalidate
+                # while this turn's environment is still nominally in effect.
+                # #5988 round 5 (lease-leak): NESTED in a finally so the ordered
+                # primary release runs even if the env restore above raises —
+                # the outer-finally backstop is then the second line of defense,
+                # not the only path that frees the lease.
+                if _terminal_backend_lease is not None:
+                    try:
+                        _terminal_backend_lease.release()
+                    except Exception:
+                        logger.debug(
+                            "terminal backend lease release failed (#5937)",
+                            exc_info=True,
+                        )
 
     except Exception as e:
         print('[webui] stream error:\n' + traceback.format_exc(), flush=True)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7183,6 +7183,7 @@ def _run_agent_streaming(
         # is reflected. The lease is released in the turn's finally block.
         try:
             from api.terminal_backend_isolation import (
+                TerminalBackendIsolationError,
                 acquire_terminal_backend_turn_lease,
             )
             _effective_turn_env = dict(os.environ)
@@ -7190,9 +7191,21 @@ def _run_agent_streaming(
             _terminal_backend_lease, _ = acquire_terminal_backend_turn_lease(
                 _effective_turn_env
             )
+        except TerminalBackendIsolationError:
+            # Fail CLOSED: the module rejected this turn (bounded wait timed
+            # out, or the previous backend env could not be verifiably
+            # removed). Running the turn anyway would execute tools against a
+            # slot that may belong to a different profile's backend — abort
+            # the turn instead; the exception's message is user-readable and
+            # surfaces through the standard stream error path below.
+            raise
         except Exception:
+            # An UNEXPECTED bug in the isolation module itself must not brick
+            # every chat turn; log loudly and proceed (matches the module's
+            # pre-#5988 posture for internal errors only — deliberate
+            # rejections are re-raised above).
             logger.warning(
-                "terminal backend isolation lease failed (#5937)",
+                "terminal backend isolation lease failed unexpectedly (#5937)",
                 exc_info=True,
             )
         # Still set process-level env as fallback for tools that bypass thread-local

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10351,6 +10351,23 @@ def _run_agent_streaming(
         except Exception:
             logger.debug("Failed to end metering session for stream %s", stream_id, exc_info=True)
         _metering_stop.set()
+        # #5937/#5988: BACKSTOP release of the backend-identity lease. The
+        # primary release lives in the inner try's finally so it stays ordered
+        # after the env restore — but the lease is acquired ~180 lines before
+        # that inner try begins, and an exception in the window between them
+        # (env mutation, MCP discovery, callback setup) would otherwise leak
+        # the lease. Under fail-closed admission a leaked lease is a standing
+        # denial (every later differing-backend turn waits its bound, then
+        # aborts), not just a stall. release() is idempotent, so the normal
+        # path's double-release is a no-op.
+        if _terminal_backend_lease is not None:
+            try:
+                _terminal_backend_lease.release()
+            except Exception:
+                logger.debug(
+                    "terminal backend lease backstop release failed (#5937)",
+                    exc_info=True,
+                )
         # Stop the periodic checkpoint thread before the final recovery path.
         # The checkpoint thread also uses the per-session lock; joining it first
         # avoids contending with checkpoint writes during stale-pending repair.

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7181,33 +7181,23 @@ def _run_agent_streaming(
         # with this profile's runtime env, i.e. what os.environ.update below
         # produces — not the profile env alone, so env applied by other layers
         # is reflected. The lease is released in the turn's finally block.
-        try:
-            from api.terminal_backend_isolation import (
-                TerminalBackendIsolationError,
-                acquire_terminal_backend_turn_lease,
-            )
-            _effective_turn_env = dict(os.environ)
-            _effective_turn_env.update(_safe_profile_runtime_env)
-            _terminal_backend_lease, _ = acquire_terminal_backend_turn_lease(
-                _effective_turn_env
-            )
-        except TerminalBackendIsolationError:
-            # Fail CLOSED: the module rejected this turn (bounded wait timed
-            # out, or the previous backend env could not be verifiably
-            # removed). Running the turn anyway would execute tools against a
-            # slot that may belong to a different profile's backend — abort
-            # the turn instead; the exception's message is user-readable and
-            # surfaces through the standard stream error path below.
-            raise
-        except Exception:
-            # An UNEXPECTED bug in the isolation module itself must not brick
-            # every chat turn; log loudly and proceed (matches the module's
-            # pre-#5988 posture for internal errors only — deliberate
-            # rejections are re-raised above).
-            logger.warning(
-                "terminal backend isolation lease failed unexpectedly (#5937)",
-                exc_info=True,
-            )
+        # Fail CLOSED on EVERY acquisition outcome that is not a verified
+        # lease (#5988 round 4): deliberate rejections (bounded wait timed
+        # out, previous backend env not verifiably removed) AND unexpected
+        # internal errors both abort the turn before AIAgent construction —
+        # `acquire_turn_lease_failclosed` converts the latter into the same
+        # typed `TerminalBackendIsolationError`, which surfaces through the
+        # standard stream error path below. Running the turn anyway would
+        # execute tools against a slot that may belong to a different
+        # profile's backend; for a cross-profile security boundary an
+        # isolation bug must brick the switching turn, not run it open.
+        from api.terminal_backend_isolation import acquire_turn_lease_failclosed
+
+        _effective_turn_env = dict(os.environ)
+        _effective_turn_env.update(_safe_profile_runtime_env)
+        _terminal_backend_lease, _ = acquire_turn_lease_failclosed(
+            _effective_turn_env
+        )
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/api/terminal_backend_isolation.py
+++ b/api/terminal_backend_isolation.py
@@ -55,6 +55,7 @@ probe layer here shrink to a single verified call.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import subprocess
@@ -147,21 +148,96 @@ def _env_json(runtime_env: Mapping[str, str], key: str, default: str) -> str:
         return raw
 
 
+def _forwarded_secret_fingerprint(runtime_env: Mapping[str, str]) -> str:
+    """SHA-256 (truncated) over the (name, value) pairs the backend forwards
+    from the host env into the sandbox (#5988 round 5).
+
+    The backend identity already fingerprints ``TERMINAL_DOCKER_FORWARD_ENV``
+    as a LIST of names, but the agent forwards each name's live VALUE into the
+    container. Two profiles that forward the same var NAMES with DIFFERENT
+    values (e.g. ``TENOR_API_KEY=alpha-secret`` vs ``beta-secret``) therefore
+    produced byte-identical identities and could reuse each other's cached
+    container carrying the other profile's secret. This folds the forwarded
+    values in — hashed, so no secret value ever appears in the identity tuple
+    or the logs that print it. Returns "" when nothing is forwarded.
+
+    ``TERMINAL_DOCKER_ENV`` (explicit key→value map) is NOT included here: it is
+    already value-complete in the backend identity via ``_env_json``.
+    """
+    raw = _env_value(runtime_env, "TERMINAL_DOCKER_FORWARD_ENV", "[]")
+    seed = ""
+    names: list[str] = []
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        # Unparseable list: fail closed — fold the raw text in so two different
+        # malformed values still differ, and enumerate nothing.
+        seed = "raw:" + raw
+    else:
+        if isinstance(parsed, list):
+            names = [str(n) for n in parsed]
+        else:
+            seed = "raw:" + raw
+    if not names and not seed:
+        return ""
+    parts = [seed]
+    for name in sorted(set(names)):
+        value = runtime_env.get(name)
+        # Distinguish "forwarded but unset" (None) from "forwarded empty" ("").
+        marker = "\x00" if value is None else "\x01"
+        parts.append(f"{name}{marker}{'' if value is None else value}")
+    material = "\x1e".join(parts)
+    return hashlib.sha256(material.encode("utf-8", "surrogatepass")).hexdigest()[:16]
+
+
+def _profile_identity_suffix(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
+    """Profile-boundary components appended to EVERY backend identity so two
+    distinct profiles never share a cached backend (#5988 round 5).
+
+    ``HERMES_HOME`` (the profile) is the coarse, universal boundary — it
+    applies to every backend type, including a persistent LOCAL shell that
+    inherits the host env. The forwarded-secret fingerprint is the
+    finer guard for same-home turns whose forwarded credential VALUES differ.
+    Appended (not prepended) so callers that read ``identity[0]`` for the
+    backend type — e.g. the ``_FORCE_REMOVE_ENV_TYPES`` check — keep working.
+    """
+    return (
+        "home",
+        _env_value(runtime_env, "HERMES_HOME"),
+        "fwd",
+        _forwarded_secret_fingerprint(runtime_env),
+    )
+
+
 def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
     """Return a stable identity for the terminal backend encoded in *runtime_env*.
 
     Every setting the agent's ``get_config()`` feeds into creating the
     *active* backend's environment participates (#5988 round 4: two turns are
     same-identity only when environment creation would consume identical
-    inputs). Inactive backends' settings are excluded — an SSH host left over
-    in env must not change a local backend's identity. Absent keys are
-    normalized to the agent's defaults so ``{}`` and
-    ``{"TERMINAL_SSH_PORT": "22"}`` cannot disagree. Deliberately excluded:
-    CWD (two same-backend sessions with different workspaces share one cache
-    slot by design) and per-command knobs that don't shape the environment
-    object (TERMINAL_TIMEOUT, TERMINAL_MAX_FOREGROUND_TIMEOUT,
-    TERMINAL_DISK_WARNING_GB, TERMINAL_LIFETIME_SECONDS).
+    inputs), AND the profile boundary is part of the identity (#5988 round 5:
+    ``HERMES_HOME`` + a fingerprint of the forwarded-secret values, so two
+    profiles can never share a cached backend carrying the other's secret).
+    Inactive backends' settings are excluded — an SSH host left over in env
+    must not change a local backend's identity. Absent keys are normalized to
+    the agent's defaults so ``{}`` and ``{"TERMINAL_SSH_PORT": "22"}`` cannot
+    disagree. Deliberately excluded: CWD (two same-backend sessions with
+    different workspaces share one cache slot by design) and per-command knobs
+    that don't shape the environment object (TERMINAL_TIMEOUT,
+    TERMINAL_MAX_FOREGROUND_TIMEOUT, TERMINAL_DISK_WARNING_GB,
+    TERMINAL_LIFETIME_SECONDS).
+
+    *runtime_env* must be an identity-complete, profile-safe snapshot — the
+    effective turn env with ``HERMES_HOME`` stamped to the RESOLVED profile
+    home, not raw live ``os.environ`` (whose ``HERMES_HOME`` may still be a
+    previous turn's). The streaming and ``/api/chat`` turn paths build it.
     """
+    return _backend_identity_tuple(runtime_env) + _profile_identity_suffix(runtime_env)
+
+
+def _backend_identity_tuple(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
+    """The backend-specific identity (without the profile suffix). ``[0]`` is
+    the backend type, which ``_invalidate_default_env`` reads."""
     env_type = _env_value(runtime_env, "TERMINAL_ENV", "local").lower()
     if env_type == "ssh":
         return (
@@ -191,7 +267,11 @@ def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]
             _env_value(
                 runtime_env, "TERMINAL_CONTAINER_DISK", _AGENT_DEFAULT_CONTAINER_DISK
             ),
-            _env_json(runtime_env, "TERMINAL_DOCKER_FORWARD_ENV", "[]"),
+            # TERMINAL_DOCKER_FORWARD_ENV is represented by the profile suffix's
+            # forwarded-secret fingerprint (#5988 round 5) — order-independent
+            # over the name SET and value-complete — so it is intentionally not
+            # a separate backend-tuple field (which would over-split on mere
+            # list-order differences).
             _env_json(runtime_env, "TERMINAL_DOCKER_VOLUMES", "[]"),
             _env_json(runtime_env, "TERMINAL_DOCKER_ENV", "{}"),
             _env_json(runtime_env, "TERMINAL_DOCKER_EXTRA_ARGS", "[]"),

--- a/api/terminal_backend_isolation.py
+++ b/api/terminal_backend_isolation.py
@@ -55,6 +55,7 @@ probe layer here shrink to a single verified call.
 
 from __future__ import annotations
 
+import json
 import logging
 import subprocess
 import threading
@@ -68,6 +69,12 @@ logger = logging.getLogger(__name__)
 _AGENT_DEFAULT_IMAGE = "nikolaik/python-nodejs:python3.11-nodejs20"
 _AGENT_DEFAULT_SSH_PORT = "22"
 _AGENT_DEFAULT_MODAL_MODE = "auto"
+_AGENT_DEFAULT_CONTAINER_CPU = "1"
+_AGENT_DEFAULT_CONTAINER_MEMORY = "5120"
+_AGENT_DEFAULT_CONTAINER_DISK = "51200"
+
+# Truthy set mirrored from the agent's env parsing.
+_AGENT_TRUTHY = frozenset({"true", "1", "yes"})
 
 # Backends whose cached environment is a container the agent can reattach by
 # labels without comparing image (persistent Docker). Cleanup on a transition
@@ -122,15 +129,38 @@ def _env_value(runtime_env: Mapping[str, str], key: str, default: str = "") -> s
     return text or default
 
 
+def _env_flag(runtime_env: Mapping[str, str], key: str, default: str) -> str:
+    """Normalize a boolean-ish setting the way the agent parses it, so
+    ``"true"``, ``"1"`` and ``"yes"`` (and an absent key with a truthy
+    default) all produce one identity token."""
+    return "1" if _env_value(runtime_env, key, default).lower() in _AGENT_TRUTHY else "0"
+
+
+def _env_json(runtime_env: Mapping[str, str], key: str, default: str) -> str:
+    """Canonicalize a JSON-valued setting (volumes, extra args, env maps) so
+    formatting differences don't split identities. Unparseable values keep
+    their raw text — two different broken strings must stay different."""
+    raw = _env_value(runtime_env, key, default)
+    try:
+        return json.dumps(json.loads(raw), sort_keys=True, separators=(",", ":"))
+    except (ValueError, TypeError):
+        return raw
+
+
 def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
     """Return a stable identity for the terminal backend encoded in *runtime_env*.
 
-    Only the settings the agent actually uses to create the *active* backend
-    participate — an SSH host left over in env must not change a local
-    backend's identity, and vice versa. Absent keys are normalized to the
-    agent's defaults so ``{}`` and ``{"TERMINAL_SSH_PORT": "22"}`` cannot
-    disagree. CWD is intentionally excluded so two same-backend sessions with
-    different workspaces still share one cache slot.
+    Every setting the agent's ``get_config()`` feeds into creating the
+    *active* backend's environment participates (#5988 round 4: two turns are
+    same-identity only when environment creation would consume identical
+    inputs). Inactive backends' settings are excluded — an SSH host left over
+    in env must not change a local backend's identity. Absent keys are
+    normalized to the agent's defaults so ``{}`` and
+    ``{"TERMINAL_SSH_PORT": "22"}`` cannot disagree. Deliberately excluded:
+    CWD (two same-backend sessions with different workspaces share one cache
+    slot by design) and per-command knobs that don't shape the environment
+    object (TERMINAL_TIMEOUT, TERMINAL_MAX_FOREGROUND_TIMEOUT,
+    TERMINAL_DISK_WARNING_GB, TERMINAL_LIFETIME_SECONDS).
     """
     env_type = _env_value(runtime_env, "TERMINAL_ENV", "local").lower()
     if env_type == "ssh":
@@ -140,11 +170,38 @@ def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]
             _env_value(runtime_env, "TERMINAL_SSH_USER"),
             _env_value(runtime_env, "TERMINAL_SSH_PORT", _AGENT_DEFAULT_SSH_PORT),
             _env_value(runtime_env, "TERMINAL_SSH_KEY"),
+            _env_flag(
+                runtime_env,
+                "TERMINAL_SSH_PERSISTENT",
+                _env_value(runtime_env, "TERMINAL_PERSISTENT_SHELL", "true"),
+            ),
         )
     if env_type == "docker":
         return (
             "docker",
             _env_value(runtime_env, "TERMINAL_DOCKER_IMAGE", _AGENT_DEFAULT_IMAGE),
+            _env_value(
+                runtime_env, "TERMINAL_CONTAINER_CPU", _AGENT_DEFAULT_CONTAINER_CPU
+            ),
+            _env_value(
+                runtime_env,
+                "TERMINAL_CONTAINER_MEMORY",
+                _AGENT_DEFAULT_CONTAINER_MEMORY,
+            ),
+            _env_value(
+                runtime_env, "TERMINAL_CONTAINER_DISK", _AGENT_DEFAULT_CONTAINER_DISK
+            ),
+            _env_json(runtime_env, "TERMINAL_DOCKER_FORWARD_ENV", "[]"),
+            _env_json(runtime_env, "TERMINAL_DOCKER_VOLUMES", "[]"),
+            _env_json(runtime_env, "TERMINAL_DOCKER_ENV", "{}"),
+            _env_json(runtime_env, "TERMINAL_DOCKER_EXTRA_ARGS", "[]"),
+            _env_flag(runtime_env, "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false"),
+            _env_flag(runtime_env, "TERMINAL_DOCKER_RUN_AS_HOST_USER", "false"),
+            _env_flag(runtime_env, "TERMINAL_DOCKER_NETWORK", "true"),
+            _env_flag(runtime_env, "TERMINAL_CONTAINER_PERSISTENT", "true"),
+            _env_flag(
+                runtime_env, "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
+            ),
         )
     if env_type == "modal":
         return (
@@ -153,6 +210,17 @@ def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]
             _env_value(
                 runtime_env, "TERMINAL_MODAL_MODE", _AGENT_DEFAULT_MODAL_MODE
             ).lower(),
+            _env_value(
+                runtime_env, "TERMINAL_CONTAINER_CPU", _AGENT_DEFAULT_CONTAINER_CPU
+            ),
+            _env_value(
+                runtime_env,
+                "TERMINAL_CONTAINER_MEMORY",
+                _AGENT_DEFAULT_CONTAINER_MEMORY,
+            ),
+            _env_value(
+                runtime_env, "TERMINAL_CONTAINER_DISK", _AGENT_DEFAULT_CONTAINER_DISK
+            ),
         )
     if env_type == "singularity":
         return (
@@ -167,6 +235,11 @@ def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]
         return (
             "daytona",
             _env_value(runtime_env, "TERMINAL_DAYTONA_IMAGE", _AGENT_DEFAULT_IMAGE),
+        )
+    if env_type == "local":
+        return (
+            "local",
+            _env_flag(runtime_env, "TERMINAL_LOCAL_PERSISTENT", "false"),
         )
     return (env_type,)
 
@@ -225,11 +298,22 @@ def _resolve_terminal_tool():
         return _AGENT_RUNTIME_ABSENT
 
 
+# docker/podman `inspect` prints this (modulo case) when — and only when —
+# the daemon answered and the object is definitively absent. Any other
+# nonzero outcome (daemon unreachable, permission denied, TLS error, ...)
+# proves nothing about the container.
+_PROBE_ABSENT_MARKER = "no such object"
+
+
 def _container_exists(container_id: str, docker_exe: str) -> bool:
     """Probe whether *container_id* still exists (running or stopped).
 
-    Raises on probe failure (missing docker binary, timeout) so the caller
-    treats "cannot verify" as "not verified" — fail closed.
+    Tri-state, fail closed (#5988 round 4): exit 0 means the container
+    exists; a nonzero exit is treated as ABSENT only when the daemon
+    positively reported "no such object". Every other failure (daemon
+    unreachable, missing binary, timeout, permission error) RAISES so the
+    caller treats "cannot verify" as "not verified" — a dead Docker daemon
+    must never read as "container removed".
     """
     proc = subprocess.run(
         [docker_exe or "docker", "inspect", "--format", "{{.Id}}", container_id],
@@ -237,7 +321,16 @@ def _container_exists(container_id: str, docker_exe: str) -> bool:
         timeout=_PROBE_TIMEOUT_SECONDS,
         stdin=subprocess.DEVNULL,
     )
-    return proc.returncode == 0
+    if proc.returncode == 0:
+        return True
+    stderr = (proc.stderr or b"").decode("utf-8", "replace")
+    if _PROBE_ABSENT_MARKER in stderr.lower():
+        return False
+    raise RuntimeError(
+        "docker inspect probe for container %s failed without a definitive "
+        "absence report (exit %s): %s"
+        % (container_id[:12], proc.returncode, stderr.strip()[:300] or "<no stderr>")
+    )
 
 
 def _force_remove_container(container_id: str, docker_exe: str) -> None:
@@ -302,13 +395,24 @@ def _verify_pending_container_removals(wait_seconds: Optional[float] = None) -> 
     return all_verified
 
 
-def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> bool:
+def _invalidate_default_env(
+    previous, identity, cleanup_vm, get_active_env
+) -> tuple[bool, bool]:
     """Verifiably invalidate the agent ``"default"`` slot for previous->identity.
 
-    Returns True only when the postconditions are OBSERVED (slot gone; any
-    outgoing containers gone). ``cleanup_vm`` returning is never treated as
-    success by itself: the real agent contract swallows backend-teardown
-    exceptions and returns None, and Docker force-removal runs asynchronously.
+    Returns ``(committed, invalidated)``. ``committed`` is True only when the
+    postconditions are OBSERVED (slot gone; any outgoing containers gone) —
+    ``cleanup_vm`` returning is never treated as success by itself: the real
+    agent contract swallows backend-teardown exceptions and returns None, and
+    Docker force-removal runs asynchronously. ``invalidated`` reports whether
+    an actual invalidation happened (False for a first-use commit that PROVED
+    the slot empty and had nothing to clean).
+
+    ``previous is None`` is the first-use case (#5988 round 4): the slot's
+    state is unproven — tool-capable code outside the lease discipline (or a
+    prior failed first-use attempt) may already have populated it. First use
+    therefore commits only after OBSERVING the slot absent, or after a full
+    verified cleanup when it is populated.
     """
     if cleanup_vm is None or get_active_env is None:
         terminal_tool = _resolve_terminal_tool()
@@ -324,10 +428,10 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
                     previous,
                     identity,
                 )
-                return True
+                return True, previous is not None
             # Partial injection with an absent runtime is ambiguous — the
             # caller believes an env layer exists that we cannot verify.
-            return False
+            return False, False
         if cleanup_vm is None:
             cleanup_vm = getattr(terminal_tool, "cleanup_vm", None)
         if get_active_env is None:
@@ -343,27 +447,53 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
                 "hermes-agent terminal runtime is present but cleanup_vm/"
                 "get_active_env could not be resolved (#5937); failing closed",
             )
-            return False
+            return False, False
 
-    force_remove = previous[0] in _FORCE_REMOVE_ENV_TYPES
-
-    # Ledger the outgoing container BEFORE cleanup: cleanup_vm pops the slot
+    # Observe the outgoing env BEFORE cleanup: cleanup_vm pops the slot
     # unconditionally, so this is the last moment its container id is
     # reachable. If anything below fails, the ledger survives into the retry.
-    outgoing_env = None
     try:
         outgoing_env = get_active_env("default")
     except Exception:
         logger.warning(
             "get_active_env('default') failed pre-cleanup (#5937)", exc_info=True
         )
-        return False
-    if force_remove and outgoing_env is not None:
-        container_id = getattr(outgoing_env, "_container_id", None)
-        if container_id:
-            docker_exe = getattr(outgoing_env, "_docker_exe", None) or "docker"
-            with _COND:
-                _pending_container_removals.setdefault(str(container_id), docker_exe)
+        return False, False
+
+    if previous is None and outgoing_env is None:
+        # First use with the slot OBSERVED absent. Still require the pending
+        # ledger empty: a prior failed first-use attempt may have popped the
+        # slot but left its container unverified — committing here would
+        # forget that leak.
+        if not _verify_pending_container_removals():
+            logger.warning(
+                "first-use commit blocked: ledgered container removals remain "
+                "unverified (#5937) identity=%s",
+                identity,
+            )
+            return False, False
+        logger.info(
+            "first terminal backend identity %s committed after observing the "
+            "default env slot absent (#5937)",
+            identity,
+        )
+        return True, False
+
+    # Force-removal is required when the OUTGOING env is a reattachable
+    # container. The previous identity type says so for known transitions;
+    # for first-use (previous unknown) the env object itself is the evidence.
+    container_id = (
+        getattr(outgoing_env, "_container_id", None)
+        if outgoing_env is not None
+        else None
+    )
+    force_remove = bool(container_id) or (
+        previous is not None and previous[0] in _FORCE_REMOVE_ENV_TYPES
+    )
+    if container_id:
+        docker_exe = getattr(outgoing_env, "_docker_exe", None) or "docker"
+        with _COND:
+            _pending_container_removals.setdefault(str(container_id), docker_exe)
 
     try:
         if force_remove:
@@ -379,7 +509,7 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
             identity,
             exc_info=True,
         )
-        return False
+        return False, False
 
     # Postcondition 1: the "default" slot is actually gone. The current agent
     # contract pops it before teardown, so this also guards contract drift.
@@ -392,12 +522,12 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
                 previous,
                 identity,
             )
-            return False
+            return False, False
     except Exception:
         logger.warning(
             "get_active_env('default') failed post-cleanup (#5937)", exc_info=True
         )
-        return False
+        return False, False
 
     # Postcondition 2: every ledgered outgoing container is verifiably gone.
     # DockerEnvironment.cleanup(force_remove=True) stops/removes on a daemon
@@ -419,7 +549,7 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
             previous,
             identity,
         )
-        return False
+        return False, False
 
     logger.info(
         "Invalidated agent default terminal env after backend identity change "
@@ -429,7 +559,7 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
         identity,
         force_remove,
     )
-    return True
+    return True, True
 
 
 def acquire_terminal_backend_turn_lease(
@@ -447,7 +577,11 @@ def acquire_terminal_backend_turn_lease(
     Admission rules (fail closed — a turn is never admitted against a slot
     that may belong to a different backend):
 
-    - First turn in the process records the identity without cleanup.
+    - First turn in the process VERIFIES the slot state before committing its
+      identity (#5988 round 4): commit-without-cleanup only after observing
+      the agent ``"default"`` slot absent; a populated slot (created by code
+      outside the lease discipline, or surviving a prior failed attempt) gets
+      the full verified cleanup first.
     - Same identity as the last committed turn, no transition in progress:
       admitted immediately, runs concurrently with other same-identity turns.
     - While a transition's cleanup/verification is in flight, EVERY arrival
@@ -476,15 +610,15 @@ def acquire_terminal_backend_turn_lease(
         while True:
             if _transition_identity is None:
                 previous = _last_backend_identity
-                if previous is None or previous == identity:
-                    if previous is None:
-                        _last_backend_identity = identity
+                if previous is not None and previous == identity:
                     _active_turn_counts[identity] = (
                         _active_turn_counts.get(identity, 0) + 1
                     )
                     return TerminalBackendTurnLease(identity), False
-                # Differing identity: all active turns necessarily run on the
-                # committed identity, so becoming leader requires full drain.
+                # First use (previous None: slot state unproven, verify it
+                # outside the lock) or differing identity: all active turns
+                # necessarily run on the committed identity, so becoming
+                # leader requires full drain.
                 if not any(count > 0 for count in _active_turn_counts.values()):
                     _transition_identity = identity
                     break
@@ -499,10 +633,11 @@ def acquire_terminal_backend_turn_lease(
             _COND.wait(remaining)
         previous = _last_backend_identity
 
+    committed = False
     invalidated = False
     try:
         try:
-            invalidated = _invalidate_default_env(
+            committed, invalidated = _invalidate_default_env(
                 previous, identity, cleanup_vm, get_active_env
             )
         except Exception:
@@ -512,25 +647,67 @@ def acquire_terminal_backend_turn_lease(
                 "unexpected error during terminal backend invalidation (#5937)",
                 exc_info=True,
             )
+            committed = False
             invalidated = False
     finally:
         with _COND:
             _transition_identity = None
-            if invalidated:
+            if committed:
                 _last_backend_identity = identity
                 _active_turn_counts[identity] = (
                     _active_turn_counts.get(identity, 0) + 1
                 )
             _COND.notify_all()
 
-    if not invalidated:
+    if not committed:
         raise TerminalBackendInvalidationFailed(
             "The previous terminal backend environment could not be verifiably "
             "removed; this turn was not started to avoid running tools against "
             "a stale backend. It will be retried on the next turn — see server "
             "logs for the cleanup failure. (#5937)"
         )
-    return TerminalBackendTurnLease(identity), True
+    return TerminalBackendTurnLease(identity), invalidated
+
+
+def acquire_turn_lease_failclosed(
+    runtime_env: Mapping[str, str],
+    *,
+    cleanup_vm=None,
+    get_active_env=None,
+    wait_seconds: Optional[float] = None,
+) -> tuple[TerminalBackendTurnLease, bool]:
+    """Acquire the turn lease, converting ANY unexpected internal error into a
+    typed fail-closed rejection (#5988 round 4).
+
+    This is the entry point every in-process tool-capable turn must use. A
+    cross-profile security boundary must fail closed even against bugs in the
+    boundary itself: if acquisition breaks in an unforeseen way, the turn is
+    REJECTED (``TerminalBackendIsolationError`` propagates and blocks agent
+    construction + tool execution) rather than proceeding without a lease
+    against an unverified slot. The deliberate trade: an isolation-module bug
+    now aborts backend-switching turns loudly instead of silently running
+    them open.
+    """
+    try:
+        return acquire_terminal_backend_turn_lease(
+            runtime_env,
+            cleanup_vm=cleanup_vm,
+            get_active_env=get_active_env,
+            wait_seconds=wait_seconds,
+        )
+    except TerminalBackendIsolationError:
+        raise
+    except Exception as exc:
+        logger.error(
+            "terminal backend isolation failed unexpectedly (#5937); failing "
+            "closed — this turn will NOT run without a verified backend lease",
+            exc_info=True,
+        )
+        raise TerminalBackendIsolationError(
+            "Terminal backend isolation failed unexpectedly; this turn was not "
+            "started to avoid running tools against an unverified backend. "
+            "Please retry; see server logs for the underlying error. (#5937)"
+        ) from exc
 
 
 def maybe_invalidate_default_terminal_env(

--- a/api/terminal_backend_isolation.py
+++ b/api/terminal_backend_isolation.py
@@ -1,0 +1,124 @@
+"""Defense-in-depth for multi-profile terminal backend switches (#5937).
+
+Hermes Agent collapses ordinary session task IDs to a shared ``"default"``
+terminal/file environment cache slot (see hermes-agent ``tools/terminal_tool``
+and upstream agent issue #62720). WebUI hosts many profiles in one process and
+applies each profile's terminal settings via process env for the turn. That is
+correct for *new* environment creation, but it does not by itself evict a
+cached incompatible environment under ``"default"``.
+
+This module tracks the last backend *identity* applied for a turn and, when
+the identity changes, calls the agent's ``cleanup_vm("default")`` so the next
+terminal/file tool recreates against the now-correct ``TERMINAL_*`` env.
+
+Same-backend consecutive turns do not invalidate, preserving the agent's
+intentional cross-session sharing of one long-lived local/container env.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+# Process-global last backend identity that was applied for a WebUI agent turn.
+# Guarded by ``_LOCK``; read/write only via helpers below.
+_LOCK = threading.Lock()
+_last_backend_identity: Optional[tuple[str, ...]] = None
+
+
+def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
+    """Return a stable identity for the terminal backend encoded in *runtime_env*.
+
+    Keys match what the agent uses to create environments (TERMINAL_ENV plus
+    remote/container targeting). CWD is intentionally excluded so two same-
+    backend sessions with different workspaces still share one cache slot.
+    """
+    env_type = str(runtime_env.get("TERMINAL_ENV") or "local").strip().lower() or "local"
+    ssh_host = str(runtime_env.get("TERMINAL_SSH_HOST") or "").strip()
+    ssh_user = str(runtime_env.get("TERMINAL_SSH_USER") or "").strip()
+    ssh_port = str(runtime_env.get("TERMINAL_SSH_PORT") or "").strip()
+    docker_image = str(runtime_env.get("TERMINAL_DOCKER_IMAGE") or "").strip()
+    modal_image = str(runtime_env.get("TERMINAL_MODAL_IMAGE") or "").strip()
+    singularity_image = str(runtime_env.get("TERMINAL_SINGULARITY_IMAGE") or "").strip()
+    daytona_image = str(runtime_env.get("TERMINAL_DAYTONA_IMAGE") or "").strip()
+    return (
+        env_type,
+        ssh_host,
+        ssh_user,
+        ssh_port,
+        docker_image,
+        modal_image,
+        singularity_image,
+        daytona_image,
+    )
+
+
+def reset_terminal_backend_identity_for_tests() -> None:
+    """Clear process-global identity tracking (tests only)."""
+    global _last_backend_identity
+    with _LOCK:
+        _last_backend_identity = None
+
+
+def maybe_invalidate_default_terminal_env(
+    runtime_env: Mapping[str, str],
+    *,
+    cleanup_vm=None,
+) -> bool:
+    """Invalidate the agent ``"default"`` terminal env when backend identity changes.
+
+    Returns True when ``cleanup_vm("default")`` was invoked. First turn in a
+    process only records identity (no cleanup). Same identity as last turn is a
+    no-op.
+
+    *cleanup_vm* is injectable for unit tests; production resolves
+    ``tools.terminal_tool.cleanup_vm`` lazily so WebUI still boots when the
+    agent is not on ``sys.path``.
+    """
+    global _last_backend_identity
+
+    identity = terminal_backend_identity(runtime_env)
+    previous: Optional[tuple[str, ...]]
+    with _LOCK:
+        previous = _last_backend_identity
+        if previous is not None and previous == identity:
+            return False
+        _last_backend_identity = identity
+        if previous is None:
+            return False
+
+    if cleanup_vm is None:
+        try:
+            from tools.terminal_tool import cleanup_vm as _cleanup_vm  # type: ignore
+        except Exception:
+            logger.warning(
+                "Could not import tools.terminal_tool.cleanup_vm to invalidate "
+                "stale default terminal env after backend change (#5937); "
+                "agent-side #62720 remains the primary correctness fix",
+                exc_info=True,
+            )
+            return False
+        cleanup_vm = _cleanup_vm
+
+    try:
+        cleanup_vm("default")
+    except Exception:
+        logger.warning(
+            "cleanup_vm('default') failed after terminal backend identity change "
+            "(#5937) previous=%s current=%s",
+            previous,
+            identity,
+            exc_info=True,
+        )
+        return False
+
+    logger.info(
+        "Invalidated agent default terminal env after backend identity change "
+        "(#5937) previous=%s current=%s",
+        previous,
+        identity,
+    )
+    return True

--- a/api/terminal_backend_isolation.py
+++ b/api/terminal_backend_isolation.py
@@ -8,26 +8,49 @@ correct for *new* environment creation, but it does not by itself evict a
 cached incompatible environment under ``"default"``.
 
 This module tracks the backend *identity* in effect for each agent turn and,
-when a turn starts under a different identity, calls the agent's
-``cleanup_vm("default")`` so the next terminal/file tool recreates against the
+when a turn starts under a different identity, invalidates the agent's
+``"default"`` slot so the next terminal/file tool recreates against the
 now-correct ``TERMINAL_*`` env.
 
-Turns hold a full-turn *lease* on their identity: a differing-backend turn
-waits for in-flight turns on the previous identity to finish before
-invalidating, so it can never evict an environment that is still in use by a
-concurrent turn. Same-backend turns share the identity freely and never
-invalidate, preserving the agent's intentional cross-session sharing of one
-long-lived local/container env.
+Because a wrong reuse runs tools on another profile's backend, this is a
+security boundary and every path fails CLOSED:
 
-Persistent Docker containers are reattached by labels without comparing
-image, so a plain (non-force) cleanup can leave a stale container that a
-later Docker turn silently reuses; transitions *away from* Docker therefore
-clean up with ``force_remove=True``.
+* Turns hold a full-turn *lease* on their identity. A differing-backend turn
+  waits (bounded) for in-flight turns to finish; if they don't, the incoming
+  turn is REJECTED with :class:`TerminalBackendTransitionTimeout` — it never
+  runs against a mismatched slot, and no lease is registered for it.
+* While a transition's cleanup is in flight (explicit ``_transition_identity``
+  state) NO turn is admitted — not even same-new-identity turns. They wait for
+  the transition to complete and then re-evaluate; if the transition failed
+  they retry it themselves rather than assuming the leader succeeded.
+* Success is never inferred from ``cleanup_vm`` returning. The real agent
+  contract (hermes-agent ``tools/terminal_tool.cleanup_vm``) pops the cache
+  slot FIRST, then swallows backend-teardown exceptions and returns ``None``
+  either way — and ``DockerEnvironment.cleanup(force_remove=True)`` runs
+  ``docker stop``/``docker rm -f`` on a background daemon thread. Committing a
+  transition therefore requires *observed postconditions*: the ``"default"``
+  slot is verifiably gone (``get_active_env``), and for container-identity
+  transitions the outgoing container is verifiably removed (``docker
+  inspect`` probe, with a bounded wait for the agent's async removal and one
+  direct ``docker rm -f`` fallback). Unverifiable == failed: the transition
+  stays uncommitted, the incoming turn is rejected with
+  :class:`TerminalBackendInvalidationFailed`, and a later turn retries.
+  Outstanding container removals are remembered in a pending ledger until a
+  probe confirms them gone, so a failed removal cannot be forgotten by the
+  retry (the slot pop already happened, so the retry's ``cleanup_vm`` alone
+  would be a silent no-op).
+
+Same-backend turns share the identity freely and never invalidate, preserving
+the agent's intentional cross-session sharing of one long-lived
+local/container env. A synchronous, failure-reporting forced-cleanup contract
+on the agent side (proposed alongside hermes-agent #63361) would let the
+probe layer here shrink to a single verified call.
 """
 
 from __future__ import annotations
 
 import logging
+import subprocess
 import threading
 import time
 from typing import Mapping, Optional
@@ -42,19 +65,49 @@ _AGENT_DEFAULT_MODAL_MODE = "auto"
 
 # Backends whose cached environment is a container the agent can reattach by
 # labels without comparing image (persistent Docker). Cleanup on a transition
-# away from these must force-remove, or Docker-A -> local -> Docker-B silently
-# reuses image A's container.
+# away from these must force-remove AND verify removal, or
+# Docker-A -> local -> Docker-B silently reuses image A's container.
+# (Daytona shares the reattach shape but its cleanup() does not accept
+# force_remove yet — agent-side hermes-agent #63361 tracks that contract.)
 _FORCE_REMOVE_ENV_TYPES = frozenset({"docker"})
 
-# How long a differing-backend turn waits for in-flight turns on another
-# identity before proceeding WITHOUT invalidation. Fail-safe direction: never
-# evict an environment that may still be in use; the identity transition stays
-# uncommitted, so a later turn retries the invalidation.
+# How long a turn waits for in-flight turns on another identity (or for an
+# in-progress transition) before being rejected. Fail-closed: on timeout the
+# incoming turn does NOT run and no lease is registered for it.
 _LEASE_WAIT_SECONDS = 30.0
+
+# How long a transition leader waits for the agent's asynchronous
+# ``docker stop``/``docker rm -f`` daemon thread to actually remove the
+# outgoing container before attempting one direct ``docker rm -f`` fallback.
+# DockerEnvironment.cleanup uses stop -t 10, so the normal case is seconds.
+_CONTAINER_REMOVAL_WAIT_SECONDS = 45.0
+_CONTAINER_REMOVAL_POLL_SECONDS = 0.25
+
+_PROBE_TIMEOUT_SECONDS = 15
+_DIRECT_REMOVE_TIMEOUT_SECONDS = 30
 
 _COND = threading.Condition(threading.Lock())
 _last_backend_identity: Optional[tuple[str, ...]] = None
 _active_turn_counts: dict[tuple[str, ...], int] = {}
+# Identity currently being transitioned TO while its leader runs cleanup +
+# verification outside the lock. While set, no turn is admitted.
+_transition_identity: Optional[tuple[str, ...]] = None
+# container_id -> docker executable. Recorded BEFORE force-remove cleanup and
+# popped only once a probe confirms the container is gone, so a failed or
+# still-async removal survives into the next transition attempt.
+_pending_container_removals: dict[str, str] = {}
+
+
+class TerminalBackendIsolationError(RuntimeError):
+    """Base class for fail-closed terminal backend isolation rejections."""
+
+
+class TerminalBackendTransitionTimeout(TerminalBackendIsolationError):
+    """Raised when a turn cannot be admitted within the bounded wait."""
+
+
+class TerminalBackendInvalidationFailed(TerminalBackendIsolationError):
+    """Raised when the previous backend env could not be verifiably removed."""
 
 
 def _env_value(runtime_env: Mapping[str, str], key: str, default: str = "") -> str:
@@ -113,11 +166,13 @@ def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]
 
 
 def reset_terminal_backend_identity_for_tests() -> None:
-    """Clear process-global identity/lease tracking (tests only)."""
-    global _last_backend_identity
+    """Clear process-global identity/lease/transition tracking (tests only)."""
+    global _last_backend_identity, _transition_identity
     with _COND:
         _last_backend_identity = None
+        _transition_identity = None
         _active_turn_counts.clear()
+        _pending_container_removals.clear()
         _COND.notify_all()
 
 
@@ -157,18 +212,133 @@ def _resolve_cleanup_vm():
     return _cleanup_vm
 
 
-def _invalidate_default_env(previous, identity, cleanup_vm) -> bool:
-    """Run cleanup_vm('default') for a previous->identity transition.
+def _resolve_get_active_env():
+    try:
+        from tools.terminal_tool import get_active_env as _get_active_env  # type: ignore
+    except Exception:
+        logger.warning(
+            "Could not import tools.terminal_tool.get_active_env to verify "
+            "default terminal env removal (#5937)",
+            exc_info=True,
+        )
+        return None
+    return _get_active_env
 
-    Returns True only on success; the caller commits the identity transition
-    only then, so a transient import/cleanup failure is retried by a later
-    turn instead of being permanently skipped.
+
+def _container_exists(container_id: str, docker_exe: str) -> bool:
+    """Probe whether *container_id* still exists (running or stopped).
+
+    Raises on probe failure (missing docker binary, timeout) so the caller
+    treats "cannot verify" as "not verified" — fail closed.
+    """
+    proc = subprocess.run(
+        [docker_exe or "docker", "inspect", "--format", "{{.Id}}", container_id],
+        capture_output=True,
+        timeout=_PROBE_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+    )
+    return proc.returncode == 0
+
+
+def _force_remove_container(container_id: str, docker_exe: str) -> None:
+    """Directly ``docker rm -f`` a container the agent's async cleanup missed."""
+    subprocess.run(
+        [docker_exe or "docker", "rm", "-f", container_id],
+        capture_output=True,
+        timeout=_DIRECT_REMOVE_TIMEOUT_SECONDS,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _verify_pending_container_removals(wait_seconds: Optional[float] = None) -> bool:
+    """Confirm every ledgered outgoing container is actually gone.
+
+    Waits (bounded) for the agent's asynchronous removal thread, then attempts
+    one direct ``docker rm -f`` per surviving container and re-probes. Returns
+    True only when the ledger is empty; unverified entries stay ledgered for
+    the next transition attempt.
+    """
+    with _COND:
+        pending = dict(_pending_container_removals)
+    if not pending:
+        return True
+    timeout = (
+        _CONTAINER_REMOVAL_WAIT_SECONDS if wait_seconds is None else wait_seconds
+    )
+    deadline = time.monotonic() + timeout
+    all_verified = True
+    for container_id, docker_exe in pending.items():
+        verified = False
+        try:
+            while True:
+                if not _container_exists(container_id, docker_exe):
+                    verified = True
+                    break
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_CONTAINER_REMOVAL_POLL_SECONDS)
+            if not verified:
+                logger.warning(
+                    "Outgoing container %s still present after %.0fs; attempting "
+                    "direct removal (#5937)",
+                    container_id[:12],
+                    timeout,
+                )
+                _force_remove_container(container_id, docker_exe)
+                verified = not _container_exists(container_id, docker_exe)
+        except Exception:
+            logger.warning(
+                "Could not verify removal of outgoing container %s (#5937); "
+                "treating as not removed",
+                container_id[:12],
+                exc_info=True,
+            )
+            verified = False
+        if verified:
+            with _COND:
+                _pending_container_removals.pop(container_id, None)
+        else:
+            all_verified = False
+    return all_verified
+
+
+def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> bool:
+    """Verifiably invalidate the agent ``"default"`` slot for previous->identity.
+
+    Returns True only when the postconditions are OBSERVED (slot gone; any
+    outgoing containers gone). ``cleanup_vm`` returning is never treated as
+    success by itself: the real agent contract swallows backend-teardown
+    exceptions and returns None, and Docker force-removal runs asynchronously.
     """
     if cleanup_vm is None:
         cleanup_vm = _resolve_cleanup_vm()
         if cleanup_vm is None:
             return False
+    if get_active_env is None:
+        get_active_env = _resolve_get_active_env()
+        if get_active_env is None:
+            return False
+
     force_remove = previous[0] in _FORCE_REMOVE_ENV_TYPES
+
+    # Ledger the outgoing container BEFORE cleanup: cleanup_vm pops the slot
+    # unconditionally, so this is the last moment its container id is
+    # reachable. If anything below fails, the ledger survives into the retry.
+    outgoing_env = None
+    try:
+        outgoing_env = get_active_env("default")
+    except Exception:
+        logger.warning(
+            "get_active_env('default') failed pre-cleanup (#5937)", exc_info=True
+        )
+        return False
+    if force_remove and outgoing_env is not None:
+        container_id = getattr(outgoing_env, "_container_id", None)
+        if container_id:
+            docker_exe = getattr(outgoing_env, "_docker_exe", None) or "docker"
+            with _COND:
+                _pending_container_removals.setdefault(str(container_id), docker_exe)
+
     try:
         if force_remove:
             cleanup_vm("default", force_remove=True)
@@ -176,7 +346,7 @@ def _invalidate_default_env(previous, identity, cleanup_vm) -> bool:
             cleanup_vm("default")
     except Exception:
         logger.warning(
-            "cleanup_vm('default') failed after terminal backend identity change "
+            "cleanup_vm('default') raised after terminal backend identity change "
             "(#5937) previous=%s current=%s; transition left uncommitted so a "
             "later turn retries",
             previous,
@@ -184,9 +354,51 @@ def _invalidate_default_env(previous, identity, cleanup_vm) -> bool:
             exc_info=True,
         )
         return False
+
+    # Postcondition 1: the "default" slot is actually gone. The current agent
+    # contract pops it before teardown, so this also guards contract drift.
+    try:
+        if get_active_env("default") is not None:
+            logger.warning(
+                "cleanup_vm('default') returned but the default env slot is "
+                "still populated (#5937) previous=%s current=%s; transition "
+                "left uncommitted",
+                previous,
+                identity,
+            )
+            return False
+    except Exception:
+        logger.warning(
+            "get_active_env('default') failed post-cleanup (#5937)", exc_info=True
+        )
+        return False
+
+    # Postcondition 2: every ledgered outgoing container is verifiably gone.
+    # DockerEnvironment.cleanup(force_remove=True) stops/removes on a daemon
+    # thread; give it a bounded head start via the thread handle when we have
+    # one, then probe (the probe loop tolerates the async lag either way).
+    cleanup_thread = getattr(outgoing_env, "_cleanup_thread", None)
+    if cleanup_thread is not None:
+        try:
+            cleanup_thread.join(timeout=_CONTAINER_REMOVAL_WAIT_SECONDS)
+        except Exception:
+            logger.debug(
+                "joining outgoing env cleanup thread failed (#5937)", exc_info=True
+            )
+    if not _verify_pending_container_removals():
+        logger.warning(
+            "Outgoing container removal could not be verified after terminal "
+            "backend identity change (#5937) previous=%s current=%s; transition "
+            "left uncommitted",
+            previous,
+            identity,
+        )
+        return False
+
     logger.info(
         "Invalidated agent default terminal env after backend identity change "
-        "(#5937) previous=%s current=%s force_remove=%s",
+        "(#5937) previous=%s current=%s force_remove=%s (slot + container "
+        "removal verified)",
         previous,
         identity,
         force_remove,
@@ -198,88 +410,118 @@ def acquire_terminal_backend_turn_lease(
     runtime_env: Mapping[str, str],
     *,
     cleanup_vm=None,
+    get_active_env=None,
     wait_seconds: Optional[float] = None,
 ) -> tuple[TerminalBackendTurnLease, bool]:
-    """Acquire a full-turn lease on this turn's backend identity.
+    """Acquire a full-turn lease on this turn's backend identity, or reject.
 
     Returns ``(lease, invalidated)``. The caller MUST call ``lease.release()``
     when the turn finishes (success or failure).
 
+    Admission rules (fail closed — a turn is never admitted against a slot
+    that may belong to a different backend):
+
     - First turn in the process records the identity without cleanup.
-    - Same identity as the last committed turn: no cleanup, runs concurrently
-      with other same-identity turns.
-    - Differing identity: waits (bounded) for in-flight turns on other
-      identities to release, then invalidates the agent ``"default"`` slot.
-      Only the first turn of the new identity performs the invalidation;
-      concurrent same-identity turns piggyback on it.
-    - On wait timeout or cleanup failure the transition is NOT committed, so a
-      later turn retries; an in-use environment is never force-evicted.
+    - Same identity as the last committed turn, no transition in progress:
+      admitted immediately, runs concurrently with other same-identity turns.
+    - While a transition's cleanup/verification is in flight, EVERY arrival
+      waits — same-new-identity turns do not piggyback on an unproven
+      cleanup; they re-evaluate once the transition commits or fails (and
+      retry the invalidation themselves on failure).
+    - Differing identity: waits (bounded) for in-flight turns to release,
+      then becomes the transition leader: invalidates the agent ``"default"``
+      slot and commits only on VERIFIED success.
+    - On wait timeout raises :class:`TerminalBackendTransitionTimeout`; on
+      unverifiable cleanup raises :class:`TerminalBackendInvalidationFailed`.
+      In both cases no lease is registered and the transition stays
+      uncommitted, so a later turn retries.
 
     *runtime_env* should be the effective post-merge environment for the turn
     (process env overlaid with the profile's runtime env), not the profile env
     alone, so identity reflects what environment creation will actually see.
     """
-    global _last_backend_identity
+    global _last_backend_identity, _transition_identity
 
     identity = terminal_backend_identity(runtime_env)
     timeout = _LEASE_WAIT_SECONDS if wait_seconds is None else wait_seconds
     deadline = time.monotonic() + timeout
-    timed_out = False
+
     with _COND:
-        while any(
-            key != identity and count > 0
-            for key, count in _active_turn_counts.items()
-        ):
+        while True:
+            if _transition_identity is None:
+                previous = _last_backend_identity
+                if previous is None or previous == identity:
+                    if previous is None:
+                        _last_backend_identity = identity
+                    _active_turn_counts[identity] = (
+                        _active_turn_counts.get(identity, 0) + 1
+                    )
+                    return TerminalBackendTurnLease(identity), False
+                # Differing identity: all active turns necessarily run on the
+                # committed identity, so becoming leader requires full drain.
+                if not any(count > 0 for count in _active_turn_counts.values()):
+                    _transition_identity = identity
+                    break
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                timed_out = True
-                break
+                raise TerminalBackendTransitionTimeout(
+                    "Terminal backend switch is waiting on turns still running "
+                    "against the previous backend; this turn was not started to "
+                    "avoid running tools on the wrong backend. Please retry in "
+                    "a moment. (#5937)"
+                )
             _COND.wait(remaining)
         previous = _last_backend_identity
-        _active_turn_counts[identity] = _active_turn_counts.get(identity, 0) + 1
-        lease = TerminalBackendTurnLease(identity)
-        if previous is None:
-            _last_backend_identity = identity
-            return lease, False
-        if previous == identity:
-            return lease, False
-        if timed_out:
-            logger.warning(
-                "Terminal backend identity changed (previous=%s current=%s) but "
-                "turns on the previous identity were still active after %.0fs; "
-                "proceeding WITHOUT invalidation (#5937). The transition stays "
-                "uncommitted and will be retried by a later turn.",
-                previous,
-                identity,
-                timeout,
-            )
-            return lease, False
-        if _active_turn_counts.get(identity, 0) > 1:
-            # Another turn on this same new identity is already in flight and
-            # owns (or already performed) the invalidation; don't evict the
-            # environment it may have just created.
-            return lease, False
 
-    invalidated = _invalidate_default_env(previous, identity, cleanup_vm)
-    if invalidated:
+    invalidated = False
+    try:
+        try:
+            invalidated = _invalidate_default_env(
+                previous, identity, cleanup_vm, get_active_env
+            )
+        except Exception:
+            # _invalidate_default_env handles its own expected failures; an
+            # escape here is a bug, but the boundary still fails CLOSED.
+            logger.warning(
+                "unexpected error during terminal backend invalidation (#5937)",
+                exc_info=True,
+            )
+            invalidated = False
+    finally:
         with _COND:
-            _last_backend_identity = identity
-    return lease, invalidated
+            _transition_identity = None
+            if invalidated:
+                _last_backend_identity = identity
+                _active_turn_counts[identity] = (
+                    _active_turn_counts.get(identity, 0) + 1
+                )
+            _COND.notify_all()
+
+    if not invalidated:
+        raise TerminalBackendInvalidationFailed(
+            "The previous terminal backend environment could not be verifiably "
+            "removed; this turn was not started to avoid running tools against "
+            "a stale backend. It will be retried on the next turn — see server "
+            "logs for the cleanup failure. (#5937)"
+        )
+    return TerminalBackendTurnLease(identity), True
 
 
 def maybe_invalidate_default_terminal_env(
     runtime_env: Mapping[str, str],
     *,
     cleanup_vm=None,
+    get_active_env=None,
 ) -> bool:
     """Point-in-time invalidation check (no full-turn lease held afterwards).
 
     Kept for tests and non-turn callers; agent turns should use
     ``acquire_terminal_backend_turn_lease`` so the identity stays leased for
-    the duration of the turn.
+    the duration of the turn. Propagates the same fail-closed
+    :class:`TerminalBackendIsolationError` rejections.
     """
     lease, invalidated = acquire_terminal_backend_turn_lease(
-        runtime_env, cleanup_vm=cleanup_vm
+        runtime_env, cleanup_vm=cleanup_vm, get_active_env=get_active_env
     )
     lease.release()
     return invalidated

--- a/api/terminal_backend_isolation.py
+++ b/api/terminal_backend_isolation.py
@@ -40,6 +40,12 @@ security boundary and every path fails CLOSED:
   retry (the slot pop already happened, so the retry's ``cleanup_vm`` alone
   would be a silent no-op).
 
+One deliberate carve-out: when the hermes-agent runtime itself is not
+importable (``tools.terminal_tool`` is where the ``"default"`` cache lives),
+no cached environment can exist in this process, so a transition commits
+vacuously — that is correctness, not fail-open (exercised by webui CI, which
+runs without hermes-agent installed).
+
 Same-backend turns share the identity freely and never invalidate, preserving
 the agent's intentional cross-session sharing of one long-lived
 local/container env. A synchronous, failure-reporting forced-cleanup contract
@@ -198,31 +204,25 @@ class TerminalBackendTurnLease:
             _COND.notify_all()
 
 
-def _resolve_cleanup_vm():
-    try:
-        from tools.terminal_tool import cleanup_vm as _cleanup_vm  # type: ignore
-    except Exception:
-        logger.warning(
-            "Could not import tools.terminal_tool.cleanup_vm to invalidate "
-            "stale default terminal env after backend change (#5937); "
-            "agent-side #62720 remains the primary correctness fix",
-            exc_info=True,
-        )
-        return None
-    return _cleanup_vm
+_AGENT_RUNTIME_ABSENT = object()
 
 
-def _resolve_get_active_env():
+def _resolve_terminal_tool():
+    """Return the agent terminal_tool module, or the ``_AGENT_RUNTIME_ABSENT``
+    sentinel when hermes-agent is not installed in this process.
+
+    Absence is meaningful, not a failure: the process-global ``"default"`` env
+    cache LIVES in ``tools.terminal_tool``. If that module cannot be imported,
+    no cached environment can exist in this process, so a backend transition
+    is vacuously safe (there is nothing to invalidate). Import errors other
+    than ImportError propagate to the caller, which fails closed.
+    """
     try:
-        from tools.terminal_tool import get_active_env as _get_active_env  # type: ignore
-    except Exception:
-        logger.warning(
-            "Could not import tools.terminal_tool.get_active_env to verify "
-            "default terminal env removal (#5937)",
-            exc_info=True,
-        )
-        return None
-    return _get_active_env
+        import tools.terminal_tool as _terminal_tool  # type: ignore
+
+        return _terminal_tool
+    except ImportError:
+        return _AGENT_RUNTIME_ABSENT
 
 
 def _container_exists(container_id: str, docker_exe: str) -> bool:
@@ -310,13 +310,39 @@ def _invalidate_default_env(previous, identity, cleanup_vm, get_active_env) -> b
     success by itself: the real agent contract swallows backend-teardown
     exceptions and returns None, and Docker force-removal runs asynchronously.
     """
-    if cleanup_vm is None:
-        cleanup_vm = _resolve_cleanup_vm()
-        if cleanup_vm is None:
+    if cleanup_vm is None or get_active_env is None:
+        terminal_tool = _resolve_terminal_tool()
+        if terminal_tool is _AGENT_RUNTIME_ABSENT:
+            if cleanup_vm is None and get_active_env is None:
+                # No agent runtime -> the "default" env cache (which lives in
+                # tools.terminal_tool) cannot exist in this process. There is
+                # nothing to invalidate; the transition is vacuously safe.
+                logger.info(
+                    "hermes-agent terminal runtime not importable; no default "
+                    "terminal env cache can exist in this process — backend "
+                    "identity transition %s -> %s is vacuously safe (#5937)",
+                    previous,
+                    identity,
+                )
+                return True
+            # Partial injection with an absent runtime is ambiguous — the
+            # caller believes an env layer exists that we cannot verify.
             return False
-    if get_active_env is None:
-        get_active_env = _resolve_get_active_env()
+        if cleanup_vm is None:
+            cleanup_vm = getattr(terminal_tool, "cleanup_vm", None)
         if get_active_env is None:
+            get_active_env = getattr(terminal_tool, "get_active_env", None)
+            if get_active_env is None:
+                # Older agent builds predate get_active_env; the underlying
+                # cache dict has existed since the slot mechanism was added.
+                _envs = getattr(terminal_tool, "_active_environments", None)
+                if isinstance(_envs, dict):
+                    get_active_env = _envs.get
+        if cleanup_vm is None or get_active_env is None:
+            logger.warning(
+                "hermes-agent terminal runtime is present but cleanup_vm/"
+                "get_active_env could not be resolved (#5937); failing closed",
+            )
             return False
 
     force_remove = previous[0] in _FORCE_REMOVE_ENV_TYPES

--- a/api/terminal_backend_isolation.py
+++ b/api/terminal_backend_isolation.py
@@ -7,60 +7,264 @@ applies each profile's terminal settings via process env for the turn. That is
 correct for *new* environment creation, but it does not by itself evict a
 cached incompatible environment under ``"default"``.
 
-This module tracks the last backend *identity* applied for a turn and, when
-the identity changes, calls the agent's ``cleanup_vm("default")`` so the next
-terminal/file tool recreates against the now-correct ``TERMINAL_*`` env.
+This module tracks the backend *identity* in effect for each agent turn and,
+when a turn starts under a different identity, calls the agent's
+``cleanup_vm("default")`` so the next terminal/file tool recreates against the
+now-correct ``TERMINAL_*`` env.
 
-Same-backend consecutive turns do not invalidate, preserving the agent's
-intentional cross-session sharing of one long-lived local/container env.
+Turns hold a full-turn *lease* on their identity: a differing-backend turn
+waits for in-flight turns on the previous identity to finish before
+invalidating, so it can never evict an environment that is still in use by a
+concurrent turn. Same-backend turns share the identity freely and never
+invalidate, preserving the agent's intentional cross-session sharing of one
+long-lived local/container env.
+
+Persistent Docker containers are reattached by labels without comparing
+image, so a plain (non-force) cleanup can leave a stale container that a
+later Docker turn silently reuses; transitions *away from* Docker therefore
+clean up with ``force_remove=True``.
 """
 
 from __future__ import annotations
 
 import logging
 import threading
+import time
 from typing import Mapping, Optional
 
 logger = logging.getLogger(__name__)
 
-# Process-global last backend identity that was applied for a WebUI agent turn.
-# Guarded by ``_LOCK``; read/write only via helpers below.
-_LOCK = threading.Lock()
+# Mirror of hermes-agent tools/terminal_tool.py defaults, so an explicitly
+# configured default value and an absent key resolve to the same identity.
+_AGENT_DEFAULT_IMAGE = "nikolaik/python-nodejs:python3.11-nodejs20"
+_AGENT_DEFAULT_SSH_PORT = "22"
+_AGENT_DEFAULT_MODAL_MODE = "auto"
+
+# Backends whose cached environment is a container the agent can reattach by
+# labels without comparing image (persistent Docker). Cleanup on a transition
+# away from these must force-remove, or Docker-A -> local -> Docker-B silently
+# reuses image A's container.
+_FORCE_REMOVE_ENV_TYPES = frozenset({"docker"})
+
+# How long a differing-backend turn waits for in-flight turns on another
+# identity before proceeding WITHOUT invalidation. Fail-safe direction: never
+# evict an environment that may still be in use; the identity transition stays
+# uncommitted, so a later turn retries the invalidation.
+_LEASE_WAIT_SECONDS = 30.0
+
+_COND = threading.Condition(threading.Lock())
 _last_backend_identity: Optional[tuple[str, ...]] = None
+_active_turn_counts: dict[tuple[str, ...], int] = {}
+
+
+def _env_value(runtime_env: Mapping[str, str], key: str, default: str = "") -> str:
+    value = runtime_env.get(key)
+    text = str(value).strip() if value is not None else ""
+    return text or default
 
 
 def terminal_backend_identity(runtime_env: Mapping[str, str]) -> tuple[str, ...]:
     """Return a stable identity for the terminal backend encoded in *runtime_env*.
 
-    Keys match what the agent uses to create environments (TERMINAL_ENV plus
-    remote/container targeting). CWD is intentionally excluded so two same-
-    backend sessions with different workspaces still share one cache slot.
+    Only the settings the agent actually uses to create the *active* backend
+    participate — an SSH host left over in env must not change a local
+    backend's identity, and vice versa. Absent keys are normalized to the
+    agent's defaults so ``{}`` and ``{"TERMINAL_SSH_PORT": "22"}`` cannot
+    disagree. CWD is intentionally excluded so two same-backend sessions with
+    different workspaces still share one cache slot.
     """
-    env_type = str(runtime_env.get("TERMINAL_ENV") or "local").strip().lower() or "local"
-    ssh_host = str(runtime_env.get("TERMINAL_SSH_HOST") or "").strip()
-    ssh_user = str(runtime_env.get("TERMINAL_SSH_USER") or "").strip()
-    ssh_port = str(runtime_env.get("TERMINAL_SSH_PORT") or "").strip()
-    docker_image = str(runtime_env.get("TERMINAL_DOCKER_IMAGE") or "").strip()
-    modal_image = str(runtime_env.get("TERMINAL_MODAL_IMAGE") or "").strip()
-    singularity_image = str(runtime_env.get("TERMINAL_SINGULARITY_IMAGE") or "").strip()
-    daytona_image = str(runtime_env.get("TERMINAL_DAYTONA_IMAGE") or "").strip()
-    return (
-        env_type,
-        ssh_host,
-        ssh_user,
-        ssh_port,
-        docker_image,
-        modal_image,
-        singularity_image,
-        daytona_image,
-    )
+    env_type = _env_value(runtime_env, "TERMINAL_ENV", "local").lower()
+    if env_type == "ssh":
+        return (
+            "ssh",
+            _env_value(runtime_env, "TERMINAL_SSH_HOST"),
+            _env_value(runtime_env, "TERMINAL_SSH_USER"),
+            _env_value(runtime_env, "TERMINAL_SSH_PORT", _AGENT_DEFAULT_SSH_PORT),
+            _env_value(runtime_env, "TERMINAL_SSH_KEY"),
+        )
+    if env_type == "docker":
+        return (
+            "docker",
+            _env_value(runtime_env, "TERMINAL_DOCKER_IMAGE", _AGENT_DEFAULT_IMAGE),
+        )
+    if env_type == "modal":
+        return (
+            "modal",
+            _env_value(runtime_env, "TERMINAL_MODAL_IMAGE", _AGENT_DEFAULT_IMAGE),
+            _env_value(
+                runtime_env, "TERMINAL_MODAL_MODE", _AGENT_DEFAULT_MODAL_MODE
+            ).lower(),
+        )
+    if env_type == "singularity":
+        return (
+            "singularity",
+            _env_value(
+                runtime_env,
+                "TERMINAL_SINGULARITY_IMAGE",
+                f"docker://{_AGENT_DEFAULT_IMAGE}",
+            ),
+        )
+    if env_type == "daytona":
+        return (
+            "daytona",
+            _env_value(runtime_env, "TERMINAL_DAYTONA_IMAGE", _AGENT_DEFAULT_IMAGE),
+        )
+    return (env_type,)
 
 
 def reset_terminal_backend_identity_for_tests() -> None:
-    """Clear process-global identity tracking (tests only)."""
+    """Clear process-global identity/lease tracking (tests only)."""
     global _last_backend_identity
-    with _LOCK:
+    with _COND:
         _last_backend_identity = None
+        _active_turn_counts.clear()
+        _COND.notify_all()
+
+
+class TerminalBackendTurnLease:
+    """Held for the whole agent turn; release() decrements the identity count."""
+
+    __slots__ = ("identity", "_released")
+
+    def __init__(self, identity: tuple[str, ...]):
+        self.identity = identity
+        self._released = False
+
+    def release(self) -> None:
+        with _COND:
+            if self._released:
+                return
+            self._released = True
+            count = _active_turn_counts.get(self.identity, 0)
+            if count <= 1:
+                _active_turn_counts.pop(self.identity, None)
+            else:
+                _active_turn_counts[self.identity] = count - 1
+            _COND.notify_all()
+
+
+def _resolve_cleanup_vm():
+    try:
+        from tools.terminal_tool import cleanup_vm as _cleanup_vm  # type: ignore
+    except Exception:
+        logger.warning(
+            "Could not import tools.terminal_tool.cleanup_vm to invalidate "
+            "stale default terminal env after backend change (#5937); "
+            "agent-side #62720 remains the primary correctness fix",
+            exc_info=True,
+        )
+        return None
+    return _cleanup_vm
+
+
+def _invalidate_default_env(previous, identity, cleanup_vm) -> bool:
+    """Run cleanup_vm('default') for a previous->identity transition.
+
+    Returns True only on success; the caller commits the identity transition
+    only then, so a transient import/cleanup failure is retried by a later
+    turn instead of being permanently skipped.
+    """
+    if cleanup_vm is None:
+        cleanup_vm = _resolve_cleanup_vm()
+        if cleanup_vm is None:
+            return False
+    force_remove = previous[0] in _FORCE_REMOVE_ENV_TYPES
+    try:
+        if force_remove:
+            cleanup_vm("default", force_remove=True)
+        else:
+            cleanup_vm("default")
+    except Exception:
+        logger.warning(
+            "cleanup_vm('default') failed after terminal backend identity change "
+            "(#5937) previous=%s current=%s; transition left uncommitted so a "
+            "later turn retries",
+            previous,
+            identity,
+            exc_info=True,
+        )
+        return False
+    logger.info(
+        "Invalidated agent default terminal env after backend identity change "
+        "(#5937) previous=%s current=%s force_remove=%s",
+        previous,
+        identity,
+        force_remove,
+    )
+    return True
+
+
+def acquire_terminal_backend_turn_lease(
+    runtime_env: Mapping[str, str],
+    *,
+    cleanup_vm=None,
+    wait_seconds: Optional[float] = None,
+) -> tuple[TerminalBackendTurnLease, bool]:
+    """Acquire a full-turn lease on this turn's backend identity.
+
+    Returns ``(lease, invalidated)``. The caller MUST call ``lease.release()``
+    when the turn finishes (success or failure).
+
+    - First turn in the process records the identity without cleanup.
+    - Same identity as the last committed turn: no cleanup, runs concurrently
+      with other same-identity turns.
+    - Differing identity: waits (bounded) for in-flight turns on other
+      identities to release, then invalidates the agent ``"default"`` slot.
+      Only the first turn of the new identity performs the invalidation;
+      concurrent same-identity turns piggyback on it.
+    - On wait timeout or cleanup failure the transition is NOT committed, so a
+      later turn retries; an in-use environment is never force-evicted.
+
+    *runtime_env* should be the effective post-merge environment for the turn
+    (process env overlaid with the profile's runtime env), not the profile env
+    alone, so identity reflects what environment creation will actually see.
+    """
+    global _last_backend_identity
+
+    identity = terminal_backend_identity(runtime_env)
+    timeout = _LEASE_WAIT_SECONDS if wait_seconds is None else wait_seconds
+    deadline = time.monotonic() + timeout
+    timed_out = False
+    with _COND:
+        while any(
+            key != identity and count > 0
+            for key, count in _active_turn_counts.items()
+        ):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            _COND.wait(remaining)
+        previous = _last_backend_identity
+        _active_turn_counts[identity] = _active_turn_counts.get(identity, 0) + 1
+        lease = TerminalBackendTurnLease(identity)
+        if previous is None:
+            _last_backend_identity = identity
+            return lease, False
+        if previous == identity:
+            return lease, False
+        if timed_out:
+            logger.warning(
+                "Terminal backend identity changed (previous=%s current=%s) but "
+                "turns on the previous identity were still active after %.0fs; "
+                "proceeding WITHOUT invalidation (#5937). The transition stays "
+                "uncommitted and will be retried by a later turn.",
+                previous,
+                identity,
+                timeout,
+            )
+            return lease, False
+        if _active_turn_counts.get(identity, 0) > 1:
+            # Another turn on this same new identity is already in flight and
+            # owns (or already performed) the invalidation; don't evict the
+            # environment it may have just created.
+            return lease, False
+
+    invalidated = _invalidate_default_env(previous, identity, cleanup_vm)
+    if invalidated:
+        with _COND:
+            _last_backend_identity = identity
+    return lease, invalidated
 
 
 def maybe_invalidate_default_terminal_env(
@@ -68,57 +272,14 @@ def maybe_invalidate_default_terminal_env(
     *,
     cleanup_vm=None,
 ) -> bool:
-    """Invalidate the agent ``"default"`` terminal env when backend identity changes.
+    """Point-in-time invalidation check (no full-turn lease held afterwards).
 
-    Returns True when ``cleanup_vm("default")`` was invoked. First turn in a
-    process only records identity (no cleanup). Same identity as last turn is a
-    no-op.
-
-    *cleanup_vm* is injectable for unit tests; production resolves
-    ``tools.terminal_tool.cleanup_vm`` lazily so WebUI still boots when the
-    agent is not on ``sys.path``.
+    Kept for tests and non-turn callers; agent turns should use
+    ``acquire_terminal_backend_turn_lease`` so the identity stays leased for
+    the duration of the turn.
     """
-    global _last_backend_identity
-
-    identity = terminal_backend_identity(runtime_env)
-    previous: Optional[tuple[str, ...]]
-    with _LOCK:
-        previous = _last_backend_identity
-        if previous is not None and previous == identity:
-            return False
-        _last_backend_identity = identity
-        if previous is None:
-            return False
-
-    if cleanup_vm is None:
-        try:
-            from tools.terminal_tool import cleanup_vm as _cleanup_vm  # type: ignore
-        except Exception:
-            logger.warning(
-                "Could not import tools.terminal_tool.cleanup_vm to invalidate "
-                "stale default terminal env after backend change (#5937); "
-                "agent-side #62720 remains the primary correctness fix",
-                exc_info=True,
-            )
-            return False
-        cleanup_vm = _cleanup_vm
-
-    try:
-        cleanup_vm("default")
-    except Exception:
-        logger.warning(
-            "cleanup_vm('default') failed after terminal backend identity change "
-            "(#5937) previous=%s current=%s",
-            previous,
-            identity,
-            exc_info=True,
-        )
-        return False
-
-    logger.info(
-        "Invalidated agent default terminal env after backend identity change "
-        "(#5937) previous=%s current=%s",
-        previous,
-        identity,
+    lease, invalidated = acquire_terminal_backend_turn_lease(
+        runtime_env, cleanup_vm=cleanup_vm
     )
-    return True
+    lease.release()
+    return invalidated

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -620,6 +620,21 @@ def test_previous_identity_arrival_also_waits_during_transition():
     assert not old_arrival.is_alive()
 
 
+def test_lease_release_is_idempotent():
+    """The streaming path releases the lease twice on the normal path (inner
+    ordered release + outer backstop); the second must be a no-op and never
+    underflow another turn's count."""
+    agent = FakeAgent()
+    first, _ = turn(agent, LOCAL)
+    second, _ = turn(agent, LOCAL)
+    assert active_turn_count() == 2
+    first.release()
+    first.release()  # backstop double-release
+    assert active_turn_count() == 1  # second turn's count untouched
+    second.release()
+    assert active_turn_count() == 0
+
+
 # ── Streaming integration source guard ───────────────────────────────────────
 
 
@@ -662,5 +677,13 @@ def test_streaming_acquires_full_turn_lease_on_effective_env():
     release_idx = STREAMING_PY.find("_terminal_backend_lease.release()")
     assert restore_idx >= 0
     assert release_idx > restore_idx
+    # AND a backstop release in the outermost guaranteed-teardown finally:
+    # the lease is acquired well before the inner try begins, so an exception
+    # in that window must not leak the lease (a leaked lease under fail-closed
+    # admission is a standing denial for differing-backend turns).
+    backstop_idx = STREAMING_PY.find("_terminal_backend_lease.release()", release_idx + 1)
+    metering_teardown_idx = STREAMING_PY.find("meter().end_session(stream_id, 0)")
+    assert metering_teardown_idx > 0
+    assert backstop_idx > metering_teardown_idx
     # Point-in-time invalidation is no longer called from the turn path.
     assert "maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)" not in STREAMING_PY

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -138,12 +138,223 @@ def test_cleanup_exception_is_swallowed_and_returns_false():
     )
 
 
-def test_streaming_applies_isolation_after_profile_runtime_env_update():
-    """Source guard: the turn path must call isolation after os.environ.update."""
-    assert "maybe_invalidate_default_terminal_env" in STREAMING_PY
-    assert "terminal_backend_isolation" in STREAMING_PY
-    # Ordering: update profile runtime env, then isolation check.
+def test_streaming_acquires_full_turn_lease_on_effective_env():
+    """Source guard: the turn path leases the identity for the whole turn.
+
+    Identity must come from the effective post-merge environment (process env
+    overlaid with the profile runtime env), the lease must be acquired BEFORE
+    _ENV_LOCK (waiters must not block other turns' env restore), and it must
+    be released in the turn's finally after the env restore.
+    """
+    assert "acquire_terminal_backend_turn_lease" in STREAMING_PY
+    # Effective env = os.environ overlaid with the profile runtime env.
+    merged_idx = STREAMING_PY.find("_effective_turn_env = dict(os.environ)")
+    assert merged_idx >= 0
+    overlay_idx = STREAMING_PY.find(
+        "_effective_turn_env.update(_safe_profile_runtime_env)", merged_idx
+    )
+    assert overlay_idx > merged_idx
+    acquire_idx = STREAMING_PY.find(
+        "acquire_terminal_backend_turn_lease(", overlay_idx
+    )
+    assert acquire_idx > overlay_idx
+    # Lease acquisition happens before the env-mutation critical section.
     update_idx = STREAMING_PY.find("os.environ.update(_safe_profile_runtime_env)")
-    isolate_idx = STREAMING_PY.find("maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)")
     assert update_idx >= 0
-    assert isolate_idx > update_idx
+    assert acquire_idx < update_idx
+    # Released in the finally, after the profile env restore loop.
+    restore_idx = STREAMING_PY.find("for _key, _old_value in old_profile_env.items()")
+    release_idx = STREAMING_PY.find("_terminal_backend_lease.release()")
+    assert restore_idx >= 0
+    assert release_idx > restore_idx
+    # Point-in-time invalidation is no longer called from the turn path.
+    assert "maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)" not in STREAMING_PY
+
+
+def test_docker_transition_force_removes_container():
+    """Gate #5988 CORE: leaving a Docker identity must force-remove so a stale
+    persistent container can't be reattached by labels under a new image."""
+    cleanup = MagicMock()
+    docker_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:a"}
+    local = {"TERMINAL_ENV": "local"}
+    assert isolation.maybe_invalidate_default_terminal_env(docker_a, cleanup_vm=cleanup) is False
+    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=cleanup) is True
+    cleanup.assert_called_once_with("default", force_remove=True)
+
+
+def test_docker_image_change_invalidates_with_force_remove():
+    cleanup = MagicMock()
+    docker_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:a"}
+    docker_b = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:b"}
+    isolation.maybe_invalidate_default_terminal_env(docker_a, cleanup_vm=cleanup)
+    assert isolation.maybe_invalidate_default_terminal_env(docker_b, cleanup_vm=cleanup) is True
+    cleanup.assert_called_once_with("default", force_remove=True)
+
+
+def test_non_docker_transition_does_not_force_remove():
+    cleanup = MagicMock()
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    docker = {"TERMINAL_ENV": "docker"}
+    isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=cleanup)
+    assert isolation.maybe_invalidate_default_terminal_env(docker, cleanup_vm=cleanup) is True
+    cleanup.assert_called_once_with("default")
+
+
+def test_identity_includes_ssh_key_and_modal_mode():
+    """Gate #5988: two genuinely-different backends must not hash equal."""
+    key_a = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_SSH_KEY": "/k/a"}
+    )
+    key_b = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_SSH_KEY": "/k/b"}
+    )
+    assert key_a != key_b
+    modal_direct = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "direct"}
+    )
+    modal_managed = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "managed"}
+    )
+    assert modal_direct != modal_managed
+
+
+def test_identity_normalizes_agent_defaults():
+    """Absent keys and explicitly-configured agent defaults hash equal."""
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    ) == isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_SSH_PORT": "22"}
+    )
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "docker"}
+    ) == isolation.terminal_backend_identity(
+        {
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_DOCKER_IMAGE": "nikolaik/python-nodejs:python3.11-nodejs20",
+        }
+    )
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal"}
+    ) == isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "AUTO"}
+    )
+
+
+def test_identity_excludes_inactive_backend_settings():
+    """A stray SSH/docker var in env must not perturb another backend's identity."""
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "local", "TERMINAL_SSH_HOST": "leftover.example"}
+    ) == isolation.terminal_backend_identity({"TERMINAL_ENV": "local"})
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_DOCKER_IMAGE": "img:x"}
+    ) == isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    )
+
+
+def test_cleanup_failure_is_retried_by_next_turn():
+    """Gate #5988: a transient failure must not permanently skip invalidation."""
+    failing = MagicMock(side_effect=RuntimeError("boom"))
+    ok = MagicMock()
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    local = {"TERMINAL_ENV": "local"}
+    assert isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=ok) is False
+    # Transition attempt fails: not committed.
+    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=failing) is False
+    # Next turn on the same new identity retries and succeeds.
+    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=ok) is True
+    ok.assert_called_once_with("default")
+
+
+def test_import_failure_is_retried_by_next_turn():
+    """Same retry guarantee when cleanup_vm cannot even be resolved."""
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    local = {"TERMINAL_ENV": "local"}
+    ok = MagicMock()
+    assert isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=ok) is False
+    original = isolation._resolve_cleanup_vm
+    isolation._resolve_cleanup_vm = lambda: None
+    try:
+        assert isolation.maybe_invalidate_default_terminal_env(local) is False
+    finally:
+        isolation._resolve_cleanup_vm = original
+    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=ok) is True
+    ok.assert_called_once_with("default")
+
+
+def test_differing_backend_turn_waits_for_active_lease():
+    """Gate #5988: a differing-backend turn must not evict an in-use env."""
+    import threading as _threading
+
+    cleanup = MagicMock()
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    local = {"TERMINAL_ENV": "local"}
+    first, invalidated = isolation.acquire_terminal_backend_turn_lease(
+        ssh, cleanup_vm=cleanup
+    )
+    assert invalidated is False
+
+    entered = _threading.Event()
+    result = {}
+
+    def _differing_turn():
+        entered.set()
+        lease, did = isolation.acquire_terminal_backend_turn_lease(
+            local, cleanup_vm=cleanup, wait_seconds=10
+        )
+        result["invalidated"] = did
+        lease.release()
+
+    thread = _threading.Thread(target=_differing_turn, daemon=True)
+    thread.start()
+    entered.wait(timeout=5)
+    time_waited = thread.join(timeout=0.5)  # noqa: F841 — expect still alive
+    assert thread.is_alive(), "differing-backend turn should wait on the lease"
+    cleanup.assert_not_called()
+
+    first.release()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert result["invalidated"] is True
+    cleanup.assert_called_once_with("default")
+
+
+def test_lease_wait_timeout_skips_invalidation_and_retries_later():
+    cleanup = MagicMock()
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    local = {"TERMINAL_ENV": "local"}
+    first, _ = isolation.acquire_terminal_backend_turn_lease(ssh, cleanup_vm=cleanup)
+    lease, invalidated = isolation.acquire_terminal_backend_turn_lease(
+        local, cleanup_vm=cleanup, wait_seconds=0.05
+    )
+    assert invalidated is False
+    cleanup.assert_not_called()
+    lease.release()
+    first.release()
+    # Transition was not committed — a later unobstructed turn retries.
+    lease2, invalidated2 = isolation.acquire_terminal_backend_turn_lease(
+        local, cleanup_vm=cleanup
+    )
+    assert invalidated2 is True
+    cleanup.assert_called_once_with("default")
+    lease2.release()
+
+
+def test_concurrent_same_identity_turns_share_one_invalidation():
+    cleanup = MagicMock()
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    local = {"TERMINAL_ENV": "local"}
+    seed, _ = isolation.acquire_terminal_backend_turn_lease(ssh, cleanup_vm=cleanup)
+    seed.release()
+    first, did_first = isolation.acquire_terminal_backend_turn_lease(
+        local, cleanup_vm=cleanup
+    )
+    # Second same-identity turn while the first is still running: piggybacks.
+    second, did_second = isolation.acquire_terminal_backend_turn_lease(
+        local, cleanup_vm=cleanup
+    )
+    assert did_first is True
+    assert did_second is False
+    cleanup.assert_called_once_with("default")
+    second.release()
+    first.release()

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -45,6 +45,12 @@ def setup_function(_fn=None):
     isolation.reset_terminal_backend_identity_for_tests()
 
 
+def teardown_function(_fn=None):
+    # Shard hygiene: these tests mutate process-global identity state that
+    # other streaming tests in the same shard would otherwise inherit.
+    isolation.reset_terminal_backend_identity_for_tests()
+
+
 # ── Fakes faithful to the real agent contract ────────────────────────────────
 
 
@@ -375,17 +381,36 @@ def test_unremoved_default_slot_fails_the_transition():
     assert active_turn_count() == 0
 
 
-def test_import_failure_rejects_and_is_retried_by_next_turn(monkeypatch):
-    """cleanup_vm unresolvable → the turn must NOT proceed uninvalidated."""
+def test_absent_agent_runtime_commits_vacuously(monkeypatch):
+    """When tools.terminal_tool is not importable (e.g. webui CI runs without
+    hermes-agent), no env cache can exist in this process — a transition must
+    commit vacuously instead of rejecting every turn forever."""
+    agent = FakeAgent()
+    assert one_shot(agent, SSH) is False
+    monkeypatch.setattr(
+        isolation, "_resolve_terminal_tool", lambda: isolation._AGENT_RUNTIME_ABSENT
+    )
+    assert isolation.maybe_invalidate_default_terminal_env(LOCAL) is True
+    with isolation._COND:
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(LOCAL)
+
+
+def test_present_runtime_with_unresolvable_helpers_fails_closed(monkeypatch):
+    """A present-but-broken runtime is NOT the vacuous case: the cache may
+    exist and we cannot verify it — reject the turn."""
     agent = FakeAgent()
     agent.seed_generic()
     assert one_shot(agent, SSH) is False
-    monkeypatch.setattr(isolation, "_resolve_cleanup_vm", lambda: None)
+
+    class _BrokenModule:
+        pass
+
+    monkeypatch.setattr(isolation, "_resolve_terminal_tool", lambda: _BrokenModule())
     with pytest.raises(isolation.TerminalBackendInvalidationFailed):
-        isolation.maybe_invalidate_default_terminal_env(
-            LOCAL, get_active_env=agent.get_active_env
-        )
+        isolation.maybe_invalidate_default_terminal_env(LOCAL)
+    assert active_turn_count() == 0
     monkeypatch.undo()
+    # Runtime resolvable again: retry succeeds.
     assert one_shot(agent, LOCAL) is True
     assert agent.cleanup_calls == [("default", False)]
 

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -2,13 +2,32 @@
 
 WebUI must invalidate the agent process-global "default" terminal env when the
 selected profile's backend identity changes (e.g. SSH → local), without
-evicting on same-backend consecutive turns.
+evicting on same-backend consecutive turns — and must FAIL CLOSED: no turn is
+ever admitted against a slot that may belong to a different backend.
+
+The fakes here mirror the REAL hermes-agent cleanup contract
+(tools/terminal_tool.cleanup_vm), which the #5988 round-2 gate found the
+previous mocks were hiding:
+
+* ``cleanup_vm`` pops the cache slot FIRST, then swallows backend-teardown
+  exceptions and returns ``None`` either way — it NEVER signals failure.
+* ``DockerEnvironment.cleanup(force_remove=True)`` performs ``docker stop`` /
+  ``docker rm -f`` asynchronously; returning proves nothing about the
+  container actually being removed.
+
+Success must therefore be established by observed postconditions (slot gone,
+container gone), and these tests assert that an incompatible turn is NEVER
+admitted on timeout or on unverified cleanup.
 """
 
 from __future__ import annotations
 
+import inspect
+import threading
+import time
 from pathlib import Path
-from unittest.mock import MagicMock
+
+import pytest
 
 import api.terminal_backend_isolation as isolation
 
@@ -16,9 +35,119 @@ import api.terminal_backend_isolation as isolation
 REPO_ROOT = Path(__file__).parent.parent
 STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
 
+SSH = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box.example", "TERMINAL_SSH_USER": "deploy"}
+LOCAL = {"TERMINAL_ENV": "local"}
+DOCKER_A = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:a"}
+DOCKER_B = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:b"}
+
 
 def setup_function(_fn=None):
     isolation.reset_terminal_backend_identity_for_tests()
+
+
+# ── Fakes faithful to the real agent contract ────────────────────────────────
+
+
+class FakeDockerEnv:
+    """Mirrors DockerEnvironment: container removal happens in cleanup(); a
+    silent removal failure leaves the container in ``agent.containers``."""
+
+    def __init__(self, agent, container_id):
+        self._agent = agent
+        self._container_id = container_id
+        self._docker_exe = "docker"
+        self._cleanup_thread = None
+
+    def cleanup(self, *, force_remove=False):
+        if self._agent.backend_cleanup_error is not None:
+            raise self._agent.backend_cleanup_error
+        if force_remove and not self._agent.rm_silently_fails:
+            self._agent.containers.discard(self._container_id)
+        self._container_id = None
+
+
+class FakeGenericEnv:
+    def cleanup(self):
+        pass
+
+
+class FakeAgent:
+    """Faithful stand-in for hermes-agent tools/terminal_tool."""
+
+    def __init__(self):
+        self.active = {}
+        self.containers = set()
+        self.cleanup_calls = []
+        self.backend_cleanup_error = None  # raised INSIDE env.cleanup (swallowed)
+        self.rm_silently_fails = False  # agent's async docker rm loses the race
+        self.direct_rm_results = None  # None = always works; else pop-per-call
+        self.pop_slot = True  # contract-drift knob
+
+    def seed_docker(self, container_id="cid-aaaa"):
+        self.containers.add(container_id)
+        self.active["default"] = FakeDockerEnv(self, container_id)
+        return container_id
+
+    def seed_generic(self):
+        self.active["default"] = FakeGenericEnv()
+
+    def get_active_env(self, task_id):
+        return self.active.get(task_id)
+
+    def cleanup_vm(self, task_id, *, force_remove=False):
+        """REAL contract: pop first, swallow teardown exceptions, return None."""
+        self.cleanup_calls.append((task_id, force_remove))
+        if self.pop_slot:
+            env = self.active.pop(task_id, None)
+        else:
+            env = self.active.get(task_id)
+        if env is None:
+            return None
+        try:
+            sig = inspect.signature(env.cleanup)
+            if "force_remove" in sig.parameters:
+                env.cleanup(force_remove=force_remove)
+            else:
+                env.cleanup()
+        except Exception:
+            pass  # the real cleanup_vm logs and swallows
+        return None
+
+    def direct_rm(self, container_id, docker_exe):
+        if self.direct_rm_results is None:
+            self.containers.discard(container_id)
+            return
+        if self.direct_rm_results and self.direct_rm_results.pop(0):
+            self.containers.discard(container_id)
+
+
+def patch_probes(monkeypatch, agent):
+    monkeypatch.setattr(
+        isolation, "_container_exists", lambda cid, exe: cid in agent.containers
+    )
+    monkeypatch.setattr(isolation, "_force_remove_container", agent.direct_rm)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 0.2)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_POLL_SECONDS", 0.01)
+
+
+def turn(agent, env, **kw):
+    return isolation.acquire_terminal_backend_turn_lease(
+        env, cleanup_vm=agent.cleanup_vm, get_active_env=agent.get_active_env, **kw
+    )
+
+
+def one_shot(agent, env, **kw):
+    return isolation.maybe_invalidate_default_terminal_env(
+        env, cleanup_vm=agent.cleanup_vm, get_active_env=agent.get_active_env, **kw
+    )
+
+
+def active_turn_count():
+    with isolation._COND:
+        return sum(isolation._active_turn_counts.values())
+
+
+# ── Identity (pure) ──────────────────────────────────────────────────────────
 
 
 def test_identity_defaults_missing_backend_to_local():
@@ -27,115 +156,446 @@ def test_identity_defaults_missing_backend_to_local():
 
 
 def test_identity_includes_ssh_target_not_cwd():
-    a = isolation.terminal_backend_identity(
-        {
-            "TERMINAL_ENV": "ssh",
-            "TERMINAL_SSH_HOST": "box.example",
-            "TERMINAL_SSH_USER": "deploy",
-            "TERMINAL_SSH_PORT": "22",
-            "TERMINAL_CWD": "/a",
-        }
-    )
-    b = isolation.terminal_backend_identity(
-        {
-            "TERMINAL_ENV": "ssh",
-            "TERMINAL_SSH_HOST": "box.example",
-            "TERMINAL_SSH_USER": "deploy",
-            "TERMINAL_SSH_PORT": "22",
-            "TERMINAL_CWD": "/b",
-        }
-    )
+    a = isolation.terminal_backend_identity({**SSH, "TERMINAL_CWD": "/a"})
+    b = isolation.terminal_backend_identity({**SSH, "TERMINAL_CWD": "/b"})
     assert a == b
     different_host = isolation.terminal_backend_identity(
-        {
-            "TERMINAL_ENV": "ssh",
-            "TERMINAL_SSH_HOST": "other.example",
-            "TERMINAL_SSH_USER": "deploy",
-            "TERMINAL_SSH_PORT": "22",
-        }
+        {**SSH, "TERMINAL_SSH_HOST": "other.example"}
     )
     assert a != different_host
 
 
+def test_identity_includes_ssh_key_and_modal_mode():
+    key_a = isolation.terminal_backend_identity({**SSH, "TERMINAL_SSH_KEY": "/k/a"})
+    key_b = isolation.terminal_backend_identity({**SSH, "TERMINAL_SSH_KEY": "/k/b"})
+    assert key_a != key_b
+    modal_direct = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "direct"}
+    )
+    modal_managed = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "managed"}
+    )
+    assert modal_direct != modal_managed
+
+
+def test_identity_normalizes_agent_defaults():
+    assert isolation.terminal_backend_identity(
+        SSH
+    ) == isolation.terminal_backend_identity({**SSH, "TERMINAL_SSH_PORT": "22"})
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "docker"}
+    ) == isolation.terminal_backend_identity(
+        {
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_DOCKER_IMAGE": "nikolaik/python-nodejs:python3.11-nodejs20",
+        }
+    )
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal"}
+    ) == isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "AUTO"}
+    )
+
+
+def test_identity_excludes_inactive_backend_settings():
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "local", "TERMINAL_SSH_HOST": "leftover.example"}
+    ) == isolation.terminal_backend_identity({"TERMINAL_ENV": "local"})
+    assert isolation.terminal_backend_identity(
+        {**SSH, "TERMINAL_DOCKER_IMAGE": "img:x"}
+    ) == isolation.terminal_backend_identity(SSH)
+
+
+# ── Nominal admission / invalidation ─────────────────────────────────────────
+
+
 def test_first_turn_records_identity_without_cleanup():
-    cleanup = MagicMock()
-    assert isolation.maybe_invalidate_default_terminal_env(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"},
-        cleanup_vm=cleanup,
-    ) is False
-    cleanup.assert_not_called()
+    agent = FakeAgent()
+    assert one_shot(agent, SSH) is False
+    assert agent.cleanup_calls == []
 
 
 def test_same_backend_consecutive_turns_do_not_cleanup():
-    cleanup = MagicMock()
-    env = {
-        "TERMINAL_ENV": "local",
-    }
-    assert isolation.maybe_invalidate_default_terminal_env(env, cleanup_vm=cleanup) is False
-    assert isolation.maybe_invalidate_default_terminal_env(env, cleanup_vm=cleanup) is False
-    cleanup.assert_not_called()
+    agent = FakeAgent()
+    assert one_shot(agent, LOCAL) is False
+    assert one_shot(agent, LOCAL) is False
+    assert agent.cleanup_calls == []
 
 
 def test_ssh_then_local_invalidates_default_slot():
-    cleanup = MagicMock()
-    ssh = {
-        "TERMINAL_ENV": "ssh",
-        "TERMINAL_SSH_HOST": "box.example",
-        "TERMINAL_SSH_USER": "deploy",
-        "TERMINAL_SSH_PORT": "22",
-    }
-    local = {"TERMINAL_ENV": "local"}
-    assert isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=cleanup) is False
-    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=cleanup) is True
-    cleanup.assert_called_once_with("default")
+    agent = FakeAgent()
+    agent.seed_generic()
+    assert one_shot(agent, SSH) is False
+    assert one_shot(agent, LOCAL) is True
+    assert agent.cleanup_calls == [("default", False)]
+    assert agent.get_active_env("default") is None
+    # Committed: a follow-up same-identity turn does not re-invalidate.
+    assert one_shot(agent, LOCAL) is False
+    assert len(agent.cleanup_calls) == 1
 
 
 def test_local_then_ssh_invalidates_default_slot():
-    cleanup = MagicMock()
-    assert isolation.maybe_invalidate_default_terminal_env(
-        {"TERMINAL_ENV": "local"}, cleanup_vm=cleanup
-    ) is False
-    assert isolation.maybe_invalidate_default_terminal_env(
-        {
-            "TERMINAL_ENV": "ssh",
-            "TERMINAL_SSH_HOST": "box.example",
-            "TERMINAL_SSH_USER": "deploy",
-        },
-        cleanup_vm=cleanup,
-    ) is True
-    cleanup.assert_called_once_with("default")
+    agent = FakeAgent()
+    agent.seed_generic()
+    assert one_shot(agent, LOCAL) is False
+    assert one_shot(agent, SSH) is True
+    assert agent.cleanup_calls == [("default", False)]
 
 
 def test_ssh_host_change_invalidates():
-    cleanup = MagicMock()
-    a = {
-        "TERMINAL_ENV": "ssh",
-        "TERMINAL_SSH_HOST": "a.example",
-        "TERMINAL_SSH_USER": "u",
-    }
-    b = {
-        "TERMINAL_ENV": "ssh",
-        "TERMINAL_SSH_HOST": "b.example",
-        "TERMINAL_SSH_USER": "u",
-    }
-    isolation.maybe_invalidate_default_terminal_env(a, cleanup_vm=cleanup)
-    assert isolation.maybe_invalidate_default_terminal_env(b, cleanup_vm=cleanup) is True
-    cleanup.assert_called_once_with("default")
+    agent = FakeAgent()
+    agent.seed_generic()
+    one_shot(agent, SSH)
+    assert one_shot(agent, {**SSH, "TERMINAL_SSH_HOST": "b.example"}) is True
+    assert agent.cleanup_calls == [("default", False)]
 
 
-def test_cleanup_exception_is_swallowed_and_returns_false():
-    cleanup = MagicMock(side_effect=RuntimeError("boom"))
-    isolation.maybe_invalidate_default_terminal_env(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "a"},
-        cleanup_vm=cleanup,
-    )
-    assert (
-        isolation.maybe_invalidate_default_terminal_env(
-            {"TERMINAL_ENV": "local"},
-            cleanup_vm=cleanup,
+# ── Docker force-remove + verified removal ───────────────────────────────────
+
+
+def test_docker_transition_force_removes_and_verifies_container(monkeypatch):
+    """Gate #5988 CORE: leaving a Docker identity must force-remove AND the
+    commit must be backed by an observed container removal, not by
+    cleanup_vm returning."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    cid = agent.seed_docker()
+    assert one_shot(agent, DOCKER_A) is False
+    assert one_shot(agent, LOCAL) is True
+    assert agent.cleanup_calls == [("default", True)]
+    assert cid not in agent.containers
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+
+
+def test_docker_image_change_invalidates_with_force_remove(monkeypatch):
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    agent.seed_docker()
+    one_shot(agent, DOCKER_A)
+    assert one_shot(agent, DOCKER_B) is True
+    assert agent.cleanup_calls == [("default", True)]
+
+
+def test_non_docker_transition_does_not_force_remove():
+    agent = FakeAgent()
+    agent.seed_generic()
+    one_shot(agent, SSH)
+    assert one_shot(agent, {"TERMINAL_ENV": "docker"}) is True
+    assert agent.cleanup_calls == [("default", False)]
+
+
+# ── Fail closed: cleanup failure under the REAL contract ─────────────────────
+
+
+def test_silent_docker_rm_failure_is_caught_and_turn_rejected(monkeypatch):
+    """Gate #5988 CORE: the real cleanup_vm returns None even when the docker
+    removal silently fails. The verification layer must catch it: transition
+    uncommitted, turn NOT admitted, container ledgered for retry."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    cid = agent.seed_docker()
+    agent.rm_silently_fails = True
+    agent.direct_rm_results = [False]  # direct fallback also fails this round
+    docker_identity = isolation.terminal_backend_identity(DOCKER_A)
+
+    assert one_shot(agent, DOCKER_A) is False
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        one_shot(agent, LOCAL)
+
+    # cleanup_vm WAS called and returned None — but nothing was inferred from it.
+    assert agent.cleanup_calls == [("default", True)]
+    assert cid in agent.containers  # the leak the old mocks hid
+    with isolation._COND:
+        assert isolation._last_backend_identity == docker_identity  # uncommitted
+        assert isolation._pending_container_removals == {cid: "docker"}
+    assert active_turn_count() == 0  # the rejected turn was NOT admitted
+
+    # Next turn retries; the direct fallback now works. The slot was already
+    # popped, so only the pending-container ledger can close the leak.
+    agent.direct_rm_results = None
+    assert one_shot(agent, LOCAL) is True
+    assert cid not in agent.containers
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(LOCAL)
+
+
+def test_backend_cleanup_exception_swallowed_by_agent_is_still_a_failure(monkeypatch):
+    """env.cleanup raising is swallowed by the real cleanup_vm (returns None);
+    the container survives and the transition must not commit."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    cid = agent.seed_docker()
+    agent.backend_cleanup_error = RuntimeError("docker daemon unreachable")
+    one_shot(agent, DOCKER_A)
+    agent.direct_rm_results = [False]
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        one_shot(agent, LOCAL)
+    assert cid in agent.containers
+    assert active_turn_count() == 0
+    # Daemon recovers: retry commits via the ledger + direct removal.
+    agent.direct_rm_results = None
+    assert one_shot(agent, LOCAL) is True
+    assert cid not in agent.containers
+
+
+def test_async_docker_removal_is_awaited_not_assumed(monkeypatch):
+    """The agent removes the container on a background thread AFTER cleanup_vm
+    returns; the probe loop must wait for it rather than failing instantly."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 5.0)
+    cid = agent.seed_docker()
+    env = agent.active["default"]
+
+    def _async_cleanup(*, force_remove=False):
+        t = threading.Thread(
+            target=lambda: (time.sleep(0.15), agent.containers.discard(cid)),
+            daemon=True,
         )
-        is False
+        t.start()
+        env._cleanup_thread = t
+
+    env.cleanup = _async_cleanup
+    one_shot(agent, DOCKER_A)
+    assert one_shot(agent, LOCAL) is True
+    assert cid not in agent.containers
+
+
+def test_unremoved_default_slot_fails_the_transition():
+    """Contract-drift guard: if cleanup_vm stops popping the slot, committing
+    would hand the new identity a live stale env — must fail closed."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    agent.pop_slot = False
+    one_shot(agent, SSH)
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        one_shot(agent, LOCAL)
+    assert active_turn_count() == 0
+
+
+def test_import_failure_rejects_and_is_retried_by_next_turn(monkeypatch):
+    """cleanup_vm unresolvable → the turn must NOT proceed uninvalidated."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    assert one_shot(agent, SSH) is False
+    monkeypatch.setattr(isolation, "_resolve_cleanup_vm", lambda: None)
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        isolation.maybe_invalidate_default_terminal_env(
+            LOCAL, get_active_env=agent.get_active_env
+        )
+    monkeypatch.undo()
+    assert one_shot(agent, LOCAL) is True
+    assert agent.cleanup_calls == [("default", False)]
+
+
+# ── Fail closed: admission control ───────────────────────────────────────────
+
+
+def test_differing_backend_turn_waits_for_active_lease():
+    """A differing-backend turn must not evict an in-use env."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    first, invalidated = turn(agent, SSH)
+    assert invalidated is False
+
+    entered = threading.Event()
+    result = {}
+
+    def _differing_turn():
+        entered.set()
+        lease, did = turn(agent, LOCAL, wait_seconds=10)
+        result["invalidated"] = did
+        lease.release()
+
+    thread = threading.Thread(target=_differing_turn, daemon=True)
+    thread.start()
+    entered.wait(timeout=5)
+    thread.join(timeout=0.3)
+    assert thread.is_alive(), "differing-backend turn should wait on the lease"
+    assert agent.cleanup_calls == []
+
+    first.release()
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert result["invalidated"] is True
+    assert agent.cleanup_calls == [("default", False)]
+
+
+def test_lease_wait_timeout_rejects_turn_without_admitting_it():
+    """Gate #5988 CORE: on timeout the incoming turn must be REJECTED — never
+    admitted alongside the still-active previous identity."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    ssh_identity = isolation.terminal_backend_identity(SSH)
+    first, _ = turn(agent, SSH)
+    with pytest.raises(isolation.TerminalBackendTransitionTimeout):
+        turn(agent, LOCAL, wait_seconds=0.05)
+    assert agent.cleanup_calls == []
+    with isolation._COND:
+        # Only the SSH turn is registered; the rejected turn left no lease.
+        assert dict(isolation._active_turn_counts) == {ssh_identity: 1}
+        assert isolation._last_backend_identity == ssh_identity
+    first.release()
+    # Transition was not committed — a later unobstructed turn succeeds.
+    lease2, invalidated2 = turn(agent, LOCAL)
+    assert invalidated2 is True
+    lease2.release()
+
+
+def test_no_turn_is_admitted_while_transition_cleanup_is_in_flight():
+    """Same-new-identity arrivals must WAIT on the transition — no piggyback
+    on an unproven cleanup."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    seed, _ = turn(agent, SSH)
+    seed.release()
+
+    in_cleanup = threading.Event()
+    release_cleanup = threading.Event()
+
+    def held_cleanup(task_id, **kw):
+        in_cleanup.set()
+        release_cleanup.wait(timeout=10)
+        return agent.cleanup_vm(task_id, **kw)
+
+    leader_result = {}
+
+    def _leader():
+        lease, did = isolation.acquire_terminal_backend_turn_lease(
+            LOCAL, cleanup_vm=held_cleanup, get_active_env=agent.get_active_env
+        )
+        leader_result["invalidated"] = did
+        lease.release()
+
+    leader = threading.Thread(target=_leader, daemon=True)
+    leader.start()
+    assert in_cleanup.wait(timeout=5), "leader never reached cleanup_vm"
+
+    piggy_result = {}
+
+    def _piggy():
+        lease, did = turn(agent, LOCAL, wait_seconds=10)
+        piggy_result["invalidated"] = did
+        lease.release()
+
+    piggy = threading.Thread(target=_piggy, daemon=True)
+    piggy.start()
+    piggy.join(timeout=0.3)
+    assert piggy.is_alive(), "same-new-identity turn must wait for the transition"
+    # The leader is still blocked inside held_cleanup (which records the call
+    # only when it delegates) — the piggybacker must not have invalidated.
+    assert agent.cleanup_calls == []
+
+    release_cleanup.set()
+    leader.join(timeout=10)
+    piggy.join(timeout=10)
+    assert leader_result["invalidated"] is True
+    assert piggy_result["invalidated"] is False  # committed by the leader
+    assert len(agent.cleanup_calls) == 1  # exactly one invalidation total
+
+
+def test_waiter_retries_invalidation_itself_when_leader_cleanup_fails(monkeypatch):
+    """Gate #5988 CORE: a waiter must not assume the leader invalidated. When
+    the leader's cleanup fails verification, the waiter performs its OWN
+    verified invalidation instead of running against the stale slot."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    cid = agent.seed_docker()
+    agent.rm_silently_fails = True
+    agent.direct_rm_results = [False, True]  # leader's fallback fails; waiter's works
+    seed, _ = turn(agent, DOCKER_A)
+    seed.release()
+
+    in_cleanup = threading.Event()
+    release_cleanup = threading.Event()
+
+    def held_cleanup(task_id, **kw):
+        in_cleanup.set()
+        release_cleanup.wait(timeout=10)
+        return agent.cleanup_vm(task_id, **kw)
+
+    leader_result = {}
+
+    def _leader():
+        try:
+            lease, did = isolation.acquire_terminal_backend_turn_lease(
+                LOCAL, cleanup_vm=held_cleanup, get_active_env=agent.get_active_env
+            )
+            lease.release()
+            leader_result["outcome"] = ("admitted", did)
+        except isolation.TerminalBackendInvalidationFailed:
+            leader_result["outcome"] = ("rejected", None)
+
+    leader = threading.Thread(target=_leader, daemon=True)
+    leader.start()
+    assert in_cleanup.wait(timeout=5)
+
+    waiter_result = {}
+
+    def _waiter():
+        lease, did = turn(agent, LOCAL, wait_seconds=10)
+        waiter_result["invalidated"] = did
+        lease.release()
+
+    waiter = threading.Thread(target=_waiter, daemon=True)
+    waiter.start()
+    waiter.join(timeout=0.3)
+    assert waiter.is_alive(), "waiter admitted during an in-flight transition"
+
+    release_cleanup.set()
+    leader.join(timeout=10)
+    waiter.join(timeout=10)
+    assert leader_result["outcome"] == ("rejected", None)
+    # The waiter did NOT trust the failed leader: it ran its own verified
+    # invalidation (ledgered container removed via the direct fallback).
+    assert waiter_result["invalidated"] is True
+    assert cid not in agent.containers
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(LOCAL)
+
+
+def test_previous_identity_arrival_also_waits_during_transition():
+    """During a transition even previous-identity turns wait: the slot is
+    mid-destruction and admitting them would recreate under a moving target."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    seed, _ = turn(agent, SSH)
+    seed.release()
+
+    in_cleanup = threading.Event()
+    release_cleanup = threading.Event()
+
+    def held_cleanup(task_id, **kw):
+        in_cleanup.set()
+        release_cleanup.wait(timeout=10)
+        return agent.cleanup_vm(task_id, **kw)
+
+    leader = threading.Thread(
+        target=lambda: isolation.acquire_terminal_backend_turn_lease(
+            LOCAL, cleanup_vm=held_cleanup, get_active_env=agent.get_active_env
+        )[0].release(),
+        daemon=True,
     )
+    leader.start()
+    assert in_cleanup.wait(timeout=5)
+
+    old_arrival = threading.Thread(
+        target=lambda: turn(agent, SSH, wait_seconds=10)[0].release(), daemon=True
+    )
+    old_arrival.start()
+    old_arrival.join(timeout=0.3)
+    assert old_arrival.is_alive(), "previous-identity turn admitted mid-transition"
+
+    release_cleanup.set()
+    leader.join(timeout=10)
+    old_arrival.join(timeout=10)
+    assert not old_arrival.is_alive()
+
+
+# ── Streaming integration source guard ───────────────────────────────────────
 
 
 def test_streaming_acquires_full_turn_lease_on_effective_env():
@@ -143,8 +603,10 @@ def test_streaming_acquires_full_turn_lease_on_effective_env():
 
     Identity must come from the effective post-merge environment (process env
     overlaid with the profile runtime env), the lease must be acquired BEFORE
-    _ENV_LOCK (waiters must not block other turns' env restore), and it must
-    be released in the turn's finally after the env restore.
+    _ENV_LOCK (waiters must not block other turns' env restore), it must be
+    released in the turn's finally after the env restore, and deliberate
+    isolation rejections must ABORT the turn (fail closed) rather than being
+    swallowed.
     """
     assert "acquire_terminal_backend_turn_lease" in STREAMING_PY
     # Effective env = os.environ overlaid with the profile runtime env.
@@ -162,6 +624,14 @@ def test_streaming_acquires_full_turn_lease_on_effective_env():
     update_idx = STREAMING_PY.find("os.environ.update(_safe_profile_runtime_env)")
     assert update_idx >= 0
     assert acquire_idx < update_idx
+    # Deliberate rejections fail closed: the typed error is imported and
+    # re-raised (turn aborts); only unexpected module bugs fall through open.
+    assert "TerminalBackendIsolationError" in STREAMING_PY
+    reject_idx = STREAMING_PY.find("except TerminalBackendIsolationError:")
+    assert reject_idx > 0
+    raise_idx = STREAMING_PY.find("raise", reject_idx)
+    generic_idx = STREAMING_PY.find("except Exception:", reject_idx)
+    assert 0 < raise_idx < generic_idx
     # Released in the finally, after the profile env restore loop.
     restore_idx = STREAMING_PY.find("for _key, _old_value in old_profile_env.items()")
     release_idx = STREAMING_PY.find("_terminal_backend_lease.release()")
@@ -169,251 +639,3 @@ def test_streaming_acquires_full_turn_lease_on_effective_env():
     assert release_idx > restore_idx
     # Point-in-time invalidation is no longer called from the turn path.
     assert "maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)" not in STREAMING_PY
-
-
-def test_docker_transition_force_removes_container():
-    """Gate #5988 CORE: leaving a Docker identity must force-remove so a stale
-    persistent container can't be reattached by labels under a new image."""
-    cleanup = MagicMock()
-    docker_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:a"}
-    local = {"TERMINAL_ENV": "local"}
-    assert isolation.maybe_invalidate_default_terminal_env(docker_a, cleanup_vm=cleanup) is False
-    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=cleanup) is True
-    cleanup.assert_called_once_with("default", force_remove=True)
-
-
-def test_docker_image_change_invalidates_with_force_remove():
-    cleanup = MagicMock()
-    docker_a = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:a"}
-    docker_b = {"TERMINAL_ENV": "docker", "TERMINAL_DOCKER_IMAGE": "img:b"}
-    isolation.maybe_invalidate_default_terminal_env(docker_a, cleanup_vm=cleanup)
-    assert isolation.maybe_invalidate_default_terminal_env(docker_b, cleanup_vm=cleanup) is True
-    cleanup.assert_called_once_with("default", force_remove=True)
-
-
-def test_non_docker_transition_does_not_force_remove():
-    cleanup = MagicMock()
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    docker = {"TERMINAL_ENV": "docker"}
-    isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=cleanup)
-    assert isolation.maybe_invalidate_default_terminal_env(docker, cleanup_vm=cleanup) is True
-    cleanup.assert_called_once_with("default")
-
-
-def test_identity_includes_ssh_key_and_modal_mode():
-    """Gate #5988: two genuinely-different backends must not hash equal."""
-    key_a = isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_SSH_KEY": "/k/a"}
-    )
-    key_b = isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_SSH_KEY": "/k/b"}
-    )
-    assert key_a != key_b
-    modal_direct = isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "direct"}
-    )
-    modal_managed = isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "managed"}
-    )
-    assert modal_direct != modal_managed
-
-
-def test_identity_normalizes_agent_defaults():
-    """Absent keys and explicitly-configured agent defaults hash equal."""
-    assert isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    ) == isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_SSH_PORT": "22"}
-    )
-    assert isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "docker"}
-    ) == isolation.terminal_backend_identity(
-        {
-            "TERMINAL_ENV": "docker",
-            "TERMINAL_DOCKER_IMAGE": "nikolaik/python-nodejs:python3.11-nodejs20",
-        }
-    )
-    assert isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "modal"}
-    ) == isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "modal", "TERMINAL_MODAL_MODE": "AUTO"}
-    )
-
-
-def test_identity_excludes_inactive_backend_settings():
-    """A stray SSH/docker var in env must not perturb another backend's identity."""
-    assert isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "local", "TERMINAL_SSH_HOST": "leftover.example"}
-    ) == isolation.terminal_backend_identity({"TERMINAL_ENV": "local"})
-    assert isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box", "TERMINAL_DOCKER_IMAGE": "img:x"}
-    ) == isolation.terminal_backend_identity(
-        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    )
-
-
-def test_cleanup_failure_is_retried_by_next_turn():
-    """Gate #5988: a transient failure must not permanently skip invalidation."""
-    failing = MagicMock(side_effect=RuntimeError("boom"))
-    ok = MagicMock()
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    local = {"TERMINAL_ENV": "local"}
-    assert isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=ok) is False
-    # Transition attempt fails: not committed.
-    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=failing) is False
-    # Next turn on the same new identity retries and succeeds.
-    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=ok) is True
-    ok.assert_called_once_with("default")
-
-
-def test_import_failure_is_retried_by_next_turn():
-    """Same retry guarantee when cleanup_vm cannot even be resolved."""
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    local = {"TERMINAL_ENV": "local"}
-    ok = MagicMock()
-    assert isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=ok) is False
-    original = isolation._resolve_cleanup_vm
-    isolation._resolve_cleanup_vm = lambda: None
-    try:
-        assert isolation.maybe_invalidate_default_terminal_env(local) is False
-    finally:
-        isolation._resolve_cleanup_vm = original
-    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=ok) is True
-    ok.assert_called_once_with("default")
-
-
-def test_differing_backend_turn_waits_for_active_lease():
-    """Gate #5988: a differing-backend turn must not evict an in-use env."""
-    import threading as _threading
-
-    cleanup = MagicMock()
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    local = {"TERMINAL_ENV": "local"}
-    first, invalidated = isolation.acquire_terminal_backend_turn_lease(
-        ssh, cleanup_vm=cleanup
-    )
-    assert invalidated is False
-
-    entered = _threading.Event()
-    result = {}
-
-    def _differing_turn():
-        entered.set()
-        lease, did = isolation.acquire_terminal_backend_turn_lease(
-            local, cleanup_vm=cleanup, wait_seconds=10
-        )
-        result["invalidated"] = did
-        lease.release()
-
-    thread = _threading.Thread(target=_differing_turn, daemon=True)
-    thread.start()
-    entered.wait(timeout=5)
-    time_waited = thread.join(timeout=0.5)  # noqa: F841 — expect still alive
-    assert thread.is_alive(), "differing-backend turn should wait on the lease"
-    cleanup.assert_not_called()
-
-    first.release()
-    thread.join(timeout=10)
-    assert not thread.is_alive()
-    assert result["invalidated"] is True
-    cleanup.assert_called_once_with("default")
-
-
-def test_lease_wait_timeout_skips_invalidation_and_retries_later():
-    cleanup = MagicMock()
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    local = {"TERMINAL_ENV": "local"}
-    first, _ = isolation.acquire_terminal_backend_turn_lease(ssh, cleanup_vm=cleanup)
-    lease, invalidated = isolation.acquire_terminal_backend_turn_lease(
-        local, cleanup_vm=cleanup, wait_seconds=0.05
-    )
-    assert invalidated is False
-    cleanup.assert_not_called()
-    lease.release()
-    first.release()
-    # Transition was not committed — a later unobstructed turn retries.
-    lease2, invalidated2 = isolation.acquire_terminal_backend_turn_lease(
-        local, cleanup_vm=cleanup
-    )
-    assert invalidated2 is True
-    cleanup.assert_called_once_with("default")
-    lease2.release()
-
-
-def test_concurrent_same_identity_turns_share_one_invalidation():
-    cleanup = MagicMock()
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    local = {"TERMINAL_ENV": "local"}
-    seed, _ = isolation.acquire_terminal_backend_turn_lease(ssh, cleanup_vm=cleanup)
-    seed.release()
-    first, did_first = isolation.acquire_terminal_backend_turn_lease(
-        local, cleanup_vm=cleanup
-    )
-    # Second same-identity turn while the first is still running: piggybacks.
-    second, did_second = isolation.acquire_terminal_backend_turn_lease(
-        local, cleanup_vm=cleanup
-    )
-    assert did_first is True
-    assert did_second is False
-    cleanup.assert_called_once_with("default")
-    second.release()
-    first.release()
-
-
-def test_piggyback_during_failing_leader_cleanup_stays_uncommitted():
-    """Gate residual: the genuine >1 piggyback window — a second same-new-identity
-    turn acquiring while the leader is still inside cleanup_vm. The piggybacker
-    proceeds without invalidating (never evicts what the leader may have built);
-    when the leader's cleanup then FAILS, the transition stays uncommitted and
-    the next unobstructed turn retries. Documents the intended self-healing
-    semantics of that window."""
-    import threading as _threading
-
-    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
-    local = {"TERMINAL_ENV": "local"}
-
-    def _acquire_once(env, cleanup):
-        return isolation.acquire_terminal_backend_turn_lease(env, cleanup_vm=cleanup)
-
-    seed, _ = _acquire_once(ssh, MagicMock())
-    seed.release()
-
-    in_cleanup = _threading.Event()
-    release_cleanup = _threading.Event()
-    cleanup_calls = []
-
-    def _failing_held_cleanup(*args, **kwargs):
-        cleanup_calls.append((args, kwargs))
-        in_cleanup.set()
-        release_cleanup.wait(timeout=10)
-        raise RuntimeError("cleanup blew up mid-transition")
-
-    leader_result = {}
-
-    def _leader_thread():
-        lease, did = _acquire_once(local, _failing_held_cleanup)
-        lease.release()
-        leader_result["invalidated"] = did
-
-    leader = _threading.Thread(target=_leader_thread, daemon=True)
-    leader.start()
-    assert in_cleanup.wait(timeout=5), "leader never reached cleanup_vm"
-
-    # Leader is mid-cleanup (identity registered, transition NOT yet committed).
-    # A same-new-identity turn acquiring NOW hits the genuine >1 piggyback path.
-    piggy, piggy_invalidated = _acquire_once(local, MagicMock())
-    assert piggy_invalidated is False
-    assert len(cleanup_calls) == 1  # piggybacker did not double-invalidate
-    piggy.release()
-
-    release_cleanup.set()
-    leader.join(timeout=10)
-    assert not leader.is_alive()
-    assert leader_result["invalidated"] is False  # cleanup failed -> not invalidated
-
-    # Failure left the transition uncommitted: the next unobstructed turn retries.
-    ok = MagicMock()
-    retry, retry_invalidated = _acquire_once(local, ok)
-    assert retry_invalidated is True
-    ok.assert_called_once_with("default")
-    retry.release()

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -1167,3 +1167,146 @@ def test_api_chat_sync_handler_is_under_the_same_lease():
     restore_idx = handler_src.find('os.environ["HERMES_SESSION_KEY"] = old_session_key')
     release_idx = handler_src.find("_terminal_backend_lease.release()")
     assert 0 < restore_idx < release_idx
+
+
+# ── Round 5: profile-complete, profile-safe identity ─────────────────────────
+#
+# Gate #5988 round 5 [CORE]: the identity that gates backend reuse omitted the
+# profile (HERMES_HOME) and the forwarded-secret VALUES, so two profiles with
+# identical backend config produced byte-identical identities and one could
+# reuse the other's cached container carrying the other profile's secret.
+
+ALPHA = {
+    **DOCKER_A,
+    "HERMES_HOME": "/profiles/alpha",
+    "TERMINAL_DOCKER_FORWARD_ENV": '["TENOR_API_KEY"]',
+    "TENOR_API_KEY": "alpha-secret",
+}
+BETA = {
+    **DOCKER_A,
+    "HERMES_HOME": "/profiles/beta",
+    "TERMINAL_DOCKER_FORWARD_ENV": '["TENOR_API_KEY"]',
+    "TENOR_API_KEY": "beta-secret",
+}
+
+
+def test_backend_type_still_readable_at_index_0():
+    """The profile components are APPENDED, so callers that read identity[0]
+    for the backend type (e.g. the _FORCE_REMOVE_ENV_TYPES check) keep working."""
+    assert isolation.terminal_backend_identity({})[0] == "local"
+    assert isolation.terminal_backend_identity(SSH)[0] == "ssh"
+    assert isolation.terminal_backend_identity(DOCKER_A)[0] == "docker"
+
+
+def test_identity_carries_profile_suffix():
+    ident = isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "local", "HERMES_HOME": "/h"}
+    )
+    assert "home" in ident and "/h" in ident and "fwd" in ident
+
+
+def test_distinct_profile_homes_split_identity_even_with_identical_backend():
+    """The reproduced cross-profile leak: identical backend config, different
+    profile — identities MUST differ so no reuse is possible."""
+    assert isolation.terminal_backend_identity(ALPHA) != isolation.terminal_backend_identity(BETA)
+
+
+def test_hermes_home_splits_even_a_local_backend():
+    """Profile boundary is universal — a persistent LOCAL shell inherits the
+    host env, so two profiles must not share one local slot either."""
+    a = isolation.terminal_backend_identity({"TERMINAL_ENV": "local", "HERMES_HOME": "/a"})
+    b = isolation.terminal_backend_identity({"TERMINAL_ENV": "local", "HERMES_HOME": "/b"})
+    assert a != b
+    assert a[0] == "local"
+
+
+def test_same_home_different_forwarded_secret_value_splits_identity():
+    base = {**DOCKER_A, "HERMES_HOME": "/p/x", "TERMINAL_DOCKER_FORWARD_ENV": '["TENOR_API_KEY"]'}
+    a = isolation.terminal_backend_identity({**base, "TENOR_API_KEY": "aaa"})
+    b = isolation.terminal_backend_identity({**base, "TENOR_API_KEY": "bbb"})
+    assert a != b
+
+
+def test_forwarded_secret_value_never_appears_in_identity_tuple():
+    """The fingerprint is a hash — the raw secret must not leak into the
+    identity tuple (which gets logged)."""
+    ident = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_FORWARD_ENV": '["TENOR_API_KEY"]', "TENOR_API_KEY": "top-secret-value"}
+    )
+    assert "top-secret-value" not in "\x1e".join(map(str, ident))
+
+
+def test_forwarded_env_unset_vs_empty_value_differ():
+    fwd = '["K"]'
+    unset = isolation.terminal_backend_identity({**DOCKER_A, "TERMINAL_DOCKER_FORWARD_ENV": fwd})
+    empty = isolation.terminal_backend_identity({**DOCKER_A, "TERMINAL_DOCKER_FORWARD_ENV": fwd, "K": ""})
+    assert unset != empty
+
+
+def test_forwarded_fingerprint_is_forward_list_order_stable():
+    a = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_FORWARD_ENV": '["A","B"]', "A": "1", "B": "2"}
+    )
+    b = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_FORWARD_ENV": '["B","A"]', "A": "1", "B": "2"}
+    )
+    assert a == b
+
+
+def test_no_forwarded_env_yields_empty_fingerprint():
+    assert isolation._forwarded_secret_fingerprint({}) == ""
+    assert isolation._forwarded_secret_fingerprint({"TERMINAL_DOCKER_FORWARD_ENV": "[]"}) == ""
+
+
+def test_distinct_profiles_do_not_reuse_a_cached_backend(monkeypatch):
+    """End-to-end: alpha commits a docker identity and seeds its container;
+    a beta turn (different home + secret) must NOT reuse it — it triggers a
+    verified transition (force-remove alpha's container), not a silent share."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    # alpha first use: slot observed absent, commits, no cleanup
+    assert one_shot(agent, ALPHA) is False
+    cid = agent.seed_docker()  # alpha's container now cached under "default"
+    # beta arrives: different identity → transition, force-remove alpha's cid
+    assert one_shot(agent, BETA) is True
+    assert agent.cleanup_calls == [("default", True)]
+    assert cid not in agent.containers
+    with isolation._COND:
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(BETA)
+
+
+# ── Round 5: lease-leak on synchronous setup / restore failure ───────────────
+
+
+def test_streaming_stamps_profile_home_and_nests_the_release():
+    """Source guard: the streaming identity snapshot stamps the RESOLVED
+    profile home (not stale os.environ), and the primary release is nested in
+    a finally so a restore failure can't skip it."""
+    assert "_effective_turn_env['HERMES_HOME'] = _profile_home" in STREAMING_PY
+    restore = STREAMING_PY.find("for _key, _old_value in old_profile_env.items()")
+    assert restore > 0
+    release = STREAMING_PY.find("_terminal_backend_lease.release()", restore)
+    # a `finally:` sits between the restore loop and the primary release
+    nested_finally = STREAMING_PY.rfind("finally:", restore, release)
+    assert 0 < restore < nested_finally < release
+
+
+def test_api_chat_sync_lease_survives_setup_and_restore_failure():
+    """Source guard (#5988 round 5 lease-leak): in _handle_chat_sync the env
+    MUTATION is inside the guarded try (round-4 left it between the acquire and
+    the try → a throw leaked the lease with no backstop), and the release is
+    NESTED in a finally so a restore failure can't skip it."""
+    start = ROUTES_PY.find("def _handle_chat_sync(")
+    end = ROUTES_PY.find("\ndef ", start + 1)
+    src = ROUTES_PY[start:end]
+    acquire = src.find("acquire_turn_lease_failclosed(")
+    assert acquire > 0
+    guarded_try = src.find("\n    try:", acquire)
+    mutation = src.find('os.environ["TERMINAL_CWD"] = str(workspace)', acquire)
+    # mutation is AFTER the guarding try opens (i.e. inside it), not before it
+    assert 0 < acquire < guarded_try < mutation
+    # release is nested under a finally that follows the restore
+    restore = src.find('os.environ.pop("TERMINAL_CWD", None)', mutation)
+    release = src.find("_terminal_backend_lease.release()", restore)
+    nested_finally = src.rfind("finally:", restore, release)
+    assert 0 < restore < nested_finally < release

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -1,0 +1,149 @@
+"""Regression tests for #5937 multi-profile terminal backend isolation.
+
+WebUI must invalidate the agent process-global "default" terminal env when the
+selected profile's backend identity changes (e.g. SSH → local), without
+evicting on same-backend consecutive turns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import api.terminal_backend_isolation as isolation
+
+
+REPO_ROOT = Path(__file__).parent.parent
+STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+
+
+def setup_function(_fn=None):
+    isolation.reset_terminal_backend_identity_for_tests()
+
+
+def test_identity_defaults_missing_backend_to_local():
+    assert isolation.terminal_backend_identity({})[0] == "local"
+    assert isolation.terminal_backend_identity({"TERMINAL_ENV": "  SSH "})[0] == "ssh"
+
+
+def test_identity_includes_ssh_target_not_cwd():
+    a = isolation.terminal_backend_identity(
+        {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_SSH_HOST": "box.example",
+            "TERMINAL_SSH_USER": "deploy",
+            "TERMINAL_SSH_PORT": "22",
+            "TERMINAL_CWD": "/a",
+        }
+    )
+    b = isolation.terminal_backend_identity(
+        {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_SSH_HOST": "box.example",
+            "TERMINAL_SSH_USER": "deploy",
+            "TERMINAL_SSH_PORT": "22",
+            "TERMINAL_CWD": "/b",
+        }
+    )
+    assert a == b
+    different_host = isolation.terminal_backend_identity(
+        {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_SSH_HOST": "other.example",
+            "TERMINAL_SSH_USER": "deploy",
+            "TERMINAL_SSH_PORT": "22",
+        }
+    )
+    assert a != different_host
+
+
+def test_first_turn_records_identity_without_cleanup():
+    cleanup = MagicMock()
+    assert isolation.maybe_invalidate_default_terminal_env(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"},
+        cleanup_vm=cleanup,
+    ) is False
+    cleanup.assert_not_called()
+
+
+def test_same_backend_consecutive_turns_do_not_cleanup():
+    cleanup = MagicMock()
+    env = {
+        "TERMINAL_ENV": "local",
+    }
+    assert isolation.maybe_invalidate_default_terminal_env(env, cleanup_vm=cleanup) is False
+    assert isolation.maybe_invalidate_default_terminal_env(env, cleanup_vm=cleanup) is False
+    cleanup.assert_not_called()
+
+
+def test_ssh_then_local_invalidates_default_slot():
+    cleanup = MagicMock()
+    ssh = {
+        "TERMINAL_ENV": "ssh",
+        "TERMINAL_SSH_HOST": "box.example",
+        "TERMINAL_SSH_USER": "deploy",
+        "TERMINAL_SSH_PORT": "22",
+    }
+    local = {"TERMINAL_ENV": "local"}
+    assert isolation.maybe_invalidate_default_terminal_env(ssh, cleanup_vm=cleanup) is False
+    assert isolation.maybe_invalidate_default_terminal_env(local, cleanup_vm=cleanup) is True
+    cleanup.assert_called_once_with("default")
+
+
+def test_local_then_ssh_invalidates_default_slot():
+    cleanup = MagicMock()
+    assert isolation.maybe_invalidate_default_terminal_env(
+        {"TERMINAL_ENV": "local"}, cleanup_vm=cleanup
+    ) is False
+    assert isolation.maybe_invalidate_default_terminal_env(
+        {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_SSH_HOST": "box.example",
+            "TERMINAL_SSH_USER": "deploy",
+        },
+        cleanup_vm=cleanup,
+    ) is True
+    cleanup.assert_called_once_with("default")
+
+
+def test_ssh_host_change_invalidates():
+    cleanup = MagicMock()
+    a = {
+        "TERMINAL_ENV": "ssh",
+        "TERMINAL_SSH_HOST": "a.example",
+        "TERMINAL_SSH_USER": "u",
+    }
+    b = {
+        "TERMINAL_ENV": "ssh",
+        "TERMINAL_SSH_HOST": "b.example",
+        "TERMINAL_SSH_USER": "u",
+    }
+    isolation.maybe_invalidate_default_terminal_env(a, cleanup_vm=cleanup)
+    assert isolation.maybe_invalidate_default_terminal_env(b, cleanup_vm=cleanup) is True
+    cleanup.assert_called_once_with("default")
+
+
+def test_cleanup_exception_is_swallowed_and_returns_false():
+    cleanup = MagicMock(side_effect=RuntimeError("boom"))
+    isolation.maybe_invalidate_default_terminal_env(
+        {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "a"},
+        cleanup_vm=cleanup,
+    )
+    assert (
+        isolation.maybe_invalidate_default_terminal_env(
+            {"TERMINAL_ENV": "local"},
+            cleanup_vm=cleanup,
+        )
+        is False
+    )
+
+
+def test_streaming_applies_isolation_after_profile_runtime_env_update():
+    """Source guard: the turn path must call isolation after os.environ.update."""
+    assert "maybe_invalidate_default_terminal_env" in STREAMING_PY
+    assert "terminal_backend_isolation" in STREAMING_PY
+    # Ordering: update profile runtime env, then isolation check.
+    update_idx = STREAMING_PY.find("os.environ.update(_safe_profile_runtime_env)")
+    isolate_idx = STREAMING_PY.find("maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)")
+    assert update_idx >= 0
+    assert isolate_idx > update_idx

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -358,3 +358,62 @@ def test_concurrent_same_identity_turns_share_one_invalidation():
     cleanup.assert_called_once_with("default")
     second.release()
     first.release()
+
+
+def test_piggyback_during_failing_leader_cleanup_stays_uncommitted():
+    """Gate residual: the genuine >1 piggyback window — a second same-new-identity
+    turn acquiring while the leader is still inside cleanup_vm. The piggybacker
+    proceeds without invalidating (never evicts what the leader may have built);
+    when the leader's cleanup then FAILS, the transition stays uncommitted and
+    the next unobstructed turn retries. Documents the intended self-healing
+    semantics of that window."""
+    import threading as _threading
+
+    ssh = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box"}
+    local = {"TERMINAL_ENV": "local"}
+
+    def _acquire_once(env, cleanup):
+        return isolation.acquire_terminal_backend_turn_lease(env, cleanup_vm=cleanup)
+
+    seed, _ = _acquire_once(ssh, MagicMock())
+    seed.release()
+
+    in_cleanup = _threading.Event()
+    release_cleanup = _threading.Event()
+    cleanup_calls = []
+
+    def _failing_held_cleanup(*args, **kwargs):
+        cleanup_calls.append((args, kwargs))
+        in_cleanup.set()
+        release_cleanup.wait(timeout=10)
+        raise RuntimeError("cleanup blew up mid-transition")
+
+    leader_result = {}
+
+    def _leader_thread():
+        lease, did = _acquire_once(local, _failing_held_cleanup)
+        lease.release()
+        leader_result["invalidated"] = did
+
+    leader = _threading.Thread(target=_leader_thread, daemon=True)
+    leader.start()
+    assert in_cleanup.wait(timeout=5), "leader never reached cleanup_vm"
+
+    # Leader is mid-cleanup (identity registered, transition NOT yet committed).
+    # A same-new-identity turn acquiring NOW hits the genuine >1 piggyback path.
+    piggy, piggy_invalidated = _acquire_once(local, MagicMock())
+    assert piggy_invalidated is False
+    assert len(cleanup_calls) == 1  # piggybacker did not double-invalidate
+    piggy.release()
+
+    release_cleanup.set()
+    leader.join(timeout=10)
+    assert not leader.is_alive()
+    assert leader_result["invalidated"] is False  # cleanup failed -> not invalidated
+
+    # Failure left the transition uncommitted: the next unobstructed turn retries.
+    ok = MagicMock()
+    retry, retry_invalidated = _acquire_once(local, ok)
+    assert retry_invalidated is True
+    ok.assert_called_once_with("default")
+    retry.release()

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -1310,3 +1310,28 @@ def test_api_chat_sync_lease_survives_setup_and_restore_failure():
     release = src.find("_terminal_backend_lease.release()", restore)
     nested_finally = src.rfind("finally:", restore, release)
     assert 0 < restore < nested_finally < release
+
+
+def test_api_chat_sync_identity_comes_from_resolved_profile_not_raw_environ():
+    """Source guard (#5988 P1 / greptile): /api/chat must build the lease
+    identity from THIS request's RESOLVED profile overlay + stamped
+    HERMES_HOME, not raw process-global os.environ (which a concurrent
+    streaming turn owns for its whole run). Building it from live os.environ
+    would let a sync turn reuse the streaming profile's cached backend."""
+    start = ROUTES_PY.find("def _handle_chat_sync(")
+    end = ROUTES_PY.find("\ndef ", start + 1)
+    src = ROUTES_PY[start:end]
+    # The raw-os.environ acquire is gone.
+    assert "acquire_turn_lease_failclosed(dict(os.environ))" not in src
+    # The profile is resolved and overlaid, HERMES_HOME stamped, and THAT
+    # snapshot is what the lease is acquired from.
+    resolve = src.find("get_hermes_home_for_profile(")
+    overlay = src.find("_effective_turn_env.update(_chat_safe_profile_env)")
+    stamp = src.find('_effective_turn_env["HERMES_HOME"] = _chat_profile_home')
+    acquire = src.find("acquire_turn_lease_failclosed(_effective_turn_env)")
+    assert 0 < resolve < overlay < acquire
+    assert 0 < stamp < acquire
+    # And the resolved profile env is actually APPLIED for the turn (so the
+    # agent creates the backend the identity names), then restored.
+    assert "os.environ.update(_chat_safe_profile_env)" in src
+    assert "for _pk, _pv in _old_profile_env.items():" in src

--- a/tests/test_issue5937_terminal_backend_isolation.py
+++ b/tests/test_issue5937_terminal_backend_isolation.py
@@ -5,24 +5,37 @@ selected profile's backend identity changes (e.g. SSH → local), without
 evicting on same-backend consecutive turns — and must FAIL CLOSED: no turn is
 ever admitted against a slot that may belong to a different backend.
 
-The fakes here mirror the REAL hermes-agent cleanup contract
-(tools/terminal_tool.cleanup_vm), which the #5988 round-2 gate found the
-previous mocks were hiding:
+Two layers of coverage:
 
-* ``cleanup_vm`` pops the cache slot FIRST, then swallows backend-teardown
-  exceptions and returns ``None`` either way — it NEVER signals failure.
-* ``DockerEnvironment.cleanup(force_remove=True)`` performs ``docker stop`` /
-  ``docker rm -f`` asynchronously; returning proves nothing about the
-  container actually being removed.
+* Fakes faithful to the REAL hermes-agent cleanup contract
+  (tools/terminal_tool.cleanup_vm), which the #5988 round-2 gate found the
+  previous mocks were hiding:
 
-Success must therefore be established by observed postconditions (slot gone,
-container gone), and these tests assert that an incompatible turn is NEVER
-admitted on timeout or on unverified cleanup.
+  - ``cleanup_vm`` pops the cache slot FIRST, then swallows backend-teardown
+    exceptions and returns ``None`` either way — it NEVER signals failure.
+  - ``DockerEnvironment.cleanup(force_remove=True)`` performs ``docker stop``
+    / ``docker rm -f`` asynchronously; returning proves nothing about the
+    container actually being removed.
+
+* The INSTALLED ``tools.terminal_tool`` module itself (#5988 round 4): the
+  real ``cleanup_vm`` seeded through the real module cache, with the module's
+  own helper resolution, driven against scripted ``docker`` executables so
+  the actual subprocess probe path is exercised — including the reproduced
+  false-commit where a Docker daemon failure used to read as "container
+  removed". These tests skip when hermes-agent is not installed (upstream
+  webui CI); the fake-based suite keeps the logic covered there, and the
+  agent-installed lane (run before every push) exercises the real contract.
+
+Success must be established by observed postconditions (slot gone, container
+gone), "cannot verify" must never count as "verified", and these tests assert
+that an incompatible turn is NEVER admitted on timeout, on unverified
+cleanup, on daemon-failure probes, or on unexpected isolation-module errors.
 """
 
 from __future__ import annotations
 
 import inspect
+import sys
 import threading
 import time
 from pathlib import Path
@@ -34,6 +47,7 @@ import api.terminal_backend_isolation as isolation
 
 REPO_ROOT = Path(__file__).parent.parent
 STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 
 SSH = {"TERMINAL_ENV": "ssh", "TERMINAL_SSH_HOST": "box.example", "TERMINAL_SSH_USER": "deploy"}
 LOCAL = {"TERMINAL_ENV": "local"}
@@ -212,10 +226,75 @@ def test_identity_excludes_inactive_backend_settings():
     ) == isolation.terminal_backend_identity(SSH)
 
 
+def test_identity_fingerprints_all_docker_creation_inputs():
+    """Gate #5988 round 4: every setting the agent's get_config() feeds into
+    Docker environment creation must split the identity — volumes, env maps,
+    network, extra args, resources, user mode, forwarded env, persistence."""
+    base = isolation.terminal_backend_identity(DOCKER_A)
+    for key, val in [
+        ("TERMINAL_DOCKER_VOLUMES", '["/data:/data"]'),
+        ("TERMINAL_DOCKER_ENV", '{"X": "1"}'),
+        ("TERMINAL_DOCKER_EXTRA_ARGS", '["--privileged"]'),
+        ("TERMINAL_DOCKER_FORWARD_ENV", '["PATH"]'),
+        ("TERMINAL_DOCKER_NETWORK", "false"),
+        ("TERMINAL_DOCKER_RUN_AS_HOST_USER", "true"),
+        ("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true"),
+        ("TERMINAL_CONTAINER_CPU", "4"),
+        ("TERMINAL_CONTAINER_MEMORY", "8192"),
+        ("TERMINAL_CONTAINER_DISK", "10240"),
+        ("TERMINAL_CONTAINER_PERSISTENT", "false"),
+        ("TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "false"),
+    ]:
+        changed = isolation.terminal_backend_identity({**DOCKER_A, key: val})
+        assert changed != base, f"{key} must participate in the docker identity"
+
+
+def test_identity_fingerprints_ssh_local_and_modal_creation_inputs():
+    assert isolation.terminal_backend_identity(
+        {**SSH, "TERMINAL_SSH_PERSISTENT": "false"}
+    ) != isolation.terminal_backend_identity(SSH)
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "local", "TERMINAL_LOCAL_PERSISTENT": "true"}
+    ) != isolation.terminal_backend_identity(LOCAL)
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "modal", "TERMINAL_CONTAINER_MEMORY": "8192"}
+    ) != isolation.terminal_backend_identity({"TERMINAL_ENV": "modal"})
+
+
+def test_identity_normalizes_json_and_flag_formatting():
+    """Formatting-only differences in JSON/boolean settings must not split
+    identities (and thereby force spurious verified transitions)."""
+    a = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_ENV": '{"A": "1", "B": "2"}'}
+    )
+    b = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_ENV": '{"B":"2","A":"1"}'}
+    )
+    assert a == b
+    assert isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_NETWORK": "yes"}
+    ) == isolation.terminal_backend_identity(DOCKER_A)  # default is true
+    assert isolation.terminal_backend_identity(
+        {**SSH, "TERMINAL_SSH_PERSISTENT": "1"}
+    ) == isolation.terminal_backend_identity(SSH)  # default is true
+    assert isolation.terminal_backend_identity(
+        {"TERMINAL_ENV": "local", "TERMINAL_LOCAL_PERSISTENT": "false"}
+    ) == isolation.terminal_backend_identity(LOCAL)
+    # Unparseable JSON stays raw: two different broken values differ.
+    broken_a = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_VOLUMES": "[not json"}
+    )
+    broken_b = isolation.terminal_backend_identity(
+        {**DOCKER_A, "TERMINAL_DOCKER_VOLUMES": "[also not json"}
+    )
+    assert broken_a != broken_b
+
+
 # ── Nominal admission / invalidation ─────────────────────────────────────────
 
 
 def test_first_turn_records_identity_without_cleanup():
+    """First use with the slot OBSERVED absent: commit, nothing to clean."""
     agent = FakeAgent()
     assert one_shot(agent, SSH) is False
     assert agent.cleanup_calls == []
@@ -230,8 +309,8 @@ def test_same_backend_consecutive_turns_do_not_cleanup():
 
 def test_ssh_then_local_invalidates_default_slot():
     agent = FakeAgent()
-    agent.seed_generic()
     assert one_shot(agent, SSH) is False
+    agent.seed_generic()  # env created during the SSH era
     assert one_shot(agent, LOCAL) is True
     assert agent.cleanup_calls == [("default", False)]
     assert agent.get_active_env("default") is None
@@ -242,18 +321,117 @@ def test_ssh_then_local_invalidates_default_slot():
 
 def test_local_then_ssh_invalidates_default_slot():
     agent = FakeAgent()
-    agent.seed_generic()
     assert one_shot(agent, LOCAL) is False
+    agent.seed_generic()
     assert one_shot(agent, SSH) is True
     assert agent.cleanup_calls == [("default", False)]
 
 
 def test_ssh_host_change_invalidates():
     agent = FakeAgent()
-    agent.seed_generic()
     one_shot(agent, SSH)
+    agent.seed_generic()
     assert one_shot(agent, {**SSH, "TERMINAL_SSH_HOST": "b.example"}) is True
     assert agent.cleanup_calls == [("default", False)]
+
+
+# ── First-use slot verification (#5988 round 4) ──────────────────────────────
+
+
+def test_first_use_with_populated_slot_performs_verified_cleanup():
+    """The first lease in the process must not blindly record its identity:
+    tool-capable code outside the lease discipline may already have created
+    the "default" env. A populated slot gets the full verified cleanup."""
+    agent = FakeAgent()
+    agent.seed_generic()
+    assert one_shot(agent, SSH) is True  # invalidated, not merely recorded
+    assert agent.cleanup_calls == [("default", False)]
+    assert agent.get_active_env("default") is None
+    with isolation._COND:
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(SSH)
+
+
+def test_first_use_with_populated_container_slot_fails_closed(monkeypatch):
+    """First use finding a container-backed env whose removal cannot be
+    verified must REJECT the turn — committing would let the very first turn
+    run against a container nobody proved gone."""
+    agent = FakeAgent()
+    patch_probes(monkeypatch, agent)
+    cid = agent.seed_docker()
+    agent.rm_silently_fails = True
+    agent.direct_rm_results = [False]
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        one_shot(agent, DOCKER_A)
+    # Force-removal was requested off the env object's own evidence, even
+    # though there is no previous identity to consult.
+    assert agent.cleanup_calls == [("default", True)]
+    with isolation._COND:
+        assert isolation._last_backend_identity is None  # never committed
+        assert isolation._pending_container_removals == {cid: "docker"}
+    assert active_turn_count() == 0
+
+    # The slot was already popped by the failed attempt (real pop-first
+    # contract) — the retry goes through the observed-absent path and must
+    # STILL refuse to commit while the container stays ledgered.
+    assert agent.get_active_env("default") is None
+    agent.direct_rm_results = [False]
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        one_shot(agent, DOCKER_A)
+    with isolation._COND:
+        assert isolation._last_backend_identity is None
+
+    # Removal finally verifies: first use commits.
+    agent.direct_rm_results = None
+    assert one_shot(agent, DOCKER_A) is False  # nothing left to clean
+    assert cid not in agent.containers
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(DOCKER_A)
+
+
+def test_concurrent_first_use_arrivals_serialize_through_the_transition():
+    """Two racing first arrivals: one verifies, the other waits and is then
+    admitted on the committed identity — never both probing concurrently."""
+    agent = FakeAgent()
+    in_probe = threading.Event()
+    release_probe = threading.Event()
+
+    def held_get_active_env(task_id):
+        in_probe.set()
+        release_probe.wait(timeout=10)
+        return agent.get_active_env(task_id)
+
+    leader_result = {}
+
+    def _leader():
+        lease, did = isolation.acquire_terminal_backend_turn_lease(
+            SSH, cleanup_vm=agent.cleanup_vm, get_active_env=held_get_active_env
+        )
+        leader_result["invalidated"] = did
+        lease.release()
+
+    leader = threading.Thread(target=_leader, daemon=True)
+    leader.start()
+    assert in_probe.wait(timeout=5)
+
+    follower_result = {}
+
+    def _follower():
+        lease, did = turn(agent, SSH, wait_seconds=10)
+        follower_result["invalidated"] = did
+        lease.release()
+
+    follower = threading.Thread(target=_follower, daemon=True)
+    follower.start()
+    follower.join(timeout=0.3)
+    assert follower.is_alive(), "second first-use arrival must wait for the leader"
+
+    release_probe.set()
+    leader.join(timeout=10)
+    follower.join(timeout=10)
+    assert leader_result["invalidated"] is False
+    assert follower_result["invalidated"] is False
+    assert agent.cleanup_calls == []
 
 
 # ── Docker force-remove + verified removal ───────────────────────────────────
@@ -265,8 +443,8 @@ def test_docker_transition_force_removes_and_verifies_container(monkeypatch):
     cleanup_vm returning."""
     agent = FakeAgent()
     patch_probes(monkeypatch, agent)
-    cid = agent.seed_docker()
     assert one_shot(agent, DOCKER_A) is False
+    cid = agent.seed_docker()
     assert one_shot(agent, LOCAL) is True
     assert agent.cleanup_calls == [("default", True)]
     assert cid not in agent.containers
@@ -277,16 +455,16 @@ def test_docker_transition_force_removes_and_verifies_container(monkeypatch):
 def test_docker_image_change_invalidates_with_force_remove(monkeypatch):
     agent = FakeAgent()
     patch_probes(monkeypatch, agent)
-    agent.seed_docker()
     one_shot(agent, DOCKER_A)
+    agent.seed_docker()
     assert one_shot(agent, DOCKER_B) is True
     assert agent.cleanup_calls == [("default", True)]
 
 
 def test_non_docker_transition_does_not_force_remove():
     agent = FakeAgent()
-    agent.seed_generic()
     one_shot(agent, SSH)
+    agent.seed_generic()
     assert one_shot(agent, {"TERMINAL_ENV": "docker"}) is True
     assert agent.cleanup_calls == [("default", False)]
 
@@ -300,12 +478,12 @@ def test_silent_docker_rm_failure_is_caught_and_turn_rejected(monkeypatch):
     uncommitted, turn NOT admitted, container ledgered for retry."""
     agent = FakeAgent()
     patch_probes(monkeypatch, agent)
-    cid = agent.seed_docker()
-    agent.rm_silently_fails = True
-    agent.direct_rm_results = [False]  # direct fallback also fails this round
     docker_identity = isolation.terminal_backend_identity(DOCKER_A)
 
     assert one_shot(agent, DOCKER_A) is False
+    cid = agent.seed_docker()
+    agent.rm_silently_fails = True
+    agent.direct_rm_results = [False]  # direct fallback also fails this round
     with pytest.raises(isolation.TerminalBackendInvalidationFailed):
         one_shot(agent, LOCAL)
 
@@ -332,9 +510,9 @@ def test_backend_cleanup_exception_swallowed_by_agent_is_still_a_failure(monkeyp
     the container survives and the transition must not commit."""
     agent = FakeAgent()
     patch_probes(monkeypatch, agent)
+    one_shot(agent, DOCKER_A)
     cid = agent.seed_docker()
     agent.backend_cleanup_error = RuntimeError("docker daemon unreachable")
-    one_shot(agent, DOCKER_A)
     agent.direct_rm_results = [False]
     with pytest.raises(isolation.TerminalBackendInvalidationFailed):
         one_shot(agent, LOCAL)
@@ -352,6 +530,7 @@ def test_async_docker_removal_is_awaited_not_assumed(monkeypatch):
     agent = FakeAgent()
     patch_probes(monkeypatch, agent)
     monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 5.0)
+    one_shot(agent, DOCKER_A)
     cid = agent.seed_docker()
     env = agent.active["default"]
 
@@ -364,7 +543,6 @@ def test_async_docker_removal_is_awaited_not_assumed(monkeypatch):
         env._cleanup_thread = t
 
     env.cleanup = _async_cleanup
-    one_shot(agent, DOCKER_A)
     assert one_shot(agent, LOCAL) is True
     assert cid not in agent.containers
 
@@ -373,9 +551,9 @@ def test_unremoved_default_slot_fails_the_transition():
     """Contract-drift guard: if cleanup_vm stops popping the slot, committing
     would hand the new identity a live stale env — must fail closed."""
     agent = FakeAgent()
+    one_shot(agent, SSH)
     agent.seed_generic()
     agent.pop_slot = False
-    one_shot(agent, SSH)
     with pytest.raises(isolation.TerminalBackendInvalidationFailed):
         one_shot(agent, LOCAL)
     assert active_turn_count() == 0
@@ -399,8 +577,8 @@ def test_present_runtime_with_unresolvable_helpers_fails_closed(monkeypatch):
     """A present-but-broken runtime is NOT the vacuous case: the cache may
     exist and we cannot verify it — reject the turn."""
     agent = FakeAgent()
-    agent.seed_generic()
     assert one_shot(agent, SSH) is False
+    agent.seed_generic()
 
     class _BrokenModule:
         pass
@@ -415,15 +593,247 @@ def test_present_runtime_with_unresolvable_helpers_fails_closed(monkeypatch):
     assert agent.cleanup_calls == [("default", False)]
 
 
+# ── Honest Docker probe (#5988 round 4: daemon failure ≠ removed) ────────────
+
+
+def _write_fake_docker(tmp_path, name, stderr_text, exit_code, stdout_text=""):
+    script = tmp_path / name
+    script.write_text(
+        "#!/bin/sh\n"
+        + (f"printf '%s\\n' \"{stdout_text}\"\n" if stdout_text else "")
+        + (f"printf '%s\\n' \"{stderr_text}\" >&2\n" if stderr_text else "")
+        + f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return str(script)
+
+
+needs_sh = pytest.mark.skipif(
+    sys.platform == "win32", reason="scripted docker executables need a POSIX sh"
+)
+
+
+@needs_sh
+def test_probe_exit_zero_means_container_exists(tmp_path):
+    exe = _write_fake_docker(tmp_path, "docker-up", "", 0, stdout_text="sha256:abc")
+    assert isolation._container_exists("cid-1234", exe) is True
+
+
+@needs_sh
+def test_probe_no_such_object_means_container_gone(tmp_path):
+    exe = _write_fake_docker(
+        tmp_path, "docker-gone", "Error: No such object: cid-1234", 1
+    )
+    assert isolation._container_exists("cid-1234", exe) is False
+
+
+@needs_sh
+def test_probe_daemon_failure_raises_instead_of_reporting_gone(tmp_path):
+    """The reproduced round-4 false-commit: a dead daemon exits nonzero, which
+    the old probe read as "container removed". It must raise (unverifiable)."""
+    exe = _write_fake_docker(
+        tmp_path,
+        "docker-down",
+        "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. "
+        "Is the docker daemon running?",
+        1,
+    )
+    with pytest.raises(RuntimeError):
+        isolation._container_exists("cid-1234", exe)
+
+
+@needs_sh
+def test_daemon_failure_keeps_container_ledgered_and_blocks_commit(tmp_path, monkeypatch):
+    """Through the verification layer (real probe subprocess, no probe mocks):
+    a daemon failure keeps the removal unverified — the entry stays ledgered
+    and the transition that depends on it is rejected."""
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 0.2)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_POLL_SECONDS", 0.05)
+    daemon_down = _write_fake_docker(
+        tmp_path, "docker-down", "Cannot connect to the Docker daemon", 1
+    )
+    with isolation._COND:
+        isolation._pending_container_removals["cid-9999"] = daemon_down
+    assert isolation._verify_pending_container_removals() is False
+    with isolation._COND:
+        assert isolation._pending_container_removals == {"cid-9999": daemon_down}
+
+    # Daemon comes back and reports the object definitively absent: verified.
+    Path(daemon_down).write_text(
+        "#!/bin/sh\nprintf '%s\\n' 'Error: No such object: cid-9999' >&2\nexit 1\n",
+        encoding="utf-8",
+    )
+    assert isolation._verify_pending_container_removals() is True
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+
+
+# ── REAL installed agent contract (#5988 round 4) ────────────────────────────
+#
+# These drive the module's OWN helper resolution against the installed
+# tools.terminal_tool: the real cleanup_vm (pop-first, swallow, return None)
+# seeded through the real module cache, with scripted docker executables so
+# the actual subprocess probe path decides the outcome. Skipped when
+# hermes-agent is not installed (upstream webui CI); run on the
+# agent-installed verification lane.
+
+
+def _real_terminal_tool_or_skip():
+    terminal_tool = pytest.importorskip(
+        "tools.terminal_tool",
+        reason="hermes-agent not installed; real-contract lane runs agent-installed",
+    )
+    if "force_remove" not in inspect.signature(terminal_tool.cleanup_vm).parameters:
+        pytest.skip("installed hermes-agent predates cleanup_vm(force_remove=...)")
+    return terminal_tool
+
+
+class _SeededContainerEnv:
+    """Container-shaped env seeded into the REAL module cache. cleanup()
+    raising mirrors a daemon-unreachable teardown — which the real cleanup_vm
+    swallows."""
+
+    def __init__(self, container_id, docker_exe, cleanup_error=None):
+        self._container_id = container_id
+        self._docker_exe = docker_exe
+        self._cleanup_thread = None
+        self._cleanup_error = cleanup_error
+        self.cleanup_calls = []
+
+    def cleanup(self, force_remove=False):
+        self.cleanup_calls.append(force_remove)
+        if self._cleanup_error is not None:
+            raise self._cleanup_error
+
+
+@needs_sh
+def test_real_cleanup_vm_daemon_failure_is_rejected_not_admitted(tmp_path, monkeypatch):
+    """THE reproduced round-4 scenario, against the real contract end to end:
+    committed local identity, a container-backed env appears in the REAL
+    module cache, an incompatible turn arrives while the Docker daemon is
+    down. The real cleanup_vm pops the slot, swallows the teardown error and
+    returns None; the probe cannot verify removal — the turn must be
+    REJECTED and the identity left uncommitted (it used to be ADMITTED with
+    committed=('local',))."""
+    terminal_tool = _real_terminal_tool_or_skip()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {}, raising=True)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 0.2)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_POLL_SECONDS", 0.05)
+
+    # Commit an initial local identity through the module's own resolution
+    # (empty real cache → observed-absent first use).
+    lease, invalidated = isolation.acquire_terminal_backend_turn_lease(LOCAL)
+    assert invalidated is False
+    lease.release()
+    local_identity = isolation.terminal_backend_identity(LOCAL)
+
+    daemon_down = _write_fake_docker(
+        tmp_path, "docker-down", "Cannot connect to the Docker daemon", 1
+    )
+    env = _SeededContainerEnv(
+        "cid-real-1", daemon_down, cleanup_error=RuntimeError("daemon unreachable")
+    )
+    terminal_tool._active_environments["default"] = env
+
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        isolation.acquire_terminal_backend_turn_lease(DOCKER_A)
+
+    # Real pop-first contract happened...
+    assert env.cleanup_calls == [True]  # force-removal requested
+    assert terminal_tool._active_environments.get("default") is None
+    # ...and none of it was inferred as success.
+    with isolation._COND:
+        assert isolation._last_backend_identity == local_identity  # uncommitted
+        assert isolation._pending_container_removals == {"cid-real-1": daemon_down}
+    assert active_turn_count() == 0
+
+    # Daemon recovers and reports the container definitively gone: the retry
+    # verifies through the ledger and commits.
+    Path(daemon_down).write_text(
+        "#!/bin/sh\nprintf '%s\\n' 'Error: No such object: cid-real-1' >&2\nexit 1\n",
+        encoding="utf-8",
+    )
+    lease, invalidated = isolation.acquire_terminal_backend_turn_lease(DOCKER_A)
+    assert invalidated is True
+    lease.release()
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(DOCKER_A)
+
+
+@needs_sh
+def test_real_cleanup_vm_swallowed_teardown_with_verified_removal_commits(
+    tmp_path, monkeypatch
+):
+    """Counterpart: the real cleanup_vm swallows a teardown error, but the
+    probe POSITIVELY verifies the container absent — the transition commits.
+    Proves the fail-closed layer keys on observed state, not on exceptions."""
+    terminal_tool = _real_terminal_tool_or_skip()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {}, raising=True)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 0.2)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_POLL_SECONDS", 0.05)
+
+    lease, _ = isolation.acquire_terminal_backend_turn_lease(LOCAL)
+    lease.release()
+
+    gone = _write_fake_docker(
+        tmp_path, "docker-gone", "Error: No such object: cid-real-2", 1
+    )
+    env = _SeededContainerEnv(
+        "cid-real-2", gone, cleanup_error=RuntimeError("teardown hiccup")
+    )
+    terminal_tool._active_environments["default"] = env
+
+    lease, invalidated = isolation.acquire_terminal_backend_turn_lease(DOCKER_A)
+    assert invalidated is True
+    lease.release()
+    assert env.cleanup_calls == [True]
+    with isolation._COND:
+        assert isolation._pending_container_removals == {}
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(DOCKER_A)
+
+
+@needs_sh
+def test_real_first_use_with_populated_cache_verifies_before_commit(tmp_path, monkeypatch):
+    """First lease in the process finds a container env already in the REAL
+    cache (created by code outside the lease discipline): it must be
+    verifiably cleaned before ANY identity commits."""
+    terminal_tool = _real_terminal_tool_or_skip()
+    monkeypatch.setattr(terminal_tool, "_active_environments", {}, raising=True)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_WAIT_SECONDS", 0.2)
+    monkeypatch.setattr(isolation, "_CONTAINER_REMOVAL_POLL_SECONDS", 0.05)
+
+    daemon_down = _write_fake_docker(
+        tmp_path, "docker-down", "Cannot connect to the Docker daemon", 1
+    )
+    env = _SeededContainerEnv("cid-real-3", daemon_down)
+    terminal_tool._active_environments["default"] = env
+
+    with pytest.raises(isolation.TerminalBackendInvalidationFailed):
+        isolation.acquire_terminal_backend_turn_lease(LOCAL)
+    with isolation._COND:
+        assert isolation._last_backend_identity is None  # nothing committed
+
+    Path(daemon_down).write_text(
+        "#!/bin/sh\nprintf '%s\\n' 'Error: No such object: cid-real-3' >&2\nexit 1\n",
+        encoding="utf-8",
+    )
+    lease, _ = isolation.acquire_terminal_backend_turn_lease(LOCAL)
+    lease.release()
+    with isolation._COND:
+        assert isolation._last_backend_identity == isolation.terminal_backend_identity(LOCAL)
+
+
 # ── Fail closed: admission control ───────────────────────────────────────────
 
 
 def test_differing_backend_turn_waits_for_active_lease():
     """A differing-backend turn must not evict an in-use env."""
     agent = FakeAgent()
-    agent.seed_generic()
     first, invalidated = turn(agent, SSH)
     assert invalidated is False
+    agent.seed_generic()
 
     entered = threading.Event()
     result = {}
@@ -452,9 +862,9 @@ def test_lease_wait_timeout_rejects_turn_without_admitting_it():
     """Gate #5988 CORE: on timeout the incoming turn must be REJECTED — never
     admitted alongside the still-active previous identity."""
     agent = FakeAgent()
-    agent.seed_generic()
     ssh_identity = isolation.terminal_backend_identity(SSH)
     first, _ = turn(agent, SSH)
+    agent.seed_generic()
     with pytest.raises(isolation.TerminalBackendTransitionTimeout):
         turn(agent, LOCAL, wait_seconds=0.05)
     assert agent.cleanup_calls == []
@@ -473,9 +883,9 @@ def test_no_turn_is_admitted_while_transition_cleanup_is_in_flight():
     """Same-new-identity arrivals must WAIT on the transition — no piggyback
     on an unproven cleanup."""
     agent = FakeAgent()
-    agent.seed_generic()
     seed, _ = turn(agent, SSH)
     seed.release()
+    agent.seed_generic()
 
     in_cleanup = threading.Event()
     release_cleanup = threading.Event()
@@ -527,11 +937,11 @@ def test_waiter_retries_invalidation_itself_when_leader_cleanup_fails(monkeypatc
     verified invalidation instead of running against the stale slot."""
     agent = FakeAgent()
     patch_probes(monkeypatch, agent)
+    seed, _ = turn(agent, DOCKER_A)
+    seed.release()
     cid = agent.seed_docker()
     agent.rm_silently_fails = True
     agent.direct_rm_results = [False, True]  # leader's fallback fails; waiter's works
-    seed, _ = turn(agent, DOCKER_A)
-    seed.release()
 
     in_cleanup = threading.Event()
     release_cleanup = threading.Event()
@@ -586,9 +996,9 @@ def test_previous_identity_arrival_also_waits_during_transition():
     """During a transition even previous-identity turns wait: the slot is
     mid-destruction and admitting them would recreate under a moving target."""
     agent = FakeAgent()
-    agent.seed_generic()
     seed, _ = turn(agent, SSH)
     seed.release()
+    agent.seed_generic()
 
     in_cleanup = threading.Event()
     release_cleanup = threading.Event()
@@ -635,20 +1045,68 @@ def test_lease_release_is_idempotent():
     assert active_turn_count() == 0
 
 
-# ── Streaming integration source guard ───────────────────────────────────────
+# ── Fail closed: unexpected isolation-module errors (#5988 round 4) ──────────
+
+
+def test_failclosed_helper_converts_unexpected_errors_to_typed_rejection(monkeypatch):
+    """Gate #5988 CORE: an UNEXPECTED failure during acquisition must not let
+    the turn proceed without a lease. The turn entry point converts it to the
+    same typed rejection that blocks AIAgent construction + tool execution."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("isolation module bug")
+
+    monkeypatch.setattr(isolation, "acquire_terminal_backend_turn_lease", _boom)
+    with pytest.raises(isolation.TerminalBackendIsolationError) as excinfo:
+        isolation.acquire_turn_lease_failclosed(LOCAL)
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    # No lease was registered for the rejected turn.
+    assert active_turn_count() == 0
+
+
+def test_failclosed_helper_passes_deliberate_rejections_through(monkeypatch):
+    """Typed rejections keep their subtype (callers/tests distinguish timeout
+    from invalidation failure) — the helper only converts UNEXPECTED errors."""
+    agent = FakeAgent()
+    first, _ = isolation.acquire_turn_lease_failclosed(
+        SSH, cleanup_vm=agent.cleanup_vm, get_active_env=agent.get_active_env
+    )
+    with pytest.raises(isolation.TerminalBackendTransitionTimeout):
+        isolation.acquire_turn_lease_failclosed(
+            LOCAL,
+            cleanup_vm=agent.cleanup_vm,
+            get_active_env=agent.get_active_env,
+            wait_seconds=0.05,
+        )
+    first.release()
+
+
+def test_failclosed_helper_returns_lease_on_success():
+    agent = FakeAgent()
+    lease, invalidated = isolation.acquire_turn_lease_failclosed(
+        LOCAL, cleanup_vm=agent.cleanup_vm, get_active_env=agent.get_active_env
+    )
+    assert invalidated is False
+    assert active_turn_count() == 1
+    lease.release()
+    assert active_turn_count() == 0
+
+
+# ── Turn-path integration source guards ──────────────────────────────────────
 
 
 def test_streaming_acquires_full_turn_lease_on_effective_env():
-    """Source guard: the turn path leases the identity for the whole turn.
+    """Source guard: the streaming turn path leases the identity for the whole
+    turn, fail-closed on EVERY acquisition outcome.
 
     Identity must come from the effective post-merge environment (process env
     overlaid with the profile runtime env), the lease must be acquired BEFORE
-    _ENV_LOCK (waiters must not block other turns' env restore), it must be
-    released in the turn's finally after the env restore, and deliberate
-    isolation rejections must ABORT the turn (fail closed) rather than being
-    swallowed.
+    _ENV_LOCK (waiters must not block other turns' env restore) via the
+    fail-closed entry point (#5988 round 4: unexpected acquisition errors must
+    abort the turn, not run it open), and it must be released in the turn's
+    finally after the env restore.
     """
-    assert "acquire_terminal_backend_turn_lease" in STREAMING_PY
+    assert "acquire_turn_lease_failclosed" in STREAMING_PY
     # Effective env = os.environ overlaid with the profile runtime env.
     merged_idx = STREAMING_PY.find("_effective_turn_env = dict(os.environ)")
     assert merged_idx >= 0
@@ -656,22 +1114,17 @@ def test_streaming_acquires_full_turn_lease_on_effective_env():
         "_effective_turn_env.update(_safe_profile_runtime_env)", merged_idx
     )
     assert overlay_idx > merged_idx
-    acquire_idx = STREAMING_PY.find(
-        "acquire_terminal_backend_turn_lease(", overlay_idx
-    )
+    acquire_idx = STREAMING_PY.find("acquire_turn_lease_failclosed(", overlay_idx)
     assert acquire_idx > overlay_idx
     # Lease acquisition happens before the env-mutation critical section.
     update_idx = STREAMING_PY.find("os.environ.update(_safe_profile_runtime_env)")
     assert update_idx >= 0
     assert acquire_idx < update_idx
-    # Deliberate rejections fail closed: the typed error is imported and
-    # re-raised (turn aborts); only unexpected module bugs fall through open.
-    assert "TerminalBackendIsolationError" in STREAMING_PY
-    reject_idx = STREAMING_PY.find("except TerminalBackendIsolationError:")
-    assert reject_idx > 0
-    raise_idx = STREAMING_PY.find("raise", reject_idx)
-    generic_idx = STREAMING_PY.find("except Exception:", reject_idx)
-    assert 0 < raise_idx < generic_idx
+    # No fail-open remnant: the turn path must not swallow acquisition errors
+    # (the pre-round-4 "log loudly and proceed" posture) and must not bypass
+    # the fail-closed wrapper by calling the raw acquisition function.
+    assert "log loudly and proceed" not in STREAMING_PY
+    assert "acquire_terminal_backend_turn_lease(" not in STREAMING_PY
     # Released in the finally, after the profile env restore loop.
     restore_idx = STREAMING_PY.find("for _key, _old_value in old_profile_env.items()")
     release_idx = STREAMING_PY.find("_terminal_backend_lease.release()")
@@ -685,5 +1138,32 @@ def test_streaming_acquires_full_turn_lease_on_effective_env():
     metering_teardown_idx = STREAMING_PY.find("meter().end_session(stream_id, 0)")
     assert metering_teardown_idx > 0
     assert backstop_idx > metering_teardown_idx
-    # Point-in-time invalidation is no longer called from the turn path.
-    assert "maybe_invalidate_default_terminal_env(_safe_profile_runtime_env)" not in STREAMING_PY
+
+
+def test_api_chat_sync_handler_is_under_the_same_lease():
+    """Source guard (#5988 round 4): the fallback POST /api/chat handler
+    constructs a tool-capable AIAgent and must hold the same full-turn
+    backend-identity lease — acquired fail-closed BEFORE its TERMINAL_* env
+    mutation and AIAgent construction, rejected turns surfaced as a
+    retryable error instead of running, and released in its finally after
+    the env restore."""
+    start = ROUTES_PY.find("def _handle_chat_sync(")
+    assert start >= 0
+    end = ROUTES_PY.find("\ndef ", start + 1)
+    handler_src = ROUTES_PY[start:end]
+    acquire_idx = handler_src.find("acquire_turn_lease_failclosed(")
+    assert acquire_idx > 0, "/api/chat must acquire the backend-identity lease"
+    # Fail closed: deliberate rejections return an error response...
+    reject_idx = handler_src.find("except TerminalBackendIsolationError", acquire_idx)
+    assert reject_idx > acquire_idx
+    assert "status=503" in handler_src[reject_idx : reject_idx + 300]
+    # ...and the raw (non-fail-closed) acquisition function is never used.
+    assert "acquire_terminal_backend_turn_lease(" not in handler_src
+    # Ordering: lease before the env mutation, env mutation before the agent.
+    env_mutation_idx = handler_src.find('os.environ["TERMINAL_CWD"]')
+    agent_idx = handler_src.find("AIAgent(")
+    assert 0 < acquire_idx < env_mutation_idx < agent_idx
+    # Released in the finally after the env restore (idempotent release).
+    restore_idx = handler_src.find('os.environ["HERMES_SESSION_KEY"] = old_session_key')
+    release_idx = handler_src.find("_terminal_backend_lease.release()")
+    assert 0 < restore_idx < release_idx


### PR DESCRIPTION
## Summary

Fixes #5937 (WebUI defense-in-depth for multi-profile terminal backend switches).

When Hermes WebUI runs multiple profiles in one process, profile terminal settings are applied via process env each turn, but Hermes Agent collapses ordinary session task IDs to a shared `\"default\"` terminal/file environment cache slot. An earlier SSH/remote turn can therefore leave a remote environment that a later local-backend profile reuses.

This PR implements the maintainer-scoped WebUI-only path:

- Track a process-global **backend identity** (`TERMINAL_ENV` + SSH target + container images; **not** CWD).
- When the identity **changes**, call `cleanup_vm(\"default\")` so the next tool recreates against the correct env.
- Same-backend consecutive turns do **not** invalidate (preserves intentional cross-session local/container sharing).
- First turn in a process only records identity.

Agent-side #62720 remains the primary correctness fix for non-WebUI callers.

## Changes

- New `api/terminal_backend_isolation.py`
- Hook in `api/streaming.py` immediately after `os.environ.update(_safe_profile_runtime_env)`
- Unit tests in `tests/test_issue5937_terminal_backend_isolation.py`

## Test plan

- [x] Unit tests for identity / SSH→local / same-backend no-op / host change / cleanup errors (9 passed; Windows local run used `--noconftest` due to symlink privilege; Linux CI exercises full suite)
- [ ] CI green on this PR
- [ ] Manual (if available): remote-backend profile turn → local-backend profile turn in one process → local execution

## AI usage

Built with Grok 4.5 (Kai).