### PR TITLE
fix: omit auxiliary reasoning body on custom routes

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -51,6 +51,9 @@ from api.config import (
     coerce_reasoning_effort_for_model,
     _main_model_request_overrides,
     PROCESS_SESSION_INDEX, PROCESS_SESSION_INDEX_LOCK,
+    _PROVIDER_MODELS,
+    _PROVIDER_DISPLAY,
+    _resolve_provider_alias,
 )
 from api.helpers import (
     redact_session_data,
@@ -4124,21 +4127,29 @@ def _is_minimax_route(provider: str = '', model: str = '', base_url: str = '') -
     return 'minimax' in text or 'minimaxi.com' in text
 
 
-def _route_rejects_reasoning_extra(provider: str = '', model: str = '', base_url: str = '') -> bool:
-    """Routes known to reject an ``extra_body`` ``reasoning`` parameter with HTTP 400.
+_REASONING_EXTRA_COMPATIBLE_PROVIDER_IDS = frozenset({
+    'ai-gateway',
+    'vercel',
+    'vercel-ai-gateway',
+    'ai_gateway',
+    'aigateway',
+})
 
-    Title generation injects ``extra_body={"reasoning": {"enabled": False}}`` to
-    suppress thinking on reasoning-capable models (#2083). But OpenAI Chat
-    Completions (and Azure OpenAI) reject unknown top-level params with a 400, so
-    that inject silently fails the title call and falls back to a low-quality
-    heuristic title (#4161). Skip the inject for those routes.
 
-    OpenRouter Anthropic mandatory-reasoning models (Claude Sonnet 4.6 / Opus 4.8)
-    are reasoning-capable but reject a reasoning *disable* — title gen only needs
-    reasoning off, so skip the inject for them too rather than risk the same 400.
+def _route_accepts_reasoning_extra(provider: str = '', model: str = '', base_url: str = '') -> bool:
+    """Whether an auxiliary title route can receive reasoning suppression.
+
+    Known built-in routes are resolved even when their URL is implicit, and keep
+    ``extra_body={"reasoning": {"enabled": False}}`` so title generation does
+    not spend its budget on hidden reasoning.  The known reject set (OpenAI,
+    Azure/Azure AI Foundry, and OpenRouter Anthropic) is excluded.  A route is
+    otherwise fail-safe: an unknown provider backed by a custom URL is omitted
+    until it has an explicit compatibility classification.
     """
     provider_lower = str(provider or '').strip().lower()
     model_lower = str(model or '').strip().lower()
+    if not model_lower:
+        return False
     # Hostname-based match (not substring) so a proxy URL that merely *contains*
     # one of these strings in a path segment isn't mis-classified.
     host = ''
@@ -4148,22 +4159,232 @@ def _route_rejects_reasoning_extra(provider: str = '', model: str = '', base_url
     except Exception:
         host = ''
     if host == 'api.openai.com' or host.endswith('.openai.azure.com'):
-        return True
+        return False
     # Azure AI Foundry chat-completions hosts (also reject the reasoning param).
     if host.endswith('.services.ai.azure.com') or host.endswith('.cognitiveservices.azure.com'):
-        return True
+        return False
     if provider_lower in ('openai', 'openai-api', 'openai-codex'):
-        return True
+        return False
     if (
         provider_lower in ('azure', 'azure-foundry', 'azure-ai-foundry', 'azure-ai')
         or provider_lower.startswith('azure/')
         or provider_lower.startswith('azure-')
     ):
-        return True
-    if (host == 'openrouter.ai' or host.endswith('.openrouter.ai')) and model_lower.startswith('anthropic/'):
+        return False
+    if (
+        provider_lower == 'openrouter'
+        or host == 'openrouter.ai'
+        or host.endswith('.openrouter.ai')
+    ) and model_lower.startswith('anthropic/'):
         # Anthropic on OpenRouter: mandatory-reasoning families reject a disable.
+        return False
+
+    provider_canonical = str(_resolve_provider_alias(provider_lower) or '').strip().lower()
+    if (
+        provider_lower in _REASONING_EXTRA_COMPATIBLE_PROVIDER_IDS
+        or provider_canonical in _REASONING_EXTRA_COMPATIBLE_PROVIDER_IDS
+    ):
+        return True
+
+    # Provider IDs from the built-in catalog resolve their endpoint in the
+    # client.  Do not mistake an implicit URL for an unresolved custom route.
+    builtin_providers = set(_PROVIDER_MODELS) | set(_PROVIDER_DISPLAY)
+    # Some catalog entries intentionally use their user-facing ID (notably
+    # ``x-ai`` and ``ollama``), while aliases such as ``google-gemini`` resolve
+    # to their canonical catalog ID.  Both names describe a known route.
+    if provider_lower in builtin_providers or provider_canonical in builtin_providers:
+        return True
+
+    # Provider can be omitted for an implicit MiniMax configuration. Its
+    # canonical China or global endpoint still makes this an effective, known
+    # route.
+    if (
+        host == 'api.minimaxi.com'
+        or host.endswith('.minimaxi.com')
+        or host == 'api.minimax.io'
+        or host.endswith('.minimax.io')
+    ):
         return True
     return False
+
+
+def _safe_aux_route_for_log(base_url: str = '') -> str:
+    """Return a route diagnostic without URL userinfo, query, or fragment."""
+    raw = str(base_url or '').strip()
+    if not raw:
+        return '<implicit>'
+    try:
+        from urllib.parse import urlsplit, urlunsplit
+
+        parsed = urlsplit(raw)
+        if not parsed.scheme or not parsed.hostname:
+            return '<unparseable>'
+        host = parsed.hostname
+        if ':' in host and not host.startswith('['):
+            host = f'[{host}]'
+        try:
+            if parsed.port is not None:
+                host = f'{host}:{parsed.port}'
+        except ValueError:
+            return '<unparseable>'
+        return urlunsplit((parsed.scheme, host, parsed.path, '', ''))
+    except Exception:
+        return '<unparseable>'
+
+
+def _redact_urls_for_log(text: str) -> str:
+    """Remove credentials carried by any HTTP(S) URL in exception text."""
+    # Scrub before parsing. Exception renderers can wrap URLs in delimiters or
+    # preserve whitespace in userinfo, either of which can defeat a conventional
+    # URL match before its credentials are removed.
+    redacted = re.sub(
+        r"(?i)(https?://)[^@\r\n]*@",
+        r"\1<redacted>@",
+        str(text or ''),
+    )
+    redacted = re.sub(
+        # Values can be quoted/bracketed or contain spaces. Stop only at the
+        # next query field, a fragment, or a newline.
+        r"(?i)([?&]\s*(?:api_key|token|key|secret)\s*=\s*)[^&#\r\n]*",
+        r"\1<redacted>",
+        redacted,
+    )
+    redacted = re.sub(
+        # Do not let punctuation which commonly wraps an exception value bound
+        # this match.  _safe_aux_route_for_log drops a trailing delimiter along
+        # with any URL credentials it encounters.
+        r"https?://[^\s'\"<>{}]+",
+        lambda match: _safe_aux_route_for_log(match.group(0)),
+        redacted,
+    )
+    # Exception text is not guaranteed to contain a URL that parses cleanly:
+    # clients can quote, delimit, or otherwise mangle it.  Scrub the complete
+    # rendered message as a final defense, rather than trusting URL parsing.
+    redacted = re.sub(
+        r"(?i)(https?://)[^@\r\n]*@",
+        r"\1<redacted>@",
+        redacted,
+    )
+    redacted = re.sub(
+        # Also cover a userinfo fragment which an exception formatter has
+        # separated from its scheme (for example, ``)user:secret@host``),
+        # including delimiters and whitespace around its components.
+        r"(?i)(?<![\w/])[^@:\r\n]{1,128}?\s*:\s*[^@\r\n]{1,128}?@",
+        "<redacted>@",
+        redacted,
+    )
+    return re.sub(
+        r"(?i)([?&]\s*(?:api_key|token|key|secret)\s*=\s*)[^&#\r\n]*",
+        r"\1<redacted>",
+        redacted,
+    )
+
+
+def _log_aux_title_failure(message: str, base_url: str, provider: str, model: str) -> None:
+    """Log auxiliary failure context without exposing URL-carried credentials."""
+    rendered = '%s (route=%s provider=%s model=%s)\n%s' % (
+        message,
+        _safe_aux_route_for_log(base_url),
+        provider,
+        model,
+        _redact_urls_for_log(traceback.format_exc()),
+    )
+    # Run the forced scrub over *all* fields, including the route diagnostic,
+    # because callers and tracebacks may contain delimiter-wrapped URLs.
+    logger.error('%s', _redact_urls_for_log(rendered))
+
+
+def _aux_default_model_for_provider(provider: str) -> str:
+    """Return the Agent's authoritative auxiliary default for *provider*.
+
+    The Agent owns these defaults because they are provider-profile data, not
+    WebUI picker/catalog data.  In particular, the first entry in
+    ``_PROVIDER_MODELS`` is a display choice and can differ from the cheap
+    auxiliary model that the Agent will actually request.  An empty result is
+    meaningful (for example, a provider whose valid model set is account
+    dependent) and must remain empty rather than falling back to the main
+    route.
+    """
+    try:
+        from agent.auxiliary_client import _get_aux_model_for_provider
+
+        return str(_get_aux_model_for_provider(provider) or '').strip()
+    except Exception:
+        # Version-skewed/missing Agent installs must not make WebUI invent a
+        # model from its display catalog or the main route.
+        return ''
+
+
+def _effective_aux_title_route(provider: str, model: str, base_url: str) -> tuple[str, str, str]:
+    """Resolve the one auxiliary title route used for requests and compatibility.
+
+    Only implicit, auto/local, and picker routes inherit resolver output.  A
+    configured explicit route is itself the request contract: it must never be
+    filled with the main route's model or endpoint.  In particular, a base URL
+    is sufficient to make a route explicit even if its model is blank.
+    """
+    supplied_provider = str(provider or '').strip()
+    supplied_model = str(model or '').strip()
+    supplied_base_url = str(base_url or '').strip()
+    provider_lower = supplied_provider.lower()
+    implicit_route = provider_lower in {'', 'auto', 'local'}
+    picker_route = supplied_model.startswith('@')
+
+    if supplied_base_url and not picker_route:
+        # A base URL is an explicit Agent-custom endpoint contract even when
+        # its provider and model are blank.  Running an unqualified model
+        # through the main-model resolver here would substitute the main
+        # provider/model (for example OpenAI/gpt-main) and silently send title
+        # traffic to the wrong route.  Blank-provider base-URL-only routes and
+        # the legacy ``local`` spelling are both OpenAI-compatible custom
+        # endpoints; make that explicit for the Agent instead of borrowing the
+        # main route.  A configured blank provider with an explicit model keeps
+        # its historical Agent-custom (None) provider contract.
+        if (
+            provider_lower == 'local'
+            or (provider_lower in {'', 'auto'} and not supplied_model)
+        ):
+            return 'custom', supplied_model, supplied_base_url
+        if supplied_model:
+            return supplied_provider, supplied_model, supplied_base_url
+
+        # An explicit provider with a blank model still belongs to that
+        # provider, even when it uses a custom endpoint. Let the explicit
+        # provider route below obtain the Agent-owned auxiliary default.
+
+    if not implicit_route and not picker_route:
+        if supplied_model:
+            # Preserve explicit model IDs (including :free/:thinking suffixes)
+            # and the supplied endpoint exactly as configured.
+            return supplied_provider, supplied_model, supplied_base_url
+        own_default = _aux_default_model_for_provider(supplied_provider)
+        if not own_default:
+            # An unresolved explicit route must fail closed rather than borrow
+            # a model from the main chat route.
+            return supplied_provider, '', supplied_base_url
+        # Keep this exact Agent-selected model for both the request and the
+        # compatibility gate below.  Re-resolving through the WebUI picker can
+        # replace it with a main-route or display-catalog model.
+        return supplied_provider, own_default, supplied_base_url
+
+    effective_model = supplied_model
+    if not effective_model:
+        try:
+            model_cfg = get_config().get('model', {})
+            if isinstance(model_cfg, dict):
+                effective_model = str(model_cfg.get('default') or model_cfg.get('name') or '').strip()
+        except Exception:
+            pass
+    try:
+        resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(effective_model)
+        return (
+            str(resolved_provider or supplied_provider),
+            str(resolved_model or effective_model),
+            supplied_base_url or str(resolved_base_url or ''),
+        )
+    except Exception:
+        # A failed resolution is deliberately treated as unknown by the gate.
+        return supplied_provider, supplied_model, supplied_base_url
 
 
 def _get_aux_title_config() -> dict:
@@ -4357,26 +4578,18 @@ def generate_title_raw_via_aux(
         provider = ''
     model = model or configured.get('model', '') or ''
     base_url = base_url or configured.get('base_url', '') or ''
-    try:
-        from api.profiles import _split_webui_provider_model_value
-
-        normalized_model, normalized_provider = _split_webui_provider_model_value(
-            model or None,
-            provider or None,
-        )
-        model = normalized_model or ''
-        provider = normalized_provider or ''
-    except ValueError:
-        pass
     api_key = ''
     if not caller_supplied_route:
         api_key = str(configured.get('api_key', '') or '').strip()
-    base_max_tokens = _title_completion_budget(provider, model, base_url)
+    provider, model, base_url = _effective_aux_title_route(
+        provider, model, base_url,
+    )
     reasoning_extra = {}
-    if not _route_rejects_reasoning_extra(provider, model, base_url):
+    if _route_accepts_reasoning_extra(provider, model, base_url):
         reasoning_extra["reasoning"] = {"enabled": False}
-    if _is_minimax_route(provider, model, base_url):
-        reasoning_extra["reasoning_split"] = True
+        if _is_minimax_route(provider, model, base_url):
+            reasoning_extra["reasoning_split"] = True
+    base_max_tokens = _title_completion_budget(provider, model, base_url)
     try:
         _timeout = _aux_title_timeout()
         from agent.auxiliary_client import call_llm
@@ -4407,9 +4620,14 @@ def generate_title_raw_via_aux(
                     last_status = empty_status or 'llm_empty_aux'
                     if budget_idx == 0 and _title_retry_status(last_status):
                         budgets.append(_title_retry_completion_budget(provider, model, base_url))
-            except Exception as e:
+            except Exception:
                 last_status = 'llm_error_aux'
-                logger.debug("Aux title generation attempt %s failed: %s", idx + 1, e)
+                _log_aux_title_failure(
+                    f'Aux title generation attempt {idx + 1} failed',
+                    base_url,
+                    provider,
+                    model,
+                )
             # If the model just burned its budget on hidden reasoning, retrying
             # the next prompt against the same model produces the same shape.
             # Short-circuit to the local fallback path (#2083).
@@ -4420,8 +4638,8 @@ def generate_title_raw_via_aux(
                 )
                 break
         return None, last_status
-    except Exception as e:
-        logger.debug("Aux title generation failed: %s", e)
+    except Exception:
+        _log_aux_title_failure('Aux title generation failed', base_url, provider, model)
         return None, 'llm_error_aux'
 
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -162,6 +162,25 @@ PR-body content on GitHub. A future release-time or CI check could
 surface contract-affecting diffs whose PR body lacks `Contract Routing`, but this
 document only defines the review expectation.
 
+## Auxiliary-title request injection and omission
+
+Auxiliary title generation is routed through the Agent's
+`title_generation` auxiliary task. Its effective provider, model, and base URL
+form one request contract: the reasoning-compatibility gate and the LLM request
+must consume that same resolved route.
+
+- A configured explicit provider/model/base URL is injected into the auxiliary
+  request. A caller-supplied route does not receive the configured task API key.
+- A blank provider plus an explicit base URL and non-picker model is an
+  Agent-custom route. Preserve its blank provider, model, and URL; never borrow
+  the main chat provider or model.
+- An explicit provider with a blank model uses the Agent's authoritative
+  auxiliary default. If the Agent has no default, preserve the blank model; do
+  not substitute the WebUI picker catalog or the main route.
+- Reasoning suppression is injected only for a known compatible effective
+  route. Unknown/custom routes, rejected provider routes, and routes with no
+  resolved model omit it (fail closed).
+
 Release batches should list included contract-affecting PRs explicitly so
 reviewers can distinguish ordinary green-CI fixes from changes that update the
 project's product or runtime guardrails.

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -274,7 +274,11 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
             'base_url': 'http://openrouter:4000/v1',
             'api_key': 'test-title-api-key',
         }
-        with _patch_tg_config(tg_config):
+        # Patch the streaming boundary directly so this regression is
+        # independent of any real/stub Agent module or shared config/import
+        # state from another test.  The blank provider assertion below is the
+        # route-preservation contract for an explicit custom endpoint.
+        with patch('api.streaming._get_aux_title_config', return_value=tg_config):
             with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
                 result, status = generate_title_raw_via_aux(
                     user_text='Summarize this title routing bug.',

--- a/tests/test_title_gen_reasoning_extra_gate.py
+++ b/tests/test_title_gen_reasoning_extra_gate.py
@@ -1,56 +1,496 @@
-"""Consolidated regression tests for title-gen reasoning extra_body gating.
-
-Consolidates #2083 (suppress thinking on reasoning models so titles aren't
-polluted) with #4161 (OpenAI/Azure Chat Completions reject the `reasoning`
-extra_body param with a 400 -> silent fallback to heuristic titles).
-
-Aux path (`generate_title_raw_via_aux`, no agent object): inject the
-reasoning-disable EXCEPT on reject-listed routes (OpenAI/Azure).
-Agent path (`generate_title_raw_via_agent`): inject only when the agent's
-canonical `_supports_reasoning_extra_body()` says the route is reasoning-
-tolerant AND the route is not reject-listed — which additionally excludes
-OpenRouter Anthropic mandatory-reasoning models (Claude Sonnet 4.6 / Opus 4.8)
-that are reasoning-capable but 400 on a disable.
-"""
+"""Regression coverage for auxiliary title reasoning-suppression routing."""
 from __future__ import annotations
 
-from api.streaming import _route_rejects_reasoning_extra
+import importlib
+import importlib.util
+import sys
+from unittest.mock import patch
+
+import pytest
+
+_MISSING = object()
+_AGENT_BEFORE_COLLECTION = sys.modules.get("agent", _MISSING)
+_AGENT_SPEC_BEFORE_COLLECTION = getattr(_AGENT_BEFORE_COLLECTION, "__spec__", _MISSING)
+_AGENT_PATH_BEFORE_COLLECTION = getattr(_AGENT_BEFORE_COLLECTION, "__path__", _MISSING)
+try:
+    _AGENT_IMPORT_SPEC_BEFORE_COLLECTION = importlib.util.find_spec("agent")
+except (ImportError, ValueError):
+    _AGENT_IMPORT_SPEC_BEFORE_COLLECTION = None
+
+from api.streaming import _route_accepts_reasoning_extra, generate_title_raw_via_aux
+
+_AGENT_AFTER_COLLECTION = sys.modules.get("agent", _MISSING)
 
 
-class TestAuxRejectList:
-    def test_openai_direct_is_reject_listed(self):
-        assert _route_rejects_reasoning_extra("openai", "gpt-5.5", "https://api.openai.com/v1") is True
+def test_collection_preserves_the_real_agent_package():
+    """Importing this regression module must not poison later Agent imports."""
+    if _AGENT_BEFORE_COLLECTION is _MISSING:
+        agent_module = _AGENT_AFTER_COLLECTION
+        if agent_module is _MISSING:
+            if _AGENT_IMPORT_SPEC_BEFORE_COLLECTION is None:
+                pytest.skip("Hermes Agent is not installed in this WebUI-only environment")
+            agent_module = importlib.import_module("agent")
 
-    def test_azure_is_reject_listed(self):
-        assert _route_rejects_reasoning_extra("azure", "gpt-4", "https://x.openai.azure.com/") is True
-        assert _route_rejects_reasoning_extra("azure/foo", "gpt-4", "") is True
+        agent_spec = getattr(agent_module, "__spec__", None)
+        agent_path = getattr(agent_module, "__path__", _MISSING)
+        assert agent_spec is not None
+        assert agent_path is not _MISSING
+        if _AGENT_IMPORT_SPEC_BEFORE_COLLECTION is not None:
+            assert agent_spec.origin == _AGENT_IMPORT_SPEC_BEFORE_COLLECTION.origin
+            assert tuple(agent_path) == tuple(
+                _AGENT_IMPORT_SPEC_BEFORE_COLLECTION.submodule_search_locations or ()
+            )
+        assert importlib.import_module("agent.model_metadata") is not None
+        return
 
-    def test_azure_foundry_aliases_reject_listed(self):
-        assert _route_rejects_reasoning_extra("azure-foundry", "gpt-5", "") is True
-        assert _route_rejects_reasoning_extra("azure-ai-foundry", "gpt-5", "") is True
-        assert _route_rejects_reasoning_extra("azure-ai", "gpt-5", "") is True
-        # Foundry host-based detection (services.ai.azure.com / cognitiveservices)
-        assert _route_rejects_reasoning_extra("custom", "gpt-5", "https://x.services.ai.azure.com/v1") is True
+    assert _AGENT_AFTER_COLLECTION is _AGENT_BEFORE_COLLECTION
+    assert getattr(_AGENT_AFTER_COLLECTION, "__spec__", _MISSING) is _AGENT_SPEC_BEFORE_COLLECTION
+    assert getattr(_AGENT_AFTER_COLLECTION, "__path__", _MISSING) is _AGENT_PATH_BEFORE_COLLECTION
+    assert _AGENT_SPEC_BEFORE_COLLECTION is not None
+    assert _AGENT_PATH_BEFORE_COLLECTION is not _MISSING
+    assert importlib.import_module("agent.model_metadata") is not None
 
-    def test_hostname_match_not_substring(self):
-        # A proxy whose PATH merely contains api.openai.com must NOT be reject-listed.
-        assert _route_rejects_reasoning_extra("custom", "qwen3", "https://proxy.example.test/api.openai.com/v1") is False
-        # but the real OpenAI host is.
-        assert _route_rejects_reasoning_extra("custom", "gpt-5", "https://api.openai.com/v1") is True
 
-    def test_openai_codex_alias_is_reject_listed(self):
-        assert _route_rejects_reasoning_extra("openai-codex", "gpt-5", "") is True
+@pytest.fixture
+def _scoped_auxiliary_client_module(monkeypatch):
+    """Provide a call boundary per test without mutating collection state."""
+    try:
+        auxiliary_client = importlib.import_module("agent.auxiliary_client")
+    except Exception:
+        agent_module = sys.modules.get("agent")
+        if agent_module is None:
+            agent_spec = importlib.util.spec_from_loader(
+                "agent", loader=None, is_package=True
+            )
+            agent_module = importlib.util.module_from_spec(agent_spec)
+            monkeypatch.setitem(sys.modules, "agent", agent_module)
 
-    def test_openrouter_non_anthropic_is_not_reject_listed(self):
-        assert _route_rejects_reasoning_extra("openrouter", "deepseek/deepseek-r1", "https://openrouter.ai/api/v1") is False
+        auxiliary_spec = importlib.util.spec_from_loader(
+            "agent.auxiliary_client", loader=None
+        )
+        auxiliary_client = importlib.util.module_from_spec(auxiliary_spec)
+        monkeypatch.setitem(
+            sys.modules, "agent.auxiliary_client", auxiliary_client
+        )
+        monkeypatch.setattr(
+            agent_module, "auxiliary_client", auxiliary_client, raising=False
+        )
 
-    def test_openrouter_anthropic_mandatory_is_reject_listed(self):
-        # Promoted into the shared helper so BOTH aux and agent paths skip it.
-        assert _route_rejects_reasoning_extra("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1") is True
-        assert _route_rejects_reasoning_extra("openrouter", "anthropic/claude-opus-4.8", "https://openrouter.ai/api/v1") is True
+    yield auxiliary_client
 
-    def test_local_lmstudio_is_not_reject_listed(self):
-        assert _route_rejects_reasoning_extra("lmstudio", "qwen3-8b", "http://localhost:1234/v1") is False
 
-    def test_minimax_is_not_reject_listed(self):
-        assert _route_rejects_reasoning_extra("", "minimax-m2", "https://api.minimaxi.com/v1") is False
+@pytest.mark.usefixtures("_scoped_auxiliary_client_module")
+class TestAuxReasoningExtraRouteContract:
+    def test_known_reasoning_routes_keep_suppression(self):
+        assert _route_accepts_reasoning_extra(
+            'openrouter', 'deepseek/deepseek-r1', 'https://openrouter.ai/api/v1'
+        ) is True
+        assert _route_accepts_reasoning_extra('lmstudio', 'qwen3-8b', 'http://localhost:1234/v1') is True
+        assert _route_accepts_reasoning_extra('', 'minimax-m2', 'https://api.minimaxi.com/v1') is True
+        assert _route_accepts_reasoning_extra('', 'MiniMax-M3', 'https://api.minimax.io/v1') is True
+        assert _route_accepts_reasoning_extra('', 'MiniMax-M3', 'https://edge.api.minimax.io/v1') is True
+
+    def test_builtin_routes_are_resolved_when_url_is_implicit(self):
+        assert _route_accepts_reasoning_extra('deepseek', 'deepseek-reasoner', '') is True
+        assert _route_accepts_reasoning_extra('anthropic', 'claude-sonnet-4-6', '') is True
+        assert _route_accepts_reasoning_extra('lmstudio', 'qwen3-8b', '') is True
+        assert _route_accepts_reasoning_extra('google-gemini', 'gemini-2.5-pro', '') is True
+        assert _route_accepts_reasoning_extra('x-ai', 'grok-4', '') is True
+        assert _route_accepts_reasoning_extra('ollama', 'qwen3', '') is True
+
+    @pytest.mark.parametrize('provider', (
+        'ai-gateway',
+        'vercel',
+        'vercel-ai-gateway',
+        'ai_gateway',
+        'aigateway',
+    ))
+    def test_ai_gateway_request_keeps_reasoning_suppression(self, provider):
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': provider,
+            'model': 'google/gemini-3-flash',
+            'base_url': '',
+        }), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            provider,
+            'google/gemini-3-flash',
+            None,
+        )
+        assert request['extra_body'] == {'reasoning': {'enabled': False}}
+
+    @pytest.mark.parametrize(
+        ("provider", "model", "base_url"),
+        (
+            ("openai", "gpt-5", "https://api.openai.com/v1"),
+            ("openai-codex", "gpt-5", ""),
+            ("azure", "gpt-4", ""),
+            ("azure-foundry", "gpt-4", ""),
+            ("azure-ai-foundry", "gpt-4", ""),
+            ("azure-ai", "gpt-4", ""),
+            ("azure/deployment", "gpt-4", ""),
+            ("azure-deployment", "gpt-4", ""),
+            ("custom", "gpt-5", "https://x.openai.azure.com/v1"),
+            ("custom", "gpt-5", "https://x.services.ai.azure.com/v1"),
+            ("custom", "gpt-5", "https://x.cognitiveservices.azure.com/v1"),
+            (
+                "openrouter",
+                "anthropic/claude-sonnet-4.6",
+                "https://openrouter.ai/api/v1",
+            ),
+            (
+                "openrouter",
+                "anthropic/claude-opus-4.8",
+                "https://openrouter.ai/api/v1",
+            ),
+        ),
+    )
+    def test_known_reject_routes_omit_suppression(
+        self, provider, model, base_url
+    ):
+        assert _route_accepts_reasoning_extra(provider, model, base_url) is False
+
+    def test_unknown_custom_route_omits_suppression(self):
+        assert _route_accepts_reasoning_extra('custom:relay', 'reasoning-model', 'https://relay.example.test/v1') is False
+
+    def test_hostname_matching_does_not_use_path_substrings(self):
+        assert _route_accepts_reasoning_extra(
+            'deepseek', 'deepseek-r1', 'https://proxy.example.test/api.openai.com/v1'
+        ) is True
+
+    def test_missing_route_fields_are_not_treated_as_resolved(self):
+        assert _route_accepts_reasoning_extra('', '', '') is False
+        assert _route_accepts_reasoning_extra('custom:relay', '', 'https://relay.example.test/v1') is False
+        assert _route_accepts_reasoning_extra('', 'reasoning-model', '') is False
+
+    def test_aux_route_matrix_uses_one_resolved_route_for_request_and_gate(self):
+        cases = (
+            # auxiliary_provider, auxiliary_model, auxiliary_url,
+            # default_provider, default_model, default_url, request route, extra_body
+            ('auto', '', '', 'qwen', 'qwen3-title', '',
+             ('qwen', 'qwen3-title', None), {'reasoning': {'enabled': False}}),
+            ('local', '', '', 'deepseek', 'deepseek-reasoner', '',
+             ('deepseek', 'deepseek-reasoner', None), {'reasoning': {'enabled': False}}),
+            ('deepseek', '', '', 'deepseek', 'deepseek-reasoner', '',
+             ('deepseek', 'deepseek-v4-flash', None), {'reasoning': {'enabled': False}}),
+            ('auto', '', '', 'openai', 'gpt-5', '',
+             ('openai', 'gpt-5', None), None),
+            ('local', '', '', 'custom', 'title-model', 'https://relay.example/v1',
+             ('custom', 'title-model', 'https://relay.example/v1'), None),
+            ('auto', '@openrouter:deepseek/deepseek-r1:free', '', 'openai', 'gpt-5', '',
+             ('openrouter', 'deepseek/deepseek-r1:free', None), {'reasoning': {'enabled': False}}),
+            ('auto', '@custom:relay:vendor/model:thinking', 'https://relay.example/v1', 'openai', 'gpt-5', '',
+             ('custom:relay', 'vendor/model:thinking', 'https://relay.example/v1'), None),
+            ('auto', '', '', 'minimax', 'MiniMax-M2.5', 'https://api.minimaxi.com/v1',
+             ('minimax', 'MiniMax-M2.5', 'https://api.minimaxi.com/v1'),
+             {'reasoning': {'enabled': False}, 'reasoning_split': True}),
+            # Explicit routes must not inherit a differing main route's model
+            # or endpoint, including namespaced OpenRouter identifiers.
+            ('deepseek', 'deepseek-reasoner', 'https://api.deepseek.com/v1', 'openai', 'gpt-5.5', 'https://api.openai.com/v1',
+             ('deepseek', 'deepseek-reasoner', 'https://api.deepseek.com/v1'),
+             {'reasoning': {'enabled': False}}),
+            ('openrouter', 'deepseek/deepseek-r1:free', 'https://openrouter.ai/api/v1', 'openai', 'gpt-5.5', 'https://api.openai.com/v1',
+             ('openrouter', 'deepseek/deepseek-r1:free', 'https://openrouter.ai/api/v1'),
+             {'reasoning': {'enabled': False}}),
+            ('openrouter', 'anthropic/claude-sonnet-4.6:thinking', 'https://openrouter.ai/api/v1', 'openai', 'gpt-5.5', 'https://api.openai.com/v1',
+             ('openrouter', 'anthropic/claude-sonnet-4.6:thinking', 'https://openrouter.ai/api/v1'), None),
+            # An explicit relay/model contract with a blank provider is
+            # Agent-custom, not a request to borrow the differing main route.
+            ('', 'gemma-4-31b-it', 'https://relay.example.test/v1', 'openai', 'gpt-main', 'https://api.openai.com/v1',
+             (None, 'gemma-4-31b-it', 'https://relay.example.test/v1'), None),
+        )
+        for (
+            provider, model, base_url, default_provider, default_model, default_url,
+            expected_route, expected_extra,
+        ) in cases:
+            captured = []
+
+            def call_llm(*, _captured=captured, **kwargs):
+                _captured.append(kwargs)
+                return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+            with patch('api.streaming._get_aux_title_config', return_value={
+                'provider': provider, 'model': model, 'base_url': base_url,
+            }), patch('api.config.cfg', {
+                'model': {
+                    'provider': default_provider,
+                    'default': default_model,
+                    'base_url': default_url,
+                },
+            }), patch(
+                'agent.auxiliary_client._get_aux_model_for_provider',
+                side_effect=lambda provider: {'deepseek': 'deepseek-v4-flash'}.get(provider, ''),
+                create=True,
+            ), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+                generate_title_raw_via_aux('question', 'answer')
+            request = captured[-1]
+            assert (request['provider'], request['model'], request['base_url']) == expected_route
+            assert request['extra_body'] == expected_extra
+
+    def test_explicit_blank_model_uses_its_own_default_not_the_main_route(self):
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'deepseek', 'model': '', 'base_url': '',
+        }), patch('api.config.cfg', {
+            'model': {'provider': 'openai', 'default': 'gpt-5.5', 'base_url': 'https://api.openai.com/v1'},
+            'providers': {'deepseek': {'models': ['deepseek-chat']}},
+        }), patch(
+            'agent.auxiliary_client._get_aux_model_for_provider',
+            return_value='deepseek-v4-flash',
+            create=True,
+        ) as aux_default, patch(
+            'agent.auxiliary_client.call_llm', side_effect=call_llm, create=True,
+        ):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        aux_default.assert_called_once_with('deepseek')
+        assert request['provider'] == 'deepseek'
+        assert request['model'] == 'deepseek-v4-flash'
+        assert request['base_url'] is None
+        assert request['extra_body'] == {'reasoning': {'enabled': False}}
+
+    def test_explicit_blank_model_with_custom_url_uses_its_own_default(self):
+        """A custom endpoint must not bypass an explicit provider's default."""
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'deepseek', 'model': '', 'base_url': 'https://deepseek.example.test/v1',
+        }), patch('api.config.cfg', {
+            'model': {'provider': 'openai', 'default': 'gpt-5.5', 'base_url': 'https://api.openai.com/v1'},
+        }), patch(
+            'agent.auxiliary_client._get_aux_model_for_provider',
+            return_value='deepseek-chat',
+            create=True,
+        ) as aux_default, patch(
+            'agent.auxiliary_client.call_llm', side_effect=call_llm, create=True,
+        ):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        aux_default.assert_called_once_with('deepseek')
+        assert (request['provider'], request['model'], request['base_url']) == (
+            'deepseek', 'deepseek-chat', 'https://deepseek.example.test/v1',
+        )
+        assert request['extra_body'] == {'reasoning': {'enabled': False}}
+
+    def test_explicit_blank_model_without_a_provider_default_fails_closed(self):
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'custom:unconfigured', 'model': '', 'base_url': 'https://relay.example/v1',
+        }), patch('api.config.cfg', {
+            'model': {'provider': 'openai', 'default': 'gpt-5.5', 'base_url': 'https://api.openai.com/v1'},
+        }), patch(
+            'agent.auxiliary_client._get_aux_model_for_provider',
+            return_value='',
+            create=True,
+        ), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            'custom:unconfigured', None, 'https://relay.example/v1',
+        )
+        assert request['extra_body'] is None
+
+    def test_unresolved_minimax_endpoint_omits_every_reasoning_extra(self):
+        """An unresolved custom route cannot inherit MiniMax-specific extras."""
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'custom:unconfigured',
+            'model': '',
+            'base_url': 'https://api.minimaxi.com/v1',
+        }), patch(
+            'agent.auxiliary_client._get_aux_model_for_provider',
+            return_value='',
+            create=True,
+        ), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            'custom:unconfigured', None, 'https://api.minimaxi.com/v1',
+        )
+        assert request['extra_body'] is None
+
+    def test_blank_provider_minimax_global_endpoint_preserves_route_and_extras(self):
+        """The canonical global MiniMax endpoint must not inherit the main route."""
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': '',
+            'model': 'MiniMax-M3',
+            'base_url': 'https://api.minimax.io/v1',
+        }), patch('api.config.cfg', {
+            'model': {
+                'provider': 'openai',
+                'default': 'gpt-main',
+                'base_url': 'https://api.openai.com/v1',
+            },
+        }), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            None, 'MiniMax-M3', 'https://api.minimax.io/v1',
+        )
+        assert request['extra_body'] == {
+            'reasoning': {'enabled': False},
+            'reasoning_split': True,
+        }
+
+    @pytest.mark.parametrize(
+        ('main_provider', 'main_model', 'main_base_url'),
+        (
+            ('openai', 'gpt-main', 'https://api.openai.com/v1'),
+            ('anthropic', 'claude-main', 'https://api.anthropic.com'),
+        ),
+    )
+    def test_explicit_relay_route_never_uses_the_differing_main_resolver(
+        self, main_provider, main_model, main_base_url,
+    ):
+        """Production resolver regression: relay config is its own route."""
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': '',
+            'model': 'gemma-4-31b-it',
+            'base_url': 'https://relay.example.test/v1',
+        }), patch('api.config.cfg', {
+            'model': {
+                'provider': main_provider,
+                'default': main_model,
+                'base_url': main_base_url,
+            },
+        }), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            None, 'gemma-4-31b-it', 'https://relay.example.test/v1',
+        )
+        assert request['extra_body'] is None
+
+    def test_base_url_only_route_is_custom_not_the_anthropic_main_route(self):
+        """A URL alone is an auxiliary custom-route contract."""
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': '', 'model': '', 'base_url': 'https://relay.example.test/v1',
+        }), patch('api.config.cfg', {
+            'model': {
+                'provider': 'anthropic',
+                'default': 'claude-main',
+                'base_url': 'https://api.anthropic.com',
+            },
+        }), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            'custom', None, 'https://relay.example.test/v1',
+        )
+        assert request['extra_body'] is None
+
+    def test_legacy_local_base_url_route_is_custom_not_the_codex_main_route(self):
+        """The legacy local spelling must use the custom auxiliary client path."""
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'local', 'model': '', 'base_url': 'https://relay.example.test/v1',
+        }), patch('api.config.cfg', {
+            'model': {
+                'provider': 'openai-codex',
+                'default': 'gpt-main',
+                'base_url': 'https://chatgpt.com/backend-api/codex',
+            },
+        }), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        request = captured[-1]
+        assert (request['provider'], request['model'], request['base_url']) == (
+            'custom', None, 'https://relay.example.test/v1',
+        )
+        assert request['extra_body'] is None
+
+    @pytest.mark.parametrize('model', (
+        '@openai:gpt-5.5',
+        '@openrouter:anthropic/claude-sonnet-4.6',
+    ))
+    def test_auto_provider_qualified_reject_routes_omit_suppression(self, model):
+        captured = []
+
+        def call_llm(**kwargs):
+            captured.append(kwargs)
+            return {'choices': [{'message': {'content': 'Title'}, 'finish_reason': 'stop'}]}
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'auto', 'model': model, 'base_url': '',
+        }), patch('agent.auxiliary_client.call_llm', side_effect=call_llm, create=True):
+            generate_title_raw_via_aux('question', 'answer')
+
+        assert captured[-1]['extra_body'] is None
+
+    @pytest.mark.parametrize('url', (
+        '(https://USER MARKER:PASSWORD MARKER@relay.example/v1)?api_key=(KEY MARKER)&token=[TOKEN MARKER]',
+        '["https://USER [MARKER] : PASSWORD (MARKER) @relay.example/v1"?token="TOKEN MARKER"&key=\'KEY MARKER\']',
+    ))
+    def test_delimiter_wrapped_url_is_redacted_from_route_and_traceback(self, url):
+        logged = []
+
+        def fail(**_kwargs):
+            raise RuntimeError(f'provider failed at {url}')
+
+        with patch('api.streaming._get_aux_title_config', return_value={
+            'provider': 'custom:relay', 'model': 'title-model', 'base_url': url,
+        }), patch('agent.auxiliary_client.call_llm', side_effect=fail, create=True), patch(
+            'api.streaming.logger.error', side_effect=lambda *args: logged.append(args),
+        ):
+            generate_title_raw_via_aux('question', 'answer')
+
+        output = '\n'.join(' '.join(map(str, args)) for args in logged)
+        for marker in ('USER', 'PASSWORD', 'KEY', 'TOKEN'):
+            assert marker not in output


### PR DESCRIPTION
## Current Status — 2026-09-09

Forward-port complete. The PR is now a single clean commit, `80a52812dc8a9655df525b39a780b5789646ddb5`, directly on current `master` `b1792e64e73043cb32f36c17c69d95138e686afd`.

GitHub currently reports the PR **mergeable**, and the diff remains limited to the intended four files: `api/streaming.py`, `docs/CONTRACTS.md`, `tests/test_title_aux_routing.py`, and `tests/test_title_gen_reasoning_extra_gate.py`. The previous head is preserved on the fork as `backup/pr-6051-a41f922-20260909`.

The last formal review blocker—collection-time `sys.modules` poisoning—remains addressed. The current head uses the GitHub-resolved three-way merge result for the overlapping PR files while preserving all newer upstream changes from `master`.

## Thinking Path

- Auxiliary title generation must omit optional request fields unless the resolved route accepts them.
- The route used for the capability decision and the route used for the request must be the same effective route.
- Strict OpenAI/Azure and OpenRouter-Anthropic routes reject reasoning suppression, while known compatible built-ins should retain it.
- Vercel AI Gateway and its supported aliases were the remaining compatible-route false negative.
- Unknown/custom routes should fail closed until compatibility is known.
- Test scaffolding must not mutate collection-global import state or replace the real `agent` package.

## What Changed

- Resolve one effective auxiliary-title route and use it for both classification and `call_llm()`.
- Send `reasoning: {"enabled": false}` only on classified compatible routes.
- Preserve suppression for Vercel AI Gateway provider IDs `ai-gateway`, `vercel`, `vercel-ai-gateway`, `ai_gateway`, and `aigateway`.
- Keep OpenAI, Azure/Azure AI Foundry, `openai-codex`, OpenRouter-Anthropic (including Opus), and unclassified custom routes excluded.
- Use per-test auxiliary-client scaffolding rather than collection-time `sys.modules` replacement.
- Preserve the composed collection regression plus explicit deny-route coverage for Azure aliases/hosts, `openai-codex`, and OpenRouter Opus.
- Sanitize URL-carried credentials from auxiliary-title failure logging.
- Document the public auxiliary-title payload-routing contract in `docs/CONTRACTS.md`.

## Why It Matters

Strict endpoints should not reject auxiliary title requests because of an unsupported field, while compatible routes should continue avoiding hidden-reasoning budget exhaustion and heuristic-title fallback. The same effective route must drive both the compatibility decision and the actual request so a resolver cannot classify one route and send to another.

Release-note wording: Auxiliary title generation preserves reasoning suppression on classified compatible routes such as Vercel AI Gateway while omitting unsupported reasoning fields on strict or unclassified custom routes.

## Contract Routing

Task type: product-semantic routing correction.

Touched areas: auxiliary title effective-route resolution, request construction, capability gating, safe route diagnostics, and regression-test isolation.

Relevant public docs:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/GUIDELINES.md`
- `docs/CONTRACTS.md`

Evidence: `tests/test_title_gen_reasoning_extra_gate.py` and `tests/test_title_aux_routing.py` exercise the production request boundary and assert the effective provider/model/base URL plus emitted `extra_body`. The collection-isolation regression verifies that importing these tests does not poison the real Agent package.

The Hermes Agent provider profile/catalog owns provider IDs and AI Gateway capability declaration. These WebUI tests prove WebUI route resolution and wire-payload construction; they do not replace provider-owned API conformance testing.

## Contract Change

Previous rule: reasoning suppression was injected unless a known reject route matched.

New rule: suppression is injected only when the effective route is classified compatible. Unknown/custom routes fail closed, while known compatible built-ins—including Vercel AI Gateway aliases—retain suppression.

Affected docs and tests: `docs/CONTRACTS.md`, `tests/test_title_gen_reasoning_extra_gate.py`, and `tests/test_title_aux_routing.py` move together. The compatibility reason is to prevent both strict-route HTTP 400 failures and compatible-route title-budget regressions.

## Verification

### Historical implementation verification

On the previous exact head `a41f92297ad86181891642b165fa92dae2d5b110`, based on older `master` `e168b67e4278df618d1cab61fdb3a8dc55b29a81`:

- Pre-fix proof failed for all five AI Gateway identifiers because `call_llm()` received `extra_body=None`.
- `./scripts/test.sh tests/test_title_gen_reasoning_extra_gate.py tests/test_title_aux_routing.py tests/test_custom_provider_prefix_collisions.py -q` completed with **93 passed, 8 subtests passed**.
- `py_compile` and `git diff --check` passed.
- Ruff showed the same 18 pre-existing findings on that base and head; no lint regressions were added.

These results are retained as historical regression evidence only; they are not claimed as a current-head full-suite run.

### Current-master verification

Current head: `80a52812dc8a9655df525b39a780b5789646ddb5` on `master` `b1792e64e73043cb32f36c17c69d95138e686afd`.

- Forward-port was constructed from the clean GitHub three-way merge resolution and overlaid only the four intended PR files onto the exact current `master` tree.
- GitHub reports `mergeable=true`.
- PR diff remains exactly four intended files and one commit.
- Upstream workflows were created for **Tests**, **Docs CI**, **Browser smoke**, and **Conversation lifecycle**, but GitHub currently reports them as `action_required`, i.e. awaiting maintainer approval for the fork-triggered runs.
- No current-head `./scripts/test.sh` pass is claimed until those checks are approved/run or an equivalent local run is provided.

## Risks / Follow-ups

- Full current-head repo verification is waiting on maintainer approval of the fork-triggered GitHub Actions runs.
- A newly compatible custom endpoint remains excluded until it receives an explicit compatibility classification.
- No UI or interaction flow changed, so before/after visual evidence is not applicable.
- The pre-forward-port head is preserved on `backup/pr-6051-a41f922-20260909`.

## Model Used / AI Assistance

OpenAI GPT-5 / Codex was used for the original implementation and prior rebases. On 2026-09-09, GPT-5.6 Sol in ChatGPT with connected GitHub access was used to re-audit repository requirements, identify current-master overlaps, preserve the previous head, construct the clean forward-port from GitHub's three-way resolution, and verify the resulting PR metadata/diff. No current-head test execution is being claimed by the AI-assisted forward-port itself.