### PR TITLE
Release exp: cross-session subagent completion routing (#6002)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,12 +159,17 @@ Per-request environment variables (set by chat handler, restored after):
     HERMES_EXEC_ASK      Set to "1" to enable approval gate for dangerous commands.
     HERMES_SESSION_KEY   Set to session_id. The approval tool keys pending entries
                          by this value, enabling per-session approval state.
+    HERMES_UI_SESSION_ID Bound context-locally to the browser session_id. Detached
+                         process and subagent completions capture it as their exact
+                         return address.
     HERMES_HOME          Set to the active profile's directory before running agent.
                          Saved and restored around each agent run.
 
-WARNING: These env vars are process-global. Two concurrent chat requests will clobber
-each other. This is safe only for single-user, single-concurrent-request use.
-See Architecture Phase B for the fix.
+The process-global environment mirror remains for compatibility with older tool
+consumers, but completion routing identity is bound through Hermes contextvars for
+the full turn. Modern completion events carry ``origin_ui_session_id``; WebUI
+treats that exact owner as authoritative and uses the session-key index only for
+legacy events that do not provide it.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,9 +159,11 @@ Per-request environment variables (set by chat handler, restored after):
     HERMES_EXEC_ASK      Set to "1" to enable approval gate for dangerous commands.
     HERMES_SESSION_KEY   Set to session_id. The approval tool keys pending entries
                          by this value, enabling per-session approval state.
-    HERMES_UI_SESSION_ID Bound context-locally to the browser session_id. Detached
-                         process and subagent completions capture it as their exact
-                         return address.
+    HERMES_UI_SESSION_ID Bound context-locally to the browser session_id. Async-
+                         delegation/subagent completions capture it as their exact
+                         return address. Detached terminal completions currently
+                         fall back to the context-local HERMES_SESSION_KEY until
+                         Hermes Agent stamps this field on process events.
     HERMES_HOME          Set to the active profile's directory before running agent.
                          Saved and restored around each agent run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- **Background/subagent completions no longer surface in the wrong session.** A detached terminal or subagent completion event now carries its exact origin browser-session id, so a finished background task routes only to the session that started it — instead of possibly waking a *different* open session through a stale/contaminated routing key. Events without an owner id keep their previous same-session delivery and are never broadcast to a wrong session; the identity binding is per-turn and reset on exit (no leak across concurrent sessions). Thanks @soria-clawd-bot. (#6002)
+
 - **Gateway provider errors are reported accurately, and your prompt survives a failed turn.** On gateway-backed sessions, a terminal provider error (bad model id, exhausted credentials, etc.) mid-turn is now classified and shown as the real error instead of a generic empty turn, the error card is bound to the correct session, and the in-flight user prompt plus any partial output is persisted so it survives a reload — even when you'd just re-sent an identical prompt (e.g. "continue"). Thanks @rodboev. (#5969, #5940)
 
 - **"Fork from here" works during an active response.** The fork button was silently dead while the agent was generating — clicking it did nothing. You can now fork from any past (already-committed) message while a response streams; only the currently-streaming message and the just-sent (not-yet-committed) prompt are blocked, with a clear toast. Thanks @kertisalex. (#5994, #5993)

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -872,6 +872,32 @@ def _resolve_wakeup_target(
     return owner
 
 
+def _resolve_completion_target(
+    *,
+    session_key_resolved_sid: str,
+    origin_ui_session_id: str,
+) -> str:
+    """Return the WebUI session that owns a detached completion event.
+
+    Modern Hermes events carry ``origin_ui_session_id`` as an exact, immutable
+    return address captured from the commissioning browser turn. It is
+    authoritative over the mutable/legacy session-key index. Older Agent events
+    omit it and retain the existing session-key fallback for compatibility.
+    """
+    resolved = str(session_key_resolved_sid or "")
+    owner = str(origin_ui_session_id or "")
+    if not owner:
+        return resolved
+    if resolved and resolved != owner:
+        logger.error(
+            "cross-session completion route BLOCKED: session_key resolved to %r "
+            "but exact origin_ui_session_id is %r; routing to the exact owner",
+            resolved,
+            owner,
+        )
+    return owner
+
+
 def _process_one(evt: dict) -> None:
     """Route a single completion_queue event to the matching WebUI session."""
     from api import config as _cfg
@@ -889,6 +915,7 @@ def _process_one(evt: dict) -> None:
 
     process_id = str(evt.get("session_id") or "")
     session_key = str(evt.get("session_key") or "")
+    origin_ui_session_id = str(evt.get("origin_ui_session_id") or "")
     # Root-cause fix (t_0f447014): the notify_on_complete completion event
     # enqueued by ProcessRegistry._move_to_finished() carries NO "session_key"
     # field — only the watch_match enqueue includes one. Without it the old
@@ -912,30 +939,26 @@ def _process_one(evt: dict) -> None:
                 process_id,
                 exc_info=True,
             )
-    if not session_key:
+    if not session_key and not origin_ui_session_id:
         logger.debug(
-            "process_complete drop: no recoverable session_key for process_id=%r",
+            "process_complete drop: no recoverable session_key or exact UI owner "
+            "for process_id=%r",
             process_id,
         )
         return
-    with _cfg.PROCESS_SESSION_INDEX_LOCK:
-        session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key)
-    if not session_id:
+    session_id = ""
+    if session_key:
+        with _cfg.PROCESS_SESSION_INDEX_LOCK:
+            session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key) or ""
+    if not session_id and not origin_ui_session_id:
         # No mapping — could be a cron/gateway process that uses the same
         # registry but a non-WebUI session_key. Ignore.
         logger.debug("process_complete drop: no session mapping for key=%r", session_key)
         return
     # ── xsession wakeup misroute defense-in-depth (Option 3) ──────────────
-    # session_id above came from PROCESS_SESSION_INDEX.get(session_key), and
-    # session_key was captured by the terminal tool from the (historically
-    # racy) process-global env at spawn. Option 1 binds the per-turn identity
-    # to a contextvar so that capture is no longer racy — but as an INDEPENDENT
-    # safety net, cross-check the resolved target against the env-immune
-    # spawn owner (when the core ProcessSession exposes one). On a positive
-    # mismatch this re-routes the wakeup (and the live-view emit + dedupe
-    # markers below) to the TRUE owner instead of waking the wrong session.
-    # Pure pass-through when no env-immune owner is available (today's core,
-    # cron/CLI procs, pre-Option-1 spawns) — never suppresses a valid wakeup.
+    # First retain the process-registry spawn-owner cross-check for legacy
+    # terminal events. Then apply origin_ui_session_id as the final authority;
+    # that exact owner is shared by process and async-delegation completions.
     try:
         _ps_xs = _process_registry.get(process_id) if (_process_registry is not None and process_id) else None
     except Exception:
@@ -945,6 +968,13 @@ def _process_one(evt: dict) -> None:
         session_key_resolved_sid=session_id,
         proc_session=_ps_xs,
     )
+    session_id = _resolve_completion_target(
+        session_key_resolved_sid=session_id,
+        origin_ui_session_id=origin_ui_session_id,
+    )
+    if not session_id:
+        logger.debug("process_complete drop: completion target resolved empty")
+        return
     # ── Idempotency vs the REAL merged upstream #2279 (shared dedupe key) ──
     # The real merged #2279 next-turn drain
     # (api/streaming._drain_webui_process_notifications) dedupes ONLY via

--- a/api/routes.py
+++ b/api/routes.py
@@ -21865,8 +21865,9 @@ def _handle_chat_sync(handler, body):
         os.environ["HERMES_SESSION_KEY"] = s.session_id
     try:
         from run_agent import AIAgent
+        from api.streaming import _bind_turn_session_identity
 
-        with CHAT_LOCK:
+        with CHAT_LOCK, _bind_turn_session_identity(s.session_id):
             from api.config import (
                 resolve_model_provider,
                 resolve_custom_provider_connection,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1795,24 +1795,27 @@ def _set_turn_session_identity(session_id: str):
     """Bind THIS turn's session identity to the current (task/thread-local)
     context and return an opaque token for _reset_turn_session_identity.
 
-    Binds two context-locals so every session-key consumer is covered without
-    a race:
+    Binds three context-locals so every routing consumer is covered without a
+    race:
       * ``tools.approval._approval_session_key`` — checked FIRST by
         ``get_current_session_key`` (the exact call terminal_tool.py makes for
         a notify_on_complete background spawn: the bug path).
       * ``gateway.session_context._SESSION_KEY`` — read by direct
         ``get_session_env("HERMES_SESSION_KEY")`` consumers (e.g. the sudo
         password cache scope, terminal_tool.py:272).
+      * ``gateway.session_context._SESSION_UI_SESSION_ID`` — captured as the
+        exact return address on detached process and async-delegation completion
+        events. This lets WebUI reject a contaminated/stale session-key route.
 
     It deliberately does NOT call ``gateway.session_context.set_session_vars``:
     that blanket setter also zeroes the platform/chat_id/user contextvars,
     flipping ``HERMES_SESSION_PLATFORM`` from its env fallback (``'webui'``,
     still written to os.environ at turn-start) to an explicit ``""`` — which
     would break the ``notify_on_complete`` watcher registration gate in
-    terminal_tool.py:~1966. Only the session-key identity is bound; every
-    other session var keeps its existing os.environ fallback (CLI/cron compat
-    preserved — when these contextvars are _UNSET, get_session_env still falls
-    back to os.environ).
+    terminal_tool.py:~1966. Only routing identity is bound; every other session
+    var keeps its existing os.environ fallback (CLI/cron compat preserved —
+    when these contextvars are _UNSET, get_session_env still falls back to
+    os.environ).
     """
     sid = str(session_id or "")
     tokens: dict = {}
@@ -1826,6 +1829,11 @@ def _set_turn_session_identity(session_id: str):
         tokens["session_key"] = _SK.set(sid)
     except Exception:
         logger.debug("per-turn _SESSION_KEY bind failed", exc_info=True)
+    try:
+        from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
+        tokens["ui_session_id"] = _UI_SID.set(sid)
+    except Exception:
+        logger.debug("per-turn _SESSION_UI_SESSION_ID bind failed", exc_info=True)
     return tokens
 
 
@@ -1840,6 +1848,13 @@ def _reset_turn_session_identity(tokens) -> None:
     """
     if not tokens:
         return
+    tok = tokens.get("ui_session_id")
+    if tok is not None:
+        try:
+            from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
+            _UI_SID.reset(tok)
+        except Exception:
+            logger.debug("per-turn _SESSION_UI_SESSION_ID reset failed", exc_info=True)
     tok = tokens.get("session_key")
     if tok is not None:
         try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1944,13 +1944,14 @@ def _mark_process_completion_consumed(process_registry, process_id: str) -> None
 def _drain_webui_process_notifications(session_id: str) -> list[str]:
     """Return completion notifications that belong to this WebUI session.
 
-    The agent registry completion queue is process-wide and events do not carry
-    the WebUI session key directly. Look up the live process session before
-    delivery so completions from other tabs remain queued for their owners.
+    The agent registry completion queue is process-wide. Modern events carry
+    the exact originating WebUI session; older events fall back to the live
+    process session key. Keep events for other tabs queued for their owners.
     """
     if not session_id:
         return []
     try:
+        from api.background_process import _resolve_completion_target
         from tools.process_registry import process_registry
     except Exception:
         return []
@@ -1984,7 +1985,14 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
             proc = process_registry.get(evt_sid)
         except Exception:
             proc = None
-        if getattr(proc, 'session_key', None) != session_id:
+        owner_session_id = _resolve_completion_target(
+            session_key_resolved_sid=str(getattr(proc, 'session_key', None) or ''),
+            origin_ui_session_id=(
+                str(evt.get('origin_ui_session_id') or '')
+                if isinstance(evt, dict) else ''
+            ),
+        )
+        if owner_session_id != session_id:
             skipped_events.append(evt)
             continue
 

--- a/tests/test_notify_on_complete_webui.py
+++ b/tests/test_notify_on_complete_webui.py
@@ -7,7 +7,9 @@ def test_webui_drains_only_matching_background_completion_events():
     assert "def _drain_webui_process_notifications(session_id: str)" in src
     assert "from tools.process_registry import process_registry" in src
     assert "proc = process_registry.get(evt_sid)" in src
-    assert "getattr(proc, 'session_key', None) != session_id" in src
+    assert "from api.background_process import _resolve_completion_target" in src
+    assert "owner_session_id = _resolve_completion_target(" in src
+    assert "if owner_session_id != session_id:" in src
     assert "skipped_events.append(evt)" in src
     assert "completion_queue.put(evt)" in src
 

--- a/tests/test_xsession_wakeup_misroute.py
+++ b/tests/test_xsession_wakeup_misroute.py
@@ -179,6 +179,28 @@ def test_turn_identity_binder_restores_previous_value():
     assert sc._SESSION_PLATFORM.get() is sc._UNSET
 
 
+def test_turn_identity_binder_publishes_exact_ui_completion_owner():
+    """Detached terminal and subagent completions need a precise WebUI return
+    address, not only the durable/routable session key.
+
+    Hermes captures ``HERMES_UI_SESSION_ID`` into both process-completion and
+    async-delegation events. WebUI must bind that contextvar for the whole agent
+    turn so the producer can publish the exact browser-session owner.
+    """
+    streaming = importlib.import_module("api.streaming")
+    pytest.importorskip("gateway.session_context")
+    from gateway import session_context as sc
+
+    ui_var = getattr(sc, "_SESSION_UI_SESSION_ID", None)
+    if ui_var is None:
+        pytest.fail("installed hermes-agent lacks _SESSION_UI_SESSION_ID")
+
+    assert ui_var.get() is sc._UNSET
+    with streaming._bind_turn_session_identity("webui-session-a"):
+        assert sc.get_session_env("HERMES_UI_SESSION_ID", "") == "webui-session-a"
+    assert ui_var.get() is sc._UNSET
+
+
 # ---------------------------------------------------------------------------
 # Option 3 — completion-time second-check against the env-immune spawn owner
 # ---------------------------------------------------------------------------
@@ -257,3 +279,86 @@ def test_resolve_wakeup_target_passthrough_when_owner_unknown():
         session_key_resolved_sid=sid,
         proc_session=None,
     ) == sid
+
+
+# ---------------------------------------------------------------------------
+# Exact event ownership — shared by process and async-delegation completions
+# ---------------------------------------------------------------------------
+
+
+def test_exact_ui_owner_overrides_contaminated_session_key_mapping():
+    """The event producer's exact owner is authoritative.
+
+    This is the subagent contamination case: the mutable/fallback session-key
+    index points at B, while the completion event says the browser turn that
+    commissioned the child was A. The completion must return to A.
+    """
+    bp = importlib.import_module("api.background_process")
+
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid="webui-session-b",
+        origin_ui_session_id="webui-session-a",
+    ) == "webui-session-a"
+
+
+def test_exact_ui_owner_routes_without_session_key_index_entry():
+    """Exact ownership still works after a stale/missing fallback-index row."""
+    bp = importlib.import_module("api.background_process")
+
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid="",
+        origin_ui_session_id="webui-session-a",
+    ) == "webui-session-a"
+
+
+def test_legacy_completion_without_exact_owner_keeps_session_key_fallback():
+    """Pre-origin Agent events remain compatible while modern events can no
+    longer contaminate another session.
+    """
+    bp = importlib.import_module("api.background_process")
+
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid="legacy-session",
+        origin_ui_session_id="",
+    ) == "legacy-session"
+
+
+def test_async_delegation_drain_uses_exact_owner_end_to_end(monkeypatch):
+    """Exercise the real queue-consumer routing seam, not only its helper."""
+    bp = importlib.import_module("api.background_process")
+    cfg = importlib.import_module("api.config")
+
+    monkeypatch.setattr(
+        cfg,
+        "PROCESS_SESSION_INDEX",
+        {"contaminated-key": "webui-session-b"},
+    )
+    monkeypatch.setattr(cfg, "BG_TASK_COMPLETE_EVENTS_SEEN", {})
+    monkeypatch.setattr(cfg, "PENDING_BG_TASK_COMPLETIONS", set())
+
+    emitted: list[str] = []
+    started: list[str] = []
+    monkeypatch.setattr(
+        bp,
+        "_emit_bg_task_complete_events_coalesced",
+        lambda session_id, payload: emitted.append(session_id),
+    )
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda session_id: False)
+    monkeypatch.setattr(
+        bp,
+        "_start_server_side_wakeup_turn",
+        lambda session_id, wakeup_prompt, process_id="": started.append(session_id),
+    )
+
+    bp._process_one({
+        "type": "async_delegation",
+        "delegation_id": "deleg_routing_regression",
+        "session_key": "contaminated-key",
+        "origin_ui_session_id": "webui-session-a",
+        "goal": "routing regression",
+        "result": {"status": "completed", "summary": "ok"},
+    })
+
+    assert emitted == ["webui-session-a"]
+    assert cfg.PENDING_BG_TASK_COMPLETIONS == {"webui-session-a"}
+    assert started == ["webui-session-a"]

--- a/tests/test_xsession_wakeup_misroute.py
+++ b/tests/test_xsession_wakeup_misroute.py
@@ -33,6 +33,7 @@ tests/test_session_channel_option_x.py.
 from __future__ import annotations
 
 import importlib
+import queue
 import threading
 
 import pytest
@@ -362,3 +363,45 @@ def test_async_delegation_drain_uses_exact_owner_end_to_end(monkeypatch):
     assert emitted == ["webui-session-a"]
     assert cfg.PENDING_BG_TASK_COMPLETIONS == {"webui-session-a"}
     assert started == ["webui-session-a"]
+
+
+def test_next_turn_drain_uses_same_exact_owner_policy(monkeypatch):
+    """A later user turn in B must not adopt a process completion owned by A."""
+    from types import SimpleNamespace
+
+    streaming = importlib.import_module("api.streaming")
+    process_registry_module = importlib.import_module("tools.process_registry")
+
+    completion_queue: queue.Queue = queue.Queue()
+    completion_queue.put({
+        "type": "completion",
+        "session_id": "proc_exact_owner",
+        "session_key": "route-b",
+        "origin_ui_session_id": "webui-session-a",
+        "exit_code": 0,
+        "command": "probe",
+        "output": "ok",
+    })
+    fake_registry = SimpleNamespace(
+        completion_queue=completion_queue,
+        _lock=threading.Lock(),
+        _completion_consumed=set(),
+        is_completion_consumed=lambda _pid: False,
+        get=lambda _pid: SimpleNamespace(session_key="webui-session-b"),
+    )
+    monkeypatch.setattr(process_registry_module, "process_registry", fake_registry)
+
+    assert streaming._drain_webui_process_notifications("webui-session-b") == []
+    assert completion_queue.qsize() == 1
+
+    notifications = streaming._drain_webui_process_notifications("webui-session-a")
+    assert len(notifications) == 1
+    assert completion_queue.empty()
+    assert fake_registry._completion_consumed == {"proc_exact_owner"}
+
+
+def test_sync_chat_path_binds_exact_turn_owner():
+    """The direct fallback endpoint must use the same context-local binder."""
+    routes = importlib.import_module("api.routes")
+
+    assert "_bind_turn_session_identity" in routes._handle_chat_sync.__code__.co_names


### PR DESCRIPTION
Ships #6002 (@soria-clawd-bot). Detached terminal/subagent completion events now carry their exact `origin_ui_session_id` (context-local, reset on exit), so a finished background task routes only to its origin browser session — closing the cross-session wakeup misroute. Owner-less events keep same-session delivery and are never broadcast. Codex SAFE (round 2 — impl unchanged from the safe round, tests re-aligned to genuinely assert the exact-owner contract, 100-round concurrent stress zero leaks), stream-gate GREEN all modes (the hide_all RED was the known load flake — isolated re-run clean), 18/18 regression tests pass together (the earlier stale-source-assertion break is resolved).