### PR TITLE
fix(worktrees): unlock before remove so WebUI-created worktrees can be reaped

### DIFF
--- a/api/worktrees.py
+++ b/api/worktrees.py
@@ -265,6 +265,18 @@ def remove_worktree_for_session(session, *, force: bool = False) -> dict:
     repo_root = getattr(session, "worktree_repo_root", None)
     if not repo_root:
         raise ValueError("Session missing worktree_repo_root")
+
+    # Unlock the creation-time bookkeeping lock before removing (fail-soft).
+    # The agent locks every worktree it creates (cli._setup_worktree), and git
+    # refuses to remove a locked worktree with a single --force, so without
+    # this every WebUI-created worktree is unremovable.  The dirty/untracked/
+    # unpushed/stream/terminal guards above are the real safety layer, not
+    # git's lock — mirrors the agent's own _cleanup_worktree ordering.
+    try:
+        _run_git(["worktree", "unlock", str(worktree_path)], str(repo_root), timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        pass  # already unlocked / never locked — non-fatal
+
     try:
         remove_args = ["worktree", "remove"]
         if force:

--- a/tests/test_worktree_remove.py
+++ b/tests/test_worktree_remove.py
@@ -78,6 +78,80 @@ def test_remove_clean_worktree_succeeds(tmp_path):
     assert not wt_path.exists()
 
 
+def test_remove_locked_worktree_succeeds_without_force(tmp_path):
+    """Issue #6023: WebUI-created worktrees are locked at creation by the
+    agent (cli._setup_worktree).  Removal must unlock first — otherwise git
+    refuses with \"use 'remove -f -f' to override or unlock first\" and every
+    WebUI-created worktree is unremovable from the UI."""
+    import subprocess
+    from api.models import Session
+
+    main = _make_minimal_git_repo(tmp_path)
+    wt_path = tmp_path / "wt_locked"
+    subprocess.run(
+        ["git", "-C", str(main), "worktree", "add", str(wt_path), "-b", "hermes/testlocked"],
+        check=True, capture_output=True,
+    )
+    # Reproduce the agent's creation-time lock.
+    subprocess.run(
+        ["git", "-C", str(main), "worktree", "lock", "--reason", "hermes pid=12345", str(wt_path)],
+        check=True, capture_output=True,
+    )
+
+    s = Session(
+        session_id="testlocked",
+        title="Locked",
+        workspace=str(wt_path),
+        worktree_path=str(wt_path),
+        worktree_branch="hermes/testlocked",
+        worktree_repo_root=str(main),
+    )
+
+    result = worktrees.remove_worktree_for_session(s, force=False)
+    assert result["ok"] is True
+    assert result["removed_path"] == str(wt_path.resolve())
+    assert not wt_path.exists()
+    listed = subprocess.run(
+        ["git", "-C", str(main), "worktree", "list", "--porcelain"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert str(wt_path.resolve()) not in listed
+
+
+def test_remove_never_locked_worktree_unlock_is_fail_soft(tmp_path):
+    """The pre-remove unlock must be fail-soft: removing a worktree that was
+    never locked still succeeds (unlock exits non-zero, _run_git is
+    check=False, remove proceeds)."""
+    import subprocess
+    from api.models import Session
+
+    main = _make_minimal_git_repo(tmp_path)
+    wt_path = tmp_path / "wt_neverlocked"
+    subprocess.run(
+        ["git", "-C", str(main), "worktree", "add", str(wt_path), "-b", "hermes/testneverlocked"],
+        check=True, capture_output=True,
+    )
+    # Sanity: not locked — `git worktree unlock` on it would fail.
+    probe = subprocess.run(
+        ["git", "-C", str(main), "worktree", "unlock", str(wt_path)],
+        capture_output=True, text=True,
+    )
+    assert probe.returncode != 0
+
+    s = Session(
+        session_id="testneverlocked",
+        title="Never locked",
+        workspace=str(wt_path),
+        worktree_path=str(wt_path),
+        worktree_branch="hermes/testneverlocked",
+        worktree_repo_root=str(main),
+    )
+
+    result = worktrees.remove_worktree_for_session(s, force=False)
+    assert result["ok"] is True
+    assert not wt_path.exists()
+
+
 def test_remove_clean_worktree_does_not_force(tmp_path, monkeypatch):
     from api.models import Session
 
@@ -111,7 +185,9 @@ def test_remove_clean_worktree_does_not_force(tmp_path, monkeypatch):
 
     result = worktrees.remove_worktree_for_session(s, force=False)
     assert result["ok"] is True
-    assert calls[0] == ["worktree", "remove", str(worktree_path.resolve())]
+    # Unlock (fail-soft) runs first, then the non-force remove.
+    assert calls[0] == ["worktree", "unlock", str(worktree_path.resolve())]
+    assert calls[1] == ["worktree", "remove", str(worktree_path.resolve())]
 
 
 def test_remove_dirty_worktree_without_force_is_rejected(tmp_path, monkeypatch):
@@ -234,7 +310,9 @@ def test_remove_force_warns_and_uses_git_force(tmp_path, monkeypatch):
 
     result = worktrees.remove_worktree_for_session(s, force=True)
     assert result["ok"] is True
-    assert calls[0] == ["worktree", "remove", "--force", str(worktree_path.resolve())]
+    # Unlock (fail-soft) runs first, then the forced remove.
+    assert calls[0] == ["worktree", "unlock", str(worktree_path.resolve())]
+    assert calls[1] == ["worktree", "remove", "--force", str(worktree_path.resolve())]
     assert "untracked file" in " ".join(result["warnings"])
     assert "unpushed commit" in " ".join(result["warnings"])
 


### PR DESCRIPTION
## Summary

Implements the unlock-before-remove fix confirmed in #6023: `remove_worktree_for_session` now runs a fail-soft `git worktree unlock` right before the remove, mirroring the agent's own `_cleanup_worktree` ordering.

WebUI-created worktrees are locked at creation on the agent side (`cli._setup_worktree`, reused via `create_worktree_for_workspace` → `_setup_agent_worktree`), and the remove path never unlocked — so git refused every UI-driven removal with `use 'remove -f -f' to override or unlock first`, `force=true` included.

## Approach

Exactly the shape recommended in the issue thread:

- Unlock is inserted after all dirty/untracked/unpushed/stream/terminal guards have passed — those guards remain the real safety layer, not git's lock.
- Fail-soft: `_run_git` is `check=False`, so unlocking a never-locked worktree is a no-op; the `try/except (OSError, TimeoutExpired)` keeps environmental failures non-fatal too.
- Double-`--force` deliberately not used: `force` keeps meaning "override dirty working state", never "blow past a foreign lock" — the `locked_by_stream`/`locked_by_terminal` guards stay meaningful.

## Tests

Real-repo tests (same pattern as the existing fixture-based cases in `tests/test_worktree_remove.py`):

- `test_remove_locked_worktree_succeeds_without_force` — reproduces the agent's creation-time lock (`git worktree lock --reason 'hermes pid=…'`), then asserts a plain `force=False` remove succeeds, the directory is gone, and `git worktree list` no longer lists it.
- `test_remove_never_locked_worktree_unlock_is_fail_soft` — sanity-probes that unlock would exit non-zero, then asserts removal still succeeds.
- Existing mocked call-order assertions updated for the leading unlock call (unlock first, then remove / remove --force).

`./scripts/test.sh tests/test_worktree_remove.py tests/test_issue2057_worktree_status.py tests/test_issue2057_worktree_lifecycle.py` — 24 passed.

The `remove_worktree: true` archive-time cleanup rider from the issue is intentionally left out per the thread — additive, separate change.

Fixes #6023
