### PR TITLE
fix(streaming): suppress false no-response after tool limit

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8891,7 +8891,7 @@ def _run_agent_streaming(
                 )
                 if (
                     _terminal_failure
-                    and _soft_partial_terminal_failure
+                    and (_soft_partial_terminal_failure or _tool_limit_reached)
                     and _classification['type'] == 'no_response'
                     and not _saved_transcript_lacks_final_answer
                 ):

--- a/tests/test_tool_limit_terminal_state.py
+++ b/tests/test_tool_limit_terminal_state.py
@@ -255,8 +255,9 @@ def test_streaming_tool_limit_with_final_answer_persists_clean_done_state(tmp_pa
     assert assistant["_statusCard"]["title"] == "Tool iteration limit reached"
 
 
-def test_streaming_tool_limit_without_final_answer_emits_no_final_apperror(tmp_path, monkeypatch):
+def test_streaming_tool_limit_partial_without_final_answer_emits_no_final_apperror(tmp_path, monkeypatch):
     result = {
+        "status": "partial",
         "turn_exit_reason": "max_iterations_reached(30/30)",
         "messages": [
             {"role": "user", "content": "Do the long task."},
@@ -406,7 +407,10 @@ def test_maybe_inject_max_iteration_summary_fallback_skips_when_no_fallback():
     assert out == messages
 
 
-def test_streaming_tool_limit_terminal_failure_does_not_mark_final_answer(tmp_path, monkeypatch):
+def test_streaming_tool_limit_partial_with_final_answer_suppresses_false_no_response(
+    tmp_path,
+    monkeypatch,
+):
     result = {
         "status": "partial",
         "turn_exit_reason": "max_iterations_reached(30/30)",
@@ -418,19 +422,21 @@ def test_streaming_tool_limit_terminal_failure_does_not_mark_final_answer(tmp_pa
 
     events, payload = _run_streaming_with_fake_agent(tmp_path, monkeypatch, result)
 
-    apperror_payloads = [payload for event, payload in events if event == "apperror"]
-    assert apperror_payloads, "expected terminal-failure apperror"
-    assert apperror_payloads[-1]["type"] == "tool_limit_reached"
-    assert not [payload for event, payload in events if event == "done"]
+    assert not [event_payload for event, event_payload in events if event == "apperror"]
+    done_payloads = [event_payload for event, event_payload in events if event == "done"]
+    assert done_payloads, "expected done SSE payload"
+    assert done_payloads[-1]["terminal_state"] == "tool_limit_reached"
+    assert done_payloads[-1]["terminal_reason"] == "max_iterations"
     assistant = next(
         message
         for message in payload["messages"]
         if message.get("role") == "assistant"
         and message.get("content") == "I reached the limit; here is the summary."
     )
-    assert "_terminal_state" not in assistant
-    assert "_statusCard" not in assistant
-    assert payload["messages"][-1]["_error"] is True
+    assert assistant["_terminal_state"] == "tool_limit_reached"
+    assert assistant["_terminal_reason"] == "max_iterations"
+    assert assistant["_statusCard"]["title"] == "Tool iteration limit reached"
+    assert payload["messages"][-1] is assistant
 
 
 def test_streaming_historical_synthetic_prompt_normal_result_does_not_emit_tool_limit(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #6079.

## Thinking Path

The turn-completion classifier treats `status=partial` as terminal. Its existing false-`no_response` suppression only admitted `_soft_partial_terminal_failure`, while that helper deliberately excludes `_tool_limit_reached`. As a result, `max_iterations_reached` could override the authoritative transcript result and append an error after a durable final assistant answer.

I traced the current turn from the agent result through result-message cleanup, display merge, transcript final-answer evaluation, terminal classification, persistence, and the final SSE event. The shared chokepoint is the suppression predicate at settlement. I also checked the sibling states: soft-partial results remain covered; tool-limit turns without final prose still fail honestly; explicit provider errors, cancellations, and interruptions remain outside this suppression; and #5902's checkpointed-user transcript boundary is unchanged.

## What Changed

- Admit `_tool_limit_reached` to the existing false-`no_response` suppression only when the current-turn transcript already has a final assistant answer.
- Update the streaming regression fixtures to cover both sides of that invariant with `status=partial`:
  - final answer present: emit `done`, preserve the answer, and attach the tool-limit status metadata without an error card;
  - final answer absent: keep the `tool_limit_reached` terminal error.

Release-note wording: Fixed a false "No response from provider" card when a tool-limit turn already contains a final assistant answer.

## Why It Matters

Users should not be told that a provider returned no content immediately after receiving a valid answer. The change preserves truthful limit-reached metadata while preventing a later classifier from contradicting durable transcript state.

## Verification

- Red before fix:
  - `./scripts/test.sh tests/test_tool_limit_terminal_state.py::test_streaming_tool_limit_partial_with_final_answer_suppresses_false_no_response tests/test_tool_limit_terminal_state.py::test_streaming_tool_limit_partial_without_final_answer_emits_no_final_apperror`
  - Result: `1 failed, 1 passed`; the answered fixture received a `tool_limit_reached` `apperror`.
- Green after fix: the same focused command passed `2 passed`.
- Neighboring streaming sweep: `120 passed` across tool-limit, terminal-failure transcript evaluation, terminal provider errors, silent failures, compression terminal failures, lost-response recovery, quota classification, and legacy no-response handling.
- Full repository suite: `12954 passed, 155 skipped, 2 xfailed, 1 xpassed, 34 subtests passed` in 7m47s. The runner reported that 30 Hermes-Agent-dependent tests were skipped because that external package is not installed locally.
- `python scripts/ruff_lint.py --diff origin/master`: 0 findings on added or modified lines.
- `git diff --check origin/master...HEAD`: passed.

## Risks / Follow-ups

- This is deliberately limited to the settlement classifier and its existing streaming integration fixtures; it does not change renderer, protocol, schema, retry, or checkpoint-boundary behavior.
- Maintainers noted that this crown-jewel streaming path will also receive the private stream-regression gate before merge; I could not run that private gate locally.

## Contract Routing

- Task type: narrow streaming settlement bug fix.
- Touched state layer: `api/streaming.py` turn settlement and the persisted current-turn transcript.
- Invariant: once the owned turn has a durable final assistant answer, later terminal classification must not append synthetic `no_response`; when no final answer exists, tool-limit state remains honest.
- Guidance reviewed: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `ARCHITECTURE.md`, `TESTING.md`, `docs/rfcs/README.md`, `docs/rfcs/webui-run-state-consistency-contract.md`, and `docs/rfcs/live-to-final-assistant-replies.md`.
- Contract scope: preserves the accepted contract; no public contract or documentation change is introduced.

## Model Used

- Provider: OpenAI
- Model: GPT-5 via Codex
- Mode: default collaboration mode
- Tools: local shell and Git, `apply_patch`, GitHub CLI, and the repository's `scripts/test.sh` / `scripts/ruff_lint.py` wrappers
