### PR TITLE
fix: keep mobile model picker in visual viewport

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3112,6 +3112,8 @@
     .composer-mobile-config-panel.open{display:flex;}
     .composer-mobile-config-action{box-sizing:border-box;flex:1 1 0;min-height:44px;min-width:0;background:var(--input-bg);border-color:var(--border);}
     .composer-mobile-context-action{flex:1 0 100%;}
+    /* Keep the rich picker in the visual viewport when mobile browser chrome moves. */
+    #composerModelDropdown{position:fixed;bottom:auto;box-sizing:border-box;min-width:0;width:calc(100vw - 16px);max-width:calc(100vw - 16px);z-index:220;}
     /* icon-only composer chips continue below mobile widths */
     .composer-divider{display:none;}
     .composer-status{flex:0 1 auto;min-width:0;max-width:96px;font-size:10px;text-align:right;}
@@ -3241,6 +3243,10 @@
 .ws-dropdown.open{display:block;}
 .ws-dropdown-footer{left:0;right:auto;bottom:calc(100% + 4px);min-width:280px;max-width:min(420px,calc(100vw - 32px));}
 .model-dropdown{display:none;position:absolute;bottom:calc(100% + 4px);left:0;min-width:280px;max-width:min(420px,calc(100vw - 32px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:200;overflow:hidden;max-height:min(70vh,640px);overflow-y:auto;}
+/* Re-assert the mobile picker after the base dropdown rule below the phone media block. */
+@media (max-width:640px){
+ #composerModelDropdown{position:fixed;bottom:auto;box-sizing:border-box;min-width:0;width:calc(100vw - 16px);max-width:calc(100vw - 16px);z-index:220;}
+}
 .model-dropdown.open{display:block;}
 .model-scope-note{position:sticky;top:0;z-index:2;padding:9px 14px;border-bottom:1px solid var(--border);color:var(--text);font-size:11px;font-weight:650;line-height:1.4;background:color-mix(in srgb,var(--surface) 82%,var(--accent-bg));box-shadow:0 1px 0 rgba(0,0,0,.12);}
 .model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;}.model-group.collapsible{cursor:pointer;user-select:none}.model-group.collapsible:before{content:'\25b6';display:inline-block;font-size:8px;margin-right:5px;transition:transform .15s ease}.model-group.collapsible.open:before{transform:rotate(90deg)}.model-group-body:empty{display:none}

--- a/static/ui.js
+++ b/static/ui.js
@@ -3662,12 +3662,52 @@ function _positionModelDropdown(){
   const panel=$('composerMobileConfigPanel');
   const anchor=(panel&&panel.classList.contains('open')&&mobileAction)?mobileAction:(chip&&chip.offsetParent?chip:mobileAction);
   if(!anchor) return;
-  const chipRect=anchor.getBoundingClientRect();
+  const anchorRect=anchor.getBoundingClientRect();
+  const isPhone=typeof window.matchMedia==='function'&&window.matchMedia('(max-width:640px)').matches;
+  if(isPhone){
+    const visualViewport=window.visualViewport;
+    const viewportWidth=Math.max(1,Number(visualViewport&&visualViewport.width)||window.innerWidth||1);
+    const viewportHeight=Math.max(1,Number(visualViewport&&visualViewport.height)||window.innerHeight||1);
+    const viewportTop=Math.max(0,Number(visualViewport&&visualViewport.offsetTop)||0);
+    const viewportBottom=viewportTop+viewportHeight;
+    const margin=8;
+    const gap=6;
+    const viewportLeft=Math.max(0,Number(visualViewport&&visualViewport.offsetLeft)||0);
+    const viewportRight=viewportLeft+viewportWidth;
+    const titlebar=document.querySelector('.app-titlebar');
+    const titlebarBottom=titlebar&&typeof titlebar.getBoundingClientRect==='function'
+      ? Number(titlebar.getBoundingClientRect().bottom)||0
+      : 0;
+    const contentTop=Math.max(viewportTop+margin,titlebarBottom+margin);
+    const menuWidth=Math.max(1,viewportWidth-margin*2);
+    const left=Math.max(viewportLeft+margin,Math.min(anchorRect.left,viewportRight-menuWidth-margin));
+    dd.style.left=`${left}px`;
+    dd.style.width=`${menuWidth}px`;
+    dd.style.maxWidth=`${menuWidth}px`;
+    dd.style.bottom='auto';
+    const menuHeight=Math.max(dd.scrollHeight,dd.offsetHeight);
+    const aboveSpace=Math.max(0,anchorRect.top-contentTop-gap-margin);
+    const belowSpace=Math.max(0,viewportBottom-anchorRect.bottom-gap-margin);
+    const openAbove=aboveSpace>=Math.min(menuHeight,belowSpace)||aboveSpace>=belowSpace;
+    const availableHeight=Math.max(1,openAbove?aboveSpace:belowSpace);
+    dd.style.maxHeight=`${availableHeight}px`;
+    const visibleHeight=Math.min(menuHeight||availableHeight,availableHeight);
+    const top=openAbove
+      ? anchorRect.top-gap-visibleHeight
+      : anchorRect.bottom+gap;
+    dd.style.top=`${Math.max(contentTop,Math.min(top,viewportBottom-margin-visibleHeight))}px`;
+    return;
+  }
   const footerRect=footer.getBoundingClientRect();
-  let left=chipRect.left-footerRect.left;
+  let left=anchorRect.left-footerRect.left;
   const maxLeft=Math.max(0, footer.clientWidth-dd.offsetWidth);
   left=Math.max(0, Math.min(left, maxLeft));
   dd.style.left=`${left}px`;
+  dd.style.top='';
+  dd.style.bottom='';
+  dd.style.width='';
+  dd.style.maxWidth='';
+  dd.style.maxHeight='';
 }
 
 function _readModelOverflowData(group){
@@ -4596,6 +4636,21 @@ window.addEventListener('resize',()=>{
 // Stage classes on .composer-footer:
 //   (none) full labels · .cf-icons icon chips · .cf-icons.cf-burger hamburger.
 let _composerFitScheduled=false;
+let _modelDropdownRepositionScheduled=false;
+function _repositionOpenModelDropdown(){
+  const dd=$('composerModelDropdown');
+  if(!(dd&&dd.classList.contains('open'))||_modelDropdownRepositionScheduled) return;
+  _modelDropdownRepositionScheduled=true;
+  requestAnimationFrame(()=>{
+    _modelDropdownRepositionScheduled=false;
+    const openDd=$('composerModelDropdown');
+    if(openDd&&openDd.classList.contains('open')) _positionModelDropdown();
+  });
+}
+if(window.visualViewport){
+  window.visualViewport.addEventListener('resize',_repositionOpenModelDropdown);
+  window.visualViewport.addEventListener('scroll',_repositionOpenModelDropdown);
+}
 let _composerFitResizeObserver=null;
 let _composerFitMutationObserver=null;
 let _composerFitObservedFooter=null;

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1708,3 +1708,29 @@ def test_mobile_enter_does_not_affect_desktop_logic():
     # The else branch (desktop, sends on Enter without Shift) must still be present
     assert "if(!e.shiftKey){e.preventDefault();send();" in boot_js, \
         "Desktop Enter-to-send logic (else branch) must still be present in boot.js"
+
+
+def test_mobile_model_dropdown_uses_visual_viewport_safe_positioning():
+    """The phone picker must stay inside the visual viewport while browser chrome moves."""
+    ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+    position_body = _js_function_body(ui_js, "_positionModelDropdown")
+    assert "visualViewport" in position_body, \
+        "mobile model picker positioning must account for the visual viewport"
+    assert "style.top" in position_body and "style.maxHeight" in position_body, \
+        "mobile model picker positioning must clamp both its top edge and height"
+    assert "viewportBottom" in position_body and "anchorRect.bottom" in position_body, \
+        "mobile model picker must choose an available side of its touch anchor"
+    assert "scrollHeight" in position_body, \
+        "mobile model picker must size from full menu content before clamping"
+
+    mobile_css = _composer_phone_media_block()
+    dropdown = _declarations(_rule_body(mobile_css, "#composerModelDropdown"))
+    assert dropdown.get("position") == "fixed", \
+        "phone model picker must escape composer stacking/overflow geometry"
+    assert dropdown.get("bottom") == "auto", \
+        "phone model picker must use the computed visual-viewport top position"
+
+    base_rule = CSS.find(".model-dropdown{display:none;position:absolute;")
+    mobile_override = CSS.rfind("#composerModelDropdown{position:fixed;")
+    assert base_rule >= 0 and mobile_override > base_rule, \
+        "the mobile fixed override must come after the base dropdown CSS"

--- a/tests/test_mobile_model_picker_behavior.py
+++ b/tests/test_mobile_model_picker_behavior.py
@@ -1,0 +1,219 @@
+"""Behavioral coverage for the mobile composer model picker.
+
+These tests execute the real positioning helper from ``static/ui.js`` under a
+small DOM/viewport harness.  Source-presence assertions alone missed the
+Settings-picker selector regression and the titlebar clipping case in PR #6026.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+CSS_PATH = REPO_ROOT / "static" / "style.css"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const input = JSON.parse(process.argv[3]);
+
+function extractFunction(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1;
+  i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+const dd = {
+  style: Object.assign({}, input.initialStyle || {}),
+  scrollHeight: input.menuHeight || 0,
+  offsetHeight: input.offsetHeight || 0,
+  offsetWidth: input.offsetWidth || 0,
+  classList: {contains: name => name === 'open'},
+};
+const anchor = {
+  offsetParent: {},
+  getBoundingClientRect: () => input.anchor,
+};
+const mobileAction = {
+  getBoundingClientRect: () => input.anchor,
+};
+const footer = {
+  clientWidth: input.footerWidth || 0,
+  getBoundingClientRect: () => input.footer,
+};
+const titlebar = input.titlebarBottom == null
+  ? null
+  : {getBoundingClientRect: () => ({bottom: input.titlebarBottom})};
+
+const rafQueue = [];
+const positionCalls = [];
+global.window = {
+  innerWidth: input.innerWidth || 0,
+  innerHeight: input.innerHeight || 0,
+  visualViewport: input.visualViewport,
+  matchMedia: () => ({matches: Boolean(input.phone)}),
+};
+global.requestAnimationFrame = callback => {
+  rafQueue.push(callback);
+  return rafQueue.length;
+};
+global.document = {
+  querySelector: selector => {
+    if (selector === '.composer-footer') return footer;
+    if (selector === '.app-titlebar') return titlebar;
+    return null;
+  },
+};
+global.$ = id => id === 'composerModelDropdown'
+  ? dd
+  : id === 'composerModelChip'
+    ? anchor
+    : id === 'composerMobileModelAction'
+      ? mobileAction
+      : id === 'composerMobileConfigPanel'
+        ? {classList: {contains: () => false}}
+        : null;
+
+if (input.mode === 'schedule') {
+  global._positionModelDropdown = () => positionCalls.push('position');
+  eval("let _modelDropdownRepositionScheduled=false;" + extractFunction('_repositionOpenModelDropdown'));
+  _repositionOpenModelDropdown();
+  _repositionOpenModelDropdown();
+  const queued = rafQueue.length;
+  if (rafQueue.length) rafQueue.shift()();
+  process.stdout.write(JSON.stringify({queued, calls: positionCalls.length}));
+} else {
+  eval(extractFunction('_positionModelDropdown'));
+  _positionModelDropdown();
+  process.stdout.write(JSON.stringify({style: dd.style}));
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("mobile_model_picker_driver") / "driver.js"
+    path.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(path)
+
+
+def _run(driver_path, case):
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), json.dumps(case)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def test_mobile_positioning_respects_visual_viewport_offset_and_titlebar(driver_path):
+    result = _run(driver_path, {
+        "phone": True,
+        "innerWidth": 360,
+        "innerHeight": 732,
+        "visualViewport": {"width": 360, "height": 300, "offsetLeft": 40, "offsetTop": 20},
+        "titlebarBottom": 72,
+        "anchor": {"left": 30, "top": 250, "bottom": 270},
+        "footer": {"left": 0},
+        "footerWidth": 360,
+        "menuHeight": 220,
+        "offsetHeight": 180,
+    })
+
+    assert result["style"]["left"] == "48px"
+    assert result["style"]["maxHeight"] == "156px"
+    assert result["style"]["top"] == "88px"
+
+
+def test_mobile_positioning_falls_back_without_visual_viewport(driver_path):
+    result = _run(driver_path, {
+        "phone": True,
+        "innerWidth": 375,
+        "innerHeight": 700,
+        "visualViewport": None,
+        "titlebarBottom": 60,
+        "anchor": {"left": 50, "top": 100, "bottom": 130},
+        "footer": {"left": 0},
+        "footerWidth": 375,
+        "menuHeight": 80,
+        "offsetHeight": 80,
+    })
+
+    assert result["style"]["left"] == "8px"
+    assert result["style"]["top"] == "136px"
+    assert result["style"]["maxHeight"] == "556px"
+
+
+def test_desktop_positioning_clears_mobile_inline_geometry(driver_path):
+    result = _run(driver_path, {
+        "phone": False,
+        "innerWidth": 1440,
+        "innerHeight": 900,
+        "visualViewport": None,
+        "anchor": {"left": 50, "top": 100, "bottom": 130},
+        "footer": {"left": 20},
+        "footerWidth": 300,
+        "menuHeight": 80,
+        "offsetHeight": 80,
+        "offsetWidth": 120,
+        "initialStyle": {
+            "top": "136px",
+            "bottom": "auto",
+            "width": "359px",
+            "maxWidth": "359px",
+            "maxHeight": "554px",
+        },
+    })
+
+    assert result["style"] == {
+        "top": "",
+        "bottom": "",
+        "width": "",
+        "maxWidth": "",
+        "maxHeight": "",
+        "left": "30px",
+    }
+
+
+def test_visual_viewport_reposition_events_are_coalesced(driver_path):
+    result = _run(driver_path, {"mode": "schedule"})
+    assert result == {"queued": 1, "calls": 1}
+
+
+def test_mobile_fixed_rule_targets_composer_picker_only():
+    css = CSS_PATH.read_text(encoding="utf-8")
+    assert css.count("#composerModelDropdown{position:fixed;") >= 2
+    assert ".model-dropdown{position:fixed;" not in css
+
+    base = re.search(
+        r"\.model-dropdown\{display:none;position:absolute;",
+        css,
+    )
+    assert base, "the shared model-dropdown base rule must remain absolute"
+    assert "#settingsModelDropdown" not in css.split(base.group(0), 1)[0].split("@media", 1)[-1]
+
+    settings = re.search(r"\.settings-model-dropdown\{(?P<body>[^}]*)\}", css)
+    assert settings, "the Settings picker rule must remain present"
+    assert "position:fixed" not in settings.group("body")


### PR DESCRIPTION
## Summary

- Keep the mobile model picker inside the visible visual viewport.
- Reposition the open picker when mobile browser chrome, the keyboard, or the visual viewport changes.
- Preserve the existing desktop dropdown behavior.
- Add regression coverage for viewport-safe positioning, CSS cascade order, and full menu-height measurement.

## Root cause

On phones, the model dropdown was absolutely positioned relative to the composer. Changes to the visual viewport could move it outside the visible area or let it overlap the mobile composer controls. The mobile override was also declared before the later desktop base rule, so the cascade restored `position: absolute`. Finally, measuring only the current `offsetHeight` before applying the available height could make the menu grow past the position that had just been calculated.

## Validation

- 100 relevant model-picker and mobile-layout tests passed.
- `node --check static/ui.js` passed.
- Verified model switching with Chromium touch emulation at 360×732.
- Verified model switching with a desktop viewport at 1440×900.
