### PR TITLE
fix: allow manual update check when auto-update is disabled (#6082)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13722,7 +13722,12 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/updates/check":
         settings = load_settings()
         if not settings.get("check_for_updates", True):
-            return j(handler, {"disabled": True})
+            force = bool(body.get("force", False)) if isinstance(body, dict) else False
+            if force:
+                # Manual force-check bypasses auto-check toggle (#6082)
+                pass
+            else:
+                return j(handler, {"disabled": True})
         include_agent_updates = not bool(settings.get("ignore_agent_updates"))
         force = bool(body.get("force", False))
         # Allow the client to pass the channel explicitly in the POST body. This


### PR DESCRIPTION
When check_for_updates is false, the POST /api/updates/check with force=true should still work for manual checks. Only the GET auto-check should return disabled.\n\nFixes #6082.