### PR TITLE
Release exp: gateway terminal errors + cross-session completion routing (#5969, #6002)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,12 +159,17 @@ Per-request environment variables (set by chat handler, restored after):
     HERMES_EXEC_ASK      Set to "1" to enable approval gate for dangerous commands.
     HERMES_SESSION_KEY   Set to session_id. The approval tool keys pending entries
                          by this value, enabling per-session approval state.
+    HERMES_UI_SESSION_ID Bound context-locally to the browser session_id. Detached
+                         process and subagent completions capture it as their exact
+                         return address.
     HERMES_HOME          Set to the active profile's directory before running agent.
                          Saved and restored around each agent run.
 
-WARNING: These env vars are process-global. Two concurrent chat requests will clobber
-each other. This is safe only for single-user, single-concurrent-request use.
-See Architecture Phase B for the fix.
+The process-global environment mirror remains for compatibility with older tool
+consumers, but completion routing identity is bound through Hermes contextvars for
+the full turn. Modern completion events carry ``origin_ui_session_id``; WebUI
+treats that exact owner as authoritative and uses the session-key index only for
+legacy events that do not provide it.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,9 +159,11 @@ Per-request environment variables (set by chat handler, restored after):
     HERMES_EXEC_ASK      Set to "1" to enable approval gate for dangerous commands.
     HERMES_SESSION_KEY   Set to session_id. The approval tool keys pending entries
                          by this value, enabling per-session approval state.
-    HERMES_UI_SESSION_ID Bound context-locally to the browser session_id. Detached
-                         process and subagent completions capture it as their exact
-                         return address.
+    HERMES_UI_SESSION_ID Bound context-locally to the browser session_id. Async-
+                         delegation/subagent completions capture it as their exact
+                         return address. Detached terminal completions currently
+                         fall back to the context-local HERMES_SESSION_KEY until
+                         Hermes Agent stamps this field on process events.
     HERMES_HOME          Set to the active profile's directory before running agent.
                          Saved and restored around each agent run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ### Fixed
 
+- **Gateway provider errors are reported accurately, and your prompt survives a failed turn.** On gateway-backed sessions, a terminal provider error (bad model id, exhausted credentials, etc.) mid-turn is now classified and shown as the real error instead of a generic empty turn, the error card is bound to the correct session, and the in-flight user prompt plus any partial output is persisted so it survives a reload — even when you'd just re-sent an identical prompt (e.g. "continue"). Thanks @rodboev. (#5969, #5940)
+
+- **Background/subagent completions no longer wake up the wrong session.** Detached terminal and subagent completion events now carry their exact origin browser-session id, so a finished background task routes only to the session that started it instead of possibly surfacing in another open session via a stale routing key. Legacy events without an owner id keep their previous same-session delivery and are never broadcast to a wrong session. Thanks @soria-claw. (#6002)
+
 - **"Fork from here" works during an active response.** The fork button was silently dead while the agent was generating — clicking it did nothing. You can now fork from any past (already-committed) message while a response streams; only the currently-streaming message and the just-sent (not-yet-committed) prompt are blocked, with a clear toast. Thanks @kertisalex. (#5994, #5993)
 
 - **No more false "No response from provider" after a completed answer that used tools.** When an assistant turn ended with a real final answer delivered as structured content following tool calls (common with reasoning models and multi-tool turns), the completion detector could miss the final text and render a spurious "No response from provider" card under the finished reply. Final-answer detection now understands structured content parts (text after tool-use boundaries), while genuine empty completions still correctly show the no-response notice, and a real terminal provider error still surfaces as an error (never masked as a final answer). Thanks @jtstothard. (#5990, #5686)

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -872,6 +872,32 @@ def _resolve_wakeup_target(
     return owner
 
 
+def _resolve_completion_target(
+    *,
+    session_key_resolved_sid: str,
+    origin_ui_session_id: str,
+) -> str:
+    """Return the WebUI session that owns a detached completion event.
+
+    Modern Hermes events carry ``origin_ui_session_id`` as an exact, immutable
+    return address captured from the commissioning browser turn. It is
+    authoritative over the mutable/legacy session-key index. Older Agent events
+    omit it and retain the existing session-key fallback for compatibility.
+    """
+    resolved = str(session_key_resolved_sid or "")
+    owner = str(origin_ui_session_id or "")
+    if not owner:
+        return resolved
+    if resolved and resolved != owner:
+        logger.error(
+            "cross-session completion route BLOCKED: session_key resolved to %r "
+            "but exact origin_ui_session_id is %r; routing to the exact owner",
+            resolved,
+            owner,
+        )
+    return owner
+
+
 def _process_one(evt: dict) -> None:
     """Route a single completion_queue event to the matching WebUI session."""
     from api import config as _cfg
@@ -889,6 +915,7 @@ def _process_one(evt: dict) -> None:
 
     process_id = str(evt.get("session_id") or "")
     session_key = str(evt.get("session_key") or "")
+    origin_ui_session_id = str(evt.get("origin_ui_session_id") or "")
     # Root-cause fix (t_0f447014): the notify_on_complete completion event
     # enqueued by ProcessRegistry._move_to_finished() carries NO "session_key"
     # field — only the watch_match enqueue includes one. Without it the old
@@ -912,30 +939,26 @@ def _process_one(evt: dict) -> None:
                 process_id,
                 exc_info=True,
             )
-    if not session_key:
+    if not session_key and not origin_ui_session_id:
         logger.debug(
-            "process_complete drop: no recoverable session_key for process_id=%r",
+            "process_complete drop: no recoverable session_key or exact UI owner "
+            "for process_id=%r",
             process_id,
         )
         return
-    with _cfg.PROCESS_SESSION_INDEX_LOCK:
-        session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key)
-    if not session_id:
+    session_id = ""
+    if session_key:
+        with _cfg.PROCESS_SESSION_INDEX_LOCK:
+            session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key) or ""
+    if not session_id and not origin_ui_session_id:
         # No mapping — could be a cron/gateway process that uses the same
         # registry but a non-WebUI session_key. Ignore.
         logger.debug("process_complete drop: no session mapping for key=%r", session_key)
         return
     # ── xsession wakeup misroute defense-in-depth (Option 3) ──────────────
-    # session_id above came from PROCESS_SESSION_INDEX.get(session_key), and
-    # session_key was captured by the terminal tool from the (historically
-    # racy) process-global env at spawn. Option 1 binds the per-turn identity
-    # to a contextvar so that capture is no longer racy — but as an INDEPENDENT
-    # safety net, cross-check the resolved target against the env-immune
-    # spawn owner (when the core ProcessSession exposes one). On a positive
-    # mismatch this re-routes the wakeup (and the live-view emit + dedupe
-    # markers below) to the TRUE owner instead of waking the wrong session.
-    # Pure pass-through when no env-immune owner is available (today's core,
-    # cron/CLI procs, pre-Option-1 spawns) — never suppresses a valid wakeup.
+    # First retain the process-registry spawn-owner cross-check for legacy
+    # terminal events. Then apply origin_ui_session_id as the final authority;
+    # that exact owner is shared by process and async-delegation completions.
     try:
         _ps_xs = _process_registry.get(process_id) if (_process_registry is not None and process_id) else None
     except Exception:
@@ -945,6 +968,13 @@ def _process_one(evt: dict) -> None:
         session_key_resolved_sid=session_id,
         proc_session=_ps_xs,
     )
+    session_id = _resolve_completion_target(
+        session_key_resolved_sid=session_id,
+        origin_ui_session_id=origin_ui_session_id,
+    )
+    if not session_id:
+        logger.debug("process_complete drop: completion target resolved empty")
+        return
     # ── Idempotency vs the REAL merged upstream #2279 (shared dedupe key) ──
     # The real merged #2279 next-turn drain
     # (api/streaming._drain_webui_process_notifications) dedupes ONLY via

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -638,6 +638,9 @@ def _run_gateway_chat_streaming(
     def put_gateway_event(event, data):
         if cancel_event.is_set() and not success_writeback_committed and event not in ("cancel", "error", "apperror"):
             return
+        if event == "apperror" and isinstance(data, dict):
+            data = data.copy()
+            data.setdefault("session_id", session_id)
         event_id = None
         if run_journal is not None:
             try:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -44,6 +44,19 @@ _WEBUI_GATEWAY_API_KEY_ENV = "HERMES_WEBUI_GATEWAY_API_KEY"
 _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
+
+def _gateway_provider_error_payload(message: str) -> dict | None:
+    from api.streaming import _classify_provider_error, _provider_error_payload
+
+    classification = _classify_provider_error(message)
+    if classification["type"] == "error":
+        return None
+    return _provider_error_payload(
+        message,
+        classification["type"],
+        classification.get("hint", ""),
+    )
+
 # Total byte-silence budget (seconds) for the gateway SSE socket, applied via
 # ``urlopen(timeout=...)``. A stream that emits ANY byte within the window never
 # trips it, so a genuinely alive (if slow) token stream is untouched; only more
@@ -515,6 +528,8 @@ def _run_gateway_runs_api_streaming(
                 sse_event = "message"
                 continue
             if payload_event == "run.completed":
+                if payload.get("error"):
+                    raise RuntimeError(str(payload["error"]))
                 output = str(payload.get("output") or "")
                 if output and not final_text:
                     final_text = output
@@ -647,6 +662,7 @@ def _run_gateway_chat_streaming(
 
     s = None
     final_text = ""
+    terminal_error = ""
     usage = {"input_tokens": 0, "output_tokens": 0, "estimated_cost": 0}
     try:
         s = get_session(session_id)
@@ -728,7 +744,8 @@ def _run_gateway_chat_streaming(
                     session=s,
                 )
             except Exception as exc:
-                put_gateway_event("apperror", {
+                error_payload = _gateway_provider_error_payload(str(exc))
+                put_gateway_event("apperror", error_payload or {
                     "label": "Gateway runs API error",
                     "type": "gateway_runs_error",
                     "message": str(exc)[:400],
@@ -879,6 +896,8 @@ def _run_gateway_chat_streaming(
                         sse_event = "message"
                         continue
                     last_payload = payload
+                    if payload.get("error"):
+                        terminal_error = str(payload["error"])
                     reasoning_delta = _gateway_sse_reasoning_delta(payload)
                     if reasoning_delta:
                         if stream_id in STREAM_REASONING_TEXT:
@@ -894,6 +913,11 @@ def _run_gateway_chat_streaming(
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
         assistant_text = final_text.strip()
         if not assistant_text:
+            if terminal_error:
+                error_payload = _gateway_provider_error_payload(terminal_error)
+                if error_payload:
+                    put_gateway_event("apperror", error_payload)
+                    return
             put_gateway_event("apperror", {
                 "label": "Gateway returned no response",
                 "type": "gateway_empty_response",

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -556,6 +556,63 @@ def _run_gateway_runs_api_streaming(
     return final_text, usage
 
 
+def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, model_provider, terminal_error):
+    from api.streaming import (
+        _classify_provider_error,
+        _materialize_pending_user_turn_before_error,
+        _provider_error_payload,
+        _session_payload_with_full_messages,
+        _snapshot_and_append_partial_on_error,
+    )
+
+    with _get_session_agent_lock(session_id):
+        session = get_session(session_id)
+        if not _stream_writeback_is_current(session, stream_id):
+            return None
+        error_classification = _classify_provider_error(terminal_error)
+        error_payload = _provider_error_payload(
+            terminal_error,
+            error_classification["type"],
+            error_classification.get("hint", ""),
+        )
+        _materialize_pending_user_turn_before_error(session)
+        session.active_stream_id = None
+        session.pending_user_message = None
+        session.pending_attachments = []
+        session.pending_started_at = None
+        session.pending_user_source = None
+        try:
+            _snapshot_and_append_partial_on_error(session, stream_id)
+        except Exception:
+            logger.debug("Failed to snapshot gateway partials on terminal error", exc_info=True)
+        error_message = {
+            "role": "assistant",
+            "content": (
+                f"**{error_classification['label']}:** "
+                f"{error_payload.get('message') or error_classification['label']}"
+            ) + (f"\n\n*{error_payload['hint']}*" if error_payload.get("hint") else ""),
+            "timestamp": int(time.time()),
+            "_error": True,
+        }
+        if error_payload.get("details"):
+            error_message["provider_details"] = error_payload["details"]
+        if not isinstance(session.messages, list):
+            session.messages = []
+        session.messages.append(error_message)
+        session.workspace = str(workspace)
+        session.model = model
+        session.model_provider = model_provider
+        try:
+            session.save()
+        except Exception:
+            logger.debug("Failed to persist gateway terminal error settlement", exc_info=True)
+        error_payload["session"] = redact_session_data(
+            _session_payload_with_full_messages(session, tool_calls=[])
+        )
+        error_payload["session_id"] = session.session_id
+        return error_payload
+
+
 def _stream_writeback_is_current(session: Any, stream_id: str) -> bool:
     return bool(stream_id and getattr(session, "active_stream_id", None) == stream_id)
 
@@ -745,13 +802,17 @@ def _run_gateway_chat_streaming(
                     session=s,
                 )
             except Exception as exc:
-                error_payload = _gateway_provider_error_payload(str(exc))
-                put_gateway_event("apperror", error_payload or {
-                    "label": "Gateway runs API error",
-                    "type": "gateway_runs_error",
-                    "message": str(exc)[:400],
-                    "hint": "Check that the Hermes Gateway runs API (/v1/runs) is available.",
-                })
+                error_payload = _settle_gateway_terminal_error(
+                    session_id,
+                    stream_id,
+                    workspace,
+                    model,
+                    model_provider,
+                    str(exc),
+                )
+                if error_payload is None:
+                    return
+                put_gateway_event("apperror", error_payload)
                 return
             if final_text is None:
                 return
@@ -914,7 +975,17 @@ def _run_gateway_chat_streaming(
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
         assistant_text = final_text.strip()
         if terminal_error:
-            put_gateway_event("apperror", _gateway_provider_error_payload(terminal_error))
+            error_payload = _settle_gateway_terminal_error(
+                session_id,
+                stream_id,
+                workspace,
+                model,
+                model_provider,
+                terminal_error,
+            )
+            if error_payload is None:
+                return
+            put_gateway_event("apperror", error_payload)
             return
         if not assistant_text:
             put_gateway_event("apperror", {

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -45,12 +45,10 @@ _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
 
-def _gateway_provider_error_payload(message: str) -> dict | None:
+def _gateway_provider_error_payload(message: str) -> dict:
     from api.streaming import _classify_provider_error, _provider_error_payload
 
     classification = _classify_provider_error(message)
-    if classification["type"] == "error":
-        return None
     return _provider_error_payload(
         message,
         classification["type"],
@@ -912,12 +910,10 @@ def _run_gateway_chat_streaming(
                     usage.update({k: v for k, v in _gateway_stream_usage(payload).items() if v})
             usage.update({k: v for k, v in _gateway_stream_usage(last_payload).items() if v})
         assistant_text = final_text.strip()
+        if terminal_error:
+            put_gateway_event("apperror", _gateway_provider_error_payload(terminal_error))
+            return
         if not assistant_text:
-            if terminal_error:
-                error_payload = _gateway_provider_error_payload(terminal_error)
-                if error_payload:
-                    put_gateway_event("apperror", error_payload)
-                    return
             put_gateway_event("apperror", {
                 "label": "Gateway returned no response",
                 "type": "gateway_empty_response",

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -45,16 +45,6 @@ _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
 
 
-def _gateway_provider_error_payload(message: str) -> dict:
-    from api.streaming import _classify_provider_error, _provider_error_payload
-
-    classification = _classify_provider_error(message)
-    return _provider_error_payload(
-        message,
-        classification["type"],
-        classification.get("hint", ""),
-    )
-
 # Total byte-silence budget (seconds) for the gateway SSE socket, applied via
 # ``urlopen(timeout=...)``. A stream that emits ANY byte within the window never
 # trips it, so a genuinely alive (if slow) token stream is untouched; only more

--- a/api/models.py
+++ b/api/models.py
@@ -801,19 +801,26 @@ def _append_recovered_turn_to_context(session, recovered: dict) -> None:
     context_messages = getattr(session, 'context_messages', None)
     if not isinstance(context_messages, list) or not context_messages:
         return
-    role = str(recovered.get('role') or '')
-    recovered_text = " ".join(str(recovered.get('content') or '').split())
+    recovered_text = _normalize_journal_recovery_text(recovered.get('content'))
     if not recovered_text and not recovered.get('tool_call_id') and not recovered.get('tool_calls'):
         return
     if recovered_text:
-        for existing in reversed(context_messages[-8:]):
-            if not isinstance(existing, dict) or existing.get('role') != role:
-                continue
-            existing_text = " ".join(str(existing.get('content') or '').split())
-            if existing_text == recovered_text:
+        if recovered.get('role') == 'user':
+            if _message_matches_pending_checkpoint(
+                context_messages[-1] if context_messages else None,
+                recovered.get('content'),
+                recovered.get('timestamp'),
+                recovered.get('_source'),
+                recovered.get('attachments'),
+            ):
                 return
-    context_entry = {k: v for k, v in recovered.items() if k != 'timestamp'}
-    context_messages.append(context_entry)
+        else:
+            for existing in reversed(context_messages[-8:]):
+                if not isinstance(existing, dict) or existing.get('role') != recovered.get('role'):
+                    continue
+                if _normalize_journal_recovery_text(existing.get('content')) == recovered_text:
+                    return
+    context_messages.append(dict(recovered))
 
 
 def _append_recovered_pending_turn(session, *, timestamp: int | None = None) -> dict | None:
@@ -2191,6 +2198,41 @@ def _normalize_journal_recovery_text(value) -> str:
     return " ".join(str(value or "").split())
 
 
+def _message_matches_pending_checkpoint(message, pending_text, timestamp, source, attachments):
+    if not isinstance(message, dict) or message.get('role') != 'user':
+        return False
+    try:
+        message_timestamp = int(message.get('timestamp'))
+        expected_timestamp = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    return (
+        _normalize_journal_recovery_text(message.get('content'))
+        == _normalize_journal_recovery_text(pending_text)
+        and message_timestamp == expected_timestamp
+        and (message.get('_source') or 'webui') == (source or 'webui')
+        and list(message.get('attachments') or []) == list(attachments or [])
+    )
+
+
+def _message_matches_pending_text(message, pending_text):
+    if not isinstance(message, dict) or message.get('role') != 'user':
+        return False
+    return (
+        _normalize_journal_recovery_text(message.get('content'))
+        == _normalize_journal_recovery_text(pending_text)
+    )
+
+
+def _latest_user_matches_pending_text(messages, pending_text):
+    if not isinstance(messages, list) or not pending_text:
+        return False
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get('role') == 'user':
+            return _message_matches_pending_text(message, pending_text)
+    return False
+
+
 def _partial_message_signature(message: dict) -> tuple:
     """Return a stable identity for partial assistant markers recovered on load."""
     if not isinstance(message, dict):
@@ -2887,21 +2929,24 @@ def _apply_core_sync_or_error_marker(
     # prompt submitted just before a server restart, so materialize it before
     # clearing runtime stream state.
     if len(session.messages) != 0:
-        _pending_text = " ".join(str(session.pending_user_message or "").split())
-        _already_checkpointed = False
-        if _pending_text and session.messages:
-            for _last_msg in reversed(session.messages):
-                if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
-                    _last_text = " ".join(str(_last_msg.get('content') or "").split())
-                    _already_checkpointed = _last_text == _pending_text
-                    break
         _recovered_ts = int(time.time())
         if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
             _recovered_ts = int(session.pending_started_at)
+        _already_checkpointed = _message_matches_pending_checkpoint(
+            session.messages[-1],
+            session.pending_user_message,
+            _recovered_ts,
+            session.pending_user_source,
+            session.pending_attachments,
+        )
+        _tail_user_already_checkpointed = _already_checkpointed or _message_matches_pending_text(
+            session.messages[-1],
+            session.pending_user_message,
+        )
         _stream_id = stream_id_for_recheck or session.active_stream_id
         _pending_started_at = session.pending_started_at
         if _run_journal_terminal_state(session, _stream_id) == 'completed':
-            if not _already_checkpointed:
+            if not (_already_checkpointed or _latest_user_matches_pending_text(session.messages, session.pending_user_message)):
                 _append_recovered_pending_turn(session, timestamp=_recovered_ts)
             _append_journaled_partial_output(
                 session,
@@ -2920,14 +2965,18 @@ def _apply_core_sync_or_error_marker(
                 _stream_id,
             )
             return True
-        if not _already_checkpointed:
+        if not _tail_user_already_checkpointed:
             _append_recovered_pending_turn(session, timestamp=_recovered_ts)
         else:
             recovered = {
                 'role': 'user',
                 'content': session.pending_user_message,
+                'timestamp': _recovered_ts,
                 '_recovered': True,
             }
+            pending_source = getattr(session, 'pending_user_source', None)
+            if pending_source and pending_source != 'webui':
+                recovered['_source'] = pending_source
             if session.pending_attachments:
                 recovered['attachments'] = list(session.pending_attachments)
             _append_recovered_turn_to_context(session, recovered)
@@ -2968,21 +3017,25 @@ def _apply_core_sync_or_error_marker(
                 if core.get(field) is not None:
                     setattr(session, field, core[field])
             _pending_text = _normalize_journal_recovery_text(session.pending_user_message)
-            _already_checkpointed = False
-            if _pending_text and session.messages:
-                for _last_msg in reversed(session.messages):
-                    if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
-                        _last_text = _normalize_journal_recovery_text(_last_msg.get('content'))
-                        _already_checkpointed = _last_text == _pending_text
-                        break
+            _recovered_ts = int(time.time())
+            if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
+                _recovered_ts = int(session.pending_started_at)
+            _already_checkpointed = _message_matches_pending_checkpoint(
+                session.messages[-1] if session.messages else None,
+                session.pending_user_message,
+                _recovered_ts,
+                session.pending_user_source,
+                session.pending_attachments,
+            )
+            _tail_user_already_checkpointed = _already_checkpointed or _message_matches_pending_text(
+                session.messages[-1] if session.messages else None,
+                session.pending_user_message,
+            )
             if (
                 _pending_text
-                and not _already_checkpointed
+                and not _tail_user_already_checkpointed
                 and _run_journal_has_visible_output(session, _stream_id)
             ):
-                _recovered_ts = int(time.time())
-                if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
-                    _recovered_ts = int(session.pending_started_at)
                 _append_recovered_pending_turn(session, timestamp=_recovered_ts)
             recovered_output = _append_journaled_partial_output(
                 session,

--- a/api/routes.py
+++ b/api/routes.py
@@ -21865,8 +21865,9 @@ def _handle_chat_sync(handler, body):
         os.environ["HERMES_SESSION_KEY"] = s.session_id
     try:
         from run_agent import AIAgent
+        from api.streaming import _bind_turn_session_identity
 
-        with CHAT_LOCK:
+        with CHAT_LOCK, _bind_turn_session_identity(s.session_id):
             from api.config import (
                 resolve_model_provider,
                 resolve_custom_provider_connection,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6077,30 +6077,43 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     pending_text = str(getattr(session, 'pending_user_message', None) or '')
     if not pending_text:
         return False
-    normalized_pending = " ".join(pending_text.split())
-    if normalized_pending:
-        for existing in reversed(list(getattr(session, 'messages', None) or [])[-8:]):
-            if not isinstance(existing, dict) or existing.get('role') != 'user':
-                continue
-            existing_text = " ".join(str(existing.get('content') or '').split())
-            if existing_text == normalized_pending:
-                return False
     recovered_ts = int(time.time())
     pending_started_at = getattr(session, 'pending_started_at', None)
     if isinstance(pending_started_at, (int, float)) and pending_started_at > 0:
         recovered_ts = int(pending_started_at)
+    pending_source = getattr(session, 'pending_user_source', None) or 'webui'
+    pending_attachments = list(getattr(session, 'pending_attachments', None) or [])
+
+    def is_exact_checkpoint(messages):
+        if not isinstance(messages, list) or not messages:
+            return False
+        existing = messages[-1]
+        if not isinstance(existing, dict) or existing.get('role') != 'user':
+            return False
+        existing_source = existing.get('_source') or 'webui'
+        try:
+            existing_ts = int(existing.get('timestamp'))
+        except (TypeError, ValueError):
+            return False
+        return (
+            _normalize_user_text(existing.get('content')) == _normalize_user_text(pending_text)
+            and existing_ts == recovered_ts
+            and existing_source == pending_source
+            and list(existing.get('attachments') or []) == pending_attachments
+        )
+
+    if is_exact_checkpoint(getattr(session, 'messages', None)):
+        return False
     recovered = {
         'role': 'user',
         'content': pending_text,
         'timestamp': recovered_ts,
         '_recovered': True,
     }
-    pending_source = getattr(session, 'pending_user_source', None)
-    if pending_source and pending_source != 'webui':
+    if pending_source != 'webui':
         recovered['_source'] = pending_source
-    pending_attachments = getattr(session, 'pending_attachments', None)
     if pending_attachments:
-        recovered['attachments'] = list(pending_attachments)
+        recovered['attachments'] = pending_attachments
     session.messages.append(recovered)
     # Mirror to context_messages so the _recovered flag survives the state.db
     # round-trip (#4283).  state.db has no _recovered column, so without this
@@ -6111,14 +6124,8 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     # Placing the mirror here (rather than in _persist_cancelled_turn) covers
     # all three callers: cancel, provider-error, and exception paths.
     ctx = getattr(session, 'context_messages', None)
-    if isinstance(ctx, list) and ctx:
-        rec_text = " ".join(str(recovered.get('content') or '').split())
-        if not any(
-            isinstance(e, dict) and e.get('role') == 'user'
-            and " ".join(str(e.get('content') or '').split()) == rec_text
-            for e in ctx[-8:]
-        ):
-            ctx.append({k: v for k, v in recovered.items() if k != 'timestamp'})
+    if isinstance(ctx, list) and ctx and not is_exact_checkpoint(ctx):
+        ctx.append(dict(recovered))
     # The new user turn is now committed to messages (#3831): advance a positive
     # truncation watermark left over from a prior retry/undo/edit so that
     # merge_session_messages_append_only() still filters out replaced pre-edit

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1795,24 +1795,27 @@ def _set_turn_session_identity(session_id: str):
     """Bind THIS turn's session identity to the current (task/thread-local)
     context and return an opaque token for _reset_turn_session_identity.
 
-    Binds two context-locals so every session-key consumer is covered without
-    a race:
+    Binds three context-locals so every routing consumer is covered without a
+    race:
       * ``tools.approval._approval_session_key`` — checked FIRST by
         ``get_current_session_key`` (the exact call terminal_tool.py makes for
         a notify_on_complete background spawn: the bug path).
       * ``gateway.session_context._SESSION_KEY`` — read by direct
         ``get_session_env("HERMES_SESSION_KEY")`` consumers (e.g. the sudo
         password cache scope, terminal_tool.py:272).
+      * ``gateway.session_context._SESSION_UI_SESSION_ID`` — captured as the
+        exact return address on detached process and async-delegation completion
+        events. This lets WebUI reject a contaminated/stale session-key route.
 
     It deliberately does NOT call ``gateway.session_context.set_session_vars``:
     that blanket setter also zeroes the platform/chat_id/user contextvars,
     flipping ``HERMES_SESSION_PLATFORM`` from its env fallback (``'webui'``,
     still written to os.environ at turn-start) to an explicit ``""`` — which
     would break the ``notify_on_complete`` watcher registration gate in
-    terminal_tool.py:~1966. Only the session-key identity is bound; every
-    other session var keeps its existing os.environ fallback (CLI/cron compat
-    preserved — when these contextvars are _UNSET, get_session_env still falls
-    back to os.environ).
+    terminal_tool.py:~1966. Only routing identity is bound; every other session
+    var keeps its existing os.environ fallback (CLI/cron compat preserved —
+    when these contextvars are _UNSET, get_session_env still falls back to
+    os.environ).
     """
     sid = str(session_id or "")
     tokens: dict = {}
@@ -1826,6 +1829,11 @@ def _set_turn_session_identity(session_id: str):
         tokens["session_key"] = _SK.set(sid)
     except Exception:
         logger.debug("per-turn _SESSION_KEY bind failed", exc_info=True)
+    try:
+        from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
+        tokens["ui_session_id"] = _UI_SID.set(sid)
+    except Exception:
+        logger.debug("per-turn _SESSION_UI_SESSION_ID bind failed", exc_info=True)
     return tokens
 
 
@@ -1840,6 +1848,13 @@ def _reset_turn_session_identity(tokens) -> None:
     """
     if not tokens:
         return
+    tok = tokens.get("ui_session_id")
+    if tok is not None:
+        try:
+            from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
+            _UI_SID.reset(tok)
+        except Exception:
+            logger.debug("per-turn _SESSION_UI_SESSION_ID reset failed", exc_info=True)
     tok = tokens.get("session_key")
     if tok is not None:
         try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1944,13 +1944,14 @@ def _mark_process_completion_consumed(process_registry, process_id: str) -> None
 def _drain_webui_process_notifications(session_id: str) -> list[str]:
     """Return completion notifications that belong to this WebUI session.
 
-    The agent registry completion queue is process-wide and events do not carry
-    the WebUI session key directly. Look up the live process session before
-    delivery so completions from other tabs remain queued for their owners.
+    The agent registry completion queue is process-wide. Modern events carry
+    the exact originating WebUI session; older events fall back to the live
+    process session key. Keep events for other tabs queued for their owners.
     """
     if not session_id:
         return []
     try:
+        from api.background_process import _resolve_completion_target
         from tools.process_registry import process_registry
     except Exception:
         return []
@@ -1984,7 +1985,14 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
             proc = process_registry.get(evt_sid)
         except Exception:
             proc = None
-        if getattr(proc, 'session_key', None) != session_id:
+        owner_session_id = _resolve_completion_target(
+            session_key_resolved_sid=str(getattr(proc, 'session_key', None) or ''),
+            origin_ui_session_id=(
+                str(evt.get('origin_ui_session_id') or '')
+                if isinstance(evt, dict) else ''
+            ),
+        )
+        if owner_session_id != session_id:
             skipped_events.append(evt)
             continue
 

--- a/tests/test_issue1361_cancel_data_loss.py
+++ b/tests/test_issue1361_cancel_data_loss.py
@@ -402,9 +402,16 @@ def test_stream_error_pending_materialization_does_not_duplicate_eager_checkpoin
         pending_msg="please restart the WebUI",
         messages=[
             {"role": "assistant", "content": "previous answer"},
-            {"role": "user", "content": "please restart the WebUI"},
+            {
+                "role": "user",
+                "content": "[Workspace::v1: C:\\repo]\nplease   restart the WebUI",
+                "timestamp": 1778098700,
+                "attachments": [{"name": "screen.png"}],
+            },
         ],
     )
+    s.pending_started_at = 1778098700.0
+    s.pending_attachments = [{"name": "screen.png"}]
 
     appended = _materialize_pending_user_turn_before_error(s)
 

--- a/tests/test_issue4283_recovered_context_replay.py
+++ b/tests/test_issue4283_recovered_context_replay.py
@@ -264,7 +264,7 @@ class _DummySession:
         self.context_messages = context_messages
         self.pending_user_message = pending_msg
         self.pending_attachments = []
-        self.pending_started_at = None
+        self.pending_started_at = 1778098700.0
         self.active_stream_id = "stream-test"
         self.truncation_watermark = None
         self.path = ""
@@ -293,6 +293,7 @@ def test_materialize_mirrors_recovered_user_to_context_messages():
     ctx_users = [m for m in s.context_messages if m.get("role") == "user"]
     assert any(m.get("_recovered") for m in ctx_users)
     assert any("restart the gateway" in m.get("content", "") for m in ctx_users)
+    assert any(m.get("timestamp") == 1778098700 for m in ctx_users)
 
 
 def test_materialize_does_not_duplicate_context_messages():

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -547,6 +547,75 @@ class TestEmptyMessagesGuard:
         assert s.pending_user_message is None
         assert s.active_stream_id is None
 
+    def test_repeated_pending_prompt_uses_current_checkpoint_identity(self, hermes_home, monkeypatch):
+        """Historical identical text must not suppress the current pending turn."""
+        s = _make_session(
+            messages=[
+                {"role": "user", "content": "repeat this", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+                {"role": "assistant", "content": "Earlier answer"},
+            ],
+            context_messages=[
+                {"role": "user", "content": "repeat this", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+                {"role": "assistant", "content": "Earlier answer"},
+            ],
+        )
+        s.pending_user_message = "repeat this"
+        s.pending_started_at = 222.0
+        s.pending_attachments = [{"name": "current.png"}]
+        s.active_stream_id = "stream_1"
+        lock = config._get_session_agent_lock(s.session_id)
+
+        with lock:
+            core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
+            result = _apply_core_sync_or_error_marker(
+                s, core_path, stream_id_for_recheck="stream_1",
+            )
+
+        assert result is True
+        users = [m for m in s.messages if m.get("role") == "user"]
+        assert len(users) == 2
+        assert users[-1]["timestamp"] == 222
+        assert users[-1]["attachments"] == [{"name": "current.png"}]
+        context_users = [m for m in s.context_messages if m.get("role") == "user"]
+        assert len(context_users) == 2
+        assert context_users[-1]["timestamp"] == 222
+        assert context_users[-1]["attachments"] == [{"name": "current.png"}]
+
+    def test_recovered_assistant_context_row_still_deduplicates(self):
+        s = _make_session(
+            context_messages=[{"role": "assistant", "content": "Recovered answer"}],
+        )
+        recovered = {
+            "role": "assistant",
+            "content": "Recovered answer",
+            "timestamp": 222,
+        }
+
+        models._append_recovered_turn_to_context(s, recovered)
+
+        assert s.context_messages == [{"role": "assistant", "content": "Recovered answer"}]
+
+    def test_recovered_user_context_row_requires_tail_checkpoint(self):
+        s = _make_session(
+            context_messages=[
+                {"role": "user", "content": "repeat this", "timestamp": 222, "attachments": [{"name": "same.png"}]},
+                {"role": "assistant", "content": "Earlier answer"},
+            ],
+        )
+        recovered = {
+            "role": "user",
+            "content": "repeat this",
+            "timestamp": 222,
+            "attachments": [{"name": "same.png"}],
+            "_recovered": True,
+        }
+
+        models._append_recovered_turn_to_context(s, recovered)
+
+        context_users = [m for m in s.context_messages if m.get("role") == "user"]
+        assert len(context_users) == 2
+        assert context_users[-1]["timestamp"] == 222
+
     def test_bails_when_pending_user_message_none(self, hermes_home, monkeypatch):
         """If pending_user_message is None, repair bails out."""
         s = _make_session(messages=[])

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -433,6 +433,7 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     apperrors = [item[1] for item in events if item[0] == "apperror"]
     assert apperrors
     assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+    assert apperrors[-1]["session_id"] == s.session_id
 
     response_error[0] = ""
     empty_stream_id = "stream-gateway-empty-response-test"
@@ -455,6 +456,7 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     )
     empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
     assert empty_errors[-1]["type"] == "gateway_empty_response"
+    assert empty_errors[-1]["session_id"] == s.session_id
 
     response_error[0] = "Gateway provider failed without a known classification"
     unknown_stream_id = "stream-gateway-unknown-terminal-error-test"
@@ -1370,6 +1372,7 @@ def test_gateway_runs_api_classifies_terminal_provider_error():
             )
         apperrors = [item[1] for item in events if item[0] == "apperror"]
         assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+        assert apperrors[-1]["session_id"] == "sess-runs-terminal-error"
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -375,6 +375,85 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert all(len(item) == 3 and item[2] for item in events)
 
 
+def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp_path, monkeypatch):
+    """Gateway terminal errors must survive an empty assistant stream."""
+    from unittest.mock import MagicMock
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+    error_text = (
+        'HTTP 400: {"detail":"Invalid Request: Invalid model format or no credentials '
+        'for provider: <redacted>"}'
+    )
+    response_error = [error_text]
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            if response_error[0]:
+                yield f'data: {{"error":{json.dumps(response_error[0])}}}\n\n'.encode()
+            yield b"data: [DONE]\n\n"
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    events = []
+    channel = MagicMock()
+    channel.put_nowait = lambda item: events.append(item)
+    s = new_session()
+    stream_id = "stream-gateway-terminal-provider-error-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    apperrors = [item[1] for item in events if item[0] == "apperror"]
+    assert apperrors
+    assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+
+    response_error[0] = ""
+    empty_stream_id = "stream-gateway-empty-response-test"
+    s = new_session()
+    s.active_stream_id = empty_stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    empty_events = []
+    empty_channel = MagicMock()
+    empty_channel.put_nowait = lambda item: empty_events.append(item)
+    STREAMS[empty_stream_id] = empty_channel
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        empty_stream_id,
+        [],
+    )
+    empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
+    assert empty_errors[-1]["type"] == "gateway_empty_response"
+
+
 def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
@@ -1185,6 +1264,62 @@ def test_gateway_runs_api_body_includes_session_id():
                 )
         assert "/v1/runs" in captured["url"]
         assert captured["body"]["session_id"] == "sess-stable-uuid"
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+
+
+def test_gateway_runs_api_classifies_terminal_provider_error():
+    from unittest.mock import MagicMock, patch
+
+    from api.config import STREAMS, STREAMS_LOCK
+    from api.gateway_chat import _run_gateway_chat_streaming
+
+    error_text = "HTTP 400: Invalid model format or no credentials for provider"
+    events = []
+    q = MagicMock()
+    q.put_nowait = lambda item: events.append(item)
+    stream_id = "sid-runs-terminal-provider-error"
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = q
+
+    call_count = [0]
+
+    def fake_urlopen(req, *, timeout=None):
+        call_count[0] += 1
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        if call_count[0] == 1:
+            resp.read = lambda sz=65536: b'{"run_id":"run_error"}'
+        else:
+            resp.__iter__ = lambda s: iter([
+                b'event: run.failed\n',
+                f'data: {{"error":{json.dumps(error_text)}}}\n'.encode(),
+            ])
+        return resp
+
+    try:
+        with patch.dict("os.environ", {
+            "HERMES_WEBUI_CHAT_BACKEND": "gateway",
+            "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1",
+            "HERMES_WEBUI_GATEWAY_BASE_URL": "http://gateway.local",
+        }, clear=True), \
+             patch("api.gateway_chat.gateway_supports_approval", return_value=True), \
+             patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("api.gateway_chat.get_session", return_value=MagicMock(
+                 active_stream_id=stream_id, workspace="/tmp", profile=None,
+                 context_messages=[], messages=[],
+             )):
+            _run_gateway_chat_streaming(
+                session_id="sess-runs-terminal-error",
+                msg_text="hi",
+                model="test",
+                workspace="/tmp",
+                stream_id=stream_id,
+            )
+        apperrors = [item[1] for item in events if item[0] == "apperror"]
+        assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -417,7 +417,16 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     stream_id = "stream-gateway-terminal-provider-error-test"
     s.active_stream_id = stream_id
     s.pending_user_message = "Say hello"
-    s.pending_attachments = []
+    s.pending_started_at = 222
+    s.pending_attachments = [{"name": "current.png"}]
+    s.messages = [
+        {"role": "user", "content": "Say hello", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
+    s.context_messages = [
+        {"role": "user", "content": "Say hello", "timestamp": 111, "attachments": [{"name": "old.png"}]},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
     s.save()
     STREAMS[stream_id] = channel
 
@@ -434,6 +443,16 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     assert apperrors
     assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
     assert apperrors[-1]["session_id"] == s.session_id
+    saved = models.get_session(s.session_id)
+    user_messages = [m for m in saved.messages if m.get("role") == "user"]
+    assert len(user_messages) == 2
+    assert user_messages[-1]["timestamp"] == 222
+    assert user_messages[-1]["attachments"] == [{"name": "current.png"}]
+    context_users = [m for m in saved.context_messages if m.get("role") == "user"]
+    assert len(context_users) == 2
+    assert context_users[-1]["timestamp"] == 222
+    assert context_users[-1]["attachments"] == [{"name": "current.png"}]
+    assert saved.messages[-1].get("_error") is True
 
     response_error[0] = ""
     empty_stream_id = "stream-gateway-empty-response-test"

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -398,7 +398,10 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
             return False
 
         def __iter__(self):
-            if response_error[0]:
+            if response_error[0] == "partial":
+                yield b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n'
+                yield f'data: {{"error":{json.dumps(error_text)}}}\n\n'.encode()
+            elif response_error[0]:
                 yield f'data: {{"error":{json.dumps(response_error[0])}}}\n\n'.encode()
             yield b"data: [DONE]\n\n"
 
@@ -452,6 +455,53 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     )
     empty_errors = [item[1] for item in empty_events if item[0] == "apperror"]
     assert empty_errors[-1]["type"] == "gateway_empty_response"
+
+    response_error[0] = "Gateway provider failed without a known classification"
+    unknown_stream_id = "stream-gateway-unknown-terminal-error-test"
+    s = new_session()
+    s.active_stream_id = unknown_stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    unknown_events = []
+    unknown_channel = MagicMock()
+    unknown_channel.put_nowait = lambda item: unknown_events.append(item)
+    STREAMS[unknown_stream_id] = unknown_channel
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        unknown_stream_id,
+        [],
+    )
+    unknown_errors = [item[1] for item in unknown_events if item[0] == "apperror"]
+    assert unknown_errors[-1]["type"] == "error"
+    assert "Gateway provider failed" in unknown_errors[-1]["message"]
+
+    response_error[0] = "partial"
+    partial_stream_id = "stream-gateway-partial-terminal-error-test"
+    s = new_session()
+    s.active_stream_id = partial_stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    partial_events = []
+    partial_channel = MagicMock()
+    partial_channel.put_nowait = lambda item: partial_events.append(item)
+    STREAMS[partial_stream_id] = partial_channel
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        partial_stream_id,
+        [],
+    )
+    partial_errors = [item[1] for item in partial_events if item[0] == "apperror"]
+    assert partial_errors[-1]["type"] in {"model_not_found", "auth_mismatch"}
+    saved = models.get_session(s.session_id)
+    assert not any(message.get("role") == "assistant" for message in saved.messages)
 
 
 def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -503,7 +503,89 @@ def test_gateway_chat_worker_classifies_terminal_provider_error_without_text(tmp
     partial_errors = [item[1] for item in partial_events if item[0] == "apperror"]
     assert partial_errors[-1]["type"] in {"model_not_found", "auth_mismatch"}
     saved = models.get_session(s.session_id)
-    assert not any(message.get("role") == "assistant" for message in saved.messages)
+    assert [message.get("role") for message in saved.messages[-3:]] == ["user", "assistant", "assistant"]
+    partial_message = saved.messages[-2]
+    assert partial_message.get("_partial") is True
+    assert partial_message["content"] == "partial"
+    error_message = saved.messages[-1]
+    assert error_message.get("_error") is True
+    assert "Invalid Request" in error_message.get("provider_details", "")
+    payload_messages = partial_errors[-1]["session"]["messages"]
+    assert payload_messages[-2]["_partial"] is True
+    assert payload_messages[-2]["content"] == "partial"
+    assert payload_messages[-1]["_error"] is True
+
+
+def test_gateway_chat_worker_persists_reasoning_and_tool_state_on_terminal_error(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    error_text = (
+        'HTTP 400: {"detail":"Invalid Request: Invalid model format or no credentials '
+        'for provider: <redacted>"}'
+    )
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"part"}}]}\n\n'
+            yield b'event: hermes.tool.progress\n'
+            yield b'data: {"tool":"terminal","label":"terminal: pytest","toolCallId":"call-1","status":"running","arguments":{}}\n\n'
+            yield b'event: reasoning.available\n'
+            yield b'data: {"text":"Preview reasoning"}\n\n'
+            yield f'data: {{"error":{json.dumps(error_text)}}}\n\n'.encode()
+            yield b"data: [DONE]\n\n"
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(streaming, "_load_webui_prefill_context", lambda cfg: {"status": "not_configured", "source": "none", "label": "", "message_count": 0, "messages": []})
+    monkeypatch.setattr(streaming, "_prefill_messages_with_webui_context", lambda ctx, cfg: [])
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda req, timeout=0: FakeResponse())
+
+    events = []
+    channel = MagicMock()
+    channel.put_nowait = lambda item: events.append(item)
+    s = new_session()
+    stream_id = "stream-gateway-terminal-reasoning-tool-error-test"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hello"
+    s.pending_attachments = []
+    s.save()
+    STREAMS[stream_id] = channel
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hello",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    saved = models.get_session(s.session_id)
+    partial_message = saved.messages[-2]
+    assert partial_message.get("_partial") is True
+    assert partial_message["content"] == "part"
+    assert partial_message["reasoning"] == "Preview reasoning"
+    assert partial_message["_partial_tool_calls"] == [{
+        "name": "terminal",
+        "args": {},
+        "done": False,
+        "tid": "call-1",
+    }]
+    apperrors = [item[1] for item in events if item[0] == "apperror"]
+    assert apperrors[-1]["session"]["messages"][-2]["reasoning"] == "Preview reasoning"
+    assert apperrors[-1]["session"]["messages"][-2]["_partial_tool_calls"][0]["name"] == "terminal"
+    assert apperrors[-1]["session"]["messages"][-1]["_error"] is True
 
 
 def test_gateway_chat_worker_preserves_reasoning_delta_whitespace_and_persists_reasoning(tmp_path, monkeypatch):
@@ -1321,13 +1403,18 @@ def test_gateway_runs_api_body_includes_session_id():
             STREAMS.pop(stream_id, None)
 
 
-def test_gateway_runs_api_classifies_terminal_provider_error():
+def test_gateway_runs_api_classifies_terminal_provider_error(tmp_path, monkeypatch):
     from unittest.mock import MagicMock, patch
 
     from api.config import STREAMS, STREAMS_LOCK
     from api.gateway_chat import _run_gateway_chat_streaming
 
     error_text = "HTTP 400: Invalid model format or no credentials for provider"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
     events = []
     q = MagicMock()
     q.put_nowait = lambda item: events.append(item)
@@ -1352,19 +1439,20 @@ def test_gateway_runs_api_classifies_terminal_provider_error():
         return resp
 
     try:
+        s = new_session()
+        s.active_stream_id = stream_id
+        s.pending_user_message = "hi"
+        s.pending_attachments = []
+        s.save()
         with patch.dict("os.environ", {
             "HERMES_WEBUI_CHAT_BACKEND": "gateway",
             "HERMES_WEBUI_GATEWAY_USE_RUNS_API": "1",
             "HERMES_WEBUI_GATEWAY_BASE_URL": "http://gateway.local",
         }, clear=True), \
              patch("api.gateway_chat.gateway_supports_approval", return_value=True), \
-             patch("urllib.request.urlopen", side_effect=fake_urlopen), \
-             patch("api.gateway_chat.get_session", return_value=MagicMock(
-                 active_stream_id=stream_id, workspace="/tmp", profile=None,
-                 context_messages=[], messages=[],
-             )):
+             patch("urllib.request.urlopen", side_effect=fake_urlopen):
             _run_gateway_chat_streaming(
-                session_id="sess-runs-terminal-error",
+                session_id=s.session_id,
                 msg_text="hi",
                 model="test",
                 workspace="/tmp",
@@ -1372,7 +1460,11 @@ def test_gateway_runs_api_classifies_terminal_provider_error():
             )
         apperrors = [item[1] for item in events if item[0] == "apperror"]
         assert apperrors[-1]["type"] in {"model_not_found", "auth_mismatch"}
-        assert apperrors[-1]["session_id"] == "sess-runs-terminal-error"
+        assert apperrors[-1]["session_id"] == s.session_id
+        saved = models.get_session(s.session_id)
+        assert [message.get("role") for message in saved.messages[-2:]] == ["user", "assistant"]
+        assert saved.messages[-1]["_error"] is True
+        assert apperrors[-1]["session"]["messages"][-1]["_error"] is True
     finally:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_xsession_wakeup_misroute.py
+++ b/tests/test_xsession_wakeup_misroute.py
@@ -179,6 +179,28 @@ def test_turn_identity_binder_restores_previous_value():
     assert sc._SESSION_PLATFORM.get() is sc._UNSET
 
 
+def test_turn_identity_binder_publishes_exact_ui_completion_owner():
+    """Detached terminal and subagent completions need a precise WebUI return
+    address, not only the durable/routable session key.
+
+    Hermes captures ``HERMES_UI_SESSION_ID`` into both process-completion and
+    async-delegation events. WebUI must bind that contextvar for the whole agent
+    turn so the producer can publish the exact browser-session owner.
+    """
+    streaming = importlib.import_module("api.streaming")
+    pytest.importorskip("gateway.session_context")
+    from gateway import session_context as sc
+
+    ui_var = getattr(sc, "_SESSION_UI_SESSION_ID", None)
+    if ui_var is None:
+        pytest.fail("installed hermes-agent lacks _SESSION_UI_SESSION_ID")
+
+    assert ui_var.get() is sc._UNSET
+    with streaming._bind_turn_session_identity("webui-session-a"):
+        assert sc.get_session_env("HERMES_UI_SESSION_ID", "") == "webui-session-a"
+    assert ui_var.get() is sc._UNSET
+
+
 # ---------------------------------------------------------------------------
 # Option 3 — completion-time second-check against the env-immune spawn owner
 # ---------------------------------------------------------------------------
@@ -257,3 +279,86 @@ def test_resolve_wakeup_target_passthrough_when_owner_unknown():
         session_key_resolved_sid=sid,
         proc_session=None,
     ) == sid
+
+
+# ---------------------------------------------------------------------------
+# Exact event ownership — shared by process and async-delegation completions
+# ---------------------------------------------------------------------------
+
+
+def test_exact_ui_owner_overrides_contaminated_session_key_mapping():
+    """The event producer's exact owner is authoritative.
+
+    This is the subagent contamination case: the mutable/fallback session-key
+    index points at B, while the completion event says the browser turn that
+    commissioned the child was A. The completion must return to A.
+    """
+    bp = importlib.import_module("api.background_process")
+
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid="webui-session-b",
+        origin_ui_session_id="webui-session-a",
+    ) == "webui-session-a"
+
+
+def test_exact_ui_owner_routes_without_session_key_index_entry():
+    """Exact ownership still works after a stale/missing fallback-index row."""
+    bp = importlib.import_module("api.background_process")
+
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid="",
+        origin_ui_session_id="webui-session-a",
+    ) == "webui-session-a"
+
+
+def test_legacy_completion_without_exact_owner_keeps_session_key_fallback():
+    """Pre-origin Agent events remain compatible while modern events can no
+    longer contaminate another session.
+    """
+    bp = importlib.import_module("api.background_process")
+
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid="legacy-session",
+        origin_ui_session_id="",
+    ) == "legacy-session"
+
+
+def test_async_delegation_drain_uses_exact_owner_end_to_end(monkeypatch):
+    """Exercise the real queue-consumer routing seam, not only its helper."""
+    bp = importlib.import_module("api.background_process")
+    cfg = importlib.import_module("api.config")
+
+    monkeypatch.setattr(
+        cfg,
+        "PROCESS_SESSION_INDEX",
+        {"contaminated-key": "webui-session-b"},
+    )
+    monkeypatch.setattr(cfg, "BG_TASK_COMPLETE_EVENTS_SEEN", {})
+    monkeypatch.setattr(cfg, "PENDING_BG_TASK_COMPLETIONS", set())
+
+    emitted: list[str] = []
+    started: list[str] = []
+    monkeypatch.setattr(
+        bp,
+        "_emit_bg_task_complete_events_coalesced",
+        lambda session_id, payload: emitted.append(session_id),
+    )
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda session_id: False)
+    monkeypatch.setattr(
+        bp,
+        "_start_server_side_wakeup_turn",
+        lambda session_id, wakeup_prompt, process_id="": started.append(session_id),
+    )
+
+    bp._process_one({
+        "type": "async_delegation",
+        "delegation_id": "deleg_routing_regression",
+        "session_key": "contaminated-key",
+        "origin_ui_session_id": "webui-session-a",
+        "goal": "routing regression",
+        "result": {"status": "completed", "summary": "ok"},
+    })
+
+    assert emitted == ["webui-session-a"]
+    assert cfg.PENDING_BG_TASK_COMPLETIONS == {"webui-session-a"}
+    assert started == ["webui-session-a"]

--- a/tests/test_xsession_wakeup_misroute.py
+++ b/tests/test_xsession_wakeup_misroute.py
@@ -33,6 +33,7 @@ tests/test_session_channel_option_x.py.
 from __future__ import annotations
 
 import importlib
+import queue
 import threading
 
 import pytest
@@ -362,3 +363,45 @@ def test_async_delegation_drain_uses_exact_owner_end_to_end(monkeypatch):
     assert emitted == ["webui-session-a"]
     assert cfg.PENDING_BG_TASK_COMPLETIONS == {"webui-session-a"}
     assert started == ["webui-session-a"]
+
+
+def test_next_turn_drain_uses_same_exact_owner_policy(monkeypatch):
+    """A later user turn in B must not adopt a process completion owned by A."""
+    from types import SimpleNamespace
+
+    streaming = importlib.import_module("api.streaming")
+    process_registry_module = importlib.import_module("tools.process_registry")
+
+    completion_queue: queue.Queue = queue.Queue()
+    completion_queue.put({
+        "type": "completion",
+        "session_id": "proc_exact_owner",
+        "session_key": "route-b",
+        "origin_ui_session_id": "webui-session-a",
+        "exit_code": 0,
+        "command": "probe",
+        "output": "ok",
+    })
+    fake_registry = SimpleNamespace(
+        completion_queue=completion_queue,
+        _lock=threading.Lock(),
+        _completion_consumed=set(),
+        is_completion_consumed=lambda _pid: False,
+        get=lambda _pid: SimpleNamespace(session_key="webui-session-b"),
+    )
+    monkeypatch.setattr(process_registry_module, "process_registry", fake_registry)
+
+    assert streaming._drain_webui_process_notifications("webui-session-b") == []
+    assert completion_queue.qsize() == 1
+
+    notifications = streaming._drain_webui_process_notifications("webui-session-a")
+    assert len(notifications) == 1
+    assert completion_queue.empty()
+    assert fake_registry._completion_consumed == {"proc_exact_owner"}
+
+
+def test_sync_chat_path_binds_exact_turn_owner():
+    """The direct fallback endpoint must use the same context-local binder."""
+    routes = importlib.import_module("api.routes")
+
+    assert "_bind_turn_session_identity" in routes._handle_chat_sync.__code__.co_names


### PR DESCRIPTION
Two backend reliability fixes, both Codex SAFE:

- **#5969** (@rodboev, closes #5940) — gateway terminal provider errors now classified + surfaced as the real error (not generic empty turn), session_id-bound, and the in-flight prompt + partial output persist through reload including a repeated prompt (`is_exact_checkpoint`). 4-round convergence. Codex SAFE + stream-gate GREEN all modes.
- **#6002** (@soria-claw) — detached terminal/subagent completions carry their exact `origin_ui_session_id` (context-local, reset on exit), closing the cross-session wakeup misroute; legacy owner-less events keep same-session delivery, never broadcast. Codex SAFE, 100/100 concurrent-stress rounds.

55 targeted tests pass.