### PR TITLE
fix(gateway_chat): use parseable session key format for X-Hermes-Session-Key

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -371,7 +371,7 @@ def _run_gateway_runs_api_streaming(
     }
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-        headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
+        headers["X-Hermes-Session-Key"] = f"agent:main:api_server:dm:{session_id}"
     message_content: Any = str(msg_text or "")
     if attachments:
         try:
@@ -835,7 +835,7 @@ def _run_gateway_chat_streaming(
                 headers["Authorization"] = f"Bearer {api_key}"
                 # Scope Gateway long-term continuity to this WebUI conversation
                 # without exposing the browser's auth cookie or CSRF material.
-                headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
+                headers["X-Hermes-Session-Key"] = f"agent:main:api_server:dm:{session_id}"
             message_content: Any = str(msg_text or "")
             if attachments:
                 try:

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -328,7 +328,7 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert captured["url"] == "http://gateway.local/v1/chat/completions"
     assert captured["headers"]["Authorization"] == "Bearer secret-token"
     assert captured["headers"]["X-hermes-session-id"] == s.session_id
-    assert captured["headers"]["X-hermes-session-key"] == f"webui:{s.session_id}"
+    assert captured["headers"]["X-hermes-session-key"] == f"agent:main:api_server:dm:{s.session_id}"
     assert '"stream": true' in captured["body"]
     payload = json.loads(captured["body"])
     assert payload["reasoning_effort"] == "high"


### PR DESCRIPTION
## Summary

The WebUI gateway bridge (`gateway_chat.py`) sends `X-Hermes-Session-Key` as `f"webui:{session_id}"` at two call sites (lines 374 and 838). But the gateway's `_parse_session_key()` (`gateway/run.py:2164`) requires the format `agent:main:{platform}:{chat_type}:{chat_id}` — 5+ colon-separated parts starting with `agent:main`.

With the `webui:` prefix, `_parse_session_key()` returns `None`, which breaks async delegation result routing back to WebUI sessions.

## Root Cause Trace

When a background delegation completes while a WebUI gateway session is active, the result must route back through the gateway's notification injection path:

1. `_async_delegation_watcher()` peeks the completion queue for `async_delegation` events
2. `_enrich_async_delegation_routing(evt)` calls `_parse_session_key(evt.get("session_key"))` to fill `platform`/`chat_type`/`chat_id` on the event
3. `_build_process_event_source(evt)` uses those fields to resolve the target session via `session_store._entries` lookup, then `_parse_session_key()` as fallback
4. `_inject_watch_notification()` finds the matching adapter and injects the result

With `webui:{session_id}` as the session key:

- **Step 2:** `_parse_session_key("webui:abc123")` → `parts = ["webui", "abc123"]`, `len(parts) = 2 < 5` → returns `None` — enrichment is skipped, event has no `platform`/`chat_type`/`chat_id`
- **Step 3:** `session_store._entries.get("webui:abc123")` → `None` (api_server sessions are registered under their canonical key, and the api_server platform never calls `register_session()` — the session only exists in the store when a key in the correct format is used). `_get_cached_session_source()` → `None`. `_parse_session_key()` → `None`. All derived fields are empty.
- **Step 4:** `_build_process_event_source()` returns `None` → `_inject_watch_notification()` logs `"Dropping watch notification with no routing metadata"` and returns

**The result is silently dropped.** This is the exact symptom in #4691.

## The Fix

Change both call sites from:
```python
headers["X-Hermes-Session-Key"] = f"webui:{session_id}"
```
to:
```python
headers["X-Hermes-Session-Key"] = f"agent:main:api_server:dm:{session_id}"
```

With the corrected format:
- `_parse_session_key()` parses successfully → `{"platform": "api_server", "chat_type": "dm", "chat_id": "<session_id>"}`
- `session_store._entries` contains the key (confirmed: live session store shows `agent:main:api_server:dm:fda0f4178fab` registered with proper origin metadata)
- `_build_process_event_source()` resolves to a valid `SessionSource` with `platform=api_server`
- The `api_server` adapter is in `self.adapters` (registered during gateway startup)
- Result is injected via `adapter.handle_message(synth_event)`

## Why This Is Still Needed After PR #4799 and Core `d0e9a42ce`

PR #4799 was closed today as superseded by the durable delivery model in `d0e9a42ce` ("harden durable completion delivery"). However, the durable delivery changes address **tracking and dedup** — `claim_event_delivery()` / `complete_event_delivery()` / persistent completion records. They do NOT change the routing path.

The routing for async delegation completions still flows through:
```
_async_delegation_watcher → _enrich_async_delegation_routing → _parse_session_key → _build_process_event_source → _inject_watch_notification
```

`_parse_session_key()` is the sole mechanism for extracting routing fields from a session key. If the key format is wrong, routing fails regardless of how robust the delivery tracking is. The durable model ensures a completion is delivered **exactly once** — but only if it can be **delivered at all**, which requires a parseable session key.

## Scope

Exactly 2 lines changed (2 insertions, 2 deletions) across 2 call sites in `gateway_chat.py`:
- Line 374: `_run_gateway_runs_api_streaming()` (POST /v1/runs endpoint)
- Line 838: `_run_gateway_chat_streaming()` (POST /v1/chat/completions endpoint)

No new dependencies, no behavior change for in-process (non-gateway) WebUI mode, no impact on existing session continuity or Honcho memory scoping (the key is still unique per WebUI conversation).

## Related

- Fixes the routing root cause of #4691
- Complements #4912 (v0.51.652 — formatting fix for the display side)
- Independent of PR #4799 (closed) and core `d0e9a42ce` (durable delivery — addresses tracking, not routing)
