### PR TITLE
Fix approval "once" persisting as a session approval (#6017)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -23344,7 +23344,7 @@ def _resolve_approval_legacy(sid: str, approval_id: str, choice: str) -> bool:
     # Collect keys from both _pending and _gateway_queues
     keys_from_pending = pending.get("pattern_keys") or [pending.get("pattern_key", "")] if pending else []
     all_keys = [k for k in keys_from_pending if k] + [k for k in gateway_keys if k]
-    if choice in ("once", "session"):
+    if choice == "session":
         for k in all_keys:
             approve_session(sid, k)
     elif choice == "always":
@@ -23352,6 +23352,11 @@ def _resolve_approval_legacy(sid: str, approval_id: str, choice: str) -> bool:
             approve_session(sid, k)
             approve_permanent(k)
         save_permanent_allowlist(_permanent_approved)
+    # choice == "once": no persistence — approval lasts this single call only.
+    # resolve_gateway_approval() below unblocks the parked agent thread for
+    # every choice, so "once" still lets the current tool run; we just must not
+    # call approve_session() here, or the next matching guarded call would find
+    # the pattern already session-approved and skip its approval card (#6017).
     # Unblock the agent thread waiting in the gateway approval queue.
     # This is the primary signal when streaming is active — the agent
     # thread is parked in entry.event.wait() and needs to be woken up.

--- a/tests/test_issue6017_approve_once_no_persist.py
+++ b/tests/test_issue6017_approve_once_no_persist.py
@@ -1,0 +1,100 @@
+"""Regression test for #6017: "Approve once" must not persist as a session
+approval.
+
+Bug
+---
+In the local (non-gateway) approval path, ``_resolve_approval_legacy`` in
+``api/routes.py`` grouped ``"once"`` together with ``"session"`` and called
+``approve_session()`` for both. ``approve_session()`` records the pattern in the
+session-wide allowlist that the guard later consults, so a single "Approve
+once" click silently approved every later matching tool call for the whole
+session -- a destructive tool could then run with no approval card.
+
+Fix
+---
+Only ``"session"``/``"always"`` persist. ``"once"`` releases the currently
+parked call via ``resolve_gateway_approval()`` (which unblocks the waiting agent
+thread for every choice) and writes nothing to ``_session_approved``.
+
+State layer: ``tools.approval._session_approved`` -- the session-scoped approval
+allowlist that ``is_approved()`` consults. These tests drive the real
+``_resolve_approval_legacy`` against a seeded gateway approval entry and assert
+the persistence outcome directly via ``is_approved()``.
+"""
+from __future__ import annotations
+
+import importlib
+import uuid
+
+from tests.conftest import requires_agent_modules
+
+pytestmark = requires_agent_modules
+
+
+def _seed_gateway_entry(ta, sid, pattern_key):
+    """Park one guarded command in the gateway queue for ``sid``.
+
+    Mirrors the local in-process agent path: a guarded command blocks on an
+    ``_ApprovalEntry`` in ``_gateway_queues`` waiting for the user's choice.
+    """
+    entry = ta._ApprovalEntry({
+        "command": "rm -rf /tmp/6017",
+        "pattern_key": pattern_key,
+        "pattern_keys": [pattern_key],
+        "description": "recursive delete",
+    })
+    with ta._lock:
+        ta._pending.pop(sid, None)
+        ta._gateway_queues.setdefault(sid, []).append(entry)
+    return entry
+
+
+def _cleanup(ta, sid):
+    with ta._lock:
+        ta._gateway_queues.pop(sid, None)
+        ta._session_approved.pop(sid, None)
+        ta._pending.pop(sid, None)
+
+
+def test_approve_once_releases_call_but_does_not_persist():
+    """'once' unblocks the current call yet leaves nothing session-approved, so
+    the next matching guarded call still re-prompts."""
+    routes = importlib.import_module("api.routes")
+    ta = importlib.import_module("tools.approval")
+
+    sid = f"issue6017-once-{uuid.uuid4().hex[:8]}"
+    key = f"pattern-{uuid.uuid4().hex[:8]}"
+    entry = _seed_gateway_entry(ta, sid, key)
+    try:
+        assert not ta.is_approved(sid, key), "precondition: pattern not yet approved"
+        assert not entry.event.is_set(), "precondition: parked call not yet released"
+
+        routes._resolve_approval_legacy(sid, "", "once")
+
+        assert entry.event.is_set(), "'once' must release the currently parked call"
+        assert ta.is_approved(sid, key) is False, (
+            "'once' must NOT persist a session approval -- the next matching "
+            "guarded call must re-prompt (#6017)"
+        )
+    finally:
+        _cleanup(ta, sid)
+
+
+def test_approve_session_persists_session_approval():
+    """Regression guard: 'session' still persists, so a later matching call in
+    the same session is not re-prompted."""
+    routes = importlib.import_module("api.routes")
+    ta = importlib.import_module("tools.approval")
+
+    sid = f"issue6017-session-{uuid.uuid4().hex[:8]}"
+    key = f"pattern-{uuid.uuid4().hex[:8]}"
+    entry = _seed_gateway_entry(ta, sid, key)
+    try:
+        routes._resolve_approval_legacy(sid, "", "session")
+
+        assert entry.event.is_set(), "'session' must release the currently parked call"
+        assert ta.is_approved(sid, key) is True, (
+            "'session' must persist so later matching calls are not re-prompted"
+        )
+    finally:
+        _cleanup(ta, sid)


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI mirrors the Hermes agent's approval gate in the browser; its safety promise is that a guarded tool re-prompts unless the user chose to remember the approval.
- Approvals have three persistence levels: `once` (this call only), `session` (rest of the session), `always` (permanent allowlist).
- In the local (non-gateway) path, `_resolve_approval_legacy` collapsed `once` and `session` into one branch, both calling `approve_session()`.
- `approve_session()` writes the pattern into the session-wide allowlist that `is_approved()` consults, so a single "Approve once" click made every later matching call auto-run with no card.
- The fix restores the agent's own contract (`once` = no persistence): only `session`/`always` persist; `once` just releases the current call.
- Result: after "Approve once", the next matching guarded call prompts again, closing the approval-bypass on destructive tools.

## What Changed

- `api/routes.py`, `_resolve_approval_legacy`: changed `if choice in ("once", "session"):` to `if choice == "session":`, so `once` no longer calls `approve_session()`.
- The existing `resolve_gateway_approval(sid, choice, resolve_all=False)` call just below still unblocks the parked agent thread for every choice, so the current tool call still proceeds on `once` — it just isn't remembered.
- Added `tests/test_issue6017_approve_once_no_persist.py` (2 tests) driving the real `_resolve_approval_legacy`:
  - after `once`: the parked entry's event is set (call released) and `is_approved` stays `False` (not persisted);
  - after `session`: `is_approved` is `True` (persistence preserved).

## Why It Matters

- Approval bypass on a safety-critical path: a destructive tool ran without a card after a single "Approve once" (the issue's Critical Bug Fix milestone).
- Realigns the WebUI with the agent's documented contract in `tools/approval.py`: `# choice == "once": no persistence — approval lasts this single call only.`

## Verification

- Relevant approval tests via `./scripts/test.sh` (hermes-agent modules present) — all pass:
  - `test_issue6017_approve_once_no_persist.py` (new)
  - `test_approval_unblock.py`, `test_approval_queue.py`, `test_runtime_adapter_seam.py`, `test_issue4771_local_approval_regression.py`, `test_attention_session_events.py`
- Negative check: against the pre-fix code the new `once` test fails on `is_approved(...) is False` (`assert True is False`), confirming it guards the regression; the `event.is_set()` release assertion passes in both versions (release is choice-independent, as intended).
- Manual (human-tested in the real app): reproduced the issue flow in a running Hermes WebUI from an iPhone, then confirmed with the fix that a second matching guarded call re-prompts, while "Approve for session" still suppresses the re-prompt.
- Lint: `python3 scripts/ruff_lint.py --diff origin/master` clean on changed lines.

## Risks / Follow-ups

- No UI/layout/interaction change (the approval card itself is unchanged — this only affects whether it re-appears), so no before/after images. Happy to add a short screen recording if you want UI evidence.
- Scope limited to the local `_resolve_approval_legacy` path — the only site that grouped `once` with `session` (a repo-wide grep for the grouping shows a single occurrence). The gateway `/approve` path already passes the choice through without persisting `once`.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.8 (`claude-opus-4-8`)
- Tooling: Claude Code CLI — traced the agent approval source, ran the repo test runner, and verified against a live instance. Human-reviewed.

## Contract Routing

- Task type: bug fix restoring intended approval-persistence behavior.
- Touched areas: local approval resolution in `api/routes.py` (`_resolve_approval_legacy`).
- State layer: `tools.approval._session_approved` — the session-scoped allowlist `is_approved()` consults.
- Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md` (approval/clarify subsystem).
- Scope boundaries: no contract document, RFC, or existing product-semantics test changed; this fixes code to match the existing contract and adds a regression test. Not a `Contract Change`.

## Security

- Touches a security-sensitive path (approval of destructive tool calls). Verified via the automated tests and the live manual check that the current call still proceeds on `once` (parked thread released) while nothing persists, and that `session`/`always` persistence is unchanged.

Fixes #6017.
