### PR TITLE
fix: prevent final reply disappearing at stream settlement (#6112)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -6734,7 +6734,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             return !!stagedKey && stagedKey===currentKey;
           })
         );
-        const _preserveCurrentTranscript=preserveVisibleOnShorterTerminalSnapshot&&_stagedMatchesCurrentPrefix;
+        const _preserveCurrentTranscript=(preserveVisibleOnShorterTerminalSnapshot||allowUnmarkedShorterTerminalSnapshot)&&_stagedMatchesCurrentPrefix;
         const _resolvedMessages=_preserveCurrentTranscript
           ? [..._stagedMessages,..._currentVisibleMessages.slice(_stagedMessages.length)]
           : _stagedMessages;

--- a/static/messages.js
+++ b/static/messages.js
@@ -6645,6 +6645,23 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     return `${m.role}|${ts}|${body.slice(0,160)}`;
   }
+  // Full-authoritative identity for the shorter-snapshot prefix decision in
+  // _restoreSettledSession. Unlike _messageIdentityKey (used by the lenient
+  // ephemeral carry-forward, which intentionally truncates content to 160
+  // chars), this key compares the COMPLETE content: two messages sharing
+  // role/timestamp/first-160-chars but differing later must NOT be treated
+  // as a matching prefix — otherwise a divergent authoritative tail would be
+  // masked and a stale visible reply preserved.
+  function _messageAuthoritativeKey(m){
+    if(!m||!m.role) return '';
+    const ts=m._ts||m.timestamp||'';
+    let body='';
+    if(typeof m.content==='string') body=m.content;
+    else if(Array.isArray(m.content)){
+      try{ body=m.content.map(p=>(p&&typeof p==='object')?(p.text||p.input_text||'')||'':String(p||'')).join(''); }catch(_){ body=''; }
+    }
+    return `${m.role}|${ts}|${body}`;
+  }
   const _EPHEMERAL_TURN_FIELDS=['_turnUsage','_turnDuration','_turnTps','_gatewayRouting','_statusCard','_anchor_stream_id','_anchor_activity_scene'];
   function _isHistoricalAnchorActivityScene(scene){
     if(!scene||typeof scene!=='object') return false;
@@ -6729,8 +6746,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           _stagedMessages.length<_currentVisibleMessages.length &&
           (_currentVisibleEndsWithTerminalMarker || allowUnmarkedShorterTerminalSnapshot) &&
           _stagedMessages.every((message, idx)=>{
-            const stagedKey=_messageIdentityKey(message);
-            const currentKey=_messageIdentityKey(_currentVisibleMessages[idx]);
+            const stagedKey=_messageAuthoritativeKey(message);
+            const currentKey=_messageAuthoritativeKey(_currentVisibleMessages[idx]);
             return !!stagedKey && stagedKey===currentKey;
           })
         );

--- a/static/messages.js
+++ b/static/messages.js
@@ -2363,7 +2363,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       return;
     }
     _streamEndRecoveryTimer=null;
-    const status=await _restoreSettledSession(source,{status:true});
+    const status=await _restoreSettledSession(source,{status:true,allowUnmarkedShorterTerminalSnapshot:true});
     if(status==='restored'){
       _clearStreamEndRecovery();
       return;
@@ -6149,7 +6149,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // live DOM/inflight state remains projected and can duplicate Thinking or
       // assistant content until a later session switch. Settle from the persisted
       // session before closing so the pane converges on canonical state.
-      const status=await _restoreSettledSession(source,{status:true,preserveVisibleOnShorterTerminalSnapshot:true});
+      const status=await _restoreSettledSession(source,{status:true,allowUnmarkedShorterTerminalSnapshot:true});
       if(status==='restored'){
         return;
       }
@@ -6679,6 +6679,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   async function _restoreSettledSession(source, options=null){
     const returnStatus=!!(options&&options.status);
     const preserveVisibleOnShorterTerminalSnapshot=!!(options&&options.preserveVisibleOnShorterTerminalSnapshot);
+    const allowUnmarkedShorterTerminalSnapshot=!!(options&&options.allowUnmarkedShorterTerminalSnapshot);
     if(_isActiveSession() && S.activeStreamId!==streamId){
       _closeSource(source);
       return returnStatus?'stale':false;
@@ -6726,7 +6727,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const _stagedMatchesCurrentPrefix=(
           _stagedMessages.length>0 &&
           _stagedMessages.length<_currentVisibleMessages.length &&
-          (_currentVisibleEndsWithTerminalMarker || preserveVisibleOnShorterTerminalSnapshot) &&
+          (_currentVisibleEndsWithTerminalMarker || allowUnmarkedShorterTerminalSnapshot) &&
           _stagedMessages.every((message, idx)=>{
             const stagedKey=_messageIdentityKey(message);
             const currentKey=_messageIdentityKey(_currentVisibleMessages[idx]);

--- a/static/messages.js
+++ b/static/messages.js
@@ -6149,7 +6149,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // live DOM/inflight state remains projected and can duplicate Thinking or
       // assistant content until a later session switch. Settle from the persisted
       // session before closing so the pane converges on canonical state.
-      const status=await _restoreSettledSession(source,{status:true});
+      const status=await _restoreSettledSession(source,{status:true,preserveVisibleOnShorterTerminalSnapshot:true});
       if(status==='restored'){
         return;
       }
@@ -6726,7 +6726,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const _stagedMatchesCurrentPrefix=(
           _stagedMessages.length>0 &&
           _stagedMessages.length<_currentVisibleMessages.length &&
-          _currentVisibleEndsWithTerminalMarker &&
+          (_currentVisibleEndsWithTerminalMarker || preserveVisibleOnShorterTerminalSnapshot) &&
           _stagedMessages.every((message, idx)=>{
             const stagedKey=_messageIdentityKey(message);
             const currentKey=_messageIdentityKey(_currentVisibleMessages[idx]);

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -99,9 +99,9 @@ def test_stream_end_without_done_restores_settled_session_before_closing():
     never replaces the pane with the persisted transcript when done is missing.
     """
     body = _event_body("stream_end")
-    restore_idx = body.find("_restoreSettledSession(source,{status:true})")
+    restore_idx = body.find("_restoreSettledSession(source,{status:true,allowUnmarkedShorterTerminalSnapshot:true})")
     if restore_idx == -1:
-        restore_idx = body.find("_restoreSettledSession(source)")
+        restore_idx = body.find("_restoreSettledSession(source,{status:true})")
     close_idx = body.find("_closeSource(source)", restore_idx)
     if close_idx == -1:
         close_idx = body.find("_finalizeStreamEndFallback(source)", restore_idx)

--- a/tests/test_6120_unmarked_stream_end_preservation.py
+++ b/tests/test_6120_unmarked_stream_end_preservation.py
@@ -1,0 +1,449 @@
+"""Regression coverage for #6120: scoped allowUnmarkedShorterTerminalSnapshot.
+
+The new scoped option preserves a matching visible final tail when stream_end
+arrives without a preceding done event — but replaces it when the authoritative
+prefix diverges. Covers both the direct path and the active→settled retry path.
+"""
+
+import json
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node is required to execute message runtime tests")
+
+
+_DRIVER = r"""
+const fs = require('fs');
+
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const scenario = JSON.parse(process.argv[3] || '{}');
+
+function extractFunction(source, name) {
+  const markers = [`async function ${name}(`, `function ${name}(`];
+  let start = -1;
+  for (const marker of markers) {
+    start = source.indexOf(marker);
+    if (start >= 0) break;
+  }
+  if (start < 0) {
+    throw new Error(`missing ${name}`);
+  }
+  let i = source.indexOf('{', start);
+  if (i < 0) {
+    throw new Error(`missing function body for ${name}`);
+  }
+  let depth = 1;
+  i++;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+    i++;
+  }
+  throw new Error(`unterminated function body for ${name}`);
+}
+
+function extractFunctionByName(name) {
+  return extractFunction(src, name);
+}
+
+function installRuntimeHelpers() {
+  const helpers = [
+    "_isMarkerOnlyAssistantMessage",
+    "_streamRecoveryControlMessageText",
+    "_streamRecoveryControlMessage",
+    "_filterRecoveryControlMessages",
+    "_replaceMarkerOnlyAssistantWithStreamError",
+    "_messageIdentityKey",
+    "_carryForwardEphemeralTurnFields",
+    "_isTerminalStreamErrorMarkerMessage",
+    "_ensureSingleTerminalStreamErrorMarker",
+    "_restoreSettledSession",
+  ];
+  for (const helper of helpers) {
+    const body = extractFunctionByName(helper);
+    const factory = new Function(`${body}; return ${helper};`);
+    globalThis[helper] = factory();
+  }
+}
+
+function buildRuntime() {
+  const activeSid = scenario.activeSid || 'session-6120';
+  const streamId = scenario.streamId || 'stream-6120';
+  const calls = [];
+  globalThis.activeSid = activeSid;
+  globalThis.streamId = streamId;
+  globalThis.assistantText = false;
+  globalThis.S = JSON.parse(JSON.stringify(scenario.state || {}));
+  if (!globalThis.S.session) {
+    globalThis.S.session = { session_id: activeSid };
+  }
+  if (!Object.prototype.hasOwnProperty.call(globalThis.S, 'activeStreamId')) {
+    globalThis.S.activeStreamId = streamId;
+  }
+  globalThis.INFLIGHT = {};
+  globalThis._EPHEMERAL_TURN_FIELDS = [
+    '_turnUsage',
+    '_turnDuration',
+    '_turnTps',
+    '_gatewayRouting',
+    '_statusCard',
+    '_anchor_stream_id',
+    '_anchor_activity_scene',
+  ];
+  globalThis._isActiveSession = () => scenario.isActiveSession !== false;
+  globalThis._isSessionCurrentPane = () => scenario.isSessionCurrentPane !== false;
+  globalThis._isSessionActivelyViewed = () => !!scenario.isSessionActivelyViewed;
+  globalThis._closeSource = () => calls.push('closeSource');
+  globalThis._clearStreamEndRecovery = () => calls.push('clearStreamEndRecovery');
+  globalThis._clearOwnerInflightState = () => calls.push('clearOwnerInflight');
+  globalThis.clearLiveToolCards = () => calls.push('clearLiveToolCards');
+  globalThis.removeThinking = () => calls.push('removeThinking');
+  globalThis._flushReasoningToAnchor = () => calls.push('flushReasoning');
+  globalThis._applyToAnchor = () => calls.push('applyToAnchor');
+  globalThis._attachProjectedAnchorSceneToLastAssistant = () => calls.push('attachProjected');
+  globalThis._hydrateTodosFromSession = () => calls.push('hydrateTodos');
+  globalThis._scheduleAnchorRegistryCleanup = () => calls.push('scheduleAnchorRegistryCleanup');
+  globalThis._smdEndParser = () => calls.push('smdEndParser');
+  globalThis._markSessionCompletionUnread = () => calls.push('markCompletionUnread');
+  globalThis._markSessionViewed = () => calls.push('markSessionViewed');
+  globalThis.localStorage = {
+    setItem: () => calls.push('setLocalStorageItem'),
+    getItem: () => null,
+    removeItem: () => calls.push('removeLocalStorageItem'),
+  };
+  globalThis._setActiveSessionUrl = () => calls.push('setActiveSessionUrl');
+  globalThis.showToast = () => calls.push('showToast');
+  globalThis._clearApprovalForOwner = () => calls.push('clearApprovalForOwner');
+  globalThis._clearClarifyForOwner = () => calls.push('clearClarifyForOwner');
+  globalThis._streamFadeCleanupReduceMotionListener = () => calls.push('streamFadeCleanup');
+  globalThis._cancelThrottledSnapshotTimer = () => calls.push('cancelThrottledSnapshot');
+  globalThis._clearAnchorProseIncrementalNode = () => calls.push('clearAnchorProse');
+  globalThis._cancelAnimationFramePendingStreamRender = () => calls.push('cancelRaf');
+  globalThis.finalizeThinkingCard = () => calls.push('finalizeThinkingCard');
+  globalThis.syncTopbar = () => calls.push('syncTopbar');
+  globalThis.renderMessages = () => calls.push('renderMessages');
+  globalThis.renderSessionList = () => calls.push('renderSessionList');
+  globalThis._setActivePaneIdleIfOwner = () => calls.push('setActivePaneIdle');
+  globalThis.setBusy = () => calls.push('setBusy');
+  globalThis.setComposerStatus = () => calls.push('setComposerStatus');
+  globalThis.setStatus = () => calls.push('setStatus');
+  globalThis._messageRenderableMessageCount = () => scenario.messageRenderableCount || 50;
+  globalThis._currentMessageRenderWindowSize = () => scenario.currentWindowSize || 12;
+  globalThis._messageRenderWindowSize = 20;
+  globalThis._streamFinalized = !!scenario.streamFinalized;
+  globalThis._persistTimer = null;
+  globalThis.api = async () => scenario.apiPayload || { session: null };
+  globalThis.msgContent = undefined;
+  globalThis._isPreservedCompressionTaskListMarkerOnlyText = () => false;
+  return calls;
+}
+
+(async () => {
+  installRuntimeHelpers();
+  const calls = buildRuntime();
+
+  const mode = scenario.mode || 'direct';
+
+  if (mode === 'direct') {
+    // Direct stream_end-without-done path: simulate the handler calling
+    // _restoreSettledSession with allowUnmarkedShorterTerminalSnapshot:true.
+    // In production this is the non-active-scene fallback branch in the
+    // stream_end event listener.
+    const status = await _restoreSettledSession({}, {
+      status: true,
+      allowUnmarkedShorterTerminalSnapshot: true,
+    });
+    const messages = Array.isArray(S.messages) ? S.messages : [];
+    console.log(JSON.stringify({
+      mode,
+      status,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      calls,
+    }));
+    return;
+  }
+
+  if (mode === 'retry') {
+    // Active→settled retry path: simulate _runStreamEndRecovery calling
+    // _restoreSettledSession with allowUnmarkedShorterTerminalSnapshot:true
+    // after the first direct restore returned 'active'.
+    const status = await _restoreSettledSession({}, {
+      status: true,
+      allowUnmarkedShorterTerminalSnapshot: true,
+    });
+    const messages = Array.isArray(S.messages) ? S.messages : [];
+    console.log(JSON.stringify({
+      mode,
+      status,
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      calls,
+    }));
+    return;
+  }
+
+  throw new Error(`unknown mode: ${mode}`);
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    driver = tmp_path_factory.mktemp("issue6120_driver") / "driver.js"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    return str(driver)
+
+
+def _run_scenario(driver_path: str, scenario: dict) -> dict:
+    command = [NODE, driver_path, str(MESSAGES_JS), json.dumps(scenario)]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return json.loads(result.stdout.strip())
+
+
+def test_unmarked_direct_preserves_matching_visible_tail(driver_path):
+    """Direct stream_end-without-done: preserve tail when the server snapshot
+    is a prefix of a longer visible transcript."""
+    outcome = _run_scenario(driver_path, {
+        "mode": "direct",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 4},
+            "messages": [
+                {"role": "user", "content": "What is the capital of France?", "_ts": "u1"},
+                {"role": "assistant", "content": "The capital of France is Paris.", "_ts": "a1"},
+                {"role": "assistant", "content": "Paris is known as the City of Light.", "_ts": "a2"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "What is the capital of France?", "_ts": "u1"},
+                    {"role": "assistant", "content": "The capital of France is Paris.", "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "stream-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "What is the capital of France?"),
+        ("assistant", "The capital of France is Paris."),
+        ("assistant", "Paris is known as the City of Light."),
+    ]
+    assert observed == expected, (
+        f"unmarked direct restore should preserve matching visible tail: {observed}"
+    )
+
+
+def test_unmarked_direct_replaces_when_prefix_diverges(driver_path):
+    """Direct stream_end-without-done: replace with authoritative server snapshot
+    when the prefix identity check fails."""
+    outcome = _run_scenario(driver_path, {
+        "mode": "direct",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 4},
+            "messages": [
+                {"role": "user", "content": "What is the capital of France?", "_ts": "u1"},
+                {"role": "assistant", "content": "The capital of France is Paris.", "_ts": "a1"},
+                {"role": "assistant", "content": "Paris is known as the City of Light.", "_ts": "a2"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "What is the capital of France?", "_ts": "u1"},
+                    {"role": "assistant", "content": "Paris became the capital in 508 CE.", "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "stream-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "What is the capital of France?"),
+        ("assistant", "Paris became the capital in 508 CE."),
+    ]
+    assert observed == expected, (
+        f"unmarked direct restore should replace when authoritative prefix diverges: {observed}"
+    )
+
+
+def test_unmarked_retry_preserves_matching_visible_tail(driver_path):
+    """Active→settled retry: preserve tail when the server snapshot is a prefix
+    of a longer visible transcript."""
+    outcome = _run_scenario(driver_path, {
+        "mode": "retry",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Tell me about Berlin.", "_ts": "u1"},
+                {"role": "assistant", "content": "Berlin is the capital of Germany.", "_ts": "a1"},
+                {"role": "assistant", "content": "It has a population of about 3.7 million.", "_ts": "a2"},
+                {"role": "assistant", "content": "Berlin is famous for its history and culture.", "_ts": "a3"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Tell me about Berlin.", "_ts": "u1"},
+                    {"role": "assistant", "content": "Berlin is the capital of Germany.", "_ts": "a1"},
+                    {"role": "assistant", "content": "It has a population of about 3.7 million.", "_ts": "a2"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "stream-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "Tell me about Berlin."),
+        ("assistant", "Berlin is the capital of Germany."),
+        ("assistant", "It has a population of about 3.7 million."),
+        ("assistant", "Berlin is famous for its history and culture."),
+    ]
+    assert observed == expected, (
+        f"unmarked retry restore should preserve matching visible tail: {observed}"
+    )
+
+
+def test_unmarked_retry_replaces_when_prefix_diverges(driver_path):
+    """Active→settled retry: replace with authoritative server snapshot when the
+    prefix identity check fails."""
+    outcome = _run_scenario(driver_path, {
+        "mode": "retry",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Tell me about Berlin.", "_ts": "u1"},
+                {"role": "assistant", "content": "Berlin is the capital of Germany.", "_ts": "a1"},
+                {"role": "assistant", "content": "It has a population of about 3.7 million.", "_ts": "a2"},
+                {"role": "assistant", "content": "Berlin is famous for its history and culture.", "_ts": "a3"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Tell me about Berlin.", "_ts": "u1"},
+                    {"role": "assistant", "content": "Berlin became the capital in 1990.", "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "stream-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "Tell me about Berlin."),
+        ("assistant", "Berlin became the capital in 1990."),
+    ]
+    assert observed == expected, (
+        f"unmarked retry restore should replace when authoritative prefix diverges: {observed}"
+    )
+
+
+def test_unmarked_preservation_ignores_historic_terminal_marker(driver_path):
+    """Even without a terminal marker on the final visible message, an older
+    historic marker must NOT trigger preservation — the gate only engages via
+    allowUnmarkedShorterTerminalSnapshot, not the marker check."""
+    outcome = _run_scenario(driver_path, {
+        "mode": "direct",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 7},
+            "messages": [
+                {"role": "user", "content": "Earlier question", "_ts": "u0"},
+                {"role": "assistant", "content": "Earlier answer", "_ts": "a0"},
+                {"role": "assistant", "content": "**Connection interrupted:** The browser lost the live SSE connection before the response finished.", "_ts": "err0"},
+                {"role": "user", "content": "Current question", "_ts": "u1"},
+                {"role": "assistant", "content": "Current final reply", "_ts": "a1"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Earlier question", "_ts": "u0"},
+                    {"role": "assistant", "content": "Earlier answer", "_ts": "a0"},
+                    {"role": "assistant", "content": "**Connection interrupted:** The browser lost the live SSE connection before the response finished.", "_ts": "err0"},
+                    {"role": "user", "content": "Current question", "_ts": "u1"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "session-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "Earlier question"),
+        ("assistant", "Earlier answer"),
+        ("assistant", "**Connection interrupted:** The browser lost the live SSE connection before the response finished."),
+        ("user", "Current question"),
+    ]
+    # The visible tail "Current final reply" should NOT be preserved because
+    # the server snapshot is an authoritative prefix. The historic terminal
+    # marker from an earlier turn must not preserve the tail.
+    assert observed == expected, (
+        f"unmarked preservation must replace with authoritative server snapshot (no marker on tail): {observed}"
+    )

--- a/tests/test_6120_unmarked_stream_end_preservation.py
+++ b/tests/test_6120_unmarked_stream_end_preservation.py
@@ -58,6 +58,37 @@ function extractFunctionByName(name) {
   return extractFunction(src, name);
 }
 
+// Extract the real production `stream_end` listener registration block from
+// _wireSSE so the test can dispatch the ACTUAL registered handler.
+function extractStreamEndListener(sourceText) {
+  const marker = "source.addEventListener('stream_end'";
+  const start = sourceText.indexOf(marker);
+  if (start < 0) {
+    throw new Error('missing stream_end listener registration');
+  }
+  const arrowIdx = sourceText.indexOf('=>', start);
+  if (arrowIdx < 0) {
+    throw new Error('missing arrow in stream_end listener');
+  }
+  const bodyStart = sourceText.indexOf('{', arrowIdx);
+  if (bodyStart < 0) {
+    throw new Error('missing body in stream_end listener');
+  }
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < sourceText.length; i++) {
+    const ch = sourceText[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  let end = i + 1;
+  while (end < sourceText.length && '); \n'.includes(sourceText[end])) end++;
+  return sourceText.slice(start, end);
+}
+
 function installRuntimeHelpers() {
   const helpers = [
     "_isMarkerOnlyAssistantMessage",
@@ -66,10 +97,15 @@ function installRuntimeHelpers() {
     "_filterRecoveryControlMessages",
     "_replaceMarkerOnlyAssistantWithStreamError",
     "_messageIdentityKey",
+    "_messageAuthoritativeKey",
     "_carryForwardEphemeralTurnFields",
+    "_isHistoricalAnchorActivityScene",
     "_isTerminalStreamErrorMarkerMessage",
     "_ensureSingleTerminalStreamErrorMarker",
     "_restoreSettledSession",
+    "_scheduleStreamEndRecovery",
+    "_runStreamEndRecovery",
+    "_clearStreamEndRecovery",
   ];
   for (const helper of helpers) {
     const body = extractFunctionByName(helper);
@@ -82,6 +118,7 @@ function buildRuntime() {
   const activeSid = scenario.activeSid || 'session-6120';
   const streamId = scenario.streamId || 'stream-6120';
   const calls = [];
+  const timers = [];
   globalThis.activeSid = activeSid;
   globalThis.streamId = streamId;
   globalThis.assistantText = false;
@@ -106,7 +143,8 @@ function buildRuntime() {
   globalThis._isSessionCurrentPane = () => scenario.isSessionCurrentPane !== false;
   globalThis._isSessionActivelyViewed = () => !!scenario.isSessionActivelyViewed;
   globalThis._closeSource = () => calls.push('closeSource');
-  globalThis._clearStreamEndRecovery = () => calls.push('clearStreamEndRecovery');
+  globalThis._bailOutOfTerminalEventsFromStaleStream = () => false;
+  globalThis._liveStreamEndScenePresent = () => false;
   globalThis._clearOwnerInflightState = () => calls.push('clearOwnerInflight');
   globalThis.clearLiveToolCards = () => calls.push('clearLiveToolCards');
   globalThis.removeThinking = () => calls.push('removeThinking');
@@ -144,31 +182,85 @@ function buildRuntime() {
   globalThis._messageRenderWindowSize = 20;
   globalThis._streamFinalized = !!scenario.streamFinalized;
   globalThis._persistTimer = null;
-  globalThis.api = async () => scenario.apiPayload || { session: null };
+  // Stream-end recovery module state (mirrors the module-scope lets).
+  globalThis._terminalStateReached = false;
+  globalThis._pendingStreamEndRecovery = false;
+  globalThis._streamEndRecoveryAttempts = 0;
+  globalThis._streamEndRecoveryTimer = null;
+  globalThis._queueDrainSid = null;
+  // Capture scheduled timers so the test can run the ACTUAL scheduled
+  // _runStreamEndRecovery callback after the API settles.
+  globalThis.setTimeout = (fn, delay) => { timers.push({ fn, delay }); return timers.length; };
+  globalThis.clearTimeout = () => {};
+  globalThis._finalizeStreamEndFallback = () => calls.push('finalizeFallback');
+  // Mutable API payload: the retry scenario swaps to a settled snapshot
+  // between the first restore (active) and the scheduled recovery run.
+  let apiPayload = scenario.apiPayload || { session: null };
+  globalThis.api = async () => apiPayload;
   globalThis.msgContent = undefined;
   globalThis._isPreservedCompressionTaskListMarkerOnlyText = () => false;
-  return calls;
+
+  // Observability wrappers around the REAL production functions — the
+  // production implementation still runs, we just record statuses/calls.
+  const realRestore = globalThis._restoreSettledSession;
+  const realSchedule = globalThis._scheduleStreamEndRecovery;
+  const realClear = globalThis._clearStreamEndRecovery;
+  const realRun = globalThis._runStreamEndRecovery;
+  const restoreStatuses = [];
+  globalThis._restoreSettledSession = async (s, o) => {
+    const st = await realRestore(s, o);
+    restoreStatuses.push(st);
+    return st;
+  };
+  globalThis._scheduleStreamEndRecovery = (s, delay) => {
+    calls.push('scheduleStreamEndRecovery');
+    realSchedule(s, delay);
+  };
+  globalThis._clearStreamEndRecovery = () => {
+    calls.push('clearStreamEndRecovery');
+    realClear();
+  };
+  let recoveryFinished = false;
+  globalThis._runStreamEndRecovery = async (s) => {
+    await realRun(s);
+    recoveryFinished = true;
+    calls.push('runStreamEndRecovery');
+  };
+
+  return { calls, timers, restoreStatuses, setApiPayload: (p) => { apiPayload = p; }, getRecoveryFinished: () => recoveryFinished };
 }
 
 (async () => {
   installRuntimeHelpers();
-  const calls = buildRuntime();
+  const runtime = buildRuntime();
+  const { calls, timers, restoreStatuses } = runtime;
+
+  // Register the REAL production stream_end handler on a fake source and
+  // dispatch it exactly like the browser EventSource would.
+  const streamEndBlock = extractStreamEndListener(src);
+  const source = {
+    listeners: {},
+    addEventListener(type, fn) { this.listeners[type] = fn; },
+    close() { calls.push('sourceClose'); },
+  };
+  eval(streamEndBlock);
+  const streamEndHandler = source.listeners['stream_end'];
+  if (!streamEndHandler) {
+    throw new Error('stream_end handler was not registered on the fake source');
+  }
 
   const mode = scenario.mode || 'direct';
 
   if (mode === 'direct') {
-    // Direct stream_end-without-done path: simulate the handler calling
-    // _restoreSettledSession with allowUnmarkedShorterTerminalSnapshot:true.
-    // In production this is the non-active-scene fallback branch in the
-    // stream_end event listener.
-    const status = await _restoreSettledSession({}, {
-      status: true,
-      allowUnmarkedShorterTerminalSnapshot: true,
-    });
+    // Real path: dispatch the registered production stream_end listener. The
+    // handler runs _restoreSettledSession with the scoped unmarked option
+    // (non-active-scene fallback branch) exactly as in production.
+    await streamEndHandler({ data: '{}' });
     const messages = Array.isArray(S.messages) ? S.messages : [];
     console.log(JSON.stringify({
       mode,
-      status,
+      status: restoreStatuses[restoreStatuses.length - 1] || null,
+      restoreStatuses,
       messages: messages.map((m) => ({ role: m.role, content: m.content })),
       calls,
     }));
@@ -176,17 +268,29 @@ function buildRuntime() {
   }
 
   if (mode === 'retry') {
-    // Active→settled retry path: simulate _runStreamEndRecovery calling
-    // _restoreSettledSession with allowUnmarkedShorterTerminalSnapshot:true
-    // after the first direct restore returned 'active'.
-    const status = await _restoreSettledSession({}, {
-      status: true,
-      allowUnmarkedShorterTerminalSnapshot: true,
-    });
+    // First dispatch: the API still reports the stream active, so the real
+    // handler gets 'active' back and schedules _scheduleStreamEndRecovery.
+    await streamEndHandler({ data: '{}' });
+    const scheduled = timers.length > 0;
+    const scheduledDelay = timers.length ? timers[0].delay : null;
+    // Settle the API, then run the ACTUAL scheduled callback — the timer was
+    // registered by the real _scheduleStreamEndRecovery and invokes the real
+    // _runStreamEndRecovery.
+    runtime.setApiPayload(scenario.apiPayloadSettled || scenario.apiPayload);
+    if (timers.length) {
+      timers[0].fn();
+      for (let k = 0; k < 20 && !runtime.getRecoveryFinished(); k++) {
+        await new Promise((r) => setImmediate(r));
+      }
+    }
     const messages = Array.isArray(S.messages) ? S.messages : [];
     console.log(JSON.stringify({
       mode,
-      status,
+      status: restoreStatuses[restoreStatuses.length - 1] || null,
+      restoreStatuses,
+      scheduled,
+      scheduledDelay,
+      recoveryFinished: runtime.getRecoveryFinished(),
       messages: messages.map((m) => ({ role: m.role, content: m.content })),
       calls,
     }));
@@ -224,8 +328,9 @@ def _run_scenario(driver_path: str, scenario: dict) -> dict:
 
 
 def test_unmarked_direct_preserves_matching_visible_tail(driver_path):
-    """Direct stream_end-without-done: preserve tail when the server snapshot
-    is a prefix of a longer visible transcript."""
+    """Direct stream_end-without-done: the REAL registered stream_end listener
+    preserves the tail when the server snapshot is a prefix of a longer
+    visible transcript (scoped allowUnmarkedShorterTerminalSnapshot)."""
     outcome = _run_scenario(driver_path, {
         "mode": "direct",
         "state": {
@@ -255,6 +360,13 @@ def test_unmarked_direct_preserves_matching_visible_tail(driver_path):
     })
 
     assert outcome["status"] == "restored"
+    # The real production stream_end handler calls _clearStreamEndRecovery()
+    # before restoring; the direct _restoreSettledSession path does not. Its
+    # presence proves the registered listener was actually dispatched.
+    assert "clearStreamEndRecovery" in outcome["calls"], (
+        "real stream_end listener must have been dispatched: "
+        f"calls={outcome['calls']}"
+    )
     observed = [(item["role"], item["content"]) for item in outcome["messages"]]
     expected = [
         ("user", "What is the capital of France?"),
@@ -267,8 +379,9 @@ def test_unmarked_direct_preserves_matching_visible_tail(driver_path):
 
 
 def test_unmarked_direct_replaces_when_prefix_diverges(driver_path):
-    """Direct stream_end-without-done: replace with authoritative server snapshot
-    when the prefix identity check fails."""
+    """Direct stream_end-without-done: the REAL registered stream_end listener
+    replaces with the authoritative server snapshot when the prefix identity
+    check fails."""
     outcome = _run_scenario(driver_path, {
         "mode": "direct",
         "state": {
@@ -308,9 +421,58 @@ def test_unmarked_direct_replaces_when_prefix_diverges(driver_path):
     )
 
 
+def test_unmarked_direct_replaces_when_authoritative_tail_diverges(driver_path):
+    """Divergent-tail regression (direct): role/timestamp/first-160 chars match
+    but later content diverges — the prefix decision must use the FULL
+    authoritative content, so the server snapshot replaces the visible tail."""
+    long_visible = "A" * 200
+    long_server = ("A" * 160) + ("B" * 40)
+    assert long_visible[:160] == long_server[:160]
+    assert long_visible != long_server
+    outcome = _run_scenario(driver_path, {
+        "mode": "direct",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 4},
+            "messages": [
+                {"role": "user", "content": "Q", "_ts": "u1"},
+                {"role": "assistant", "content": long_visible, "_ts": "a1"},
+                {"role": "assistant", "content": "visible tail after divergent reply", "_ts": "a2"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Q", "_ts": "u1"},
+                    {"role": "assistant", "content": long_server, "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "stream-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "Q"),
+        ("assistant", long_server),
+    ]
+    assert observed == expected, (
+        "staged/visible share role+timestamp+first-160-chars but diverge later — "
+        f"must replace from the authoritative server snapshot: {observed}"
+    )
+
+
 def test_unmarked_retry_preserves_matching_visible_tail(driver_path):
-    """Active→settled retry: preserve tail when the server snapshot is a prefix
-    of a longer visible transcript."""
+    """Active→settled retry: the REAL stream_end listener gets 'active' back,
+    schedules _scheduleStreamEndRecovery, and the ACTUAL scheduled
+    _runStreamEndRecovery callback preserves the tail after settlement."""
     outcome = _run_scenario(driver_path, {
         "mode": "retry",
         "state": {
@@ -324,6 +486,17 @@ def test_unmarked_retry_preserves_matching_visible_tail(driver_path):
             "activeStreamId": "stream-6120",
         },
         "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": "stream-6120",
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Tell me about Berlin.", "_ts": "u1"},
+                    {"role": "assistant", "content": "Berlin is the capital of Germany.", "_ts": "a1"},
+                ],
+            },
+        },
+        "apiPayloadSettled": {
             "session": {
                 "session_id": "session-6120",
                 "active_stream_id": None,
@@ -341,6 +514,16 @@ def test_unmarked_retry_preserves_matching_visible_tail(driver_path):
         "isSessionCurrentPane": True,
     })
 
+    assert outcome["scheduled"] is True, "retry must schedule stream-end recovery"
+    assert outcome["scheduledDelay"] == 200, (
+        f"recovery must be scheduled at 200ms, got {outcome['scheduledDelay']}"
+    )
+    assert outcome["recoveryFinished"] is True, (
+        "the actual scheduled _runStreamEndRecovery callback must run"
+    )
+    assert "runStreamEndRecovery" in outcome["calls"], (
+        "the real _runStreamEndRecovery must be invoked by the scheduled callback"
+    )
     assert outcome["status"] == "restored"
     observed = [(item["role"], item["content"]) for item in outcome["messages"]]
     expected = [
@@ -355,8 +538,8 @@ def test_unmarked_retry_preserves_matching_visible_tail(driver_path):
 
 
 def test_unmarked_retry_replaces_when_prefix_diverges(driver_path):
-    """Active→settled retry: replace with authoritative server snapshot when the
-    prefix identity check fails."""
+    """Active→settled retry: the scheduled _runStreamEndRecovery replaces with
+    the authoritative server snapshot when the prefix identity check fails."""
     outcome = _run_scenario(driver_path, {
         "mode": "retry",
         "state": {
@@ -370,6 +553,17 @@ def test_unmarked_retry_replaces_when_prefix_diverges(driver_path):
             "activeStreamId": "stream-6120",
         },
         "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": "stream-6120",
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Tell me about Berlin.", "_ts": "u1"},
+                    {"role": "assistant", "content": "Berlin is the capital of Germany.", "_ts": "a1"},
+                ],
+            },
+        },
+        "apiPayloadSettled": {
             "session": {
                 "session_id": "session-6120",
                 "active_stream_id": None,
@@ -386,6 +580,10 @@ def test_unmarked_retry_replaces_when_prefix_diverges(driver_path):
         "isSessionCurrentPane": True,
     })
 
+    assert outcome["scheduled"] is True, "retry must schedule stream-end recovery"
+    assert outcome["scheduledDelay"] == 200
+    assert outcome["recoveryFinished"] is True
+    assert "runStreamEndRecovery" in outcome["calls"]
     assert outcome["status"] == "restored"
     observed = [(item["role"], item["content"]) for item in outcome["messages"]]
     expected = [
@@ -397,10 +595,76 @@ def test_unmarked_retry_replaces_when_prefix_diverges(driver_path):
     )
 
 
+def test_unmarked_retry_replaces_when_authoritative_tail_diverges(driver_path):
+    """Divergent-tail regression (retry): the scheduled _runStreamEndRecovery
+    must replace from the server snapshot when role/timestamp/first-160 chars
+    match but later content diverges."""
+    long_visible = "C" * 200
+    long_server = ("C" * 160) + ("D" * 40)
+    assert long_visible[:160] == long_server[:160]
+    assert long_visible != long_server
+    outcome = _run_scenario(driver_path, {
+        "mode": "retry",
+        "state": {
+            "session": {"session_id": "session-6120", "message_count": 5},
+            "messages": [
+                {"role": "user", "content": "Q", "_ts": "u1"},
+                {"role": "assistant", "content": long_visible, "_ts": "a1"},
+                {"role": "assistant", "content": "visible tail after divergent reply", "_ts": "a2"},
+            ],
+            "activeStreamId": "stream-6120",
+        },
+        "apiPayload": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": "stream-6120",
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Q", "_ts": "u1"},
+                    {"role": "assistant", "content": long_visible, "_ts": "a1"},
+                ],
+            },
+        },
+        "apiPayloadSettled": {
+            "session": {
+                "session_id": "session-6120",
+                "active_stream_id": None,
+                "pending_user_message": None,
+                "messages": [
+                    {"role": "user", "content": "Q", "_ts": "u1"},
+                    {"role": "assistant", "content": long_server, "_ts": "a1"},
+                ],
+            },
+        },
+        "activeSid": "session-6120",
+        "streamId": "stream-6120",
+        "isActiveSession": True,
+        "isSessionCurrentPane": True,
+    })
+
+    assert outcome["scheduled"] is True, "retry must schedule stream-end recovery"
+    assert outcome["scheduledDelay"] == 200
+    assert outcome["recoveryFinished"] is True
+    assert "runStreamEndRecovery" in outcome["calls"]
+    assert outcome["status"] == "restored"
+    observed = [(item["role"], item["content"]) for item in outcome["messages"]]
+    expected = [
+        ("user", "Q"),
+        ("assistant", long_server),
+    ]
+    assert observed == expected, (
+        "retry staged/visible share role+timestamp+first-160-chars but diverge later — "
+        f"must replace from the authoritative server snapshot: {observed}"
+    )
+
+
 def test_unmarked_preservation_ignores_historic_terminal_marker(driver_path):
     """Even without a terminal marker on the final visible message, an older
     historic marker must NOT trigger preservation — the gate only engages via
-    allowUnmarkedShorterTerminalSnapshot, not the marker check."""
+    allowUnmarkedShorterTerminalSnapshot, not the marker check. Because the
+    server snapshot is an exact prefix of the visible transcript and the
+    scoped unmarked option is active, the matching visible final reply
+    ('Current final reply') is preserved."""
     outcome = _run_scenario(driver_path, {
         "mode": "direct",
         "state": {
@@ -428,7 +692,7 @@ def test_unmarked_preservation_ignores_historic_terminal_marker(driver_path):
             },
         },
         "activeSid": "session-6120",
-        "streamId": "session-6120",
+        "streamId": "stream-6120",
         "isActiveSession": True,
         "isSessionCurrentPane": True,
     })
@@ -440,10 +704,10 @@ def test_unmarked_preservation_ignores_historic_terminal_marker(driver_path):
         ("assistant", "Earlier answer"),
         ("assistant", "**Connection interrupted:** The browser lost the live SSE connection before the response finished."),
         ("user", "Current question"),
+        ("assistant", "Current final reply"),
     ]
-    # The visible tail "Current final reply" should NOT be preserved because
-    # the server snapshot is an authoritative prefix. The historic terminal
-    # marker from an earlier turn must not preserve the tail.
+    # The server snapshot is an exact prefix and the scoped unmarked option is
+    # active, so the matching visible final reply is preserved.
     assert observed == expected, (
-        f"unmarked preservation must replace with authoritative server snapshot (no marker on tail): {observed}"
+        f"unmarked preservation must keep the matching visible final reply: {observed}"
     )

--- a/tests/test_issue5224_terminal_error_transcript_preserve.py
+++ b/tests/test_issue5224_terminal_error_transcript_preserve.py
@@ -62,6 +62,7 @@ function installRuntimeHelpers() {
     "_replaceMarkerOnlyAssistantWithStreamError",
     "_messageIdentityKey",
     "_isHistoricalAnchorActivityScene",
+    "_messageAuthoritativeKey",
     "_carryForwardEphemeralTurnFields",
     "_isTerminalStreamErrorMarkerMessage",
     "_ensureSingleTerminalStreamErrorMarker",

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -28,7 +28,7 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     # to the handler while widening the slice enough to cover the new helper
     # state and the unchanged localStorage/update-url writes.
     completion_block = MESSAGES_JS[completion_pos : completion_pos + 1000]
-    settled_block = MESSAGES_JS[settled_pos : settled_pos + 1800]
+    settled_block = MESSAGES_JS[settled_pos : settled_pos + 2500]
 
     for block in (completion_block, settled_block):
         assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block

--- a/tests/test_stream_end_recovery_gating.py
+++ b/tests/test_stream_end_recovery_gating.py
@@ -69,7 +69,7 @@ def test_stream_end_defers_settlement_when_live_assistant_still_present():
 
 def test_stream_end_fallback_does_not_finalize_when_session_is_still_active():
     body = _event_block("stream_end")
-    assert "const status=await _restoreSettledSession(source,{status:true});" in body
+    assert "const status=await _restoreSettledSession(source,{status:true,allowUnmarkedShorterTerminalSnapshot:true});" in body
     assert "if(status==='active'&&S.activeStreamId===streamId)" in body
     assert "_scheduleStreamEndRecovery(source,200);" in body
     assert "_finalizeStreamEndFallback(source);" in body
@@ -78,7 +78,7 @@ def test_stream_end_fallback_does_not_finalize_when_session_is_still_active():
 def test_stream_end_recovery_helper_retries_while_session_is_still_active():
     fn = _function_body("_runStreamEndRecovery")
     assert "if(_streamFinalized || _terminalStateReached || !_pendingStreamEndRecovery)" in fn
-    assert "_restoreSettledSession(source,{status:true})" in fn
+    assert "_restoreSettledSession(source,{status:true,allowUnmarkedShorterTerminalSnapshot:true})" in fn
     assert "if(status==='active'&&_streamEndRecoveryAttempts<10)" in fn
     assert "_scheduleStreamEndRecovery(source,200);" in fn
     assert "_finalizeStreamEndFallback(source);" in fn


### PR DESCRIPTION
When stream_end arrives without a preceding done event, _restoreSettledSession could overwrite current (complete) messages with stale server data, making the final assistant reply disappear.\n\n- Pass preserveVisibleOnShorterTerminalSnapshot to stream_end handler\n- Relax the terminal-marker requirement for prefix match when the flag is set\n\nCloses #6112