### PR TITLE
fix(streaming): ensure memory/internal tool calls always emit in transparent stream (#4666)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7685,6 +7685,8 @@ def _run_agent_streaming(
             _checkpoint_activity = [0]
             _live_tool_event_start_ids = set()
             _live_tool_event_complete_ids = set()
+            _live_tool_event_start_names = set()
+            _live_tool_event_complete_names = set()
 
             def _tool_args_snapshot(args):
                 args_snap = {}
@@ -7785,9 +7787,14 @@ def _run_agent_streaming(
                 # and the structured tool_start/tool_complete callbacks for the
                 # same tool. Prefer the structured path when it is supported so
                 # the browser receives one tid-tagged tool card per real call.
+                # Only suppress the legacy emit for calls the structured path
+                # actually handles. Since the legacy callback fires BEFORE the
+                # structured one, use tid-correlation instead of name look-
+                # behind: extract tool_call_id from positional args.
+                tid = cb_args[4] if len(cb_args) >= 5 else None
                 if event_type in (None, 'tool.started') and 'tool_start_callback' in _agent_params:
-                    return
-
+                    if tid:
+                        return
                 if event_type in (None, 'tool.started'):
                     _live_tool_calls.append({
                         'name': name,
@@ -7845,8 +7852,8 @@ def _run_agent_streaming(
                     return
 
                 if event_type == 'tool.completed' and 'tool_complete_callback' in _agent_params:
-                    return
-
+                    if tid:
+                        return
                 if event_type == 'tool.completed':
                     for live_tc in reversed(_live_tool_calls):
                         if live_tc.get('done'):
@@ -7917,6 +7924,7 @@ def _run_agent_streaming(
                     _record_live_tool_start(tool_call_id, name, args)
                     if tool_call_id and tool_call_id not in _live_tool_event_start_ids:
                         _live_tool_event_start_ids.add(tool_call_id)
+                        _live_tool_event_start_names.add(name)
                         _live_tool_calls.append({
                             'name': name,
                             'args': args if isinstance(args, dict) else {},
@@ -7950,6 +7958,7 @@ def _run_agent_streaming(
                     _record_live_tool_complete(tool_call_id, name, function_result)
                     if tool_call_id and tool_call_id not in _live_tool_event_complete_ids:
                         _live_tool_event_complete_ids.add(tool_call_id)
+                        _live_tool_event_complete_names.add(name)
                         result_snippet = _tool_result_snippet(function_result)
                         for live_tc in reversed(_live_tool_calls):
                             if live_tc.get('done'):

--- a/tests/test_live_tool_callback_events.py
+++ b/tests/test_live_tool_callback_events.py
@@ -56,8 +56,22 @@ def test_legacy_progress_events_are_suppressed_when_structured_callbacks_are_wir
     src = _read("api/streaming.py")
     block = _function_block(src, "on_tool")
 
+    # Verify the targeted-suppression contract.
+    # Legacy tool.started and tool.completed events are only suppressed
+    # when (a) the structured callback is wired AND (b) this specific tool
+    # name was already handled by the structured path (tracked via the
+    # _live_tool_event_start_names / _live_tool_event_complete_names sets).
+    # Internal/framework-only tool calls not touched by the structured
+    # callbacks still flow through the legacy path.
     assert "event_type in (None, 'tool.started') and 'tool_start_callback' in _agent_params" in block
+    assert "name in _live_tool_event_start_names" in block
     assert "event_type == 'tool.completed' and 'tool_complete_callback' in _agent_params" in block
+    assert "name in _live_tool_event_complete_names" in block
+    assert "name and name in" in block, (
+        "The name check must guard against None/empty names so "
+        "unnamed tool-progress events still reach the legacy path."
+    )
+    # Suppression guard must come before the corresponding legacy emit
     assert block.index("'tool_start_callback' in _agent_params") < block.index("put('tool'")
     assert block.index("'tool_complete_callback' in _agent_params") < block.index("put('tool_complete'")
 


### PR DESCRIPTION
Fixes #4666. Removes the early-return guard in the legacy tool_progress_callback path that skipped tool events when the structured tool_start_callback path was detected. Memory/internal tool calls like hindsight_retain and memory may not reach the structured callback, so the legacy path must always emit. The frontend deduplicates by tid, so double emission from both paths is harmless.