### PR TITLE
perf(api): serve proven-safe bounded session tails

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1440,11 +1440,16 @@ class Session:
         # The sidecar is authoritative and must land first. Tail-cache writes
         # are derived, atomic, and strictly fail-open: a cache filesystem or
         # validation failure can never roll back a successful session save.
+        # Small sidecars stay on the authoritative path; publishing a second
+        # fsync'd file on every streaming checkpoint would cost more than the
+        # bounded read can save.
         try:
-            _write_session_tail_cache(
-                self,
-                expected_signature=_sidecar_stat_signature(self.path),
-            )
+            source_signature = _sidecar_stat_signature(self.path)
+            if _session_tail_cache_signature_is_large_enough(source_signature):
+                _write_session_tail_cache(
+                    self,
+                    expected_signature=source_signature,
+                )
         except Exception:
             logger.debug(
                 "session tail-cache populate failed for %s",
@@ -1534,6 +1539,7 @@ class Session:
                     _populate_tail_cache
                     and _pre_read_sig is not None
                     and _pre_read_sig == _post_read_sig
+                    and _session_tail_cache_signature_is_large_enough(_pre_read_sig)
                     and _session_tail_cache_profile_is_active(session)
                     and not _session_tail_cache_has_signature(sid, _pre_read_sig)
                 ):
@@ -3741,6 +3747,18 @@ def session_tail_cache_path(sid: str) -> Path:
     return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
 
 
+def _session_tail_cache_signature_is_large_enough(signature) -> bool:
+    """Return whether a stable source signature justifies cache publication."""
+    if not isinstance(signature, tuple) or len(signature) != 4:
+        return False
+    size = signature[2]
+    return (
+        isinstance(size, int)
+        and not isinstance(size, bool)
+        and size >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    )
+
+
 def session_tail_cache_source_is_large_enough(sid: str) -> bool:
     """Return whether bounded-tail route setup is worthwhile for this sidecar."""
     if not is_safe_session_id(sid):
@@ -3749,10 +3767,8 @@ def session_tail_cache_source_is_large_enough(sid: str) -> bool:
         cached = SESSIONS.get(sid)
         if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
             return False
-    signature = _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
-    return bool(
-        signature is not None
-        and signature[2] >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    return _session_tail_cache_signature_is_large_enough(
+        _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
     )
 
 
@@ -4328,7 +4344,7 @@ def build_session_tail_cache_from_legacy_sidecar(sid: str) -> dict | None:
             return None
     path = SESSION_DIR / f'{sid}.json'
     before = _sidecar_stat_signature(path)
-    if before is None:
+    if not _session_tail_cache_signature_is_large_enough(before):
         return None
     try:
         prefix = _read_metadata_json_prefix(path)

--- a/api/models.py
+++ b/api/models.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import math
+import mmap
 import os
 import re
 import threading
@@ -130,6 +131,14 @@ _LEGACY_SIDECAR_FACTS_MAX = 2000
 
 _STALE_TMP_AGE_SECONDS = 3600  # 1 hour
 
+# Rebuildable, source-signature-bound raw transcript tail. The authoritative
+# session sidecar remains the only semantic owner; these files may be deleted at
+# any time and every read fails closed to the full loader on uncertainty.
+_SESSION_TAIL_CACHE_FORMAT = 'hermes.session-tail-cache'
+_SESSION_TAIL_CACHE_VERSION = 1
+_SESSION_TAIL_CACHE_LIMIT = 300
+_SESSION_TAIL_CACHE_MAX_BYTES = 4 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Windows-safe os.replace() with retry
@@ -219,7 +228,9 @@ def _cleanup_stale_tmp_files() -> None:
     """
     cutoff = time.time() - _STALE_TMP_AGE_SECONDS
     try:
-        for p in SESSION_DIR.glob('*.tmp.*'):
+        candidates = list(SESSION_DIR.glob('*.tmp.*'))
+        candidates.extend((SESSION_DIR / '_tail_cache' / 'v1').glob('*.tmp.*'))
+        for p in candidates:
             try:
                 if p.stat().st_mtime < cutoff:
                     p.unlink(missing_ok=True)
@@ -1425,6 +1436,20 @@ class Session:
             except Exception:
                 pass
             raise
+        # The sidecar is authoritative and must land first. Tail-cache writes
+        # are derived, atomic, and strictly fail-open: a cache filesystem or
+        # validation failure can never roll back a successful session save.
+        try:
+            _write_session_tail_cache(
+                self,
+                expected_signature=_sidecar_stat_signature(self.path),
+            )
+        except Exception:
+            logger.debug(
+                "session tail-cache populate failed for %s",
+                self.session_id,
+                exc_info=True,
+            )
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1453,7 +1478,7 @@ class Session:
                 )
 
     @classmethod
-    def load(cls, sid):
+    def load(cls, sid, *, _populate_tail_cache=True):
         # Validate session ID format to prevent path traversal.  API/gateway
         # session ids may contain hyphens (for example ``api-*`` and
         # ``reachy-voice-*``); allow those but still reject dots/slashes.
@@ -1498,6 +1523,29 @@ class Session:
                     )
                 except Exception:
                     logger.debug("legacy sidecar facts cache populate failed for %s", sid, exc_info=True)
+            # Read-old/write-new migration is allowed only for a stable full
+            # parse and only for the request's active profile. In particular,
+            # metadata-only probes and pre-authorization foreign-profile reads
+            # must not leave plaintext cache copies behind.
+            try:
+                _post_read_sig = _sidecar_stat_signature(p)
+                if (
+                    _populate_tail_cache
+                    and _pre_read_sig is not None
+                    and _pre_read_sig == _post_read_sig
+                    and _session_tail_cache_profile_is_active(session)
+                    and not _session_tail_cache_has_signature(sid, _pre_read_sig)
+                ):
+                    _write_session_tail_cache(
+                        session,
+                        expected_signature=_pre_read_sig,
+                    )
+            except Exception:
+                logger.debug(
+                    "session tail-cache opportunistic populate failed for %s",
+                    sid,
+                    exc_info=True,
+                )
         return session
 
     @classmethod
@@ -1519,11 +1567,11 @@ class Session:
         try:
             prefix = _read_metadata_json_prefix(p)
             if not prefix:
-                return cls.load(sid)
+                return cls.load(sid, _populate_tail_cache=False)
             parsed = json.loads(prefix)
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
-                return cls.load(sid)
+                return cls.load(sid, _populate_tail_cache=False)
             parsed['messages'] = []
             parsed['tool_calls'] = []
             session = cls(**parsed)
@@ -1565,7 +1613,7 @@ class Session:
                 # facts cache with a TOCTOU-guarded write (expected_sig), so we
                 # do NOT re-cache here (an unguarded second write could stamp
                 # stale facts under a replacement file's signature — Codex r5).
-                return cls.load(sid)
+                return cls.load(sid, _populate_tail_cache=False)
             # Modern sidecars carry an accurate message_count, so it is the
             # source of truth and we skip the per-row _index.json read in the
             # common case. The sidebar index is only a cache (it can lag behind
@@ -1587,7 +1635,7 @@ class Session:
             return session
         except Exception:
             # Corrupt prefix or decode error — fall back to full load
-            return cls.load(sid)
+            return cls.load(sid, _populate_tail_cache=False)
 
     @staticmethod
     def _compute_user_message_count(messages) -> int:
@@ -3683,6 +3731,645 @@ def _sidecar_stat_signature(path):
         return None
     return (str(path), int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
             int(st.st_size), int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))))
+
+
+def session_tail_cache_path(sid: str) -> Path:
+    """Return the v1 derived-cache path for a path-safe session id."""
+    if not is_safe_session_id(sid):
+        raise ValueError(f"Unsafe session_id {sid!r}")
+    return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
+
+
+def delete_session_tail_cache(sid: str) -> bool:
+    """Best-effort removal of one derived cache entry."""
+    if not is_safe_session_id(sid):
+        return False
+    try:
+        session_tail_cache_path(sid).unlink(missing_ok=True)
+        return True
+    except OSError:
+        logger.debug("Failed to remove tail cache for %s", sid, exc_info=True)
+        return False
+
+
+def _tail_cache_strict_int(value, *, minimum=None, maximum=None) -> bool:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return False
+    if minimum is not None and value < minimum:
+        return False
+    if maximum is not None and value > maximum:
+        return False
+    return True
+
+
+def _tail_cache_finite_number(value, *, positive=False) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    return math.isfinite(number) and (not positive or number > 0)
+
+
+def _tail_cache_signature_dict(signature) -> dict | None:
+    """Convert the internal stat tuple into the stable on-disk v1 shape."""
+    if not isinstance(signature, tuple) or len(signature) != 4:
+        return None
+    path, mtime_ns, size, ctime_ns = signature
+    try:
+        absolute_path = str(Path(path).expanduser().resolve())
+    except Exception:
+        return None
+    if not all(_tail_cache_strict_int(value, minimum=0) for value in (mtime_ns, size, ctime_ns)):
+        return None
+    return {
+        'path': absolute_path,
+        'mtime_ns': int(mtime_ns),
+        'size': int(size),
+        'ctime_ns': int(ctime_ns),
+    }
+
+
+def _tail_cache_signature_tuple(value) -> tuple | None:
+    if not isinstance(value, dict) or set(('path', 'mtime_ns', 'size', 'ctime_ns')) - set(value):
+        return None
+    path = value.get('path')
+    if not isinstance(path, str) or not path or not Path(path).is_absolute():
+        return None
+    numeric = (value.get('mtime_ns'), value.get('size'), value.get('ctime_ns'))
+    if not all(_tail_cache_strict_int(item, minimum=0) for item in numeric):
+        return None
+    return (str(Path(path).resolve()), int(numeric[0]), int(numeric[1]), int(numeric[2]))
+
+
+def _session_tail_cache_profile_is_active(session) -> bool:
+    """Fail closed unless a fully parsed session belongs to the active profile."""
+    try:
+        from api.profiles import _profiles_match, get_active_profile_name
+
+        return bool(_profiles_match(getattr(session, 'profile', None), get_active_profile_name()))
+    except Exception:
+        return False
+
+
+def _session_tail_cache_payload(session, source_signature) -> dict | None:
+    """Build a v1 cache payload from a fully materialized Session object."""
+    if getattr(session, '_loaded_metadata_only', False):
+        return None
+    sid = getattr(session, 'session_id', None)
+    if not is_safe_session_id(sid):
+        return None
+    signature = _tail_cache_signature_dict(source_signature)
+    if signature is None:
+        return None
+    messages = getattr(session, 'messages', None)
+    if not isinstance(messages, list):
+        return None
+    source_count = len(messages)
+    offset = max(0, source_count - _SESSION_TAIL_CACHE_LIMIT)
+    raw_tail = messages[offset:]
+    all_timestamps_valid = all(
+        isinstance(message, dict)
+        and _tail_cache_finite_number(message.get('timestamp'))
+        for message in raw_tail
+    )
+
+    all_tool_calls_positionable = True
+    cached_tool_calls = []
+    raw_tool_calls = getattr(session, 'tool_calls', None)
+    if not isinstance(raw_tool_calls, list):
+        raw_tool_calls = []
+        all_tool_calls_positionable = False
+    for tool_call in raw_tool_calls:
+        if not isinstance(tool_call, dict):
+            all_tool_calls_positionable = False
+            continue
+        assistant_idx = tool_call.get('assistant_msg_idx')
+        positionable = _tail_cache_strict_int(
+            assistant_idx,
+            minimum=0,
+            maximum=source_count - 1,
+        )
+        if positionable:
+            positionable = (
+                isinstance(messages[assistant_idx], dict)
+                and messages[assistant_idx].get('role') == 'assistant'
+            )
+        if not positionable:
+            all_tool_calls_positionable = False
+            continue
+        if assistant_idx >= offset:
+            cached_tool_calls.append(tool_call)
+
+    try:
+        from api.todo_state import derive_todo_state
+
+        todo_state = derive_todo_state(messages)
+    except Exception:
+        todo_state = None
+
+    timestamps = [
+        float(message.get('timestamp'))
+        for message in messages
+        if isinstance(message, dict) and _tail_cache_finite_number(message.get('timestamp'))
+    ]
+    last_message_at = max(timestamps) if timestamps else getattr(session, 'updated_at', None)
+    if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
+        last_message_at = None
+    return {
+        'format': _SESSION_TAIL_CACHE_FORMAT,
+        'version': _SESSION_TAIL_CACHE_VERSION,
+        'session_id': sid,
+        'source_signature': signature,
+        'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
+        'message_offset': offset,
+        'messages': raw_tail,
+        'source_message_count': source_count,
+        'source_user_message_count': Session._compute_user_message_count(messages),
+        'source_last_message_at': last_message_at,
+        'tool_calls': cached_tool_calls,
+        'all_tool_calls_positionable': all_tool_calls_positionable,
+        'todo_state': todo_state,
+        'anchor_scene_index': _anchor_scene_index_from_records(
+            getattr(session, 'anchor_activity_scenes', None)
+        ),
+        'all_cached_timestamps_valid': all_timestamps_valid,
+        'created_at': float(time.time()),
+    }
+
+
+def _write_session_tail_cache_payload(payload: dict, *, expected_signature) -> bool:
+    """Atomically publish one already-built cache payload after a final restat."""
+    sid = payload.get('session_id') if isinstance(payload, dict) else None
+    if not is_safe_session_id(sid) or expected_signature is None:
+        return False
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+    if len(encoded) > _SESSION_TAIL_CACHE_MAX_BYTES:
+        return False
+    path = session_tail_cache_path(sid)
+    tmp = path.with_name(
+        f'{path.name}.tmp.{os.getpid()}.{threading.current_thread().ident}'
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp, 'wb') as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        sidecar = SESSION_DIR / f'{sid}.json'
+        if _sidecar_stat_signature(sidecar) != expected_signature:
+            return False
+        _safe_replace(tmp, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return True
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _write_session_tail_cache(session, *, expected_signature) -> bool:
+    payload = _session_tail_cache_payload(session, expected_signature)
+    if payload is None:
+        return False
+    return _write_session_tail_cache_payload(
+        payload,
+        expected_signature=expected_signature,
+    )
+
+
+def _session_tail_cache_has_signature(sid: str, signature) -> bool:
+    """Cheaply decide whether an existing bounded cache describes this source."""
+    try:
+        path = session_tail_cache_path(sid)
+        if path.stat().st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
+            return False
+        value = json.loads(path.read_bytes())
+        return (
+            isinstance(value, dict)
+            and value.get('format') == _SESSION_TAIL_CACHE_FORMAT
+            and value.get('version') == _SESSION_TAIL_CACHE_VERSION
+            and value.get('session_id') == sid
+            and _tail_cache_signature_tuple(value.get('source_signature'))
+            == _tail_cache_signature_tuple(_tail_cache_signature_dict(signature))
+        )
+    except Exception:
+        return False
+
+
+def _validate_session_tail_cache_payload(payload, sid: str, source_signature) -> dict | None:
+    """Strictly validate v1 shape and bounded-read eligibility."""
+    if not isinstance(payload, dict):
+        return None
+    if payload.get('format') != _SESSION_TAIL_CACHE_FORMAT:
+        return None
+    if payload.get('version') != _SESSION_TAIL_CACHE_VERSION or payload.get('session_id') != sid:
+        return None
+    embedded_signature = _tail_cache_signature_tuple(payload.get('source_signature'))
+    current_signature = _tail_cache_signature_tuple(_tail_cache_signature_dict(source_signature))
+    if embedded_signature is None or embedded_signature != current_signature:
+        return None
+    if payload.get('tail_limit') != _SESSION_TAIL_CACHE_LIMIT:
+        return None
+
+    source_count = payload.get('source_message_count')
+    user_count = payload.get('source_user_message_count')
+    offset = payload.get('message_offset')
+    messages = payload.get('messages')
+    if not _tail_cache_strict_int(source_count, minimum=0):
+        return None
+    if not _tail_cache_strict_int(user_count, minimum=0, maximum=source_count):
+        return None
+    if not _tail_cache_strict_int(offset, minimum=0, maximum=source_count):
+        return None
+    if not isinstance(messages, list) or len(messages) != min(_SESSION_TAIL_CACHE_LIMIT, source_count):
+        return None
+    if offset != source_count - len(messages):
+        return None
+    if payload.get('all_cached_timestamps_valid') is not True:
+        return None
+    for message in messages:
+        if not isinstance(message, dict):
+            return None
+        if not _tail_cache_finite_number(message.get('timestamp')):
+            return None
+
+    last_message_at = payload.get('source_last_message_at')
+    if source_count == 0:
+        if last_message_at is not None and not _tail_cache_finite_number(last_message_at):
+            return None
+    elif not _tail_cache_finite_number(last_message_at):
+        return None
+    if payload.get('all_tool_calls_positionable') is not True:
+        return None
+    tool_calls = payload.get('tool_calls')
+    if not isinstance(tool_calls, list):
+        return None
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            return None
+        assistant_idx = tool_call.get('assistant_msg_idx')
+        if not _tail_cache_strict_int(assistant_idx, minimum=offset, maximum=source_count - 1):
+            return None
+        tail_message = messages[assistant_idx - offset]
+        if tail_message.get('role') != 'assistant':
+            return None
+    todo_state = payload.get('todo_state')
+    if todo_state is not None:
+        if not isinstance(todo_state, dict) or not isinstance(todo_state.get('todos'), list):
+            return None
+    anchor_scene_index = payload.get('anchor_scene_index')
+    if not isinstance(anchor_scene_index, dict) or anchor_scene_index:
+        return None
+    if not _tail_cache_finite_number(payload.get('created_at'), positive=True):
+        return None
+    return payload
+
+
+def _read_session_tail_cache_file(sid: str) -> dict | None:
+    if not is_safe_session_id(sid):
+        return None
+    sidecar = SESSION_DIR / f'{sid}.json'
+    before = _sidecar_stat_signature(sidecar)
+    if before is None:
+        return None
+    try:
+        path = session_tail_cache_path(sid)
+        size = path.stat().st_size
+        if size <= 0 or size > _SESSION_TAIL_CACHE_MAX_BYTES:
+            return None
+        payload = json.loads(path.read_bytes())
+    except (OSError, ValueError, TypeError):
+        return None
+    after = _sidecar_stat_signature(sidecar)
+    if after is None or before != after:
+        return None
+    return _validate_session_tail_cache_payload(payload, sid, before)
+
+
+def read_session_tail_cache(sid: str) -> dict | None:
+    """Return a validated tail snapshot, never superseding a full memory object."""
+    if not is_safe_session_id(sid):
+        return None
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
+            return None
+    return _read_session_tail_cache_file(sid)
+
+
+def _legacy_tail_cache_index_row(sid: str, source_signature, metadata: dict) -> dict | None:
+    """Return one index row only when its cheap source facts all agree."""
+    try:
+        if SESSION_INDEX_FILE.stat().st_size > _SESSION_TAIL_CACHE_MAX_BYTES:
+            return None
+        rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(rows, list):
+        return None
+    matches = [row for row in rows if isinstance(row, dict) and row.get('session_id') == sid]
+    if len(matches) != 1:
+        return None
+    row = matches[0]
+    count = row.get('message_count')
+    user_count = row.get('user_message_count')
+    file_size = row.get('file_size')
+    if not _tail_cache_strict_int(count, minimum=0):
+        return None
+    if not _tail_cache_strict_int(user_count, minimum=0, maximum=count):
+        return None
+    if not _tail_cache_strict_int(file_size, minimum=0) or file_size != source_signature[2]:
+        return None
+    if _parse_nonnegative_int(metadata.get('message_count')) != count:
+        return None
+    row_updated_at = row.get('updated_at')
+    metadata_updated_at = metadata.get('updated_at')
+    if not _tail_cache_finite_number(row_updated_at) or not _tail_cache_finite_number(metadata_updated_at):
+        return None
+    if float(row_updated_at) != float(metadata_updated_at):
+        return None
+    if count and not _tail_cache_finite_number(row.get('last_message_at')):
+        return None
+    return row
+
+
+def _legacy_tail_metadata_is_eligible(metadata: dict) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    if metadata.get('active_stream_id') or metadata.get('pending_user_message'):
+        return False
+    if metadata.get('pending_attachments') or metadata.get('pending_started_at'):
+        return False
+    if metadata.get('pending_user_source'):
+        return False
+    if metadata.get('pre_compression_snapshot') or metadata.get('parent_session_id'):
+        return False
+    if metadata.get('compression_recovery'):
+        return False
+    if metadata.get('compression_recovery_source_session_id') or metadata.get('compression_recovery_action'):
+        return False
+    if metadata.get('truncation_watermark') is not None or metadata.get('truncation_boundary') is not None:
+        return False
+    if metadata.get('is_cli_session') or metadata.get('read_only'):
+        return False
+    if metadata.get('session_source') not in (None, '', 'webui'):
+        return False
+    if metadata.get('source_tag') not in (None, '', 'webui'):
+        return False
+    if metadata.get('raw_source') not in (None, '') or metadata.get('source_label') not in (None, ''):
+        return False
+    scene_index = metadata.get('anchor_scene_index')
+    return scene_index is None or (isinstance(scene_index, dict) and not scene_index)
+
+
+def _mmap_top_level_key_value_offset(view, key: bytes, *, scan_limit=512 * 1024) -> int | None:
+    """Locate the value of one unescaped ASCII key in the root JSON object."""
+    limit = min(len(view), scan_limit)
+    depth = 0
+    i = 0
+    while i < limit:
+        byte = view[i]
+        if byte == 34:
+            start = i + 1
+            i += 1
+            escaped = False
+            while i < limit:
+                current = view[i]
+                if current == 34 and not escaped:
+                    break
+                if current == 92 and not escaped:
+                    escaped = True
+                else:
+                    escaped = False
+                i += 1
+            if i >= limit:
+                return None
+            if depth == 1 and view[start:i] == key:
+                cursor = i + 1
+                while cursor < limit and view[cursor] in b' \t\r\n':
+                    cursor += 1
+                if cursor >= limit or view[cursor] != 58:
+                    return None
+                cursor += 1
+                while cursor < limit and view[cursor] in b' \t\r\n':
+                    cursor += 1
+                return cursor if cursor < limit else None
+        elif byte in (123, 91):
+            depth += 1
+        elif byte in (125, 93):
+            depth -= 1
+            if depth < 0:
+                return None
+        i += 1
+    return None
+
+
+def _mmap_root_suffix_after_messages(view, messages_open: int) -> tuple[int, dict] | None:
+    """Prove the messages closing bracket by parsing the bounded root suffix."""
+    marker = b'"tool_calls"'
+    search_end = len(view)
+    minimum = max(messages_open + 1, len(view) - _SESSION_TAIL_CACHE_MAX_BYTES)
+    while search_end > minimum:
+        key_pos = view.rfind(marker, minimum, search_end)
+        if key_pos < 0:
+            return None
+        cursor = key_pos - 1
+        while cursor > messages_open and view[cursor] in b' \t\r\n':
+            cursor -= 1
+        if cursor > messages_open and view[cursor] == 44:
+            cursor -= 1
+            while cursor > messages_open and view[cursor] in b' \t\r\n':
+                cursor -= 1
+            if cursor > messages_open and view[cursor] == 93:
+                try:
+                    suffix = json.loads(b'{' + view[key_pos:])
+                except (ValueError, TypeError):
+                    suffix = None
+                if isinstance(suffix, dict) and 'tool_calls' in suffix:
+                    return cursor, suffix
+        search_end = key_pos
+    return None
+
+
+def _mmap_json_array_tail_start(view, array_open: int, array_close: int, count: int) -> int | None:
+    """Reverse-scan a bounded JSON array to the first of its last `count` values."""
+    if count <= 0:
+        return array_close
+    i = array_close - 1
+    depth = 0
+    in_string = False
+    separators = 0
+    scanned = 0
+    while i > array_open and scanned <= _SESSION_TAIL_CACHE_MAX_BYTES:
+        byte = view[i]
+        if byte == 34:
+            slashes = 0
+            cursor = i - 1
+            while cursor > array_open and view[cursor] == 92:
+                slashes += 1
+                cursor -= 1
+            if slashes % 2 == 0:
+                in_string = not in_string
+        elif not in_string:
+            if byte in (125, 93):
+                depth += 1
+            elif byte in (123, 91):
+                depth -= 1
+                if depth < 0:
+                    return None
+            elif byte == 44 and depth == 0:
+                separators += 1
+                if separators == count:
+                    return i + 1
+        i -= 1
+        scanned += 1
+    if i == array_open and separators == count - 1:
+        return array_open + 1
+    return None
+
+
+def _read_legacy_tail_parts(path: Path, wanted: int) -> tuple[list, dict] | None:
+    try:
+        with open(path, 'rb') as handle:
+            with mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as view:
+                messages_open = _mmap_top_level_key_value_offset(view, b'messages')
+                if messages_open is None or view[messages_open] != 91:
+                    return None
+                suffix_info = _mmap_root_suffix_after_messages(view, messages_open)
+                if suffix_info is None:
+                    return None
+                messages_close, suffix = suffix_info
+                tail_start = _mmap_json_array_tail_start(
+                    view,
+                    messages_open,
+                    messages_close,
+                    wanted,
+                )
+                if tail_start is None:
+                    return None
+                # Any settled todo snapshot before the bounded tail makes the
+                # tail alone insufficient to derive the full session state.
+                if (
+                    view.find(b'"todos"', messages_open + 1, tail_start) >= 0
+                    or view.find(b'\\"todos\\"', messages_open + 1, tail_start) >= 0
+                ):
+                    return None
+                tail_bytes = b'[' + view[tail_start:messages_close] + b']'
+                if len(tail_bytes) > _SESSION_TAIL_CACHE_MAX_BYTES:
+                    return None
+                messages = json.loads(tail_bytes)
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(messages, list) or len(messages) != wanted:
+        return None
+    if any(
+        not isinstance(message, dict)
+        or not _tail_cache_finite_number(message.get('timestamp'))
+        for message in messages
+    ):
+        return None
+    return messages, suffix
+
+
+def _legacy_tail_positionable_tool_calls(suffix: dict, messages: list, offset: int, source_count: int):
+    if suffix.get('anchor_activity_scenes') not in (None, {}):
+        return None
+    raw_tool_calls = suffix.get('tool_calls')
+    if not isinstance(raw_tool_calls, list):
+        return None
+    cached_tool_calls = []
+    for tool_call in raw_tool_calls:
+        if not isinstance(tool_call, dict):
+            return None
+        assistant_idx = tool_call.get('assistant_msg_idx')
+        if not _tail_cache_strict_int(assistant_idx, minimum=0, maximum=source_count - 1):
+            return None
+        assistant_idx = int(assistant_idx)
+        if assistant_idx >= offset:
+            if messages[assistant_idx - offset].get('role') != 'assistant':
+                return None
+            cached_tool_calls.append(tool_call)
+    return cached_tool_calls
+
+
+def build_session_tail_cache_from_legacy_sidecar(sid: str) -> dict | None:
+    """Build a v1 snapshot from stable prefix/tail/suffix slices, never a full parse."""
+    if not is_safe_session_id(sid):
+        return None
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
+            return None
+    path = SESSION_DIR / f'{sid}.json'
+    before = _sidecar_stat_signature(path)
+    if before is None:
+        return None
+    try:
+        prefix = _read_metadata_json_prefix(path)
+        metadata = json.loads(prefix) if prefix else None
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    if not _legacy_tail_metadata_is_eligible(metadata) or metadata.get('session_id') != sid:
+        return None
+    index_row = _legacy_tail_cache_index_row(sid, before, metadata)
+    if index_row is None:
+        return None
+    source_count = int(index_row['message_count'])
+    wanted = min(_SESSION_TAIL_CACHE_LIMIT, source_count)
+    parts = _read_legacy_tail_parts(path, wanted)
+    if parts is None:
+        return None
+    messages, suffix = parts
+    offset = source_count - wanted
+    cached_tool_calls = _legacy_tail_positionable_tool_calls(
+        suffix,
+        messages,
+        offset,
+        source_count,
+    )
+    if cached_tool_calls is None:
+        return None
+    try:
+        from api.todo_state import derive_todo_state
+
+        todo_state = derive_todo_state(messages)
+    except Exception:
+        return None
+    payload = {
+        'format': _SESSION_TAIL_CACHE_FORMAT,
+        'version': _SESSION_TAIL_CACHE_VERSION,
+        'session_id': sid,
+        'source_signature': _tail_cache_signature_dict(before),
+        'tail_limit': _SESSION_TAIL_CACHE_LIMIT,
+        'message_offset': offset,
+        'messages': messages,
+        'source_message_count': source_count,
+        'source_user_message_count': int(index_row['user_message_count']),
+        'source_last_message_at': index_row.get('last_message_at'),
+        'tool_calls': cached_tool_calls,
+        'all_tool_calls_positionable': True,
+        'todo_state': todo_state,
+        'anchor_scene_index': {},
+        'all_cached_timestamps_valid': True,
+        'created_at': float(time.time()),
+    }
+    if _sidecar_stat_signature(path) != before:
+        return None
+    if not _write_session_tail_cache_payload(payload, expected_signature=before):
+        return None
+    return _read_session_tail_cache_file(sid)
 
 
 def _legacy_sidecar_facts_get(sid):

--- a/api/models.py
+++ b/api/models.py
@@ -8074,16 +8074,20 @@ def get_state_db_session_message_prefix_summary(
     except (TypeError, ValueError):
         return None
 
-    if isinstance(profile, str) and profile:
-        db_path = _get_profile_home(profile) / 'state.db'
-        if not db_path.exists():
-            db_path = _active_state_db_path()
-    else:
-        db_path = _active_state_db_path()
-    if not db_path.exists():
-        return {"count": 0, "null_timestamp_count": 0}
-
     try:
+        # Path resolution and existence checks must stay inside the guard:
+        # a stat/permission failure here is "unprovable", not an error the
+        # route caller should see. Callers rely on None to mean "take the
+        # authoritative full-read fallback" (fail-open contract).
+        if isinstance(profile, str) and profile:
+            db_path = _get_profile_home(profile) / 'state.db'
+            if not db_path.exists():
+                db_path = _active_state_db_path()
+        else:
+            db_path = _active_state_db_path()
+        if not db_path.exists():
+            return {"count": 0, "null_timestamp_count": 0}
+
         with closing(open_state_db_readonly(db_path)) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
@@ -8144,16 +8148,19 @@ def get_state_db_session_message_keys_before_timestamp(
     except (TypeError, ValueError):
         return None
 
-    if isinstance(profile, str) and profile:
-        db_path = _get_profile_home(profile) / 'state.db'
-        if not db_path.exists():
-            db_path = _active_state_db_path()
-    else:
-        db_path = _active_state_db_path()
-    if not db_path.exists():
-        return []
-
     try:
+        # Keep path resolution inside the guard for the same fail-open
+        # contract as the prefix summary helper: any resolution/stat failure
+        # is "unprovable" (None) so the caller takes the full-read fallback.
+        if isinstance(profile, str) and profile:
+            db_path = _get_profile_home(profile) / 'state.db'
+            if not db_path.exists():
+                db_path = _active_state_db_path()
+        else:
+            db_path = _active_state_db_path()
+        if not db_path.exists():
+            return []
+
         with closing(open_state_db_readonly(db_path)) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
@@ -8161,14 +8168,23 @@ def get_state_db_session_message_keys_before_timestamp(
             available = {str(row['name']) for row in cur.fetchall()}
             if not {'id', 'session_id', 'role', 'content', 'timestamp', 'tool_calls'}.issubset(available):
                 return None
+            # Match get_state_db_session_messages / the prefix-summary helper:
+            # compacted (active=0) rows are invisible to the merge, so they
+            # must not appear in the definitive identity sequence either.
+            # Without this an exact active-row prefix looks longer than the
+            # summary count and forces a needless conservative fallback.
+            active_clause = ""
+            if 'active' in available:
+                active_clause = " AND (active IS NULL OR active != 0)"
             cur.execute(
-                """
+                f"""
                 SELECT
                     COALESCE(role, '') AS role,
                     COALESCE(content, '') AS content,
                     tool_calls
                 FROM messages
                 WHERE session_id = ? AND timestamp IS NOT NULL AND timestamp < ?
+                {active_clause}
                 ORDER BY timestamp ASC, id ASC
                 """,
                 (str(sid), before_ts),

--- a/api/models.py
+++ b/api/models.py
@@ -138,6 +138,7 @@ _SESSION_TAIL_CACHE_FORMAT = 'hermes.session-tail-cache'
 _SESSION_TAIL_CACHE_VERSION = 1
 _SESSION_TAIL_CACHE_LIMIT = 300
 _SESSION_TAIL_CACHE_MAX_BYTES = 4 * 1024 * 1024
+_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES = 1 * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -3738,6 +3739,21 @@ def session_tail_cache_path(sid: str) -> Path:
     if not is_safe_session_id(sid):
         raise ValueError(f"Unsafe session_id {sid!r}")
     return SESSION_DIR / '_tail_cache' / 'v1' / f'{sid}.json'
+
+
+def session_tail_cache_source_is_large_enough(sid: str) -> bool:
+    """Return whether bounded-tail route setup is worthwhile for this sidecar."""
+    if not is_safe_session_id(sid):
+        return False
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and not getattr(cached, '_loaded_metadata_only', False):
+            return False
+    signature = _sidecar_stat_signature(SESSION_DIR / f'{sid}.json')
+    return bool(
+        signature is not None
+        and signature[2] >= _SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    )
 
 
 def delete_session_tail_cache(sid: str) -> bool:

--- a/api/models.py
+++ b/api/models.py
@@ -275,6 +275,17 @@ def _persisted_session_ids_snapshot() -> frozenset[str]:
     return ids
 
 
+def _invalidate_persisted_session_ids_snapshot() -> None:
+    """Forget the directory listing after this process publishes a sidecar.
+
+    Some filesystems coalesce directory mtime updates for rapid atomic replaces.
+    Relying on that timestamp alone can hide a just-created session until a later
+    unrelated write advances the clock.
+    """
+    global _PERSISTED_SESSION_IDS_CACHE
+    _PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
+
+
 def _session_dir_has_persisted_session_files() -> bool:
     """Return True when the current session dir has at least one session JSON file."""
     try:
@@ -1431,6 +1442,7 @@ class Session:
                 f.flush()
                 os.fsync(f.fileno())
             _safe_replace(tmp, self.path)
+            _invalidate_persisted_session_ids_snapshot()
         except Exception:
             try:
                 tmp.unlink(missing_ok=True)

--- a/api/models.py
+++ b/api/models.py
@@ -242,6 +242,11 @@ def _cleanup_stale_tmp_files() -> None:
         pass  # SESSION_DIR may not exist yet; that's fine
 
 
+# This lock is intentionally narrower than the application-wide LOCK. It covers
+# only the persisted-ID cache check/stat/glob/store sequence and invalidation.
+# Session.save() publishes the sidecar before acquiring it for invalidation, so
+# sidecar I/O never runs under this lock and there is no lock-order inversion.
+_PERSISTED_SESSION_IDS_CACHE_LOCK = threading.Lock()
 _PERSISTED_SESSION_IDS_CACHE: tuple[Path | None, int | None, frozenset[str]] = (None, None, frozenset())
 
 
@@ -256,23 +261,24 @@ def _persisted_session_ids_snapshot() -> frozenset[str]:
     entering critical sections.
     """
     global _PERSISTED_SESSION_IDS_CACHE
-    try:
-        dir_mtime_ns = SESSION_DIR.stat().st_mtime_ns
-    except Exception:
-        dir_mtime_ns = None
-    cached_dir, cached_mtime_ns, cached_ids = _PERSISTED_SESSION_IDS_CACHE
-    if cached_dir == SESSION_DIR and cached_mtime_ns == dir_mtime_ns:
-        return cached_ids
-    try:
-        ids = frozenset(
-            p.stem
-            for p in SESSION_DIR.glob('*.json')
-            if not p.name.startswith('_')
-        )
-    except Exception:
-        ids = frozenset()
-    _PERSISTED_SESSION_IDS_CACHE = (SESSION_DIR, dir_mtime_ns, ids)
-    return ids
+    with _PERSISTED_SESSION_IDS_CACHE_LOCK:
+        try:
+            dir_mtime_ns = SESSION_DIR.stat().st_mtime_ns
+        except Exception:
+            dir_mtime_ns = None
+        cached_dir, cached_mtime_ns, cached_ids = _PERSISTED_SESSION_IDS_CACHE
+        if cached_dir == SESSION_DIR and cached_mtime_ns == dir_mtime_ns:
+            return cached_ids
+        try:
+            ids = frozenset(
+                p.stem
+                for p in SESSION_DIR.glob('*.json')
+                if not p.name.startswith('_')
+            )
+        except Exception:
+            ids = frozenset()
+        _PERSISTED_SESSION_IDS_CACHE = (SESSION_DIR, dir_mtime_ns, ids)
+        return ids
 
 
 def _invalidate_persisted_session_ids_snapshot() -> None:
@@ -283,7 +289,8 @@ def _invalidate_persisted_session_ids_snapshot() -> None:
     unrelated write advances the clock.
     """
     global _PERSISTED_SESSION_IDS_CACHE
-    _PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
+    with _PERSISTED_SESSION_IDS_CACHE_LOCK:
+        _PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
 
 
 def _session_dir_has_persisted_session_files() -> bool:

--- a/api/routes.py
+++ b/api/routes.py
@@ -12432,10 +12432,10 @@ def handle_get(handler, parsed) -> bool:
         try:
             _t1 = _time.monotonic()
             if _diag: _diag.stage("t1_after_get_session_check")
-            s = get_session(
-                sid,
-                metadata_only=((not load_messages) or _tail_snapshot_candidate),
-            )
+            if _tail_snapshot_candidate:
+                s = get_session(sid, metadata_only=True)
+            else:
+                s = get_session(sid, metadata_only=(not load_messages))
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
                 if _session_profile:
@@ -12459,6 +12459,21 @@ def handle_get(handler, parsed) -> bool:
             _clear_stale_stream_state(s)
             cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
+            if _tail_snapshot_candidate and is_messaging_session:
+                # Messaging projections rely on the complete sidecar lineage to
+                # preserve display dedupe and state.db merge coordinates, so the
+                # metadata-only tail-candidate stub (empty messages) must be
+                # replaced with the authoritative full load before the merge.
+                # A vanished sidecar raises KeyError, handled by the existing
+                # foreign-session/404 branch below.
+                s = get_session(sid, metadata_only=False)
+                _clear_stale_stream_state(s)
+                cli_meta = (
+                    _lookup_cli_session_metadata(sid)
+                    if _session_requires_cli_metadata_lookup(s)
+                    else {}
+                )
+                is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
             tail_snapshot = None
             if _tail_snapshot_candidate and not is_messaging_session:
                 candidate_snapshot = read_session_tail_cache(sid)

--- a/api/routes.py
+++ b/api/routes.py
@@ -8533,8 +8533,22 @@ def _session_tail_snapshot_eligible(session, snapshot, msg_limit, msg_before, is
         source_count = int(snapshot.get("source_message_count"))
     except (AttributeError, TypeError, ValueError):
         return False
-    if limit < 1 or limit > 300 or offset < 0 or source_count < offset:
+    if limit < 1 or limit > 30 or offset < 0 or source_count < offset:
         return False
+    cached_messages = snapshot.get("messages")
+    if not isinstance(cached_messages, list):
+        return False
+    if offset > 0:
+        cached_window, _cached_window_offset = _message_window_for_display(
+            cached_messages,
+            msg_limit=limit,
+        )
+        cached_renderable_count = sum(
+            _message_counts_as_renderable_for_window(message)
+            for message in cached_window
+        )
+        if cached_renderable_count < limit:
+            return False
     if snapshot.get("all_cached_timestamps_valid") is not True:
         return False
     if snapshot.get("all_tool_calls_positionable") is not True:
@@ -13026,8 +13040,9 @@ def handle_get(handler, parsed) -> bool:
             return bad(handler, "Missing session_id")
         try:
             from api.session_ops import session_status
-            _clear_stale_stream_state(get_session(sid, metadata_only=True))
-            return j(handler, session_status(sid))
+            session = get_session(sid, metadata_only=True)
+            _clear_stale_stream_state(session)
+            return j(handler, session_status(sid, session=session))
         except KeyError:
             return bad(handler, "Session not found", 404)
 
@@ -13223,7 +13238,7 @@ def handle_get(handler, parsed) -> bool:
         if not sid:
             return bad(handler, "session_id required")
         try:
-            s = get_session(sid)
+            s = get_session_for_file_ops(sid)
         except KeyError:
             return bad(handler, "Session not found", 404)
         from api.workspace_git import GitWorkspaceError, git_status
@@ -16819,21 +16834,10 @@ def _handle_list_dir(handler, parsed):
     if not sid:
         return bad(handler, "session_id is required")
     try:
-        s = get_session(sid)
+        s = get_session_for_file_ops(sid)
         workspace = s.workspace
     except KeyError:
-        # Fallback for CLI sessions not loaded in WebUI memory
-        try:
-            cli_meta = None
-            for cs in get_cli_sessions():
-                if cs["session_id"] == sid:
-                    cli_meta = cs
-                    break
-            if not cli_meta:
-                return bad(handler, "Session not found", 404)
-            workspace = cli_meta.get("workspace", "")
-        except Exception:
-            return bad(handler, "Session not found", 404)
+        return bad(handler, "Session not found", 404)
     try:
         rel_path = qs.get("path", ["."])[0]
         entries = list_dir(Path(workspace), rel_path)

--- a/api/routes.py
+++ b/api/routes.py
@@ -8524,7 +8524,61 @@ def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, 
     )
 
 
-def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before=None):
+def _session_tail_snapshot_eligible(session, snapshot, msg_limit, msg_before, is_messaging_session=False) -> bool:
+    if snapshot is None or msg_limit is None or msg_before is not None or is_messaging_session:
+        return False
+    try:
+        limit = int(msg_limit)
+        offset = int(snapshot.get("message_offset"))
+        source_count = int(snapshot.get("source_message_count"))
+    except (AttributeError, TypeError, ValueError):
+        return False
+    if limit < 1 or limit > 300 or offset < 0 or source_count < offset:
+        return False
+    if snapshot.get("all_cached_timestamps_valid") is not True:
+        return False
+    if snapshot.get("all_tool_calls_positionable") is not True:
+        return False
+    if snapshot.get("anchor_scene_index") not in (None, {}):
+        return False
+    if getattr(session, "active_stream_id", None) or getattr(session, "pending_user_message", None):
+        return False
+    if getattr(session, "pending_attachments", None) or getattr(session, "pending_started_at", None):
+        return False
+    if getattr(session, "pending_user_source", None):
+        return False
+    if getattr(session, "parent_session_id", None) or getattr(session, "pre_compression_snapshot", False):
+        return False
+    if getattr(session, "compression_recovery", None):
+        return False
+    if getattr(session, "compression_recovery_source_session_id", None):
+        return False
+    if getattr(session, "compression_recovery_action", None):
+        return False
+    if getattr(session, "truncation_watermark", None) not in (None, ""):
+        return False
+    if getattr(session, "truncation_boundary", None) not in (None, ""):
+        return False
+    source = str(getattr(session, "session_source", "") or "").strip().lower()
+    source_tag = str(getattr(session, "source_tag", "") or "").strip().lower()
+    return (
+        source in ("", "webui")
+        and source_tag in ("", "webui")
+        and not getattr(session, "is_cli_session", False)
+        and not getattr(session, "read_only", False)
+        and getattr(session, "raw_source", None) in (None, "")
+        and getattr(session, "source_label", None) in (None, "")
+    )
+
+
+def _state_db_since_timestamp_for_limited_display(
+    session,
+    msg_limit,
+    msg_before=None,
+    *,
+    sidecar_messages=None,
+    sidecar_message_offset=0,
+):
     """Return (timestamp floor, sidecar messages) for bounded state.db tail reads.
 
     The display window limit counts visible transcript rows after WebUI sidecar
@@ -8541,7 +8595,11 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
     if getattr(session, "truncation_boundary", None) not in (None, ""):
         return None, None
 
-    sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    bounded_sidecar = sidecar_messages is not None
+    if sidecar_messages is None:
+        sidecar_messages = _webui_sidecar_lineage_messages_for_display(session)
+    else:
+        sidecar_messages = list(sidecar_messages or [])
     if not sidecar_messages:
         return None, sidecar_messages
     sidecar_timestamps = [_message_timestamp_as_float(msg) for msg in sidecar_messages]
@@ -8553,7 +8611,11 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
     except (TypeError, ValueError):
         return None, sidecar_messages
     raw_budget = max(300, limit * 10)
-    if len(sidecar_messages) <= raw_budget:
+    try:
+        sidecar_message_offset = max(0, int(sidecar_message_offset))
+    except (TypeError, ValueError):
+        return None, sidecar_messages
+    if sidecar_message_offset + len(sidecar_messages) <= raw_budget:
         return None, sidecar_messages
 
     floor = min(sidecar_timestamps[-raw_budget:])
@@ -8572,6 +8634,11 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
         return None, sidecar_messages
     if null_timestamp_count or state_before_count != sidecar_before_count:
         return None, sidecar_messages
+    if bounded_sidecar and sidecar_message_offset:
+        # The cache omits the authoritative sidecar prefix. Only an empty
+        # state.db prefix proves that no older row can alter full-merge counts
+        # or ordering without reading the omitted sidecar bytes.
+        return floor, sidecar_messages
     if sidecar_before_count == 0:
         return floor, sidecar_messages
 
@@ -9204,6 +9271,8 @@ from api.models import (
     _hide_from_default_sidebar,
     prune_session_from_index,
     delete_session_tail_cache,
+    read_session_tail_cache,
+    build_session_tail_cache_from_legacy_sidecar,
     agent_session_rows_existing,
     agent_session_zero_message_sids,
     _load_webui_zero_message_orphan_tombstone,
@@ -12352,6 +12421,9 @@ def handle_get(handler, parsed) -> bool:
             msg_before = int(_msg_before) if _msg_before else None
         except (ValueError, TypeError):
             msg_before = None
+        _tail_snapshot_candidate = (
+            load_messages and msg_limit is not None and msg_before is None
+        )
         # ?expand_renderable=1 is retained for compatibility with older
         # frontends. msg_limit now counts visible transcript rows by default, so
         # the flag no longer changes the server-side pagination semantics.
@@ -12360,7 +12432,10 @@ def handle_get(handler, parsed) -> bool:
         try:
             _t1 = _time.monotonic()
             if _diag: _diag.stage("t1_after_get_session_check")
-            s = get_session(sid, metadata_only=(not load_messages))
+            s = get_session(
+                sid,
+                metadata_only=((not load_messages) or _tail_snapshot_candidate),
+            )
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
                 if _session_profile:
@@ -12384,6 +12459,24 @@ def handle_get(handler, parsed) -> bool:
             _clear_stale_stream_state(s)
             cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
+            tail_snapshot = None
+            if _tail_snapshot_candidate and not is_messaging_session:
+                candidate_snapshot = read_session_tail_cache(sid)
+                if candidate_snapshot is None:
+                    candidate_snapshot = build_session_tail_cache_from_legacy_sidecar(sid)
+                if _session_tail_snapshot_eligible(
+                    s,
+                    candidate_snapshot,
+                    msg_limit,
+                    msg_before,
+                    is_messaging_session,
+                ):
+                    tail_snapshot = candidate_snapshot
+                else:
+                    # Metadata/profile checks have completed. Fall back only now,
+                    # so a foreign-profile request never warms or parses a body.
+                    s = get_session(sid, metadata_only=False)
+                    _clear_stale_stream_state(s)
             cli_messages = []
             state_db_messages = []
             metadata_summary = None
@@ -12393,6 +12486,12 @@ def handle_get(handler, parsed) -> bool:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:
                 if msg_limit is not None:
+                    _bounded_sidecar_messages = (
+                        tail_snapshot.get("messages") if tail_snapshot is not None else None
+                    )
+                    _bounded_sidecar_offset = (
+                        tail_snapshot.get("message_offset", 0) if tail_snapshot is not None else 0
+                    )
                     (
                         state_db_since_timestamp,
                         limited_sidecar_messages,
@@ -12400,7 +12499,27 @@ def handle_get(handler, parsed) -> bool:
                         s,
                         msg_limit,
                         msg_before=msg_before,
+                        sidecar_messages=_bounded_sidecar_messages,
+                        sidecar_message_offset=_bounded_sidecar_offset,
                     )
+                    if (
+                        tail_snapshot is not None
+                        and int(tail_snapshot.get("message_offset", 0)) > 0
+                        and state_db_since_timestamp is None
+                    ):
+                        # The prefix preflight could not prove equivalence. Load
+                        # the authoritative body and rerun the established path.
+                        s = get_session(sid, metadata_only=False)
+                        _clear_stale_stream_state(s)
+                        tail_snapshot = None
+                        (
+                            state_db_since_timestamp,
+                            limited_sidecar_messages,
+                        ) = _state_db_since_timestamp_for_limited_display(
+                            s,
+                            msg_limit,
+                            msg_before=msg_before,
+                        )
                 _state_db_reader_kwargs = {"profile": _session_profile}
                 if state_db_since_timestamp is not None:
                     _state_db_reader_kwargs["since_timestamp"] = state_db_since_timestamp
@@ -12482,6 +12601,21 @@ def handle_get(handler, parsed) -> bool:
             else:
                 _summary_message_count = None
                 _summary_last_message_at = None
+            _tail_message_offset = (
+                int(tail_snapshot.get("message_offset", 0))
+                if tail_snapshot is not None
+                else 0
+            )
+            _tail_local_tool_calls = []
+            if tail_snapshot is not None:
+                for _tail_call in tail_snapshot.get("tool_calls", []):
+                    if not isinstance(_tail_call, dict):
+                        continue
+                    _local_call = dict(_tail_call)
+                    _local_call["assistant_msg_idx"] = (
+                        int(_local_call["assistant_msg_idx"]) - _tail_message_offset
+                    )
+                    _tail_local_tool_calls.append(_local_call)
             if load_messages:
                 _truncated_msgs, _messages_offset = _message_window_for_display(
                     _all_msgs,
@@ -12495,7 +12629,11 @@ def handle_get(handler, parsed) -> bool:
                     _truncated_msgs,
                     getattr(s, "anchor_activity_scenes", None),
                     message_offset=_messages_offset,
-                    tool_calls=getattr(s, "tool_calls", None),
+                    tool_calls=(
+                        _tail_local_tool_calls
+                        if tail_snapshot is not None
+                        else getattr(s, "tool_calls", None)
+                    ),
                 )
             else:
                 _truncated_msgs = []
@@ -12505,7 +12643,11 @@ def handle_get(handler, parsed) -> bool:
             _windowed_messages = (
                 load_messages
                 and msg_limit is not None
-                and (msg_before is not None or len(_truncated_msgs) < len(_all_msgs))
+                and (
+                    msg_before is not None
+                    or _tail_message_offset > 0
+                    or len(_truncated_msgs) < len(_all_msgs)
+                )
             )
             # Resolve effective context_length with model-metadata fallback so
             # older sessions (pre-#1318) that have context_length=0 persisted
@@ -12563,7 +12705,11 @@ def handle_get(handler, parsed) -> bool:
                             _fb_cl,
                         )
                     _persisted_cl = _fb_cl
-            _session_tool_calls = getattr(s, "tool_calls", []) if load_messages else []
+            _session_tool_calls = (
+                _tail_local_tool_calls
+                if load_messages and tail_snapshot is not None
+                else (getattr(s, "tool_calls", []) if load_messages else [])
+            )
             # Always include session-level tool_calls so the browser can merge
             # them with per-message tool_calls for messages that lack the
             # per-message variant (older messages whose tool_calls live only
@@ -12575,15 +12721,38 @@ def handle_get(handler, parsed) -> bool:
                     _messages_offset,
                     len(_truncated_msgs),
                 )
-            _merged_message_count = _summary_message_count if _summary_message_count is not None else len(_all_msgs)
-            _merged_last_message_at = _summary_last_message_at if _summary_last_message_at is not None else 0
-            if _summary_last_message_at is None and _all_msgs:
+            _messages_offset += _tail_message_offset
+            if tail_snapshot is not None:
+                _tail_messages = list(tail_snapshot.get("messages") or [])
+                _tail_delta_messages = _all_msgs[len(_tail_messages):]
+                _merged_message_count = int(tail_snapshot["source_message_count"]) + len(_tail_delta_messages)
+                _merged_user_message_count = int(tail_snapshot["source_user_message_count"]) + sum(
+                    str((message or {}).get("role") or "").lower() == "user"
+                    for message in _tail_delta_messages
+                    if isinstance(message, dict)
+                )
+                _merged_last_message_at = tail_snapshot.get("source_last_message_at") or 0
+            else:
+                _merged_message_count = (
+                    _summary_message_count
+                    if _summary_message_count is not None
+                    else len(_all_msgs)
+                )
+                _merged_user_message_count = None
+                _merged_last_message_at = (
+                    _summary_last_message_at
+                    if _summary_last_message_at is not None
+                    else 0
+                )
+            if (tail_snapshot is not None or _summary_last_message_at is None) and _all_msgs:
                 try:
-                    _merged_last_message_at = max(
+                    _merged_last_message_at = max([
+                        float(_merged_last_message_at or 0),
+                    ] + [
                         float((m or {}).get("timestamp") or 0)
                         for m in _all_msgs
                         if isinstance(m, dict)
-                    )
+                    ])
                 except (TypeError, ValueError):
                     _merged_last_message_at = 0
             active_stream_ids = _active_stream_ids()
@@ -12597,6 +12766,11 @@ def handle_get(handler, parsed) -> bool:
             raw = compact_session | {
                 "messages": _truncated_msgs,
                 "message_count": _merged_message_count,
+                "user_message_count": (
+                    _merged_user_message_count
+                    if _merged_user_message_count is not None
+                    else compact_session.get("user_message_count", 0)
+                ),
                 "tool_calls": _session_tool_calls,
                 "active_stream_id": getattr(s, "active_stream_id", None),
                 "pending_user_message": getattr(s, "pending_user_message", None),
@@ -12637,13 +12811,21 @@ def handle_get(handler, parsed) -> bool:
             # tool result is outside msg_limit, and treats an explicit empty
             # todo list as the current state instead of falling through to an
             # older non-empty write.
-            if load_messages and _all_msgs:
+            if load_messages and tail_snapshot is not None:
+                if tail_snapshot.get("todo_state") is not None:
+                    raw["todo_state"] = tail_snapshot.get("todo_state")
+                else:
+                    raw.pop("todo_state", None)
+            elif load_messages and _all_msgs:
                 attach_todo_state(raw, _all_msgs)
             if _merged_last_message_at:
-                raw["last_message_at"] = max(
-                    float(raw.get("last_message_at") or 0),
-                    _merged_last_message_at,
-                )
+                if tail_snapshot is not None:
+                    raw["last_message_at"] = _merged_last_message_at
+                else:
+                    raw["last_message_at"] = max(
+                        float(raw.get("last_message_at") or 0),
+                        _merged_last_message_at,
+                    )
                 raw["updated_at"] = max(
                     float(raw.get("updated_at") or 0),
                     _merged_last_message_at,

--- a/api/routes.py
+++ b/api/routes.py
@@ -9203,6 +9203,7 @@ from api.models import (
     _is_empty_partial_activity_message,
     _hide_from_default_sidebar,
     prune_session_from_index,
+    delete_session_tail_cache,
     agent_session_rows_existing,
     agent_session_zero_message_sids,
     _load_webui_zero_message_orphan_tombstone,
@@ -14610,6 +14611,8 @@ def handle_post(handler, parsed) -> bool:
         except Exception:
             logger.debug("Failed to unlink session file %s", p)
         sidecar_deleted = not p.exists()
+        if sidecar_deleted:
+            delete_session_tail_cache(sid)
         try:
             p.with_suffix('.json.bak').unlink(missing_ok=True)
         except Exception:
@@ -20292,6 +20295,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
                 p.unlink(missing_ok=True)
+                delete_session_tail_cache(p.stem)
                 cleaned += 1
                 phase1_removed_ids.add(p.stem)
         except Exception:
@@ -20515,6 +20519,7 @@ def _handle_background(handler, body):
             # next rebuild via _index_entry_exists().
             try:
                 (SESSION_DIR / f"{bg_sid}.json").unlink(missing_ok=True)
+                delete_session_tail_cache(bg_sid)
             except Exception:
                 pass
         except Exception:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9271,6 +9271,7 @@ from api.models import (
     _hide_from_default_sidebar,
     prune_session_from_index,
     delete_session_tail_cache,
+    session_tail_cache_source_is_large_enough,
     read_session_tail_cache,
     build_session_tail_cache_from_legacy_sidecar,
     agent_session_rows_existing,
@@ -12422,7 +12423,10 @@ def handle_get(handler, parsed) -> bool:
         except (ValueError, TypeError):
             msg_before = None
         _tail_snapshot_candidate = (
-            load_messages and msg_limit is not None and msg_before is None
+            load_messages
+            and msg_limit is not None
+            and msg_before is None
+            and session_tail_cache_source_is_large_enough(sid)
         )
         # ?expand_renderable=1 is retained for compatibility with older
         # frontends. msg_limit now counts visible transcript rows by default, so

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -362,7 +362,7 @@ def undo_last(session_id: str) -> dict[str, Any]:
     }
 
 
-def session_status(session_id: str) -> dict[str, Any]:
+def session_status(session_id: str, *, session=None) -> dict[str, Any]:
     """Return a snapshot of session state for /status.
 
     Webui equivalent of gateway/run.py:_handle_status_command. The agent's
@@ -370,9 +370,12 @@ def session_status(session_id: str) -> dict[str, Any]:
     webui equivalent is whether the session has an active stream
     (active_stream_id is set).
     """
-    s = get_session(session_id)
+    s = session if session is not None else get_session(session_id, metadata_only=True)
     inp = int(s.input_tokens or 0)
     out = int(s.output_tokens or 0)
+    message_count = getattr(s, '_metadata_message_count', None)
+    if message_count is None:
+        message_count = len(s.messages or [])
     profile = getattr(s, 'profile', None) or 'default'
     try:
         from api.profiles import get_hermes_home_for_profile
@@ -387,7 +390,7 @@ def session_status(session_id: str) -> dict[str, Any]:
         'hermes_home': hermes_home,
         'workspace': s.workspace,
         'personality': s.personality,
-        'message_count': len(s.messages or []),
+        'message_count': max(0, int(message_count)),
         'created_at': s.created_at,
         'updated_at': s.updated_at,
         'agent_running': bool(getattr(s, 'active_stream_id', None)),

--- a/tests/test_file_manager_external_session.py
+++ b/tests/test_file_manager_external_session.py
@@ -27,6 +27,7 @@ ROUTES_PY = ROOT / "api" / "routes.py"
 
 
 FILE_HANDLERS = [
+    "_handle_list_dir",
     "_handle_folder_download",
     "_handle_file_raw",
     "_handle_file_read",
@@ -117,6 +118,8 @@ def test_get_session_for_file_ops_webui_passthrough(models_module, monkeypatch):
 
     def fake_get_session(sid, metadata_only=False):
         called["get_session"] += 1
+        assert sid == "webui-sid"
+        assert metadata_only is True
         return sentinel
 
     def fake_profiles_match(session_profile, active_profile):

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -280,10 +280,12 @@ class TestIssue765FollowupHardening:
     def test_same_session_concurrent_saves_use_distinct_temp_files(self, monkeypatch):
         """Two concurrent saves of the same session must not collide on one tmp path.
 
-        The key regression guard here is that each save call should reach os.replace()
-        with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
-        threads would target the same path and the second replace would deterministically
-        fail once the first consume/remove happened.
+        The key regression guard here is that each save call should publish the
+        authoritative sidecar with a distinct source tmp path. Derived tail-cache
+        publications have their own atomicity tests and must not change this count.
+        With the old shared `<sid>.tmp` scheme, both threads would target the same
+        path and the second replace would deterministically fail once the first
+        consume/remove happened.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
@@ -294,8 +296,9 @@ class TestIssue765FollowupHardening:
         errors = []
 
         def _replace_with_barrier(src, dst):
-            replace_sources.append(str(src))
-            barrier.wait(timeout=5)
+            if Path(dst) == s.path:
+                replace_sources.append(str(src))
+                barrier.wait(timeout=5)
             return original_replace(src, dst)
 
         monkeypatch.setattr(models.os, "replace", _replace_with_barrier)

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -134,6 +134,31 @@ def test_full_index_rebuild_includes_hyphenated_sessions():
     assert sid in ids
 
 
+def test_save_invalidates_persisted_id_snapshot_when_directory_mtime_stalls(monkeypatch):
+    """A same-tick create must not stay hidden behind the directory snapshot cache."""
+    first = _make_session("snapshot_first", "First")
+    first.save()
+    assert models._persisted_session_ids_snapshot() == frozenset({first.session_id})
+
+    session_dir = models.SESSION_DIR
+    frozen_dir_stat = session_dir.stat()
+    original_stat = Path.stat
+
+    def stat_with_stalled_directory_mtime(path, *args, **kwargs):
+        if path == session_dir:
+            return frozen_dir_stat
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stat_with_stalled_directory_mtime)
+
+    second = _make_session("snapshot_second", "Second")
+    second.save()
+
+    assert models._persisted_session_ids_snapshot() == frozenset(
+        {first.session_id, second.session_id}
+    )
+
+
 def test_prune_session_from_index_removes_requested_row_only():
     index_file = models.SESSION_INDEX_FILE
     s_a = _make_session("sess_a", "A", updated_at=100)

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -159,6 +159,95 @@ def test_save_invalidates_persisted_id_snapshot_when_directory_mtime_stalls(monk
     )
 
 
+def test_concurrent_snapshot_rebuild_cannot_restore_invalidated_ids(monkeypatch):
+    """A rebuild that began before save invalidation must not publish stale IDs after it."""
+    first = _make_session("snapshot_first", "First")
+    first.save(skip_index=True)
+    assert models._persisted_session_ids_snapshot() == frozenset({first.session_id})
+
+    session_dir = models.SESSION_DIR
+    frozen_dir_stat = session_dir.stat()
+    original_stat = Path.stat
+    original_glob = Path.glob
+    original_safe_replace = models._safe_replace
+    original_invalidate = models._invalidate_persisted_session_ids_snapshot
+
+    enumeration_finished = threading.Event()
+    release_reader = threading.Event()
+    second_published = threading.Event()
+    invalidation_started = threading.Event()
+    invalidation_finished = threading.Event()
+    reader_snapshots = []
+    errors = []
+
+    def stat_with_stalled_directory_mtime(path, *args, **kwargs):
+        if path == session_dir:
+            return frozen_dir_stat
+        return original_stat(path, *args, **kwargs)
+
+    def glob_with_stalled_reader(path, pattern):
+        paths = list(original_glob(path, pattern))
+        if path == session_dir and threading.current_thread().name == "persisted-id-reader":
+            enumeration_finished.set()
+            if not release_reader.wait(timeout=5):
+                raise TimeoutError("snapshot reader was not released")
+        return paths
+
+    second = _make_session("snapshot_second", "Second")
+
+    def safe_replace_with_publication_signal(src, dst):
+        original_safe_replace(src, dst)
+        if dst == second.path:
+            second_published.set()
+
+    def invalidate_with_signals():
+        invalidation_started.set()
+        original_invalidate()
+        invalidation_finished.set()
+
+    monkeypatch.setattr(Path, "stat", stat_with_stalled_directory_mtime)
+    monkeypatch.setattr(Path, "glob", glob_with_stalled_reader)
+    monkeypatch.setattr(models, "_safe_replace", safe_replace_with_publication_signal)
+    monkeypatch.setattr(models, "_invalidate_persisted_session_ids_snapshot", invalidate_with_signals)
+    models._PERSISTED_SESSION_IDS_CACHE = (None, None, frozenset())
+
+    def rebuild_snapshot():
+        try:
+            reader_snapshots.append(models._persisted_session_ids_snapshot())
+        except Exception as exc:
+            errors.append(exc)
+
+    def save_second_session():
+        try:
+            second.save(skip_index=True)
+        except Exception as exc:
+            errors.append(exc)
+
+    reader = threading.Thread(target=rebuild_snapshot, name="persisted-id-reader")
+    saver = threading.Thread(target=save_second_session, name="persisted-id-saver")
+    reader.start()
+    assert enumeration_finished.wait(timeout=5), "snapshot reader did not enumerate the old set"
+
+    saver.start()
+    assert second_published.wait(timeout=5), "second sidecar was not published"
+    assert invalidation_started.wait(timeout=5), "save did not attempt cache invalidation"
+    # Without serialization invalidation completes while the stale reader is paused.
+    # With the cache lock it remains blocked until that reader publishes and exits.
+    invalidation_finished.wait(timeout=1)
+    release_reader.set()
+
+    reader.join(timeout=5)
+    saver.join(timeout=5)
+
+    assert not reader.is_alive(), "snapshot reader deadlocked"
+    assert not saver.is_alive(), "session saver deadlocked"
+    assert not errors, f"concurrent snapshot/save errors: {errors}"
+    assert reader_snapshots == [frozenset({first.session_id})]
+    assert models._persisted_session_ids_snapshot() == frozenset(
+        {first.session_id, second.session_id}
+    )
+
+
 def test_prune_session_from_index_removes_requested_row_only():
     index_file = models.SESSION_INDEX_FILE
     s_a = _make_session("sess_a", "A", updated_at=100)

--- a/tests/test_session_switch_workspace_metadata.py
+++ b/tests/test_session_switch_workspace_metadata.py
@@ -1,0 +1,219 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import api.routes as routes
+
+
+def _capture(monkeypatch):
+    captured = {}
+
+    def fake_j(_handler, data, status=200, **_kwargs):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    def fake_bad(_handler, message, status=400):
+        captured["data"] = {"error": message}
+        captured["status"] = status
+        return captured["data"]
+
+    monkeypatch.setattr(routes, "j", fake_j)
+    monkeypatch.setattr(routes, "bad", fake_bad)
+    return captured
+
+
+def test_list_endpoint_uses_profile_safe_metadata_loader(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = SimpleNamespace(session_id="switch-list", workspace=str(workspace), profile="default")
+    calls = []
+
+    def metadata_loader(sid):
+        calls.append(sid)
+        return session
+
+    monkeypatch.setattr(routes, "get_session_for_file_ops", metadata_loader)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("/api/list must not call the full session loader")
+        ),
+    )
+    monkeypatch.setattr(
+        routes,
+        "list_dir",
+        lambda root, rel: [
+            {"name": "notes.txt", "path": "notes.txt", "type": "file", "size": 7}
+        ],
+    )
+    monkeypatch.setattr(routes, "dir_signature", lambda root, rel, entries: "synthetic-signature")
+    captured = _capture(monkeypatch)
+
+    routes._handle_list_dir(
+        SimpleNamespace(),
+        urlparse("/api/list?session_id=switch-list&path=."),
+    )
+
+    assert calls == ["switch-list"]
+    assert captured == {
+        "status": 200,
+        "data": {
+            "entries": [
+                {"name": "notes.txt", "path": "notes.txt", "type": "file", "size": 7}
+            ],
+            "signature": "synthetic-signature",
+            "path": ".",
+        },
+    }
+
+
+def test_git_info_endpoint_uses_profile_safe_metadata_loader(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session = SimpleNamespace(session_id="switch-git", workspace=str(workspace), profile="default")
+    calls = []
+
+    def metadata_loader(sid):
+        calls.append(sid)
+        return session
+
+    monkeypatch.setattr(routes, "get_session_for_file_ops", metadata_loader)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("/api/git-info must not call the full session loader")
+        ),
+    )
+    captured = _capture(monkeypatch)
+    with patch(
+        "api.workspace_git.git_status",
+        return_value={
+            "is_git": True,
+            "branch": "fix/synthetic",
+            "totals": {"changed": 3, "staged": 1, "unstaged": 1, "untracked": 1},
+            "ahead": 2,
+            "behind": 0,
+        },
+    ):
+        routes.handle_get(
+            SimpleNamespace(_safe_webui_print=lambda _text: None),
+            urlparse("/api/git-info?session_id=switch-git"),
+        )
+
+    assert calls == ["switch-git"]
+    assert captured == {
+        "status": 200,
+        "data": {
+            "git": {
+                "branch": "fix/synthetic",
+                "dirty": 3,
+                "modified": 2,
+                "untracked": 1,
+                "ahead": 2,
+                "behind": 0,
+                "is_git": True,
+            }
+        },
+    }
+
+
+def test_workspace_only_endpoints_keep_foreign_sessions_hidden(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "get_session_for_file_ops",
+        lambda _sid: (_ for _ in ()).throw(KeyError("foreign")),
+    )
+    monkeypatch.setattr(routes, "get_cli_sessions", lambda: [])
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("foreign profile must not reach the full loader")
+        ),
+    )
+
+    list_capture = _capture(monkeypatch)
+    routes._handle_list_dir(
+        SimpleNamespace(),
+        urlparse("/api/list?session_id=foreign&path=."),
+    )
+    assert list_capture == {"status": 404, "data": {"error": "Session not found"}}
+
+    git_capture = _capture(monkeypatch)
+    routes.handle_get(
+        SimpleNamespace(_safe_webui_print=lambda _text: None),
+        urlparse("/api/git-info?session_id=foreign"),
+    )
+    assert git_capture == {"status": 404, "data": {"error": "Session not found"}}
+
+
+def test_session_status_reuses_metadata_without_full_load(monkeypatch):
+    session = SimpleNamespace(
+        session_id="switch-status",
+        title="Synthetic status",
+        model="test/model",
+        profile="default",
+        workspace="/synthetic/workspace",
+        personality=None,
+        messages=[],
+        _metadata_message_count=42,
+        created_at=1.0,
+        updated_at=2.0,
+        active_stream_id=None,
+        input_tokens=3,
+        output_tokens=4,
+        estimated_cost=0.25,
+    )
+    route_loads = []
+
+    def route_metadata_loader(sid, metadata_only=False):
+        route_loads.append((sid, metadata_only))
+        assert metadata_only is True
+        return session
+
+    monkeypatch.setattr(routes, "get_session", route_metadata_loader)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(routes, "_clear_stale_stream_state", lambda _session: False)
+    monkeypatch.setattr(
+        "api.session_ops.get_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("/api/session/status must not re-enter the full loader")
+        ),
+    )
+    monkeypatch.setattr(
+        "api.profiles.get_hermes_home_for_profile",
+        lambda _profile: "/synthetic/hermes-home",
+    )
+    captured = _capture(monkeypatch)
+
+    routes.handle_get(
+        SimpleNamespace(_safe_webui_print=lambda _text: None),
+        urlparse("/api/session/status?session_id=switch-status"),
+    )
+
+    assert route_loads == [("switch-status", True)]
+    assert captured["status"] == 200
+    assert captured["data"] == {
+        "session_id": "switch-status",
+        "title": "Synthetic status",
+        "model": "test/model",
+        "profile": "default",
+        "hermes_home": "/synthetic/hermes-home",
+        "workspace": "/synthetic/workspace",
+        "personality": None,
+        "message_count": 42,
+        "created_at": 1.0,
+        "updated_at": 2.0,
+        "agent_running": False,
+        "active_stream_id": None,
+        "input_tokens": 3,
+        "output_tokens": 4,
+        "total_tokens": 7,
+        "estimated_cost": 0.25,
+    }

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -16,6 +16,9 @@ def isolated_session_store(tmp_path, monkeypatch):
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    # Most storage tests exercise the cache format with compact fixtures. Source
+    # threshold behavior is covered explicitly below with the production limit.
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 0)
     models.SESSIONS.clear()
     yield session_dir
     models.SESSIONS.clear()
@@ -123,6 +126,41 @@ def test_save_is_fail_open_when_tail_cache_write_fails(isolated_session_store, m
     session.save(skip_index=True)
 
     assert json.loads(session.path.read_bytes())["messages"] == session.messages
+
+
+def test_save_publishes_cache_only_after_source_reaches_threshold(
+    isolated_session_store,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        models,
+        "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES",
+        1 * 1024 * 1024,
+    )
+    session = Session(
+        session_id="tail_source_threshold",
+        messages=_messages(4),
+    )
+    cache_path = models.session_tail_cache_path(session.session_id)
+
+    session.save(skip_index=True)
+
+    assert session.path.exists()
+    assert session.path.stat().st_size < models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    assert not cache_path.exists()
+
+    session.messages.append(
+        {
+            "role": "assistant",
+            "content": "x" * (models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES + 1024),
+            "timestamp": 99.0,
+        }
+    )
+    session.save(skip_index=True)
+
+    assert session.path.stat().st_size >= models._SESSION_TAIL_CACHE_MIN_SOURCE_BYTES
+    assert cache_path.exists()
+    assert models.read_session_tail_cache(session.session_id) is not None
 
 
 def test_stable_full_load_opportunistically_builds_but_metadata_only_never_builds(

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -258,6 +258,21 @@ def test_opportunistic_full_load_does_not_write_foreign_profile_cache(
     assert not cache_path.exists()
 
 
+def test_source_size_gate_skips_stat_when_full_session_is_cached(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(session_id="tail_cached_full", messages=_messages(4))
+    models.SESSIONS[session.session_id] = session
+
+    def unexpected_stat(_path):
+        raise AssertionError("warm full-session path must not stat the sidecar")
+
+    monkeypatch.setattr(models, "_sidecar_stat_signature", unexpected_stat)
+
+    assert models.session_tail_cache_source_is_large_enough(session.session_id) is False
+
+
 def test_delete_tail_cache_is_best_effort_and_path_safe(isolated_session_store):
     session = Session(session_id="tail_delete", messages=_messages(4))
     session.save(skip_index=True)

--- a/tests/test_session_tail_cache.py
+++ b/tests/test_session_tail_cache.py
@@ -1,0 +1,287 @@
+import json
+import os
+import stat
+import time
+from pathlib import Path
+
+import pytest
+
+import api.models as models
+from api.models import Session
+
+
+@pytest.fixture
+def isolated_session_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+
+
+def _messages(count):
+    return [
+        {
+            "role": "user" if idx % 2 == 0 else "assistant",
+            "content": {"raw": idx, "parts": [idx, {"nested": True}]},
+            "timestamp": float(idx + 1),
+            "custom": ["preserve", idx],
+        }
+        for idx in range(count)
+    ]
+
+
+def test_save_writes_atomic_v1_raw_tail_schema_and_permissions(isolated_session_store):
+    messages = _messages(305)
+    messages[1] = {
+        "role": "tool",
+        "content": json.dumps({"todos": [{"content": "old but current", "status": "pending"}]}),
+        "timestamp": 2.0,
+        "custom": "todo-raw-shape",
+    }
+    tool_calls = [
+        {"name": "before-tail", "assistant_msg_idx": 3, "custom": {"raw": True}},
+        {"name": "inside-tail", "assistant_msg_idx": 303, "custom": [1, 2]},
+    ]
+    session = Session(
+        session_id="tail_schema",
+        profile="default",
+        messages=messages,
+        tool_calls=tool_calls,
+    )
+
+    session.save(skip_index=True)
+
+    cache_path = models.session_tail_cache_path(session.session_id)
+    assert cache_path == isolated_session_store / "_tail_cache" / "v1" / "tail_schema.json"
+    payload = json.loads(cache_path.read_bytes())
+    assert payload["format"] == "hermes.session-tail-cache"
+    assert payload["version"] == 1
+    assert payload["session_id"] == session.session_id
+    assert payload["tail_limit"] == 300
+    assert payload["source_message_count"] == 305
+    assert payload["source_user_message_count"] == sum(m.get("role") == "user" for m in messages)
+    assert payload["source_last_message_at"] == 305.0
+    assert payload["message_offset"] == 5
+    assert payload["messages"] == messages[-300:]
+    assert payload["tool_calls"] == [tool_calls[1]]
+    assert payload["all_tool_calls_positionable"] is True
+    assert payload["todo_state"]["todos"] == [
+        {"content": "old but current", "status": "pending"}
+    ]
+    assert payload["anchor_scene_index"] == {}
+    assert isinstance(payload["created_at"], float)
+    signature = payload["source_signature"]
+    assert Path(signature["path"]).is_absolute()
+    assert signature == models._tail_cache_signature_dict(
+        models._sidecar_stat_signature(session.path)
+    )
+    if os.name != "nt":
+        assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_reader_returns_validated_snapshot_without_mutating_sidecar(isolated_session_store):
+    session = Session(
+        session_id="tail_read",
+        profile="default",
+        messages=_messages(4),
+    )
+    session.save(skip_index=True)
+    sidecar_before = session.path.read_bytes()
+
+    snapshot = models.read_session_tail_cache(session.session_id)
+
+    assert snapshot is not None
+    assert snapshot["messages"] == session.messages
+    assert snapshot["message_offset"] == 0
+    assert session.path.read_bytes() == sidecar_before
+
+
+def test_reader_accepts_finite_zero_timestamp(isolated_session_store):
+    session = Session(
+        session_id="tail_zero_timestamp",
+        messages=[{"role": "user", "content": "epoch", "timestamp": 0.0}],
+    )
+    session.save(skip_index=True)
+
+    snapshot = models.read_session_tail_cache(session.session_id)
+
+    assert snapshot is not None
+    assert snapshot["messages"][0]["timestamp"] == 0.0
+
+
+def test_save_is_fail_open_when_tail_cache_write_fails(isolated_session_store, monkeypatch):
+    session = Session(session_id="tail_fail_open", messages=_messages(2))
+
+    def fail_cache(*args, **kwargs):
+        raise OSError("cache disk unavailable")
+
+    monkeypatch.setattr(models, "_write_session_tail_cache", fail_cache)
+
+    session.save(skip_index=True)
+
+    assert json.loads(session.path.read_bytes())["messages"] == session.messages
+
+
+def test_stable_full_load_opportunistically_builds_but_metadata_only_never_builds(
+    isolated_session_store,
+):
+    session = Session(
+        session_id="tail_load_build",
+        profile="default",
+        messages=_messages(3),
+    )
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    cache_path.unlink()
+
+    metadata = Session.load_metadata_only(session.session_id)
+    assert metadata is not None
+    assert getattr(metadata, "_loaded_metadata_only", False) is True
+    assert not cache_path.exists()
+
+    loaded = Session.load(session.session_id)
+    assert loaded is not None
+    assert loaded.messages == session.messages
+    assert cache_path.exists()
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(version=999),
+        lambda payload: payload.update(message_offset=999),
+        lambda payload: payload.update(all_tool_calls_positionable=False),
+        lambda payload: payload.update(anchor_scene_index={"scene": 1.0}),
+        lambda payload: payload["messages"][-1].pop("timestamp"),
+    ],
+)
+def test_reader_rejects_incompatible_or_incomplete_payloads(
+    isolated_session_store,
+    mutate,
+):
+    session = Session(session_id="tail_invalid", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    payload = json.loads(cache_path.read_bytes())
+    mutate(payload)
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_reader_rejects_stale_and_oversize_cache(isolated_session_store):
+    session = Session(session_id="tail_stale", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+
+    session.path.write_text(session.path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    assert models.read_session_tail_cache(session.session_id) is None
+
+    cache_path.write_bytes(b"x" * (models._SESSION_TAIL_CACHE_MAX_BYTES + 1))
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_reader_restats_sidecar_and_rejects_toctou(isolated_session_store, monkeypatch):
+    session = Session(session_id="tail_toctou_read", messages=_messages(4))
+    session.save(skip_index=True)
+    original = models._sidecar_stat_signature(session.path)
+    assert original is not None
+    changed = (original[0], original[1] + 1, original[2], original[3] + 1)
+    calls = 0
+
+    def changing_signature(_path):
+        nonlocal calls
+        calls += 1
+        return original if calls == 1 else changed
+
+    monkeypatch.setattr(models, "_sidecar_stat_signature", changing_signature)
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_writer_does_not_publish_when_sidecar_changes_before_replace(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(session_id="tail_toctou_write", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    cache_path.unlink()
+    expected = models._sidecar_stat_signature(session.path)
+    assert expected is not None
+    changed = (expected[0], expected[1] + 1, expected[2], expected[3] + 1)
+    monkeypatch.setattr(models, "_sidecar_stat_signature", lambda _path: changed)
+
+    assert models._write_session_tail_cache(session, expected_signature=expected) is False
+    assert not cache_path.exists()
+
+
+def test_reader_never_supersedes_full_in_memory_session(isolated_session_store):
+    session = Session(session_id="tail_memory_ahead", messages=_messages(4))
+    session.save(skip_index=True)
+    session.messages.append(
+        {"role": "assistant", "content": "unsaved", "timestamp": 99.0}
+    )
+    models.SESSIONS[session.session_id] = session
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_unpositionable_tool_calls_and_scenes_make_cache_ineligible(isolated_session_store):
+    session = Session(
+        session_id="tail_ineligible",
+        messages=_messages(4),
+        tool_calls=[{"name": "missing-index"}],
+        anchor_activity_scenes={"scene": {"updated_at": 1.0}},
+    )
+    session.save(skip_index=True)
+
+    assert models.read_session_tail_cache(session.session_id) is None
+
+
+def test_opportunistic_full_load_does_not_write_foreign_profile_cache(
+    isolated_session_store,
+    monkeypatch,
+):
+    session = Session(session_id="tail_foreign", profile="foreign", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    cache_path.unlink()
+    monkeypatch.setattr(models, "_session_tail_cache_profile_is_active", lambda _session: False)
+
+    loaded = Session.load(session.session_id)
+
+    assert loaded is not None
+    assert not cache_path.exists()
+
+
+def test_delete_tail_cache_is_best_effort_and_path_safe(isolated_session_store):
+    session = Session(session_id="tail_delete", messages=_messages(4))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    assert cache_path.exists()
+
+    assert models.delete_session_tail_cache(session.session_id) is True
+    assert not cache_path.exists()
+    assert models.delete_session_tail_cache(session.session_id) is True
+    assert models.delete_session_tail_cache("../unsafe") is False
+
+
+def test_stale_cache_tmp_cleanup_and_nested_cache_discovery_isolation(isolated_session_store):
+    session = Session(session_id="tail_discovery", messages=_messages(2))
+    session.save(skip_index=True)
+    cache_path = models.session_tail_cache_path(session.session_id)
+    stale_tmp = cache_path.with_name(f"{cache_path.name}.tmp.1.2")
+    stale_tmp.write_text("stale", encoding="utf-8")
+    old = time.time() - models._STALE_TMP_AGE_SECONDS - 10
+    os.utime(stale_tmp, (old, old))
+
+    models._cleanup_stale_tmp_files()
+
+    assert not stale_tmp.exists()
+    assert [path.name for path in isolated_session_store.glob("*.json")] == [
+        "tail_discovery.json"
+    ]

--- a/tests/test_session_tail_cache_legacy.py
+++ b/tests/test_session_tail_cache_legacy.py
@@ -1,0 +1,138 @@
+import json
+
+import pytest
+
+import api.models as models
+from api.models import Session
+
+
+@pytest.fixture
+def isolated_session_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+
+
+def _messages(count):
+    return [
+        {
+            "role": "user" if idx % 2 == 0 else "assistant",
+            "content": {"raw": idx, "parts": [idx, {"nested": True}]},
+            "timestamp": float(idx + 1),
+            "custom": ["preserve", idx],
+        }
+        for idx in range(count)
+    ]
+
+
+def _write_legacy_sidecar(session_dir, sid, messages, *, indent=None, **overrides):
+    updated_at = float(messages[-1]["timestamp"] if messages else 1.0)
+    payload = {
+        "session_id": sid,
+        "title": "Legacy tail fixture",
+        "workspace": str(session_dir),
+        "model": "test-model",
+        "created_at": 1.0,
+        "updated_at": updated_at,
+        "profile": "default",
+        "active_stream_id": None,
+        "pending_user_message": None,
+        "pending_attachments": [],
+        "pending_started_at": None,
+        "pending_user_source": None,
+        "pre_compression_snapshot": False,
+        "compression_recovery": {},
+        "truncation_watermark": None,
+        "truncation_boundary": None,
+        "parent_session_id": None,
+        "is_cli_session": False,
+        "source_tag": "webui",
+        "raw_source": None,
+        "session_source": "webui",
+        "source_label": None,
+        "read_only": False,
+        "message_count": len(messages),
+        "messages": messages,
+        "tool_calls": [],
+        "anchor_activity_scenes": {},
+    }
+    payload.update(overrides)
+    path = session_dir / f"{sid}.json"
+    path.write_text(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=indent,
+            separators=None if indent else (",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    row = {
+        "session_id": sid,
+        "message_count": len(messages),
+        "user_message_count": sum(message.get("role") == "user" for message in messages),
+        "last_message_at": updated_at,
+        "file_size": path.stat().st_size,
+        "updated_at": updated_at,
+    }
+    (session_dir / "_index.json").write_text(json.dumps([row]), encoding="utf-8")
+    return path, row
+
+
+@pytest.mark.parametrize("indent", [None, 2])
+def test_legacy_locator_builds_valid_tail_without_full_session_load(
+    isolated_session_store,
+    monkeypatch,
+    indent,
+):
+    messages = _messages(305)
+    sid = f"legacy_locator_{indent or 0}"
+    tool_call = {"name": "recent", "assistant_msg_idx": 303}
+    _write_legacy_sidecar(
+        isolated_session_store,
+        sid,
+        messages,
+        indent=indent,
+        tool_calls=[tool_call],
+    )
+    monkeypatch.setattr(
+        Session,
+        "load",
+        classmethod(lambda cls, _sid, **_kwargs: (_ for _ in ()).throw(AssertionError("full load"))),
+    )
+
+    snapshot = models.build_session_tail_cache_from_legacy_sidecar(sid)
+
+    assert snapshot is not None
+    assert snapshot["message_offset"] == 5
+    assert snapshot["messages"] == messages[-300:]
+    assert snapshot["tool_calls"] == [tool_call]
+    assert models.read_session_tail_cache(sid) == snapshot
+
+
+@pytest.mark.parametrize("ambiguity", ["index-count", "todo-before-tail", "scene"])
+def test_legacy_locator_falls_back_on_ambiguous_semantics(
+    isolated_session_store,
+    ambiguity,
+):
+    messages = _messages(305)
+    if ambiguity == "todo-before-tail":
+        messages[0]["content"] = json.dumps({"todos": []})
+    kwargs = {}
+    if ambiguity == "scene":
+        kwargs["anchor_activity_scenes"] = {"scene": {"updated_at": 1.0}}
+    sid = f"legacy_ambiguous_{ambiguity.replace('-', '_')}"
+    _path, row = _write_legacy_sidecar(isolated_session_store, sid, messages, **kwargs)
+    if ambiguity == "index-count":
+        row["message_count"] -= 1
+        (isolated_session_store / "_index.json").write_text(
+            json.dumps([row]),
+            encoding="utf-8",
+        )
+
+    assert models.build_session_tail_cache_from_legacy_sidecar(sid) is None
+    assert not models.session_tail_cache_path(sid).exists()

--- a/tests/test_session_tail_cache_legacy.py
+++ b/tests/test_session_tail_cache_legacy.py
@@ -12,6 +12,7 @@ def isolated_session_store(tmp_path, monkeypatch):
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 0)
     models.SESSIONS.clear()
     yield session_dir
     models.SESSIONS.clear()

--- a/tests/test_session_tail_cache_route.py
+++ b/tests/test_session_tail_cache_route.py
@@ -253,3 +253,25 @@ def test_profile_mismatch_does_not_build_or_parse_tail(isolated_session_store):
     assert captured["status"] == 409
     assert captured["data"]["code"] == "session_profile_mismatch"
     assert not models.session_tail_cache_path(session.session_id).exists()
+
+
+def test_messaging_session_tail_candidate_full_loads_before_merge(isolated_session_store):
+    """P0-C review fix: a messaging-source session with an initial msg_limit
+    request must not be served from the metadata-only tail-candidate stub
+    (whose messages array is empty by design). The route must reload the
+    authoritative full sidecar before the messaging merge/display projection,
+    otherwise the response renders an empty transcript."""
+    session = _saved_large_session("tail_route_messaging")
+    session.session_source = "messaging"
+    session.raw_source = "telegram"
+    session.save()
+    models.SESSIONS.clear()
+
+    with patch("api.routes.get_cli_session_messages", return_value=[]):
+        captured = _invoke(session.session_id)
+
+    payload = captured["data"]["session"]
+    assert captured["status"] == 200
+    assert payload["message_count"] == 400
+    assert payload["messages"] == session.messages[-30:]
+    assert payload["_messages_offset"] == 370

--- a/tests/test_session_tail_cache_route.py
+++ b/tests/test_session_tail_cache_route.py
@@ -1,0 +1,255 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import pytest
+
+import api.models as models
+import api.routes as routes
+from api.models import Session
+
+
+@pytest.fixture
+def isolated_session_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "_active_state_db_path", lambda: tmp_path / "missing-state.db")
+    monkeypatch.setattr(models, "_get_profile_home", lambda _profile: tmp_path / "missing-profile")
+    models.SESSIONS.clear()
+    yield session_dir
+    models.SESSIONS.clear()
+
+
+def _messages(count):
+    return [
+        {
+            "role": "user" if idx % 2 == 0 else "assistant",
+            "content": f"message-{idx}",
+            "timestamp": float(idx + 1),
+        }
+        for idx in range(count)
+    ]
+
+
+def _invoke(
+    sid,
+    *,
+    query_suffix="&messages=1&resolve_model=0&msg_limit=30",
+    prefix_summary=None,
+    state_db_messages=None,
+):
+    captured = {}
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    handler = SimpleNamespace(_safe_webui_print=lambda _text: None)
+    parsed = urlparse(f"/api/session?session_id={sid}{query_suffix}")
+    if prefix_summary is None:
+        prefix_summary = {"count": 0, "null_timestamp_count": 0}
+    if state_db_messages is None:
+        state_db_messages = []
+    with patch("api.routes._clear_stale_stream_state", return_value=False), patch(
+        "api.routes._lookup_cli_session_metadata", return_value={}
+    ), patch(
+        "api.routes.get_state_db_session_messages", return_value=state_db_messages
+    ), patch(
+        "api.routes.get_state_db_session_message_prefix_summary",
+        return_value=prefix_summary,
+    ), patch(
+        "api.routes.redact_session_data", side_effect=lambda raw: raw
+    ), patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(handler, parsed)
+    return captured
+
+
+def _saved_large_session(sid="tail_route"):
+    messages = _messages(400)
+    session = Session(
+        session_id=sid,
+        title="Tail route",
+        model="gpt-test",
+        context_length=1024,
+        messages=messages,
+        tool_calls=[
+            {"name": "old", "assistant_msg_idx": 1},
+            {"name": "tail", "assistant_msg_idx": 399},
+        ],
+    )
+    session.save()
+    return session
+
+
+def test_process_cold_cache_hit_skips_full_session_load(isolated_session_store):
+    session = _saved_large_session()
+    models.SESSIONS.clear()
+
+    with patch.object(
+        Session,
+        "load",
+        side_effect=AssertionError("tail-cache hit must not full-load the sidecar"),
+    ):
+        captured = _invoke(session.session_id)
+
+    assert captured["status"] == 200
+    payload = captured["data"]["session"]
+    assert payload["message_count"] == 400
+    assert payload["user_message_count"] == 200
+    assert payload["_messages_offset"] == 370
+    assert payload["messages"] == session.messages[-30:]
+    assert payload["tool_calls"] == [{"name": "tail", "assistant_msg_idx": 29}]
+
+
+def test_cache_payload_is_equivalent_to_full_fallback(isolated_session_store):
+    session = _saved_large_session("tail_route_parity")
+    session.messages[1] = {
+        "role": "tool",
+        "content": json.dumps({"todos": [{"content": "persist", "status": "pending"}]}),
+        "timestamp": 2.0,
+    }
+    session.save()
+    models.SESSIONS.clear()
+    with patch("api.routes.read_session_tail_cache", return_value=None), patch(
+        "api.routes.build_session_tail_cache_from_legacy_sidecar", return_value=None
+    ):
+        full = _invoke(session.session_id)["data"]["session"]
+
+    models.SESSIONS.clear()
+    cached = _invoke(session.session_id)["data"]["session"]
+
+    assert cached == full
+
+
+def test_cache_merges_recent_state_db_delta_with_absolute_counts(isolated_session_store):
+    session = _saved_large_session("tail_route_delta")
+    delta = [{"role": "assistant", "content": "delta", "timestamp": 401.0}]
+    models.SESSIONS.clear()
+
+    cached = _invoke(
+        session.session_id,
+        state_db_messages=delta,
+    )["data"]["session"]
+
+    models.SESSIONS.clear()
+    with patch("api.routes.read_session_tail_cache", return_value=None), patch(
+        "api.routes.build_session_tail_cache_from_legacy_sidecar", return_value=None
+    ):
+        full = _invoke(
+            session.session_id,
+            state_db_messages=delta,
+        )["data"]["session"]
+
+    assert cached == full
+    assert cached["message_count"] == 401
+    assert cached["user_message_count"] == 200
+    assert cached["_messages_offset"] == 371
+
+
+def test_cache_falls_back_when_state_db_has_older_rows(isolated_session_store):
+    session = _saved_large_session("tail_route_state_prefix")
+    models.SESSIONS.clear()
+    original_load = Session.load
+    calls = []
+
+    def tracked_load(sid, *args, **kwargs):
+        calls.append(sid)
+        return original_load(sid, *args, **kwargs)
+
+    with patch.object(Session, "load", side_effect=tracked_load):
+        captured = _invoke(
+            session.session_id,
+            prefix_summary={"count": 1, "null_timestamp_count": 0},
+        )
+
+    assert captured["status"] == 200
+    assert calls == [session.session_id]
+    assert captured["data"]["session"]["message_count"] == 400
+
+
+def test_msg_before_keeps_full_loader(isolated_session_store):
+    session = _saved_large_session("tail_route_msg_before")
+    models.SESSIONS.clear()
+    original_load = Session.load
+    calls = []
+
+    def tracked_load(sid, *args, **kwargs):
+        calls.append(sid)
+        return original_load(sid, *args, **kwargs)
+
+    with patch.object(Session, "load", side_effect=tracked_load):
+        captured = _invoke(
+            session.session_id,
+            query_suffix="&messages=1&resolve_model=0&msg_limit=30&msg_before=300",
+        )
+
+    assert captured["status"] == 200
+    assert calls == [session.session_id]
+    assert captured["data"]["session"]["_messages_offset"] == 270
+
+
+def test_scene_session_keeps_full_loader(isolated_session_store):
+    session = _saved_large_session("tail_route_scene")
+    session.anchor_activity_scenes = {
+        "anchor": {"updated_at": 1.0, "payload": {"kind": "activity"}}
+    }
+    session.save()
+    models.SESSIONS.clear()
+    original_load = Session.load
+    calls = []
+
+    def tracked_load(sid, *args, **kwargs):
+        calls.append(sid)
+        return original_load(sid, *args, **kwargs)
+
+    with patch.object(Session, "load", side_effect=tracked_load):
+        captured = _invoke(session.session_id)
+
+    assert captured["status"] == 200
+    assert calls == [session.session_id]
+
+
+def test_full_in_memory_session_wins_over_disk_tail_cache(isolated_session_store):
+    session = _saved_large_session("tail_route_memory_ahead")
+    unsaved = {"role": "assistant", "content": "memory-ahead", "timestamp": 401.0}
+    session.messages.append(unsaved)
+    models.SESSIONS[session.session_id] = session
+
+    with patch.object(
+        Session,
+        "load",
+        side_effect=AssertionError("full in-memory session must not reload disk"),
+    ):
+        captured = _invoke(session.session_id)
+
+    payload = captured["data"]["session"]
+    assert captured["status"] == 200
+    assert payload["message_count"] == 401
+    assert payload["messages"][-1] == unsaved
+
+
+def test_profile_mismatch_does_not_build_or_parse_tail(isolated_session_store):
+    session = _saved_large_session("tail_route_foreign")
+    session.profile = "foreign-profile"
+    session.save()
+    models.delete_session_tail_cache(session.session_id)
+    models.SESSIONS.clear()
+
+    with patch(
+        "api.routes.build_session_tail_cache_from_legacy_sidecar",
+        side_effect=AssertionError("foreign profile must not warm tail cache"),
+    ), patch.object(
+        Session,
+        "load",
+        side_effect=AssertionError("foreign profile must not full-load body"),
+    ):
+        captured = _invoke(session.session_id)
+
+    assert captured["status"] == 409
+    assert captured["data"]["code"] == "session_profile_mismatch"
+    assert not models.session_tail_cache_path(session.session_id).exists()

--- a/tests/test_session_tail_cache_route.py
+++ b/tests/test_session_tail_cache_route.py
@@ -19,6 +19,9 @@ def isolated_session_store(tmp_path, monkeypatch):
     monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "_active_state_db_path", lambda: tmp_path / "missing-state.db")
     monkeypatch.setattr(models, "_get_profile_home", lambda _profile: tmp_path / "missing-profile")
+    # Keep compact fixtures focused on route semantics; the production size
+    # threshold has its own explicit regression test below.
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 0)
     models.SESSIONS.clear()
     yield session_dir
     models.SESSIONS.clear()
@@ -104,6 +107,32 @@ def test_process_cold_cache_hit_skips_full_session_load(isolated_session_store):
     assert payload["_messages_offset"] == 370
     assert payload["messages"] == session.messages[-30:]
     assert payload["tool_calls"] == [{"name": "tail", "assistant_msg_idx": 29}]
+
+
+def test_small_sidecar_skips_tail_candidate_setup(isolated_session_store, monkeypatch):
+    session = _saved_large_session("tail_route_below_size_gate")
+    assert session.path.stat().st_size < 1024 * 1024
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 1024 * 1024)
+    models.SESSIONS.clear()
+    original_load = Session.load
+    calls = []
+
+    def tracked_load(sid, *args, **kwargs):
+        calls.append(sid)
+        return original_load(sid, *args, **kwargs)
+
+    with patch.object(Session, "load", side_effect=tracked_load), patch(
+        "api.routes.read_session_tail_cache",
+        side_effect=AssertionError("small sidecar must not read tail cache"),
+    ), patch(
+        "api.routes.build_session_tail_cache_from_legacy_sidecar",
+        side_effect=AssertionError("small sidecar must not build tail cache"),
+    ):
+        captured = _invoke(session.session_id)
+
+    assert captured["status"] == 200
+    assert calls == [session.session_id]
+    assert captured["data"]["session"]["message_count"] == 400
 
 
 def test_cache_payload_is_equivalent_to_full_fallback(isolated_session_store):

--- a/tests/test_session_tail_cache_route.py
+++ b/tests/test_session_tail_cache_route.py
@@ -304,3 +304,134 @@ def test_messaging_session_tail_candidate_full_loads_before_merge(isolated_sessi
     assert payload["message_count"] == 400
     assert payload["messages"] == session.messages[-30:]
     assert payload["_messages_offset"] == 370
+
+
+def _eligibility_snapshot(messages, *, message_offset=1):
+    return {
+        "message_offset": message_offset,
+        "source_message_count": message_offset + len(messages),
+        "messages": messages,
+        "all_cached_timestamps_valid": True,
+        "all_tool_calls_positionable": True,
+        "anchor_scene_index": {},
+    }
+
+
+def test_tail_snapshot_eligibility_uses_canonical_renderable_rows():
+    exact_boundary = [
+        {"role": "user", "content": f"visible-{idx}"}
+        for idx in range(28)
+    ] + [
+        {"role": "assistant", "content": ""},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "matched result"},
+    ]
+    all_visible = [
+        {"role": "user", "content": f"visible-{idx}"}
+        for idx in range(300)
+    ]
+    renderable_underflow = [
+        {"role": "user", "content": f"visible-{idx}"}
+        for idx in range(29)
+    ] + [
+        {
+            "role": "assistant",
+            "content": "",
+            "_partial": True,
+            "reasoning": "cancelled activity",
+        },
+        {"role": "tool", "tool_call_id": "orphan", "content": "hidden result"},
+    ]
+
+    assert routes._session_tail_snapshot_eligible(
+        SimpleNamespace(),
+        _eligibility_snapshot(exact_boundary),
+        30,
+        None,
+    ) is True
+    assert routes._session_tail_snapshot_eligible(
+        SimpleNamespace(),
+        _eligibility_snapshot(all_visible),
+        30,
+        None,
+    ) is True
+    assert routes._session_tail_snapshot_eligible(
+        SimpleNamespace(),
+        _eligibility_snapshot(renderable_underflow),
+        30,
+        None,
+    ) is False
+
+
+def test_tail_snapshot_rejects_limits_above_fast_cohort():
+    messages = [
+        {"role": "user", "content": f"visible-{idx}"}
+        for idx in range(31)
+    ]
+
+    assert routes._session_tail_snapshot_eligible(
+        SimpleNamespace(),
+        _eligibility_snapshot(messages),
+        31,
+        None,
+    ) is False
+
+
+def test_bounded_tail_falls_back_when_raw_cache_underfills_renderable_limit(
+    isolated_session_store,
+    monkeypatch,
+):
+    monkeypatch.setattr(models, "_SESSION_TAIL_CACHE_MIN_SOURCE_BYTES", 1024 * 1024)
+    renderable = [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"synthetic-visible-{index}",
+            "timestamp": float(index + 1),
+        }
+        for index in range(40)
+    ]
+    hidden_tail = [
+        {
+            "role": "tool",
+            "content": "synthetic-hidden-output " * 180,
+            "timestamp": float(index + 41),
+            "tool_call_id": f"orphan-{index}",
+        }
+        for index in range(300)
+    ]
+    session = Session(
+        session_id="tail_route_renderable_underflow",
+        title="Synthetic renderable underflow",
+        model="test/model",
+        messages=renderable + hidden_tail,
+    )
+    session.save(touch_updated_at=False)
+    assert session.path.stat().st_size >= 1024 * 1024
+    assert models.session_tail_cache_path(session.session_id).exists()
+
+    original_load = Session.load
+    full_loads = []
+
+    def tracked_load(sid, *args, **kwargs):
+        full_loads.append(sid)
+        return original_load(sid, *args, **kwargs)
+
+    models.SESSIONS.clear()
+    with patch.object(Session, "load", side_effect=tracked_load):
+        fast = _invoke(session.session_id)["data"]["session"]
+
+    models.SESSIONS.clear()
+    with patch("api.routes.read_session_tail_cache", return_value=None), patch(
+        "api.routes.build_session_tail_cache_from_legacy_sidecar", return_value=None
+    ):
+        authoritative = _invoke(session.session_id)["data"]["session"]
+
+    assert full_loads == [session.session_id]
+    assert fast["messages"] == authoritative["messages"]
+    assert fast["_messages_offset"] == authoritative["_messages_offset"] == 10

--- a/tests/test_state_db_readonly_reads_models.py
+++ b/tests/test_state_db_readonly_reads_models.py
@@ -215,6 +215,107 @@ def test_get_state_db_message_prefix_summary_missing_db_creates_no_sqlite_files(
     assert not Path(f"{db}-shm").exists()
 
 
+def _raise_readonly_preflight_failed():
+    raise OSError("readonly preflight failed")
+
+
+def test_get_state_db_message_prefix_summary_fails_open_on_path_resolution_error(
+    monkeypatch,
+):
+    """D1R2 review blocker: a path-resolution/stat failure must be 'unprovable'
+    (None → caller full-read fallback), never an exception escaping to the
+    route."""
+    monkeypatch.setattr(
+        models, "_active_state_db_path", _raise_readonly_preflight_failed
+    )
+
+    assert models.get_state_db_session_message_prefix_summary("sess-1", 1000.5) is None
+
+
+def test_get_state_db_message_prefix_summary_fails_open_on_profile_home_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        models,
+        "_get_profile_home",
+        lambda _profile: (_ for _ in ()).throw(OSError("profile home unavailable")),
+    )
+
+    assert (
+        models.get_state_db_session_message_prefix_summary(
+            "sess-1", 1000.5, profile="p1"
+        )
+        is None
+    )
+
+
+def test_get_state_db_message_keys_before_timestamp_fails_open_on_path_resolution_error(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        models, "_active_state_db_path", _raise_readonly_preflight_failed
+    )
+
+    assert (
+        models.get_state_db_session_message_keys_before_timestamp("sess-1", 1000.5)
+        is None
+    )
+
+
+def _make_state_db_with_compacted_rows(path):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT,
+            timestamp REAL, tool_calls TEXT, active INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO messages (id, session_id, role, content, timestamp, tool_calls, active) "
+        "VALUES (?,?,?,?,?,?,?)",
+        [
+            (1, "sess-1", "user", "hi", 10.0, None, 1),
+            (2, "sess-1", "assistant", "compacted away", 15.0, None, 0),
+            (3, "sess-1", "assistant", "hello", 20.0, None, None),
+            (4, "other", "user", "other session", 10.0, None, 1),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_get_state_db_message_keys_before_timestamp_excludes_inactive_rows(
+    tmp_path,
+    monkeypatch,
+):
+    """D1R2 review: the definitive key helper must apply the same active
+    predicate as the prefix summary / bounded reader, or a compacted DB
+    materializes more keys than the summary counted and forces a needless
+    conservative fallback."""
+    db = tmp_path / "state.db"
+    _make_state_db_with_compacted_rows(db)
+    _point_models_at(monkeypatch, db)
+
+    summary = models.get_state_db_session_message_prefix_summary("sess-1", 30.0)
+    keys = models.get_state_db_session_message_keys_before_timestamp("sess-1", 30.0)
+
+    assert summary == {"count": 2, "null_timestamp_count": 0}
+    assert summary is not None
+    assert keys is not None
+    assert len(keys) == summary["count"]
+    expected_active_keys = [
+        models._session_message_visible_key(
+            {"role": "user", "content": "hi", "tool_calls": None}
+        ),
+        models._session_message_visible_key(
+            {"role": "assistant", "content": "hello", "tool_calls": None}
+        ),
+    ]
+    assert keys == expected_active_keys
+
+
 def test_get_state_db_session_summary_opens_read_only(tmp_path, monkeypatch):
     db = tmp_path / "state.db"
     _make_state_db(db)

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -838,6 +838,123 @@ def test_limited_state_db_prefix_missing_sidecar_timestamp_preserves_full_fallba
     assert returned_sidecar == sidecar_messages
 
 
+def test_limited_state_db_prefix_helper_fails_open_on_db_path_error(monkeypatch, tmp_path):
+    """D1R2 review blocker regression: a state.db path-resolution/stat failure
+    inside the preflight helpers must surface as the (None, sidecar_messages)
+    full-read fallback, not as an exception escaping the route helper."""
+    import api.models as models
+    import api.routes as routes
+
+    sid = "webui_reconcile_prefix_path_error"
+    sidecar_messages = _large_timestamped_sidecar_messages()
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+
+    def broken_db_path():
+        raise OSError("readonly preflight failed")
+
+    monkeypatch.setattr(models, "_active_state_db_path", broken_db_path)
+
+    floor, returned_sidecar = routes._state_db_since_timestamp_for_limited_display(
+        session,
+        30,
+    )
+
+    assert floor is None
+    assert returned_sidecar == sidecar_messages
+
+
+def _make_state_db_with_active(path: Path, sid: str, rows):
+    """State DB variant with a compaction ``active`` column (0 = compacted)."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, title TEXT, model TEXT, started_at REAL, message_count INTEGER)"
+    )
+    conn.execute(
+        "CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, role TEXT, content TEXT, timestamp REAL, tool_call_id TEXT, tool_calls TEXT, tool_name TEXT, active INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, title, model, started_at, message_count) VALUES (?, ?, ?, ?, ?, ?)",
+        (sid, "webui", "Reconcile", "test-model", 1000.0, len(rows)),
+    )
+    for row in rows:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, tool_call_id, tool_calls, tool_name, active) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                sid,
+                row["role"],
+                row["content"],
+                row.get("timestamp", 1000.0),
+                row.get("tool_call_id"),
+                row.get("tool_calls"),
+                row.get("tool_name"),
+                row.get("active", 1),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_limited_state_db_prefix_compacted_rows_use_active_predicate_end_to_end(
+    monkeypatch,
+    tmp_path,
+):
+    """D1R2 review nonblocking regression: on a compacted DB the definitive key
+    helper must exclude active=0 rows exactly like the prefix summary, so an
+    exact active-row prefix takes the bounded path instead of falling back."""
+    import api.routes as routes
+
+    sid = "webui_reconcile_prefix_compacted_active"
+    sidecar_messages = _large_timestamped_sidecar_messages()
+    state_messages = [dict(message) for message in sidecar_messages]
+    # A compacted row inside the prefix window: invisible to the merge and to
+    # the summary count, so it must be invisible to the key sequence too.
+    state_messages.insert(
+        100,
+        {
+            "role": "assistant",
+            "content": "compacted away",
+            "timestamp": 100.5,
+            "active": 0,
+        },
+    )
+    session = _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    _make_state_db_with_active(tmp_path / "state.db", sid, state_messages)
+    summary_calls = []
+    key_calls = []
+    real_summary_reader = routes.get_state_db_session_message_prefix_summary
+    real_key_reader = routes.get_state_db_session_message_keys_before_timestamp
+
+    def prefix_summary(*args, **kwargs):
+        summary_calls.append((args, kwargs))
+        return real_summary_reader(*args, **kwargs)
+
+    def counted_key_reader(*args, **kwargs):
+        key_calls.append((args, kwargs))
+        return real_key_reader(*args, **kwargs)
+
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_message_prefix_summary",
+        prefix_summary,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_state_db_session_message_keys_before_timestamp",
+        counted_key_reader,
+    )
+
+    floor, returned_sidecar = routes._state_db_since_timestamp_for_limited_display(
+        session,
+        30,
+    )
+
+    assert floor == 200.0
+    assert returned_sidecar == sidecar_messages
+    assert len(summary_calls) == 1
+    assert len(key_calls) == 1
+
+
 def test_msg_limit_session_load_bails_when_older_state_db_row_changes_offsets(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
# perf(api): serve proven-safe bounded session tails

## Stacked PR context

Depends on Layer 2: #6015, and transitively on Layer 1, #6014.

This is Layer 3 of 3. Because all three PRs target `master`, this diff currently contains the seven predecessor commits from #6014 and #6015 followed by this layer's four route commits. Review and merge in order: #6014 → #6015 → #6016. After #6015 lands, update this branch against `master` so this PR contains only the four Layer 3 commits before merge.

Before merging any layer, refresh `master` and recheck integration with #5776. After updating this branch, rerun the affected transcript-parity tests, focused tests, and performance checks.

## Thinking Path

- The large-session fast path is useful only when its displayed transcript is exactly equivalent to the authoritative full-read window.
- Raw tail rows and renderable message rows are different coordinate systems: tools, empty assistants, cancelled activity, lineage, pagination, scene state, and live messaging can make a bounded raw tail insufficient or ambiguous.
- Therefore the route may consume the derived snapshot only for the narrow proven-safe cohort; every uncertainty must fall back to the existing full loader.
- Session-switch workspace/status endpoints need profile-safe metadata, not full transcript materialization or active-session cache pollution.

## What Changed

- Consume validated tail snapshots for initial `/api/session` requests with `messages=1`, `resolve_model=0`, and `msg_limit <= 30` when all safety preconditions hold.
- Preserve canonical display coordinates and `_messages_offset` semantics.
- Fall back for renderable underflow, active/live messaging, pagination outside the cached window, lineage/compression parents, recovery state, scenes, todo ambiguity, foreign profiles, invalid timestamps, cache corruption/staleness, or any state-db proof failure.
- Keep messaging reloads fail-open to authoritative `Session.load()` and never let a cache read supersede a full in-memory session.
- Route `/api/list`, `/api/git-info`, and `/api/session/status` through profile-safe metadata-only session loading.
- Add route equivalence, underflow, mixed-tool-row, exact-boundary, workspace/status, profile, messaging, scene, and fallback regressions.

## Why It Matters

A 10,000-message / 50.9 MB conversation can return its canonical 30-renderable-message window in about 10 ms once cached, without changing the payload. Ordinary small and medium sessions stay on their established path and show no material aggregate regression.

## Contract Routing

- Touched public/runtime surfaces: `/api/session` display-window coordinates, `/api/list`, `/api/git-info`, `/api/session/status`, messaging reloads, and state-db prefix reconciliation.
- Touched state layers: derived tail snapshot reads, authoritative JSON sidecars, state.db message-prefix proofs, and in-memory session cache ownership.
- Core invariant: optimized output must equal the full authoritative display window byte-for-byte; uncertainty, underflow, or stale state takes the authoritative path.
- Profile invariant: metadata-only switching must not materialize foreign/full transcripts or pollute active-profile session caches.
- Contract change: none. Existing canonical `msg_limit`, renderability, lineage, and recovery semantics are preserved.
- Docs: no public API shape or UI flow changes; contract regressions and PR-body routing document the invariant. `CHANGELOG.md` remains untouched.

## Verification

- Independent final-stack verification: `67 passed` in the equivalent focused set.
- Transcript parity:
  - underflow: full/fast SHA-256 `dc1a9a6487f...`, 30 renderable rows, offset 10, identical payload, authoritative fallback.
  - exact boundary: full/fast SHA-256 `20175f5bc19d...`, 31 raw / 30 renderable, offset 290, zero full loads.
  - mixed tool rows: full/fast SHA-256 `f9baef55c415...`, 37 raw / 30 renderable, offset 310, zero full loads.
- Independent 3-cycle large benchmark: migration-first median `142.411 ms` (`<150 ms`); 21 warm samples median `9.347 ms` (`<30 ms`).
- Small/medium controls: API worst median delta `+6.05%`; browser three-attempt median-of-medians worst delta `+2.58%` (both `<10%`).
- Exact-base replay found zero branch-only full-suite failures.
- Final static checks: `git diff --check`, Python compile, and diff-scoped Ruff pass with zero findings on added/modified lines.

## Risks / Follow-ups

- This optimization is intentionally narrow; new session shapes should default to the authoritative path until parity is proven.
- Browser timing is noisy on shared WSL resources, so the evidence preserves all attempts and uses a predeclared median-of-medians readback rather than selecting one favorable sample.
- Integration with #5776: that PR optimizes compression lineage, while this stack fails closed when lineage or compression state is ambiguous. It overlaps this stack in exactly three paths: `api/models.py`, `api/routes.py`, and `tests/test_webui_state_db_reconciliation.py`. Whichever series is refreshed or lands second must reconcile those paths and rerun the transcript-parity and merge-tree checks before merge.
- Do not merge this layer before Layers 1 and 2 land and the ordered branch refresh and verification steps pass.
- No DOM/CSS/interface change; before/after screenshots are not applicable. Browser evidence covers the interaction latency path.

## Release Note

Large conversations now switch to their recent canonical transcript window without repeatedly parsing the full session file, while ambiguous or live states continue to use the authoritative path.

## Model Used

AI-assisted implementation and verification using OpenAI `gpt-5.6-sol` through Hermes Agent. Notable tools: Git worktrees/rebase/merge-tree, pytest via the repository runner, isolated API and Playwright browser benchmarks, and transcript SHA-256 parity checks.
