### PR TITLE
Release: clear stale gateway approval attention badge (#6117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale sidebar approval attention badge now clears once its gateway approval has drained.** A parent session could keep showing the red approval "attention" dot in the sidebar after the underlying gateway approval was already resolved/gone — the live gateway queue drained but the sidebar summary kept the mirrored approval alive. `_session_attention_summary()` now reconciles the gateway pending-mirror before counting attention (the same self-healing repair the approval-pending route already does), so the badge clears correctly. Live approvals stay visible and actionable and the clarify fallback is unchanged. This is the WebUI read-path mitigation; the child-session context-propagation root cause stays tracked in #6100. Thanks @rodboev. (#6117, #6100)
+
 ### Added
 
 - **Pinch-to-zoom for Mermaid diagrams on touch devices.** The zoomable Mermaid viewer (which already had mouse-wheel zoom + single-finger pan) now supports two-finger pinch-to-zoom on phones/tablets, anchored on the pinch midpoint. Pointer/drag handlers are guarded so an active pinch never fights the pan gesture; desktop mouse-wheel zoom and single-finger pan are unchanged. Uses Touch Events for iOS Safari robustness. Thanks @silent-reader-cn. (#5913)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9528,6 +9528,7 @@ def _session_attention_summary(session_id: str) -> dict | None:
     """Return sidebar attention metadata for pending approval/clarify work."""
     approval_count = 0
     with _lock:
+        reconcile_gateway_pending_mirror_locked(session_id)
         queue_list = _pending.get(session_id)
         if isinstance(queue_list, list):
             approval_count = len(queue_list)

--- a/tests/test_session_attention_badges.py
+++ b/tests/test_session_attention_badges.py
@@ -2,6 +2,7 @@ import io
 import json
 import pathlib
 import sys
+from types import SimpleNamespace
 from urllib.parse import urlparse
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -40,6 +41,56 @@ def _clear_attention_state(*session_ids):
             routes._gateway_queues.pop(sid, None)
     for sid in session_ids:
         clarify.clear_pending(sid)
+
+
+def test_attention_summary_purges_stale_gateway_mirror():
+    sid = "attention-stale-gateway-session"
+    _clear_attention_state(sid)
+    try:
+        approval = {
+            "approval_id": "stale-gateway-approval",
+            "command": "rm -rf /tmp/nope",
+            "description": "Danger",
+        }
+        with routes._lock:
+            routes._gateway_queues[sid] = [SimpleNamespace(data=dict(approval))]
+        routes.submit_gateway_pending_mirror(sid, approval)
+
+        with routes._lock:
+            assert routes._pending[sid]
+            routes._gateway_queues[sid].pop(0)
+            assert routes._pending[sid]
+
+        assert routes._session_attention_summary(sid) is None
+        with routes._lock:
+            assert sid not in routes._pending
+    finally:
+        _clear_attention_state(sid)
+
+
+def test_attention_summary_keeps_live_gateway_mirror():
+    sid = "attention-live-gateway-session"
+    _clear_attention_state(sid)
+    try:
+        approval = {
+            "approval_id": "live-gateway-approval",
+            "command": "touch /tmp/nope",
+            "description": "Also danger",
+        }
+        with routes._lock:
+            routes._gateway_queues[sid] = [SimpleNamespace(data=dict(approval))]
+        routes.submit_gateway_pending_mirror(sid, approval)
+
+        assert routes._session_attention_summary(sid) == {
+            "kind": "approval",
+            "count": 1,
+            "severity": "critical",
+        }
+        with routes._lock:
+            assert len(routes._pending[sid]) == 1
+            assert routes._pending[sid][0]["approval_id"] == approval["approval_id"]
+    finally:
+        _clear_attention_state(sid)
 
 
 def test_attention_summary_prefers_pending_approvals_over_clarify_questions():


### PR DESCRIPTION
## Release: clear stale gateway approval attention badge (#6117)

Ships **#6117** by @rodboev (fixes the WebUI slice of #6100).

### What
`_session_attention_summary()` now reconciles the gateway pending-mirror before counting sidebar approval attention, so a parent session's red approval "attention" dot clears once the underlying gateway approval has already drained. Live approvals stay visible + actionable; the clarify fallback is unchanged. This is the self-healing read-path repair the approval-pending route already does, applied to the shared sidebar summary path too.

### Scope
- `api/routes.py`: +1 line (reconcile call inside the already-held `_lock`)
- `tests/test_session_attention_badges.py`: +51 (stale-mirror reproduction + live-head preservation)

### Gate
- **Codex adversarial review: SAFE TO SHIP (5/5)** — no deadlock (reconcile is CALLER-MUST-HOLD-`_lock`, no re-acquire), mirror-only purge (live head + ordinary approvals + clarify all preserved), all 5 existing reconcile sites unchanged, base-fails/head-passes reproduction confirmed.
- **Full suite: 13,133 passed** (0 failures), single-process.
- Gateway/approval/attention/clarify slice: 826 passed.
- CI green (18/18) on the source branch.

Co-authored-by: rodboev <rodboev@users.noreply.github.com>

Closes #6117.
