### PR TITLE
perf(sessions): persist validated bounded tail snapshots

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -13,6 +13,7 @@ import re
 import threading
 import time
 import uuid
+import weakref
 from contextlib import closing, contextmanager
 from pathlib import Path
 
@@ -139,6 +140,22 @@ _SESSION_TAIL_CACHE_VERSION = 1
 _SESSION_TAIL_CACHE_LIMIT = 300
 _SESSION_TAIL_CACHE_MAX_BYTES = 4 * 1024 * 1024
 _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES = 1 * 1024 * 1024
+
+# Storage publication ownership is separate from the non-reentrant agent lock:
+# callers commonly hold the latter while calling Session.save(). Weak values keep
+# the registry bounded while all concurrent users of one sidecar share one lock.
+_SESSION_SAVE_PUBLICATION_LOCKS_GUARD = threading.Lock()
+_SESSION_SAVE_PUBLICATION_LOCKS = weakref.WeakValueDictionary()
+
+
+def _get_session_save_publication_lock(path: Path):
+    key = str(path.expanduser().resolve())
+    with _SESSION_SAVE_PUBLICATION_LOCKS_GUARD:
+        lock = _SESSION_SAVE_PUBLICATION_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SESSION_SAVE_PUBLICATION_LOCKS[key] = lock
+        return lock
 
 
 # ---------------------------------------------------------------------------
@@ -1305,6 +1322,50 @@ class Session:
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
+        if getattr(self, '_loaded_metadata_only', False):
+            raise RuntimeError(
+                f"Refusing to save metadata-only session {self.session_id!r}: "
+                f"would atomically overwrite on-disk messages with []. "
+                f"Reload with metadata_only=False before mutating state. "
+                f"See #1558."
+            )
+        sidecar_path = self.path
+        with _get_session_save_publication_lock(sidecar_path):
+            saved = self._save_authoritative_sidecar_and_tail_cache(
+                touch_updated_at=touch_updated_at,
+            )
+        if not saved:
+            return
+        if not skip_index:
+            _write_session_index(updates=[self])
+
+        # #4985 belt-and-suspenders self-heal: a successful save with at
+        # least one real message on the sidecar is unconditional proof the
+        # row is alive (the #4985 "zero-message orphan" only ever exists
+        # when ``len(self.messages) == 0``). Clear the tombstone so the
+        # next ``/api/sessions`` poll does not need the prune helper to
+        # run before the row re-appears — useful when the message-commit
+        # happens on a poll that does not yet see state.db.messages rows
+        # (e.g. the WebUI's own sidecar commit lands before the agent's
+        # state.db append, or the helper is skipped via a different code
+        # path). Wrapped because a tombstone failure must never block a
+        # save. The helper's self-healing branch in
+        # ``_prune_orphaned_webui_zero_message_sessions`` is the primary
+        # fix; this is the belt.
+        if self.messages:
+            try:
+                _clear_webui_zero_message_orphan_tombstone(self.session_id)
+                _clear_webui_deleted_session_tombstone(self.session_id)
+            except Exception:
+                logger.debug(
+                    "Failed to clear webui tombstone for %s",
+                    self.session_id,
+                    exc_info=True,
+                )
+
+    def _save_authoritative_sidecar_and_tail_cache(self, touch_updated_at: bool = True) -> bool:
+        if not is_safe_session_id(self.session_id):
+            raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
         # Refuse to save a session that was loaded with metadata_only=True.
         # Such sessions have messages=[] (it's the whole point of the partial
@@ -1377,7 +1438,8 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        frozen_snapshot = copy.deepcopy({**meta, **extra})
+        payload = json.dumps(frozen_snapshot, ensure_ascii=False, indent=2)
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -1413,7 +1475,7 @@ class Session:
                         incoming_msg_count,
                         self.active_stream_id,
                     )
-                    return
+                    return False
                 if existing_msg_count > incoming_msg_count:
                     bak_path = self.path.with_suffix('.json.bak')
                     # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,
@@ -1463,10 +1525,15 @@ class Session:
         # fsync'd file on every streaming checkpoint would cost more than the
         # bounded read can save.
         try:
+            # Every successful authoritative publication invalidates its previous
+            # derived bytes. An eligible source is republished below; an ineligible
+            # source stays cache-free. Failure is non-fatal and the reader still
+            # rejects any retained stale entry by its old source signature.
+            delete_session_tail_cache(self.session_id)
             source_signature = _sidecar_stat_signature(self.path)
             if _session_tail_cache_signature_is_large_enough(source_signature):
                 _write_session_tail_cache(
-                    self,
+                    frozen_snapshot,
                     expected_signature=source_signature,
                 )
         except Exception:
@@ -1475,32 +1542,7 @@ class Session:
                 self.session_id,
                 exc_info=True,
             )
-        if not skip_index:
-            _write_session_index(updates=[self])
-
-        # #4985 belt-and-suspenders self-heal: a successful save with at
-        # least one real message on the sidecar is unconditional proof the
-        # row is alive (the #4985 "zero-message orphan" only ever exists
-        # when ``len(self.messages) == 0``). Clear the tombstone so the
-        # next ``/api/sessions`` poll does not need the prune helper to
-        # run before the row re-appears — useful when the message-commit
-        # happens on a poll that does not yet see state.db.messages rows
-        # (e.g. the WebUI's own sidecar commit lands before the agent's
-        # state.db append, or the helper is skipped via a different code
-        # path). Wrapped because a tombstone failure must never block a
-        # save. The helper's self-healing branch in
-        # ``_prune_orphaned_webui_zero_message_sessions`` is the primary
-        # fix; this is the belt.
-        if self.messages:
-            try:
-                _clear_webui_zero_message_orphan_tombstone(self.session_id)
-                _clear_webui_deleted_session_tombstone(self.session_id)
-            except Exception:
-                logger.debug(
-                    "Failed to clear webui tombstone for %s",
-                    self.session_id,
-                    exc_info=True,
-                )
+        return True
 
     @classmethod
     def load(cls, sid, *, _populate_tail_cache=True):
@@ -3803,6 +3845,24 @@ def delete_session_tail_cache(sid: str) -> bool:
         return False
 
 
+def delete_session_sidecar_and_tail_cache(sid: str) -> bool:
+    """Best-effort removal of one session's authoritative and derived files."""
+    if not is_safe_session_id(sid):
+        return False
+    sidecar = SESSION_DIR / f'{sid}.json'
+    with _get_session_save_publication_lock(sidecar):
+        try:
+            sidecar.unlink(missing_ok=True)
+            sidecar_deleted = True
+        except OSError:
+            logger.debug("Failed to remove session sidecar for %s", sid, exc_info=True)
+            sidecar_deleted = False
+        # Keep separate failure handling: a sidecar failure must not retain the
+        # derived copy, and a cache failure must not resurrect/fail the source.
+        cache_deleted = delete_session_tail_cache(sid)
+    return sidecar_deleted and cache_deleted
+
+
 def _tail_cache_strict_int(value, *, minimum=None, maximum=None) -> bool:
     if isinstance(value, bool) or not isinstance(value, int):
         return False
@@ -3864,17 +3924,23 @@ def _session_tail_cache_profile_is_active(session) -> bool:
         return False
 
 
+def _session_tail_cache_snapshot_value(snapshot, key, default=None):
+    if isinstance(snapshot, dict):
+        return snapshot.get(key, default)
+    return getattr(snapshot, key, default)
+
+
 def _session_tail_cache_payload(session, source_signature) -> dict | None:
-    """Build a v1 cache payload from a fully materialized Session object."""
-    if getattr(session, '_loaded_metadata_only', False):
+    """Build a v1 cache payload from a Session or its frozen save snapshot."""
+    if _session_tail_cache_snapshot_value(session, '_loaded_metadata_only', False):
         return None
-    sid = getattr(session, 'session_id', None)
+    sid = _session_tail_cache_snapshot_value(session, 'session_id')
     if not is_safe_session_id(sid):
         return None
     signature = _tail_cache_signature_dict(source_signature)
     if signature is None:
         return None
-    messages = getattr(session, 'messages', None)
+    messages = _session_tail_cache_snapshot_value(session, 'messages')
     if not isinstance(messages, list):
         return None
     source_count = len(messages)
@@ -3888,7 +3954,7 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
 
     all_tool_calls_positionable = True
     cached_tool_calls = []
-    raw_tool_calls = getattr(session, 'tool_calls', None)
+    raw_tool_calls = _session_tail_cache_snapshot_value(session, 'tool_calls')
     if not isinstance(raw_tool_calls, list):
         raw_tool_calls = []
         all_tool_calls_positionable = False
@@ -3925,7 +3991,10 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
         for message in messages
         if isinstance(message, dict) and _tail_cache_finite_number(message.get('timestamp'))
     ]
-    last_message_at = max(timestamps) if timestamps else getattr(session, 'updated_at', None)
+    last_message_at = max(timestamps) if timestamps else _session_tail_cache_snapshot_value(
+        session,
+        'updated_at',
+    )
     if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
         last_message_at = None
     return {
@@ -3943,7 +4012,7 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
         'all_tool_calls_positionable': all_tool_calls_positionable,
         'todo_state': todo_state,
         'anchor_scene_index': _anchor_scene_index_from_records(
-            getattr(session, 'anchor_activity_scenes', None)
+            _session_tail_cache_snapshot_value(session, 'anchor_activity_scenes')
         ),
         'all_cached_timestamps_valid': all_timestamps_valid,
         'created_at': float(time.time()),

--- a/api/models.py
+++ b/api/models.py
@@ -164,7 +164,7 @@ def _open_windows_directory_handle(path: Path):  # pragma: no cover - Windows on
     import ctypes
     from ctypes import wintypes
 
-    kernel32 = getattr(ctypes, 'WinDLL')('kernel32', use_last_error=True)
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)  # type: ignore[attr-defined]
     create_file = kernel32.CreateFileW
     create_file.argtypes = (
         wintypes.LPCWSTR,
@@ -187,7 +187,7 @@ def _open_windows_directory_handle(path: Path):  # pragma: no cover - Windows on
     )
     invalid = wintypes.HANDLE(-1).value
     if handle == invalid:
-        raise getattr(ctypes, 'WinError')(getattr(ctypes, 'get_last_error')())
+        raise ctypes.WinError(ctypes.get_last_error())  # type: ignore[attr-defined]
     return handle
 
 
@@ -196,9 +196,9 @@ def _close_windows_handle(handle) -> None:  # pragma: no cover - Windows only.
         return
     import ctypes
 
-    kernel32 = getattr(ctypes, 'WinDLL')('kernel32', use_last_error=True)
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)  # type: ignore[attr-defined]
     if not kernel32.CloseHandle(handle):
-        raise getattr(ctypes, 'WinError')(getattr(ctypes, 'get_last_error')())
+        raise ctypes.WinError(ctypes.get_last_error())  # type: ignore[attr-defined]
 
 
 class _BoundSessionSidecarTarget:

--- a/api/models.py
+++ b/api/models.py
@@ -1440,11 +1440,16 @@ class Session:
         # The sidecar is authoritative and must land first. Tail-cache writes
         # are derived, atomic, and strictly fail-open: a cache filesystem or
         # validation failure can never roll back a successful session save.
+        # Small sidecars stay on the authoritative path; publishing a second
+        # fsync'd file on every streaming checkpoint would cost more than the
+        # bounded read can save.
         try:
-            _write_session_tail_cache(
-                self,
-                expected_signature=_sidecar_stat_signature(self.path),
-            )
+            source_signature = _sidecar_stat_signature(self.path)
+            if _session_tail_cache_signature_is_large_enough(source_signature):
+                _write_session_tail_cache(
+                    self,
+                    expected_signature=source_signature,
+                )
         except Exception:
             logger.debug(
                 "session tail-cache populate failed for %s",
@@ -1534,6 +1539,7 @@ class Session:
                     _populate_tail_cache
                     and _pre_read_sig is not None
                     and _pre_read_sig == _post_read_sig
+                    and _session_tail_cache_signature_is_large_enough(_pre_read_sig)
                     and _session_tail_cache_profile_is_active(session)
                     and not _session_tail_cache_has_signature(sid, _pre_read_sig)
                 ):
@@ -3741,6 +3747,18 @@ def session_tail_cache_path(sid: str) -> Path:
     return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
 
 
+def _session_tail_cache_signature_is_large_enough(signature) -> bool:
+    """Return whether a stable source signature justifies cache publication."""
+    if not isinstance(signature, tuple) or len(signature) != 4:
+        return False
+    size = signature[2]
+    return (
+        isinstance(size, int)
+        and not isinstance(size, bool)
+        and size >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    )
+
+
 def session_tail_cache_source_is_large_enough(sid: str) -> bool:
     """Return whether bounded-tail route setup is worthwhile for this sidecar."""
     if not is_safe_session_id(sid):
@@ -3749,10 +3767,8 @@ def session_tail_cache_source_is_large_enough(sid: str) -> bool:
         cached = SESSIONS.get(sid)
         if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
             return False
-    signature = _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
-    return bool(
-        signature is not None
-        and signature[2] >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    return _session_tail_cache_signature_is_large_enough(
+        _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
     )
 
 
@@ -4328,7 +4344,7 @@ def build_session_tail_cache_from_legacy_sidecar(sid: str) -> dict | None:
             return None
     path = SESSION_DIR / f'{sid}.json'
     before = _sidecar_stat_signature(path)
-    if before is None:
+    if not _session_tail_cache_signature_is_large_enough(before):
         return None
     try:
         prefix = _read_metadata_json_prefix(path)

--- a/api/models.py
+++ b/api/models.py
@@ -2,6 +2,7 @@
 import collections
 import copy
 import datetime
+import errno
 import hashlib
 import inspect
 import json
@@ -203,15 +204,46 @@ def _close_windows_handle(handle) -> None:  # pragma: no cover - Windows only.
 class _BoundSessionSidecarTarget:
     """One parent identity used for lock lookup and every save/cache I/O."""
 
-    def __init__(self, requested_path: Path):
+    def __init__(self, requested_path: Path, cached_parent_binding=None):
         requested = Path(requested_path).expanduser()
         self.requested_parent = requested.parent
         self.name = requested.name
-        self.parent = self.requested_parent.resolve(strict=True)
-        self.path = self.parent / self.name
-        self.cache_dir = self.parent / '_tail_cache' / 'v1'
-        self.cache_path = self.cache_dir / self.name
-        self.lock_key = _session_save_publication_lock_key(self.path)
+        requested_key = os.path.normcase(
+            os.path.normpath(os.path.abspath(self.requested_parent))
+        )
+        requested_stat = os.stat(self.requested_parent)
+        requested_identity = _filesystem_object_identity(requested_stat)
+        self._requested_identity = requested_identity
+        if (
+            isinstance(cached_parent_binding, tuple)
+            and len(cached_parent_binding) == 8
+            and cached_parent_binding[0] == requested_key
+            and cached_parent_binding[1] == requested_identity
+            and cached_parent_binding[2] == self.name
+        ):
+            (
+                self.parent,
+                self.path,
+                self.cache_dir,
+                self.cache_path,
+                self.lock_key,
+            ) = cached_parent_binding[3:]
+        else:
+            self.parent = self.requested_parent.resolve(strict=True)
+            self.path = self.parent / self.name
+            self.cache_dir = self.parent / '_tail_cache' / 'v1'
+            self.cache_path = self.cache_dir / self.name
+            self.lock_key = os.path.normcase(os.path.normpath(os.fspath(self.path)))
+        self.parent_binding = (
+            requested_key,
+            requested_identity,
+            self.name,
+            self.parent,
+            self.path,
+            self.cache_dir,
+            self.cache_path,
+            self.lock_key,
+        )
         self._parent_fd = None
         self._cache_fd = None
         self._windows_parent_handle = None
@@ -236,7 +268,8 @@ class _BoundSessionSidecarTarget:
             if self._parent_fd is not None
             else os.stat(self.parent, follow_symlinks=False)
         )
-        self.validate_binding()
+        if _filesystem_object_identity(self._parent_stat) != self._requested_identity:
+            raise OSError('session sidecar parent changed during target binding')
         return self
 
     def __exit__(self, _exc_type, _exc, _tb):
@@ -255,7 +288,11 @@ class _BoundSessionSidecarTarget:
 
     def validate_binding(self) -> None:
         try:
-            current_parent = self.requested_parent.resolve(strict=True)
+            requested_absolute = Path(os.path.abspath(self.requested_parent))
+            if requested_absolute == self.parent:
+                current_parent = self.parent
+            else:
+                current_parent = self.requested_parent.resolve(strict=True)
             current_stat = os.stat(self.parent, follow_symlinks=False)
         except OSError as exc:
             raise OSError('session sidecar parent changed after target binding') from exc
@@ -272,7 +309,7 @@ class _BoundSessionSidecarTarget:
                 raise OSError('session sidecar parent changed after target binding')
 
     def owns(self, path: Path) -> bool:
-        candidate = Path(path)
+        candidate = path if isinstance(path, Path) else Path(path)
         return candidate.parent == self.parent or candidate.parent == self.cache_dir
 
     def _open_child_directory(self, parent_fd: int, name: str) -> int:
@@ -318,7 +355,7 @@ class _BoundSessionSidecarTarget:
             self._windows_cache_handles.append(_open_windows_directory_handle(directory))
 
     def _location(self, path: Path, *, create_cache=False):
-        candidate = Path(path)
+        candidate = path if isinstance(path, Path) else Path(path)
         if candidate.parent == self.parent:
             return self._parent_fd, candidate.name, candidate
         if candidate.parent == self.cache_dir:
@@ -344,13 +381,26 @@ class _BoundSessionSidecarTarget:
         raise OSError(f'path escaped bound session target: {candidate}')
 
     def open(self, path: Path, mode: str, *, encoding=None):
-        self.validate_binding()
         create_cache = any(flag in mode for flag in ('w', 'a', 'x', '+'))
         dir_fd, name, absolute = self._location(path, create_cache=create_cache)
         if os.name == 'nt':  # pragma: no cover - Windows only.
             if absolute.is_symlink():
                 raise OSError('refusing to follow final symlink for session sidecar I/O')
             return open(absolute, mode, encoding=encoding)
+
+        if mode in ('rb', 'xb'):
+            flags = os.O_RDONLY if mode == 'rb' else os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            flags |= getattr(os, 'O_CLOEXEC', 0)
+            flags |= getattr(os, 'O_NOFOLLOW', 0)
+            try:
+                fd = os.open(name, flags, 0o600, dir_fd=dir_fd)
+            except OSError as exc:
+                if exc.errno == errno.ELOOP:
+                    raise OSError(
+                        'refusing to follow final symlink for session sidecar I/O'
+                    ) from exc
+                raise
+            return os.fdopen(fd, mode, encoding=encoding)
 
         def opener(_path, flags):
             flags |= getattr(os, 'O_CLOEXEC', 0)
@@ -365,14 +415,12 @@ class _BoundSessionSidecarTarget:
             raise
 
     def stat(self, path: Path):
-        self.validate_binding()
         dir_fd, name, absolute = self._location(path)
         if dir_fd is None:  # pragma: no cover - Windows only.
             return os.stat(absolute, follow_symlinks=False)
         return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
 
     def unlink(self, path: Path, *, missing_ok=False) -> None:
-        self.validate_binding()
         try:
             dir_fd, name, absolute = self._location(path)
             if dir_fd is None:  # pragma: no cover - Windows only.
@@ -384,7 +432,6 @@ class _BoundSessionSidecarTarget:
                 raise
 
     def replace(self, src: Path, dst: Path) -> None:
-        self.validate_binding()
         src_fd, src_name, src_absolute = self._location(src)
         dst_fd, dst_name, dst_absolute = self._location(dst)
         if src_fd is not None and dst_fd is not None:
@@ -403,9 +450,9 @@ def _active_session_sidecar_target():
 
 
 @contextmanager
-def _bound_session_sidecar_target(path: Path):
+def _bound_session_sidecar_target(path: Path, *, cached_parent_binding=None):
     previous = _active_session_sidecar_target()
-    with _BoundSessionSidecarTarget(path) as target:
+    with _BoundSessionSidecarTarget(path, cached_parent_binding) as target:
         _SESSION_SIDECAR_TARGET_LOCAL.value = target
         try:
             yield target
@@ -418,6 +465,15 @@ def _bound_open(path: Path, mode: str, *, encoding=None):
     if target is not None and target.owns(path):
         return target.open(path, mode, encoding=encoding)
     return open(path, mode, encoding=encoding)
+
+
+def _bound_open_exclusive(path: Path):
+    """Create a temp file without a common-path pre-unlink syscall."""
+    try:
+        return _bound_open(path, 'xb')
+    except FileExistsError:
+        _bound_unlink(path, missing_ok=True)
+        return _bound_open(path, 'xb')
 
 
 def _bound_stat(path: Path):
@@ -1665,7 +1721,11 @@ class Session:
                 f"Reload with metadata_only=False before mutating state. "
                 f"See #1558."
             )
-        with _bound_session_sidecar_target(self.path) as target:
+        with _bound_session_sidecar_target(
+            self.path,
+            cached_parent_binding=getattr(self, '_save_parent_binding', None),
+        ) as target:
+            self._save_parent_binding = target.parent_binding
             publication_path_key = target.lock_key
             publication_lock = getattr(self, '_save_publication_lock', None)
             if (
@@ -1677,7 +1737,14 @@ class Session:
                 # save path without leaking locks after all same-ID objects expire.
                 self._save_publication_lock = publication_lock
                 self._save_publication_path_key = publication_path_key
+                lock_was_resolved_now = True
+            else:
+                lock_was_resolved_now = False
             with publication_lock:
+                if lock_was_resolved_now:
+                    # Lock lookup is an extension point used by the target-swap
+                    # adversarial controls; revalidate any first-lookup gap.
+                    target.validate_binding()
                 saved = self._save_authoritative_sidecar_and_tail_cache(
                     touch_updated_at=touch_updated_at,
                     sidecar_path=target.path,
@@ -1876,8 +1943,7 @@ class Session:
                 try:
                     # Retain the exact proven source bytes; text-mode newline
                     # translation would weaken this recovery contract on Windows.
-                    _bound_unlink(bak_tmp, missing_ok=True)
-                    with _bound_open(bak_tmp, 'xb') as bf:
+                    with _bound_open_exclusive(bak_tmp) as bf:
                         bf.write(existing_bytes)
                         bf.flush()
                         os.fsync(bf.fileno())
@@ -1891,15 +1957,10 @@ class Session:
 
         tmp = sidecar_path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
-            _bound_unlink(tmp, missing_ok=True)
-            with _bound_open(tmp, 'xb') as f:
+            with _bound_open_exclusive(tmp) as f:
                 f.write(payload_bytes)
                 f.flush()
                 os.fsync(f.fileno())
-            current_source = _sidecar_content_proof(sidecar_path)
-            current_proof = current_source[0] if current_source is not None else None
-            if current_proof != existing_proof:
-                raise OSError('authoritative session source changed before publication')
             _safe_replace(tmp, sidecar_path)
             _invalidate_persisted_session_ids_snapshot()
         except Exception:
@@ -1926,8 +1987,15 @@ class Session:
             # derived bytes. An eligible source is republished below; an ineligible
             # source stays cache-free. Cache cleanup/population remains non-fatal;
             # the reader rejects retained bytes without an exact source proof.
-            delete_session_tail_cache(self.session_id)
-            if _session_tail_cache_signature_is_large_enough(source_signature):
+            source_is_large = _session_tail_cache_signature_is_large_enough(source_signature)
+            cleanup_needed = (
+                source_is_large
+                or _session_tail_cache_signature_is_large_enough(existing_signature)
+                or getattr(self, '_tail_cache_cleanup_pending', False)
+            )
+            if cleanup_needed:
+                self._tail_cache_cleanup_pending = not delete_session_tail_cache(self.session_id)
+            if source_is_large:
                 _write_session_tail_cache(
                     frozen_snapshot,
                     expected_proof=source_proof,
@@ -4233,8 +4301,13 @@ def _sidecar_content_proof(path: Path):
         or int(current.st_size) != len(source_bytes)
     ):
         raise OSError('session sidecar changed while authoritative bytes were read')
-    signature = _sidecar_stat_signature(path)
-    if signature is None or signature[2] != len(source_bytes):
+    signature = (
+        str(path),
+        int(getattr(current, 'st_mtime_ns', int(current.st_mtime * 1_000_000_000))),
+        int(current.st_size),
+        int(getattr(current, 'st_ctime_ns', int(current.st_ctime * 1_000_000_000))),
+    )
+    if signature[2] != len(source_bytes):
         raise OSError('session sidecar stat/content proof is uncertain')
     proof = (signature, hashlib.sha256(source_bytes).hexdigest())
     return proof, source_bytes
@@ -4519,8 +4592,7 @@ def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> b
             target.ensure_cache_dir()
         else:
             path.parent.mkdir(parents=True, exist_ok=True)
-        _bound_unlink(tmp, missing_ok=True)
-        with _bound_open(tmp, 'xb') as handle:
+        with _bound_open_exclusive(tmp) as handle:
             handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
@@ -4529,12 +4601,10 @@ def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> b
             except (AttributeError, OSError):
                 pass
         sidecar = target.path if target is not None and target.sid == sid else SESSION_DIR / f'{sid}.json'
-        current_source = _sidecar_content_proof(sidecar)
         expected_digest = _tail_cache_content_digest(payload.get('source_sha256'))
         if (
-            current_source is None
-            or expected_digest is None
-            or current_source[0] != (expected_signature, expected_digest)
+            expected_digest is None
+            or _sidecar_stat_signature(sidecar) != expected_signature
         ):
             return False
         _safe_replace(tmp, path)

--- a/api/models.py
+++ b/api/models.py
@@ -10,6 +10,7 @@ import math
 import mmap
 import os
 import re
+import stat as _stat
 import threading
 import time
 import uuid
@@ -111,8 +112,9 @@ _SIDECAR_METADATA_CACHE_MAX = 2000
 # its message_count or scene fingerprint. Without this, an unchanged legacy
 # large-scene session would full-parse on every poll (recreating the #4633
 # churn for legacy files) and could not be LRU-evicted. Populated once per file
-# from a full Session.load(); keyed by the sidecar's stat signature so any edit
-# invalidates it. Bounded. Value: {"message_count": int, "scene_index": dict}.
+# from a full Session.load(); keyed by the sidecar's complete content proof so
+# same-metadata edits invalidate it. Bounded. Value: {"message_count": int,
+# "scene_index": dict}.
 _LEGACY_SIDECAR_FACTS_LOCK = threading.Lock()
 _LEGACY_SIDECAR_FACTS: "collections.OrderedDict[tuple, dict]" = collections.OrderedDict()
 _LEGACY_SIDECAR_FACTS_MAX = 2000
@@ -146,6 +148,291 @@ _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES = 1 * 1024 * 1024
 # the registry bounded while all concurrent users of one sidecar share one lock.
 _SESSION_SAVE_PUBLICATION_LOCKS_GUARD = threading.Lock()
 _SESSION_SAVE_PUBLICATION_LOCKS = weakref.WeakValueDictionary()
+_SESSION_SIDECAR_TARGET_LOCAL = threading.local()
+
+
+def _filesystem_object_identity(value) -> tuple:
+    return (
+        int(getattr(value, 'st_dev', 0)),
+        int(getattr(value, 'st_ino', 0)),
+    )
+
+
+def _open_windows_directory_handle(path: Path):  # pragma: no cover - Windows only.
+    """Pin a Windows directory against rename/replacement for path-based I/O."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = getattr(ctypes, 'WinDLL')('kernel32', use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        os.fspath(path),
+        0,
+        0x00000001 | 0x00000002,  # FILE_SHARE_READ | FILE_SHARE_WRITE; no delete sharing.
+        None,
+        3,  # OPEN_EXISTING
+        0x02000000 | 0x00200000,  # BACKUP_SEMANTICS | OPEN_REPARSE_POINT
+        None,
+    )
+    invalid = wintypes.HANDLE(-1).value
+    if handle == invalid:
+        raise getattr(ctypes, 'WinError')(getattr(ctypes, 'get_last_error')())
+    return handle
+
+
+def _close_windows_handle(handle) -> None:  # pragma: no cover - Windows only.
+    if handle is None:
+        return
+    import ctypes
+
+    kernel32 = getattr(ctypes, 'WinDLL')('kernel32', use_last_error=True)
+    if not kernel32.CloseHandle(handle):
+        raise getattr(ctypes, 'WinError')(getattr(ctypes, 'get_last_error')())
+
+
+class _BoundSessionSidecarTarget:
+    """One parent identity used for lock lookup and every save/cache I/O."""
+
+    def __init__(self, requested_path: Path):
+        requested = Path(requested_path).expanduser()
+        self.requested_parent = requested.parent
+        self.name = requested.name
+        self.parent = self.requested_parent.resolve(strict=True)
+        self.path = self.parent / self.name
+        self.cache_dir = self.parent / '_tail_cache' / 'v1'
+        self.cache_path = self.cache_dir / self.name
+        self.lock_key = _session_save_publication_lock_key(self.path)
+        self._parent_fd = None
+        self._cache_fd = None
+        self._windows_parent_handle = None
+        self._windows_cache_handles = []
+        self._parent_stat = None
+
+    @property
+    def sid(self) -> str:
+        return self.name[:-5] if self.name.endswith('.json') else ''
+
+    def __enter__(self):
+        if os.name == 'nt':  # pragma: no cover - exercised by the native-Windows gate.
+            self._windows_parent_handle = _open_windows_directory_handle(self.parent)
+        else:
+            flags = os.O_RDONLY
+            flags |= getattr(os, 'O_DIRECTORY', 0)
+            flags |= getattr(os, 'O_CLOEXEC', 0)
+            flags |= getattr(os, 'O_NOFOLLOW', 0)
+            self._parent_fd = os.open(self.parent, flags)
+        self._parent_stat = (
+            os.fstat(self._parent_fd)
+            if self._parent_fd is not None
+            else os.stat(self.parent, follow_symlinks=False)
+        )
+        self.validate_binding()
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        if self._cache_fd is not None:
+            os.close(self._cache_fd)
+            self._cache_fd = None
+        if self._parent_fd is not None:
+            os.close(self._parent_fd)
+            self._parent_fd = None
+        for handle in reversed(self._windows_cache_handles):
+            _close_windows_handle(handle)
+        self._windows_cache_handles.clear()
+        if self._windows_parent_handle is not None:
+            _close_windows_handle(self._windows_parent_handle)
+            self._windows_parent_handle = None
+
+    def validate_binding(self) -> None:
+        try:
+            current_parent = self.requested_parent.resolve(strict=True)
+            current_stat = os.stat(self.parent, follow_symlinks=False)
+        except OSError as exc:
+            raise OSError('session sidecar parent changed after target binding') from exc
+        if (
+            os.path.normcase(os.path.normpath(os.fspath(current_parent)))
+            != os.path.normcase(os.path.normpath(os.fspath(self.parent)))
+            or _filesystem_object_identity(current_stat)
+            != _filesystem_object_identity(self._parent_stat)
+        ):
+            raise OSError('session sidecar parent changed after target binding')
+        if self._parent_fd is not None:
+            opened_stat = os.fstat(self._parent_fd)
+            if _filesystem_object_identity(opened_stat) != _filesystem_object_identity(self._parent_stat):
+                raise OSError('session sidecar parent changed after target binding')
+
+    def owns(self, path: Path) -> bool:
+        candidate = Path(path)
+        return candidate.parent == self.parent or candidate.parent == self.cache_dir
+
+    def _open_child_directory(self, parent_fd: int, name: str) -> int:
+        flags = os.O_RDONLY
+        flags |= getattr(os, 'O_DIRECTORY', 0)
+        flags |= getattr(os, 'O_CLOEXEC', 0)
+        flags |= getattr(os, 'O_NOFOLLOW', 0)
+        try:
+            return os.open(name, flags, dir_fd=parent_fd)
+        except FileNotFoundError:
+            os.mkdir(name, mode=0o700, dir_fd=parent_fd)
+            return os.open(name, flags, dir_fd=parent_fd)
+
+    def ensure_cache_dir(self) -> None:
+        if self._cache_fd is not None or self._windows_cache_handles:
+            return
+        self.validate_binding()
+        if self._parent_fd is not None:
+            tail_fd = self._open_child_directory(self._parent_fd, '_tail_cache')
+            try:
+                self._cache_fd = self._open_child_directory(tail_fd, 'v1')
+            finally:
+                os.close(tail_fd)
+            return
+        tail_dir = self.parent / '_tail_cache'
+        cache_dir = tail_dir / 'v1'
+        for directory in (tail_dir, cache_dir):  # pragma: no cover - Windows only.
+            try:
+                directory.mkdir(mode=0o700)
+            except FileExistsError:
+                pass
+            if directory.is_symlink():
+                raise OSError('refusing symlinked session tail-cache directory')
+            self._windows_cache_handles.append(_open_windows_directory_handle(directory))
+
+    def _open_existing_windows_cache_dir(self) -> None:  # pragma: no cover - Windows only.
+        if self._windows_cache_handles:
+            return
+        self.validate_binding()
+        for directory in (self.parent / '_tail_cache', self.cache_dir):
+            if directory.is_symlink():
+                raise OSError('refusing symlinked session tail-cache directory')
+            self._windows_cache_handles.append(_open_windows_directory_handle(directory))
+
+    def _location(self, path: Path, *, create_cache=False):
+        candidate = Path(path)
+        if candidate.parent == self.parent:
+            return self._parent_fd, candidate.name, candidate
+        if candidate.parent == self.cache_dir:
+            if create_cache:
+                self.ensure_cache_dir()
+            elif self._parent_fd is not None and self._cache_fd is None:
+                tail_fd = os.open(
+                    '_tail_cache',
+                    os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0),
+                    dir_fd=self._parent_fd,
+                )
+                try:
+                    self._cache_fd = os.open(
+                        'v1',
+                        os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0),
+                        dir_fd=tail_fd,
+                    )
+                finally:
+                    os.close(tail_fd)
+            elif self._parent_fd is None and not self._windows_cache_handles:
+                self._open_existing_windows_cache_dir()
+            return self._cache_fd, candidate.name, candidate
+        raise OSError(f'path escaped bound session target: {candidate}')
+
+    def open(self, path: Path, mode: str, *, encoding=None):
+        self.validate_binding()
+        create_cache = any(flag in mode for flag in ('w', 'a', 'x', '+'))
+        dir_fd, name, absolute = self._location(path, create_cache=create_cache)
+        if os.name == 'nt':  # pragma: no cover - Windows only.
+            if absolute.is_symlink():
+                raise OSError('refusing to follow final symlink for session sidecar I/O')
+            return open(absolute, mode, encoding=encoding)
+
+        def opener(_path, flags):
+            flags |= getattr(os, 'O_CLOEXEC', 0)
+            flags |= getattr(os, 'O_NOFOLLOW', 0)
+            return os.open(name, flags, dir_fd=dir_fd)
+
+        try:
+            return open(name, mode, encoding=encoding, opener=opener)
+        except OSError as exc:
+            if getattr(exc, 'errno', None) == 40:  # ELOOP
+                raise OSError('refusing to follow final symlink for session sidecar I/O') from exc
+            raise
+
+    def stat(self, path: Path):
+        self.validate_binding()
+        dir_fd, name, absolute = self._location(path)
+        if dir_fd is None:  # pragma: no cover - Windows only.
+            return os.stat(absolute, follow_symlinks=False)
+        return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+
+    def unlink(self, path: Path, *, missing_ok=False) -> None:
+        self.validate_binding()
+        try:
+            dir_fd, name, absolute = self._location(path)
+            if dir_fd is None:  # pragma: no cover - Windows only.
+                os.unlink(absolute)
+            else:
+                os.unlink(name, dir_fd=dir_fd)
+        except FileNotFoundError:
+            if not missing_ok:
+                raise
+
+    def replace(self, src: Path, dst: Path) -> None:
+        self.validate_binding()
+        src_fd, src_name, src_absolute = self._location(src)
+        dst_fd, dst_name, dst_absolute = self._location(dst)
+        if src_fd is not None and dst_fd is not None:
+            os.replace(
+                src_name,
+                dst_name,
+                src_dir_fd=src_fd,
+                dst_dir_fd=dst_fd,
+            )
+        else:  # pragma: no cover - Windows only.
+            os.replace(src_absolute, dst_absolute)
+
+
+def _active_session_sidecar_target():
+    return getattr(_SESSION_SIDECAR_TARGET_LOCAL, 'value', None)
+
+
+@contextmanager
+def _bound_session_sidecar_target(path: Path):
+    previous = _active_session_sidecar_target()
+    with _BoundSessionSidecarTarget(path) as target:
+        _SESSION_SIDECAR_TARGET_LOCAL.value = target
+        try:
+            yield target
+        finally:
+            _SESSION_SIDECAR_TARGET_LOCAL.value = previous
+
+
+def _bound_open(path: Path, mode: str, *, encoding=None):
+    target = _active_session_sidecar_target()
+    if target is not None and target.owns(path):
+        return target.open(path, mode, encoding=encoding)
+    return open(path, mode, encoding=encoding)
+
+
+def _bound_stat(path: Path):
+    target = _active_session_sidecar_target()
+    if target is not None and target.owns(path):
+        return target.stat(path)
+    return os.stat(path, follow_symlinks=False)
+
+
+def _bound_unlink(path: Path, *, missing_ok=False) -> None:
+    target = _active_session_sidecar_target()
+    if target is not None and target.owns(path):
+        target.unlink(path, missing_ok=missing_ok)
+        return
+    Path(path).unlink(missing_ok=missing_ok)
 
 
 def _session_save_publication_lock_key(path: Path) -> str:
@@ -217,14 +504,21 @@ _WINDOWS_REPLACE_INITIAL_DELAY = 0.05  # 50 ms
 
 def _safe_replace(src: Path, dst: Path) -> None:
     """Atomic replace with retries on Windows file-locking errors."""
+    target = _active_session_sidecar_target()
     if os.name != 'nt':
-        os.replace(src, dst)
+        if target is not None and target.owns(src) and target.owns(dst):
+            target.replace(src, dst)
+        else:
+            os.replace(src, dst)
         return
 
     delay = _WINDOWS_REPLACE_INITIAL_DELAY
     for attempt in range(_WINDOWS_REPLACE_MAX_RETRIES):
         try:
-            os.replace(src, dst)
+            if target is not None and target.owns(src) and target.owns(dst):
+                target.replace(src, dst)
+            else:
+                os.replace(src, dst)
             return
         except PermissionError:
             if attempt == _WINDOWS_REPLACE_MAX_RETRIES - 1:
@@ -1371,25 +1665,23 @@ class Session:
                 f"Reload with metadata_only=False before mutating state. "
                 f"See #1558."
             )
-        sidecar_path = self.path
-        publication_path_key = os.fspath(sidecar_path)
-        publication_lock = getattr(self, '_save_publication_lock', None)
-        if (
-            publication_lock is None
-            or getattr(self, '_save_publication_path_key', None) != publication_path_key
-        ):
-            publication_lock = _get_session_save_publication_lock(sidecar_path)
-            # Keep the weak-registry value alive for this Session object's hot
-            # save path without leaking locks after all same-ID objects expire.
-            # The raw spelling is only a fast-path invalidation hint; registry
-            # ownership itself is keyed by the canonical parent + final name.
-            self._save_publication_lock = publication_lock
-            self._save_publication_path_key = publication_path_key
-        with publication_lock:
-            saved = self._save_authoritative_sidecar_and_tail_cache(
-                touch_updated_at=touch_updated_at,
-                sidecar_path=sidecar_path,
-            )
+        with _bound_session_sidecar_target(self.path) as target:
+            publication_path_key = target.lock_key
+            publication_lock = getattr(self, '_save_publication_lock', None)
+            if (
+                publication_lock is None
+                or getattr(self, '_save_publication_path_key', None) != publication_path_key
+            ):
+                publication_lock = _get_session_save_publication_lock(target.path)
+                # Keep the weak-registry value alive for this Session object's hot
+                # save path without leaking locks after all same-ID objects expire.
+                self._save_publication_lock = publication_lock
+                self._save_publication_path_key = publication_path_key
+            with publication_lock:
+                saved = self._save_authoritative_sidecar_and_tail_cache(
+                    touch_updated_at=touch_updated_at,
+                    sidecar_path=target.path,
+                )
         if not saved:
             return
         if not skip_index:
@@ -1499,11 +1791,14 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        existing_signature = _sidecar_stat_signature(sidecar_path)
-        previous_signature = getattr(self, '_last_saved_source_signature', None)
+        existing_source = _sidecar_content_proof(sidecar_path)
+        existing_proof = existing_source[0] if existing_source is not None else None
+        existing_bytes = existing_source[1] if existing_source is not None else None
+        existing_signature = existing_proof[0] if existing_proof is not None else None
+        previous_proof = getattr(self, '_last_saved_source_proof', None)
         fast_small_snapshot = (
-            existing_signature is not None
-            and existing_signature == previous_signature
+            existing_proof is not None
+            and existing_proof == previous_proof
             and not _session_tail_cache_signature_is_large_enough(existing_signature)
         )
         if fast_small_snapshot:
@@ -1539,94 +1834,77 @@ class Session:
         # The recovery path is api/session_recovery.py — at server startup and
         # via /api/session/recover, sessions whose JSON has fewer messages than
         # their .bak get restored automatically.
+        payload_bytes = payload.encode('utf-8')
         incoming_msg_count = len(frozen_snapshot.get('messages') or [])
-        try:
-            if existing_signature is not None:
-                existing_text = None
-                existing_msg_count = -1
-                if (
-                    existing_signature == getattr(self, '_last_saved_source_signature', None)
-                    and isinstance(getattr(self, '_last_saved_message_count', None), int)
-                ):
-                    # The same Session object still owns the exact bytes it last
-                    # published. Avoid re-reading and full-parsing them on every
-                    # checkpoint; any external/in-process replacement changes the
-                    # stat signature and falls through to the authoritative read.
-                    existing_msg_count = self._last_saved_message_count
-                else:
-                    existing_text = sidecar_path.read_text(encoding='utf-8')
+        if existing_proof is not None:
+            if (
+                existing_proof == getattr(self, '_last_saved_source_proof', None)
+                and isinstance(getattr(self, '_last_saved_message_count', None), int)
+            ):
+                # A full-source digest, not metadata, proves these are the exact
+                # bytes whose count this process cached.
+                existing_msg_count = self._last_saved_message_count
+            else:
+                try:
+                    if existing_bytes is None:
+                        raise ValueError('missing authoritative source bytes')
+                    existing = json.loads(existing_bytes)
+                    existing_msg_count = len(existing.get('messages') or [])
+                except (json.JSONDecodeError, UnicodeDecodeError, ValueError, TypeError) as exc:
+                    raise OSError(
+                        'cannot prove previous authoritative session message count'
+                    ) from exc
+            if (
+                existing_msg_count > 0
+                and incoming_msg_count == 0
+                and (self.active_stream_id or self.pending_user_message)
+            ):
+                logger.warning(
+                    "refusing to overwrite session %s messages with empty active/pending snapshot "
+                    "(existing=%s, incoming=%s, stream=%s)",
+                    self.session_id,
+                    existing_msg_count,
+                    incoming_msg_count,
+                    self.active_stream_id,
+                )
+                return False
+            if existing_msg_count > incoming_msg_count:
+                bak_path = sidecar_path.with_suffix('.json.bak')
+                bak_tmp = bak_path.with_suffix(
+                    f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
+                )
+                try:
+                    # Retain the exact proven source bytes; text-mode newline
+                    # translation would weaken this recovery contract on Windows.
+                    _bound_unlink(bak_tmp, missing_ok=True)
+                    with _bound_open(bak_tmp, 'xb') as bf:
+                        bf.write(existing_bytes)
+                        bf.flush()
+                        os.fsync(bf.fileno())
+                    _safe_replace(bak_tmp, bak_path)
+                except Exception:
                     try:
-                        existing = json.loads(existing_text)
-                        existing_msg_count = len(existing.get('messages') or [])
-                    except (json.JSONDecodeError, ValueError):
-                        existing_msg_count = -1
-                if (
-                    existing_msg_count > 0
-                    and incoming_msg_count == 0
-                    and (self.active_stream_id or self.pending_user_message)
-                ):
-                    logger.warning(
-                        "refusing to overwrite session %s messages with empty active/pending snapshot "
-                        "(existing=%s, incoming=%s, stream=%s)",
-                        self.session_id,
-                        existing_msg_count,
-                        incoming_msg_count,
-                        self.active_stream_id,
-                    )
-                    return False
-                if existing_msg_count > incoming_msg_count:
-                    if existing_text is None:
-                        # A shrink needs the actual previous bytes for the backup.
-                        # Re-parse after the read so a replacement between the fast
-                        # stat and this slow path cannot back up an unrelated count.
-                        existing_text = sidecar_path.read_text(encoding='utf-8')
-                        try:
-                            existing = json.loads(existing_text)
-                            existing_msg_count = len(existing.get('messages') or [])
-                        except (json.JSONDecodeError, ValueError):
-                            existing_msg_count = -1
-                    if existing_msg_count <= incoming_msg_count:
-                        existing_text = None
-                    bak_path = sidecar_path.with_suffix('.json.bak')
-                    # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,
-                    # mirroring the main save() pattern below. Prevents a
-                    # torn .bak from a crash mid-write or a concurrent
-                    # backup-producing save. Recovery defends against a
-                    # torn .bak (JSONDecodeError → no_action), so the
-                    # failure mode pre-fix was "backup is lost"; with
-                    # this fix the backup either lands cleanly or doesn't
-                    # land at all.
-                    try:
-                        if existing_text is None:
-                            raise OSError("authoritative source changed before backup")
-                        bak_tmp = bak_path.with_suffix(
-                            f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
-                        )
-                        with open(bak_tmp, 'w', encoding='utf-8') as bf:
-                            bf.write(existing_text)
-                            bf.flush()
-                            os.fsync(bf.fileno())
-                        _safe_replace(bak_tmp, bak_path)
-                    except OSError:
-                        # Backup is best-effort; main save proceeds regardless.
-                        try:
-                            bak_tmp.unlink(missing_ok=True)
-                        except Exception:
-                            pass
-        except OSError:
-            pass
+                        _bound_unlink(bak_tmp, missing_ok=True)
+                    except Exception:
+                        pass
+                    raise
 
         tmp = sidecar_path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
-            with open(tmp, 'w', encoding='utf-8') as f:
-                f.write(payload)
+            _bound_unlink(tmp, missing_ok=True)
+            with _bound_open(tmp, 'xb') as f:
+                f.write(payload_bytes)
                 f.flush()
                 os.fsync(f.fileno())
+            current_source = _sidecar_content_proof(sidecar_path)
+            current_proof = current_source[0] if current_source is not None else None
+            if current_proof != existing_proof:
+                raise OSError('authoritative session source changed before publication')
             _safe_replace(tmp, sidecar_path)
             _invalidate_persisted_session_ids_snapshot()
         except Exception:
             try:
-                tmp.unlink(missing_ok=True)
+                _bound_unlink(tmp, missing_ok=True)
             except Exception:
                 pass
             raise
@@ -1636,19 +1914,23 @@ class Session:
         # Small sidecars stay on the authoritative path; publishing a second
         # fsync'd file on every streaming checkpoint would cost more than the
         # bounded read can save.
+        source_signature = _sidecar_stat_signature(sidecar_path)
+        if source_signature is None:
+            raise OSError('authoritative source stat failed after publication')
+        source_proof = (source_signature, hashlib.sha256(payload_bytes).hexdigest())
+        self._last_saved_source_signature = source_signature
+        self._last_saved_source_proof = source_proof
+        self._last_saved_message_count = incoming_msg_count
         try:
             # Every successful authoritative publication invalidates its previous
             # derived bytes. An eligible source is republished below; an ineligible
-            # source stays cache-free. Failure is non-fatal and the reader still
-            # rejects any retained stale entry by its old source signature.
-            source_signature = _sidecar_stat_signature(sidecar_path)
-            self._last_saved_source_signature = source_signature
-            self._last_saved_message_count = incoming_msg_count
+            # source stays cache-free. Cache cleanup/population remains non-fatal;
+            # the reader rejects retained bytes without an exact source proof.
             delete_session_tail_cache(self.session_id)
             if _session_tail_cache_signature_is_large_enough(source_signature):
                 _write_session_tail_cache(
                     frozen_snapshot,
-                    expected_signature=source_signature,
+                    expected_proof=source_proof,
                     snapshot_is_immutable=snapshot_is_immutable,
                 )
         except Exception:
@@ -1667,13 +1949,15 @@ class Session:
         if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
-        if not p.exists():
+        # One complete source proof owns both the parse and any opportunistic
+        # derived-cache publication. Metadata alone cannot establish stability.
+        with _bound_session_sidecar_target(p) as target:
+            _pre_read_source = _sidecar_content_proof(target.path)
+        if _pre_read_source is None:
             return None
-        # #5854: snapshot the stat signature BEFORE reading so a legacy-facts
-        # cache write is only committed if the file didn't change under us
-        # during the parse (TOCTOU guard against an atomic replace mid-read).
-        _pre_read_sig = _sidecar_stat_signature(p)
-        data = json.loads(p.read_text(encoding='utf-8'))
+        _pre_read_proof, _pre_read_bytes = _pre_read_source
+        _pre_read_sig = _pre_read_proof[0]
+        data = json.loads(_pre_read_bytes)
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
         if _collapsed_partials:
@@ -1690,9 +1974,8 @@ class Session:
             # scenes serialize before them, so cache the authoritative facts we
             # just parsed. This keeps the metadata-only path and the eviction
             # check from full-parsing this unchanged file again on every poll.
-            # Keyed by stat signature, so any edit invalidates it; the next
-            # save() rewrites the modern layout and the fallback stops firing.
-            # expected_sig guards against an atomic replace during the read.
+            # Keyed by complete content proof, so any edit invalidates it; the
+            # next save() rewrites the modern layout and the fallback stops firing.
             # (When _collapsed_partials fired, save() above already rewrote the
             # modern layout, so no legacy caching is needed.)
             if 'anchor_scene_index' not in data:
@@ -1701,7 +1984,7 @@ class Session:
                         sid,
                         len(getattr(session, 'messages', None) or []),
                         _anchor_scene_index_from_records(getattr(session, 'anchor_activity_scenes', None)),
-                        expected_sig=_pre_read_sig,
+                        expected_proof=_pre_read_proof,
                     )
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
@@ -1710,19 +1993,20 @@ class Session:
             # metadata-only probes and pre-authorization foreign-profile reads
             # must not leave plaintext cache copies behind.
             try:
-                _post_read_sig = _sidecar_stat_signature(p)
-                if (
-                    _populate_tail_cache
-                    and _pre_read_sig is not None
-                    and _pre_read_sig == _post_read_sig
-                    and _session_tail_cache_signature_is_large_enough(_pre_read_sig)
-                    and _session_tail_cache_profile_is_active(session)
-                    and not _session_tail_cache_has_signature(sid, _pre_read_sig)
-                ):
-                    _write_session_tail_cache(
-                        session,
-                        expected_signature=_pre_read_sig,
-                    )
+                with _bound_session_sidecar_target(p) as target:
+                    _post_read_source = _sidecar_content_proof(target.path)
+                    if (
+                        _populate_tail_cache
+                        and _post_read_source is not None
+                        and _pre_read_proof == _post_read_source[0]
+                        and _session_tail_cache_signature_is_large_enough(_pre_read_sig)
+                        and _session_tail_cache_profile_is_active(session)
+                        and not _session_tail_cache_has_signature(sid, _pre_read_proof)
+                    ):
+                        _write_session_tail_cache(
+                            session,
+                            expected_proof=_pre_read_proof,
+                        )
             except Exception:
                 logger.debug(
                     "session tail-cache opportunistic populate failed for %s",
@@ -3903,23 +4187,75 @@ def _disk_scene_fingerprint(disk_meta_prefix: dict):
 
 
 def _sidecar_stat_signature(path):
-    """Stat signature for a sidecar path, or None if it can't be stat'd.
-
-    Any edit (atomic-rename or in-place) changes at least one component, so a
-    cached entry keyed by this signature is auto-invalidated on the next write.
-    """
+    """Return cheap source metadata, never treating it as a content proof."""
     try:
-        st = path.stat()
+        st = _bound_stat(Path(path))
     except OSError:
+        return None
+    if not _stat.S_ISREG(st.st_mode):
         return None
     return (str(path), int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
             int(st.st_size), int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))))
+
+
+def _sidecar_content_proof(path: Path):
+    """Read stable authoritative bytes and return ``((stat, sha256), bytes)``.
+
+    The digest covers the complete JSON source, so every cache semantic input
+    (prefix facts, lineage/todo facts, message tail, and tool calls) participates.
+    Stat metadata remains an optimization/diagnostic field only. A final-symlink
+    or parent-identity uncertainty raises instead of silently following a target.
+    """
+    path = Path(path)
+    target = _active_session_sidecar_target()
+    if target is None:
+        with _bound_session_sidecar_target(path) as bound:
+            return _sidecar_content_proof(bound.path)
+    try:
+        with _bound_open(path, 'rb') as handle:
+            before = os.fstat(handle.fileno())
+            if not _stat.S_ISREG(before.st_mode):
+                raise OSError('refusing non-regular session sidecar source')
+            source_bytes = handle.read()
+            after = os.fstat(handle.fileno())
+    except FileNotFoundError:
+        return None
+    if (
+        _filesystem_object_identity(before) != _filesystem_object_identity(after)
+        or int(before.st_size) != int(after.st_size)
+        or len(source_bytes) != int(after.st_size)
+    ):
+        raise OSError('session sidecar changed while authoritative bytes were read')
+    current = _bound_stat(path)
+    if (
+        not _stat.S_ISREG(current.st_mode)
+        or _filesystem_object_identity(current) != _filesystem_object_identity(after)
+        or int(current.st_size) != len(source_bytes)
+    ):
+        raise OSError('session sidecar changed while authoritative bytes were read')
+    signature = _sidecar_stat_signature(path)
+    if signature is None or signature[2] != len(source_bytes):
+        raise OSError('session sidecar stat/content proof is uncertain')
+    proof = (signature, hashlib.sha256(source_bytes).hexdigest())
+    return proof, source_bytes
+
+
+def _tail_cache_content_digest(value) -> str | None:
+    if not isinstance(value, str) or len(value) != 64:
+        return None
+    lowered = value.lower()
+    if any(character not in '0123456789abcdef' for character in lowered):
+        return None
+    return lowered
 
 
 def session_tail_cache_path(sid: str) -> Path:
     """Return the v1 derived-cache path for a path-safe session id."""
     if not is_safe_session_id(sid):
         raise ValueError(f"Unsafe session_id {sid!r}")
+    target = _active_session_sidecar_target()
+    if target is not None and target.sid == sid:
+        return target.cache_path
     return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
 
 
@@ -3953,7 +4289,7 @@ def delete_session_tail_cache(sid: str) -> bool:
     if not is_safe_session_id(sid):
         return False
     try:
-        os.unlink(session_tail_cache_path(sid))
+        _bound_unlink(session_tail_cache_path(sid))
         return True
     except FileNotFoundError:
         return True
@@ -3967,16 +4303,21 @@ def delete_session_sidecar_and_tail_cache(sid: str) -> bool:
     if not is_safe_session_id(sid):
         return False
     sidecar = SESSION_DIR / f'{sid}.json'
-    with _get_session_save_publication_lock(sidecar):
-        try:
-            sidecar.unlink(missing_ok=True)
-            sidecar_deleted = True
-        except OSError:
-            logger.debug("Failed to remove session sidecar for %s", sid, exc_info=True)
-            sidecar_deleted = False
-        # Keep separate failure handling: a sidecar failure must not retain the
-        # derived copy, and a cache failure must not resurrect/fail the source.
-        cache_deleted = delete_session_tail_cache(sid)
+    try:
+        with _bound_session_sidecar_target(sidecar) as target:
+            with _get_session_save_publication_lock(target.path):
+                try:
+                    _bound_unlink(target.path, missing_ok=True)
+                    sidecar_deleted = True
+                except OSError:
+                    logger.debug("Failed to remove session sidecar for %s", sid, exc_info=True)
+                    sidecar_deleted = False
+                # Keep separate failure handling: a sidecar failure must not retain the
+                # derived copy, and a cache failure must not resurrect/fail the source.
+                cache_deleted = delete_session_tail_cache(sid)
+    except OSError:
+        logger.debug("Failed to bind session sidecar target for %s", sid, exc_info=True)
+        return False
     return sidecar_deleted and cache_deleted
 
 
@@ -4049,7 +4390,7 @@ def _session_tail_cache_snapshot_value(snapshot, key, default=None):
 
 def _session_tail_cache_payload(
     session,
-    source_signature,
+    source_proof,
     *,
     snapshot_is_immutable: bool = False,
 ) -> dict | None:
@@ -4059,8 +4400,11 @@ def _session_tail_cache_payload(
     sid = _session_tail_cache_snapshot_value(session, 'session_id')
     if not is_safe_session_id(sid):
         return None
-    signature = _tail_cache_signature_dict(source_signature)
-    if signature is None:
+    if not isinstance(source_proof, tuple) or len(source_proof) != 2:
+        return None
+    signature = _tail_cache_signature_dict(source_proof[0])
+    source_digest = _tail_cache_content_digest(source_proof[1])
+    if signature is None or source_digest is None:
         return None
     messages = _session_tail_cache_snapshot_value(session, 'messages')
     if not isinstance(messages, list):
@@ -4126,6 +4470,7 @@ def _session_tail_cache_payload(
         'version': _SESSION_TAIL_CACHE_VERSION,
         'session_id': sid,
         'source_signature': signature,
+        'source_sha256': source_digest,
         'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
         'message_offset': offset,
         'messages': raw_tail,
@@ -4151,10 +4496,16 @@ def _session_tail_cache_payload(
 
 
 def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> bool:
-    """Atomically publish one already-built cache payload after a final restat."""
+    """Atomically publish one payload after a full-source proof check."""
     sid = payload.get('session_id') if isinstance(payload, dict) else None
     if not is_safe_session_id(sid) or expected_signature is None:
         return False
+    if _active_session_sidecar_target() is None:
+        with _bound_session_sidecar_target(SESSION_DIR / f'{sid}.json'):
+            return _write_session_tail_cache_payload(
+                payload,
+                expected_signature=expected_signature,
+            )
     encoded = json.dumps(payload, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
     if len(encoded) > _SESSION_TAIL_CACHE_MAX_BYTES:
         return False
@@ -4163,27 +4514,34 @@ def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> b
         f'{path.name}.tmp.{os.getpid()}.{threading.current_thread().ident}'
     )
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(tmp, 'wb') as handle:
+        target = _active_session_sidecar_target()
+        if target is not None and target.owns(path):
+            target.ensure_cache_dir()
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        _bound_unlink(tmp, missing_ok=True)
+        with _bound_open(tmp, 'xb') as handle:
             handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
-        try:
-            os.chmod(tmp, 0o600)
-        except OSError:
-            pass
-        sidecar = SESSION_DIR / f'{sid}.json'
-        if _sidecar_stat_signature(sidecar) != expected_signature:
+            try:
+                os.fchmod(handle.fileno(), 0o600)
+            except (AttributeError, OSError):
+                pass
+        sidecar = target.path if target is not None and target.sid == sid else SESSION_DIR / f'{sid}.json'
+        current_source = _sidecar_content_proof(sidecar)
+        expected_digest = _tail_cache_content_digest(payload.get('source_sha256'))
+        if (
+            current_source is None
+            or expected_digest is None
+            or current_source[0] != (expected_signature, expected_digest)
+        ):
             return False
         _safe_replace(tmp, path)
-        try:
-            os.chmod(path, 0o600)
-        except OSError:
-            pass
         return True
     finally:
         try:
-            tmp.unlink(missing_ok=True)
+            _bound_unlink(tmp, missing_ok=True)
         except OSError:
             pass
 
@@ -4191,42 +4549,65 @@ def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> b
 def _write_session_tail_cache(
     session,
     *,
-    expected_signature,
+    expected_proof=None,
+    expected_signature=None,
     snapshot_is_immutable: bool = False,
 ) -> bool:
+    sid = _session_tail_cache_snapshot_value(session, 'session_id')
+    if not is_safe_session_id(sid):
+        return False
+    if _active_session_sidecar_target() is None:
+        with _bound_session_sidecar_target(SESSION_DIR / f'{sid}.json'):
+            return _write_session_tail_cache(
+                session,
+                expected_proof=expected_proof,
+                expected_signature=expected_signature,
+                snapshot_is_immutable=snapshot_is_immutable,
+            )
+    if expected_proof is None:
+        sidecar = SESSION_DIR / f'{sid}.json'
+        current_source = _sidecar_content_proof(sidecar)
+        if current_source is None or current_source[0][0] != expected_signature:
+            return False
+        expected_proof = current_source[0]
     payload = _session_tail_cache_payload(
         session,
-        expected_signature,
+        expected_proof,
         snapshot_is_immutable=snapshot_is_immutable,
     )
     if payload is None:
         return False
     return _write_session_tail_cache_payload(
         payload,
-        expected_signature=expected_signature,
+        expected_signature=expected_proof[0],
     )
 
 
-def _session_tail_cache_has_signature(sid: str, signature) -> bool:
-    """Cheaply decide whether an existing bounded cache describes this source."""
+def _session_tail_cache_has_signature(sid: str, source_proof) -> bool:
+    """Decide whether an existing bounded cache has this full-source proof."""
+    if not isinstance(source_proof, tuple) or len(source_proof) != 2:
+        return False
     try:
         path = session_tail_cache_path(sid)
-        if path.stat().st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
+        if _bound_stat(path).st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
             return False
-        value = json.loads(path.read_bytes())
+        with _bound_open(path, 'rb') as handle:
+            value = json.loads(handle.read())
         return (
             isinstance(value, dict)
             and value.get('format') == _SESSION_TAIL_CACHE_FORMAT
             and value.get('version') == _SESSION_TAIL_CACHE_VERSION
             and value.get('session_id') == sid
             and _tail_cache_signature_tuple(value.get('source_signature'))
-            == _tail_cache_signature_tuple(_tail_cache_signature_dict(signature))
+            == _tail_cache_signature_tuple(_tail_cache_signature_dict(source_proof[0]))
+            and _tail_cache_content_digest(value.get('source_sha256'))
+            == _tail_cache_content_digest(source_proof[1])
         )
     except Exception:
         return False
 
 
-def _validate_session_tail_cache_payload(payload, sid: str, source_signature) -> dict | None:
+def _validate_session_tail_cache_payload(payload, sid: str, source_proof) -> dict | None:
     """Strictly validate v1 shape and bounded-read eligibility."""
     if not isinstance(payload, dict):
         return None
@@ -4234,9 +4615,18 @@ def _validate_session_tail_cache_payload(payload, sid: str, source_signature) ->
         return None
     if payload.get('version') != _SESSION_TAIL_CACHE_VERSION or payload.get('session_id') != sid:
         return None
+    if not isinstance(source_proof, tuple) or len(source_proof) != 2:
+        return None
     embedded_signature = _tail_cache_signature_tuple(payload.get('source_signature'))
-    current_signature = _tail_cache_signature_tuple(_tail_cache_signature_dict(source_signature))
-    if embedded_signature is None or embedded_signature != current_signature:
+    current_signature = _tail_cache_signature_tuple(_tail_cache_signature_dict(source_proof[0]))
+    embedded_digest = _tail_cache_content_digest(payload.get('source_sha256'))
+    current_digest = _tail_cache_content_digest(source_proof[1])
+    if (
+        embedded_signature is None
+        or embedded_signature != current_signature
+        or embedded_digest is None
+        or embedded_digest != current_digest
+    ):
         return None
     if payload.get('tail_limit') != _SESSION_TAIL_CACHE_LIMIT:
         return None
@@ -4298,22 +4688,23 @@ def _validate_session_tail_cache_payload(payload, sid: str, source_signature) ->
 def _read_session_tail_cache_file(sid: str) -> dict | None:
     if not is_safe_session_id(sid):
         return None
-    sidecar = SESSION_DIR / f'{sid}.json'
-    before = _sidecar_stat_signature(sidecar)
-    if before is None:
-        return None
     try:
-        path = session_tail_cache_path(sid)
-        size = path.stat().st_size
-        if size <= 0 or size > _SESSION_TAIL_CACHE_MAX_BYTES:
-            return None
-        payload = json.loads(path.read_bytes())
+        with _bound_session_sidecar_target(SESSION_DIR / f'{sid}.json') as target:
+            path = target.cache_path
+            size = _bound_stat(path).st_size
+            if size <= 0 or size > _SESSION_TAIL_CACHE_MAX_BYTES:
+                return None
+            with _bound_open(path, 'rb') as handle:
+                payload = json.loads(handle.read())
+            # Read the complete authoritative source after the derived bytes.
+            # Returning a cache requires an exact digest match, so same-stat
+            # in-place and atomic replacements fail closed without JSON parsing.
+            source = _sidecar_content_proof(target.path)
+            if source is None:
+                return None
+            return _validate_session_tail_cache_payload(payload, sid, source[0])
     except (OSError, ValueError, TypeError):
         return None
-    after = _sidecar_stat_signature(sidecar)
-    if after is None or before != after:
-        return None
-    return _validate_session_tail_cache_payload(payload, sid, before)
 
 
 def read_session_tail_cache(sid: str) -> dict | None:
@@ -4563,7 +4954,7 @@ def _legacy_tail_positionable_tool_calls(suffix: dict, messages: list, offset: i
 
 
 def build_session_tail_cache_from_legacy_sidecar(sid: str) -> dict | None:
-    """Build a v1 snapshot from stable prefix/tail/suffix slices, never a full parse."""
+    """Build a v1 snapshot from one content-proven authoritative source read."""
     if not is_safe_session_id(sid):
         return None
     with LOCK:
@@ -4571,112 +4962,95 @@ def build_session_tail_cache_from_legacy_sidecar(sid: str) -> dict | None:
         if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
             return None
     path = SESSION_DIR / f'{sid}.json'
-    before = _sidecar_stat_signature(path)
-    if not _session_tail_cache_signature_is_large_enough(before):
-        return None
     try:
-        prefix = _read_metadata_json_prefix(path)
-        metadata = json.loads(prefix) if prefix else None
+        with _bound_session_sidecar_target(path) as target:
+            source = _sidecar_content_proof(target.path)
+            if source is None or not _session_tail_cache_signature_is_large_enough(source[0][0]):
+                return None
+            snapshot = json.loads(source[1])
+            if (
+                not isinstance(snapshot, dict)
+                or snapshot.get('session_id') != sid
+                or not _legacy_tail_metadata_is_eligible(snapshot)
+            ):
+                return None
+            index_row = _legacy_tail_cache_index_row(sid, source[0][0], snapshot)
+            messages = snapshot.get('messages')
+            if index_row is None or not isinstance(messages, list):
+                return None
+            uncached_prefix = messages[:-_SESSION_TAIL_CACHE_LIMIT]
+            if any(
+                isinstance(message, dict)
+                and isinstance(message.get('content'), str)
+                and (
+                    '"todos"' in message['content']
+                    or '\\"todos\\"' in message['content']
+                )
+                for message in uncached_prefix
+            ):
+                return None
+            payload = _session_tail_cache_payload(snapshot, source[0])
+            if payload is None:
+                return None
+            if not _write_session_tail_cache_payload(
+                payload,
+                expected_signature=source[0][0],
+            ):
+                return None
+            validated = _read_session_tail_cache_file(sid)
+            if validated is None:
+                delete_session_tail_cache(sid)
+            return validated
     except (OSError, ValueError, TypeError):
         return None
-    if not isinstance(metadata, dict):
-        return None
-    if not _legacy_tail_metadata_is_eligible(metadata) or metadata.get('session_id') != sid:
-        return None
-    index_row = _legacy_tail_cache_index_row(sid, before, metadata)
-    if index_row is None:
-        return None
-    source_count = int(index_row['message_count'])
-    wanted = min(_SESSION_TAIL_CACHE_LIMIT, source_count)
-    parts = _read_legacy_tail_parts(path, wanted)
-    if parts is None:
-        return None
-    messages, suffix = parts
-    offset = source_count - wanted
-    cached_tool_calls = _legacy_tail_positionable_tool_calls(
-        suffix,
-        messages,
-        offset,
-        source_count,
-    )
-    if cached_tool_calls is None:
-        return None
-    try:
-        from api.todo_state import derive_todo_state
-
-        todo_state = derive_todo_state(messages)
-    except Exception:
-        return None
-    payload = {
-        'format': _SESSION_TAIL_CACHE_FORMAT,
-        'version': _SESSION_TAIL_CACHE_VERSION,
-        'session_id': sid,
-        'source_signature': _tail_cache_signature_dict(before),
-        'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
-        'message_offset': offset,
-        'messages': messages,
-        'source_message_count': source_count,
-        'source_user_message_count': int(index_row['user_message_count']),
-        'source_last_message_at': index_row.get('last_message_at'),
-        'tool_calls': cached_tool_calls,
-        'all_tool_calls_positionable': True,
-        'todo_state': todo_state,
-        'anchor_scene_index': {},
-        'all_cached_timestamps_valid': True,
-        'created_at': float(time.time()),
-    }
-    if _sidecar_stat_signature(path) != before:
-        return None
-    if not _write_session_tail_cache_payload(payload, expected_signature=before):
-        return None
-    return _read_session_tail_cache_file(sid)
 
 
 def _legacy_sidecar_facts_get(sid):
     """Return cached authoritative facts for a LEGACY sidecar, or None (#5854).
 
-    Only returns a hit when the file's current stat signature matches the cached
-    one, so a stale entry can never be served after an edit.
+    Only returns a hit when the file's complete content proof matches the cached
+    one, so same-metadata edits cannot serve stale facts.
     """
     if not is_safe_session_id(sid):
         return None
-    sig = _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
-    if sig is None:
+    try:
+        source = _sidecar_content_proof(SESSION_DIR / f'{sid}.json')
+    except OSError:
         return None
+    if source is None:
+        return None
+    proof = source[0]
     with _LEGACY_SIDECAR_FACTS_LOCK:
-        hit = _LEGACY_SIDECAR_FACTS.get(sig)
+        hit = _LEGACY_SIDECAR_FACTS.get(proof)
         if hit is not None:
-            _LEGACY_SIDECAR_FACTS.move_to_end(sig)
+            _LEGACY_SIDECAR_FACTS.move_to_end(proof)
             return dict(hit)
     return None
 
 
-def _legacy_sidecar_facts_put(sid, message_count, scene_index, *, expected_sig):
-    """Cache authoritative facts for a legacy sidecar keyed by its stat signature.
+def _legacy_sidecar_facts_put(sid, message_count, scene_index, *, expected_proof):
+    """Cache authoritative facts for a legacy sidecar keyed by content proof.
 
-    #5854 TOCTOU guard: ``expected_sig`` (MANDATORY) is the signature captured
-    BEFORE the caller parsed the file. The facts were derived from that snapshot,
-    so we only cache when the file's CURRENT signature still equals it —
-    otherwise the file was atomically replaced during the parse and these facts
-    describe the old content; caching them under the new signature would serve
-    stale data. Pass ``None`` explicitly only if the caller genuinely has no
-    snapshot (then this is a no-op, refusing to cache unverified facts).
+    The expected proof was captured with the exact bytes parsed by the caller.
+    Re-read and compare before insertion so replacements and in-place edits both
+    fail closed.
     """
     if not is_safe_session_id(sid):
         return
-    if expected_sig is None:
+    if expected_proof is None:
         return
-    sig = _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
-    if sig is None:
+    try:
+        source = _sidecar_content_proof(SESSION_DIR / f'{sid}.json')
+    except OSError:
         return
-    if sig != expected_sig:
+    if source is None or source[0] != expected_proof:
         # File changed under us during the parse — do not cache stale facts.
         return
     entry = {"message_count": message_count,
              "scene_index": dict(scene_index) if isinstance(scene_index, dict) else {}}
     with _LEGACY_SIDECAR_FACTS_LOCK:
-        _LEGACY_SIDECAR_FACTS[sig] = entry
-        _LEGACY_SIDECAR_FACTS.move_to_end(sig)
+        _LEGACY_SIDECAR_FACTS[expected_proof] = entry
+        _LEGACY_SIDECAR_FACTS.move_to_end(expected_proof)
         while len(_LEGACY_SIDECAR_FACTS) > _LEGACY_SIDECAR_FACTS_MAX:
             _LEGACY_SIDECAR_FACTS.popitem(last=False)
 
@@ -4942,22 +5316,25 @@ def _persisted_message_count(sid) -> int | None:
                 # as "do not evict"), which can let new_session() evict its own
                 # unsaved session and 404 the first send. Full-parse to get the
                 # authoritative count (Session.load re-caches the facts for
-                # legacy files under a TOCTOU-guarded signature). Re-verify the
-                # stat signature is stable across the parse so we never return a
-                # count from a file that was atomically replaced mid-read; retry
+                # legacy files under a TOCTOU-guarded content proof). Re-read that
+                # proof through the facts lookup so same-stat in-place and atomic
+                # replacements cannot return a count from old bytes. Retry
                 # boundedly on mismatch, then fall through to None. Bounded
                 # overall: the next save() rewrites the modern layout.
                 for _attempt in range(3):
-                    sig_before = _sidecar_stat_signature(p)
                     try:
                         _full = Session.load(sid)
                     except Exception:
                         _full = None
-                    sig_after = _sidecar_stat_signature(p)
                     if _full is None:
                         return None
-                    if sig_before is not None and sig_before == sig_after:
-                        return len(getattr(_full, 'messages', None) or [])
+                    _verified_facts = _legacy_sidecar_facts_get(sid)
+                    if _verified_facts is not None:
+                        verified_count = _parse_nonnegative_int(
+                            _verified_facts.get('message_count')
+                        )
+                        if verified_count is not None:
+                            return verified_count
                     # File changed during the parse — the count is uncertain;
                     # retry with a fresh snapshot.
                 return None

--- a/api/models.py
+++ b/api/models.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import math
+import mmap
 import os
 import re
 import threading
@@ -130,6 +131,14 @@ _LEGACY_SIDECAR_FACTS_MAX = 2000
 
 _STALE_TMP_AGE_SECONDS = 3600  # 1 hour
 
+# Rebuildable, source-signature-bound raw transcript tail. The authoritative
+# session sidecar remains the only semantic owner; these files may be deleted at
+# any time and every read fails closed to the full loader on uncertainty.
+_SESSION_TAIL_CACHE_FORMAT = 'hermes.session-tail-cache'
+_SESSION_TAIL_CACHE_VERSION = 1
+_SESSION_TAIL_CACHE_LIMIT = 300
+_SESSION_TAIL_CACHE_MAX_BYTES = 4 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Windows-safe os.replace() with retry
@@ -219,7 +228,9 @@ def _cleanup_stale_tmp_files() -> None:
     """
     cutoff = time.time() - _STALE_TMP_AGE_SECONDS
     try:
-        for p in SESSION_DIR.glob('*.tmp.*'):
+        candidates = list(SESSION_DIR.glob('*.tmp.*'))
+        candidates.extend((SESSION_DIR / '_tail_cache' / 'v1').glob('*.tmp.*'))
+        for p in candidates:
             try:
                 if p.stat().st_mtime < cutoff:
                     p.unlink(missing_ok=True)
@@ -1425,6 +1436,20 @@ class Session:
             except Exception:
                 pass
             raise
+        # The sidecar is authoritative and must land first. Tail-cache writes
+        # are derived, atomic, and strictly fail-open: a cache filesystem or
+        # validation failure can never roll back a successful session save.
+        try:
+            _write_session_tail_cache(
+                self,
+                expected_signature=_sidecar_stat_signature(self.path),
+            )
+        except Exception:
+            logger.debug(
+                "session tail-cache populate failed for %s",
+                self.session_id,
+                exc_info=True,
+            )
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1453,7 +1478,7 @@ class Session:
                 )
 
     @classmethod
-    def load(cls, sid):
+    def load(cls, sid, *, _populate_tail_cache=True):
         # Validate session ID format to prevent path traversal.  API/gateway
         # session ids may contain hyphens (for example ``api-*`` and
         # ``reachy-voice-*``); allow those but still reject dots/slashes.
@@ -1498,6 +1523,29 @@ class Session:
                     )
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
+            # Read-old/write-new migration is allowed only for a stable full
+            # parse and only for the request's active profile. In particular,
+            # metadata-only probes and pre-authorization foreign-profile reads
+            # must not leave plaintext cache copies behind.
+            try:
+                _post_read_sig = _sidecar_stat_signature(p)
+                if (
+                    _populate_tail_cache
+                    and _pre_read_sig is not None
+                    and _pre_read_sig == _post_read_sig
+                    and _session_tail_cache_profile_is_active(session)
+                    and not _session_tail_cache_has_signature(sid, _pre_read_sig)
+                ):
+                    _write_session_tail_cache(
+                        session,
+                        expected_signature=_pre_read_sig,
+                    )
+            except Exception:
+                logger.debug(
+                    "session tail-cache opportunistic populate failed for %s",
+                    sid,
+                    exc_info=True,
+                )
         return session
 
     @classmethod
@@ -1519,11 +1567,11 @@ class Session:
         try:
             prefix = _read_metadata_json_prefix(p)
             if not prefix:
-                return cls.load(sid)
+                return cls.load(sid, _populate_tail_cache=False)
             parsed = json.loads(prefix)
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
-                return cls.load(sid)
+                return cls.load(sid, _populate_tail_cache=False)
             parsed['messages'] = []
             parsed['tool_calls'] = []
             session = cls(**parsed)
@@ -1565,7 +1613,7 @@ class Session:
                 # facts cache with a TOCTOU-guarded write (expected_sig), so we
                 # do NOT re-cache here (an unguarded second write could stamp
                 # stale facts under a replacement file's signature — Codex r5).
-                return cls.load(sid)
+                return cls.load(sid, _populate_tail_cache=False)
             # Modern sidecars carry an accurate message_count, so it is the
             # source of truth and we skip the per-row _index.json read in the
             # common case. The sidebar index is only a cache (it can lag behind
@@ -1587,7 +1635,7 @@ class Session:
             return session
         except Exception:
             # Corrupt prefix or decode error — fall back to full load
-            return cls.load(sid)
+            return cls.load(sid, _populate_tail_cache=False)
 
     @staticmethod
     def _compute_user_message_count(messages) -> int:
@@ -3683,6 +3731,645 @@ def _sidecar_stat_signature(path):
         return None
     return (str(path), int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
             int(st.st_size), int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))))
+
+
+def session_tail_cache_path(sid: str) -> Path:
+    """Return the v1 derived-cache path for a path-safe session id."""
+    if not is_safe_session_id(sid):
+        raise ValueError(f"Unsafe session_id {sid!r}")
+    return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
+
+
+def delete_session_tail_cache(sid: str) -> bool:
+    """Best-effort removal of one derived cache entry."""
+    if not is_safe_session_id(sid):
+        return False
+    try:
+        session_tail_cache_path(sid).unlink(missing_ok=True)
+        return True
+    except OSError:
+        logger.debug("Failed to remove tail cache for %s", sid, exc_info=True)
+        return False
+
+
+def _tail_cache_strict_int(value, *, minimum=None, maximum=None) -> bool:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return False
+    if minimum is not None and value < minimum:
+        return False
+    if maximum is not None and value > maximum:
+        return False
+    return True
+
+
+def _tail_cache_finite_number(value, *, positive=False) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    return math.isfinite(number) and (not positive or number > 0)
+
+
+def _tail_cache_signature_dict(signature) -> dict | None:
+    """Convert the internal stat tuple into the stable on-disk v1 shape."""
+    if not isinstance(signature, tuple) or len(signature) != 4:
+        return None
+    path, mtime_ns, size, ctime_ns = signature
+    try:
+        absolute_path = str(Path(path).expanduser().resolve())
+    except Exception:
+        return None
+    if not all(_tail_cache_strict_int(value, minimum=0) for value in (mtime_ns, size, ctime_ns)):
+        return None
+    return {
+        'path': absolute_path,
+        'mtime_ns': int(mtime_ns),
+        'size': int(size),
+        'ctime_ns': int(ctime_ns),
+    }
+
+
+def _tail_cache_signature_tuple(value) -> tuple | None:
+    if not isinstance(value, dict) or set(('path', 'mtime_ns', 'size', 'ctime_ns')) - set(value):
+        return None
+    path = value.get('path')
+    if not isinstance(path, str) or not path or not Path(path).is_absolute():
+        return None
+    numeric = (value.get('mtime_ns'), value.get('size'), value.get('ctime_ns'))
+    if not all(_tail_cache_strict_int(item, minimum=0) for item in numeric):
+        return None
+    return (str(Path(path).resolve()), int(numeric[0]), int(numeric[1]), int(numeric[2]))
+
+
+def _session_tail_cache_profile_is_active(session) -> bool:
+    """Fail closed unless a fully parsed session belongs to the active profile."""
+    try:
+        from api.profiles import _profiles_match, get_active_profile_name
+
+        return bool(_profiles_match(getattr(session, 'profile', None), get_active_profile_name()))
+    except Exception:
+        return False
+
+
+def _session_tail_cache_payload(session, source_signature) -> dict | None:
+    """Build a v1 cache payload from a fully materialized Session object."""
+    if getattr(session, '_loaded_metadata_only', False):
+        return None
+    sid = getattr(session, 'session_id', None)
+    if not is_safe_session_id(sid):
+        return None
+    signature = _tail_cache_signature_dict(source_signature)
+    if signature is None:
+        return None
+    messages = getattr(session, 'messages', None)
+    if not isinstance(messages, list):
+        return None
+    source_count = len(messages)
+    offset = max(0, source_count - _SESSION_TAIL_CACHE_LIMIT)
+    raw_tail = messages[offset:]
+    all_timestamps_valid = all(
+        isinstance(message, dict)
+        and _tail_cache_finite_number(message.get('timestamp'))
+        for message in raw_tail
+    )
+
+    all_tool_calls_positionable = True
+    cached_tool_calls = []
+    raw_tool_calls = getattr(session, 'tool_calls', None)
+    if not isinstance(raw_tool_calls, list):
+        raw_tool_calls = []
+        all_tool_calls_positionable = False
+    for tool_call in raw_tool_calls:
+        if not isinstance(tool_call, dict):
+            all_tool_calls_positionable = False
+            continue
+        assistant_idx = tool_call.get('assistant_msg_idx')
+        positionable = _tail_cache_strict_int(
+            assistant_idx,
+            minimum=0,
+            maximum=source_count - 1,
+        )
+        if positionable:
+            positionable = (
+                isinstance(messages[assistant_idx], dict)
+                and messages[assistant_idx].get('role') == 'assistant'
+            )
+        if not positionable:
+            all_tool_calls_positionable = False
+            continue
+        if assistant_idx >= offset:
+            cached_tool_calls.append(tool_call)
+
+    try:
+        from api.todo_state import derive_todo_state
+
+        todo_state = derive_todo_state(messages)
+    except Exception:
+        todo_state = None
+
+    timestamps = [
+        float(message.get('timestamp'))
+        for message in messages
+        if isinstance(message, dict) and _tail_cache_finite_number(message.get('timestamp'))
+    ]
+    last_message_at = max(timestamps) if timestamps else getattr(session, 'updated_at', None)
+    if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
+        last_message_at = None
+    return {
+        'format': _SESSION_TAIL_CACHE_FORMAT,
+        'version': _SESSION_TAIL_CACHE_VERSION,
+        'session_id': sid,
+        'source_signature': signature,
+        'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
+        'message_offset': offset,
+        'messages': raw_tail,
+        'source_message_count': source_count,
+        'source_user_message_count': Session._compute_user_message_count(messages),
+        'source_last_message_at': last_message_at,
+        'tool_calls': cached_tool_calls,
+        'all_tool_calls_positionable': all_tool_calls_positionable,
+        'todo_state': todo_state,
+        'anchor_scene_index': _anchor_scene_index_from_records(
+            getattr(session, 'anchor_activity_scenes', None)
+        ),
+        'all_cached_timestamps_valid': all_timestamps_valid,
+        'created_at': float(time.time()),
+    }
+
+
+def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> bool:
+    """Atomically publish one already-built cache payload after a final restat."""
+    sid = payload.get('session_id') if isinstance(payload, dict) else None
+    if not is_safe_session_id(sid) or expected_signature is None:
+        return False
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+    if len(encoded) > _SESSION_TAIL_CACHE_MAX_BYTES:
+        return False
+    path = session_tail_cache_path(sid)
+    tmp = path.with_name(
+        f'{path.name}.tmp.{os.getpid()}.{threading.current_thread().ident}'
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp, 'wb') as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        sidecar = SESSION_DIR / f'{sid}.json'
+        if _sidecar_stat_signature(sidecar) != expected_signature:
+            return False
+        _safe_replace(tmp, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return True
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _write_session_tail_cache(session, *, expected_signature) -> bool:
+    payload = _session_tail_cache_payload(session, expected_signature)
+    if payload is None:
+        return False
+    return _write_session_tail_cache_payload(
+        payload,
+        expected_signature=expected_signature,
+    )
+
+
+def _session_tail_cache_has_signature(sid: str, signature) -> bool:
+    """Cheaply decide whether an existing bounded cache describes this source."""
+    try:
+        path = session_tail_cache_path(sid)
+        if path.stat().st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
+            return False
+        value = json.loads(path.read_bytes())
+        return (
+            isinstance(value, dict)
+            and value.get('format') == _SESSION_TAIL_CACHE_FORMAT
+            and value.get('version') == _SESSION_TAIL_CACHE_VERSION
+            and value.get('session_id') == sid
+            and _tail_cache_signature_tuple(value.get('source_signature'))
+            == _tail_cache_signature_tuple(_tail_cache_signature_dict(signature))
+        )
+    except Exception:
+        return False
+
+
+def _validate_session_tail_cache_payload(payload, sid: str, source_signature) -> dict | None:
+    """Strictly validate v1 shape and bounded-read eligibility."""
+    if not isinstance(payload, dict):
+        return None
+    if payload.get('format') != _SESSION_TAIL_CACHE_FORMAT:
+        return None
+    if payload.get('version') != _SESSION_TAIL_CACHE_VERSION or payload.get('session_id') != sid:
+        return None
+    embedded_signature = _tail_cache_signature_tuple(payload.get('source_signature'))
+    current_signature = _tail_cache_signature_tuple(_tail_cache_signature_dict(source_signature))
+    if embedded_signature is None or embedded_signature != current_signature:
+        return None
+    if payload.get('tail_limit') != _SESSION_TAIL_CACHE_LIMIT:
+        return None
+
+    source_count = payload.get('source_message_count')
+    user_count = payload.get('source_user_message_count')
+    offset = payload.get('message_offset')
+    messages = payload.get('messages')
+    if not _tail_cache_strict_int(source_count, minimum=0):
+        return None
+    if not _tail_cache_strict_int(user_count, minimum=0, maximum=source_count):
+        return None
+    if not _tail_cache_strict_int(offset, minimum=0, maximum=source_count):
+        return None
+    if not isinstance(messages, list) or len(messages) != min(_SESSION_TAIL_CACHE_LIMIT, source_count):
+        return None
+    if offset != source_count - len(messages):
+        return None
+    if payload.get('all_cached_timestamps_valid') is not True:
+        return None
+    for message in messages:
+        if not isinstance(message, dict):
+            return None
+        if not _tail_cache_finite_number(message.get('timestamp')):
+            return None
+
+    last_message_at = payload.get('source_last_message_at')
+    if source_count == 0:
+        if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
+            return None
+    elif not _tail_cache_finite_number(last_message_at):
+        return None
+    if payload.get('all_tool_calls_positionable') is not True:
+        return None
+    tool_calls = payload.get('tool_calls')
+    if not isinstance(tool_calls, list):
+        return None
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            return None
+        assistant_idx = tool_call.get('assistant_msg_idx')
+        if not _tail_cache_strict_int(assistant_idx, minimum=offset, maximum=source_count - 1):
+            return None
+        tail_message = messages[assistant_idx - offset]
+        if tail_message.get('role') != 'assistant':
+            return None
+    todo_state = payload.get('todo_state')
+    if todo_state is not None:
+        if not isinstance(todo_state, dict) or not isinstance(todo_state.get('todos'), list):
+            return None
+    anchor_scene_index = payload.get('anchor_scene_index')
+    if not isinstance(anchor_scene_index, dict) or anchor_scene_index:
+        return None
+    if not _tail_cache_finite_number(payload.get('created_at'), positive=True):
+        return None
+    return payload
+
+
+def _read_session_tail_cache_file(sid: str) -> dict | None:
+    if not is_safe_session_id(sid):
+        return None
+    sidecar = SESSION_DIR / f'{sid}.json'
+    before = _sidecar_stat_signature(sidecar)
+    if before is None:
+        return None
+    try:
+        path = session_tail_cache_path(sid)
+        size = path.stat().st_size
+        if size <= 0 or size > _SESSION_TAIL_CACHE_MAX_BYTES:
+            return None
+        payload = json.loads(path.read_bytes())
+    except (OSError, ValueError, TypeError):
+        return None
+    after = _sidecar_stat_signature(sidecar)
+    if after is None or before != after:
+        return None
+    return _validate_session_tail_cache_payload(payload, sid, before)
+
+
+def read_session_tail_cache(sid: str) -> dict | None:
+    """Return a validated tail snapshot, never superseding a full memory object."""
+    if not is_safe_session_id(sid):
+        return None
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
+            return None
+    return _read_session_tail_cache_file(sid)
+
+
+def _legacy_tail_cache_index_row(sid: str, source_signature, metadata: dict) -> dict | None:
+    """Return one index row only when its cheap source facts all agree."""
+    try:
+        if SESSION_INDEX_FILE.stat().st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
+            return None
+        rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(rows, list):
+        return None
+    matches = [row for row in rows if isinstance(row, dict) and row.get('session_id') == sid]
+    if len(matches) != 1:
+        return None
+    row = matches[0]
+    count = row.get('message_count')
+    user_count = row.get('user_message_count')
+    file_size = row.get('file_size')
+    if not _tail_cache_strict_int(count, minimum=0):
+        return None
+    if not _tail_cache_strict_int(user_count, minimum=0, maximum=count):
+        return None
+    if not _tail_cache_strict_int(file_size, minimum=0) or file_size != source_signature[2]:
+        return None
+    if _parse_nonnegative_int(metadata.get('message_count')) != count:
+        return None
+    row_updated_at = row.get('updated_at')
+    metadata_updated_at = metadata.get('updated_at')
+    if not _tail_cache_finite_number(row_updated_at) or not _tail_cache_finite_number(metadata_updated_at):
+        return None
+    if float(row_updated_at) != float(metadata_updated_at):
+        return None
+    if count and not _tail_cache_finite_number(row.get('last_message_at')):
+        return None
+    return row
+
+
+def _legacy_tail_metadata_is_eligible(metadata: dict) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    if metadata.get('active_stream_id') or metadata.get('pending_user_message'):
+        return False
+    if metadata.get('pending_attachments') or metadata.get('pending_started_at'):
+        return False
+    if metadata.get('pending_user_source'):
+        return False
+    if metadata.get('pre_compression_snapshot') or metadata.get('parent_session_id'):
+        return False
+    if metadata.get('compression_recovery'):
+        return False
+    if metadata.get('compression_recovery_source_session_id') or metadata.get('compression_recovery_action'):
+        return False
+    if metadata.get('truncation_watermark') is not None or metadata.get('truncation_boundary') is not None:
+        return False
+    if metadata.get('is_cli_session') or metadata.get('read_only'):
+        return False
+    if metadata.get('session_source') not in (None, '', 'webui'):
+        return False
+    if metadata.get('source_tag') not in (None, '', 'webui'):
+        return False
+    if metadata.get('raw_source') not in (None, '') or metadata.get('source_label') not in (None, ''):
+        return False
+    scene_index = metadata.get('anchor_scene_index')
+    return scene_index is None or (isinstance(scene_index, dict) and not scene_index)
+
+
+def _mmap_top_level_key_value_offset(view, key: bytes, *, scan_limit=512 * 1024) -> int | None:
+    """Locate the value of one unescaped ASCII key in the root JSON object."""
+    limit = min(len(view), scan_limit)
+    depth = 0
+    i = 0
+    while i < limit:
+        byte = view[i]
+        if byte == 34:
+            start = i + 1
+            i += 1
+            escaped = False
+            while i < limit:
+                current = view[i]
+                if current == 34 and not escaped:
+                    break
+                if current == 92 and not escaped:
+                    escaped = True
+                else:
+                    escaped = False
+                i += 1
+            if i >= limit:
+                return None
+            if depth == 1 and view[start:i] == key:
+                cursor = i + 1
+                while cursor < limit and view[cursor] in b' \t\r\n':
+                    cursor += 1
+                if cursor >= limit or view[cursor] != 58:
+                    return None
+                cursor += 1
+                while cursor < limit and view[cursor] in b' \t\r\n':
+                    cursor += 1
+                return cursor if cursor < limit else None
+        elif byte in (123, 91):
+            depth += 1
+        elif byte in (125, 93):
+            depth -= 1
+            if depth < 0:
+                return None
+        i += 1
+    return None
+
+
+def _mmap_root_suffix_after_messages(view, messages_open: int) -> tuple[int, dict] | None:
+    """Prove the messages closing bracket by parsing the bounded root suffix."""
+    marker = b'"tool_calls"'
+    search_end = len(view)
+    minimum = max(messages_open + 1, len(view) - _SESSION_TAIL_CACHE_MAX_BYTES)
+    while search_end > minimum:
+        key_pos = view.rfind(marker, minimum, search_end)
+        if key_pos < 0:
+            return None
+        cursor = key_pos - 1
+        while cursor > messages_open and view[cursor] in b' \t\r\n':
+            cursor -= 1
+        if cursor > messages_open and view[cursor] == 44:
+            cursor -= 1
+            while cursor > messages_open and view[cursor] in b' \t\r\n':
+                cursor -= 1
+            if cursor > messages_open and view[cursor] == 93:
+                try:
+                    suffix = json.loads(b'{' + view[key_pos:])
+                except (ValueError, TypeError):
+                    suffix = None
+                if isinstance(suffix, dict) and 'tool_calls' in suffix:
+                    return cursor, suffix
+        search_end = key_pos
+    return None
+
+
+def _mmap_json_array_tail_start(view, array_open: int, array_close: int, count: int) -> int | None:
+    """Reverse-scan a bounded JSON array to the first of its last `count` values."""
+    if count <= 0:
+        return array_close
+    i = array_close - 1
+    depth = 0
+    in_string = False
+    separators = 0
+    scanned = 0
+    while i > array_open and scanned <= _SESSION_TAIL_CACHE_MAX_BYTES:
+        byte = view[i]
+        if byte == 34:
+            slashes = 0
+            cursor = i - 1
+            while cursor > array_open and view[cursor] == 92:
+                slashes += 1
+                cursor -= 1
+            if slashes % 2 == 0:
+                in_string = not in_string
+        elif not in_string:
+            if byte in (125, 93):
+                depth += 1
+            elif byte in (123, 91):
+                depth -= 1
+                if depth < 0:
+                    return None
+            elif byte == 44 and depth == 0:
+                separators += 1
+                if separators == count:
+                    return i + 1
+        i -= 1
+        scanned += 1
+    if i == array_open and separators == count - 1:
+        return array_open + 1
+    return None
+
+
+def _read_legacy_tail_parts(path: Path, wanted: int) -> tuple[list, dict] | None:
+    try:
+        with open(path, 'rb') as handle:
+            with mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as view:
+                messages_open = _mmap_top_level_key_value_offset(view, b'messages')
+                if messages_open is None or view[messages_open] != 91:
+                    return None
+                suffix_info = _mmap_root_suffix_after_messages(view, messages_open)
+                if suffix_info is None:
+                    return None
+                messages_close, suffix = suffix_info
+                tail_start = _mmap_json_array_tail_start(
+                    view,
+                    messages_open,
+                    messages_close,
+                    wanted,
+                )
+                if tail_start is None:
+                    return None
+                # Any settled todo snapshot before the bounded tail makes the
+                # tail alone insufficient to derive the full session state.
+                if (
+                    view.find(b'"todos"', messages_open + 1, tail_start) >= 0
+                    or view.find(b'\\"todos\\"', messages_open + 1, tail_start) >= 0
+                ):
+                    return None
+                tail_bytes = b'[' + view[tail_start:messages_close] + b']'
+                if len(tail_bytes) > _SESSION_TAIL_CACHE_MAX_BYTES:
+                    return None
+                messages = json.loads(tail_bytes)
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(messages, list) or len(messages) != wanted:
+        return None
+    if any(
+        not isinstance(message, dict)
+        or not _tail_cache_finite_number(message.get('timestamp'))
+        for message in messages
+    ):
+        return None
+    return messages, suffix
+
+
+def _legacy_tail_positionable_tool_calls(suffix: dict, messages: list, offset: int, source_count: int):
+    if suffix.get('anchor_activity_scenes') not in (None, {}):
+        return None
+    raw_tool_calls = suffix.get('tool_calls')
+    if not isinstance(raw_tool_calls, list):
+        return None
+    cached_tool_calls = []
+    for tool_call in raw_tool_calls:
+        if not isinstance(tool_call, dict):
+            return None
+        assistant_idx = tool_call.get('assistant_msg_idx')
+        if not _tail_cache_strict_int(assistant_idx, minimum=0, maximum=source_count - 1):
+            return None
+        assistant_idx = int(assistant_idx)
+        if assistant_idx >= offset:
+            if messages[assistant_idx - offset].get('role') != 'assistant':
+                return None
+            cached_tool_calls.append(tool_call)
+    return cached_tool_calls
+
+
+def build_session_tail_cache_from_legacy_sidecar(sid: str) -> dict | None:
+    """Build a v1 snapshot from stable prefix/tail/suffix slices, never a full parse."""
+    if not is_safe_session_id(sid):
+        return None
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
+            return None
+    path = SESSION_DIR / f'{sid}.json'
+    before = _sidecar_stat_signature(path)
+    if before is None:
+        return None
+    try:
+        prefix = _read_metadata_json_prefix(path)
+        metadata = json.loads(prefix) if prefix else None
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    if not _legacy_tail_metadata_is_eligible(metadata) or metadata.get('session_id') != sid:
+        return None
+    index_row = _legacy_tail_cache_index_row(sid, before, metadata)
+    if index_row is None:
+        return None
+    source_count = int(index_row['message_count'])
+    wanted = min(_SESSION_TAIL_CACHE_LIMIT, source_count)
+    parts = _read_legacy_tail_parts(path, wanted)
+    if parts is None:
+        return None
+    messages, suffix = parts
+    offset = source_count - wanted
+    cached_tool_calls = _legacy_tail_positionable_tool_calls(
+        suffix,
+        messages,
+        offset,
+        source_count,
+    )
+    if cached_tool_calls is None:
+        return None
+    try:
+        from api.todo_state import derive_todo_state
+
+        todo_state = derive_todo_state(messages)
+    except Exception:
+        return None
+    payload = {
+        'format': _SESSION_TAIL_CACHE_FORMAT,
+        'version': _SESSION_TAIL_CACHE_VERSION,
+        'session_id': sid,
+        'source_signature': _tail_cache_signature_dict(before),
+        'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
+        'message_offset': offset,
+        'messages': messages,
+        'source_message_count': source_count,
+        'source_user_message_count': int(index_row['user_message_count']),
+        'source_last_message_at': index_row.get('last_message_at'),
+        'tool_calls': cached_tool_calls,
+        'all_tool_calls_positionable': True,
+        'todo_state': todo_state,
+        'anchor_scene_index': {},
+        'all_cached_timestamps_valid': True,
+        'created_at': float(time.time()),
+    }
+    if _sidecar_stat_signature(path) != before:
+        return None
+    if not _write_session_tail_cache_payload(payload, expected_signature=before):
+        return None
+    return _read_session_tail_cache_file(sid)
 
 
 def _legacy_sidecar_facts_get(sid):

--- a/api/models.py
+++ b/api/models.py
@@ -8074,16 +8074,20 @@ def get_state_db_session_message_prefix_summary(
     except (TypeError, ValueError):
         return None
 
-    if isinstance(profile, str) and profile:
-        db_path = _get_profile_home(profile) / 'state.db'
-        if not db_path.exists():
-            db_path = _active_state_db_path()
-    else:
-        db_path = _active_state_db_path()
-    if not db_path.exists():
-        return {"count": 0, "null_timestamp_count": 0}
-
     try:
+        # Path resolution and existence checks must stay inside the guard:
+        # a stat/permission failure here is "unprovable", not an error the
+        # route caller should see. Callers rely on None to mean "take the
+        # authoritative full-read fallback" (fail-open contract).
+        if isinstance(profile, str) and profile:
+            db_path = _get_profile_home(profile) / 'state.db'
+            if not db_path.exists():
+                db_path = _active_state_db_path()
+        else:
+            db_path = _active_state_db_path()
+        if not db_path.exists():
+            return {"count": 0, "null_timestamp_count": 0}
+
         with closing(open_state_db_readonly(db_path)) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
@@ -8144,16 +8148,19 @@ def get_state_db_session_message_keys_before_timestamp(
     except (TypeError, ValueError):
         return None
 
-    if isinstance(profile, str) and profile:
-        db_path = _get_profile_home(profile) / 'state.db'
-        if not db_path.exists():
-            db_path = _active_state_db_path()
-    else:
-        db_path = _active_state_db_path()
-    if not db_path.exists():
-        return []
-
     try:
+        # Keep path resolution inside the guard for the same fail-open
+        # contract as the prefix summary helper: any resolution/stat failure
+        # is "unprovable" (None) so the caller takes the full-read fallback.
+        if isinstance(profile, str) and profile:
+            db_path = _get_profile_home(profile) / 'state.db'
+            if not db_path.exists():
+                db_path = _active_state_db_path()
+        else:
+            db_path = _active_state_db_path()
+        if not db_path.exists():
+            return []
+
         with closing(open_state_db_readonly(db_path)) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
@@ -8161,14 +8168,23 @@ def get_state_db_session_message_keys_before_timestamp(
             available = {str(row['name']) for row in cur.fetchall()}
             if not {'id', 'session_id', 'role', 'content', 'timestamp', 'tool_calls'}.issubset(available):
                 return None
+            # Match get_state_db_session_messages / the prefix-summary helper:
+            # compacted (active=0) rows are invisible to the merge, so they
+            # must not appear in the definitive identity sequence either.
+            # Without this an exact active-row prefix looks longer than the
+            # summary count and forces a needless conservative fallback.
+            active_clause = ""
+            if 'active' in available:
+                active_clause = " AND (active IS NULL OR active != 0)"
             cur.execute(
-                """
+                f"""
                 SELECT
                     COALESCE(role, '') AS role,
                     COALESCE(content, '') AS content,
                     tool_calls
                 FROM messages
                 WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ?
+                {active_clause}
                 ORDER BY timestamp ASC, id ASC
                 """,
                 (str(sid), before_ts),

--- a/api/models.py
+++ b/api/models.py
@@ -148,17 +148,56 @@ _SESSION_SAVE_PUBLICATION_LOCKS_GUARD = threading.Lock()
 _SESSION_SAVE_PUBLICATION_LOCKS = weakref.WeakValueDictionary()
 
 
+def _session_save_publication_lock_key(path: Path) -> str:
+    """Return the canonical, final-name-scoped identity for one sidecar lock.
+
+    Resolve only the parent directory: aliases through symlinked parents and
+    relative/``..`` spellings must converge before the sidecar exists, while an
+    attacker-swapped final symlink must not redirect lock ownership. Session
+    sidecars are atomically replaced, name-scoped files; inode/hard-link aliases
+    are intentionally not treated as another supported storage identity.
+    ``normcase`` supplies Windows' case-insensitive path semantics.
+    """
+    candidate = Path(path).expanduser()
+    canonical_parent = candidate.parent.resolve(strict=False)
+    canonical = canonical_parent / candidate.name
+    return os.path.normcase(os.path.normpath(os.fspath(canonical)))
+
+
 def _get_session_save_publication_lock(path: Path):
-    # ``SESSION_DIR`` is already process-owned canonical storage. Avoid
-    # ``Path.resolve()`` here: it stats every path component on each save and
-    # materially penalizes the small-session hot path.
-    key = os.fspath(path)
+    key = _session_save_publication_lock_key(path)
     with _SESSION_SAVE_PUBLICATION_LOCKS_GUARD:
         lock = _SESSION_SAVE_PUBLICATION_LOCKS.get(key)
         if lock is None:
             lock = threading.Lock()
             _SESSION_SAVE_PUBLICATION_LOCKS[key] = lock
         return lock
+
+
+def _session_save_writer_snapshot(meta: dict, extra: dict) -> dict:
+    """Detach every cache-relevant value before authoritative serialization.
+
+    The bounded raw tail and tool calls are deep copies. Prefix messages get a
+    detached top-level mapping so cache facts (role, timestamp, counts) cannot
+    change after serialization; tool-result messages are fully detached because
+    todo derivation consumes their content. The returned object is used by both
+    authoritative ``json.dumps`` and derived-cache construction.
+    """
+    snapshot = {**meta, **extra}
+    messages = list(snapshot.get('messages') or [])
+    tail_offset = max(0, len(messages) - _SESSION_TAIL_CACHE_LIMIT)
+    frozen_messages = []
+    for index, message in enumerate(messages):
+        if index >= tail_offset or not isinstance(message, dict) or message.get('role') == 'tool':
+            frozen_messages.append(copy.deepcopy(message))
+        else:
+            frozen_messages.append(dict(message))
+    snapshot['messages'] = frozen_messages
+    snapshot['tool_calls'] = copy.deepcopy(snapshot.get('tool_calls'))
+    anchor_scene_index = snapshot.get('anchor_scene_index')
+    if isinstance(anchor_scene_index, dict):
+        snapshot['anchor_scene_index'] = copy.deepcopy(anchor_scene_index)
+    return snapshot
 
 
 # ---------------------------------------------------------------------------
@@ -1333,20 +1372,23 @@ class Session:
                 f"See #1558."
             )
         sidecar_path = self.path
-        publication_key = os.fspath(sidecar_path)
+        publication_path_key = os.fspath(sidecar_path)
         publication_lock = getattr(self, '_save_publication_lock', None)
         if (
             publication_lock is None
-            or getattr(self, '_save_publication_lock_key', None) != publication_key
+            or getattr(self, '_save_publication_path_key', None) != publication_path_key
         ):
             publication_lock = _get_session_save_publication_lock(sidecar_path)
             # Keep the weak-registry value alive for this Session object's hot
             # save path without leaking locks after all same-ID objects expire.
+            # The raw spelling is only a fast-path invalidation hint; registry
+            # ownership itself is keyed by the canonical parent + final name.
             self._save_publication_lock = publication_lock
-            self._save_publication_lock_key = publication_key
+            self._save_publication_path_key = publication_path_key
         with publication_lock:
             saved = self._save_authoritative_sidecar_and_tail_cache(
                 touch_updated_at=touch_updated_at,
+                sidecar_path=sidecar_path,
             )
         if not saved:
             return
@@ -1377,7 +1419,12 @@ class Session:
                     exc_info=True,
                 )
 
-    def _save_authoritative_sidecar_and_tail_cache(self, touch_updated_at: bool = True) -> bool:
+    def _save_authoritative_sidecar_and_tail_cache(
+        self,
+        touch_updated_at: bool = True,
+        *,
+        sidecar_path: Path,
+    ) -> bool:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
@@ -1452,14 +1499,33 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        # Freeze list membership while the per-sidecar publication lock is held.
-        # Concurrent writers use independent Session objects; copying this list
-        # binds later cache derivation to the exact writer snapshot without a
-        # full transcript deepcopy on every small save. The bounded tail itself
-        # is deep-copied when its derived payload is built below.
-        frozen_snapshot = {**meta, **extra}
-        frozen_snapshot['messages'] = list(frozen_snapshot.get('messages') or [])
-        payload = json.dumps(frozen_snapshot, ensure_ascii=False, indent=2)
+        existing_signature = _sidecar_stat_signature(sidecar_path)
+        previous_signature = getattr(self, '_last_saved_source_signature', None)
+        fast_small_snapshot = (
+            existing_signature is not None
+            and existing_signature == previous_signature
+            and not _session_tail_cache_signature_is_large_enough(existing_signature)
+        )
+        if fast_small_snapshot:
+            # Stable small sidecars never publish a tail cache. Preserve the cheap
+            # membership snapshot on their checkpoint hot path; if this save grows
+            # past the threshold, rebuild one detached snapshot before publication.
+            frozen_snapshot = {**meta, **extra}
+            frozen_snapshot['messages'] = list(frozen_snapshot.get('messages') or [])
+            payload = json.dumps(frozen_snapshot, ensure_ascii=False, indent=2)
+            if len(payload.encode('utf-8')) >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES:
+                frozen_snapshot = _session_save_writer_snapshot(meta, extra)
+                payload = json.dumps(frozen_snapshot, ensure_ascii=False, indent=2)
+                snapshot_is_immutable = True
+            else:
+                snapshot_is_immutable = False
+        else:
+            # One detached writer snapshot owns both authoritative serialization
+            # and every cache-relevant tail/tool/fact value. Mutating ``self``
+            # after this point cannot produce accepted derived bytes that differ.
+            frozen_snapshot = _session_save_writer_snapshot(meta, extra)
+            payload = json.dumps(frozen_snapshot, ensure_ascii=False, indent=2)
+            snapshot_is_immutable = True
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -1473,15 +1539,27 @@ class Session:
         # The recovery path is api/session_recovery.py — at server startup and
         # via /api/session/recover, sessions whose JSON has fewer messages than
         # their .bak get restored automatically.
+        incoming_msg_count = len(frozen_snapshot.get('messages') or [])
         try:
-            if self.path.exists():
-                existing_text = self.path.read_text(encoding='utf-8')
-                try:
-                    existing = json.loads(existing_text)
-                    existing_msg_count = len(existing.get('messages') or [])
-                except (json.JSONDecodeError, ValueError):
-                    existing_msg_count = -1  # corrupt → always back up
-                incoming_msg_count = len(self.messages or [])
+            if existing_signature is not None:
+                existing_text = None
+                existing_msg_count = -1
+                if (
+                    existing_signature == getattr(self, '_last_saved_source_signature', None)
+                    and isinstance(getattr(self, '_last_saved_message_count', None), int)
+                ):
+                    # The same Session object still owns the exact bytes it last
+                    # published. Avoid re-reading and full-parsing them on every
+                    # checkpoint; any external/in-process replacement changes the
+                    # stat signature and falls through to the authoritative read.
+                    existing_msg_count = self._last_saved_message_count
+                else:
+                    existing_text = sidecar_path.read_text(encoding='utf-8')
+                    try:
+                        existing = json.loads(existing_text)
+                        existing_msg_count = len(existing.get('messages') or [])
+                    except (json.JSONDecodeError, ValueError):
+                        existing_msg_count = -1
                 if (
                     existing_msg_count > 0
                     and incoming_msg_count == 0
@@ -1497,7 +1575,19 @@ class Session:
                     )
                     return False
                 if existing_msg_count > incoming_msg_count:
-                    bak_path = self.path.with_suffix('.json.bak')
+                    if existing_text is None:
+                        # A shrink needs the actual previous bytes for the backup.
+                        # Re-parse after the read so a replacement between the fast
+                        # stat and this slow path cannot back up an unrelated count.
+                        existing_text = sidecar_path.read_text(encoding='utf-8')
+                        try:
+                            existing = json.loads(existing_text)
+                            existing_msg_count = len(existing.get('messages') or [])
+                        except (json.JSONDecodeError, ValueError):
+                            existing_msg_count = -1
+                    if existing_msg_count <= incoming_msg_count:
+                        existing_text = None
+                    bak_path = sidecar_path.with_suffix('.json.bak')
                     # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,
                     # mirroring the main save() pattern below. Prevents a
                     # torn .bak from a crash mid-write or a concurrent
@@ -1507,6 +1597,8 @@ class Session:
                     # this fix the backup either lands cleanly or doesn't
                     # land at all.
                     try:
+                        if existing_text is None:
+                            raise OSError("authoritative source changed before backup")
                         bak_tmp = bak_path.with_suffix(
                             f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
                         )
@@ -1524,13 +1616,13 @@ class Session:
         except OSError:
             pass
 
-        tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+        tmp = sidecar_path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
             with open(tmp, 'w', encoding='utf-8') as f:
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())
-            _safe_replace(tmp, self.path)
+            _safe_replace(tmp, sidecar_path)
             _invalidate_persisted_session_ids_snapshot()
         except Exception:
             try:
@@ -1549,12 +1641,15 @@ class Session:
             # derived bytes. An eligible source is republished below; an ineligible
             # source stays cache-free. Failure is non-fatal and the reader still
             # rejects any retained stale entry by its old source signature.
+            source_signature = _sidecar_stat_signature(sidecar_path)
+            self._last_saved_source_signature = source_signature
+            self._last_saved_message_count = incoming_msg_count
             delete_session_tail_cache(self.session_id)
-            source_signature = _sidecar_stat_signature(self.path)
             if _session_tail_cache_signature_is_large_enough(source_signature):
                 _write_session_tail_cache(
                     frozen_snapshot,
                     expected_signature=source_signature,
+                    snapshot_is_immutable=snapshot_is_immutable,
                 )
         except Exception:
             logger.debug(
@@ -3952,7 +4047,12 @@ def _session_tail_cache_snapshot_value(snapshot, key, default=None):
     return getattr(snapshot, key, default)
 
 
-def _session_tail_cache_payload(session, source_signature) -> dict | None:
+def _session_tail_cache_payload(
+    session,
+    source_signature,
+    *,
+    snapshot_is_immutable: bool = False,
+) -> dict | None:
     """Build a v1 cache payload from a Session or its frozen save snapshot."""
     if _session_tail_cache_snapshot_value(session, '_loaded_metadata_only', False):
         return None
@@ -3967,7 +4067,7 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
         return None
     source_count = len(messages)
     offset = max(0, source_count - _SESSION_TAIL_CACHE_LIMIT)
-    raw_tail = copy.deepcopy(messages[offset:])
+    raw_tail = messages[offset:] if snapshot_is_immutable else copy.deepcopy(messages[offset:])
     all_timestamps_valid = all(
         isinstance(message, dict)
         and _tail_cache_finite_number(message.get('timestamp'))
@@ -3999,7 +4099,9 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
             all_tool_calls_positionable = False
             continue
         if assistant_idx >= offset:
-            cached_tool_calls.append(copy.deepcopy(tool_call))
+            cached_tool_calls.append(
+                tool_call if snapshot_is_immutable else copy.deepcopy(tool_call)
+            )
 
     try:
         from api.todo_state import derive_todo_state
@@ -4033,8 +4135,10 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
         'tool_calls': cached_tool_calls,
         'all_tool_calls_positionable': all_tool_calls_positionable,
         'todo_state': todo_state,
-        'anchor_scene_index': copy.deepcopy(
+        'anchor_scene_index': (
             _session_tail_cache_snapshot_value(session, 'anchor_scene_index')
+            if snapshot_is_immutable
+            else copy.deepcopy(_session_tail_cache_snapshot_value(session, 'anchor_scene_index'))
         ) if isinstance(
             _session_tail_cache_snapshot_value(session, 'anchor_scene_index'),
             dict,
@@ -4084,8 +4188,17 @@ def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> b
             pass
 
 
-def _write_session_tail_cache(session, *, expected_signature) -> bool:
-    payload = _session_tail_cache_payload(session, expected_signature)
+def _write_session_tail_cache(
+    session,
+    *,
+    expected_signature,
+    snapshot_is_immutable: bool = False,
+) -> bool:
+    payload = _session_tail_cache_payload(
+        session,
+        expected_signature,
+        snapshot_is_immutable=snapshot_is_immutable,
+    )
     if payload is None:
         return False
     return _write_session_tail_cache_payload(

--- a/api/models.py
+++ b/api/models.py
@@ -178,7 +178,7 @@ def _open_windows_directory_handle(path: Path):  # pragma: no cover - Windows on
     create_file.restype = wintypes.HANDLE
     handle = create_file(
         os.fspath(path),
-        0,
+        0x00010080,  # DELETE | FILE_READ_ATTRIBUTES; pin against rename/replacement.
         0x00000001 | 0x00000002,  # FILE_SHARE_READ | FILE_SHARE_WRITE; no delete sharing.
         None,
         3,  # OPEN_EXISTING

--- a/api/models.py
+++ b/api/models.py
@@ -1948,12 +1948,31 @@ class Session:
                         bf.flush()
                         os.fsync(bf.fileno())
                     _safe_replace(bak_tmp, bak_path)
-                except Exception:
+                except OSError:
+                    # The pre-shrink backup is a best-effort recovery aid, not
+                    # part of the authoritative save transaction. A backup-side
+                    # disk failure (OSError) must never abort the authoritative
+                    # shrink write below, so log it with the exception and fall
+                    # through to the authoritative block. Only OSError is
+                    # normalized here: a programming/type error is not a disk
+                    # failure and must still surface.
+                    logger.warning(
+                        "session %s pre-shrink backup publication failed; "
+                        "continuing best-effort with authoritative save",
+                        self.session_id,
+                        exc_info=True,
+                    )
+                    # Clean up the temp so a partial backup can't masquerade as a
+                    # recoverable source. Cleanup is itself best-effort and must
+                    # not replace or erase the original backup-failure warning.
                     try:
                         _bound_unlink(bak_tmp, missing_ok=True)
                     except Exception:
-                        pass
-                    raise
+                        logger.debug(
+                            "session %s pre-shrink backup temp cleanup failed",
+                            self.session_id,
+                            exc_info=True,
+                        )
 
         tmp = sidecar_path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:

--- a/api/models.py
+++ b/api/models.py
@@ -149,7 +149,10 @@ _SESSION_SAVE_PUBLICATION_LOCKS = weakref.WeakValueDictionary()
 
 
 def _get_session_save_publication_lock(path: Path):
-    key = str(path.expanduser().resolve())
+    # ``SESSION_DIR`` is already process-owned canonical storage. Avoid
+    # ``Path.resolve()`` here: it stats every path component on each save and
+    # materially penalizes the small-session hot path.
+    key = os.fspath(path)
     with _SESSION_SAVE_PUBLICATION_LOCKS_GUARD:
         lock = _SESSION_SAVE_PUBLICATION_LOCKS.get(key)
         if lock is None:
@@ -1330,7 +1333,18 @@ class Session:
                 f"See #1558."
             )
         sidecar_path = self.path
-        with _get_session_save_publication_lock(sidecar_path):
+        publication_key = os.fspath(sidecar_path)
+        publication_lock = getattr(self, '_save_publication_lock', None)
+        if (
+            publication_lock is None
+            or getattr(self, '_save_publication_lock_key', None) != publication_key
+        ):
+            publication_lock = _get_session_save_publication_lock(sidecar_path)
+            # Keep the weak-registry value alive for this Session object's hot
+            # save path without leaking locks after all same-ID objects expire.
+            self._save_publication_lock = publication_lock
+            self._save_publication_lock_key = publication_key
+        with publication_lock:
             saved = self._save_authoritative_sidecar_and_tail_cache(
                 touch_updated_at=touch_updated_at,
             )
@@ -1438,7 +1452,13 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        frozen_snapshot = copy.deepcopy({**meta, **extra})
+        # Freeze list membership while the per-sidecar publication lock is held.
+        # Concurrent writers use independent Session objects; copying this list
+        # binds later cache derivation to the exact writer snapshot without a
+        # full transcript deepcopy on every small save. The bounded tail itself
+        # is deep-copied when its derived payload is built below.
+        frozen_snapshot = {**meta, **extra}
+        frozen_snapshot['messages'] = list(frozen_snapshot.get('messages') or [])
         payload = json.dumps(frozen_snapshot, ensure_ascii=False, indent=2)
 
         # ── #1558 backup safeguard ──────────────────────────────────────
@@ -3838,7 +3858,9 @@ def delete_session_tail_cache(sid: str) -> bool:
     if not is_safe_session_id(sid):
         return False
     try:
-        session_tail_cache_path(sid).unlink(missing_ok=True)
+        os.unlink(session_tail_cache_path(sid))
+        return True
+    except FileNotFoundError:
         return True
     except OSError:
         logger.debug("Failed to remove tail cache for %s", sid, exc_info=True)
@@ -3945,7 +3967,7 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
         return None
     source_count = len(messages)
     offset = max(0, source_count - _SESSION_TAIL_CACHE_LIMIT)
-    raw_tail = messages[offset:]
+    raw_tail = copy.deepcopy(messages[offset:])
     all_timestamps_valid = all(
         isinstance(message, dict)
         and _tail_cache_finite_number(message.get('timestamp'))
@@ -3977,7 +3999,7 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
             all_tool_calls_positionable = False
             continue
         if assistant_idx >= offset:
-            cached_tool_calls.append(tool_call)
+            cached_tool_calls.append(copy.deepcopy(tool_call))
 
     try:
         from api.todo_state import derive_todo_state
@@ -4011,7 +4033,12 @@ def _session_tail_cache_payload(session, source_signature) -> dict | None:
         'tool_calls': cached_tool_calls,
         'all_tool_calls_positionable': all_tool_calls_positionable,
         'todo_state': todo_state,
-        'anchor_scene_index': _anchor_scene_index_from_records(
+        'anchor_scene_index': copy.deepcopy(
+            _session_tail_cache_snapshot_value(session, 'anchor_scene_index')
+        ) if isinstance(
+            _session_tail_cache_snapshot_value(session, 'anchor_scene_index'),
+            dict,
+        ) else _anchor_scene_index_from_records(
             _session_tail_cache_snapshot_value(session, 'anchor_activity_scenes')
         ),
         'all_cached_timestamps_valid': all_timestamps_valid,

--- a/api/models.py
+++ b/api/models.py
@@ -138,6 +138,7 @@ _SESSION_TAIL_CACHE_FORMAT = 'hermes.session-tail-cache'
 _SESSION_TAIL_CACHE_VERSION = 1
 _SESSION_TAIL_CACHE_LIMIT = 300
 _SESSION_TAIL_CACHE_MAX_BYTES = 4 * 1024 * 1024
+_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES = 1 * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -3738,6 +3739,21 @@ def session_tail_cache_path(sid: str) -> Path:
     if not is_safe_session_id(sid):
         raise ValueError(f"Unsafe session_id {sid!r}")
     return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
+
+
+def session_tail_cache_source_is_large_enough(sid: str) -> bool:
+    """Return whether bounded-tail route setup is worthwhile for this sidecar."""
+    if not is_safe_session_id(sid):
+        return False
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
+            return False
+    signature = _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
+    return bool(
+        signature is not None
+        and signature[2] >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    )
 
 
 def delete_session_tail_cache(sid: str) -> bool:

--- a/api/models.py
+++ b/api/models.py
@@ -275,6 +275,17 @@ def _persisted_session_ids_snapshot() -> frozenset[str]:
     return ids
 
 
+def _invalidate_persisted_session_ids_snapshot() -> None:
+    """Forget the directory listing after this process publishes a sidecar.
+
+    Some filesystems coalesce directory mtime updates for rapid atomic replaces.
+    Relying on that timestamp alone can hide a just-created session until a later
+    unrelated write advances the clock.
+    """
+    global _PERSISTED_SESSION_IDS_CACHE
+    _PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
+
+
 def _session_dir_has_persisted_session_files() -> bool:
     """Return True when the current session dir has at least one session JSON file."""
     try:
@@ -1431,6 +1442,7 @@ class Session:
                 f.flush()
                 os.fsync(f.fileno())
             _safe_replace(tmp, self.path)
+            _invalidate_persisted_session_ids_snapshot()
         except Exception:
             try:
                 tmp.unlink(missing_ok=True)

--- a/api/models.py
+++ b/api/models.py
@@ -143,6 +143,28 @@ _SESSION_TAIL_CACHE_VERSION = 1
 _SESSION_TAIL_CACHE_LIMIT = 300
 _SESSION_TAIL_CACHE_MAX_BYTES = 4 * 1024 * 1024
 _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES = 1 * 1024 * 1024
+_SESSION_TAIL_CACHE_SEMANTIC_KEYS = (
+    'message_offset',
+    'messages',
+    'source_message_count',
+    'source_user_message_count',
+    'source_last_message_at',
+    'tool_calls',
+    'all_tool_calls_positionable',
+    'todo_state',
+    'anchor_scene_index',
+    'all_cached_timestamps_valid',
+)
+_SESSION_TAIL_CACHE_V1_KEYS = frozenset((
+    'format',
+    'version',
+    'session_id',
+    'source_signature',
+    'source_sha256',
+    'tail_limit',
+    *_SESSION_TAIL_CACHE_SEMANTIC_KEYS,
+    'created_at',
+))
 
 # Storage publication ownership is separate from the non-reentrant agent lock:
 # callers commonly hold the latter while calling Session.save(). Weak values keep
@@ -4433,6 +4455,47 @@ def _tail_cache_finite_number(value, *, positive=False) -> bool:
     return math.isfinite(number) and (not positive or number > 0)
 
 
+def _tail_cache_strict_json_object(pairs) -> dict:
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f'duplicate JSON object member: {key!r}')
+        value[key] = item
+    return value
+
+
+def _tail_cache_reject_json_constant(value):
+    raise ValueError(f'non-standard JSON constant: {value}')
+
+
+def _tail_cache_strict_json_decode(raw):
+    """Decode untrusted cache/source JSON without ambiguous object members."""
+    return json.loads(
+        raw,
+        object_pairs_hook=_tail_cache_strict_json_object,
+        parse_constant=_tail_cache_reject_json_constant,
+    )
+
+
+def _tail_cache_exact_json_equal(left, right) -> bool:
+    """Compare decoded JSON recursively without Python numeric coercion."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return set(left) == set(right) and all(
+            _tail_cache_exact_json_equal(left[key], right[key])
+            for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _tail_cache_exact_json_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right)
+        )
+    if left is None or isinstance(left, (str, bool, int, float)):
+        return left == right
+    return False
+
+
 def _tail_cache_signature_dict(signature) -> dict | None:
     """Convert the internal stat tuple into the stable on-disk v1 shape."""
     if not isinstance(signature, tuple) or len(signature) != 4:
@@ -4480,6 +4543,96 @@ def _session_tail_cache_snapshot_value(snapshot, key, default=None):
     return getattr(snapshot, key, default)
 
 
+def _session_tail_cache_projection(
+    session,
+    *,
+    snapshot_is_immutable: bool = False,
+) -> dict | None:
+    """Build the deterministic source-derived portion of a v1 cache."""
+    if _session_tail_cache_snapshot_value(session, '_loaded_metadata_only', False):
+        return None
+    messages = _session_tail_cache_snapshot_value(session, 'messages')
+    if not isinstance(messages, list):
+        return None
+    try:
+        source_count = len(messages)
+        offset = max(0, source_count - _SESSION_TAIL_CACHE_LIMIT)
+        raw_tail = messages[offset:] if snapshot_is_immutable else copy.deepcopy(messages[offset:])
+        all_timestamps_valid = all(
+            isinstance(message, dict)
+            and _tail_cache_finite_number(message.get('timestamp'))
+            for message in raw_tail
+        )
+
+        all_tool_calls_positionable = True
+        cached_tool_calls = []
+        raw_tool_calls = _session_tail_cache_snapshot_value(session, 'tool_calls')
+        if not isinstance(raw_tool_calls, list):
+            raw_tool_calls = []
+            all_tool_calls_positionable = False
+        for tool_call in raw_tool_calls:
+            if not isinstance(tool_call, dict):
+                all_tool_calls_positionable = False
+                continue
+            assistant_idx = tool_call.get('assistant_msg_idx')
+            positionable = _tail_cache_strict_int(
+                assistant_idx,
+                minimum=0,
+                maximum=source_count - 1,
+            )
+            if positionable:
+                positionable = (
+                    isinstance(messages[assistant_idx], dict)
+                    and messages[assistant_idx].get('role') == 'assistant'
+                )
+            if not positionable:
+                all_tool_calls_positionable = False
+                continue
+            if assistant_idx >= offset:
+                cached_tool_calls.append(
+                    tool_call if snapshot_is_immutable else copy.deepcopy(tool_call)
+                )
+
+        from api.todo_state import derive_todo_state
+
+        todo_state = derive_todo_state(messages)
+
+        timestamps = [
+            float(message.get('timestamp'))
+            for message in messages
+            if isinstance(message, dict) and _tail_cache_finite_number(message.get('timestamp'))
+        ]
+        last_message_at = max(timestamps) if timestamps else _session_tail_cache_snapshot_value(
+            session,
+            'updated_at',
+        )
+        if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
+            last_message_at = None
+        return {
+            'message_offset': offset,
+            'messages': raw_tail,
+            'source_message_count': source_count,
+            'source_user_message_count': Session._compute_user_message_count(messages),
+            'source_last_message_at': last_message_at,
+            'tool_calls': cached_tool_calls,
+            'all_tool_calls_positionable': all_tool_calls_positionable,
+            'todo_state': todo_state,
+            'anchor_scene_index': (
+                _session_tail_cache_snapshot_value(session, 'anchor_scene_index')
+                if snapshot_is_immutable
+                else copy.deepcopy(_session_tail_cache_snapshot_value(session, 'anchor_scene_index'))
+            ) if isinstance(
+                _session_tail_cache_snapshot_value(session, 'anchor_scene_index'),
+                dict,
+            ) else _anchor_scene_index_from_records(
+                _session_tail_cache_snapshot_value(session, 'anchor_activity_scenes')
+            ),
+            'all_cached_timestamps_valid': all_timestamps_valid,
+        }
+    except Exception:
+        return None
+
+
 def _session_tail_cache_payload(
     session,
     source_proof,
@@ -4487,8 +4640,6 @@ def _session_tail_cache_payload(
     snapshot_is_immutable: bool = False,
 ) -> dict | None:
     """Build a v1 cache payload from a Session or its frozen save snapshot."""
-    if _session_tail_cache_snapshot_value(session, '_loaded_metadata_only', False):
-        return None
     sid = _session_tail_cache_snapshot_value(session, 'session_id')
     if not is_safe_session_id(sid):
         return None
@@ -4498,65 +4649,12 @@ def _session_tail_cache_payload(
     source_digest = _tail_cache_content_digest(source_proof[1])
     if signature is None or source_digest is None:
         return None
-    messages = _session_tail_cache_snapshot_value(session, 'messages')
-    if not isinstance(messages, list):
-        return None
-    source_count = len(messages)
-    offset = max(0, source_count - _SESSION_TAIL_CACHE_LIMIT)
-    raw_tail = messages[offset:] if snapshot_is_immutable else copy.deepcopy(messages[offset:])
-    all_timestamps_valid = all(
-        isinstance(message, dict)
-        and _tail_cache_finite_number(message.get('timestamp'))
-        for message in raw_tail
-    )
-
-    all_tool_calls_positionable = True
-    cached_tool_calls = []
-    raw_tool_calls = _session_tail_cache_snapshot_value(session, 'tool_calls')
-    if not isinstance(raw_tool_calls, list):
-        raw_tool_calls = []
-        all_tool_calls_positionable = False
-    for tool_call in raw_tool_calls:
-        if not isinstance(tool_call, dict):
-            all_tool_calls_positionable = False
-            continue
-        assistant_idx = tool_call.get('assistant_msg_idx')
-        positionable = _tail_cache_strict_int(
-            assistant_idx,
-            minimum=0,
-            maximum=source_count - 1,
-        )
-        if positionable:
-            positionable = (
-                isinstance(messages[assistant_idx], dict)
-                and messages[assistant_idx].get('role') == 'assistant'
-            )
-        if not positionable:
-            all_tool_calls_positionable = False
-            continue
-        if assistant_idx >= offset:
-            cached_tool_calls.append(
-                tool_call if snapshot_is_immutable else copy.deepcopy(tool_call)
-            )
-
-    try:
-        from api.todo_state import derive_todo_state
-
-        todo_state = derive_todo_state(messages)
-    except Exception:
-        todo_state = None
-
-    timestamps = [
-        float(message.get('timestamp'))
-        for message in messages
-        if isinstance(message, dict) and _tail_cache_finite_number(message.get('timestamp'))
-    ]
-    last_message_at = max(timestamps) if timestamps else _session_tail_cache_snapshot_value(
+    projection = _session_tail_cache_projection(
         session,
-        'updated_at',
+        snapshot_is_immutable=snapshot_is_immutable,
     )
-    if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
-        last_message_at = None
+    if projection is None:
+        return None
     return {
         'format': _SESSION_TAIL_CACHE_FORMAT,
         'version': _SESSION_TAIL_CACHE_VERSION,
@@ -4564,25 +4662,7 @@ def _session_tail_cache_payload(
         'source_signature': signature,
         'source_sha256': source_digest,
         'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
-        'message_offset': offset,
-        'messages': raw_tail,
-        'source_message_count': source_count,
-        'source_user_message_count': Session._compute_user_message_count(messages),
-        'source_last_message_at': last_message_at,
-        'tool_calls': cached_tool_calls,
-        'all_tool_calls_positionable': all_tool_calls_positionable,
-        'todo_state': todo_state,
-        'anchor_scene_index': (
-            _session_tail_cache_snapshot_value(session, 'anchor_scene_index')
-            if snapshot_is_immutable
-            else copy.deepcopy(_session_tail_cache_snapshot_value(session, 'anchor_scene_index'))
-        ) if isinstance(
-            _session_tail_cache_snapshot_value(session, 'anchor_scene_index'),
-            dict,
-        ) else _anchor_scene_index_from_records(
-            _session_tail_cache_snapshot_value(session, 'anchor_activity_scenes')
-        ),
-        'all_cached_timestamps_valid': all_timestamps_valid,
+        **projection,
         'created_at': float(time.time()),
     }
 
@@ -4681,7 +4761,7 @@ def _session_tail_cache_has_signature(sid: str, source_proof) -> bool:
         if _bound_stat(path).st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
             return False
         with _bound_open(path, 'rb') as handle:
-            value = json.loads(handle.read())
+            value = _tail_cache_strict_json_decode(handle.read())
         return (
             isinstance(value, dict)
             and value.get('format') == _SESSION_TAIL_CACHE_FORMAT
@@ -4696,14 +4776,19 @@ def _session_tail_cache_has_signature(sid: str, source_proof) -> bool:
         return False
 
 
-def _validate_session_tail_cache_payload(payload, sid: str, source_proof) -> dict | None:
+def _validate_session_tail_cache_payload(payload, sid: str, source) -> dict | None:
     """Strictly validate v1 shape and bounded-read eligibility."""
     if not isinstance(payload, dict):
+        return None
+    if set(payload) != _SESSION_TAIL_CACHE_V1_KEYS:
         return None
     if payload.get('format') != _SESSION_TAIL_CACHE_FORMAT:
         return None
     if payload.get('version') != _SESSION_TAIL_CACHE_VERSION or payload.get('session_id') != sid:
         return None
+    if not isinstance(source, tuple) or len(source) != 2:
+        return None
+    source_proof, source_bytes = source
     if not isinstance(source_proof, tuple) or len(source_proof) != 2:
         return None
     embedded_signature = _tail_cache_signature_tuple(payload.get('source_signature'))
@@ -4718,6 +4803,22 @@ def _validate_session_tail_cache_payload(payload, sid: str, source_proof) -> dic
     ):
         return None
     if payload.get('tail_limit') != _SESSION_TAIL_CACHE_LIMIT:
+        return None
+
+    try:
+        authoritative = _tail_cache_strict_json_decode(source_bytes)
+        if not isinstance(authoritative, dict) or authoritative.get('session_id') != sid:
+            return None
+        expected_projection = _session_tail_cache_projection(
+            authoritative,
+            snapshot_is_immutable=True,
+        )
+        if expected_projection is None or any(
+            not _tail_cache_exact_json_equal(payload[key], expected_projection[key])
+            for key in _SESSION_TAIL_CACHE_SEMANTIC_KEYS
+        ):
+            return None
+    except Exception:
         return None
 
     source_count = payload.get('source_message_count')
@@ -4784,14 +4885,14 @@ def _read_session_tail_cache_file(sid: str) -> dict | None:
             if size <= 0 or size > _SESSION_TAIL_CACHE_MAX_BYTES:
                 return None
             with _bound_open(path, 'rb') as handle:
-                payload = json.loads(handle.read())
+                payload = _tail_cache_strict_json_decode(handle.read())
             # Read the complete authoritative source after the derived bytes.
-            # Returning a cache requires an exact digest match, so same-stat
-            # in-place and atomic replacements fail closed without JSON parsing.
+            # Returning a cache requires both an exact proof match and an exact
+            # source-derived semantic projection from these already-proven bytes.
             source = _sidecar_content_proof(target.path)
             if source is None:
                 return None
-            return _validate_session_tail_cache_payload(payload, sid, source[0])
+            return _validate_session_tail_cache_payload(payload, sid, source)
     except (OSError, ValueError, TypeError):
         return None
 

--- a/api/models.py
+++ b/api/models.py
@@ -242,6 +242,11 @@ def _cleanup_stale_tmp_files() -> None:
         pass  # SESSION_DIR may not exist yet; that's fine
 
 
+# This lock is intentionally narrower than the application-wide LOCK. It covers
+# only the persisted-ID cache check/stat/glob/store sequence and invalidation.
+# Session.save() publishes the sidecar before acquiring it for invalidation, so
+# sidecar I/O never runs under this lock and there is no lock-order inversion.
+_PERSISTED_SESSION_IDS_CACHE_LOCK = threading.Lock()
 _PERSISTED_SESSION_IDS_CACHE: tuple[Path | None, int | None, frozenset[str]] = (None, None, frozenset())
 
 
@@ -256,23 +261,24 @@ def _persisted_session_ids_snapshot() -> frozenset[str]:
     entering critical sections.
     """
     global _PERSISTED_SESSION_IDS_CACHE
-    try:
-        dir_mtime_ns = SESSION_DIR.stat().st_mtime_ns
-    except Exception:
-        dir_mtime_ns = None
-    cached_dir, cached_mtime_ns, cached_ids = _PERSISTED_SESSION_IDS_CACHE
-    if cached_dir == SESSION_DIR and cached_mtime_ns == dir_mtime_ns:
-        return cached_ids
-    try:
-        ids = frozenset(
-            p.stem
-            for p in SESSION_DIR.glob('*.json')
-            if not p.name.startswith('_')
-        )
-    except Exception:
-        ids = frozenset()
-    _PERSISTED_SESSION_IDS_CACHE = (SESSION_DIR, dir_mtime_ns, ids)
-    return ids
+    with _PERSISTED_SESSION_IDS_CACHE_LOCK:
+        try:
+            dir_mtime_ns = SESSION_DIR.stat().st_mtime_ns
+        except Exception:
+            dir_mtime_ns = None
+        cached_dir, cached_mtime_ns, cached_ids = _PERSISTED_SESSION_IDS_CACHE
+        if cached_dir == SESSION_DIR and cached_mtime_ns == dir_mtime_ns:
+            return cached_ids
+        try:
+            ids = frozenset(
+                p.stem
+                for p in SESSION_DIR.glob('*.json')
+                if not p.name.startswith('_')
+            )
+        except Exception:
+            ids = frozenset()
+        _PERSISTED_SESSION_IDS_CACHE = (SESSION_DIR, dir_mtime_ns, ids)
+        return ids
 
 
 def _invalidate_persisted_session_ids_snapshot() -> None:
@@ -283,7 +289,8 @@ def _invalidate_persisted_session_ids_snapshot() -> None:
     unrelated write advances the clock.
     """
     global _PERSISTED_SESSION_IDS_CACHE
-    _PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
+    with _PERSISTED_SESSION_IDS_CACHE_LOCK:
+        _PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
 
 
 def _session_dir_has_persisted_session_files() -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9203,6 +9203,7 @@ from api.models import (
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
+    delete_session_tail_cache,
     agent_session_rows_existing,
     agent_session_zero_message_sids,
     _load_webui_zero_message_orphan_tombstone,
@@ -14610,6 +14611,8 @@ def handle_post(handler, parsed) -> bool:
         except Exception:
             logger.debug("Failed to unlink session file %s", p)
         sidecar_deleted = not p.exists()
+        if sidecar_deleted:
+            delete_session_tail_cache(sid)
         try:
             p.with_suffix('.json.bak').unlink(missing_ok=True)
         except Exception:
@@ -20292,6 +20295,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
                 p.unlink(missing_ok=True)
+                delete_session_tail_cache(p.stem)
                 cleaned += 1
                 phase1_removed_ids.add(p.stem)
         except Exception:
@@ -20515,6 +20519,7 @@ def _handle_background(handler, body):
             # next rebuild via _index_entry_exists().
             try:
                 (SESSION_DIR / f"{bg_sid}.json").unlink(missing_ok=True)
+                delete_session_tail_cache(bg_sid)
             except Exception:
                 pass
         except Exception:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1520,18 +1520,46 @@ def _persist_cancelled_turn(session, *, message: str = 'Task cancelled.') -> Non
         })
 
 
-def _cleanup_ephemeral_cancelled_turn(session) -> None:
-    """Remove transient /btw session state after a cancel without saving it."""
+def _cleanup_ephemeral_session(
+    session,
+    *,
+    checkpoint_stop=None,
+    checkpoint_thread=None,
+) -> None:
+    """Stop checkpoint publication, then remove transient /btw storage."""
     session.active_stream_id = None
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
     session.pending_user_source = None
+    if checkpoint_stop is not None:
+        checkpoint_stop.set()
+    if (
+        checkpoint_thread is not None
+        and checkpoint_thread is not threading.current_thread()
+    ):
+        # Deletion must happen after a checkpoint already inside Session.save()
+        # exits; otherwise that writer can recreate both files after cleanup.
+        checkpoint_thread.join()
+    sid = getattr(session, 'session_id', None)
+    if sid:
+        try:
+            from api.models import delete_session_sidecar_and_tail_cache
+
+            delete_session_sidecar_and_tail_cache(sid)
+            return
+        except Exception:
+            logger.debug("Failed to clean up ephemeral session storage", exc_info=True)
     try:
         import pathlib
         pathlib.Path(session.path).unlink(missing_ok=True)
     except Exception:
-        logger.debug("Failed to clean up ephemeral cancelled session", exc_info=True)
+        logger.debug("Failed to clean up ephemeral session sidecar", exc_info=True)
+
+
+def _cleanup_ephemeral_cancelled_turn(session) -> None:
+    """Remove transient /btw session state after a cancel without saving it."""
+    _cleanup_ephemeral_session(session)
 
 
 def _finalize_cancelled_turn(session, *, ephemeral: bool = False, message: str = 'Task cancelled.') -> None:
@@ -8534,13 +8562,17 @@ def _run_agent_streaming(
             # sub-100ms window reaches the live Thinking view before the terminal done event.
             _flush_reasoning_buffer()
             if cancel_event.is_set():
-                if _checkpoint_stop is not None:
-                    _checkpoint_stop.set()
-                if _ckpt_thread is not None:
-                    _ckpt_thread.join(timeout=15)
                 if ephemeral:
-                    _cleanup_ephemeral_cancelled_turn(s)
+                    _cleanup_ephemeral_session(
+                        s,
+                        checkpoint_stop=_checkpoint_stop,
+                        checkpoint_thread=_ckpt_thread,
+                    )
                 else:
+                    if _checkpoint_stop is not None:
+                        _checkpoint_stop.set()
+                    if _ckpt_thread is not None:
+                        _ckpt_thread.join(timeout=15)
                     with _agent_lock:
                         _finalize_cancelled_turn(s, ephemeral=False)
                         try:
@@ -8570,13 +8602,11 @@ def _run_agent_streaming(
                     'ephemeral': True,
                     'answer': _answer,
                 })
-                if _checkpoint_stop is not None:
-                    _checkpoint_stop.set()
-                try:
-                    import pathlib
-                    pathlib.Path(s.path).unlink(missing_ok=True)
-                except Exception:
-                    pass
+                _cleanup_ephemeral_session(
+                    s,
+                    checkpoint_stop=_checkpoint_stop,
+                    checkpoint_thread=_ckpt_thread,
+                )
                 return  # skip all normal persistence for ephemeral sessions
             if _checkpoint_stop is not None:
                 _checkpoint_stop.set()

--- a/tests/test_btw_ephemeral_cleanup.py
+++ b/tests/test_btw_ephemeral_cleanup.py
@@ -241,7 +241,15 @@ def test_ephemeral_tail_cleanup_failure_is_nonfatal_and_still_removes_source(
     original_unlink = models.os.unlink
 
     def fail_cache_unlink(path, *args, **kwargs):
-        if Path(path) == cache_path:
+        target = models._active_session_sidecar_target()
+        is_bound_cache = (
+            target is not None
+            and kwargs.get("dir_fd") is not None
+            and kwargs["dir_fd"] == target._cache_fd
+        )
+        if Path(path).name == cache_path.name and (
+            Path(path) == cache_path or is_bound_cache
+        ):
             raise OSError("simulated ephemeral tail-cache cleanup failure")
         return original_unlink(path, *args, **kwargs)
 

--- a/tests/test_btw_ephemeral_cleanup.py
+++ b/tests/test_btw_ephemeral_cleanup.py
@@ -238,14 +238,14 @@ def test_ephemeral_tail_cleanup_failure_is_nonfatal_and_still_removes_source(
     monkeypatch,
 ):
     session, stream_id, event_queue, cache_path = _prepare_ephemeral(tmp_path, "FAILURE")
-    original_unlink = Path.unlink
+    original_unlink = models.os.unlink
 
     def fail_cache_unlink(path, *args, **kwargs):
-        if path == cache_path:
+        if Path(path) == cache_path:
             raise OSError("simulated ephemeral tail-cache cleanup failure")
         return original_unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "unlink", fail_cache_unlink)
+    monkeypatch.setattr(models.os, "unlink", fail_cache_unlink)
     _run_ephemeral_worker(monkeypatch, session, stream_id)
 
     events = _events(event_queue)

--- a/tests/test_btw_ephemeral_cleanup.py
+++ b/tests/test_btw_ephemeral_cleanup.py
@@ -1,0 +1,255 @@
+import queue
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+import api.config as config
+import api.models as models
+import api.streaming as streaming
+from api.models import Session
+
+
+@pytest.fixture(autouse=True)
+def isolated_ephemeral_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    config.STREAM_REASONING_TEXT.clear()
+    config.STREAM_LIVE_TOOL_CALLS.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+    try:
+        config.SESSION_AGENT_CACHE.clear()
+    except Exception:
+        pass
+    yield session_dir
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    config.STREAM_REASONING_TEXT.clear()
+    config.STREAM_LIVE_TOOL_CALLS.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+    try:
+        config.SESSION_AGENT_CACHE.clear()
+    except Exception:
+        pass
+
+
+def _large_messages(marker):
+    return [
+        {
+            "role": "user",
+            "content": marker + ("x" * (models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES + 1024)),
+            "timestamp": 1.0,
+        },
+        {"role": "assistant", "content": "parent answer", "timestamp": 2.0},
+    ]
+
+
+def _prepare_ephemeral(tmp_path, marker):
+    session_id = f"btw_{marker.lower()}"
+    stream_id = f"stream-{session_id}"
+    session = Session(
+        session_id=session_id,
+        title="Ephemeral cleanup test",
+        workspace=str(tmp_path),
+        model="test-model",
+        profile="default",
+        messages=_large_messages(marker),
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "answer this aside"
+    session.pending_started_at = 3.0
+    session.pending_user_source = "webui"
+    session.save()
+    models.SESSIONS[session_id] = session
+    event_queue = queue.Queue()
+    streaming.STREAMS[stream_id] = event_queue
+    cache_path = models.session_tail_cache_path(session_id)
+    assert session.path.exists()
+    assert cache_path.exists()
+    return session, stream_id, event_queue, cache_path
+
+
+def _run_ephemeral_worker(monkeypatch, session, stream_id, *, cancel_on_agent_init=False):
+    result_messages = [
+        *session.messages,
+        {"role": "user", "content": "answer this aside", "timestamp": 3.0},
+        {"role": "assistant", "content": "ephemeral answer", "timestamp": 4.0},
+    ]
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.session_id = kwargs.get("session_id")
+            self.stream_delta_callback = kwargs.get("stream_delta_callback")
+            self.context_compressor = None
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = None
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+            if cancel_on_agent_init:
+                streaming.CANCEL_FLAGS[stream_id].set()
+
+        def run_conversation(self, **kwargs):
+            return {"messages": result_messages}
+
+        def interrupt(self, _message):
+            return None
+
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda *_args, **_kwargs: object()
+    with monkeypatch.context() as scoped:
+        scoped.setattr(streaming, "get_session", lambda _sid: session)
+        scoped.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+        scoped.setattr(
+            streaming,
+            "resolve_model_provider",
+            lambda *_args, **_kwargs: ("test-model", "test-provider", None),
+        )
+        scoped.setattr("api.config.get_config", lambda *_args, **_kwargs: {})
+        scoped.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+        scoped.setitem(sys.modules, "hermes_state", fake_hermes_state)
+        streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text=session.pending_user_message,
+            model="test-model",
+            workspace=session.workspace,
+            stream_id=stream_id,
+            ephemeral=True,
+        )
+    event_queue = streaming.STREAMS.get(stream_id)
+    if event_queue is None:
+        # The worker teardown removes STREAMS, but the caller still owns the queue
+        # object supplied during setup.
+        return result_messages
+    return result_messages
+
+
+def _events(event_queue):
+    items = []
+    while not event_queue.empty():
+        item = event_queue.get_nowait()
+        items.append((item[0], item[1]))
+    return items
+
+
+def test_btw_success_preserves_done_payload_and_removes_all_session_bytes(
+    tmp_path,
+    monkeypatch,
+):
+    session, stream_id, event_queue, cache_path = _prepare_ephemeral(tmp_path, "SUCCESS")
+    result_messages = _run_ephemeral_worker(monkeypatch, session, stream_id)
+
+    events = _events(event_queue)
+    done = [payload for event, payload in events if event == "done"]
+    assert done == [
+        {
+            "session": {"session_id": session.session_id, "messages": result_messages},
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "ephemeral": True,
+            "answer": "ephemeral answer",
+        }
+    ]
+    assert not any(event in {"cancel", "stream_end"} for event, _payload in events)
+    assert not session.path.exists()
+    assert not cache_path.exists()
+
+
+def test_btw_agent_init_cancel_preserves_cancel_semantics_and_removes_all_session_bytes(
+    tmp_path,
+    monkeypatch,
+):
+    session, stream_id, event_queue, cache_path = _prepare_ephemeral(tmp_path, "CANCEL")
+    original_messages = list(session.messages)
+    _run_ephemeral_worker(
+        monkeypatch,
+        session,
+        stream_id,
+        cancel_on_agent_init=True,
+    )
+
+    events = _events(event_queue)
+    cancel = [payload for event, payload in events if event == "cancel"]
+    assert len(cancel) == 1
+    assert cancel[0]["message"] == "Cancelled by user"
+    assert not any(event in {"done", "stream_end"} for event, _payload in events)
+    assert session.active_stream_id is None
+    assert session.pending_user_message is None
+    assert session.pending_attachments == []
+    assert session.pending_started_at is None
+    assert session.pending_user_source is None
+    assert session.messages == original_messages
+    assert not session.path.exists()
+    assert not cache_path.exists()
+
+
+def test_ephemeral_cleanup_joins_checkpoint_before_deleting_files(tmp_path):
+    session, _stream_id, _event_queue, cache_path = _prepare_ephemeral(tmp_path, "CHECKPOINT")
+    checkpoint_stop = threading.Event()
+    checkpoint_entered = threading.Event()
+    release_checkpoint = threading.Event()
+
+    def late_checkpoint():
+        checkpoint_entered.set()
+        assert release_checkpoint.wait(timeout=5)
+        session.save(touch_updated_at=False, skip_index=True)
+
+    checkpoint_thread = threading.Thread(target=late_checkpoint)
+    checkpoint_thread.start()
+    assert checkpoint_entered.wait(timeout=5)
+    cleanup_thread = threading.Thread(
+        target=streaming._cleanup_ephemeral_session,
+        kwargs={
+            "session": session,
+            "checkpoint_stop": checkpoint_stop,
+            "checkpoint_thread": checkpoint_thread,
+        },
+    )
+    cleanup_thread.start()
+    assert checkpoint_stop.wait(timeout=5)
+    assert cleanup_thread.is_alive(), "cleanup deleted before the checkpoint completed"
+    release_checkpoint.set()
+    cleanup_thread.join(timeout=5)
+    checkpoint_thread.join(timeout=5)
+
+    assert not cleanup_thread.is_alive()
+    assert not checkpoint_thread.is_alive()
+    assert not session.path.exists()
+    assert not cache_path.exists()
+
+
+def test_ephemeral_tail_cleanup_failure_is_nonfatal_and_still_removes_source(
+    tmp_path,
+    monkeypatch,
+):
+    session, stream_id, event_queue, cache_path = _prepare_ephemeral(tmp_path, "FAILURE")
+    original_unlink = Path.unlink
+
+    def fail_cache_unlink(path, *args, **kwargs):
+        if path == cache_path:
+            raise OSError("simulated ephemeral tail-cache cleanup failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_cache_unlink)
+    _run_ephemeral_worker(monkeypatch, session, stream_id)
+
+    events = _events(event_queue)
+    assert any(event == "done" and payload.get("ephemeral") is True for event, payload in events)
+    assert not session.path.exists()
+    assert cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is None

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -295,10 +295,13 @@ class TestIssue765FollowupHardening:
         replace_sources = []
         errors = []
 
-        def _record_replace(src, dst):
-            if Path(dst) == s.path:
+        def _record_replace(src, dst, *args, **kwargs):
+            destination_is_sidecar = Path(dst) == s.path
+            if kwargs.get("dst_dir_fd") is not None:
+                destination_is_sidecar = Path(dst).name == s.path.name
+            if destination_is_sidecar:
                 replace_sources.append(str(src))
-            return original_replace(src, dst)
+            return original_replace(src, dst, *args, **kwargs)
 
         monkeypatch.setattr(models.os, "replace", _record_replace)
 

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -280,10 +280,12 @@ class TestIssue765FollowupHardening:
     def test_same_session_concurrent_saves_use_distinct_temp_files(self, monkeypatch):
         """Two concurrent saves of the same session must not collide on one tmp path.
 
-        The key regression guard here is that each save call should reach os.replace()
-        with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
-        threads would target the same path and the second replace would deterministically
-        fail once the first consume/remove happened.
+        The key regression guard here is that each save call should publish the
+        authoritative sidecar with a distinct source tmp path. Derived tail-cache
+        publications have their own atomicity tests and must not change this count.
+        With the old shared `<sid>.tmp` scheme, both threads would target the same
+        path and the second replace would deterministically fail once the first
+        consume/remove happened.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
@@ -294,8 +296,9 @@ class TestIssue765FollowupHardening:
         errors = []
 
         def _replace_with_barrier(src, dst):
-            replace_sources.append(str(src))
-            barrier.wait(timeout=5)
+            if Path(dst) == s.path:
+                replace_sources.append(str(src))
+                barrier.wait(timeout=5)
             return original_replace(src, dst)
 
         monkeypatch.setattr(models.os, "replace", _replace_with_barrier)

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -291,20 +291,22 @@ class TestIssue765FollowupHardening:
         s.save(skip_index=True)  # seed the file on disk
 
         original_replace = models.os.replace
-        barrier = threading.Barrier(2)
+        start_barrier = threading.Barrier(2)
         replace_sources = []
         errors = []
 
-        def _replace_with_barrier(src, dst):
+        def _record_replace(src, dst):
             if Path(dst) == s.path:
                 replace_sources.append(str(src))
-                barrier.wait(timeout=5)
             return original_replace(src, dst)
 
-        monkeypatch.setattr(models.os, "replace", _replace_with_barrier)
+        monkeypatch.setattr(models.os, "replace", _record_replace)
 
         def _save_worker():
             try:
+                # Both callers enter save concurrently, but same-ID publication is
+                # intentionally serialized by the storage-owned transaction lock.
+                start_barrier.wait(timeout=5)
                 s.save(skip_index=True)
             except Exception as e:
                 errors.append(e)

--- a/tests/test_pr1341_context_window_persistence.py
+++ b/tests/test_pr1341_context_window_persistence.py
@@ -16,6 +16,7 @@ This test verifies that:
 Implementation reference: api/streaming.py around line 2188 (the per-turn
 post-merge save) writes from getattr(agent, 'context_compressor', None).
 """
+import inspect
 import re
 from pathlib import Path
 
@@ -73,14 +74,12 @@ def test_streaming_persists_context_fields_on_session_before_save():
 
 def test_session_init_accepts_context_fields():
     """Session.__init__ must accept the three fields as named kwargs."""
-    src = MODELS.read_text(encoding="utf-8")
-    # The init signature spans many lines — read the full def block
-    init_match = re.search(r"def __init__\(self,(.*?)\):", src, re.DOTALL)
-    assert init_match, "Session.__init__ signature not found"
-    sig = init_match.group(1)
-    assert "context_length" in sig, "Session.__init__ must accept context_length"
-    assert "threshold_tokens" in sig, "Session.__init__ must accept threshold_tokens"
-    assert "last_prompt_tokens" in sig, "Session.__init__ must accept last_prompt_tokens"
+    from api import models
+
+    parameters = inspect.signature(models.Session.__init__).parameters
+    assert "context_length" in parameters, "Session.__init__ must accept context_length"
+    assert "threshold_tokens" in parameters, "Session.__init__ must accept threshold_tokens"
+    assert "last_prompt_tokens" in parameters, "Session.__init__ must accept last_prompt_tokens"
 
 
 def test_session_metadata_fields_includes_context_fields():

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -134,6 +134,31 @@ def test_full_index_rebuild_includes_hyphenated_sessions():
     assert sid in ids
 
 
+def test_save_invalidates_persisted_id_snapshot_when_directory_mtime_stalls(monkeypatch):
+    """A same-tick create must not stay hidden behind the directory snapshot cache."""
+    first = _make_session("snapshot_first", "First")
+    first.save()
+    assert models._persisted_session_ids_snapshot() == frozenset({first.session_id})
+
+    session_dir = models.SESSION_DIR
+    frozen_dir_stat = session_dir.stat()
+    original_stat = Path.stat
+
+    def stat_with_stalled_directory_mtime(path, *args, **kwargs):
+        if path == session_dir:
+            return frozen_dir_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stat_with_stalled_directory_mtime)
+
+    second = _make_session("snapshot_second", "Second")
+    second.save()
+
+    assert models._persisted_session_ids_snapshot() == frozenset(
+        {first.session_id, second.session_id}
+    )
+
+
 def test_prune_session_from_index_removes_requested_row_only():
     index_file = models.SESSION_INDEX_FILE
     s_a = _make_session("sess_a", "A", updated_at=100)

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -159,6 +159,95 @@ def test_save_invalidates_persisted_id_snapshot_when_directory_mtime_stalls(monk
     )
 
 
+def test_concurrent_snapshot_rebuild_cannot_restore_invalidated_ids(monkeypatch):
+    """A rebuild that began before save invalidation must not publish stale IDs after it."""
+    first = _make_session("snapshot_first", "First")
+    first.save(skip_index=True)
+    assert models._persisted_session_ids_snapshot() == frozenset({first.session_id})
+
+    session_dir = models.SESSION_DIR
+    frozen_dir_stat = session_dir.stat()
+    original_stat = Path.stat
+    original_glob = Path.glob
+    original_safe_replace = models._safe_replace
+    original_invalidate = models._invalidate_persisted_session_ids_snapshot
+
+    enumeration_finished = threading.Event()
+    release_reader = threading.Event()
+    second_published = threading.Event()
+    invalidation_started = threading.Event()
+    invalidation_finished = threading.Event()
+    reader_snapshots = []
+    errors = []
+
+    def stat_with_stalled_directory_mtime(path, *args, **kwargs):
+        if path == session_dir:
+            return frozen_dir_stat
+        return original_stat(path, *args, **kwargs)
+
+    def glob_with_stalled_reader(path, pattern):
+        paths = list(original_glob(path, pattern))
+        if path == session_dir and threading.current_thread().name == "persisted-id-reader":
+            enumeration_finished.set()
+            if not release_reader.wait(timeout=5):
+                raise TimeoutError("snapshot reader was not released")
+        return paths
+
+    second = _make_session("snapshot_second", "Second")
+
+    def safe_replace_with_publication_signal(src, dst):
+        original_safe_replace(src, dst)
+        if dst == second.path:
+            second_published.set()
+
+    def invalidate_with_signals():
+        invalidation_started.set()
+        original_invalidate()
+        invalidation_finished.set()
+
+    monkeypatch.setattr(Path, "stat", stat_with_stalled_directory_mtime)
+    monkeypatch.setattr(Path, "glob", glob_with_stalled_reader)
+    monkeypatch.setattr(models, "_safe_replace", safe_replace_with_publication_signal)
+    monkeypatch.setattr(models, "_invalidate_persisted_session_ids_snapshot", invalidate_with_signals)
+    models._PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
+
+    def rebuild_snapshot():
+        try:
+            reader_snapshots.append(models._persisted_session_ids_snapshot())
+        except Exception as exc:
+            errors.append(exc)
+
+    def save_second_session():
+        try:
+            second.save(skip_index=True)
+        except Exception as exc:
+            errors.append(exc)
+
+    reader = threading.Thread(target=rebuild_snapshot, name="persisted-id-reader")
+    saver = threading.Thread(target=save_second_session, name="persisted-id-saver")
+    reader.start()
+    assert enumeration_finished.wait(timeout=5), "snapshot reader did not enumerate the old set"
+
+    saver.start()
+    assert second_published.wait(timeout=5), "second sidecar was not published"
+    assert invalidation_started.wait(timeout=5), "save did not attempt cache invalidation"
+    # Without serialization invalidation completes while the stale reader is paused.
+    # With the cache lock it remains blocked until that reader publishes and exits.
+    invalidation_finished.wait(timeout=1)
+    release_reader.set()
+
+    reader.join(timeout=5)
+    saver.join(timeout=5)
+
+    assert not reader.is_alive(), "snapshot reader deadlocked"
+    assert not saver.is_alive(), "session saver deadlocked"
+    assert not errors, f"concurrent snapshot/save errors: {errors}"
+    assert reader_snapshots == [frozenset({first.session_id})]
+    assert models._persisted_session_ids_snapshot() == frozenset(
+        {first.session_id, second.session_id}
+    )
+
+
 def test_prune_session_from_index_removes_requested_row_only():
     index_file = models.SESSION_INDEX_FILE
     s_a = _make_session("sess_a", "A", updated_at=100)

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -16,6 +16,9 @@ def isolated_session_store(tmp_path, monkeypatch):
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    # Most storage tests exercise the cache format with compact fixtures. Source
+    # threshold behavior is covered explicitly below with the production limit.
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 0)
     models.SESSIONS.clear()
     yield session_dir
     models.SESSIONS.clear()
@@ -123,6 +126,41 @@ def test_save_is_fail_open_when_tail_cache_write_fails(isolated_session_store, m
     session.save(skip_index=True)
 
     assert json.loads(session.path.read_bytes())["messages"] == session.messages
+
+
+def test_save_publishes_cache_only_after_source_reaches_threshold(
+    isolated_session_store,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        models,
+        "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES",
+        1 * 1024 * 1024,
+    )
+    session = Session(
+        session_id="tail_source_threshold",
+        messages=_messages(4),
+    )
+    cache_path = models.session_tail_cache_path(session.session_id)
+
+    session.save(skip_index=True)
+
+    assert session.path.exists()
+    assert session.path.stat().st_size < models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    assert not cache_path.exists()
+
+    session.messages.append(
+        {
+            "role": "assistant",
+            "content": "x" * (models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES + 1024),
+            "timestamp": 99.0,
+        }
+    )
+    session.save(skip_index=True)
+
+    assert session.path.stat().st_size >= models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    assert cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is not None
 
 
 def test_stable_full_load_opportunistically_builds_but_metadata_only_never_builds(

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -378,15 +378,15 @@ def test_cache_cleanup_failure_is_nonfatal_after_authoritative_save(
     session.save(touch_updated_at=False, skip_index=True)
     assert cache_path.exists()
     attempted = []
-    original_unlink = Path.unlink
+    original_unlink = models.os.unlink
 
     def fail_cache_unlink(path, *args, **kwargs):
-        if path == cache_path:
-            attempted.append(path)
+        if Path(path) == cache_path:
+            attempted.append(Path(path))
             raise OSError("simulated tail-cache unlink failure")
         return original_unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "unlink", fail_cache_unlink)
+    monkeypatch.setattr(models.os, "unlink", fail_cache_unlink)
     new_messages = _messages(2)
     session.messages = new_messages
     caplog.set_level("DEBUG", logger="api.models")

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -258,6 +258,21 @@ def test_opportunistic_full_load_does_not_write_foreign_profile_cache(
     assert not cache_path.exists()
 
 
+def test_source_size_gate_skips_stat_when_full_session_is_cached(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(session_id="tail_cached_full", messages=_messages(4))
+    models.SESSIONS[session.session_id] = session
+
+    def unexpected_stat(_path):
+        raise AssertionError("warm full-session path must not stat the sidecar")
+
+    monkeypatch.setattr(models, "_sidecar_stat_signature", unexpected_stat)
+
+    assert models.session_tail_cache_source_is_large_enough(session.session_id) is False
+
+
 def test_delete_tail_cache_is_best_effort_and_path_safe(isolated_session_store):
     session = Session(session_id="tail_delete", messages=_messages(4))
     session.save(skip_index=True)

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -1,6 +1,7 @@
 import gc
 import hashlib
 import json
+import logging
 import os
 import stat
 import threading
@@ -201,6 +202,171 @@ def test_save_is_fail_open_when_tail_cache_write_fails(isolated_session_store, m
     session.save(skip_index=True)
 
     assert json.loads(session.path.read_bytes())["messages"] == session.messages
+
+
+def _backup_shrink_remaining_files(root):
+    return sorted(
+        str(path.relative_to(root))
+        for path in root.rglob("*")
+        if path.is_file()
+    )
+
+
+def _backup_warning_records(caplog, session_id):
+    return [
+        record
+        for record in caplog.records
+        if record.name == "api.models"
+        and record.levelno >= logging.WARNING
+        and "backup" in record.getMessage().lower()
+        and session_id in record.getMessage()
+    ]
+
+
+def test_shrink_save_survives_backup_publication_oserror(
+    isolated_session_store, monkeypatch, caplog
+):
+    session = Session(
+        session_id="shrink_backup_besteffort",
+        messages=[_message(index) for index in range(4)],
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    authoritative_before = session.path.read_bytes()
+    assert len(json.loads(authoritative_before)["messages"]) == 4
+    session.messages = session.messages[:2]
+
+    original_safe_replace = models._safe_replace
+
+    def fail_backup_replace(src, dst):
+        if Path(dst).name.endswith(".json.bak"):
+            raise OSError("injected backup publication failure")
+        return original_safe_replace(src, dst)
+
+    monkeypatch.setattr(models, "_safe_replace", fail_backup_replace)
+    caplog.set_level(logging.DEBUG, logger="api.models")
+
+    # A backup-publication OSError is best-effort: the authoritative shrink
+    # save must still land the requested two messages without raising.
+    session.save(touch_updated_at=False, skip_index=True)
+
+    authoritative_after = json.loads(session.path.read_bytes())
+    assert authoritative_after["messages"] == session.messages
+    assert len(authoritative_after["messages"]) == 2
+    assert session.path.read_bytes() != authoritative_before
+
+    remaining = _backup_shrink_remaining_files(isolated_session_store)
+    assert not any(".bak.tmp." in name for name in remaining), remaining
+    assert not any(
+        ".tmp." in name and ".bak.tmp." not in name for name in remaining
+    ), remaining
+    assert not session.path.with_suffix(".json.bak").exists()
+
+    backup_warnings = _backup_warning_records(caplog, session.session_id)
+    assert backup_warnings, [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "api.models"
+    ]
+    assert any(record.exc_info for record in backup_warnings)
+
+
+def test_shrink_save_survives_backup_temp_cleanup_error(
+    isolated_session_store, monkeypatch, caplog
+):
+    session = Session(
+        session_id="shrink_backup_cleanup_besteffort",
+        messages=[_message(index) for index in range(4)],
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    session.messages = session.messages[:2]
+
+    original_safe_replace = models._safe_replace
+    original_bound_unlink = models._bound_unlink
+
+    def fail_backup_replace(src, dst):
+        if Path(dst).name.endswith(".json.bak"):
+            raise OSError("injected backup publication failure")
+        return original_safe_replace(src, dst)
+
+    def fail_backup_temp_unlink(path, *, missing_ok=False):
+        if ".bak.tmp." in Path(path).name:
+            raise OSError("injected backup temp cleanup failure")
+        return original_bound_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(models, "_safe_replace", fail_backup_replace)
+    monkeypatch.setattr(models, "_bound_unlink", fail_backup_temp_unlink)
+    caplog.set_level(logging.DEBUG, logger="api.models")
+
+    # Even when best-effort backup-temp cleanup itself fails, the authoritative
+    # two-message save must complete and the original backup error must survive.
+    session.save(touch_updated_at=False, skip_index=True)
+
+    authoritative_after = json.loads(session.path.read_bytes())
+    assert authoritative_after["messages"] == session.messages
+    assert len(authoritative_after["messages"]) == 2
+
+    backup_error_records = [
+        record
+        for record in _backup_warning_records(caplog, session.session_id)
+        if record.exc_info
+    ]
+    assert backup_error_records, [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "api.models"
+    ]
+    # The cleanup failure may add a debug record but must not erase the
+    # authoritative backup-failure warning that came first.
+    assert "injected backup publication failure" in "".join(
+        record.getMessage()
+        + ("".join(map(str, record.exc_info)) if record.exc_info else "")
+        for record in backup_error_records
+    ) or any(
+        record.exc_info and record.exc_info[1] is not None
+        for record in backup_error_records
+    )
+
+
+def test_authoritative_publication_oserror_remains_fatal_after_backup_failure(
+    isolated_session_store, monkeypatch, caplog
+):
+    session = Session(
+        session_id="authoritative_still_fatal",
+        messages=[_message(index) for index in range(4)],
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    authoritative_before = session.path.read_bytes()
+    assert len(json.loads(authoritative_before)["messages"]) == 4
+    session.messages = session.messages[:2]
+
+    original_safe_replace = models._safe_replace
+
+    def fail_both_replacements(src, dst):
+        name = Path(dst).name
+        if name.endswith(".json.bak"):
+            raise OSError("injected backup publication failure")
+        if name.endswith(".json"):
+            raise OSError("injected authoritative publication failure")
+        return original_safe_replace(src, dst)
+
+    monkeypatch.setattr(models, "_safe_replace", fail_both_replacements)
+    caplog.set_level(logging.DEBUG, logger="api.models")
+
+    # The best-effort backup must never swallow an authoritative publication
+    # error: the second, authoritative OSError has to propagate.
+    with pytest.raises(OSError, match="injected authoritative publication failure"):
+        session.save(touch_updated_at=False, skip_index=True)
+
+    assert session.path.read_bytes() == authoritative_before
+    assert len(json.loads(session.path.read_bytes())["messages"]) == 4
+
+    remaining = _backup_shrink_remaining_files(isolated_session_store)
+    assert not any(".bak.tmp." in name for name in remaining), remaining
+    assert not any(
+        ".tmp." in name and ".bak.tmp." not in name for name in remaining
+    ), remaining
+
+    assert _backup_warning_records(caplog, session.session_id)
 
 
 def test_save_publishes_cache_only_after_source_reaches_threshold(

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -1,6 +1,7 @@
 import json
 import os
 import stat
+import threading
 import time
 from pathlib import Path
 
@@ -34,6 +35,31 @@ def _messages(count):
         }
         for idx in range(count)
     ]
+
+
+def _writer_messages(label, count):
+    messages = _messages(count)
+    messages[-2] = {
+        "role": "tool",
+        "content": json.dumps(
+            {
+                "todos": [
+                    {
+                        "id": f"todo-{label}",
+                        "content": f"todo from {label}",
+                        "status": "pending",
+                    }
+                ]
+            }
+        ),
+        "timestamp": float(count - 1),
+    }
+    messages[-1] = {
+        "role": "assistant",
+        "content": f"FINAL_FROM_{label}",
+        "timestamp": float(count),
+    }
+    return messages
 
 
 def test_save_writes_atomic_v1_raw_tail_schema_and_permissions(isolated_session_store):
@@ -161,6 +187,217 @@ def test_save_publishes_cache_only_after_source_reaches_threshold(
     assert session.path.stat().st_size >= models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
     assert cache_path.exists()
     assert models.read_session_tail_cache(session.session_id) is not None
+
+
+def test_same_id_concurrent_saves_bind_cache_to_authoritative_writer(
+    isolated_session_store,
+    monkeypatch,
+):
+    session_id = "tail_same_id_race"
+    messages_a = _writer_messages("A", 306)
+    messages_b = _writer_messages("B", 308)
+    writer_a = Session(
+        session_id=session_id,
+        messages=messages_a,
+        tool_calls=[{"name": "tool-A", "assistant_msg_idx": len(messages_a) - 1}],
+    )
+    writer_b = Session(
+        session_id=session_id,
+        messages=messages_b,
+        tool_calls=[{"name": "tool-B", "assistant_msg_idx": len(messages_b) - 1}],
+    )
+    cache_path = models.session_tail_cache_path(session_id)
+    a_replaced_source = threading.Event()
+    b_reached_source_replace = threading.Event()
+    b_published_cache = threading.Event()
+    release_a = threading.Event()
+    original_replace = models._safe_replace
+
+    def observed_replace(src, dst):
+        current_name = threading.current_thread().name
+        if current_name == "writer-b" and dst == writer_b.path:
+            b_reached_source_replace.set()
+        original_replace(src, dst)
+        if current_name == "writer-a" and dst == writer_a.path:
+            a_replaced_source.set()
+            assert release_a.wait(timeout=5), "writer A was not released"
+        if current_name == "writer-b" and dst == cache_path:
+            b_published_cache.set()
+
+    monkeypatch.setattr(models, "_safe_replace", observed_replace)
+    errors = []
+
+    def save(session):
+        try:
+            session.save(touch_updated_at=False, skip_index=True)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread_a = threading.Thread(target=save, args=(writer_a,), name="writer-a")
+    thread_b = threading.Thread(target=save, args=(writer_b,), name="writer-b")
+    thread_a.start()
+    assert a_replaced_source.wait(timeout=5), "writer A did not publish its source"
+    thread_b.start()
+    try:
+        if b_reached_source_replace.wait(timeout=0.5):
+            assert b_published_cache.wait(timeout=5), "writer B did not publish its cache"
+    finally:
+        release_a.set()
+    thread_a.join(timeout=5)
+    thread_b.join(timeout=5)
+
+    assert not thread_a.is_alive()
+    assert not thread_b.is_alive()
+    assert errors == []
+    authoritative = json.loads(writer_a.path.read_bytes())
+    assert authoritative["messages"] == messages_b
+    snapshot = models.read_session_tail_cache(session_id)
+    assert snapshot is not None
+    assert snapshot["messages"] == messages_b[-models._SESSION_TAIL_CACHE_LIMIT :]
+    assert snapshot["source_message_count"] == len(messages_b)
+    assert snapshot["source_user_message_count"] == sum(
+        message.get("role") == "user" for message in messages_b
+    )
+    assert snapshot["tool_calls"] == writer_b.tool_calls
+    assert snapshot["todo_state"]["todos"][0]["id"] == "todo-B"
+    assert snapshot["source_signature"] == models._tail_cache_signature_dict(
+        models._sidecar_stat_signature(writer_b.path)
+    )
+
+
+def test_session_save_lock_is_per_id_not_global(isolated_session_store, monkeypatch):
+    session_a = Session(session_id="tail_lock_a", messages=_messages(4))
+    session_b = Session(session_id="tail_lock_b", messages=_messages(4))
+    a_entered_cache_publication = threading.Event()
+    b_entered_cache_publication = threading.Event()
+    release_a = threading.Event()
+    original_writer = models._write_session_tail_cache_payload
+
+    def observed_writer(payload, *, expected_signature):
+        if payload["session_id"] == session_a.session_id:
+            a_entered_cache_publication.set()
+            assert release_a.wait(timeout=5), "session A was not released"
+        elif payload["session_id"] == session_b.session_id:
+            b_entered_cache_publication.set()
+        return original_writer(payload, expected_signature=expected_signature)
+
+    monkeypatch.setattr(models, "_write_session_tail_cache_payload", observed_writer)
+    errors = []
+
+    def save(session):
+        try:
+            session.save(touch_updated_at=False, skip_index=True)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread_a = threading.Thread(target=save, args=(session_a,))
+    thread_b = threading.Thread(target=save, args=(session_b,))
+    thread_a.start()
+    assert a_entered_cache_publication.wait(timeout=5)
+    thread_b.start()
+    try:
+        assert b_entered_cache_publication.wait(timeout=2), (
+            "different session IDs were serialized by a global save lock"
+        )
+    finally:
+        release_a.set()
+    thread_a.join(timeout=5)
+    thread_b.join(timeout=5)
+
+    assert not thread_a.is_alive()
+    assert not thread_b.is_alive()
+    assert errors == []
+
+
+def _large_messages_with_marker(marker):
+    return [
+        {
+            "role": "user",
+            "content": marker + ("x" * (models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES + 1024)),
+            "timestamp": 1.0,
+        },
+        {
+            "role": "assistant",
+            "content": "large response",
+            "timestamp": 2.0,
+        },
+    ]
+
+
+def test_large_to_small_save_removes_tail_cache_bytes(isolated_session_store, monkeypatch):
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 1 * 1024 * 1024)
+    marker = "STALE_LARGE_TO_SMALL_SECRET"
+    session = Session(
+        session_id="tail_large_to_small",
+        messages=_large_messages_with_marker(marker),
+    )
+    cache_path = models.session_tail_cache_path(session.session_id)
+    session.save(touch_updated_at=False, skip_index=True)
+    assert cache_path.exists()
+    assert marker.encode() in cache_path.read_bytes()
+
+    session.messages = _messages(2)
+    session.save(touch_updated_at=False, skip_index=True)
+
+    assert session.path.stat().st_size < models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    assert not cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_large_to_empty_save_removes_tail_cache_bytes(isolated_session_store, monkeypatch):
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 1 * 1024 * 1024)
+    marker = "STALE_LARGE_TO_EMPTY_SECRET"
+    session = Session(
+        session_id="tail_large_to_empty",
+        messages=_large_messages_with_marker(marker),
+    )
+    cache_path = models.session_tail_cache_path(session.session_id)
+    session.save(touch_updated_at=False, skip_index=True)
+    assert cache_path.exists()
+    assert marker.encode() in cache_path.read_bytes()
+
+    session.messages = []
+    session.save(touch_updated_at=False, skip_index=True)
+
+    assert json.loads(session.path.read_bytes())["messages"] == []
+    assert not cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_cache_cleanup_failure_is_nonfatal_after_authoritative_save(
+    isolated_session_store,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 1 * 1024 * 1024)
+    session = Session(
+        session_id="tail_cleanup_failure",
+        messages=_large_messages_with_marker("STALE_CLEANUP_FAILURE_SECRET"),
+    )
+    cache_path = models.session_tail_cache_path(session.session_id)
+    session.save(touch_updated_at=False, skip_index=True)
+    assert cache_path.exists()
+    attempted = []
+    original_unlink = Path.unlink
+
+    def fail_cache_unlink(path, *args, **kwargs):
+        if path == cache_path:
+            attempted.append(path)
+            raise OSError("simulated tail-cache unlink failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_cache_unlink)
+    new_messages = _messages(2)
+    session.messages = new_messages
+    caplog.set_level("DEBUG", logger="api.models")
+
+    session.save(touch_updated_at=False, skip_index=True)
+
+    assert attempted == [cache_path]
+    assert json.loads(session.path.read_bytes())["messages"] == new_messages
+    assert cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert "Failed to remove tail cache" in caplog.text
 
 
 def test_stable_full_load_opportunistically_builds_but_metadata_only_never_builds(

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -1,0 +1,287 @@
+import json
+import os
+import stat
+import time
+from pathlib import Path
+
+import pytest
+
+import api.models as models
+from api.models import Session
+
+
+@pytest.fixture
+def isolated_session_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+
+
+def _messages(count):
+    return [
+        {
+            "role": "user" if idx % 2 == 0 else "assistant",
+            "content": {"raw": idx, "parts": [idx, {"nested": True}]},
+            "timestamp": float(idx + 1),
+            "custom": ["preserve", idx],
+        }
+        for idx in range(count)
+    ]
+
+
+def test_save_writes_atomic_v1_raw_tail_schema_and_permissions(isolated_session_store):
+    messages = _messages(305)
+    messages[1] = {
+        "role": "tool",
+        "content": json.dumps({"todos": [{"content": "old but current", "status": "pending"}]}),
+        "timestamp": 2.0,
+        "custom": "todo-raw-shape",
+    }
+    tool_calls = [
+        {"name": "before-tail", "assistant_msg_idx": 3, "custom": {"raw": True}},
+        {"name": "inside-tail", "assistant_msg_idx": 303, "custom": [1, 2]},
+    ]
+    session = Session(
+        session_id="tail_schema",
+        profile="default",
+        messages=messages,
+        tool_calls=tool_calls,
+    )
+
+    session.save(skip_index=True)
+
+    cache_path = models.session_tail_cache_path(session.session_id)
+    assert cache_path == isolated_session_store / "_tail_cache" / "v1" / "tail_schema.json"
+    payload = json.loads(cache_path.read_bytes())
+    assert payload["format"] == "hermes.session-tail-cache"
+    assert payload["version"] == 1
+    assert payload["session_id"] == session.session_id
+    assert payload["tail_limit"] == 300
+    assert payload["source_message_count"] == 305
+    assert payload["source_user_message_count"] == sum(m.get("role") == "user" for m in messages)
+    assert payload["source_last_message_at"] == 305.0
+    assert payload["message_offset"] == 5
+    assert payload["messages"] == messages[-300:]
+    assert payload["tool_calls"] == [tool_calls[1]]
+    assert payload["all_tool_calls_positionable"] is True
+    assert payload["todo_state"]["todos"] == [
+        {"content": "old but current", "status": "pending"}
+    ]
+    assert payload["anchor_scene_index"] == {}
+    assert isinstance(payload["created_at"], float)
+    signature = payload["source_signature"]
+    assert Path(signature["path"]).is_absolute()
+    assert signature == models._tail_cache_signature_dict(
+        models._sidecar_stat_signature(session.path)
+    )
+    if os.name != "nt":
+        assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_reader_returns_validated_snapshot_without_mutating_sidecar(isolated_session_store):
+    session = Session(
+        session_id="tail_read",
+        profile="default",
+        messages=_messages(4),
+    )
+    session.save(skip_index=True)
+    sidecar_before = session.path.read_bytes()
+
+    snapshot = models.read_session_tail_cache(session.session_id)
+
+    assert snapshot is not None
+    assert snapshot["messages"] == session.messages
+    assert snapshot["message_offset"] == 0
+    assert session.path.read_bytes() == sidecar_before
+
+
+def test_reader_accepts_finite_zero_timestamp(isolated_session_store):
+    session = Session(
+        session_id="tail_zero_timestamp",
+        messages=[{"role": "user", "content": "epoch", "timestamp": 0.0}],
+    )
+    session.save(skip_index=True)
+
+    snapshot = models.read_session_tail_cache(session.session_id)
+
+    assert snapshot is not None
+    assert snapshot["messages"][0]["timestamp"] == 0.0
+
+
+def test_save_is_fail_open_when_tail_cache_write_fails(isolated_session_store, monkeypatch):
+    session = Session(session_id="tail_fail_open", messages=_messages(2))
+
+    def fail_cache(*args, **kwargs):
+        raise OSError("cache disk unavailable")
+
+    monkeypatch.setattr(models, "_write_session_tail_cache", fail_cache)
+
+    session.save(skip_index=True)
+
+    assert json.loads(session.path.read_bytes())["messages"] == session.messages
+
+
+def test_stable_full_load_opportunistically_builds_but_metadata_only_never_builds(
+    isolated_session_store,
+):
+    session = Session(
+        session_id="tail_load_build",
+        profile="default",
+        messages=_messages(3),
+    )
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    cache_path.unlink()
+
+    metadata = Session.load_metadata_only(session.session_id)
+    assert metadata is not None
+    assert getattr(metadata, "_loaded_metadata_only", False) is True
+    assert not cache_path.exists()
+
+    loaded = Session.load(session.session_id)
+    assert loaded is not None
+    assert loaded.messages == session.messages
+    assert cache_path.exists()
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(version=999),
+        lambda payload: payload.update(message_offset=999),
+        lambda payload: payload.update(all_tool_calls_positionable=False),
+        lambda payload: payload.update(anchor_scene_index={"scene": 1.0}),
+        lambda payload: payload["messages"][-1].pop("timestamp"),
+    ],
+)
+def test_reader_rejects_incompatible_or_incomplete_payloads(
+    isolated_session_store,
+    mutate,
+):
+    session = Session(session_id="tail_invalid", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    payload = json.loads(cache_path.read_bytes())
+    mutate(payload)
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_reader_rejects_stale_and_oversize_cache(isolated_session_store):
+    session = Session(session_id="tail_stale", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+
+    session.path.write_text(session.path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    assert models.read_session_tail_cache(session.session_id) is None
+
+    cache_path.write_bytes(b"x" * (models._SESSION_TAIL_CACHE_MAX_BYTES + 1))
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_reader_restats_sidecar_and_rejects_toctou(isolated_session_store, monkeypatch):
+    session = Session(session_id="tail_toctou_read", messages=_messages(4))
+    session.save(skip_index=True)
+    original = models._sidecar_stat_signature(session.path)
+    assert original is not None
+    changed = (original[0], original[1] + 1, original[2], original[3] + 1)
+    calls = 0
+
+    def changing_signature(_path):
+        nonlocal calls
+        calls += 1
+        return original if calls == 1 else changed
+
+    monkeypatch.setattr(models, "_sidecar_stat_signature", changing_signature)
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_writer_does_not_publish_when_sidecar_changes_before_replace(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(session_id="tail_toctou_write", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    cache_path.unlink()
+    expected = models._sidecar_stat_signature(session.path)
+    assert expected is not None
+    changed = (expected[0], expected[1] + 1, expected[2], expected[3] + 1)
+    monkeypatch.setattr(models, "_sidecar_stat_signature", lambda _path: changed)
+
+    assert models._write_session_tail_cache(session, expected_signature=expected) is False
+    assert not cache_path.exists()
+
+
+def test_reader_never_supersedes_full_in_memory_session(isolated_session_store):
+    session = Session(session_id="tail_memory_ahead", messages=_messages(4))
+    session.save(skip_index=True)
+    session.messages.append(
+        {"role": "assistant", "content": "unsaved", "timestamp": 99.0}
+    )
+    models.SESSIONS[session.session_id] = session
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_unpositionable_tool_calls_and_scenes_make_cache_ineligible(isolated_session_store):
+    session = Session(
+        session_id="tail_ineligible",
+        messages=_messages(4),
+        tool_calls=[{"name": "missing-index"}],
+        anchor_activity_scenes={"scene": {"updated_at": 1.0}},
+    )
+    session.save(skip_index=True)
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_opportunistic_full_load_does_not_write_foreign_profile_cache(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(session_id="tail_foreign", profile="foreign", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    cache_path.unlink()
+    monkeypatch.setattr(models, "_session_tail_cache_profile_is_active", lambda _session: False)
+
+    loaded = Session.load(session.session_id)
+
+    assert loaded is not None
+    assert not cache_path.exists()
+
+
+def test_delete_tail_cache_is_best_effort_and_path_safe(isolated_session_store):
+    session = Session(session_id="tail_delete", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    assert cache_path.exists()
+
+    assert models.delete_session_tail_cache(session.session_id) is True
+    assert not cache_path.exists()
+    assert models.delete_session_tail_cache(session.session_id) is True
+    assert models.delete_session_tail_cache("../unsafe") is False
+
+
+def test_stale_cache_tmp_cleanup_and_nested_cache_discovery_isolation(isolated_session_store):
+    session = Session(session_id="tail_discovery", messages=_messages(2))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    stale_tmp = cache_path.with_name(f"{cache_path.name}.tmp.1.2")
+    stale_tmp.write_text("stale", encoding="utf-8")
+    old = time.time() - models._STALE_TMP_AGE_SECONDS - 10
+    os.utime(stale_tmp, (old, old))
+
+    models._cleanup_stale_tmp_files()
+
+    assert not stale_tmp.exists()
+    assert [path.name for path in isolated_session_store.glob("*.json")] == [
+        "tail_discovery.json"
+    ]

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -1,8 +1,10 @@
+import gc
 import json
 import os
 import stat
 import threading
 import time
+import weakref
 from pathlib import Path
 
 import pytest
@@ -263,6 +265,177 @@ def test_same_id_concurrent_saves_bind_cache_to_authoritative_writer(
     assert snapshot["source_signature"] == models._tail_cache_signature_dict(
         models._sidecar_stat_signature(writer_b.path)
     )
+
+
+def test_tail_cache_uses_exact_nested_snapshot_serialized_to_authoritative_source(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(
+        session_id="nested_snapshot_binding",
+        messages=[
+            {"role": "user", "content": {"value": "SOURCE_BYTES"}, "timestamp": 1.0},
+            {"role": "assistant", "content": "answer", "timestamp": 2.0},
+        ],
+    )
+    source_replaced = threading.Event()
+    mutation_done = threading.Event()
+    original_replace = models._safe_replace
+
+    def observed_replace(src, dst):
+        original_replace(src, dst)
+        if dst == session.path:
+            source_replaced.set()
+            assert mutation_done.wait(timeout=5)
+
+    monkeypatch.setattr(models, "_safe_replace", observed_replace)
+
+    def mutate_nested_message_after_source_publish():
+        assert source_replaced.wait(timeout=5)
+        session.messages[0]["content"]["value"] = "MUTATED_AFTER_SOURCE"
+        mutation_done.set()
+
+    mutator = threading.Thread(target=mutate_nested_message_after_source_publish)
+    mutator.start()
+    session.save(touch_updated_at=False, skip_index=True)
+    mutator.join(timeout=5)
+    assert not mutator.is_alive()
+
+    authoritative = json.loads(session.path.read_bytes())
+    snapshot = models.read_session_tail_cache(session.session_id)
+    assert snapshot is not None
+    assert snapshot["messages"] == authoritative["messages"], (
+        "accepted cache was derived from nested objects mutated after authoritative "
+        "serialization instead of the exact frozen source snapshot"
+    )
+
+
+def test_tail_cache_detaches_nested_message_lists_and_tool_calls_before_replace(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(
+        session_id="nested_tool_snapshot_binding",
+        messages=[
+            {
+                "role": "user",
+                "content": {"parts": ["SOURCE", {"nested": "SOURCE"}]},
+                "timestamp": 1.0,
+            },
+            {"role": "assistant", "content": "answer", "timestamp": 2.0},
+        ],
+        tool_calls=[
+            {
+                "name": "source-tool",
+                "assistant_msg_idx": 1,
+                "custom": {"parts": ["SOURCE", {"nested": "SOURCE"}]},
+            }
+        ],
+    )
+    original_replace = models._safe_replace
+
+    def mutate_after_serialization_before_replace(src, dst):
+        if dst == session.path:
+            session.messages[0]["content"]["parts"][1]["nested"] = "MUTATED"
+            session.tool_calls[0]["custom"]["parts"][1]["nested"] = "MUTATED"
+        original_replace(src, dst)
+
+    monkeypatch.setattr(models, "_safe_replace", mutate_after_serialization_before_replace)
+
+    session.save(touch_updated_at=False, skip_index=True)
+
+    authoritative = json.loads(session.path.read_bytes())
+    snapshot = models.read_session_tail_cache(session.session_id)
+    assert snapshot is not None
+    assert snapshot["messages"] == authoritative["messages"]
+    assert snapshot["tool_calls"] == authoritative["tool_calls"]
+
+
+def test_same_canonical_sidecar_aliases_share_publication_lock(tmp_path, monkeypatch):
+    real = tmp_path / "real"
+    real.mkdir()
+    nested = real / "nested"
+    nested.mkdir()
+    alias = tmp_path / "alias"
+    try:
+        alias.symlink_to(real, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - Windows privilege/filesystem dependent
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    absolute = real / "same.json"
+    aliases = [
+        alias / "same.json",
+        Path(os.fspath(real) + "/./nested/../same.json"),
+    ]
+    monkeypatch.chdir(tmp_path)
+    aliases.append(Path("real/same.json"))
+
+    assert not absolute.exists()
+    expected_lock = models._get_session_save_publication_lock(absolute)
+    for spelling in aliases:
+        assert spelling.resolve() == absolute.resolve()
+        assert models._get_session_save_publication_lock(spelling) is expected_lock
+    assert not absolute.exists(), "lock lookup must not create the sidecar"
+
+
+def test_session_dir_rewiring_to_same_store_reuses_publication_lock(tmp_path, monkeypatch):
+    real = tmp_path / "profiles" / "default" / "sessions"
+    real.mkdir(parents=True)
+    alias = tmp_path / "active-profile-sessions"
+    try:
+        alias.symlink_to(real, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - Windows privilege/filesystem dependent
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    monkeypatch.setattr(models, "SESSION_DIR", real)
+    first = Session(session_id="profile_rewire", messages=_messages(2))
+    first_lock = models._get_session_save_publication_lock(first.path)
+
+    monkeypatch.setattr(models, "SESSION_DIR", alias)
+    second = Session(session_id="profile_rewire", messages=_messages(2))
+    second_lock = models._get_session_save_publication_lock(second.path)
+
+    assert first.path.resolve() == second.path.resolve()
+    assert second_lock is first_lock
+    assert not first.path.exists(), "lock lookup must work before the sidecar exists"
+
+
+def test_publication_lock_does_not_follow_final_symlink_and_is_name_scoped(tmp_path):
+    store = tmp_path / "sessions"
+    store.mkdir()
+    sidecar = store / "same.json"
+    target = store / "attacker-target.json"
+    target.write_text("target", encoding="utf-8")
+
+    by_name_lock = models._get_session_save_publication_lock(sidecar)
+    try:
+        sidecar.symlink_to(target)
+    except OSError as exc:  # pragma: no cover - Windows privilege/filesystem dependent
+        pytest.skip(f"file symlinks unavailable: {exc}")
+
+    assert sidecar.resolve() == target.resolve()
+    assert models._get_session_save_publication_lock(sidecar) is by_name_lock
+    assert models._get_session_save_publication_lock(target) is not by_name_lock
+
+
+def test_session_retained_publication_lock_releases_after_gc(
+    isolated_session_store,
+):
+    with models._SESSION_SAVE_PUBLICATION_LOCKS_GUARD:
+        models._SESSION_SAVE_PUBLICATION_LOCKS.clear()
+    session = Session(session_id="weak_lifetime", messages=[])
+
+    session.save(touch_updated_at=False, skip_index=True)
+
+    lock_ref = weakref.ref(session._save_publication_lock)
+    assert len(models._SESSION_SAVE_PUBLICATION_LOCKS) == 1
+    assert lock_ref() is not None
+
+    del session
+    gc.collect()
+
+    assert lock_ref() is None
+    assert len(models._SESSION_SAVE_PUBLICATION_LOCKS) == 0
 
 
 def test_session_save_lock_is_per_id_not_global(isolated_session_store, monkeypatch):

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -64,6 +64,49 @@ def _writer_messages(label, count):
     return messages
 
 
+def _message(index):
+    return {
+        "role": "user" if index % 2 == 0 else "assistant",
+        "content": f"message-{index}",
+        "timestamp": float(index + 1),
+    }
+
+
+def _same_size_replacement_with_extra_message(path: Path) -> bytes:
+    source = json.loads(path.read_bytes())
+    original_size = len(path.read_bytes())
+    original_title = source["title"]
+    source["messages"].append(_message(len(source["messages"])))
+    expanded = json.dumps(source, ensure_ascii=False, indent=2).encode("utf-8")
+    delta = len(expanded) - original_size
+    assert delta > 0
+    assert len(original_title) > delta
+    source["title"] = original_title[:-delta]
+    replacement = json.dumps(source, ensure_ascii=False, indent=2).encode("utf-8")
+    assert len(replacement) == original_size
+    return replacement
+
+
+def _replace_bytes(path: Path, replacement: bytes, mode: str) -> None:
+    if mode == "in_place":
+        path.write_bytes(replacement)
+        return
+    temp = path.with_name(f"{path.name}.external")
+    temp.write_bytes(replacement)
+    os.replace(temp, path)
+
+
+def _force_signature_collision(monkeypatch, path: Path, signature) -> None:
+    original_signature = models._sidecar_stat_signature
+
+    def colliding_signature(candidate):
+        if Path(candidate) == path:
+            return signature
+        return original_signature(candidate)
+
+    monkeypatch.setattr(models, "_sidecar_stat_signature", colliding_signature)
+
+
 def test_save_writes_atomic_v1_raw_tail_schema_and_permissions(isolated_session_store):
     messages = _messages(305)
     messages[1] = {
@@ -776,3 +819,203 @@ def test_stale_cache_tmp_cleanup_and_nested_cache_discovery_isolation(isolated_s
     assert [path.name for path in isolated_session_store.glob("*.json")] == [
         "tail_discovery.json"
     ]
+
+
+@pytest.mark.parametrize("replacement_mode", ["in_place", "atomic_replace"])
+def test_same_stat_tuple_shrink_backs_up_exact_authoritative_bytes(
+    isolated_session_store,
+    monkeypatch,
+    replacement_mode,
+):
+    session = Session(
+        session_id=f"content_proof_shrink_{replacement_mode}",
+        title="P" * 5000,
+        messages=[_message(0), _message(1), _message(2)],
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    path = session.path
+    signature = models._sidecar_stat_signature(path)
+    replacement = _same_size_replacement_with_extra_message(path)
+    _replace_bytes(path, replacement, replacement_mode)
+    _force_signature_collision(monkeypatch, path, signature)
+
+    session.save(touch_updated_at=False, skip_index=True)
+
+    backup = path.with_suffix(".json.bak")
+    assert backup.read_bytes() == replacement
+    assert len(json.loads(path.read_bytes())["messages"]) == 3
+
+
+@pytest.mark.parametrize("replacement_mode", ["in_place", "atomic_replace"])
+def test_same_stat_tuple_reader_rejects_same_count_content_replacement(
+    isolated_session_store,
+    monkeypatch,
+    replacement_mode,
+):
+    session = Session(
+        session_id=f"content_proof_reader_{replacement_mode}",
+        messages=[_message(0), _message(1)],
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    path = session.path
+    signature = models._sidecar_stat_signature(path)
+    source = json.loads(path.read_bytes())
+    source["messages"][0]["content"] = "changed-0"
+    replacement = json.dumps(source, ensure_ascii=False, indent=2).encode("utf-8")
+    assert len(replacement) == path.stat().st_size
+    _replace_bytes(path, replacement, replacement_mode)
+    _force_signature_collision(monkeypatch, path, signature)
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_process_local_source_proof_is_invalidated_by_second_session_writer(
+    isolated_session_store,
+    monkeypatch,
+):
+    original = Session(
+        session_id="content_proof_second_writer",
+        title="P" * 5000,
+        messages=[_message(0), _message(1), _message(2)],
+    )
+    original.save(touch_updated_at=False, skip_index=True)
+    original_signature = models._sidecar_stat_signature(original.path)
+    replacement = _same_size_replacement_with_extra_message(original.path)
+    second = Session(**json.loads(replacement))
+
+    second.save(touch_updated_at=False, skip_index=True)
+    second_writer_bytes = original.path.read_bytes()
+    assert len(second_writer_bytes) == len(replacement)
+    assert len(json.loads(second_writer_bytes)["messages"]) == 4
+    _force_signature_collision(monkeypatch, original.path, original_signature)
+
+    original.save(touch_updated_at=False, skip_index=True)
+
+    assert original.path.with_suffix(".json.bak").read_bytes() == second_writer_bytes
+
+
+def test_parent_symlink_rewire_after_binding_fails_closed(tmp_path, monkeypatch):
+    real_a = tmp_path / "real-a"
+    real_b = tmp_path / "real-b"
+    real_a.mkdir()
+    real_b.mkdir()
+    alias = tmp_path / "active-sessions"
+    try:
+        alias.symlink_to(real_a, target_is_directory=True)
+    except OSError as exc:  # pragma: no cover - platform/filesystem dependent
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    monkeypatch.setattr(models, "SESSION_DIR", alias)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", alias / "_index.json")
+    original_get = models._get_session_save_publication_lock
+    swapped = False
+
+    def get_lock_then_rewire(path):
+        nonlocal swapped
+        lock = original_get(path)
+        if not swapped:
+            swapped = True
+            alias.unlink()
+            alias.symlink_to(real_b, target_is_directory=True)
+        return lock
+
+    monkeypatch.setattr(models, "_get_session_save_publication_lock", get_lock_then_rewire)
+    session = Session(session_id="parent_symlink_rewire", messages=_messages(2))
+
+    with pytest.raises(OSError, match="session sidecar parent changed"):
+        session.save(touch_updated_at=False, skip_index=True)
+
+    assert not (real_a / "parent_symlink_rewire.json").exists()
+    assert not (real_b / "parent_symlink_rewire.json").exists()
+
+
+def test_parent_rename_and_replacement_after_binding_fails_closed(tmp_path, monkeypatch):
+    store = tmp_path / "sessions"
+    moved_store = tmp_path / "sessions-moved"
+    store.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", store)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", store / "_index.json")
+    original_get = models._get_session_save_publication_lock
+    swapped = False
+
+    def get_lock_then_replace_parent(path):
+        nonlocal swapped
+        lock = original_get(path)
+        if not swapped:
+            swapped = True
+            store.rename(moved_store)
+            store.mkdir()
+        return lock
+
+    monkeypatch.setattr(models, "_get_session_save_publication_lock", get_lock_then_replace_parent)
+    session = Session(session_id="parent_replaced", messages=_messages(2))
+
+    with pytest.raises(OSError, match="session sidecar parent changed"):
+        session.save(touch_updated_at=False, skip_index=True)
+
+    assert not (moved_store / "parent_replaced.json").exists()
+    assert not (store / "parent_replaced.json").exists()
+
+
+def test_final_symlink_swap_after_binding_fails_closed(tmp_path, monkeypatch):
+    store = tmp_path / "sessions"
+    store.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", store)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", store / "_index.json")
+    attacker_target = tmp_path / "attacker.json"
+    attacker_bytes = json.dumps({"messages": _messages(4)}, indent=2).encode("utf-8")
+    attacker_target.write_bytes(attacker_bytes)
+    sidecar = store / "final_symlink_swap.json"
+    original_get = models._get_session_save_publication_lock
+    swapped = False
+
+    def get_lock_then_swap_final(path):
+        nonlocal swapped
+        lock = original_get(path)
+        if not swapped:
+            swapped = True
+            try:
+                sidecar.symlink_to(attacker_target)
+            except OSError as exc:  # pragma: no cover - platform/filesystem dependent
+                pytest.skip(f"file symlinks unavailable: {exc}")
+        return lock
+
+    monkeypatch.setattr(models, "_get_session_save_publication_lock", get_lock_then_swap_final)
+    session = Session(session_id="final_symlink_swap", messages=_messages(2))
+
+    with pytest.raises(OSError, match="refusing to follow final symlink"):
+        session.save(touch_updated_at=False, skip_index=True)
+
+    assert sidecar.is_symlink()
+    assert attacker_target.read_bytes() == attacker_bytes
+    assert not sidecar.with_suffix(".json.bak").exists()
+
+
+def test_session_dir_rewire_cannot_split_source_and_cache_targets(tmp_path, monkeypatch):
+    store_a = tmp_path / "store-a"
+    store_b = tmp_path / "store-b"
+    store_a.mkdir()
+    store_b.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", store_a)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", store_a / "_index.json")
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 0)
+    original_get = models._get_session_save_publication_lock
+    rewired = False
+
+    def get_lock_then_rewire_profile(path):
+        nonlocal rewired
+        lock = original_get(path)
+        if not rewired:
+            rewired = True
+            monkeypatch.setattr(models, "SESSION_DIR", store_b)
+            monkeypatch.setattr(models, "SESSION_INDEX_FILE", store_b / "_index.json")
+        return lock
+
+    monkeypatch.setattr(models, "_get_session_save_publication_lock", get_lock_then_rewire_profile)
+    session = Session(session_id="profile_target_binding", messages=_messages(2))
+
+    session.save(touch_updated_at=False, skip_index=True)
+
+    assert (store_a / "profile_target_binding.json").exists()
+    assert (store_a / "_tail_cache" / "v1" / "profile_target_binding.json").exists()
+    assert not (store_b / "profile_target_binding.json").exists()
+    assert not (store_b / "_tail_cache" / "v1" / "profile_target_binding.json").exists()

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -178,6 +178,327 @@ def test_reader_returns_validated_snapshot_without_mutating_sidecar(isolated_ses
     assert session.path.read_bytes() == sidecar_before
 
 
+_TAIL_CACHE_PROOF_FIELDS = (
+    "format",
+    "version",
+    "session_id",
+    "source_signature",
+    "source_sha256",
+    "tail_limit",
+)
+
+
+def _semantic_tail_cache_fixture(session_id):
+    messages = [_message(index) for index in range(305)]
+    messages[1] = {
+        "role": "tool",
+        "content": json.dumps(
+            {"todos": [{"id": "todo-1", "content": "keep me", "status": "pending"}]}
+        ),
+        "timestamp": 2.0,
+    }
+    messages[303] = {
+        "role": "assistant",
+        "content": "assistant-with-tool-call",
+        "timestamp": 304.0,
+    }
+    tool_calls = [
+        {
+            "name": "inside-tail",
+            "assistant_msg_idx": 303,
+            "arguments": {"value": "authoritative"},
+        }
+    ]
+    session = Session(
+        session_id=session_id,
+        profile="default",
+        messages=messages,
+        tool_calls=tool_calls,
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    models.SESSIONS.pop(session.session_id, None)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    return session, cache_path, json.loads(cache_path.read_bytes())
+
+
+def _mutate_semantic_tail_cache(payload, case):
+    if case == "cached-message":
+        payload["messages"][-1]["content"] = "CORRUPTED_ASSISTANT_CONTENT"
+    elif case == "coordinated-total-count":
+        payload["source_message_count"] += 1
+        payload["message_offset"] += 1
+        for tool_call in payload["tool_calls"]:
+            tool_call["assistant_msg_idx"] += 1
+    elif case == "user-count":
+        payload["source_user_message_count"] = 0
+    elif case == "assistant-role-derived-count":
+        tool_indices = {call["assistant_msg_idx"] for call in payload["tool_calls"]}
+        for tail_index, message in enumerate(payload["messages"]):
+            source_index = payload["message_offset"] + tail_index
+            if message.get("role") == "assistant" and source_index not in tool_indices:
+                message["role"] = "user"
+                payload["source_user_message_count"] += 1
+                payload["source_assistant_message_count"] = -999
+                break
+        else:  # pragma: no cover - fixture contract
+            raise AssertionError("no non-tool assistant message found")
+    elif case == "tool-call-content":
+        payload["tool_calls"][0].update(
+            name="CORRUPTED_TOOL_CALL",
+            arguments={"value": "corrupted"},
+        )
+    elif case == "tool-call-count":
+        payload["tool_calls"] = []
+        payload["source_tool_call_count"] = 999
+    elif case == "todo-state":
+        payload["todo_state"] = {
+            "todos": [{"id": "evil", "content": "CORRUPTED_TODO", "status": "done"}]
+        }
+    else:  # pragma: no cover - parameter contract
+        raise AssertionError(f"unknown semantic corruption case: {case}")
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "cached-message",
+        "coordinated-total-count",
+        "user-count",
+        "assistant-role-derived-count",
+        "tool-call-content",
+        "tool-call-count",
+        "todo-state",
+    ],
+)
+def test_reader_rejects_semantic_cache_corruption_with_valid_source_proof(
+    isolated_session_store,
+    case,
+):
+    session, cache_path, payload = _semantic_tail_cache_fixture(
+        f"semantic_corruption_{case.replace('-', '_')}"
+    )
+    proof_before = {key: payload[key] for key in _TAIL_CACHE_PROOF_FIELDS}
+    _mutate_semantic_tail_cache(payload, case)
+    proof_after = {key: payload[key] for key in _TAIL_CACHE_PROOF_FIELDS}
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert proof_after == proof_before
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+@pytest.mark.parametrize("case", ["unknown-key", "missing-todo-state"])
+def test_reader_requires_exact_v1_schema_keys(isolated_session_store, case):
+    session, cache_path, payload = _semantic_tail_cache_fixture(
+        f"exact_schema_{case.replace('-', '_')}"
+    )
+    if case == "unknown-key":
+        payload["unexpected_semantic_field"] = {"accepted": True}
+    else:
+        payload.pop("todo_state")
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def _rewrite_tail_cache_proof_for_source(session, cache_path, payload):
+    source = models._sidecar_content_proof(session.path)
+    assert source is not None
+    source_proof, _source_bytes = source
+    payload["source_signature"] = models._tail_cache_signature_dict(source_proof[0])
+    payload["source_sha256"] = source_proof[1]
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _strict_json_semantics_fixture(session_id):
+    session = Session(
+        session_id=session_id,
+        profile="default",
+        messages=[
+            {
+                "role": "user",
+                "content": {"count": 1, "nested": ["stable", 1]},
+                "timestamp": 1.0,
+            },
+            {
+                "role": "assistant",
+                "content": "answer",
+                "timestamp": 2.0,
+            },
+        ],
+    )
+    session.save(touch_updated_at=False, skip_index=True)
+    models.SESSIONS.pop(session.session_id, None)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    return session, cache_path, json.loads(cache_path.read_bytes())
+
+
+@pytest.mark.parametrize(
+    ("replacement", "case_name"),
+    [(True, "bool"), (1.0, "float")],
+    ids=["nested-int-to-bool", "nested-int-to-float"],
+)
+def test_reader_rejects_exact_json_type_confusion_with_valid_source_proof(
+    isolated_session_store,
+    replacement,
+    case_name,
+):
+    session, cache_path, payload = _strict_json_semantics_fixture(
+        f"strict_json_type_{case_name}"
+    )
+    assert models.read_session_tail_cache(session.session_id) is not None
+    models.SESSIONS.pop(session.session_id, None)
+
+    proof_before = {key: payload[key] for key in _TAIL_CACHE_PROOF_FIELDS}
+    payload["messages"][0]["content"]["count"] = replacement
+    payload["messages"][0]["content"]["nested"][1] = replacement
+    proof_after = {key: payload[key] for key in _TAIL_CACHE_PROOF_FIELDS}
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+    source_before = session.path.read_bytes()
+    cache_before = cache_path.read_bytes()
+
+    assert proof_after == proof_before
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert session.path.read_bytes() == source_before
+    assert cache_path.read_bytes() == cache_before
+
+
+def test_reader_rejects_duplicate_authoritative_object_members(
+    isolated_session_store,
+):
+    session, cache_path, payload = _strict_json_semantics_fixture(
+        "strict_json_duplicate_source"
+    )
+    assert models.read_session_tail_cache(session.session_id) is not None
+    models.SESSIONS.pop(session.session_id, None)
+
+    source_bytes = session.path.read_bytes()
+    assert source_bytes.count(b'"count"') == 1
+    ambiguous_source = source_bytes.replace(
+        b'"count": 1,\n',
+        b'"count": 1,\n          "count": 1,\n',
+        1,
+    )
+    assert ambiguous_source.count(b'"count"') == 2
+    session.path.write_bytes(ambiguous_source)
+    _rewrite_tail_cache_proof_for_source(session, cache_path, payload)
+    source_before = session.path.read_bytes()
+    cache_before = cache_path.read_bytes()
+
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert session.path.read_bytes() == source_before
+    assert cache_path.read_bytes() == cache_before
+
+
+def test_reader_rejects_duplicate_cache_object_members(
+    isolated_session_store,
+):
+    session, cache_path, payload = _strict_json_semantics_fixture(
+        "strict_json_duplicate_cache"
+    )
+    assert models.read_session_tail_cache(session.session_id) is not None
+    models.SESSIONS.pop(session.session_id, None)
+
+    cache_text = json.dumps(payload)
+    assert cache_text.count('"count": 1') == 1
+    ambiguous_cache = cache_text.replace(
+        '"count": 1,',
+        '"count": 1, "count": 1,',
+        1,
+    )
+    assert ambiguous_cache.count('"count": 1') == 2
+    cache_path.write_text(ambiguous_cache, encoding="utf-8")
+    source_before = session.path.read_bytes()
+    cache_before = cache_path.read_bytes()
+
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert session.path.read_bytes() == source_before
+    assert cache_path.read_bytes() == cache_before
+
+
+def test_reader_rejects_unparseable_authoritative_source_even_with_matching_proof(
+    isolated_session_store,
+):
+    session, cache_path, payload = _semantic_tail_cache_fixture("unparseable_source")
+    session.path.write_bytes(b'{"session_id":"unparseable_source",')
+    _rewrite_tail_cache_proof_for_source(session, cache_path, payload)
+    source_before = session.path.read_bytes()
+    cache_before = cache_path.read_bytes()
+
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert session.path.read_bytes() == source_before
+    assert cache_path.read_bytes() == cache_before
+
+
+def test_reader_rejects_authoritative_source_identity_mismatch_even_with_matching_proof(
+    isolated_session_store,
+):
+    session, cache_path, payload = _semantic_tail_cache_fixture("source_identity_mismatch")
+    authoritative = json.loads(session.path.read_bytes())
+    authoritative["session_id"] = "different_source_identity"
+    session.path.write_text(json.dumps(authoritative), encoding="utf-8")
+    _rewrite_tail_cache_proof_for_source(session, cache_path, payload)
+    source_before = session.path.read_bytes()
+    cache_before = cache_path.read_bytes()
+
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert session.path.read_bytes() == source_before
+    assert cache_path.read_bytes() == cache_before
+
+
+def test_reader_falls_back_when_authoritative_projection_is_ambiguous(
+    isolated_session_store,
+    monkeypatch,
+):
+    from api import todo_state
+
+    session, cache_path, _payload = _semantic_tail_cache_fixture("ambiguous_reader_projection")
+    source_before = session.path.read_bytes()
+    cache_before = cache_path.read_bytes()
+
+    def fail_todo_derivation(_messages):
+        raise RuntimeError("injected todo derivation ambiguity")
+
+    monkeypatch.setattr(todo_state, "derive_todo_state", fail_todo_derivation)
+
+    assert models.read_session_tail_cache(session.session_id) is None
+    assert session.path.read_bytes() == source_before
+    assert cache_path.read_bytes() == cache_before
+
+
+def test_save_is_fail_open_when_tail_cache_projection_is_ambiguous(
+    isolated_session_store,
+    monkeypatch,
+):
+    from api import todo_state
+
+    session = Session(session_id="ambiguous_writer_projection", messages=_messages(4))
+    cache_path = models.session_tail_cache_path(session.session_id)
+
+    def fail_todo_derivation(_messages):
+        raise RuntimeError("injected todo derivation ambiguity")
+
+    monkeypatch.setattr(todo_state, "derive_todo_state", fail_todo_derivation)
+
+    session.save(touch_updated_at=False, skip_index=True)
+
+    assert json.loads(session.path.read_bytes())["messages"] == session.messages
+    assert not cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_reader_accepts_matching_semantics_with_valid_independent_created_at(
+    isolated_session_store,
+):
+    session, cache_path, payload = _semantic_tail_cache_fixture("independent_created_at")
+    payload["created_at"] = 123.456
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    snapshot = models.read_session_tail_cache(session.session_id)
+
+    assert snapshot is not None
+    assert snapshot["created_at"] == 123.456
+
+
 def test_reader_accepts_finite_zero_timestamp(isolated_session_store):
     session = Session(
         session_id="tail_zero_timestamp",

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -378,6 +378,17 @@ def test_same_canonical_sidecar_aliases_share_publication_lock(tmp_path, monkeyp
     assert not absolute.exists(), "lock lookup must not create the sidecar"
 
 
+def test_publication_lock_key_applies_windows_case_normalization(tmp_path, monkeypatch):
+    store = tmp_path / "Sessions"
+    store.mkdir()
+    monkeypatch.setattr(models.os.path, "normcase", lambda value: value.casefold())
+
+    upper = models._get_session_save_publication_lock(store / "Session.JSON")
+    lower = models._get_session_save_publication_lock(store / "session.json")
+
+    assert upper is lower
+
+
 def test_session_dir_rewiring_to_same_store_reuses_publication_lock(tmp_path, monkeypatch):
     real = tmp_path / "profiles" / "default" / "sessions"
     real.mkdir(parents=True)
@@ -416,6 +427,23 @@ def test_publication_lock_does_not_follow_final_symlink_and_is_name_scoped(tmp_p
     assert sidecar.resolve() == target.resolve()
     assert models._get_session_save_publication_lock(sidecar) is by_name_lock
     assert models._get_session_save_publication_lock(target) is not by_name_lock
+
+
+def test_publication_lock_is_final_name_scoped_for_hardlink_aliases(tmp_path):
+    store = tmp_path / "sessions"
+    store.mkdir()
+    first = store / "first.json"
+    second = store / "second.json"
+    first.write_text("source", encoding="utf-8")
+    try:
+        os.link(first, second)
+    except OSError as exc:  # pragma: no cover - filesystem dependent
+        pytest.skip(f"hard links unavailable: {exc}")
+
+    assert os.path.samefile(first, second)
+    assert models._get_session_save_publication_lock(first) is not (
+        models._get_session_save_publication_lock(second)
+    )
 
 
 def test_session_retained_publication_lock_releases_after_gc(

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -1,4 +1,5 @@
 import gc
+import hashlib
 import json
 import os
 import stat
@@ -147,6 +148,7 @@ def test_save_writes_atomic_v1_raw_tail_schema_and_permissions(isolated_session_
     ]
     assert payload["anchor_scene_index"] == {}
     assert isinstance(payload["created_at"], float)
+    assert payload["source_sha256"] == hashlib.sha256(session.path.read_bytes()).hexdigest()
     signature = payload["source_signature"]
     assert Path(signature["path"]).is_absolute()
     assert signature == models._tail_cache_signature_dict(
@@ -625,8 +627,10 @@ def test_cache_cleanup_failure_is_nonfatal_after_authoritative_save(
     original_unlink = models.os.unlink
 
     def fail_cache_unlink(path, *args, **kwargs):
-        if Path(path) == cache_path:
-            attempted.append(Path(path))
+        if Path(path).name == cache_path.name and (
+            Path(path) == cache_path or kwargs.get("dir_fd") is not None
+        ):
+            attempted.append(cache_path)
             raise OSError("simulated tail-cache unlink failure")
         return original_unlink(path, *args, **kwargs)
 
@@ -706,17 +710,32 @@ def test_reader_rejects_stale_and_oversize_cache(isolated_session_store):
 def test_reader_restats_sidecar_and_rejects_toctou(isolated_session_store, monkeypatch):
     session = Session(session_id="tail_toctou_read", messages=_messages(4))
     session.save(skip_index=True)
-    original = models._sidecar_stat_signature(session.path)
-    assert original is not None
-    changed = (original[0], original[1] + 1, original[2], original[3] + 1)
-    calls = 0
+    cache_path = models.session_tail_cache_path(session.session_id)
+    original_open = models._bound_open
 
-    def changing_signature(_path):
-        nonlocal calls
-        calls += 1
-        return original if calls == 1 else changed
+    class ChangeSourceAfterCacheRead:
+        def __init__(self, handle):
+            self.handle = handle
 
-    monkeypatch.setattr(models, "_sidecar_stat_signature", changing_signature)
+        def __enter__(self):
+            self.handle.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.handle.__exit__(*args)
+
+        def read(self):
+            payload = self.handle.read()
+            session.path.write_bytes(session.path.read_bytes() + b"\n")
+            return payload
+
+    def changing_open(path, mode, *, encoding=None):
+        handle = original_open(path, mode, encoding=encoding)
+        if Path(path) == cache_path and mode == "rb":
+            return ChangeSourceAfterCacheRead(handle)
+        return handle
+
+    monkeypatch.setattr(models, "_bound_open", changing_open)
 
     assert models.read_session_tail_cache(session.session_id) is None
 

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -97,15 +97,17 @@ def _replace_bytes(path: Path, replacement: bytes, mode: str) -> None:
     os.replace(temp, path)
 
 
-def _force_signature_collision(monkeypatch, path: Path, signature) -> None:
-    original_signature = models._sidecar_stat_signature
+def _force_signature_collision(monkeypatch, path, signature):
+    original = models._sidecar_content_proof
 
-    def colliding_signature(candidate):
-        if Path(candidate) == path:
-            return signature
-        return original_signature(candidate)
+    def colliding(candidate):
+        source = original(candidate)
+        if source is not None and Path(candidate) == path:
+            proof, source_bytes = source
+            return (signature, proof[1]), source_bytes
+        return source
 
-    monkeypatch.setattr(models, "_sidecar_stat_signature", colliding_signature)
+    monkeypatch.setattr(models, "_sidecar_content_proof", colliding)
 
 
 def test_save_writes_atomic_v1_raw_tail_schema_and_permissions(isolated_session_store):

--- a/tests/test_session_tail_cache_legacy.py
+++ b/tests/test_session_tail_cache_legacy.py
@@ -1,0 +1,138 @@
+import json
+
+import pytest
+
+import api.models as models
+from api.models import Session
+
+
+@pytest.fixture
+def isolated_session_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+
+
+def _messages(count):
+    return [
+        {
+            "role": "user" if idx % 2 == 0 else "assistant",
+            "content": {"raw": idx, "parts": [idx, {"nested": True}]},
+            "timestamp": float(idx + 1),
+            "custom": ["preserve", idx],
+        }
+        for idx in range(count)
+    ]
+
+
+def _write_legacy_sidecar(session_dir, sid, messages, *, indent=None, **overrides):
+    updated_at = float(messages[-1]["timestamp"] if messages else 1.0)
+    payload = {
+        "session_id": sid,
+        "title": "Legacy tail fixture",
+        "workspace": str(session_dir),
+        "model": "test-model",
+        "created_at": 1.0,
+        "updated_at": updated_at,
+        "profile": "default",
+        "active_stream_id": None,
+        "pending_user_message": None,
+        "pending_attachments": [],
+        "pending_started_at": None,
+        "pending_user_source": None,
+        "pre_compression_snapshot": False,
+        "compression_recovery": {},
+        "truncation_watermark": None,
+        "truncation_boundary": None,
+        "parent_session_id": None,
+        "is_cli_session": False,
+        "source_tag": "webui",
+        "raw_source": None,
+        "session_source": "webui",
+        "source_label": None,
+        "read_only": False,
+        "message_count": len(messages),
+        "messages": messages,
+        "tool_calls": [],
+        "anchor_activity_scenes": {},
+    }
+    payload.update(overrides)
+    path = session_dir / f"{sid}.json"
+    path.write_text(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=indent,
+            separators=None if indent else (",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    row = {
+        "session_id": sid,
+        "message_count": len(messages),
+        "user_message_count": sum(message.get("role") == "user" for message in messages),
+        "last_message_at": updated_at,
+        "file_size": path.stat().st_size,
+        "updated_at": updated_at,
+    }
+    (session_dir / "_index.json").write_text(json.dumps([row]), encoding="utf-8")
+    return path, row
+
+
+@pytest.mark.parametrize("indent", [None, 2])
+def test_legacy_locator_builds_valid_tail_without_full_session_load(
+    isolated_session_store,
+    monkeypatch,
+    indent,
+):
+    messages = _messages(305)
+    sid = f"legacy_locator_{indent or 0}"
+    tool_call = {"name": "recent", "assistant_msg_idx": 303}
+    _write_legacy_sidecar(
+        isolated_session_store,
+        sid,
+        messages,
+        indent=indent,
+        tool_calls=[tool_call],
+    )
+    monkeypatch.setattr(
+        Session,
+        "load",
+        classmethod(lambda cls, _sid, **_kwargs: (_ for _ in ()).throw(AssertionError("full load"))),
+    )
+
+    snapshot = models.build_session_tail_cache_from_legacy_sidecar(sid)
+
+    assert snapshot is not None
+    assert snapshot["message_offset"] == 5
+    assert snapshot["messages"] == messages[-300:]
+    assert snapshot["tool_calls"] == [tool_call]
+    assert models.read_session_tail_cache(sid) == snapshot
+
+
+@pytest.mark.parametrize("ambiguity", ["index-count", "todo-before-tail", "scene"])
+def test_legacy_locator_falls_back_on_ambiguous_semantics(
+    isolated_session_store,
+    ambiguity,
+):
+    messages = _messages(305)
+    if ambiguity == "todo-before-tail":
+        messages[0]["content"] = json.dumps({"todos": []})
+    kwargs = {}
+    if ambiguity == "scene":
+        kwargs["anchor_activity_scenes"] = {"scene": {"updated_at": 1.0}}
+    sid = f"legacy_ambiguous_{ambiguity.replace('-', '_')}"
+    _path, row = _write_legacy_sidecar(isolated_session_store, sid, messages, **kwargs)
+    if ambiguity == "index-count":
+        row["message_count"] -= 1
+        (isolated_session_store / "_index.json").write_text(
+            json.dumps([row]),
+            encoding="utf-8",
+        )
+
+    assert models.build_session_tail_cache_from_legacy_sidecar(sid) is None
+    assert not models.session_tail_cache_path(sid).exists()

--- a/tests/test_session_tail_cache_legacy.py
+++ b/tests/test_session_tail_cache_legacy.py
@@ -12,6 +12,7 @@ def isolated_session_store(tmp_path, monkeypatch):
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 0)
     models.SESSIONS.clear()
     yield session_dir
     models.SESSIONS.clear()

--- a/tests/test_state_db_readonly_reads_models.py
+++ b/tests/test_state_db_readonly_reads_models.py
@@ -215,6 +215,107 @@ def test_get_state_db_message_prefix_summary_missing_db_creates_no_sqlite_files(
     assert not Path(f"{db}-shm").exists()
 
 
+def _raise_readonly_preflight_failed():
+    raise OSError("readonly preflight failed")
+
+
+def test_get_state_db_message_prefix_summary_fails_open_on_path_resolution_error(
+    monkeypatch,
+):
+    """D1R2 review blocker: a path-resolution/stat failure must be 'unprovable'
+    (None → caller full-read fallback), never an exception escaping to the
+    route."""
+    monkeypatch.setattr(
+        models, "_active_state_db_path", _raise_readonly_preflight_failed
+    )
+
+    assert models.get_state_db_session_message_prefix_summary("sess-1", 1000.5) is None
+
+
+def test_get_state_db_message_prefix_summary_fails_open_on_profile_home_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        models,
+        "_get_profile_home",
+        lambda _profile: (_ for _ in ()).throw(OSError("profile home unavailable")),
+    )
+
+    assert (
+        models.get_state_db_session_message_prefix_summary(
+            "sess-1", 1000.5, profile="p1"
+        )
+        is None
+    )
+
+
+def test_get_state_db_message_keys_before_timestamp_fails_open_on_path_resolution_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        models, "_active_state_db_path", _raise_readonly_preflight_failed
+    )
+
+    assert (
+        models.get_state_db_session_message_keys_before_timestamp("sess-1", 1000.5)
+        is None
+    )
+
+
+def _make_state_db_with_compacted_rows(path):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT,
+            timestamp REAL, tool_calls TEXT, active INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO messages (id, session_id, role, content, timestamp, tool_calls, active) "
+        "VALUES (?,?,?,?,?,?,?)",
+        [
+            (1, "sess-1", "user", "hi", 10.0, None, 1),
+            (2, "sess-1", "assistant", "compacted away", 15.0, None, 0),
+            (3, "sess-1", "assistant", "hello", 20.0, None, None),
+            (4, "other", "user", "other session", 10.0, None, 1),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_get_state_db_message_keys_before_timestamp_excludes_inactive_rows(
+    tmp_path,
+    monkeypatch,
+):
+    """D1R2 review: the definitive key helper must apply the same active
+    predicate as the prefix summary / bounded reader, or a compacted DB
+    materializes more keys than the summary counted and forces a needless
+    conservative fallback."""
+    db = tmp_path / "state.db"
+    _make_state_db_with_compacted_rows(db)
+    _point_models_at(monkeypatch, db)
+
+    summary = models.get_state_db_session_message_prefix_summary("sess-1", 30.0)
+    keys = models.get_state_db_session_message_keys_before_timestamp("sess-1", 30.0)
+
+    assert summary == {"count": 2, "null_timestamp_count": 0}
+    assert summary is not None
+    assert keys is not None
+    assert len(keys) == summary["count"]
+    expected_active_keys = [
+        models._session_message_visible_key(
+            {"role": "user", "content": "hi", "tool_calls": None}
+        ),
+        models._session_message_visible_key(
+            {"role": "assistant", "content": "hello", "tool_calls": None}
+        ),
+    ]
+    assert keys == expected_active_keys
+
+
 def test_get_state_db_session_summary_opens_read_only(tmp_path, monkeypatch):
     db = tmp_path / "state.db"
     _make_state_db(db)

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -838,6 +838,123 @@ def test_limited_state_db_prefix_missing_sidecar_timestamp_preserves_full_fallba
     assert returned_sidecar == sidecar_messages
 
 
+def test_limited_state_db_prefix_helper_fails_open_on_db_path_error(monkeypatch, tmp_path):
+    """D1R2 review blocker regression: a state.db path-resolution/stat failure
+    inside the preflight helpers must surface as the (None, sidecar_messages)
+    full-read fallback, not as an exception escaping the route helper."""
+    import api.models as models
+    import api.routes as routes
+
+    sid = "webui_reconcile_prefix_path_error"
+    sidecar_messages = _large_timestamped_sidecar_messages()
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+
+    def broken_db_path():
+        raise OSError("readonly preflight failed")
+
+    monkeypatch.setattr(models, "_active_state_db_path", broken_db_path)
+
+    floor, returned_sidecar = routes._state_db_since_timestamp_for_limited_display(
+        session,
+        30,
+    )
+
+    assert floor is None
+    assert returned_sidecar == sidecar_messages
+
+
+def _make_state_db_with_active(path: Path, sid: str, rows):
+    """State DB variant with a compaction ``active`` column (0 = compacted)."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, model TEXT, started_at REAL, message_count INTEGER)"
+    )
+    conn.execute(
+        "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT, content TEXT, timestamp REAL, tool_call_id TEXT, tool_calls TEXT, tool_name TEXT, active INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, title, model, started_at, message_count) VALUES (?, ?, ?, ?, ?, ?)",
+        (sid, "webui", "Reconcile", "test-model", 1000.0, len(rows)),
+    )
+    for row in rows:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name, active) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                sid,
+                row["role"],
+                row["content"],
+                row.get("timestamp", 1000.0),
+                row.get("tool_call_id"),
+                row.get("tool_calls"),
+                row.get("tool_name"),
+                row.get("active", 1),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_limited_state_db_prefix_compacted_rows_use_active_predicate_end_to_end(
+    monkeypatch,
+    tmp_path,
+):
+    """D1R2 review nonblocking regression: on a compacted DB the definitive key
+    helper must exclude active=0 rows exactly like the prefix summary, so an
+    exact active-row prefix takes the bounded path instead of falling back."""
+    import api.routes as routes
+
+    sid = "webui_reconcile_prefix_compacted_active"
+    sidecar_messages = _large_timestamped_sidecar_messages()
+    state_messages = [dict(message) for message in sidecar_messages]
+    # A compacted row inside the prefix window: invisible to the merge and to
+    # the summary count, so it must be invisible to the key sequence too.
+    state_messages.insert(
+        100,
+        {
+            "role": "assistant",
+            "content": "compacted away",
+            "timestamp": 100.5,
+            "active": 0,
+        },
+    )
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db_with_active(tmp_path / "state.db", sid, state_messages)
+    summary_calls = []
+    key_calls = []
+    real_summary_reader = routes.get_state_db_session_message_prefix_summary
+    real_key_reader = routes.get_state_db_session_message_keys_before_timestamp
+
+    def prefix_summary(*args, **kwargs):
+        summary_calls.append((args, kwargs))
+        return real_summary_reader(*args, **kwargs)
+
+    def counted_key_reader(*args, **kwargs):
+        key_calls.append((args, kwargs))
+        return real_key_reader(*args, **kwargs)
+
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_message_prefix_summary",
+        prefix_summary,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_message_keys_before_timestamp",
+        counted_key_reader,
+    )
+
+    floor, returned_sidecar = routes._state_db_since_timestamp_for_limited_display(
+        session,
+        30,
+    )
+
+    assert floor == 200.0
+    assert returned_sidecar == sidecar_messages
+    assert len(summary_calls) == 1
+    assert len(key_calls) == 1
+
+
 def test_msg_limit_session_load_bails_when_older_state_db_row_changes_offsets(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
# perf(sessions): persist validated bounded tail snapshots

## Exact candidate and stack position

This PR is the Layer 2 storage foundation for #6016. Layer 1 (#6014) shipped in `exp-v0.52.70` and is already on `master`.

The exact post-review candidate is `9f03567af0c24e0263553985e95e317aa80fc0c6`, tree `0547b4246c60710f22d5bf2ed013f35fcbecc349`. It has exactly two commits over the prior public head, `0c6b9369ddedb835d34157cf788c341d20585134`, tree `b33f218a74e923e19306f6316ce09a104b3940c8`:

1. `47ab22b7480a3535235bec6b332ece9984aedb78` — `fix(sessions): keep shrink backups best-effort`
2. `9f03567af0c24e0263553985e95e317aa80fc0c6` — `fix(sessions): bind tail cache semantics to source bytes`

The two-commit follow-up changes only `api/models.py` and `tests/test_session_tail_cache.py`. `CHANGELOG.md`, `api/routes.py`, `api/streaming.py`, and `api/session_ops.py` are byte-identical to the prior head. The branch remains Layer 2-only and contains no Layer 3 route-consumption change from #6016.

#6016 remains held at `110ad1aa44c881a2372ba541d1b279410d4bf7fa` until this PR is accepted and lands. #5776 remains an independent PR at `3513f736a87e88b576da06a4c6edc216dade3cdb`; its commits are not folded into this branch.

## Prior-head CI and the current requested changes

The prior public head `0c6b9369ddedb835d34157cf788c341d20585134` passed all 18 published checks:

- `Tests` run `29466628818`: lint plus all 15 Python 3.11/3.12/3.13 test-matrix jobs passed;
- `Browser smoke` run `29466628762`: passed;
- Greptile check `87521047895`: passed.

Those results belong to `0c6b9369` only. They do not validate the two new commits.

Maintainer review `4710409716` requested two changes on exact head `0c6b9369`:

1. A backup-publication `OSError` must remain best-effort and must not abort the authoritative shrink-save.
2. Cache acceptance must prove that the cached messages, counts, tool calls, and todo state were derived from the authoritative bytes, rather than checking only source identity and proof fields.

The first follow-up commit restores backup failure isolation while preserving fatal propagation for authoritative write, fsync, and replace failures. The second decodes the authoritative bytes already returned by the source-proof read, rebuilds the expected projection, and requires exact schema and semantic equality before returning a cached tail. Any parse, projection, or comparison ambiguity returns `None` and falls back to the authoritative path.

Independent review also found two strict-JSON gaps in the first semantic-validation draft: ordinary Python equality treats `true`, `1`, and `1.0` as equal, and default JSON decoding silently accepts duplicate object members. The final candidate closes both gaps without adding a third commit. One shared recursive decoder rejects duplicate members at every depth and rejects non-standard constants. One recursive comparator preserves exact JSON types, list order and length, object key sets, and recursively exact values.

The read path keeps the single-source-read invariant. It calls the source proof once, decodes those same returned bytes, and performs no second source open, `Session.load`, recursive cache read, cache write, migration, publication-lock acquisition, or other mutation. Source and cache bytes stay unchanged on every failed validation.

## Exact-candidate verification

Independent local review accepted exact head `9f03567a`, tree `0547b424`, against prior head `0c6b9369` with the following results:

- candidate manifest: `52/52` SHA-256 entries verified; bundle reconstruction, two-commit topology, parent chain, tree, and two-path scope all matched;
- strict semantic RED controls: all 4 new cases failed for the intended final rejection assertion on the unmodified pre-fix candidate and on exact prior head `0c6b9369`;
- strict semantic GREEN: `14/14` passed, including nested int-to-bool, int-to-float, duplicate authoritative-member, duplicate cache-member, exact schema, independent `created_at`, and the 300-message boundary;
- fail-closed and no-side-effect cases: `6/6` passed; independent instrumentation observed exactly one authoritative-source open per cache read;
- backup, shrink, torn, stale, clear, and `/btw` failure matrix: `21/21` passed;
- focused tail-cache, legacy, and metadata-save files: `86/86` passed;
- canonical target, snapshot, cleanup, compression, todo, index, and reconciliation matrix: `110/110` passed;
- same-session concurrency: `20/20` fresh processes passed;
- repository stream/persistence surrogate: `53/53` passed;
- affected Layer 2 durability set: `137/137` passed;
- controlled full suite: `13,093 passed`, `102 skipped`, `1 xfailed`, `2 xpassed`, `34 subtests`, exit 0;
- browser smoke for `/`, `/#settings`, and `/#sessions`: passed with zero console errors;
- direct-reader benchmark: cache-to-full-load ratio `0.740425` against a `<= 1.10` gate, with exactly one source open on every candidate attempt.

The controlled full-suite process used disclosed test-only compatibility controls for a local curl/OpenSSL close-notify quirk, explicitly opted-in offline provider probes, one restored compression module-graph fixture, and one local HTTP test timeout extended from 10 to 30 seconds. The timeout node passed independently on both this candidate and exact prior head. These controls are local evidence, not substitutions for ordinary public CI.

The maintainer-private three-mode stream-regression harness is not available locally. I am not claiming a private-harness receipt for `9f03567a`. That harness and the maintainer re-review remain pending external reruns after this exact head is published.

## What changed in the Layer 2 production candidate

The feature is a bounded, disposable `_tail_cache/v1/<session_id>.json` snapshot for eligible large session sidecars. The authoritative session JSON and `state.db` continue to own semantics. Any uncertainty makes a cache read fail closed to the authoritative path.

### Authoritative content proof and semantic binding

- Stable source bytes are read and SHA-256-proven before a cached count, backup decision, cache publication, cache acceptance, or process-local fast path can rely on prior content.
- A `(path, mtime_ns, size, ctime_ns)` tuple remains diagnostic metadata; it is not content proof.
- Same-size, same-tick in-place edits and atomic replacements cannot make a stale cache readable or suppress a required shrink backup.
- Cache validation rebuilds the expected projection from the exact bytes returned by the single proof read and compares every schema and semantic field with exact JSON type identity.
- Duplicate members, non-standard constants, type confusion, malformed source, malformed cache, source-identity mismatch, projection ambiguity, and comparison ambiguity all fail closed.

### Exact backup bytes and failure isolation

- A shrinking save backs up the exact authoritative bytes read at the decision point.
- Binary behavior is preserved on native Windows. The backup is not reconstructed from parsed JSON or trusted metadata.
- Backup temp/write/publication `OSError` is logged, cleaned up, and isolated from the authoritative save.
- Authoritative write, fsync, and replace failures remain fatal. Cache publication and cleanup failures remain non-fatal.

### One bound canonical target per save

- Lock lookup, authoritative temp/replace, backup, cache directory and publication, and cleanup all use one bound canonical parent/name.
- POSIX uses descriptor-relative no-follow operations. Native Windows pins the parent directory handle and fails closed if the final object is a symlink.
- Parent symlink rewiring, parent rename/replacement, final-object symlinks, and profile or `SESSION_DIR` rewiring cannot split lock ownership from the target actually written.

### Immutable writer snapshot and lifecycle cleanup

- One detached writer-owned snapshot supplies both authoritative JSON and derived cache bytes. Nested messages and tool calls cannot diverge during a save.
- Same-ID writers serialize; different sidecars remain concurrent; weak lock ownership stays bounded.
- Large-to-small and large-to-empty saves remove the prior cache on the normal path. A cleanup failure can retain stale bytes, but source proof and semantic validation keep them unreadable.
- `/btw` success and cancellation share checkpoint stop/join plus independent authoritative-JSON and cache cleanup without changing the stream payload or persistence contract.

The cumulative Layer 2 remediation after public `f8000df3` touches `api/models.py` and `api/streaming.py`. Regression coverage includes `tests/test_session_tail_cache.py`, `tests/test_btw_ephemeral_cleanup.py`, and `tests/test_issue765_streaming_persistence.py`. The earlier F5 repair changed only `tests/test_pr1341_context_window_persistence.py` and did not alter product behavior.

The Issue-765 adjustment remains test-only and needs explicit reviewer acknowledgement. Its old same-session temp-file probe placed a barrier inside both authoritative replacements, which contradicts the required same-ID serializer and deadlocks. The replacement moves the start barrier before `save()` while preserving the contract: both concurrent callers succeed and use distinct thread-specific temporary paths.

## Layer 2 history and prior review receipts

The accepted F4 production candidate was `2c3e71fe3bca0bcbc8430b2e35d6259e3b107145`, tree `284852ede7d4675a2cacd6987b090d979f0acaf4`, against baseline `f8000df33d0935fd809ac45bbab76931bd24a700`.

Its committed regression tests were first run against exact F3 production head `ac9f5f0`: all 9 selected cases failed for the intended missing-backup, stale-cache, process-local invalidation, parent/target binding, and final-symlink reasons. Exact F4 then passed:

- the three complete affected test files: `71/71`;
- explicit critical and cleanup focus: `18/18`;
- process-isolated adversarial repetition: `20/20` processes, `180/180` tests;
- process-isolated same-ID repetition: `20/20` processes, `40/40` tests.

The retained F4 evidence also includes `223/223` Layer 2 focus, `47/47` session index, `67/67` Layer 1 against the then-current master, `37/37` deletion/worktree cascade, `25/25` Issue-765, 100-process adversarial and same-ID controls, a `20/20` persisted-ID race, and `80/80` shrink/clear plus `/btw` executions.

Native Windows was executed on exact F4 source under `C:\Python314\python.exe` with `os.name == "nt"`. It confirmed parent rename denial, final-symlink fail-closed behavior, atomic replacement, colocated cache publication, and return code 0.

### Prior CI repair

The first public F4 `Tests` run `29437363348` failed in exactly three shard-3 jobs, one each on Python 3.11, 3.12, and 3.13. Every job failed only `tests/test_pr1341_context_window_persistence.py::test_session_init_accepts_context_fields`, with `1 failed, 2504 passed, 27 skipped, 1 xpassed`.

The runtime `Session.__init__` contract was intact. A module-wide regex had selected the earlier `_BoundSessionSidecarTarget.__init__` instead. F5, exact head `0c6b9369`, replaced that source-order check with `inspect.signature(models.Session.__init__).parameters`. Independent falsification confirmed that an unrelated earlier helper cannot make the test pass and that removing any required constructor parameter makes it fail. The published F5 checks later passed as listed above.

Do not rerun the old failed workflow. It is valid evidence for `2c3e71fe`, while the later green checks are valid evidence for `0c6b9369`. The two new commits require fresh ordinary commit-triggered CI on exact `9f03567a`.

## Performance history and acceptance rule

The original relative-only small-save gate did not pass on exact F4. Every small-save round exceeded `+10%`, so the old every-round gate is `FAIL (0/3)`. I am not presenting that result as a pass.

Independent review approved this general floor-aware rule:

- correctness, source/cache parity, exact backup bytes, bound-target behavior, and fail-closed behavior are mandatory;
- when the baseline median is below `1.00 ms`, every round must keep the candidate below `1.00 ms` and satisfy `candidate - baseline <= max(10% of baseline, 0.10 ms)`;
- when the baseline median is at least `1.00 ms`, every round retains the original `<= +10%` relative ceiling;
- payload, cache, and backup predicates must pass in every round. No bad round may be averaged away.

Each F4 round ran sequentially with nine alternating baseline/candidate attempt pairs per fixture and seven timed saves per worker. Across three rounds, that was 108 isolated workers and 756 timed saves. The small fixture was 14,822 bytes; the large fixture was 50,904,773 bytes.

| Round | Fixture | `f8000df3` median | `2c3e71fe` median | Absolute delta | Relative delta | Result |
|---:|---|---:|---:|---:|---:|---|
| 1 | small | 0.1630 ms | 0.1888 ms | +0.0258 ms | +15.83% | old gate FAIL; revised gate PASS |
| 2 | small | 0.1500 ms | 0.2033 ms | +0.0533 ms | +35.53% | old gate FAIL; revised gate PASS |
| 3 | small | 0.1405 ms | 0.2153 ms | +0.0748 ms | +53.24% | old gate FAIL; revised gate PASS |
| 1 | large | 258.3583 ms | 237.8295 ms | -20.5288 ms | -7.95% | PASS |
| 2 | large | 258.8845 ms | 244.0513 ms | -14.8332 ms | -5.73% | PASS |
| 3 | large | 256.6062 ms | 238.9379 ms | -17.6683 ms | -6.89% | PASS |

All three small rounds kept the candidate below `1 ms` and the absolute delta below `0.10 ms`. All three large rounds improved. The revised every-round gate is `PASS (3/3)` without rewriting the old result.

A separate instrumented F4 profile measured baseline `Session.save()` at `0.400736 ms/call` and candidate `Session.save()` at `0.662895 ms/call`, an absolute change of `+0.262159 ms/call` (`+65.42%`). It confirmed expected chokepoints but did not reproduce the uninstrumented timing direction. The alternating uninstrumented campaigns remain the acceptance measurement; cProfile is diagnostic, not a wall-clock gate.

The F6R2 follow-up was remeasured rather than inheriting the invalidated first-draft timing. Three fresh save campaigns passed the floor-aware rule. Its source-bound cache read is slower in absolute terms than F5's cache read, as expected from rebuilding the authoritative projection, but it remains faster than the full-load path with ratio `0.740425` against the `<= 1.10` gate.

## Current `master`, #5776, and #6016 boundaries

A fresh read-only capture on 2026-07-16 at 13:45 UTC found upstream `master` at `6ed474ca54399dce45969301d87b34ca6d8d4a00`, #6016 still open at `110ad1aa44c881a2372ba541d1b279410d4bf7fa`, and #5776 still open at `3513f736a87e88b576da06a4c6edc216dade3cdb`.

The earlier reviewed `master` movement from `c677e4c7` through `7a862c9f` contained 38 commits across 22 paths, not only its final merge. It shared `api/models.py`, `api/routes.py`, and `api/streaming.py` with this PR's range. That review found no same-base hunk overlap and a clean merge-tree with exact F5. Shared enclosing symbols changed different branches, but the `api/models.py` movement remained session-lifecycle contract movement. Historical candidate tests do not validate a combined future master tree, so fresh exact-head CI and maintainer review remain mandatory.

A separate merge-tree review reported one content conflict between exact F5 and #5776 in `api/models.py`. The intended semantics are additive: keep this PR's content proof, strict semantic cache validation, exact backup, immutable snapshot, and bound-target behavior together with #5776's todo/compression-boundary metadata and fail-closed NULL-timestamp handling.

This is not permission to merge #5776 silently into #6015, copy its commits into this branch, or maintain a combined branch. Whichever lands second must rebase or rebuild on then-current `master`, resolve from source, and rerun the affected reconciliation, compression, todo, tail-cache, transcript-parity, cleanup, and performance tests.

Do not merge #6016 before this layer lands. After #6015 lands, rebase or rebuild #6016 on then-current `master`, confirm its PR-only range contains only the four Layer 3 commits, refresh #5776, and rerun focused storage/index tests, browser/transcript parity, metadata/session-switch and messaging fallbacks, overlap, performance, static, exact-head CI, and maintainer-review gates.

## Remaining gates

- Publish only exact head `9f03567af0c24e0263553985e95e317aa80fc0c6`, tree `0547b4246c60710f22d5bf2ed013f35fcbecc349`, by an ordinary non-force fast-forward from exact prior head `0c6b9369ddedb835d34157cf788c341d20585134`.
- Require fresh ordinary checks to bind to `9f03567a`: all 15 test-matrix jobs, lint, Browser smoke, and automatic Greptile.
- Ask the maintainer to rerun the private three-mode stream-regression harness and re-review this exact head. No local result substitutes for that receipt.
- Keep #6016 held and #5776 independent until these gates complete.

## Risks and follow-ups

- Derived cache files use additional disk for eligible large sessions. They are bounded, versioned, disposable, and never authoritative.
- External processes that bypass the in-process lock remain protected by point-of-use content proof, exact semantic validation, final source restat, and fail-closed reads.
- A cleanup failure can retain stale bytes, but it cannot fail the authoritative save or make stale cache bytes readable.
- No UI/UX or visual change; screenshots are not applicable.

## Release note

Added safe, rebuildable large-session tail snapshots so recent conversation state can be loaded without repeatedly parsing the full session file.

## Model used

AI-assisted implementation and verification used OpenAI `gpt-5.6-sol` through Hermes Agent. Verification used isolated Git branches, bundle reconstruction, pytest/TDD, deterministic race tests, native Windows probes, process-isolated benchmarks, static and AST audits, exact-tree checks, browser smoke, and independent review.
