### PR TITLE
Release exp: pinch-to-zoom for Mermaid diagrams on touch devices (#5913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Added
 
+- **Pinch-to-zoom for Mermaid diagrams on touch devices.** The zoomable Mermaid viewer (which already had mouse-wheel zoom + single-finger pan) now supports two-finger pinch-to-zoom on phones/tablets, anchored on the pinch midpoint. Pointer/drag handlers are guarded so an active pinch never fights the pan gesture; desktop mouse-wheel zoom and single-finger pan are unchanged. Uses Touch Events for iOS Safari robustness. Thanks @silent-reader-cn. (#5913)
+
 - **Collapsed `read_file` tool rows now show the requested line range.** When the agent reads a slice of a file (`read_file` with `offset`/`limit`), the collapsed tool label now appends the range — e.g. `Read hermes_constants.py · L321-480`, or `L42` for an offset-only read — so you can see which part of a large file was read without expanding the row. Full-file reads and any tool call without a trustworthy positive-integer range keep the plain filename label (invalid, non-integer, non-positive, and overflowing ranges all fall back safely). Only `read_file` is affected. Thanks @franksong2702. (#6062)
 
 - **Images and media now render inline *as the response streams*, not just after it finishes.** When the assistant emits a `MEDIA:` token (generated image, video, audio, PDF, diff, CSV, Excalidraw, etc.) mid-turn, it now appears inline in real time during streaming instead of only materializing once the turn settles — including markers that arrive split across streaming chunks. Media routes through the same escaped `/api/media` path (no XSS surface: `javascript:`/`data:`/`file:` neutralized, SVG stays an `<img>`), remote `.webm` correctly renders as video, and normal prose streaming (including the fade effect) is unchanged when no media is present. Thanks @silent-reader-cn. (#5802)

--- a/static/ui.js
+++ b/static/ui.js
@@ -2013,6 +2013,9 @@ function _mountMermaidViewer(svgEl, options = {}) {
     viewport,
     x: 0,
     y: 0,
+    pinching: false,
+    pinchStartDist: 0,
+    pinchStartScale: 1,
   };
   root._mermaidViewer = state;
 
@@ -2157,6 +2160,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   function _onPointerDown(e){
+    if(state.pinching) return;
     if(e.button != null && e.button !== 0) return;
     state.dragging = true;
     state.dragged = false;
@@ -2171,6 +2175,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   function _onPointerMove(e){
+    if(state.pinching) return;
     if(!state.dragging) return;
     const dx = (Number(e.clientX) || 0) - state.dragOriginX;
     const dy = (Number(e.clientY) || 0) - state.dragOriginY;
@@ -2191,6 +2196,7 @@ function _mountMermaidViewer(svgEl, options = {}) {
   }
 
   function _openViewerOnClick(e){
+    if(state.pinching) return;
     if(mode !== 'inline') return;
     if(state.dragged){
       state.dragged = false;
@@ -2201,6 +2207,41 @@ function _mountMermaidViewer(svgEl, options = {}) {
     openLightbox();
   }
 
+  function _touchDist(touches){
+    if(!touches || touches.length < 2) return 0;
+    const dx = touches[0].clientX - touches[1].clientX;
+    const dy = touches[0].clientY - touches[1].clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  function _onTouchStart(e){
+    if(e.touches.length === 2){
+      state.pinching = true;
+      state.pinchStartDist = _touchDist(e.touches);
+      state.pinchStartScale = state.scale;
+      _endPointerDrag();
+      if(e.preventDefault) e.preventDefault();
+    }
+  }
+
+  function _onTouchMove(e){
+    if(!state.pinching || e.touches.length < 2) return;
+    const currDist = _touchDist(e.touches);
+    if(state.pinchStartDist > 0){
+      const rect = viewport.getBoundingClientRect();
+      const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2 - (rect.left || 0);
+      const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2 - (rect.top || 0);
+      _setScale(state.pinchStartScale * (currDist / state.pinchStartDist), cx, cy);
+    }
+    if(e.preventDefault) e.preventDefault();
+  }
+
+  function _onTouchEnd(e){
+    if(e.touches.length < 2){
+      state.pinching = false;
+    }
+  }
+
   viewport.onpointerdown = _onPointerDown;
   viewport.onpointermove = _onPointerMove;
   viewport.onpointerup = _endPointerDrag;
@@ -2208,6 +2249,10 @@ function _mountMermaidViewer(svgEl, options = {}) {
   viewport.onpointerleave = _endPointerDrag;
   viewport.onwheel = _zoomFromWheel;
   viewport.onclick = _openViewerOnClick;
+  viewport.addEventListener('touchstart', _onTouchStart, {passive: false});
+  viewport.addEventListener('touchmove', _onTouchMove, {passive: false});
+  viewport.addEventListener('touchend', _onTouchEnd);
+  viewport.addEventListener('touchcancel', function _onTouchCancel(){ state.pinching = false; });
   root.onclick = e => e.stopPropagation();
   state.fit = _fitViewer;
   state.reset = _resetViewer;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2016,6 +2016,10 @@ function _mountMermaidViewer(svgEl, options = {}) {
     pinching: false,
     pinchStartDist: 0,
     pinchStartScale: 1,
+    pinchStartCX: 0,
+    pinchStartCY: 0,
+    pinchStartX: 0,
+    pinchStartY: 0,
   };
   root._mermaidViewer = state;
 
@@ -2219,6 +2223,11 @@ function _mountMermaidViewer(svgEl, options = {}) {
       state.pinching = true;
       state.pinchStartDist = _touchDist(e.touches);
       state.pinchStartScale = state.scale;
+      state.pinchStartX = state.x;
+      state.pinchStartY = state.y;
+      const rect = viewport.getBoundingClientRect();
+      state.pinchStartCX = (e.touches[0].clientX + e.touches[1].clientX) / 2 - (rect.left || 0);
+      state.pinchStartCY = (e.touches[0].clientY + e.touches[1].clientY) / 2 - (rect.top || 0);
       _endPointerDrag();
       if(e.preventDefault) e.preventDefault();
     }
@@ -2226,19 +2235,26 @@ function _mountMermaidViewer(svgEl, options = {}) {
 
   function _onTouchMove(e){
     if(!state.pinching || e.touches.length < 2) return;
+    const rect = viewport.getBoundingClientRect();
+    const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2 - (rect.left || 0);
+    const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2 - (rect.top || 0);
     const currDist = _touchDist(e.touches);
-    if(state.pinchStartDist > 0){
-      const rect = viewport.getBoundingClientRect();
-      const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2 - (rect.left || 0);
-      const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2 - (rect.top || 0);
-      _setScale(state.pinchStartScale * (currDist / state.pinchStartDist), cx, cy);
+    if(state.pinchStartDist > 0 && state.pinchStartScale > 0){
+      const rawScale = state.pinchStartScale * (currDist / state.pinchStartDist);
+      const boundedScale = Math.max(_minScale(), Math.min(_MERMAID_VIEWER_MAX_SCALE, rawScale));
+      const ratio = boundedScale / state.pinchStartScale;
+      state.scale = boundedScale;
+      state.x = cx - (state.pinchStartCX - state.pinchStartX) * ratio;
+      state.y = cy - (state.pinchStartCY - state.pinchStartY) * ratio;
+      _applyTransform();
     }
     if(e.preventDefault) e.preventDefault();
   }
 
   function _onTouchEnd(e){
-    if(e.touches.length < 2){
+    if(e.touches.length < 2 && state.pinching){
       state.pinching = false;
+      state.dragged = true;
     }
   }
 

--- a/tests/test_issue4814_mermaid_toolbar.py
+++ b/tests/test_issue4814_mermaid_toolbar.py
@@ -113,6 +113,15 @@ function makeElement(tagName) {
       this.releasedPointerId = pointerId;
       if (this.capturedPointerId === pointerId) this.capturedPointerId = null;
     },
+    _listeners: {},
+    addEventListener(type, handler, _options) {
+      (this._listeners[type] ||= []).push(handler);
+    },
+    removeEventListener(type, handler) {
+      const list = this._listeners[type] || [];
+      const idx = list.indexOf(handler);
+      if (idx >= 0) list.splice(idx, 1);
+    },
     cloneNode() {
       const copy = makeElement(this.tagName);
       copy.className = this.className;


### PR DESCRIPTION
Release exp: pinch-to-zoom for Mermaid diagrams on touch devices (#5913)

## What ships
**#5913** (@silent-reader-cn) — two-finger pinch-to-zoom on the Mermaid diagram viewer for phones/tablets, anchored on the pinch midpoint. The viewer already had mouse-wheel zoom + single-finger pan; this brings touch-device zoom parity. Uses Touch Events (touchstart/move/end/cancel) for iOS Safari robustness, with `state.pinching` guards on the pointer/drag/click handlers so an active pinch never fights the pan gesture or opens the lightbox. +61 lines, isolated to `_mountMermaidViewer` in static/ui.js.

## Gate (double-gated per maintainer condition)
- Codex adversarial review: **SAFE TO SHIP**, verified in Chromium — pinch exits cleanly on the 2→1 finger transition + cancel (no stuck state killing pan/click), midpoint anchor math stable (no jump), no lightbox double-open, single-finger pan + wheel zoom still functional, only two-finger gestures call `preventDefault` (transcript scroll outside the viewport untouched), touch listeners are viewport-owned + collectible on teardown, desktop/non-touch paths unchanged.
- Full suite: **13,123 passed**, 0 failures. ESLint runtime gate clean.
- Maintainer (Nathan) approved to ship.

Closes #5913. Thanks @silent-reader-cn.
