### PR TITLE
Fix: gateway approval card gets a usable approval_id (#6008)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -49,14 +49,21 @@ _STREAM_RUN_IDS: dict[str, str] = {}
 # relay; the cap bounds growth from approvals that are never answered.
 _APPROVAL_RUN_IDS: dict[tuple[str, str], str] = {}
 _APPROVAL_RUN_IDS_MAX = 256
+# Guards the eviction loop below and the respond endpoint's pop: each run
+# streams on its own worker thread, and the read-then-delete pair in eviction
+# is not atomic under the GIL — two writers can pick the same oldest key
+# (KeyError), or a concurrent pop can mutate the dict between iter() and
+# next() (RuntimeError), killing that run's stream mid-loop.
+_APPROVAL_RUN_IDS_LOCK = threading.Lock()
 
 
 def _register_approval_run_id(session_id: str, approval_id: str, run_id: str) -> None:
     if not (session_id and approval_id and run_id):
         return
-    _APPROVAL_RUN_IDS[(session_id, approval_id)] = run_id
-    while len(_APPROVAL_RUN_IDS) > _APPROVAL_RUN_IDS_MAX:
-        del _APPROVAL_RUN_IDS[next(iter(_APPROVAL_RUN_IDS))]
+    with _APPROVAL_RUN_IDS_LOCK:
+        _APPROVAL_RUN_IDS[(session_id, approval_id)] = run_id
+        while len(_APPROVAL_RUN_IDS) > _APPROVAL_RUN_IDS_MAX:
+            del _APPROVAL_RUN_IDS[next(iter(_APPROVAL_RUN_IDS))]
 
 _WEBUI_CHAT_BACKEND_ENV = "HERMES_WEBUI_CHAT_BACKEND"
 _WEBUI_GATEWAY_BASE_URL_ENV = "HERMES_WEBUI_GATEWAY_BASE_URL"

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -8,6 +8,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+import uuid
 from typing import Any
 
 from api.config import (
@@ -37,6 +38,25 @@ logger = logging.getLogger(__name__)
 
 # Maps stream_id -> gateway run_id for approval response relay.
 _STREAM_RUN_IDS: dict[str, str] = {}
+
+# Maps (session_id, approval_id) -> gateway run_id so approve/deny can still be
+# relayed after the stream worker exits (e.g. a run parked on approval past the
+# read timeout): _STREAM_RUN_IDS is popped in the worker's finally block and
+# the gateway pending mirror never holds runs-API approvals (it rebuilds only
+# from the in-process _gateway_queues, which the remote runs API never
+# populates), so without this map a click on a still-rendered card would find
+# no run_id and fail with ok:false (#6008). Entries are popped on successful
+# relay; the cap bounds growth from approvals that are never answered.
+_APPROVAL_RUN_IDS: dict[tuple[str, str], str] = {}
+_APPROVAL_RUN_IDS_MAX = 256
+
+
+def _register_approval_run_id(session_id: str, approval_id: str, run_id: str) -> None:
+    if not (session_id and approval_id and run_id):
+        return
+    _APPROVAL_RUN_IDS[(session_id, approval_id)] = run_id
+    while len(_APPROVAL_RUN_IDS) > _APPROVAL_RUN_IDS_MAX:
+        del _APPROVAL_RUN_IDS[next(iter(_APPROVAL_RUN_IDS))]
 
 _WEBUI_CHAT_BACKEND_ENV = "HERMES_WEBUI_CHAT_BACKEND"
 _WEBUI_GATEWAY_BASE_URL_ENV = "HERMES_WEBUI_GATEWAY_BASE_URL"
@@ -334,6 +354,20 @@ def _gateway_runs_approval_event(payload: dict) -> dict | None:
     args = payload.get("args") if isinstance(payload.get("args"), (list, dict)) else []
     run_id = str(payload.get("run_id") or "").strip()
     approval_id = str(payload.get("approval_id") or payload.get("id") or "").strip()
+    if not approval_id:
+        # The runs-API approval.request payload carries run_id but no
+        # approval_id, and this card is streamed straight to the frontend
+        # without passing through submit_pending (which would have assigned a
+        # uuid). An empty id fails the frontend dismissed-card guard and is
+        # rejected by _handle_approval_respond, so the card can never be
+        # approved or denied and the run stays blocked (#6008). Synthesize a
+        # WebUI-local uuid — unique per event, so a repeat approval for the
+        # same command in one run can't inherit an earlier card's dismissal.
+        # The gateway resolves the parked run FIFO by the URL run_id and
+        # ignores the relayed approval_id; the stream loops record the id in
+        # _APPROVAL_RUN_IDS so the respond endpoint can recover the run_id
+        # even after the stream pointer is gone.
+        approval_id = "gw-" + uuid.uuid4().hex
     risk = str(payload.get("risk_level") or "high").strip()
     choices = payload.get("choices") if isinstance(payload.get("choices"), list) else []
     allow_permanent = payload.get("allow_permanent")
@@ -472,6 +506,7 @@ def _run_gateway_runs_api_streaming(
                 approval_data = _gateway_runs_approval_event(payload)
                 if approval_data:
                     approval_data["run_id"] = run_id
+                    _register_approval_run_id(session_id, approval_data["approval_id"], run_id)
                     put_gateway_event("approval", approval_data)
                 sse_event = "message"
                 continue
@@ -898,6 +933,7 @@ def _run_gateway_chat_streaming(
                             _approval_run_id = str(approval_data.get("run_id") or "").strip()
                             if _approval_run_id:
                                 _STREAM_RUN_IDS[stream_id] = _approval_run_id
+                                _register_approval_run_id(session_id, approval_data["approval_id"], _approval_run_id)
                             put_gateway_event("approval", approval_data)
                             try:
                                 from api.route_approvals import submit_gateway_pending_mirror

--- a/api/routes.py
+++ b/api/routes.py
@@ -23432,6 +23432,7 @@ def _handle_approval_respond(handler, body):
     # stream pointer has already been cleared.
     try:
         from api.gateway_chat import (
+            _APPROVAL_RUN_IDS,
             _STREAM_RUN_IDS,
             _gateway_base_url,
             _gateway_api_key,
@@ -23445,7 +23446,7 @@ def _handle_approval_respond(handler, body):
             if active_sid:
                 _run_id = _STREAM_RUN_IDS.get(active_sid)
             if not _run_id and approval_id:
-                _run_id = _gateway_mirrored_pending_run_id(sid, approval_id)
+                _run_id = _APPROVAL_RUN_IDS.get((sid, approval_id)) or _gateway_mirrored_pending_run_id(sid, approval_id)
         if _run_id:
             if not approval_id:
                 return bad(handler, "approval_id is required for gateway approvals")
@@ -23457,6 +23458,7 @@ def _handle_approval_respond(handler, body):
                 HttpRunnerClient(base_url=_base, api_key=_key).respond_approval(_run_id, approval_id, choice)
             except (RunnerClientError, ValueError) as exc:
                 return j(handler, {"ok": False, "choice": choice, "relayed": True, "error": str(exc)}, status=502)
+            _APPROVAL_RUN_IDS.pop((sid, approval_id), None)
             # The outbound relay only resumes the remote run; the local mirror
             # still needs the same cleanup path so the parked entry, mirrored
             # card, and agent signal all settle here too.

--- a/api/routes.py
+++ b/api/routes.py
@@ -23427,12 +23427,12 @@ def _handle_approval_respond(handler, body):
         return bad(handler, f"Invalid choice: {choice}")
     approval_id = body.get("approval_id", "")
 
-    # Gateway relay: forward choice to the runs API when session has an active run,
-    # or recover the run_id from the mirrored gateway approval entry if the
-    # stream pointer has already been cleared.
+    # Gateway relay: route by the card's own run first, then fall back to the
+    # session's active run or the mirrored gateway approval entry.
     try:
         from api.gateway_chat import (
             _APPROVAL_RUN_IDS,
+            _APPROVAL_RUN_IDS_LOCK,
             _STREAM_RUN_IDS,
             _gateway_base_url,
             _gateway_api_key,
@@ -23442,11 +23442,18 @@ def _handle_approval_respond(handler, body):
         s = get_session(sid)
         _run_id = None
         if s is not None:
-            active_sid = getattr(s, "active_stream_id", None)
-            if active_sid:
-                _run_id = _STREAM_RUN_IDS.get(active_sid)
+            # The card's mapping wins over the active stream: the active
+            # stream may belong to a newer run in the same session, and the
+            # gateway resolves approvals FIFO per run, so posting a stale
+            # card's choice there could approve an action the user never saw.
+            if approval_id:
+                _run_id = _APPROVAL_RUN_IDS.get((sid, approval_id))
+            if not _run_id:
+                active_sid = getattr(s, "active_stream_id", None)
+                if active_sid:
+                    _run_id = _STREAM_RUN_IDS.get(active_sid)
             if not _run_id and approval_id:
-                _run_id = _APPROVAL_RUN_IDS.get((sid, approval_id)) or _gateway_mirrored_pending_run_id(sid, approval_id)
+                _run_id = _gateway_mirrored_pending_run_id(sid, approval_id)
         if _run_id:
             if not approval_id:
                 return bad(handler, "approval_id is required for gateway approvals")
@@ -23458,7 +23465,8 @@ def _handle_approval_respond(handler, body):
                 HttpRunnerClient(base_url=_base, api_key=_key).respond_approval(_run_id, approval_id, choice)
             except (RunnerClientError, ValueError) as exc:
                 return j(handler, {"ok": False, "choice": choice, "relayed": True, "error": str(exc)}, status=502)
-            _APPROVAL_RUN_IDS.pop((sid, approval_id), None)
+            with _APPROVAL_RUN_IDS_LOCK:
+                _APPROVAL_RUN_IDS.pop((sid, approval_id), None)
             # The outbound relay only resumes the remote run; the local mirror
             # still needs the same cleanup path so the parked entry, mirrored
             # card, and agent signal all settle here too.

--- a/tests/test_gateway_approval_legacy_path.py
+++ b/tests/test_gateway_approval_legacy_path.py
@@ -117,8 +117,9 @@ def test_legacy_loop_resets_sse_event_after_approval():
     approval_idx = loop.find('"hermes.approval.request"')
     assert approval_idx >= 0
     # Window sized to cover the approval handling block including the run_id
-    # recording added in the #4549 follow-up (reset lands ~1360 chars in).
-    block_after = loop[approval_idx:approval_idx + 1500]
+    # recording added in the #4549 follow-up and the approval_id -> run_id
+    # registration added for #6008 (reset lands ~1470 chars in).
+    block_after = loop[approval_idx:approval_idx + 1700]
     assert 'sse_event = "message"' in block_after, (
         "Must reset sse_event to 'message' after approval handling to prevent bleed"
     )

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -701,6 +701,49 @@ def test_gateway_approval_response_relay_recovers_run_id_without_stream():
         _APPROVAL_RUN_IDS.pop(("sess-recover", "gw-recover"), None)
 
 
+def test_gateway_approval_response_relay_prefers_card_run_over_active_stream():
+    """A stale card's choice relays to its own run, not the newer active run.
+
+    The gateway resolves approvals FIFO per run and ignores the posted
+    approval_id, so routing a stale card through the session's active stream
+    could approve a pending action the user never saw.
+    """
+    from api.gateway_chat import _APPROVAL_RUN_IDS, _STREAM_RUN_IDS, _register_approval_run_id
+
+    _register_approval_run_id("sess-stale", "gw-stale", "run-old")
+    _STREAM_RUN_IDS["sid-newer"] = "run-new"
+
+    mock_session = MagicMock()
+    mock_session.active_stream_id = "sid-newer"
+
+    captured = {}
+
+    def fake_request_json(self, req):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return {"ok": True}
+
+    handler = MagicMock()
+    handler.wfile = io.BytesIO()
+
+    body = {"session_id": "sess-stale", "choice": "deny", "approval_id": "gw-stale"}
+
+    try:
+        with patch("api.routes.get_session", return_value=mock_session), \
+             patch("api.runner_client.HttpRunnerClient._request_json", new=fake_request_json), \
+             patch("api.gateway_chat._gateway_base_url", return_value="http://gw:8642"), \
+             patch("api.gateway_chat._gateway_api_key", return_value=""):
+            from api.routes import _handle_approval_respond
+            _handle_approval_respond(handler, body)
+
+        assert captured.get("url", "") == "http://gw:8642/v1/runs/run-old/approval"
+        assert captured["body"] == {"choice": "deny", "approval_id": "gw-stale"}
+        handler.send_response.assert_called_with(200)
+    finally:
+        _APPROVAL_RUN_IDS.pop(("sess-stale", "gw-stale"), None)
+        _STREAM_RUN_IDS.pop("sid-newer", None)
+
+
 def test_gateway_approval_response_relay_failure_returns_502():
     """Gateway relay failures must surface as HTTP errors to the frontend."""
     from api.gateway_chat import _STREAM_RUN_IDS

--- a/tests/test_gateway_approval_runs_api.py
+++ b/tests/test_gateway_approval_runs_api.py
@@ -313,9 +313,39 @@ def test_gateway_approval_event_translation():
     assert downgraded is not None
     assert downgraded["allow_permanent"] is False
 
+    # Only `id` present (no approval_id) is used verbatim, not synthesized.
+    id_only = _gateway_runs_approval_event({
+        "command": "rm -rf /tmp/x",
+        "id": "appr-from-id",
+    })
+    assert id_only is not None
+    assert id_only["approval_id"] == "appr-from-id"
+
     # Missing command/description/tool should return None.
     assert _gateway_runs_approval_event({"risk_level": "high"}) is None
     assert _gateway_runs_approval_event({}) is None
+
+
+def test_gateway_approval_event_synthesizes_id_when_missing():
+    """Runs-API approval payloads without approval_id/id get a unique gw- id (#6008)."""
+    from api.gateway_chat import _gateway_runs_approval_event
+
+    payload = {
+        "command": "rm -rf /tmp/x",
+        "description": "Dangerous command approval",
+        "pattern_key": "dangerous_command",
+        "run_id": "run-6008",
+    }
+    result = _gateway_runs_approval_event(payload)
+    assert result is not None
+    assert result["approval_id"].startswith("gw-")
+    assert result["approval_id"] != "gw-"
+
+    # Unique per event: a repeat approval for the same command in the same run
+    # must get its own id, or dismissing the first card would make the
+    # frontend dismissed-guard suppress the second one and block the run.
+    repeat = _gateway_runs_approval_event(dict(payload))
+    assert repeat["approval_id"] != result["approval_id"]
 
 
 def test_gateway_runs_api_streaming_parses_real_run_events():
@@ -578,6 +608,97 @@ def test_gateway_approval_response_relay():
 
     # Cleanup.
     _STREAM_RUN_IDS.pop("sid-relay", None)
+
+
+def test_gateway_approval_response_relay_synthesized_id():
+    """A synthesized gw- approval id relays end to end through the gateway branch (#6008)."""
+    from api.gateway_chat import _STREAM_RUN_IDS, _gateway_runs_approval_event
+
+    # Translate a runs-API payload that omits approval_id, then relay the
+    # synthesized id the frontend echoes back on the approve/deny click.
+    approval = _gateway_runs_approval_event({
+        "command": "rm -rf /tmp/x",
+        "description": "Dangerous command approval",
+        "pattern_key": "dangerous_command",
+        "run_id": "run-6008",
+    })
+    approval_id = approval["approval_id"]
+    assert approval_id.startswith("gw-")
+
+    _STREAM_RUN_IDS["sid-relay-synth"] = "run-6008"
+
+    mock_session = MagicMock()
+    mock_session.active_stream_id = "sid-relay-synth"
+
+    captured = {}
+
+    def fake_request_json(self, req):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return {"ok": True}
+
+    handler = MagicMock()
+    handler.wfile = io.BytesIO()
+
+    body = {"session_id": "sess-relay", "choice": "session", "approval_id": approval_id}
+
+    with patch("api.routes.get_session", return_value=mock_session), \
+         patch("api.runner_client.HttpRunnerClient._request_json", new=fake_request_json), \
+         patch("api.gateway_chat._gateway_base_url", return_value="http://gw:8642"), \
+         patch("api.gateway_chat._gateway_api_key", return_value=""):
+        from api.routes import _handle_approval_respond
+        _handle_approval_respond(handler, body)
+
+    assert captured.get("url", "") == "http://gw:8642/v1/runs/run-6008/approval"
+    assert captured["body"] == {"choice": "session", "approval_id": approval_id}
+    handler.send_response.assert_called_with(200)
+
+    _STREAM_RUN_IDS.pop("sid-relay-synth", None)
+
+
+def test_gateway_approval_response_relay_recovers_run_id_without_stream():
+    """Approve/deny still relays after the stream pointer is gone (#6008).
+
+    A run parked on approval past the SSE read timeout loses its stream worker
+    (_STREAM_RUN_IDS is popped in the finally block) and the gateway pending
+    mirror never holds runs-API approvals, so the respond endpoint must
+    recover the run_id from _APPROVAL_RUN_IDS.
+    """
+    from api.gateway_chat import _APPROVAL_RUN_IDS, _register_approval_run_id
+
+    _register_approval_run_id("sess-recover", "gw-recover", "run-recover")
+
+    mock_session = MagicMock()
+    mock_session.active_stream_id = None
+
+    captured = {}
+
+    def fake_request_json(self, req):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return {"ok": True}
+
+    handler = MagicMock()
+    handler.wfile = io.BytesIO()
+
+    body = {"session_id": "sess-recover", "choice": "once", "approval_id": "gw-recover"}
+
+    try:
+        with patch("api.routes.get_session", return_value=mock_session), \
+             patch("api.runner_client.HttpRunnerClient._request_json", new=fake_request_json), \
+             patch("api.gateway_chat._gateway_base_url", return_value="http://gw:8642"), \
+             patch("api.gateway_chat._gateway_api_key", return_value=""):
+            from api.routes import _handle_approval_respond
+            _handle_approval_respond(handler, body)
+
+        assert captured.get("url", "") == "http://gw:8642/v1/runs/run-recover/approval"
+        assert captured["body"] == {"choice": "once", "approval_id": "gw-recover"}
+        handler.send_response.assert_called_with(200)
+
+        # A successful relay retires the mapping.
+        assert ("sess-recover", "gw-recover") not in _APPROVAL_RUN_IDS
+    finally:
+        _APPROVAL_RUN_IDS.pop(("sess-recover", "gw-recover"), None)
 
 
 def test_gateway_approval_response_relay_failure_returns_502():


### PR DESCRIPTION
Closes #6008

## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI in a browser, including the approval gate for risky agent actions.
- When the WebUI runs chat through the Gateway runs API, the agent's `approval.request` SSE event carries `run_id` but no `approval_id`.
- `_gateway_runs_approval_event` normalized the missing field to `""`, and the runs-API path streams the card straight to the frontend — it never passes through `submit_pending`, whose `setdefault("approval_id", uuid)` would have filled one in.
- With an empty id the card renders but `_handle_approval_respond` rejects the response with 400, so the run stays blocked forever.
- This PR synthesizes a WebUI-local `approval_id` at the one translation point both gateway paths share, and records `approval_id -> run_id` server-side so the response still relays after the stream worker exits.

## What Changed

- `api/gateway_chat.py`
  - `_gateway_runs_approval_event`: when the payload has no `approval_id` and no `id`, synthesize `"gw-" + uuid4().hex` — unique per event.
  - New `_APPROVAL_RUN_IDS` map: `(session_id, approval_id) -> run_id`, capped at 256 entries, populated in both stream loops (runs-API and legacy) when an approval card is emitted, popped on successful relay.
  - Replaced `import hashlib` with `import uuid`.
  - Upstream identifiers are still preferred: `approval_id`, then `id`, then the synthesized fallback.
- `api/routes.py` — `_handle_approval_respond`
  - When `active_stream_id` is gone, recover the run_id from `_APPROVAL_RUN_IDS` before the existing gateway-mirror fallback.
  - Pop the entry after a successful relay.
- `tests/test_gateway_approval_runs_api.py`
  - `id`-only payload uses `id` verbatim (no synthesis).
  - New: payload with neither field gets a non-empty `gw-` id; two translations of the same payload get distinct ids (per-event uniqueness).
  - New: end-to-end relay of a synthesized id returns 200.
  - New: relay recovers the run_id from `_APPROVAL_RUN_IDS` when the stream pointer is gone, and retires the mapping on success.
- `tests/test_gateway_approval_legacy_path.py`
  - Widened the sse_event-reset scan window (1500 -> 1700) to cover the added registration line.

## Why It Matters

- Restores the ability to approve or deny gateway-run agent actions from the WebUI; without it the card is a dead end and the run never resumes.
- A non-empty unique id is what the frontend's dismissed-card guard and render-dedupe signature require, and what `_handle_approval_respond` needs to route the response.
- Per-event uniqueness matters: a repeat approval for the same command in one run must get its own id, or dismissing the first card would make the frontend suppress the second and re-block the run.
- The `_APPROVAL_RUN_IDS` map is needed because `_STREAM_RUN_IDS` is popped when the stream worker exits (e.g. a run parked on approval past the SSE read timeout) and the gateway pending mirror never holds runs-API approvals — so without it a click on a still-rendered card finds no run_id and fails with `ok:false`.

## Maintainer-guidance note

The issue thread carries two suggested fixes:

1. Synthesize a WebUI-local identifier in `_gateway_runs_approval_event`.
2. Drop the empty-identifier requirement and route by `run_id` alone.

This PR implements option 1. Reasons from the code:

- The frontend needs a non-empty unique `approval_id` for its dismissed-card guard and render-dedupe signature.
- `_resolve_approval_legacy` with an empty id pops the oldest pending entry, which could consume an unrelated local pending approval — the #527 parallel-approval guard exists against exactly this.
- The mirror-based `run_id` recovery in `_handle_approval_respond` needs a non-empty id.

Happy to switch to the route-by-`run_id` variant if you prefer it.

## Known limitation: parallel approvals in one run

- The gateway resolves approvals FIFO and ignores the posted `approval_id` (`resolve_gateway_approval` in hermes-agent `tools/approval.py`).
- With two approvals pending in one run (parallel subagents, or a batch of approval-gated commands), the card shows the newest command but Approve resolves the oldest — a command the user never explicitly saw.
- Scope is per chat session: each session has its own queue, so sequential tool use never hits it. I could not reproduce it in practice.
- Pre-existing for payloads with real ids; this fix widens exposure only by making id-less cards clickable at all.
- Proper fix belongs in hermes-agent: match on `approval_id` when supplied, falling back to FIFO. The WebUI already posts the id on every respond, so no further WebUI change is needed once the agent honors it.

## Verification

- State/event surface: gateway approval event translation, the `approval_id -> run_id` recovery map, and the approval response relay (runs-API + legacy paths).
- `./scripts/test.sh tests/test_gateway_approval_runs_api.py tests/test_gateway_approval_legacy_path.py` — 35 passed.
- `./scripts/test.sh -k approval` — 267 passed, 4 skipped.
- `ruff check` on the changed lines — clean (pre-existing findings elsewhere in `api/routes.py` are untouched).
- Manually tested by a human contributor and confirmed working. Note: the contributor is not the original reporter and was not affected by this bug directly, so the reporter's exact pre-fix condition could not be reproduced first-hand.

## Risks / Follow-ups

- The synthesized id is opaque and WebUI-local; the agent ignores it and resolves the parked run FIFO by the URL `run_id`, so it never needs to match anything upstream.
- Parallel-approval limitation above needs a hermes-agent change to fully close.
- If the maintainer prefers routing by `run_id` alone (option 2), the frontend guard and `_resolve_approval_legacy` empty-id behavior would need adjustment too — out of scope here.
- No UI change: the card already renders; a non-empty id makes the existing submit path work, so no before/after screenshots apply.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.8 (`claude-opus-4-8`), via Claude Code CLI.
- AI produced the initial synthesized-id fix and tests. The contributor revised the identifier to a per-event uuid, added the server-side `(session_id, approval_id) -> run_id` recovery map and the respond-endpoint lookup, and manually verified the fix.
