### PR TITLE
fix(worktrees): resolve canonical repo root so worktrees never nest

### DIFF
--- a/api/worktrees.py
+++ b/api/worktrees.py
@@ -312,8 +312,20 @@ def remove_worktree_for_session(session, *, force: bool = False) -> dict:
 def find_git_repo_root(workspace: str | Path) -> Path:
     """Return the enclosing git repo root for *workspace*.
 
-    Use git itself instead of checking ``workspace/.git`` so nested workspaces
-    and linked git worktrees are both handled correctly.
+    Uses git itself instead of checking ``workspace/.git`` so nested
+    subdirectories and linked git worktrees are both handled correctly.
+
+    When *workspace* lives inside a **linked worktree** — e.g. a session that
+    started in ``<repo>/.worktrees/hermes-XXXX`` — ``git rev-parse
+    --show-toplevel`` returns that worktree's own root, not the canonical
+    clone. Feeding that root to worktree creation nests the new worktree
+    *inside* the existing one (``.worktrees/hermes-A/.worktrees/hermes-B``);
+    a session spawned from that worktree then nests one level deeper again,
+    recursively. ``git rev-parse --git-common-dir`` always resolves to the
+    main repository's ``.git`` even from a linked worktree, so its parent is
+    the canonical clone root. We redirect to it for a normal (non-bare) clone
+    whose common dir is a ``.git`` directory; bare repos and unusual layouts
+    keep the ``--show-toplevel`` result (prior behavior).
     """
     ws = Path(workspace).expanduser().resolve()
     if not ws.is_dir():
@@ -334,7 +346,33 @@ def find_git_repo_root(workspace: str | Path) -> Path:
     root = result.stdout.strip()
     if not root:
         raise ValueError("Workspace is not inside a git repository")
-    return Path(root).expanduser().resolve()
+    toplevel = Path(root).expanduser().resolve()
+
+    # Redirect to the canonical (main) worktree when *ws* is inside a linked
+    # worktree, so new worktrees are never created nested inside another one.
+    try:
+        common = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=ws,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return toplevel
+    if common.returncode == 0:
+        common_dir = common.stdout.strip()
+        if common_dir:
+            # --git-common-dir may print an absolute path or one relative to
+            # cwd; joining onto *ws* is a no-op for an absolute path in
+            # pathlib, so this handles both forms.
+            common_path = (ws / common_dir).resolve()
+            if common_path.name == ".git":
+                canonical = common_path.parent
+                if canonical.is_dir():
+                    return canonical
+    return toplevel
 
 
 def _setup_agent_worktree(repo_root: str) -> dict:

--- a/tests/test_issue1955_worktree_sessions.py
+++ b/tests/test_issue1955_worktree_sessions.py
@@ -105,6 +105,45 @@ def test_find_git_repo_root_uses_git_from_nested_workspace(tmp_path):
     assert find_git_repo_root(nested) == repo.resolve()
 
 
+def test_find_git_repo_root_redirects_from_linked_worktree(tmp_path):
+    """A workspace inside a linked worktree must resolve to the CANONICAL
+    clone, not the worktree's own root — otherwise new worktrees get created
+    nested inside the existing one, recursively (the nesting bug)."""
+    from api.worktrees import find_git_repo_root
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "--allow-empty", "-m", "init"],
+        cwd=repo, check=True, capture_output=True,
+    )
+    # Create a linked worktree the same way a session would: <repo>/.worktrees/hermes-XXXX
+    linked = repo / ".worktrees" / "hermes-abcd1234"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "hermes/hermes-abcd1234", str(linked)],
+        cwd=repo, check=True, capture_output=True,
+    )
+    assert linked.is_dir()
+
+    # Sanity: --show-toplevel (the OLD behavior) would return the worktree root.
+    tl = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=linked, text=True, capture_output=True, check=True,
+    ).stdout.strip()
+    assert Path(tl).resolve() == linked.resolve()
+
+    # The fix: resolve to the canonical clone so the next worktree lands at
+    # <repo>/.worktrees/, never <linked>/.worktrees/.
+    assert find_git_repo_root(linked) == repo.resolve()
+
+    # And a subdirectory *inside* the linked worktree resolves the same way.
+    sub = linked / "src" / "pkg"
+    sub.mkdir(parents=True)
+    assert find_git_repo_root(sub) == repo.resolve()
+
+
 def test_find_git_repo_root_rejects_non_git_workspace(tmp_path):
     from api.worktrees import find_git_repo_root
 


### PR DESCRIPTION
## Summary

`find_git_repo_root()` (`api/worktrees.py`) resolves the repo root with `git rev-parse --show-toplevel`. From inside a **linked worktree**, that returns the *worktree's own root*, not the canonical clone. Since the result is fed straight into worktree creation (`create_worktree_for_workspace` → agent `_setup_worktree`, which builds `<repo_root>/.worktrees/hermes-XXXX`), a session that starts inside a worktree creates its new worktree **nested inside the existing one**:

```
pkm/.worktrees/hermes-A/.worktrees/hermes-B/.worktrees/hermes-C/...
```

A session spawned from a worktree session nests one level deeper, recursively. With worktree-backed sessions becoming the default, this compounds fast — I hit a real vault nested **three** levels deep in normal WebUI use.

The function's own docstring claimed it "handles nested workspaces and linked worktrees correctly" — this PR makes that true.

## Fix

After `--show-toplevel`, consult `git rev-parse --git-common-dir`, which always resolves to the **main repository's** `.git` even from a linked worktree. Its parent is the canonical clone root, so worktrees are always created at `<canonical>/.worktrees/`, regardless of where the session started.

Scoped conservatively:
- Only redirects for a **normal (non-bare) clone** whose common dir is a `.git` **directory**. Bare repos and unusual layouts keep the prior `--show-toplevel` result.
- Handles both absolute and cwd-relative `--git-common-dir` output (pathlib join is a no-op for an absolute path).
- Any subprocess failure falls back to the previous behavior — never worse than before.
- Single caller (`create_worktree_for_workspace`), so no other call site is affected.

## Design notes

- `--git-common-dir` is the standard git primitive for "the shared git dir behind all worktrees"; its parent is the main working tree for a conventional clone. I preferred it over parsing `git worktree list` (heavier, needs the main entry disambiguated) or reading `.git` gitlink files by hand.
- The companion agent-side helper `_setup_worktree()` in hermes-agent has the same root-resolution issue on the CLI path (`hermes -w`); that's a separate repo and out of scope here. This PR fixes the WebUI path end to end because `find_git_repo_root()` is where the WebUI computes `repo_root` before delegating.

## Tests

Added `test_find_git_repo_root_redirects_from_linked_worktree` to `tests/test_issue1955_worktree_sessions.py` using a **real** worktree-inside-a-worktree fixture: it asserts `--show-toplevel` would (wrongly) return the worktree root, then that `find_git_repo_root()` redirects to the canonical clone — for both the worktree root itself and a subdirectory inside it. The existing `test_find_git_repo_root_uses_git_from_nested_workspace` (plain subdirectory) stays green, proving the subdir path is unaffected.

```
./scripts/test.sh tests/test_issue1955_worktree_sessions.py
  9 passed

# regression sweep across worktree modules
./scripts/test.sh tests/test_issue1955_worktree_sessions.py \
  tests/test_worktree_remove.py tests/test_issue2057_worktree_status.py \
  tests/test_state_db_worktree_recovery.py
  32 passed

scripts/ruff_lint.py
  no new violations on added/modified lines. OK.
```
