### PR TITLE
fix: stream event timestamps layout on narrow foldable screens (#6099)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4091,6 +4091,7 @@ body.resizing .sidebar{transition:none!important;}
   border-radius:0;
   color:var(--muted);
   transition:background .18s ease,color .18s ease;
+  overflow:hidden;
 }
 .transparent-event-row .tool-card-header:hover,
 .transparent-event-row .thinking-card-header:hover{background:var(--hover-bg);color:var(--text);}
@@ -4117,6 +4118,9 @@ body.resizing .sidebar{transition:none!important;}
   overflow:hidden;
   text-overflow:ellipsis;
   white-space:nowrap;
+}
+@media (max-width:360px){
+  .transparent-event-row .tool-card-name{display:none;}
 }
 .transparent-event-row .tool-card-title,
 .transparent-event-row .tool-card-preview{


### PR DESCRIPTION
On very narrow screens (<360px), stream event timestamps broke the row layout.\n\n- Added `overflow:hidden` to tool/thinking card headers to prevent flex children from spilling out\n- Added `@media (max-width:360px)` hiding `.tool-card-name` — icon + preview + status badge still identify the event\n\nProgressive narrow-screen behavior:\n- ≤ 600px: Larger touch targets\n- ≤ 420px: Timestamp hidden (existing)\n- ≤ 360px: Tool name hidden (new)\n\nCloses #6099