### PR TITLE
fix: session-open blocks up to 60s on a live model-catalog probe (prefer_cache/session_visit)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -7856,6 +7856,43 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
     elif force_refresh:
         stale_disk_groups = _load_stale_models_cache_from_disk()
 
+    # ── prefer_cache: resolve WITHOUT ever blocking ──────────────────────────
+    # The docstring promises prefer_cache "resolves WITHOUT ever triggering a
+    # live provider probe ... so a cold catalog can never block." The pre-fix
+    # code broke that promise: a prefer_cache caller still fell through to the
+    # ``should_wait`` condition-variable wait (up to 60s) AND the blocking
+    # ``_available_models_cache_lock`` acquire below — and the cold path holds
+    # that lock across its up-to-_LIVE_REBUILD_BUDGET_SECONDS ``build_done``
+    # wait. A latency-sensitive caller (session-open model resolution, Option-Z
+    # wakeup) therefore blocked multiple seconds on a catalog already cached on
+    # disk. Resolve here, before the lock, and NEVER wait:
+    #   1. warm in-memory cache — read under a NON-BLOCKING lock acquire
+    #      (skipped entirely if a rebuild currently holds the lock);
+    #   2. the on-disk cache (loaded above; lock-free file I/O);
+    #   3. a shape-valid stale on-disk cache;
+    #   4. a network-free minimal static catalog (last resort, as before).
+    # This never sets or clears _cache_build_in_progress (Greptile P1): a
+    # concurrent cold-path rebuild keeps its serialization intact.
+    if prefer_cache:
+        if _available_models_cache_lock.acquire(blocking=False):
+            try:
+                _pc_cached = _get_fresh_memory_models_cache(time.monotonic())
+            finally:
+                _available_models_cache_lock.release()
+            if _pc_cached is not None:
+                return _pc_cached
+        _pc_disk = disk_groups if disk_groups is not None else _load_models_cache_from_disk()
+        if _pc_disk is not None:
+            return copy.deepcopy(_pc_disk)
+        _pc_stale = (
+            stale_disk_groups
+            if stale_disk_groups is not None
+            else _load_stale_models_cache_from_disk()
+        )
+        if _pc_stale is not None:
+            return copy.deepcopy(_pc_stale)
+        return copy.deepcopy(_minimal_static_models_catalog())
+
     with _available_models_cache_lock:
         # If another thread is already building, wait for its result instead
         # of re-entering the cold path (avoids duplicate 10s zai load_pool calls).
@@ -8265,6 +8302,78 @@ def warm_models_catalog_provenance_if_cold() -> None:
         _available_models_cache_lock.release()
 
 
+_session_visit_refresh_in_flight = threading.Event()
+_session_visit_refresh_lock = threading.Lock()
+
+
+def _spawn_session_visit_background_refresh() -> bool:
+    """Kick a live catalog refresh onto a detached daemon; never block the caller.
+
+    Stale-while-revalidate helper for ``get_available_models_for_session_visit``:
+    a user-facing session-open serves the (possibly stale) disk cache instantly
+    and calls this to freshen the catalog out-of-band. The refresh reuses the one
+    source of truth — ``get_available_models(force_refresh=True)`` — so all of the
+    thundering-herd coalescing, bounded-rebuild, and single-publisher machinery is
+    shared, not reimplemented.
+
+    Returns True if THIS call started the worker, False if a refresh was already
+    in flight (coalesced) — the ``_session_visit_refresh_in_flight`` guard keeps a
+    burst of session-opens from spawning N redundant rebuild daemons.
+
+    Profile isolation (#3957): the detached worker inherits neither the request
+    profile TLS nor os.environ, so the active profile name is captured HERE (on
+    the request thread) and re-bound inside the worker via
+    ``profile_scope_for_detached_worker`` — identical to the bounded-rebuild path.
+    """
+    # threading.Event has no atomic test-and-set, so claim the "spawn" right
+    # under a lock: exactly one caller wins and starts the worker; the rest
+    # coalesce onto that in-flight refresh.
+    with _session_visit_refresh_lock:
+        if _session_visit_refresh_in_flight.is_set():
+            return False
+        _session_visit_refresh_in_flight.set()
+
+    from contextlib import nullcontext as _nullcontext
+
+    _active_profile_name = ""
+    _prof_scope_worker = None
+    try:
+        from api.profiles import (
+            get_active_profile_name as _gapn,
+            profile_scope_for_detached_worker as _prof_scope_worker,
+        )
+        _active_profile_name = (_gapn() or "").strip()
+    except Exception:
+        _prof_scope_worker = None
+
+    def _worker() -> None:
+        _scope = (
+            _prof_scope_worker(_active_profile_name, "session-visit refresh (worker)")
+            if _prof_scope_worker is not None
+            else _nullcontext()
+        )
+        try:
+            with _scope:
+                get_available_models(force_refresh=True)
+        except Exception:
+            logger.debug("session-visit background refresh failed", exc_info=True)
+        finally:
+            _session_visit_refresh_in_flight.clear()
+
+    try:
+        threading.Thread(
+            target=_worker,
+            name="models-session-visit-refresh",
+            daemon=True,
+        ).start()
+    except Exception:
+        # Never leave the guard latched if the thread failed to even start,
+        # or the catalog would never refresh again for the process lifetime.
+        _session_visit_refresh_in_flight.clear()
+        raise
+    return True
+
+
 def get_available_models_for_session_visit() -> dict:
     """Return /api/models with a short session-visit freshness horizon.
 
@@ -8328,19 +8437,37 @@ def get_available_models_for_session_visit() -> dict:
     _mark("cache_age_stale_or_missing")
     stale_cached = disk_cached or _load_stale_models_cache_from_disk()
     _mark(f"stale_cached_loaded:{bool(stale_cached)}")
+
+    # ── Stale-while-revalidate ──────────────────────────────────────────────
+    # A user-facing session-open must NEVER block on a live provider probe.
+    # Before this fix, a cache older than the freshness horizon fell through to
+    # get_available_models(force_refresh=True), which blocks the request thread
+    # up to _LIVE_REBUILD_BUDGET_SECONDS on per-provider network calls (the
+    # anthropic /models fetch et al.) — the proven source of the multi-second
+    # /api/session and /api/models?freshness=session_visit latency on session
+    # open. Instead: if ANY shape-valid cache exists, serve it immediately and
+    # freshen the catalog on a detached daemon. The next session-open gets the
+    # warm result; this one pays ~0ms.
+    if stale_cached is not None:
+        _spawn_session_visit_background_refresh()
+        _mark("stale_served_background_refresh")
+        _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
+        return copy.deepcopy(stale_cached)
+
+    # True cold boot: no cache on disk at all (first run, or cache cleared).
+    # There is nothing to serve, so fall back to the bounded rebuild — itself
+    # capped at _LIVE_REBUILD_BUDGET_SECONDS and never unbounded — and, failing
+    # that, the network-free minimal catalog. This is the ONLY branch that can
+    # wait, and only when there is literally no cached catalog to return.
     try:
-        _mark("force_refresh_start")
+        _mark("cold_boot_bounded_rebuild_start")
         result = get_available_models(force_refresh=True)
-        _mark("force_refresh_done")
+        _mark("cold_boot_bounded_rebuild_done")
         _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
         return result
     except Exception:
-        _mark("force_refresh_failed")
+        _mark("cold_boot_rebuild_failed")
         logger.debug("session-visit models refresh failed", exc_info=True)
-        if stale_cached is not None:
-            _mark("stale_fallback_return")
-            _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
-            return copy.deepcopy(stale_cached)
         _mark("prefer_cache_fallback")
         _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
         return get_available_models(prefer_cache=True)

--- a/api/config.py
+++ b/api/config.py
@@ -5959,16 +5959,30 @@ def _model_aliases_from_config() -> dict[str, str]:
     return {}
 
 
-def _load_stale_models_cache_from_disk() -> dict | None:
+def _load_stale_models_cache_from_disk(enforce_fingerprint: bool = False) -> dict | None:
     """Load a shape-valid stale /api/models disk cache for timeout fallback only.
 
-    The main cache loader enforces metadata stamps for a full cold-path cache hit.
-    This helper intentionally does not apply that stricter policy, so we can still
-    recover a useful fallback payload when the strict loader rejected cache because
-    metadata or fingerprint fields are stale. It DOES still enforce the schema
-    version: a cross-schema cache can have an incompatible groups/badge shape, so
-    serving it to the picker could surface a broken catalog — schema mismatch is a
-    hard reject even on the fallback path.
+    The main cache loader (`_is_loadable_disk_cache`) rejects on any of three
+    axes: schema version, WebUI release version, and profile source-fingerprint.
+    This helper always relaxes the release version so a cache written by a
+    previous release is still a usable fallback while the live rebuild runs, and
+    always enforces the schema version (a cross-schema cache can have an
+    incompatible groups/badge shape that would surface a broken picker).
+
+    The source-fingerprint axis is the CALLER'S policy, via ``enforce_fingerprint``:
+
+    - ``False`` (default) — the #3928 over-budget timeout fallback. The caller is
+      actively rebuilding the *current* profile and just needs any shape-valid
+      catalog to serve for the ~seconds until that rebuild publishes; a
+      fingerprint mismatch (config edit, catalog drift) is acceptable and by
+      design, because the in-flight rebuild corrects it. Serving a slightly-stale
+      catalog beats the bare minimal-static one.
+    - ``True`` — latency-sensitive session-open paths (``prefer_cache`` tier-3,
+      ``get_available_models_for_session_visit``) where NO same-request rebuild
+      will correct a wrong serve (Greptile P1). The fingerprint is profile/config
+      identity: serving a mismatched cache would hand one profile the *other*
+      profile's providers + default model (or a pre-edit config's catalog). A
+      mismatch must fall through to the profile-aware minimal-static catalog.
     """
     try:
         import json as _j
@@ -5981,6 +5995,10 @@ def _load_stale_models_cache_from_disk() -> dict | None:
         if not _is_valid_models_cache(cache):
             return None
         if cache.get("_schema_version") != _MODELS_CACHE_SCHEMA_VERSION:
+            return None
+        if enforce_fingerprint and cache.get("_source_fingerprint") != _models_cache_source_fingerprint():
+            # Profile/config identity mismatch — never serve another profile's
+            # (or a superseded config's) catalog on a session-open hot path.
             return None
         aliases = cache.get("aliases")
         if not isinstance(aliases, dict):
@@ -7884,11 +7902,15 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         _pc_disk = disk_groups if disk_groups is not None else _load_models_cache_from_disk()
         if _pc_disk is not None:
             return copy.deepcopy(_pc_disk)
-        _pc_stale = (
-            stale_disk_groups
-            if stale_disk_groups is not None
-            else _load_stale_models_cache_from_disk()
-        )
+        # Tier 3 does its OWN fingerprint-enforced stale load rather than reusing
+        # the ``stale_disk_groups`` pre-load: that pre-load is fingerprint-BLIND
+        # (it feeds the #3928 over-budget fallback below, which is rebuilding the
+        # current profile and tolerates a mismatch). On this session-open hot
+        # path no same-request rebuild corrects a wrong serve, so a mismatched
+        # cache must be rejected (Greptile P1) — reusing the blind pre-load would
+        # silently bypass that. The extra ~0.1ms disk read only hits the stalest
+        # tier (memory + fresh disk both missed).
+        _pc_stale = _load_stale_models_cache_from_disk(enforce_fingerprint=True)
         if _pc_stale is not None:
             return copy.deepcopy(_pc_stale)
         return copy.deepcopy(_minimal_static_models_catalog())
@@ -8302,8 +8324,14 @@ def warm_models_catalog_provenance_if_cold() -> None:
         _available_models_cache_lock.release()
 
 
-_session_visit_refresh_in_flight = threading.Event()
 _session_visit_refresh_lock = threading.Lock()
+# Profiles with a session-visit refresh currently in flight, keyed by profile
+# name. A process-global flag (Greptile P1) cross-suppresses profiles: each
+# refresh is bound to ONE profile and writes that profile's own cache, so a slow
+# refresh for profile A must not stop profile B from revalidating. Per-profile
+# keying coalesces same-profile bursts while letting different profiles refresh
+# in parallel.
+_session_visit_refresh_in_flight: set[str] = set()
 
 
 def _spawn_session_visit_background_refresh() -> bool:
@@ -8316,25 +8344,21 @@ def _spawn_session_visit_background_refresh() -> bool:
     thundering-herd coalescing, bounded-rebuild, and single-publisher machinery is
     shared, not reimplemented.
 
-    Returns True if THIS call started the worker, False if a refresh was already
-    in flight (coalesced) — the ``_session_visit_refresh_in_flight`` guard keeps a
-    burst of session-opens from spawning N redundant rebuild daemons.
+    Returns True if THIS call started the worker, False if a refresh for the same
+    profile was already in flight (coalesced) — the per-profile
+    ``_session_visit_refresh_in_flight`` guard keeps a burst of same-profile
+    session-opens from spawning N redundant rebuild daemons while still letting a
+    different profile refresh concurrently.
 
     Profile isolation (#3957): the detached worker inherits neither the request
     profile TLS nor os.environ, so the active profile name is captured HERE (on
-    the request thread) and re-bound inside the worker via
-    ``profile_scope_for_detached_worker`` — identical to the bounded-rebuild path.
+    the request thread) — it is both the coalescing key and the scope re-bound
+    inside the worker via ``profile_scope_for_detached_worker``.
     """
-    # threading.Event has no atomic test-and-set, so claim the "spawn" right
-    # under a lock: exactly one caller wins and starts the worker; the rest
-    # coalesce onto that in-flight refresh.
-    with _session_visit_refresh_lock:
-        if _session_visit_refresh_in_flight.is_set():
-            return False
-        _session_visit_refresh_in_flight.set()
-
     from contextlib import nullcontext as _nullcontext
 
+    # Capture the active profile on the REQUEST thread — needed before the guard
+    # claim because the guard is now keyed by profile.
     _active_profile_name = ""
     _prof_scope_worker = None
     try:
@@ -8345,6 +8369,13 @@ def _spawn_session_visit_background_refresh() -> bool:
         _active_profile_name = (_gapn() or "").strip()
     except Exception:
         _prof_scope_worker = None
+
+    # Claim the per-profile spawn right under the lock: exactly one caller per
+    # profile wins and starts the worker; the rest coalesce onto it.
+    with _session_visit_refresh_lock:
+        if _active_profile_name in _session_visit_refresh_in_flight:
+            return False
+        _session_visit_refresh_in_flight.add(_active_profile_name)
 
     def _worker() -> None:
         _scope = (
@@ -8358,7 +8389,8 @@ def _spawn_session_visit_background_refresh() -> bool:
         except Exception:
             logger.debug("session-visit background refresh failed", exc_info=True)
         finally:
-            _session_visit_refresh_in_flight.clear()
+            with _session_visit_refresh_lock:
+                _session_visit_refresh_in_flight.discard(_active_profile_name)
 
     try:
         threading.Thread(
@@ -8368,8 +8400,10 @@ def _spawn_session_visit_background_refresh() -> bool:
         ).start()
     except Exception:
         # Never leave the guard latched if the thread failed to even start,
-        # or the catalog would never refresh again for the process lifetime.
-        _session_visit_refresh_in_flight.clear()
+        # or that profile's catalog would never refresh again for the process
+        # lifetime.
+        with _session_visit_refresh_lock:
+            _session_visit_refresh_in_flight.discard(_active_profile_name)
         raise
     return True
 
@@ -8435,7 +8469,7 @@ def get_available_models_for_session_visit() -> dict:
             return copy.deepcopy(disk_cached)
 
     _mark("cache_age_stale_or_missing")
-    stale_cached = disk_cached or _load_stale_models_cache_from_disk()
+    stale_cached = disk_cached or _load_stale_models_cache_from_disk(enforce_fingerprint=True)
     _mark(f"stale_cached_loaded:{bool(stale_cached)}")
 
     # ── Stale-while-revalidate ──────────────────────────────────────────────

--- a/api/config.py
+++ b/api/config.py
@@ -8368,7 +8368,15 @@ def _spawn_session_visit_background_refresh() -> bool:
         )
         _active_profile_name = (_gapn() or "").strip()
     except Exception:
+        # profiles module unavailable (pathological): the worker rebuilds under
+        # nullcontext() with no profile rebind, and _active_profile_name stays ""
+        # — so every such spawn coalesces under the empty key rather than per
+        # profile. Re-assigned explicitly here (not just left at the init default)
+        # so the degradation is visible at the failure site instead of implied by
+        # omission. Self-correcting: the enforce-fingerprint read side rejects a
+        # mismatched publish on the next visit.
         _prof_scope_worker = None
+        _active_profile_name = ""
 
     # Claim the per-profile spawn right under the lock: exactly one caller per
     # profile wins and starts the worker; the rest coalesce onto it.

--- a/api/config.py
+++ b/api/config.py
@@ -8453,25 +8453,38 @@ def get_available_models_for_session_visit() -> dict:
     if cache_age is not None and cache_age < _SESSION_VISIT_MODELS_FRESHNESS_SECONDS:
         _mark("cache_age_within_ttl")
         now_mono = time.monotonic()
-        with _available_models_cache_lock:
-            cached = _get_fresh_memory_models_cache(now_mono)
+        if _available_models_cache_lock.acquire(blocking=False):
+            try:
+                cached = _get_fresh_memory_models_cache(now_mono)
+            finally:
+                _available_models_cache_lock.release()
             if cached is not None:
                 _mark("memory_cache_hit")
                 _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
                 return cached
+        else:
+            _mark("memory_cache_lock_busy")
         _mark("memory_cache_miss_loading_disk")
         disk_cached = _load_models_cache_from_disk()
         if disk_cached is not None:
-            with _available_models_cache_lock:
-                cached = _get_fresh_memory_models_cache(time.monotonic())
-                if cached is not None:
-                    _mark("disk_then_memory_cache_hit")
-                    _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
-                    return cached
-                _available_models_cache = copy.deepcopy(disk_cached)
-                _available_models_cache_ts = time.monotonic()
-                _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
-                _sync_models_cache_provenance()
+            if _available_models_cache_lock.acquire(blocking=False):
+                try:
+                    cached = _get_fresh_memory_models_cache(time.monotonic())
+                    if cached is not None:
+                        _mark("disk_then_memory_cache_hit")
+                        _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
+                        return cached
+                    _available_models_cache = copy.deepcopy(disk_cached)
+                    _available_models_cache_ts = time.monotonic()
+                    _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
+                    _sync_models_cache_provenance()
+                finally:
+                    _available_models_cache_lock.release()
+            else:
+                # The disk payload is already validated for this profile and
+                # release. Publishing it to memory is optional; never wait on a
+                # concurrent rebuild before returning it to session-open.
+                _mark("disk_cache_publish_lock_busy")
             _mark("disk_cache_returned")
             _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
             return copy.deepcopy(disk_cached)
@@ -8497,22 +8510,15 @@ def get_available_models_for_session_visit() -> dict:
         return copy.deepcopy(stale_cached)
 
     # True cold boot: no cache on disk at all (first run, or cache cleared).
-    # There is nothing to serve, so fall back to the bounded rebuild — itself
-    # capped at _LIVE_REBUILD_BUDGET_SECONDS and never unbounded — and, failing
-    # that, the network-free minimal catalog. This is the ONLY branch that can
-    # wait, and only when there is literally no cached catalog to return.
-    try:
-        _mark("cold_boot_bounded_rebuild_start")
-        result = get_available_models(force_refresh=True)
-        _mark("cold_boot_bounded_rebuild_done")
-        _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
-        return result
-    except Exception:
-        _mark("cold_boot_rebuild_failed")
-        logger.debug("session-visit models refresh failed", exc_info=True)
-        _mark("prefer_cache_fallback")
-        _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
-        return get_available_models(prefer_cache=True)
+    # Return the network-free static catalog now and populate the durable cache
+    # on the existing detached refresh worker. Session-open never owns live
+    # provider work, even on the first request after installation.
+    _spawn_session_visit_background_refresh()
+    _mark("cold_boot_background_refresh_spawned")
+    result = get_available_models(prefer_cache=True)
+    _mark("cold_boot_static_returned")
+    _maybe_log_slow_stages(_logger, _stagelog, _slow_threshold_ms, "models.session_visit")
+    return result
 
 
 def _maybe_log_slow_stages(

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -28,6 +28,22 @@ def _catalog(label: str) -> dict:
     }
 
 
+def _wait_until(predicate, timeout: float = 3.0, interval: float = 0.01) -> bool:
+    """Poll ``predicate`` until true or ``timeout`` elapses. Used to join the
+    detached stale-while-revalidate daemon before a test returns — otherwise
+    monkeypatch teardown restores the real rebuild and the daemon races into
+    live provider probes.
+    """
+    import time as _t
+
+    deadline = _t.monotonic() + timeout
+    while _t.monotonic() < deadline:
+        if predicate():
+            return True
+        _t.sleep(interval)
+    return predicate()
+
+
 def _reset_models_memory_cache(monkeypatch):
     import api.config as cfg
 
@@ -36,6 +52,9 @@ def _reset_models_memory_cache(monkeypatch):
     monkeypatch.setattr(cfg, "_available_models_live_rebuild_ts", 0.0, raising=False)
     monkeypatch.setattr(cfg, "_available_models_cache_source_fingerprint", None, raising=False)
     monkeypatch.setattr(cfg, "_cache_build_in_progress", False, raising=False)
+    # Fresh per-profile revalidation guard per test (auto-restored on teardown),
+    # so a leaked in-flight profile name can't suppress a spawn in the next test.
+    monkeypatch.setattr(cfg, "_session_visit_refresh_in_flight", set(), raising=False)
 
 
 def test_session_visit_fresh_profile_cache_returns_without_live_rebuild(tmp_path, monkeypatch):
@@ -51,7 +70,7 @@ def test_session_visit_fresh_profile_cache_returns_without_live_rebuild(tmp_path
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: disk_catalog)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: None)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: {"profile": "demo"})
 
     def _unexpected_live_rebuild(**_kwargs):
@@ -63,6 +82,12 @@ def test_session_visit_fresh_profile_cache_returns_without_live_rebuild(tmp_path
 
 
 def test_session_visit_ignores_recently_warmed_memory_when_disk_cache_is_stale(tmp_path, monkeypatch):
+    """#6038 async contract: a stale disk cache is served IMMEDIATELY (no block)
+    and the live rebuild is kicked onto the detached daemon. Under #4756 this
+    returned the freshly-rebuilt catalog synchronously; stale-while-revalidate
+    favors latency, so the first visit gets stale + an out-of-band refresh whose
+    result a subsequent visit sees.
+    """
     import api.config as cfg
 
     _reset_models_memory_cache(monkeypatch)
@@ -77,7 +102,7 @@ def test_session_visit_ignores_recently_warmed_memory_when_disk_cache_is_stale(t
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: stale_catalog)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: {"profile": "demo"})
     monkeypatch.setattr(cfg, "_available_models_cache", stale_catalog, raising=False)
     monkeypatch.setattr(cfg, "_available_models_cache_ts", time.monotonic(), raising=False)
@@ -89,11 +114,19 @@ def test_session_visit_ignores_recently_warmed_memory_when_disk_cache_is_stale(t
 
     monkeypatch.setattr(cfg, "get_available_models", _live_rebuild)
 
-    assert cfg.get_available_models_for_session_visit() == rebuilt_catalog
-    assert calls == [{"force_refresh": True}]
+    # Served immediately from the stale cache — not the rebuilt catalog.
+    assert cfg.get_available_models_for_session_visit() == stale_catalog
+    # The revalidation ran out-of-band on the daemon, calling force_refresh.
+    assert _wait_until(lambda: calls == [{"force_refresh": True}]), (
+        f"background refresh did not run exactly once; calls={calls}"
+    )
 
 
-def test_session_visit_stale_profile_cache_revalidates_with_live_rebuild(tmp_path, monkeypatch):
+def test_session_visit_stale_profile_cache_revalidates_async(tmp_path, monkeypatch):
+    """#6038 async contract (was ...revalidates_with_live_rebuild): a stale
+    profile cache is returned immediately and revalidated on the background
+    daemon, rather than blocking the request thread on a synchronous rebuild.
+    """
     import api.config as cfg
 
     _reset_models_memory_cache(monkeypatch)
@@ -108,7 +141,7 @@ def test_session_visit_stale_profile_cache_revalidates_with_live_rebuild(tmp_pat
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: stale_catalog)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
 
     def _live_rebuild(**kwargs):
         calls.append(kwargs)
@@ -116,11 +149,23 @@ def test_session_visit_stale_profile_cache_revalidates_with_live_rebuild(tmp_pat
 
     monkeypatch.setattr(cfg, "get_available_models", _live_rebuild)
 
-    assert cfg.get_available_models_for_session_visit() == rebuilt_catalog
-    assert calls == [{"force_refresh": True}]
+    assert cfg.get_available_models_for_session_visit() == stale_catalog
+    assert _wait_until(lambda: calls == [{"force_refresh": True}]), (
+        f"stale profile cache did not trigger exactly one async revalidation; calls={calls}"
+    )
 
 
-def test_session_visit_overlapping_stale_calls_coalesce_to_single_live_rebuild(tmp_path, monkeypatch):
+def test_session_visit_overlapping_stale_calls_coalesce_to_single_background_refresh(tmp_path, monkeypatch):
+    """#6038 async contract: two concurrent session-visits on a stale cache both
+    return stale immediately, and the per-profile guard coalesces them to ONE
+    background refresh daemon (was: one in-request live rebuild).
+
+    Coalescing is deterministic: `_spawn_session_visit_background_refresh` claims
+    the per-profile guard under a lock BEFORE starting the daemon thread, so the
+    second spawn is rejected as long as it runs before the daemon clears the
+    guard. Blocking the rebuild until both visits have returned guarantees that
+    ordering without sleeps.
+    """
     import api.config as cfg
     import threading
     from concurrent.futures import ThreadPoolExecutor
@@ -128,53 +173,40 @@ def test_session_visit_overlapping_stale_calls_coalesce_to_single_live_rebuild(t
     _reset_models_memory_cache(monkeypatch)
     stale_catalog = _catalog("stale-model")
     rebuilt_catalog = _catalog("rebuilt-model")
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}", encoding="utf-8")
     cache_path = tmp_path / "models_cache.profile.json"
     cache_path.write_text("{}", encoding="utf-8")
     old = time.time() - 600.0
     os.utime(cache_path, (old, old))
-    fingerprint = {"profile": "demo"}
-    stale_load_counts = {}
-    stale_load_lock = threading.Lock()
-    second_load_gate = threading.Barrier(2)
     rebuild_count = 0
     rebuild_lock = threading.Lock()
+    release = threading.Event()
 
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
-    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
-    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
-    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
-    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
-    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
 
-    def _load_stale_models_cache_from_disk():
-        ident = threading.get_ident()
-        with stale_load_lock:
-            count = stale_load_counts.get(ident, 0) + 1
-            stale_load_counts[ident] = count
-        if count == 2:
-            second_load_gate.wait(timeout=5)
-        return stale_catalog
-
-    def _invoke_models_rebuild(_builder):
+    def _live_rebuild(**kwargs):
         nonlocal rebuild_count
         with rebuild_lock:
             rebuild_count += 1
+        release.wait(timeout=5.0)  # hold the guard until both visits have run
         return rebuilt_catalog
 
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", _load_stale_models_cache_from_disk)
-    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
+    monkeypatch.setattr(cfg, "get_available_models", _live_rebuild)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         futures = [executor.submit(cfg.get_available_models_for_session_visit) for _ in range(2)]
         results = [future.result(timeout=10) for future in futures]
 
-    assert all(result == rebuilt_catalog for result in results)
-    assert rebuild_count == 1
+    # Both visits returned stale immediately without blocking on the rebuild.
+    assert all(result == stale_catalog for result in results)
+    release.set()
+    # Exactly one daemon ran the live refresh; the sibling visit coalesced.
+    assert _wait_until(lambda: rebuild_count == 1), f"expected 1 rebuild, got {rebuild_count}"
+    assert _wait_until(lambda: not cfg._session_visit_refresh_in_flight), (
+        "per-profile guard must clear after the refresh completes"
+    )
 
 
 def test_force_refresh_sync_followers_wait_past_legacy_timeout(tmp_path, monkeypatch):
@@ -201,7 +233,7 @@ def test_force_refresh_sync_followers_wait_past_legacy_timeout(tmp_path, monkeyp
     monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
     monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
 
@@ -259,7 +291,7 @@ def test_force_refresh_sync_followers_retry_after_failed_active_rebuild(tmp_path
     monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
     monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
 
@@ -310,7 +342,7 @@ def test_force_refresh_bounded_followers_wait_only_remaining_budget(tmp_path, mo
     monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
     monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
 
@@ -336,10 +368,17 @@ def test_force_refresh_bounded_followers_wait_only_remaining_budget(tmp_path, mo
     assert elapsed < 0.1
 
 
-def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebuild(tmp_path, monkeypatch):
+def test_session_visit_background_refresh_eventually_publishes_rebuilt_catalog(tmp_path, monkeypatch):
+    """#6038 async contract: after a stale session-visit serves the stale catalog
+    and kicks the background refresh, the daemon must eventually PUBLISH the
+    rebuilt catalog into the shared memory cache — so a subsequent visit sees
+    fresh. This is the "revalidate" half of stale-while-revalidate.
+
+    The daemon runs the real `get_available_models(force_refresh=True)` publish
+    path; only the innermost `_invoke_models_rebuild` builder is stubbed, so the
+    memory-cache publish + fingerprint stamping are exercised for real.
+    """
     import api.config as cfg
-    import threading
-    from concurrent.futures import ThreadPoolExecutor
 
     _reset_models_memory_cache(monkeypatch)
     stale_catalog = _catalog("stale-model")
@@ -351,73 +390,6 @@ def test_session_visit_overlapping_stale_calls_do_not_duplicate_over_budget_rebu
     old = time.time() - 600.0
     os.utime(cache_path, (old, old))
     fingerprint = {"profile": "demo"}
-    stale_load_counts = {}
-    stale_load_lock = threading.Lock()
-    second_load_gate = threading.Barrier(2)
-    rebuild_count = 0
-    rebuild_lock = threading.Lock()
-
-    monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
-    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.01, raising=False)
-    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
-    monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
-    monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
-    monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
-    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
-    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
-
-    def _load_stale_models_cache_from_disk():
-        ident = threading.get_ident()
-        with stale_load_lock:
-            count = stale_load_counts.get(ident, 0) + 1
-            stale_load_counts[ident] = count
-        if count == 2:
-            second_load_gate.wait(timeout=5)
-        return stale_catalog
-
-    def _invoke_models_rebuild(_builder):
-        nonlocal rebuild_count
-        with rebuild_lock:
-            rebuild_count += 1
-        time.sleep(0.05)
-        return rebuilt_catalog
-
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", _load_stale_models_cache_from_disk)
-    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        futures = [executor.submit(cfg.get_available_models_for_session_visit) for _ in range(2)]
-        results = [future.result(timeout=10) for future in futures]
-
-    assert all(result == stale_catalog for result in results)
-    assert rebuild_count == 1
-    time.sleep(0.1)
-    assert cfg._available_models_cache == rebuilt_catalog
-    assert cfg._cache_build_in_progress is False
-
-
-def test_session_visit_force_refresh_ignores_plain_disk_publish_started_after_refresh(tmp_path, monkeypatch):
-    import api.config as cfg
-    import threading
-    from concurrent.futures import ThreadPoolExecutor
-
-    _reset_models_memory_cache(monkeypatch)
-    stale_catalog = _catalog("stale-model")
-    rebuilt_catalog = _catalog("rebuilt-model")
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("{}", encoding="utf-8")
-    cache_path = tmp_path / "models_cache.profile.json"
-    cache_path.write_text("{}", encoding="utf-8")
-    old = time.time() - 600.0
-    os.utime(cache_path, (old, old))
-    fingerprint = {"profile": "demo"}
-    stale_load_counts = {}
-    stale_load_lock = threading.Lock()
-    force_refresh_waiting = threading.Event()
-    plain_publish_done = threading.Event()
-    rebuild_count = 0
-    rebuild_lock = threading.Lock()
 
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.0, raising=False)
@@ -425,44 +397,21 @@ def test_session_visit_force_refresh_ignores_plain_disk_publish_started_after_re
     monkeypatch.setattr(cfg, "_cfg_path", config_path, raising=False)
     monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
-    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
     monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: None)
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", lambda _builder: rebuilt_catalog)
 
-    def _load_stale_models_cache_from_disk():
-        ident = threading.get_ident()
-        with stale_load_lock:
-            count = stale_load_counts.get(ident, 0) + 1
-            stale_load_counts[ident] = count
-        if count == 2:
-            force_refresh_waiting.set()
-            assert plain_publish_done.wait(timeout=5)
-        return stale_catalog
+    # First visit: stale served immediately.
+    assert cfg.get_available_models_for_session_visit() == stale_catalog
 
-    def _invoke_models_rebuild(_builder):
-        nonlocal rebuild_count
-        with rebuild_lock:
-            rebuild_count += 1
-        return rebuilt_catalog
-
-    def _plain_disk_hit():
-        result = cfg.get_available_models()
-        plain_publish_done.set()
-        return result
-
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", _load_stale_models_cache_from_disk)
-    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _invoke_models_rebuild)
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        refresh_future = executor.submit(cfg.get_available_models_for_session_visit)
-        assert force_refresh_waiting.wait(timeout=5)
-        plain_result = executor.submit(_plain_disk_hit).result(timeout=10)
-        refresh_result = refresh_future.result(timeout=10)
-
-    assert plain_result == stale_catalog
-    assert refresh_result == rebuilt_catalog
-    assert rebuild_count == 1
-    assert cfg._available_models_cache == rebuilt_catalog
+    # Daemon eventually publishes the rebuilt catalog into the shared memory cache.
+    assert _wait_until(lambda: cfg._available_models_cache == rebuilt_catalog), (
+        "background refresh never published the rebuilt catalog"
+    )
+    assert _wait_until(lambda: not cfg._session_visit_refresh_in_flight)
+    assert cfg._cache_build_in_progress is False
 
 
 def test_session_visit_fresh_disk_hit_does_not_overwrite_newer_memory_cache(tmp_path, monkeypatch):
@@ -488,7 +437,7 @@ def test_session_visit_fresh_disk_hit_does_not_overwrite_newer_memory_cache(tmp_
         return stale_catalog
 
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", _disk_hit_after_newer_memory_publish)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: None)
     monkeypatch.setattr(
         cfg,
         "get_available_models",
@@ -517,7 +466,7 @@ def test_force_refresh_keeps_build_flag_set_until_disk_save_finishes(tmp_path, m
     monkeypatch.setattr(cfg, "_cfg_mtime", config_path.stat().st_mtime, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: None)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: None)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: fingerprint)
     monkeypatch.setattr(cfg, "_invoke_models_rebuild", lambda _builder: rebuilt_catalog)
 
@@ -546,7 +495,7 @@ def test_default_disk_hit_does_not_restamp_stale_cache_for_session_visit(tmp_pat
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: stale_catalog)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
     monkeypatch.setattr(cfg, "_models_cache_source_fingerprint", lambda: {"profile": "demo"})
     monkeypatch.setattr(cfg, "_cfg_mtime", 0.0, raising=False)
     monkeypatch.setattr(cfg, "_save_models_cache_to_disk", lambda _cache: (_ for _ in ()).throw(
@@ -561,8 +510,12 @@ def test_default_disk_hit_does_not_restamp_stale_cache_for_session_visit(tmp_pat
 
     monkeypatch.setattr(cfg, "get_available_models", _live_rebuild)
 
-    assert cfg.get_available_models_for_session_visit() == rebuilt_catalog
-    assert refresh_calls == [{"force_refresh": True}]
+    # #6038 async contract: session_visit serves the stale catalog immediately and
+    # revalidates on the background daemon (was: returned rebuilt synchronously).
+    assert cfg.get_available_models_for_session_visit() == stale_catalog
+    assert _wait_until(lambda: refresh_calls == [{"force_refresh": True}]), (
+        f"session_visit did not trigger exactly one async revalidation; calls={refresh_calls}"
+    )
 
 
 def test_session_visit_live_rebuild_failure_falls_back_to_cached_catalog(tmp_path, monkeypatch):
@@ -578,7 +531,7 @@ def test_session_visit_live_rebuild_failure_falls_back_to_cached_catalog(tmp_pat
     monkeypatch.setattr(cfg, "_SESSION_VISIT_MODELS_FRESHNESS_SECONDS", 300.0, raising=False)
     monkeypatch.setattr(cfg, "_get_models_cache_path", lambda: cache_path)
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None)
-    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda: stale_catalog)
+    monkeypatch.setattr(cfg, "_load_stale_models_cache_from_disk", lambda **_kw: stale_catalog)
 
     def _failing_live_rebuild(**kwargs):
         assert kwargs == {"force_refresh": True}

--- a/tests/test_session_open_model_catalog_blocking.py
+++ b/tests/test_session_open_model_catalog_blocking.py
@@ -24,10 +24,10 @@ Two contract fixes, asserted here as invariants (not snapshots):
    holds _available_models_cache_lock across an in-flight cold rebuild. It
    serves warm-memory (non-blocking lock) → disk → stale-disk → minimal-static.
 
-2. get_available_models_for_session_visit is stale-while-revalidate: with ANY
-   shape-valid cache it returns immediately and refreshes on a detached daemon.
-   Only a true cold boot (no cache at all) may fall back to the *bounded*
-   rebuild, which is itself capped at _LIVE_REBUILD_BUDGET_SECONDS.
+2. get_available_models_for_session_visit never waits on catalog work: it serves
+   any shape-valid cache immediately, skips contended cache locks, and starts a
+   detached refresh. On a true cold boot it returns the network-free static
+   catalog immediately while the detached refresh populates the durable cache.
 """
 
 from __future__ import annotations
@@ -204,10 +204,57 @@ def test_session_visit_serves_stale_without_blocking(monkeypatch):
     assert result["default_model"] == "anthropic/claude-sonnet-4"
 
 
-def test_session_visit_cold_boot_uses_bounded_rebuild(monkeypatch):
-    """True cold boot — NO cache on disk at all — is the only branch allowed to
-    wait, and even then it uses the *bounded* rebuild (capped at
-    _LIVE_REBUILD_BUDGET_SECONDS), never an unbounded blocking probe.
+def test_session_visit_fresh_disk_does_not_wait_behind_catalog_lock(monkeypatch):
+    """A validated fresh-disk payload must remain immediately usable while a
+    concurrent catalog rebuild owns the in-memory publication lock.
+
+    Both lock acquisitions in the fresh-disk path must be non-blocking: the
+    first memory check is optional, and a busy publication lock must not delay
+    returning the already-validated disk payload.
+    """
+    from api import config as cfg
+
+    cfg.invalidate_models_cache()
+    monkeypatch.setattr(
+        cfg, "_models_cache_file_age_seconds", lambda *a, **k: 0.0, raising=True
+    )
+    monkeypatch.setattr(
+        cfg,
+        "_load_models_cache_from_disk",
+        lambda: _catalog("anthropic/claude-opus-4"),
+        raising=True,
+    )
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def _holder():
+        with cfg._available_models_cache_lock:
+            holding.set()
+            release.wait(timeout=1.0)
+
+    t = threading.Thread(target=_holder, daemon=True)
+    t.start()
+    try:
+        assert holding.wait(timeout=0.5), "holder thread never acquired the lock"
+
+        t0 = time.monotonic()
+        result = cfg.get_available_models_for_session_visit()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.25, (
+            f"fresh-disk session visit waited {elapsed:.2f}s behind the catalog "
+            "lock instead of returning the validated disk payload"
+        )
+        assert result["default_model"] == "anthropic/claude-opus-4"
+    finally:
+        release.set()
+        t.join(timeout=1.0)
+
+
+def test_session_visit_cold_boot_returns_static_and_refreshes_async(monkeypatch):
+    """True cold boot must return a network-free catalog immediately and move
+    the live rebuild onto the existing detached refresh worker.
     """
     from api import config as cfg
 
@@ -219,30 +266,33 @@ def test_session_visit_cold_boot_uses_bounded_rebuild(monkeypatch):
     monkeypatch.setattr(
         cfg, "_load_stale_models_cache_from_disk", lambda **_kw: None, raising=True
     )
-    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.4, raising=True)
 
-    rebuilt = {"n": 0}
+    spawned = {"n": 0}
+    prefer_cache_calls = {"n": 0}
 
-    def _slow_rebuild(_builder):
-        rebuilt["n"] += 1
-        time.sleep(0.8)  # 2x budget — stands in for a hung provider probe
+    def _spy_spawn():
+        spawned["n"] += 1
+        return True
+
+    def _network_free_catalog(*, prefer_cache=False, force_refresh=False):
+        assert prefer_cache is True
+        assert force_refresh is False
+        prefer_cache_calls["n"] += 1
         return _catalog()
 
-    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_rebuild, raising=True)
+    monkeypatch.setattr(
+        cfg, "_spawn_session_visit_background_refresh", _spy_spawn, raising=True
+    )
+    monkeypatch.setattr(cfg, "get_available_models", _network_free_catalog, raising=True)
 
     t0 = time.monotonic()
     result = cfg.get_available_models_for_session_visit()
     elapsed = time.monotonic() - t0
 
-    assert rebuilt["n"] == 1, "cold boot with no cache must attempt the bounded rebuild"
-    assert elapsed < 2.0, (
-        f"cold-boot rebuild was not bounded ({elapsed:.2f}s) — the "
-        f"{cfg._LIVE_REBUILD_BUDGET_SECONDS}s budget did not apply"
-    )
-    # Structurally valid, usable catalog regardless of which fallback served it.
-    assert isinstance(result, dict)
-    for k in ("active_provider", "default_model", "configured_model_badges", "groups"):
-        assert k in result, f"cold-boot fallback catalog missing {k!r}"
+    assert elapsed < 0.25, f"cold session visit blocked {elapsed:.2f}s"
+    assert spawned["n"] == 1, "cold boot must start one detached live refresh"
+    assert prefer_cache_calls["n"] == 1, "cold boot must return the network-free catalog"
+    assert result["default_model"] == "anthropic/claude-sonnet-4"
 
 
 # ---------------------------------------------------------------------------
@@ -359,15 +409,15 @@ def test_session_visit_stale_path_spawns_background_refresh():
     assert "_spawn_session_visit_background_refresh()" in body, (
         "session_visit must spawn a background refresh on the stale path"
     )
-    # The stale branch returns before the cold-boot rebuild. Anchor on the
-    # code-only stage markers (comments also mention force_refresh, so match
-    # the _mark() labels which appear solely in executable lines).
+    # The stale branch returns before the cold-boot fallback. Anchor on the
+    # code-only stage markers so this guard proves both branches use detached
+    # refresh rather than merely matching explanatory comments.
     spawn = body.find('_mark("stale_served_background_refresh")')
-    cold = body.find('_mark("cold_boot_bounded_rebuild_start")')
+    cold = body.find('_mark("cold_boot_background_refresh_spawned")')
     assert spawn != -1 and cold != -1
     assert spawn < cold, (
         "the stale-serve + background-refresh must precede the cold-boot "
-        "bounded rebuild"
+        "background-refresh fallback"
     )
 
 

--- a/tests/test_session_open_model_catalog_blocking.py
+++ b/tests/test_session_open_model_catalog_blocking.py
@@ -137,7 +137,7 @@ def test_prefer_cache_serves_stale_disk_when_no_fresh_cache(monkeypatch):
     monkeypatch.setattr(
         cfg,
         "_load_stale_models_cache_from_disk",
-        lambda: _catalog("anthropic/claude-opus-4"),
+        lambda **_kw: _catalog("anthropic/claude-opus-4"),
         raising=True,
     )
     monkeypatch.setattr(
@@ -172,7 +172,7 @@ def test_session_visit_serves_stale_without_blocking(monkeypatch):
     )
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None, raising=True)
     monkeypatch.setattr(
-        cfg, "_load_stale_models_cache_from_disk", lambda: _catalog(), raising=True
+        cfg, "_load_stale_models_cache_from_disk", lambda **_kw: _catalog(), raising=True
     )
 
     spawned = {"n": 0}
@@ -217,7 +217,7 @@ def test_session_visit_cold_boot_uses_bounded_rebuild(monkeypatch):
     )
     monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None, raising=True)
     monkeypatch.setattr(
-        cfg, "_load_stale_models_cache_from_disk", lambda: None, raising=True
+        cfg, "_load_stale_models_cache_from_disk", lambda **_kw: None, raising=True
     )
     monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.4, raising=True)
 
@@ -288,7 +288,7 @@ def test_background_refresh_coalesces_concurrent_spawns(monkeypatch):
         release.set()
 
     assert _wait_until(
-        lambda: not cfg._session_visit_refresh_in_flight.is_set(), timeout=2.0
+        lambda: not cfg._session_visit_refresh_in_flight, timeout=2.0
     ), "in-flight guard must clear after the refresh completes"
 
 
@@ -316,7 +316,7 @@ def test_background_refresh_reuses_get_available_models_force_refresh(monkeypatc
         "background refresh must call get_available_models(force_refresh=True)"
     )
     assert _wait_until(
-        lambda: not cfg._session_visit_refresh_in_flight.is_set(), timeout=2.0
+        lambda: not cfg._session_visit_refresh_in_flight, timeout=2.0
     )
 
 

--- a/tests/test_session_open_model_catalog_blocking.py
+++ b/tests/test_session_open_model_catalog_blocking.py
@@ -1,0 +1,385 @@
+"""Regression tests — session-open must never block on a live model-catalog probe.
+
+Proven root cause (live thread-stack + Chrome DevTools waterfall on modern
+hardware: /api/session 7.09s, model_resolve=7073ms; /api/models?freshness=
+session_visit 4.0s; a ~60s sidebar because every queued request stacks behind
+the blocked catalog thread under ThreadingHTTPServer + the browser's 6-conn
+per-host cap):
+
+    /api/session?resolve_model=1
+      → _resolve_effective_session_model_for_display
+        → _resolve_compatible_session_model_state
+          → get_available_models(prefer_cache=True)   # docstring: "never blocks"
+            → BLOCKED up to 60s on _cache_build_cv.wait_for(...)   # contract broken
+
+    /api/models?freshness=session_visit
+      → get_available_models_for_session_visit
+        → get_available_models(force_refresh=True)
+          → _build_available_models_uncached → _read_live_provider_model_ids
+            → hermes_cli.models._fetch_anthropic_models → urllib HTTPS  # BLOCKED
+
+Two contract fixes, asserted here as invariants (not snapshots):
+
+1. prefer_cache=True must resolve WITHOUT waiting — even while another thread
+   holds _available_models_cache_lock across an in-flight cold rebuild. It
+   serves warm-memory (non-blocking lock) → disk → stale-disk → minimal-static.
+
+2. get_available_models_for_session_visit is stale-while-revalidate: with ANY
+   shape-valid cache it returns immediately and refreshes on a detached daemon.
+   Only a true cold boot (no cache at all) may fall back to the *bounded*
+   rebuild, which is itself capped at _LIVE_REBUILD_BUDGET_SECONDS.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _catalog(default_model: str = "anthropic/claude-sonnet-4") -> dict:
+    return {
+        "active_provider": "anthropic",
+        "default_model": default_model,
+        "configured_model_badges": {},
+        "groups": [],
+        "aliases": {},
+    }
+
+
+def _wait_until(predicate, timeout: float = 2.0, interval: float = 0.01) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — prefer_cache must never block, even behind an in-flight rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_prefer_cache_does_not_block_when_rebuild_holds_lock(monkeypatch):
+    """The core contract violation: a concurrent cold rebuild holds
+    _available_models_cache_lock across its bounded ``build_done`` wait AND has
+    _cache_build_in_progress set. Before the fix, prefer_cache fell through to
+    the ``should_wait`` condition-variable wait and the blocking lock acquire,
+    stalling session-open for seconds on a catalog already cached on disk. It
+    must now resolve from disk immediately without touching either.
+    """
+    from api import config as cfg
+
+    cfg.invalidate_models_cache()
+    monkeypatch.setattr(
+        cfg, "_load_models_cache_from_disk", lambda: _catalog(), raising=True
+    )
+
+    # prefer_cache must never invoke the live rebuild seam.
+    monkeypatch.setattr(
+        cfg,
+        "_invoke_models_rebuild",
+        lambda _b: (_ for _ in ()).throw(
+            AssertionError("prefer_cache triggered the live rebuild seam")
+        ),
+        raising=True,
+    )
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def _holder():
+        # Mirror the real bounded-rebuild critical section: hold the cache lock
+        # AND mark a build in progress across a long wait.
+        with cfg._available_models_cache_lock:
+            with cfg._cache_build_cv:
+                cfg._cache_build_in_progress = True
+            holding.set()
+            release.wait(timeout=5.0)
+            with cfg._cache_build_cv:
+                cfg._cache_build_in_progress = False
+                cfg._cache_build_cv.notify_all()
+
+    t = threading.Thread(target=_holder, daemon=True)
+    t.start()
+    try:
+        assert holding.wait(timeout=2.0), "holder thread never acquired the lock"
+
+        t0 = time.monotonic()
+        result = cfg.get_available_models(prefer_cache=True)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.5, (
+            f"prefer_cache blocked {elapsed:.2f}s while a rebuild held the lock — "
+            f"it must resolve from cache without waiting"
+        )
+        assert result["default_model"] == "anthropic/claude-sonnet-4"
+    finally:
+        release.set()
+        t.join(timeout=2.0)
+        # Leave the module global clean for other tests in the process.
+        with cfg._cache_build_cv:
+            cfg._cache_build_in_progress = False
+            cfg._cache_build_cv.notify_all()
+
+
+def test_prefer_cache_serves_stale_disk_when_no_fresh_cache(monkeypatch):
+    """prefer_cache with no fresh memory/disk cache but a shape-valid STALE disk
+    cache must serve the stale payload rather than blocking or probing.
+    """
+    from api import config as cfg
+
+    cfg.invalidate_models_cache()
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None, raising=True)
+    monkeypatch.setattr(
+        cfg,
+        "_load_stale_models_cache_from_disk",
+        lambda: _catalog("anthropic/claude-opus-4"),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        cfg,
+        "_invoke_models_rebuild",
+        lambda _b: (_ for _ in ()).throw(
+            AssertionError("prefer_cache triggered the live rebuild seam")
+        ),
+        raising=True,
+    )
+
+    result = cfg.get_available_models(prefer_cache=True)
+    assert result["default_model"] == "anthropic/claude-opus-4"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — session_visit is stale-while-revalidate (serve now, refresh later)
+# ---------------------------------------------------------------------------
+
+
+def test_session_visit_serves_stale_without_blocking(monkeypatch):
+    """A stale (past-freshness-horizon) cache must be served immediately with a
+    background refresh kicked off — NEVER a synchronous live rebuild on the
+    request thread.
+    """
+    from api import config as cfg
+
+    cfg.invalidate_models_cache()
+    # Force the "stale or missing" branch: age check reports no fresh file.
+    monkeypatch.setattr(
+        cfg, "_models_cache_file_age_seconds", lambda *a, **k: None, raising=True
+    )
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None, raising=True)
+    monkeypatch.setattr(
+        cfg, "_load_stale_models_cache_from_disk", lambda: _catalog(), raising=True
+    )
+
+    spawned = {"n": 0}
+
+    def _spy_spawn():
+        spawned["n"] += 1
+        return True
+
+    monkeypatch.setattr(
+        cfg, "_spawn_session_visit_background_refresh", _spy_spawn, raising=True
+    )
+
+    # If the stale path ran a synchronous live rebuild, this fires.
+    monkeypatch.setattr(
+        cfg,
+        "_invoke_models_rebuild",
+        lambda _b: (_ for _ in ()).throw(
+            AssertionError("session_visit ran a synchronous rebuild on a stale cache")
+        ),
+        raising=True,
+    )
+
+    t0 = time.monotonic()
+    result = cfg.get_available_models_for_session_visit()
+    elapsed = time.monotonic() - t0
+
+    assert spawned["n"] == 1, "stale cache must trigger exactly one background refresh"
+    assert elapsed < 0.5, f"session_visit blocked {elapsed:.2f}s serving a stale cache"
+    assert result["default_model"] == "anthropic/claude-sonnet-4"
+
+
+def test_session_visit_cold_boot_uses_bounded_rebuild(monkeypatch):
+    """True cold boot — NO cache on disk at all — is the only branch allowed to
+    wait, and even then it uses the *bounded* rebuild (capped at
+    _LIVE_REBUILD_BUDGET_SECONDS), never an unbounded blocking probe.
+    """
+    from api import config as cfg
+
+    cfg.invalidate_models_cache()
+    monkeypatch.setattr(
+        cfg, "_models_cache_file_age_seconds", lambda *a, **k: None, raising=True
+    )
+    monkeypatch.setattr(cfg, "_load_models_cache_from_disk", lambda: None, raising=True)
+    monkeypatch.setattr(
+        cfg, "_load_stale_models_cache_from_disk", lambda: None, raising=True
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.4, raising=True)
+
+    rebuilt = {"n": 0}
+
+    def _slow_rebuild(_builder):
+        rebuilt["n"] += 1
+        time.sleep(0.8)  # 2x budget — stands in for a hung provider probe
+        return _catalog()
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _slow_rebuild, raising=True)
+
+    t0 = time.monotonic()
+    result = cfg.get_available_models_for_session_visit()
+    elapsed = time.monotonic() - t0
+
+    assert rebuilt["n"] == 1, "cold boot with no cache must attempt the bounded rebuild"
+    assert elapsed < 2.0, (
+        f"cold-boot rebuild was not bounded ({elapsed:.2f}s) — the "
+        f"{cfg._LIVE_REBUILD_BUDGET_SECONDS}s budget did not apply"
+    )
+    # Structurally valid, usable catalog regardless of which fallback served it.
+    assert isinstance(result, dict)
+    for k in ("active_provider", "default_model", "configured_model_badges", "groups"):
+        assert k in result, f"cold-boot fallback catalog missing {k!r}"
+
+
+# ---------------------------------------------------------------------------
+# Background-refresh helper — coalescing + guard cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_background_refresh_coalesces_concurrent_spawns(monkeypatch):
+    """A burst of session-opens must spawn ONE refresh daemon, not N. The
+    in-flight guard clears once the refresh finishes so the next horizon can
+    refresh again.
+    """
+    from api import config as cfg
+
+    cfg._session_visit_refresh_in_flight.clear()
+
+    release = threading.Event()
+    calls = {"n": 0}
+    calls_lock = threading.Lock()
+
+    def _blocking_force(*_a, **_k):
+        with calls_lock:
+            calls["n"] += 1
+        release.wait(timeout=5.0)
+        return _catalog()
+
+    # The worker body calls get_available_models(force_refresh=True).
+    monkeypatch.setattr(cfg, "get_available_models", _blocking_force, raising=True)
+
+    try:
+        first = cfg._spawn_session_visit_background_refresh()
+        # Let the worker enter and latch the guard.
+        assert _wait_until(lambda: calls["n"] == 1, timeout=2.0), "worker never started"
+        second = cfg._spawn_session_visit_background_refresh()
+        third = cfg._spawn_session_visit_background_refresh()
+
+        assert first is True, "first spawn should win the claim"
+        assert second is False and third is False, (
+            "concurrent spawns must coalesce onto the in-flight refresh"
+        )
+        assert calls["n"] == 1, "only the winning spawn may run the live refresh"
+    finally:
+        release.set()
+
+    assert _wait_until(
+        lambda: not cfg._session_visit_refresh_in_flight.is_set(), timeout=2.0
+    ), "in-flight guard must clear after the refresh completes"
+
+
+def test_background_refresh_reuses_get_available_models_force_refresh(monkeypatch):
+    """The background refresh must reuse the single source of truth
+    (get_available_models(force_refresh=True)), not a bespoke probe path.
+    """
+    from api import config as cfg
+
+    cfg._session_visit_refresh_in_flight.clear()
+
+    seen = {"force_refresh": None}
+    done = threading.Event()
+
+    def _capture(*_a, **kwargs):
+        seen["force_refresh"] = kwargs.get("force_refresh")
+        done.set()
+        return _catalog()
+
+    monkeypatch.setattr(cfg, "get_available_models", _capture, raising=True)
+
+    assert cfg._spawn_session_visit_background_refresh() is True
+    assert done.wait(timeout=2.0), "background worker never called get_available_models"
+    assert seen["force_refresh"] is True, (
+        "background refresh must call get_available_models(force_refresh=True)"
+    )
+    assert _wait_until(
+        lambda: not cfg._session_visit_refresh_in_flight.is_set(), timeout=2.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Source-grep wiring guards (match the repo's existing guard-test style)
+# ---------------------------------------------------------------------------
+
+
+def test_prefer_cache_resolves_before_blocking_lock():
+    """White-box guard: the prefer_cache fast path must be positioned BEFORE the
+    ``with _available_models_cache_lock:`` blocking acquire, so a refactor can't
+    silently reintroduce the blocking behaviour.
+    """
+    src = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+    i = src.find("def get_available_models(")
+    assert i != -1
+    j = src.find("\ndef ", i + 1)
+    body = src[i:j]
+    pc = body.find("if prefer_cache:")
+    lock = body.find("with _available_models_cache_lock:")
+    assert pc != -1 and lock != -1
+    assert pc < lock, (
+        "the prefer_cache fast path must resolve BEFORE the blocking "
+        "_available_models_cache_lock acquire"
+    )
+    assert "acquire(blocking=False)" in body[pc:lock], (
+        "prefer_cache must read the memory cache under a NON-BLOCKING lock acquire"
+    )
+
+
+def test_session_visit_stale_path_spawns_background_refresh():
+    """White-box guard: the session-visit stale branch must serve the cached
+    payload and spawn a background refresh — never a synchronous force_refresh.
+    """
+    src = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+    i = src.find("def get_available_models_for_session_visit(")
+    assert i != -1
+    j = src.find("\ndef ", i + 1)
+    body = src[i:j]
+    assert "_spawn_session_visit_background_refresh()" in body, (
+        "session_visit must spawn a background refresh on the stale path"
+    )
+    # The stale branch returns before the cold-boot rebuild. Anchor on the
+    # code-only stage markers (comments also mention force_refresh, so match
+    # the _mark() labels which appear solely in executable lines).
+    spawn = body.find('_mark("stale_served_background_refresh")')
+    cold = body.find('_mark("cold_boot_bounded_rebuild_start")')
+    assert spawn != -1 and cold != -1
+    assert spawn < cold, (
+        "the stale-serve + background-refresh must precede the cold-boot "
+        "bounded rebuild"
+    )
+
+
+def test_spawn_helper_exists_and_uses_detached_worker():
+    from api import config as cfg
+
+    assert hasattr(cfg, "_spawn_session_visit_background_refresh")
+    assert hasattr(cfg, "_session_visit_refresh_in_flight")
+    src = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+    i = src.find("def _spawn_session_visit_background_refresh(")
+    j = src.find("\ndef ", i + 1)
+    body = src[i:j]
+    # Profile isolation on the detached worker (#3957 pattern).
+    assert "profile_scope_for_detached_worker" in body
+    assert "daemon=True" in body


### PR DESCRIPTION
## Summary

Opening a session in the WebUI blocks for **tens of seconds** on a live, synchronous, per-provider network probe run on the request thread. On a fast, wired, modern machine the sidebar takes roughly **60 seconds** to render. The database read for the same request is **16 ms**. All of the latency is a model-catalog refresh that ignores a valid cache sitting on disk.

Two request paths on every session-open are affected, and one of them **violates its own documented contract**.

## Evidence (production, modern hardware)

Server-side slow log for a single `/api/session` open:

```
[SLOW] session_id=… get_session=16.2ms  model_resolve=7073.0ms  compact=0.8ms  total=7091.5ms
```

The DB load is 16 ms. The other **7,073 ms is `model_resolve`**. The live thread-stack captured by the built-in request-diagnostics watchdog shows exactly where it sits:

```
api/routes.py  _resolve_effective_session_model_for_display
  → _resolve_compatible_session_model_state
    → api/config.py  get_available_models(prefer_cache=True)
      → _build_available_models_uncached → _read_live_provider_model_ids
        → hermes_cli.models._fetch_anthropic_models
          → urllib.request.urlopen(api.anthropic.com)   ← BLOCKED on SSL read
```

Chrome DevTools **Timing** for the same class of request, three separate captures:

| Metric | Capture A | Capture B | Capture C |
|---|---|---|---|
| Queued at | 5.6 min | 36.77 s | — |
| Waiting for server response | **35.44 s** | **27.44 s** | — |
| Stalled | 55.74 s | — | — |
| Total | 1.5 min | 27.46 s | ~60 s to sidebar |

516 requests, 32 MB transferred on a session open. The individual `/api/session` and `/api/models?freshness=session_visit` calls block on the catalog probe; every other poll then queues behind them under `ThreadingHTTPServer` (shared GIL) and the browser's 6-connections-per-host cap. The multi-second block is the root; the queue/stall pile-up is the amplifier.

## Root cause

Two user-facing request paths call into `get_available_models` and end up waiting on the network:

### 1. `get_available_models(prefer_cache=True)` blocks — contradicting its own docstring

The docstring (api/config.py) is explicit:

> `prefer_cache=True` resolves **WITHOUT** ever triggering a live provider probe … so a cold catalog **can never block**.

The code did not honour that. A `prefer_cache` caller still fell through to:

- the `should_wait` branch → `_cache_build_cv.wait_for(..., timeout=60.0)` — a **60-second** condition-variable wait; and
- the `with _available_models_cache_lock:` acquire — and the cold rebuild path **holds that lock across its up-to-`_LIVE_REBUILD_BUDGET_SECONDS` `build_done.wait()`** (a plain `Event`, so the RLock is not released).

So a latency-sensitive caller (session-open model resolution, Option-Z wakeup) blocked multiple seconds — up to 60 — on a catalog that was already cached on disk. The one code path documented as the safe, never-block path was the one hanging session-open.

### 2. `get_available_models_for_session_visit` does a synchronous live rebuild on every stale cache

Once the cache passed its 5-minute freshness horizon, the function called `get_available_models(force_refresh=True)` **on the request thread**, blocking up to the live-rebuild budget on per-provider network calls — while a perfectly serviceable (merely stale) cache sat on disk unused.

## Fix

Both fixes are caller-side and reuse the existing rebuild/coalescing/publish machinery — no new subsystem, no new network path.

**1. `prefer_cache` resolves before the lock and never waits.** A new fast path runs ahead of the blocking acquire and resolves in order:
1. warm in-memory cache — read under a **non-blocking** `acquire(blocking=False)` (skipped entirely if a rebuild currently holds the lock);
2. the on-disk cache (lock-free file I/O);
3. a shape-valid stale on-disk cache;
4. the network-free minimal static catalog (last resort, unchanged).

It never sets or clears `_cache_build_in_progress`, so a concurrent cold rebuild keeps its serialization intact (preserves the Greptile P1 note already in the file).

**2. `get_available_models_for_session_visit` becomes stale-while-revalidate.** If any shape-valid cache exists, it is returned immediately and a live refresh is dispatched to a detached daemon via a new `_spawn_session_visit_background_refresh()` helper. The helper reuses the single source of truth — `get_available_models(force_refresh=True)` — captures the active profile on the request thread and re-binds it on the worker (the existing `#3957` `profile_scope_for_detached_worker` pattern), and coalesces a burst of session-opens down to one refresh daemon. Only a **true cold boot** (no cache on disk at all) may fall back to the already-bounded rebuild.

Net effect: a user-facing request thread never performs, or blocks on, a live provider probe again. Session-open serves the cached catalog in ~0 ms and the catalog still self-freshens out of band.

## Tests

`tests/test_session_open_model_catalog_blocking.py` — behaviour-contract tests (not snapshots):

- `prefer_cache` returns in < 0.5 s **even while another thread holds `_available_models_cache_lock` across an in-flight rebuild** (the exact production deadlock condition);
- `prefer_cache` serves a stale disk cache instead of probing;
- `session_visit` serves a stale cache without blocking and spawns exactly one background refresh;
- true cold boot (no cache) uses the **bounded** rebuild and returns within budget;
- the background refresh coalesces concurrent spawns and reuses `force_refresh=True`;
- source-grep wiring guards pin the fast-path ordering so a future refactor can't silently reintroduce the block.

```
tests/test_session_open_model_catalog_blocking.py .... 9 passed
tests/test_wakeup_model_resolve_hang.py ............... 7 passed  (existing, still green)
```

Broader models-catalog regression sweep (74 tests across cache version-stamp, config-reload stampede, profile providers, active-provider fallback, cache fingerprint) — all green. `ruff` on the changed lines is clean (the file's 4 pre-existing `F401`/`F811` findings are untouched and out of scope).

## Scope

Deliberately server-side only. The polling volume (516 requests / session open) and the `ThreadingHTTPServer` concurrency model are real and worth a separate look, but the multi-second block is the root cause and this PR removes it without touching the transport or the request surface.
