### PR TITLE
fix(streaming): classify final answers by result provenance

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5617,8 +5617,19 @@ def _stamp_missing_message_timestamps(messages, *, now: float | None = None) -> 
     return stamped
 
 
-def _assistant_reply_added_after_current_turn(result_messages, previous_context, msg_text) -> bool:
-    """Return True only when the just-finished turn produced assistant text."""
+def _assistant_reply_added_after_current_turn(
+    result_messages,
+    previous_context,
+    msg_text,
+    *,
+    previous_display=None,
+    drop_replayed_assistant: bool = False,
+) -> bool:
+    """Return True only when the just-finished turn produced assistant text.
+
+    When a terminal/partial result may contain replayed history, an assistant
+    row already present before this turn is not proof of a new final answer.
+    """
     result_messages = list(result_messages or [])
     previous_context = list(previous_context or [])
     if _messages_have_prefix(result_messages, previous_context):
@@ -5626,13 +5637,35 @@ def _assistant_reply_added_after_current_turn(result_messages, previous_context,
     else:
         current_user_idx = _find_current_user_turn(result_messages, msg_text)
         candidates = result_messages[current_user_idx + 1:] if current_user_idx is not None else result_messages
-    return any(
-        isinstance(m, dict)
-        and m.get('role') == 'assistant'
-        and not m.get('_error')
-        and _assistant_message_has_final_visible_text(m)
-        for m in candidates
-    )
+    prior_assistant_ids = set()
+    prior_legacy_assistant_keys = set()
+    if drop_replayed_assistant:
+        for prior in [*list(previous_display or []), *previous_context]:
+            if not isinstance(prior, dict) or prior.get('role') != 'assistant':
+                continue
+            prior_id = prior.get('id')
+            if prior_id is not None:
+                prior_assistant_ids.add(prior_id)
+            else:
+                prior_legacy_assistant_keys.add(_message_identity(prior))
+    for candidate in candidates:
+        if not isinstance(candidate, dict) or candidate.get('role') != 'assistant':
+            continue
+        if candidate.get('_error') or not _assistant_message_has_final_visible_text(candidate):
+            continue
+        if drop_replayed_assistant:
+            candidate_id = candidate.get('id')
+            if candidate_id in prior_assistant_ids:
+                continue
+            if _message_identity(candidate) in prior_legacy_assistant_keys:
+                # Pre-stable-id history is ambiguous because result rows are
+                # stamped just before settlement. Fail closed on a content match:
+                # it may be a replayed legacy row wearing a freshly minted id.
+                # Modern history retains row ids, allowing a genuinely new but
+                # text-identical answer to pass via its distinct id.
+                continue
+        return True
+    return False
 
 
 def _session_lacks_final_assistant_answer(messages) -> bool:
@@ -5731,6 +5764,41 @@ def _merged_transcript_lacks_final_assistant_answer(
         source=source,
         drop_replayed_assistant=drop_replayed_assistant,
     )
+
+
+def _settled_turn_answer_state(
+    previous_display,
+    previous_context,
+    result_messages,
+    msg_text,
+    *,
+    source: str = "webui",
+    drop_replayed_assistant: bool = False,
+) -> tuple[bool, bool]:
+    """Return ``(result_added_answer, transcript_lacks_answer)`` for settlement.
+
+    The transcript evaluator remains fail-safe for checkpointed/repeated prompts,
+    while a provenance-checked new result row can prove that the current turn did
+    produce a final answer. Replayed historical rows never provide that proof.
+    """
+    result_added_answer = _assistant_reply_added_after_current_turn(
+        result_messages,
+        previous_context,
+        msg_text,
+        previous_display=previous_display,
+        drop_replayed_assistant=drop_replayed_assistant,
+    )
+    transcript_lacks_answer = _merged_transcript_lacks_final_assistant_answer(
+        previous_display,
+        previous_context,
+        result_messages,
+        msg_text,
+        source=source,
+        drop_replayed_assistant=drop_replayed_assistant,
+    )
+    if result_added_answer:
+        transcript_lacks_answer = False
+    return result_added_answer, transcript_lacks_answer
 
 
 def _agent_result_terminal_failure(result) -> bool:
@@ -8835,11 +8903,6 @@ def _run_agent_streaming(
                 # checks introduced on master.
                 _all_result_messages = result.get('messages') or []
                 _prev_len = len(_previous_context_messages)
-                _assistant_added = _assistant_reply_added_after_current_turn(
-                    _all_result_messages,
-                    _previous_context_messages,
-                    msg_text,
-                )
                 _last_err = getattr(agent, '_last_error', None) or result.get('error') or ''
                 # #5940: if the Agent aborted on a non-retryable provider error
                 # (captured from its lifecycle status_callback) but left no error on
@@ -8862,7 +8925,7 @@ def _run_agent_streaming(
                     or bool(getattr(agent, '_last_error', None))
                     or ('error' in result and result.get('error') is not None)
                 )
-                _saved_transcript_lacks_final_answer = _merged_transcript_lacks_final_assistant_answer(
+                _result_assistant_added, _saved_transcript_lacks_final_answer = _settled_turn_answer_state(
                     _previous_messages,
                     _previous_context_messages,
                     _all_result_messages,
@@ -8870,6 +8933,7 @@ def _run_agent_streaming(
                     source=getattr(s, 'pending_user_source', None) or 'webui',
                     drop_replayed_assistant=_drop_replayed_assistant,
                 )
+                _assistant_added = _result_assistant_added
                 _is_agent_result_terminal = _agent_result_terminal_failure(result)
                 _terminal_failure = (
                     _captured_terminal_failure

--- a/tests/test_issue5141_terminal_failure_transcript_evaluator.py
+++ b/tests/test_issue5141_terminal_failure_transcript_evaluator.py
@@ -126,3 +126,126 @@ def test_merged_wrapper_delegates_to_turn_evaluator():
     assert calls[0]["source"] == "cli"
     assert calls[0]["drop_replayed_assistant"] is True
     assert calls[0]["merged_len"] >= 1
+
+
+def test_checkpointed_current_user_accepts_new_result_answer_by_provenance():
+    msg_text = "current prompt"
+    previous_display = [
+        {"role": "user", "content": "older prompt"},
+        {"role": "assistant", "content": "older answer"},
+        {"role": "user", "content": msg_text},
+    ]
+    result_messages = list(previous_display) + [
+        {"role": "assistant", "content": "real final answer"},
+    ]
+
+    # The positional merged evaluator is intentionally conservative at this
+    # checkpoint boundary, but result provenance proves the unique final row.
+    assert streaming._settled_turn_answer_state(
+        previous_display,
+        previous_display,
+        result_messages,
+        msg_text,
+        source="webui",
+        drop_replayed_assistant=True,
+    ) == (True, False)
+
+
+def test_checkpointed_repeated_prompt_rejects_replayed_historical_answer():
+    msg_text = "repeat this"
+    stale_answer = {"id": 2, "role": "assistant", "content": "historical answer"}
+    previous_display = [
+        {"id": 1, "role": "user", "content": msg_text},
+        dict(stale_answer),
+        {"id": 3, "role": "user", "content": msg_text},
+    ]
+    result_messages = list(previous_display) + [dict(stale_answer)]
+
+    assert streaming._settled_turn_answer_state(
+        previous_display,
+        previous_display,
+        result_messages,
+        msg_text,
+        source="webui",
+        drop_replayed_assistant=True,
+    ) == (False, True)
+
+
+def test_identical_new_answer_is_valid_when_it_has_new_row_identity():
+    msg_text = "repeat this"
+    previous_display = [
+        {"id": 1, "role": "user", "content": msg_text},
+        {"id": 2, "role": "assistant", "content": "same answer"},
+        {"id": 3, "role": "user", "content": msg_text},
+    ]
+    result_messages = list(previous_display) + [
+        {"id": 4, "role": "assistant", "content": "same answer"},
+    ]
+
+    assert streaming._settled_turn_answer_state(
+        previous_display,
+        previous_display,
+        result_messages,
+        msg_text,
+        source="webui",
+        drop_replayed_assistant=True,
+    ) == (True, False)
+
+
+def test_replay_filter_unions_display_and_context_row_ids():
+    msg_text = "current prompt"
+    previous_display = [
+        {"id": 1, "role": "user", "content": msg_text},
+    ]
+    context_only_answer = {"id": 2, "role": "assistant", "content": "context answer"}
+    previous_context = [*previous_display, context_only_answer]
+    result_messages = [*previous_context, dict(context_only_answer)]
+
+    assert streaming._assistant_reply_added_after_current_turn(
+        result_messages,
+        previous_context,
+        msg_text,
+        previous_display=previous_display,
+        drop_replayed_assistant=True,
+    ) is False
+
+
+def test_structured_content_without_text_is_not_a_final_answer():
+    previous = [{"id": 1, "role": "user", "content": "prompt"}]
+    result_messages = [
+        *previous,
+        {"id": 2, "role": "assistant", "content": [{"type": "image"}]},
+    ]
+
+    assert streaming._assistant_reply_added_after_current_turn(
+        result_messages,
+        previous,
+        "prompt",
+        previous_display=previous,
+        drop_replayed_assistant=True,
+    ) is False
+
+
+def test_legacy_idless_replay_with_freshly_minted_id_is_rejected():
+    msg_text = "repeat this"
+    previous_display = [
+        {"role": "user", "content": msg_text},
+        {"role": "assistant", "content": "legacy answer"},
+        {"role": "user", "content": msg_text},
+    ]
+    # Settlement stamps an id on every id-less result row. A replayed legacy
+    # assistant can therefore arrive with a fresh id even though its prior copy
+    # had none; content fallback must still reject it.
+    result_messages = [
+        *previous_display,
+        {"id": 4, "role": "assistant", "content": "legacy answer"},
+    ]
+
+    assert streaming._settled_turn_answer_state(
+        previous_display,
+        previous_display,
+        result_messages,
+        msg_text,
+        source="webui",
+        drop_replayed_assistant=True,
+    ) == (False, True)


### PR DESCRIPTION
## Summary

- classifies a settled assistant answer from the current agent result, not only from the reconstructed display transcript
- rejects historical assistant rows replayed from display/context history by stable row ID
- preserves fail-closed handling for legacy ID-less history and structured assistant content without final visible text

This supersedes the current approach in #5902 and implements the provenance-aware fix requested in its formal review.

## Root cause

A current user row may already be checkpointed in `previous_display` before turn settlement. In that geometry, the merged-transcript evaluator can conservatively report that the turn still ends at the user row even when the provider result contains a real new final assistant row. The silent-failure fallback then emits `no_response` after the completed answer.

Simply moving the positional boundary is unsafe: a repeated prompt plus context backfill can place a stale historical assistant row after that boundary. That is the blocker identified on #5902.

The settlement gate now combines two signals:

1. the existing merged-transcript evaluator remains fail-closed;
2. a final answer can override it only when the current result contains a usable assistant row whose stable row ID is absent from both pre-turn display and context history.

Legacy history without row IDs falls back conservatively to content identity because settlement may just have minted a new ID onto a replayed old row.

## State/invariant

State layer: the live-to-final run settlement in `api/streaming.py`.

Invariant: a completed provider answer must settle once without a trailing synthetic `no_response`; a replayed/backfilled historical answer must never make an answerless current turn appear successful. Explicit terminal failures, cancellation, compression exhaustion, and tool-limit exits retain their existing gates.

## Verification

- `113 passed` across:
  - terminal-failure transcript evaluation
  - cancellation
  - streaming persistence
  - compression terminal failures
  - tool-limit terminal state
  - transcript compaction
- focused test file passes Ruff
- `py_compile` passes
- `git diff --check` passes
- live isolated Codex smoke:
  - SSE: tokens → one `done` → one `stream_end`
  - no `apperror` / `no_response`
  - persisted transcript contains exactly one user row and one final assistant row, with no `_partial` or `_error` rows

The full `api/streaming.py` Ruff scan has the same seven unrelated baseline findings as `origin/master`; this change introduces none.

## Regression coverage

Covers:

- checkpointed current prompt plus a genuinely new final result row
- repeated prompt plus replayed historical answer
- legitimate text-identical answer with a distinct stable row ID
- context-only historical replay
- structured content with no final visible text
- legacy ID-less replay that receives a freshly minted result ID
