### PR TITLE
feat(sessions): honor the agent's worktree config default in /api/session/new

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -7596,7 +7596,11 @@ def _worktree_default_from_config(profile: str | None) -> bool:
             cfg_dict = get_config_for_profile_home(get_hermes_home_for_profile(profile))
         else:
             cfg_dict = get_config_for_profile_home(None)
-        return bool((cfg_dict or {}).get("worktree", False))
+        # Strict boolean: only a real YAML `true` opts in.  Any other shape
+        # ("true", 1, [], {}, null, ...) is malformed for this key and must
+        # fall to the safe no-worktree default rather than truthiness-coerce
+        # into minting worktrees.
+        return (cfg_dict or {}).get("worktree", False) is True
     except Exception:
         # Config resolution must never break session creation.
         logger.warning("failed to read worktree config default", exc_info=True)
@@ -13914,7 +13918,11 @@ def handle_post(handler, parsed) -> bool:
         # worktree (e.g. the boot-time auto-bind) send ``worktree: false``
         # explicitly.
         raw_worktree = body.get("worktree")
-        worktree_explicit = raw_worktree is not None
+        # Presence-based, not truthiness-based: a client that sends the key at
+        # all (even ``worktree: null``) has spoken explicitly and never falls
+        # through to the config default.  ``null`` parses as non-true below,
+        # i.e. an explicit opt-out — only a genuinely ABSENT key inherits.
+        worktree_explicit = "worktree" in body
         if worktree_explicit:
             worktree_requested = (
                 raw_worktree is True

--- a/api/routes.py
+++ b/api/routes.py
@@ -7574,6 +7574,35 @@ def _rescale_threshold_tokens_for_context_window(
     return max(1, int(threshold * new_window / old_window))
 
 
+def _worktree_default_from_config(profile: str | None) -> bool:
+    """Return the agent's config-level ``worktree:`` default for *profile*.
+
+    The agent CLI honors ``worktree: true`` in config.yaml for every session
+    it creates (``use_worktree = worktree or w or CLI_CONFIG.get("worktree",
+    False)``).  /api/session/new consults this only when the request body has
+    no explicit ``worktree`` key, so both entry points to the same repo agree
+    on isolation (#6022).  Explicit body values always win.
+
+    Profile-aware on purpose: the WebUI serves multiple profiles from one
+    process, and a user with ``worktree: true`` in one profile but not another
+    expects per-profile behavior.  ``get_config_for_profile_home`` handles the
+    ambient/common case via the mtime-tracked cache and reads a diverging
+    profile's config.yaml directly off disk (see #3294).
+    """
+    try:
+        if profile:
+            from api.profiles import get_hermes_home_for_profile
+
+            cfg_dict = get_config_for_profile_home(get_hermes_home_for_profile(profile))
+        else:
+            cfg_dict = get_config_for_profile_home(None)
+        return bool((cfg_dict or {}).get("worktree", False))
+    except Exception:
+        # Config resolution must never break session creation.
+        logger.warning("failed to read worktree config default", exc_info=True)
+        return False
+
+
 def _session_model_state_from_request(
     model: str | None,
     requested_provider: str | None,
@@ -13877,10 +13906,22 @@ def handle_post(handler, parsed) -> bool:
         except (TypeError, ValueError) as e:
             return bad(handler, str(e))
         worktree_info = None
-        worktree_requested = (
-            body.get("worktree") is True
-            or str(body.get("worktree")).strip().lower() in {"1", "true", "yes", "on"}
-        )
+        worktree_skipped = None
+        # Three-value worktree model (#6022): an explicit body value always
+        # wins; an ABSENT key falls back to the agent's config-level
+        # ``worktree:`` default so WebUI sessions and CLI sessions agree on
+        # isolation for the same repo.  Clients that must never create a
+        # worktree (e.g. the boot-time auto-bind) send ``worktree: false``
+        # explicitly.
+        raw_worktree = body.get("worktree")
+        worktree_explicit = raw_worktree is not None
+        if worktree_explicit:
+            worktree_requested = (
+                raw_worktree is True
+                or str(raw_worktree).strip().lower() in {"1", "true", "yes", "on"}
+            )
+        else:
+            worktree_requested = _worktree_default_from_config(body.get("profile") or None)
         if worktree_requested:
             try:
                 from api.worktrees import create_worktree_for_workspace
@@ -13890,7 +13931,15 @@ def handle_post(handler, parsed) -> bool:
                 worktree_info = create_worktree_for_workspace(base_workspace)
                 workspace = worktree_info["path"]
             except (TypeError, ValueError) as e:
-                return bad(handler, str(e), status=400)
+                # Explicit requests keep the hard failure.  A config-default
+                # request on a non-git workspace (create_worktree_for_workspace
+                # raises ValueError) degrades to a plain session instead —
+                # otherwise `worktree: true` in config.yaml would 400 every
+                # session in every non-git directory.
+                if worktree_explicit:
+                    return bad(handler, str(e), status=400)
+                worktree_info = None
+                worktree_skipped = str(e)
             except Exception as e:
                 logger.exception("failed to create worktree-backed session")
                 return bad(handler, f"Failed to create worktree: {e}", status=500)
@@ -13973,7 +14022,12 @@ def handle_post(handler, parsed) -> bool:
                 profile=getattr(s, "profile", None),
                 session_id=getattr(s, "session_id", None),
             )
-        return j(handler, {"session": s.compact() | {"messages": s.messages}})
+        payload = {"session": s.compact() | {"messages": s.messages}}
+        if worktree_skipped:
+            # Config-default worktree was skipped (non-git workspace); tell the
+            # client the session is plain so the UI doesn't assume isolation.
+            payload["worktree_skipped"] = worktree_skipped
+        return j(handler, payload)
 
     if parsed.path == "/api/session/compression-recovery/start":
         return _handle_session_compression_recovery_start(handler, body)

--- a/static/boot.js
+++ b/static/boot.js
@@ -303,7 +303,10 @@ async function _maybeBindFreshDefaultWorkspaceSession(prefillIntent=null){
   if(_workspacePanelMode!=='browse') return false;
   if(!S._profileDefaultWorkspace) return false;
   try{
-    await newSession(false, {awaitWorkspaceLoad: true});
+    // worktree:false is explicit and load-bearing — this auto-bind runs on
+    // page load, and a config-level worktree default must never leak a fresh
+    // worktree + branch from simply opening the UI (#6022).
+    await newSession(false, {awaitWorkspaceLoad: true, worktree: false});
     return true;
   }catch(e){
     console.warn('[hermes] failed to bind fresh default workspace session', e);

--- a/static/commands.js
+++ b/static/commands.js
@@ -801,7 +801,9 @@ async function cmdTerminal(){
       const first=(data&&data.workspaces||[])[0];
       S._profileSwitchWorkspace=(data&&data.last)||(first&&first.path)||null;
     }
-    await newSession();
+    // System-minted session (#6022): opening the terminal auto-creates a
+    // session — explicit worktree:false so the config default can't leak.
+    await newSession(false, {worktree: false});
     if(typeof renderSessionList==='function') await renderSessionList();
   }
   if(!S.session||!S.session.workspace){

--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -527,7 +527,9 @@ async function _finishOnboarding(){
   await loadWorkspaceList();
   if(typeof renderSessionList==='function') await renderSessionList();
   if(!S.session && typeof newSession==='function'){
-    await newSession(true);
+    // System-minted session (no deliberate New Chat intent) — like the boot
+    // auto-bind, it must not inherit a config-level worktree default (#6022).
+    await newSession(true, {worktree: false});
     await renderSessionList();
   }
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6303,7 +6303,9 @@ async function promptWorkspacePath(){
     const ws=(typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'';
     if(!ws)return;
     try{
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws})});
+      // System-minted session (#6022): worktree:false is explicit so a config
+      // worktree default can't leak a worktree from a workspace prompt.
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];if(typeof syncTopbar==='function')syncTopbar();if(typeof renderMessages==='function')renderMessages();if(typeof renderSessionList==='function')await renderSessionList();}
     }catch(e){showToast(t('workspace_switch_failed')+e.message);return;}
     if(!S.session)return;
@@ -6339,7 +6341,9 @@ async function switchToWorkspace(path,name){
     const ws=path||(typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'';
     if(!ws){showToast(t('no_workspace'));return;}
     try{
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws})});
+      // System-minted session (#6022): explicit worktree:false — a workspace
+      // switch from a blank page is not deliberate New Chat intent.
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];if(typeof syncTopbar==='function')syncTopbar();if(typeof renderMessages==='function')renderMessages();if(typeof renderSessionList==='function')await renderSessionList();}
     }catch(e){if(typeof setStatus==='function')setStatus(t('switch_failed')+e.message);return;}
     if(!S.session)return;
@@ -7128,7 +7132,7 @@ async function switchToProfile(name) {
       // The current session has messages and belongs to the previous profile.
       // Start a new session for the new profile so nothing gets cross-tagged.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
-      await newSession(false, {awaitWorkspaceLoad: workspaceVisible});
+      await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false});
       if (_switchGen !== _profileSwitchGeneration) return false;
       // Keep topbar chips (workspace/profile) in sync after creating the
       // new profile-scoped session.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1362,7 +1362,11 @@ async function newSession(flash, options={}){
       profile:S.activeProfile||'default',
     };
     if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
-    if(options&&options.worktree) reqBody.worktree=true;
+    // Three-value worktree contract (#6022): explicit true/false is forwarded
+    // verbatim; an ABSENT key lets the server apply the agent's config-level
+    // `worktree:` default. Auto-bind paths pass worktree:false explicitly so a
+    // config default can never mint a worktree (+ branch) on mere page load.
+    if(options&&Object.prototype.hasOwnProperty.call(options,'worktree')) reqBody.worktree=!!options.worktree;
     if(Object.prototype.hasOwnProperty.call(options,'project_id')){
       reqBody.project_id=options.project_id;
     } else if(_activeProject&&_activeProject!==NO_PROJECT_FILTER){

--- a/static/ui.js
+++ b/static/ui.js
@@ -19566,7 +19566,9 @@ async function promptNewFile(targetDir = S.currentDir || '.'){
     const ws=(typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'';
     if(!ws) return;
     try{
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws})});
+      // System-minted session (#6022): explicit worktree:false — creating a
+      // file from a blank page must not inherit the config worktree default.
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];syncTopbar();renderMessages();await renderSessionList();}
     }catch(e){setStatus(t('create_failed')+e.message);return;}
   }
@@ -19597,7 +19599,9 @@ async function promptNewFolder(targetDir = S.currentDir || '.'){
     const ws=(typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'';
     if(!ws) return;
     try{
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws})});
+      // System-minted session (#6022): explicit worktree:false — creating a
+      // folder from a blank page must not inherit the config worktree default.
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];syncTopbar();renderMessages();await renderSessionList();}
     }catch(e){setStatus(t('folder_create_failed')+e.message);return;}
   }

--- a/tests/test_embedded_workspace_terminal.py
+++ b/tests/test_embedded_workspace_terminal.py
@@ -170,7 +170,9 @@ def test_terminal_slash_command_preflights_remote_backend_before_session_create(
     assert "syncTerminalBackendState(data)" in cmd_block
     assert "data&&data.terminal_remote_backend" in cmd_block
     assert "_terminalRemoteBackendUnsupportedMessage" in cmd_block
-    assert cmd_block.index("data&&data.terminal_remote_backend") < cmd_block.index("await newSession()")
+    # #6022: the auto-mint passes explicit worktree:false so the config
+    # default can't leak a worktree from opening the terminal.
+    assert cmd_block.index("data&&data.terminal_remote_backend") < cmd_block.index("await newSession(false, {worktree: false})")
 
 
 def test_terminal_v1_does_not_expose_send_to_chat_action():

--- a/tests/test_issue1955_worktree_ui_static.py
+++ b/tests/test_issue1955_worktree_ui_static.py
@@ -18,7 +18,9 @@ def test_session_new_route_accepts_worktree_flag_and_uses_worktree_info():
 def test_new_session_request_can_include_worktree_flag():
     src = read("static/sessions.js")
     assert "async function newSession(flash, options={})" in src
-    assert "reqBody.worktree=true" in src
+    # Three-value contract (#6022): explicit true/false forwarded verbatim,
+    # absent key omitted so the server applies the config default.
+    assert "reqBody.worktree=!!options.worktree" in src
 
 
 def test_workspace_dropdown_exposes_new_worktree_conversation_action():

--- a/tests/test_issue4877_fresh_blank_boot_workspace_bind.py
+++ b/tests/test_issue4877_fresh_blank_boot_workspace_bind.py
@@ -116,7 +116,10 @@ def test_blank_boot_open_panel_auto_binds_default_workspace_session():
     result = _helper_driver("browse", "/default-workspace")
 
     assert result["bound"] is True
-    assert result["calls"] == [{"arg0": False, "arg1": {"awaitWorkspaceLoad": True}}]
+    # worktree:false is explicit and load-bearing (#6022): the boot auto-bind
+    # must opt out so a config-level worktree default can't mint a worktree
+    # from merely opening the page.
+    assert result["calls"] == [{"arg0": False, "arg1": {"awaitWorkspaceLoad": True, "worktree": False}}]
 
 
 @node_test

--- a/tests/test_issue6022_worktree_config_default.py
+++ b/tests/test_issue6022_worktree_config_default.py
@@ -142,6 +142,27 @@ def test_explicit_false_beats_config_default_true(tmp_path, monkeypatch):
     assert session.get("worktree_path") in (None, "")
 
 
+def test_explicit_null_beats_config_default_true(tmp_path, monkeypatch):
+    """Sending the key at all — even ``worktree: null`` — is an explicit
+    statement and must never fall through to the config default."""
+    repo, worktree = _mk_repo_dirs(tmp_path)
+
+    def _fail(workspace):
+        pytest.fail("worktree must not be created when body sends worktree=null")
+
+    monkeypatch.setattr(worktrees, "create_worktree_for_workspace", _fail)
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(repo), "profile": "default", "worktree": None},
+        config_default=True,
+        workspace_dir=repo,
+    )
+    assert captured["status"] == 200
+    session = captured["payload"]["session"]
+    assert session.get("worktree_path") in (None, "")
+
+
 def test_explicit_true_with_config_default_off_creates_worktree(tmp_path, monkeypatch):
     repo, worktree = _mk_repo_dirs(tmp_path)
     captured = _post_session_new(
@@ -222,6 +243,25 @@ def test_worktree_default_resolves_named_profile_home(monkeypatch, tmp_path):
     monkeypatch.setattr(routes, "get_config_for_profile_home", fake_cfg)
     assert routes._worktree_default_from_config("work") is True
     assert seen["home"] == tmp_path / "work"
+
+
+def test_worktree_default_requires_strict_boolean_true(monkeypatch):
+    """Only a real YAML ``true`` opts in — malformed shapes (quoted strings,
+    ints, lists, dicts, null) must fall to the safe no-worktree default, not
+    truthiness-coerce into minting worktrees."""
+    for malformed in ("true", "yes", 1, [True], {"enabled": True}, None, 0, ""):
+        monkeypatch.setattr(
+            routes,
+            "get_config_for_profile_home",
+            lambda home, _v=malformed: {"worktree": _v},
+        )
+        assert routes._worktree_default_from_config(None) is False, (
+            f"non-boolean config value {malformed!r} must not enable worktrees"
+        )
+    monkeypatch.setattr(
+        routes, "get_config_for_profile_home", lambda home: {"worktree": True}
+    )
+    assert routes._worktree_default_from_config(None) is True
 
 
 def test_worktree_default_is_fail_soft_on_config_errors(monkeypatch):

--- a/tests/test_issue6022_worktree_config_default.py
+++ b/tests/test_issue6022_worktree_config_default.py
@@ -1,0 +1,232 @@
+"""Tests for the config-level worktree default in /api/session/new (Issue #6022).
+
+Three-value contract:
+  - body ``worktree`` ABSENT   -> agent config ``worktree:`` default applies
+  - body ``worktree`` explicit -> honored verbatim (explicit always wins)
+
+Config-default requests degrade to a plain session (+ ``worktree_skipped`` in
+the payload) on non-git workspaces; explicit requests keep the hard 400.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import api.models as models
+import api.routes as routes
+import api.worktrees as worktrees
+from api.models import SESSIONS
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sessions(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path.parent.resolve()))
+    SESSIONS.clear()
+    yield session_dir
+    SESSIONS.clear()
+
+
+def _post_session_new(tmp_path, monkeypatch, body, *, config_default, workspace_dir=None, fake_worktree=None):
+    """Drive POST /api/session/new with a stubbed transport and worktree factory."""
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda handler: body)
+    monkeypatch.setattr(
+        routes, "_worktree_default_from_config", lambda profile: config_default
+    )
+    if workspace_dir is not None:
+        monkeypatch.setattr(
+            routes, "resolve_trusted_workspace", lambda raw: workspace_dir
+        )
+    if fake_worktree is not None:
+        monkeypatch.setattr(
+            worktrees, "create_worktree_for_workspace", lambda workspace: fake_worktree
+        )
+    captured = {}
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda handler, payload, status=200, extra_headers=None: captured.update(
+            payload=payload, status=status
+        )
+        or True,
+    )
+    import api.helpers as helpers
+
+    monkeypatch.setattr(
+        helpers,
+        "j",
+        lambda handler, payload, status=200, extra_headers=None: captured.update(
+            payload=payload, status=status
+        )
+        or True,
+    )
+    assert routes.handle_post(object(), SimpleNamespace(path="/api/session/new")) is True
+    return captured
+
+
+def _fake_worktree_info(repo, worktree):
+    return {
+        "path": str(worktree),
+        "branch": "hermes/hermes-6022",
+        "repo_root": str(repo),
+        "created_at": 321.0,
+    }
+
+
+def _mk_repo_dirs(tmp_path):
+    repo = tmp_path / "repo"
+    worktree = repo / ".worktrees" / "hermes-6022"
+    repo.mkdir()
+    worktree.mkdir(parents=True)
+    return repo, worktree
+
+
+# ── Route matrix: absent key ─────────────────────────────────────────────────
+
+
+def test_absent_key_with_config_default_off_creates_plain_session(tmp_path, monkeypatch):
+    repo, _ = _mk_repo_dirs(tmp_path)
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(repo), "profile": "default"},
+        config_default=False,
+        workspace_dir=repo,
+    )
+    assert captured["status"] == 200
+    session = captured["payload"]["session"]
+    assert session.get("worktree_path") in (None, "")
+    assert "worktree_skipped" not in captured["payload"]
+
+
+def test_absent_key_with_config_default_on_creates_worktree_session(tmp_path, monkeypatch):
+    repo, worktree = _mk_repo_dirs(tmp_path)
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(repo), "profile": "default"},
+        config_default=True,
+        workspace_dir=repo,
+        fake_worktree=_fake_worktree_info(repo, worktree),
+    )
+    assert captured["status"] == 200
+    session = captured["payload"]["session"]
+    assert session["workspace"] == str(worktree.resolve())
+    assert session["worktree_path"] == str(worktree.resolve())
+    assert session["worktree_branch"] == "hermes/hermes-6022"
+
+
+# ── Route matrix: explicit wins ──────────────────────────────────────────────
+
+
+def test_explicit_false_beats_config_default_true(tmp_path, monkeypatch):
+    repo, worktree = _mk_repo_dirs(tmp_path)
+
+    def _fail(workspace):
+        pytest.fail("worktree must not be created when body says worktree=false")
+
+    monkeypatch.setattr(worktrees, "create_worktree_for_workspace", _fail)
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(repo), "profile": "default", "worktree": False},
+        config_default=True,
+        workspace_dir=repo,
+    )
+    assert captured["status"] == 200
+    session = captured["payload"]["session"]
+    assert session.get("worktree_path") in (None, "")
+
+
+def test_explicit_true_with_config_default_off_creates_worktree(tmp_path, monkeypatch):
+    repo, worktree = _mk_repo_dirs(tmp_path)
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(repo), "profile": "default", "worktree": True},
+        config_default=False,
+        workspace_dir=repo,
+        fake_worktree=_fake_worktree_info(repo, worktree),
+    )
+    assert captured["status"] == 200
+    session = captured["payload"]["session"]
+    assert session["worktree_path"] == str(worktree.resolve())
+
+
+# ── Route matrix: non-git workspace ──────────────────────────────────────────
+
+
+def test_config_default_on_non_git_workspace_falls_back_to_plain_session(tmp_path, monkeypatch):
+    non_git = tmp_path / "plain"
+    non_git.mkdir()
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(non_git), "profile": "default"},
+        config_default=True,
+        workspace_dir=non_git,
+        # real create_worktree_for_workspace -> find_git_repo_root raises ValueError
+    )
+    assert captured["status"] == 200
+    session = captured["payload"]["session"]
+    assert session.get("worktree_path") in (None, "")
+    assert "not inside a git repository" in captured["payload"]["worktree_skipped"]
+
+
+def test_explicit_true_on_non_git_workspace_still_hard_400(tmp_path, monkeypatch):
+    non_git = tmp_path / "plain"
+    non_git.mkdir()
+    captured = _post_session_new(
+        tmp_path,
+        monkeypatch,
+        {"workspace": str(non_git), "profile": "default", "worktree": True},
+        config_default=False,
+        workspace_dir=non_git,
+    )
+    assert captured["status"] == 400
+    assert "not inside a git repository" in captured["payload"].get("error", "")
+
+
+# ── Config helper ────────────────────────────────────────────────────────────
+
+
+def test_worktree_default_reads_ambient_config_when_no_profile(monkeypatch):
+    monkeypatch.setattr(
+        routes, "get_config_for_profile_home", lambda home: {"worktree": True}
+    )
+    assert routes._worktree_default_from_config(None) is True
+    monkeypatch.setattr(
+        routes, "get_config_for_profile_home", lambda home: {"worktree": False}
+    )
+    assert routes._worktree_default_from_config(None) is False
+    monkeypatch.setattr(routes, "get_config_for_profile_home", lambda home: {})
+    assert routes._worktree_default_from_config(None) is False
+
+
+def test_worktree_default_resolves_named_profile_home(monkeypatch, tmp_path):
+    import api.profiles as profiles
+
+    seen = {}
+    monkeypatch.setattr(
+        profiles, "get_hermes_home_for_profile", lambda name: tmp_path / name
+    )
+
+    def fake_cfg(home):
+        seen["home"] = home
+        return {"worktree": True}
+
+    monkeypatch.setattr(routes, "get_config_for_profile_home", fake_cfg)
+    assert routes._worktree_default_from_config("work") is True
+    assert seen["home"] == tmp_path / "work"
+
+
+def test_worktree_default_is_fail_soft_on_config_errors(monkeypatch):
+    def boom(home):
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(routes, "get_config_for_profile_home", boom)
+    assert routes._worktree_default_from_config(None) is False

--- a/tests/test_issue6022_worktree_ui_static.py
+++ b/tests/test_issue6022_worktree_ui_static.py
@@ -42,6 +42,54 @@ def test_onboarding_session_sends_explicit_worktree_false():
     assert "worktree: false" in finish
 
 
+def test_profile_switch_session_sends_explicit_worktree_false():
+    src = read("static/panels.js")
+    assert (
+        "await newSession(false, {awaitWorkspaceLoad: workspaceVisible, worktree: false});"
+        in src
+    )
+
+
+def test_workspace_bind_prompts_send_explicit_worktree_false():
+    # promptWorkspacePath + switchToWorkspace both auto-mint a session from a
+    # blank page; each must opt out of the config default explicitly.
+    src = read("static/panels.js")
+    assert (
+        src.count(
+            "body:JSON.stringify({workspace:ws,worktree:false})"
+        )
+        >= 2
+    ), "panels.js blank-page session mints must send worktree:false"
+    # No panels.js session/new call may omit the worktree key.
+    assert "body:JSON.stringify({workspace:ws})" not in src
+
+
+def test_file_and_folder_creation_send_explicit_worktree_false():
+    src = read("static/ui.js")
+    for fn in ("async function promptNewFile", "async function promptNewFolder"):
+        block = src[src.index(fn) :]
+        block = block[: block.index("\n}\n")]
+        assert "worktree:false" in block, f"{fn} must opt out of the config default"
+    assert "body:JSON.stringify({workspace:ws})" not in src
+
+
+def test_terminal_auto_session_sends_explicit_worktree_false():
+    src = read("static/commands.js")
+    assert "await newSession(false, {worktree: false});" in src
+
+
+def test_no_bare_session_new_posts_remain_in_static_js():
+    # Belt-and-suspenders: no static file may POST /api/session/new with a
+    # body that has a workspace but silently omits the worktree key on an
+    # auto-mint path. All known auto-mint sites are asserted above; this
+    # catches future regressions of the same shape.
+    for name in ("panels.js", "ui.js"):
+        src = read(f"static/{name}")
+        assert "body:JSON.stringify({workspace:ws})" not in src, (
+            f"static/{name}: auto-mint session/new must pass explicit worktree:false"
+        )
+
+
 def test_deliberate_new_chat_paths_do_not_pin_worktree():
     # Sidebar "New Chat" and command paths must NOT pass an explicit worktree
     # value — they inherit the server-side config default by design.

--- a/tests/test_issue6022_worktree_ui_static.py
+++ b/tests/test_issue6022_worktree_ui_static.py
@@ -1,0 +1,55 @@
+"""Static assertions for the frontend half of Issue #6022.
+
+The three-value worktree contract only holds if system-minted sessions
+(boot-time auto-bind, onboarding) explicitly opt OUT — otherwise a config
+``worktree: true`` default would leak a fresh worktree + branch on every page
+load, with nothing to reap it (#6023).
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_new_session_forwards_explicit_worktree_and_omits_absent():
+    src = read("static/sessions.js")
+    # Explicit true/false forwarded verbatim; absent key stays absent so the
+    # server can apply the config default.
+    assert (
+        "if(options&&Object.prototype.hasOwnProperty.call(options,'worktree')) "
+        "reqBody.worktree=!!options.worktree;" in src
+    )
+    # The old shape (only-true is ever sent) must be gone.
+    assert "if(options&&options.worktree) reqBody.worktree=true;" not in src
+
+
+def test_boot_auto_bind_sends_explicit_worktree_false():
+    src = read("static/boot.js")
+    bind = src[src.index("async function _maybeBindFreshDefaultWorkspaceSession") :]
+    bind = bind[: bind.index("\n}\n")]
+    assert "worktree: false" in bind
+
+
+def test_onboarding_session_sends_explicit_worktree_false():
+    src = read("static/onboarding.js")
+    finish = src[src.index("async function _finishOnboarding") :]
+    finish = finish[: finish.index("\n}\n")]
+    assert "worktree: false" in finish
+
+
+def test_deliberate_new_chat_paths_do_not_pin_worktree():
+    # Sidebar "New Chat" and command paths must NOT pass an explicit worktree
+    # value — they inherit the server-side config default by design.
+    boot = read("static/boot.js")
+    for line_no in (
+        i
+        for i, line in enumerate(boot.splitlines(), 1)
+        if "await newSession();await renderSessionList();closeMobileSidebar();" in line
+    ):
+        line = boot.splitlines()[line_no - 1]
+        assert "worktree" not in line


### PR DESCRIPTION
## Summary

Implements the config-default worktree behavior confirmed in #6022: `/api/session/new` now consults the agent's config-level `worktree:` key when the request body has no explicit `worktree` value, so WebUI sessions and CLI sessions agree on isolation for the same repo.

## Three-value model

- **body `worktree` absent** → agent config default applies
- **explicit `true`/`false`** → honored verbatim; explicit always wins (including `worktree: false` with config default `true` → plain session, covered by a dedicated test)

## Design decisions (per the issue thread)

**Profile-aware config read.** Rather than `hermes_cli.config.load_config()` (which would read one fixed config), the helper `_worktree_default_from_config(profile)` resolves the session's own profile via `get_hermes_home_for_profile` → `get_config_for_profile_home` — the mtime-tracked, profile-aware path already used to fix #3294. A user with `worktree: true` in one profile but not another gets per-profile behavior; the common single-profile case hits the ambient cache. Fail-soft: any config-resolution error logs a warning and returns `False` (config must never break session creation).

**Non-git fallback (`worktree_explicit` gate).** `create_worktree_for_workspace` → `find_git_repo_root` raises `ValueError` on non-git workspaces:
- explicit `worktree: true` → keeps today's hard 400,
- config-default request → degrades to a plain session and surfaces `worktree_skipped` (the reason string) in the response payload, so `worktree: true` in config.yaml doesn't 400 every session in every non-git directory.

**Boot-time auto-bind opts out in this same PR.** `_maybeBindFreshDefaultWorkspaceSession` (boot.js) and the post-onboarding session now send `worktree: false` explicitly — a server-side default must never mint a worktree + branch from merely opening the page (which would compound #6023's unremovable-worktree pile-up; fix for that side is #6028). `newSession()` forwards explicit true/false and omits the key otherwise; deliberate "New Chat" paths send nothing and inherit the default. Worktree-backed sessions were already excluded from new-chat draft reuse (`_isRestorableNewChatDraftSession` rejects `worktree_path`), so no change needed there.

## Tests

`tests/test_issue6022_worktree_config_default.py` — route matrix:
- config default off/on × body absent → plain / worktree-backed
- explicit `false` beats config default `true` (worktree factory pytest-fails if called)
- explicit `true` with config default off still creates a worktree
- non-git + config default → 200 plain session + `worktree_skipped`
- non-git + explicit `true` → 400
- `_worktree_default_from_config`: ambient read, named-profile home resolution, fail-soft on config errors

`tests/test_issue6022_worktree_ui_static.py` — static assertions that the auto-bind and onboarding paths opt out explicitly, `newSession()` implements the forward-verbatim/omit-absent contract, and deliberate New Chat paths don't pin a value.

One existing assertion updated (`test_issue1955_worktree_ui_static.py`) for the new `reqBody.worktree=!!options.worktree` shape.

`./scripts/test.sh` across all worktree/session-new test files (`test_issue6022_*`, `test_issue1955_*`, `test_issue2057_*`, `test_worktree_remove.py`, `test_issue5420_profile_switch_session_new.py`) — 59 passed. `scripts/ruff_lint.py` — no new findings.

Fixes #6022
