### PR TITLE
fix(#6100): clear stale gateway approval attention

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -9528,6 +9528,7 @@ def _session_attention_summary(session_id: str) -> dict | None:
     """Return sidebar attention metadata for pending approval/clarify work."""
     approval_count = 0
     with _lock:
+        reconcile_gateway_pending_mirror_locked(session_id)
         queue_list = _pending.get(session_id)
         if isinstance(queue_list, list):
             approval_count = len(queue_list)

--- a/tests/test_session_attention_badges.py
+++ b/tests/test_session_attention_badges.py
@@ -2,6 +2,7 @@ import io
 import json
 import pathlib
 import sys
+from types import SimpleNamespace
 from urllib.parse import urlparse
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -40,6 +41,56 @@ def _clear_attention_state(*session_ids):
             routes._gateway_queues.pop(sid, None)
     for sid in session_ids:
         clarify.clear_pending(sid)
+
+
+def test_attention_summary_purges_stale_gateway_mirror():
+    sid = "attention-stale-gateway-session"
+    _clear_attention_state(sid)
+    try:
+        approval = {
+            "approval_id": "stale-gateway-approval",
+            "command": "rm -rf /tmp/nope",
+            "description": "Danger",
+        }
+        with routes._lock:
+            routes._gateway_queues[sid] = [SimpleNamespace(data=dict(approval))]
+        routes.submit_gateway_pending_mirror(sid, approval)
+
+        with routes._lock:
+            assert routes._pending[sid]
+            routes._gateway_queues[sid].pop(0)
+            assert routes._pending[sid]
+
+        assert routes._session_attention_summary(sid) is None
+        with routes._lock:
+            assert sid not in routes._pending
+    finally:
+        _clear_attention_state(sid)
+
+
+def test_attention_summary_keeps_live_gateway_mirror():
+    sid = "attention-live-gateway-session"
+    _clear_attention_state(sid)
+    try:
+        approval = {
+            "approval_id": "live-gateway-approval",
+            "command": "touch /tmp/nope",
+            "description": "Also danger",
+        }
+        with routes._lock:
+            routes._gateway_queues[sid] = [SimpleNamespace(data=dict(approval))]
+        routes.submit_gateway_pending_mirror(sid, approval)
+
+        assert routes._session_attention_summary(sid) == {
+            "kind": "approval",
+            "count": 1,
+            "severity": "critical",
+        }
+        with routes._lock:
+            assert len(routes._pending[sid]) == 1
+            assert routes._pending[sid][0]["approval_id"] == approval["approval_id"]
+    finally:
+        _clear_attention_state(sid)
 
 
 def test_attention_summary_prefers_pending_approvals_over_clarify_questions():


### PR DESCRIPTION
## Thinking Path

- The parent-session red dot is a WebUI projection problem, not just an agent-side ownership problem: once the live gateway queue drains, the sidebar summary can still keep the mirrored approval alive.
- The approval-pending route already repairs that drift by reconciling the gateway mirror before it reads `_pending`; the shared sidebar summary path does not.
- The maintainer's split comment on [#6100](https://github.com/nesquena/hermes-webui/issues/6100#issuecomment-4985606871) narrows this repo's slice to that self-healing read-path repair, while the root cause stays in hermes-agent.

## What Changed

- `api/routes.py`: `_session_attention_summary()` now reconciles gateway mirrors before it counts sidebar approval attention.
- `tests/test_session_attention_badges.py`: focused gateway-mirror regressions cover the stale-mirror reproduction and the adjacent live-head preservation case, while the existing direct-approval and clarify tests keep the rest of the summary contract in scope.

## Why It Matters

Parent sessions stop showing a red approval dot after the underlying gateway approval is already gone. Live approvals remain visible and actionable, and the clarify fallback still behaves the same way.

## Verification

Focused sidebar-attention regression coverage now exercises the stale-mirror reproduction, a live gateway head, a direct pending approval, and clarify fallback. In a throwaway base worktree with the branch's added stale-mirror tests applied against base `api/routes.py`, the focused file failed exactly at the reproduction (`1 failed, 5 passed`) with `AssertionError: assert {'count': 1, 'kind': 'approval', 'severity': 'critical'} is None`; on the branch head the same focused file passed clean (`6 passed`). The proof report passed `assert-proof-evidence`, and `git diff --check` stayed clean; CI covers the full Python matrix.

## Risks / Follow-ups

This is the WebUI mitigation only. The child-session context propagation bug that keys delegated approvals to the parent remains the root cause and stays in #6100 on the hermes-agent side.

Release note: stale sidebar approval attention now clears once its gateway approval has drained.

No local screenshot pair is attached yet. The visible state here is a stale approval mirror reproduced through isolated injected approval state rather than a stable manual UI flow, so the current proof for this PR is the focused regression plus the proof report.

## Contract Routing

Task type: narrow sidebar-attention bug fix
Touched areas: approval-mirror projection and session sidebar metadata
Relevant public docs:
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries: WebUI attention reads only; no agent-side changes, no frontend layout changes, no approval-authority changes
Evidence needed before claiming done: one base-fails/head-passes stale-mirror regression plus preservation checks for the live gateway, direct pending, and clarify-only states

## Upstream

Refs #6100.

Scope follows the maintainer's split in https://github.com/nesquena/hermes-webui/issues/6100#issuecomment-4985606871, which keeps this PR on the WebUI self-healing slice.

## Model Used

GPT-5 via Codex CLI
