### PR TITLE
fix: honor per-model reasoning effort metadata

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3761,6 +3761,33 @@ def resolve_model_reasoning_efforts(
     return filtered
 
 
+def _configured_reasoning_effort_lists(provider_entry, model_id: str) -> list:
+    """Return model-level then provider-level effort lists from config."""
+    if not isinstance(provider_entry, dict):
+        return []
+
+    configured_lists = []
+    models = provider_entry.get("models")
+    if isinstance(models, dict):
+        model_key = str(model_id or "").strip().lower()
+        model_entry = models.get(model_id)
+        if not isinstance(model_entry, dict) and model_key:
+            model_entry = next(
+                (
+                    metadata
+                    for configured_id, metadata in models.items()
+                    if str(configured_id).strip().lower() == model_key
+                    and isinstance(metadata, dict)
+                ),
+                None,
+            )
+        if isinstance(model_entry, dict):
+            configured_lists.append(model_entry.get("reasoning_efforts"))
+
+    configured_lists.append(provider_entry.get("reasoning_efforts"))
+    return configured_lists
+
+
 def _resolve_model_reasoning_efforts_impl(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -3794,29 +3821,32 @@ def _resolve_model_reasoning_efforts_impl(
     if _nested_route_reasoning_denied(hinted_model):
         return []
 
-    # 0. Provider config: providers.<name>.reasoning_efforts or named
-    # custom_providers[].reasoning_efforts. When the user has explicitly listed
-    # valid efforts for a provider, return that list directly — no heuristics,
-    # no models.dev lookup.
-    # Only short-circuits when the filtered list is non-empty; an all-invalid
-    # list (e.g. typos) falls through to heuristics instead of hiding reasoning.
-    _re_list = None
+    # 0. Model/provider config: a models.<model>.reasoning_efforts list takes
+    # precedence over its provider-level reasoning_efforts list. Explicit valid
+    # config is authoritative — no heuristics or models.dev lookup. Invalid or
+    # empty model metadata falls through to the provider list, then heuristics.
+    _re_lists = []
     try:
         if provider and provider.startswith("custom:"):
             for _entry in _custom_provider_entries():
                 if _custom_provider_slug_from_name(_entry.get("name")) == provider:
-                    _re_list = _entry.get("reasoning_efforts")
+                    _re_lists = _configured_reasoning_effort_lists(
+                        _entry, hinted_model
+                    )
                     break
         elif provider:
             _prov_entry = (cfg.get("providers") or {}).get(provider, {})
             if isinstance(_prov_entry, dict):
-                _re_list = _prov_entry.get("reasoning_efforts")
-        if isinstance(_re_list, list) and _re_list:
-            _filtered = [str(x).strip().lower() for x in _re_list
-                         if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
-            _filtered = list(dict.fromkeys(_filtered))
-            if _filtered:
-                return _filtered
+                _re_lists = _configured_reasoning_effort_lists(
+                    _prov_entry, hinted_model
+                )
+        for _re_list in _re_lists:
+            if isinstance(_re_list, list) and _re_list:
+                _filtered = [str(x).strip().lower() for x in _re_list
+                             if str(x).strip().lower() in {*VALID_REASONING_EFFORTS, "none"}]
+                _filtered = list(dict.fromkeys(_filtered))
+                if _filtered:
+                    return _filtered
     except Exception:
         pass
 

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -192,6 +192,63 @@ def test_named_custom_provider_config_reasoning_efforts(monkeypatch):
             monkeypatch.setitem(cfg.cfg, "custom_providers", original)
 
 
+def test_named_custom_provider_model_reasoning_efforts_take_precedence(monkeypatch):
+    original = cfg.cfg.get("custom_providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "custom_providers",
+        [
+            {
+                "name": "llm-proxy",
+                "reasoning_efforts": ["high"],
+                "models": {
+                    "Inkling": {
+                        "reasoning_efforts": ["none", "low", "medium", "high", "xhigh"]
+                    }
+                },
+            }
+        ],
+    )
+    try:
+        assert cfg.resolve_model_reasoning_efforts(
+            "inkling",
+            provider_id="custom:llm-proxy",
+        ) == ["none", "low", "medium", "high", "xhigh"]
+        assert cfg.resolve_model_reasoning_efforts(
+            "another-model",
+            provider_id="custom:llm-proxy",
+        ) == ["high"]
+    finally:
+        if original is None:
+            cfg.cfg.pop("custom_providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "custom_providers", original)
+
+
+def test_model_reasoning_efforts_fall_back_to_provider_when_invalid(monkeypatch):
+    original = cfg.cfg.get("providers")
+    monkeypatch.setitem(
+        cfg.cfg,
+        "providers",
+        {
+            "wandb": {
+                "reasoning_efforts": ["none", "high"],
+                "models": {"inkling": {"reasoning_efforts": ["bogus", "typo"]}},
+            }
+        },
+    )
+    try:
+        assert cfg.resolve_model_reasoning_efforts(
+            "inkling",
+            provider_id="wandb",
+        ) == ["none", "high"]
+    finally:
+        if original is None:
+            cfg.cfg.pop("providers", None)
+        else:
+            monkeypatch.setitem(cfg.cfg, "providers", original)
+
+
 def test_acp_guards_win_over_configured_reasoning_efforts(monkeypatch):
     original = cfg.cfg.get("providers")
     monkeypatch.setitem(
@@ -216,7 +273,16 @@ def test_nested_route_deny_wins_over_configured_reasoning_efforts(monkeypatch):
     monkeypatch.setitem(
         cfg.cfg,
         "custom_providers",
-        [{"name": "agg", "reasoning_efforts": ["low", "high"]}],
+        [
+            {
+                "name": "agg",
+                "reasoning_efforts": ["low", "high"],
+                "models": {
+                    "vertex/gemini-image-1.0": {"reasoning_efforts": ["high"]},
+                    "vertex/gemini-embedding-001": {"reasoning_efforts": ["high"]},
+                },
+            }
+        ],
     )
     try:
         for model in ("vertex/gemini-image-1.0", "vertex/gemini-embedding-001"):


### PR DESCRIPTION
## Summary

Honor `models.<model>.reasoning_efforts` before a provider-wide `reasoning_efforts` list when resolving the WebUI reasoning picker.

Hermes Agent custom-provider config already stores model metadata under `custom_providers[].models`. The WebUI resolver only read `custom_providers[].reasoning_efforts`, so an unrecognized model such as Inkling could not expose its declared modes without assigning one effort ladder to every model behind the provider.

The precedence is now:

1. Hard route/provider denies.
2. Per-model configured efforts.
3. Provider-wide configured efforts.
4. Existing models.dev, provider-specific, and heuristic detection.

Matching is case-insensitive. An empty or all-invalid model list falls back to provider metadata and then existing detection; it never empties a previously valid picker.

## Existing PR review

- No PR or issue mentioning Inkling was found.
- This is a narrow extension of merged #5313, preserving its config-authoritative behavior, invalid-list fallback, ACP guards, and nested Gemini image/embedding hard denies.
- Open #5987 and #5972 are session/run-scoped effort persistence changes, not model capability discovery.

## Why this scope

Provider-wide metadata is insufficient when one OpenAI-compatible endpoint serves models with different effort ladders. This patch consumes the per-model metadata already present in Hermes config; it adds no new setting, heuristic model family, transport behavior, dependency, or UI interaction.

Example:

```yaml
custom_providers:
  - name: vllm-cwb101
    models:
      inkling:
        reasoning_efforts: [none, low, medium, high, xhigh]
```

## Verification

- `./scripts/test.sh tests/test_reasoning_effort_model_capabilities.py tests/test_custom_provider_bare_model_reasoning.py tests/test_models_dev_reasoning.py tests/test_reasoning_show_hide.py -q` — 104 passed.
- `ruff check --ignore F401,F811 api/config.py tests/test_reasoning_effort_model_capabilities.py` — passed. (`origin/master` currently has four unrelated F401/F811 findings in `api/config.py`.)
- Live config resolution for `inkling` / `custom:vllm-cwb101` returned `supported_efforts: [none, low, medium, high, xhigh]` and `supports_reasoning_effort: true`.
- The live service restarted cleanly and `/health?deep=1` returned `status: ok`.

## Release note

Custom-provider models can declare their own `reasoning_efforts` list, so the composer reasoning picker exposes only the levels supported by the selected model instead of applying one provider-wide list.
