### PR TITLE
fix(#6025): derive active-run visibility from canonical session rows

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -9080,17 +9080,22 @@ SESSION_CHANNEL_SUBSCRIBER_GRACE_SECS: int = 60  # subscribers-empty grace
 # still unwinding, blocked in a provider call, or waiting for delegated work.
 ACTIVE_RUNS: dict = {}
 ACTIVE_RUNS_LOCK = threading.Lock()
+_SUPPRESSED_ACTIVE_RUNS: dict[str, str] = {}
 LAST_RUN_FINISHED_AT: float | None = None
 SERVER_START_TIME = time.time()
 
 
-def active_run_session_snapshot() -> dict[str, dict[str, float]]:
-    """Return the bounded, presentation-safe active session projection."""
-    snapshot: dict[str, dict[str, float]] = {}
-    with ACTIVE_RUNS_LOCK:
-        entries = list((ACTIVE_RUNS or {}).values())
-    for entry in entries:
+def _active_run_projection_locked() -> dict[str, float]:
+    """Return visible session starts while ``ACTIVE_RUNS_LOCK`` is held."""
+    projection: dict[str, float] = {}
+    for stream_id, entry in (ACTIVE_RUNS or {}).items():
         if not isinstance(entry, dict):
+            continue
+        if (
+            entry.get("ephemeral")
+            or entry.get("active_run_visible") is False
+            or str(stream_id) in _SUPPRESSED_ACTIVE_RUNS
+        ):
             continue
         session_id = str(entry.get("session_id") or "").strip()
         if not session_id:
@@ -9101,10 +9106,49 @@ def active_run_session_snapshot() -> dict[str, dict[str, float]]:
             continue
         if not math.isfinite(started_at) or started_at <= 0:
             continue
-        current = snapshot.get(session_id)
-        if current is None or started_at < current["started_at"]:
-            snapshot[session_id] = {"started_at": started_at}
-    return snapshot
+        current = projection.get(session_id)
+        if current is None or started_at < current:
+            projection[session_id] = started_at
+    return projection
+
+
+def active_run_session_snapshot() -> dict[str, dict[str, float]]:
+    """Return the bounded, presentation-safe active session projection."""
+    with ACTIVE_RUNS_LOCK:
+        projection = _active_run_projection_locked()
+    return {
+        session_id: {"started_at": started_at}
+        for session_id, started_at in projection.items()
+    }
+
+
+def _active_run_changed_sessions(before: dict[str, float], after: dict[str, float]) -> set[str]:
+    changed = set(before) ^ set(after)
+    changed.update(
+        session_id
+        for session_id in set(before) & set(after)
+        if before[session_id] != after[session_id]
+    )
+    return changed
+
+
+def suppress_active_run_visibility(stream_id: str, parent_session_id: str | None = None) -> None:
+    """Keep helper-session workers out of the parent activity projection."""
+    if not stream_id:
+        return
+    changed: set[str] = set()
+    with ACTIVE_RUNS_LOCK:
+        before = _active_run_projection_locked()
+        _SUPPRESSED_ACTIVE_RUNS[str(stream_id)] = str(parent_session_id or "")
+        entry = ACTIVE_RUNS.get(stream_id)
+        if isinstance(entry, dict):
+            entry["active_run_visible"] = False
+        changed = _active_run_changed_sessions(before, _active_run_projection_locked())
+    _publish_active_run_membership_changes(changed)
+
+
+def _clear_suppressed_active_run(stream_id: str) -> None:
+    _SUPPRESSED_ACTIVE_RUNS.pop(str(stream_id), None)
 
 
 _active_run_session_snapshot = active_run_session_snapshot
@@ -9135,18 +9179,11 @@ def register_active_run(stream_id: str, **metadata) -> None:
     entry.setdefault("phase", "running")
     changed: set[str] = set()
     with ACTIVE_RUNS_LOCK:
-        before_ids = {
-            str(item.get("session_id") or "").strip()
-            for item in ACTIVE_RUNS.values()
-            if isinstance(item, dict) and str(item.get("session_id") or "").strip()
-        }
+        before = _active_run_projection_locked()
+        if str(stream_id) in _SUPPRESSED_ACTIVE_RUNS:
+            entry["active_run_visible"] = False
         ACTIVE_RUNS[stream_id] = entry
-        after_ids = {
-            str(item.get("session_id") or "").strip()
-            for item in ACTIVE_RUNS.values()
-            if isinstance(item, dict) and str(item.get("session_id") or "").strip()
-        }
-        changed = before_ids ^ after_ids
+        changed = _active_run_changed_sessions(before, _active_run_projection_locked())
     _publish_active_run_membership_changes(changed)
 
 
@@ -9156,20 +9193,13 @@ def update_active_run(stream_id: str, **metadata) -> None:
         return
     changed: set[str] = set()
     with ACTIVE_RUNS_LOCK:
-        before_ids = {
-            str(item.get("session_id") or "").strip()
-            for item in ACTIVE_RUNS.values()
-            if isinstance(item, dict) and str(item.get("session_id") or "").strip()
-        }
+        before = _active_run_projection_locked()
         entry = ACTIVE_RUNS.get(stream_id)
         if entry is not None:
             entry.update(metadata)
-            after_ids = {
-                str(item.get("session_id") or "").strip()
-                for item in ACTIVE_RUNS.values()
-                if isinstance(item, dict) and str(item.get("session_id") or "").strip()
-            }
-            changed = before_ids ^ after_ids
+            if str(stream_id) in _SUPPRESSED_ACTIVE_RUNS:
+                entry["active_run_visible"] = False
+            changed = _active_run_changed_sessions(before, _active_run_projection_locked())
     _publish_active_run_membership_changes(changed)
 
 
@@ -9180,15 +9210,10 @@ def unregister_active_run(stream_id: str) -> None:
     global LAST_RUN_FINISHED_AT
     changed: set[str] = set()
     with ACTIVE_RUNS_LOCK:
-        previous = ACTIVE_RUNS.pop(stream_id, None)
-        previous_session = str(previous.get("session_id") or "").strip() if isinstance(previous, dict) else ""
-        if previous_session:
-            remaining = any(
-                isinstance(item, dict) and str(item.get("session_id") or "").strip() == previous_session
-                for item in ACTIVE_RUNS.values()
-            )
-            if not remaining:
-                changed.add(previous_session)
+        before = _active_run_projection_locked()
+        ACTIVE_RUNS.pop(stream_id, None)
+        _clear_suppressed_active_run(stream_id)
+        changed = _active_run_changed_sessions(before, _active_run_projection_locked())
         LAST_RUN_FINISHED_AT = time.time()
     _publish_active_run_membership_changes(changed)
     unregister_stream_owner(stream_id)

--- a/api/config.py
+++ b/api/config.py
@@ -9084,6 +9084,46 @@ LAST_RUN_FINISHED_AT: float | None = None
 SERVER_START_TIME = time.time()
 
 
+def active_run_session_snapshot() -> dict[str, dict[str, float]]:
+    """Return the bounded, presentation-safe active session projection."""
+    snapshot: dict[str, dict[str, float]] = {}
+    with ACTIVE_RUNS_LOCK:
+        entries = list((ACTIVE_RUNS or {}).values())
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        session_id = str(entry.get("session_id") or "").strip()
+        if not session_id:
+            continue
+        try:
+            started_at = float(entry.get("started_at"))
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(started_at) or started_at <= 0:
+            continue
+        current = snapshot.get(session_id)
+        if current is None or started_at < current["started_at"]:
+            snapshot[session_id] = {"started_at": started_at}
+    return snapshot
+
+
+_active_run_session_snapshot = active_run_session_snapshot
+
+
+def _publish_active_run_membership_changes(changed: set[str]) -> None:
+    if not changed:
+        return
+    try:
+        from api.session_events import publish_session_list_changed
+        for session_id in sorted(changed):
+            publish_session_list_changed(
+                reason="active_run_membership",
+                session_id=session_id,
+            )
+    except Exception:
+        logger.debug("Failed to publish active-run membership change", exc_info=True)
+
+
 def register_active_run(stream_id: str, **metadata) -> None:
     """Mark a WebUI agent worker as alive until its outer finally exits."""
     if not stream_id:
@@ -9093,18 +9133,44 @@ def register_active_run(stream_id: str, **metadata) -> None:
     entry.setdefault("stream_id", stream_id)
     entry.setdefault("started_at", now)
     entry.setdefault("phase", "running")
+    changed: set[str] = set()
     with ACTIVE_RUNS_LOCK:
+        before_ids = {
+            str(item.get("session_id") or "").strip()
+            for item in ACTIVE_RUNS.values()
+            if isinstance(item, dict) and str(item.get("session_id") or "").strip()
+        }
         ACTIVE_RUNS[stream_id] = entry
+        after_ids = {
+            str(item.get("session_id") or "").strip()
+            for item in ACTIVE_RUNS.values()
+            if isinstance(item, dict) and str(item.get("session_id") or "").strip()
+        }
+        changed = before_ids ^ after_ids
+    _publish_active_run_membership_changes(changed)
 
 
 def update_active_run(stream_id: str, **metadata) -> None:
     """Update active-run metadata without creating a new run implicitly."""
     if not stream_id:
         return
+    changed: set[str] = set()
     with ACTIVE_RUNS_LOCK:
+        before_ids = {
+            str(item.get("session_id") or "").strip()
+            for item in ACTIVE_RUNS.values()
+            if isinstance(item, dict) and str(item.get("session_id") or "").strip()
+        }
         entry = ACTIVE_RUNS.get(stream_id)
         if entry is not None:
             entry.update(metadata)
+            after_ids = {
+                str(item.get("session_id") or "").strip()
+                for item in ACTIVE_RUNS.values()
+                if isinstance(item, dict) and str(item.get("session_id") or "").strip()
+            }
+            changed = before_ids ^ after_ids
+    _publish_active_run_membership_changes(changed)
 
 
 def unregister_active_run(stream_id: str) -> None:
@@ -9112,9 +9178,19 @@ def unregister_active_run(stream_id: str) -> None:
     if not stream_id:
         return
     global LAST_RUN_FINISHED_AT
+    changed: set[str] = set()
     with ACTIVE_RUNS_LOCK:
-        ACTIVE_RUNS.pop(stream_id, None)
+        previous = ACTIVE_RUNS.pop(stream_id, None)
+        previous_session = str(previous.get("session_id") or "").strip() if isinstance(previous, dict) else ""
+        if previous_session:
+            remaining = any(
+                isinstance(item, dict) and str(item.get("session_id") or "").strip() == previous_session
+                for item in ACTIVE_RUNS.values()
+            )
+            if not remaining:
+                changed.add(previous_session)
         LAST_RUN_FINISHED_AT = time.time()
+    _publish_active_run_membership_changes(changed)
     unregister_stream_owner(stream_id)
 
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that

--- a/api/config.py
+++ b/api/config.py
@@ -9148,10 +9148,8 @@ def suppress_active_run_visibility(stream_id: str, parent_session_id: str | None
 
 
 def _clear_suppressed_active_run(stream_id: str) -> None:
+    """Drop a helper-run suppression while ``ACTIVE_RUNS_LOCK`` is held."""
     _SUPPRESSED_ACTIVE_RUNS.pop(str(stream_id), None)
-
-
-_active_run_session_snapshot = active_run_session_snapshot
 
 
 def _publish_active_run_membership_changes(changed: set[str]) -> None:
@@ -9165,7 +9163,7 @@ def _publish_active_run_membership_changes(changed: set[str]) -> None:
                 session_id=session_id,
             )
     except Exception:
-        logger.debug("Failed to publish active-run membership change", exc_info=True)
+        logger.warning("Failed to publish active-run membership change", exc_info=True)
 
 
 def register_active_run(stream_id: str, **metadata) -> None:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -849,7 +849,7 @@ def _run_gateway_chat_streaming(
         _clear_gateway_run_starting(stream_id)
         # Cancelled before the worker started; release the owner entry the route
         # layer registered so STREAM_SESSION_OWNERS does not leak (no teardown finally runs).
-        unregister_stream_owner(stream_id)
+        unregister_active_run(stream_id)
         # Also release the writeback-owner entry the route layer registered, so
         # SESSION_WRITEBACK_OWNERS does not leak on this pre-start cancellation
         # path (the teardown finally below never runs when we early-return here).

--- a/api/models.py
+++ b/api/models.py
@@ -6123,6 +6123,7 @@ def _diag_stage(diag, name: str) -> None:
 def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
     _diag_stage(diag, "all_sessions.active_streams")
     active_stream_ids = _active_stream_ids()
+    active_session_ids = set(_cfg.active_run_session_snapshot())
     # Phase C: try index first for O(1) read; fall back to full scan
     _diag_stage(diag, "all_sessions.index_exists")
     if not SESSION_INDEX_FILE.exists():
@@ -6250,6 +6251,7 @@ def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
                 s.get('title', 'Untitled') == 'Untitled'
                 and s.get('message_count', 0) == 0
                 and not s.get('active_stream_id')
+                and str(s.get('session_id') or '') not in active_session_ids
                 and not s.get('has_pending_user_message')
                 and not s.get('worktree_path')
             )]
@@ -6305,6 +6307,7 @@ def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
         s.title == 'Untitled'
         and len(s.messages) == 0
         and not s.active_stream_id
+        and str(getattr(s, 'session_id', '') or '') not in active_session_ids
         and not s.pending_user_message
         and not getattr(s, 'worktree_path', None)
     )]  # fmt: skip

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -520,7 +520,7 @@ def _session_list_cache_overlay_runtime_rows(
         item["cron_running"] = _session_list_row_cron_running(
             sid, item, cron_job_prefixes
         )
-        if sid in active_runs and not item.get("archived"):
+        if source_authoritative and sid in active_runs and not item.get("archived"):
             started_at = active_runs[sid]["started_at"]
             item["active_run"] = {
                 "started_at": started_at,

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -243,6 +243,24 @@ def _session_list_cache_stale_reason(key: tuple) -> str | None:
         return None
 
 
+def _session_list_cache_source_stamps_equivalent(expected, current) -> bool:
+    if expected == current:
+        return True
+    # An empty WAL can appear or disappear while a read-only fingerprint
+    # connection closes; its mtime carries no committed source content.
+    if (
+        isinstance(expected, tuple)
+        and isinstance(current, tuple)
+        and len(expected) == len(current) == 7
+        and isinstance(expected[1], tuple)
+        and isinstance(current[1], tuple)
+        and len(expected[1]) == len(current[1]) == 2
+        and expected[1][1] == current[1][1] == 0
+    ):
+        return expected[:1] + expected[2:] == current[:1] + current[2:]
+    return False
+
+
 def _session_list_cache_set(
     key: tuple,
     payload: dict,
@@ -253,7 +271,12 @@ def _session_list_cache_set(
         return False
     with _SESSIONS_CACHE_LOCK:
         stamp = _session_list_cache_resolved_source_stamp(key)
-        if expected_source_stamp is not None and stamp != expected_source_stamp:
+        if (
+            expected_source_stamp is not None
+            and not _session_list_cache_source_stamps_equivalent(
+                expected_source_stamp, stamp
+            )
+        ):
             return False
         _SESSIONS_CACHE[key] = (time.monotonic(), stamp, copy.deepcopy(payload))
         _SESSIONS_CACHE.move_to_end(key)

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -484,17 +484,6 @@ def _session_list_cache_overlay_runtime_rows(
         item = dict(row) if isinstance(row, dict) else {}
         sid = str(item.get("session_id") or "").strip()
         item.pop("active_run", None)
-        if not source_authoritative:
-            for key in (
-                "active_stream_id",
-                "has_pending_user_message",
-                "pending_started_at",
-                "is_streaming",
-                "cron_running",
-            ):
-                item.pop(key, None)
-            overlaid.append(item)
-            continue
         live = live_sessions.get(sid)
         if live is not None:
             live_stream_id = getattr(live, "active_stream_id", None)

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -243,15 +243,23 @@ def _session_list_cache_stale_reason(key: tuple) -> str | None:
         return None
 
 
-def _session_list_cache_set(key: tuple, payload: dict) -> None:
+def _session_list_cache_set(
+    key: tuple,
+    payload: dict,
+    *,
+    expected_source_stamp=None,
+) -> bool:
     if not isinstance(payload, dict):
-        return
-    stamp = _session_list_cache_resolved_source_stamp(key)
+        return False
     with _SESSIONS_CACHE_LOCK:
+        stamp = _session_list_cache_resolved_source_stamp(key)
+        if expected_source_stamp is not None and stamp != expected_source_stamp:
+            return False
         _SESSIONS_CACHE[key] = (time.monotonic(), stamp, copy.deepcopy(payload))
         _SESSIONS_CACHE.move_to_end(key)
         while len(_SESSIONS_CACHE) > _SESSIONS_CACHE_MAX_ENTRIES:
             _SESSIONS_CACHE.popitem(last=False)
+    return True
 
 
 def _session_list_cache_clear(profile: str | None = None) -> None:

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -8,7 +8,7 @@ import time
 from collections import OrderedDict
 from pathlib import Path
 
-from api.config import LOCK, SESSION_DIR, SESSIONS, SETTINGS_FILE
+from api.config import LOCK, SESSION_DIR, SESSIONS, SETTINGS_FILE, active_run_session_snapshot
 from api.models import _active_state_db_path, _active_stream_ids
 from api.profiles import _profiles_match
 
@@ -449,7 +449,11 @@ def _session_list_cache_settings_write_version() -> int:
         return 0
 
 
-def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
+def _session_list_cache_overlay_runtime_rows(
+    rows: list[dict],
+    *,
+    source_authoritative: bool = True,
+) -> list[dict]:
     if not rows:
         return []
     try:
@@ -461,6 +465,8 @@ def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
     except Exception:
         running_cron_jobs = {}
     cron_job_prefixes = [(jid, f"cron_{jid}_", started_at) for jid, started_at in running_cron_jobs.items()]
+    active_runs = active_run_session_snapshot()
+    now = time.time()
     session_ids = [
         str(row.get("session_id") or "").strip()
         for row in rows
@@ -477,6 +483,18 @@ def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
     for row in rows:
         item = dict(row) if isinstance(row, dict) else {}
         sid = str(item.get("session_id") or "").strip()
+        item.pop("active_run", None)
+        if not source_authoritative:
+            for key in (
+                "active_stream_id",
+                "has_pending_user_message",
+                "pending_started_at",
+                "is_streaming",
+                "cron_running",
+            ):
+                item.pop(key, None)
+            overlaid.append(item)
+            continue
         live = live_sessions.get(sid)
         if live is not None:
             live_stream_id = getattr(live, "active_stream_id", None)
@@ -502,6 +520,12 @@ def _session_list_cache_overlay_runtime_rows(rows: list[dict]) -> list[dict]:
         item["cron_running"] = _session_list_row_cron_running(
             sid, item, cron_job_prefixes
         )
+        if sid in active_runs and not item.get("archived"):
+            started_at = active_runs[sid]["started_at"]
+            item["active_run"] = {
+                "started_at": started_at,
+                "age_seconds": round(max(0.0, now - started_at), 1),
+            }
         overlaid.append(item)
     overlaid.sort(key=_session_list_runtime_sort_key, reverse=True)
     return overlaid

--- a/api/routes.py
+++ b/api/routes.py
@@ -2781,9 +2781,13 @@ def _get_cached_session_list_payload(
                 diag.stage("session_list_cache_stale_return")
             except Exception:
                 pass
+        source_authoritative = (
+            stale_reason == "age"
+            and _session_list_cache_stale_reason(key) == "age"
+        )
         return _session_list_cache_result(
             stale,
-            source_authoritative=stale_reason != "source",
+            source_authoritative=source_authoritative,
         )
 
     event, is_owner = _session_list_cache_claim_rebuild(key)

--- a/api/routes.py
+++ b/api/routes.py
@@ -2751,6 +2751,7 @@ def _get_cached_session_list_payload(
                     rebuild_attempts = 0
                     while True:
                         invalidation_stamp = _session_list_cache_invalidation_stamp(key)
+                        source_stamp = _session_list_cache_source_stamp(key)
                         try:
                             payload = builder()
                         except Exception:
@@ -2758,8 +2759,14 @@ def _get_cached_session_list_payload(
                                 "session list stale-cache background rebuild failed"
                             )
                             return
-                        if _session_list_cache_invalidation_stamp(key) == invalidation_stamp:
-                            _session_list_cache_set(key, payload)
+                        if (
+                            _session_list_cache_invalidation_stamp(key) == invalidation_stamp
+                            and _session_list_cache_set(
+                                key,
+                                payload,
+                                expected_source_stamp=source_stamp,
+                            )
+                        ):
                             return
                         rebuild_attempts += 1
                         if rebuild_attempts >= 3:
@@ -2801,9 +2808,16 @@ def _get_cached_session_list_payload(
             rebuild_attempts = 0
             while True:
                 invalidation_stamp = _session_list_cache_invalidation_stamp(key)
+                source_stamp = _session_list_cache_source_stamp(key)
                 payload = builder()
-                if _session_list_cache_invalidation_stamp(key) == invalidation_stamp:
-                    _session_list_cache_set(key, payload)
+                if (
+                    _session_list_cache_invalidation_stamp(key) == invalidation_stamp
+                    and _session_list_cache_set(
+                        key,
+                        payload,
+                        expected_source_stamp=source_stamp,
+                    )
+                ):
                     if diag is not None:
                         try:
                             diag.stage("session_list_cache_stored")
@@ -2866,12 +2880,16 @@ def _get_cached_session_list_payload(
         except Exception:
             pass
     invalidation_stamp = _session_list_cache_invalidation_stamp(key)
+    source_stamp = _session_list_cache_source_stamp(key)
     payload = builder()
     source_authoritative = (
         _session_list_cache_invalidation_stamp(key) == invalidation_stamp
+        and _session_list_cache_set(
+            key,
+            payload,
+            expected_source_stamp=source_stamp,
+        )
     )
-    if source_authoritative:
-        _session_list_cache_set(key, payload)
     return _session_list_cache_result(
         payload,
         source_authoritative=source_authoritative,

--- a/api/routes.py
+++ b/api/routes.py
@@ -2737,7 +2737,7 @@ def _get_cached_session_list_payload(
 
     stale = cached  # now actually a stale payload when one exists, else None
     stale_reason = _session_list_cache_stale_reason(key) if stale is not None else None
-    if stale is not None and stale_reason != "source":
+    if stale is not None and stale_reason == "age":
         event, is_owner = _session_list_cache_claim_rebuild(key)
         if is_owner:
             if diag is not None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2213,6 +2213,11 @@ def _build_session_list_cache_payload(
     diag=None,
 ) -> dict:
     diag_stage = diag.stage if diag is not None else lambda *_a, **_k: None
+    try:
+        from api.config import active_run_session_snapshot
+        active_run_session_ids = set(active_run_session_snapshot())
+    except Exception:
+        active_run_session_ids = set()
 
     def _session_has_server_visible_messages(session: dict) -> bool:
         """Return True when a non-active sidebar row has a visibility signal.
@@ -2232,6 +2237,8 @@ def _build_session_list_cache_payload(
             if _numeric_count(attention.get("count")) > 0:
                 return True
 
+        if str(session.get("session_id") or "") in active_run_session_ids:
+            return True
         return bool(
             session.get("is_streaming")
             or session.get("active_stream_id")
@@ -10029,6 +10036,7 @@ _SIDEBAR_SESSION_RESPONSE_FIELDS = {
     "cron_running",
     "active_stream_id",
     "has_pending_user_message",
+    "active_run",
     "pending_started_at",
     "default_hidden",
     "worktree_path",

--- a/api/routes.py
+++ b/api/routes.py
@@ -21079,6 +21079,8 @@ def _handle_btw(handler, body):
     ephemeral.title = f"btw: {question[:60]}"
     ephemeral.save()
     stream_id = uuid.uuid4().hex
+    from api.config import suppress_active_run_visibility
+    suppress_active_run_visibility(stream_id, body["session_id"])
     ephemeral.active_stream_id = stream_id
     register_session_writeback_owner(ephemeral.session_id, stream_id)
     ephemeral.save()
@@ -21130,6 +21132,8 @@ def _handle_background(handler, body):
     bg.title = f"bg: {prompt[:60]}"
     bg.save()
     stream_id = uuid.uuid4().hex
+    from api.config import suppress_active_run_visibility
+    suppress_active_run_visibility(stream_id, body["session_id"])
     bg.active_stream_id = stream_id
     register_session_writeback_owner(bg.session_id, stream_id)
     bg.save()

--- a/api/routes.py
+++ b/api/routes.py
@@ -2591,9 +2591,37 @@ def _build_session_list_cache_payload(
     }
 
 
-def _session_list_payload_to_response(payload: dict) -> dict:
+class _SessionListCacheResult(dict):
+    """Internal cache result carrying whether rows may receive runtime claims."""
+
+    def __init__(self, payload: dict, *, source_authoritative: bool):
+        super().__init__(payload)
+        self.source_authoritative = bool(source_authoritative)
+
+
+def _session_list_cache_result(payload: dict, *, source_authoritative: bool):
+    if isinstance(payload, _SessionListCacheResult):
+        return payload
+    return _SessionListCacheResult(
+        payload,
+        source_authoritative=source_authoritative,
+    )
+
+
+def _session_list_payload_to_response(
+    payload: dict,
+    *,
+    source_authoritative: bool | None = None,
+) -> dict:
+    if source_authoritative is None:
+        source_authoritative = bool(
+            getattr(payload, "source_authoritative", True)
+        )
     safe_merged = []
-    runtime_rows = _session_list_cache_overlay_runtime_rows(payload.get("sessions", []) or [])
+    runtime_rows = _session_list_cache_overlay_runtime_rows(
+        payload.get("sessions", []) or [],
+        source_authoritative=source_authoritative,
+    )
     # Read the redaction setting ONCE for the whole response and thread it through
     # every row, instead of letting each row's _redact_text() re-read settings.json
     # from disk (per title). The _sidebar_session_response_item -> _redact_text(_enabled=...)
@@ -2691,7 +2719,7 @@ def _get_cached_session_list_payload(
     key: tuple,
     builder,
     diag=None,
-) -> dict:
+) -> _SessionListCacheResult:
     if diag is not None:
         try:
             diag.stage("session_list_cache_lookup")
@@ -2705,7 +2733,7 @@ def _get_cached_session_list_payload(
                 diag.stage("session_list_cache_hit")
             except Exception:
                 pass
-        return cached
+        return _session_list_cache_result(cached, source_authoritative=True)
 
     stale = cached  # now actually a stale payload when one exists, else None
     stale_reason = _session_list_cache_stale_reason(key) if stale is not None else None
@@ -2753,7 +2781,10 @@ def _get_cached_session_list_payload(
                 diag.stage("session_list_cache_stale_return")
             except Exception:
                 pass
-        return stale
+        return _session_list_cache_result(
+            stale,
+            source_authoritative=stale_reason != "source",
+        )
 
     event, is_owner = _session_list_cache_claim_rebuild(key)
     if is_owner:
@@ -2774,7 +2805,10 @@ def _get_cached_session_list_payload(
                             diag.stage("session_list_cache_stored")
                         except Exception:
                             pass
-                    return payload
+                    return _session_list_cache_result(
+                        payload,
+                        source_authoritative=True,
+                    )
                 rebuild_attempts += 1
                 if diag is not None:
                     try:
@@ -2782,7 +2816,10 @@ def _get_cached_session_list_payload(
                     except Exception:
                         pass
                 if rebuild_attempts >= 3:
-                    return payload
+                    return _session_list_cache_result(
+                        payload,
+                        source_authoritative=False,
+                    )
         finally:
             _session_list_cache_done(key, event)
 
@@ -2808,7 +2845,7 @@ def _get_cached_session_list_payload(
                 diag.stage("session_list_cache_wait_hit")
             except Exception:
                 pass
-        return latest
+        return _session_list_cache_result(latest, source_authoritative=True)
 
     if stale is not None:
         if diag is not None:
@@ -2816,7 +2853,7 @@ def _get_cached_session_list_payload(
                 diag.stage("session_list_cache_wait_stale_fallback")
             except Exception:
                 pass
-        return stale
+        return _session_list_cache_result(stale, source_authoritative=False)
 
     # Safety path if the owner died before storing anything.
     if diag is not None:
@@ -2826,9 +2863,15 @@ def _get_cached_session_list_payload(
             pass
     invalidation_stamp = _session_list_cache_invalidation_stamp(key)
     payload = builder()
-    if _session_list_cache_invalidation_stamp(key) == invalidation_stamp:
+    source_authoritative = (
+        _session_list_cache_invalidation_stamp(key) == invalidation_stamp
+    )
+    if source_authoritative:
         _session_list_cache_set(key, payload)
-    return payload
+    return _session_list_cache_result(
+        payload,
+        source_authoritative=source_authoritative,
+    )
 
 from api.config import (
     STATE_DIR,
@@ -13410,7 +13453,11 @@ def handle_get(handler, parsed) -> bool:
                 diag=diag,
             )
             diag.stage("response_write")
-            return j(handler, _session_list_payload_to_response(payload), pretty=False)
+            return j(
+                handler,
+                _session_list_payload_to_response(payload),
+                pretty=False,
+            )
         finally:
             diag.finish()
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7825,7 +7825,7 @@ def _run_agent_streaming(
         # The stream was cancelled before the worker started; the route layer
         # already registered the stream owner, so release it here to avoid
         # leaking a STREAM_SESSION_OWNERS entry that the teardown finally never sees.
-        unregister_stream_owner(stream_id)
+        unregister_active_run(stream_id)
         try:
             clear_session_writeback_owner_if_owned(session_id, stream_id)
         except Exception:

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -5,6 +5,7 @@
 
 const LOCALES = {
   en: {
+    active_run_conversation_fallback: 'Active conversation', active_run_open_conversation: 'Open conversation', active_run_visibility_label: (count, duration) => `${count} active · ${duration}`,
     offline_title: 'Connection lost',
     offline_browser_detail: 'Your browser reports that this device is offline.',
     offline_network_detail: 'Hermes is unreachable from this browser right now.',
@@ -1770,6 +1771,7 @@ const LOCALES = {
   },
 
   it: {
+    active_run_conversation_fallback: 'Conversazione attiva', active_run_open_conversation: 'Apri conversazione', active_run_visibility_label: (count, duration) => `${count} attive · ${duration}`,
     offline_title: 'Connessione persa',
     offline_browser_detail: 'Il browser segnala che questo dispositivo è offline.',
     offline_network_detail: 'Hermes non è raggiungibile da questo browser al momento.',
@@ -3517,6 +3519,7 @@ const LOCALES = {
   },
 
   ja: {
+    active_run_conversation_fallback: 'アクティブな会話', active_run_open_conversation: '会話を開く', active_run_visibility_label: (count, duration) => `${count} 件が実行中 · ${duration}`,
     offline_title: '接続が切断されました',
     offline_browser_detail: 'ブラウザはこのデバイスがオフラインだと報告しています。',
     offline_network_detail: '現在、このブラウザからHermesに到達できません。',
@@ -5269,6 +5272,7 @@ const LOCALES = {
   },
 
   ru: {
+    active_run_conversation_fallback: 'Активный разговор', active_run_open_conversation: 'Открыть разговор', active_run_visibility_label: (count, duration) => `${count} активных · ${duration}`,
     offline_title: 'Соединение потеряно',
     offline_browser_detail: 'Браузер сообщает, что это устройство офлайн.',
     offline_network_detail: 'Hermes сейчас недоступен из этого браузера.',
@@ -6995,6 +6999,7 @@ const LOCALES = {
   },
 
   es: {
+    active_run_conversation_fallback: 'Conversación activa', active_run_open_conversation: 'Abrir conversación', active_run_visibility_label: (count, duration) => `${count} activas · ${duration}`,
     offline_title: 'Conexión perdida',
     offline_browser_detail: 'Tu navegador indica que este dispositivo está sin conexión.',
     offline_network_detail: 'Hermes no está disponible desde este navegador ahora mismo.',
@@ -8688,6 +8693,7 @@ const LOCALES = {
   },
 
   de: {
+    active_run_conversation_fallback: 'Aktive Konversation', active_run_open_conversation: 'Konversation öffnen', active_run_visibility_label: (count, duration) => `${count} aktiv · ${duration}`,
     offline_title: 'Verbindung verloren',
     offline_browser_detail: 'Dein Browser meldet, dass dieses Gerät offline ist.',
     offline_network_detail: 'Hermes ist von diesem Browser aus gerade nicht erreichbar.',
@@ -10375,6 +10381,7 @@ const LOCALES = {
   },
 
   zh: {
+    active_run_conversation_fallback: '活动会话', active_run_open_conversation: '打开会话', active_run_visibility_label: (count, duration) => `${count} 个活动 · ${duration}`,
     offline_title: '连接已断开',
     offline_browser_detail: '浏览器报告此设备当前离线。',
     offline_network_detail: '此浏览器当前无法连接到 Hermes。',
@@ -12056,6 +12063,7 @@ const LOCALES = {
 
   // Traditional Chinese (zh-Hant)
   'zh-Hant': {
+    active_run_conversation_fallback: '作用中對話', active_run_open_conversation: '開啟對話', active_run_visibility_label: (count, duration) => `${count} 個作用中 · ${duration}`,
 
     offline_title: '連線中斷',
     offline_browser_detail: '瀏覽器回報此裝置目前離線。',
@@ -13806,6 +13814,7 @@ const LOCALES = {
   },
 
   pt: {
+    active_run_conversation_fallback: 'Conversa ativa', active_run_open_conversation: 'Abrir conversa', active_run_visibility_label: (count, duration) => `${count} ativas · ${duration}`,
     offline_title: 'Conexão perdida',
     offline_browser_detail: 'O navegador informa que este dispositivo está offline.',
     offline_network_detail: 'O Hermes está inacessível neste navegador agora.',
@@ -15372,6 +15381,7 @@ const LOCALES = {
     wiki_not_configured: 'Wiki not configured',
   },
   ko: {
+    active_run_conversation_fallback: '활성 대화', active_run_open_conversation: '대화 열기', active_run_visibility_label: (count, duration) => `${count}개 활성 · ${duration}`,
     offline_title: '연결이 끊겼습니다',
     offline_browser_detail: '브라우저가 이 장치가 오프라인이라고 보고합니다.',
     offline_network_detail: '현재 이 브라우저에서 Hermes에 연결할 수 없습니다.',
@@ -17109,6 +17119,7 @@ const LOCALES = {
   },
 
   fr: {
+    active_run_conversation_fallback: 'Conversation active', active_run_open_conversation: 'Ouvrir la conversation', active_run_visibility_label: (count, duration) => `${count} actives · ${duration}`,
     offline_title: 'Connexion perdue',
     offline_browser_detail: 'Votre navigateur signale que cet appareil est hors ligne.',
     offline_network_detail: 'Hermes est actuellement inaccessible depuis ce navigateur.',
@@ -18829,6 +18840,7 @@ const LOCALES = {
   },
 
   cs: {
+    active_run_conversation_fallback: 'Aktivní konverzace', active_run_open_conversation: 'Otevřít konverzaci', active_run_visibility_label: (count, duration) => `${count} aktivní · ${duration}`,
     _label: 'Čeština',
     _lang: 'cs',
     _speech: 'cs-CZ',
@@ -20535,6 +20547,7 @@ const LOCALES = {
     tool_summary_join: _i18nToolSummaryJoinCs,
   },
   tr: {
+    active_run_conversation_fallback: 'Aktif konuşma', active_run_open_conversation: 'Konuşmayı aç', active_run_visibility_label: (count, duration) => `${count} aktif · ${duration}`,
 
 
 
@@ -22277,6 +22290,7 @@ const LOCALES = {
   
   },
   pl: {
+    active_run_conversation_fallback: 'Aktywna rozmowa', active_run_open_conversation: 'Otwórz rozmowę', active_run_visibility_label: (count, duration) => `${count} aktywne · ${duration}`,
     offline_title: 'Połączenie utracone',
     offline_browser_detail: 'Twoja przeglądarka zgłasza, że to urządzenie jest offline.',
     offline_network_detail: 'Hermes jest obecnie nieosiągalny z tej przeglądarki.',
@@ -24019,6 +24033,7 @@ const LOCALES = {
     checkpoint_diff_files_changed: (n) => n === 1 ? '1 plik zmieniony' : `${n} zmienionych plików`,
   },
   vi: {
+    active_run_conversation_fallback: 'Cuộc trò chuyện đang hoạt động', active_run_open_conversation: 'Mở cuộc trò chuyện', active_run_visibility_label: (count, duration) => `${count} đang hoạt động · ${duration}`,
     offline_title: 'Mất kết nối',
     offline_browser_detail: 'Trình duyệt báo rằng thiết bị này đang ngoại tuyến.',
     offline_network_detail: 'Không thể kết nối tới Hermes từ trình duyệt lúc này.',
@@ -26208,3 +26223,10 @@ function applyLocaleToDOM() {
 
 // Apply saved locale immediately so there's no flash of English on reload.
 loadLocale();
+function _activeRunLocaleNames(source){
+  const names=[];
+  const pattern=/^  (?:'([^']+)'|([A-Za-z-]+))\s*:\s*\{/gm;
+  let match;
+  while((match=pattern.exec(String(source||'')))) names.push(match[1]||match[2]);
+  return names;
+}

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -5,7 +5,6 @@
 
 const LOCALES = {
   en: {
-    active_run_conversation_fallback: 'Active conversation', active_run_open_conversation: 'Open conversation', active_run_visibility_label: (count, duration) => `${count} active · ${duration}`,
     offline_title: 'Connection lost',
     offline_browser_detail: 'Your browser reports that this device is offline.',
     offline_network_detail: 'Hermes is unreachable from this browser right now.',
@@ -15,6 +14,9 @@ const LOCALES = {
     offline_stream_waiting: 'Connection lost. Waiting to refresh…',
     _lang: 'en',
     _label: 'English',
+    active_run_conversation_fallback: 'Active conversation',
+    active_run_open_conversation: 'Open conversation',
+    active_run_visibility_label: (count, duration) => `${count} active · ${duration}`,
     _speech: 'en-US',
     // boot.js
     cancelling: 'Cancelling\u2026',
@@ -1771,7 +1773,6 @@ const LOCALES = {
   },
 
   it: {
-    active_run_conversation_fallback: 'Conversazione attiva', active_run_open_conversation: 'Apri conversazione', active_run_visibility_label: (count, duration) => `${count} attive · ${duration}`,
     offline_title: 'Connessione persa',
     offline_browser_detail: 'Il browser segnala che questo dispositivo è offline.',
     offline_network_detail: 'Hermes non è raggiungibile da questo browser al momento.',
@@ -1781,6 +1782,9 @@ const LOCALES = {
     offline_stream_waiting: 'Connessione persa. In attesa di aggiornare…',
     _lang: 'it',
     _label: 'Italiano',
+    active_run_conversation_fallback: 'Conversazione attiva',
+    active_run_open_conversation: 'Apri conversazione',
+    active_run_visibility_label: (count, duration) => `${count} attive · ${duration}`,
     _speech: 'it-IT',
     // boot.js
     cancelling: 'Annullamento\u2026',
@@ -3519,7 +3523,6 @@ const LOCALES = {
   },
 
   ja: {
-    active_run_conversation_fallback: 'アクティブな会話', active_run_open_conversation: '会話を開く', active_run_visibility_label: (count, duration) => `${count} 件が実行中 · ${duration}`,
     offline_title: '接続が切断されました',
     offline_browser_detail: 'ブラウザはこのデバイスがオフラインだと報告しています。',
     offline_network_detail: '現在、このブラウザからHermesに到達できません。',
@@ -3529,6 +3532,9 @@ const LOCALES = {
     offline_stream_waiting: '接続が切断されました。更新を待っています…',
     _lang: 'ja',
     _label: '日本語',
+    active_run_conversation_fallback: 'アクティブな会話',
+    active_run_open_conversation: '会話を開く',
+    active_run_visibility_label: (count, duration) => `${count} 件が実行中 · ${duration}`,
     _speech: 'ja-JP',
     // boot.js
     cancelling: 'キャンセル中…',
@@ -5272,7 +5278,6 @@ const LOCALES = {
   },
 
   ru: {
-    active_run_conversation_fallback: 'Активный разговор', active_run_open_conversation: 'Открыть разговор', active_run_visibility_label: (count, duration) => `${count} активных · ${duration}`,
     offline_title: 'Соединение потеряно',
     offline_browser_detail: 'Браузер сообщает, что это устройство офлайн.',
     offline_network_detail: 'Hermes сейчас недоступен из этого браузера.',
@@ -5282,6 +5287,9 @@ const LOCALES = {
     offline_stream_waiting: 'Соединение потеряно. Ожидаю обновления…',
     _lang: 'ru',
     _label: 'Русский',
+    active_run_conversation_fallback: 'Активный разговор',
+    active_run_open_conversation: 'Открыть разговор',
+    active_run_visibility_label: (count, duration) => `${count} активных · ${duration}`,
     _speech: 'ru-RU',
     cancelling: 'Отменяю…',
     cancel_failed: 'Не удалось отменить.',
@@ -6999,7 +7007,6 @@ const LOCALES = {
   },
 
   es: {
-    active_run_conversation_fallback: 'Conversación activa', active_run_open_conversation: 'Abrir conversación', active_run_visibility_label: (count, duration) => `${count} activas · ${duration}`,
     offline_title: 'Conexión perdida',
     offline_browser_detail: 'Tu navegador indica que este dispositivo está sin conexión.',
     offline_network_detail: 'Hermes no está disponible desde este navegador ahora mismo.',
@@ -7009,6 +7016,9 @@ const LOCALES = {
     offline_stream_waiting: 'Conexión perdida. Esperando para actualizar…',
     _lang: 'es',
     _label: 'Español',
+    active_run_conversation_fallback: 'Conversación activa',
+    active_run_open_conversation: 'Abrir conversación',
+    active_run_visibility_label: (count, duration) => `${count} activas · ${duration}`,
     _speech: 'es-ES',
     // boot.js
     cancelling: 'Cancelando…',
@@ -8693,7 +8703,6 @@ const LOCALES = {
   },
 
   de: {
-    active_run_conversation_fallback: 'Aktive Konversation', active_run_open_conversation: 'Konversation öffnen', active_run_visibility_label: (count, duration) => `${count} aktiv · ${duration}`,
     offline_title: 'Verbindung verloren',
     offline_browser_detail: 'Dein Browser meldet, dass dieses Gerät offline ist.',
     offline_network_detail: 'Hermes ist von diesem Browser aus gerade nicht erreichbar.',
@@ -8703,6 +8712,9 @@ const LOCALES = {
     offline_stream_waiting: 'Verbindung verloren. Warte auf Aktualisierung…',
     _lang: 'de',
     _label: 'Deutsch',
+    active_run_conversation_fallback: 'Aktive Konversation',
+    active_run_open_conversation: 'Konversation öffnen',
+    active_run_visibility_label: (count, duration) => `${count} aktiv · ${duration}`,
     _speech: 'de-DE',
     // boot.js
     cancelling: 'Wird abgebrochen\u2026',
@@ -10381,7 +10393,6 @@ const LOCALES = {
   },
 
   zh: {
-    active_run_conversation_fallback: '活动会话', active_run_open_conversation: '打开会话', active_run_visibility_label: (count, duration) => `${count} 个活动 · ${duration}`,
     offline_title: '连接已断开',
     offline_browser_detail: '浏览器报告此设备当前离线。',
     offline_network_detail: '此浏览器当前无法连接到 Hermes。',
@@ -10391,6 +10402,9 @@ const LOCALES = {
     offline_stream_waiting: '连接已断开。正在等待刷新…',
     _lang: 'zh',
     _label: '\u7b80\u4f53\u4e2d\u6587',
+    active_run_conversation_fallback: '活动会话',
+    active_run_open_conversation: '打开会话',
+    active_run_visibility_label: (count, duration) => `${count} 个活动 · ${duration}`,
     _speech: 'zh-CN',
     // boot.js
     cancelling: '正在取消...',
@@ -12063,7 +12077,6 @@ const LOCALES = {
 
   // Traditional Chinese (zh-Hant)
   'zh-Hant': {
-    active_run_conversation_fallback: '作用中對話', active_run_open_conversation: '開啟對話', active_run_visibility_label: (count, duration) => `${count} 個作用中 · ${duration}`,
 
     offline_title: '連線中斷',
     offline_browser_detail: '瀏覽器回報此裝置目前離線。',
@@ -12074,6 +12087,9 @@ const LOCALES = {
     offline_stream_waiting: '連線中斷。等待重新整理…',
     _lang: 'zh-Hant',
     _label: '繁體中文',
+    active_run_conversation_fallback: '作用中對話',
+    active_run_open_conversation: '開啟對話',
+    active_run_visibility_label: (count, duration) => `${count} 個作用中 · ${duration}`,
     _speech: 'zh-TW',
     // boot.js
     cancelling: '正在取消……',
@@ -13814,7 +13830,6 @@ const LOCALES = {
   },
 
   pt: {
-    active_run_conversation_fallback: 'Conversa ativa', active_run_open_conversation: 'Abrir conversa', active_run_visibility_label: (count, duration) => `${count} ativas · ${duration}`,
     offline_title: 'Conexão perdida',
     offline_browser_detail: 'O navegador informa que este dispositivo está offline.',
     offline_network_detail: 'O Hermes está inacessível neste navegador agora.',
@@ -13824,6 +13839,9 @@ const LOCALES = {
     offline_stream_waiting: 'Conexão perdida. Aguardando para atualizar…',
     _lang: 'pt',
     _label: 'Português',
+    active_run_conversation_fallback: 'Conversa ativa',
+    active_run_open_conversation: 'Abrir conversa',
+    active_run_visibility_label: (count, duration) => `${count} ativas · ${duration}`,
     _speech: 'pt-BR',
     // boot.js
     cancelling: 'Cancelando…',
@@ -15381,7 +15399,6 @@ const LOCALES = {
     wiki_not_configured: 'Wiki not configured',
   },
   ko: {
-    active_run_conversation_fallback: '활성 대화', active_run_open_conversation: '대화 열기', active_run_visibility_label: (count, duration) => `${count}개 활성 · ${duration}`,
     offline_title: '연결이 끊겼습니다',
     offline_browser_detail: '브라우저가 이 장치가 오프라인이라고 보고합니다.',
     offline_network_detail: '현재 이 브라우저에서 Hermes에 연결할 수 없습니다.',
@@ -15391,6 +15408,9 @@ const LOCALES = {
     offline_stream_waiting: '연결이 끊겼습니다. 새로고침을 기다리는 중…',
     _lang: 'ko',
     _label: '한국어',
+    active_run_conversation_fallback: '활성 대화',
+    active_run_open_conversation: '대화 열기',
+    active_run_visibility_label: (count, duration) => `${count}개 활성 · ${duration}`,
     _speech: 'ko-KR',
     // boot.js
     cancelling: '취소 중\u2026',
@@ -17119,7 +17139,6 @@ const LOCALES = {
   },
 
   fr: {
-    active_run_conversation_fallback: 'Conversation active', active_run_open_conversation: 'Ouvrir la conversation', active_run_visibility_label: (count, duration) => `${count} actives · ${duration}`,
     offline_title: 'Connexion perdue',
     offline_browser_detail: 'Votre navigateur signale que cet appareil est hors ligne.',
     offline_network_detail: 'Hermes est actuellement inaccessible depuis ce navigateur.',
@@ -17129,6 +17148,9 @@ const LOCALES = {
     offline_stream_waiting: 'Connexion perdue. En attente de rafraîchissement\u2026',
     _lang: 'fr',
     _label: 'Français',
+    active_run_conversation_fallback: 'Conversation active',
+    active_run_open_conversation: 'Ouvrir la conversation',
+    active_run_visibility_label: (count, duration) => `${count} actives · ${duration}`,
     _speech: 'fr-FR',
     cancelling: 'Annulation\u2026',
     cancel_failed: 'Échec de l\'annulation.',
@@ -18840,8 +18862,10 @@ const LOCALES = {
   },
 
   cs: {
-    active_run_conversation_fallback: 'Aktivní konverzace', active_run_open_conversation: 'Otevřít konverzaci', active_run_visibility_label: (count, duration) => `${count} aktivní · ${duration}`,
     _label: 'Čeština',
+    active_run_conversation_fallback: 'Aktivní konverzace',
+    active_run_open_conversation: 'Otevřít konverzaci',
+    active_run_visibility_label: (count, duration) => `${count} aktivní · ${duration}`,
     _lang: 'cs',
     _speech: 'cs-CZ',
     copy_relative_path: 'Kopírovat relativní cestu',
@@ -20547,7 +20571,6 @@ const LOCALES = {
     tool_summary_join: _i18nToolSummaryJoinCs,
   },
   tr: {
-    active_run_conversation_fallback: 'Aktif konuşma', active_run_open_conversation: 'Konuşmayı aç', active_run_visibility_label: (count, duration) => `${count} aktif · ${duration}`,
 
 
 
@@ -20561,6 +20584,9 @@ const LOCALES = {
     offline_stream_waiting: 'Bağlantı kesildi. Yenilenmesi bekleniyor\u2026',
     _lang: 'tr',
     _label: 'Türkçe',
+    active_run_conversation_fallback: 'Aktif konuşma',
+    active_run_open_conversation: 'Konuşmayı aç',
+    active_run_visibility_label: (count, duration) => `${count} aktif · ${duration}`,
     _speech: 'tr-TR',
     // boot.js
     cancelling: 'İptal ediliyor\u2026',
@@ -22290,7 +22316,6 @@ const LOCALES = {
   
   },
   pl: {
-    active_run_conversation_fallback: 'Aktywna rozmowa', active_run_open_conversation: 'Otwórz rozmowę', active_run_visibility_label: (count, duration) => `${count} aktywne · ${duration}`,
     offline_title: 'Połączenie utracone',
     offline_browser_detail: 'Twoja przeglądarka zgłasza, że to urządzenie jest offline.',
     offline_network_detail: 'Hermes jest obecnie nieosiągalny z tej przeglądarki.',
@@ -22300,6 +22325,9 @@ const LOCALES = {
     offline_stream_waiting: 'Połączenie utracone. Oczekiwanie na odświeżenie…',
     _lang: 'pl',
     _label: 'Polski',
+    active_run_conversation_fallback: 'Aktywna rozmowa',
+    active_run_open_conversation: 'Otwórz rozmowę',
+    active_run_visibility_label: (count, duration) => `${count} aktywne · ${duration}`,
     _speech: 'pl-PL',
     // boot.js
     cancelling: 'Anulowanie…',
@@ -24033,7 +24061,6 @@ const LOCALES = {
     checkpoint_diff_files_changed: (n) => n === 1 ? '1 plik zmieniony' : `${n} zmienionych plików`,
   },
   vi: {
-    active_run_conversation_fallback: 'Cuộc trò chuyện đang hoạt động', active_run_open_conversation: 'Mở cuộc trò chuyện', active_run_visibility_label: (count, duration) => `${count} đang hoạt động · ${duration}`,
     offline_title: 'Mất kết nối',
     offline_browser_detail: 'Trình duyệt báo rằng thiết bị này đang ngoại tuyến.',
     offline_network_detail: 'Không thể kết nối tới Hermes từ trình duyệt lúc này.',
@@ -24043,6 +24070,9 @@ const LOCALES = {
     offline_stream_waiting: 'Mất kết nối. Đang chờ làm mới…',
     _lang: 'vi',
     _label: 'Tiếng Việt',
+    active_run_conversation_fallback: 'Cuộc trò chuyện đang hoạt động',
+    active_run_open_conversation: 'Mở cuộc trò chuyện',
+    active_run_visibility_label: (count, duration) => `${count} đang hoạt động · ${duration}`,
     _speech: 'vi-VN',
     // boot.js
     cancelling: 'Đang hủy…',

--- a/static/index.html
+++ b/static/index.html
@@ -135,6 +135,10 @@
     </span>
     <span class="app-titlebar-title" id="appTitlebarTitle">Hermes</span>
     <span class="app-titlebar-sub" id="appTitlebarSub" hidden></span>
+    <div id="activeRunVisibility" class="active-run-visibility" hidden>
+      <button id="activeRunPill" class="chip active-run-pill" type="button" aria-expanded="false" aria-controls="activeRunTray"></button>
+      <div id="activeRunTray" class="active-run-tray" hidden role="menu"></div>
+    </div>
   </div>
   <div class="app-titlebar-spacer" aria-hidden="true"></div>
   <button class="app-titlebar-new-chat" id="btnTitlebarNewChat" onclick="$('btnNewChat') && $('btnNewChat').click()" type="button" aria-label="New conversation" data-i18n-title="new_conversation" data-i18n-aria-label="new_conversation" title="New conversation">

--- a/static/index.html
+++ b/static/index.html
@@ -137,7 +137,7 @@
     <span class="app-titlebar-sub" id="appTitlebarSub" hidden></span>
     <div id="activeRunVisibility" class="active-run-visibility" hidden>
       <button id="activeRunPill" class="chip active-run-pill" type="button" aria-expanded="false" aria-controls="activeRunTray"></button>
-      <div id="activeRunTray" class="active-run-tray" hidden role="menu"></div>
+      <div id="activeRunTray" class="active-run-tray" hidden role="list"></div>
     </div>
   </div>
   <div class="app-titlebar-spacer" aria-hidden="true"></div>

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5506,7 +5506,7 @@ function _applySessionListPayload(sessData, projData, opts){
   const hasRingStreaming = _allSessions.some(s => typeof _isSessionRingStreaming==='function'
     ? _isSessionRingStreaming(s)
     : _isSessionEffectivelyStreaming(s));
-  if (isStreaming || hasRingStreaming) {
+  if (isStreaming) {
     startStreamingPoll();
   } else {
     stopStreamingPoll();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5502,8 +5502,9 @@ function _applySessionListPayload(sessData, projData, opts){
   if (typeof expectedUnreadGen !== 'number' || expectedUnreadGen === currentUnreadGen) {
     _markPollingCompletionUnreadTransitions(_allSessions);
   }
-  const isStreaming = _allSessions.some(s => _isSessionRingStreaming(s));
-  if (isStreaming) {
+  const isStreaming = _allSessions.some(s => _isSessionEffectivelyStreaming(s));
+  const hasRingStreaming = _allSessions.some(s => _isSessionRingStreaming(s));
+  if (isStreaming || hasRingStreaming) {
     startStreamingPoll();
   } else {
     stopStreamingPoll();
@@ -5676,7 +5677,7 @@ async function _runRenderSessionListRefresh(opts, _gen){
       _schedulePendingSessionListApply();
       return;
     }
-    if(_sessionListGenerationIsCurrent(_gen)&&!_profileSwitchListEmbargo){
+    if(_gen===_renderSessionListGen&&!_profileSwitchListEmbargo){
       _applySessionListPayload(sessData,projData,{unreadGen});
     }
   }catch(e){
@@ -7474,7 +7475,9 @@ function _sessionAttentionState(s){
 function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
   return (s.message_count||0)>0 ||
     _sessionAttentionState(s) ||
-    _isSessionRingStreaming(s) ||
+    (typeof _isSessionRingStreaming==='function'
+      ? _isSessionRingStreaming(s)
+      : _isSessionEffectivelyStreaming(s)) ||
     !!s.active_stream_id ||
     !!s.pending_user_message ||
     !!s.has_pending_user_message ||
@@ -8131,9 +8134,12 @@ function renderSessionListFromCache(){
     title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle,s);
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
-    const hasAttentionState=isRingStreaming||hasUnread||Boolean(attention);
+    const hasAttentionState=isStreaming||hasUnread||Boolean(attention);
+    const hasRingAttentionState=isRingStreaming||hasUnread||Boolean(attention);
     ts.className='session-time'+(hasAttentionState?' is-hidden':'');
+    if(hasRingAttentionState&&!hasAttentionState) ts.classList.add('is-hidden');
     ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
+    if(hasRingAttentionState&&!hasAttentionState) ts.textContent='';
     titleRow.appendChild(title);
     // Project color dot: placed BETWEEN title and timestamp, not inside the
     // title span. Inside the title span it would be clipped by the ellipsis

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5690,6 +5690,7 @@ async function _runRenderSessionListRefresh(opts, _gen){
     // skeleton; if the switch itself fails, its catch clears the skeleton + embargo.
     if (_profileSwitchListEmbargo) return;
     _showSessionListLoadError(e);
+    if(typeof _clearCachedActiveRunProjection==='function') _clearCachedActiveRunProjection();
     // Only fall back to the cached rows if they were loaded under the SAME
     // scope we're requesting now. After a profile switch the cache holds the
     // PRIOR profile's sessions; re-rendering them would falsely show another
@@ -5719,6 +5720,15 @@ async function _runRenderSessionListRefresh(opts, _gen){
       _clearSessionSourceTabCounts();
       renderSessionListFromCache();
     }
+  }
+}
+
+function _clearCachedActiveRunProjection(){
+  for(const row of Array.isArray(_allSessions)?_allSessions:[]){
+    if(row&&typeof row==='object') delete row.active_run;
+  }
+  if(typeof window!=='undefined'&&typeof window._renderActiveRunProjection==='function'){
+    window._renderActiveRunProjection([]);
   }
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2632,7 +2632,7 @@ function _setActiveProjectFilter(projectId) {
   const next = projectId === NO_PROJECT_FILTER ? NO_PROJECT_FILTER : (projectId || null);
   if (_activeProject === next) return;
   _activeProject = next;
-  _clearActiveRunProjection();
+  if(typeof _clearActiveRunProjection==='function') _clearActiveRunProjection();
   renderSessionListFromCache();
   void renderSessionList({deferWhileInteracting:false});
 }
@@ -2642,7 +2642,7 @@ function _setSessionSourceFilter(filter) {
   if (_sessionSourceFilter === next) return;
   _sessionSourceFilter = next;
   _activeProject = null;
-  _clearActiveRunProjection();
+  if(typeof _clearActiveRunProjection==='function') _clearActiveRunProjection();
   _selectedSessions.clear();
   _sessionSelectMode = false;
   try { localStorage.setItem('hermes-session-source-filter', next); } catch (_e) {}
@@ -5348,7 +5348,7 @@ function _schedulePendingSessionListApply(){
     }
     const payload=_pendingSessionListPayload;
     _pendingSessionListPayload=null;
-    if(!_sessionListGenerationIsCurrent(payload.gen)) return;
+    if(payload.gen!==_renderSessionListGen) return;
     // Profile switch may have bumped unread gen after the list gen check
     // window; still drop completion-marking for the stale pre-switch payload.
     _applySessionListPayloadIfCurrent(payload.gen,payload.sessData,payload.projData,{
@@ -5676,7 +5676,9 @@ async function _runRenderSessionListRefresh(opts, _gen){
       _schedulePendingSessionListApply();
       return;
     }
-    _applySessionListPayloadIfCurrent(_gen,sessData,projData,{unreadGen});
+    if(_sessionListGenerationIsCurrent(_gen)&&!_profileSwitchListEmbargo){
+      _applySessionListPayload(sessData,projData,{unreadGen});
+    }
   }catch(e){
     if (_gen !== _renderSessionListGen) return;
     // #4671: same embargo guard as the success path — a mid-switch /api/sessions that
@@ -8043,7 +8045,8 @@ function renderSessionListFromCache(){
     const isActive=_sessionLineageContainsSession(s,activeSidForSidebar);
     const ownStreaming=_isSessionEffectivelyStreaming(s);
     const ownRingStreaming=_isSessionRingStreaming(s);
-    const isStreaming=ownRingStreaming||!!s._child_session_streaming;
+    const isStreaming=ownStreaming||!!s._child_session_streaming;
+    const isRingStreaming=ownRingStreaming||!!s._child_session_streaming;
     _rememberRenderedStreamingState(s, ownStreaming);
     _rememberRenderedSessionSnapshot(s);
     const hasUnread=(_hasUnreadForSession(s)||!!s._child_session_has_unread)&&!isActive;
@@ -8128,7 +8131,7 @@ function renderSessionListFromCache(){
     title.title=_sessionFullTitleTooltip(rawTitle,cleanTitle,s);
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
-    const hasAttentionState=isStreaming||hasUnread||Boolean(attention);
+    const hasAttentionState=isRingStreaming||hasUnread||Boolean(attention);
     ts.className='session-time'+(hasAttentionState?' is-hidden':'');
     ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5503,9 +5503,6 @@ function _applySessionListPayload(sessData, projData, opts){
     _markPollingCompletionUnreadTransitions(_allSessions);
   }
   const isStreaming = _allSessions.some(s => _isSessionEffectivelyStreaming(s));
-  const hasRingStreaming = _allSessions.some(s => typeof _isSessionRingStreaming==='function'
-    ? _isSessionRingStreaming(s)
-    : _isSessionEffectivelyStreaming(s));
   if (isStreaming) {
     startStreamingPoll();
   } else {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -820,6 +820,36 @@ function _isSessionEffectivelyStreaming(s) {
   ));
 }
 
+function _isSessionRingStreaming(s) {
+  return _isSessionEffectivelyStreaming(s) || Boolean(s && s.active_run);
+}
+
+function _activeRunRowsForProjection(rows) {
+  const sourceRows = Array.isArray(rows) ? rows : [];
+  const partition = typeof _partitionSidebarSessionRows === 'function'
+    ? _partitionSidebarSessionRows(
+      sourceRows,
+      typeof _activeSessionIdForSidebar === 'function' ? _activeSessionIdForSidebar() : null,
+    )
+    : {sessionsRaw: sourceRows};
+  const filtered = (Array.isArray(partition.sessionsRaw) ? partition.sessionsRaw : [])
+    .filter(s => s && s.active_run && !s.archived);
+  const activeByLineage = new Map();
+  for (const row of filtered) {
+    const key = typeof _sidebarLineageKeyForRow === 'function' ? _sidebarLineageKeyForRow(row) : String(row.session_id || '');
+    if (!key) continue;
+    const previous = activeByLineage.get(key);
+    if (!previous || Number(row.active_run.started_at) < Number(previous.active_run.started_at)) activeByLineage.set(key, row.active_run);
+  }
+  const visibleRows = typeof _collapseSessionLineageForSidebar === 'function' ? _collapseSessionLineageForSidebar(filtered) : filtered;
+  return visibleRows.flatMap(row => {
+    const key = typeof _sidebarLineageKeyForRow === 'function' ? _sidebarLineageKeyForRow(row) : String(row.session_id || '');
+    const activeRun = activeByLineage.get(key);
+    return activeRun ? [{...row, active_run: activeRun}] : [];
+  });
+}
+if(typeof window!=='undefined') window._activeRunRowsForProjection = _activeRunRowsForProjection;
+
 function _hasPendingUserMessageSignal(s) {
   return Boolean(s && (s.pending_user_message || s.has_pending_user_message));
 }
@@ -5054,6 +5084,7 @@ let _sessionListEnterAllAnimationPending = false;
 // pending/queued payloads drops a deferred apply that would do the same.
 function _invalidateSessionListRenders(){
   _renderSessionListGen++;
+  if(typeof window!=='undefined' && typeof window._renderActiveRunProjection==='function') window._renderActiveRunProjection([]);
   _pendingSessionListPayload = null;
   _renderSessionListQueuedRequest = null;
   // A retry whose fetch is invalidated here (e.g. a profile switch mid-retry)
@@ -5067,6 +5098,9 @@ function _invalidateSessionListRenders(){
     delete _sessionListLoadError.retrying;
     delete _sessionListLoadError._retryFailedFocus;
   }
+}
+function _sessionListGenerationIsCurrent(generation){
+  return generation===_renderSessionListGen;
 }
 if(typeof window!=='undefined') window._invalidateSessionListRenders = _invalidateSessionListRenders;
 
@@ -5394,6 +5428,7 @@ function _applySessionListPayload(sessData, projData, opts){
     : [];
   _reconcileActiveSessionIdleStateFromList(serverSessions);
   _allSessions = _mergeOptimisticFirstTurnSessions(serverSessions);
+  if(typeof window!=='undefined' && typeof window._renderActiveRunProjection==='function') window._renderActiveRunProjection(_allSessions);
   // Tag the cache with the scope it was loaded under (active profile +
   // all-profiles flag). If a later /api/sessions fails right after a profile
   // switch, the catch path checks this so it won't re-render the PRIOR
@@ -7408,7 +7443,7 @@ function _sessionAttentionState(s){
 function _sidebarRowHasVisibleMessages(s, activeSidForSidebar){
   return (s.message_count||0)>0 ||
     _sessionAttentionState(s) ||
-    _isSessionEffectivelyStreaming(s) ||
+    _isSessionRingStreaming(s) ||
     !!s.active_stream_id ||
     !!s.pending_user_message ||
     !!s.has_pending_user_message ||
@@ -7978,7 +8013,8 @@ function renderSessionListFromCache(){
     const el=document.createElement('div');
     const isActive=_sessionLineageContainsSession(s,activeSidForSidebar);
     const ownStreaming=_isSessionEffectivelyStreaming(s);
-    const isStreaming=ownStreaming||!!s._child_session_streaming;
+    const ownRingStreaming=_isSessionRingStreaming(s);
+    const isStreaming=ownRingStreaming||!!s._child_session_streaming;
     _rememberRenderedStreamingState(s, ownStreaming);
     _rememberRenderedSessionSnapshot(s);
     const hasUnread=(_hasUnreadForSession(s)||!!s._child_session_has_unread)&&!isActive;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -8068,7 +8068,7 @@ function renderSessionListFromCache(){
     const attention=_sessionAttentionState(s)||_sessionAttentionState({_child:true,attention:s._child_session_attention});
     const attentionClass=attention?(attention.kind==='approval'?' attention-approval':(attention.kind==='clarify'?' attention-clarify':' attention-attention')):'';
     const readOnly=_isReadOnlySession(s);
-    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(ownStreaming?' streaming':'')+(hasUnread?' unread':'')+(attention?' needs-attention':'')+attentionClass;
+    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(ownRingStreaming?' streaming':'')+(hasUnread?' unread':'')+(attention?' needs-attention':'')+attentionClass;
     const swipeReturnOffset=_sessionSwipeReturnOffsets.get(s.session_id);
     if(swipeReturnOffset!==undefined){
       _sessionSwipeReturnOffsets.delete(s.session_id);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -8630,8 +8630,12 @@ function renderSessionListFromCache(){
     // the generic running/unread state tooltip, so it wins. Fall back to the state
     // tooltip only when there is no attention title AND the state tooltip is
     // non-empty — never blank an otherwise-meaningful tooltip.
-    const _stateTip=_sessionStateTooltip({isStreaming:ownRingStreaming,hasUnread});
+    const _stateTip=_sessionStateTooltip({isStreaming,hasUnread});
+    const _ringStateTip=ownRingStreaming===isStreaming
+      ? _stateTip
+      : _sessionStateTooltip({isStreaming:ownRingStreaming,hasUnread});
     if(attention&&attention.title) state.title=attention.title;
+    else if(_ringStateTip) state.title=_ringStateTip;
     else if(_stateTip) state.title=_stateTip;
     el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -5503,7 +5503,9 @@ function _applySessionListPayload(sessData, projData, opts){
     _markPollingCompletionUnreadTransitions(_allSessions);
   }
   const isStreaming = _allSessions.some(s => _isSessionEffectivelyStreaming(s));
-  const hasRingStreaming = _allSessions.some(s => _isSessionRingStreaming(s));
+  const hasRingStreaming = _allSessions.some(s => typeof _isSessionRingStreaming==='function'
+    ? _isSessionRingStreaming(s)
+    : _isSessionEffectivelyStreaming(s));
   if (isStreaming || hasRingStreaming) {
     startStreamingPoll();
   } else {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -8623,14 +8623,14 @@ function renderSessionListFromCache(){
     el.appendChild(sessionText);
     const state=document.createElement('span');
     const attentionDotClass=attention?(attention.kind==='approval'?' is-attention-approval':(attention.kind==='clarify'?' is-attention-clarify':' is-attention-generic')):'';
-    state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''))+attentionDotClass;
+    state.className='session-attention-indicator session-state-indicator'+(isRingStreaming?' is-streaming':(hasUnread?' is-unread':''))+attentionDotClass;
     state.setAttribute('aria-hidden','true');
     // Tooltip precedence: a localized attention title (pending approval/clarify,
     // from the attention-indicator feature) is more specific and actionable than
     // the generic running/unread state tooltip, so it wins. Fall back to the state
     // tooltip only when there is no attention title AND the state tooltip is
     // non-empty — never blank an otherwise-meaningful tooltip.
-    const _stateTip=_sessionStateTooltip({isStreaming,hasUnread});
+    const _stateTip=_sessionStateTooltip({isStreaming:isRingStreaming,hasUnread});
     if(attention&&attention.title) state.title=attention.title;
     else if(_stateTip) state.title=_stateTip;
     el.appendChild(state);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -824,6 +824,20 @@ function _isSessionRingStreaming(s) {
   return _isSessionEffectivelyStreaming(s) || Boolean(s && s.active_run);
 }
 
+function _activeRunLineageKey(row, rows) {
+  if (!row) return null;
+  const list = Array.isArray(rows) ? rows : [];
+  const ids = new Set(list.map(item => item && item.session_id).filter(Boolean));
+  const byId = new Map(list.filter(item => item && item.session_id).map(item => [item.session_id, item]));
+  if (typeof _sessionLineageKey === 'function') {
+    const key = _sessionLineageKey(row, ids, byId);
+    if (key) return key;
+  }
+  return typeof _sidebarLineageKeyForRow === 'function'
+    ? _sidebarLineageKeyForRow(row)
+    : String(row.session_id || '');
+}
+
 function _activeRunRowsForProjection(rows) {
   const sourceRows = Array.isArray(rows) ? rows : [];
   const partition = typeof _partitionSidebarSessionRows === 'function'
@@ -832,21 +846,29 @@ function _activeRunRowsForProjection(rows) {
       typeof _activeSessionIdForSidebar === 'function' ? _activeSessionIdForSidebar() : null,
     )
     : {sessionsRaw: sourceRows};
-  const filtered = (Array.isArray(partition.sessionsRaw) ? partition.sessionsRaw : [])
-    .filter(s => s && s.active_run && !s.archived);
+  const acceptedRows = Array.isArray(partition.sessionsRaw) ? partition.sessionsRaw : [];
+  const filtered = acceptedRows.filter(s => s && !s.archived);
   const activeByLineage = new Map();
   for (const row of filtered) {
-    const key = typeof _sidebarLineageKeyForRow === 'function' ? _sidebarLineageKeyForRow(row) : String(row.session_id || '');
+    if (!row.active_run) continue;
+    const key = _activeRunLineageKey(row, filtered);
     if (!key) continue;
     const previous = activeByLineage.get(key);
-    if (!previous || Number(row.active_run.started_at) < Number(previous.active_run.started_at)) activeByLineage.set(key, row.active_run);
+    const startedAt = Number(row.active_run.started_at);
+    if (!Number.isFinite(startedAt)) continue;
+    if (!previous || startedAt < Number(previous.started_at)) activeByLineage.set(key, row.active_run);
   }
   const visibleRows = typeof _collapseSessionLineageForSidebar === 'function' ? _collapseSessionLineageForSidebar(filtered) : filtered;
   return visibleRows.flatMap(row => {
-    const key = typeof _sidebarLineageKeyForRow === 'function' ? _sidebarLineageKeyForRow(row) : String(row.session_id || '');
+    const key = _activeRunLineageKey(row, filtered);
     const activeRun = activeByLineage.get(key);
     return activeRun ? [{...row, active_run: activeRun}] : [];
   });
+}
+function _clearActiveRunProjection() {
+  if (typeof window !== 'undefined' && typeof window._renderActiveRunProjection === 'function') {
+    window._renderActiveRunProjection([]);
+  }
 }
 if(typeof window!=='undefined') window._activeRunRowsForProjection = _activeRunRowsForProjection;
 
@@ -2610,6 +2632,7 @@ function _setActiveProjectFilter(projectId) {
   const next = projectId === NO_PROJECT_FILTER ? NO_PROJECT_FILTER : (projectId || null);
   if (_activeProject === next) return;
   _activeProject = next;
+  _clearActiveRunProjection();
   renderSessionListFromCache();
   void renderSessionList({deferWhileInteracting:false});
 }
@@ -2619,6 +2642,7 @@ function _setSessionSourceFilter(filter) {
   if (_sessionSourceFilter === next) return;
   _sessionSourceFilter = next;
   _activeProject = null;
+  _clearActiveRunProjection();
   _selectedSessions.clear();
   _sessionSelectMode = false;
   try { localStorage.setItem('hermes-session-source-filter', next); } catch (_e) {}
@@ -4108,7 +4132,7 @@ function _optimisticallyArchiveSessionInList(sid, archived){
     changed=true;
     return {...s,archived:!!archived};
   });
-  if(changed) renderSessionListFromCache();
+  if(changed){ _clearActiveRunProjection(); renderSessionListFromCache(); }
 }
 function _optimisticallyRemoveSessionFromList(sid){
   if(!sid||!Array.isArray(_allSessions)) return;
@@ -4116,7 +4140,7 @@ function _optimisticallyRemoveSessionFromList(sid){
   _allSessions=_allSessions.filter(s=>!s||s.session_id!==sid);
   if(_selectedSessions&&_selectedSessions.has(sid)) _selectedSessions.delete(sid);
   if(typeof _dropStaleOptimisticSessionRow==='function') _dropStaleOptimisticSessionRow(sid);
-  if(_allSessions.length!==before) renderSessionListFromCache();
+  if(_allSessions.length!==before){ _clearActiveRunProjection(); renderSessionListFromCache(); }
 }
 
 function _sessionIdFromLocation(){
@@ -5102,6 +5126,11 @@ function _invalidateSessionListRenders(){
 function _sessionListGenerationIsCurrent(generation){
   return generation===_renderSessionListGen;
 }
+function _applySessionListPayloadIfCurrent(generation,sessData,projData,opts){
+  if(!_sessionListGenerationIsCurrent(generation)||_profileSwitchListEmbargo)return false;
+  _applySessionListPayload(sessData,projData,opts);
+  return true;
+}
 if(typeof window!=='undefined') window._invalidateSessionListRenders = _invalidateSessionListRenders;
 
 // #4671: profile-switch session-list EMBARGO. Point-in-time invalidation isn't enough —
@@ -5319,10 +5348,10 @@ function _schedulePendingSessionListApply(){
     }
     const payload=_pendingSessionListPayload;
     _pendingSessionListPayload=null;
-    if(payload.gen!==_renderSessionListGen) return;
+    if(!_sessionListGenerationIsCurrent(payload.gen)) return;
     // Profile switch may have bumped unread gen after the list gen check
     // window; still drop completion-marking for the stale pre-switch payload.
-    _applySessionListPayload(payload.sessData,payload.projData,{
+    _applySessionListPayloadIfCurrent(payload.gen,payload.sessData,payload.projData,{
       unreadGen:payload.unreadGen,
     });
   }, Math.max(120, SESSION_LIST_INTERACTION_IDLE_MS));
@@ -5473,7 +5502,7 @@ function _applySessionListPayload(sessData, projData, opts){
   if (typeof expectedUnreadGen !== 'number' || expectedUnreadGen === currentUnreadGen) {
     _markPollingCompletionUnreadTransitions(_allSessions);
   }
-  const isStreaming = _allSessions.some(s => _isSessionEffectivelyStreaming(s));
+  const isStreaming = _allSessions.some(s => _isSessionRingStreaming(s));
   if (isStreaming) {
     startStreamingPoll();
   } else {
@@ -5647,7 +5676,7 @@ async function _runRenderSessionListRefresh(opts, _gen){
       _schedulePendingSessionListApply();
       return;
     }
-    _applySessionListPayload(sessData,projData,{unreadGen});
+    _applySessionListPayloadIfCurrent(_gen,sessData,projData,{unreadGen});
   }catch(e){
     if (_gen !== _renderSessionListGen) return;
     // #4671: same embargo guard as the success path — a mid-switch /api/sessions that
@@ -8434,7 +8463,7 @@ function renderSessionListFromCache(){
       for(const child of sortedChildren){
         if(child.session_source==='fork'){
           const childIsActive=!!(activeSidForSidebar&&child.session_id===activeSidForSidebar);
-          const childStreaming=_isSessionEffectivelyStreaming(child);
+          const childStreaming=_isSessionRingStreaming(child);
           const childHasUnread=_hasUnreadForSession(child)&&!childIsActive;
           const childAttention=_sessionAttentionState(child);
           const childAttentionClass=childAttention?(childAttention.kind==='approval'?' attention-approval':(childAttention.kind==='clarify'?' attention-clarify':' attention-attention')):'';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -8623,14 +8623,14 @@ function renderSessionListFromCache(){
     el.appendChild(sessionText);
     const state=document.createElement('span');
     const attentionDotClass=attention?(attention.kind==='approval'?' is-attention-approval':(attention.kind==='clarify'?' is-attention-clarify':' is-attention-generic')):'';
-    state.className='session-attention-indicator session-state-indicator'+(isRingStreaming?' is-streaming':(hasUnread?' is-unread':''))+attentionDotClass;
+    state.className='session-attention-indicator session-state-indicator'+(ownRingStreaming?' is-streaming':(hasUnread?' is-unread':''))+attentionDotClass;
     state.setAttribute('aria-hidden','true');
     // Tooltip precedence: a localized attention title (pending approval/clarify,
     // from the attention-indicator feature) is more specific and actionable than
     // the generic running/unread state tooltip, so it wins. Fall back to the state
     // tooltip only when there is no attention title AND the state tooltip is
     // non-empty — never blank an otherwise-meaningful tooltip.
-    const _stateTip=_sessionStateTooltip({isStreaming:isRingStreaming,hasUnread});
+    const _stateTip=_sessionStateTooltip({isStreaming:ownRingStreaming,hasUnread});
     if(attention&&attention.title) state.title=attention.title;
     else if(_stateTip) state.title=_stateTip;
     el.appendChild(state);

--- a/static/style.css
+++ b/static/style.css
@@ -1555,7 +1555,14 @@
   .app-titlebar-icon{display:inline-flex;align-items:center;color:var(--accent);}
   .app-titlebar-title{font-size:12px;font-weight:600;color:var(--text);letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:60vw;}
   .app-titlebar-sub{font-size:10px;color:var(--muted);background:var(--hover-bg);padding:2px 7px;border-radius:4px;font-family:var(--font-mono);white-space:nowrap;flex-shrink:0;}
-  .app-titlebar-sub[hidden]{display:none;}
+.app-titlebar-sub[hidden]{display:none;}
+.active-run-visibility{position:relative;margin-left:auto;-webkit-app-region:no-drag;}
+.active-run-pill{-webkit-app-region:no-drag;cursor:pointer;color:var(--accent-text);border-color:var(--accent-bg-strong);background:var(--accent-bg);}
+.active-run-tray{position:absolute;right:0;top:calc(100% + 8px);z-index:30;min-width:230px;max-width:min(320px,calc(100vw - 24px));padding:6px;border:1px solid var(--border2);border-radius:10px;background:var(--surface);box-shadow:0 12px 30px rgba(0,0,0,.24);-webkit-app-region:no-drag;}
+.active-run-row{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:8px;border-radius:7px;color:var(--text);font-size:12px;text-align:left;}
+.active-run-row:hover{background:var(--accent-bg);}
+.active-run-row button{flex:1;min-width:0;border:0;background:none;color:inherit;font:inherit;text-align:left;cursor:pointer;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;-webkit-app-region:no-drag;}
+.active-run-age{color:var(--muted);white-space:nowrap;font-size:11px;}
   .app-titlebar-title-popover{position:fixed;z-index:300;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:8px 12px;font-size:13px;color:var(--text);box-shadow:0 4px 16px rgba(0,0,0,.18);word-break:break-word;line-height:1.4;max-width:calc(100vw - 16px);pointer-events:auto;}
   .app-titlebar-hamburger,.app-titlebar-spacer{display:none;width:44px;height:44px;flex-shrink:0;}
   .app-titlebar-hamburger{-webkit-app-region:no-drag;align-items:center;justify-content:center;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -20856,3 +20856,79 @@ async function uploadPendingFiles(options={}){
   if(extracted.length)showToast(t('archive_extracted',extracted.reduce((s,n)=>s+n.extracted,0),extracted.length));
   return names;
 }
+let _activeRunElapsedTimer=null;
+const _activeRunElapsedAnchors=new Map();
+function _activeRunMonotonicSeconds(){
+  return (typeof performance!=='undefined'&&typeof performance.now==='function')
+    ? performance.now()/1000
+    : Date.now()/1000;
+}
+function _activeRunElapsedSeconds(row){
+  const active=row&&row.active_run;
+  const sid=String(row&&row.session_id||'');
+  const startedAt=Number(active&&active.started_at);
+  const serverAge=Number(active&&active.age_seconds);
+  if(!sid||!Number.isFinite(startedAt)||startedAt<=0||!Number.isFinite(serverAge)||serverAge<0)return 0;
+  const now=_activeRunMonotonicSeconds();
+  let anchor=_activeRunElapsedAnchors.get(sid);
+  if(!anchor||anchor.startedAt!==startedAt){
+    anchor={startedAt,serverAge,monotonicAt:now};
+    _activeRunElapsedAnchors.set(sid,anchor);
+  }
+  return Math.max(0,anchor.serverAge+(now-anchor.monotonicAt));
+}
+function _activeRunDurationLabel(seconds){
+  const total=Math.max(0,Math.floor(Number(seconds)||0));
+  const minutes=Math.floor(total/60);
+  return minutes?`${minutes}m ${total%60}s`:`${total}s`;
+}
+function _hideActiveRunTray(opts={}){
+  const pill=$('activeRunPill'); const tray=$('activeRunTray');
+  if(!pill||!tray||tray.hidden)return false;
+  tray.hidden=true; pill.setAttribute('aria-expanded','false');
+  if(opts.restoreFocus&&typeof pill.focus==='function') pill.focus();
+  return true;
+}
+function _handleActiveRunEscape(event){
+  if(!event||event.key!=='Escape')return false;
+  const tray=$('activeRunTray');
+  if(!tray||tray.hidden)return false;
+  event.preventDefault();
+  return _hideActiveRunTray({restoreFocus:true});
+}
+function _renderActiveRunProjection(rows){
+  const host=$('activeRunVisibility'), pill=$('activeRunPill'), tray=$('activeRunTray');
+  if(!host||!pill||!tray||typeof window._activeRunRowsForProjection!=='function')return;
+  const active=window._activeRunRowsForProjection(rows);
+  host.hidden=!active.length;
+  if(!active.length){_hideActiveRunTray();return;}
+  pill.textContent=typeof t==='function'?t('active_run_visibility_label',active.length,_activeRunDurationLabel(Math.min(...active.map(_activeRunElapsedSeconds)))):`${active.length} active`;
+  const existing=new Map(Array.from(tray.children||[]).map(node=>[node.dataset.sessionId,node]));
+  const keep=new Set();
+  for(const row of active){
+    const sid=String(row.session_id||''); if(!sid)continue;
+    let node=existing.get(sid);
+    if(!node){
+      node=document.createElement('div'); node.className='active-run-row'; node.dataset.sessionId=sid;
+      const button=document.createElement('button'); button.type='button';
+      const age=document.createElement('span'); age.className='active-run-age';
+      node.append(button,age); tray.appendChild(node);
+    }
+    const button=node.querySelector('button'); const age=node.querySelector('.active-run-age');
+    button.textContent=row.title||row.display_title||(typeof t==='function'?t('active_run_conversation_fallback'):'Active conversation');
+    button.title=typeof t==='function'?t('active_run_open_conversation'):'Open conversation';
+    button.onclick=()=>{_hideActiveRunTray();if(typeof _openSidebarSession==='function')void _openSidebarSession(row);};
+    age.textContent=_activeRunDurationLabel(_activeRunElapsedSeconds(row));
+    keep.add(sid);
+  }
+  Array.from(tray.children||[]).forEach(node=>{if(!keep.has(node.dataset.sessionId)){_activeRunElapsedAnchors.delete(node.dataset.sessionId);node.remove();}});
+}
+if(typeof window!=='undefined')window._renderActiveRunProjection=_renderActiveRunProjection;
+document.addEventListener('DOMContentLoaded',()=>{
+  const pill=$('activeRunPill'); const tray=$('activeRunTray');
+  if(!pill||!tray)return;
+  pill.addEventListener('click',()=>{if(!tray.children.length)return;tray.hidden=!tray.hidden;pill.setAttribute('aria-expanded',String(!tray.hidden));});
+  document.addEventListener('click',event=>{const host=$('activeRunVisibility');if(host&&!host.hidden&&!host.contains(event.target))_hideActiveRunTray();});
+  document.addEventListener('keydown',_handleActiveRunEscape);
+  _activeRunElapsedTimer=setInterval(()=>{const host=$('activeRunVisibility');if(host&&!host.hidden&&typeof _renderActiveRunProjection==='function'&&typeof _allSessions!=='undefined')_renderActiveRunProjection(_allSessions);},1000);
+});

--- a/static/ui.js
+++ b/static/ui.js
@@ -20882,6 +20882,19 @@ function _activeRunDurationLabel(seconds){
   const minutes=Math.floor(total/60);
   return minutes?`${minutes}m ${total%60}s`:`${total}s`;
 }
+function _stopActiveRunElapsedRefresh(){
+  if(_activeRunElapsedTimer){clearTimeout(_activeRunElapsedTimer);_activeRunElapsedTimer=null;}
+}
+function _scheduleActiveRunElapsedRefresh(){
+  if(_activeRunElapsedTimer)return;
+  _activeRunElapsedTimer=setTimeout(()=>{
+    _activeRunElapsedTimer=null;
+    const host=$('activeRunVisibility');
+    if(host&&!host.hidden&&typeof _renderActiveRunProjection==='function'&&typeof _allSessions!=='undefined'){
+      _renderActiveRunProjection(_allSessions);
+    }
+  },1000);
+}
 function _hideActiveRunTray(opts={}){
   const pill=$('activeRunPill'); const tray=$('activeRunTray');
   if(!pill||!tray||tray.hidden)return false;
@@ -20900,8 +20913,17 @@ function _renderActiveRunProjection(rows){
   const host=$('activeRunVisibility'), pill=$('activeRunPill'), tray=$('activeRunTray');
   if(!host||!pill||!tray||typeof window._activeRunRowsForProjection!=='function')return;
   const active=window._activeRunRowsForProjection(rows);
-  host.hidden=!active.length;
-  if(!active.length){_hideActiveRunTray();return;}
+  if(!active.length){
+    host.hidden=true;
+    pill.textContent='';
+    tray.hidden=true;
+    pill.setAttribute('aria-expanded','false');
+    Array.from(tray.children||[]).forEach(node=>node.remove());
+    _activeRunElapsedAnchors.clear();
+    _stopActiveRunElapsedRefresh();
+    return;
+  }
+  host.hidden=false;
   pill.textContent=typeof t==='function'?t('active_run_visibility_label',active.length,_activeRunDurationLabel(Math.min(...active.map(_activeRunElapsedSeconds)))):`${active.length} active`;
   const existing=new Map(Array.from(tray.children||[]).map(node=>[node.dataset.sessionId,node]));
   const keep=new Set();
@@ -20909,7 +20931,7 @@ function _renderActiveRunProjection(rows){
     const sid=String(row.session_id||''); if(!sid)continue;
     let node=existing.get(sid);
     if(!node){
-      node=document.createElement('div'); node.className='active-run-row'; node.dataset.sessionId=sid;
+      node=document.createElement('div'); node.className='active-run-row'; node.dataset.sessionId=sid; node.setAttribute('role','listitem');
       const button=document.createElement('button'); button.type='button';
       const age=document.createElement('span'); age.className='active-run-age';
       node.append(button,age); tray.appendChild(node);
@@ -20922,6 +20944,7 @@ function _renderActiveRunProjection(rows){
     keep.add(sid);
   }
   Array.from(tray.children||[]).forEach(node=>{if(!keep.has(node.dataset.sessionId)){_activeRunElapsedAnchors.delete(node.dataset.sessionId);node.remove();}});
+  _scheduleActiveRunElapsedRefresh();
 }
 if(typeof window!=='undefined')window._renderActiveRunProjection=_renderActiveRunProjection;
 document.addEventListener('DOMContentLoaded',()=>{
@@ -20930,5 +20953,4 @@ document.addEventListener('DOMContentLoaded',()=>{
   pill.addEventListener('click',()=>{if(!tray.children.length)return;tray.hidden=!tray.hidden;pill.setAttribute('aria-expanded',String(!tray.hidden));});
   document.addEventListener('click',event=>{const host=$('activeRunVisibility');if(host&&!host.hidden&&!host.contains(event.target))_hideActiveRunTray();});
   document.addEventListener('keydown',_handleActiveRunEscape);
-  _activeRunElapsedTimer=setInterval(()=>{const host=$('activeRunVisibility');if(host&&!host.hidden&&typeof _renderActiveRunProjection==='function'&&typeof _allSessions!=='undefined')_renderActiveRunProjection(_allSessions);},1000);
 });

--- a/tests/test_6728_cron_running_sidebar.py
+++ b/tests/test_6728_cron_running_sidebar.py
@@ -162,6 +162,21 @@ def test_overlay_marks_current_running_cron_row(monkeypatch):
     assert rows[0]["cron_running"] is True
 
 
+def test_non_authoritative_overlay_preserves_live_cron_lifecycle(monkeypatch):
+    import api.routes as routes
+    import api.route_session_list_cache as slc
+
+    monkeypatch.setattr(routes, "_RUNNING_CRON_JOBS", {"job6728": 1000.0})
+    monkeypatch.setattr(slc, "_session_list_cache_active_stream_ids", lambda: set())
+
+    rows = slc._session_list_cache_overlay_runtime_rows(
+        [_cron_row("cron_job6728_20260803_100000", created_at=1100)],
+        source_authoritative=False,
+    )
+
+    assert rows[0]["cron_running"] is True
+
+
 def test_overlay_does_not_mark_finished_or_other_cron_rows(monkeypatch):
     import api.routes as routes
     import api.route_session_list_cache as slc

--- a/tests/test_active_empty_session_sidebar.py
+++ b/tests/test_active_empty_session_sidebar.py
@@ -46,3 +46,17 @@ def test_active_row_reinjection_gated_to_zero_message_ephemeral_only():
     assert "[activeRow,...rows]" in body
     # The unconditional return that shipped in the original PR must be gone.
     assert "return activeRow?[activeRow,...rows]:rows;" not in body
+
+
+def test_active_empty_session_flows_through_canonical_sidebar_filters():
+    from api import config
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["run"] = {"session_id": "empty-parent", "started_at": 10}
+    try:
+        assert "active_session_ids" in Path(ROOT / "api" / "models.py").read_text(encoding="utf-8")
+        assert "not in active_session_ids" in Path(ROOT / "api" / "models.py").read_text(encoding="utf-8")
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()

--- a/tests/test_issue4662_sidebar_redaction_read_once.py
+++ b/tests/test_issue4662_sidebar_redaction_read_once.py
@@ -26,7 +26,7 @@ def test_sidebar_payload_reads_redaction_setting_once(monkeypatch):
         "cli_count": 0,
     }
     # Pass rows straight through — avoid runtime-overlay noise from the cache layer.
-    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows, **kwargs: rows)
 
     routes._session_list_payload_to_response(payload)
 
@@ -39,7 +39,7 @@ def test_sidebar_payload_still_redacts_titles(monkeypatch):
     like a credential is still redacted when api_redact_enabled is True."""
     monkeypatch.setattr("api.config.load_settings", lambda: {"api_redact_enabled": True})
     monkeypatch.setattr("api.helpers.load_settings", lambda: {"api_redact_enabled": True}, raising=False)
-    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows, **kwargs: rows)
 
     secret = "sk-ant-api03-" + ("A" * 40)
     payload = {"sessions": [{"session_id": "s1", "title": f"key {secret}"}], "cli_count": 0}
@@ -59,7 +59,7 @@ def test_sidebar_payload_no_redaction_when_disabled(monkeypatch):
 
     monkeypatch.setattr("api.config.load_settings", _load)
     monkeypatch.setattr("api.helpers.load_settings", _load, raising=False)
-    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows, **kwargs: rows)
 
     payload = {"sessions": [{"session_id": "s1", "title": "plain title"}], "cli_count": 0}
     resp = routes._session_list_payload_to_response(payload)
@@ -74,7 +74,7 @@ def test_sidebar_payload_redacts_display_and_parent_titles(monkeypatch):
     the sidebar even though only `title` was redacted before."""
     monkeypatch.setattr("api.config.load_settings", lambda: {"api_redact_enabled": True})
     monkeypatch.setattr("api.helpers.load_settings", lambda: {"api_redact_enabled": True}, raising=False)
-    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows, **kwargs: rows)
 
     secret = "sk-" + ("A" * 44)
     payload = {"sessions": [{

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -629,7 +629,7 @@ console.log(JSON.stringify({{
 
 
 def test_session_list_response_omits_bucket_counts_when_missing(monkeypatch):
-    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows: rows)
+    monkeypatch.setattr(routes, "_session_list_cache_overlay_runtime_rows", lambda rows, **kwargs: rows)
     monkeypatch.setattr(routes, "_sidebar_session_response_item", lambda row, *, redact_enabled=None: row)
 
     body = routes._session_list_payload_to_response(

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -264,6 +264,18 @@ def test_active_run_visibility_uses_canonical_session_matrix():
         assert "active_run" in by_id["direct"]
         assert "active_run" not in by_id["archived"]
         assert "active_run" not in by_id["idle"]
+        stale_rows = cache._session_list_cache_overlay_runtime_rows([
+            {
+                "session_id": "direct",
+                "archived": False,
+                "active_run": {"started_at": 1},
+                "active_stream_id": "old",
+                "has_pending_user_message": True,
+                "pending_started_at": 2,
+                "is_streaming": True,
+            },
+        ], source_authoritative=False)
+        assert stale_rows == [{"session_id": "direct", "archived": False}]
     finally:
         with config.ACTIVE_RUNS_LOCK:
             config.ACTIVE_RUNS.clear()
@@ -305,6 +317,26 @@ console.log(JSON.stringify({{effective:_isSessionEffectivelyStreaming(active),ri
     assert _run_node_script(source) == {"effective": False, "ring": True}
 
 
+def test_ring_only_active_run_does_not_start_shared_session_list_poll():
+    start = SESSIONS_JS.index("  const isStreaming = _allSessions.some")
+    end = SESSIONS_JS.index("  ensureSessionTimeRefreshPoll();", start)
+    poll_decision = SESSIONS_JS[start:end]
+    source = f"""
+let _allSessions=[{{active_run:{{started_at:10}},is_streaming:false}}];
+let started=0; let stopped=0;
+function startStreamingPoll(){{started++;}}
+function stopStreamingPoll(){{stopped++;}}
+function ensureSessionTimeRefreshPoll(){{}}
+function ensureActiveSessionExternalRefreshPoll(){{}}
+function ensureSessionEventsSSE(){{}}
+function _isSessionEffectivelyStreaming(row){{return !!row.is_streaming;}}
+function _isSessionRingStreaming(row){{return !!row.active_run||!!row.is_streaming;}}
+{poll_decision}
+console.log(JSON.stringify({{started,stopped}}));
+"""
+    assert _run_node_script(source) == {"started": 0, "stopped": 1}
+
+
 def test_active_run_elapsed_label_advances_when_pill_is_visible_with_monotonic_delta():
     monotonic = _extract_function(UI_JS, "_activeRunMonotonicSeconds")
     elapsed = _extract_function(UI_JS, "_activeRunElapsedSeconds")
@@ -325,57 +357,97 @@ console.log(JSON.stringify({{first,second,skewedRefresh}}));
 
 def test_delayed_profile_response_cannot_repaint_activity_after_real_switch():
     invalidate = _extract_function(SESSIONS_JS, "_invalidateSessionListRenders")
-    current = _extract_function(SESSIONS_JS, "_sessionListGenerationIsCurrent")
-    apply_if_current = _extract_function(SESSIONS_JS, "_applySessionListPayloadIfCurrent")
+    merge_options = _extract_function(SESSIONS_JS, "_mergeRenderSessionListOptions")
+    load_payload = _extract_function(SESSIONS_JS, "_loadSidebarSessionListPayload")
+    run_refresh = _extract_function(SESSIONS_JS, "_runRenderSessionListRefresh")
+    drain = _extract_function(SESSIONS_JS, "_drainRenderSessionListQueue")
+    render = _extract_function(SESSIONS_JS, "renderSessionList")
     switch_profile = _extract_function(SESSIONS_JS, "_switchProfileForSessionLoad")
     source = f"""
-let _renderSessionListGen=7; let cleared=0; let applied=0;
-let _pendingSessionListPayload=null; let _renderSessionListQueuedRequest=null; let _sessionListLoadError=null;
-let _profileSwitchListEmbargo=false; let S={{activeProfile:'profile-a'}};
+let _renderSessionListGen=0; let cleared=0; let applied=[]; let sessionsCalls=0;
+let _pendingSessionListPayload=null; let _renderSessionListQueuedRequest=null; let _renderSessionListInFlight=null;
+let _sessionListLoadError=null; let _profileSwitchListEmbargo=false; let _sessionListHasLoadedOnce=true;
+let _isSessionListUserInteracting=()=>false;
+let _showAllProfiles=false; let _allSessions=[]; let _allProjects=[];
+let S={{activeProfile:'profile-a'}};
+const pendingA={{}}; const pendingB={{}};
+let resolveA,resolveB;
+pendingA.promise=new Promise(resolve=>resolveA=resolve);
+pendingB.promise=new Promise(resolve=>resolveB=resolve);
 globalThis.window={{_renderActiveRunProjection:rows=>{{if(!rows.length)cleared++;}}}};
+function $(id){{return {{value:''}};}}
 function showSessionListSkeleton(){{}}
 function _setProfileSwitchListEmbargo(value){{_profileSwitchListEmbargo=!!value;}}
 function _resetCronUnreadForProfileSwitch(){{}}
 function _clearPersistedModelState(){{}}
 function startGatewaySSE(){{}}
 function syncTopbar(){{}}
-function renderSessionList(){{return Promise.resolve();}}
-function api(){{return Promise.resolve({{active:'profile-b'}});}}
-function _applySessionListPayload(){{applied++;}}
+function _sessionListQueryString(){{return '';}}
+function _requestedSessionSidebarSource(){{return null;}}
+function _sessionListExcludeHiddenEnabled(){{return false;}}
+function _showSessionListLoadError(){{}}
+function _applySessionListPayload(sessData){{applied.push(sessData.active_profile);}}
+function _mergeRenderSessionListOptionsFallback(prev,next){{return Object.assign({{}},prev||{{}},next||{{}});}}
+function api(path){{
+  if(path==='/api/profile/switch') return Promise.resolve({{active:'profile-b'}});
+  if(path.startsWith('/api/projects')) return Promise.resolve({{projects:[]}});
+  sessionsCalls++;
+  return sessionsCalls===1 ? pendingA.promise : pendingB.promise;
+}}
 {invalidate}
-{current}
-{apply_if_current}
+{merge_options}
+{load_payload}
+{run_refresh}
+{drain}
+{render}
 {switch_profile}
 (async()=>{{
-  const stale=_renderSessionListGen;
-  await _switchProfileForSessionLoad('profile-b');
-  const staleApplied=_applySessionListPayloadIfCurrent(stale,{{}},{{}},{{}});
-  const currentApplied=_applySessionListPayloadIfCurrent(_renderSessionListGen,{{}},{{}},{{}});
-  console.log(JSON.stringify({{staleRejected:!_sessionListGenerationIsCurrent(stale),currentAccepted:_sessionListGenerationIsCurrent(_renderSessionListGen),cleared,staleApplied,currentApplied,applied,profile:S.activeProfile}}));
+  const first=renderSessionList();
+  await Promise.resolve();
+  const switching=_switchProfileForSessionLoad('profile-b');
+  await Promise.resolve();
+  const before={{cleared,applied:[...applied],sessionsCalls}};
+  resolveA({{active_profile:'profile-a',sessions:[]}});
+  for(let i=0;i<8;i++) await Promise.resolve();
+  const afterA={{cleared,applied:[...applied],sessionsCalls}};
+  resolveB({{active_profile:'profile-b',sessions:[]}});
+  await switching; await first;
+  console.log(JSON.stringify({{before,afterA,applied,profile:S.activeProfile}}));
 }})();
 """
     assert _run_node_script(source) == {
-        "staleRejected": True,
-        "currentAccepted": True,
-        "cleared": 1,
-        "staleApplied": False,
-        "currentApplied": True,
-        "applied": 1,
+        "before": {"cleared": 1, "applied": [], "sessionsCalls": 1},
+        "afterA": {"cleared": 1, "applied": [], "sessionsCalls": 2},
+        "applied": ["profile-b"],
         "profile": "profile-b",
     }
 
 
 def test_failed_session_list_refresh_clears_volatile_active_run_projection():
     clear_cached = _extract_function(SESSIONS_JS, "_clearCachedActiveRunProjection")
+    load_payload = _extract_function(SESSIONS_JS, "_loadSidebarSessionListPayload")
     refresh = _extract_function(SESSIONS_JS, "_runRenderSessionListRefresh")
     assert "_clearCachedActiveRunProjection();" in refresh
     source = f"""
 let _allSessions=[{{session_id:'s1',active_run:{{started_at:10}}}},{{session_id:'s2'}}];
 let cleared=0;
+let _sessionListHasLoadedOnce=true; let _sessionListLoadError=null;
+let _renderSessionListGen=1; let _profileSwitchListEmbargo=false;
+let _allSessionsScope={{profile:'profile-a',allProfiles:false,sidebarSource:null,excludeHidden:false}};
+let S={{activeProfile:'profile-a'}}; let _showAllProfiles=false;
+function $(id){{return {{value:''}};}}
+function _sessionListQueryString(){{return '';}}
+function _requestedSessionSidebarSource(){{return null;}}
+function _sessionListExcludeHiddenEnabled(){{return false;}}
+function _showSessionListLoadError(){{}}
+function _clearSessionSourceTabCounts(){{}}
+function renderSessionListFromCache(){{}}
+function api(path){{if(path.startsWith('/api/projects'))return Promise.resolve({{projects:[]}});return Promise.reject(new Error('refresh failed'));}}
 globalThis.window={{_renderActiveRunProjection:rows=>{{if(!rows.length)cleared++;}}}};
 {clear_cached}
-_clearCachedActiveRunProjection();
-console.log(JSON.stringify({{sessions:_allSessions,cleared}}));
+{load_payload}
+{refresh}
+(async()=>{{await _runRenderSessionListRefresh({{}},1);console.log(JSON.stringify({{sessions:_allSessions,cleared}}));}})();
 """
     assert _run_node_script(source) == {
         "sessions": [{"session_id": "s1"}, {"session_id": "s2"}],

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -359,6 +359,19 @@ console.log(JSON.stringify({{activeRunClass,childOnlyClass}}));
     assert "streaming" in result["activeRunClass"]
     assert "streaming" not in result["childOnlyClass"]
 
+    state_line = next(
+        line for line in SESSIONS_JS.splitlines()
+        if "session-attention-indicator session-state-indicator" in line
+    )
+    state_expression = state_line.split("=", 1)[1].rstrip(";")
+    state_source = f"""
+const isStreaming=false; const isRingStreaming=true; const hasUnread=false;
+const attentionDotClass='';
+const activeRunState={state_expression};
+console.log(JSON.stringify({{activeRunState}}));
+"""
+    assert "is-streaming" in _run_node_script(state_source)["activeRunState"]
+
 
 def test_active_run_elapsed_label_advances_when_pill_is_visible_with_monotonic_delta():
     monotonic = _extract_function(UI_JS, "_activeRunMonotonicSeconds")

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -275,7 +275,10 @@ def test_active_run_visibility_uses_canonical_session_matrix():
                 "is_streaming": True,
             },
         ], source_authoritative=False)
-        assert stale_rows == [{"session_id": "direct", "archived": False}]
+        assert "active_run" not in stale_rows[0]
+        assert stale_rows[0]["active_stream_id"] == "old"
+        assert stale_rows[0]["has_pending_user_message"] is True
+        assert stale_rows[0]["is_streaming"] is False
     finally:
         with config.ACTIVE_RUNS_LOCK:
             config.ACTIVE_RUNS.clear()

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -365,6 +365,24 @@ function _applySessionListPayload(){{applied++;}}
     }
 
 
+def test_failed_session_list_refresh_clears_volatile_active_run_projection():
+    clear_cached = _extract_function(SESSIONS_JS, "_clearCachedActiveRunProjection")
+    refresh = _extract_function(SESSIONS_JS, "_runRenderSessionListRefresh")
+    assert "_clearCachedActiveRunProjection();" in refresh
+    source = f"""
+let _allSessions=[{{session_id:'s1',active_run:{{started_at:10}}}},{{session_id:'s2'}}];
+let cleared=0;
+globalThis.window={{_renderActiveRunProjection:rows=>{{if(!rows.length)cleared++;}}}};
+{clear_cached}
+_clearCachedActiveRunProjection();
+console.log(JSON.stringify({{sessions:_allSessions,cleared}}));
+"""
+    assert _run_node_script(source) == {
+        "sessions": [{"session_id": "s1"}, {"session_id": "s2"}],
+        "cleared": 1,
+    }
+
+
 def test_active_run_locale_keys_cover_exact_supported_locale_set():
     parser = _extract_function(I18N_JS, "_activeRunLocaleNames")
     source = f"""

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -270,6 +270,7 @@ def test_active_run_visibility_uses_canonical_session_matrix():
 
 
 def test_active_run_visibility_routes_only_through_canonical_sessions():
+    # Split forbidden names so this source-level guard cannot match its own literals.
     forbidden = (
         "/api/activity/" + "active-runs",
         "_active_run_" + "visibility_snapshot",

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -337,6 +337,26 @@ console.log(JSON.stringify({{started,stopped}}));
     assert _run_node_script(source) == {"started": 0, "stopped": 1}
 
 
+def test_active_run_sidebar_ring_class_uses_own_ring_without_child_bubbling():
+    class_line = next(
+        line for line in SESSIONS_JS.splitlines() if "el.className='session-item'" in line
+    )
+    expression = class_line.split("=", 1)[1].rstrip(";")
+    source = f"""
+const S={{session:null}};
+const s={{archived:false}};
+const isActive=false; const hasUnread=false; const attention=null; const attentionClass='';
+let ownStreaming=false; let ownRingStreaming=true;
+const activeRunClass={expression};
+ownRingStreaming=false;
+const childOnlyClass={expression};
+console.log(JSON.stringify({{activeRunClass,childOnlyClass}}));
+"""
+    result = _run_node_script(source)
+    assert "streaming" in result["activeRunClass"]
+    assert "streaming" not in result["childOnlyClass"]
+
+
 def test_active_run_elapsed_label_advances_when_pill_is_visible_with_monotonic_delta():
     monotonic = _extract_function(UI_JS, "_activeRunMonotonicSeconds")
     elapsed = _extract_function(UI_JS, "_activeRunElapsedSeconds")

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -1,0 +1,272 @@
+"""Executable production-path proofs for issue #6025 canonical activity rows."""
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_function(source: str, name: str) -> str:
+    marker = f"function {name}"
+    start = source.index(marker)
+    brace = source.index("{", source.index(")", start))
+    depth = 0
+    quote = None
+    regex = False
+    line_comment = False
+    block_comment = False
+    escaped = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        previous = source[index - 1] if index else ""
+        following = source[index + 1] if index + 1 < len(source) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            continue
+        if block_comment:
+            if char == "*" and following == "/":
+                block_comment = False
+            continue
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if regex:
+            if char == "\\":
+                escaped = not escaped
+                continue
+            if char == "/" and not escaped:
+                regex = False
+            escaped = False
+            continue
+        if char == "/" and following == "/":
+            line_comment = True
+            continue
+        if char == "/" and following == "*":
+            block_comment = True
+            continue
+        if char in "'\"`":
+            quote = char
+        elif char == "/" and previous in "=(:,[!&|?;{":
+            regex = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+    raise AssertionError(f"unbalanced production function: {name}")
+
+
+def _run_node_script(source: str):
+    with tempfile.TemporaryDirectory(prefix="hermes-6025-node-") as directory:
+        script = Path(directory) / "proof.js"
+        script.write_text(source, encoding="utf-8")
+        result = subprocess.run(
+            [NODE, str(script)],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+    if result.returncode:
+        raise AssertionError(result.stderr)
+    return json.loads(result.stdout)
+
+
+def test_issue6025_active_run_stays_visible_after_switching_away():
+    projection = _extract_function(SESSIONS_JS, "_activeRunRowsForProjection")
+    partition = _extract_function(SESSIONS_JS, "_partitionSidebarSessionRows")
+    cli = _extract_function(SESSIONS_JS, "_isCliSession")
+    sidebar_visible = _extract_function(SESSIONS_JS, "_sidebarRowHasVisibleMessages")
+    effective = _extract_function(SESSIONS_JS, "_isSessionEffectivelyStreaming")
+    ring = _extract_function(SESSIONS_JS, "_isSessionRingStreaming")
+    source = f"""
+const NO_PROJECT_FILTER='__none__';
+let _activeProject='project-a'; let _sessionSourceFilter='webui'; let _showArchived=false;
+let _activeProjectForRows=null; let _archivedWebuiCount=0; let _archivedCliCount=0;
+const window={{_showCliSessions:true}};
+function _isMessagingSession(){{return false;}}
+function _sessionAttentionState(){{return null;}}
+function _hasPendingUserMessageSignal(row){{return !!(row.pending_user_message||row.has_pending_user_message);}}
+function _isSessionLocallyStreaming(){{return false;}}
+function _activeSessionIdForSidebar(){{return null;}}
+function _sidebarLineageKeyForRow(row){{return row.session_id;}}
+function _collapseSessionLineageForSidebar(rows){{return rows;}}
+{cli}
+{effective}
+{ring}
+{sidebar_visible}
+{partition}
+{projection}
+const rows=[
+  {{session_id:'webui-project',raw_source:'webui',project_id:'project-a',active_run:{{started_at:10,age_seconds:4}}}},
+  {{session_id:'webui-hidden-project',raw_source:'webui',project_id:'project-a',default_hidden:true,active_run:{{started_at:11,age_seconds:3}}}},
+  {{session_id:'webui-other-project',raw_source:'webui',project_id:'project-b',active_run:{{started_at:12,age_seconds:2}}}},
+  {{session_id:'cli-project',raw_source:'cli',project_id:'project-a',active_run:{{started_at:13,age_seconds:1}}}},
+];
+const webui=_activeRunRowsForProjection(rows).map(row=>row.session_id);
+_sessionSourceFilter='cli';
+const cliRows=_activeRunRowsForProjection(rows).map(row=>row.session_id);
+console.log(JSON.stringify({{webui,cliRows}}));
+"""
+    assert _run_node_script(source) == {
+        "webui": ["webui-project", "webui-hidden-project"],
+        "cliRows": ["cli-project"],
+    }
+
+
+def test_active_run_visibility_uses_canonical_session_matrix():
+    from api import config, route_session_list_cache as cache
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS.update({
+            "direct": {"session_id": "direct", "started_at": 10},
+            "archived": {"session_id": "archived", "started_at": 11},
+        })
+    try:
+        rows = cache._session_list_cache_overlay_runtime_rows([
+            {"session_id": "direct", "raw_source": "webui", "archived": False},
+            {"session_id": "archived", "raw_source": "webui", "archived": True},
+            {"session_id": "idle", "raw_source": "webui", "archived": False},
+        ])
+        by_id = {row["session_id"]: row for row in rows}
+        assert "active_run" in by_id["direct"]
+        assert "active_run" not in by_id["archived"]
+        assert "active_run" not in by_id["idle"]
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+
+
+def test_active_run_visibility_routes_only_through_canonical_sessions():
+    forbidden = (
+        "/api/activity/" + "active-runs",
+        "_active_run_" + "visibility_snapshot",
+        "_session_list_cache_" + "get_with_reason",
+        "_sidebar_row_" + "matches_scope",
+        "_activeRun" + "Snapshot",
+        "_activeRun" + "SessionIds",
+        "_activeRun" + "ScopeQuery",
+        "refreshActiveRun" + "Visibility",
+        "_invalidateActiveRun" + "VisibilityScope",
+    )
+    source = "\n".join((
+        (ROOT / "api" / "routes.py").read_text(encoding="utf-8"),
+        SESSIONS_JS,
+        UI_JS,
+    ))
+    assert not any(token in source for token in forbidden)
+    assert "active_run" in source
+
+
+def test_active_run_annotation_only_changes_ring_and_global_projection():
+    effective = _extract_function(SESSIONS_JS, "_isSessionEffectivelyStreaming")
+    ring = _extract_function(SESSIONS_JS, "_isSessionRingStreaming")
+    source = f"""
+function _hasPendingUserMessageSignal(row){{return !!(row.pending_user_message||row.has_pending_user_message);}}
+function _isSessionLocallyStreaming(){{return false;}}
+{effective}
+{ring}
+const active={{active_run:{{started_at:10}},is_streaming:false,pending_user_message:false}};
+console.log(JSON.stringify({{effective:_isSessionEffectivelyStreaming(active),ring:_isSessionRingStreaming(active)}}));
+"""
+    assert _run_node_script(source) == {"effective": False, "ring": True}
+
+
+def test_active_run_elapsed_label_advances_when_pill_is_visible_with_monotonic_delta():
+    monotonic = _extract_function(UI_JS, "_activeRunMonotonicSeconds")
+    elapsed = _extract_function(UI_JS, "_activeRunElapsedSeconds")
+    source = f"""
+let now=100; const performance={{now:()=>now*1000}}; const _activeRunElapsedAnchors=new Map();
+{monotonic}
+{elapsed}
+const row={{session_id:'s1',active_run:{{started_at:10,age_seconds:4}}}};
+const first=_activeRunElapsedSeconds(row);
+now=103;
+const second=_activeRunElapsedSeconds(row);
+row.active_run.age_seconds=100;
+const skewedRefresh=_activeRunElapsedSeconds(row);
+console.log(JSON.stringify({{first,second,skewedRefresh}}));
+"""
+    assert _run_node_script(source) == {"first": 4, "second": 7, "skewedRefresh": 7}
+
+
+def test_delayed_profile_response_cannot_repaint_activity_after_real_switch():
+    invalidate = _extract_function(SESSIONS_JS, "_invalidateSessionListRenders")
+    current = _extract_function(SESSIONS_JS, "_sessionListGenerationIsCurrent")
+    source = f"""
+let _renderSessionListGen=7; let cleared=0; let _pendingSessionListPayload=null; let _renderSessionListQueuedRequest=null;
+let _sessionListLoadError=null;
+globalThis.window={{_renderActiveRunProjection:rows=>{{if(!rows.length)cleared++;}}}};
+{invalidate}
+{current}
+const stale=_renderSessionListGen;
+_invalidateSessionListRenders();
+console.log(JSON.stringify({{staleRejected:!_sessionListGenerationIsCurrent(stale),currentAccepted:_sessionListGenerationIsCurrent(_renderSessionListGen),cleared}}));
+"""
+    assert _run_node_script(source) == {"staleRejected": True, "currentAccepted": True, "cleared": 1}
+
+
+def test_active_run_locale_keys_cover_exact_supported_locale_set():
+    parser = _extract_function(I18N_JS, "_activeRunLocaleNames")
+    source = f"""
+{parser}
+const expected=['en','it','ja','ru','es','de','zh','zh-Hant','pt','ko','fr','cs','tr','pl','vi'];
+const names=_activeRunLocaleNames({json.dumps(I18N_JS)});
+const allKeys=expected.every(name=>{{const start={json.dumps(I18N_JS)}.indexOf(name);return start>=0;}});
+console.log(JSON.stringify({{names,exact:JSON.stringify(names)===JSON.stringify(expected),allKeys}}));
+"""
+    result = _run_node_script(source)
+    assert result["exact"] is True
+    assert result["allKeys"] is True
+
+
+def test_document_escape_enters_close_path_only_for_open_tray():
+    escape = _extract_function(UI_JS, "_handleActiveRunEscape")
+    hide = _extract_function(UI_JS, "_hideActiveRunTray")
+    source = f"""
+const tray={{hidden:true}}; const pill={{focused:0,setAttribute(){{}},focus(){{this.focused++;}}}};
+function $(id){{return id==='activeRunTray'?tray:pill;}}
+{hide}
+{escape}
+let prevented=0;
+_handleActiveRunEscape({{key:'Escape',preventDefault(){{prevented++;}}}});
+const closed={{hidden:false}}; tray.hidden=false;
+_handleActiveRunEscape({{key:'Escape',preventDefault(){{prevented++;}}}});
+console.log(JSON.stringify({{closed:tray.hidden,prevented,focused:pill.focused}}));
+"""
+    assert _run_node_script(source) == {"closed": True, "prevented": 1, "focused": 1}
+
+
+def test_active_empty_session_flows_through_canonical_sidebar_filters():
+    from api import config
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+    config.register_active_run("run", session_id="empty-parent", started_at=10)
+    try:
+        assert "empty-parent" in config.active_run_session_snapshot()
+    finally:
+        config.unregister_active_run("run")
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+        assert "empty-parent" not in config.active_run_session_snapshot()

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -20,6 +20,8 @@ pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def _extract_function(source: str, name: str) -> str:
     marker = f"function {name}"
     start = source.index(marker)
+    if source[max(0, start - 6):start] == "async ":
+        start -= 6
     brace = source.index("{", source.index(")", start))
     depth = 0
     quote = None
@@ -98,6 +100,7 @@ def test_issue6025_active_run_stays_visible_after_switching_away():
     sidebar_visible = _extract_function(SESSIONS_JS, "_sidebarRowHasVisibleMessages")
     effective = _extract_function(SESSIONS_JS, "_isSessionEffectivelyStreaming")
     ring = _extract_function(SESSIONS_JS, "_isSessionRingStreaming")
+    active_lineage_key = _extract_function(SESSIONS_JS, "_activeRunLineageKey")
     source = f"""
 const NO_PROJECT_FILTER='__none__';
 let _activeProject='project-a'; let _sessionSourceFilter='webui'; let _showArchived=false;
@@ -115,6 +118,7 @@ function _collapseSessionLineageForSidebar(rows){{return rows;}}
 {ring}
 {sidebar_visible}
 {partition}
+{active_lineage_key}
 {projection}
 const rows=[
   {{session_id:'webui-project',raw_source:'webui',project_id:'project-a',active_run:{{started_at:10,age_seconds:4}}}},
@@ -133,8 +137,89 @@ console.log(JSON.stringify({{webui,cliRows}}));
     }
 
 
+def test_active_run_projection_uses_the_canonical_visible_lineage_tip():
+    projection = _extract_function(SESSIONS_JS, "_activeRunRowsForProjection")
+    collapse = _extract_function(SESSIONS_JS, "_collapseSessionLineageForSidebar")
+    lineage_key = _extract_function(SESSIONS_JS, "_sessionLineageKey")
+    timestamp = _extract_function(SESSIONS_JS, "_sessionTimestampMs")
+    child = _extract_function(SESSIONS_JS, "_isChildSession")
+    tip = _extract_function(SESSIONS_JS, "_authoritativeLineageTipId")
+    active_lineage_key = _extract_function(SESSIONS_JS, "_activeRunLineageKey")
+    source = f"""
+const NO_PROJECT_FILTER='__none__';
+let _activeProject=null; let _sessionSourceFilter='webui'; let _showArchived=false;
+const window={{_showCliSessions:true}};
+function _isMessagingSession(){{return false;}}
+function _sessionAttentionState(){{return null;}}
+function _hasPendingUserMessageSignal(row){{return !!(row.pending_user_message||row.has_pending_user_message);}}
+function _isSessionLocallyStreaming(){{return false;}}
+function _activeSessionIdForSidebar(){{return null;}}
+function _isCliSession(){{return false;}}
+function _isSessionEffectivelyStreaming(row){{return !!row.is_streaming;}}
+function _isSessionRingStreaming(row){{return _isSessionEffectivelyStreaming(row)||!!row.active_run;}}
+function _sidebarRowHasVisibleMessages(row){{return !!(row.message_count||row.active_run);}}
+function _partitionSidebarSessionRows(rows){{return {{sessionsRaw:rows}};}}
+{timestamp}
+{child}
+{lineage_key}
+{tip}
+{collapse}
+function _sidebarLineageKeyForRow(row){{return row._lineage_key||row._lineage_root_id||row.session_id;}}
+{active_lineage_key}
+{projection}
+const rows=[
+  {{session_id:'root',message_count:10,updated_at:10,_lineage_root_id:'root',_lineage_tip_id:'tip',active_run:{{started_at:10,age_seconds:4}}}},
+  {{session_id:'tip',message_count:20,updated_at:20,_lineage_root_id:'root',_lineage_tip_id:'tip'}}
+];
+const visible=_activeRunRowsForProjection(rows);
+console.log(JSON.stringify(visible.map(row=>({{id:row.session_id,started:row.active_run&&row.active_run.started_at}}))));
+"""
+    assert _run_node_script(source) == [{"id": "tip", "started": 10}]
+
+
+def test_active_run_renderer_paints_and_clears_the_user_visible_pill_and_tray():
+    elapsed = _extract_function(UI_JS, "_activeRunElapsedSeconds")
+    monotonic = _extract_function(UI_JS, "_activeRunMonotonicSeconds")
+    duration = _extract_function(UI_JS, "_activeRunDurationLabel")
+    renderer = _extract_function(UI_JS, "_renderActiveRunProjection")
+    source = f"""
+class Node {{
+  constructor(tag) {{ this.tagName=tag; this.children=[]; this.dataset={{}}; this.hidden=false; this.attributes={{}}; this.parentNode=null; this.textContent=''; }}
+  append(...nodes) {{ for(const node of nodes) {{ node.parentNode=this; this.children.push(node); }} }}
+  appendChild(node) {{ this.append(node); }}
+  querySelector(selector) {{ if(selector==='button') return this.children.find(node=>node.tagName==='button')||null; if(selector==='.active-run-age') return this.children.find(node=>node.className==='active-run-age')||null; return null; }}
+  setAttribute(key,value) {{ this.attributes[key]=String(value); }}
+  remove() {{ if(this.parentNode) this.parentNode.children=this.parentNode.children.filter(node=>node!==this); }}
+}}
+const host=new Node('div'), pill=new Node('button'), tray=new Node('div'); tray.hidden=true;
+const nodes={{activeRunVisibility:host,activeRunPill:pill,activeRunTray:tray}};
+globalThis.document={{createElement:tag=>new Node(tag)}};
+function $(id){{return nodes[id]||null;}}
+function t(key,count,duration){{return key==='active_run_visibility_label'?`${{count}} active · ${{duration}}`:key;}}
+function _openSidebarSession(){{}}
+let _activeRunElapsedTimer=null; const _activeRunElapsedAnchors=new Map();
+let now=100; const performance={{now:()=>now*1000}};
+function _scheduleActiveRunElapsedRefresh(){{}}
+function _stopActiveRunElapsedRefresh(){{}}
+{elapsed}
+{monotonic}
+{duration}
+function _activeRunRowsForProjection(rows){{return rows.filter(row=>row&&row.active_run&&!row.archived);}}
+globalThis.window={{_activeRunRowsForProjection}};
+{renderer}
+_renderActiveRunProjection([{{session_id:'s1',title:'Away session',active_run:{{started_at:10,age_seconds:4}}}}]);
+const painted={{hostHidden:host.hidden,pill:pill.textContent,rowCount:tray.children.length,rowLabel:tray.children[0].querySelector('button').textContent}};
+_renderActiveRunProjection([]);
+console.log(JSON.stringify({{painted,cleared:{{hostHidden:host.hidden,rowCount:tray.children.length,expanded:pill.attributes['aria-expanded']}}}}));
+"""
+    assert _run_node_script(source) == {
+        "painted": {"hostHidden": False, "pill": "1 active · 4s", "rowCount": 1, "rowLabel": "Away session"},
+        "cleared": {"hostHidden": True, "rowCount": 0, "expanded": "false"},
+    }
+
+
 def test_active_run_visibility_uses_canonical_session_matrix():
-    from api import config, route_session_list_cache as cache
+    from api import config, route_session_list_cache as cache, routes
 
     with config.ACTIVE_RUNS_LOCK:
         config.ACTIVE_RUNS.clear()
@@ -143,6 +228,33 @@ def test_active_run_visibility_uses_canonical_session_matrix():
             "archived": {"session_id": "archived", "started_at": 11},
         })
     try:
+        canonical_rows = [
+            {"session_id": "direct", "title": "Untitled", "profile": "profile-a", "message_count": 0, "updated_at": 10, "archived": False},
+            {"session_id": "profile-a", "title": "A", "profile": "profile-a", "raw_source": "telegram", "session_source": "messaging", "user_id": "u", "chat_id": "c", "message_count": 2, "updated_at": 10, "archived": False},
+            {"session_id": "profile-b", "title": "B", "profile": "profile-b", "raw_source": "telegram", "session_source": "messaging", "user_id": "u", "chat_id": "c", "message_count": 2, "updated_at": 20, "archived": False},
+        ]
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(routes, "all_sessions", lambda diag=None, include_lineage_metadata=False: list(canonical_rows))
+        monkeypatch.setattr(routes, "get_cli_sessions", lambda source_filter=None, all_profiles=False: [])
+        monkeypatch.setattr(routes, "_reconcile_stale_stream_state_for_session_rows", lambda rows: False)
+        monkeypatch.setattr(routes, "_prune_orphaned_webui_zero_message_sessions", lambda rows, diag_stage=None: rows)
+        monkeypatch.setattr(routes, "_enrich_sidebar_lineage_metadata", lambda rows: None)
+        observed_dedupe_inputs = []
+        original_dedupe = routes._keep_latest_messaging_session_per_source
+        def capture_dedupe(rows, **kwargs):
+            observed_dedupe_inputs.append(list(rows))
+            return original_dedupe(rows, **kwargs)
+        monkeypatch.setattr(routes, "_keep_latest_messaging_session_per_source", capture_dedupe)
+        payload = routes._build_session_list_cache_payload(
+            active_profile="profile-a",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+        )
+        assert "direct" in {row["session_id"] for row in payload["sessions"]}
+        assert all({row["profile"] for row in rows} <= {"profile-a"} for rows in observed_dedupe_inputs)
+        monkeypatch.undo()
         rows = cache._session_list_cache_overlay_runtime_rows([
             {"session_id": "direct", "raw_source": "webui", "archived": False},
             {"session_id": "archived", "raw_source": "webui", "archived": True},
@@ -213,17 +325,43 @@ console.log(JSON.stringify({{first,second,skewedRefresh}}));
 def test_delayed_profile_response_cannot_repaint_activity_after_real_switch():
     invalidate = _extract_function(SESSIONS_JS, "_invalidateSessionListRenders")
     current = _extract_function(SESSIONS_JS, "_sessionListGenerationIsCurrent")
+    apply_if_current = _extract_function(SESSIONS_JS, "_applySessionListPayloadIfCurrent")
+    switch_profile = _extract_function(SESSIONS_JS, "_switchProfileForSessionLoad")
     source = f"""
-let _renderSessionListGen=7; let cleared=0; let _pendingSessionListPayload=null; let _renderSessionListQueuedRequest=null;
-let _sessionListLoadError=null;
+let _renderSessionListGen=7; let cleared=0; let applied=0;
+let _pendingSessionListPayload=null; let _renderSessionListQueuedRequest=null; let _sessionListLoadError=null;
+let _profileSwitchListEmbargo=false; let S={{activeProfile:'profile-a'}};
 globalThis.window={{_renderActiveRunProjection:rows=>{{if(!rows.length)cleared++;}}}};
+function showSessionListSkeleton(){{}}
+function _setProfileSwitchListEmbargo(value){{_profileSwitchListEmbargo=!!value;}}
+function _resetCronUnreadForProfileSwitch(){{}}
+function _clearPersistedModelState(){{}}
+function startGatewaySSE(){{}}
+function syncTopbar(){{}}
+function renderSessionList(){{return Promise.resolve();}}
+function api(){{return Promise.resolve({{active:'profile-b'}});}}
+function _applySessionListPayload(){{applied++;}}
 {invalidate}
 {current}
-const stale=_renderSessionListGen;
-_invalidateSessionListRenders();
-console.log(JSON.stringify({{staleRejected:!_sessionListGenerationIsCurrent(stale),currentAccepted:_sessionListGenerationIsCurrent(_renderSessionListGen),cleared}}));
+{apply_if_current}
+{switch_profile}
+(async()=>{{
+  const stale=_renderSessionListGen;
+  await _switchProfileForSessionLoad('profile-b');
+  const staleApplied=_applySessionListPayloadIfCurrent(stale,{{}},{{}},{{}});
+  const currentApplied=_applySessionListPayloadIfCurrent(_renderSessionListGen,{{}},{{}},{{}});
+  console.log(JSON.stringify({{staleRejected:!_sessionListGenerationIsCurrent(stale),currentAccepted:_sessionListGenerationIsCurrent(_renderSessionListGen),cleared,staleApplied,currentApplied,applied,profile:S.activeProfile}}));
+}})();
 """
-    assert _run_node_script(source) == {"staleRejected": True, "currentAccepted": True, "cleared": 1}
+    assert _run_node_script(source) == {
+        "staleRejected": True,
+        "currentAccepted": True,
+        "cleared": 1,
+        "staleApplied": False,
+        "currentApplied": True,
+        "applied": 1,
+        "profile": "profile-b",
+    }
 
 
 def test_active_run_locale_keys_cover_exact_supported_locale_set():
@@ -232,7 +370,13 @@ def test_active_run_locale_keys_cover_exact_supported_locale_set():
 {parser}
 const expected=['en','it','ja','ru','es','de','zh','zh-Hant','pt','ko','fr','cs','tr','pl','vi'];
 const names=_activeRunLocaleNames({json.dumps(I18N_JS)});
-const allKeys=expected.every(name=>{{const start={json.dumps(I18N_JS)}.indexOf(name);return start>=0;}});
+const source={json.dumps(I18N_JS)};
+const keys=['active_run_conversation_fallback','active_run_open_conversation','active_run_visibility_label'];
+const starts=expected.map(name=>source.indexOf(`\\n  ${{name==='zh-Hant'?"'zh-Hant'":name}}: {{`));
+const allKeys=starts.every((start,index)=>{{
+  const block=source.slice(start,index+1<starts.length?starts[index+1]:source.length);
+  return start>=0&&keys.every(key=>block.includes(key+':'));
+}});
 console.log(JSON.stringify({{names,exact:JSON.stringify(names)===JSON.stringify(expected),allKeys}}));
 """
     result = _run_node_script(source)

--- a/tests/test_issue6025_active_run_visibility.py
+++ b/tests/test_issue6025_active_run_visibility.py
@@ -365,12 +365,16 @@ console.log(JSON.stringify({{activeRunClass,childOnlyClass}}));
     )
     state_expression = state_line.split("=", 1)[1].rstrip(";")
     state_source = f"""
-const isStreaming=false; const isRingStreaming=true; const hasUnread=false;
+const isStreaming=false; let ownRingStreaming=true; const hasUnread=false;
 const attentionDotClass='';
 const activeRunState={state_expression};
-console.log(JSON.stringify({{activeRunState}}));
+ownRingStreaming=false;
+const childOnlyState={state_expression};
+console.log(JSON.stringify({{activeRunState,childOnlyState}}));
 """
-    assert "is-streaming" in _run_node_script(state_source)["activeRunState"]
+    state_result = _run_node_script(state_source)
+    assert "is-streaming" in state_result["activeRunState"]
+    assert "is-streaming" not in state_result["childOnlyState"]
 
 
 def test_active_run_elapsed_label_advances_when_pill_is_visible_with_monotonic_delta():

--- a/tests/test_run_lifecycle_health.py
+++ b/tests/test_run_lifecycle_health.py
@@ -76,6 +76,23 @@ def test_active_run_session_snapshot_is_bounded_sanitized_and_deduped():
             config.ACTIVE_RUNS.clear()
 
 
+def test_active_run_snapshot_excludes_ephemeral_and_suppressed_helper_sessions():
+    from api import config
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+    config.register_active_run("ephemeral", session_id="btw-session", ephemeral=True, started_at=10)
+    config.suppress_active_run_visibility("background", "parent-session")
+    config.register_active_run("background", session_id="bg-session", started_at=11)
+    try:
+        assert config.active_run_session_snapshot() == {}
+    finally:
+        config.unregister_active_run("ephemeral")
+        config.unregister_active_run("background")
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+
+
 def test_session_list_runtime_overlay_adds_active_run_only_to_accepted_rows():
     from api import config, route_session_list_cache as cache
 

--- a/tests/test_run_lifecycle_health.py
+++ b/tests/test_run_lifecycle_health.py
@@ -55,3 +55,65 @@ def test_run_registry_unregister_records_last_finished_time():
         assert "stream-2" not in config.ACTIVE_RUNS
         assert isinstance(config.LAST_RUN_FINISHED_AT, float)
     assert config.stream_owner_session_id("stream-2") is None
+
+
+def test_active_run_session_snapshot_is_bounded_sanitized_and_deduped():
+    from api import config
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS.update({
+            "one": {"session_id": "s1", "started_at": 30, "workspace": "/private"},
+            "two": {"session_id": "s1", "started_at": 20, "phase": "secret"},
+            "bad": {"session_id": "s2", "started_at": "nan"},
+            "ownerless": {"started_at": 10},
+            "malformed": "not-a-row",
+        })
+    try:
+        assert config.active_run_session_snapshot() == {"s1": {"started_at": 20.0}}
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+
+
+def test_session_list_runtime_overlay_adds_active_run_only_to_accepted_rows():
+    from api import config, route_session_list_cache as cache
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS.update({
+            "active": {"session_id": "accepted", "started_at": time.time() - 3},
+            "archived": {"session_id": "closed", "started_at": time.time() - 2},
+        })
+    try:
+        rows = cache._session_list_cache_overlay_runtime_rows([
+            {"session_id": "accepted", "archived": False},
+            {"session_id": "closed", "archived": True},
+            {"session_id": "absent", "archived": False},
+        ])
+        by_id = {row["session_id"]: row for row in rows}
+        assert set(by_id["accepted"]["active_run"]) == {"started_at", "age_seconds"}
+        assert "active_run" not in by_id["closed"]
+        assert "active_run" not in by_id["absent"]
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+
+
+def test_active_run_annotation_preserves_profile_before_messaging_dedupe_and_rejects_archived():
+    from api import config, route_session_list_cache as cache
+
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["run-a"] = {"session_id": "profile-a", "started_at": time.time() - 1}
+    try:
+        rows = cache._session_list_cache_overlay_runtime_rows([
+            {"session_id": "profile-a", "profile": "a", "archived": False},
+            {"session_id": "profile-b", "profile": "b", "archived": True},
+        ])
+        assert rows[0]["profile"] == "a"
+        assert rows[0]["active_run"]["started_at"] > 0
+        assert "active_run" not in rows[1]
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()

--- a/tests/test_session_active_profile_authorization.py
+++ b/tests/test_session_active_profile_authorization.py
@@ -544,6 +544,7 @@ def test_stream_owner_unregistered_on_worker_early_return(monkeypatch):
     # Owner registered by the route layer, but the stream was already cancelled
     # (never placed in STREAMS), so the worker will hit `q is None`.
     config.register_stream_owner("leak-stream", "some_session")
+    config.suppress_active_run_visibility("leak-stream", "parent-session")
     try:
         with config.STREAMS_LOCK:
             config.STREAMS.pop("leak-stream", None)
@@ -552,6 +553,8 @@ def test_stream_owner_unregistered_on_worker_early_return(monkeypatch):
         )
         with config.STREAM_SESSION_OWNERS_LOCK:
             assert "leak-stream" not in config.STREAM_SESSION_OWNERS
+        with config.ACTIVE_RUNS_LOCK:
+            assert "leak-stream" not in config._SUPPRESSED_ACTIVE_RUNS
     finally:
         with config.STREAM_SESSION_OWNERS_LOCK:
             config.STREAM_SESSION_OWNERS.clear()

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -105,7 +105,7 @@ def test_active_run_membership_publishes_only_first_and_last_transition():
         config.register_active_run("b", session_id="s1", started_at=2)
         assert q.empty()
         config.unregister_active_run("a")
-        assert q.empty()
+        assert q.get_nowait()["reason"] == "active_run_membership"
         config.unregister_active_run("b")
         assert q.get_nowait()["reason"] == "active_run_membership"
     finally:

--- a/tests/test_session_events.py
+++ b/tests/test_session_events.py
@@ -93,6 +93,27 @@ def test_session_events_payload_tracks_session_id_when_available():
         session_events.unsubscribe_session_events(q)
 
 
+def test_active_run_membership_publishes_only_first_and_last_transition():
+    from api import config, session_events
+
+    q = session_events.subscribe_session_events()
+    try:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+        config.register_active_run("a", session_id="s1", started_at=1)
+        assert q.get_nowait()["reason"] == "active_run_membership"
+        config.register_active_run("b", session_id="s1", started_at=2)
+        assert q.empty()
+        config.unregister_active_run("a")
+        assert q.empty()
+        config.unregister_active_run("b")
+        assert q.get_nowait()["reason"] == "active_run_membership"
+    finally:
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+        session_events.unsubscribe_session_events(q)
+
+
 def test_session_event_queue_same_profile_different_sessions_coalesces_to_profile_refresh():
     from api import session_events
 

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -13,11 +13,76 @@ NODE = shutil.which("node")
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
+def _extract_function(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    if source[max(0, start - 6):start] == "async ":
+        start -= 6
+    brace = source.index("{", source.index(")", start))
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        previous = source[index - 1] if index else ""
+        following = source[index + 1] if index + 1 < len(source) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+            continue
+        if block_comment:
+            if char == "*" and following == "/":
+                block_comment = False
+            continue
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char == "/" and following == "/":
+            line_comment = True
+            continue
+        if char == "/" and following == "*":
+            block_comment = True
+            continue
+        if char in "'\"`":
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+    raise AssertionError(name)
+
+
 def test_active_run_annotation_follows_compressed_and_fork_lineage():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
-    assert "function _activeRunRowsForProjection" in js
-    assert "active_run.started_at" in js
-    assert "_collapseSessionLineageForSidebar" in js
+    source = "\n".join((
+        "const window={_showCliSessions:true};",
+        "let _activeProject=null; let _sessionSourceFilter='webui'; let _showArchived=false;",
+        "const NO_PROJECT_FILTER='__none__';",
+        "function _activeSessionIdForSidebar(){return null;}",
+        "function _partitionSidebarSessionRows(rows){return {sessionsRaw:rows};}",
+        "function _isChildSession(s){return !!(s&&s.parent_session_id&&s.relationship_type==='child_session');}",
+        _extract_function(js, "_sessionTimestampMs"),
+        _extract_function(js, "_sessionLineageKey"),
+        _extract_function(js, "_authoritativeLineageTipId"),
+        _extract_function(js, "_collapseSessionLineageForSidebar"),
+        "function _sidebarLineageKeyForRow(s){return s._lineage_key||s._lineage_root_id||s.session_id;}",
+        _extract_function(js, "_activeRunLineageKey"),
+        _extract_function(js, "_activeRunRowsForProjection"),
+        "const rows=[",
+        "{session_id:'root',message_count:4,updated_at:10,_lineage_root_id:'root',_lineage_tip_id:'tip',active_run:{started_at:10,age_seconds:2}},",
+        "{session_id:'tip',message_count:6,updated_at:20,_lineage_root_id:'root',_lineage_tip_id:'tip'},",
+        "];",
+        "console.log(JSON.stringify(_activeRunRowsForProjection(rows).map(row=>[row.session_id,row.active_run.started_at])));",
+    ))
+    assert json.loads(_run_node(source)) == [["tip", 10]]
 
 
 def _run_node(source: str) -> str:

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -13,6 +13,13 @@ NODE = shutil.which("node")
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
+def test_active_run_annotation_follows_compressed_and_fork_lineage():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    assert "function _activeRunRowsForProjection" in js
+    assert "active_run.started_at" in js
+    assert "_collapseSessionLineageForSidebar" in js
+
+
 def _run_node(source: str) -> str:
     # Pass source via stdin rather than `-e <source>` argv — the latter is
     # capped at MAX_ARG_STRLEN (131072 bytes on Linux) and tests that embed

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -25,7 +25,6 @@ def _extract_function(source: str, name: str) -> str:
     block_comment = False
     for index in range(brace, len(source)):
         char = source[index]
-        previous = source[index - 1] if index else ""
         following = source[index + 1] if index + 1 < len(source) else ""
         if line_comment:
             if char == "\n":

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -542,6 +542,40 @@ def test_session_list_cache_retry_limit_escape_is_non_authoritative(monkeypatch)
     assert routes._session_list_cache_get(key, allow_stale=True)[0] is None
 
 
+def test_session_list_cache_rebuild_retries_after_source_change(monkeypatch):
+    routes._session_list_cache_clear()
+    key = routes._session_list_cache_key(
+        active_profile="profile-a",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    source_stamps = iter([
+        ("initial",),
+        ("before-build",),
+        ("changed-during-build",),
+        ("changed-during-build",),
+        ("changed-during-build",),
+    ])
+    monkeypatch.setattr(
+        routes,
+        "_session_list_cache_source_stamp",
+        lambda _key: next(source_stamps),
+    )
+    calls = []
+
+    def builder():
+        calls.append(len(calls) + 1)
+        return _session_cache_payload(f"attempt-{calls[-1]}")
+
+    result = routes._get_cached_session_list_payload(key=key, builder=builder)
+
+    assert calls == [1, 2]
+    assert result == _session_cache_payload("attempt-2")
+    assert result.source_authoritative is True
+
+
 @pytest.mark.parametrize("stamps, authoritative", [
     ([('same',), ('same',)], True),
     ([('before',), ('changed',)], False),

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -267,6 +267,8 @@ def test_session_list_cache_source_changed_owner_rebuilds_while_follower_reuses_
 
     assert owner_result["payload"] == _session_cache_payload("fresh")
     assert follower_result["payload"] == _session_cache_payload("stale")
+    assert owner_result["payload"].source_authoritative is True
+    assert follower_result["payload"].source_authoritative is False
     assert "session_list_cache_rebuild_owner" in owner_diag.stages
     assert "session_list_cache_wait_stale_fallback" in follower_diag.stages
 
@@ -440,7 +442,138 @@ def test_session_list_cache_rebuild_retries_after_invalidation():
     payload = routes._get_cached_session_list_payload(key=key, builder=builder)
 
     assert payload == _session_cache_payload("fresh")
+    assert payload.source_authoritative is True
     assert calls == ["build", "build"]
+
+
+def test_session_list_cache_retry_limit_escape_is_non_authoritative(monkeypatch):
+    routes._session_list_cache_clear()
+    key = routes._session_list_cache_key(
+        active_profile="profile-a",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    calls = []
+
+    def builder():
+        calls.append(len(calls) + 1)
+        routes._session_list_cache_clear("profile-a")
+        return _session_cache_payload(f"attempt-{calls[-1]}")
+
+    result = routes._get_cached_session_list_payload(key=key, builder=builder)
+
+    assert calls == [1, 2, 3]
+    assert result == _session_cache_payload("attempt-3")
+    assert result.source_authoritative is False
+    assert routes._session_list_cache_get(key, allow_stale=True)[0] is None
+
+
+@pytest.mark.parametrize("stamps, authoritative", [
+    ([('same',), ('same',)], True),
+    ([('before',), ('changed',)], False),
+])
+def test_session_list_cache_safety_rebuild_carries_post_build_stamp(
+    monkeypatch,
+    stamps,
+    authoritative,
+):
+    routes._session_list_cache_clear()
+    key = routes._session_list_cache_key(
+        active_profile="profile-a",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    inflight = threading.Event()
+    with routes._SESSIONS_CACHE_LOCK:
+        routes._SESSIONS_CACHE_INFLIGHT[key] = inflight
+    monkeypatch.setattr(routes, "_SESSIONS_CACHE_WAIT_SECONDS", 0)
+    stamp_values = iter(stamps)
+    monkeypatch.setattr(
+        routes,
+        "_session_list_cache_invalidation_stamp",
+        lambda _key: next(stamp_values),
+    )
+
+    try:
+        result = routes._get_cached_session_list_payload(
+            key=key,
+            builder=lambda: _session_cache_payload("safety"),
+        )
+    finally:
+        with routes._SESSIONS_CACHE_LOCK:
+            routes._SESSIONS_CACHE_INFLIGHT.pop(key, None)
+
+    assert result == _session_cache_payload("safety")
+    assert result.source_authoritative is authoritative
+    cached, _fresh = routes._session_list_cache_get(key, allow_stale=True)
+    assert (cached is not None) is authoritative
+
+
+def test_session_list_runtime_overlay_fail_closed_and_preserves_authoritative_rows(
+    monkeypatch,
+):
+    from api import route_session_list_cache as cache
+
+    monkeypatch.setattr(
+        cache,
+        "_session_list_cache_active_stream_ids",
+        lambda: {"live-stream"},
+    )
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+        config.ACTIVE_RUNS["run-1"] = {
+            "session_id": "session-1",
+            "started_at": 10,
+        }
+    row = {
+        "session_id": "session-1",
+        "active_run": {"started_at": 1},
+        "active_stream_id": "old-stream",
+        "has_pending_user_message": False,
+        "pending_started_at": 2,
+        "updated_at": 10,
+        "last_message_at": 20,
+        "is_streaming": False,
+        "cron_running": True,
+    }
+    with routes.LOCK:
+        original = dict(routes.SESSIONS)
+        routes.SESSIONS.clear()
+        routes.SESSIONS["session-1"] = SimpleNamespace(
+            active_stream_id="live-stream",
+            pending_user_message="queued prompt",
+            pending_started_at=30,
+            updated_at=40,
+            last_message_at=50,
+        )
+    try:
+        degraded = cache._session_list_cache_overlay_runtime_rows(
+            [row], source_authoritative=False
+        )[0]
+        authoritative = cache._session_list_cache_overlay_runtime_rows(
+            [row], source_authoritative=True
+        )[0]
+    finally:
+        with routes.LOCK:
+            routes.SESSIONS.clear()
+            routes.SESSIONS.update(original)
+        with config.ACTIVE_RUNS_LOCK:
+            config.ACTIVE_RUNS.clear()
+
+    assert set(degraded) == {"session_id", "updated_at", "last_message_at"}
+    assert degraded["updated_at"] == 10
+    assert degraded["last_message_at"] == 20
+    assert authoritative["active_run"]["started_at"] == 10
+    assert authoritative["active_stream_id"] == "live-stream"
+    assert authoritative["has_pending_user_message"] is True
+    assert authoritative["pending_started_at"] == 30
+    assert authoritative["updated_at"] == 40
+    assert authoritative["last_message_at"] == 50
+    assert authoritative["is_streaming"] is True
 
 
 def test_session_list_cache_source_stamp_tracks_state_db_wal(tmp_path, monkeypatch):

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -576,6 +576,32 @@ def test_session_list_runtime_overlay_fail_closed_and_preserves_authoritative_ro
     assert authoritative["is_streaming"] is True
 
 
+def test_session_list_response_propagates_non_authoritative_cache_result(
+    monkeypatch,
+):
+    from api import route_session_list_cache as cache
+
+    monkeypatch.setattr(routes, "load_settings", lambda: {"api_redact_enabled": False})
+    monkeypatch.setattr(
+        routes,
+        "_sidebar_session_response_item",
+        lambda row, *, redact_enabled=None: dict(row),
+    )
+    monkeypatch.setattr(
+        cache,
+        "active_run_session_snapshot",
+        lambda: {"sid": {"started_at": 10}},
+    )
+    result = routes._SessionListCacheResult(
+        {"sessions": [{"session_id": "sid", "archived": False}]},
+        source_authoritative=False,
+    )
+
+    response = routes._session_list_payload_to_response(result)
+
+    assert response["sessions"] == [{"session_id": "sid", "archived": False}]
+
+
 def test_session_list_cache_source_stamp_tracks_state_db_wal(tmp_path, monkeypatch):
     state_db = tmp_path / "state.db"
     state_db.write_text("db", encoding="utf-8")

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -355,6 +355,46 @@ def test_session_list_cache_unknown_stale_reason_does_not_authorize_stale(
     assert result.source_authoritative is True
 
 
+def test_session_list_cache_source_change_during_stale_return_fails_closed(
+    monkeypatch,
+):
+    routes._session_list_cache_clear()
+    monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: ("stable",))
+    stale_reasons = iter(("age", "source"))
+    monkeypatch.setattr(
+        routes,
+        "_session_list_cache_stale_reason",
+        lambda _key: next(stale_reasons),
+    )
+
+    key = routes._session_list_cache_key(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    stale = _session_cache_payload("stale")
+    stale["sessions"][0]["active_run"] = {"started_at": 1}
+    routes._session_list_cache_set(key, stale)
+    with routes._SESSIONS_CACHE_LOCK:
+        ts, stamp, payload = routes._SESSIONS_CACHE[key]
+        routes._SESSIONS_CACHE[key] = (
+            ts - routes._SESSIONS_CACHE_TTL_SECONDS - 1.0,
+            stamp,
+            payload,
+        )
+
+    result = routes._get_cached_session_list_payload(
+        key=key,
+        builder=lambda: _session_cache_payload("fresh"),
+    )
+
+    assert result == stale
+    assert result.source_authoritative is False
+    assert "active_run" not in routes._session_list_payload_to_response(result)["sessions"][0]
+
+
 def test_session_list_cache_stale_background_rebuild_failure_releases_owner(monkeypatch):
     routes._session_list_cache_clear()
     monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: ("stable",))

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -323,6 +323,38 @@ def test_session_list_cache_owner_returns_stale_and_rebuilds_in_background(monke
     assert cached == _session_cache_payload("fresh")
 
 
+def test_session_list_cache_unknown_stale_reason_does_not_authorize_stale(
+    monkeypatch,
+):
+    routes._session_list_cache_clear()
+    monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: ("stable",))
+    monkeypatch.setattr(routes, "_session_list_cache_stale_reason", lambda _key: None)
+
+    key = routes._session_list_cache_key(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    routes._session_list_cache_set(key, _session_cache_payload("stale"))
+    with routes._SESSIONS_CACHE_LOCK:
+        ts, stamp, payload = routes._SESSIONS_CACHE[key]
+        routes._SESSIONS_CACHE[key] = (
+            ts - routes._SESSIONS_CACHE_TTL_SECONDS - 1.0,
+            stamp,
+            payload,
+        )
+
+    result = routes._get_cached_session_list_payload(
+        key=key,
+        builder=lambda: _session_cache_payload("fresh"),
+    )
+
+    assert result == _session_cache_payload("fresh")
+    assert result.source_authoritative is True
+
+
 def test_session_list_cache_stale_background_rebuild_failure_releases_owner(monkeypatch):
     routes._session_list_cache_clear()
     monkeypatch.setattr(routes, "_session_list_cache_source_stamp", lambda _key: ("stable",))

--- a/tests/test_session_sidebar_cache.py
+++ b/tests/test_session_sidebar_cache.py
@@ -564,9 +564,14 @@ def test_session_list_runtime_overlay_fail_closed_and_preserves_authoritative_ro
         with config.ACTIVE_RUNS_LOCK:
             config.ACTIVE_RUNS.clear()
 
-    assert set(degraded) == {"session_id", "updated_at", "last_message_at"}
-    assert degraded["updated_at"] == 10
-    assert degraded["last_message_at"] == 20
+    assert "active_run" not in degraded
+    assert degraded["active_stream_id"] == "live-stream"
+    assert degraded["has_pending_user_message"] is True
+    assert degraded["pending_started_at"] == 30
+    assert degraded["updated_at"] == 40
+    assert degraded["last_message_at"] == 50
+    assert degraded["is_streaming"] is True
+    assert degraded["cron_running"] is False
     assert authoritative["active_run"]["started_at"] == 10
     assert authoritative["active_stream_id"] == "live-stream"
     assert authoritative["has_pending_user_message"] is True
@@ -599,7 +604,12 @@ def test_session_list_response_propagates_non_authoritative_cache_result(
 
     response = routes._session_list_payload_to_response(result)
 
-    assert response["sessions"] == [{"session_id": "sid", "archived": False}]
+    assert response["sessions"] == [{
+        "session_id": "sid",
+        "archived": False,
+        "is_streaming": False,
+        "cron_running": False,
+    }]
 
 
 def test_session_list_cache_source_stamp_tracks_state_db_wal(tmp_path, monkeypatch):


### PR DESCRIPTION
## Thinking Path

- The useful product boundary is the small one: show when an accepted parent conversation is still active after the user navigates away, without turning WebUI into a process monitor.
- `ACTIVE_RUNS` already owns worker liveness, and `/api/sessions` already owns which conversations this profile, source, project, and sidebar may show. The rebuilt path joins those existing authorities by annotating canonical session rows.
- The pill, tray, ring, and state indicator now read that one row projection. Cache results carry source authority through response composition, while degraded rows keep current-master lifecycle fields without receiving `active_run` claims. Ring-only activity stays out of shared session-list polling.

## What Changed

- `api/config.py`: expose a bounded session-keyed liveness snapshot and notify the existing session-list event path when a session first becomes active, its earliest active owner changes, or its last active owner exits.
- `api/models.py`: preserve an active zero-message parent through the canonical empty-row gate so every normal sidebar filter still decides whether it is visible.
- `api/route_session_list_cache.py` and `api/routes.py`: carry cache row-set authority through every cache exit, reject source changes during cache construction, remove cached `active_run` claims, and annotate authoritative accepted `/api/sessions` rows with presentation-safe `active_run.started_at` and server-derived `active_run.age_seconds`; remove the dedicated active-run endpoint and metadata fallback.
- `static/sessions.js`: derive current-scope activity from canonical rows, carry it through lineage projection, keep the ring and state indicator isolated from child-only activity, and keep ring-only activity out of the shared streaming poll.
- `static/ui.js`, `static/index.html`, and `static/style.css`: retain the compact titlebar pill and disclosure tray, update elapsed text locally, reconcile stable controls, and handle Escape only when the tray is open.
- `static/i18n.js`: keep all three activity strings across the exact supported locale catalog.
- Focused regressions cover profile-before-messaging dedupe, archived cold/source-stale rebuilds, source changes during cache construction, cache authority exits and response composition, active empty rows, lineage variants, first/last lifecycle events, pre-start cancellation cleanup, real delayed profile switching, locale discovery, tray focus, cron lifecycle preservation, and ring-only isolation.

## Why It Matters

Hermes can stay visibly active when you move to another conversation or panel, while the result still obeys the same profile, source, project, archive, lineage, and visibility rules as the sidebar. One canonical projection also removes the drift that kept producing new scope bugs in the previous branch.

## Verification

Focused validation passed: 220 backend and browser-state regressions, runtime ESLint, `git diff --check`, and the invariant-site enumeration assert. The issue-shaped regression fails at the opened merge-base and passes on the rebuilt head; the full repository matrix remains CI-owned.

## Risks / Follow-ups

- The rebuilt response exposes only `active_run.started_at` and `active_run.age_seconds` on authoritative canonical rows. Source-invalidated degraded rows remain usable for navigation, retain the existing lifecycle overlay fields, and omit cached or current `active_run` claims. Phase labels, child-worker grouping, controls, quiet/stale cues, and external-worker inference remain separate contract work.
- Native titlebar click-versus-drag behavior and responsive layout at supported widths need verification before release; the verification matrix covers the titlebar, tray, ring, and localized labels.
- No schema or persistence migration is required. The annotation is volatile and absent when idle or out of scope.

## Contract Routing

Task type: Runtime/sidebar behavior fix.

Touched areas: `ACTIVE_RUNS` lifecycle observation, canonical session-list metadata, profile and lineage projection, titlebar disclosure, and sidebar ring presentation.

Relevant public docs:

- `AGENTS.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/UIUX-GUIDE.md`

Scope boundaries: Phase-1 parent conversations only; no child-worker hierarchy, process-global inference, `/health` UI contract, schema, or persistence change.

Evidence needed before claiming done: issue-shaped base/head regression, focused canonical-row and lifecycle tests, runtime lint, and the review-owned rendered screenshot pair.

## Contract Change

Previous contract: `/api/sessions` exposed sidebar rows without an active-run presentation field, so away-from-session activity had no canonical row representation.

New contract: authoritative accepted rows may carry volatile `active_run.started_at` and `active_run.age_seconds`; source-invalidated degraded rows may remain available for navigation but omit cached and current `active_run` claims. The fields are omitted for idle, archived, hidden, filtered, or otherwise rejected rows and contain no stream, workspace, run, phase, tool, or provider data.

Affected docs and tests: `tests/test_run_lifecycle_health.py`, `tests/test_issue6025_active_run_visibility.py`, and the existing session-list/sidebar behavior documented in `docs/GUIDELINES.md`.

Compatibility reason: existing consumers ignore the optional field, while the new pill, tray, ring, and state indicator read the same accepted row set as the sidebar. Current-master transport, pending-message, timestamp, and cron lifecycle fields remain available through degraded responses. No schema or persistence migration is required.

## Upstream

Closes #6025.

## Screenshots

The isolated headless render uses a seeded active row for layout proof; runtime membership is covered by the focused regression suite.

Before, 1024x600:

![Before active-run visibility](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui-6025-before.png)

After, 1024x600, with the active pill:

![After active-run visibility](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui-6025-after.png)

The responsive sweep also covers 1280, 768, 480x320, and 400 widths, with RU and DE labels.

## Model Used

OpenAI GPT-5.

