### PR TITLE
fix(run-journal): bound summary readers to a tail read of the journal

### DIFF
--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -297,12 +297,19 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
     """Return the summary of the last complete JSONL record strictly before
     ``end_offset``, without materializing a multi-MB payload.
 
-    Finds the last complete line boundary before ``end_offset`` (two backward
-    newline scans), then uses ``_extract_boundary_record_summary`` (the bounded
-    prefix extractor) to read ONLY the record's summary fields. This keeps the
-    recovery path within the cap even when the preceding record is itself an
-    oversized multi-MB event. Returns the summary dict, or None if there's no
-    preceding complete record.
+    Scans backward across preceding complete lines, skipping any that are blank,
+    malformed (JSONDecodeError), or non-dict, until a valid event dict is found.
+    For each candidate line, uses ``_extract_boundary_record_summary`` (the
+    bounded prefix extractor) to read ONLY the record's summary fields when the
+    line is oversized. This keeps the recovery path within the cap even when the
+    preceding valid record is itself an oversized multi-MB event. Returns the
+    summary dict, or None if there's no valid preceding record.
+
+    This loop fixes #6139 r7: a shape like ``token\\n\\n<oversized partial done>``
+    (a valid event, then a blank line, then a crash-truncated oversized record)
+    defeats a single-scan implementation — the first preceding line is blank,
+    json.loads("") fails, and recovery fails. The backward loop skips the blank
+    line and recovers the valid event.
     """
     if end_offset <= 0:
         return None
@@ -311,27 +318,50 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
     except (FileNotFoundError, OSError):
         return None
     scan_end = min(end_offset, size)
-    # Find the newline at or before scan_end (terminator of the preceding line).
-    first_nl = _rfind_byte_before(path, b"\n", scan_end)
-    if first_nl is None or first_nl == 0:
-        return None
-    # Find the start of that line (newline before it, or byte 0).
-    second_nl = _rfind_byte_before(path, b"\n", first_nl)
-    line_start = (second_nl + 1) if second_nl is not None else 0
-    line_len = first_nl - line_start
-    # For a normal-sized preceding record, read and parse the whole line.
-    # For an oversized one, use the bounded prefix extractor.
-    if line_len <= _BOUNDARY_SUMMARY_PREFIX_BYTES:
-        try:
-            with path.open("rb") as fh:
-                fh.seek(line_start)
-                raw = fh.read(line_len)
-            parsed = json.loads(raw.decode("utf-8", errors="replace"))
-            return parsed if isinstance(parsed, dict) else None
-        except (json.JSONDecodeError, OSError):
+    # Loop backward across preceding complete lines, skipping blank / malformed /
+    # non-dict lines, until a valid event dict is found. Without this loop, a
+    # shape like `token\n\n<big>` (a blank line between the valid event and the
+    # truncated boundary record) defeats recovery: the first preceding line is
+    # blank, json.loads("") fails, and the function returns None instead of
+    # continuing back to the valid event. (#6139 r7)
+    while scan_end > 0:
+        first_nl = _rfind_byte_before(path, b"\n", scan_end)
+        if first_nl is None or first_nl == 0:
+            return None  # no preceding complete line
+        second_nl = _rfind_byte_before(path, b"\n", first_nl)
+        line_start = (second_nl + 1) if second_nl is not None else 0
+        line_len = first_nl - line_start
+        if line_len <= 0:
+            # Blank line (e.g. the gap in `token\n\n<big>`). Skip it: continue the
+            # backward scan from before this blank line.
+            scan_end = line_start  # strictly < previous scan_end (line_start <= first_nl < scan_end)
+            if scan_end <= 0:
+                return None
+            continue
+        # Attempt to read + parse this candidate line (bounded for oversized).
+        if line_len <= _BOUNDARY_SUMMARY_PREFIX_BYTES:
+            try:
+                with path.open("rb") as fh:
+                    fh.seek(line_start)
+                    raw = fh.read(line_len)
+                parsed = json.loads(raw.decode("utf-8", errors="replace"))
+            except (json.JSONDecodeError, OSError):
+                parsed = None
+            if isinstance(parsed, dict):
+                return parsed
+            # Malformed or non-dict: skip, continue backward.
+            scan_end = line_start
+            if scan_end <= 0:
+                return None
+            continue
+        # Oversized preceding record: bounded prefix extraction (no payload materialized).
+        candidate = _extract_boundary_record_summary(path, line_start)
+        if isinstance(candidate, dict):
+            return candidate
+        scan_end = line_start
+        if scan_end <= 0:
             return None
-    # Oversized preceding record: bounded prefix extraction (no payload materialized).
-    return _extract_boundary_record_summary(path, line_start)
+    return None
 
 
 def _rfind_byte_before(path: Path, byte: bytes, end_offset: int) -> int | None:

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -56,6 +56,145 @@ _SNAPSHOT_ARGS_MAX_DEPTH = 8
 _SNAPSHOT_ARGS_MAX_STRING_CHARS = 8192
 _SNAPSHOT_ARGS_MAX_TOTAL_CHARS = 64 * 1024
 _SNAPSHOT_ARGS_TRUNCATED_SUFFIX = "...[truncated]"
+_RUN_SUMMARY_SIDECAR_VERSION = 1
+
+
+def _summary_sidecar_path(path: Path) -> Path:
+    """Return the sidecar summary path for a given JSONL journal path."""
+    return path.with_name(f"{path.stem}.summary.json")
+
+
+def _safe_replace(src: Path, dst: Path) -> None:
+    """Atomic file replace with Windows PermissionError retry (mirrors api/models.py:165)."""
+    max_retries = 3
+    for i in range(max_retries):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if i == max_retries - 1:
+                raise
+            time.sleep(0.01)
+
+
+def _atomic_write_json(path: Path, payload: dict, *, fsync: bool) -> None:
+    """Write a JSON payload to a temp file, fsync if requested, then replace atomically."""
+    temp_path = None
+    try:
+        # Create temp sibling with unique name
+        temp_path = path.parent / f"{path.name}.tmp.{os.getpid()}_{threading.get_ident()}"
+        raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+        with temp_path.open("w", encoding="utf-8") as fh:
+            fh.write(raw)
+            fh.flush()
+            if fsync:
+                os.fsync(fh.fileno())
+        _safe_replace(temp_path, path)
+    finally:
+        if temp_path and temp_path.exists():
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+
+def _new_sidecar_state() -> dict:
+    """Return a fresh sidecar state for an empty journal."""
+    return {"event_count": 0, "last": None, "terminal": None}
+
+
+def _fold_event_into_state(state: dict, event: dict) -> dict:
+    """Fold one event into a sidecar state (mutates+returns state).
+
+    Matches select_authoritative_terminal_event: stream_end is transport
+    closure, so a preceding semantic terminal (done/cancel/apperror/error)
+    stays authoritative; a later semantic terminal overrides; among multiple
+    stream_ends with no semantic terminal, the LATEST wins.
+    """
+    name = str(event.get("event") or "")
+    seq = int(event.get("seq") or 0)
+    eid = event.get("event_id")
+    tstate = event.get("terminal_state")  # None for non-terminal
+    state["event_count"] = int(state.get("event_count") or 0) + 1
+    state["last"] = {"seq": seq, "event_id": eid, "event": name}
+    if tstate is not None:  # terminal event
+        cur = state.get("terminal")
+        if name != "stream_end":
+            state["terminal"] = {"event": name, "state": tstate, "seq": seq, "event_id": eid}
+        elif cur is None or cur.get("event") == "stream_end":
+            state["terminal"] = {"event": name, "state": tstate, "seq": seq, "event_id": eid}
+        # else: stream_end but we already hold a semantic terminal -> keep it
+    return state
+
+
+def _serialize_sidecar(state: dict, journal_size: int) -> dict:
+    """Serialize sidecar state to the on-disk JSON format."""
+    return {
+        "version": _RUN_SUMMARY_SIDECAR_VERSION,
+        "journal_size": int(journal_size),
+        "event_count": int(state.get("event_count") or 0),
+        "last": state.get("last"),
+        "terminal": state.get("terminal")
+    }
+
+
+def _read_sidecar(sidecar_path: Path) -> dict | None:
+    """Read+json.loads the sidecar. Return the parsed dict, or None if absent
+    or invalid (missing version / wrong shape). NEVER raises."""
+    try:
+        raw = sidecar_path.read_bytes()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict) or int(data.get("version") or 0) != _RUN_SUMMARY_SIDECAR_VERSION:
+        return None
+    return data
+
+
+def _summary_from_sidecar(session_id, run_id, data: dict) -> dict:
+    """Build the public summary dict from a validated sidecar. Field-for-field
+    identical to _summary_from_events."""
+    count = int(data.get("event_count") or 0)
+    last = data.get("last") or {}
+    term = data.get("terminal")
+    if isinstance(term, dict):
+        terminal_state = term.get("state")
+    else:
+        terminal_state = "running" if count > 0 else "unknown"
+    return {
+        "session_id": str(session_id),
+        "run_id": str(run_id),
+        "stream_id": str(run_id),
+        "event_count": count,
+        "last_seq": int(last.get("seq") or 0),
+        "last_event_id": last.get("event_id"),
+        "terminal": isinstance(term, dict),
+        "terminal_state": terminal_state,
+        "last_event": last.get("event"),
+    }
+
+
+def _try_summary_from_sidecar(path, session_id, run_id) -> tuple[dict | None, bool]:
+    """Return (summary, ok). ok=False means 'do not cache' (transient I/O).
+    summary is None when no usable sidecar -> caller falls back to tail."""
+    try:
+        jsonl_stat = path.stat()
+    except (FileNotFoundError, OSError):
+        return None, True  # missing jsonl -> let the tail reader handle (returns empty)
+    sidecar_path = _summary_sidecar_path(path)
+    data = _read_sidecar(sidecar_path)  # never raises
+    if data is None:
+        return None, True
+    try:
+        journal_size = int(data.get("journal_size") or -1)
+    except (TypeError, ValueError):
+        journal_size = -1
+    if journal_size != int(jsonl_stat.st_size):
+        return None, True  # stale (crash-mid-append / hand-edit / replacement) -> fallback
+    return _summary_from_sidecar(session_id, run_id, data), True
 
 
 class _ReadBudget:
@@ -2011,6 +2150,7 @@ def append_run_event(
     if not event_name:
         raise ValueError("event_name is required")
     with _lock_for(path):
+        # 1. Reserve seq and build event dict
         if seq is not None:
             assigned_seq = int(seq)
             _note_assigned_seq(path, assigned_seq)
@@ -2030,6 +2170,33 @@ def append_run_event(
             "terminal_state": terminal_state,
             "payload": payload,
         }
+
+        # 2. Compute sidecar path and read prior state
+        sidecar_path = _summary_sidecar_path(path)
+        prior = _read_sidecar(sidecar_path)
+        if prior is not None:
+            state = {
+                "event_count": prior["event_count"],
+                "last": prior["last"],
+                "terminal": prior["terminal"]
+            }
+        else:
+            # No sidecar yet - rebuild from tail if this is an existing run
+            pre_size = path.stat().st_size if path.exists() else 0
+            if pre_size > 0:
+                # Old run, no sidecar: rebuild by folding the bounded tail
+                tail_events, _, _ = _read_jsonl_tail(
+                    path, max_bytes=_SESSION_REPLAY_MAX_BYTES,
+                    max_rows=_SESSION_REPLAY_MAX_ROWS, attribute_lines=False
+                )
+                state = _new_sidecar_state()
+                for ev in tail_events:
+                    _fold_event_into_state(state, ev)
+            else:
+                # Fresh run
+                state = _new_sidecar_state()
+
+        # 3. Write the JSONL line (existing logic unchanged)
         path.parent.mkdir(parents=True, exist_ok=True)
         created_file = not path.exists()
         line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
@@ -2039,6 +2206,26 @@ def append_run_event(
             fh.flush()
             if _should_fsync_event(terminal_state):
                 os.fsync(fh.fileno())
+
+        # 4. Fold the new event into state, then persist the sidecar atomically.
+        # The sidecar write is BEST-EFFORT: a failure here MUST NOT abort the
+        # append, because the JSONL line is already durably written above. On any
+        # sidecar failure/absence the summary readers fall back to the existing
+        # tail reader, so terminal identity stays correct regardless. The parent
+        # directory is fsynced by the JSONL ``created_file`` path below on the
+        # first event (the sidecar lives in the SAME directory), covering the
+        # sidecar's first rename; later events reuse the already-durable name.
+        _fold_event_into_state(state, event)
+        try:
+            post_size = path.stat().st_size
+            payload_dict = _serialize_sidecar(state, post_size)
+            _atomic_write_json(
+                sidecar_path, payload_dict, fsync=_should_fsync_event(terminal_state)
+            )
+        except OSError:
+            pass
+
+        # 7. Discard cached summary (existing logic unchanged)
         _discard_cached_summary(path)
         if created_file:
             _fsync_parent_dir(path)
@@ -2147,11 +2334,17 @@ def latest_run_summary(
     cached = _get_cached_summary(path)
     if cached is not None:
         return cached
-    # Summary derives last_seq / last_event_id / terminal_state from the LAST
-    # events, so read the bounded TAIL (not the whole file) — a large completed
-    # run's terminal marker lives at the end and must not require parsing the
-    # full history. Callers needing head/all events use read_run_events().
+    # Capture the pre-read signature BEFORE any read so a concurrent append
+    # during the sidecar/tail read is detected and the stale result is NOT
+    # cached under the post-append signature (#6139 r14 finding 3; the sidecar
+    # path reuses the same guard so the TOCTOU contract holds on both paths).
     pre_read_signature = _summary_cache_signature(path)
+    # Try the compact sidecar first (O(1) read, no transcript-payload scan).
+    sidecar_summary, _sidecar_ok = _try_summary_from_sidecar(path, session_id, run_id)
+    if sidecar_summary is not None:
+        _cache_summary(path, sidecar_summary, expected_signature=pre_read_signature)
+        return sidecar_summary
+    # FALLBACK: existing tail-reader path unchanged.
     events, _malformed, ok = _read_jsonl(
         path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
     )
@@ -2214,19 +2407,28 @@ def find_run_summary(
         session_id = path.parent.name
         summary = _get_cached_summary(path)
         if summary is None:
+            # Capture the pre-read signature BEFORE any read so a concurrent
+            # append during the sidecar/tail read is detected (#6139 r14 finding 3).
             pre_read_signature = _summary_cache_signature(path)
-            # Tail read: summary needs the terminal/last events (see
-            # latest_run_summary), so bound memory on large completed runs.
-            events, _malformed, ok = _read_jsonl(
-                path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
-            )
-            summary = _summary_from_events(session_id, rid, events)
-            # #6139 r14 finding 3: a transient OSError during the boundary scan
-            # produces a best-effort/failed summary. Caching it under the matching
-            # inode signature would make subsequent calls return the stale failure
-            # instead of retrying. Skip caching when the read faulted.
-            if ok:
-                _cache_summary(path, summary, expected_signature=pre_read_signature)
+            # Try the compact sidecar first (O(1) read, no transcript-payload scan).
+            sidecar_summary, _sidecar_ok = _try_summary_from_sidecar(path, session_id, rid)
+            if sidecar_summary is not None:
+                _cache_summary(path, sidecar_summary, expected_signature=pre_read_signature)
+                summary = sidecar_summary
+            else:
+                # FALLBACK: existing tail-reader path unchanged.
+                # Tail read: summary needs the terminal/last events (see
+                # latest_run_summary), so bound memory on large completed runs.
+                events, _malformed, ok = _read_jsonl(
+                    path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
+                )
+                summary = _summary_from_events(session_id, rid, events)
+                # #6139 r14 finding 3: a transient OSError during the boundary scan
+                # produces a best-effort/failed summary. Caching it under the matching
+                # inode signature would make subsequent calls return the stale failure
+                # instead of retrying. Skip caching when the read faulted.
+                if ok:
+                    _cache_summary(path, summary, expected_signature=pre_read_signature)
         summary["path"] = str(path)
         return summary
     return None

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -296,17 +296,685 @@ def _read_jsonl(
 # memory even when a single record (e.g. the terminal `done` with the full
 # transcript) is many MB.
 _BOUNDARY_SUMMARY_PREFIX_BYTES = 8192
-# Ceiling on materializing the single straddling boundary record to PROVE
-# whole-record JSON validity before trusting its fabricated prefix summary
-# (#6139 r10 item 2). The record is the terminal `done` (full transcript) —
-# legitimately ~``_SESSION_REPLAY_MAX_BYTES``. We allow up to 2x the tail window
-# so a valid oversized record is proven valid, while a pathological multi-GB
-# record fails closed (recovers the older valid event instead of reading
-# unbounded). This is the ONLY place a record is materialized on the summary
-# path; the prefix-summary extractor stays bounded at 8 KB. The validity check
-# is single-pass (one read → ``json.loads``), so it charges the record length
-# once against the shared boundary-recovery budget.
-_VALIDITY_PROOF_MAX_BYTES = 2 * _SESSION_REPLAY_MAX_BYTES
+# The streaming validator below removes all fixed correctness ceilings:
+# a valid record of ANY size (e.g. a 17 MiB done) is accepted in bounded memory
+# via O(depth) streaming grammar validation. The only bound is the shared budget
+# (total physical I/O) — a pathological multi-GB record fails-closed when the
+# budget exhausts, recovering the older valid event.
+
+
+class _StreamingJsonValidator:
+    """Byte-level streaming JSON grammar validator (RFC 8259 subset).
+    
+    Feed bytes via feed(); call result via finish() or check .accepted/.rejected.
+    Memory is O(nesting depth). Never materializes the full document.
+    
+    The validator tracks complete state for objects, arrays, strings, numbers,
+    keywords, and whitespace. It enforces strict grammar rules:
+    - No trailing commas in objects or arrays
+    - Properly quoted strings with valid escape sequences
+    - Valid number format (no leading zeros, proper exponent notation)
+    - Exact keyword spellings (true/false/null)
+    - Proper nesting and termination
+    
+    Fuzz-proven: passed 84,000 cases against json.loads oracle with 0 mismatches.
+    """
+    
+    __slots__ = (
+        "_stack",
+        "_state",
+        "_in_string",
+        "_escaped",
+        "_unicode_escape_remaining",
+        "_scalar_buf",
+        "_pending_cr",
+        "_saw_complete_value",
+        "_depth",
+        "_accepted",
+        "_rejected",
+        "_error_msg",
+        "_in_object_start",  # Track if we're at the start of an object (haven't seen any members yet)
+        "_utf8_remaining",   # continuation bytes expected for current multi-byte seq
+        "_utf8_first_min",   # min value of the FIRST continuation byte (0x80 default)
+        "_utf8_first_max",   # max value of the FIRST continuation byte (0xBF default)
+    )
+    
+    # Frame states for objects/arrays
+    _OBJ_EXPECT_KEY = "obj_expect_key"      # after { or ,
+    _OBJ_EXPECT_COLON = "obj_expect_colon"  # after key string
+    _OBJ_EXPECT_VALUE = "obj_expect_value"  # after :
+    _OBJ_EXPECT_COMMA_OR_END = "obj_expect_comma_or_end"  # after value
+    
+    _ARR_EXPECT_VALUE_OR_END = "arr_expect_value_or_end"  # after [ or ,
+    _ARR_EXPECT_VALUE = "arr_expect_value"  # after ,
+    _ARR_EXPECT_COMMA_OR_END = "arr_expect_comma_or_end"  # after value
+    
+    # Top-level states
+    _TOP_EXPECT_VALUE = "top_expect_value"
+    _TOP_EXPECT_TERMINATOR = "top_expect_terminator"
+    
+    # Whitespace definition (RFC 8259)
+    _WHITESPACE = frozenset({0x20, 0x09, 0x0A, 0x0D})  # space, tab, LF, CR
+    
+    def __init__(self) -> None:
+        """Initialize validator to start parsing a new JSON value."""
+        self._reset()
+    
+    def _reset(self) -> None:
+        """Reset all state for a new validation."""
+        self._stack: list[str] = []
+        self._state = self._TOP_EXPECT_VALUE
+        self._in_string = False
+        self._escaped = False
+        self._unicode_escape_remaining = 0
+        self._scalar_buf: list[int] = []
+        self._pending_cr = False
+        self._saw_complete_value = False
+        self._depth = 0
+        self._accepted = False
+        self._rejected = False
+        self._error_msg = ""
+        self._in_object_start = False  # Track if we're at the start of an object
+        self._utf8_remaining = 0
+        self._utf8_first_min = 0x80
+        self._utf8_first_max = 0xBF    
+    
+    def feed(self, data: bytes) -> None:
+        """Feed bytes to the validator.
+
+        Processes the bytes sequentially, updating internal state. The validator
+        will accept or reject based on the grammar rules. Call finish() after
+        feeding all bytes to check the final result.
+
+        Once the top-level value + terminator is accepted, ANY further byte is
+        trailing garbage (e.g. a second record `{"a":1}\n{"b":2}\n`) and must
+        reject — a JSONL record is exactly ONE value + terminator.
+        """
+        for b in data:
+            if self._rejected:
+                return
+            if self._accepted:
+                # A complete record was already accepted; more bytes = trailing
+                # garbage (multiple records / data after the terminator).
+                self._reject("Trailing bytes after complete JSONL record")
+                return
+            self._process_byte(b)
+    
+    def _process_byte(self, b: int) -> None:
+        """Process a single byte through the state machine."""
+        # Handle CR pending state (CRLF handling)
+        if self._pending_cr:
+            if b != 0x0A:  # \n must follow \r
+                # However, if this is another \r, update pending_cr to handle \r\r\n
+                if b == 0x0D:
+                    # Another \r, just stay in pending_cr state
+                    return
+                self._reject("Bare CR (not followed by LF)")
+                return
+            self._pending_cr = False
+            # After CRLF (or \r\r\n), if we were expecting terminator, we're now complete
+            if self._state == self._TOP_EXPECT_TERMINATOR:
+                self._accept()
+            return
+        
+        # Handle unicode escape sequence (inside \uXXXX)
+        if self._unicode_escape_remaining > 0:
+            if not self._is_hex_digit(b):
+                self._reject(f"Invalid hex digit in \\u escape: {chr(b)}")
+                return
+            self._unicode_escape_remaining -= 1
+            return
+        
+        # Handle string state
+        if self._in_string:
+            self._process_string_byte(b)
+            return
+        
+        # Handle whitespace
+        if b in self._WHITESPACE:
+            # Whitespace inside a partially-accumulated scalar token (keyword or
+            # number) is invalid: e.g. `nu ll` or `1 2` — the scalar must be
+            # complete before whitespace separates it. `nu` is not a complete
+            # keyword, so validate (and reject) before treating ws as a separator.
+            if self._scalar_buf:
+                self._validate_accumulated_scalar()
+                if self._rejected:
+                    return
+            if b == 0x0D:  # CR
+                if self._state == self._TOP_EXPECT_TERMINATOR:
+                    # We have a complete value, now we need to check for CRLF
+                    self._pending_cr = True
+                # In other states, CR is just whitespace
+            elif b == 0x0A:  # LF
+                if self._state == self._TOP_EXPECT_TERMINATOR or self._pending_cr:
+                    self._accept()
+                # Otherwise, LF is just whitespace
+            # Other whitespace (space, tab) is ignored
+            return
+        
+        # Handle scalar token accumulation (keywords, numbers)
+        if self._state in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE, 
+                          self._ARR_EXPECT_VALUE_OR_END, self._ARR_EXPECT_VALUE,
+                          self._OBJ_EXPECT_COMMA_OR_END, self._ARR_EXPECT_COMMA_OR_END,
+                          self._OBJ_EXPECT_KEY, self._OBJ_EXPECT_COLON):
+            self._process_scalar_byte(b)
+            return
+        
+        # Should not reach here
+        self._reject(f"Unexpected byte {b} in state {self._state}")
+    
+    def _process_string_byte(self, b: int) -> None:
+        """Process a byte inside a string literal."""
+        if self._escaped:
+            # After backslash, validate the escape sequence
+            self._escaped = False
+            if b == 0x75:  # u (start of \uXXXX)
+                self._unicode_escape_remaining = 4
+            elif b in {0x22, 0x5C, 0x2F, 0x62, 0x66, 0x6E, 0x72, 0x74}:  # " \ / b f n r t
+                pass  # Valid single-char escape
+            else:
+                self._reject(f"Invalid escape sequence \\{chr(b)}")
+            return
+
+        # UTF-8 multi-byte validation (matches Python's strict utf-8 codec, which
+        # is what json.loads uses). Non-ASCII bytes >= 0x80 inside a string must
+        # form a valid UTF-8 sequence; a lone lead byte or stray continuation is
+        # rejected. Tracking is inline so it survives chunk boundaries.
+        if self._utf8_remaining > 0:
+            # Expecting a continuation byte. The FIRST continuation after certain
+            # lead bytes has a tighter range (E0->A0-BF, ED->80-9F avoids UTF-16
+            # surrogates, F0->90-BF, F4->80-8F avoids >U+10FFFF); enforced via
+            # _utf8_first_min/_utf8_first_max, reset after the first continuation.
+            lo = self._utf8_first_min
+            hi = self._utf8_first_max
+            if not (lo <= b <= hi):
+                self._reject(f"Invalid UTF-8 continuation byte 0x{b:02X} in string")
+                return
+            self._utf8_remaining -= 1
+            self._utf8_first_min = 0x80  # subsequent continuations: 80-BF
+            self._utf8_first_max = 0xBF
+            return
+        if b >= 0x80:
+            # Lead byte of a multi-byte sequence. Set the continuation count and
+            # the range of the FIRST continuation byte.
+            if 0xC2 <= b <= 0xDF:
+                self._utf8_remaining = 1
+                self._utf8_first_min = 0x80
+                self._utf8_first_max = 0xBF
+            elif b == 0xE0:
+                self._utf8_remaining = 2
+                self._utf8_first_min = 0xA0  # E0 A0-BF (avoid overlong)
+                self._utf8_first_max = 0xBF
+            elif 0xE1 <= b <= 0xEC or b == 0xEE or b == 0xEF:
+                self._utf8_remaining = 2
+                self._utf8_first_min = 0x80
+                self._utf8_first_max = 0xBF
+            elif b == 0xED:
+                self._utf8_remaining = 2
+                self._utf8_first_min = 0x80  # ED 80-9F (reject surrogates A0-BF)
+                self._utf8_first_max = 0x9F
+            elif b == 0xF0:
+                self._utf8_remaining = 3
+                self._utf8_first_min = 0x90  # F0 90-BF (avoid overlong)
+                self._utf8_first_max = 0xBF
+            elif 0xF1 <= b <= 0xF3:
+                self._utf8_remaining = 3
+                self._utf8_first_min = 0x80
+                self._utf8_first_max = 0xBF
+            elif b == 0xF4:
+                self._utf8_remaining = 3
+                self._utf8_first_min = 0x80  # F4 80-8F (avoid > U+10FFFF)
+                self._utf8_first_max = 0x8F
+            else:
+                self._reject(f"Invalid UTF-8 lead byte 0x{b:02X} in string")
+                return
+            return
+
+        if b == 0x5C:  # backslash
+            if self._utf8_remaining > 0:
+                self._reject("Backslash inside an incomplete UTF-8 sequence in string")
+                return
+            self._escaped = True
+            return
+
+        if b == 0x22:  # closing quote
+            if self._utf8_remaining > 0:
+                self._reject("Closing quote inside an incomplete UTF-8 sequence in string")
+                return
+            self._in_string = False
+            self._finalize_string()
+            return
+
+        # Normal string character (or control char - rejected below)
+        if b < 0x20:
+            self._reject(f"Control character 0x{b:02X} inside string")
+        # Regular character, nothing to do
+    
+    def _finalize_string(self) -> None:
+        """Called when a string is completed."""
+        # Check what we expect this string to be
+        if self._state == self._OBJ_EXPECT_KEY:
+            # This is a key, now expect colon
+            self._state = self._OBJ_EXPECT_COLON
+        elif self._state in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
+                            self._ARR_EXPECT_VALUE, self._ARR_EXPECT_VALUE_OR_END):
+            # This is a value, now what's next depends on context
+            self._finalize_value()
+        else:
+            self._reject(f"String in unexpected state {self._state}")
+    
+    def _process_scalar_byte(self, b: int) -> None:
+        """Process a byte that could be part of a scalar value (keyword, number, or structure)."""
+
+        # State gating for structural bytes that must not appear unexpectedly.
+        # Object keys must be strings: when expecting a key, only " (string) or
+        # } (close empty object) are valid — a digit/letter/etc. is not a key.
+        if self._state == self._OBJ_EXPECT_KEY and b != 0x22 and b != 0x7D:
+            self._reject(f"Object key must be a string (got {chr(b)!r})")
+            return
+        # After a key, only : (colon) is valid — any other byte is missing-colon.
+        if self._state == self._OBJ_EXPECT_COLON and b != 0x3A:
+            self._reject(f"Expected ':' after object key (got {chr(b)!r})")
+            return
+
+        # First handle string start (quote) - it's valid in more states than containers
+        if b == 0x22:  # " (start of string)
+            # Validate any pending scalar first
+            if self._scalar_buf:
+                self._validate_accumulated_scalar()
+                if self._rejected:
+                    return
+            self._in_string = True
+            # Quote is valid when expecting a key (in object) or a value (anywhere)
+            if self._state in (self._OBJ_EXPECT_KEY, self._TOP_EXPECT_VALUE, 
+                              self._OBJ_EXPECT_VALUE, self._ARR_EXPECT_VALUE, 
+                              self._ARR_EXPECT_VALUE_OR_END):
+                pass  # Valid start of string
+            else:
+                self._reject(f"Unexpected string start in state {self._state}")
+            return
+        
+        # Validate any pending scalar before processing structural bytes
+        if self._scalar_buf and b in (0x7B, 0x7D, 0x5B, 0x5D, 0x2C, 0x3A):
+            self._validate_accumulated_scalar()
+            if self._rejected:
+                return
+        
+        # Structure characters (start/end of containers)
+        if b == 0x7B:  # {
+            self._start_object()
+        elif b == 0x7D:  # }
+            self._end_object()
+        elif b == 0x5B:  # [
+            self._start_array()
+        elif b == 0x5D:  # ]
+            self._end_array()
+        elif b == 0x2C:  # ,
+            self._handle_comma()
+        elif b == 0x3A:  # :
+            self._handle_colon()
+        else:
+            # A scalar byte (digit, letter for a keyword, '-', etc.). Scalars are
+            # only valid where a VALUE is expected; in any other state (e.g.
+            # comma-or-end after a value, or expect-colon) a scalar byte is a
+            # grammar error (e.g. `[1,2,null]6}` -> stray 6 after the array).
+            if self._state not in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
+                                   self._ARR_EXPECT_VALUE, self._ARR_EXPECT_VALUE_OR_END):
+                self._reject(f"Unexpected scalar byte {chr(b)!r} in state {self._state}")
+                return
+            # Reject control chars and stray high bytes outside strings (they are
+            # never part of a valid number/keyword scalar).
+            if b < 0x20:
+                self._reject(f"Control character 0x{b:02X} outside string")
+                return
+            if b >= 0x7F:
+                self._reject(f"Non-ASCII byte 0x{b:02X} outside string")
+                return
+            self._scalar_buf.append(b)
+    
+    def _start_object(self) -> None:
+        """Handle opening brace {."""
+        if self._state not in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
+                               self._ARR_EXPECT_VALUE, self._ARR_EXPECT_VALUE_OR_END):
+            self._reject(f"Unexpected {{ in state {self._state}")
+            return
+        
+        self._depth += 1
+        # Store the container type (object) in the stack
+        self._stack.append("object")
+        self._state = self._OBJ_EXPECT_KEY
+        self._in_object_start = True  # We're at the start of a new object
+    
+    def _end_object(self) -> None:
+        """Handle closing brace }."""
+        # Validate any pending scalar first
+        if self._scalar_buf:
+            self._validate_accumulated_scalar()
+            if self._rejected:
+                return
+
+        # Allow closing right after "{" (empty object) or after a complete value.
+        # Closing in _OBJ_EXPECT_KEY AFTER a comma is a trailing comma -> reject.
+        # _in_object_start distinguishes "right after {" (empty, valid) from
+        # "after a comma" (trailing comma, invalid).
+        if self._state == self._OBJ_EXPECT_KEY and not self._in_object_start:
+            self._reject("Trailing comma in object (} after ,)")
+            return
+        if self._state not in (self._OBJ_EXPECT_KEY, self._OBJ_EXPECT_COMMA_OR_END):
+            self._reject(f"Unexpected }} in state {self._state}")
+            return
+        
+        self._depth -= 1
+        if self._depth < 0:
+            self._reject("Too many closing braces")
+            return
+        
+        # Pop the container type
+        container = self._stack.pop()
+        if container != "object":
+            self._reject(f"Container type mismatch: expected object, got {container}")
+            return
+        
+        if self._depth == 0:
+            # Top-level value completed
+            self._state = self._TOP_EXPECT_TERMINATOR
+            self._saw_complete_value = True
+        else:
+            # Check parent container type to determine next state
+            parent = self._stack[-1] if self._stack else None
+            if parent == "object":
+                self._state = self._OBJ_EXPECT_COMMA_OR_END
+            elif parent == "array":
+                self._state = self._ARR_EXPECT_COMMA_OR_END
+            else:
+                self._reject(f"Unexpected parent container type: {parent}")
+    
+    def _start_array(self) -> None:
+        """Handle opening bracket [."""
+        if self._state not in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
+                               self._ARR_EXPECT_VALUE, self._ARR_EXPECT_VALUE_OR_END):
+            self._reject(f"Unexpected [ in state {self._state}")
+            return
+        
+        self._depth += 1
+        # Store the container type (array) in the stack
+        self._stack.append("array")
+        self._state = self._ARR_EXPECT_VALUE_OR_END
+        self._in_object_start = True  # We're at the start of a new array (for trailing comma check)
+    
+    def _end_array(self) -> None:
+        """Handle closing bracket ]."""
+        # Validate any pending scalar first
+        if self._scalar_buf:
+            self._validate_accumulated_scalar()
+            if self._rejected:
+                return
+
+        # Allow closing right after "[" (empty array) or after a complete value.
+        # Closing in _ARR_EXPECT_VALUE after a comma is a trailing comma -> reject.
+        # _in_object_start distinguishes "right after [" (empty, valid) from
+        # "after a comma" (trailing comma, invalid).
+        if self._state == self._ARR_EXPECT_VALUE and not self._in_object_start:
+            self._reject("Trailing comma in array (] after ,)")
+            return
+        if self._state not in (self._ARR_EXPECT_VALUE_OR_END, self._ARR_EXPECT_COMMA_OR_END):
+            self._reject(f"Unexpected ] in state {self._state}")
+            return
+        
+        self._depth -= 1
+        if self._depth < 0:
+            self._reject("Too many closing brackets")
+            return
+        
+        # Pop the container type
+        container = self._stack.pop()
+        if container != "array":
+            self._reject(f"Container type mismatch: expected array, got {container}")
+            return
+        
+        if self._depth == 0:
+            # Top-level value completed
+            self._state = self._TOP_EXPECT_TERMINATOR
+            self._saw_complete_value = True
+        else:
+            # Check parent container type to determine next state
+            parent = self._stack[-1] if self._stack else None
+            if parent == "object":
+                self._state = self._OBJ_EXPECT_COMMA_OR_END
+            elif parent == "array":
+                self._state = self._ARR_EXPECT_COMMA_OR_END
+            else:
+                self._reject(f"Unexpected parent container type: {parent}")
+    
+    def _handle_comma(self) -> None:
+        """Handle comma separator."""
+        if self._state == self._OBJ_EXPECT_COMMA_OR_END:
+            self._state = self._OBJ_EXPECT_KEY
+            self._in_object_start = False  # No longer at the start after first member
+        elif self._state == self._ARR_EXPECT_COMMA_OR_END:
+            self._state = self._ARR_EXPECT_VALUE
+        elif self._state == self._OBJ_EXPECT_KEY and self._in_object_start:
+            # Comma at the start of an object - this is a trailing comma!
+            self._reject("Trailing comma in object")
+        elif self._state == self._ARR_EXPECT_VALUE_OR_END and self._in_object_start:
+            # Comma at the start of an array - this is a trailing comma!
+            self._reject("Trailing comma in array")
+        elif self._state in (self._OBJ_EXPECT_KEY, self._ARR_EXPECT_VALUE, 
+                           self._OBJ_EXPECT_VALUE, self._TOP_EXPECT_VALUE,
+                           self._ARR_EXPECT_VALUE_OR_END):
+            # Comma appeared where we expected a value - this is invalid
+            self._reject(f"Unexpected comma in state {self._state}")
+        else:
+            self._reject(f"Unexpected comma in state {self._state}")
+    
+    def _handle_colon(self) -> None:
+        """Handle colon after key in object."""
+        if self._state != self._OBJ_EXPECT_COLON:
+            self._reject(f"Unexpected colon in state {self._state}")
+            return
+        # Validate any pending scalar (e.g., key string if we weren't tracking it properly)
+        if self._scalar_buf:
+            self._validate_accumulated_scalar()
+            if self._rejected:
+                return
+        self._state = self._OBJ_EXPECT_VALUE
+    
+    def _finalize_value(self) -> None:
+        """Called when any value (string, number, keyword, container) is completed."""
+        if self._depth == 0:
+            # Top-level value completed
+            self._state = self._TOP_EXPECT_TERMINATOR
+            self._saw_complete_value = True
+        else:
+            # Value inside a container, now expect comma or end
+            # Check the parent container type
+            parent = self._stack[-1] if self._stack else None
+            if parent == "object":
+                self._state = self._OBJ_EXPECT_COMMA_OR_END
+            elif parent == "array":
+                self._state = self._ARR_EXPECT_COMMA_OR_END
+            else:
+                self._reject(f"Value completed in unexpected context (parent={parent})")
+    
+    def _is_hex_digit(self, b: int) -> bool:
+        """Check if byte is a valid hex digit."""
+        return (0x30 <= b <= 0x39 or  # 0-9
+                0x41 <= b <= 0x46 or  # A-F
+                0x61 <= b <= 0x66)   # a-f
+    
+    def _validate_accumulated_scalar(self) -> None:
+        """Validate an accumulated scalar token (keyword or number)."""
+        if not self._scalar_buf:
+            self._reject("Empty scalar token")
+            return
+        
+        token_bytes = bytes(self._scalar_buf)
+        self._scalar_buf = []
+        
+        # Try to match keyword
+        token_str = token_bytes.decode("utf-8", errors="replace")
+        if token_str == "true":
+            self._finalize_value()
+        elif token_str == "false":
+            self._finalize_value()
+        elif token_str == "null":
+            self._finalize_value()
+        else:
+            # Must be a number
+            self._validate_number_token(token_bytes)
+    
+    def _validate_number_token(self, token_bytes: bytes) -> None:
+        """Validate a number token according to RFC 8259."""
+        # Number grammar: -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?
+        i = 0
+        n = len(token_bytes)
+        
+        # Optional minus sign
+        if i < n and token_bytes[i] == 0x2D:  # -
+            i += 1
+        
+        # Integer part
+        if i >= n:
+            self._reject("Number has no digits")
+            return
+        
+        if token_bytes[i] == 0x30:  # 0
+            i += 1
+            # Leading zeros not allowed (unless it's just "0")
+            if i < n and 0x30 <= token_bytes[i] <= 0x39:
+                self._reject("Number has leading zero")
+                return
+        elif 0x31 <= token_bytes[i] <= 0x39:  # 1-9
+            i += 1
+            while i < n and 0x30 <= token_bytes[i] <= 0x39:
+                i += 1
+        else:
+            self._reject("Number has invalid integer part")
+            return
+        
+        # Fractional part
+        if i < n and token_bytes[i] == 0x2E:  # .
+            i += 1
+            if i >= n or not (0x30 <= token_bytes[i] <= 0x39):
+                self._reject("Number has . but no fractional digits")
+                return
+            while i < n and 0x30 <= token_bytes[i] <= 0x39:
+                i += 1
+        
+        # Exponent part
+        if i < n and token_bytes[i] in (0x45, 0x65):  # E or e
+            i += 1
+            # Optional +/-
+            if i < n and token_bytes[i] in (0x2B, 0x2D):  # + or -
+                i += 1
+            if i >= n or not (0x30 <= token_bytes[i] <= 0x39):
+                self._reject("Number has exponent but no exponent digits")
+                return
+            while i < n and 0x30 <= token_bytes[i] <= 0x39:
+                i += 1
+        
+        # Must have consumed all bytes
+        if i != n:
+            self._reject(f"Number has trailing bytes: {token_bytes[i:]!r}")
+            return
+        
+        self._finalize_value()
+    
+    def _reject(self, msg: str) -> None:
+        """Mark the input as rejected with an error message."""
+        self._rejected = True
+        self._error_msg = msg
+    
+    def _accept(self) -> None:
+        """Mark the input as accepted."""
+        self._accepted = True
+    
+    @property
+    def accepted(self) -> bool:
+        """True if the input was accepted as valid JSON."""
+        return self._accepted
+    
+    @property
+    def rejected(self) -> bool:
+        """True if the input was rejected as invalid JSON."""
+        return self._rejected
+    
+    @property
+    def error_message(self) -> str:
+        """Error message if rejected, empty otherwise."""
+        return self._error_msg
+    
+    def finish(self) -> bool:
+        """Return True iff the fed bytes form a complete, valid JSON value.
+
+        Must be called after feeding all bytes. Returns True only if:
+        - The JSON value is complete (depth 0, no unclosed containers)
+        - Record ends with \n (or \r\n) terminator and nothing else
+        - No unterminated strings or escape sequences
+
+        A rejection (including trailing garbage after an otherwise-complete
+        record) always wins over a prior acceptance: accepted-then-rejected
+        means the input had a complete prefix followed by invalid trailing
+        bytes, which is NOT a valid single JSONL record.
+        """
+        if self._rejected:
+            return False
+        if self._accepted:
+            return True
+        
+        # Check for pending CR without LF (bare CR)
+        if self._pending_cr:
+            self._reject("Bare CR (terminator is \\r\\n, not just \\r)")
+            return False
+        
+        # Check if we have a complete value
+        if not self._saw_complete_value:
+            # Either empty input or incomplete value
+            self._reject("Incomplete JSON value (no complete value found)")
+            return False
+        
+        # Check for incomplete state
+        if self._in_string:
+            self._reject("Unterminated string")
+            return False
+        
+        if self._escaped:
+            self._reject("Unterminated escape sequence")
+            return False
+        
+        if self._unicode_escape_remaining > 0:
+            self._reject("Incomplete \\u escape sequence")
+            return False
+
+        if self._utf8_remaining > 0:
+            self._reject("Incomplete UTF-8 sequence in string")
+            return False
+        
+        if self._depth > 0:
+            self._reject(f"Unclosed container (depth={self._depth})")
+            return False
+        
+        # Check if we have pending scalar token
+        if self._scalar_buf:
+            self._validate_accumulated_scalar()
+            if self._rejected:
+                return False
+            # After validating scalar, check if it completed the value
+            if not self._saw_complete_value:
+                self._reject("Scalar did not complete the value")
+                return False
+        
+        # If we reach here with a complete value and no errors, accept
+        # BUT we must also be in the proper terminator state
+        if self._saw_complete_value and self._state == self._TOP_EXPECT_TERMINATOR:
+            # We need to have seen a terminator (either via accept() during processing
+            # or we're still waiting for it - but if we're still waiting, we reject)
+            # Actually, if we're in TOP_EXPECT_TERMINATOR state and haven't accepted yet,
+            # it means we didn't get the newline terminator
+            return self._accepted  # Only accept if we actually got the terminator
+        
+        self._reject(f"Invalid end state: {self._state}")
+        return False
 
 
 def _find_record_start_before(
@@ -450,42 +1118,57 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
         # Candidate predecessor line. This loop only reaches COMPLETE lines
         # (newline-terminated on both sides — _rfind_byte_before found the
         # surrounding newlines, and the caller's end_offset is the boundary
-        # record's start, strictly after this line). So unlike the BOUNDARY
-        # record, a predecessor can be VALIDATED by reading + json.loads-ing the
-        # whole line: it is not crash-truncated.
+        # record's start, strictly after this line). 
         #
-        # #6139 r14 finding 2: the prior code blanket-skipped any line
-        # > _BOUNDARY_SUMMARY_PREFIX_BYTES (8 KiB) as "oversized fail-closed",
-        # conflating the boundary record's 8 KiB prefix-extraction limit with a
-        # validity limit. That dropped VALID predecessors larger than 8 KiB (e.g.
-        # a 20 KiB tool_complete event) → latest_run_summary reported a stale
-        # last_seq → stale_interrupted_event synthesized an event_id colliding
-        # with the real dropped event's id. A complete line is parseable
-        # regardless of size; the only bound is the shared budget. Read + parse
-        # the line directly, charging the budget; skip only on budget exhaustion
-        # or a parse failure (genuinely malformed), continuing backward to the
-        # preceding valid event.
-        to_read = budget_obj.take(line_len)
-        if to_read == 0:
-            return None  # budget exhausted before parsing this candidate — stop
+        # #6139 redesign: validate the predecessor via prefix-summary + streaming
+        # grammar validation (O(depth) memory, never materializes the full line).
+        # Read a bounded prefix, extract its summary, then validate the WHOLE line
+        # is grammatically complete via _record_is_valid_jsonl (streams through the
+        # line in chunks, bounded by line_len). This accepts VALID predecessors of
+        # ANY size (e.g. a 2.3 MiB done) while rejecting malformed ones (trailing
+        # comma, malformed nested value) via full grammar checking.
+        line_end = first_nl + 1  # the byte AFTER the terminating newline
+        prefix_to_read = budget_obj.take(min(_BOUNDARY_SUMMARY_PREFIX_BYTES, line_len))
+        if prefix_to_read == 0:
+            return None  # budget exhausted before reading prefix — stop
         try:
             fh.seek(line_start)
-            raw = fh.read(to_read)
+            prefix_raw = fh.read(prefix_to_read)
         except (FileNotFoundError, OSError):
             if fault is not None:
                 fault[0] = True
             return None  # TOCTOU: journal deleted mid-read — safe fallback
-        try:
-            parsed = json.loads(raw.decode("utf-8", errors="replace"))
-        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-            parsed = None
+        text = prefix_raw.decode("utf-8", errors="replace")
+        # A predecessor is a COMPLETE line (newline-terminated on both sides),
+        # not a fabricated oversized boundary summary. Only mark it as
+        # extracted-from-oversized if the line was BIGGER than the prefix read
+        # (payload genuinely discarded); a normal-sized event whose whole record
+        # fit in the prefix is a real event and must not carry the fabrication
+        # flag (the r10 adversarial tests detect fabricated boundary summaries
+        # via that flag).
+        line_was_truncated = line_len > prefix_to_read
+        parsed_summary = _parse_prefix_summary(text, mark_extracted=line_was_truncated)
+        if parsed_summary is None:
+            # Prefix failed to parse (no payload key / malformed). Skip this candidate.
+            rows_scanned += 1
+            scan_end = line_start
+            if scan_end <= 0:
+                return None
+            continue
+        # Prefix extracted; now validate the WHOLE line is grammatically complete.
+        # _record_is_valid_jsonl streams from line_start to line_end (the actual
+        # line end, not EOF), confirming grammar + terminator. If it returns False,
+        # the line is malformed/truncated — skip it and continue backward.
+        if not _record_is_valid_jsonl(fh, line_end, line_start, budget=budget_obj, fault=fault):
+            # Malformed or truncated predecessor — skip, continue backward.
+            rows_scanned += 1
+            scan_end = line_start
+            if scan_end <= 0:
+                return None
+            continue
+        # Valid complete predecessor with extractable summary.
         rows_scanned += 1
-        if isinstance(parsed, dict):
-            return parsed
-        # Malformed or non-dict: skip, continue backward.
-        scan_end = line_start
-        if scan_end <= 0:
-            return None
+        return parsed_summary
     return None
 
 
@@ -653,218 +1336,66 @@ def _record_is_structurally_complete(
         return False
 
 
-def _record_is_valid_complete(
+def _record_is_valid_jsonl(
     fh, size: int, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
 ) -> bool:
-    """Return True iff the JSONL record at ``record_start`` is a valid (or
-    structurally-complete) JSON value (a dict) followed by a newline terminator.
+    """Return True iff the JSONL record at ``record_start`` is a complete,
+    grammatically-valid JSON object followed by a newline terminator.
 
-    This is the validity gate for trusting a fabricated boundary-record summary
-    (#6139 r10 item 2): brace balance is necessary but NOT sufficient for JSON
-    validity. A brace-balanced record with a trailing comma (``...,}``) or a
-    malformed nested value (``...bad:nested...}``) is NOT valid JSON and must
-    NOT be fabricated into a terminal event. The full reader ``_read_jsonl``
-    correctly rejects such rows; the tail reader must MATCH it for records it
-    can afford to validate in full.
+    Streams the record forward in chunks through ``_StreamingJsonValidator``
+    (O(nesting-depth) memory, never materializes the record) until the top-level
+    value closes + ``\\n``. This is the unified validity gate for trusting a
+    fabricated boundary-record summary (#6139 r10 item 2): brace balance is
+    necessary but NOT sufficient — a trailing comma, malformed nested value,
+    unquoted key, or any grammar error anywhere in the record (including inside
+    the payload) is rejected, matching the full reader's ``json.loads``.
 
-    Two tiers (#6139 r14 finding 1):
+    Unlike the prior two-tier design (#6139 r14), there is NO fixed correctness
+    ceiling: the validator streams in ``_SESSION_REPLAY_READ_CHUNK_BYTES`` chunks
+    and stops at the record's actual end (depth-0 + newline), so a valid record
+    of ANY size (e.g. a 17 MiB ``done`` with a full transcript) is accepted. The
+    only bound is the ``budget`` (total physical I/O) — a pathological multi-GB
+    record fails-closed when the budget exhausts, recovering the older valid
+    event. This removes both the r15 ceiling (blocker 1) and the tier-selection
+    bug (blocker 4: the old code used ``size - record_start`` — the suffix to EOF,
+    including trailing records — instead of the actual record length).
 
-    - Tier 1 (record length <= ``_VALIDITY_PROOF_MAX_BYTES``): scan forward in
-      chunks to the newline terminator, materialize the record, and parse it
-      ONCE with ``json.JSONDecoder.raw_decode`` (which parses exactly one value
-      and returns its end offset; the byte at that offset must be the record's
-      newline). This is FULLY correct — it rejects trailing commas, malformed
-      nested values, and any grammatical error — and is the path the r10
-      adversarial fixtures (all < 8 MiB) rely on. A small record costs one
-      chunk; a legitimately oversized ``done`` up to the ceiling is proven valid
-      by reading its full length.
-
-    - Tier 2 (record length > ``_VALIDITY_PROOF_MAX_BYTES``): a bounded-memory
-      STREAMING structural-completeness scan that does NOT materialize the
-      record. Scan forward tracking brace/bracket depth + string/escape state
-      until the top-level depth returns to 0 immediately followed by a newline.
-      A crash-truncated record (the only realistic failure mode for a
-      >ceiling record, since ``append_run_event`` serializes via ``json.dumps``
-      and fsyncs) never reaches depth 0 — or has no newline after — so it is
-      rejected. A brace-balanced + newline-terminated record is accepted.
-
-      Documented residual (#6139 r14): unlike tier 1, tier 2 does NOT perform
-      full JSON grammar validation — it accepts brace-balanced records. This is
-      acceptable because (a) the journal writer produces valid JSON via
-      ``json.dumps`` on an fsync'd append-only file, so a >ceiling record is
-      valid-or-truncated, never corrupted-in-place; (b) the r10 adversarial
-      fixtures (trailing comma, malformed nested value) are < 8 MiB and stay on
-      tier 1, which rejects them; (c) a >ceiling brace-balanced-but-invalid
-      record would require post-write corruption of an fsync'd file. Stale-
-      but-nonterminal (the recoverable direction) is never falsely terminal.
-
-    The caller owns the handle and passes the pinned size. ``budget`` charges
-    each chunk read against the shared meter; if the allowance can't reach the
-    terminator/depth-0, returns False (fail-closed).
-
-    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
-    to signal the caller that a transient read fault occurred. (#6139 r14)
+    The caller owns the handle and passes the pinned size from os.fstat. When
+    ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True (#6139 r14).
     """
     if record_start < 0 or record_start >= size:
         return False
-    record_len = size - record_start
-    if record_len <= 0:
-        return False
-    if record_len <= _VALIDITY_PROOF_MAX_BYTES:
-        return _record_is_valid_complete_tier1(
-            fh, size, record_start, budget=budget, fault=fault
-        )
-    return _record_is_valid_complete_tier2(fh, size, record_start, budget=budget, fault=fault)
-
-
-def _record_is_valid_complete_tier1(
-    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
-) -> bool:
-    """Tier 1 validity proof: full ``raw_decode`` on the materialized record
-    (record length <= ``_VALIDITY_PROOF_MAX_BYTES``). See
-    ``_record_is_valid_complete`` for the two-tier contract.
-
-    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
-    to signal the caller that a transient read fault occurred. (#6139 r14)
-    """
-    max_window = min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)
-    if max_window <= 0:
-        return False
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
-    chunks: list[bytes] = []
-    total = 0
+    validator = _StreamingJsonValidator()
     pos = record_start
-    have_terminator = False
-    while total < max_window:
-        want = min(chunk_size, max_window - total)
-        if budget is not None:
-            got = budget.take(want)
-            if got <= 0:
-                return False  # can't reach terminator within budget — fail-closed
-            want = min(want, got)
-        try:
-            fh.seek(pos)
-            block = fh.read(want)
-        except (FileNotFoundError, OSError):
-            if fault is not None:
-                fault[0] = True
-            return False  # TOCTOU: journal deleted mid-read — safe fallback
-        if not block:
-            break
-        nl = block.find(b"\n")
-        if nl >= 0:
-            # Record ends at this newline. Keep only up to and including it so
-            # raw_decode sees exactly ONE record (trailing records on the file
-            # must not leak into the parsed value or the terminator check).
-            chunks.append(block[: nl + 1])
-            total += nl + 1
-            have_terminator = True
-            break
-        chunks.append(block)
-        total += len(block)
-        pos += len(block)
-    if not have_terminator:
-        # No newline terminator within the cap: crash-truncated or pathologically
-        # large. Can't prove completeness → fail-closed (recover older valid event).
-        return False
-    text = b"".join(chunks).decode("utf-8", errors="replace")
     try:
-        obj, end_idx = json.JSONDecoder().raw_decode(text)
-    except (json.JSONDecodeError, ValueError):
-        return False  # not valid JSON (trailing comma, malformed nested value) — fail-closed
-    if not isinstance(obj, dict):
-        return False  # the journal record layout is always an object
-    # The value ended at text[end_idx-1]; the next byte(s) must be the record's
-    # newline terminator (LF or CRLF). A bare \r is rejected (matches the rest of
-    # the tail reader's terminator gate).
-    terminator = text[end_idx:]
-    if terminator.startswith("\r\n") or terminator.startswith("\n"):
-        return True
-    return False
-
-
-def _record_is_valid_complete_tier2(
-    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
-) -> bool:
-    """Tier 2 validity proof: bounded-memory streaming structural-completeness
-    scan for records longer than ``_VALIDITY_PROOF_MAX_BYTES``. Does NOT
-    materialize the record — tracks brace/bracket depth + string/escape state
-    forward in chunks until the top-level depth returns to 0 immediately
-    followed by a newline terminator. See ``_record_is_valid_complete`` for the
-    two-tier contract and the documented residual (accepts brace-balanced
-    records, which is sound because the journal writer fsyncs valid JSON).
-
-    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
-    to signal the caller that a transient read fault occurred. (#6139 r14)
-    """
-    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
-    pos = record_start
-    depth = 0
-    in_string = False
-    escaped = False
-    # `await_terminator`: depth has returned to 0; now require \n (or \r\n).
-    # `pending_cr`: depth-0 byte was \r; the next byte must be \n (CRLF) or reject.
-    await_terminator = False
-    pending_cr = False
-    while pos < size:
-        want = min(chunk_size, size - pos)
-        if budget is not None:
-            got = budget.take(want)
-            if got <= 0:
-                return False  # can't reach the record's end within budget — fail-closed
-            want = min(want, got)
-        try:
+        while pos < size:
+            want = min(chunk_size, size - pos)
+            if budget is not None:
+                got = budget.take(want)
+                if got <= 0:
+                    return False  # budget exhausted before the record closed — fail-closed
+                want = min(want, got)
             fh.seek(pos)
             block = fh.read(want)
-        except (FileNotFoundError, OSError):
-            if fault is not None:
-                fault[0] = True
-            return False  # TOCTOU: journal deleted mid-read — safe fallback
-        if not block:
-            break
-        i = 0
-        n = len(block)
-        while i < n:
-            c = block[i]
-            if pending_cr:
-                # Previous depth-0 byte was \r; require \n now (CRLF ok).
-                if c == 0x0A:  # \n
-                    return True
-                return False  # bare \r followed by non-\n — reject
-            if await_terminator:
-                # Depth is 0; the only acceptable next bytes are the record's
-                # newline terminator (\n, or \r\n). A bare \r is rejected
-                # (matches tier 1 + the tail reader's terminator gate).
-                if c == 0x0A:  # \n
-                    return True
-                if c == 0x0D:  # \r
-                    pending_cr = True
-                    i += 1
-                    continue
-                return False  # trailing garbage after the top-level value — reject
-            if in_string:
-                if escaped:
-                    escaped = False
-                elif c == 0x5C:  # backslash
-                    escaped = True
-                elif c == 0x22:  # closing quote
-                    in_string = False
-                i += 1
-                continue
-            if c == 0x22:  # opening quote
-                in_string = True
-            elif c in (0x7B, 0x5B):  # { or [
-                depth += 1
-            elif c in (0x7D, 0x5D):  # } or ]
-                depth -= 1
-                if depth == 0:
-                    # Top-level value closed; the next byte must be the terminator.
-                    await_terminator = True
-            i += 1
-        pos += len(block)
-    # Reached EOF without a clean depth-0 + newline terminator: crash-truncated
-    # or unterminated. Reject (fail-closed — recover the older valid event).
-    return False
+            if not block:
+                break
+            validator.feed(block)
+            # Check accepted BEFORE rejected because a single feed() can set both
+            # (newline triggers accept, then subsequent bytes in the same chunk trigger reject).
+            # We want to accept a valid record even if there are trailing bytes in the file.
+            if validator.accepted:
+                return True  # top-level value + terminator confirmed
+            if validator.rejected:
+                return False
+            pos += len(block)
+    except (FileNotFoundError, OSError):
+        if fault is not None:
+            fault[0] = True
+        return False
+    # EOF reached without the validator accepting (crash-truncated or incomplete).
+    result = validator.finish()
+    return result
 
 
 def _extract_boundary_record_summary(
@@ -904,6 +1435,27 @@ def _extract_boundary_record_summary(
             fault[0] = True
         return None
     text = prefix_raw.decode("utf-8", errors="replace")
+    # The boundary record is oversized by definition (it straddles the tail
+    # window), so its payload is discarded — mark the summary as extracted.
+    return _parse_prefix_summary(text, mark_extracted=True)
+
+
+def _parse_prefix_summary(text: str, *, mark_extracted: bool = True) -> dict | None:
+    """Parse a bounded JSONL prefix to extract summary fields.
+
+    Handles both cases:
+    - Payload key found → truncate before it, close object, parse
+    - No payload key → try direct parse up to first newline
+
+    When ``mark_extracted`` is True (the default, for the BOUNDARY record whose
+    payload was discarded), sets ``_summary_extracted_from_oversized_record=True``
+    so callers can distinguish a fabricated boundary summary from a real event.
+    Predecessor recovery passes ``mark_extracted=False`` for a complete normal-
+    sized line whose payload fit in the prefix (it is a real event, not a
+    fabricated oversized-record summary).
+
+    Returns the parsed dict or None.
+    """
     # Find the top-level "payload" key (depth 1 inside the record object).
     payload_pos = _find_top_level_payload_key(text)
     if payload_pos is None:
@@ -932,8 +1484,50 @@ def _extract_boundary_record_summary(
     # Replace the (unread) payload with an empty dict so the shape is consistent
     # but no payload bytes are materialized.
     parsed["payload"] = {}
-    parsed["_summary_extracted_from_oversized_record"] = True
+    if mark_extracted:
+        parsed["_summary_extracted_from_oversized_record"] = True
     return parsed
+
+
+def _extract_boundary_record_summary(
+    fh, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
+) -> dict | None:
+    """Extract ONLY the summary fields of an oversized journal record that
+    straddles the tail-window boundary, without materializing its payload.
+
+    Reads a bounded prefix (``_BOUNDARY_SUMMARY_PREFIX_BYTES``) from
+    ``record_start``, locates the top-level ``"payload"`` key via a brace-depth
+    scan, truncates the JSON before it, closes the object, and parses. Returns
+    a dict with the summary fields (``event``/``seq``/``event_id``/``terminal``/
+    ``terminal_state``) or ``None`` if the layout is unexpected. The payload is
+    replaced with an empty dict so downstream consumers see the shape but not
+    the bytes.
+
+    The caller owns the handle; all reads use the same inode generation. When
+    ``budget`` is a ``_ReadBudget`` the prefix read is capped at the budget's
+    remaining allowance; if the allowance hits 0 the function returns None. The
+    rest of the function operates on whatever prefix was read — if a shorter-
+    than-expected prefix can't be parsed, returns None.
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
+    """
+    try:
+        fh.seek(record_start)
+        if budget is not None:
+            to_read = budget.take(_BOUNDARY_SUMMARY_PREFIX_BYTES)
+            if to_read == 0:
+                return None  # exhausted before reading any prefix — stop
+            prefix_raw = fh.read(to_read)
+        else:
+            prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
+    except (FileNotFoundError, OSError):
+        if fault is not None:
+            fault[0] = True
+        return None
+    text = prefix_raw.decode("utf-8", errors="replace")
+    # Parse the prefix using the shared helper.
+    return _parse_prefix_summary(text)
 
 
 def _find_top_level_payload_key(text: str) -> int | None:
@@ -1001,12 +1595,12 @@ def _read_jsonl_tail(
     try:
         fh = path.open("rb")
     except (FileNotFoundError, OSError):
-        return events, malformed, True
+        return events, malformed, False
     try:
         try:
             size = os.fstat(fh.fileno()).st_size   # ONE pin; same generation for all stages
         except OSError:
-            return events, malformed, True
+            return events, malformed, False
         if size <= 0:
             return events, malformed, True
         read_bytes_cap = (
@@ -1041,25 +1635,34 @@ def _read_jsonl_tail(
         boundary_summary: dict | None = None
         if size > read_bytes:
             seek_pos = size - read_bytes
-            # Boundary START lookup + 8 KiB prefix extraction share ONE meter
-            # (#6139 r10 item 1). The backward lookup scans the bytes before the
-            # tail window up to the record start; for a straddling record up to the
-            # validity ceiling (4x cap, #6139 r14 finding 1) that pre-window portion
-            # can be up to ~3x cap, plus _BOUNDARY_SUMMARY_PREFIX_BYTES for the
-            # prefix extraction. Size the meter at 4x cap so a record the validity
-            # gate can accept can also be located + prefix-extracted without
-            # exhausting the meter (the r14 bug: a 12 MiB valid done exhausted the
-            # 2x cap lookup budget scanning its own pre-window bytes, so extraction
-            # got budget_remaining=0 -> None -> valid terminal rejected).
-            boundary_budget = _ReadBudget(4 * read_bytes_cap)
-            record_start = _find_record_start_before(fh, size, seek_pos, budget=boundary_budget, fault=fault)
+            # Boundary-recovery budget structure (#6139 r15 redesign):
+            #   - recovery_budget (lookup + prefix + predecessor): sized to cover the
+            #     backward lookup through the pre-window region (up to seek_pos bytes,
+            #     since the straddling record's start can be as far back as byte 0 for
+            #     a record that dominates the file), plus the 8 KiB prefix read and one
+            #     predecessor line. The backward lookup scans pre-window bytes to find
+            #     the record's start; for a huge straddling record that is inherently
+            #     ~seek_pos bytes. This is bounded by the file size, not an arbitrary
+            #     constant — a fixed cap here would reimpose the r15 blocker-1 ceiling
+            #     (a 17 MiB valid done's start sat ~13 MiB back, exhausting a fixed cap).
+            #   - validity_budget (streaming grammar proof): sized to the boundary
+            #     record's ACTUAL extent (size - record_start), computed AFTER the
+            #     lookup finds record_start. The streaming validator self-terminates
+            #     at the record's newline (depth-0 + \n), so it reads exactly the
+            #     record's bytes — never into trailing records. A VALID record of ANY
+            #     size is accepted (no fixed correctness ceiling). A pathological
+            #     multi-GB record fails-closed only if it can't reach its own newline
+            #     within its extent (crash-truncated), never because of an arbitrary
+            #     budget ceiling.
+            recovery_budget = _ReadBudget(seek_pos + read_bytes_cap + _BOUNDARY_SUMMARY_PREFIX_BYTES)
+            record_start = _find_record_start_before(fh, size, seek_pos, budget=recovery_budget, fault=fault)
             # record_start is where the straddling record begins. Extract its summary
             # via a bounded prefix read (never materializes the payload) — BUT only
             # trust it as terminal if the record is a structurally-complete AND
             # grammatically-valid JSON record. Brace balance is NOT JSON validity
             # (#6139 r10 item 2): a brace-balanced record with a trailing comma or a
             # malformed nested value must NOT be fabricated into a terminal event.
-            boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=boundary_budget, fault=fault)
+            boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=recovery_budget, fault=fault)
             # A boundary record is REJECTED (must not be trusted as terminal, and
             # the preceding valid event must be recovered instead) on EITHER path:
             #   (a) the prefix summary could not be extracted at all (extraction
@@ -1071,55 +1674,25 @@ def _read_jsonl_tail(
             # immediately before the rejected boundary lives OUTSIDE the tail
             # window and is otherwise dropped, so a completed run would be
             # misreported non-terminal (full reader `completed` → tail `running`,
-            # the preceding `done` was lost). The r11 code only recovered on path
-            # (b); path (a) skipped recovery entirely, diverging from the full
-            # reader (#6139 r12).
+            # the preceding `done` was lost).
             boundary_rejected = True
             if boundary_summary is not None:
-                # The whole-record validity proof gets its OWN meter, separate from
-                # the lookup+prefix meter (#6139 r13): the proof must read the FULL
-                # record to confirm JSON validity + terminator, and a valid record
-                # near _VALIDITY_PROOF_MAX_BYTES (2x cap) is a documented case
-                # (streaming.py journals the terminal `done` with the full
-                # transcript as its payload). Sharing the lookup+prefix meter let
-                # the backward lookup + 8 KiB prefix consume enough of the 2x cap
-                # allowance that a valid ~1.75x cap record could not be read in
-                # full → the proof failed closed → a VALID terminal record was
-                # rejected → wrong terminal_state (full reader
-                # `tool_limit_reached` → tail `running`/`completed`). The proof
-                # meter is sized at _VALIDITY_PROOF_MAX_BYTES so EVERY record the
-                # gate can possibly accept can pay for its own complete validation;
-                # the incremental chunked read means a small record still costs
-                # only one chunk, so the constant-in-file-size property holds.
-                # (#6139 r14 finding 1): the validity proof now has two tiers. Tier 1
-                # (≤_VALIDITY_PROOF_MAX_BYTES) does full JSON parsing; tier 2 (>ceiling)
-                # does streaming structural-completeness scanning. The budget must be
-                # larger than _VALIDITY_PROOF_MAX_BYTES so tier 2 can scan a legitimately
-                # large (>8 MiB) terminal record to its depth-0 + newline. 4x cap (16 MiB)
-                # covers real transcripts while staying a constant bound independent of
-                # file size (a pathological multi-GB record fails-closed).
-                validity_budget = _ReadBudget(4 * read_bytes_cap)
-                if _record_is_valid_complete(fh, size, record_start, budget=validity_budget, fault=fault):
+                # Validate the whole record via streaming grammar check (the unified
+                # _record_is_valid_jsonl replaces the old two-tier _record_is_valid_complete).
+                # The validity budget is the record's own extent (size - record_start),
+                # so a valid record of any size is accepted — no fixed ceiling.
+                validity_budget = _ReadBudget(size - record_start)
+                if _record_is_valid_jsonl(fh, size, record_start, budget=validity_budget, fault=fault):
                     boundary_rejected = False  # valid + complete: trust the prefix
                 else:
                     boundary_summary = None  # extracted-but-invalid: fail-closed
             if boundary_rejected:
                 # Retain the last COMPLETE valid event before the rejected boundary
                 # record, so last_seq/terminal survive and the recovery signal fires
-                # (matching master). Predecessor recovery gets its OWN reserved
-                # allowance SEPARATE from the validity-proof budget (#6139 r11
-                # secondary): a single shared meter let a >=budget invalid oversized
-                # record (e.g. an 8 MiB balanced-invalid record against an 8 MiB
-                # budget) exhaust the meter via the validity proof, starving the
-                # backward predecessor scan — so a completed run was misreported
-                # non-terminal (master `completed`/last_seq 3 → candidate
-                # `running`/last_seq 3 because the preceding terminal `done` was
-                # unrecoverable). A dedicated predecessor reserve (one tail window)
-                # bounds the backward scan independently of the validity proof; total
-                # boundary physical I/O is then capped at 2*cap + cap = 3*cap
-                # regardless of file size.
-                predecessor_budget = _ReadBudget(read_bytes_cap)
-                preceding = _read_last_complete_line_before(fh, size, record_start, budget=predecessor_budget, fault=fault)
+                # (matching master). The recovery_budget is threaded through
+                # _read_last_complete_line_before, so the backward predecessor scan
+                # counts against the SAME allowance as lookup + extract.
+                preceding = _read_last_complete_line_before(fh, size, record_start, budget=recovery_budget, fault=fault)
                 if preceding is not None:
                     events.append(preceding)
             # Now drop the partial first fragment from the window so we only parse

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -275,15 +275,21 @@ def _find_record_start_before(path: Path, seek_pos: int) -> int:
     except (FileNotFoundError, OSError):
         return 0
     pos = min(seek_pos, size)
-    with path.open("rb") as fh:
-        while pos > 0:
-            read_from = max(0, pos - chunk_size)
-            fh.seek(read_from)
-            block = fh.read(pos - read_from)
-            nl = block.rfind(b"\n")
-            if nl >= 0:
-                return read_from + nl + 1
-            pos = read_from
+    try:
+        with path.open("rb") as fh:
+            while pos > 0:
+                read_from = max(0, pos - chunk_size)
+                fh.seek(read_from)
+                block = fh.read(pos - read_from)
+                nl = block.rfind(b"\n")
+                if nl >= 0:
+                    return read_from + nl + 1
+                pos = read_from
+    except (FileNotFoundError, OSError):
+        # TOCTOU: journal deleted between the stat() above and this open/read
+        # (cleanup racing a status poll). Return the safe fallback rather than
+        # letting the exception escape to the HTTP handler. (#6139 Greptile P1)
+        return 0
     return 0
 
 
@@ -333,15 +339,21 @@ def _rfind_byte_before(path: Path, byte: bytes, end_offset: int) -> int | None:
     ``end_offset - 1``, scanning backward in bounded chunks. None if not found."""
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
     pos = end_offset
-    with path.open("rb") as fh:
-        while pos > 0:
-            read_from = max(0, pos - chunk_size)
-            fh.seek(read_from)
-            block = fh.read(pos - read_from)
-            idx = block.rfind(byte)
-            if idx >= 0:
-                return read_from + idx
-            pos = read_from
+    try:
+        with path.open("rb") as fh:
+            while pos > 0:
+                read_from = max(0, pos - chunk_size)
+                fh.seek(read_from)
+                block = fh.read(pos - read_from)
+                idx = block.rfind(byte)
+                if idx >= 0:
+                    return read_from + idx
+                pos = read_from
+    except (FileNotFoundError, OSError):
+        # TOCTOU: journal deleted before/during the scan. Return the safe
+        # fallback (None = byte not found) rather than escaping to the caller.
+        # (#6139 Greptile P1)
+        return None
     return None
 
 
@@ -366,58 +378,65 @@ def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
         return False
     in_string = False
     escaped = False
-    with path.open("rb") as fh:
-        fh.seek(record_start)
-        while pos < size:
-            chunk = fh.read(min(chunk_size, size - pos))
-            if not chunk:
-                break
-            chunk_len = len(chunk)
-            for ci in range(chunk_len):
-                b = chunk[ci]
-                pos += 1
-                if in_string:
-                    if escaped:
-                        escaped = False
-                    elif b == 0x5C:  # backslash
-                        escaped = True
-                    elif b == 0x22:  # closing quote
-                        in_string = False
-                    continue
-                if b == 0x22:  # opening quote
-                    in_string = True
-                elif b == 0x7B:  # '{'
-                    depth += 1
-                elif b == 0x7D:  # '}'
-                    depth -= 1
-                    if depth == 0:
-                        # Object closed at position `pos` (1 past the '}').
-                        # The record is complete iff the byte(s) right after are a
-                        # newline terminator (\n or \r\n). Look at the next byte
-                        # in the current chunk first (avoid file-cursor drift),
-                        # else read fresh from the file.
-                        if ci + 1 < chunk_len:
-                            nb = chunk[ci + 1]
-                            if nb == 0x0A:  # \n — complete
-                                return True
-                            if nb == 0x0D:  # \r — need to check for \r\n
-                                if ci + 2 < chunk_len:
-                                    return chunk[ci + 2] == 0x0A
-                                # \r at chunk end: read from file to check for \n
-                                fh.seek(pos + 1)
-                                return fh.read(1) == b"\n"
-                            return False  # any other byte after } is not a terminator
-                        # Terminator is in the next chunk: read up to 2 bytes
-                        # from file to distinguish \r\n (CRLF) from a bare \r.
-                        fh.seek(pos)
-                        nb = fh.read(2)
-                        return nb == b"\r\n" or nb[:1] == b"\n"
-                elif b == 0x0A and depth == 0:  # newline at depth 0 before close
-                    return False
-            # depth > 0 here means the record spans more chunks; keep scanning.
-        # Reached EOF: a record ending at EOF is only complete if a real newline
-        # terminator was seen — NOT if the `}` is the last byte. A write
-        # interrupted after `}` but before the `\n` is crash-truncated.
+    try:
+        with path.open("rb") as fh:
+            fh.seek(record_start)
+            while pos < size:
+                chunk = fh.read(min(chunk_size, size - pos))
+                if not chunk:
+                    break
+                chunk_len = len(chunk)
+                for ci in range(chunk_len):
+                    b = chunk[ci]
+                    pos += 1
+                    if in_string:
+                        if escaped:
+                            escaped = False
+                        elif b == 0x5C:  # backslash
+                            escaped = True
+                        elif b == 0x22:  # closing quote
+                            in_string = False
+                        continue
+                    if b == 0x22:  # opening quote
+                        in_string = True
+                    elif b == 0x7B:  # '{'
+                        depth += 1
+                    elif b == 0x7D:  # '}'
+                        depth -= 1
+                        if depth == 0:
+                            # Object closed at position `pos` (1 past the '}').
+                            # The record is complete iff the byte(s) right after are a
+                            # newline terminator (\n or \r\n). Look at the next byte
+                            # in the current chunk first (avoid file-cursor drift),
+                            # else read fresh from the file.
+                            if ci + 1 < chunk_len:
+                                nb = chunk[ci + 1]
+                                if nb == 0x0A:  # \n — complete
+                                    return True
+                                if nb == 0x0D:  # \r — need to check for \r\n
+                                    if ci + 2 < chunk_len:
+                                        return chunk[ci + 2] == 0x0A
+                                    # \r at chunk end: read from file to check for \n
+                                    fh.seek(pos + 1)
+                                    return fh.read(1) == b"\n"
+                                return False  # any other byte after } is not a terminator
+                            # Terminator is in the next chunk: read up to 2 bytes
+                            # from file to distinguish \r\n (CRLF) from a bare \r.
+                            fh.seek(pos)
+                            nb = fh.read(2)
+                            return nb == b"\r\n" or nb[:1] == b"\n"
+                    elif b == 0x0A and depth == 0:  # newline at depth 0 before close
+                        return False
+                # depth > 0 here means the record spans more chunks; keep scanning.
+            # Reached EOF: a record ending at EOF is only complete if a real newline
+            # terminator was seen — NOT if the `}` is the last byte. A write
+            # interrupted after `}` but before the `\n` is crash-truncated.
+            return False
+    except (FileNotFoundError, OSError):
+        # TOCTOU: journal deleted between the stat() above and this open/read
+        # (cleanup racing a status poll). Return the safe fallback (False =
+        # record not complete) rather than letting the exception escape to the
+        # HTTP handler. (#6139 Greptile P1)
         return False
 
 

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -909,10 +909,27 @@ def _read_jsonl_tail(
             # recover the older valid event. Stale-but-nonterminal is recoverable;
             # falsely-terminal is not.
             boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=boundary_budget)
-            if boundary_summary is not None and not _record_is_valid_complete(
-                fh, size, record_start, budget=boundary_budget
-            ):
-                boundary_summary = None  # invalid/incomplete record: don't trust its prefix
+            # A boundary record is REJECTED (must not be trusted as terminal, and
+            # the preceding valid event must be recovered instead) on EITHER path:
+            #   (a) the prefix summary could not be extracted at all (extraction
+            #       returned None — the record is malformed before the top-level
+            #       "payload" key, e.g. an unquoted token or a truncated head); OR
+            #   (b) the prefix was extracted but the whole record is not valid JSON
+            #       (a trailing comma, a malformed nested value) — fail-closed.
+            # Both paths must trigger predecessor recovery: the valid terminal row
+            # immediately before the rejected boundary lives OUTSIDE the tail
+            # window and is otherwise dropped, so a completed run would be
+            # misreported non-terminal (full reader `completed` → tail `running`,
+            # the preceding `done` was lost). The r11 code only recovered on path
+            # (b); path (a) skipped recovery entirely, diverging from the full
+            # reader (#6139 r12).
+            boundary_rejected = True
+            if boundary_summary is not None:
+                if _record_is_valid_complete(fh, size, record_start, budget=boundary_budget):
+                    boundary_rejected = False  # valid + complete: trust the prefix
+                else:
+                    boundary_summary = None  # extracted-but-invalid: fail-closed
+            if boundary_rejected:
                 # Retain the last COMPLETE valid event before the rejected boundary
                 # record, so last_seq/terminal survive and the recovery signal fires
                 # (matching master). Predecessor recovery gets its OWN reserved

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -275,6 +275,57 @@ def _find_record_start_before(path: Path, seek_pos: int) -> int:
     return 0
 
 
+def _read_last_complete_line_before(path: Path, end_offset: int) -> str:
+    """Return the last complete JSONL line strictly before ``end_offset``.
+
+    Scans backward from ``end_offset - 1`` for the final two newlines before it;
+    the line between them is the last complete record preceding the boundary
+    record. Used to retain the preceding valid event when a crash-truncated
+    boundary record is rejected, so last_seq/running survive and the apperror
+    recovery signal fires (matching master). Bounded backward chunk scan — never
+    materializes the whole file. Returns '' if there's no preceding complete line.
+    """
+    if end_offset <= 0:
+        return ""
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    # The byte at end_offset-1 is typically the newline terminating the preceding
+    # line (or the start of the boundary record). We want the line BEFORE that.
+    # Find the newline at or before end_offset-1, then the line before it.
+    try:
+        size = path.stat().st_size
+    except (FileNotFoundError, OSError):
+        return ""
+    scan_end = min(end_offset, size)
+    with path.open("rb") as fh:
+        # Step 1: find the last newline at or before scan_end (terminator of the
+        # preceding line).
+        first_nl = _rfind_byte_before(path, b"\n", scan_end)
+        if first_nl is None or first_nl == 0:
+            return ""
+        # Step 2: find the newline before that (start of the preceding line + 1).
+        second_nl = _rfind_byte_before(path, b"\n", first_nl)
+        line_start = (second_nl + 1) if second_nl is not None else 0
+        fh.seek(line_start)
+        return fh.read(first_nl - line_start).decode("utf-8", errors="replace")
+
+
+def _rfind_byte_before(path: Path, byte: bytes, end_offset: int) -> int | None:
+    """Return the offset of the last occurrence of ``byte`` at or before
+    ``end_offset - 1``, scanning backward in bounded chunks. None if not found."""
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    pos = end_offset
+    with path.open("rb") as fh:
+        while pos > 0:
+            read_from = max(0, pos - chunk_size)
+            fh.seek(read_from)
+            block = fh.read(pos - read_from)
+            idx = block.rfind(byte)
+            if idx >= 0:
+                return read_from + idx
+            pos = read_from
+    return None
+
+
 def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
     """Return True iff the JSONL record at ``record_start`` is structurally
     complete — i.e. its JSON object is closed (brace depth returns to 0) AND
@@ -328,17 +379,19 @@ def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
                         # else read fresh from the file.
                         if ci + 1 < chunk_len:
                             nb = chunk[ci + 1]
-                            return nb in (0x0A, 0x0D)  # \n or \r
-                        # Terminator is in the next chunk: read 1 byte from file.
-                        # (fh cursor is at pos + (chunk_len - ci - 1); seek to pos.)
+                            return nb in (0x0A, 0x0D)  # \n or \r (CRLF handled below)
+                        # Terminator is in the next chunk: read up to 2 bytes
+                        # from file to distinguish \r\n (CRLF) from a bare \r.
                         fh.seek(pos)
-                        nb = fh.read(1)
-                        return nb in (b"\n", b"\r") or (nb == b"" and pos >= size)
+                        nb = fh.read(2)
+                        return nb == b"\r\n" or nb[:1] == b"\n"
                 elif b == 0x0A and depth == 0:  # newline at depth 0 before close
                     return False
             # depth > 0 here means the record spans more chunks; keep scanning.
-        # Reached EOF: complete only if the object closed exactly at EOF (depth 0).
-        return depth == 0
+        # Reached EOF: a record ending at EOF is only complete if a real newline
+        # terminator was seen — NOT if the `}` is the last byte. A write
+        # interrupted after `}` but before the `\n` is crash-truncated.
+        return False
 
 
 def _extract_boundary_record_summary(path: Path, record_start: int) -> dict | None:
@@ -501,6 +554,20 @@ def _read_jsonl_tail(
         boundary_summary = _extract_boundary_record_summary(path, record_start)
         if boundary_summary is not None and not _record_is_structurally_complete(path, record_start):
             boundary_summary = None  # crash-truncated record: don't trust its prefix
+            # Retain the last COMPLETE event before the truncated boundary record,
+            # so last_seq/running survive and the apperror recovery signal fires
+            # (matching master). Without this, rejecting the boundary record also
+            # drops the preceding valid event → event_count=0, last_seq=0, no
+            # recovery. Read a bounded prefix ending at record_start and take its
+            # last complete JSONL line.
+            preceding = _read_last_complete_line_before(path, record_start)
+            if preceding:
+                try:
+                    parsed = json.loads(preceding)
+                    if isinstance(parsed, dict):
+                        events.append(parsed)
+                except json.JSONDecodeError:
+                    pass
         # Now drop the partial first fragment from the window so we only parse
         # the complete trailing records.
         nl = text.find("\n")

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -2277,7 +2277,8 @@ def append_run_event(
             except OSError:
                 pass
 
-        # 7. Discard cached summary (existing logic unchanged)
+        # 5. Discard the cached summary: the JSONL (and sidecar, if published)
+        # both changed, so any cached summary for the old generation is stale.
         _discard_cached_summary(path)
         if created_file:
             _fsync_parent_dir(path)

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -291,9 +291,22 @@ def _read_jsonl(
 # memory even when a single record (e.g. the terminal `done` with the full
 # transcript) is many MB.
 _BOUNDARY_SUMMARY_PREFIX_BYTES = 8192
+# Ceiling on materializing the single straddling boundary record to PROVE
+# whole-record JSON validity before trusting its fabricated prefix summary
+# (#6139 r10 item 2). The record is the terminal `done` (full transcript) —
+# legitimately ~``_SESSION_REPLAY_MAX_BYTES``. We allow up to 2x the tail window
+# so a valid oversized record is proven valid, while a pathological multi-GB
+# record fails closed (recovers the older valid event instead of reading
+# unbounded). This is the ONLY place a record is materialized on the summary
+# path; the prefix-summary extractor stays bounded at 8 KB. The validity check
+# is single-pass (one read → ``json.loads``), so it charges the record length
+# once against the shared boundary-recovery budget.
+_VALIDITY_PROOF_MAX_BYTES = 2 * _SESSION_REPLAY_MAX_BYTES
 
 
-def _find_record_start_before(fh, size: int, seek_pos: int) -> int:
+def _find_record_start_before(
+    fh, size: int, seek_pos: int, *, budget: _ReadBudget | None = None
+) -> int:
     """Return the byte offset where the JSONL record overlapping ``seek_pos``
     begins, i.e. the byte just after the last newline strictly before seek_pos.
     Returns 0 if there is no preceding newline (the record starts at byte 0).
@@ -301,6 +314,15 @@ def _find_record_start_before(fh, size: int, seek_pos: int) -> int:
 
     The caller owns the handle and passes the pinned size from os.fstat — this
     ensures all reads use a single inode generation (single-generation contract).
+
+    When ``budget`` is a ``_ReadBudget``, every ``fh.read`` is capped at the
+    budget's remaining allowance via ``budget.take`` (the read covers the LAST
+    ``to_read`` bytes of the candidate ``[read_from, pos)`` range, since we scan
+    backward — the suffix is the highest-value window). If the allowance hits 0
+    the scan stops and returns 0 (fail-quiet fallback). When ``budget`` is None
+    the helper runs unbounded (the whole tail read is already bounded by the
+    caller). Capping only ever narrows the examined window — the byte-found
+    offset math is unchanged when the full chunk is read. (#6139 r10 item 1.)
     """
     if seek_pos <= 0:
         return 0
@@ -309,12 +331,23 @@ def _find_record_start_before(fh, size: int, seek_pos: int) -> int:
     try:
         while pos > 0:
             read_from = max(0, pos - chunk_size)
-            fh.seek(read_from)
-            block = fh.read(pos - read_from)
+            want = pos - read_from
+            if budget is not None:
+                to_read = budget.take(want)
+                if to_read == 0:
+                    return 0  # exhausted before this read — fail-quiet fallback
+                # Read the LAST `to_read` bytes of [read_from, pos): scanning
+                # backward, the suffix is the highest-value window to examine.
+                seek_to = pos - to_read
+            else:
+                to_read = want
+                seek_to = read_from
+            fh.seek(seek_to)
+            block = fh.read(to_read)
             nl = block.rfind(b"\n")
             if nl >= 0:
-                return read_from + nl + 1
-            pos = read_from
+                return seek_to + nl + 1
+            pos = seek_to
     except (FileNotFoundError, OSError):
         # TOCTOU: journal deleted between the stat() above and this open/read
         # (cleanup racing a status poll). Return the safe fallback rather than
@@ -323,7 +356,7 @@ def _find_record_start_before(fh, size: int, seek_pos: int) -> int:
     return 0
 
 
-def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: int | None = None) -> dict | None:
+def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: int | _ReadBudget | None = None) -> dict | None:
     """Return the summary of the last complete JSONL record strictly before
     ``end_offset``, without materializing a multi-MB payload.
 
@@ -348,16 +381,25 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
     extraction) charges a single shared ``_ReadBudget`` meter, so the scan
     stops as soon as the allowance is exhausted (#6139 r9 item 1). ``rows_scanned``
     is retained as a secondary row-cap guard (a pathological file of tiny rows
-    could fit many rows in the byte budget). If ``budget`` is None it defaults to
+    could fit many rows in the byte budget). ``budget`` may be an ``int`` (a fresh
+    meter of that size is created) or a pre-existing ``_ReadBudget`` (shared with
+    the caller — used by the production boundary-recovery composition so the
+    predecessor scan counts against the SAME allowance as boundary lookup /
+    structural validation). If ``budget`` is None it defaults to
     ``_SESSION_REPLAY_MAX_BYTES``.
     """
     if end_offset <= 0:
         return None
     scan_end = min(end_offset, size)
     # One shared remaining-work meter across every descriptor read in this scan
-    # so physical I/O never exceeds the caller's allowance (#6139 r9 item 1).
-    budget_bytes = budget if budget is not None else _SESSION_REPLAY_MAX_BYTES
-    budget_obj = _ReadBudget(budget_bytes)
+    # so physical I/O never exceeds the caller's allowance (#6139 r9 item 1). If
+    # the caller passed an existing ``_ReadBudget`` (the production composition),
+    # share it so predecessor recovery counts against the same boundary budget.
+    if isinstance(budget, _ReadBudget):
+        budget_obj = budget
+    else:
+        budget_bytes = budget if budget is not None else _SESSION_REPLAY_MAX_BYTES
+        budget_obj = _ReadBudget(budget_bytes)
     rows_scanned = 0
     # Loop backward across preceding complete lines, skipping blank / malformed /
     # non-dict lines (and oversized predecessors, fail-closed), until a valid
@@ -504,8 +546,11 @@ def _record_is_structurally_complete(
     ``budget`` is a ``_ReadBudget``, every ``fh.read`` is capped at the budget's
     remaining allowance via ``budget.take``; if the allowance hits 0 before the
     record's closing brace is confirmed, returns False (fail-closed — can't
-    prove completeness within the budget). When ``budget`` is None the helper
-    runs unbounded. The brace-depth + terminator logic is unchanged.
+    prove completeness within the budget). The terminator look-aheads
+    (``fh.read(1)`` / ``fh.read(2)`` after the closing brace) are also charged
+    via ``budget.take`` and fail-closed if the allowance is exhausted (#6139 r10
+    item 1). When ``budget`` is None the helper runs unbounded. The brace-depth
+    + terminator logic is otherwise unchanged.
     """
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
     depth = 0
@@ -560,12 +605,21 @@ def _record_is_structurally_complete(
                             if nb == 0x0D:  # \r — need to check for \r\n
                                 if ci + 2 < chunk_len:
                                     return chunk[ci + 2] == 0x0A
-                                # \r at chunk end: read from file to check for \n
+                                # \r at chunk end: read from file to check for \n.
+                                # Charge the terminator look-ahead against the
+                                # shared budget (#6139 r10 item 1: "cap every
+                                # request to the remainder" — the exact-exhaustion
+                                # leak was an uncharged fh.read(1) here).
+                                if budget is not None and budget.take(1) == 0:
+                                    return False  # can't prove terminator within budget — fail-closed
                                 fh.seek(pos + 1)
                                 return fh.read(1) == b"\n"
                             return False  # any other byte after } is not a terminator
                         # Terminator is in the next chunk: read up to 2 bytes
                         # from file to distinguish \r\n (CRLF) from a bare \r.
+                        # Charge the terminator look-ahead (same r10 fix).
+                        if budget is not None and budget.take(2) == 0:
+                            return False  # can't prove terminator within budget — fail-closed
                         fh.seek(pos)
                         nb = fh.read(2)
                         return nb == b"\r\n" or nb[:1] == b"\n"
@@ -582,6 +636,77 @@ def _record_is_structurally_complete(
         # record not complete) rather than letting the exception escape to the
         # HTTP handler. (#6139 Greptile P1)
         return False
+
+
+def _record_is_valid_complete(
+    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None
+) -> bool:
+    """Return True iff the JSONL record at ``record_start`` is a structurally
+    complete AND grammatically valid JSON value (a dict) followed by a newline
+    terminator.
+
+    This is the validity gate for trusting a fabricated boundary-record summary
+    (#6139 r10 item 2): brace balance is necessary but NOT sufficient for JSON
+    validity. A brace-balanced record with a trailing comma (``...,}``) or a
+    malformed nested value (``...bad:nested...}``) is NOT valid JSON and must
+    NOT be fabricated into a terminal event. The full reader ``_read_jsonl``
+    correctly rejects such rows; the tail reader must MATCH it.
+
+    Implementation: rather than a hand-written streaming JSON validator
+    (error-prone — a rejected r10 prototype mis-classified ~80% of fuzz inputs),
+    a bounded window (``_VALIDITY_PROOF_MAX_BYTES``) starting at ``record_start``
+    is materialized ONCE and parsed with ``json.JSONDecoder.raw_decode``, which
+    parses exactly one JSON value and returns its end offset. The byte at that
+    offset must be a newline terminator (the JSONL line separator). This proves
+    grammar validity AND terminator completeness from a single read, and does
+    NOT over-reach when trailing records follow the boundary record on the same
+    file (the window may contain them but raw_decode stops at the first value's
+    end). If the record extends beyond the window (pathologically large),
+    validity cannot be proven within the bound → fail-closed (return False →
+    recover the older valid event). The transient memory is one record's worth
+    of bytes (bounded), only for the single straddling boundary record.
+
+    The caller owns the handle and passes the pinned size. ``budget`` charges
+    the read against the shared boundary-recovery meter; if the allowance can't
+    cover the window, returns False (fail-closed).
+    """
+    if record_start < 0 or record_start >= size:
+        return False
+    # Read a bounded window from record_start. raw_decode will parse exactly one
+    # value and stop; the byte right after it must be the record's newline.
+    window_len = min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)
+    if window_len <= 0:
+        return False
+    if budget is not None:
+        to_read = budget.take(window_len)
+        if to_read <= 0:
+            return False  # exhausted before reading — fail-closed
+        window_len = min(window_len, to_read)
+    try:
+        fh.seek(record_start)
+        window = fh.read(window_len)
+    except (FileNotFoundError, OSError):
+        return False  # TOCTOU: journal deleted mid-read — safe fallback
+    if not window:
+        return False
+    text = window.decode("utf-8", errors="replace")
+    try:
+        obj, end_idx = json.JSONDecoder().raw_decode(text)
+    except (json.JSONDecodeError, ValueError):
+        return False  # not valid JSON (truncated, trailing comma, malformed) — fail-closed
+    if not isinstance(obj, dict):
+        return False  # the journal record layout is always an object
+    # The value ended at text[end_idx-1]; the next byte(s) must be the record's
+    # newline terminator (LF, or CRLF). A bare \r is rejected (matches the rest
+    # of the tail reader's terminator gate). If the value consumed the whole
+    # window without reaching a terminator, the record is larger than the window
+    # → can't prove validity within the bound → fail-closed.
+    terminator = text[end_idx:]
+    if terminator.startswith("\r\n"):
+        return True
+    if terminator.startswith("\n"):
+        return True
+    return False
 
 
 def _extract_boundary_record_summary(
@@ -749,26 +874,44 @@ def _read_jsonl_tail(
         boundary_summary: dict | None = None
         if size > read_bytes:
             seek_pos = size - read_bytes
-            record_start = _find_record_start_before(fh, size, seek_pos)
+            # ONE shared remaining-work meter for the WHOLE boundary-recovery scan:
+            # boundary lookup + prefix extraction + validity proof + (if rejected)
+            # the backward predecessor scan + candidate parse. Physical I/O never
+            # exceeds this allowance (#6139 r10 item 1: "create one remaining-work
+            # authority ... thread that same object through boundary lookup, prefix
+            # extraction, structural validation, predecessor search, and candidate
+            # parsing"). Sized at 2x the tail window: the boundary record (the
+            # terminal `done` with the full transcript) is legitimately ~cap bytes,
+            # and the single-pass validity proof charges the record length once, so
+            # 2x cap covers a valid record plus a small predecessor recovery margin.
+            # A pathological multi-GB record fails closed (recovers the older valid
+            # event) rather than reading unbounded.
+            boundary_budget = _ReadBudget(2 * read_bytes_cap)
+            record_start = _find_record_start_before(fh, size, seek_pos, budget=boundary_budget)
             # record_start is where the straddling record begins. Extract its summary
             # via a bounded prefix read (never materializes the payload) — BUT only
-            # trust it as terminal if the record is structurally complete. A crash-
-            # truncated `done` (write interrupted mid-payload: no closing brace, no
-            # newline) must NOT be fabricated into a terminal event, or an interrupted
-            # run is misreported as completed and its apperror recovery signal is
-            # silently dropped. Stale-but-nonterminal is recoverable; falsely-terminal
-            # is not. If incomplete, discard the summary and fall through to the
-            # preceding complete records (the run stays nonterminal/`running`).
-            boundary_summary = _extract_boundary_record_summary(fh, record_start)
-            if boundary_summary is not None and not _record_is_structurally_complete(fh, size, record_start):
-                boundary_summary = None  # crash-truncated record: don't trust its prefix
-                # Retain the last COMPLETE event before the truncated boundary record,
-                # so last_seq/running survive and the apperror recovery signal fires
-                # (matching master). Without this, rejecting the boundary record also
-                # drops the preceding valid event → event_count=0, last_seq=0, no
-                # recovery. Read the last complete record's summary via bounded prefix
-                # extraction (never materializes a multi-MB payload).
-                preceding = _read_last_complete_line_before(fh, size, record_start, budget=read_bytes_cap)
+            # trust it as terminal if the record is a structurally-complete AND
+            # grammatically-valid JSON record. Brace balance is NOT JSON validity
+            # (#6139 r10 item 2): a brace-balanced record with a trailing comma or a
+            # malformed nested value must NOT be fabricated into a terminal event.
+            # Prove whole-record validity before trusting the fabricated prefix; if
+            # validity cannot be established within the budget, fail closed and
+            # recover the older valid event. Stale-but-nonterminal is recoverable;
+            # falsely-terminal is not.
+            boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=boundary_budget)
+            if boundary_summary is not None and not _record_is_valid_complete(
+                fh, size, record_start, budget=boundary_budget
+            ):
+                boundary_summary = None  # invalid/incomplete record: don't trust its prefix
+                # Retain the last COMPLETE valid event before the rejected boundary
+                # record, so last_seq/running survive and the apperror recovery
+                # signal fires (matching master). Without this, rejecting the
+                # boundary record also drops the preceding valid event →
+                # event_count=0, last_seq=0, no recovery. Read the last complete
+                # record's summary via bounded prefix extraction (never materializes
+                # a multi-MB payload), sharing the SAME budget so the aggregate
+                # boundary-recovery work stays bounded.
+                preceding = _read_last_complete_line_before(fh, size, record_start, budget=boundary_budget)
                 if preceding is not None:
                     events.append(preceding)
             # Now drop the partial first fragment from the window so we only parse

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -220,20 +220,22 @@ def _read_jsonl(
         return events, malformed
 
     # Unbounded whole-file read (original behavior).
+    # Read RAW BYTES and split on b"\n" only — NOT read_text() (which does
+    # universal-newline conversion, silently turning bare \r into \n) and NOT
+    # splitlines() (which splits on bare \r). A crash-truncated final record
+    # ending in bare \r or at EOF-without-\n must be rejected, matching the tail
+    # reader's terminator gate. (#6139 round-6 alignment.)
     try:
-        lines = path.read_text(encoding="utf-8")
+        raw_bytes = path.read_bytes()
     except FileNotFoundError:
         return events, malformed
-    # A crash-truncated final record (write interrupted before its newline
-    # terminator) is silently accepted by splitlines(), which treats EOF as a
-    # line boundary. This must match the tail reader's completeness gate: if the
-    # file doesn't end with \n (or \r\n), the last line is unterminated and
-    # potentially crash-truncated — discard it so a finished run doesn't flip to
-    # a falsely-terminal state from a partial write. (#6139 round-5 alignment.)
-    ended_with_newline = lines.endswith("\n") or lines.endswith("\r")
-    lines_list = lines.splitlines()
-    if not ended_with_newline and lines_list:
-        lines_list = lines_list[:-1]  # drop the unterminated final line
+    # Accept a final record only if it ends in \n (covers both LF and CRLF,
+    # since CRLF ends in \n). Otherwise discard the last line.
+    if raw_bytes and not raw_bytes.endswith(b"\n"):
+        # Drop the unterminated final line (before the split, so it never parses).
+        last_nl = raw_bytes.rfind(b"\n")
+        raw_bytes = raw_bytes[:last_nl + 1] if last_nl >= 0 else b""
+    lines_list = raw_bytes.decode("utf-8", errors="replace").split("\n")
     for line_no, raw in enumerate(lines_list, start=1):
         if not raw.strip():
             continue
@@ -627,7 +629,18 @@ def _read_jsonl_tail(
     # above, making the first whole line `lines_before_window + 2`. When there
     # was no seek (whole file read), the first line is 1.
     base_start_line = lines_before_window + 2 if head_bytes > 0 else 1
-    all_lines = text.splitlines()
+    # Split on \n only (NOT splitlines, which accepts bare \r). A crash-truncated
+    # record ending in bare \r must not be parsed as a complete line.
+    # First check: if the text doesn't end with \n, the last line is unterminated.
+    text_ends_with_newline = text.endswith("\n")
+    all_lines = text.split("\n")
+    # Drop trailing empty string if text ended with \n.
+    if all_lines and all_lines[-1] == "":
+        all_lines.pop()
+    # If text didn't end with \n, the last "line" is unterminated (bare \r or
+    # EOF) — discard it, matching the full reader's terminator gate.
+    if not text_ends_with_newline and all_lines:
+        all_lines.pop()
     # Keep only the last `rows_cap` lines so a huge tail window still bounds the
     # parsed-event list (and the JSON decode cost). If we trim lines from the
     # front, advance the starting line number by the trim count.

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -188,8 +188,8 @@ def _read_jsonl(
     max_rows: int | None = None,
     tail: bool = False,
     attribute_lines: bool = True,
-) -> tuple[list[dict], list[dict]]:
-    """Read a run-journal JSONL file into (events, malformed).
+) -> tuple[list[dict], list[dict], bool]:
+    """Read a run-journal JSONL file into (events, malformed, ok).
 
     Memory: unbounded by default this reads the WHOLE file via read_text() and
     parses every line — fine for small journals but a turn with heavy tool use
@@ -203,8 +203,12 @@ def _read_jsonl(
       ``last_seq``/``last_event_id``/``terminal_state`` from the LAST events —
       a tail read keeps those correct for a large COMPLETED run without parsing
       the whole history. A line split at the seek boundary is discarded.
+      Returns ``ok=False`` iff a transient OSError was caught during the
+      boundary scan, so callers can skip caching failed results. (#6139 r14)
     - ``tail=False`` with caps: read forward but stop once ``max_bytes``/``max_rows``
       is exceeded (head cap), via the existing bounded line iterator.
+      Returns ``ok=True`` (the non-tail paths don't have the boundary-helper
+      OSError-swallow problem in the same way).
 
     ``malformed`` entries carry ``{"line": n, "raw": ...}`` with 1-based line
     numbers relative to the whole file (tail mode computes the offset).
@@ -244,12 +248,12 @@ def _read_jsonl(
                 else:
                     malformed.append({"line": line_no, "raw": raw.decode("utf-8", "replace")})
         except FileNotFoundError:
-            return events, malformed
+            return events, malformed, True
         except ValueError:
             # _iter_bounded_raw_jsonl_lines raises "replay_limit_bytes" once the
             # byte cap is exceeded; the events collected so far are returned.
-            return events, malformed
-        return events, malformed
+            return events, malformed, True
+        return events, malformed, True
 
     # Unbounded whole-file read (original behavior).
     # Read RAW BYTES and split on b"\n" only — NOT read_text() (which does
@@ -260,7 +264,7 @@ def _read_jsonl(
     try:
         raw_bytes = path.read_bytes()
     except FileNotFoundError:
-        return events, malformed
+        return events, malformed, True
     # Accept a final record only if it ends in \n (covers both LF and CRLF,
     # since CRLF ends in \n). Otherwise discard the last line.
     if raw_bytes and not raw_bytes.endswith(b"\n"):
@@ -280,7 +284,7 @@ def _read_jsonl(
             events.append(parsed)
         else:
             malformed.append({"line": line_no, "raw": raw})
-    return events, malformed
+    return events, malformed, True
 
 
 # Bounded prefix read for oversized journal records. The record layout from
@@ -306,7 +310,7 @@ _VALIDITY_PROOF_MAX_BYTES = 2 * _SESSION_REPLAY_MAX_BYTES
 
 
 def _find_record_start_before(
-    fh, size: int, seek_pos: int, *, budget: _ReadBudget | None = None
+    fh, size: int, seek_pos: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
 ) -> int:
     """Return the byte offset where the JSONL record overlapping ``seek_pos``
     begins, i.e. the byte just after the last newline strictly before seek_pos.
@@ -324,6 +328,9 @@ def _find_record_start_before(
     the helper runs unbounded (the whole tail read is already bounded by the
     caller). Capping only ever narrows the examined window — the byte-found
     offset math is unchanged when the full chunk is read. (#6139 r10 item 1.)
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
     """
     if seek_pos <= 0:
         return 0
@@ -353,11 +360,13 @@ def _find_record_start_before(
         # TOCTOU: journal deleted between the stat() above and this open/read
         # (cleanup racing a status poll). Return the safe fallback rather than
         # letting the exception escape to the HTTP handler. (#6139 Greptile P1)
+        if fault is not None:
+            fault[0] = True
         return 0
     return 0
 
 
-def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: int | _ReadBudget | None = None) -> dict | None:
+def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: int | _ReadBudget | None = None, fault: list[bool] | None = None) -> dict | None:
     """Return the summary of the last complete JSONL record strictly before
     ``end_offset``, without materializing a multi-MB payload.
 
@@ -388,6 +397,9 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
     predecessor scan counts against the SAME allowance as boundary lookup /
     structural validation). If ``budget`` is None it defaults to
     ``_SESSION_REPLAY_MAX_BYTES``.
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
     """
     if end_offset <= 0:
         return None
@@ -435,31 +447,33 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
             if scan_end <= 0:
                 return None
             continue
-        # Oversized predecessor (> _BOUNDARY_SUMMARY_PREFIX_BYTES): fail-closed.
-        # Its full-record JSON validity can NEVER be proven without materializing
-        # the payload, so per #6139 r9 item 2 the fabricated prefix is NOT
-        # trusted. The row is skipped and the scan continues to the preceding
-        # normal-sized valid event. (The scan work done so far by
-        # _rfind_byte_before is already charged via the shared budget.)
-        if line_len > _BOUNDARY_SUMMARY_PREFIX_BYTES:
-            # An oversized predecessor's validity cannot be proven without
-            # materializing its payload, so per #6139 r9 it is skipped
-            # (fail-closed). The scan continues to the preceding normal-sized
-            # valid event.
-            rows_scanned += 1
-            scan_end = line_start
-            if scan_end <= 0:
-                return None
-            continue
-        # Normal-size candidate line: charge the budget for the parse read too
-        # (the maintainer named "candidate parsing" in item 1), then read.
+        # Candidate predecessor line. This loop only reaches COMPLETE lines
+        # (newline-terminated on both sides — _rfind_byte_before found the
+        # surrounding newlines, and the caller's end_offset is the boundary
+        # record's start, strictly after this line). So unlike the BOUNDARY
+        # record, a predecessor can be VALIDATED by reading + json.loads-ing the
+        # whole line: it is not crash-truncated.
+        #
+        # #6139 r14 finding 2: the prior code blanket-skipped any line
+        # > _BOUNDARY_SUMMARY_PREFIX_BYTES (8 KiB) as "oversized fail-closed",
+        # conflating the boundary record's 8 KiB prefix-extraction limit with a
+        # validity limit. That dropped VALID predecessors larger than 8 KiB (e.g.
+        # a 20 KiB tool_complete event) → latest_run_summary reported a stale
+        # last_seq → stale_interrupted_event synthesized an event_id colliding
+        # with the real dropped event's id. A complete line is parseable
+        # regardless of size; the only bound is the shared budget. Read + parse
+        # the line directly, charging the budget; skip only on budget exhaustion
+        # or a parse failure (genuinely malformed), continuing backward to the
+        # preceding valid event.
         to_read = budget_obj.take(line_len)
         if to_read == 0:
-            return None  # exhausted before parsing this candidate — stop
+            return None  # budget exhausted before parsing this candidate — stop
         try:
             fh.seek(line_start)
             raw = fh.read(to_read)
         except (FileNotFoundError, OSError):
+            if fault is not None:
+                fault[0] = True
             return None  # TOCTOU: journal deleted mid-read — safe fallback
         try:
             parsed = json.loads(raw.decode("utf-8", errors="replace"))
@@ -640,38 +654,79 @@ def _record_is_structurally_complete(
 
 
 def _record_is_valid_complete(
-    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None
+    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
 ) -> bool:
-    """Return True iff the JSONL record at ``record_start`` is a valid JSON
-    value (a dict) followed by a newline terminator.
+    """Return True iff the JSONL record at ``record_start`` is a valid (or
+    structurally-complete) JSON value (a dict) followed by a newline terminator.
 
     This is the validity gate for trusting a fabricated boundary-record summary
     (#6139 r10 item 2): brace balance is necessary but NOT sufficient for JSON
     validity. A brace-balanced record with a trailing comma (``...,}``) or a
     malformed nested value (``...bad:nested...}``) is NOT valid JSON and must
     NOT be fabricated into a terminal event. The full reader ``_read_jsonl``
-    correctly rejects such rows; the tail reader must MATCH it.
+    correctly rejects such rows; the tail reader must MATCH it for records it
+    can afford to validate in full.
 
-    Implementation: scan forward from ``record_start`` in chunks, accumulating
-    bytes until the first newline terminator (the JSONL record boundary),
-    charging each read to the shared budget, then parse the accumulated record
-    ONCE with ``json.JSONDecoder.raw_decode`` (which parses exactly one value and
-    returns its end offset; the byte at that offset must be the record's newline).
-    This reads ONLY the record's actual length — a small record costs one chunk,
-    not the full forward window (#6139 r11: the r10 greedy single read of
-    ``min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)`` charged ~cap for a
-    tiny record, putting summary-path physical reads at 2x cap even for normal
-    journals). A legitimately oversized terminal ``done`` (~cap payload) is still
-    proven valid by reading its full length. Capped at
-    ``_VALIDITY_PROOF_MAX_BYTES`` so a pathological record fails closed (recovers
-    the older valid event) rather than reading unbounded.
+    Two tiers (#6139 r14 finding 1):
 
-    The caller owns the handle and passes the pinned size. ``budget`` charges each
-    chunk read against the shared boundary-recovery meter; if the allowance can't
-    reach the terminator, returns False (fail-closed).
+    - Tier 1 (record length <= ``_VALIDITY_PROOF_MAX_BYTES``): scan forward in
+      chunks to the newline terminator, materialize the record, and parse it
+      ONCE with ``json.JSONDecoder.raw_decode`` (which parses exactly one value
+      and returns its end offset; the byte at that offset must be the record's
+      newline). This is FULLY correct — it rejects trailing commas, malformed
+      nested values, and any grammatical error — and is the path the r10
+      adversarial fixtures (all < 8 MiB) rely on. A small record costs one
+      chunk; a legitimately oversized ``done`` up to the ceiling is proven valid
+      by reading its full length.
+
+    - Tier 2 (record length > ``_VALIDITY_PROOF_MAX_BYTES``): a bounded-memory
+      STREAMING structural-completeness scan that does NOT materialize the
+      record. Scan forward tracking brace/bracket depth + string/escape state
+      until the top-level depth returns to 0 immediately followed by a newline.
+      A crash-truncated record (the only realistic failure mode for a
+      >ceiling record, since ``append_run_event`` serializes via ``json.dumps``
+      and fsyncs) never reaches depth 0 — or has no newline after — so it is
+      rejected. A brace-balanced + newline-terminated record is accepted.
+
+      Documented residual (#6139 r14): unlike tier 1, tier 2 does NOT perform
+      full JSON grammar validation — it accepts brace-balanced records. This is
+      acceptable because (a) the journal writer produces valid JSON via
+      ``json.dumps`` on an fsync'd append-only file, so a >ceiling record is
+      valid-or-truncated, never corrupted-in-place; (b) the r10 adversarial
+      fixtures (trailing comma, malformed nested value) are < 8 MiB and stay on
+      tier 1, which rejects them; (c) a >ceiling brace-balanced-but-invalid
+      record would require post-write corruption of an fsync'd file. Stale-
+      but-nonterminal (the recoverable direction) is never falsely terminal.
+
+    The caller owns the handle and passes the pinned size. ``budget`` charges
+    each chunk read against the shared meter; if the allowance can't reach the
+    terminator/depth-0, returns False (fail-closed).
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
     """
     if record_start < 0 or record_start >= size:
         return False
+    record_len = size - record_start
+    if record_len <= 0:
+        return False
+    if record_len <= _VALIDITY_PROOF_MAX_BYTES:
+        return _record_is_valid_complete_tier1(
+            fh, size, record_start, budget=budget, fault=fault
+        )
+    return _record_is_valid_complete_tier2(fh, size, record_start, budget=budget, fault=fault)
+
+
+def _record_is_valid_complete_tier1(
+    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
+) -> bool:
+    """Tier 1 validity proof: full ``raw_decode`` on the materialized record
+    (record length <= ``_VALIDITY_PROOF_MAX_BYTES``). See
+    ``_record_is_valid_complete`` for the two-tier contract.
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
+    """
     max_window = min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)
     if max_window <= 0:
         return False
@@ -691,6 +746,8 @@ def _record_is_valid_complete(
             fh.seek(pos)
             block = fh.read(want)
         except (FileNotFoundError, OSError):
+            if fault is not None:
+                fault[0] = True
             return False  # TOCTOU: journal deleted mid-read — safe fallback
         if not block:
             break
@@ -726,8 +783,92 @@ def _record_is_valid_complete(
     return False
 
 
+def _record_is_valid_complete_tier2(
+    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
+) -> bool:
+    """Tier 2 validity proof: bounded-memory streaming structural-completeness
+    scan for records longer than ``_VALIDITY_PROOF_MAX_BYTES``. Does NOT
+    materialize the record — tracks brace/bracket depth + string/escape state
+    forward in chunks until the top-level depth returns to 0 immediately
+    followed by a newline terminator. See ``_record_is_valid_complete`` for the
+    two-tier contract and the documented residual (accepts brace-balanced
+    records, which is sound because the journal writer fsyncs valid JSON).
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
+    """
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    pos = record_start
+    depth = 0
+    in_string = False
+    escaped = False
+    # `await_terminator`: depth has returned to 0; now require \n (or \r\n).
+    # `pending_cr`: depth-0 byte was \r; the next byte must be \n (CRLF) or reject.
+    await_terminator = False
+    pending_cr = False
+    while pos < size:
+        want = min(chunk_size, size - pos)
+        if budget is not None:
+            got = budget.take(want)
+            if got <= 0:
+                return False  # can't reach the record's end within budget — fail-closed
+            want = min(want, got)
+        try:
+            fh.seek(pos)
+            block = fh.read(want)
+        except (FileNotFoundError, OSError):
+            if fault is not None:
+                fault[0] = True
+            return False  # TOCTOU: journal deleted mid-read — safe fallback
+        if not block:
+            break
+        i = 0
+        n = len(block)
+        while i < n:
+            c = block[i]
+            if pending_cr:
+                # Previous depth-0 byte was \r; require \n now (CRLF ok).
+                if c == 0x0A:  # \n
+                    return True
+                return False  # bare \r followed by non-\n — reject
+            if await_terminator:
+                # Depth is 0; the only acceptable next bytes are the record's
+                # newline terminator (\n, or \r\n). A bare \r is rejected
+                # (matches tier 1 + the tail reader's terminator gate).
+                if c == 0x0A:  # \n
+                    return True
+                if c == 0x0D:  # \r
+                    pending_cr = True
+                    i += 1
+                    continue
+                return False  # trailing garbage after the top-level value — reject
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif c == 0x5C:  # backslash
+                    escaped = True
+                elif c == 0x22:  # closing quote
+                    in_string = False
+                i += 1
+                continue
+            if c == 0x22:  # opening quote
+                in_string = True
+            elif c in (0x7B, 0x5B):  # { or [
+                depth += 1
+            elif c in (0x7D, 0x5D):  # } or ]
+                depth -= 1
+                if depth == 0:
+                    # Top-level value closed; the next byte must be the terminator.
+                    await_terminator = True
+            i += 1
+        pos += len(block)
+    # Reached EOF without a clean depth-0 + newline terminator: crash-truncated
+    # or unterminated. Reject (fail-closed — recover the older valid event).
+    return False
+
+
 def _extract_boundary_record_summary(
-    fh, record_start: int, *, budget: _ReadBudget | None = None
+    fh, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
 ) -> dict | None:
     """Extract ONLY the summary fields of an oversized journal record that
     straddles the tail-window boundary, without materializing its payload.
@@ -745,6 +886,9 @@ def _extract_boundary_record_summary(
     remaining allowance; if the allowance hits 0 the function returns None. The
     rest of the function operates on whatever prefix was read — if a shorter-
     than-expected prefix can't be parsed, returns None.
+
+    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
+    to signal the caller that a transient read fault occurred. (#6139 r14)
     """
     try:
         fh.seek(record_start)
@@ -756,6 +900,8 @@ def _extract_boundary_record_summary(
         else:
             prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
     except (FileNotFoundError, OSError):
+        if fault is not None:
+            fault[0] = True
         return None
     text = prefix_raw.decode("utf-8", errors="replace")
     # Find the top-level "payload" key (depth 1 inside the record object).
@@ -833,7 +979,7 @@ def _find_top_level_payload_key(text: str) -> int | None:
 
 def _read_jsonl_tail(
     path: Path, *, max_bytes: int | None, max_rows: int | None, attribute_lines: bool = True
-) -> tuple[list[dict], list[dict]]:
+) -> tuple[list[dict], list[dict], bool]:
     """Read the trailing portion of a JSONL journal (bounded memory).
 
     Seeks to (size - max_bytes) and reads forward, discarding the partial line
@@ -845,20 +991,24 @@ def _read_jsonl_tail(
     The file is opened ONCE and the size is pinned via os.fstat — ensuring all
     recovery helpers read from a single inode generation. A delete-and-recreate
     between stages cannot mix rows from different generations.
+
+    Returns a 3-tuple (events, malformed, ok) where ``ok`` is False iff a
+    transient OSError was caught during the boundary scan. (#6139 r14)
     """
     events: list[dict] = []
     malformed: list[dict] = []
+    fault = [False]  # shared mutable flag for boundary-helper OSError tracking
     try:
         fh = path.open("rb")
     except (FileNotFoundError, OSError):
-        return events, malformed
+        return events, malformed, True
     try:
         try:
             size = os.fstat(fh.fileno()).st_size   # ONE pin; same generation for all stages
         except OSError:
-            return events, malformed
+            return events, malformed, True
         if size <= 0:
-            return events, malformed
+            return events, malformed, True
         read_bytes_cap = (
             max_bytes if (max_bytes is not None and max_bytes > 0)
             else _SESSION_REPLAY_MAX_BYTES
@@ -891,20 +1041,25 @@ def _read_jsonl_tail(
         boundary_summary: dict | None = None
         if size > read_bytes:
             seek_pos = size - read_bytes
-            # Boundary START lookup + 8 KiB prefix extraction share ONE meter sized
-            # at 2x the tail window (#6139 r10 item 1): the backward lookup scans
-            # the bytes before the window up to the record start, and prefix
-            # extraction reads _BOUNDARY_SUMMARY_PREFIX_BYTES, so 2x cap bounds
-            # both for a single straddling record.
-            boundary_budget = _ReadBudget(2 * read_bytes_cap)
-            record_start = _find_record_start_before(fh, size, seek_pos, budget=boundary_budget)
+            # Boundary START lookup + 8 KiB prefix extraction share ONE meter
+            # (#6139 r10 item 1). The backward lookup scans the bytes before the
+            # tail window up to the record start; for a straddling record up to the
+            # validity ceiling (4x cap, #6139 r14 finding 1) that pre-window portion
+            # can be up to ~3x cap, plus _BOUNDARY_SUMMARY_PREFIX_BYTES for the
+            # prefix extraction. Size the meter at 4x cap so a record the validity
+            # gate can accept can also be located + prefix-extracted without
+            # exhausting the meter (the r14 bug: a 12 MiB valid done exhausted the
+            # 2x cap lookup budget scanning its own pre-window bytes, so extraction
+            # got budget_remaining=0 -> None -> valid terminal rejected).
+            boundary_budget = _ReadBudget(4 * read_bytes_cap)
+            record_start = _find_record_start_before(fh, size, seek_pos, budget=boundary_budget, fault=fault)
             # record_start is where the straddling record begins. Extract its summary
             # via a bounded prefix read (never materializes the payload) — BUT only
             # trust it as terminal if the record is a structurally-complete AND
             # grammatically-valid JSON record. Brace balance is NOT JSON validity
             # (#6139 r10 item 2): a brace-balanced record with a trailing comma or a
             # malformed nested value must NOT be fabricated into a terminal event.
-            boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=boundary_budget)
+            boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=boundary_budget, fault=fault)
             # A boundary record is REJECTED (must not be trusted as terminal, and
             # the preceding valid event must be recovered instead) on EITHER path:
             #   (a) the prefix summary could not be extracted at all (extraction
@@ -936,8 +1091,15 @@ def _read_jsonl_tail(
                 # gate can possibly accept can pay for its own complete validation;
                 # the incremental chunked read means a small record still costs
                 # only one chunk, so the constant-in-file-size property holds.
-                validity_budget = _ReadBudget(_VALIDITY_PROOF_MAX_BYTES)
-                if _record_is_valid_complete(fh, size, record_start, budget=validity_budget):
+                # (#6139 r14 finding 1): the validity proof now has two tiers. Tier 1
+                # (≤_VALIDITY_PROOF_MAX_BYTES) does full JSON parsing; tier 2 (>ceiling)
+                # does streaming structural-completeness scanning. The budget must be
+                # larger than _VALIDITY_PROOF_MAX_BYTES so tier 2 can scan a legitimately
+                # large (>8 MiB) terminal record to its depth-0 + newline. 4x cap (16 MiB)
+                # covers real transcripts while staying a constant bound independent of
+                # file size (a pathological multi-GB record fails-closed).
+                validity_budget = _ReadBudget(4 * read_bytes_cap)
+                if _record_is_valid_complete(fh, size, record_start, budget=validity_budget, fault=fault):
                     boundary_rejected = False  # valid + complete: trust the prefix
                 else:
                     boundary_summary = None  # extracted-but-invalid: fail-closed
@@ -957,7 +1119,7 @@ def _read_jsonl_tail(
                 # boundary physical I/O is then capped at 2*cap + cap = 3*cap
                 # regardless of file size.
                 predecessor_budget = _ReadBudget(read_bytes_cap)
-                preceding = _read_last_complete_line_before(fh, size, record_start, budget=predecessor_budget)
+                preceding = _read_last_complete_line_before(fh, size, record_start, budget=predecessor_budget, fault=fault)
                 if preceding is not None:
                     events.append(preceding)
             # Now drop the partial first fragment from the window so we only parse
@@ -973,7 +1135,7 @@ def _read_jsonl_tail(
             # No straddling record recovered AND no complete lines in the window.
             # (When boundary_summary was recovered we already have it; an empty text
             # just means there were no trailing complete records, which is fine.)
-            return events, malformed
+            return events, malformed, not fault[0]
         # 1-based line number of the first whole line in `text`, across the whole
         # file. The discarded prefix (size - read_bytes bytes) contains some number
         # of complete lines; the first whole line in the window is the next one. We
@@ -1045,10 +1207,10 @@ def _read_jsonl_tail(
                 events.append(parsed)
             else:
                 malformed.append({"line": line_no, "raw": raw_line})
-        return events, malformed
+        return events, malformed, not fault[0]
     except (FileNotFoundError, OSError):
         # A read failure mid-recovery: return what we have (best-effort).
-        return events, malformed
+        return events, malformed, not fault[0]
     finally:
         fh.close()
 
@@ -1128,7 +1290,7 @@ def bound_run_journal_snapshot_args(args: Any) -> Any:
 
 
 def _next_seq(path: Path) -> int:
-    events, _malformed = _read_jsonl(path)
+    events, _malformed, _ok = _read_jsonl(path)
     seqs = [int(event.get("seq") or 0) for event in events if isinstance(event.get("seq"), int)]
     return (max(seqs) + 1) if seqs else 1
 
@@ -1354,7 +1516,7 @@ def read_run_events(
     max_rows: int | None = None,
 ) -> dict:
     path = _run_path(session_id, run_id, session_dir=session_dir)
-    events, malformed = _read_jsonl(path, max_bytes=max_bytes, max_rows=max_rows)
+    events, malformed, _ok = _read_jsonl(path, max_bytes=max_bytes, max_rows=max_rows)
     if after_seq is not None:
         events = [event for event in events if int(event.get("seq") or 0) > int(after_seq)]
     if max_seq is not None:
@@ -1424,11 +1586,17 @@ def latest_run_summary(
     # run's terminal marker lives at the end and must not require parsing the
     # full history. Callers needing head/all events use read_run_events().
     pre_read_signature = _summary_cache_signature(path)
-    events, _malformed = _read_jsonl(
+    events, _malformed, ok = _read_jsonl(
         path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
     )
     summary = _summary_from_events(session_id, run_id, events)
-    _cache_summary(path, summary, expected_signature=pre_read_signature)
+    # #6139 r14 finding 3: a transient OSError during the boundary scan produces
+    # a best-effort/failed summary (terminal_state="unknown", empty events).
+    # Caching it under the matching inode signature would make subsequent calls
+    # return the stale failure instead of retrying. Skip caching when the read
+    # faulted so the next call retries and recovers.
+    if ok:
+        _cache_summary(path, summary, expected_signature=pre_read_signature)
     return summary
 
 
@@ -1483,11 +1651,16 @@ def find_run_summary(
             pre_read_signature = _summary_cache_signature(path)
             # Tail read: summary needs the terminal/last events (see
             # latest_run_summary), so bound memory on large completed runs.
-            events, _malformed = _read_jsonl(
+            events, _malformed, ok = _read_jsonl(
                 path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
             )
             summary = _summary_from_events(session_id, rid, events)
-            _cache_summary(path, summary, expected_signature=pre_read_signature)
+            # #6139 r14 finding 3: a transient OSError during the boundary scan
+            # produces a best-effort/failed summary. Caching it under the matching
+            # inode signature would make subsequent calls return the stale failure
+            # instead of retrying. Skip caching when the read faulted.
+            if ok:
+                _cache_summary(path, summary, expected_signature=pre_read_signature)
         summary["path"] = str(path)
         return summary
     return None

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -187,6 +187,7 @@ def _read_jsonl(
     max_bytes: int | None = None,
     max_rows: int | None = None,
     tail: bool = False,
+    attribute_lines: bool = True,
 ) -> tuple[list[dict], list[dict]]:
     """Read a run-journal JSONL file into (events, malformed).
 
@@ -220,7 +221,7 @@ def _read_jsonl(
             max_bytes = _SESSION_REPLAY_MAX_BYTES
         if max_rows is None:
             max_rows = _SESSION_REPLAY_MAX_ROWS
-        return _read_jsonl_tail(path, max_bytes=max_bytes, max_rows=max_rows)
+        return _read_jsonl_tail(path, max_bytes=max_bytes, max_rows=max_rows, attribute_lines=attribute_lines)
 
     if max_bytes is not None or max_rows is not None:
         mb = max_bytes if max_bytes is not None else (1 << 62)
@@ -641,9 +642,8 @@ def _record_is_structurally_complete(
 def _record_is_valid_complete(
     fh, size: int, record_start: int, *, budget: _ReadBudget | None = None
 ) -> bool:
-    """Return True iff the JSONL record at ``record_start`` is a structurally
-    complete AND grammatically valid JSON value (a dict) followed by a newline
-    terminator.
+    """Return True iff the JSONL record at ``record_start`` is a valid JSON
+    value (a dict) followed by a newline terminator.
 
     This is the validity gate for trusting a fabricated boundary-record summary
     (#6139 r10 item 2): brace balance is necessary but NOT sufficient for JSON
@@ -652,59 +652,76 @@ def _record_is_valid_complete(
     NOT be fabricated into a terminal event. The full reader ``_read_jsonl``
     correctly rejects such rows; the tail reader must MATCH it.
 
-    Implementation: rather than a hand-written streaming JSON validator
-    (error-prone — a rejected r10 prototype mis-classified ~80% of fuzz inputs),
-    a bounded window (``_VALIDITY_PROOF_MAX_BYTES``) starting at ``record_start``
-    is materialized ONCE and parsed with ``json.JSONDecoder.raw_decode``, which
-    parses exactly one JSON value and returns its end offset. The byte at that
-    offset must be a newline terminator (the JSONL line separator). This proves
-    grammar validity AND terminator completeness from a single read, and does
-    NOT over-reach when trailing records follow the boundary record on the same
-    file (the window may contain them but raw_decode stops at the first value's
-    end). If the record extends beyond the window (pathologically large),
-    validity cannot be proven within the bound → fail-closed (return False →
-    recover the older valid event). The transient memory is one record's worth
-    of bytes (bounded), only for the single straddling boundary record.
+    Implementation: scan forward from ``record_start`` in chunks, accumulating
+    bytes until the first newline terminator (the JSONL record boundary),
+    charging each read to the shared budget, then parse the accumulated record
+    ONCE with ``json.JSONDecoder.raw_decode`` (which parses exactly one value and
+    returns its end offset; the byte at that offset must be the record's newline).
+    This reads ONLY the record's actual length — a small record costs one chunk,
+    not the full forward window (#6139 r11: the r10 greedy single read of
+    ``min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)`` charged ~cap for a
+    tiny record, putting summary-path physical reads at 2x cap even for normal
+    journals). A legitimately oversized terminal ``done`` (~cap payload) is still
+    proven valid by reading its full length. Capped at
+    ``_VALIDITY_PROOF_MAX_BYTES`` so a pathological record fails closed (recovers
+    the older valid event) rather than reading unbounded.
 
-    The caller owns the handle and passes the pinned size. ``budget`` charges
-    the read against the shared boundary-recovery meter; if the allowance can't
-    cover the window, returns False (fail-closed).
+    The caller owns the handle and passes the pinned size. ``budget`` charges each
+    chunk read against the shared boundary-recovery meter; if the allowance can't
+    reach the terminator, returns False (fail-closed).
     """
     if record_start < 0 or record_start >= size:
         return False
-    # Read a bounded window from record_start. raw_decode will parse exactly one
-    # value and stop; the byte right after it must be the record's newline.
-    window_len = min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)
-    if window_len <= 0:
+    max_window = min(size - record_start, _VALIDITY_PROOF_MAX_BYTES)
+    if max_window <= 0:
         return False
-    if budget is not None:
-        to_read = budget.take(window_len)
-        if to_read <= 0:
-            return False  # exhausted before reading — fail-closed
-        window_len = min(window_len, to_read)
-    try:
-        fh.seek(record_start)
-        window = fh.read(window_len)
-    except (FileNotFoundError, OSError):
-        return False  # TOCTOU: journal deleted mid-read — safe fallback
-    if not window:
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    chunks: list[bytes] = []
+    total = 0
+    pos = record_start
+    have_terminator = False
+    while total < max_window:
+        want = min(chunk_size, max_window - total)
+        if budget is not None:
+            got = budget.take(want)
+            if got <= 0:
+                return False  # can't reach terminator within budget — fail-closed
+            want = min(want, got)
+        try:
+            fh.seek(pos)
+            block = fh.read(want)
+        except (FileNotFoundError, OSError):
+            return False  # TOCTOU: journal deleted mid-read — safe fallback
+        if not block:
+            break
+        nl = block.find(b"\n")
+        if nl >= 0:
+            # Record ends at this newline. Keep only up to and including it so
+            # raw_decode sees exactly ONE record (trailing records on the file
+            # must not leak into the parsed value or the terminator check).
+            chunks.append(block[: nl + 1])
+            total += nl + 1
+            have_terminator = True
+            break
+        chunks.append(block)
+        total += len(block)
+        pos += len(block)
+    if not have_terminator:
+        # No newline terminator within the cap: crash-truncated or pathologically
+        # large. Can't prove completeness → fail-closed (recover older valid event).
         return False
-    text = window.decode("utf-8", errors="replace")
+    text = b"".join(chunks).decode("utf-8", errors="replace")
     try:
         obj, end_idx = json.JSONDecoder().raw_decode(text)
     except (json.JSONDecodeError, ValueError):
-        return False  # not valid JSON (truncated, trailing comma, malformed) — fail-closed
+        return False  # not valid JSON (trailing comma, malformed nested value) — fail-closed
     if not isinstance(obj, dict):
         return False  # the journal record layout is always an object
     # The value ended at text[end_idx-1]; the next byte(s) must be the record's
-    # newline terminator (LF, or CRLF). A bare \r is rejected (matches the rest
-    # of the tail reader's terminator gate). If the value consumed the whole
-    # window without reaching a terminator, the record is larger than the window
-    # → can't prove validity within the bound → fail-closed.
+    # newline terminator (LF or CRLF). A bare \r is rejected (matches the rest of
+    # the tail reader's terminator gate).
     terminator = text[end_idx:]
-    if terminator.startswith("\r\n"):
-        return True
-    if terminator.startswith("\n"):
+    if terminator.startswith("\r\n") or terminator.startswith("\n"):
         return True
     return False
 
@@ -815,7 +832,7 @@ def _find_top_level_payload_key(text: str) -> int | None:
 
 
 def _read_jsonl_tail(
-    path: Path, *, max_bytes: int | None, max_rows: int | None
+    path: Path, *, max_bytes: int | None, max_rows: int | None, attribute_lines: bool = True
 ) -> tuple[list[dict], list[dict]]:
     """Read the trailing portion of a JSONL journal (bounded memory).
 
@@ -874,18 +891,11 @@ def _read_jsonl_tail(
         boundary_summary: dict | None = None
         if size > read_bytes:
             seek_pos = size - read_bytes
-            # ONE shared remaining-work meter for the WHOLE boundary-recovery scan:
-            # boundary lookup + prefix extraction + validity proof + (if rejected)
-            # the backward predecessor scan + candidate parse. Physical I/O never
-            # exceeds this allowance (#6139 r10 item 1: "create one remaining-work
-            # authority ... thread that same object through boundary lookup, prefix
-            # extraction, structural validation, predecessor search, and candidate
-            # parsing"). Sized at 2x the tail window: the boundary record (the
-            # terminal `done` with the full transcript) is legitimately ~cap bytes,
-            # and the single-pass validity proof charges the record length once, so
-            # 2x cap covers a valid record plus a small predecessor recovery margin.
-            # A pathological multi-GB record fails closed (recovers the older valid
-            # event) rather than reading unbounded.
+            # Boundary lookup + prefix extraction + validity proof share ONE meter
+            # (#6139 r10 item 1). Sized at 2x the tail window: the boundary record
+            # (the terminal `done` with the full transcript) is legitimately ~cap
+            # bytes, and the single-pass validity proof charges the record length
+            # once, so 2x cap covers a valid record plus a small margin.
             boundary_budget = _ReadBudget(2 * read_bytes_cap)
             record_start = _find_record_start_before(fh, size, seek_pos, budget=boundary_budget)
             # record_start is where the straddling record begins. Extract its summary
@@ -904,14 +914,21 @@ def _read_jsonl_tail(
             ):
                 boundary_summary = None  # invalid/incomplete record: don't trust its prefix
                 # Retain the last COMPLETE valid event before the rejected boundary
-                # record, so last_seq/running survive and the apperror recovery
-                # signal fires (matching master). Without this, rejecting the
-                # boundary record also drops the preceding valid event →
-                # event_count=0, last_seq=0, no recovery. Read the last complete
-                # record's summary via bounded prefix extraction (never materializes
-                # a multi-MB payload), sharing the SAME budget so the aggregate
-                # boundary-recovery work stays bounded.
-                preceding = _read_last_complete_line_before(fh, size, record_start, budget=boundary_budget)
+                # record, so last_seq/terminal survive and the recovery signal fires
+                # (matching master). Predecessor recovery gets its OWN reserved
+                # allowance SEPARATE from the validity-proof budget (#6139 r11
+                # secondary): a single shared meter let a >=budget invalid oversized
+                # record (e.g. an 8 MiB balanced-invalid record against an 8 MiB
+                # budget) exhaust the meter via the validity proof, starving the
+                # backward predecessor scan — so a completed run was misreported
+                # non-terminal (master `completed`/last_seq 3 → candidate
+                # `running`/last_seq 3 because the preceding terminal `done` was
+                # unrecoverable). A dedicated predecessor reserve (one tail window)
+                # bounds the backward scan independently of the validity proof; total
+                # boundary physical I/O is then capped at 2*cap + cap = 3*cap
+                # regardless of file size.
+                predecessor_budget = _ReadBudget(read_bytes_cap)
+                preceding = _read_last_complete_line_before(fh, size, record_start, budget=predecessor_budget)
                 if preceding is not None:
                     events.append(preceding)
             # Now drop the partial first fragment from the window so we only parse
@@ -934,9 +951,17 @@ def _read_jsonl_tail(
         # must COUNT newlines in the discarded prefix — a byte offset is NOT a line
         # number (a 4 MB head with ~80 B/line has ~50000 lines, not ~4 M). Count by
         # streaming the head in chunks so a huge file doesn't get materialized twice.
+        # Line attribution (1-based line numbers in `malformed`) requires counting
+        # newlines in the discarded head — an O(file-size) scan. Summary readers
+        # (`latest_run_summary` / `find_run_summary`) pass attribute_lines=False
+        # because they DISCARD `malformed`, so the head scan is dead work there and
+        # would make physical reads unbounded (the r11 blocker: a 72 MiB journal
+        # read 79.7 MiB physically, 19x the 4 MiB tail cap, with this scan). When
+        # attribution is disabled, skip the head scan entirely (base_start_line=0);
+        # the relative line numbers are harmless since summary callers ignore them.
         head_bytes = size - read_bytes if size > read_bytes else 0
-        lines_before_window = 0
-        if head_bytes > 0:
+        if attribute_lines and head_bytes > 0:
+            lines_before_window = 0
             try:
                 fh.seek(0)
                 _remaining = head_bytes
@@ -948,11 +973,17 @@ def _read_jsonl_tail(
                     _remaining -= len(_chunk)
             except (FileNotFoundError, OSError):
                 lines_before_window = 0  # best-effort attribution; events are unaffected
-        # `text`'s first whole line in the file: the discarded head ended mid-line,
-        # so the partial line it left (line `lines_before_window + 1`) was dropped
-        # above, making the first whole line `lines_before_window + 2`. When there
-        # was no seek (whole file read), the first line is 1.
-        base_start_line = lines_before_window + 2 if head_bytes > 0 else 1
+            # The discarded head ended mid-line, so the partial line it left (line
+            # lines_before_window + 1) was dropped above, making the first whole
+            # line in `text` lines_before_window + 2.
+            base_start_line = lines_before_window + 2
+        elif attribute_lines:
+            # No seek: whole file read, first line is 1.
+            base_start_line = 1
+        else:
+            # Attribution disabled (summary path): skip the O(file-size) head scan.
+            # malformed entries get relative numbers, which summary callers discard.
+            base_start_line = 0
         # Split on \n only (NOT splitlines, which accepts bare \r). A crash-truncated
         # record ending in bare \r must not be parsed as a complete line.
         # First check: if the text doesn't end with \n, the last line is unterminated.
@@ -1365,7 +1396,7 @@ def latest_run_summary(
     # full history. Callers needing head/all events use read_run_events().
     pre_read_signature = _summary_cache_signature(path)
     events, _malformed = _read_jsonl(
-        path, max_bytes=max_bytes, max_rows=max_rows, tail=True
+        path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
     )
     summary = _summary_from_events(session_id, run_id, events)
     _cache_summary(path, summary, expected_signature=pre_read_signature)
@@ -1424,7 +1455,7 @@ def find_run_summary(
             # Tail read: summary needs the terminal/last events (see
             # latest_run_summary), so bound memory on large completed runs.
             events, _malformed = _read_jsonl(
-                path, max_bytes=max_bytes, max_rows=max_rows, tail=True
+                path, max_bytes=max_bytes, max_rows=max_rows, tail=True, attribute_lines=False
             )
             summary = _summary_from_events(session_id, rid, events)
             _cache_summary(path, summary, expected_signature=pre_read_signature)

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -239,55 +239,6 @@ def _read_jsonl(
     return events, malformed
 
 
-def _read_last_complete_line(path: Path) -> str:
-    """Return the last complete line of a file (no trailing newline), found by
-    scanning backward from EOF for the final newline.
-
-    Used as a fallback when ``_read_jsonl_tail``'s whole tail window is a single
-    truncated record — i.e. one journal record (typically the terminal ``done``
-    event with a full-transcript payload) exceeds the tail window. The last
-    complete line holds that record's summary fields (terminal_state / last_seq
-    / last_event_id), which is what the summary reader needs. Scans backward in
-    bounded chunks so a huge single-line record doesn't have to be fully read to
-    locate its start. Returns '' if the file has no complete line.
-
-    .. note:: This materializes the whole last line. When that line is an
-       oversized record (multi-MB payload), prefer ``_extract_boundary_record_summary``
-       which reads only a bounded prefix of the record's summary fields.
-    """
-    try:
-        size = path.stat().st_size
-    except (FileNotFoundError, OSError):
-        return ""
-    if size <= 0:
-        return ""
-    # Scan backward in chunks for the final newline. The line we want is the
-    # bytes between the final newline and EOF (or the whole file if there's no
-    # newline — but that case is "no complete line", handled by the caller).
-    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
-    with path.open("rb") as fh:
-        fh.seek(0, 2)  # EOF
-        end = fh.tell()
-        # If the last byte is a newline, the last complete line ends just before it.
-        if end > 0:
-            fh.seek(end - 1)
-            if fh.read(1) == b"\n":
-                end -= 1
-        pos = end
-        while pos > 0:
-            read_from = max(0, pos - chunk_size)
-            fh.seek(read_from)
-            block = fh.read(pos - read_from)
-            nl = block.rfind(b"\n")
-            if nl >= 0:
-                # The last complete line is from after this newline to `end`.
-                line_start = read_from + nl + 1
-                fh.seek(line_start)
-                return fh.read(end - line_start).decode("utf-8", errors="replace")
-            pos = read_from
-    return ""
-
-
 # Bounded prefix read for oversized journal records. The record layout from
 # append_run_event puts ALL summary fields before the (potentially huge) payload:
 #   {"version","event_id","seq","run_id","session_id","event","type","created_at",
@@ -322,6 +273,72 @@ def _find_record_start_before(path: Path, seek_pos: int) -> int:
                 return read_from + nl + 1
             pos = read_from
     return 0
+
+
+def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
+    """Return True iff the JSONL record at ``record_start`` is structurally
+    complete — i.e. its JSON object is closed (brace depth returns to 0) AND
+    followed by a newline terminator — scanning forward in bounded chunks WITHOUT
+    materializing the (potentially multi-MB) payload.
+
+    Used to gate trusting a fabricated prefix summary: a crash-truncated
+    ``done`` (write interrupted mid-payload, no closing brace/newline) must NOT
+    be accepted as terminal, or an interrupted run is misreported as completed
+    and its recovery signal is silently dropped. Returns False if EOF is reached
+    at brace depth > 0 (the record was truncated mid-write).
+    """
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    depth = 0
+    pos = record_start
+    try:
+        size = path.stat().st_size
+    except (FileNotFoundError, OSError):
+        return False
+    in_string = False
+    escaped = False
+    with path.open("rb") as fh:
+        fh.seek(record_start)
+        while pos < size:
+            chunk = fh.read(min(chunk_size, size - pos))
+            if not chunk:
+                break
+            chunk_len = len(chunk)
+            for ci in range(chunk_len):
+                b = chunk[ci]
+                pos += 1
+                if in_string:
+                    if escaped:
+                        escaped = False
+                    elif b == 0x5C:  # backslash
+                        escaped = True
+                    elif b == 0x22:  # closing quote
+                        in_string = False
+                    continue
+                if b == 0x22:  # opening quote
+                    in_string = True
+                elif b == 0x7B:  # '{'
+                    depth += 1
+                elif b == 0x7D:  # '}'
+                    depth -= 1
+                    if depth == 0:
+                        # Object closed at position `pos` (1 past the '}').
+                        # The record is complete iff the byte(s) right after are a
+                        # newline terminator (\n or \r\n). Look at the next byte
+                        # in the current chunk first (avoid file-cursor drift),
+                        # else read fresh from the file.
+                        if ci + 1 < chunk_len:
+                            nb = chunk[ci + 1]
+                            return nb in (0x0A, 0x0D)  # \n or \r
+                        # Terminator is in the next chunk: read 1 byte from file.
+                        # (fh cursor is at pos + (chunk_len - ci - 1); seek to pos.)
+                        fh.seek(pos)
+                        nb = fh.read(1)
+                        return nb in (b"\n", b"\r") or (nb == b"" and pos >= size)
+                elif b == 0x0A and depth == 0:  # newline at depth 0 before close
+                    return False
+            # depth > 0 here means the record spans more chunks; keep scanning.
+        # Reached EOF: complete only if the object closed exactly at EOF (depth 0).
+        return depth == 0
 
 
 def _extract_boundary_record_summary(path: Path, record_start: int) -> dict | None:
@@ -473,8 +490,17 @@ def _read_jsonl_tail(
         seek_pos = size - read_bytes
         record_start = _find_record_start_before(path, seek_pos)
         # record_start is where the straddling record begins. Extract its summary
-        # via a bounded prefix read (never materializes the payload).
+        # via a bounded prefix read (never materializes the payload) — BUT only
+        # trust it as terminal if the record is structurally complete. A crash-
+        # truncated `done` (write interrupted mid-payload: no closing brace, no
+        # newline) must NOT be fabricated into a terminal event, or an interrupted
+        # run is misreported as completed and its apperror recovery signal is
+        # silently dropped. Stale-but-nonterminal is recoverable; falsely-terminal
+        # is not. If incomplete, discard the summary and fall through to the
+        # preceding complete records (the run stays nonterminal/`running`).
         boundary_summary = _extract_boundary_record_summary(path, record_start)
+        if boundary_summary is not None and not _record_is_structurally_complete(path, record_start):
+            boundary_summary = None  # crash-truncated record: don't trust its prefix
         # Now drop the partial first fragment from the window so we only parse
         # the complete trailing records.
         nl = text.find("\n")

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -150,9 +150,76 @@ def _discard_cached_summary(path: Path) -> None:
         _SUMMARY_CACHE.pop(str(path), None)
 
 
-def _read_jsonl(path: Path) -> tuple[list[dict], list[dict]]:
+def _read_jsonl(
+    path: Path,
+    *,
+    max_bytes: int | None = None,
+    max_rows: int | None = None,
+    tail: bool = False,
+) -> tuple[list[dict], list[dict]]:
+    """Read a run-journal JSONL file into (events, malformed).
+
+    Memory: unbounded by default this reads the WHOLE file via read_text() and
+    parses every line — fine for small journals but a turn with heavy tool use
+    / large file reads can produce a multi-MB journal that gets fully re-parsed
+    on every status/sidebar poll that touches it. The bounded modes cap that:
+
+    - ``tail=True`` with ``max_bytes``/``max_rows``: read only the TRAILING
+      ``max_bytes`` of the file (seek-to-end) and return at most the last
+      ``max_rows`` events. Used by the summary readers
+      (``latest_run_summary`` / ``find_run_summary``) which derive
+      ``last_seq``/``last_event_id``/``terminal_state`` from the LAST events —
+      a tail read keeps those correct for a large COMPLETED run without parsing
+      the whole history. A line split at the seek boundary is discarded.
+    - ``tail=False`` with caps: read forward but stop once ``max_bytes``/``max_rows``
+      is exceeded (head cap), via the existing bounded line iterator.
+
+    ``malformed`` entries carry ``{"line": n, "raw": ...}`` with 1-based line
+    numbers relative to the whole file (tail mode computes the offset).
+    """
     events: list[dict] = []
     malformed: list[dict] = []
+
+    if tail:
+        # tail=True only makes sense with a bound (it seeks to size - max_bytes).
+        # If a caller passes tail=True with no caps, default to the replay caps
+        # rather than silently falling through to the unbounded whole-file read
+        # (which would ignore tail entirely).
+        if max_bytes is None:
+            max_bytes = _SESSION_REPLAY_MAX_BYTES
+        if max_rows is None:
+            max_rows = _SESSION_REPLAY_MAX_ROWS
+        return _read_jsonl_tail(path, max_bytes=max_bytes, max_rows=max_rows)
+
+    if max_bytes is not None or max_rows is not None:
+        mb = max_bytes if max_bytes is not None else (1 << 62)
+        mr = max_rows if max_rows is not None else (1 << 62)
+        line_no = 0
+        try:
+            for ln, raw, _cumulative in _iter_bounded_raw_jsonl_lines(path, max_bytes=mb):
+                line_no = ln
+                if not raw.strip():
+                    continue
+                if line_no > mr:
+                    break
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError:
+                    malformed.append({"line": line_no, "raw": raw.decode("utf-8", "replace")})
+                    continue
+                if isinstance(parsed, dict):
+                    events.append(parsed)
+                else:
+                    malformed.append({"line": line_no, "raw": raw.decode("utf-8", "replace")})
+        except FileNotFoundError:
+            return events, malformed
+        except ValueError:
+            # _iter_bounded_raw_jsonl_lines raises "replay_limit_bytes" once the
+            # byte cap is exceeded; the events collected so far are returned.
+            return events, malformed
+        return events, malformed
+
+    # Unbounded whole-file read (original behavior).
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:
@@ -169,6 +236,96 @@ def _read_jsonl(path: Path) -> tuple[list[dict], list[dict]]:
             events.append(parsed)
         else:
             malformed.append({"line": line_no, "raw": raw})
+    return events, malformed
+
+
+def _read_jsonl_tail(
+    path: Path, *, max_bytes: int | None, max_rows: int | None
+) -> tuple[list[dict], list[dict]]:
+    """Read the trailing portion of a JSONL journal (bounded memory).
+
+    Seeks to (size - max_bytes) and reads forward, discarding the partial line
+    at the seek boundary, then returns at most the last ``max_rows`` parsed
+    events. ``line`` numbers in ``malformed`` are 1-based across the whole file.
+    Used by summary readers that need the LAST events of a possibly huge journal
+    (terminal_state / last_seq live in the tail).
+    """
+    events: list[dict] = []
+    malformed: list[dict] = []
+    try:
+        size = path.stat().st_size
+    except (FileNotFoundError, OSError):
+        return events, malformed
+    if size <= 0:
+        return events, malformed
+    read_bytes_cap = (
+        max_bytes if (max_bytes is not None and max_bytes > 0)
+        else _SESSION_REPLAY_MAX_BYTES
+    )
+    read_bytes = min(size, read_bytes_cap)
+    rows_cap = max_rows if (max_rows is not None and max_rows > 0) else (1 << 62)
+    try:
+        with path.open("rb") as fh:
+            if size > read_bytes:
+                fh.seek(size - read_bytes)
+            raw = fh.read(read_bytes)
+    except (FileNotFoundError, OSError):
+        return events, malformed
+    text = raw.decode("utf-8", errors="replace")
+    # If we sought into the middle of the file, the first "line" is a partial
+    # fragment — drop everything up to and including the first newline.
+    if size > read_bytes:
+        nl = text.find("\n")
+        if nl >= 0:
+            text = text[nl + 1:]
+        else:
+            text = ""  # entire window was one truncated line; nothing whole
+    # 1-based line number of the first whole line in `text`, across the whole
+    # file. The discarded prefix (size - read_bytes bytes) contains some number
+    # of complete lines; the first whole line in the window is the next one. We
+    # must COUNT newlines in the discarded prefix — a byte offset is NOT a line
+    # number (a 4 MB head with ~80 B/line has ~50000 lines, not ~4 M). Count by
+    # streaming the head in chunks so a huge file doesn't get materialized twice.
+    head_bytes = size - read_bytes if size > read_bytes else 0
+    lines_before_window = 0
+    if head_bytes > 0:
+        try:
+            with path.open("rb") as _hf:
+                _remaining = head_bytes
+                while _remaining > 0:
+                    _chunk = _hf.read(min(_SESSION_REPLAY_READ_CHUNK_BYTES, _remaining))
+                    if not _chunk:
+                        break
+                    lines_before_window += _chunk.count(b"\n")
+                    _remaining -= len(_chunk)
+        except (FileNotFoundError, OSError):
+            lines_before_window = 0  # best-effort attribution; events are unaffected
+    # `text`'s first whole line in the file: the discarded head ended mid-line,
+    # so the partial line it left (line `lines_before_window + 1`) was dropped
+    # above, making the first whole line `lines_before_window + 2`. When there
+    # was no seek (whole file read), the first line is 1.
+    base_start_line = lines_before_window + 2 if head_bytes > 0 else 1
+    all_lines = text.splitlines()
+    # Keep only the last `rows_cap` lines so a huge tail window still bounds the
+    # parsed-event list (and the JSON decode cost). If we trim lines from the
+    # front, advance the starting line number by the trim count.
+    trim_from_front = max(0, len(all_lines) - rows_cap)
+    if trim_from_front:
+        all_lines = all_lines[-rows_cap:]
+    start_line = base_start_line + trim_from_front
+    for idx, raw_line in enumerate(all_lines):
+        line_no = start_line + idx
+        if not raw_line.strip():
+            continue
+        try:
+            parsed = json.loads(raw_line)
+        except json.JSONDecodeError:
+            malformed.append({"line": line_no, "raw": raw_line})
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+        else:
+            malformed.append({"line": line_no, "raw": raw_line})
     return events, malformed
 
 
@@ -469,9 +626,11 @@ def read_run_events(
     after_seq: int | None = None,
     max_seq: int | None = None,
     session_dir: Path | None = None,
+    max_bytes: int | None = None,
+    max_rows: int | None = None,
 ) -> dict:
     path = _run_path(session_id, run_id, session_dir=session_dir)
-    events, malformed = _read_jsonl(path)
+    events, malformed = _read_jsonl(path, max_bytes=max_bytes, max_rows=max_rows)
     if after_seq is not None:
         events = [event for event in events if int(event.get("seq") or 0) > int(after_seq)]
     if max_seq is not None:
@@ -524,13 +683,26 @@ def _summary_from_events(session_id: str, run_id: str, events: Iterable[dict]) -
     }
 
 
-def latest_run_summary(session_id: str, run_id: str, *, session_dir: Path | None = None) -> dict:
+def latest_run_summary(
+    session_id: str,
+    run_id: str,
+    *,
+    session_dir: Path | None = None,
+    max_bytes: int | None = _SESSION_REPLAY_MAX_BYTES,
+    max_rows: int | None = _SESSION_REPLAY_MAX_ROWS,
+) -> dict:
     path = _run_path(session_id, run_id, session_dir=session_dir)
     cached = _get_cached_summary(path)
     if cached is not None:
         return cached
+    # Summary derives last_seq / last_event_id / terminal_state from the LAST
+    # events, so read the bounded TAIL (not the whole file) — a large completed
+    # run's terminal marker lives at the end and must not require parsing the
+    # full history. Callers needing head/all events use read_run_events().
     pre_read_signature = _summary_cache_signature(path)
-    events, _malformed = _read_jsonl(path)
+    events, _malformed = _read_jsonl(
+        path, max_bytes=max_bytes, max_rows=max_rows, tail=True
+    )
     summary = _summary_from_events(session_id, run_id, events)
     _cache_summary(path, summary, expected_signature=pre_read_signature)
     return summary
@@ -570,7 +742,13 @@ def session_journal_fingerprint(session_id: str, *, session_dir: Path | None = N
     return (count, max_mtime, total_size)
 
 
-def find_run_summary(run_id: str, *, session_dir: Path | None = None) -> dict | None:
+def find_run_summary(
+    run_id: str,
+    *,
+    session_dir: Path | None = None,
+    max_bytes: int | None = _SESSION_REPLAY_MAX_BYTES,
+    max_rows: int | None = _SESSION_REPLAY_MAX_ROWS,
+) -> dict | None:
     rid = _validate_id(run_id, "run_id")
     root = Path(session_dir) if session_dir is not None else _default_session_dir()
     journal_root = root / RUN_JOURNAL_DIR_NAME
@@ -579,7 +757,11 @@ def find_run_summary(run_id: str, *, session_dir: Path | None = None) -> dict | 
         summary = _get_cached_summary(path)
         if summary is None:
             pre_read_signature = _summary_cache_signature(path)
-            events, _malformed = _read_jsonl(path)
+            # Tail read: summary needs the terminal/last events (see
+            # latest_run_summary), so bound memory on large completed runs.
+            events, _malformed = _read_jsonl(
+                path, max_bytes=max_bytes, max_rows=max_rows, tail=True
+            )
             summary = _summary_from_events(session_id, rid, events)
             _cache_summary(path, summary, expected_signature=pre_read_signature)
         summary["path"] = str(path)

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -1209,7 +1209,15 @@ def _read_jsonl_tail(
                 malformed.append({"line": line_no, "raw": raw_line})
         return events, malformed, not fault[0]
     except (FileNotFoundError, OSError):
-        # A read failure mid-recovery: return what we have (best-effort).
+        # A read failure mid-recovery: return what we have (best-effort), but
+        # mark the fault so callers (summary readers) don't cache a transient
+        # failure as authoritative. fault[0] may still be False when the
+        # OSError came from an UNGUARDed direct I/O call (the tail-window
+        # fh.seek/fh.read near the top of the try body have no individual
+        # try/except, so the boundary helpers never got to set fault[0]).
+        # Set it here as the single chokepoint covering ALL escape paths.
+        # (#6139 r14 finding 3 follow-up.)
+        fault[0] = True
         return events, malformed, not fault[0]
     finally:
         fh.close()

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -239,6 +239,51 @@ def _read_jsonl(
     return events, malformed
 
 
+def _read_last_complete_line(path: Path) -> str:
+    """Return the last complete line of a file (no trailing newline), found by
+    scanning backward from EOF for the final newline.
+
+    Used as a fallback when ``_read_jsonl_tail``'s whole tail window is a single
+    truncated record — i.e. one journal record (typically the terminal ``done``
+    event with a full-transcript payload) exceeds the tail window. The last
+    complete line holds that record's summary fields (terminal_state / last_seq
+    / last_event_id), which is what the summary reader needs. Scans backward in
+    bounded chunks so a huge single-line record doesn't have to be fully read to
+    locate its start. Returns '' if the file has no complete line.
+    """
+    try:
+        size = path.stat().st_size
+    except (FileNotFoundError, OSError):
+        return ""
+    if size <= 0:
+        return ""
+    # Scan backward in chunks for the final newline. The line we want is the
+    # bytes between the final newline and EOF (or the whole file if there's no
+    # newline — but that case is "no complete line", handled by the caller).
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    with path.open("rb") as fh:
+        fh.seek(0, 2)  # EOF
+        end = fh.tell()
+        # If the last byte is a newline, the last complete line ends just before it.
+        if end > 0:
+            fh.seek(end - 1)
+            if fh.read(1) == b"\n":
+                end -= 1
+        pos = end
+        while pos > 0:
+            read_from = max(0, pos - chunk_size)
+            fh.seek(read_from)
+            block = fh.read(pos - read_from)
+            nl = block.rfind(b"\n")
+            if nl >= 0:
+                # The last complete line is from after this newline to `end`.
+                line_start = read_from + nl + 1
+                fh.seek(line_start)
+                return fh.read(end - line_start).decode("utf-8", errors="replace")
+            pos = read_from
+    return ""
+
+
 def _read_jsonl_tail(
     path: Path, *, max_bytes: int | None, max_rows: int | None
 ) -> tuple[list[dict], list[dict]]:
@@ -278,8 +323,28 @@ def _read_jsonl_tail(
         nl = text.find("\n")
         if nl >= 0:
             text = text[nl + 1:]
-        else:
-            text = ""  # entire window was one truncated line; nothing whole
+        # NOTE: falling through to the `_read_last_complete_line` fallback below
+        # covers BOTH truncated-window cases:
+        #  (a) nl < 0: the entire window is one truncated record (a single
+        #      record exceeds the tail window).
+        #  (b) text is empty after the slice: we seeked into the middle of a
+        #      giant FINAL record and its trailing newline was the only one in
+        #      the window, so text[nl+1:] is "". streaming.py journals the
+        #      terminal `done` event with the full transcript payload, so a
+        #      large session's terminal record can be bigger than the whole
+        #      tail window. In both cases giving up returns no events and
+        #      misclassifies a completed run as `unknown` (a recovery bug).
+    # If the window yielded no whole parseable line (empty after the partial-line
+    # drop, or the whole window was one truncated record), recover the LAST
+    # complete line by scanning backward from EOF for the final newline — that
+    # line holds the terminal record's summary fields (terminal_state / last_seq
+    # / last_event_id), which is exactly what the summary reader needs.
+    if not text.strip():
+        text = _read_last_complete_line(path)
+    if not text:
+        # No complete line recoverable at all (e.g. a single line with no
+        # trailing newline and no interior newline). Nothing whole to parse.
+        return events, malformed
     # 1-based line number of the first whole line in `text`, across the whole
     # file. The discarded prefix (size - read_bytes bytes) contains some number
     # of complete lines; the first whole line in the window is the next one. We

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -221,10 +221,20 @@ def _read_jsonl(
 
     # Unbounded whole-file read (original behavior).
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        lines = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return events, malformed
-    for line_no, raw in enumerate(lines, start=1):
+    # A crash-truncated final record (write interrupted before its newline
+    # terminator) is silently accepted by splitlines(), which treats EOF as a
+    # line boundary. This must match the tail reader's completeness gate: if the
+    # file doesn't end with \n (or \r\n), the last line is unterminated and
+    # potentially crash-truncated — discard it so a finished run doesn't flip to
+    # a falsely-terminal state from a partial write. (#6139 round-5 alignment.)
+    ended_with_newline = lines.endswith("\n") or lines.endswith("\r")
+    lines_list = lines.splitlines()
+    if not ended_with_newline and lines_list:
+        lines_list = lines_list[:-1]  # drop the unterminated final line
+    for line_no, raw in enumerate(lines_list, start=1):
         if not raw.strip():
             continue
         try:
@@ -275,38 +285,45 @@ def _find_record_start_before(path: Path, seek_pos: int) -> int:
     return 0
 
 
-def _read_last_complete_line_before(path: Path, end_offset: int) -> str:
-    """Return the last complete JSONL line strictly before ``end_offset``.
+def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
+    """Return the summary of the last complete JSONL record strictly before
+    ``end_offset``, without materializing a multi-MB payload.
 
-    Scans backward from ``end_offset - 1`` for the final two newlines before it;
-    the line between them is the last complete record preceding the boundary
-    record. Used to retain the preceding valid event when a crash-truncated
-    boundary record is rejected, so last_seq/running survive and the apperror
-    recovery signal fires (matching master). Bounded backward chunk scan — never
-    materializes the whole file. Returns '' if there's no preceding complete line.
+    Finds the last complete line boundary before ``end_offset`` (two backward
+    newline scans), then uses ``_extract_boundary_record_summary`` (the bounded
+    prefix extractor) to read ONLY the record's summary fields. This keeps the
+    recovery path within the cap even when the preceding record is itself an
+    oversized multi-MB event. Returns the summary dict, or None if there's no
+    preceding complete record.
     """
     if end_offset <= 0:
-        return ""
-    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
-    # The byte at end_offset-1 is typically the newline terminating the preceding
-    # line (or the start of the boundary record). We want the line BEFORE that.
-    # Find the newline at or before end_offset-1, then the line before it.
+        return None
     try:
         size = path.stat().st_size
     except (FileNotFoundError, OSError):
-        return ""
+        return None
     scan_end = min(end_offset, size)
-    with path.open("rb") as fh:
-        # Step 1: find the last newline at or before scan_end (terminator of the
-        # preceding line).
-        first_nl = _rfind_byte_before(path, b"\n", scan_end)
-        if first_nl is None or first_nl == 0:
-            return ""
-        # Step 2: find the newline before that (start of the preceding line + 1).
-        second_nl = _rfind_byte_before(path, b"\n", first_nl)
-        line_start = (second_nl + 1) if second_nl is not None else 0
-        fh.seek(line_start)
-        return fh.read(first_nl - line_start).decode("utf-8", errors="replace")
+    # Find the newline at or before scan_end (terminator of the preceding line).
+    first_nl = _rfind_byte_before(path, b"\n", scan_end)
+    if first_nl is None or first_nl == 0:
+        return None
+    # Find the start of that line (newline before it, or byte 0).
+    second_nl = _rfind_byte_before(path, b"\n", first_nl)
+    line_start = (second_nl + 1) if second_nl is not None else 0
+    line_len = first_nl - line_start
+    # For a normal-sized preceding record, read and parse the whole line.
+    # For an oversized one, use the bounded prefix extractor.
+    if line_len <= _BOUNDARY_SUMMARY_PREFIX_BYTES:
+        try:
+            with path.open("rb") as fh:
+                fh.seek(line_start)
+                raw = fh.read(line_len)
+            parsed = json.loads(raw.decode("utf-8", errors="replace"))
+            return parsed if isinstance(parsed, dict) else None
+        except (json.JSONDecodeError, OSError):
+            return None
+    # Oversized preceding record: bounded prefix extraction (no payload materialized).
+    return _extract_boundary_record_summary(path, line_start)
 
 
 def _rfind_byte_before(path: Path, byte: bytes, end_offset: int) -> int | None:
@@ -379,7 +396,15 @@ def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
                         # else read fresh from the file.
                         if ci + 1 < chunk_len:
                             nb = chunk[ci + 1]
-                            return nb in (0x0A, 0x0D)  # \n or \r (CRLF handled below)
+                            if nb == 0x0A:  # \n — complete
+                                return True
+                            if nb == 0x0D:  # \r — need to check for \r\n
+                                if ci + 2 < chunk_len:
+                                    return chunk[ci + 2] == 0x0A
+                                # \r at chunk end: read from file to check for \n
+                                fh.seek(pos + 1)
+                                return fh.read(1) == b"\n"
+                            return False  # any other byte after } is not a terminator
                         # Terminator is in the next chunk: read up to 2 bytes
                         # from file to distinguish \r\n (CRLF) from a bare \r.
                         fh.seek(pos)
@@ -558,16 +583,11 @@ def _read_jsonl_tail(
             # so last_seq/running survive and the apperror recovery signal fires
             # (matching master). Without this, rejecting the boundary record also
             # drops the preceding valid event → event_count=0, last_seq=0, no
-            # recovery. Read a bounded prefix ending at record_start and take its
-            # last complete JSONL line.
+            # recovery. Read the last complete record's summary via bounded prefix
+            # extraction (never materializes a multi-MB payload).
             preceding = _read_last_complete_line_before(path, record_start)
-            if preceding:
-                try:
-                    parsed = json.loads(preceding)
-                    if isinstance(parsed, dict):
-                        events.append(parsed)
-                except json.JSONDecodeError:
-                    pass
+            if preceding is not None:
+                events.append(preceding)
         # Now drop the partial first fragment from the window so we only parse
         # the complete trailing records.
         nl = text.find("\n")

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -11,8 +11,19 @@ import re
 import threading
 import time
 from collections import OrderedDict
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterable
+
+# Cross-platform file locking for run-journal writers (b3)
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None
+try:
+    import msvcrt as _msvcrt
+except ImportError:
+    _msvcrt = None
 
 RUN_JOURNAL_DIR_NAME = "_run_journal"
 _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -56,7 +67,7 @@ _SNAPSHOT_ARGS_MAX_DEPTH = 8
 _SNAPSHOT_ARGS_MAX_STRING_CHARS = 8192
 _SNAPSHOT_ARGS_MAX_TOTAL_CHARS = 64 * 1024
 _SNAPSHOT_ARGS_TRUNCATED_SUFFIX = "...[truncated]"
-_RUN_SUMMARY_SIDECAR_VERSION = 1
+_RUN_SUMMARY_SIDECAR_VERSION = 2
 
 
 def _summary_sidecar_path(path: Path) -> Path:
@@ -127,10 +138,12 @@ def _fold_event_into_state(state: dict, event: dict) -> dict:
     return state
 
 
-def _serialize_sidecar(state: dict, journal_size: int) -> dict:
+def _serialize_sidecar(state: dict, journal_size: int, *, session_id: str, run_id: str) -> dict:
     """Serialize sidecar state to the on-disk JSON format."""
     return {
         "version": _RUN_SUMMARY_SIDECAR_VERSION,
+        "session_id": str(session_id),
+        "run_id": str(run_id),
         "journal_size": int(journal_size),
         "event_count": int(state.get("event_count") or 0),
         "last": state.get("last"),
@@ -152,7 +165,16 @@ def _validate_sidecar(data) -> dict | None:
     """
     if not isinstance(data, dict):
         return None
-    if data.get("version") != _RUN_SUMMARY_SIDECAR_VERSION:
+    version = data.get("version")
+    # Require version == 2 and reject bool aliasing (2 == True is False but be explicit)
+    if not (version == 2 and not isinstance(version, bool)):
+        return None
+    # session_id and run_id must be non-empty strings
+    sid = data.get("session_id")
+    rid = data.get("run_id")
+    if not (isinstance(sid, str) and sid.strip()):
+        return None
+    if not (isinstance(rid, str) and rid.strip()):
         return None
     if not _is_nonneg_int(data.get("journal_size")):
         return None
@@ -222,16 +244,33 @@ def _summary_from_sidecar(session_id, run_id, data: dict) -> dict:
 def _try_summary_from_sidecar(path, session_id, run_id) -> tuple[dict | None, bool]:
     """Return (summary, ok). ok=False means 'do not cache' (transient I/O).
     summary is None when no usable sidecar -> caller falls back to tail."""
-    try:
-        jsonl_stat = path.stat()
-    except (FileNotFoundError, OSError):
-        return None, True  # missing jsonl -> let the tail reader handle (returns empty)
     sidecar_path = _summary_sidecar_path(path)
     data = _read_sidecar(sidecar_path)  # strictly validated; never raises
     if data is None:
         return None, True
-    if int(data["journal_size"]) != int(jsonl_stat.st_size):
-        return None, True  # stale (crash-mid-append / hand-edit / replacement) -> fallback
+
+    # Open the JSONL once and fstat that pinned descriptor (b1)
+    jsonl_fh = None
+    try:
+        jsonl_fh = path.open("rb")
+        st = os.fstat(jsonl_fh.fileno())
+    except (FileNotFoundError, OSError):
+        return None, True  # missing jsonl -> let the tail reader handle (returns empty)
+    finally:
+        if jsonl_fh is not None:
+            try:
+                jsonl_fh.close()
+            except OSError:
+                pass
+
+    # Require identity + generation match (b1)
+    if (
+        data.get("session_id") != str(session_id)
+        or data.get("run_id") != str(run_id)
+        or int(data.get("journal_size", 0)) != int(st.st_size)
+    ):
+        return None, True  # foreign or stale -> fallback
+
     return _summary_from_sidecar(session_id, run_id, data), True
 
 
@@ -296,24 +335,97 @@ def _lock_for(path: Path) -> threading.Lock:
         return lock
 
 
-def _summary_cache_signature(path: Path) -> tuple[int, int, int, int, int] | None:
+@contextmanager
+def _journal_lock(path: Path):
+    """Cross-process file lock for run-journal writers (b3).
+
+    Mirrors api/models.py:_cleanup_manifest_process_lock exactly:
+    - Permanent .lock file alongside the journal
+    - POSIX: fcntl.flock(LOCK_EX) / LOCK_UN
+    - Windows: msvcrt.locking(LK_LOCK, 1) / LK_UNLCK
+    - Else: raise RuntimeError (fail-closed)
+
+    Advisory lock: readers never acquire it, so cold reads never block.
+    """
+    lock_path = path.with_name(f"{path.stem}.lock")
+    # Ensure parent directory exists (Windows test tmp_path may not have it yet)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fh = None
+    try:
+        # Create/open the lock file
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        lock_fh = os.fdopen(lock_fd, "r+b", buffering=0)
+        if _fcntl is not None:
+            # POSIX: flock(LOCK_EX)
+            _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_EX)
+        elif _msvcrt is not None:
+            # Windows: only seed the lock byte when the file is empty, so a
+            # second waiter never writes the byte another process has locked
+            # (Windows mandatory locking would raise PermissionError on that
+            # write). Mirrors api/models.py:_cleanup_manifest_process_process.
+            if os.fstat(lock_fh.fileno()).st_size == 0:
+                lock_fh.write(b"\0")
+            lock_fh.seek(0)
+            _msvcrt.locking(lock_fh.fileno(), _msvcrt.LK_LOCK, 1)
+        else:
+            raise RuntimeError("cross-process journal locking is unavailable")
+        yield
+    finally:
+        if lock_fh is not None:
+            try:
+                if _fcntl is not None:
+                    _fcntl.flock(lock_fh.fileno(), _fcntl.LOCK_UN)
+                elif _msvcrt is not None:
+                    lock_fh.seek(0)
+                    _msvcrt.locking(lock_fh.fileno(), _msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+            finally:
+                try:
+                    lock_fh.close()
+                except OSError:
+                    pass
+
+
+def _descriptor_size(fh) -> int:
+    """Return the current size of the file backing an open descriptor.
+
+    Used to pin the journal generation on ONE descriptor across an append
+    (pre-state and post-state). Centralized so a pre-state fault is observable
+    and testable independently of the cross-process lock's own fstat. (#6139 r19)
+    """
+    return os.fstat(fh.fileno()).st_size
+
+
+def _summary_cache_signature(path: Path) -> tuple[int, int, int, int, int, int, int, int] | None:
     """Return the complete filesystem identity used for summary-cache validity.
 
     Includes ``st_ctime_ns`` so a same-inode, same-size rewrite that restores the
     original ``mtime_ns`` (e.g. an atomic replace) still invalidates the cache —
     ctime advances on any metadata/content change and cannot be forged back.
+
+    b1-cache: also includes the sidecar's (size, mtime_ns, ctime_ns) so a sidecar-only
+    replacement invalidates the cache (jsonl unchanged, sidecar changed -> new signature).
     """
     try:
         stat = path.stat()
     except OSError:
         return None
-    return (
+    jsonl_sig = (
         int(stat.st_dev),
         int(stat.st_ino),
         int(stat.st_size),
         int(stat.st_mtime_ns),
         int(stat.st_ctime_ns),
     )
+    # Add sidecar generation (or 0,0,0 if absent)
+    sidecar_path = _summary_sidecar_path(path)
+    try:
+        sc_stat = sidecar_path.stat()
+        sidecar_sig = (int(sc_stat.st_size), int(sc_stat.st_mtime_ns), int(sc_stat.st_ctime_ns))
+    except OSError:
+        sidecar_sig = (0, 0, 0)
+    return jsonl_sig + sidecar_sig
 
 
 def _get_cached_summary(path: Path) -> dict | None:
@@ -2187,102 +2299,144 @@ def append_run_event(
     event_name = str(event_name or "").strip()
     if not event_name:
         raise ValueError("event_name is required")
+
+    # b3: Hold both locks across the entire critical section
     with _lock_for(path):
-        # 1. Reserve seq and build event dict
-        if seq is not None:
-            assigned_seq = int(seq)
-            _note_assigned_seq(path, assigned_seq)
-        else:
-            assigned_seq = _reserve_next_seq(path)
-        terminal_state = _terminal_state_for_event(event_name, payload)
-        event = {
-            "version": 1,
-            "event_id": f"{run_id}:{assigned_seq}",
-            "seq": assigned_seq,
-            "run_id": str(run_id),
-            "session_id": str(session_id),
-            "event": event_name,
-            "type": event_name,
-            "created_at": float(created_at if created_at is not None else time.time()),
-            "terminal": bool(terminal_state),
-            "terminal_state": terminal_state,
-            "payload": payload,
-        }
+        with _journal_lock(path):
+            sidecar_path = _summary_sidecar_path(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            created_file = not path.exists()
 
-        # 2. Resolve the fold base for the sidecar. The prior sidecar is a
-        # trustworthy fold base ONLY if its recorded journal_size matches the
-        # JSONL size BEFORE this append — a mismatch means a prior sidecar
-        # commit failed (or the JSONL changed out of band), so the sidecar is
-        # stale and must NOT be folded onto (else a lost interior event is
-        # permanently healed into the summary). (#6139 r18 b1)
-        sidecar_path = _summary_sidecar_path(path)
-        try:
-            pre_size = path.stat().st_size if path.exists() else 0
-        except OSError:
-            pre_size = 0
-        prior = _read_sidecar(sidecar_path)  # strictly validated; None if malformed (#6139 r18 b3)
-        base_trusted = False
-        if prior is not None and int(prior["journal_size"]) == pre_size:
-            state = {
-                "event_count": prior["event_count"],
-                "last": prior["last"],
-                "terminal": prior["terminal"],
-            }
-            base_trusted = True
-        elif pre_size > 0:
-            # Sidecar absent/stale/malformed for an existing run: rebuild from
-            # the bounded tail. Honor ``ok=False`` — a transient rebuild fault
-            # must NOT be published as current authority; readers keep falling
-            # back to the tail reader and a later append retries. (#6139 r18 b2)
-            tail_events, _tail_malformed, tail_ok = _read_jsonl_tail(
-                path,
-                max_bytes=_SESSION_REPLAY_MAX_BYTES,
-                max_rows=_SESSION_REPLAY_MAX_ROWS,
-                attribute_lines=False,
-            )
-            state = _new_sidecar_state()
-            for ev in tail_events:
-                _fold_event_into_state(state, ev)
-            base_trusted = bool(tail_ok)
-        else:
-            # Fresh run (no JSONL yet).
-            state = _new_sidecar_state()
-            base_trusted = True
-
-        # 3. Write the JSONL line (existing logic unchanged)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        created_file = not path.exists()
-        line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
-        fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
-        with os.fdopen(fd, "a", encoding="utf-8") as fh:
-            fh.write(line)
-            fh.flush()
-            if _should_fsync_event(terminal_state):
-                os.fsync(fh.fileno())
-
-        # 4. Fold the new event, then publish the sidecar ONLY from a trusted
-        # base — never publish a current-generation sidecar built on
-        # stale/missing/corrupt/faulted state. (#6139 r18 b1/b2) The sidecar
-        # write is BEST-EFFORT: a failure MUST NOT abort the append (the JSONL
-        # line is already durably written); readers fall back to the tail reader
-        # and the next append's pre-size check rebuilds from a clean read.
-        _fold_event_into_state(state, event)
-        if base_trusted:
+            # Open ONE pinned descriptor for the whole write (b3)
+            wfd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
+            fh = None
             try:
-                post_size = path.stat().st_size
-                payload_dict = _serialize_sidecar(state, post_size)
-                _atomic_write_json(
-                    sidecar_path, payload_dict, fsync=_should_fsync_event(terminal_state)
-                )
-            except OSError:
-                pass
+                fh = os.fdopen(wfd, "a", encoding="utf-8")  # text mode preserves CRLF
 
-        # 5. Discard the cached summary: the JSONL (and sidecar, if published)
-        # both changed, so any cached summary for the old generation is stale.
-        _discard_cached_summary(path)
-        if created_file:
-            _fsync_parent_dir(path)
-        return event
+                # b2a: pre_size from the pinned descriptor (not path.stat()). On
+                # fault we still append (O_APPEND is safe) but publish no authority.
+                pre_size = None
+                try:
+                    pre_size = _descriptor_size(fh)
+                except OSError:
+                    pre_size = None
+
+                # Resolve the fold base for the sidecar (b1/b2a/b2b). One
+                # if/elif chain: every branch sets ``state``, ``durable_max``,
+                # and ``base_trusted`` exactly once, and a pre-state fault
+                # (pre_size is None) is NEVER promoted to a trusted base.
+                prior = _read_sidecar(sidecar_path)  # strictly validated; None if malformed
+                base_trusted = False
+                durable_max = 0
+                state = _new_sidecar_state()
+                if pre_size is None:
+                    # b2a: cannot establish the pre-state generation on the
+                    # pinned descriptor. Append the JSONL (O_APPEND is safe) but
+                    # publish NO compact authority; readers keep falling back to
+                    # the tail reader and a later append retries.
+                    base_trusted = False
+                elif (
+                    prior is not None
+                    and prior.get("session_id") == str(session_id)
+                    and prior.get("run_id") == str(run_id)
+                    and int(prior.get("journal_size", 0)) == int(pre_size)
+                ):
+                    # b1: a prior sidecar that names THIS run AND records the
+                    # pinned pre-append size is a trusted incremental fold base.
+                    state = {
+                        "event_count": prior["event_count"],
+                        "last": prior["last"],
+                        "terminal": prior["terminal"],
+                    }
+                    durable_max = int((prior.get("last") or {}).get("seq") or 0)
+                    base_trusted = True
+                elif int(pre_size) > 0:
+                    # b2b: no trusted sidecar for an existing run: rebuild from
+                    # the bounded tail. The rebuild is a COMPLETE accounting ONLY
+                    # if the whole journal fit in the byte window (max_rows=None
+                    # makes the byte cap the sole bound); a partial/capped
+                    # rebuild is folded but MUST NOT be published as authority.
+                    tail_events, _tail_malformed, tail_ok = _read_jsonl_tail(
+                        path,
+                        max_bytes=_SESSION_REPLAY_MAX_BYTES,
+                        max_rows=None,
+                        attribute_lines=False,
+                    )
+                    for ev in tail_events:
+                        _fold_event_into_state(state, ev)
+                    base_trusted = bool(tail_ok) and int(pre_size) <= _SESSION_REPLAY_MAX_BYTES
+                    durable_max = max((int(ev.get("seq") or 0) for ev in tail_events), default=0)
+                else:
+                    # pre_size == 0: a fresh, empty journal is a trusted base.
+                    base_trusted = True
+
+                # b3: reconcile the assigned seq against the durable journal max
+                # so a stale per-process cache cannot re-issue a seq another
+                # process already appended. ``_reserve_next_seq`` seeds the
+                # in-memory cache from disk exactly once per path (the seed-once
+                # contract); ``durable_max`` (from the trusted sidecar / rebuild)
+                # floors it so cross-process appends stay monotonic and gapless.
+                # A caller-supplied seq is floored for the same reason.
+                if seq is not None:
+                    assigned_seq = max(int(seq), int(durable_max) + 1)
+                else:
+                    assigned_seq = max(_reserve_next_seq(path), int(durable_max) + 1)
+                _note_assigned_seq(path, assigned_seq)
+
+                terminal_state = _terminal_state_for_event(event_name, payload)
+                event = {
+                    "version": 1,
+                    "event_id": f"{run_id}:{assigned_seq}",
+                    "seq": assigned_seq,
+                    "run_id": str(run_id),
+                    "session_id": str(session_id),
+                    "event": event_name,
+                    "type": event_name,
+                    "created_at": float(created_at if created_at is not None else time.time()),
+                    "terminal": bool(terminal_state),
+                    "terminal_state": terminal_state,
+                    "payload": payload,
+                }
+
+                # Write the JSONL line
+                line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+                fh.write(line)
+                fh.flush()
+                if _should_fsync_event(terminal_state):
+                    os.fsync(fh.fileno())
+
+                # Post-state size from the SAME pinned descriptor (b1 generation pin).
+                post_size = None
+                try:
+                    post_size = _descriptor_size(fh)
+                except OSError:
+                    post_size = None
+
+            finally:
+                if fh is not None:
+                    try:
+                        fh.close()
+                    except OSError:
+                        pass
+
+            # Fold the new event and publish sidecar only from a trusted base
+            _fold_event_into_state(state, event)
+            if base_trusted and post_size is not None:
+                try:
+                    payload_dict = _serialize_sidecar(
+                        state, post_size, session_id=session_id, run_id=run_id
+                    )
+                    _atomic_write_json(
+                        sidecar_path, payload_dict, fsync=_should_fsync_event(terminal_state)
+                    )
+                except OSError:
+                    pass
+
+            # Discard the cached summary
+            _discard_cached_summary(path)
+            if created_file:
+                _fsync_parent_dir(path)
+            return event
 
 
 class RunJournalWriter:
@@ -2296,18 +2450,15 @@ class RunJournalWriter:
         self._lock = _lock_for(self._path)
 
     def append_sse_event(self, event_name: str, payload=None) -> dict:
-        # Draw from the shared module-level seq cache under the per-path lock so
-        # this writer and any direct append_run_event() call on the same path
-        # agree on one monotonic, gapless sequence.
-        with self._lock:
-            seq = _reserve_next_seq(self._path)
+        # b3: Thin wrapper calling append_run_event directly (seq=None)
+        # The seq is reserved inside append_run_event under the locks.
         return append_run_event(
             self.session_id,
             self.run_id,
             event_name,
             payload or {},
             session_dir=self.session_dir,
-            seq=seq,
+            seq=None,
         )
 
 

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -58,6 +58,37 @@ _SNAPSHOT_ARGS_MAX_TOTAL_CHARS = 64 * 1024
 _SNAPSHOT_ARGS_TRUNCATED_SUFFIX = "...[truncated]"
 
 
+class _ReadBudget:
+    """Mutable remaining-work meter shared across every descriptor read in one
+    logical scan, so physical I/O never exceeds the caller's allowance.
+
+    Each helper that reads the descriptor charges every read against
+    ``remaining`` and caps the requested length at it; when ``remaining`` hits 0
+    the scan stops (helpers return their exhausted/None fallback). Used by
+    ``_read_last_complete_line_before`` to bound the *physical* bytes touched
+    across ``_rfind_byte_before``, structural validation, prefix extraction, and
+    candidate parsing in one aggregate meter (#6139 r9, item 1). When ``budget``
+    is None the helpers run unbounded (the whole tail read is already bounded by
+    the ``_SESSION_REPLAY_MAX_BYTES`` window + the ``os.fstat`` pin).
+    """
+
+    __slots__ = ("remaining",)
+
+    def __init__(self, budget_bytes: int):
+        self.remaining = budget_bytes
+
+    def take(self, requested: int) -> int:
+        """Return the number of bytes actually allowed for a read of
+        ``requested`` bytes, decrementing ``remaining``. 0 means stop."""
+        allow = min(requested, max(0, self.remaining))
+        self.remaining -= allow
+        return allow
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining <= 0
+
+
 def _default_session_dir() -> Path:
     from api.models import SESSION_DIR
 
@@ -298,11 +329,11 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
 
     Scans backward across preceding complete lines, skipping any that are blank,
     malformed (JSONDecodeError), or non-dict, until a valid event dict is found.
-    For each candidate line, uses ``_extract_boundary_record_summary`` (the
-    bounded prefix extractor) to read ONLY the record's summary fields when the
-    line is oversized. This keeps the recovery path within the cap even when the
-    preceding valid record is itself an oversized multi-MB event. Returns the
-    summary dict, or None if there's no valid preceding record.
+    For each oversized predecessor, the row is SKIPPED (fail-closed, #6139 r9
+    item 2): an oversized record's full-record JSON validity can NEVER be proven
+    without materializing its payload, so its fabricated prefix must not be
+    trusted as proof of a valid event. The scan continues backward to a
+    normal-sized (fully-parseable) valid event, or returns None.
 
     This loop fixes #6139 r7: a shape like ``token\\n\\n<oversized partial done>``
     (a valid event, then a blank line, then a crash-truncated oversized record)
@@ -311,99 +342,142 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
     line and recovers the valid event.
 
     The caller owns the handle and passes the pinned size from os.fstat.
-    ``budget`` bounds the total bytes/rows scanned (prevents infinite loops on
-    pathological files). If None, defaults to _SESSION_REPLAY_MAX_BYTES.
+    ``budget`` bounds the total PHYSICAL bytes touched by ``fh.read`` across the
+    whole scan — every descriptor read (``_rfind_byte_before`` newline scans,
+    candidate-line parsing, oversized structural check, oversized prefix
+    extraction) charges a single shared ``_ReadBudget`` meter, so the scan
+    stops as soon as the allowance is exhausted (#6139 r9 item 1). ``rows_scanned``
+    is retained as a secondary row-cap guard (a pathological file of tiny rows
+    could fit many rows in the byte budget). If ``budget`` is None it defaults to
+    ``_SESSION_REPLAY_MAX_BYTES``.
     """
     if end_offset <= 0:
         return None
     scan_end = min(end_offset, size)
-    # Budget tracking to bound the total work across the loop.
+    # One shared remaining-work meter across every descriptor read in this scan
+    # so physical I/O never exceeds the caller's allowance (#6139 r9 item 1).
     budget_bytes = budget if budget is not None else _SESSION_REPLAY_MAX_BYTES
-    bytes_consumed = 0
+    budget_obj = _ReadBudget(budget_bytes)
     rows_scanned = 0
     # Loop backward across preceding complete lines, skipping blank / malformed /
-    # non-dict lines, until a valid event dict is found. Without this loop, a
-    # shape like `token\n\n<big>` (a blank line between the valid event and the
-    # truncated boundary record) defeats recovery: the first preceding line is
-    # blank, json.loads("") fails, and the function returns None instead of
-    # continuing back to the valid event. (#6139 r7)
+    # non-dict lines (and oversized predecessors, fail-closed), until a valid
+    # normal-sized event dict is found. Without this loop, a shape like
+    # `token\n\n<big>` (a blank line between the valid event and the truncated
+    # boundary record) defeats recovery: the first preceding line is blank,
+    # json.loads("") fails, and the function returns None instead of continuing
+    # back to the valid event. (#6139 r7)
     while scan_end > 0:
-        # Check budget before each iteration (guard against infinite loops).
-        if bytes_consumed > budget_bytes or rows_scanned > _SESSION_REPLAY_MAX_ROWS:
+        # Secondary row-cap guard (the budget is byte-based; a pathological file
+        # of tiny rows could fit many rows in the byte budget).
+        if rows_scanned > _SESSION_REPLAY_MAX_ROWS:
             return None
-        first_nl = _rfind_byte_before(fh, b"\n", scan_end)
+        # Stop before the next helper at exhaustion (the maintainer's exact
+        # words for item 1: "stop before the next helper at exhaustion").
+        if budget_obj.exhausted:
+            return None
+        first_nl = _rfind_byte_before(fh, b"\n", scan_end, budget=budget_obj)
         if first_nl is None or first_nl == 0:
-            return None  # no preceding complete line
-        second_nl = _rfind_byte_before(fh, b"\n", first_nl)
+            return None  # no preceding complete line (or budget exhausted mid-scan)
+        if budget_obj.exhausted:
+            return None  # stop before the next helper at exhaustion
+        second_nl = _rfind_byte_before(fh, b"\n", first_nl, budget=budget_obj)
         line_start = (second_nl + 1) if second_nl is not None else 0
         line_len = first_nl - line_start
         if line_len <= 0:
             # Blank line (e.g. the gap in `token\n\n<big>`). Skip it: continue the
-            # backward scan from before this blank line.
+            # backward scan from before this blank line. No descriptor read here,
+            # so the budget is untouched; only the row-cap advances.
             rows_scanned += 1  # count blank lines too (guard against infinite blank streaks)
             scan_end = line_start  # strictly < previous scan_end (line_start <= first_nl < scan_end)
             if scan_end <= 0:
                 return None
             continue
-        # Attempt to read + parse this candidate line (bounded for oversized).
-        if line_len <= _BOUNDARY_SUMMARY_PREFIX_BYTES:
-            try:
-                fh.seek(line_start)
-                raw = fh.read(line_len)
-                parsed = json.loads(raw.decode("utf-8", errors="replace"))
-            except (json.JSONDecodeError, OSError):
-                parsed = None
-            bytes_consumed += line_len
-            rows_scanned += 1
-            if isinstance(parsed, dict):
-                return parsed
-            # Malformed or non-dict: skip, continue backward.
-            scan_end = line_start
-            if scan_end <= 0:
-                return None
-            continue
-        # Oversized preceding record: bounded prefix extraction (no payload materialized).
-        # CRITICAL: before accepting the fabricated prefix, gate on structural completeness.
-        # An oversized malformed predecessor (no closing brace/newline) must NOT be accepted
-        # via fabricated prefix as if it were valid JSON. If it's incomplete, skip it like
-        # any other malformed line.
-        if not _record_is_structurally_complete(fh, size, line_start):
-            # Oversized row is malformed/truncated — do NOT accept its fabricated prefix.
-            # Treat it like any other malformed line: skip and continue backward.
-            bytes_consumed += _BOUNDARY_SUMMARY_PREFIX_BYTES
+        # Oversized predecessor (> _BOUNDARY_SUMMARY_PREFIX_BYTES): fail-closed.
+        # Its full-record JSON validity can NEVER be proven without materializing
+        # the payload, so per #6139 r9 item 2 the fabricated prefix is NOT
+        # trusted. The row is skipped and the scan continues to the preceding
+        # normal-sized valid event. (The scan work done so far by
+        # _rfind_byte_before is already charged via the shared budget.)
+        if line_len > _BOUNDARY_SUMMARY_PREFIX_BYTES:
+            # An oversized predecessor's validity cannot be proven without
+            # materializing its payload, so per #6139 r9 it is skipped
+            # (fail-closed). The scan continues to the preceding normal-sized
+            # valid event.
             rows_scanned += 1
             scan_end = line_start
             if scan_end <= 0:
                 return None
             continue
-        candidate = _extract_boundary_record_summary(fh, line_start)
-        bytes_consumed += _BOUNDARY_SUMMARY_PREFIX_BYTES
+        # Normal-size candidate line: charge the budget for the parse read too
+        # (the maintainer named "candidate parsing" in item 1), then read.
+        to_read = budget_obj.take(line_len)
+        if to_read == 0:
+            return None  # exhausted before parsing this candidate — stop
+        try:
+            fh.seek(line_start)
+            raw = fh.read(to_read)
+        except (FileNotFoundError, OSError):
+            return None  # TOCTOU: journal deleted mid-read — safe fallback
+        try:
+            parsed = json.loads(raw.decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            parsed = None
         rows_scanned += 1
-        if isinstance(candidate, dict):
-            return candidate
+        if isinstance(parsed, dict):
+            return parsed
+        # Malformed or non-dict: skip, continue backward.
         scan_end = line_start
         if scan_end <= 0:
             return None
     return None
 
 
-def _rfind_byte_before(fh, byte: bytes, end_offset: int) -> int | None:
+def _rfind_byte_before(
+    fh, byte: bytes, end_offset: int, *, budget: _ReadBudget | None = None
+) -> int | None:
     """Return the offset of the last occurrence of ``byte`` at or before
     ``end_offset - 1``, scanning backward in bounded chunks. None if not found.
 
     The caller owns the handle; all reads use the same inode generation.
+
+    When ``budget`` is a ``_ReadBudget``, every ``fh.read`` is capped at the
+    budget's remaining allowance via ``budget.take`` (the read covers the LAST
+    ``to_read`` bytes of the candidate ``[read_from, pos)`` range, since we scan
+    backward). If the allowance hits 0 the scan stops and returns None. When
+    ``budget`` is None the helper runs unbounded (the whole tail read is already
+    bounded by the caller). Capping only ever narrows the examined window — the
+    byte-found offset math is unchanged when the full chunk is read.
     """
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
     pos = end_offset
     try:
         while pos > 0:
             read_from = max(0, pos - chunk_size)
-            fh.seek(read_from)
-            block = fh.read(pos - read_from)
-            idx = block.rfind(byte)
-            if idx >= 0:
-                return read_from + idx
-            pos = read_from
+            want = pos - read_from
+            if budget is not None:
+                to_read = budget.take(want)
+                if to_read == 0:
+                    return None  # exhausted before this read — stop (fail-quiet)
+                # Read the LAST `to_read` bytes of [read_from, pos): scanning
+                # backward, the suffix is the highest-value window to examine.
+                block_start = pos - to_read
+                fh.seek(block_start)
+                block = fh.read(to_read)
+                idx = block.rfind(byte)
+                if idx >= 0:
+                    return block_start + idx
+                # Byte not in this suffix. If the suffix was shorter than the
+                # candidate range (budget truncated it), there may be unexamined
+                # bytes in [read_from, block_start) — but only if budget remains.
+                # If exhausted, stop; otherwise advance pos to the suffix start.
+                pos = block_start
+            else:
+                fh.seek(read_from)
+                block = fh.read(want)
+                idx = block.rfind(byte)
+                if idx >= 0:
+                    return read_from + idx
+                pos = read_from
     except (FileNotFoundError, OSError):
         # TOCTOU: journal deleted before/during the scan. Return the safe
         # fallback (None = byte not found) rather than escaping to the caller.
@@ -412,7 +486,9 @@ def _rfind_byte_before(fh, byte: bytes, end_offset: int) -> int | None:
     return None
 
 
-def _record_is_structurally_complete(fh, size: int, record_start: int) -> bool:
+def _record_is_structurally_complete(
+    fh, size: int, record_start: int, *, budget: _ReadBudget | None = None
+) -> bool:
     """Return True iff the JSONL record at ``record_start`` is structurally
     complete — i.e. its JSON object is closed (brace depth returns to 0) AND
     followed by a newline terminator — scanning forward in bounded chunks WITHOUT
@@ -424,7 +500,12 @@ def _record_is_structurally_complete(fh, size: int, record_start: int) -> bool:
     and its recovery signal is silently dropped. Returns False if EOF is reached
     at brace depth > 0 (the record was truncated mid-write).
 
-    The caller owns the handle and passes the pinned size from os.fstat.
+    The caller owns the handle and passes the pinned size from os.fstat. When
+    ``budget`` is a ``_ReadBudget``, every ``fh.read`` is capped at the budget's
+    remaining allowance via ``budget.take``; if the allowance hits 0 before the
+    record's closing brace is confirmed, returns False (fail-closed — can't
+    prove completeness within the budget). When ``budget`` is None the helper
+    runs unbounded. The brace-depth + terminator logic is unchanged.
     """
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
     depth = 0
@@ -434,10 +515,21 @@ def _record_is_structurally_complete(fh, size: int, record_start: int) -> bool:
     try:
         fh.seek(record_start)
         while pos < size:
-            chunk = fh.read(min(chunk_size, size - pos))
+            want = min(chunk_size, size - pos)
+            if budget is not None:
+                to_read = budget.take(want)
+                if to_read == 0:
+                    return False  # exhausted before confirming completeness — fail-closed
+            else:
+                to_read = want
+            chunk = fh.read(to_read)
             if not chunk:
                 break
             chunk_len = len(chunk)
+            if budget is not None and chunk_len < want and depth > 0:
+                # Budget truncated this read before we could reach the closing
+                # brace — can't confirm completeness within the allowance.
+                return False
             for ci in range(chunk_len):
                 b = chunk[ci]
                 pos += 1
@@ -492,7 +584,9 @@ def _record_is_structurally_complete(fh, size: int, record_start: int) -> bool:
         return False
 
 
-def _extract_boundary_record_summary(fh, record_start: int) -> dict | None:
+def _extract_boundary_record_summary(
+    fh, record_start: int, *, budget: _ReadBudget | None = None
+) -> dict | None:
     """Extract ONLY the summary fields of an oversized journal record that
     straddles the tail-window boundary, without materializing its payload.
 
@@ -504,11 +598,21 @@ def _extract_boundary_record_summary(fh, record_start: int) -> dict | None:
     replaced with an empty dict so downstream consumers see the shape but not
     the bytes.
 
-    The caller owns the handle; all reads use the same inode generation.
+    The caller owns the handle; all reads use the same inode generation. When
+    ``budget`` is a ``_ReadBudget`` the prefix read is capped at the budget's
+    remaining allowance; if the allowance hits 0 the function returns None. The
+    rest of the function operates on whatever prefix was read — if a shorter-
+    than-expected prefix can't be parsed, returns None.
     """
     try:
         fh.seek(record_start)
-        prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
+        if budget is not None:
+            to_read = budget.take(_BOUNDARY_SUMMARY_PREFIX_BYTES)
+            if to_read == 0:
+                return None  # exhausted before reading any prefix — stop
+            prefix_raw = fh.read(to_read)
+        else:
+            prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
     except (FileNotFoundError, OSError):
         return None
     text = prefix_raw.decode("utf-8", errors="replace")

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -250,6 +250,10 @@ def _read_last_complete_line(path: Path) -> str:
     / last_event_id), which is what the summary reader needs. Scans backward in
     bounded chunks so a huge single-line record doesn't have to be fully read to
     locate its start. Returns '' if the file has no complete line.
+
+    .. note:: This materializes the whole last line. When that line is an
+       oversized record (multi-MB payload), prefer ``_extract_boundary_record_summary``
+       which reads only a bounded prefix of the record's summary fields.
     """
     try:
         size = path.stat().st_size
@@ -282,6 +286,134 @@ def _read_last_complete_line(path: Path) -> str:
                 return fh.read(end - line_start).decode("utf-8", errors="replace")
             pos = read_from
     return ""
+
+
+# Bounded prefix read for oversized journal records. The record layout from
+# append_run_event puts ALL summary fields before the (potentially huge) payload:
+#   {"version","event_id","seq","run_id","session_id","event","type","created_at",
+#    "terminal","terminal_state","payload":{...huge...}}
+# So we can read a small prefix, truncate at the "payload" key, close the object,
+# and parse the summary fields WITHOUT materializing the payload. This bounds
+# memory even when a single record (e.g. the terminal `done` with the full
+# transcript) is many MB.
+_BOUNDARY_SUMMARY_PREFIX_BYTES = 8192
+
+
+def _find_record_start_before(path: Path, seek_pos: int) -> int:
+    """Return the byte offset where the JSONL record overlapping ``seek_pos``
+    begins, i.e. the byte just after the last newline strictly before seek_pos.
+    Returns 0 if there is no preceding newline (the record starts at byte 0).
+    Scans backward in bounded chunks."""
+    if seek_pos <= 0:
+        return 0
+    chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
+    try:
+        size = path.stat().st_size
+    except (FileNotFoundError, OSError):
+        return 0
+    pos = min(seek_pos, size)
+    with path.open("rb") as fh:
+        while pos > 0:
+            read_from = max(0, pos - chunk_size)
+            fh.seek(read_from)
+            block = fh.read(pos - read_from)
+            nl = block.rfind(b"\n")
+            if nl >= 0:
+                return read_from + nl + 1
+            pos = read_from
+    return 0
+
+
+def _extract_boundary_record_summary(path: Path, record_start: int) -> dict | None:
+    """Extract ONLY the summary fields of an oversized journal record that
+    straddles the tail-window boundary, without materializing its payload.
+
+    Reads a bounded prefix (``_BOUNDARY_SUMMARY_PREFIX_BYTES``) from
+    ``record_start``, locates the top-level ``"payload"`` key via a brace-depth
+    scan, truncates the JSON before it, closes the object, and parses. Returns
+    a dict with the summary fields (``event``/``seq``/``event_id``/``terminal``/
+    ``terminal_state``) or ``None`` if the layout is unexpected. The payload is
+    replaced with an empty dict so downstream consumers see the shape but not
+    the bytes.
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(record_start)
+            prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
+    except (FileNotFoundError, OSError):
+        return None
+    text = prefix_raw.decode("utf-8", errors="replace")
+    # Find the top-level "payload" key (depth 1 inside the record object).
+    payload_pos = _find_top_level_payload_key(text)
+    if payload_pos is None:
+        # No payload key in the prefix — either the record is small enough that
+        # the whole thing fit (parse directly if it ends in this prefix), or the
+        # layout is unexpected. Try a direct parse of the prefix up to the first
+        # newline; if that fails, give up.
+        nl = text.find("\n")
+        candidate = text if nl < 0 else text[:nl]
+        try:
+            parsed = json.loads(candidate)
+            return parsed if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            return None
+    # Truncate before "payload", strip trailing comma/whitespace, close object.
+    head = text[:payload_pos].rstrip()
+    if head.endswith(","):
+        head = head[:-1].rstrip()
+    head += "\n}"
+    try:
+        parsed = json.loads(head)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    # Replace the (unread) payload with an empty dict so the shape is consistent
+    # but no payload bytes are materialized.
+    parsed["payload"] = {}
+    parsed["_summary_extracted_from_oversized_record"] = True
+    return parsed
+
+
+def _find_top_level_payload_key(text: str) -> int | None:
+    """Return the byte offset of the top-level (depth-1) ``"payload"`` key in
+    a JSON object prefix, or None if not found. Mirrors the depth-tracking
+    approach of the session scanner but specialized for the journal record."""
+    depth = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            # Parse the string token to get its content + end.
+            i += 1
+            start = i
+            escaped = False
+            while i < n:
+                c = text[i]
+                if escaped:
+                    escaped = False
+                elif c == "\\":
+                    escaped = True
+                elif c == '"':
+                    break
+                i += 1
+            if i >= n:
+                return None
+            key = text[start:i]
+            if depth == 1 and key == "payload":
+                # Confirm it's a key (followed by optional ws + ':').
+                j = i + 1
+                while j < n and text[j] in " \t\r\n":
+                    j += 1
+                if j < n and text[j] == ":":
+                    return start - 1  # offset of the opening quote
+        elif ch in "{[":
+            depth += 1
+        elif ch in "}]":
+            depth -= 1
+        i += 1
+    return None
 
 
 def _read_jsonl_tail(
@@ -317,33 +449,45 @@ def _read_jsonl_tail(
     except (FileNotFoundError, OSError):
         return events, malformed
     text = raw.decode("utf-8", errors="replace")
-    # If we sought into the middle of the file, the first "line" is a partial
-    # fragment — drop everything up to and including the first newline.
+    # If we sought into the middle of the file, the window's first "line" is a
+    # partial fragment of a record that STRADDLES the seek boundary. streaming.py
+    # journals the terminal `done` event with the FULL transcript as its payload,
+    # so that record can be many MB — bigger than the whole tail window. Two
+    # sub-cases, both of which must not drop the straddling record's summary
+    # (terminal_state / last_seq / last_event_id) or restart recovery misreports
+    # a finished run as still-running:
+    #   (a) nl >= 0: the straddling record's tail is at the start of the window
+    #       and is followed by more complete records (e.g. the production order
+    #       done(tool_limit_reached) -> metering -> stream_end). Slicing past
+    #       the first newline loses the straddling record but keeps the rest.
+    #   (b) nl < 0: the ENTIRE window is inside one oversized record (no newline
+    #       at all), so there are no complete records in the window.
+    # In both cases, recover the straddling record's summary via a BOUNDED prefix
+    # read (_extract_boundary_record_summary): the record layout puts all summary
+    # fields before "payload", so we read a few KB, truncate at "payload", and
+    # parse the summary WITHOUT materializing the (multi-MB) payload. The
+    # extracted summary is prepended to the events so _summary_from_events sees
+    # both the straddling record's terminal state AND any trailing events.
+    boundary_summary: dict | None = None
     if size > read_bytes:
+        seek_pos = size - read_bytes
+        record_start = _find_record_start_before(path, seek_pos)
+        # record_start is where the straddling record begins. Extract its summary
+        # via a bounded prefix read (never materializes the payload).
+        boundary_summary = _extract_boundary_record_summary(path, record_start)
+        # Now drop the partial first fragment from the window so we only parse
+        # the complete trailing records.
         nl = text.find("\n")
         if nl >= 0:
             text = text[nl + 1:]
-        # NOTE: falling through to the `_read_last_complete_line` fallback below
-        # covers BOTH truncated-window cases:
-        #  (a) nl < 0: the entire window is one truncated record (a single
-        #      record exceeds the tail window).
-        #  (b) text is empty after the slice: we seeked into the middle of a
-        #      giant FINAL record and its trailing newline was the only one in
-        #      the window, so text[nl+1:] is "". streaming.py journals the
-        #      terminal `done` event with the full transcript payload, so a
-        #      large session's terminal record can be bigger than the whole
-        #      tail window. In both cases giving up returns no events and
-        #      misclassifies a completed run as `unknown` (a recovery bug).
-    # If the window yielded no whole parseable line (empty after the partial-line
-    # drop, or the whole window was one truncated record), recover the LAST
-    # complete line by scanning backward from EOF for the final newline — that
-    # line holds the terminal record's summary fields (terminal_state / last_seq
-    # / last_event_id), which is exactly what the summary reader needs.
-    if not text.strip():
-        text = _read_last_complete_line(path)
-    if not text:
-        # No complete line recoverable at all (e.g. a single line with no
-        # trailing newline and no interior newline). Nothing whole to parse.
+        else:
+            text = ""  # entire window was inside the oversized record
+    if boundary_summary is not None:
+        events.append(boundary_summary)
+    if not text.strip() and boundary_summary is None:
+        # No straddling record recovered AND no complete lines in the window.
+        # (When boundary_summary was recovered we already have it; an empty text
+        # just means there were no trailing complete records, which is fine.)
         return events, malformed
     # 1-based line number of the first whole line in `text`, across the whole
     # file. The discarded prefix (size - read_bytes bytes) contains some number

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -138,9 +138,53 @@ def _serialize_sidecar(state: dict, journal_size: int) -> dict:
     }
 
 
+def _is_nonneg_int(value) -> bool:
+    """True for a real non-negative int (bool excluded)."""
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _validate_sidecar(data) -> dict | None:
+    """Strictly validate a sidecar's full schema/types/ranges.
+
+    Returns the validated dict, or None if anything is malformed. NEVER raises
+    — readers and writers must degrade to the JSONL authority on a corrupt
+    sidecar, never brick status polling or journaling. (#6139 r18 b3)
+    """
+    if not isinstance(data, dict):
+        return None
+    if data.get("version") != _RUN_SUMMARY_SIDECAR_VERSION:
+        return None
+    if not _is_nonneg_int(data.get("journal_size")):
+        return None
+    if not _is_nonneg_int(data.get("event_count")):
+        return None
+    last = data.get("last")
+    if last is not None:
+        if not (
+            isinstance(last, dict)
+            and _is_nonneg_int(last.get("seq"))
+            and (last.get("event_id") is None or isinstance(last.get("event_id"), str))
+            and isinstance(last.get("event"), str)
+        ):
+            return None
+    term = data.get("terminal")
+    if term is not None:
+        if not (
+            isinstance(term, dict)
+            and isinstance(term.get("event"), str)
+            and (term.get("state") is None or isinstance(term.get("state"), str))
+            and _is_nonneg_int(term.get("seq"))
+            and (term.get("event_id") is None or isinstance(term.get("event_id"), str))
+        ):
+            return None
+    return data
+
+
 def _read_sidecar(sidecar_path: Path) -> dict | None:
-    """Read+json.loads the sidecar. Return the parsed dict, or None if absent
-    or invalid (missing version / wrong shape). NEVER raises."""
+    """Read+validate the sidecar. Return the validated dict, or None if absent
+    or malformed (wrong version / bad schema / bad types). NEVER raises: a
+    corrupt sidecar must degrade to the JSONL authority on both the read and
+    write paths. (#6139 r18 b3)"""
     try:
         raw = sidecar_path.read_bytes()
     except (FileNotFoundError, OSError):
@@ -149,9 +193,7 @@ def _read_sidecar(sidecar_path: Path) -> dict | None:
         data = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
         return None
-    if not isinstance(data, dict) or int(data.get("version") or 0) != _RUN_SUMMARY_SIDECAR_VERSION:
-        return None
-    return data
+    return _validate_sidecar(data)
 
 
 def _summary_from_sidecar(session_id, run_id, data: dict) -> dict:
@@ -185,14 +227,10 @@ def _try_summary_from_sidecar(path, session_id, run_id) -> tuple[dict | None, bo
     except (FileNotFoundError, OSError):
         return None, True  # missing jsonl -> let the tail reader handle (returns empty)
     sidecar_path = _summary_sidecar_path(path)
-    data = _read_sidecar(sidecar_path)  # never raises
+    data = _read_sidecar(sidecar_path)  # strictly validated; never raises
     if data is None:
         return None, True
-    try:
-        journal_size = int(data.get("journal_size") or -1)
-    except (TypeError, ValueError):
-        journal_size = -1
-    if journal_size != int(jsonl_stat.st_size):
+    if int(data["journal_size"]) != int(jsonl_stat.st_size):
         return None, True  # stale (crash-mid-append / hand-edit / replacement) -> fallback
     return _summary_from_sidecar(session_id, run_id, data), True
 
@@ -2171,30 +2209,45 @@ def append_run_event(
             "payload": payload,
         }
 
-        # 2. Compute sidecar path and read prior state
+        # 2. Resolve the fold base for the sidecar. The prior sidecar is a
+        # trustworthy fold base ONLY if its recorded journal_size matches the
+        # JSONL size BEFORE this append — a mismatch means a prior sidecar
+        # commit failed (or the JSONL changed out of band), so the sidecar is
+        # stale and must NOT be folded onto (else a lost interior event is
+        # permanently healed into the summary). (#6139 r18 b1)
         sidecar_path = _summary_sidecar_path(path)
-        prior = _read_sidecar(sidecar_path)
-        if prior is not None:
+        try:
+            pre_size = path.stat().st_size if path.exists() else 0
+        except OSError:
+            pre_size = 0
+        prior = _read_sidecar(sidecar_path)  # strictly validated; None if malformed (#6139 r18 b3)
+        base_trusted = False
+        if prior is not None and int(prior["journal_size"]) == pre_size:
             state = {
                 "event_count": prior["event_count"],
                 "last": prior["last"],
-                "terminal": prior["terminal"]
+                "terminal": prior["terminal"],
             }
+            base_trusted = True
+        elif pre_size > 0:
+            # Sidecar absent/stale/malformed for an existing run: rebuild from
+            # the bounded tail. Honor ``ok=False`` — a transient rebuild fault
+            # must NOT be published as current authority; readers keep falling
+            # back to the tail reader and a later append retries. (#6139 r18 b2)
+            tail_events, _tail_malformed, tail_ok = _read_jsonl_tail(
+                path,
+                max_bytes=_SESSION_REPLAY_MAX_BYTES,
+                max_rows=_SESSION_REPLAY_MAX_ROWS,
+                attribute_lines=False,
+            )
+            state = _new_sidecar_state()
+            for ev in tail_events:
+                _fold_event_into_state(state, ev)
+            base_trusted = bool(tail_ok)
         else:
-            # No sidecar yet - rebuild from tail if this is an existing run
-            pre_size = path.stat().st_size if path.exists() else 0
-            if pre_size > 0:
-                # Old run, no sidecar: rebuild by folding the bounded tail
-                tail_events, _, _ = _read_jsonl_tail(
-                    path, max_bytes=_SESSION_REPLAY_MAX_BYTES,
-                    max_rows=_SESSION_REPLAY_MAX_ROWS, attribute_lines=False
-                )
-                state = _new_sidecar_state()
-                for ev in tail_events:
-                    _fold_event_into_state(state, ev)
-            else:
-                # Fresh run
-                state = _new_sidecar_state()
+            # Fresh run (no JSONL yet).
+            state = _new_sidecar_state()
+            base_trusted = True
 
         # 3. Write the JSONL line (existing logic unchanged)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -2207,23 +2260,22 @@ def append_run_event(
             if _should_fsync_event(terminal_state):
                 os.fsync(fh.fileno())
 
-        # 4. Fold the new event into state, then persist the sidecar atomically.
-        # The sidecar write is BEST-EFFORT: a failure here MUST NOT abort the
-        # append, because the JSONL line is already durably written above. On any
-        # sidecar failure/absence the summary readers fall back to the existing
-        # tail reader, so terminal identity stays correct regardless. The parent
-        # directory is fsynced by the JSONL ``created_file`` path below on the
-        # first event (the sidecar lives in the SAME directory), covering the
-        # sidecar's first rename; later events reuse the already-durable name.
+        # 4. Fold the new event, then publish the sidecar ONLY from a trusted
+        # base — never publish a current-generation sidecar built on
+        # stale/missing/corrupt/faulted state. (#6139 r18 b1/b2) The sidecar
+        # write is BEST-EFFORT: a failure MUST NOT abort the append (the JSONL
+        # line is already durably written); readers fall back to the tail reader
+        # and the next append's pre-size check rebuilds from a clean read.
         _fold_event_into_state(state, event)
-        try:
-            post_size = path.stat().st_size
-            payload_dict = _serialize_sidecar(state, post_size)
-            _atomic_write_json(
-                sidecar_path, payload_dict, fsync=_should_fsync_event(terminal_state)
-            )
-        except OSError:
-            pass
+        if base_trusted:
+            try:
+                post_size = path.stat().st_size
+                payload_dict = _serialize_sidecar(state, post_size)
+                _atomic_write_json(
+                    sidecar_path, payload_dict, fsync=_should_fsync_event(terminal_state)
+                )
+            except OSError:
+                pass
 
         # 7. Discard cached summary (existing logic unchanged)
         _discard_cached_summary(path)

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -262,29 +262,28 @@ def _read_jsonl(
 _BOUNDARY_SUMMARY_PREFIX_BYTES = 8192
 
 
-def _find_record_start_before(path: Path, seek_pos: int) -> int:
+def _find_record_start_before(fh, size: int, seek_pos: int) -> int:
     """Return the byte offset where the JSONL record overlapping ``seek_pos``
     begins, i.e. the byte just after the last newline strictly before seek_pos.
     Returns 0 if there is no preceding newline (the record starts at byte 0).
-    Scans backward in bounded chunks."""
+    Scans backward in bounded chunks.
+
+    The caller owns the handle and passes the pinned size from os.fstat — this
+    ensures all reads use a single inode generation (single-generation contract).
+    """
     if seek_pos <= 0:
         return 0
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
-    try:
-        size = path.stat().st_size
-    except (FileNotFoundError, OSError):
-        return 0
     pos = min(seek_pos, size)
     try:
-        with path.open("rb") as fh:
-            while pos > 0:
-                read_from = max(0, pos - chunk_size)
-                fh.seek(read_from)
-                block = fh.read(pos - read_from)
-                nl = block.rfind(b"\n")
-                if nl >= 0:
-                    return read_from + nl + 1
-                pos = read_from
+        while pos > 0:
+            read_from = max(0, pos - chunk_size)
+            fh.seek(read_from)
+            block = fh.read(pos - read_from)
+            nl = block.rfind(b"\n")
+            if nl >= 0:
+                return read_from + nl + 1
+            pos = read_from
     except (FileNotFoundError, OSError):
         # TOCTOU: journal deleted between the stat() above and this open/read
         # (cleanup racing a status poll). Return the safe fallback rather than
@@ -293,7 +292,7 @@ def _find_record_start_before(path: Path, seek_pos: int) -> int:
     return 0
 
 
-def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
+def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: int | None = None) -> dict | None:
     """Return the summary of the last complete JSONL record strictly before
     ``end_offset``, without materializing a multi-MB payload.
 
@@ -310,14 +309,18 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
     defeats a single-scan implementation — the first preceding line is blank,
     json.loads("") fails, and recovery fails. The backward loop skips the blank
     line and recovers the valid event.
+
+    The caller owns the handle and passes the pinned size from os.fstat.
+    ``budget`` bounds the total bytes/rows scanned (prevents infinite loops on
+    pathological files). If None, defaults to _SESSION_REPLAY_MAX_BYTES.
     """
     if end_offset <= 0:
         return None
-    try:
-        size = path.stat().st_size
-    except (FileNotFoundError, OSError):
-        return None
     scan_end = min(end_offset, size)
+    # Budget tracking to bound the total work across the loop.
+    budget_bytes = budget if budget is not None else _SESSION_REPLAY_MAX_BYTES
+    bytes_consumed = 0
+    rows_scanned = 0
     # Loop backward across preceding complete lines, skipping blank / malformed /
     # non-dict lines, until a valid event dict is found. Without this loop, a
     # shape like `token\n\n<big>` (a blank line between the valid event and the
@@ -325,15 +328,19 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
     # blank, json.loads("") fails, and the function returns None instead of
     # continuing back to the valid event. (#6139 r7)
     while scan_end > 0:
-        first_nl = _rfind_byte_before(path, b"\n", scan_end)
+        # Check budget before each iteration (guard against infinite loops).
+        if bytes_consumed > budget_bytes or rows_scanned > _SESSION_REPLAY_MAX_ROWS:
+            return None
+        first_nl = _rfind_byte_before(fh, b"\n", scan_end)
         if first_nl is None or first_nl == 0:
             return None  # no preceding complete line
-        second_nl = _rfind_byte_before(path, b"\n", first_nl)
+        second_nl = _rfind_byte_before(fh, b"\n", first_nl)
         line_start = (second_nl + 1) if second_nl is not None else 0
         line_len = first_nl - line_start
         if line_len <= 0:
             # Blank line (e.g. the gap in `token\n\n<big>`). Skip it: continue the
             # backward scan from before this blank line.
+            rows_scanned += 1  # count blank lines too (guard against infinite blank streaks)
             scan_end = line_start  # strictly < previous scan_end (line_start <= first_nl < scan_end)
             if scan_end <= 0:
                 return None
@@ -341,12 +348,13 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
         # Attempt to read + parse this candidate line (bounded for oversized).
         if line_len <= _BOUNDARY_SUMMARY_PREFIX_BYTES:
             try:
-                with path.open("rb") as fh:
-                    fh.seek(line_start)
-                    raw = fh.read(line_len)
+                fh.seek(line_start)
+                raw = fh.read(line_len)
                 parsed = json.loads(raw.decode("utf-8", errors="replace"))
             except (json.JSONDecodeError, OSError):
                 parsed = None
+            bytes_consumed += line_len
+            rows_scanned += 1
             if isinstance(parsed, dict):
                 return parsed
             # Malformed or non-dict: skip, continue backward.
@@ -355,7 +363,22 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
                 return None
             continue
         # Oversized preceding record: bounded prefix extraction (no payload materialized).
-        candidate = _extract_boundary_record_summary(path, line_start)
+        # CRITICAL: before accepting the fabricated prefix, gate on structural completeness.
+        # An oversized malformed predecessor (no closing brace/newline) must NOT be accepted
+        # via fabricated prefix as if it were valid JSON. If it's incomplete, skip it like
+        # any other malformed line.
+        if not _record_is_structurally_complete(fh, size, line_start):
+            # Oversized row is malformed/truncated — do NOT accept its fabricated prefix.
+            # Treat it like any other malformed line: skip and continue backward.
+            bytes_consumed += _BOUNDARY_SUMMARY_PREFIX_BYTES
+            rows_scanned += 1
+            scan_end = line_start
+            if scan_end <= 0:
+                return None
+            continue
+        candidate = _extract_boundary_record_summary(fh, line_start)
+        bytes_consumed += _BOUNDARY_SUMMARY_PREFIX_BYTES
+        rows_scanned += 1
         if isinstance(candidate, dict):
             return candidate
         scan_end = line_start
@@ -364,21 +387,23 @@ def _read_last_complete_line_before(path: Path, end_offset: int) -> dict | None:
     return None
 
 
-def _rfind_byte_before(path: Path, byte: bytes, end_offset: int) -> int | None:
+def _rfind_byte_before(fh, byte: bytes, end_offset: int) -> int | None:
     """Return the offset of the last occurrence of ``byte`` at or before
-    ``end_offset - 1``, scanning backward in bounded chunks. None if not found."""
+    ``end_offset - 1``, scanning backward in bounded chunks. None if not found.
+
+    The caller owns the handle; all reads use the same inode generation.
+    """
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
     pos = end_offset
     try:
-        with path.open("rb") as fh:
-            while pos > 0:
-                read_from = max(0, pos - chunk_size)
-                fh.seek(read_from)
-                block = fh.read(pos - read_from)
-                idx = block.rfind(byte)
-                if idx >= 0:
-                    return read_from + idx
-                pos = read_from
+        while pos > 0:
+            read_from = max(0, pos - chunk_size)
+            fh.seek(read_from)
+            block = fh.read(pos - read_from)
+            idx = block.rfind(byte)
+            if idx >= 0:
+                return read_from + idx
+            pos = read_from
     except (FileNotFoundError, OSError):
         # TOCTOU: journal deleted before/during the scan. Return the safe
         # fallback (None = byte not found) rather than escaping to the caller.
@@ -387,7 +412,7 @@ def _rfind_byte_before(path: Path, byte: bytes, end_offset: int) -> int | None:
     return None
 
 
-def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
+def _record_is_structurally_complete(fh, size: int, record_start: int) -> bool:
     """Return True iff the JSONL record at ``record_start`` is structurally
     complete — i.e. its JSON object is closed (brace depth returns to 0) AND
     followed by a newline terminator — scanning forward in bounded chunks WITHOUT
@@ -398,70 +423,67 @@ def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
     be accepted as terminal, or an interrupted run is misreported as completed
     and its recovery signal is silently dropped. Returns False if EOF is reached
     at brace depth > 0 (the record was truncated mid-write).
+
+    The caller owns the handle and passes the pinned size from os.fstat.
     """
     chunk_size = _SESSION_REPLAY_READ_CHUNK_BYTES
     depth = 0
     pos = record_start
-    try:
-        size = path.stat().st_size
-    except (FileNotFoundError, OSError):
-        return False
     in_string = False
     escaped = False
     try:
-        with path.open("rb") as fh:
-            fh.seek(record_start)
-            while pos < size:
-                chunk = fh.read(min(chunk_size, size - pos))
-                if not chunk:
-                    break
-                chunk_len = len(chunk)
-                for ci in range(chunk_len):
-                    b = chunk[ci]
-                    pos += 1
-                    if in_string:
-                        if escaped:
-                            escaped = False
-                        elif b == 0x5C:  # backslash
-                            escaped = True
-                        elif b == 0x22:  # closing quote
-                            in_string = False
-                        continue
-                    if b == 0x22:  # opening quote
-                        in_string = True
-                    elif b == 0x7B:  # '{'
-                        depth += 1
-                    elif b == 0x7D:  # '}'
-                        depth -= 1
-                        if depth == 0:
-                            # Object closed at position `pos` (1 past the '}').
-                            # The record is complete iff the byte(s) right after are a
-                            # newline terminator (\n or \r\n). Look at the next byte
-                            # in the current chunk first (avoid file-cursor drift),
-                            # else read fresh from the file.
-                            if ci + 1 < chunk_len:
-                                nb = chunk[ci + 1]
-                                if nb == 0x0A:  # \n — complete
-                                    return True
-                                if nb == 0x0D:  # \r — need to check for \r\n
-                                    if ci + 2 < chunk_len:
-                                        return chunk[ci + 2] == 0x0A
-                                    # \r at chunk end: read from file to check for \n
-                                    fh.seek(pos + 1)
-                                    return fh.read(1) == b"\n"
-                                return False  # any other byte after } is not a terminator
-                            # Terminator is in the next chunk: read up to 2 bytes
-                            # from file to distinguish \r\n (CRLF) from a bare \r.
-                            fh.seek(pos)
-                            nb = fh.read(2)
-                            return nb == b"\r\n" or nb[:1] == b"\n"
-                    elif b == 0x0A and depth == 0:  # newline at depth 0 before close
-                        return False
-                # depth > 0 here means the record spans more chunks; keep scanning.
-            # Reached EOF: a record ending at EOF is only complete if a real newline
-            # terminator was seen — NOT if the `}` is the last byte. A write
-            # interrupted after `}` but before the `\n` is crash-truncated.
-            return False
+        fh.seek(record_start)
+        while pos < size:
+            chunk = fh.read(min(chunk_size, size - pos))
+            if not chunk:
+                break
+            chunk_len = len(chunk)
+            for ci in range(chunk_len):
+                b = chunk[ci]
+                pos += 1
+                if in_string:
+                    if escaped:
+                        escaped = False
+                    elif b == 0x5C:  # backslash
+                        escaped = True
+                    elif b == 0x22:  # closing quote
+                        in_string = False
+                    continue
+                if b == 0x22:  # opening quote
+                    in_string = True
+                elif b == 0x7B:  # '{'
+                    depth += 1
+                elif b == 0x7D:  # '}'
+                    depth -= 1
+                    if depth == 0:
+                        # Object closed at position `pos` (1 past the '}').
+                        # The record is complete iff the byte(s) right after are a
+                        # newline terminator (\n or \r\n). Look at the next byte
+                        # in the current chunk first (avoid file-cursor drift),
+                        # else read fresh from the file.
+                        if ci + 1 < chunk_len:
+                            nb = chunk[ci + 1]
+                            if nb == 0x0A:  # \n — complete
+                                return True
+                            if nb == 0x0D:  # \r — need to check for \r\n
+                                if ci + 2 < chunk_len:
+                                    return chunk[ci + 2] == 0x0A
+                                # \r at chunk end: read from file to check for \n
+                                fh.seek(pos + 1)
+                                return fh.read(1) == b"\n"
+                            return False  # any other byte after } is not a terminator
+                        # Terminator is in the next chunk: read up to 2 bytes
+                        # from file to distinguish \r\n (CRLF) from a bare \r.
+                        fh.seek(pos)
+                        nb = fh.read(2)
+                        return nb == b"\r\n" or nb[:1] == b"\n"
+                elif b == 0x0A and depth == 0:  # newline at depth 0 before close
+                    return False
+            # depth > 0 here means the record spans more chunks; keep scanning.
+        # Reached EOF: a record ending at EOF is only complete if a real newline
+        # terminator was seen — NOT if the `}` is the last byte. A write
+        # interrupted after `}` but before the `\n` is crash-truncated.
+        return False
     except (FileNotFoundError, OSError):
         # TOCTOU: journal deleted between the stat() above and this open/read
         # (cleanup racing a status poll). Return the safe fallback (False =
@@ -470,7 +492,7 @@ def _record_is_structurally_complete(path: Path, record_start: int) -> bool:
         return False
 
 
-def _extract_boundary_record_summary(path: Path, record_start: int) -> dict | None:
+def _extract_boundary_record_summary(fh, record_start: int) -> dict | None:
     """Extract ONLY the summary fields of an oversized journal record that
     straddles the tail-window boundary, without materializing its payload.
 
@@ -481,11 +503,12 @@ def _extract_boundary_record_summary(path: Path, record_start: int) -> dict | No
     ``terminal_state``) or ``None`` if the layout is unexpected. The payload is
     replaced with an empty dict so downstream consumers see the shape but not
     the bytes.
+
+    The caller owns the handle; all reads use the same inode generation.
     """
     try:
-        with path.open("rb") as fh:
-            fh.seek(record_start)
-            prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
+        fh.seek(record_start)
+        prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
     except (FileNotFoundError, OSError):
         return None
     text = prefix_raw.decode("utf-8", errors="replace")
@@ -572,145 +595,155 @@ def _read_jsonl_tail(
     events. ``line`` numbers in ``malformed`` are 1-based across the whole file.
     Used by summary readers that need the LAST events of a possibly huge journal
     (terminal_state / last_seq live in the tail).
+
+    The file is opened ONCE and the size is pinned via os.fstat — ensuring all
+    recovery helpers read from a single inode generation. A delete-and-recreate
+    between stages cannot mix rows from different generations.
     """
     events: list[dict] = []
     malformed: list[dict] = []
     try:
-        size = path.stat().st_size
+        fh = path.open("rb")
     except (FileNotFoundError, OSError):
         return events, malformed
-    if size <= 0:
-        return events, malformed
-    read_bytes_cap = (
-        max_bytes if (max_bytes is not None and max_bytes > 0)
-        else _SESSION_REPLAY_MAX_BYTES
-    )
-    read_bytes = min(size, read_bytes_cap)
-    rows_cap = max_rows if (max_rows is not None and max_rows > 0) else (1 << 62)
     try:
-        with path.open("rb") as fh:
-            if size > read_bytes:
-                fh.seek(size - read_bytes)
-            raw = fh.read(read_bytes)
-    except (FileNotFoundError, OSError):
-        return events, malformed
-    text = raw.decode("utf-8", errors="replace")
-    # If we sought into the middle of the file, the window's first "line" is a
-    # partial fragment of a record that STRADDLES the seek boundary. streaming.py
-    # journals the terminal `done` event with the FULL transcript as its payload,
-    # so that record can be many MB — bigger than the whole tail window. Two
-    # sub-cases, both of which must not drop the straddling record's summary
-    # (terminal_state / last_seq / last_event_id) or restart recovery misreports
-    # a finished run as still-running:
-    #   (a) nl >= 0: the straddling record's tail is at the start of the window
-    #       and is followed by more complete records (e.g. the production order
-    #       done(tool_limit_reached) -> metering -> stream_end). Slicing past
-    #       the first newline loses the straddling record but keeps the rest.
-    #   (b) nl < 0: the ENTIRE window is inside one oversized record (no newline
-    #       at all), so there are no complete records in the window.
-    # In both cases, recover the straddling record's summary via a BOUNDED prefix
-    # read (_extract_boundary_record_summary): the record layout puts all summary
-    # fields before "payload", so we read a few KB, truncate at "payload", and
-    # parse the summary WITHOUT materializing the (multi-MB) payload. The
-    # extracted summary is prepended to the events so _summary_from_events sees
-    # both the straddling record's terminal state AND any trailing events.
-    boundary_summary: dict | None = None
-    if size > read_bytes:
-        seek_pos = size - read_bytes
-        record_start = _find_record_start_before(path, seek_pos)
-        # record_start is where the straddling record begins. Extract its summary
-        # via a bounded prefix read (never materializes the payload) — BUT only
-        # trust it as terminal if the record is structurally complete. A crash-
-        # truncated `done` (write interrupted mid-payload: no closing brace, no
-        # newline) must NOT be fabricated into a terminal event, or an interrupted
-        # run is misreported as completed and its apperror recovery signal is
-        # silently dropped. Stale-but-nonterminal is recoverable; falsely-terminal
-        # is not. If incomplete, discard the summary and fall through to the
-        # preceding complete records (the run stays nonterminal/`running`).
-        boundary_summary = _extract_boundary_record_summary(path, record_start)
-        if boundary_summary is not None and not _record_is_structurally_complete(path, record_start):
-            boundary_summary = None  # crash-truncated record: don't trust its prefix
-            # Retain the last COMPLETE event before the truncated boundary record,
-            # so last_seq/running survive and the apperror recovery signal fires
-            # (matching master). Without this, rejecting the boundary record also
-            # drops the preceding valid event → event_count=0, last_seq=0, no
-            # recovery. Read the last complete record's summary via bounded prefix
-            # extraction (never materializes a multi-MB payload).
-            preceding = _read_last_complete_line_before(path, record_start)
-            if preceding is not None:
-                events.append(preceding)
-        # Now drop the partial first fragment from the window so we only parse
-        # the complete trailing records.
-        nl = text.find("\n")
-        if nl >= 0:
-            text = text[nl + 1:]
-        else:
-            text = ""  # entire window was inside the oversized record
-    if boundary_summary is not None:
-        events.append(boundary_summary)
-    if not text.strip() and boundary_summary is None:
-        # No straddling record recovered AND no complete lines in the window.
-        # (When boundary_summary was recovered we already have it; an empty text
-        # just means there were no trailing complete records, which is fine.)
-        return events, malformed
-    # 1-based line number of the first whole line in `text`, across the whole
-    # file. The discarded prefix (size - read_bytes bytes) contains some number
-    # of complete lines; the first whole line in the window is the next one. We
-    # must COUNT newlines in the discarded prefix — a byte offset is NOT a line
-    # number (a 4 MB head with ~80 B/line has ~50000 lines, not ~4 M). Count by
-    # streaming the head in chunks so a huge file doesn't get materialized twice.
-    head_bytes = size - read_bytes if size > read_bytes else 0
-    lines_before_window = 0
-    if head_bytes > 0:
         try:
-            with path.open("rb") as _hf:
+            size = os.fstat(fh.fileno()).st_size   # ONE pin; same generation for all stages
+        except OSError:
+            return events, malformed
+        if size <= 0:
+            return events, malformed
+        read_bytes_cap = (
+            max_bytes if (max_bytes is not None and max_bytes > 0)
+            else _SESSION_REPLAY_MAX_BYTES
+        )
+        read_bytes = min(size, read_bytes_cap)
+        rows_cap = max_rows if (max_rows is not None and max_rows > 0) else (1 << 62)
+        if size > read_bytes:
+            fh.seek(size - read_bytes)
+        raw = fh.read(read_bytes)
+        text = raw.decode("utf-8", errors="replace")
+        # If we sought into the middle of the file, the window's first "line" is a
+        # partial fragment of a record that STRADDLES the seek boundary. streaming.py
+        # journals the terminal `done` event with the FULL transcript as its payload,
+        # so that record can be many MB — bigger than the whole tail window. Two
+        # sub-cases, both of which must not drop the straddling record's summary
+        # (terminal_state / last_seq / last_event_id) or restart recovery misreports
+        # a finished run as still-running:
+        #   (a) nl >= 0: the straddling record's tail is at the start of the window
+        #       and is followed by more complete records (e.g. the production order
+        #       done(tool_limit_reached) -> metering -> stream_end). Slicing past
+        #       the first newline loses the straddling record but keeps the rest.
+        #   (b) nl < 0: the ENTIRE window is inside one oversized record (no newline
+        #       at all), so there are no complete records in the window.
+        # In both cases, recover the straddling record's summary via a BOUNDED prefix
+        # read (_extract_boundary_record_summary): the record layout puts all summary
+        # fields before "payload", so we read a few KB, truncate at "payload", and
+        # parse the summary WITHOUT materializing the (multi-MB) payload. The
+        # extracted summary is prepended to the events so _summary_from_events sees
+        # both the straddling record's terminal state AND any trailing events.
+        boundary_summary: dict | None = None
+        if size > read_bytes:
+            seek_pos = size - read_bytes
+            record_start = _find_record_start_before(fh, size, seek_pos)
+            # record_start is where the straddling record begins. Extract its summary
+            # via a bounded prefix read (never materializes the payload) — BUT only
+            # trust it as terminal if the record is structurally complete. A crash-
+            # truncated `done` (write interrupted mid-payload: no closing brace, no
+            # newline) must NOT be fabricated into a terminal event, or an interrupted
+            # run is misreported as completed and its apperror recovery signal is
+            # silently dropped. Stale-but-nonterminal is recoverable; falsely-terminal
+            # is not. If incomplete, discard the summary and fall through to the
+            # preceding complete records (the run stays nonterminal/`running`).
+            boundary_summary = _extract_boundary_record_summary(fh, record_start)
+            if boundary_summary is not None and not _record_is_structurally_complete(fh, size, record_start):
+                boundary_summary = None  # crash-truncated record: don't trust its prefix
+                # Retain the last COMPLETE event before the truncated boundary record,
+                # so last_seq/running survive and the apperror recovery signal fires
+                # (matching master). Without this, rejecting the boundary record also
+                # drops the preceding valid event → event_count=0, last_seq=0, no
+                # recovery. Read the last complete record's summary via bounded prefix
+                # extraction (never materializes a multi-MB payload).
+                preceding = _read_last_complete_line_before(fh, size, record_start, budget=read_bytes_cap)
+                if preceding is not None:
+                    events.append(preceding)
+            # Now drop the partial first fragment from the window so we only parse
+            # the complete trailing records.
+            nl = text.find("\n")
+            if nl >= 0:
+                text = text[nl + 1:]
+            else:
+                text = ""  # entire window was inside the oversized record
+        if boundary_summary is not None:
+            events.append(boundary_summary)
+        if not text.strip() and boundary_summary is None:
+            # No straddling record recovered AND no complete lines in the window.
+            # (When boundary_summary was recovered we already have it; an empty text
+            # just means there were no trailing complete records, which is fine.)
+            return events, malformed
+        # 1-based line number of the first whole line in `text`, across the whole
+        # file. The discarded prefix (size - read_bytes bytes) contains some number
+        # of complete lines; the first whole line in the window is the next one. We
+        # must COUNT newlines in the discarded prefix — a byte offset is NOT a line
+        # number (a 4 MB head with ~80 B/line has ~50000 lines, not ~4 M). Count by
+        # streaming the head in chunks so a huge file doesn't get materialized twice.
+        head_bytes = size - read_bytes if size > read_bytes else 0
+        lines_before_window = 0
+        if head_bytes > 0:
+            try:
+                fh.seek(0)
                 _remaining = head_bytes
                 while _remaining > 0:
-                    _chunk = _hf.read(min(_SESSION_REPLAY_READ_CHUNK_BYTES, _remaining))
+                    _chunk = fh.read(min(_SESSION_REPLAY_READ_CHUNK_BYTES, _remaining))
                     if not _chunk:
                         break
                     lines_before_window += _chunk.count(b"\n")
                     _remaining -= len(_chunk)
-        except (FileNotFoundError, OSError):
-            lines_before_window = 0  # best-effort attribution; events are unaffected
-    # `text`'s first whole line in the file: the discarded head ended mid-line,
-    # so the partial line it left (line `lines_before_window + 1`) was dropped
-    # above, making the first whole line `lines_before_window + 2`. When there
-    # was no seek (whole file read), the first line is 1.
-    base_start_line = lines_before_window + 2 if head_bytes > 0 else 1
-    # Split on \n only (NOT splitlines, which accepts bare \r). A crash-truncated
-    # record ending in bare \r must not be parsed as a complete line.
-    # First check: if the text doesn't end with \n, the last line is unterminated.
-    text_ends_with_newline = text.endswith("\n")
-    all_lines = text.split("\n")
-    # Drop trailing empty string if text ended with \n.
-    if all_lines and all_lines[-1] == "":
-        all_lines.pop()
-    # If text didn't end with \n, the last "line" is unterminated (bare \r or
-    # EOF) — discard it, matching the full reader's terminator gate.
-    if not text_ends_with_newline and all_lines:
-        all_lines.pop()
-    # Keep only the last `rows_cap` lines so a huge tail window still bounds the
-    # parsed-event list (and the JSON decode cost). If we trim lines from the
-    # front, advance the starting line number by the trim count.
-    trim_from_front = max(0, len(all_lines) - rows_cap)
-    if trim_from_front:
-        all_lines = all_lines[-rows_cap:]
-    start_line = base_start_line + trim_from_front
-    for idx, raw_line in enumerate(all_lines):
-        line_no = start_line + idx
-        if not raw_line.strip():
-            continue
-        try:
-            parsed = json.loads(raw_line)
-        except json.JSONDecodeError:
-            malformed.append({"line": line_no, "raw": raw_line})
-            continue
-        if isinstance(parsed, dict):
-            events.append(parsed)
-        else:
-            malformed.append({"line": line_no, "raw": raw_line})
-    return events, malformed
+            except (FileNotFoundError, OSError):
+                lines_before_window = 0  # best-effort attribution; events are unaffected
+        # `text`'s first whole line in the file: the discarded head ended mid-line,
+        # so the partial line it left (line `lines_before_window + 1`) was dropped
+        # above, making the first whole line `lines_before_window + 2`. When there
+        # was no seek (whole file read), the first line is 1.
+        base_start_line = lines_before_window + 2 if head_bytes > 0 else 1
+        # Split on \n only (NOT splitlines, which accepts bare \r). A crash-truncated
+        # record ending in bare \r must not be parsed as a complete line.
+        # First check: if the text doesn't end with \n, the last line is unterminated.
+        text_ends_with_newline = text.endswith("\n")
+        all_lines = text.split("\n")
+        # Drop trailing empty string if text ended with \n.
+        if all_lines and all_lines[-1] == "":
+            all_lines.pop()
+        # If text didn't end with \n, the last "line" is unterminated (bare \r or
+        # EOF) — discard it, matching the full reader's terminator gate.
+        if not text_ends_with_newline and all_lines:
+            all_lines.pop()
+        # Keep only the last `rows_cap` lines so a huge tail window still bounds the
+        # parsed-event list (and the JSON decode cost). If we trim lines from the
+        # front, advance the starting line number by the trim count.
+        trim_from_front = max(0, len(all_lines) - rows_cap)
+        if trim_from_front:
+            all_lines = all_lines[-rows_cap:]
+        start_line = base_start_line + trim_from_front
+        for idx, raw_line in enumerate(all_lines):
+            line_no = start_line + idx
+            if not raw_line.strip():
+                continue
+            try:
+                parsed = json.loads(raw_line)
+            except json.JSONDecodeError:
+                malformed.append({"line": line_no, "raw": raw_line})
+                continue
+            if isinstance(parsed, dict):
+                events.append(parsed)
+            else:
+                malformed.append({"line": line_no, "raw": raw_line})
+        return events, malformed
+    except (FileNotFoundError, OSError):
+        # A read failure mid-recovery: return what we have (best-effort).
+        return events, malformed
+    finally:
+        fh.close()
 
 
 def _parse_run_journal_event_id(raw: str | None) -> tuple[str | None, int | None]:

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -891,11 +891,11 @@ def _read_jsonl_tail(
         boundary_summary: dict | None = None
         if size > read_bytes:
             seek_pos = size - read_bytes
-            # Boundary lookup + prefix extraction + validity proof share ONE meter
-            # (#6139 r10 item 1). Sized at 2x the tail window: the boundary record
-            # (the terminal `done` with the full transcript) is legitimately ~cap
-            # bytes, and the single-pass validity proof charges the record length
-            # once, so 2x cap covers a valid record plus a small margin.
+            # Boundary START lookup + 8 KiB prefix extraction share ONE meter sized
+            # at 2x the tail window (#6139 r10 item 1): the backward lookup scans
+            # the bytes before the window up to the record start, and prefix
+            # extraction reads _BOUNDARY_SUMMARY_PREFIX_BYTES, so 2x cap bounds
+            # both for a single straddling record.
             boundary_budget = _ReadBudget(2 * read_bytes_cap)
             record_start = _find_record_start_before(fh, size, seek_pos, budget=boundary_budget)
             # record_start is where the straddling record begins. Extract its summary
@@ -904,10 +904,6 @@ def _read_jsonl_tail(
             # grammatically-valid JSON record. Brace balance is NOT JSON validity
             # (#6139 r10 item 2): a brace-balanced record with a trailing comma or a
             # malformed nested value must NOT be fabricated into a terminal event.
-            # Prove whole-record validity before trusting the fabricated prefix; if
-            # validity cannot be established within the budget, fail closed and
-            # recover the older valid event. Stale-but-nonterminal is recoverable;
-            # falsely-terminal is not.
             boundary_summary = _extract_boundary_record_summary(fh, record_start, budget=boundary_budget)
             # A boundary record is REJECTED (must not be trusted as terminal, and
             # the preceding valid event must be recovered instead) on EITHER path:
@@ -925,7 +921,23 @@ def _read_jsonl_tail(
             # reader (#6139 r12).
             boundary_rejected = True
             if boundary_summary is not None:
-                if _record_is_valid_complete(fh, size, record_start, budget=boundary_budget):
+                # The whole-record validity proof gets its OWN meter, separate from
+                # the lookup+prefix meter (#6139 r13): the proof must read the FULL
+                # record to confirm JSON validity + terminator, and a valid record
+                # near _VALIDITY_PROOF_MAX_BYTES (2x cap) is a documented case
+                # (streaming.py journals the terminal `done` with the full
+                # transcript as its payload). Sharing the lookup+prefix meter let
+                # the backward lookup + 8 KiB prefix consume enough of the 2x cap
+                # allowance that a valid ~1.75x cap record could not be read in
+                # full → the proof failed closed → a VALID terminal record was
+                # rejected → wrong terminal_state (full reader
+                # `tool_limit_reached` → tail `running`/`completed`). The proof
+                # meter is sized at _VALIDITY_PROOF_MAX_BYTES so EVERY record the
+                # gate can possibly accept can pay for its own complete validation;
+                # the incremental chunked read means a small record still costs
+                # only one chunk, so the constant-in-file-size property holds.
+                validity_budget = _ReadBudget(_VALIDITY_PROOF_MAX_BYTES)
+                if _record_is_valid_complete(fh, size, record_start, budget=validity_budget):
                     boundary_rejected = False  # valid + complete: trust the prefix
                 else:
                     boundary_summary = None  # extracted-but-invalid: fail-closed

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -305,10 +305,10 @@ _BOUNDARY_SUMMARY_PREFIX_BYTES = 8192
 
 class _StreamingJsonValidator:
     """Byte-level streaming JSON grammar validator (RFC 8259 subset).
-    
+
     Feed bytes via feed(); call result via finish() or check .accepted/.rejected.
     Memory is O(nesting depth). Never materializes the full document.
-    
+
     The validator tracks complete state for objects, arrays, strings, numbers,
     keywords, and whitespace. It enforces strict grammar rules:
     - No trailing commas in objects or arrays
@@ -316,10 +316,14 @@ class _StreamingJsonValidator:
     - Valid number format (no leading zeros, proper exponent notation)
     - Exact keyword spellings (true/false/null)
     - Proper nesting and termination
-    
+
+    Additionally accepts the three Python-specific floating-point constants
+    (NaN, Infinity, -Infinity) to match the writer's ``json.dumps(allow_nan=True)``
+    behavior and the full reader's ``json.loads`` grammar.
+
     Fuzz-proven: passed 84,000 cases against json.loads oracle with 0 mismatches.
     """
-    
+
     __slots__ = (
         "_stack",
         "_state",
@@ -338,28 +342,28 @@ class _StreamingJsonValidator:
         "_utf8_first_min",   # min value of the FIRST continuation byte (0x80 default)
         "_utf8_first_max",   # max value of the FIRST continuation byte (0xBF default)
     )
-    
+
     # Frame states for objects/arrays
     _OBJ_EXPECT_KEY = "obj_expect_key"      # after { or ,
     _OBJ_EXPECT_COLON = "obj_expect_colon"  # after key string
     _OBJ_EXPECT_VALUE = "obj_expect_value"  # after :
     _OBJ_EXPECT_COMMA_OR_END = "obj_expect_comma_or_end"  # after value
-    
+
     _ARR_EXPECT_VALUE_OR_END = "arr_expect_value_or_end"  # after [ or ,
     _ARR_EXPECT_VALUE = "arr_expect_value"  # after ,
     _ARR_EXPECT_COMMA_OR_END = "arr_expect_comma_or_end"  # after value
-    
+
     # Top-level states
     _TOP_EXPECT_VALUE = "top_expect_value"
     _TOP_EXPECT_TERMINATOR = "top_expect_terminator"
-    
+
     # Whitespace definition (RFC 8259)
     _WHITESPACE = frozenset({0x20, 0x09, 0x0A, 0x0D})  # space, tab, LF, CR
-    
+
     def __init__(self) -> None:
         """Initialize validator to start parsing a new JSON value."""
         self._reset()
-    
+
     def _reset(self) -> None:
         """Reset all state for a new validation."""
         self._stack: list[str] = []
@@ -377,8 +381,8 @@ class _StreamingJsonValidator:
         self._in_object_start = False  # Track if we're at the start of an object
         self._utf8_remaining = 0
         self._utf8_first_min = 0x80
-        self._utf8_first_max = 0xBF    
-    
+        self._utf8_first_max = 0xBF
+
     def feed(self, data: bytes) -> None:
         """Feed bytes to the validator.
 
@@ -399,7 +403,7 @@ class _StreamingJsonValidator:
                 self._reject("Trailing bytes after complete JSONL record")
                 return
             self._process_byte(b)
-    
+
     def _process_byte(self, b: int) -> None:
         """Process a single byte through the state machine."""
         # Handle CR pending state (CRLF handling)
@@ -416,7 +420,7 @@ class _StreamingJsonValidator:
             if self._state == self._TOP_EXPECT_TERMINATOR:
                 self._accept()
             return
-        
+
         # Handle unicode escape sequence (inside \uXXXX)
         if self._unicode_escape_remaining > 0:
             if not self._is_hex_digit(b):
@@ -424,12 +428,12 @@ class _StreamingJsonValidator:
                 return
             self._unicode_escape_remaining -= 1
             return
-        
+
         # Handle string state
         if self._in_string:
             self._process_string_byte(b)
             return
-        
+
         # Handle whitespace
         if b in self._WHITESPACE:
             # Whitespace inside a partially-accumulated scalar token (keyword or
@@ -451,18 +455,18 @@ class _StreamingJsonValidator:
                 # Otherwise, LF is just whitespace
             # Other whitespace (space, tab) is ignored
             return
-        
+
         # Handle scalar token accumulation (keywords, numbers)
-        if self._state in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE, 
+        if self._state in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
                           self._ARR_EXPECT_VALUE_OR_END, self._ARR_EXPECT_VALUE,
                           self._OBJ_EXPECT_COMMA_OR_END, self._ARR_EXPECT_COMMA_OR_END,
                           self._OBJ_EXPECT_KEY, self._OBJ_EXPECT_COLON):
             self._process_scalar_byte(b)
             return
-        
+
         # Should not reach here
         self._reject(f"Unexpected byte {b} in state {self._state}")
-    
+
     def _process_string_byte(self, b: int) -> None:
         """Process a byte inside a string literal."""
         if self._escaped:
@@ -549,7 +553,7 @@ class _StreamingJsonValidator:
         if b < 0x20:
             self._reject(f"Control character 0x{b:02X} inside string")
         # Regular character, nothing to do
-    
+
     def _finalize_string(self) -> None:
         """Called when a string is completed."""
         # Check what we expect this string to be
@@ -562,7 +566,7 @@ class _StreamingJsonValidator:
             self._finalize_value()
         else:
             self._reject(f"String in unexpected state {self._state}")
-    
+
     def _process_scalar_byte(self, b: int) -> None:
         """Process a byte that could be part of a scalar value (keyword, number, or structure)."""
 
@@ -586,20 +590,20 @@ class _StreamingJsonValidator:
                     return
             self._in_string = True
             # Quote is valid when expecting a key (in object) or a value (anywhere)
-            if self._state in (self._OBJ_EXPECT_KEY, self._TOP_EXPECT_VALUE, 
-                              self._OBJ_EXPECT_VALUE, self._ARR_EXPECT_VALUE, 
+            if self._state in (self._OBJ_EXPECT_KEY, self._TOP_EXPECT_VALUE,
+                              self._OBJ_EXPECT_VALUE, self._ARR_EXPECT_VALUE,
                               self._ARR_EXPECT_VALUE_OR_END):
                 pass  # Valid start of string
             else:
                 self._reject(f"Unexpected string start in state {self._state}")
             return
-        
+
         # Validate any pending scalar before processing structural bytes
         if self._scalar_buf and b in (0x7B, 0x7D, 0x5B, 0x5D, 0x2C, 0x3A):
             self._validate_accumulated_scalar()
             if self._rejected:
                 return
-        
+
         # Structure characters (start/end of containers)
         if b == 0x7B:  # {
             self._start_object()
@@ -631,20 +635,20 @@ class _StreamingJsonValidator:
                 self._reject(f"Non-ASCII byte 0x{b:02X} outside string")
                 return
             self._scalar_buf.append(b)
-    
+
     def _start_object(self) -> None:
         """Handle opening brace {."""
         if self._state not in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
                                self._ARR_EXPECT_VALUE, self._ARR_EXPECT_VALUE_OR_END):
             self._reject(f"Unexpected {{ in state {self._state}")
             return
-        
+
         self._depth += 1
         # Store the container type (object) in the stack
         self._stack.append("object")
         self._state = self._OBJ_EXPECT_KEY
         self._in_object_start = True  # We're at the start of a new object
-    
+
     def _end_object(self) -> None:
         """Handle closing brace }."""
         # Validate any pending scalar first
@@ -663,18 +667,18 @@ class _StreamingJsonValidator:
         if self._state not in (self._OBJ_EXPECT_KEY, self._OBJ_EXPECT_COMMA_OR_END):
             self._reject(f"Unexpected }} in state {self._state}")
             return
-        
+
         self._depth -= 1
         if self._depth < 0:
             self._reject("Too many closing braces")
             return
-        
+
         # Pop the container type
         container = self._stack.pop()
         if container != "object":
             self._reject(f"Container type mismatch: expected object, got {container}")
             return
-        
+
         if self._depth == 0:
             # Top-level value completed
             self._state = self._TOP_EXPECT_TERMINATOR
@@ -688,20 +692,20 @@ class _StreamingJsonValidator:
                 self._state = self._ARR_EXPECT_COMMA_OR_END
             else:
                 self._reject(f"Unexpected parent container type: {parent}")
-    
+
     def _start_array(self) -> None:
         """Handle opening bracket [."""
         if self._state not in (self._TOP_EXPECT_VALUE, self._OBJ_EXPECT_VALUE,
                                self._ARR_EXPECT_VALUE, self._ARR_EXPECT_VALUE_OR_END):
             self._reject(f"Unexpected [ in state {self._state}")
             return
-        
+
         self._depth += 1
         # Store the container type (array) in the stack
         self._stack.append("array")
         self._state = self._ARR_EXPECT_VALUE_OR_END
         self._in_object_start = True  # We're at the start of a new array (for trailing comma check)
-    
+
     def _end_array(self) -> None:
         """Handle closing bracket ]."""
         # Validate any pending scalar first
@@ -720,18 +724,18 @@ class _StreamingJsonValidator:
         if self._state not in (self._ARR_EXPECT_VALUE_OR_END, self._ARR_EXPECT_COMMA_OR_END):
             self._reject(f"Unexpected ] in state {self._state}")
             return
-        
+
         self._depth -= 1
         if self._depth < 0:
             self._reject("Too many closing brackets")
             return
-        
+
         # Pop the container type
         container = self._stack.pop()
         if container != "array":
             self._reject(f"Container type mismatch: expected array, got {container}")
             return
-        
+
         if self._depth == 0:
             # Top-level value completed
             self._state = self._TOP_EXPECT_TERMINATOR
@@ -745,7 +749,7 @@ class _StreamingJsonValidator:
                 self._state = self._ARR_EXPECT_COMMA_OR_END
             else:
                 self._reject(f"Unexpected parent container type: {parent}")
-    
+
     def _handle_comma(self) -> None:
         """Handle comma separator."""
         if self._state == self._OBJ_EXPECT_COMMA_OR_END:
@@ -759,14 +763,14 @@ class _StreamingJsonValidator:
         elif self._state == self._ARR_EXPECT_VALUE_OR_END and self._in_object_start:
             # Comma at the start of an array - this is a trailing comma!
             self._reject("Trailing comma in array")
-        elif self._state in (self._OBJ_EXPECT_KEY, self._ARR_EXPECT_VALUE, 
+        elif self._state in (self._OBJ_EXPECT_KEY, self._ARR_EXPECT_VALUE,
                            self._OBJ_EXPECT_VALUE, self._TOP_EXPECT_VALUE,
                            self._ARR_EXPECT_VALUE_OR_END):
             # Comma appeared where we expected a value - this is invalid
             self._reject(f"Unexpected comma in state {self._state}")
         else:
             self._reject(f"Unexpected comma in state {self._state}")
-    
+
     def _handle_colon(self) -> None:
         """Handle colon after key in object."""
         if self._state != self._OBJ_EXPECT_COLON:
@@ -778,7 +782,7 @@ class _StreamingJsonValidator:
             if self._rejected:
                 return
         self._state = self._OBJ_EXPECT_VALUE
-    
+
     def _finalize_value(self) -> None:
         """Called when any value (string, number, keyword, container) is completed."""
         if self._depth == 0:
@@ -795,22 +799,28 @@ class _StreamingJsonValidator:
                 self._state = self._ARR_EXPECT_COMMA_OR_END
             else:
                 self._reject(f"Value completed in unexpected context (parent={parent})")
-    
+
     def _is_hex_digit(self, b: int) -> bool:
         """Check if byte is a valid hex digit."""
         return (0x30 <= b <= 0x39 or  # 0-9
                 0x41 <= b <= 0x46 or  # A-F
                 0x61 <= b <= 0x66)   # a-f
-    
+
     def _validate_accumulated_scalar(self) -> None:
-        """Validate an accumulated scalar token (keyword or number)."""
+        """Validate an accumulated scalar token (keyword or number).
+
+        Accepts the standard RFC 8259 keywords (true, false, null) and the three
+        Python-specific floating-point constants (NaN, Infinity, -Infinity) to
+        match the writer's ``json.dumps(allow_nan=True)`` behavior and the full
+        reader's ``json.loads`` grammar.
+        """
         if not self._scalar_buf:
             self._reject("Empty scalar token")
             return
-        
+
         token_bytes = bytes(self._scalar_buf)
         self._scalar_buf = []
-        
+
         # Try to match keyword
         token_str = token_bytes.decode("utf-8", errors="replace")
         if token_str == "true":
@@ -819,25 +829,31 @@ class _StreamingJsonValidator:
             self._finalize_value()
         elif token_str == "null":
             self._finalize_value()
+        elif token_str == "NaN":
+            self._finalize_value()
+        elif token_str == "Infinity":
+            self._finalize_value()
+        elif token_str == "-Infinity":
+            self._finalize_value()
         else:
             # Must be a number
             self._validate_number_token(token_bytes)
-    
+
     def _validate_number_token(self, token_bytes: bytes) -> None:
         """Validate a number token according to RFC 8259."""
         # Number grammar: -?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?
         i = 0
         n = len(token_bytes)
-        
+
         # Optional minus sign
         if i < n and token_bytes[i] == 0x2D:  # -
             i += 1
-        
+
         # Integer part
         if i >= n:
             self._reject("Number has no digits")
             return
-        
+
         if token_bytes[i] == 0x30:  # 0
             i += 1
             # Leading zeros not allowed (unless it's just "0")
@@ -851,7 +867,7 @@ class _StreamingJsonValidator:
         else:
             self._reject("Number has invalid integer part")
             return
-        
+
         # Fractional part
         if i < n and token_bytes[i] == 0x2E:  # .
             i += 1
@@ -860,7 +876,7 @@ class _StreamingJsonValidator:
                 return
             while i < n and 0x30 <= token_bytes[i] <= 0x39:
                 i += 1
-        
+
         # Exponent part
         if i < n and token_bytes[i] in (0x45, 0x65):  # E or e
             i += 1
@@ -872,38 +888,38 @@ class _StreamingJsonValidator:
                 return
             while i < n and 0x30 <= token_bytes[i] <= 0x39:
                 i += 1
-        
+
         # Must have consumed all bytes
         if i != n:
             self._reject(f"Number has trailing bytes: {token_bytes[i:]!r}")
             return
-        
+
         self._finalize_value()
-    
+
     def _reject(self, msg: str) -> None:
         """Mark the input as rejected with an error message."""
         self._rejected = True
         self._error_msg = msg
-    
+
     def _accept(self) -> None:
         """Mark the input as accepted."""
         self._accepted = True
-    
+
     @property
     def accepted(self) -> bool:
         """True if the input was accepted as valid JSON."""
         return self._accepted
-    
+
     @property
     def rejected(self) -> bool:
         """True if the input was rejected as invalid JSON."""
         return self._rejected
-    
+
     @property
     def error_message(self) -> str:
         """Error message if rejected, empty otherwise."""
         return self._error_msg
-    
+
     def finish(self) -> bool:
         """Return True iff the fed bytes form a complete, valid JSON value.
 
@@ -921,27 +937,27 @@ class _StreamingJsonValidator:
             return False
         if self._accepted:
             return True
-        
+
         # Check for pending CR without LF (bare CR)
         if self._pending_cr:
             self._reject("Bare CR (terminator is \\r\\n, not just \\r)")
             return False
-        
+
         # Check if we have a complete value
         if not self._saw_complete_value:
             # Either empty input or incomplete value
             self._reject("Incomplete JSON value (no complete value found)")
             return False
-        
+
         # Check for incomplete state
         if self._in_string:
             self._reject("Unterminated string")
             return False
-        
+
         if self._escaped:
             self._reject("Unterminated escape sequence")
             return False
-        
+
         if self._unicode_escape_remaining > 0:
             self._reject("Incomplete \\u escape sequence")
             return False
@@ -949,11 +965,11 @@ class _StreamingJsonValidator:
         if self._utf8_remaining > 0:
             self._reject("Incomplete UTF-8 sequence in string")
             return False
-        
+
         if self._depth > 0:
             self._reject(f"Unclosed container (depth={self._depth})")
             return False
-        
+
         # Check if we have pending scalar token
         if self._scalar_buf:
             self._validate_accumulated_scalar()
@@ -963,7 +979,7 @@ class _StreamingJsonValidator:
             if not self._saw_complete_value:
                 self._reject("Scalar did not complete the value")
                 return False
-        
+
         # If we reach here with a complete value and no errors, accept
         # BUT we must also be in the proper terminator state
         if self._saw_complete_value and self._state == self._TOP_EXPECT_TERMINATOR:
@@ -972,7 +988,7 @@ class _StreamingJsonValidator:
             # Actually, if we're in TOP_EXPECT_TERMINATOR state and haven't accepted yet,
             # it means we didn't get the newline terminator
             return self._accepted  # Only accept if we actually got the terminator
-        
+
         self._reject(f"Invalid end state: {self._state}")
         return False
 
@@ -1098,12 +1114,12 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
         # words for item 1: "stop before the next helper at exhaustion").
         if budget_obj.exhausted:
             return None
-        first_nl = _rfind_byte_before(fh, b"\n", scan_end, budget=budget_obj)
+        first_nl = _rfind_byte_before(fh, b"\n", scan_end, budget=budget_obj, fault=fault)
         if first_nl is None or first_nl == 0:
             return None  # no preceding complete line (or budget exhausted mid-scan)
         if budget_obj.exhausted:
             return None  # stop before the next helper at exhaustion
-        second_nl = _rfind_byte_before(fh, b"\n", first_nl, budget=budget_obj)
+        second_nl = _rfind_byte_before(fh, b"\n", first_nl, budget=budget_obj, fault=fault)
         line_start = (second_nl + 1) if second_nl is not None else 0
         line_len = first_nl - line_start
         if line_len <= 0:
@@ -1118,7 +1134,7 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
         # Candidate predecessor line. This loop only reaches COMPLETE lines
         # (newline-terminated on both sides — _rfind_byte_before found the
         # surrounding newlines, and the caller's end_offset is the boundary
-        # record's start, strictly after this line). 
+        # record's start, strictly after this line).
         #
         # #6139 redesign: validate the predecessor via prefix-summary + streaming
         # grammar validation (O(depth) memory, never materializes the full line).
@@ -1159,7 +1175,15 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
         # _record_is_valid_jsonl streams from line_start to line_end (the actual
         # line end, not EOF), confirming grammar + terminator. If it returns False,
         # the line is malformed/truncated — skip it and continue backward.
-        if not _record_is_valid_jsonl(fh, line_end, line_start, budget=budget_obj, fault=fault):
+        # Give the predecessor's streaming validation its OWN budget sized to the
+        # discovered line extent (mirrors the boundary record's validity_budget =
+        # size - record_start). The shared recovery_budget already paid for the
+        # backward newline scan + prefix read; charging it AGAIN for full-line
+        # validation starves >4 MiB predecessors (they need ~2x their size but
+        # only ~size+cap remains). The validator self-terminates at the line's
+        # terminating newline (depth-0 + \n), so line_len + one chunk covers it.
+        predecessor_validity_budget = _ReadBudget(line_len + _SESSION_REPLAY_READ_CHUNK_BYTES)
+        if not _record_is_valid_jsonl(fh, line_end, line_start, budget=predecessor_validity_budget, fault=fault):
             # Malformed or truncated predecessor — skip, continue backward.
             rows_scanned += 1
             scan_end = line_start
@@ -1173,7 +1197,7 @@ def _read_last_complete_line_before(fh, size: int, end_offset: int, *, budget: i
 
 
 def _rfind_byte_before(
-    fh, byte: bytes, end_offset: int, *, budget: _ReadBudget | None = None
+    fh, byte: bytes, end_offset: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
 ) -> int | None:
     """Return the offset of the last occurrence of ``byte`` at or before
     ``end_offset - 1``, scanning backward in bounded chunks. None if not found.
@@ -1221,7 +1245,10 @@ def _rfind_byte_before(
     except (FileNotFoundError, OSError):
         # TOCTOU: journal deleted before/during the scan. Return the safe
         # fallback (None = byte not found) rather than escaping to the caller.
-        # (#6139 Greptile P1)
+        # Signal the transient fault so the caller does NOT cache this as an
+        # authoritative "no predecessor" result. (#6139 r16)
+        if fault is not None:
+            fault[0] = True
         return None
     return None
 
@@ -1396,48 +1423,6 @@ def _record_is_valid_jsonl(
     # EOF reached without the validator accepting (crash-truncated or incomplete).
     result = validator.finish()
     return result
-
-
-def _extract_boundary_record_summary(
-    fh, record_start: int, *, budget: _ReadBudget | None = None, fault: list[bool] | None = None
-) -> dict | None:
-    """Extract ONLY the summary fields of an oversized journal record that
-    straddles the tail-window boundary, without materializing its payload.
-
-    Reads a bounded prefix (``_BOUNDARY_SUMMARY_PREFIX_BYTES``) from
-    ``record_start``, locates the top-level ``"payload"`` key via a brace-depth
-    scan, truncates the JSON before it, closes the object, and parses. Returns
-    a dict with the summary fields (``event``/``seq``/``event_id``/``terminal``/
-    ``terminal_state``) or ``None`` if the layout is unexpected. The payload is
-    replaced with an empty dict so downstream consumers see the shape but not
-    the bytes.
-
-    The caller owns the handle; all reads use the same inode generation. When
-    ``budget`` is a ``_ReadBudget`` the prefix read is capped at the budget's
-    remaining allowance; if the allowance hits 0 the function returns None. The
-    rest of the function operates on whatever prefix was read — if a shorter-
-    than-expected prefix can't be parsed, returns None.
-
-    When ``fault`` is a mutable list[bool], a caught OSError sets fault[0]=True
-    to signal the caller that a transient read fault occurred. (#6139 r14)
-    """
-    try:
-        fh.seek(record_start)
-        if budget is not None:
-            to_read = budget.take(_BOUNDARY_SUMMARY_PREFIX_BYTES)
-            if to_read == 0:
-                return None  # exhausted before reading any prefix — stop
-            prefix_raw = fh.read(to_read)
-        else:
-            prefix_raw = fh.read(_BOUNDARY_SUMMARY_PREFIX_BYTES)
-    except (FileNotFoundError, OSError):
-        if fault is not None:
-            fault[0] = True
-        return None
-    text = prefix_raw.decode("utf-8", errors="replace")
-    # The boundary record is oversized by definition (it straddles the tail
-    # window), so its payload is discarded — mark the summary as extracted.
-    return _parse_prefix_summary(text, mark_extracted=True)
 
 
 def _parse_prefix_summary(text: str, *, mark_extracted: bool = True) -> dict | None:

--- a/tests/test_issue2841_show_cron_sessions_toggle.py
+++ b/tests/test_issue2841_show_cron_sessions_toggle.py
@@ -269,4 +269,3 @@ def test_kanban_source_filter_passed_to_dedupe():
         "source_filter must be forwarded to _dedupe_cli_sidebar_sessions_for_api "
         "so an explicit kanban filter can override the hide"
     )
-

--- a/tests/test_issue6498_memory_config_gates.py
+++ b/tests/test_issue6498_memory_config_gates.py
@@ -602,4 +602,3 @@ class TestRealLoaderNestedConfig:
         assert not (write_home / "memories").exists(), (
             "memories/ must not be created when memory is disabled"
         )
-

--- a/tests/test_issue6612_update_channel_autosave.py
+++ b/tests/test_issue6612_update_channel_autosave.py
@@ -965,4 +965,3 @@ def test_channel_writer_concurrent_selection(tmp_path, monkeypatch):
     assert result["finalSeq"] == 2, (
         f"_channelSaveSeq must be 2 after two calls; got {result['finalSeq']!r}"
     )
-

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -167,8 +167,8 @@ def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tm
 
     original_read = run_journal._read_jsonl
 
-    def append_after_read(path):
-        events, malformed = original_read(path)
+    def append_after_read(path, **kwargs):
+        events, malformed = original_read(path, **kwargs)
         append_run_event(
             "session_1",
             "run_1",
@@ -194,9 +194,9 @@ def test_summary_cache_rejects_first_append_that_races_missing_journal_read(tmp_
     original_read = run_journal._read_jsonl
     appended = False
 
-    def append_after_missing_read(path):
+    def append_after_missing_read(path, **kwargs):
         nonlocal appended
-        events, malformed = original_read(path)
+        events, malformed = original_read(path, **kwargs)
         if not appended:
             appended = True
             append_run_event(

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -62,7 +62,8 @@ def test_run_journal_default_fsyncs_terminal_events_only(tmp_path, monkeypatch):
 
     append_run_event("session_1", "run_1", "done", {"session": {}}, session_dir=tmp_path)
 
-    assert len(fsync_calls) == 1
+    # Round 17: terminal events fsync both JSONL and sidecar (2 calls total)
+    assert len(fsync_calls) == 2
 
 
 def test_run_journal_eager_fsync_mode_fsyncs_non_terminal_events(tmp_path, monkeypatch):
@@ -75,7 +76,8 @@ def test_run_journal_eager_fsync_mode_fsyncs_non_terminal_events(tmp_path, monke
 
     append_run_event("session_1", "run_1", "token", {"text": "ok"}, session_dir=tmp_path)
 
-    assert len(fsync_calls) == 1
+    # Round 17: eager mode fsyncs both JSONL and sidecar (2 calls total)
+    assert len(fsync_calls) == 2
 
 
 def test_run_journal_tolerates_malformed_lines(tmp_path):
@@ -166,9 +168,10 @@ def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tm
     import api.run_journal as run_journal
 
     original_read = run_journal._read_jsonl
+    original_try_sidecar = run_journal._try_summary_from_sidecar
 
-    def append_after_read(path, **kwargs):
-        events, malformed, ok = original_read(path, **kwargs)
+    def append_after_any_read():
+        """Append cancel event after any read (sidecar or tail)."""
         append_run_event(
             "session_1",
             "run_1",
@@ -176,11 +179,31 @@ def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tm
             {"message": "Cancelled by user"},
             session_dir=tmp_path,
         )
+
+    def append_after_read(path, **kwargs):
+        events, malformed, ok = original_read(path, **kwargs)
+        append_after_any_read()
         return events, malformed, ok
 
+    def append_after_sidecar(path, session_id, run_id):
+        result, ok = original_try_sidecar(path, session_id, run_id)
+        if result is not None:
+            append_after_any_read()
+        return result, ok
+
     monkeypatch.setattr(run_journal, "_read_jsonl", append_after_read)
+    monkeypatch.setattr(run_journal, "_try_summary_from_sidecar", append_after_sidecar)
 
     first = latest_run_summary("session_1", "run_1", session_dir=tmp_path)
+    # NOTE: no manual sidecar delete or cache clear here. The first call read
+    # the sidecar (terminal_state=completed) and a concurrent `cancel` was
+    # appended DURING that read, advancing the JSONL past the pre-read
+    # signature captured before the read. The cache must therefore REFUSE to
+    # store the stale `completed` result, so the second call re-reads and
+    # observes the new `interrupted-by-user` state. If the pre-read signature
+    # were captured AFTER the sidecar read (the r17 TOCTOU hole), the stale
+    # result would be cached under the post-append signature and the second
+    # call would wrongly return `completed`.
     second = latest_run_summary("session_1", "run_1", session_dir=tmp_path)
 
     assert first["terminal_state"] == "completed"

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -168,7 +168,7 @@ def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tm
     original_read = run_journal._read_jsonl
 
     def append_after_read(path, **kwargs):
-        events, malformed = original_read(path, **kwargs)
+        events, malformed, ok = original_read(path, **kwargs)
         append_run_event(
             "session_1",
             "run_1",
@@ -176,7 +176,7 @@ def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tm
             {"message": "Cancelled by user"},
             session_dir=tmp_path,
         )
-        return events, malformed
+        return events, malformed, ok
 
     monkeypatch.setattr(run_journal, "_read_jsonl", append_after_read)
 
@@ -196,7 +196,7 @@ def test_summary_cache_rejects_first_append_that_races_missing_journal_read(tmp_
 
     def append_after_missing_read(path, **kwargs):
         nonlocal appended
-        events, malformed = original_read(path, **kwargs)
+        events, malformed, ok = original_read(path, **kwargs)
         if not appended:
             appended = True
             append_run_event(
@@ -206,7 +206,7 @@ def test_summary_cache_rejects_first_append_that_races_missing_journal_read(tmp_
                 {"session": {}},
                 session_dir=tmp_path,
             )
-        return events, malformed
+        return events, malformed, ok
 
     monkeypatch.setattr(run_journal, "_read_jsonl", append_after_missing_read)
 

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -417,6 +417,67 @@ def test_oversized_done_closing_brace_without_newline_stays_nonterminal(tmp_path
     )
 
 
+def test_bare_carriage_return_terminator_rejected(tmp_path):
+    """Regression (reviewer round 5): a bare \\r (not \\r\\n) as the JSONL
+    terminator was accepted as a complete record — but a write interrupted after
+    a \\r (before the \\n of a CRLF pair) is crash-truncated. Only \\n or the
+    complete \\r\\n pair is a valid terminator."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    writer = RunJournalWriter("session_1", "run_bare_cr", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})
+    path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    # Append an oversized done terminated with bare \r (not \r\n).
+    huge = (
+        '{"version":1,"event_id":"run_bare_cr:2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * (_SESSION_REPLAY_MAX_BYTES + 50_000)
+        + '"}}\r'
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(huge)
+    summary = latest_run_summary(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    assert summary["terminal"] is False, (
+        f"bare-\\r terminator must not be accepted as terminal; "
+        f"got terminal_state={summary['terminal_state']!r}"
+    )
+
+
+def test_preceding_event_recovery_is_bounded(tmp_path):
+    """Regression (reviewer round 5): _read_last_complete_line_before used to
+    materialize the ENTIRE preceding record (verified at 4.27 MB), defeating the
+    memory-bound goal. The fix uses the bounded prefix extractor when the
+    preceding record is oversized, so the recovery path stays within the cap."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path, _read_last_complete_line_before
+
+    writer = RunJournalWriter("session_1", "run_bounded_preceding", session_dir=tmp_path)
+    # seq=1: an oversized but COMPLETE done (with newline)
+    huge = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
+    writer.append_sse_event("done", {"session": {"session_id": "session_1"}, **huge})
+    path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    # seq=2: crash-truncated done (no close/newline)
+    partial = (
+        '{"version":1,"event_id":"run_bounded_preceding:2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * (_SESSION_REPLAY_MAX_BYTES + 50_000)
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial)
+    size = path.stat().st_size
+    seek = size - min(size, _SESSION_REPLAY_MAX_BYTES)
+    record_start = __import__("api.run_journal", fromlist=["_find_record_start_before"])._find_record_start_before(path, seek)
+    result = _read_last_complete_line_before(path, record_start)
+    assert result is not None
+    # The preceding record's summary was extracted via bounded prefix, not materialized.
+    assert result.get("_summary_extracted_from_oversized_record") is True, (
+        "preceding oversized record was materialized instead of bounded-prefix extracted"
+    )
+    assert result["payload"] == {}, "payload should be empty (not materialized)"
+
+
+
 
 
 

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -316,4 +316,41 @@ def _summary_from_events_pub(session_id, run_id, events):
     return _summary_from_events(session_id, run_id, events)
 
 
+def test_crash_truncated_oversized_done_stays_nonterminal(tmp_path):
+    """Regression (reviewer round 3): a crash-truncated oversized `done` record
+    (write interrupted mid-payload: no closing brace, no newline terminator) must
+    NOT be fabricated into a terminal event. Origin/master reports `running` and
+    emits the recovery-control `apperror`; the prefix-summary approach without a
+    completeness check reported `completed` and suppressed that signal. The fix
+    validates the boundary record is structurally complete before trusting its
+    prefix summary — a truncated record is discarded and the run stays
+    nonterminal (its apperror recovery survives)."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    writer = RunJournalWriter("session_1", "run_crash_truncated", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})
+    # Append a PARTIAL oversized done: summary fields + partial payload, NO close.
+    path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    partial = (
+        '{"version":1,"event_id":"run_crash_truncated:2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * (_SESSION_REPLAY_MAX_BYTES + 50_000)
+    )  # no closing quote/brace/newline — crash mid-write
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial)
+
+    summary = latest_run_summary(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    # Must NOT be falsely terminal — the run was interrupted.
+    assert summary["terminal"] is False, (
+        f"a crash-truncated done must not be accepted as terminal; got "
+        f"terminal_state={summary['terminal_state']!r} terminal={summary['terminal']}"
+    )
+    # And not reported as completed (the dangerous false-positive).
+    assert summary["terminal_state"] != "completed", (
+        f"crash-truncated run misreported as completed: {summary['terminal_state']!r}"
+    )
+
+
+
 

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -352,5 +352,71 @@ def test_crash_truncated_oversized_done_stays_nonterminal(tmp_path):
     )
 
 
+def test_crash_truncated_oversized_done_retains_preceding_event(tmp_path):
+    """Regression (reviewer round 4): rejecting the crash-truncated boundary
+    record also dropped the preceding VALID event, so event_count=0 / last_seq=0
+    and stale_interrupted_event returned None → no apperror recovery emitted.
+    Master reports running/last_seq=1 and emits the recovery signal. The fix
+    retains the last complete event before the rejected boundary record."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    writer = RunJournalWriter("session_1", "run_trunc_preceding", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})  # seq=1, the preceding valid event
+    path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    partial = (
+        '{"version":1,"event_id":"run_trunc_preceding:2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * (_SESSION_REPLAY_MAX_BYTES + 50_000)
+    )  # no closing brace/newline — crash mid-write
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial)
+
+    summary = latest_run_summary(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    # The preceding token (seq=1) must survive — not falsely completed.
+    assert summary["terminal"] is False
+    assert summary["terminal_state"] != "completed"
+    assert summary["last_seq"] == 1, (
+        f"preceding event lost: last_seq={summary['last_seq']} (expected 1)"
+    )
+    assert summary["event_count"] >= 1, (
+        f"preceding event lost: event_count={summary['event_count']}"
+    )
+
+
+def test_oversized_done_closing_brace_without_newline_stays_nonterminal(tmp_path):
+    """Regression (reviewer round 4): an oversized `done` ending at EOF with a
+    closing `}` but NO JSONL newline terminator is a crash-truncated write
+    (interrupted after the brace, before the \\n), NOT a completed record. The
+    completeness scanner used to treat EOF-right-after-`}` as complete; it must
+    require an actual \\n terminator."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    writer = RunJournalWriter("session_1", "run_brace_no_newline", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})
+    path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    # A record that closes with }} but has NO trailing newline.
+    huge = (
+        '{"version":1,"event_id":"run_brace_no_newline:2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * (_SESSION_REPLAY_MAX_BYTES + 50_000)
+        + '"}}'
+    )  # closes with }} but no \n — crash after the brace
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(huge)
+
+    summary = latest_run_summary(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+    assert summary["terminal"] is False, (
+        f"a closing-brace-at-EOF-no-newline record must not be accepted as terminal; "
+        f"got terminal_state={summary['terminal_state']!r}"
+    )
+    assert summary["terminal_state"] != "completed", (
+        f"crash-truncated run (brace without newline) misreported as completed: "
+        f"{summary['terminal_state']!r}"
+    )
+
+
+
 
 

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -196,3 +196,40 @@ def test_read_jsonl_tail_line_numbers_correct_no_seek(tmp_path):
     assert len(malformed) == 1
     assert malformed[0]["line"] == 3, f"expected 3, got {malformed[0]['line']}"
 
+
+def test_terminal_state_correct_when_terminal_record_exceeds_tail_window(tmp_path):
+    """Regression: streaming.py journals the terminal `done` event with the FULL
+    transcript as its payload, so a large session's terminal record can be bigger
+    than the 4 MiB tail window. The tail reader used to seek into the middle of
+    that record, find its trailing newline as the only newline in the window,
+    slice to an empty string, and return NO events — so latest_run_summary
+    misclassified a COMPLETED run as `unknown` (a recovery bug). The fix recovers
+    the last complete line by scanning backward from EOF when the window yields
+    no whole parseable line."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES
+
+    writer = RunJournalWriter("session_1", "run_huge_done", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})
+    # Append the terminal `done` with a payload larger than the tail window —
+    # mirrors streaming.py journaling done with the full transcript.
+    huge_payload = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
+    writer.append_sse_event(
+        "done", {"session": {"session_id": "session_1"}, **huge_payload}
+    )
+
+    summary = latest_run_summary("session_1", "run_huge_done", session_dir=tmp_path)
+    # Before the fix: terminal_state was "unknown", terminal False, last_seq 0.
+    assert summary["terminal_state"] == "completed", (
+        f"a completed run must stay completed even when its terminal record "
+        f"exceeds the tail window; got {summary['terminal_state']!r}"
+    )
+    assert summary["terminal"] is True
+    assert summary["last_seq"] == 2  # 1 token + 1 done
+
+    # find_run_summary (the other summary reader) must agree.
+    found = find_run_summary("run_huge_done", session_dir=tmp_path)
+    assert found is not None
+    assert found["terminal_state"] == "completed"
+    assert found["last_seq"] == 2
+
+

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -525,3 +525,109 @@ def test_ordinary_size_done_eof_no_newline_rejected_both_readers(tmp_path):
 
 
 
+
+
+# ── Greptile P1 (2026-07-20): TOCTOU — file deleted between stat() and open() ─
+# The backward-scan helpers (_find_record_start_before, _rfind_byte_before,
+# _record_is_structurally_complete) wrap stat() in try/except but used to leave
+# the subsequent path.open() unguarded. A cleanup job racing a status poll could
+# delete the journal in that window; the FileNotFoundError would escape to the
+# HTTP handler → 500. Each helper must return its safe fallback instead.
+
+
+def test_find_record_start_before_returns_fallback_if_file_deleted(tmp_path, monkeypatch):
+    """_find_record_start_before: stat succeeds, then open() raises — must
+    return 0 (not let FileNotFoundError escape to the HTTP handler)."""
+    import json as _json
+    from pathlib import Path
+    from api import run_journal
+
+    p = tmp_path / "race.jsonl"
+    p.write_bytes((_json.dumps({"seq": 1, "event": "done"}) + "\n").encode("utf-8"))
+    real_open = Path.open
+
+    def racing_open(self, *a, **kw):
+        if self == p:
+            raise FileNotFoundError(str(p))
+        return real_open(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "open", racing_open)
+    assert run_journal._find_record_start_before(p, 50) == 0
+
+
+def test_rfind_byte_before_returns_fallback_if_file_deleted(tmp_path, monkeypatch):
+    """_rfind_byte_before: open() raises FileNotFoundError — must return None."""
+    import json as _json
+    from pathlib import Path
+    from api import run_journal
+
+    p = tmp_path / "race.jsonl"
+    p.write_bytes((_json.dumps({"seq": 1}) + "\n").encode("utf-8"))
+    real_open = Path.open
+
+    def racing_open(self, *a, **kw):
+        if self == p:
+            raise FileNotFoundError(str(p))
+        return real_open(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "open", racing_open)
+    assert run_journal._rfind_byte_before(p, b"\n", 50) is None
+
+
+def test_record_is_structurally_complete_returns_fallback_if_file_deleted(
+    tmp_path, monkeypatch
+):
+    """_record_is_structurally_complete: open() raises FileNotFoundError — must
+    return False (not raise)."""
+    import json as _json
+    from pathlib import Path
+    from api import run_journal
+
+    p = tmp_path / "race.jsonl"
+    p.write_bytes((_json.dumps({"seq": 1, "event": "done"}) + "\n").encode("utf-8"))
+    real_open = Path.open
+
+    def racing_open(self, *a, **kw):
+        if self == p:
+            raise FileNotFoundError(str(p))
+        return real_open(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "open", racing_open)
+    assert run_journal._record_is_structurally_complete(p, 0) is False
+
+
+def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, monkeypatch):
+    """End-to-end TOCTOU: a journal large enough to trigger the boundary-scan
+    path; the boundary helper raises FileNotFoundError mid-scan. latest_run_summary
+    must return a safe summary (not propagate → 500 on the poll endpoint)."""
+    from api import run_journal
+    from api.run_journal import append_run_event
+
+    # Build a journal whose tail window straddles a record (so the boundary
+    # helpers fire). Substantial payloads so the tail cap excludes the first.
+    big = "x" * 50000
+    append_run_event("s1", "r1", "done", {"session": {}, "big": big}, session_dir=tmp_path)
+    append_run_event("s1", "r1", "done",
+                     {"terminal_state": "completed", "big": big},
+                     session_dir=tmp_path)
+
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    assert path.exists(), (
+        f"journal not written where expected: {path} (glob: "
+        f"{list(tmp_path.rglob('*.jsonl'))})"
+    )
+
+    # Patch the boundary helper to raise (simulating delete-during-scan) —
+    # latest_run_summary must catch via the helper's own try/except and return
+    # a safe summary, not propagate.
+    original = run_journal._find_record_start_before
+
+    def raising_find(p, seek_pos):
+        if p == path:
+            raise FileNotFoundError(str(path))
+        return original(p, seek_pos)
+
+    monkeypatch.setattr(run_journal, "_find_record_start_before", raising_find)
+    summary = run_journal.latest_run_summary("s1", "r1", session_dir=tmp_path)
+    # Must return a dict (safe summary), not raise.
+    assert isinstance(summary, dict)

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -1,0 +1,198 @@
+"""Tests: run-journal summary readers use a bounded TAIL read.
+
+Regression: ``_read_jsonl`` read the WHOLE journal file via ``read_text()`` and
+parsed every line. ``read_session_run_events`` (the replay path) already had
+``_SESSION_REPLAY_MAX_BYTES`` / ``_SESSION_REPLAY_MAX_ROWS`` caps + chunked
+streaming, but the summary readers on the hot status/sidebar poll path
+(``latest_run_summary`` / ``find_run_summary``, via ``_read_jsonl``) did not — a
+turn with heavy tool use / large file reads produced a multi-MB journal fully
+re-parsed on every poll.
+
+The summary readers now read the bounded TAIL: ``last_seq`` /
+``last_event_id`` / ``terminal_state`` are derived from the LAST events, so a
+tail read keeps them correct for a large COMPLETED run (its terminal marker
+lives at the end) without parsing the whole history.
+"""
+import json
+
+from api.run_journal import (
+    RunJournalWriter,
+    _read_jsonl,
+    find_run_summary,
+    latest_run_summary,
+    read_run_events,
+)
+from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _SESSION_REPLAY_MAX_ROWS
+
+
+def _write_n_events(session_dir, *, session_id, run_id, n, terminal_after=None):
+    """Append n token events, optionally appending a terminal `done` at the end."""
+    writer = RunJournalWriter(session_id, run_id, session_dir=session_dir)
+    for i in range(n):
+        writer.append_sse_event("token", {"text": f"tok-{i}", "i": i})
+    if terminal_after is not None:
+        writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+
+def test_latest_run_summary_reads_tail_and_keeps_terminal_state(tmp_path):
+    """A run with FAR more events than the row cap still reports the correct
+    terminal_state and last_seq — proving the summary reads the tail (where the
+    terminal marker lives), not a head cap that would misreport it as running."""
+    n = _SESSION_REPLAY_MAX_ROWS + 1500  # well past the row cap
+    _write_n_events(
+        tmp_path,
+        session_id="session_1",
+        run_id="run_big",
+        n=n,
+        terminal_after=True,
+    )
+    summary = latest_run_summary("session_1", "run_big", session_dir=tmp_path)
+    # The terminal `done` is the LAST event; tail-read must surface it.
+    assert summary["terminal"] is True
+    assert summary["terminal_state"] == "completed"
+    # last_seq is the terminal event's seq == n + 1 (n tokens + 1 done).
+    assert summary["last_seq"] == n + 1
+
+
+def test_find_run_summary_reads_tail_and_keeps_terminal_state(tmp_path):
+    """Same tail contract for find_run_summary (used by route status polling)."""
+    n = _SESSION_REPLAY_MAX_ROWS + 500
+    _write_n_events(
+        tmp_path,
+        session_id="session_z",
+        run_id="run_zzz",
+        n=n,
+        terminal_after=True,
+    )
+    summary = find_run_summary("run_zzz", session_dir=tmp_path)
+    assert summary is not None
+    assert summary["terminal"] is True
+    assert summary["terminal_state"] == "completed"
+    assert summary["last_seq"] == n + 1
+
+
+def test_read_jsonl_tail_returns_only_recent_rows(tmp_path):
+    """_read_jsonl(tail=True) returns at most max_rows events from the END of the
+    file (newest), discarding older head events."""
+    path = tmp_path / "j.jsonl"
+    lines = []
+    for i in range(100):
+        lines.append(json.dumps({"seq": i, "event": "token", "payload": {"i": i}}))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    events, _malformed = _read_jsonl(path, max_rows=10, tail=True)
+    # Newest 10 events retained (seq 90..99); older head events dropped.
+    assert len(events) == 10
+    assert [e["seq"] for e in events] == list(range(90, 100))
+
+
+def test_read_jsonl_tail_respects_byte_cap(tmp_path):
+    """_read_jsonl(tail=True) reads at most max_bytes from the end of the file."""
+    path = tmp_path / "j.jsonl"
+    lines = []
+    for i in range(1000):
+        lines.append(json.dumps({"seq": i, "event": "token"}))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    full_size = path.stat().st_size
+    # Ask for the last ~10% of the file.
+    cap = full_size // 10
+    events, _malformed = _read_jsonl(path, max_bytes=cap, tail=True)
+    # The tail read returns only events within the byte window (bounded, not all
+    # 1000). The LAST event is always included (it's within the window).
+    assert len(events) < 1000
+    assert events[-1]["seq"] == 999
+
+
+def test_read_jsonl_default_unbounded_still_works(tmp_path):
+    """Backward compatibility: with no caps, _read_jsonl reads the whole file."""
+    path = tmp_path / "j.jsonl"
+    path.write_text(
+        "\n".join(json.dumps({"seq": i}) for i in range(5)) + "\n", encoding="utf-8"
+    )
+    events, _mal = _read_jsonl(path)
+    assert [e["seq"] for e in events] == [0, 1, 2, 3, 4]
+
+
+def test_read_run_events_accepts_optional_caps(tmp_path):
+    """read_run_events now accepts max_bytes/max_rows (forward, head cap) without
+    changing its default whole-file behavior or after_seq/max_seq filtering."""
+    writer = RunJournalWriter("s", "r", session_dir=tmp_path)
+    for i in range(5):
+        writer.append_sse_event("token", {"i": i})
+    # Default: all 5.
+    j = read_run_events("s", "r", session_dir=tmp_path)
+    assert len(j["events"]) == 5
+    # Capped: head cap returns a prefix.
+    j2 = read_run_events("s", "r", session_dir=tmp_path, max_rows=2)
+    assert len(j2["events"]) == 2
+    # after_seq filtering still applies on top.
+    j3 = read_run_events("s", "r", session_dir=tmp_path, after_seq=3)
+    assert [e["seq"] for e in j3["events"]] == [4, 5]
+
+
+def test_existing_summary_classification_still_works(tmp_path):
+    """The terminal-state classification assertions (from test_run_journal.py)
+    still hold with the tail read."""
+    w = RunJournalWriter("session_1", "run_done", session_dir=tmp_path)
+    w.append_sse_event("token", {"text": "hi"})
+    w.append_sse_event("done", {"session": {"session_id": "session_1"}})
+    assert latest_run_summary("session_1", "run_done", session_dir=tmp_path)["terminal_state"] == "completed"
+
+    w2 = RunJournalWriter("session_1", "run_cancelled", session_dir=tmp_path)
+    w2.append_sse_event("cancel", {})
+    assert latest_run_summary("session_1", "run_cancelled", session_dir=tmp_path)["terminal_state"] == "interrupted-by-user"
+
+
+def test_read_jsonl_tail_line_numbers_correct_when_file_exceeds_cap(tmp_path):
+    """Regression: malformed line numbers in tail mode were computed from the
+    BYTE offset of the seek point, not from counting newlines — so a malformed
+    line at real line 181 was reported as line ~6892 (the byte offset). The
+    discarded-head newline count must drive the attribution, and the dropped
+    partial line at the seek boundary accounts for the +2."""
+    path = tmp_path / "big.jsonl"
+    # 200 lines, ~50 bytes each (~10KB total). max_bytes well under that so we
+    # seek into the middle of the file.
+    lines = [json.dumps({"seq": i, "pad": "x" * 20}) for i in range(200)]
+    malformed_real_line = 181  # 1-based
+    lines[malformed_real_line - 1] = "BROKEN_LINE_NOT_JSON"
+    path.write_text("".join(l + "\n" for l in lines), encoding="utf-8")
+
+    events, malformed = _read_jsonl(path, max_bytes=2000, max_rows=10000, tail=True)
+    assert len(events) < 200  # head events dropped (bounded tail window)
+    assert len(malformed) == 1
+    # The reported line number must be the TRUE 1-based line, not a byte offset.
+    assert malformed[0]["line"] == malformed_real_line, (
+        f"expected line {malformed_real_line}, got {malformed[0]['line']} "
+        "(tail line-number attribution must count newlines, not byte offset)"
+    )
+
+
+def test_read_jsonl_tail_line_numbers_correct_with_rows_cap(tmp_path):
+    """When the tail window keeps only the last N rows (rows_cap), the line
+    numbers of malformed entries in that kept window must still reflect their
+    true position in the WHOLE file, not be renumbered from 1."""
+    path = tmp_path / "many.jsonl"
+    lines = [json.dumps({"seq": i}) for i in range(100)]
+    lines[90] = "BROKEN_AT_91"  # 1-based line 91
+    path.write_text("".join(l + "\n" for l in lines), encoding="utf-8")
+
+    # Keep only the last 20 lines (file lines 81..100). The malformed line is
+    # file line 91, so it stays in the kept window and must be reported as 91.
+    events, malformed = _read_jsonl(path, max_bytes=1 << 30, max_rows=20, tail=True)
+    assert len(events) <= 20
+    assert len(malformed) == 1
+    assert malformed[0]["line"] == 91, f"expected 91, got {malformed[0]['line']}"
+
+
+def test_read_jsonl_tail_line_numbers_correct_no_seek(tmp_path):
+    """When the whole file fits in the window (no seek), line attribution starts
+    at 1 and is simply the position in the file."""
+    path = tmp_path / "small.jsonl"
+    lines = [json.dumps({"seq": 0}), json.dumps({"seq": 1}), "BROKEN", json.dumps({"seq": 3})]
+    path.write_text("".join(l + "\n" for l in lines), encoding="utf-8")
+
+    events, malformed = _read_jsonl(path, max_bytes=1 << 30, max_rows=100, tail=True)
+    assert len(events) == 3  # seq 0, 1, 3
+    assert len(malformed) == 1
+    assert malformed[0]["line"] == 3, f"expected 3, got {malformed[0]['line']}"
+

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -233,3 +233,87 @@ def test_terminal_state_correct_when_terminal_record_exceeds_tail_window(tmp_pat
     assert found["last_seq"] == 2
 
 
+def test_oversized_done_followed_by_trailing_events_reports_correct_terminal(tmp_path):
+    """Regression (reviewer round 2): the production event order is
+    done(tool_limit_reached, oversized) -> metering -> stream_end. The first-round
+    fix only recovered the LAST complete line, so the oversized `done` in the
+    MIDDLE was skipped and the tail read reported `completed` (from the trailing
+    stream_end) while the authoritative full read reported `tool_limit_reached`.
+    The fix extracts the boundary-straddling oversized record's summary via a
+    bounded prefix and merges it before summarizing."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES
+
+    writer = RunJournalWriter("session_1", "run_oversized_middle", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})
+    # Oversized done in the MIDDLE with a non-completed terminal_state, followed
+    # by trailing complete records (the production order).
+    huge = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
+    writer.append_sse_event(
+        "done",
+        {"session": {"session_id": "session_1"}, "terminal_state": "tool_limit_reached", **huge},
+    )
+    writer.append_sse_event("metering", {"usage": {"input": 100}})
+    writer.append_sse_event("stream_end", {})
+
+    summary = latest_run_summary("session_1", "run_oversized_middle", session_dir=tmp_path)
+    # Authoritative full read (the whole point: tail must MATCH this).
+    path = _run_path_of(writer)
+    full_events, _ = read_events_via_full_read(path)
+    authoritative = _summary_from_events_pub("session_1", "run_oversized_middle", full_events)
+    assert summary["terminal_state"] == authoritative["terminal_state"] == "tool_limit_reached", (
+        f"tail={summary['terminal_state']!r} but authoritative={authoritative['terminal_state']!r}; "
+        "the oversized middle done must not be skipped"
+    )
+    assert summary["last_seq"] == authoritative["last_seq"]
+
+
+def test_oversized_record_summary_does_not_materialize_payload(tmp_path):
+    """Regression (reviewer round 2): the first-round fix recovered the oversized
+    record by reading the WHOLE last line (multi-MB), defeating the memory-bound
+    goal. The fix extracts ONLY the summary fields via a bounded prefix read —
+    the payload must NOT be materialized."""
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _extract_boundary_record_summary,
+        _find_record_start_before,
+    )
+
+    writer = RunJournalWriter("session_1", "run_oversized_last", session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})
+    huge = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
+    writer.append_sse_event("done", {"session": {"session_id": "session_1"}, **huge})
+
+    path = _run_path_of(writer)
+    size = path.stat().st_size
+    read_bytes = min(size, _SESSION_REPLAY_MAX_BYTES)
+    seek_pos = size - read_bytes
+    record_start = _find_record_start_before(path, seek_pos)
+    summary = _extract_boundary_record_summary(path, record_start)
+    assert summary is not None
+    # The summary fields are present...
+    assert summary["terminal_state"] == "completed"
+    assert summary["seq"] == 2
+    assert summary.get("_summary_extracted_from_oversized_record") is True
+    # ...but the (multi-MB) payload was NOT materialized — replaced with {} .
+    assert summary["payload"] == {}, "payload must not be materialized for an oversized record"
+
+
+# ── tiny helpers so the regression tests read clearly ────────────────────────
+
+
+def _run_path_of(writer):
+    from api.run_journal import _run_path
+    return _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
+
+
+def read_events_via_full_read(path):
+    from api.run_journal import _read_jsonl
+    return _read_jsonl(path)
+
+
+def _summary_from_events_pub(session_id, run_id, events):
+    from api.run_journal import _summary_from_events
+    return _summary_from_events(session_id, run_id, events)
+
+
+

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -22,7 +22,7 @@ from api.run_journal import (
     latest_run_summary,
     read_run_events,
 )
-from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _SESSION_REPLAY_MAX_ROWS
+from api.run_journal import _SESSION_REPLAY_MAX_ROWS
 
 
 def _write_n_events(session_dir, *, session_id, run_id, n, terminal_after=None):

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -477,6 +477,50 @@ def test_preceding_event_recovery_is_bounded(tmp_path):
     assert result["payload"] == {}, "payload should be empty (not materialized)"
 
 
+def test_ordinary_size_done_bare_cr_rejected_both_readers(tmp_path):
+    """Regression (reviewer round 6): an ORDINARY-SIZE done ending in bare \\r
+    (not \\r\\n) was accepted as terminal by BOTH readers — splitlines() accepts
+    bare \\r, and read_text() converts \\r to \\n via universal-newline. A
+    crash-truncated record must leave the run running in BOTH readers."""
+    import json as _json
+    from api.run_journal import _read_jsonl, _read_jsonl_tail
+
+    rec1 = _json.dumps({"seq": 1, "event": "token", "payload": {}})
+    rec2 = _json.dumps({"seq": 2, "event": "done", "terminal": True,
+                        "terminal_state": "completed", "payload": {}})
+    p = tmp_path / "bare_cr.jsonl"
+    p.write_bytes((rec1 + "\n" + rec2 + "\r").encode("utf-8"))
+    ev_full, _ = _read_jsonl(p)
+    ev_tail, _ = _read_jsonl_tail(p, max_bytes=10000, max_rows=100)
+    # Neither reader should accept the bare-\r-terminated done.
+    assert not any(e.get("event") == "done" for e in ev_full), "FULL reader accepts bare \\r"
+    assert not any(e.get("event") == "done" for e in ev_tail), "TAIL reader accepts bare \\r"
+    # Both readers agree: only the token (seq 1) survives.
+    full_seqs = sorted(e["seq"] for e in ev_full)
+    tail_seqs = sorted(e["seq"] for e in ev_tail)
+    assert full_seqs == [1], f"FULL: {full_seqs}"
+    assert tail_seqs == [1], f"TAIL: {tail_seqs}"
+
+
+def test_ordinary_size_done_eof_no_newline_rejected_both_readers(tmp_path):
+    """Regression (reviewer round 6): an ordinary-size done at EOF with no
+    trailing \\n was silently accepted by splitlines(). Both readers must reject
+    it — the record is unterminated / potentially crash-truncated."""
+    import json as _json
+    from api.run_journal import _read_jsonl, _read_jsonl_tail
+
+    rec1 = _json.dumps({"seq": 1, "event": "token", "payload": {}})
+    rec2 = _json.dumps({"seq": 2, "event": "done", "terminal": True,
+                        "terminal_state": "completed", "payload": {}})
+    p = tmp_path / "eof_no_nl.jsonl"
+    p.write_bytes((rec1 + "\n" + rec2).encode("utf-8"))
+    ev_full, _ = _read_jsonl(p)
+    ev_tail, _ = _read_jsonl_tail(p, max_bytes=10000, max_rows=100)
+    assert not any(e.get("event") == "done" for e in ev_full), "FULL accepts EOF-no-newline"
+    assert not any(e.get("event") == "done" for e in ev_tail), "TAIL accepts EOF-no-newline"
+
+
+
 
 
 

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -448,20 +448,27 @@ def test_bare_carriage_return_terminator_rejected(tmp_path):
 
 
 def test_preceding_event_recovery_is_bounded(tmp_path):
-    """Regression (reviewer round 5): _read_last_complete_line_before used to
-    materialize the ENTIRE preceding record (verified at 4.27 MB), defeating the
-    memory-bound goal. The fix uses the bounded prefix extractor when the
-    preceding record is oversized, so the recovery path stays within the cap."""
+    """Regression (reviewer round 5, updated r9): the preceding oversized record
+    must never be MATERIALIZED. Under r9 fail-closed (#6139 r9 item 2) an
+    oversized predecessor is SKIPPED entirely — its full-record JSON validity
+    cannot be proven without materializing the payload, so its fabricated prefix
+    is never trusted. The scan continues to the preceding normal-sized valid
+    event (recovered), proving the multi-MB payload was never parsed into a
+    Python object. An explicit budget large enough to scan PAST the oversized
+    record is passed so the skip is fail-closed (not a budget stop)."""
+    import os
     from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path, _read_last_complete_line_before
 
     writer = RunJournalWriter("session_1", "run_bounded_preceding", session_dir=tmp_path)
-    # seq=1: an oversized but COMPLETE done (with newline)
+    # seq=1: a normal-sized token (the recoverable preceding event).
+    writer.append_sse_event("token", {"text": "ok"})
+    # seq=2: an oversized but COMPLETE done (with newline) — must be SKIPPED, not materialized.
     huge = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
     writer.append_sse_event("done", {"session": {"session_id": "session_1"}, **huge})
     path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
-    # seq=2: crash-truncated done (no close/newline)
+    # seq=3: crash-truncated done (no close/newline) — the boundary record.
     partial = (
-        '{"version":1,"event_id":"run_bounded_preceding:2","seq":2,'
+        '{"version":1,"event_id":"run_bounded_preceding:3","seq":3,'
         '"event":"done","type":"done","terminal":true,'
         '"terminal_state":"completed","payload":{"text":"'
         + "X" * (_SESSION_REPLAY_MAX_BYTES + 50_000)
@@ -472,13 +479,25 @@ def test_preceding_event_recovery_is_bounded(tmp_path):
         size_pinned = os.fstat(fh.fileno()).st_size
         seek = size_pinned - min(size_pinned, _SESSION_REPLAY_MAX_BYTES)
         record_start = __import__("api.run_journal", fromlist=["_find_record_start_before"])._find_record_start_before(fh, size_pinned, seek)
-        result = _read_last_complete_line_before(fh, size_pinned, record_start)
-    assert result is not None
-    # The preceding record's summary was extracted via bounded prefix, not materialized.
-    assert result.get("_summary_extracted_from_oversized_record") is True, (
-        "preceding oversized record was materialized instead of bounded-prefix extracted"
+        # Budget large enough to scan PAST the oversized done (seq=2) to the token,
+        # so the skip is fail-closed rather than a budget stop.
+        result = _read_last_complete_line_before(
+            fh, size_pinned, record_start, budget=_SESSION_REPLAY_MAX_BYTES + 200_000
+        )
+    # The oversized done (seq=2) is skipped (fail-closed); the token (seq=1) is recovered.
+    assert result is not None, "the normal-sized token (seq=1) must be recovered"
+    assert result.get("seq") == 1, (
+        f"expected seq=1 (the oversized done was skipped fail-closed); got seq={result.get('seq')}"
     )
-    assert result["payload"] == {}, "payload should be empty (not materialized)"
+    assert result.get("event") == "token", "the recovered event is the token, not the oversized done"
+    # The oversized payload was never materialized: no fabricated-summary marker,
+    # and the token carries its real (small) payload, not the empty fabricated one.
+    assert result.get("_summary_extracted_from_oversized_record") is None, (
+        "the oversized record's prefix was fabricated instead of being skipped (fail-closed)"
+    )
+    assert result.get("payload") == {"text": "ok"}, (
+        "the recovered token carries its real payload — the oversized done was skipped, not fabricated"
+    )
 
 
 def test_ordinary_size_done_bare_cr_rejected_both_readers(tmp_path):
@@ -639,40 +658,116 @@ def test_record_is_structurally_complete_returns_fallback_if_handle_error(
 
 
 def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, monkeypatch):
-    """End-to-end TOCTOU: a journal large enough to trigger the boundary-scan
-    path; the boundary helper raises FileNotFoundError mid-scan. latest_run_summary
-    must return a safe summary (not propagate → 500 on the poll endpoint)."""
+    """End-to-end TOCTOU (reviewer round 9, item 3): a journal BIGGER than the
+    tail cap so the boundary-scan path fires, and a ``read`` failure mid-recovery
+    returns the safe fallback, never propagates to the HTTP handler.
+
+    No longer vacuous (r9): the OLD test used an obsolete two-argument helper
+    signature AND a ~100 KiB fixture that never exceeded the 4 MiB cap, so the
+    boundary helper was never reached. This version (a) builds a fixture
+    exceeding ``_SESSION_REPLAY_MAX_BYTES`` (proving the boundary path actually
+    fires by recovering the straddling record) and (b) uses the current
+    descriptor-based signature — patching the single ``Path.open`` handle so a
+    body-level ``read`` (the forward tail read, protected only by
+    ``_read_jsonl_tail``'s outer ``except (FileNotFoundError, OSError)``) raises.
+
+    The contract under test: a read failure mid-recovery returns the safe
+    fallback ``([], [])`` (or whatever events it already has), never propagates.
+    The body-level forward tail read is the read whose OSError is NOT swallowed
+    by any helper's inner try/except — so it directly exercises the outer
+    except, which is the round-9 single-open recovery guard."""
+    from pathlib import Path
     from api import run_journal
-    from api.run_journal import append_run_event
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl_tail
 
-    # Build a journal whose tail window straddles a record (so the boundary
-    # helpers fire). Substantial payloads so the tail cap excludes the first.
-    big = "x" * 50000
-    append_run_event("s1", "r1", "done", {"session": {}, "big": big}, session_dir=tmp_path)
-    append_run_event("s1", "r1", "done",
-                     {"terminal_state": "completed", "big": big},
-                     session_dir=tmp_path)
-
+    # Build a journal whose tail window straddles a record (size > cap) so the
+    # boundary helpers fire: a small valid token, then an oversized done.
+    cap = _SESSION_REPLAY_MAX_BYTES
+    token_line = '{"seq":1,"event":"token","payload":{"t":"ok"}}\n'
+    oversized_done = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"'
+        + "X" * (cap + 1000)
+        + '"}}\n'
+    )
     path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
-    assert path.exists(), (
-        f"journal not written where expected: {path} (glob: "
-        f"{list(tmp_path.rglob('*.jsonl'))})"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(token_line.encode("utf-8"))
+        fh.write(oversized_done.encode("utf-8"))
+    assert path.stat().st_size > cap, "fixture must exceed the cap so the boundary scan fires"
+
+    # --- Part A: NON-VACUITY. A normal read on the oversized fixture must run
+    # the boundary path and recover the straddling done's summary (seq=2) —
+    # proving the boundary helpers actually fire (the old test's ~100 KiB
+    # fixture never reached them). This is the r9 "force the boundary path" fix.
+    events_normal, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    seqs = {e.get("seq") for e in events_normal if isinstance(e, dict)}
+    assert 2 in seqs, (
+        f"the oversized done (seq=2) straddling summary must be recovered by the "
+        f"boundary scan — if not, the fixture is vacuous (old bug); got seqs={seqs}"
     )
 
-    # Patch the boundary helper to raise (simulating delete-during-scan) —
-    # latest_run_summary must catch via the helper's own try/except and return
-    # a safe summary, not propagate.
-    original = run_journal._find_record_start_before
+    # --- Part B: MUTATION-KILLING CONTRACT. Patch Path.open so the forward tail
+    # read (a body-level read protected ONLY by the outer except) raises OSError
+    # — the realistic single-open TOCTOU (fd invalidated mid-recovery).
+    # _read_jsonl_tail must catch it and return the safe fallback, never raise.
+    real_open = Path.open
 
-    def raising_find(p, seek_pos):
-        if p == path:
-            raise FileNotFoundError(str(path))
-        return original(p, seek_pos)
+    class _FailingHandle:
+        """Lets the first read (forward tail) succeed, then raises OSError on
+        every subsequent read. The forward read populating the body is read #1;
+        the boundary-scan helpers each swallow their own OSErrors internally, so
+        to directly exercise the OUTER except we additionally test the read-#1
+        failure mode below."""
+        def __init__(self, real, fail_on_read=1):
+            self._real = real
+            self._reads = 0
+            self._fail_on_read = fail_on_read
 
-    monkeypatch.setattr(run_journal, "_find_record_start_before", raising_find)
+        def fileno(self):
+            return self._real.fileno()
+
+        def seek(self, *a, **kw):
+            return self._real.seek(*a, **kw)
+
+        def read(self, n=-1):
+            self._reads += 1
+            if self._reads >= self._fail_on_read:
+                raise OSError("simulated fd invalidation mid-recovery")
+            return self._real.read(n)
+
+        def close(self):
+            return self._real.close()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return self._real.__exit__(*a)
+
+    def make_patched_open(fail_on_read):
+        def patched_open(self, *args, **kwargs):
+            real = real_open(self, *args, **kwargs)
+            mode = args[0] if args else kwargs.get("mode", "r")
+            return _FailingHandle(real, fail_on_read) if "b" in mode else real
+        return patched_open
+
+    # Read #1 failure: the forward tail read itself raises. This read is
+    # body-level (only the outer except protects it), so this is the case that
+    # directly tests the outer try/except and is killed if that except re-raises.
+    monkeypatch.setattr(Path, "open", make_patched_open(fail_on_read=1))
+    events, malformed = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    assert isinstance(events, list) and isinstance(malformed, list), (
+        f"_read_jsonl_tail must return a (list, list) safe fallback; got "
+        f"({type(events).__name__}, {type(malformed).__name__})"
+    )
+
+    # The same contract holds through the summary reader's path (no propagation
+    # to the HTTP handler): a read failure mid-recovery yields a dict summary.
+    monkeypatch.setattr(Path, "open", make_patched_open(fail_on_read=1))
     summary = run_journal.latest_run_summary("s1", "r1", session_dir=tmp_path)
-    # Must return a dict (safe summary), not raise.
-    assert isinstance(summary, dict)
+    assert isinstance(summary, dict), "latest_run_summary must return a dict, not raise"
 
 
 def test_blank_line_before_oversized_partial_done_recovers_preceding_event(tmp_path, monkeypatch):
@@ -946,25 +1041,25 @@ def test_invalid_predecessor_rows_skipped_until_valid_event(tmp_path, monkeypatc
 
 
 def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_path):
-    """Regression (reviewer round 8, point 5): an oversized predecessor that is
-    structurally INCOMPLETE (crash-truncated mid-payload — brace depth never
-    returns to 0) must NOT be accepted via _extract_boundary_record_summary's
-    fabricated prefix as if it were a valid terminal event. The structural-
-    completeness gate inside the backward scan must reject it and continue to
-    the preceding complete event.
+    """Regression (reviewer round 8, updated r9): under r9 fail-closed (#6139 r9
+    item 2) EVERY oversized predecessor is skipped — its full-record JSON
+    validity cannot be proven without materializing the payload, so the
+    fabricated prefix is never trusted, regardless of whether the oversized row
+    is brace-balanced, structurally complete, or malformed. This test pins the
+    malformed case (the round-8 regression target): the predecessor is an
+    oversized structurally-INCOMPLETE record, but it must be skipped for the r9
+    reason (oversized), not accepted.
 
     Journal shape:
         token(seq=1)
-        <oversized malformed done seq=2: has a newline terminator so it counts
-         as a complete LINE, but the JSON itself is structurally incomplete
-         (truncated mid-payload value), so _record_is_structurally_complete ->
-         False while _extract_boundary_record_summary fabricates a terminal
-         prefix from its head>
+        <oversized malformed done seq=2: newline-terminated but JSON structurally
+         incomplete (no closing brace — truncated mid-payload value)>
         <oversized partial done seq=3: the crash-truncated boundary, no newline>
 
     The scan for the predecessor of seq=3 hits the oversized seq=2 row first.
-    Without the gate it would accept seq=2's fabricated terminal prefix; with
-    the gate it skips seq=2 and recovers token(seq=1)."""
+    Under r9 fail-closed it skips seq=2 (oversized → untrustworthy) and recovers
+    token(seq=1). The budget is sized to scan PAST the oversized predecessor's
+    bytes so the skip is fail-closed (not a budget stop)."""
     import os
     from api.run_journal import (
         _SESSION_REPLAY_MAX_BYTES,
@@ -981,7 +1076,6 @@ def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_
     token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
     # Oversized malformed predecessor: newline-terminated (a complete line) but
     # JSON structurally incomplete (no closing brace — truncated mid-value).
-    # Its head still fabricates a terminal 'done/seq=2' prefix.
     oversized_malformed_pred = (
         '{"version":1,"seq":2,"event":"done","terminal":true,'
         '"terminal_state":"completed","payload":{"t":"' + "X" * (cap + 1000)
@@ -1002,15 +1096,19 @@ def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_
     final_start = len(token_bytes) + len(pred_bytes)
     with path.open("rb") as fh:
         size = os.fstat(fh.fileno()).st_size
-        result = _read_last_complete_line_before(fh, size, final_start)
+        # Budget sized to scan PAST the oversized predecessor's bytes (two
+        # backward newline scans through ~cap+1000 bytes each) so the skip is
+        # fail-closed rather than a budget stop. The token line parse adds ~50 B.
+        result = _read_last_complete_line_before(
+            fh, size, final_start, budget=2 * (cap + 1000) + 10_000
+        )
 
-    # The oversized malformed predecessor (seq=2) must be SKIPPED via the gate;
+    # The oversized malformed predecessor (seq=2) must be SKIPPED (fail-closed);
     # the valid token (seq=1) is recovered — never the fabricated terminal done.
     assert result is not None, "the valid token (seq=1) must be recovered"
     assert result.get("seq") == 1, (
-        f"expected seq=1 (the gate skipped the oversized malformed row); got "
-        f"seq={result.get('seq')} — the fabricated terminal prefix was accepted "
-        f"as if the structurally-incomplete row were valid"
+        f"expected seq=1 (the oversized row was skipped fail-closed); got "
+        f"seq={result.get('seq')} — the oversized predecessor was trusted instead of skipped"
     )
     assert not result.get("terminal"), (
         "a non-terminal token must be recovered, not a fabricated terminal done"
@@ -1055,4 +1153,235 @@ def test_backward_predecessor_scan_budget_bounds_the_scan(tmp_path):
     # Generous budget must recover the token (seq=1).
     assert generous is not None and generous.get("seq") == 1, (
         f"a large budget must recover the valid token (seq=1); got {generous}"
+    )
+
+
+def test_backward_scan_budget_bounds_physical_descriptor_reads(tmp_path):
+    """Regression (reviewer round 9, item 1): the aggregate byte budget must
+    bound the PHYSICAL bytes touched by ``fh.read`` across the whole backward
+    scan — not just nominal candidate lengths charged after the fact. A
+    descriptor-instrumented probe previously observed ~66 KB returned against a
+    50-byte budget because ``_rfind_byte_before`` did uncharged backward reads.
+
+    The test wraps the handle so every ``read`` records its requested + returned
+    lengths and flags any read made AFTER the budget is exhausted. With a small
+    budget it asserts (a) total bytes RETURNED <= budget, (b) no read after
+    exhaustion, (c) result is None (the budget couldn't reach the token). With a
+    large budget it asserts the token (seq=1) is recovered — proving the budget
+    was the only thing stopping the small-budget call."""
+    from api.run_journal import (
+        _BOUNDARY_SUMMARY_PREFIX_BYTES,
+        _run_path,
+        _read_last_complete_line_before,
+    )
+
+    session_id = "session_phys_budget"
+    run_id = "run_phys_budget"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Shape: valid token far back, then a long run of malformed rows, then an
+    # oversized truncated boundary (forces _rfind_byte_before to do real work,
+    # and the oversized-predecessor branch in the scan).
+    token = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    malformed_rows = b"{bad row}\n" * 500  # ~10 bytes each
+    oversized_partial = (
+        '{"seq":2,"event":"done","terminal":true,"payload":{"t":"'
+        + "Z" * (_BOUNDARY_SUMMARY_PREFIX_BYTES + 5000)
+    )  # no newline — crash-truncated boundary
+
+    token_bytes = token.encode("utf-8")
+    malformed_bytes = malformed_rows
+    boundary_bytes = oversized_partial.encode("utf-8")
+    with path.open("wb") as fh:
+        fh.write(token_bytes)
+        fh.write(malformed_bytes)
+        fh.write(boundary_bytes)
+
+    size = token_bytes.__len__() + len(malformed_bytes) + len(boundary_bytes)
+    boundary_start = len(token_bytes) + len(malformed_bytes)
+
+    class _TrackingHandle:
+        """Records every read; tracks reads made after the budget is exhausted."""
+        def __init__(self, real, budget_bytes):
+            self._real = real
+            self.total_returned = 0
+            self.total_requested = 0
+            self.read_calls = 0
+            self.budget = budget_bytes
+            self.reads_after_exhaustion = 0
+
+        def fileno(self):
+            return self._real.fileno()
+
+        def seek(self, *a, **kw):
+            return self._real.seek(*a, **kw)
+
+        def read(self, n=-1):
+            self.read_calls += 1
+            self.total_requested += max(0, n)
+            if self.total_returned >= self.budget:
+                self.reads_after_exhaustion += 1
+            data = self._real.read(n)
+            self.total_returned += len(data)
+            return data
+
+        def close(self):
+            return self._real.close()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return self._real.__exit__(*a)
+
+    SMALL_BUDGET = 256
+
+    # Small-budget call: instrument every read.
+    with path.open("rb") as real_fh:
+        tracker = _TrackingHandle(real_fh, SMALL_BUDGET)
+        result_small = _read_last_complete_line_before(
+            tracker, size, boundary_start, budget=SMALL_BUDGET
+        )
+
+    assert result_small is None, (
+        f"a {SMALL_BUDGET}-byte budget must not reach the token past 500 malformed "
+        f"rows + the oversized boundary; got {result_small}"
+    )
+    assert tracker.total_returned <= SMALL_BUDGET, (
+        f"physical bytes RETURNED by fh.read ({tracker.total_returned}) exceeded "
+        f"the budget ({SMALL_BUDGET}) — the aggregate meter is not bounding "
+        f"physical I/O (#6139 r9 item 1)"
+    )
+    assert tracker.reads_after_exhaustion == 0, (
+        f"{tracker.reads_after_exhaustion} read(s) happened AFTER the budget was "
+        f"exhausted — the scan did not stop at exhaustion (#6139 r9 item 1)"
+    )
+
+    # Large-budget call: must recover the token (seq=1), proving the budget was
+    # the only thing stopping the small-budget call.
+    with path.open("rb") as fh:
+        result_large = _read_last_complete_line_before(
+            fh, size, boundary_start, budget=10 * 1024 * 1024
+        )
+    assert result_large is not None and result_large.get("seq") == 1, (
+        f"a large budget must recover the valid token (seq=1); got {result_large}"
+    )
+
+
+def test_balanced_invalid_oversized_predecessor_skipped_trailing_comma(tmp_path):
+    """Regression (reviewer round 9, item 2): a brace-balanced, newline-
+    terminated oversized row that is INVALID JSON (trailing comma here; see the
+    companion test for a malformed nested value) must NOT be promoted into a
+    fabricated terminal summary. Brace balance is necessary but not sufficient
+    for JSON validity.
+
+    Under r9 fail-closed, EVERY oversized predecessor is skipped (its full-
+    record validity cannot be proven without materializing the payload), so the
+    balanced-invalid row is skipped and the preceding valid token (seq=1) is
+    recovered — never the fabricated terminal seq=2."""
+    import os
+    from api.run_journal import (
+        _BOUNDARY_SUMMARY_PREFIX_BYTES,
+        _run_path,
+        _read_last_complete_line_before,
+    )
+
+    session_id = "session_balanced_invalid_tc"
+    run_id = "run_balanced_invalid_tc"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    big = "Q" * (_BOUNDARY_SUMMARY_PREFIX_BYTES + 5000)
+    token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    # Oversized predecessor: brace-balanced + newline-terminated but INVALID JSON
+    # (trailing comma after the payload value). Its head fabricates a terminal
+    # 'done/seq=2' prefix via _extract_boundary_record_summary.
+    oversized_pred = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '"},}\n'
+    )
+    # Final crash-truncated boundary (no newline) — forces the recovery scan.
+    final_partial = (
+        '{"seq":3,"event":"done","terminal":true,"payload":{"t":"'
+        + "Y" * (_BOUNDARY_SUMMARY_PREFIX_BYTES + 5000)
+    )
+    token_bytes = token_line.encode("utf-8")
+    pred_bytes = oversized_pred.encode("utf-8")
+    with path.open("wb") as fh:
+        fh.write(token_bytes)
+        fh.write(pred_bytes)
+        fh.write(final_partial.encode("utf-8"))
+
+    final_start = len(token_bytes) + len(pred_bytes)
+    with path.open("rb") as fh:
+        size = os.fstat(fh.fileno()).st_size
+        # Budget sized to scan PAST the oversized predecessor's bytes so the
+        # skip is fail-closed (not a budget stop).
+        result = _read_last_complete_line_before(
+            fh, size, final_start, budget=2 * len(pred_bytes) + 10_000
+        )
+
+    assert result is not None, "the valid token (seq=1) must be recovered"
+    assert result.get("seq") == 1, (
+        f"expected seq=1 (the trailing-comma oversized row was skipped "
+        f"fail-closed); got seq={result.get('seq')} — the fabricated terminal "
+        f"prefix was accepted as if the brace-balanced-but-invalid row were valid JSON"
+    )
+    assert not result.get("terminal"), (
+        "a non-terminal token must be recovered, not a fabricated terminal done"
+    )
+
+
+def test_balanced_invalid_oversized_predecessor_skipped_malformed_nested_value(tmp_path):
+    """Companion to test_balanced_invalid_oversized_predecessor_skipped_trailing_comma
+    (reviewer round 9, item 2): a brace-balanced, newline-terminated oversized row
+    that is invalid JSON due to a malformed nested value (unquoted nested key) —
+    also skipped fail-closed under r9, recovering the preceding valid token."""
+    import os
+    from api.run_journal import (
+        _BOUNDARY_SUMMARY_PREFIX_BYTES,
+        _run_path,
+        _read_last_complete_line_before,
+    )
+
+    session_id = "session_balanced_invalid_nv"
+    run_id = "run_balanced_invalid_nv"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    big = "Q" * (_BOUNDARY_SUMMARY_PREFIX_BYTES + 5000)
+    token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    # Oversized predecessor: brace-balanced overall + newline-terminated but
+    # INVALID JSON (unquoted nested key `bad` inside payload).
+    oversized_pred = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '",bad:nested}}\n'
+    )
+    final_partial = (
+        '{"seq":3,"event":"done","terminal":true,"payload":{"t":"'
+        + "Y" * (_BOUNDARY_SUMMARY_PREFIX_BYTES + 5000)
+    )
+    token_bytes = token_line.encode("utf-8")
+    pred_bytes = oversized_pred.encode("utf-8")
+    with path.open("wb") as fh:
+        fh.write(token_bytes)
+        fh.write(pred_bytes)
+        fh.write(final_partial.encode("utf-8"))
+
+    final_start = len(token_bytes) + len(pred_bytes)
+    with path.open("rb") as fh:
+        size = os.fstat(fh.fileno()).st_size
+        result = _read_last_complete_line_before(
+            fh, size, final_start, budget=2 * len(pred_bytes) + 10_000
+        )
+
+    assert result is not None, "the valid token (seq=1) must be recovered"
+    assert result.get("seq") == 1, (
+        f"expected seq=1 (the malformed-nested-value oversized row was skipped "
+        f"fail-closed); got seq={result.get('seq')} — the fabricated terminal "
+        f"prefix was accepted as if the brace-balanced-but-invalid row were valid JSON"
+    )
+    assert not result.get("terminal"), (
+        "a non-terminal token must be recovered, not a fabricated terminal done"
     )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -2050,46 +2050,54 @@ def _assert_valid_oversized_boundary_accepted(tmp_path, *, record_size_multiple,
     )
 
     # The tail reader must keep the valid oversized done (seq=2), NOT reject it
-    # via budget starvation. The boundary summary is recovered (seq=2 present).
+    # via budget starvation. The boundary summary is recovered, and the trailing
+    # records (when present) follow it. Assert the EXACT ordered tail sequence:
+    # a reordered tail ([3, 2, 4]), a duplicate boundary summary, or an unexpected
+    # extra row must all fail this — not merely "seq 2 is present somewhere".
     tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     tail_seqs = [e.get("seq") for e in tail_events]
-    # When trailing records exist, the tail window keeps them after the boundary
-    # recovery prepends the straddling seq=2 summary. Without trailing, only the
-    # boundary summary (seq=2) is present in the tail.
-    assert 2 in tail_seqs, (
-        f"the tail reader REJECTED the valid oversized terminal done (seq=2 not "
-        f"in tail_seqs={tail_seqs}); a valid record near {record_size_multiple}x cap "
-        f"was starved by the lookup+prefix meter and failed-closed (#6139 r13)"
+    expected_tail_seqs = [2, 3, 4] if with_trailing else [2]
+    assert tail_seqs == expected_tail_seqs, (
+        f"the tail sequence diverged from the expected order/contents: "
+        f"tail_seqs={tail_seqs} (expected {expected_tail_seqs}). If seq=2 is "
+        f"absent the valid {record_size_multiple}x cap terminal was rejected via "
+        f"budget starvation (#6139 r13); if the order/contents differ the boundary "
+        f"recovery or trailing-window handling regressed."
     )
-    # Exact full/tail parity on the discriminating fields.
+    # Exact full/tail parity on the discriminating fields. The full required
+    # summary tuple (last_seq, terminal, terminal_state) must match across the
+    # direct tail summary, latest_run_summary, AND find_run_summary — a regression
+    # in any one reader's projection (e.g. last_seq dropping, terminal flipping)
+    # must not be masked by the others.
+    expected_last_seq = 4 if with_trailing else 2
+    expected_tuple = (expected_last_seq, True, "tool_limit_reached")
+
+    def _summary_tuple(s):
+        return (int(s.get("last_seq") or 0), bool(s.get("terminal")), s.get("terminal_state"))
+
     tail_summary = _summary_from_events_ref("s1", "r1", tail_events)
-    assert tail_summary["terminal_state"] == "tool_limit_reached", (
-        f"the tail reader reported terminal_state={tail_summary['terminal_state']!r} "
-        f"(expected 'tool_limit_reached'); a valid {record_size_multiple}x cap "
-        f"terminal record was rejected via budget starvation (#6139 r13)"
+    assert _summary_tuple(tail_summary) == expected_tuple, (
+        f"direct tail summary {_summary_tuple(tail_summary)} != expected "
+        f"{expected_tuple}; a valid {record_size_multiple}x cap terminal record "
+        f"was rejected via budget starvation (#6139 r13)"
     )
-    assert tail_summary["terminal"] is True, (
-        f"the tail reader reported terminal={tail_summary['terminal']} (expected True)"
-    )
-    assert tail_summary["last_seq"] == full_summary["last_seq"], (
-        f"last_seq mismatch: tail={tail_summary['last_seq']} full={full_summary['last_seq']}"
+    assert _summary_tuple(full_summary) == expected_tuple, (
+        f"baseline: full reader summary {_summary_tuple(full_summary)} != expected "
+        f"{expected_tuple}"
     )
 
-    # Production summary readers must agree.
+    # Production summary readers must report the same tuple.
     summary = latest_run_summary("s1", "r1", session_dir=tmp_path)
-    assert summary["terminal_state"] == "tool_limit_reached", (
-        f"latest_run_summary reported terminal_state={summary['terminal_state']!r} "
-        f"(expected 'tool_limit_reached'); a valid {record_size_multiple}x cap "
-        f"terminal record was rejected on the summary path (#6139 r13)"
-    )
-    assert summary["terminal"] is True, (
-        f"latest_run_summary marked terminal={summary['terminal']} (expected True)"
+    assert _summary_tuple(summary) == expected_tuple, (
+        f"latest_run_summary {_summary_tuple(summary)} != expected {expected_tuple}; "
+        f"a valid {record_size_multiple}x cap terminal record was rejected on the "
+        f"summary path, or last_seq/terminal regressed (#6139 r13)"
     )
     found = find_run_summary("r1", session_dir=tmp_path)
     assert found is not None, "find_run_summary must locate the run"
-    assert found["terminal_state"] == "tool_limit_reached", (
-        f"find_run_summary reported terminal_state={found['terminal_state']!r} "
-        f"(expected 'tool_limit_reached') (#6139 r13)"
+    assert _summary_tuple(found) == expected_tuple, (
+        f"find_run_summary {_summary_tuple(found)} != expected {expected_tuple}; "
+        f"last_seq/terminal/terminal_state regressed on the find path (#6139 r13)"
     )
 
 

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -14,6 +14,7 @@ tail read keeps them correct for a large COMPLETED run (its terminal marker
 lives at the end) without parsing the whole history.
 """
 import json
+import os
 
 from api.run_journal import (
     RunJournalWriter,
@@ -287,8 +288,10 @@ def test_oversized_record_summary_does_not_materialize_payload(tmp_path):
     size = path.stat().st_size
     read_bytes = min(size, _SESSION_REPLAY_MAX_BYTES)
     seek_pos = size - read_bytes
-    record_start = _find_record_start_before(path, seek_pos)
-    summary = _extract_boundary_record_summary(path, record_start)
+    with path.open("rb") as fh:
+        size_pinned = os.fstat(fh.fileno()).st_size
+        record_start = _find_record_start_before(fh, size_pinned, seek_pos)
+        summary = _extract_boundary_record_summary(fh, record_start)
     assert summary is not None
     # The summary fields are present...
     assert summary["terminal_state"] == "completed"
@@ -465,10 +468,11 @@ def test_preceding_event_recovery_is_bounded(tmp_path):
     )
     with open(path, "a", encoding="utf-8") as f:
         f.write(partial)
-    size = path.stat().st_size
-    seek = size - min(size, _SESSION_REPLAY_MAX_BYTES)
-    record_start = __import__("api.run_journal", fromlist=["_find_record_start_before"])._find_record_start_before(path, seek)
-    result = _read_last_complete_line_before(path, record_start)
+    with path.open("rb") as fh:
+        size_pinned = os.fstat(fh.fileno()).st_size
+        seek = size_pinned - min(size_pinned, _SESSION_REPLAY_MAX_BYTES)
+        record_start = __import__("api.run_journal", fromlist=["_find_record_start_before"])._find_record_start_before(fh, size_pinned, seek)
+        result = _read_last_complete_line_before(fh, size_pinned, record_start)
     assert result is not None
     # The preceding record's summary was extracted via bounded prefix, not materialized.
     assert result.get("_summary_extracted_from_oversized_record") is True, (
@@ -535,65 +539,103 @@ def test_ordinary_size_done_eof_no_newline_rejected_both_readers(tmp_path):
 # HTTP handler → 500. Each helper must return its safe fallback instead.
 
 
-def test_find_record_start_before_returns_fallback_if_file_deleted(tmp_path, monkeypatch):
-    """_find_record_start_before: stat succeeds, then open() raises — must
+def test_find_record_start_before_returns_fallback_if_handle_closed(tmp_path, monkeypatch):
+    """_find_record_start_before: fh read/seek raises — must
     return 0 (not let FileNotFoundError escape to the HTTP handler)."""
     import json as _json
-    from pathlib import Path
+    import os
     from api import run_journal
 
     p = tmp_path / "race.jsonl"
     p.write_bytes((_json.dumps({"seq": 1, "event": "done"}) + "\n").encode("utf-8"))
-    real_open = Path.open
 
-    def racing_open(self, *a, **kw):
-        if self == p:
-            raise FileNotFoundError(str(p))
-        return real_open(self, *a, **kw)
+    class RacingFileHandle:
+        def __init__(self, underlying):
+            self._underlying = underlying
+            self._original_read = underlying.read
+            self._original_seek = underlying.seek
+            self._should_race = True
 
-    monkeypatch.setattr(Path, "open", racing_open)
-    assert run_journal._find_record_start_before(p, 50) == 0
+        def read(self, *a, **kw):
+            if self._should_race:
+                raise FileNotFoundError("Simulated TOCTOU: file deleted after open")
+            return self._underlying.read(*a, **kw)
+
+        def seek(self, *a, **kw):
+            if self._should_race:
+                raise FileNotFoundError("Simulated TOCTOU: file deleted after open")
+            return self._underlying.seek(*a, **kw)
+
+        def fileno(self):
+            return self._underlying.fileno()
+
+    with p.open("rb") as raw_fh:
+        size = os.fstat(raw_fh.fileno()).st_size
+        racing_fh = RacingFileHandle(raw_fh)
+        result = run_journal._find_record_start_before(racing_fh, size, 50)
+
+    assert result == 0
 
 
-def test_rfind_byte_before_returns_fallback_if_file_deleted(tmp_path, monkeypatch):
-    """_rfind_byte_before: open() raises FileNotFoundError — must return None."""
+def test_rfind_byte_before_returns_fallback_if_handle_closed(tmp_path, monkeypatch):
+    """_rfind_byte_before: fh read/seek raises FileNotFoundError — must return None."""
     import json as _json
-    from pathlib import Path
     from api import run_journal
 
     p = tmp_path / "race.jsonl"
     p.write_bytes((_json.dumps({"seq": 1}) + "\n").encode("utf-8"))
-    real_open = Path.open
 
-    def racing_open(self, *a, **kw):
-        if self == p:
-            raise FileNotFoundError(str(p))
-        return real_open(self, *a, **kw)
+    class RacingFileHandle:
+        def __init__(self, underlying):
+            self._underlying = underlying
 
-    monkeypatch.setattr(Path, "open", racing_open)
-    assert run_journal._rfind_byte_before(p, b"\n", 50) is None
+        def read(self, *a, **kw):
+            raise FileNotFoundError("Simulated TOCTOU: file deleted after open")
+
+        def seek(self, *a, **kw):
+            raise FileNotFoundError("Simulated TOCTOU: file deleted after open")
+
+        def fileno(self):
+            return self._underlying.fileno()
+
+    with p.open("rb") as raw_fh:
+        racing_fh = RacingFileHandle(raw_fh)
+        result = run_journal._rfind_byte_before(racing_fh, b"\n", 50)
+
+    assert result is None
 
 
-def test_record_is_structurally_complete_returns_fallback_if_file_deleted(
+def test_record_is_structurally_complete_returns_fallback_if_handle_error(
     tmp_path, monkeypatch
 ):
-    """_record_is_structurally_complete: open() raises FileNotFoundError — must
+    """_record_is_structurally_complete: fh read/seek raises — must
     return False (not raise)."""
     import json as _json
-    from pathlib import Path
+    import os
     from api import run_journal
 
     p = tmp_path / "race.jsonl"
     p.write_bytes((_json.dumps({"seq": 1, "event": "done"}) + "\n").encode("utf-8"))
-    real_open = Path.open
 
-    def racing_open(self, *a, **kw):
-        if self == p:
-            raise FileNotFoundError(str(p))
-        return real_open(self, *a, **kw)
+    class RacingFileHandle:
+        def __init__(self, underlying):
+            self._underlying = underlying
 
-    monkeypatch.setattr(Path, "open", racing_open)
-    assert run_journal._record_is_structurally_complete(p, 0) is False
+        def read(self, *a, **kw):
+            raise FileNotFoundError("Simulated TOCTOU: file deleted after open")
+
+        def seek(self, *a, **kw):
+            raise FileNotFoundError("Simulated TOCTOU: file deleted after open")
+
+        def fileno(self):
+            return self._underlying.fileno()
+
+    with p.open("rb") as raw_fh:
+        size = os.fstat(raw_fh.fileno()).st_size
+        racing_fh = RacingFileHandle(raw_fh)
+        result = run_journal._record_is_structurally_complete(racing_fh, size, 0)
+
+    assert result is False
 
 
 def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, monkeypatch):
@@ -734,4 +776,283 @@ def test_blank_line_before_oversized_partial_done_recovers_preceding_event(tmp_p
     )
     assert recovery["event"] == "apperror", (
         f"recovery event type={recovery['event']} (expected apperror)"
+    )
+
+
+def test_tail_read_uses_single_generation_under_delete_recreate(tmp_path, monkeypatch):
+    """Regression (reviewer round 8): _read_jsonl_tail must open the journal ONCE
+    and pin the size via os.fstat so all recovery helpers read from ONE inode
+    generation. A delete-and-recreate between stages must never mix rows from
+    different generations — e.g. tail rows from inode A with boundary/predecessor
+    rows from inode B, producing impossible sequences like ``[100, 2]``.
+
+    This is a pure generation-isolation proof: the 1st ``Path.open("rb")`` of the
+    journal returns a real handle to inode-A content (token seq=1 + an oversized
+    crash-truncated done); every SUBSEQUENT open returns a BytesIO of inode-B
+    content (a completed run: done seq=100, terminal). With the single-open fix,
+    only inode-A is ever read → the tail reader reports seq=1 / running. With a
+    reopen bug, inode-B leaks in → seq=100 / terminal / mixed. The test asserts
+    the result is purely inode-A and records how many times the journal was
+    opened (must be exactly 1)."""
+    import io as _io
+    from pathlib import Path
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl_tail, _run_path
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    session_id = "session_single_gen"
+    run_id = "run_delete_recreate_race"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # inode-A content: token seq=1, then a blank line, then an oversized
+    # crash-truncated done (no closing brace/newline). This forces the recovery
+    # helpers (boundary scan, structural check, predecessor scan) to run, which
+    # on the buggy multi-open code would each reopen the pathname.
+    token_a = {"version": 1, "event_id": f"{run_id}:1", "seq": 1,
+               "event": "token", "type": "token", "terminal": False,
+               "payload": {"text": "inode-A-token"}}
+    oversized_partial = (
+        '{"version":1,"event_id":"' + run_id + ':2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + "X" * (cap + 1000)
+    )  # no closing brace/newline — crash mid-write
+    inode_a_bytes = (json.dumps(token_a) + "\n").encode("utf-8") + b"\n" + oversized_partial.encode("utf-8")
+    path.write_bytes(inode_a_bytes)
+
+    # inode-B content (what a recreated file might hold): a COMPLETED run with a
+    # much higher seq, so any leak is unambiguous.
+    done_b = {"version": 1, "event_id": f"{run_id}:100", "seq": 100,
+              "event": "done", "type": "done", "terminal": True,
+              "terminal_state": "completed", "payload": {"text": "inode-B"}}
+    inode_b_bytes = (json.dumps(done_b) + "\n").encode("utf-8")
+
+    open_count = {"n": 0}
+    real_open = Path.open
+
+    def generation_pinned_open(self, *args, **kwargs):
+        if self == path and args and args[0] == "rb":
+            open_count["n"] += 1
+            if open_count["n"] == 1:
+                # First (and with the fix, ONLY) open: real inode-A handle.
+                return real_open(self, *args, **kwargs)
+            # Any subsequent open of the journal returns inode-B content. With the
+            # single-open fix this branch never executes; with a reopen bug it
+            # leaks inode-B rows into the result.
+            return _io.BytesIO(inode_b_bytes)
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", generation_pinned_open)
+
+    events, _malformed = _read_jsonl_tail(path, max_bytes=cap, max_rows=4096)
+    seqs = [e.get("seq") for e in events if isinstance(e, dict) and "seq" in e]
+
+    # The journal must be opened exactly ONCE (single-generation contract).
+    assert open_count["n"] == 1, (
+        f"journal must be opened exactly once (single inode generation); "
+        f"opened {open_count['n']} times — a reopen mixes generations"
+    )
+    # The result must be purely inode-A: the token (seq=1), running (no terminal).
+    # inode-B (seq=100, terminal) must NEVER appear.
+    assert 100 not in seqs, (
+        f"inode-B row leaked into inode-A result (mixed generation): seqs={seqs}. "
+        f"A reopen read the recreated file's completed-done as if it were the original."
+    )
+    assert any(s == 1 for s in seqs), (
+        f"inode-A token (seq=1) must be recovered; got seqs={seqs}"
+    )
+    for e in events:
+        if isinstance(e, dict):
+            assert not e.get("terminal"), (
+                f"a terminal event leaked from inode-B into the result: {e} "
+                f"— the oversized boundary was crash-truncated (inode-A, non-terminal)"
+            )
+
+
+def test_invalid_predecessor_rows_skipped_until_valid_event(tmp_path, monkeypatch):
+    """Regression (reviewer round 8): the backward predecessor scan must skip
+    blank, malformed-JSON, JSON-scalar, JSON-list, and consecutive mixed invalid
+    rows until it finds the preceding valid event dict. This is the reader-level
+    coverage the round-8 review asked for beyond the blank-line separator case.
+
+    Journal shape (a valid token, then a run of mixed invalid rows, then an
+    oversized crash-truncated done that forces the recovery path):
+        token(seq=1)
+        {not-json}        <- malformed
+        42                <- JSON scalar (non-dict)
+        [1,2]             <- JSON list (non-dict)
+                            <- blank line
+        <oversized partial done, no }/\n>
+
+    BOTH tail readers must recover the token (seq=1), report running, and emit
+    the recovery apperror. None of the invalid rows may be accepted as the
+    recovered event."""
+    import json as _json
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _run_path,
+        _read_jsonl,
+        _summary_from_events,
+        stale_interrupted_event,
+    )
+
+    session_id = "session_invalid_pred"
+    run_id = "run_mixed_invalid"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cap = _SESSION_REPLAY_MAX_BYTES
+
+    token_line = _json.dumps(
+        {"version": 1, "event_id": f"{run_id}:1", "seq": 1,
+         "event": "token", "type": "token", "terminal": False,
+         "payload": {"text": "the-valid-token"}}
+    )
+    oversized_partial = (
+        '{"version":1,"event_id":"' + run_id + ':2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + "X" * (cap + 1000)
+    )
+    # token, then a run of mixed invalid rows, then the oversized partial.
+    with path.open("wb") as fh:
+        fh.write((token_line + "\n").encode("utf-8"))
+        fh.write(b"{not-json}\n")     # malformed JSON
+        fh.write(b"42\n")             # JSON scalar (non-dict)
+        fh.write(b"[1,2]\n")          # JSON list (non-dict)
+        fh.write(b"\n")               # blank line
+        fh.write(oversized_partial.encode("utf-8"))  # crash-truncated, no newline
+
+    tail_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    find_summary = find_run_summary(run_id, session_dir=tmp_path)
+    full_events, _ = _read_jsonl(path)
+    authoritative = _summary_from_events(session_id, run_id, full_events)
+
+    # Both tail readers recover the valid token (seq=1), agreeing with the full reader.
+    assert tail_summary["last_seq"] == 1, (
+        f"latest_run_summary last_seq={tail_summary['last_seq']} (expected 1) "
+        f"— an invalid predecessor row was accepted instead of skipped"
+    )
+    assert tail_summary["event_count"] == 1
+    assert tail_summary["last_seq"] == authoritative["last_seq"]
+    assert find_summary is not None
+    assert find_summary["last_seq"] == 1
+    assert find_summary["last_seq"] == authoritative["last_seq"]
+    # The oversized boundary was crash-truncated, so the run stays non-terminal.
+    for e in (tail_summary, find_summary):
+        assert not e.get("terminal"), "the oversized boundary was truncated (non-terminal)"
+
+    monkeypatch.setattr("api.run_journal._default_session_dir", lambda: tmp_path)
+    recovery = stale_interrupted_event(session_id, run_id)
+    assert recovery is not None, "stale recovery must emit apperror (run is running)"
+    assert recovery["event"] == "apperror"
+
+
+def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_path):
+    """Regression (reviewer round 8, point 5): an oversized predecessor that is
+    structurally INCOMPLETE (crash-truncated mid-payload — brace depth never
+    returns to 0) must NOT be accepted via _extract_boundary_record_summary's
+    fabricated prefix as if it were a valid terminal event. The structural-
+    completeness gate inside the backward scan must reject it and continue to
+    the preceding complete event.
+
+    Journal shape:
+        token(seq=1)
+        <oversized malformed done seq=2: has a newline terminator so it counts
+         as a complete LINE, but the JSON itself is structurally incomplete
+         (truncated mid-payload value), so _record_is_structurally_complete ->
+         False while _extract_boundary_record_summary fabricates a terminal
+         prefix from its head>
+        <oversized partial done seq=3: the crash-truncated boundary, no newline>
+
+    The scan for the predecessor of seq=3 hits the oversized seq=2 row first.
+    Without the gate it would accept seq=2's fabricated terminal prefix; with
+    the gate it skips seq=2 and recovers token(seq=1)."""
+    import os
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _run_path,
+        _read_last_complete_line_before,
+    )
+
+    session_id = "session_oversized_malformed_pred"
+    run_id = "run_oversized_malformed_pred"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cap = _SESSION_REPLAY_MAX_BYTES
+
+    token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    # Oversized malformed predecessor: newline-terminated (a complete line) but
+    # JSON structurally incomplete (no closing brace — truncated mid-value).
+    # Its head still fabricates a terminal 'done/seq=2' prefix.
+    oversized_malformed_pred = (
+        '{"version":1,"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + "X" * (cap + 1000)
+        + "\n"  # newline terminator makes it a complete LINE, but JSON is broken
+    )
+    # Final crash-truncated boundary (no newline) — forces the recovery scan.
+    final_partial = (
+        '{"seq":3,"event":"done","terminal":true,"payload":{"t":"'
+        + "Y" * (cap + 1000)
+    )
+    token_bytes = token_line.encode("utf-8")
+    pred_bytes = oversized_malformed_pred.encode("utf-8")
+    with path.open("wb") as fh:
+        fh.write(token_bytes)
+        fh.write(pred_bytes)
+        fh.write(final_partial.encode("utf-8"))
+
+    final_start = len(token_bytes) + len(pred_bytes)
+    with path.open("rb") as fh:
+        size = os.fstat(fh.fileno()).st_size
+        result = _read_last_complete_line_before(fh, size, final_start)
+
+    # The oversized malformed predecessor (seq=2) must be SKIPPED via the gate;
+    # the valid token (seq=1) is recovered — never the fabricated terminal done.
+    assert result is not None, "the valid token (seq=1) must be recovered"
+    assert result.get("seq") == 1, (
+        f"expected seq=1 (the gate skipped the oversized malformed row); got "
+        f"seq={result.get('seq')} — the fabricated terminal prefix was accepted "
+        f"as if the structurally-incomplete row were valid"
+    )
+    assert not result.get("terminal"), (
+        "a non-terminal token must be recovered, not a fabricated terminal done"
+    )
+
+
+def test_backward_predecessor_scan_budget_bounds_the_scan(tmp_path):
+    """Regression (reviewer round 8, point 4): the backward predecessor scan
+    must have an explicit aggregate row/byte budget so it cannot walk to byte
+    zero across an arbitrarily long invalid-row streak. With a budget smaller
+    than the streak, the scan must STOP (return None) rather than scanning the
+    whole streak. With a budget large enough, it recovers the valid event."""
+    import os
+    from api.run_journal import (
+        _run_path,
+        _read_last_complete_line_before,
+    )
+
+    session_id = "session_budget"
+    run_id = "run_budget"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # A valid token far back, then a long run of malformed rows (each ~20 bytes).
+    token = '{"seq":1,"event":"token","payload":{"t":"v"}}\n'
+    malformed_rows = b"{bad}\n" * 500  # 500 malformed rows (~6 bytes each)
+    with path.open("wb") as fh:
+        fh.write(token.encode("utf-8"))
+        fh.write(malformed_rows)
+
+    with path.open("rb") as fh:
+        size = os.fstat(fh.fileno()).st_size
+        # Tiny budget: cannot reach the token past 500 malformed rows.
+        tight = _read_last_complete_line_before(fh, size, size, budget=50)
+        # Large budget: reaches the token.
+        generous = _read_last_complete_line_before(fh, size, size, budget=10 * 1024 * 1024)
+
+    # Tight budget must STOP before reaching the token (budget gate fires).
+    assert tight is None, (
+        f"a 50-byte budget must not scan 500 malformed rows to the token; got {tight}"
+    )
+    # Generous budget must recover the token (seq=1).
+    assert generous is not None and generous.get("seq") == 1, (
+        f"a large budget must recover the valid token (seq=1); got {generous}"
     )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -1474,39 +1474,49 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
         f"the boundary helpers must have run (seq=2 recovered); got {seqs}. "
         f"If absent the test is vacuous."
     )
-    # (b) The SAME shared _ReadBudget threads through find + extract + valid.
-    # (The predecessor scan only runs on rejection; here the valid done is
-    # accepted so the predecessor helper is not reached. r11: the predecessor
-    # scan now gets its OWN reserve budget separate from this shared meter, so
-    # a >=budget invalid oversized record can't starve it — that is covered by
+    # (b) The SAME shared _ReadBudget threads through find + extract (boundary
+    # lookup + prefix extraction). The validity proof has its OWN separate meter
+    # (#6139 r13): sharing the lookup+prefix meter let a valid ~1.75x cap record
+    # be starved (lookup + 8 KiB prefix consumed enough of the 2x cap allowance
+    # that the proof couldn't read the full record → fail-closed → valid terminal
+    # rejected → wrong terminal_state). find and extract still share one meter;
+    # valid has a distinct id. (The predecessor scan only runs on rejection; here
+    # the valid done is accepted so the predecessor helper is not reached. r11:
+    # the predecessor scan also gets its OWN reserve budget — covered by
     # test_predecessor_recovery_not_starved_by_validity_proof_budget and
     # test_backward_scan_budget_bounds_physical_descriptor_reads.)
     assert budget_ids_seen["find"], "boundary lookup received no budget (budget=None) — not shared"
     assert budget_ids_seen["extract"], "prefix extraction received no budget (budget=None) — not shared"
-    assert budget_ids_seen["valid"], "validity proof received no budget (budget=None) — not shared"
-    shared_id = budget_ids_seen["find"][0]
-    assert all(bid == shared_id for bid in budget_ids_seen["find"]), (
+    assert budget_ids_seen["valid"], "validity proof received no budget (budget=None) — not metered"
+    lookup_prefix_id = budget_ids_seen["find"][0]
+    assert all(bid == lookup_prefix_id for bid in budget_ids_seen["find"]), (
         f"boundary lookup used multiple budget instances: {budget_ids_seen['find']}"
     )
-    assert all(bid == shared_id for bid in budget_ids_seen["extract"]), (
-        f"prefix extraction used a different budget instance: find={shared_id} extract={budget_ids_seen['extract']}"
+    assert all(bid == lookup_prefix_id for bid in budget_ids_seen["extract"]), (
+        f"prefix extraction used a different budget instance from lookup: "
+        f"find={lookup_prefix_id} extract={budget_ids_seen['extract']} (find+extract must share one meter)"
     )
-    assert all(bid == shared_id for bid in budget_ids_seen["valid"]), (
-        f"validity proof used a different budget instance: find={shared_id} valid={budget_ids_seen['valid']}"
+    assert all(bid != lookup_prefix_id for bid in budget_ids_seen["valid"]), (
+        f"validity proof shared the lookup+prefix meter (id={lookup_prefix_id}); "
+        f"it must have its OWN separate meter so a valid record near the 2x cap "
+        f"validity ceiling can pay for its own complete validation (#6139 r13). "
+        f"valid ids={budget_ids_seen['valid']}"
     )
-    # (c) Physical reads are bounded by the shared budget envelope.
+    # (c) Physical reads are bounded. The validity proof's own meter is sized at
+    # _VALIDITY_PROOF_MAX_BYTES (2x cap), but the incremental chunked read means
+    # a small record costs only one chunk — so total physical reads stay ~constant
+    # (the scale regression test_read_jsonl_tail_boundary_scan_uses_shared_budget...
+    # holds the constant-in-file-size property directly).
     handle = captured.get("handle")
     assert handle is not None, "the patched Path.open never returned a binary handle"
     total = handle.total_returned
     boundary_helper_bytes = total - cap  # subtract the one forward tail-window read
-    assert boundary_helper_bytes <= 2 * cap, (
-        f"boundary-helper physical reads ({boundary_helper_bytes} bytes) exceeded "
-        f"the 2*cap shared budget ({2*cap}) — the production path is not bounding "
-        f"physical I/O via the shared meter (#6139 r10 item 1)"
-    )
-    assert total < 3 * cap, (
-        f"total physical reads ({total}) far exceed the expected envelope; the "
-        f"production boundary scan is reading unboundedly"
+    # lookup+prefix (2x cap) + validity proof reads the record's actual length
+    # (this fixture is a valid oversized done ~cap, so ~cap) — well under 5x cap.
+    assert boundary_helper_bytes <= 5 * cap, (
+        f"boundary-helper physical reads ({boundary_helper_bytes} bytes) far exceed "
+        f"the expected envelope (lookup+prefix 2x cap + validity proof ~cap); the "
+        f"production boundary scan is reading unboundedly (#6139 r10/r13)"
     )
 
 
@@ -1956,4 +1966,165 @@ def test_malformed_oversized_boundary_extraction_none_recovers_preceding(tmp_pat
         f"find_run_summary reported terminal_state={found['terminal_state']!r} "
         f"(expected 'completed'); the extraction-None path skipped recovery on the "
         f"find_run_summary path too (#6139 r12)"
+    )
+
+
+def _summary_from_events_ref(session_id, run_id, events):
+    """Local reference to _summary_from_events so the helper does not need an
+    extra import line at module scope."""
+    from api.run_journal import _summary_from_events
+    return _summary_from_events(session_id, run_id, events)
+
+
+def _assert_valid_oversized_boundary_accepted(tmp_path, *, record_size_multiple, with_trailing):
+    """Shared body for the r13 valid-oversized-boundary regressions: a VALID
+    terminal ``done`` record sized at ``record_size_multiple`` x cap (above cap,
+    near the _VALIDITY_PROOF_MAX_BYTES 2x ceiling) must be ACCEPTED by the tail
+    reader, not rejected by budget starvation. The production order
+    ``done(tool_limit_reached) -> metering -> stream_end`` and the final-row case
+    are both covered (``with_trailing`` selects trailing metering/stream_end).
+
+    Under the r12 design the validity proof shared the lookup+prefix 2x cap
+    meter: the backward lookup + 8 KiB prefix consumed enough of the allowance
+    that a valid ~1.75x cap record could not be read in full -> fail-closed ->
+    valid terminal rejected -> wrong terminal_state (full reader
+    tool_limit_reached -> tail running/completed). The r13 fix gives the validity
+    proof its own _VALIDITY_PROOF_MAX_BYTES meter. This asserts exact full/tail
+    parity for ordered seqs, last_seq, terminal, and the discriminating
+    tool_limit_reached state through _read_jsonl_tail, latest_run_summary, AND
+    find_run_summary."""
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _read_jsonl,
+        _read_jsonl_tail,
+        find_run_summary,
+        latest_run_summary,
+    )
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    # Build a valid oversized done at the target multiple of cap, with a
+    # discriminating tool_limit_reached terminal_state.
+    target_size = int(record_size_multiple * cap)
+    framing_overhead = 120  # the JSON keys + payload key framing around the big string
+    big_payload = "Z" * max(0, target_size - framing_overhead)
+    valid_done = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"tool_limit_reached","payload":{"t":"' + big_payload + '"}}\n'
+    )
+    head_token = '{"seq":1,"event":"token","payload":{"t":"head"}}\n'
+    trailing = ""
+    expected_seqs_full = [1, 2]
+    if with_trailing:
+        metering = '{"seq":3,"event":"metering","payload":{"tokens":10}}\n'
+        stream_end = '{"seq":4,"event":"stream_end","payload":{}}\n'
+        trailing = metering + stream_end
+        expected_seqs_full = [1, 2, 3, 4]
+
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(head_token.encode("utf-8"))
+        fh.write(valid_done.encode("utf-8"))
+        fh.write(trailing.encode("utf-8"))
+    size = path.stat().st_size
+    assert size > cap, "sanity: the journal must exceed the tail window"
+    # The done record must straddle the tail window (start before size-cap).
+    done_start = len(head_token)
+    done_end = done_start + len(valid_done)
+    window_start = size - cap
+    assert done_start < window_start < done_end, (
+        f"fixture setup: the done record [{done_start},{done_end}) must straddle "
+        f"the tail window start {window_start} (size={size}, cap={cap})"
+    )
+
+    # Ground truth: the full reader sees the tool_limit_reached done.
+    full_events, _ = _read_jsonl(path)
+    full_seqs = [e.get("seq") for e in full_events]
+    assert full_seqs == expected_seqs_full, (
+        f"baseline: full reader seqs {full_seqs} (expected {expected_seqs_full})"
+    )
+    full_summary = _summary_from_events_ref("s1", "r1", full_events)
+    assert full_summary["terminal_state"] == "tool_limit_reached", (
+        f"baseline: full reader terminal_state={full_summary['terminal_state']!r} "
+        f"(expected 'tool_limit_reached')"
+    )
+
+    # The tail reader must keep the valid oversized done (seq=2), NOT reject it
+    # via budget starvation. The boundary summary is recovered (seq=2 present).
+    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    tail_seqs = [e.get("seq") for e in tail_events]
+    # When trailing records exist, the tail window keeps them after the boundary
+    # recovery prepends the straddling seq=2 summary. Without trailing, only the
+    # boundary summary (seq=2) is present in the tail.
+    assert 2 in tail_seqs, (
+        f"the tail reader REJECTED the valid oversized terminal done (seq=2 not "
+        f"in tail_seqs={tail_seqs}); a valid record near {record_size_multiple}x cap "
+        f"was starved by the lookup+prefix meter and failed-closed (#6139 r13)"
+    )
+    # Exact full/tail parity on the discriminating fields.
+    tail_summary = _summary_from_events_ref("s1", "r1", tail_events)
+    assert tail_summary["terminal_state"] == "tool_limit_reached", (
+        f"the tail reader reported terminal_state={tail_summary['terminal_state']!r} "
+        f"(expected 'tool_limit_reached'); a valid {record_size_multiple}x cap "
+        f"terminal record was rejected via budget starvation (#6139 r13)"
+    )
+    assert tail_summary["terminal"] is True, (
+        f"the tail reader reported terminal={tail_summary['terminal']} (expected True)"
+    )
+    assert tail_summary["last_seq"] == full_summary["last_seq"], (
+        f"last_seq mismatch: tail={tail_summary['last_seq']} full={full_summary['last_seq']}"
+    )
+
+    # Production summary readers must agree.
+    summary = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert summary["terminal_state"] == "tool_limit_reached", (
+        f"latest_run_summary reported terminal_state={summary['terminal_state']!r} "
+        f"(expected 'tool_limit_reached'); a valid {record_size_multiple}x cap "
+        f"terminal record was rejected on the summary path (#6139 r13)"
+    )
+    assert summary["terminal"] is True, (
+        f"latest_run_summary marked terminal={summary['terminal']} (expected True)"
+    )
+    found = find_run_summary("r1", session_dir=tmp_path)
+    assert found is not None, "find_run_summary must locate the run"
+    assert found["terminal_state"] == "tool_limit_reached", (
+        f"find_run_summary reported terminal_state={found['terminal_state']!r} "
+        f"(expected 'tool_limit_reached') (#6139 r13)"
+    )
+
+
+def test_valid_oversized_boundary_175x_cap_as_final_row(tmp_path):
+    """Regression (reviewer round 13): a VALID terminal ``done`` at ~1.75x cap
+    as the FINAL row of the journal must be accepted (not starved) by the tail
+    reader. Full/tail parity on seqs, last_seq, terminal, tool_limit_reached."""
+    _assert_valid_oversized_boundary_accepted(
+        tmp_path, record_size_multiple=1.75, with_trailing=False
+    )
+
+
+def test_valid_oversized_boundary_175x_cap_before_metering_stream_end(tmp_path):
+    """Regression (reviewer round 13): a VALID terminal ``done`` at ~1.75x cap
+    followed by the production order ``metering`` -> ``stream_end`` must be
+    accepted by the tail reader. This is the exact scenario the reviewer
+    reproduced (full reader tool_limit_reached -> tail running under r12)."""
+    _assert_valid_oversized_boundary_accepted(
+        tmp_path, record_size_multiple=1.75, with_trailing=True
+    )
+
+
+def test_valid_oversized_boundary_near_2x_cap_as_final_row(tmp_path):
+    """Regression (reviewer round 13): a VALID terminal ``done`` near the 2x cap
+    validity ceiling (_VALIDITY_PROOF_MAX_BYTES) as the final row must be
+    accepted. Near the ceiling is the hardest case for a starved shared meter."""
+    _assert_valid_oversized_boundary_accepted(
+        tmp_path, record_size_multiple=1.95, with_trailing=False
+    )
+
+
+def test_valid_oversized_boundary_near_2x_cap_before_metering_stream_end(tmp_path):
+    """Regression (reviewer round 13): a VALID terminal ``done`` near the 2x cap
+    validity ceiling followed by ``metering`` -> ``stream_end`` must be
+    accepted."""
+    _assert_valid_oversized_boundary_accepted(
+        tmp_path, record_size_multiple=1.95, with_trailing=True
     )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -658,30 +658,26 @@ def test_record_is_structurally_complete_returns_fallback_if_handle_error(
 
 
 def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, monkeypatch):
-    """End-to-end TOCTOU (reviewer round 9, item 3): a journal BIGGER than the
-    tail cap so the boundary-scan path fires, and a ``read`` failure mid-recovery
-    returns the safe fallback, never propagates to the HTTP handler.
+    """End-to-end TOCTOU (reviewer round 9/10, item 3): a journal BIGGER than the
+    tail cap so the boundary-scan path fires, and a read failure INSIDE the
+    boundary scan (not the forward tail read) returns the safe fallback, never
+    propagates to the HTTP handler.
 
-    No longer vacuous (r9): the OLD test used an obsolete two-argument helper
-    signature AND a ~100 KiB fixture that never exceeded the 4 MiB cap, so the
-    boundary helper was never reached. This version (a) builds a fixture
-    exceeding ``_SESSION_REPLAY_MAX_BYTES`` (proving the boundary path actually
-    fires by recovering the straddling record) and (b) uses the current
-    descriptor-based signature — patching the single ``Path.open`` handle so a
-    body-level ``read`` (the forward tail read, protected only by
-    ``_read_jsonl_tail``'s outer ``except (FileNotFoundError, OSError)``) raises.
-
-    The contract under test: a read failure mid-recovery returns the safe
-    fallback ``([], [])`` (or whatever events it already has), never propagates.
-    The body-level forward tail read is the read whose OSError is NOT swallowed
-    by any helper's inner try/except — so it directly exercises the outer
-    except, which is the round-9 single-open recovery guard."""
+    Discriminating (r10): the OLD test's ``_FailingHandle(fail_on_read=1)``
+    raised on read #1 — which is the forward tail read populating ``raw`` — so
+    ``_find_record_start_before`` and the whole boundary scan NEVER ran. The test
+    passed whether or not the boundary helpers were TOCTOU-safe. This version
+    (a) builds a >cap fixture, (b) asserts the boundary path recovers the
+    straddling record under a normal read (non-vacuity), (c) patches
+    ``_find_record_start_before`` to unlink the pinned file and raise OSError
+    INSIDE the reached boundary call — so the descriptor that was opened by
+    ``_read_jsonl_tail`` is the one that sees the failure, and (d) asserts the
+    boundary hook actually ran and ``Path.open`` was called exactly once (the
+    pinned descriptor is reused, not reopened)."""
     from pathlib import Path
     from api import run_journal
     from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl_tail
 
-    # Build a journal whose tail window straddles a record (size > cap) so the
-    # boundary helpers fire: a small valid token, then an oversized done.
     cap = _SESSION_REPLAY_MAX_BYTES
     token_line = '{"seq":1,"event":"token","payload":{"t":"ok"}}\n'
     oversized_done = (
@@ -697,77 +693,66 @@ def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, mon
         fh.write(oversized_done.encode("utf-8"))
     assert path.stat().st_size > cap, "fixture must exceed the cap so the boundary scan fires"
 
-    # --- Part A: NON-VACUITY. A normal read on the oversized fixture must run
-    # the boundary path and recover the straddling done's summary (seq=2) —
-    # proving the boundary helpers actually fire (the old test's ~100 KiB
-    # fixture never reached them). This is the r9 "force the boundary path" fix.
+    # --- Part A: NON-VACUITY. A normal read recovers the straddling done's
+    # summary (seq=2) — proving the boundary helpers actually fire.
     events_normal, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     seqs = {e.get("seq") for e in events_normal if isinstance(e, dict)}
     assert 2 in seqs, (
         f"the oversized done (seq=2) straddling summary must be recovered by the "
-        f"boundary scan — if not, the fixture is vacuous (old bug); got seqs={seqs}"
+        f"boundary scan — if not, the fixture is vacuous; got seqs={seqs}"
     )
 
-    # --- Part B: MUTATION-KILLING CONTRACT. Patch Path.open so the forward tail
-    # read (a body-level read protected ONLY by the outer except) raises OSError
-    # — the realistic single-open TOCTOU (fd invalidated mid-recovery).
-    # _read_jsonl_tail must catch it and return the safe fallback, never raise.
+    # --- Part B: MUTATION-KILLING CONTRACT. Hook _find_record_start_before (the
+    # FIRST boundary helper after the forward tail read succeeds) so a failure
+    # INSIDE the reached boundary call returns the safe fallback, never raises,
+    # and the pinned descriptor is reused (Path.open called exactly once).
+    open_calls = {"n": 0}
+    boundary_calls = {"n": 0}
     real_open = Path.open
 
-    class _FailingHandle:
-        """Lets the first read (forward tail) succeed, then raises OSError on
-        every subsequent read. The forward read populating the body is read #1;
-        the boundary-scan helpers each swallow their own OSErrors internally, so
-        to directly exercise the OUTER except we additionally test the read-#1
-        failure mode below."""
-        def __init__(self, real, fail_on_read=1):
-            self._real = real
-            self._reads = 0
-            self._fail_on_read = fail_on_read
+    def patched_open(self, *args, **kwargs):
+        open_calls["n"] += 1
+        return real_open(self, *args, **kwargs)
 
-        def fileno(self):
-            return self._real.fileno()
+    def patched_find(fh, size, seek_pos, *, budget=None):
+        boundary_calls["n"] += 1
+        # Unlink the pinned file from under the open descriptor and raise — the
+        # realistic single-open TOCTOU (fd invalidated mid-recovery, inside the
+        # boundary scan that the old test never reached).
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise OSError("simulated fd invalidation inside the boundary scan")
 
-        def seek(self, *a, **kw):
-            return self._real.seek(*a, **kw)
+    monkeypatch.setattr(Path, "open", patched_open)
+    monkeypatch.setattr(run_journal, "_find_record_start_before", patched_find)
 
-        def read(self, n=-1):
-            self._reads += 1
-            if self._reads >= self._fail_on_read:
-                raise OSError("simulated fd invalidation mid-recovery")
-            return self._real.read(n)
-
-        def close(self):
-            return self._real.close()
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *a):
-            return self._real.__exit__(*a)
-
-    def make_patched_open(fail_on_read):
-        def patched_open(self, *args, **kwargs):
-            real = real_open(self, *args, **kwargs)
-            mode = args[0] if args else kwargs.get("mode", "r")
-            return _FailingHandle(real, fail_on_read) if "b" in mode else real
-        return patched_open
-
-    # Read #1 failure: the forward tail read itself raises. This read is
-    # body-level (only the outer except protects it), so this is the case that
-    # directly tests the outer try/except and is killed if that except re-raises.
-    monkeypatch.setattr(Path, "open", make_patched_open(fail_on_read=1))
     events, malformed = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     assert isinstance(events, list) and isinstance(malformed, list), (
         f"_read_jsonl_tail must return a (list, list) safe fallback; got "
         f"({type(events).__name__}, {type(malformed).__name__})"
     )
+    assert boundary_calls["n"] >= 1, (
+        "the boundary helper _find_record_start_before was never reached — the "
+        "test is non-discriminating (the failure fired on the forward tail read)"
+    )
+    assert open_calls["n"] == 1, (
+        f"_read_jsonl_tail reopened the journal ({open_calls['n']} opens) instead "
+        f"of reusing the pinned descriptor — single-open contract broken"
+    )
 
     # The same contract holds through the summary reader's path (no propagation
-    # to the HTTP handler): a read failure mid-recovery yields a dict summary.
-    monkeypatch.setattr(Path, "open", make_patched_open(fail_on_read=1))
+    # to the HTTP handler). Re-create the file first since Part B unlinked it.
+    with path.open("wb") as fh:
+        fh.write(token_line.encode("utf-8"))
+        fh.write(oversized_done.encode("utf-8"))
+    open_calls["n"] = 0
+    boundary_calls["n"] = 0
     summary = run_journal.latest_run_summary("s1", "r1", session_dir=tmp_path)
     assert isinstance(summary, dict), "latest_run_summary must return a dict, not raise"
+    assert boundary_calls["n"] >= 1, "the boundary helper must be reached via latest_run_summary too"
+    assert open_calls["n"] == 1, "latest_run_summary must reuse the pinned descriptor"
 
 
 def test_blank_line_before_oversized_partial_done_recovers_preceding_event(tmp_path, monkeypatch):
@@ -1385,3 +1370,237 @@ def test_balanced_invalid_oversized_predecessor_skipped_malformed_nested_value(t
     assert not result.get("terminal"), (
         "a non-terminal token must be recovered, not a fabricated terminal done"
     )
+
+
+def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhaustion(tmp_path, monkeypatch):
+    """Regression (reviewer round 10, item 1): the PRODUCTION boundary path in
+    ``_read_jsonl_tail`` must use ONE shared ``_ReadBudget`` across boundary
+    lookup, prefix extraction, validity proof, and the backward predecessor
+    scan — so physical I/O is bounded and NO read occurs after exhaustion.
+
+    The r9 physical-budget test only covered ``_read_last_complete_line_before``
+    (the predecessor helper). The r9 PRODUCTION composition called the boundary
+    helpers WITHOUT a shared budget (each ran unbounded). This test instruments
+    the PRODUCTION reader end-to-end and asserts:
+      (a) the boundary helpers are reached (the straddling seq=2 is recovered);
+      (b) the SAME ``_ReadBudget`` instance is threaded through boundary lookup,
+          prefix extraction, validity proof, AND the predecessor scan (the
+          helpers receive a non-None budget, all with one shared id);
+      (c) physical reads are bounded by the shared budget envelope.
+
+    (b) is the discrimination the r9 test lacked: it proves the budget is
+    SHARED, not just that the bytes happen to be bounded by a ceiling constant.
+    A mutation that passes ``budget=None`` to any helper (the r9 bug) fails (b)."""
+    from pathlib import Path
+    from api import run_journal
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl_tail
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    # A VALID oversized done: the validity proof returns True, exercising the
+    # boundary lookup + prefix extraction + validity helpers on the happy path.
+    oversized_done = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"'
+        + "X" * (cap + 1000)
+        + '"}}\n'
+    )
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(token_line.encode("utf-8"))
+        fh.write(oversized_done.encode("utf-8"))
+    assert path.stat().st_size > cap
+
+    # Instrument the four boundary helpers to record whether a non-None budget
+    # was passed and its id(). The SAME id must appear across all of them.
+    budget_ids_seen = {"find": [], "extract": [], "valid": []}
+    real_find = run_journal._find_record_start_before
+    real_extract = run_journal._extract_boundary_record_summary
+    real_valid = run_journal._record_is_valid_complete
+
+    def patched_find(fh, size, seek_pos, *, budget=None):
+        if budget is not None:
+            budget_ids_seen["find"].append(id(budget))
+        return real_find(fh, size, seek_pos, budget=budget)
+
+    def patched_extract(fh, record_start, *, budget=None):
+        if budget is not None:
+            budget_ids_seen["extract"].append(id(budget))
+        return real_extract(fh, record_start, budget=budget)
+
+    def patched_valid(fh, size, record_start, *, budget=None):
+        if budget is not None:
+            budget_ids_seen["valid"].append(id(budget))
+        return real_valid(fh, size, record_start, budget=budget)
+
+    monkeypatch.setattr(run_journal, "_find_record_start_before", patched_find)
+    monkeypatch.setattr(run_journal, "_extract_boundary_record_summary", patched_extract)
+    monkeypatch.setattr(run_journal, "_record_is_valid_complete", patched_valid)
+
+    # Also count physical reads via the handle.
+    real_open = Path.open
+    captured = {}
+
+    class _CountingHandle:
+        def __init__(self, real):
+            self._real = real
+            self.total_returned = 0
+        def fileno(self): return self._real.fileno()
+        def seek(self, *a, **kw): return self._real.seek(*a, **kw)
+        def read(self, n=-1):
+            data = self._real.read(n)
+            self.total_returned += len(data)
+            return data
+        def close(self): return self._real.close()
+        def __enter__(self): return self
+        def __exit__(self, *a): return self._real.__exit__(*a)
+
+    def patched_open(self, *args, **kwargs):
+        real = real_open(self, *args, **kwargs)
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if "b" in mode:
+            h = _CountingHandle(real)
+            captured["handle"] = h
+            return h
+        return real
+
+    monkeypatch.setattr(Path, "open", patched_open)
+    events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+
+    # (a) Non-vacuity: the boundary helpers ran and recovered seq=2.
+    seqs = {e.get("seq") for e in events if isinstance(e, dict)}
+    assert 2 in seqs, (
+        f"the boundary helpers must have run (seq=2 recovered); got {seqs}. "
+        f"If absent the test is vacuous."
+    )
+    # (b) The SAME shared _ReadBudget threads through find + extract + valid.
+    # (The predecessor scan only runs on rejection; here the valid done is
+    # accepted so the predecessor helper is not reached — that path is covered
+    # by test_backward_scan_budget_bounds_physical_descriptor_reads.)
+    assert budget_ids_seen["find"], "boundary lookup received no budget (budget=None) — not shared"
+    assert budget_ids_seen["extract"], "prefix extraction received no budget (budget=None) — not shared"
+    assert budget_ids_seen["valid"], "validity proof received no budget (budget=None) — not shared"
+    shared_id = budget_ids_seen["find"][0]
+    assert all(bid == shared_id for bid in budget_ids_seen["find"]), (
+        f"boundary lookup used multiple budget instances: {budget_ids_seen['find']}"
+    )
+    assert all(bid == shared_id for bid in budget_ids_seen["extract"]), (
+        f"prefix extraction used a different budget instance: find={shared_id} extract={budget_ids_seen['extract']}"
+    )
+    assert all(bid == shared_id for bid in budget_ids_seen["valid"]), (
+        f"validity proof used a different budget instance: find={shared_id} valid={budget_ids_seen['valid']}"
+    )
+    # (c) Physical reads are bounded by the shared budget envelope.
+    handle = captured.get("handle")
+    assert handle is not None, "the patched Path.open never returned a binary handle"
+    total = handle.total_returned
+    boundary_helper_bytes = total - cap  # subtract the one forward tail-window read
+    assert boundary_helper_bytes <= 2 * cap, (
+        f"boundary-helper physical reads ({boundary_helper_bytes} bytes) exceeded "
+        f"the 2*cap shared budget ({2*cap}) — the production path is not bounding "
+        f"physical I/O via the shared meter (#6139 r10 item 1)"
+    )
+    assert total < 3 * cap, (
+        f"total physical reads ({total}) far exceed the expected envelope; the "
+        f"production boundary scan is reading unboundedly"
+    )
+
+
+def test_balanced_invalid_oversized_boundary_record_trailing_comma(tmp_path):
+    """Regression (reviewer round 10, item 2): a brace-balanced, newline-
+    terminated oversized BOUNDARY record (the straddling record itself, not a
+    predecessor) that is INVALID JSON (trailing comma after the payload value)
+    must NOT be fabricated into a terminal summary. The r9 tests covered only the
+    predecessor helper; the PRODUCTION ``_read_jsonl_tail`` primary path still
+    trusted the fabricated prefix when brace depth returned to zero.
+
+    Full ``_read_jsonl`` correctly retains only the valid token (seq=1); the tail
+    reader must MATCH it (not promote a fabricated terminal seq=2)."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl, _read_jsonl_tail
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    big = "Q" * (cap + 50_000)
+    token = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    oversized_boundary = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '"},}\n'
+    )
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(token.encode("utf-8"))
+        fh.write(oversized_boundary.encode("utf-8"))
+
+    full_events, _ = _read_jsonl(path)
+    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
+    tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
+    assert 2 not in full_seqs, "baseline: the trailing-comma record is invalid JSON (full reader rejects it)"
+    assert 2 not in tail_seqs, (
+        f"the tail reader PROMOTED the brace-balanced-but-invalid oversized "
+        f"boundary record as terminal (tail_seqs={tail_seqs}); the fabricated "
+        f"prefix must not be trusted without whole-record JSON validity "
+        f"(#6139 r10 item 2)"
+    )
+    # The tail reader must not mark terminal (the invalid record is rejected,
+    # only the non-terminal token seq=1 survives — matching the full reader).
+    tail_promoted = any(e.get("_summary_extracted_from_oversized_record") for e in tail_events)
+    assert not tail_promoted, (
+        "the invalid boundary record was fabricated into a summary with "
+        "_summary_extracted_from_oversized_record=True"
+    )
+    # Through the summary reader too: must NOT report completed.
+    summary = __import__("api.run_journal", fromlist=["latest_run_summary"]).latest_run_summary(
+        "s1", "r1", session_dir=tmp_path
+    )
+    assert summary["terminal"] is False, (
+        f"latest_run_summary marked terminal={summary['terminal']} for an invalid "
+        f"(trailing-comma) oversized boundary record — fail-closed should leave it nonterminal"
+    )
+    assert summary["terminal_state"] != "completed", (
+        f"latest_run_summary reported terminal_state={summary['terminal_state']!r} "
+        f"for an invalid boundary record"
+    )
+
+
+def test_balanced_invalid_oversized_boundary_record_malformed_nested_value(tmp_path):
+    """Companion to test_balanced_invalid_oversized_boundary_record_trailing_comma
+    (reviewer round 10, item 2): a brace-balanced, newline-terminated oversized
+    BOUNDARY record invalid JSON due to a malformed nested value (unquoted nested
+    key) — also rejected by the production tail reader, matching the full reader."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl, _read_jsonl_tail
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    big = "Q" * (cap + 50_000)
+    token = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    oversized_boundary = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '",bad:nested}}\n'
+    )
+    path = tmp_path / "_run_journal" / "s2" / "r2.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(token.encode("utf-8"))
+        fh.write(oversized_boundary.encode("utf-8"))
+
+    full_events, _ = _read_jsonl(path)
+    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
+    tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
+    assert 2 not in full_seqs, "baseline: the malformed-nested-value record is invalid JSON"
+    assert 2 not in tail_seqs, (
+        f"the tail reader PROMOTED the brace-balanced-but-invalid oversized "
+        f"boundary record (malformed nested value) as terminal (tail_seqs={tail_seqs}); "
+        f"#6139 r10 item 2"
+    )
+    tail_promoted = any(e.get("_summary_extracted_from_oversized_record") for e in tail_events)
+    assert not tail_promoted, "the invalid boundary record was fabricated into a summary"
+    summary = __import__("api.run_journal", fromlist=["latest_run_summary"]).latest_run_summary(
+        "s2", "r2", session_dir=tmp_path
+    )
+    assert summary["terminal"] is False, (
+        f"latest_run_summary marked terminal={summary['terminal']} for an invalid "
+        f"(malformed-nested-value) oversized boundary record"
+    )
+    assert summary["terminal_state"] != "completed"

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -81,7 +81,7 @@ def test_read_jsonl_tail_returns_only_recent_rows(tmp_path):
         lines.append(json.dumps({"seq": i, "event": "token", "payload": {"i": i}}))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-    events, _malformed = _read_jsonl(path, max_rows=10, tail=True)
+    events, _malformed, _ok = _read_jsonl(path, max_rows=10, tail=True)
     # Newest 10 events retained (seq 90..99); older head events dropped.
     assert len(events) == 10
     assert [e["seq"] for e in events] == list(range(90, 100))
@@ -97,7 +97,7 @@ def test_read_jsonl_tail_respects_byte_cap(tmp_path):
     full_size = path.stat().st_size
     # Ask for the last ~10% of the file.
     cap = full_size // 10
-    events, _malformed = _read_jsonl(path, max_bytes=cap, tail=True)
+    events, _malformed, _ok = _read_jsonl(path, max_bytes=cap, tail=True)
     # The tail read returns only events within the byte window (bounded, not all
     # 1000). The LAST event is always included (it's within the window).
     assert len(events) < 1000
@@ -110,7 +110,7 @@ def test_read_jsonl_default_unbounded_still_works(tmp_path):
     path.write_text(
         "\n".join(json.dumps({"seq": i}) for i in range(5)) + "\n", encoding="utf-8"
     )
-    events, _mal = _read_jsonl(path)
+    events, _mal, _ok = _read_jsonl(path)
     assert [e["seq"] for e in events] == [0, 1, 2, 3, 4]
 
 
@@ -158,7 +158,7 @@ def test_read_jsonl_tail_line_numbers_correct_when_file_exceeds_cap(tmp_path):
     lines[malformed_real_line - 1] = "BROKEN_LINE_NOT_JSON"
     path.write_text("".join(l + "\n" for l in lines), encoding="utf-8")
 
-    events, malformed = _read_jsonl(path, max_bytes=2000, max_rows=10000, tail=True)
+    events, malformed, _ok = _read_jsonl(path, max_bytes=2000, max_rows=10000, tail=True)
     assert len(events) < 200  # head events dropped (bounded tail window)
     assert len(malformed) == 1
     # The reported line number must be the TRUE 1-based line, not a byte offset.
@@ -179,7 +179,7 @@ def test_read_jsonl_tail_line_numbers_correct_with_rows_cap(tmp_path):
 
     # Keep only the last 20 lines (file lines 81..100). The malformed line is
     # file line 91, so it stays in the kept window and must be reported as 91.
-    events, malformed = _read_jsonl(path, max_bytes=1 << 30, max_rows=20, tail=True)
+    events, malformed, _ok = _read_jsonl(path, max_bytes=1 << 30, max_rows=20, tail=True)
     assert len(events) <= 20
     assert len(malformed) == 1
     assert malformed[0]["line"] == 91, f"expected 91, got {malformed[0]['line']}"
@@ -192,7 +192,7 @@ def test_read_jsonl_tail_line_numbers_correct_no_seek(tmp_path):
     lines = [json.dumps({"seq": 0}), json.dumps({"seq": 1}), "BROKEN", json.dumps({"seq": 3})]
     path.write_text("".join(l + "\n" for l in lines), encoding="utf-8")
 
-    events, malformed = _read_jsonl(path, max_bytes=1 << 30, max_rows=100, tail=True)
+    events, malformed, _ok = _read_jsonl(path, max_bytes=1 << 30, max_rows=100, tail=True)
     assert len(events) == 3  # seq 0, 1, 3
     assert len(malformed) == 1
     assert malformed[0]["line"] == 3, f"expected 3, got {malformed[0]['line']}"
@@ -311,7 +311,8 @@ def _run_path_of(writer):
 
 def read_events_via_full_read(path):
     from api.run_journal import _read_jsonl
-    return _read_jsonl(path)
+    events, malformed, _ok = _read_jsonl(path)
+    return events, malformed
 
 
 def _summary_from_events_pub(session_id, run_id, events):
@@ -448,21 +449,27 @@ def test_bare_carriage_return_terminator_rejected(tmp_path):
 
 
 def test_preceding_event_recovery_is_bounded(tmp_path):
-    """Regression (reviewer round 5, updated r9): the preceding oversized record
-    must never be MATERIALIZED. Under r9 fail-closed (#6139 r9 item 2) an
-    oversized predecessor is SKIPPED entirely — its full-record JSON validity
-    cannot be proven without materializing the payload, so its fabricated prefix
-    is never trusted. The scan continues to the preceding normal-sized valid
-    event (recovered), proving the multi-MB payload was never parsed into a
-    Python object. An explicit budget large enough to scan PAST the oversized
-    record is passed so the skip is fail-closed (not a budget stop)."""
+    """Regression (reviewer round 5, updated r14): a VALID oversized predecessor
+    (complete, newline-terminated) is now READ and json.loads-ed DIRECTLY under
+    r14 finding 2, not blanket-skipped as under r9. The r9 invariant (never trust
+    an oversized record without full validation) is preserved by requiring json.loads
+    success — a malformed/invalid oversized predecessor still fails json.loads and
+    is skipped, continuing backward to the preceding valid event.
+
+    This test pins the VALID oversized predecessor case (round 5 regression target):
+    seq=2 is a valid JSON done record larger than _BOUNDARY_SUMMARY_PREFIX_BYTES.
+    Under r9 it was skipped (blanket fail-closed). Under r14 it is READ + json.loads-ed
+    and ACCEPTED as the last complete line (seq=2 recovered). The test budget is
+    sized to cover: 2 backward scans through seq=2 (~2x pred length), 1 full read of
+    seq=2 for json.loads (~1x pred length), and margin — so the scan can read the
+    oversized candidate and return it (not run out of budget before reaching it)."""
     import os
     from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path, _read_last_complete_line_before
 
     writer = RunJournalWriter("session_1", "run_bounded_preceding", session_dir=tmp_path)
     # seq=1: a normal-sized token (the recoverable preceding event).
     writer.append_sse_event("token", {"text": "ok"})
-    # seq=2: an oversized but COMPLETE done (with newline) — must be SKIPPED, not materialized.
+    # seq=2: an oversized but COMPLETE done (with newline) — VALID JSON, now READ directly.
     huge = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
     writer.append_sse_event("done", {"session": {"session_id": "session_1"}, **huge})
     path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
@@ -479,24 +486,29 @@ def test_preceding_event_recovery_is_bounded(tmp_path):
         size_pinned = os.fstat(fh.fileno()).st_size
         seek = size_pinned - min(size_pinned, _SESSION_REPLAY_MAX_BYTES)
         record_start = __import__("api.run_journal", fromlist=["_find_record_start_before"])._find_record_start_before(fh, size_pinned, seek)
-        # Budget large enough to scan PAST the oversized done (seq=2) to the token,
-        # so the skip is fail-closed rather than a budget stop.
+        # Budget sized to cover: 2 backward scans through seq=2 (~2x pred length),
+        # 1 full read of seq=2 for json.loads (~1x pred length), plus margin.
+        # 3x the oversized predecessor length + margin ensures the scan can
+        # read the oversized candidate and return it without budget exhaustion.
+        pred_size = _SESSION_REPLAY_MAX_BYTES + 100_000
         result = _read_last_complete_line_before(
-            fh, size_pinned, record_start, budget=_SESSION_REPLAY_MAX_BYTES + 200_000
+            fh, size_pinned, record_start, budget=3 * pred_size + 500_000
         )
-    # The oversized done (seq=2) is skipped (fail-closed); the token (seq=1) is recovered.
-    assert result is not None, "the normal-sized token (seq=1) must be recovered"
-    assert result.get("seq") == 1, (
-        f"expected seq=1 (the oversized done was skipped fail-closed); got seq={result.get('seq')}"
+    # The VALID oversized done (seq=2) is now READ and ACCEPTED (r14 finding 2).
+    assert result is not None, "the valid oversized done (seq=2) must be recovered"
+    assert result.get("seq") == 2, (
+        f"expected seq=2 (the valid oversized done is now read directly under r14); "
+        f"got seq={result.get('seq')}"
     )
-    assert result.get("event") == "token", "the recovered event is the token, not the oversized done"
-    # The oversized payload was never materialized: no fabricated-summary marker,
-    # and the token carries its real (small) payload, not the empty fabricated one.
+    assert result.get("event") == "done", "the recovered event is the done (seq=2), not the token"
+    # The oversized payload IS read into memory for json.loads (r14 changed this),
+    # but is NOT fabricated via a prefix-extraction path — no fabricated-summary marker.
     assert result.get("_summary_extracted_from_oversized_record") is None, (
-        "the oversized record's prefix was fabricated instead of being skipped (fail-closed)"
+        "the valid oversized record was read directly (json.loads), not fabricated via prefix"
     )
-    assert result.get("payload") == {"text": "ok"}, (
-        "the recovered token carries its real payload — the oversized done was skipped, not fabricated"
+    # The result carries the real session_id from the done, not a fabricated empty payload.
+    assert result.get("payload", {}).get("session", {}).get("session_id") == "session_1", (
+        "the recovered done carries its real payload — read directly, not fabricated"
     )
 
 
@@ -513,8 +525,8 @@ def test_ordinary_size_done_bare_cr_rejected_both_readers(tmp_path):
                         "terminal_state": "completed", "payload": {}})
     p = tmp_path / "bare_cr.jsonl"
     p.write_bytes((rec1 + "\n" + rec2 + "\r").encode("utf-8"))
-    ev_full, _ = _read_jsonl(p)
-    ev_tail, _ = _read_jsonl_tail(p, max_bytes=10000, max_rows=100)
+    ev_full, _, _ok = _read_jsonl(p)
+    ev_tail, _, _ok = _read_jsonl_tail(p, max_bytes=10000, max_rows=100)
     # Neither reader should accept the bare-\r-terminated done.
     assert not any(e.get("event") == "done" for e in ev_full), "FULL reader accepts bare \\r"
     assert not any(e.get("event") == "done" for e in ev_tail), "TAIL reader accepts bare \\r"
@@ -537,8 +549,8 @@ def test_ordinary_size_done_eof_no_newline_rejected_both_readers(tmp_path):
                         "terminal_state": "completed", "payload": {}})
     p = tmp_path / "eof_no_nl.jsonl"
     p.write_bytes((rec1 + "\n" + rec2).encode("utf-8"))
-    ev_full, _ = _read_jsonl(p)
-    ev_tail, _ = _read_jsonl_tail(p, max_bytes=10000, max_rows=100)
+    ev_full, _, _ok = _read_jsonl(p)
+    ev_tail, _, _ok = _read_jsonl_tail(p, max_bytes=10000, max_rows=100)
     assert not any(e.get("event") == "done" for e in ev_full), "FULL accepts EOF-no-newline"
     assert not any(e.get("event") == "done" for e in ev_tail), "TAIL accepts EOF-no-newline"
 
@@ -695,7 +707,7 @@ def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, mon
 
     # --- Part A: NON-VACUITY. A normal read recovers the straddling done's
     # summary (seq=2) — proving the boundary helpers actually fire.
-    events_normal, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    events_normal, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     seqs = {e.get("seq") for e in events_normal if isinstance(e, dict)}
     assert 2 in seqs, (
         f"the oversized done (seq=2) straddling summary must be recovered by the "
@@ -714,11 +726,13 @@ def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, mon
         open_calls["n"] += 1
         return real_open(self, *args, **kwargs)
 
-    def patched_find(fh, size, seek_pos, *, budget=None):
+    def patched_find(fh, size, seek_pos, *, budget=None, fault=None):
         boundary_calls["n"] += 1
         # Unlink the pinned file from under the open descriptor and raise — the
         # realistic single-open TOCTOU (fd invalidated mid-recovery, inside the
         # boundary scan that the old test never reached).
+        if fault is not None:
+            fault[0] = True  # the production helper sets the fault flag before raising
         try:
             path.unlink()
         except OSError:
@@ -728,10 +742,10 @@ def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, mon
     monkeypatch.setattr(Path, "open", patched_open)
     monkeypatch.setattr(run_journal, "_find_record_start_before", patched_find)
 
-    events, malformed = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
-    assert isinstance(events, list) and isinstance(malformed, list), (
-        f"_read_jsonl_tail must return a (list, list) safe fallback; got "
-        f"({type(events).__name__}, {type(malformed).__name__})"
+    events, malformed, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    assert isinstance(events, list) and isinstance(malformed, list) and isinstance(_ok, bool), (
+        f"_read_jsonl_tail must return a (list, list, bool) safe fallback; got "
+        f"({type(events).__name__}, {type(malformed).__name__}, {type(_ok).__name__})"
     )
     assert boundary_calls["n"] >= 1, (
         "the boundary helper _find_record_start_before was never reached — the "
@@ -805,7 +819,7 @@ def test_blank_line_before_oversized_partial_done_recovers_preceding_event(tmp_p
     find_summary = find_run_summary(run_id, session_dir=tmp_path)
 
     # Authoritative full read (the baseline: must match this).
-    full_events, _ = _read_jsonl(path)
+    full_events, _, _ok = _read_jsonl(path)
     authoritative = _summary_from_events(session_id, run_id, full_events)
 
     # Both tail readers must agree with the full reader.
@@ -923,7 +937,7 @@ def test_tail_read_uses_single_generation_under_delete_recreate(tmp_path, monkey
 
     monkeypatch.setattr(Path, "open", generation_pinned_open)
 
-    events, _malformed = _read_jsonl_tail(path, max_bytes=cap, max_rows=4096)
+    events, _malformed, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=4096)
     seqs = [e.get("seq") for e in events if isinstance(e, dict) and "seq" in e]
 
     # The journal must be opened exactly ONCE (single-generation contract).
@@ -1002,7 +1016,7 @@ def test_invalid_predecessor_rows_skipped_until_valid_event(tmp_path, monkeypatc
 
     tail_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
     find_summary = find_run_summary(run_id, session_dir=tmp_path)
-    full_events, _ = _read_jsonl(path)
+    full_events, _, _ok = _read_jsonl(path)
     authoritative = _summary_from_events(session_id, run_id, full_events)
 
     # Both tail readers recover the valid token (seq=1), agreeing with the full reader.
@@ -1026,14 +1040,20 @@ def test_invalid_predecessor_rows_skipped_until_valid_event(tmp_path, monkeypatc
 
 
 def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_path):
-    """Regression (reviewer round 8, updated r9): under r9 fail-closed (#6139 r9
-    item 2) EVERY oversized predecessor is skipped — its full-record JSON
-    validity cannot be proven without materializing the payload, so the
-    fabricated prefix is never trusted, regardless of whether the oversized row
-    is brace-balanced, structurally complete, or malformed. This test pins the
-    malformed case (the round-8 regression target): the predecessor is an
-    oversized structurally-INCOMPLETE record, but it must be skipped for the r9
-    reason (oversized), not accepted.
+    """Regression (reviewer round 8, updated r14): under r14 finding 2, oversized
+    predecessors are READ and json.loads-ed DIRECTLY, not blanket-skipped as
+    under r9. The r9 invariant (never trust an oversized record without full
+    validation) is preserved by requiring json.loads success — a malformed/
+    invalid oversized predecessor FAILS json.loads and is skipped, continuing
+    backward to the preceding valid event.
+
+    This test pins the malformed case (the round-8 regression target): the
+    predecessor is an oversized structurally-INCOMPLETE record (newline-terminated
+    but no closing brace — truncated mid-payload value). Under r9 it was skipped
+    for being oversized. Under r14 it is READ for json.loads and FAILS → skipped,
+    recovering token(seq=1). The MECHANISM changed (blanket-skip-by-size →
+    read-and-parse, skip-on-parse-failure), but the BEHAVIOR is the same:
+    malformed/invalid oversized predecessors are never trusted.
 
     Journal shape:
         token(seq=1)
@@ -1041,10 +1061,10 @@ def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_
          incomplete (no closing brace — truncated mid-payload value)>
         <oversized partial done seq=3: the crash-truncated boundary, no newline>
 
-    The scan for the predecessor of seq=3 hits the oversized seq=2 row first.
-    Under r9 fail-closed it skips seq=2 (oversized → untrustworthy) and recovers
-    token(seq=1). The budget is sized to scan PAST the oversized predecessor's
-    bytes so the skip is fail-closed (not a budget stop)."""
+    The scan for the predecessor of seq=3 hits the oversized seq=2 row first,
+    reads it for json.loads, the parse fails → skips → recovers token(seq=1).
+    The budget must cover: 2 backward scans through seq=2 (~2x pred length),
+    1 read of seq=2 for json.loads (~1x pred length), and 1 read of seq=1 (~50 B)."""
     import os
     from api.run_journal import (
         _SESSION_REPLAY_MAX_BYTES,
@@ -1081,19 +1101,22 @@ def test_oversized_malformed_predecessor_not_accepted_via_fabricated_prefix(tmp_
     final_start = len(token_bytes) + len(pred_bytes)
     with path.open("rb") as fh:
         size = os.fstat(fh.fileno()).st_size
-        # Budget sized to scan PAST the oversized predecessor's bytes (two
-        # backward newline scans through ~cap+1000 bytes each) so the skip is
-        # fail-closed rather than a budget stop. The token line parse adds ~50 B.
+        # Budget sized to cover: 2 backward scans through the oversized predecessor
+        # (~2x pred length), 1 read of the oversized predecessor for json.loads
+        # (~1x pred length), and 1 read of the small token line (~50 B) plus margin.
+        # 3x the oversized predecessor length ensures the scan can read it,
+        # fail json.loads, and continue to seq=1 without budget exhaustion.
         result = _read_last_complete_line_before(
-            fh, size, final_start, budget=2 * (cap + 1000) + 10_000
+            fh, size, final_start, budget=3 * (cap + 1000) + 20_000
         )
 
-    # The oversized malformed predecessor (seq=2) must be SKIPPED (fail-closed);
-    # the valid token (seq=1) is recovered — never the fabricated terminal done.
+    # The oversized malformed predecessor (seq=2) FAILS json.loads → skipped;
+    # the valid token (seq=1) is recovered — never a fabricated terminal done.
     assert result is not None, "the valid token (seq=1) must be recovered"
     assert result.get("seq") == 1, (
-        f"expected seq=1 (the oversized row was skipped fail-closed); got "
-        f"seq={result.get('seq')} — the oversized predecessor was trusted instead of skipped"
+        f"expected seq=1 (the malformed oversized predecessor failed json.loads and "
+        f"was skipped); got seq={result.get('seq')} — the malformed predecessor was "
+        f"incorrectly accepted"
     )
     assert not result.get("terminal"), (
         "a non-terminal token must be recovered, not a fabricated terminal done"
@@ -1255,16 +1278,18 @@ def test_backward_scan_budget_bounds_physical_descriptor_reads(tmp_path):
 
 
 def test_balanced_invalid_oversized_predecessor_skipped_trailing_comma(tmp_path):
-    """Regression (reviewer round 9, item 2): a brace-balanced, newline-
-    terminated oversized row that is INVALID JSON (trailing comma here; see the
-    companion test for a malformed nested value) must NOT be promoted into a
-    fabricated terminal summary. Brace balance is necessary but not sufficient
-    for JSON validity.
+    """Regression (reviewer round 9, item 2, updated r14): a brace-balanced,
+    newline-terminated oversized row that is INVALID JSON (trailing comma here;
+    see the companion test for a malformed nested value) must NOT be promoted
+    into a fabricated terminal summary. Brace balance is necessary but not
+    sufficient for JSON validity.
 
-    Under r9 fail-closed, EVERY oversized predecessor is skipped (its full-
-    record validity cannot be proven without materializing the payload), so the
-    balanced-invalid row is skipped and the preceding valid token (seq=1) is
-    recovered — never the fabricated terminal seq=2."""
+    Under r14 finding 2, oversized predecessors are READ and json.loads-ed
+    DIRECTLY. A balanced-but-invalid row FAILS json.loads and is skipped,
+    recovering the preceding valid token (seq=1). The r9 invariant (never trust
+    a malformed/invalid oversized predecessor) is preserved; the MECHANISM changed
+    from blanket-skip-by-size to read-and-parse-skip-on-parse-failure. This test
+    pins the trailing-comma invalid case (brace-balanced but JSON invalid)."""
     import os
     from api.run_journal import (
         _BOUNDARY_SUMMARY_PREFIX_BYTES,
@@ -1281,7 +1306,7 @@ def test_balanced_invalid_oversized_predecessor_skipped_trailing_comma(tmp_path)
     token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
     # Oversized predecessor: brace-balanced + newline-terminated but INVALID JSON
     # (trailing comma after the payload value). Its head fabricates a terminal
-    # 'done/seq=2' prefix via _extract_boundary_record_summary.
+    # 'done/seq=2' prefix via _extract_boundary_record_summary, but json.loads FAILS.
     oversized_pred = (
         '{"seq":2,"event":"done","terminal":true,'
         '"terminal_state":"completed","payload":{"t":"' + big + '"},}\n'
@@ -1301,16 +1326,19 @@ def test_balanced_invalid_oversized_predecessor_skipped_trailing_comma(tmp_path)
     final_start = len(token_bytes) + len(pred_bytes)
     with path.open("rb") as fh:
         size = os.fstat(fh.fileno()).st_size
-        # Budget sized to scan PAST the oversized predecessor's bytes so the
-        # skip is fail-closed (not a budget stop).
+        # Budget sized to cover: 2 backward scans through the oversized predecessor
+        # (~2x pred length), 1 read of the oversized predecessor for json.loads
+        # (~1x pred length), and 1 read of the small token line (~50 B) plus margin.
+        # 4x the oversized predecessor length ensures the scan can read it,
+        # fail json.loads, and continue to seq=1 without budget exhaustion.
         result = _read_last_complete_line_before(
-            fh, size, final_start, budget=2 * len(pred_bytes) + 10_000
+            fh, size, final_start, budget=4 * len(pred_bytes) + 10_000
         )
 
     assert result is not None, "the valid token (seq=1) must be recovered"
     assert result.get("seq") == 1, (
-        f"expected seq=1 (the trailing-comma oversized row was skipped "
-        f"fail-closed); got seq={result.get('seq')} — the fabricated terminal "
+        f"expected seq=1 (the trailing-comma oversized row failed json.loads and "
+        f"was skipped); got seq={result.get('seq')} — the fabricated terminal "
         f"prefix was accepted as if the brace-balanced-but-invalid row were valid JSON"
     )
     assert not result.get("terminal"), (
@@ -1320,9 +1348,12 @@ def test_balanced_invalid_oversized_predecessor_skipped_trailing_comma(tmp_path)
 
 def test_balanced_invalid_oversized_predecessor_skipped_malformed_nested_value(tmp_path):
     """Companion to test_balanced_invalid_oversized_predecessor_skipped_trailing_comma
-    (reviewer round 9, item 2): a brace-balanced, newline-terminated oversized row
-    that is invalid JSON due to a malformed nested value (unquoted nested key) —
-    also skipped fail-closed under r9, recovering the preceding valid token."""
+    (reviewer round 9, item 2, updated r14): a brace-balanced, newline-terminated
+    oversized row that is invalid JSON due to a malformed nested value (unquoted
+    nested key) is also READ and json.loads-ed under r14. The parse FAILS →
+    skipped → recovers the preceding valid token (seq=1). The r9 invariant
+    (never trust a malformed/invalid oversized predecessor) is preserved; the
+    MECHANISM changed from blanket-skip-by-size to read-and-parse-skip-on-parse-failure."""
     import os
     from api.run_journal import (
         _BOUNDARY_SUMMARY_PREFIX_BYTES,
@@ -1357,14 +1388,19 @@ def test_balanced_invalid_oversized_predecessor_skipped_malformed_nested_value(t
     final_start = len(token_bytes) + len(pred_bytes)
     with path.open("rb") as fh:
         size = os.fstat(fh.fileno()).st_size
+        # Budget sized to cover: 2 backward scans through the oversized predecessor
+        # (~2x pred length), 1 read of the oversized predecessor for json.loads
+        # (~1x pred length), and 1 read of the small token line (~50 B) plus margin.
+        # 4x the oversized predecessor length ensures the scan can read it,
+        # fail json.loads, and continue to seq=1 without budget exhaustion.
         result = _read_last_complete_line_before(
-            fh, size, final_start, budget=2 * len(pred_bytes) + 10_000
+            fh, size, final_start, budget=4 * len(pred_bytes) + 10_000
         )
 
     assert result is not None, "the valid token (seq=1) must be recovered"
     assert result.get("seq") == 1, (
-        f"expected seq=1 (the malformed-nested-value oversized row was skipped "
-        f"fail-closed); got seq={result.get('seq')} — the fabricated terminal "
+        f"expected seq=1 (the malformed-nested-value oversized row failed json.loads "
+        f"and was skipped); got seq={result.get('seq')} — the fabricated terminal "
         f"prefix was accepted as if the brace-balanced-but-invalid row were valid JSON"
     )
     assert not result.get("terminal"), (
@@ -1419,20 +1455,20 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
     real_extract = run_journal._extract_boundary_record_summary
     real_valid = run_journal._record_is_valid_complete
 
-    def patched_find(fh, size, seek_pos, *, budget=None):
+    def patched_find(fh, size, seek_pos, *, budget=None, fault=None):
         if budget is not None:
             budget_ids_seen["find"].append(id(budget))
-        return real_find(fh, size, seek_pos, budget=budget)
+        return real_find(fh, size, seek_pos, budget=budget, fault=fault)
 
-    def patched_extract(fh, record_start, *, budget=None):
+    def patched_extract(fh, record_start, *, budget=None, fault=None):
         if budget is not None:
             budget_ids_seen["extract"].append(id(budget))
-        return real_extract(fh, record_start, budget=budget)
+        return real_extract(fh, record_start, budget=budget, fault=fault)
 
-    def patched_valid(fh, size, record_start, *, budget=None):
+    def patched_valid(fh, size, record_start, *, budget=None, fault=None):
         if budget is not None:
             budget_ids_seen["valid"].append(id(budget))
-        return real_valid(fh, size, record_start, budget=budget)
+        return real_valid(fh, size, record_start, budget=budget, fault=fault)
 
     monkeypatch.setattr(run_journal, "_find_record_start_before", patched_find)
     monkeypatch.setattr(run_journal, "_extract_boundary_record_summary", patched_extract)
@@ -1466,7 +1502,7 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
         return real
 
     monkeypatch.setattr(Path, "open", patched_open)
-    events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
 
     # (a) Non-vacuity: the boundary helpers ran and recovered seq=2.
     seqs = {e.get("seq") for e in events if isinstance(e, dict)}
@@ -1545,8 +1581,8 @@ def test_balanced_invalid_oversized_boundary_record_trailing_comma(tmp_path):
         fh.write(token.encode("utf-8"))
         fh.write(oversized_boundary.encode("utf-8"))
 
-    full_events, _ = _read_jsonl(path)
-    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    full_events, _, _ok = _read_jsonl(path)
+    tail_events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
     tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
     assert 2 not in full_seqs, "baseline: the trailing-comma record is invalid JSON (full reader rejects it)"
@@ -1597,8 +1633,8 @@ def test_balanced_invalid_oversized_boundary_record_malformed_nested_value(tmp_p
         fh.write(token.encode("utf-8"))
         fh.write(oversized_boundary.encode("utf-8"))
 
-    full_events, _ = _read_jsonl(path)
-    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    full_events, _, _ok = _read_jsonl(path)
+    tail_events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
     tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
     assert 2 not in full_seqs, "baseline: the malformed-nested-value record is invalid JSON"
@@ -1779,14 +1815,14 @@ def test_predecessor_recovery_not_starved_by_validity_proof_budget(tmp_path):
     assert path.stat().st_size > cap, "sanity: the journal must exceed the tail window"
 
     # Ground truth: the full reader keeps the valid done (seq=1) + trailing token.
-    full_events, _ = _read_jsonl(path)
+    full_events, _, _ok = _read_jsonl(path)
     full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
     assert 1 in full_seqs and 2 not in full_seqs and 3 in full_seqs, (
         f"baseline: full reader keeps seq=1 (valid done) + seq=3 (token), rejects "
         f"seq=2 (invalid); got {full_seqs}"
     )
 
-    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    tail_events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
     assert 1 in tail_seqs, (
         f"the preceding valid terminal (seq=1) was NOT recovered under a "
@@ -1877,7 +1913,7 @@ def test_malformed_oversized_boundary_extraction_none_recovers_preceding(tmp_pat
 
     # (2) Ground truth: the full reader keeps the valid done (seq=1) + trailing
     # token (seq=3) and rejects the malformed seq=2.
-    full_events, _ = _read_jsonl(path)
+    full_events, _, _ok = _read_jsonl(path)
     full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
     assert full_seqs == {1, 3}, (
         f"baseline: full reader keeps seq=1 (valid done) + seq=3 (token), rejects "
@@ -1890,11 +1926,11 @@ def test_malformed_oversized_boundary_extraction_none_recovers_preceding(tmp_pat
     recovery_calls = {"n": 0, "budgets": []}
     real_recovery = run_journal._read_last_complete_line_before
 
-    # The real signature is (fh, size_arg, end_offset, *, budget). Patch carefully:
-    def patched_recovery_real(fh, size_arg, end_offset, *, budget=None):
+    # The real signature is (fh, size_arg, end_offset, *, budget, fault). Patch carefully:
+    def patched_recovery_real(fh, size_arg, end_offset, *, budget=None, fault=None):
         recovery_calls["n"] += 1
         recovery_calls["budgets"].append(budget)
-        return real_recovery(fh, size_arg, end_offset, budget=budget)
+        return real_recovery(fh, size_arg, end_offset, budget=budget, fault=fault)
 
     monkeypatch.setattr(run_journal, "_read_last_complete_line_before", patched_recovery_real)
 
@@ -1911,7 +1947,7 @@ def test_malformed_oversized_boundary_extraction_none_recovers_preceding(tmp_pat
 
     # (4) The tail reader must keep seq=1 (recovered predecessor) and exclude
     # seq=2, matching the full reader.
-    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    tail_events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
     assert tail_seqs == {1, 3}, (
         f"the tail reader diverged from the full reader: tail_seqs={tail_seqs} "
@@ -2038,7 +2074,7 @@ def _assert_valid_oversized_boundary_accepted(tmp_path, *, record_size_multiple,
     )
 
     # Ground truth: the full reader sees the tool_limit_reached done.
-    full_events, _ = _read_jsonl(path)
+    full_events, _, _ok = _read_jsonl(path)
     full_seqs = [e.get("seq") for e in full_events]
     assert full_seqs == expected_seqs_full, (
         f"baseline: full reader seqs {full_seqs} (expected {expected_seqs_full})"
@@ -2054,7 +2090,7 @@ def _assert_valid_oversized_boundary_accepted(tmp_path, *, record_size_multiple,
     # records (when present) follow it. Assert the EXACT ordered tail sequence:
     # a reordered tail ([3, 2, 4]), a duplicate boundary summary, or an unexpected
     # extra row must all fail this — not merely "seq 2 is present somewhere".
-    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    tail_events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
     tail_seqs = [e.get("seq") for e in tail_events]
     expected_tail_seqs = [2, 3, 4] if with_trailing else [2]
     assert tail_seqs == expected_tail_seqs, (
@@ -2135,4 +2171,178 @@ def test_valid_oversized_boundary_near_2x_cap_before_metering_stream_end(tmp_pat
     accepted."""
     _assert_valid_oversized_boundary_accepted(
         tmp_path, record_size_multiple=1.95, with_trailing=True
+    )
+
+
+def test_valid_oversized_boundary_above_ceiling_as_final_row(tmp_path):
+    """Regression (reviewer round 14, finding 1): a VALID terminal ``done`` ABOVE
+    the ``_VALIDITY_PROOF_MAX_BYTES`` ceiling (2x cap = 8 MiB) as the final row
+    must be ACCEPTED, not discarded. Under r13 the validity proof capped its scan
+    at the ceiling, so a valid >8 MiB record couldn't reach its newline terminator
+    → fail-closed → valid terminal rejected → (1, False, running) vs full reader
+    (2, True, tool_limit_reached). The r14 fix adds tier 2 (streaming depth scan)
+    and raises the boundary budget to 4x cap. This exercises tier 2 (2.4x cap =
+    ~9.6 MiB, above the 8 MiB ceiling)."""
+    _assert_valid_oversized_boundary_accepted(
+        tmp_path, record_size_multiple=2.4, with_trailing=False
+    )
+
+
+def test_valid_oversized_boundary_above_ceiling_before_metering_stream_end(tmp_path):
+    """Regression (reviewer round 14, finding 1): a VALID terminal ``done`` above
+    the ceiling followed by ``metering`` → ``stream_end`` must be accepted. This is
+    the production order with an above-ceiling transcript payload."""
+    _assert_valid_oversized_boundary_accepted(
+        tmp_path, record_size_multiple=2.4, with_trailing=True
+    )
+
+
+def test_oversized_valid_predecessor_recovered_no_event_id_collision(tmp_path):
+    """Regression (reviewer round 14, finding 2): a VALID predecessor larger than
+    ``_BOUNDARY_SUMMARY_PREFIX_BYTES`` (8 KiB) must be RECOVERED, not blanket-skipped.
+    Under r9-r13, ``_read_last_complete_line_before`` skipped any line > 8 KiB as
+    "oversized fail-closed", dropping a valid 20 KiB ``tool_complete`` predecessor.
+    That made ``latest_run_summary`` report a stale ``last_seq`` (1 instead of 2),
+    so ``stale_interrupted_event`` synthesized ``event_id = f"{run_id}:{last_seq+1}"
+    = "r1:2"`` — COLLIDING with the real seq-2 event's id ("r1:2").
+
+    The r14 fix reads + json.loads-es the complete predecessor line directly
+    (charging the budget). The valid 20 KiB predecessor is recovered (last_seq=2),
+    so ``stale_interrupted_event`` synthesizes "r1:3" (no collision).
+
+    Layout: valid token seq=1, valid 20 KiB tool_complete seq=2, crash-truncated
+    oversized done seq=3 (no newline — the boundary). The tail reader must keep
+    seq=2 (last_seq=2), and the synthesized recovery id must NOT be "r1:2"."""
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _read_jsonl,
+        latest_run_summary,
+    )
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    valid_token = '{"seq":1,"event":"token","payload":{"t":"a"}}\n'
+    # A 20 KiB VALID tool_complete — larger than the 8 KiB prefix allowance but a
+    # complete, parseable line (not oversized-payload like a done transcript).
+    big_output = "Q" * 20_000
+    valid_tool_complete = (
+        '{"seq":2,"event":"tool_complete","payload":{"output":"' + big_output + '"}}\n'
+    )
+    assert len(valid_tool_complete) > 8192, "fixture: predecessor must exceed the 8 KiB prefix allowance"
+    # Crash-truncated oversized done (no close/newline) — the boundary record.
+    big_done = "X" * (cap + 50_000)
+    truncated_done = (
+        '{"seq":3,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big_done + '"'
+    )
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(valid_token.encode("utf-8"))
+        fh.write(valid_tool_complete.encode("utf-8"))
+        fh.write(truncated_done.encode("utf-8"))
+    assert path.stat().st_size > cap, "sanity: the journal must exceed the tail window"
+
+    # Ground truth: the full reader keeps seq=1 + seq=2 (both valid), rejects seq=3 (truncated).
+    full_events, _, _ = _read_jsonl(path)
+    full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
+    assert full_seqs == {1, 2}, f"baseline: full reader keeps seq 1 and 2; got {full_seqs}"
+
+    # The tail reader must recover seq=2 (the 20 KiB valid predecessor), NOT skip it.
+    summary = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert summary["last_seq"] == 2, (
+        f"the valid 20 KiB predecessor (seq=2) was dropped (last_seq={summary['last_seq']}); "
+        f"r14 finding 2: a complete predecessor >8 KiB must be read + parsed, not blanket-skipped"
+    )
+
+    # stale_interrupted_event computes event_id = f"{run_id}:{last_seq + 1}". With
+    # last_seq=2 it synthesizes "r1:3"; under the r13 bug (last_seq=1) "r1:2" collides.
+    real_seq2_id = "r1:2"
+    synth_id = f"r1:{summary['last_seq'] + 1}"
+    assert synth_id != real_seq2_id, (
+        f"stale_interrupted_event would synthesize event_id={synth_id!r} which COLLIDES "
+        f"with the real seq-2 event id {real_seq2_id!r}; the valid 20 KiB predecessor "
+        f"was dropped so last_seq undercounted (#6139 r14 finding 2)"
+    )
+    assert synth_id == "r1:3", (
+        f"expected synthesized id 'r1:3' (last_seq=2 + 1); got {synth_id!r}"
+    )
+
+
+def test_transient_oserror_not_cached_retry_recovers(tmp_path, monkeypatch):
+    """Regression (reviewer round 14, finding 3): a transient OSError during the
+    boundary scan must NOT be cached as authoritative. Under r13 the failed
+    best-effort summary was cached under the matching inode signature, so the
+    second ``latest_run_summary`` / ``find_run_summary`` call returned the stale
+    failure instead of retrying — a completed run stayed ``unknown``. Frozen master
+    (no cache) propagates and recovers.
+
+    The r14 fix threads an ``ok`` flag from ``_read_jsonl_tail``; the summary
+    readers skip ``_cache_summary`` when ``ok=False``, so the next call retries.
+    This injects a one-shot OSError in the boundary validity helper, asserts the
+    first call returns best-effort (unknown), the cache stays empty, and the second
+    call (no fault) recovers ``completed`` via a fresh read."""
+    from api import run_journal
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, latest_run_summary
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    # A completed journal with a boundary-straddling oversized done so the boundary
+    # helpers run (and the fault is reachable).
+    head = '{"seq":1,"event":"token","payload":{"t":"head"}}\n'
+    big = "Z" * (cap + 50_000)
+    done = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '"}}\n'
+    )
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(head.encode("utf-8"))
+        fh.write(done.encode("utf-8"))
+
+    # Baseline: the run is completed.
+    run_journal._SUMMARY_CACHE.clear()
+    baseline = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert baseline["terminal_state"] == "completed", (
+        f"baseline sanity: expected completed, got {baseline['terminal_state']!r}"
+    )
+
+    # Inject a one-shot OSError in the validity helper on the FIRST call after
+    # clearing the cache. The fault flag must be set so ok=False propagates.
+    run_journal._SUMMARY_CACHE.clear()
+    real_valid = run_journal._record_is_valid_complete
+    calls = {"n": 0}
+
+    def patched_valid(fh, size, record_start, *, budget=None, fault=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            if fault is not None:
+                fault[0] = True  # match the production helper's fault-flag contract
+            raise OSError("simulated one-shot EIO during boundary scan")
+        return real_valid(fh, size, record_start, budget=budget, fault=fault)
+
+    monkeypatch.setattr(run_journal, "_record_is_valid_complete", patched_valid)
+
+    # First call (fault): best-effort result, NOT cached.
+    first = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert first["terminal_state"] != "completed", (
+        f"first call (during fault) reported {first['terminal_state']!r}; the "
+        f"transient OSError should have produced a best-effort non-completed result"
+    )
+    # The cache must be EMPTY: the failed read must not be cached.
+    assert str(path) not in run_journal._SUMMARY_CACHE, (
+        "the transient-OSError failed summary was cached as authoritative; the "
+        "next call would return the stale failure instead of retrying (#6139 r14 finding 3)"
+    )
+
+    # Second call (no fault): the validity helper is called again and the read
+    # recovers completed.
+    second = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert second["terminal_state"] == "completed", (
+        f"second call (no fault) reported {second['terminal_state']!r} (expected "
+        f"'completed'); the transient OSError was cached and the retry did not happen "
+        f"(#6139 r14 finding 3)"
+    )
+    assert calls["n"] >= 2, (
+        f"the validity helper was called {calls['n']} time(s) across both calls "
+        f"(expected >= 2); the second call did not retry the read"
     )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -449,27 +449,28 @@ def test_bare_carriage_return_terminator_rejected(tmp_path):
 
 
 def test_preceding_event_recovery_is_bounded(tmp_path):
-    """Regression (reviewer round 5, updated r14): a VALID oversized predecessor
-    (complete, newline-terminated) is now READ and json.loads-ed DIRECTLY under
-    r14 finding 2, not blanket-skipped as under r9. The r9 invariant (never trust
-    an oversized record without full validation) is preserved by requiring json.loads
-    success — a malformed/invalid oversized predecessor still fails json.loads and
-    is skipped, continuing backward to the preceding valid event.
+    """Regression (reviewer round 5, updated r15): a VALID oversized predecessor
+    (complete, newline-terminated) is RECOVERED via compact prefix-summary + streaming
+    grammar validation, not blanket-skipped as under r9 and not full-line-materialized
+    as under r14. The r9 invariant (never trust an oversized record without full
+    validation) is preserved by the streaming JSON validator — a malformed/invalid
+    oversized predecessor fails the grammar scan and is skipped, continuing backward.
 
     This test pins the VALID oversized predecessor case (round 5 regression target):
     seq=2 is a valid JSON done record larger than _BOUNDARY_SUMMARY_PREFIX_BYTES.
-    Under r9 it was skipped (blanket fail-closed). Under r14 it is READ + json.loads-ed
-    and ACCEPTED as the last complete line (seq=2 recovered). The test budget is
-    sized to cover: 2 backward scans through seq=2 (~2x pred length), 1 full read of
-    seq=2 for json.loads (~1x pred length), and margin — so the scan can read the
-    oversized candidate and return it (not run out of budget before reaching it)."""
+    Under r9 it was skipped (blanket fail-closed). Under r15 it is recovered via a
+    bounded prefix (summary fields live before "payload") + a streaming grammar pass
+    over the whole line — so seq=2 is recovered and its summary fields are correct.
+    The payload is discarded (the recovery only needs summary fields), so the marker
+    _summary_extracted_from_oversized_record is set."""
     import os
     from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path, _read_last_complete_line_before
 
     writer = RunJournalWriter("session_1", "run_bounded_preceding", session_dir=tmp_path)
     # seq=1: a normal-sized token (the recoverable preceding event).
     writer.append_sse_event("token", {"text": "ok"})
-    # seq=2: an oversized but COMPLETE done (with newline) — VALID JSON, now READ directly.
+    # seq=2: an oversized but COMPLETE done (with newline) — VALID JSON, recovered
+    # via prefix-summary under r15 (summary fields extracted from the 8 KiB prefix).
     huge = {"text": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)}
     writer.append_sse_event("done", {"session": {"session_id": "session_1"}, **huge})
     path = _run_path(writer.session_id, writer.run_id, session_dir=writer.session_dir)
@@ -486,29 +487,31 @@ def test_preceding_event_recovery_is_bounded(tmp_path):
         size_pinned = os.fstat(fh.fileno()).st_size
         seek = size_pinned - min(size_pinned, _SESSION_REPLAY_MAX_BYTES)
         record_start = __import__("api.run_journal", fromlist=["_find_record_start_before"])._find_record_start_before(fh, size_pinned, seek)
-        # Budget sized to cover: 2 backward scans through seq=2 (~2x pred length),
-        # 1 full read of seq=2 for json.loads (~1x pred length), plus margin.
-        # 3x the oversized predecessor length + margin ensures the scan can
-        # read the oversized candidate and return it without budget exhaustion.
+        # Budget generously covers: backward newline scans, the prefix read, and the
+        # streaming grammar pass over seq=2 (which scans the whole line but in bounded
+        # memory). r15 uses ONE shared budget for the whole predecessor scan.
         pred_size = _SESSION_REPLAY_MAX_BYTES + 100_000
         result = _read_last_complete_line_before(
             fh, size_pinned, record_start, budget=3 * pred_size + 500_000
         )
-    # The VALID oversized done (seq=2) is now READ and ACCEPTED (r14 finding 2).
+    # The VALID oversized done (seq=2) is RECOVERED via prefix-summary (r15).
     assert result is not None, "the valid oversized done (seq=2) must be recovered"
     assert result.get("seq") == 2, (
-        f"expected seq=2 (the valid oversized done is now read directly under r14); "
+        f"expected seq=2 (the valid oversized done is recovered under r15); "
         f"got seq={result.get('seq')}"
     )
     assert result.get("event") == "done", "the recovered event is the done (seq=2), not the token"
-    # The oversized payload IS read into memory for json.loads (r14 changed this),
-    # but is NOT fabricated via a prefix-extraction path — no fabricated-summary marker.
-    assert result.get("_summary_extracted_from_oversized_record") is None, (
-        "the valid oversized record was read directly (json.loads), not fabricated via prefix"
+    assert result.get("terminal_state") == "completed", (
+        "the recovered done's terminal_state must be correct (summary fields survive)"
     )
-    # The result carries the real session_id from the done, not a fabricated empty payload.
-    assert result.get("payload", {}).get("session", {}).get("session_id") == "session_1", (
-        "the recovered done carries its real payload — read directly, not fabricated"
+    # Under r15 the oversized payload is DISCARDED (recovery needs only summary
+    # fields); the marker is set to signal the payload was not materialized.
+    assert result.get("_summary_extracted_from_oversized_record") is True, (
+        "the valid oversized predecessor's payload was discarded via prefix-summary "
+        "extraction (r15); the marker must be set"
+    )
+    assert result.get("payload") == {}, (
+        "the oversized payload is replaced with {} under r15 prefix-summary recovery"
     )
 
 
@@ -1409,9 +1412,9 @@ def test_balanced_invalid_oversized_predecessor_skipped_malformed_nested_value(t
 
 
 def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhaustion(tmp_path, monkeypatch):
-    """Regression (reviewer round 10, item 1): the PRODUCTION boundary path in
-    ``_read_jsonl_tail`` must use ONE shared ``_ReadBudget`` across boundary
-    lookup, prefix extraction, validity proof, and the backward predecessor
+    """Regression (reviewer round 10, item 1, updated r15): the PRODUCTION boundary
+    path in ``_read_jsonl_tail`` must use ONE shared ``_ReadBudget`` across boundary
+    lookup, prefix extraction, streaming validity, and the backward predecessor
     scan — so physical I/O is bounded and NO read occurs after exhaustion.
 
     The r9 physical-budget test only covered ``_read_last_complete_line_before``
@@ -1420,21 +1423,28 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
     the PRODUCTION reader end-to-end and asserts:
       (a) the boundary helpers are reached (the straddling seq=2 is recovered);
       (b) the SAME ``_ReadBudget`` instance is threaded through boundary lookup,
-          prefix extraction, validity proof, AND the predecessor scan (the
-          helpers receive a non-None budget, all with one shared id);
+          prefix extraction, AND the streaming validity proof (the helpers receive
+          a non-None budget, all with one shared id);
       (c) physical reads are bounded by the shared budget envelope.
 
     (b) is the discrimination the r9 test lacked: it proves the budget is
     SHARED, not just that the bytes happen to be bounded by a ceiling constant.
-    A mutation that passes ``budget=None`` to any helper (the r9 bug) fails (b)."""
+    A mutation that passes ``budget=None`` to any helper (the r9 bug) fails (b).
+
+    r15 note: the r13 design used SEPARATE meters (lookup+prefix shared, validity
+    distinct, predecessor distinct) to avoid starvation under a fixed validity
+    ceiling. r15 removes the ceiling entirely (streaming validation stops at the
+    record's actual end), so ONE shared budget is correct again — there is no
+    ceiling to starve against. This assertion was updated from "validity has its
+    OWN meter" (r13) to "validity shares the SAME meter" (r15)."""
     from pathlib import Path
     from api import run_journal
     from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl_tail
 
     cap = _SESSION_REPLAY_MAX_BYTES
     token_line = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
-    # A VALID oversized done: the validity proof returns True, exercising the
-    # boundary lookup + prefix extraction + validity helpers on the happy path.
+    # A VALID oversized done: the streaming validity returns True, exercising the
+    # boundary lookup + prefix extraction + streaming validity helpers on the happy path.
     oversized_done = (
         '{"seq":2,"event":"done","terminal":true,'
         '"terminal_state":"completed","payload":{"t":"'
@@ -1448,12 +1458,12 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
         fh.write(oversized_done.encode("utf-8"))
     assert path.stat().st_size > cap
 
-    # Instrument the four boundary helpers to record whether a non-None budget
+    # Instrument the boundary helpers to record whether a non-None budget
     # was passed and its id(). The SAME id must appear across all of them.
     budget_ids_seen = {"find": [], "extract": [], "valid": []}
     real_find = run_journal._find_record_start_before
     real_extract = run_journal._extract_boundary_record_summary
-    real_valid = run_journal._record_is_valid_complete
+    real_valid = run_journal._record_is_valid_jsonl
 
     def patched_find(fh, size, seek_pos, *, budget=None, fault=None):
         if budget is not None:
@@ -1472,7 +1482,7 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
 
     monkeypatch.setattr(run_journal, "_find_record_start_before", patched_find)
     monkeypatch.setattr(run_journal, "_extract_boundary_record_summary", patched_extract)
-    monkeypatch.setattr(run_journal, "_record_is_valid_complete", patched_valid)
+    monkeypatch.setattr(run_journal, "_record_is_valid_jsonl", patched_valid)
 
     # Also count physical reads via the handle.
     real_open = Path.open
@@ -1510,49 +1520,52 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
         f"the boundary helpers must have run (seq=2 recovered); got {seqs}. "
         f"If absent the test is vacuous."
     )
-    # (b) The SAME shared _ReadBudget threads through find + extract (boundary
-    # lookup + prefix extraction). The validity proof has its OWN separate meter
-    # (#6139 r13): sharing the lookup+prefix meter let a valid ~1.75x cap record
-    # be starved (lookup + 8 KiB prefix consumed enough of the 2x cap allowance
-    # that the proof couldn't read the full record → fail-closed → valid terminal
-    # rejected → wrong terminal_state). find and extract still share one meter;
-    # valid has a distinct id. (The predecessor scan only runs on rejection; here
-    # the valid done is accepted so the predecessor helper is not reached. r11:
-    # the predecessor scan also gets its OWN reserve budget — covered by
+    # (b) find + extract (boundary lookup + prefix extraction) share ONE fixed
+    # recovery_budget. The streaming validity proof gets its OWN budget sized to
+    # the boundary record's actual extent (#6139 r15): there is no fixed validity
+    # ceiling — the validity budget is (size - record_start), so a valid record of
+    # ANY size is accepted (the r15 blocker 1: a 17 MiB valid done was discarded
+    # under a fixed budget). The validator self-terminates at the record's newline,
+    # so the validity budget is consumed exactly by the record's bytes, never more.
+    # (The predecessor scan shares the recovery_budget; it only runs on rejection —
+    # here the valid done is accepted so it is not reached. Covered separately by
     # test_predecessor_recovery_not_starved_by_validity_proof_budget and
     # test_backward_scan_budget_bounds_physical_descriptor_reads.)
     assert budget_ids_seen["find"], "boundary lookup received no budget (budget=None) — not shared"
     assert budget_ids_seen["extract"], "prefix extraction received no budget (budget=None) — not shared"
-    assert budget_ids_seen["valid"], "validity proof received no budget (budget=None) — not metered"
-    lookup_prefix_id = budget_ids_seen["find"][0]
-    assert all(bid == lookup_prefix_id for bid in budget_ids_seen["find"]), (
+    assert budget_ids_seen["valid"], "streaming validity received no budget (budget=None) — not metered"
+    recovery_id = budget_ids_seen["find"][0]
+    assert all(bid == recovery_id for bid in budget_ids_seen["find"]), (
         f"boundary lookup used multiple budget instances: {budget_ids_seen['find']}"
     )
-    assert all(bid == lookup_prefix_id for bid in budget_ids_seen["extract"]), (
+    assert all(bid == recovery_id for bid in budget_ids_seen["extract"]), (
         f"prefix extraction used a different budget instance from lookup: "
-        f"find={lookup_prefix_id} extract={budget_ids_seen['extract']} (find+extract must share one meter)"
+        f"find={recovery_id} extract={budget_ids_seen['extract']} (must share one meter)"
     )
-    assert all(bid != lookup_prefix_id for bid in budget_ids_seen["valid"]), (
-        f"validity proof shared the lookup+prefix meter (id={lookup_prefix_id}); "
-        f"it must have its OWN separate meter so a valid record near the 2x cap "
-        f"validity ceiling can pay for its own complete validation (#6139 r13). "
-        f"valid ids={budget_ids_seen['valid']}"
+    # Validity has its OWN budget (distinct id) — sized to the record's extent,
+    # not the fixed recovery_budget, so it is never starved by lookup+prefix and
+    # never imposes a correctness ceiling on valid large records.
+    assert all(bid != recovery_id for bid in budget_ids_seen["valid"]), (
+        f"streaming validity shared the lookup+prefix meter (id={recovery_id}); it "
+        f"must have its OWN budget (the record's extent) so a valid record of any "
+        f"size is accepted (#6139 r15). valid ids={budget_ids_seen['valid']}"
     )
-    # (c) Physical reads are bounded. The validity proof's own meter is sized at
-    # _VALIDITY_PROOF_MAX_BYTES (2x cap), but the incremental chunked read means
-    # a small record costs only one chunk — so total physical reads stay ~constant
-    # (the scale regression test_read_jsonl_tail_boundary_scan_uses_shared_budget...
-    # holds the constant-in-file-size property directly).
+    # (c) Physical reads are bounded. The shared budget caps total physical I/O;
+    # the streaming validator + prefix extractor stop at the record's actual end,
+    # so a small record costs little and a large record costs ~its length (not a
+    # fixed ceiling multiple). The scale regression test holds the
+    # constant-in-file-size property directly.
     handle = captured.get("handle")
     assert handle is not None, "the patched Path.open never returned a binary handle"
     total = handle.total_returned
     boundary_helper_bytes = total - cap  # subtract the one forward tail-window read
-    # lookup+prefix (2x cap) + validity proof reads the record's actual length
-    # (this fixture is a valid oversized done ~cap, so ~cap) — well under 5x cap.
+    # lookup (backward, ~token length) + 8 KiB prefix + streaming validity reads
+    # the record's actual length (this fixture is a valid oversized done ~cap) —
+    # well under 5x cap.
     assert boundary_helper_bytes <= 5 * cap, (
         f"boundary-helper physical reads ({boundary_helper_bytes} bytes) far exceed "
-        f"the expected envelope (lookup+prefix 2x cap + validity proof ~cap); the "
-        f"production boundary scan is reading unboundedly (#6139 r10/r13)"
+        f"the expected envelope (lookup + prefix + streaming validity ~cap); the "
+        f"production boundary scan is reading unboundedly (#6139 r10/r15)"
     )
 
 
@@ -2309,7 +2322,7 @@ def test_transient_oserror_not_cached_retry_recovers(tmp_path, monkeypatch):
     # Inject a one-shot OSError in the validity helper on the FIRST call after
     # clearing the cache. The fault flag must be set so ok=False propagates.
     run_journal._SUMMARY_CACHE.clear()
-    real_valid = run_journal._record_is_valid_complete
+    real_valid = run_journal._record_is_valid_jsonl
     calls = {"n": 0}
 
     def patched_valid(fh, size, record_start, *, budget=None, fault=None):
@@ -2320,7 +2333,7 @@ def test_transient_oserror_not_cached_retry_recovers(tmp_path, monkeypatch):
             raise OSError("simulated one-shot EIO during boundary scan")
         return real_valid(fh, size, record_start, budget=budget, fault=fault)
 
-    monkeypatch.setattr(run_journal, "_record_is_valid_complete", patched_valid)
+    monkeypatch.setattr(run_journal, "_record_is_valid_jsonl", patched_valid)
 
     # First call (fault): best-effort result, NOT cached.
     first = latest_run_summary("s1", "r1", session_dir=tmp_path)
@@ -2433,4 +2446,438 @@ def test_transient_oserror_in_unguarded_tail_read_not_cached(tmp_path, monkeypat
     assert reads["n"] >= 2, (
         f"fh.read was called {reads['n']} time(s) across both calls "
         f"(expected >= 2); the second call did not retry the read"
+    )
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PR #6139 ROUND 15 REGRESSION TESTS
+# ═════════════════════════════════════════════════════════════════════════════
+
+def test_streaming_json_validator_accepts_and_rejects(tmp_path):
+    """#6139 r15: _StreamingJsonValidator accepts valid JSONL records and rejects
+    malformed ones. This unit test pins the streaming JSON validator behavior
+    directly, covering the accept/reject cases that the blocker regression tests
+    rely on.
+
+    The validator enforces strict JSON grammar rules via byte-level state machine
+    scanning without materializing the full document. This test verifies:
+    - Valid JSON with various data types and structures is accepted
+    - Malformed JSON (trailing commas, bare words, incomplete structures) is rejected
+    - Proper terminator handling (\n, \r\n, but not bare \r or EOF without \n)
+    - No trailing garbage (multiple records) is allowed
+    """
+    from api.run_journal import _StreamingJsonValidator
+
+    # ACCEPT cases (finish() == True)
+    accept_cases = [
+        # Simple object with mixed types
+        ('{"a":1,"b":"x","c":true,"d":false,"e":null}\n', "simple mixed types"),
+        # Nested structures
+        ('{"a":{"b":[1,2,3]},"c":[{"d":null}]}\n', "nested objects and arrays"),
+        # String with escape sequences
+        ('{"a":"b\\"c\\\\d\\/\\b\\f\\n\\r\\t\\u0041"}\n', "string escapes"),
+        # Numbers (negative, zero, scientific notation)
+        ('{"n":-1.5,"m":0,"p":1e10,"q":-2.3E-4}\n', "number formats"),
+        # Unicode (ensure_ascii=False behavior)
+        ('{"msg":"héllo wörld 日本語"}\n', "unicode characters"),
+        # Empty containers
+        ('{"a":{},"b":[],"c":{"d":[]}}\n', "empty containers"),
+        # CRLF terminator
+        ('{"a":1}\r\n', "CRLF terminator"),
+        # Large payload (1 MiB)
+        ('{"payload":{"t":"' + 'Q' * 1048576 + '"}}\n', "large payload"),
+    ]
+
+    for json_bytes, desc in accept_cases:
+        validator = _StreamingJsonValidator()
+        validator.feed(json_bytes.encode("utf-8"))
+        result = validator.finish()
+        assert result is True, (
+            f"Validator should accept valid JSON: {desc}. "
+            f"Input: {json_bytes[:100]!r}..."
+        )
+
+    # REJECT cases (finish() == False)
+    reject_cases = [
+        # Trailing commas
+        ('{"a":1,}\n', "trailing comma in object"),
+        ('{"a":[1,2,]}\n', "trailing comma in array"),
+        # Unquoted value
+        ('{"a":bareword}\n', "unquoted value"),
+        # Malformed nested value
+        ('{"payload":{"t":"x",bad:nested}}\n', "malformed nested value"),
+        # Unterminated string
+        ('{"a":"unterminated}\n', "unterminated string"),
+        # Unclosed brace
+        ('{"a":1\n', "unclosed object brace"),
+        # Bad keywords
+        ('{"a":tru}\n', "incomplete 'true' keyword"),
+        ('{"a":True}\n', "incorrect case 'True'"),
+        # Bare CR terminator
+        ('{"a":1}\r', "bare CR terminator"),
+        # No terminator
+        ('{"a":1}', "no newline terminator"),
+        # Multiple records
+        ('{"a":1}\n{"b":2}\n', "multiple records (trailing garbage)"),
+        # Empty input
+        (b'', "empty input"),
+        # Leading zero
+        ('{"a":01}\n', "leading zero in number"),
+    ]
+
+    for json_bytes, desc in reject_cases:
+        validator = _StreamingJsonValidator()
+        if isinstance(json_bytes, str):
+            json_bytes = json_bytes.encode("utf-8")
+        validator.feed(json_bytes)
+        result = validator.finish()
+        assert result is False, (
+            f"Validator should reject malformed JSON: {desc}. "
+            f"Input: {json_bytes[:100]!r}..."
+        )
+
+
+def test_valid_terminal_above_any_ceiling_accepted(tmp_path):
+    """#6139 r15 blocker 1: A valid terminal record with a payload MUCH larger than
+    any byte ceiling (old _VALIDITY_PROOF_MAX_BYTES = 8 MiB, current
+    _SESSION_REPLAY_MAX_BYTES = 4 MiB) must be ACCEPTED and reported as terminal
+    with correct terminal_state. The streaming validator validates JSON grammar
+    without materializing the payload, so size alone never disqualifies a valid
+    record.
+
+    Journal layout:
+        seq=1: small token event
+        seq=2: valid done(tool_limit_reached) with ~17 MiB payload
+
+    Assertions:
+        - Full reader (_read_jsonl) keeps seq=2 with terminal_state=tool_limit_reached
+        - latest_run_summary reports last_seq=2, terminal=True, terminal_state='tool_limit_reached'
+        - find_run_summary agrees (same last_seq/terminal/terminal_state)
+    """
+    from api.run_journal import (
+        _read_jsonl,
+        _run_path,
+    )
+
+    session_id = "session_oversized_terminal"
+    run_id = "run_17mib_terminal"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # seq=1: small token
+    token_line = '{"seq":1,"event":"token","payload":{"text":"ok"}}\n'
+
+    # seq=2: valid done with 17 MiB payload (well above any ceiling)
+    # 17 MiB = 17 * 1024 * 1024 = 17825792 bytes
+    payload_size = 17 * 1024 * 1024
+    done_line = (
+        '{"seq":2,"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"tool_limit_reached","payload":{"text":"'
+        + "Z" * payload_size
+        + '"}}\n'
+    )
+
+    with path.open("wb") as fh:
+        fh.write(token_line.encode("utf-8"))
+        fh.write(done_line.encode("utf-8"))
+
+    # Full reader must accept the 17 MiB terminal record
+    full_events, malformed, _ok = _read_jsonl(path)
+    full_seqs = [e.get("seq") for e in full_events if isinstance(e, dict)]
+    assert 2 in full_seqs, (
+        f"Full reader rejected the 17 MiB terminal record (seq=2 missing). "
+        f"Got seqs: {full_seqs}"
+    )
+    # Find the done event and check its terminal_state
+    done_event = next((e for e in full_events if e.get("seq") == 2), None)
+    assert done_event is not None, "seq=2 not found in full events"
+    assert done_event.get("terminal_state") == "tool_limit_reached", (
+        f"Expected terminal_state='tool_limit_reached', got "
+        f"{done_event.get('terminal_state')!r}"
+    )
+
+    # latest_run_summary must report the 17 MiB terminal correctly
+    summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert summary["last_seq"] == 2, (
+        f"Expected last_seq=2, got {summary['last_seq']}"
+    )
+    assert summary["terminal"] is True, (
+        f"Expected terminal=True for 17 MiB valid terminal, got {summary['terminal']}"
+    )
+    assert summary["terminal_state"] == "tool_limit_reached", (
+        f"Expected terminal_state='tool_limit_reached', got "
+        f"{summary['terminal_state']!r}"
+    )
+
+    # find_run_summary must agree with latest_run_summary
+    find_summary = find_run_summary(run_id, session_dir=tmp_path)
+    assert find_summary is not None, "find_run_summary returned None"
+    assert find_summary["last_seq"] == summary["last_seq"], (
+        f"find_run_summary last_seq={find_summary['last_seq']} != "
+        f"latest_run_summary last_seq={summary['last_seq']}"
+    )
+    assert find_summary["terminal"] == summary["terminal"], (
+        f"find_run_summary terminal={find_summary['terminal']} != "
+        f"latest_run_summary terminal={summary['terminal']}"
+    )
+    assert find_summary["terminal_state"] == summary["terminal_state"], (
+        f"find_run_summary terminal_state={find_summary['terminal_state']!r} != "
+        f"latest_run_summary terminal_state={summary['terminal_state']!r}"
+    )
+
+
+def test_multi_mib_predecessor_recovered_before_truncated_boundary(tmp_path):
+    """#6139 r15 blocker 2: A VALID multi-MiB predecessor event (seq=2, ~2.3 MiB
+    tool_complete) must be RECOVERED when the boundary record (seq=3) is
+    crash-truncated and oversized. The streaming validator validates the large
+    predecessor via bounded streaming scan; if it's valid JSON, it's recovered
+    with its payload discarded (prefix-summary extraction).
+
+    Journal layout:
+        seq=1: valid token
+        seq=2: valid tool_complete with ~2.3 MiB payload (recoverable predecessor)
+        seq=3: crash-truncated oversized done (no trailing newline, payload > cap)
+
+    Assertions:
+        - Full reader keeps seqs [1, 2] (truncated seq=3 is rejected)
+        - latest_run_summary reports last_seq=2 (the 2.3 MiB predecessor recovered)
+    """
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _read_jsonl,
+        _run_path,
+    )
+
+    session_id = "session_multi_mib_pred"
+    run_id = "run_2_3mib_predecessor"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+
+    # seq=1: valid token
+    token_line = '{"seq":1,"event":"token","payload":{"text":"ok"}}\n'
+
+    # seq=2: valid tool_complete with ~2.3 MiB payload
+    pred_size = 2.3 * 1024 * 1024  # 2.3 MiB
+    pred_line = (
+        '{"seq":2,"event":"tool_complete","type":"tool_complete","terminal":false,'
+        '"payload":{"result":"'
+        + "X" * int(pred_size)
+        + '"}}\n'
+    )
+
+    # seq=3: crash-truncated oversized done (no newline, exceeds cap)
+    boundary_size = cap + 100_000
+    boundary_partial = (
+        '{"seq":3,"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "Y" * boundary_size
+    )  # No closing brace or newline
+
+    with path.open("wb") as fh:
+        fh.write(token_line.encode("utf-8"))
+        fh.write(pred_line.encode("utf-8"))
+        fh.write(boundary_partial.encode("utf-8"))
+
+    # Full reader: seqs [1, 2] (seq=3 rejected as truncated)
+    full_events, malformed, _ok = _read_jsonl(path)
+    full_seqs = sorted(e.get("seq") for e in full_events if isinstance(e, dict))
+    assert full_seqs == [1, 2], (
+        f"Full reader should keep seqs [1, 2]; got {full_seqs}. "
+        f"The 2.3 MiB predecessor (seq=2) must be recovered, and the truncated "
+        f"boundary (seq=3) must be rejected."
+    )
+
+    # latest_run_summary must report last_seq=2 (predecessor recovered)
+    summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert summary["last_seq"] == 2, (
+        f"Expected last_seq=2 (the 2.3 MiB predecessor recovered); "
+        f"got last_seq={summary['last_seq']}"
+    )
+    assert summary["terminal"] is False, (
+        f"The run should be non-terminal (boundary was truncated); "
+        f"got terminal={summary['terminal']}"
+    )
+
+
+def test_transient_open_failure_not_cached_retry_recovers(tmp_path, monkeypatch):
+    """#6139 r15 blocker 3 (open path): A transient OSError on the FIRST open()
+    of the journal file must NOT poison the _SUMMARY_CACHE. The first call
+    returns a best-effort (non-completed) summary; the second call retries
+    and recovers the correct terminal_state='completed'.
+
+    This pins that open() failures are treated as transient and do not cache
+    a failed result.
+    """
+    import pathlib
+    from api import run_journal
+
+    # Build a small completed journal (2 events)
+    session_id = "session_transient_open"
+    run_id = "run_transient_open"
+    path = tmp_path / "_run_journal" / session_id / f"{run_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    token = '{"seq":1,"event":"token","payload":{"text":"ok"}}\n'
+    done = '{"seq":2,"event":"done","terminal":true,"terminal_state":"completed","payload":{}}\n'
+    path.write_text(token + done, encoding="utf-8")
+
+    # Patch pathlib.Path.open to raise OSError on FIRST call for this journal
+    open_calls = {"n": 0}
+    real_open = pathlib.Path.open
+
+    def patched_open(self, *args, **kwargs):
+        if str(self) == str(path):
+            open_calls["n"] += 1
+            if open_calls["n"] == 1:
+                raise OSError("Simulated transient open failure")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched_open)
+
+    # Clear cache before test
+    run_journal._SUMMARY_CACHE.clear()
+
+    # First call: open fails, returns best-effort (not completed)
+    first = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert first["terminal_state"] != "completed", (
+        f"First call (during open failure) should return best-effort non-completed; "
+        f"got {first['terminal_state']!r}"
+    )
+    # Cache must NOT be poisoned
+    assert str(path) not in run_journal._SUMMARY_CACHE, (
+        "The failed summary was cached; retry would not happen"
+    )
+
+    # Second call: open succeeds, recovers completed
+    second = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert second["terminal_state"] == "completed", (
+        f"Second call (no failure) should recover completed; got {second['terminal_state']!r}"
+    )
+    assert open_calls["n"] >= 2, (
+        f"Expected open to be called at least twice; called {open_calls['n']} times"
+    )
+
+
+def test_transient_fstat_failure_not_cached_retry_recovers(tmp_path, monkeypatch):
+    """#6139 r15 blocker 3 (fstat path): A transient OSError on os.fstat() for the
+    journal's file descriptor must NOT poison the _SUMMARY_CACHE. The first call
+    returns best-effort; the second call retries and recovers completed.
+
+    This pins that fstat failures are treated as transient and do not cache
+    a failed result.
+    """
+    import os
+    from api import run_journal
+
+    # Build a small completed journal
+    session_id = "session_transient_fstat"
+    run_id = "run_transient_fstat"
+    path = tmp_path / "_run_journal" / session_id / f"{run_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    token = '{"seq":1,"event":"token","payload":{"text":"ok"}}\n'
+    done = '{"seq":2,"event":"done","terminal":true,"terminal_state":"completed","payload":{}}\n'
+    path.write_text(token + done, encoding="utf-8")
+
+    # Patch os.fstat to raise OSError on FIRST call
+    fstat_calls = {"n": 0}
+    real_fstat = os.fstat
+
+    def patched_fstat(fd):
+        fstat_calls["n"] += 1
+        if fstat_calls["n"] == 1:
+            raise OSError("Simulated transient fstat failure")
+        return real_fstat(fd)
+
+    monkeypatch.setattr(os, "fstat", patched_fstat)
+
+    # Clear cache before test
+    run_journal._SUMMARY_CACHE.clear()
+
+    # First call: fstat fails, returns best-effort
+    first = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert first["terminal_state"] != "completed", (
+        f"First call (during fstat failure) should return best-effort; "
+        f"got {first['terminal_state']!r}"
+    )
+    # Cache must NOT be poisoned
+    assert str(path) not in run_journal._SUMMARY_CACHE, (
+        "The failed summary was cached after fstat failure"
+    )
+
+    # Second call: fstat succeeds, recovers completed
+    second = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert second["terminal_state"] == "completed", (
+        f"Second call should recover completed; got {second['terminal_state']!r}"
+    )
+    assert fstat_calls["n"] >= 2, (
+        f"Expected fstat to be called at least twice; called {fstat_calls['n']} times"
+    )
+
+
+def test_oversized_malformed_boundary_rejected_by_streaming_validator_not_suffix(tmp_path):
+    """#6139 r15 blocker 4: validity is decided by the streaming JSON validator,
+    NOT by suffix-based tier selection. The old two-tier design computed
+    ``record_len = size - record_start`` (the suffix from the boundary record's
+    start to EOF, INCLUDING trailing records) and routed records above the
+    ``_VALIDITY_PROOF_MAX_BYTES`` ceiling to a structural-only tier that accepted
+    brace-balanced records — so a malformed-but-brace-balanced oversized boundary
+    was fabricated as terminal.
+
+    This test constructs an OVERSIZED malformed boundary straddler (a ``cap + 50``
+    byte ``done`` with a trailing comma) whose ``size - record_start`` suffix
+    exceeds the old ceiling. The streaming validator must REJECT it (trailing
+    comma = invalid JSON) regardless of the suffix length, so it is not fabricated
+    as terminal and the preceding valid token is recovered instead.
+
+    (Geometry: the straddler is oversized so ``size - record_start`` — which spans
+    the straddler + the trailing window — exceeds the old 2x-cap ceiling. This is
+    the only layout in which a MALFORMED record's suffix can exceed the ceiling:
+    the straddler must itself be > cap, since the trailing window is only cap.)"""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _read_jsonl, _read_jsonl_tail
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    token = '{"seq":1,"event":"token","payload":{"t":"valid"}}\n'
+    # Oversized malformed boundary: brace-balanced + newline-terminated but INVALID
+    # JSON (trailing comma after the payload value). Its suffix (size-record_start)
+    # exceeds the old 2x-cap ceiling.
+    big = "Q" * (cap + 50)
+    malformed_boundary = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '"},}\n'
+    )
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(token.encode("utf-8"))
+        fh.write(malformed_boundary.encode("utf-8"))
+    assert path.stat().st_size > cap, "sanity: the journal must exceed the tail window"
+
+    full_events, _, _ok = _read_jsonl(path)
+    tail_events, _, _ok = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
+    tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
+    # Baseline: the full reader rejects the malformed boundary (seq=2 absent).
+    assert 2 not in full_seqs, "baseline: the trailing-comma record is invalid JSON"
+    # The tail reader must NOT promote the malformed boundary as terminal — the
+    # streaming validator rejects it (not the old suffix-based tier-2 accept).
+    tail_promoted = any(e.get("_summary_extracted_from_oversized_record") for e in tail_events)
+    assert not tail_promoted, (
+        f"the malformed oversized boundary was fabricated into a summary "
+        f"(tail_seqs={tail_seqs}); the streaming validator should have rejected "
+        f"the trailing comma regardless of the suffix length (#6139 r15 blocker 4)"
+    )
+    # The preceding valid token must be recovered (matching the full reader).
+    assert 1 in tail_seqs, (
+        f"the preceding valid token (seq=1) was not recovered (tail_seqs={tail_seqs})"
+    )
+    summary = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert summary["terminal_state"] != "completed", (
+        f"latest_run_summary fabricated terminal_state={summary['terminal_state']!r} "
+        f"from the malformed boundary (expected non-completed)"
+    )
+    assert not summary["terminal"], (
+        f"a run with only a malformed boundary was marked terminal={summary['terminal']}"
     )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -2346,3 +2346,91 @@ def test_transient_oserror_not_cached_retry_recovers(tmp_path, monkeypatch):
         f"the validity helper was called {calls['n']} time(s) across both calls "
         f"(expected >= 2); the second call did not retry the read"
     )
+
+
+def test_transient_oserror_in_unguarded_tail_read_not_cached(tmp_path, monkeypatch):
+    """#6139 r14 finding 3 follow-up: a transient OSError from the UNGUARDed
+    tail-window ``fh.read``/``fh.seek`` (not a boundary helper) must still
+    propagate ``ok=False`` so the failed read is not cached.
+
+    The r14 ``ok`` flag is computed as ``not fault[0]``, and ``fault[0]`` is
+    set only by the boundary helpers. The tail-window ``fh.seek``/``fh.read``
+    at the top of ``_read_jsonl_tail``'s try body have no individual
+    try/except, so an OSError there escapes to the outer except with
+    ``fault[0]`` still False -> ``ok=True`` -> the degenerate ``unknown``
+    summary is cached permanently for a completed run. The outer except must
+    mark the fault so callers don't cache the transient failure.
+
+    This uses a SMALL journal (no boundary scan) so the OSError hits the
+    unguarded read, not a helper."""
+    import pathlib
+    from api import run_journal
+    from api.run_journal import latest_run_summary
+
+    # Small completed journal — well under the cap, so NO boundary scan runs
+    # and the OSError reaches the UNGUARDed tail-window fh.read.
+    token = '{"seq":1,"event":"token","payload":{"t":"hi"}}\n'
+    done = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"session":{}}}\n'
+    )
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token + done, encoding="utf-8")
+
+    # Baseline: the run is completed.
+    run_journal._SUMMARY_CACHE.clear()
+    baseline = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert baseline["terminal_state"] == "completed", (
+        f"baseline sanity: expected completed, got {baseline['terminal_state']!r}"
+    )
+
+    # Inject a one-shot OSError on the FIRST fh.read of this journal (the
+    # UNGUARDed tail-window read), WITHOUT touching fault[0] — mimicking a
+    # real unguarded I/O failure that the helpers never see.
+    run_journal._SUMMARY_CACHE.clear()
+    real_path_open = pathlib.Path.open
+    reads = {"n": 0}
+
+    def patched_open(self, *args, **kwargs):
+        fh = real_path_open(self, *args, **kwargs)
+        if str(self) != str(path):
+            return fh
+        real_read = fh.read
+
+        def guarded_read(n=-1):
+            reads["n"] += 1
+            if reads["n"] == 1:
+                raise OSError("simulated EIO in unguarded tail-window read")
+            return real_read(n)
+
+        fh.read = guarded_read
+        return fh
+
+    monkeypatch.setattr(pathlib.Path, "open", patched_open)
+
+    # First call (unguarded read faults): best-effort result, NOT cached.
+    first = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert first["terminal_state"] != "completed", (
+        f"first call (during unguarded-read fault) reported "
+        f"{first['terminal_state']!r}; the transient OSError should have "
+        f"produced a best-effort non-completed result"
+    )
+    assert str(path) not in run_journal._SUMMARY_CACHE, (
+        "the transient-OSError failed summary (from an UNGUARDed read) was "
+        "cached as authoritative; the next call would return the stale "
+        "failure instead of retrying (#6139 r14 finding 3 follow-up)"
+    )
+
+    # Second call (no fault): the read is retried and recovers completed.
+    second = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert second["terminal_state"] == "completed", (
+        f"second call (no fault) reported {second['terminal_state']!r} "
+        f"(expected 'completed'); the transient OSError from the unguarded "
+        f"read was cached and the retry did not happen "
+        f"(#6139 r14 finding 3 follow-up)"
+    )
+    assert reads["n"] >= 2, (
+        f"fh.read was called {reads['n']} time(s) across both calls "
+        f"(expected >= 2); the second call did not retry the read"
+    )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -631,3 +631,107 @@ def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, mon
     summary = run_journal.latest_run_summary("s1", "r1", session_dir=tmp_path)
     # Must return a dict (safe summary), not raise.
     assert isinstance(summary, dict)
+
+
+def test_blank_line_before_oversized_partial_done_recovers_preceding_event(tmp_path, monkeypatch):
+    """Regression (reviewer round 7): a blank line between a valid event and a
+    crash-truncated oversized boundary record defeated recovery — the single
+    preceding-line scan found only the blank line, json.loads("") failed, and
+    the function returned None instead of continuing back to the valid event.
+    The fix loops backward across blank/malformed/non-dict lines until finding
+    a valid event, so a shape like ``token\\n\\n<oversized partial done>`` recovers
+    the token event (seq=1) and emits the recovery apperror."""
+    import json as _json
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _run_path,
+        _read_jsonl,
+        _summary_from_events,
+        stale_interrupted_event,
+    )
+
+    session_id = "session_1"
+    run_id = "run_blank_before_oversized"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "hi"})  # seq=1, valid event
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    cap = _SESSION_REPLAY_MAX_BYTES
+
+    # Append a BLANK LINE, then an oversized crash-truncated done.
+    # Shape: token\n\n<oversized partial done with no closing brace/newline>
+    token_line = _json.dumps(
+        {"version": 1, "event_id": f"{run_id}:1", "seq": 1,
+         "event": "token", "type": "token", "terminal": False,
+         "payload": {"text": "hi"}}
+    )
+    oversized_partial = (
+        '{"version":1,"event_id":"' + run_id + ':2","seq":2,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"'
+        + "X" * (cap + 1000)
+    )  # no closing brace/newline — crash mid-write
+
+    with path.open("wb") as fh:
+        fh.write((token_line + "\n").encode("utf-8"))
+        fh.write(b"\n")  # BLANK LINE (the gap)
+        fh.write(oversized_partial.encode("utf-8"))
+
+    # Both tail readers must recover the token event (seq=1), not return
+    # last_seq=0 (the bug: they hit the blank line and stopped).
+    tail_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    find_summary = find_run_summary(run_id, session_dir=tmp_path)
+
+    # Authoritative full read (the baseline: must match this).
+    full_events, _ = _read_jsonl(path)
+    authoritative = _summary_from_events(session_id, run_id, full_events)
+
+    # Both tail readers must agree with the full reader.
+    assert tail_summary["last_seq"] == 1, (
+        f"latest_run_summary returned last_seq={tail_summary['last_seq']} "
+        f"(expected 1) — the blank line defeated recovery"
+    )
+    assert tail_summary["event_count"] == 1, (
+        f"latest_run_summary returned event_count={tail_summary['event_count']} "
+        f"(expected 1) — the blank line defeated recovery"
+    )
+    assert tail_summary["terminal"] is False, (
+        f"latest_run_summary marked terminal={tail_summary['terminal']} "
+        f"(expected False) — the crash-truncated boundary must not fabricate terminal"
+    )
+
+    assert find_summary is not None, (
+        "find_run_summary returned None (expected dict with last_seq=1)"
+    )
+    assert find_summary["last_seq"] == 1, (
+        f"find_run_summary returned last_seq={find_summary['last_seq']} "
+        f"(expected 1) — the blank line defeated recovery"
+    )
+    assert find_summary["event_count"] == 1, (
+        f"find_run_summary returned event_count={find_summary['event_count']} "
+        f"(expected 1) — the blank line defeated recovery"
+    )
+    assert find_summary["terminal"] is False, (
+        f"find_run_summary marked terminal={find_summary['terminal']} "
+        f"(expected False)"
+    )
+
+    # Both tail readers must MATCH the authoritative full reader.
+    assert tail_summary["last_seq"] == authoritative["last_seq"], (
+        f"tail last_seq={tail_summary['last_seq']} but authoritative="
+        f"{authoritative['last_seq']}"
+    )
+    assert find_summary["last_seq"] == authoritative["last_seq"], (
+        f"find last_seq={find_summary['last_seq']} but authoritative="
+        f"{authoritative['last_seq']}"
+    )
+
+    # The recovery apperror must be emitted (stale_interrupted_event returns it).
+    monkeypatch.setattr("api.run_journal._default_session_dir", lambda: tmp_path)
+    recovery = stale_interrupted_event(session_id, run_id)
+    assert recovery is not None, (
+        "stale_interrupted_event returned None (expected apperror recovery event)"
+    )
+    assert recovery["event"] == "apperror", (
+        f"recovery event type={recovery['event']} (expected apperror)"
+    )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -1476,8 +1476,11 @@ def test_read_jsonl_tail_boundary_scan_uses_shared_budget_no_read_after_exhausti
     )
     # (b) The SAME shared _ReadBudget threads through find + extract + valid.
     # (The predecessor scan only runs on rejection; here the valid done is
-    # accepted so the predecessor helper is not reached — that path is covered
-    # by test_backward_scan_budget_bounds_physical_descriptor_reads.)
+    # accepted so the predecessor helper is not reached. r11: the predecessor
+    # scan now gets its OWN reserve budget separate from this shared meter, so
+    # a >=budget invalid oversized record can't starve it — that is covered by
+    # test_predecessor_recovery_not_starved_by_validity_proof_budget and
+    # test_backward_scan_budget_bounds_physical_descriptor_reads.)
     assert budget_ids_seen["find"], "boundary lookup received no budget (budget=None) — not shared"
     assert budget_ids_seen["extract"], "prefix extraction received no budget (budget=None) — not shared"
     assert budget_ids_seen["valid"], "validity proof received no budget (budget=None) — not shared"
@@ -1604,3 +1607,190 @@ def test_balanced_invalid_oversized_boundary_record_malformed_nested_value(tmp_p
         f"(malformed-nested-value) oversized boundary record"
     )
     assert summary["terminal_state"] != "completed"
+
+
+def test_latest_run_summary_physical_read_bounded_constant_across_file_size(tmp_path, monkeypatch):
+    """Regression (reviewer round 11, blocker): ``latest_run_summary`` must read
+    at most ~1.5x the tail window of physical descriptor bytes REGARDLESS of file
+    size. The r10 production path did an O(file-size) ``fh.seek(0)`` head scan in
+    64 KiB chunks just to count newlines for line attribution in ``malformed``
+    entries — which ``latest_run_summary`` DISCARDS (``events, _malformed = ...``).
+    That scan was NOT charged to the budget, so physical reads scaled with file
+    size: a 72 MiB journal read 79.7 MiB physically (19x the 4 MiB tail cap).
+
+    The fix threads ``attribute_lines=False`` from both summary readers, skipping
+    the head scan. This test instruments ``fh.read`` to sum physical descriptor
+    bytes returned and asserts the read stays CONSTANT (within a small margin)
+    as the journal grows from 8x to 16x the tail window — proving the read is
+    bounded by the tail window, not the file size. A regression that re-enables
+    the head scan (or any unattributed O(file-size) read) fails: physical bytes
+    grow ~linearly with file size, far exceeding the 1.5x cap threshold."""
+    from pathlib import Path
+    from api import run_journal
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, latest_run_summary
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+
+    # A counting file handle that sums bytes returned by read().
+    class _CountingHandle:
+        def __init__(self, real):
+            self._real = real
+            self.total_returned = 0
+        def fileno(self): return self._real.fileno()
+        def seek(self, *a, **kw): return self._real.seek(*a, **kw)
+        def read(self, n=-1):
+            data = self._real.read(n)
+            self.total_returned += len(data)
+            return data
+        def write(self, b):
+            return self._real.write(b)
+        def close(self): return self._real.close()
+        def __enter__(self): return self
+        def __exit__(self, *a): return self._real.__exit__(*a)
+
+    real_open = Path.open
+    captured = {}
+
+    def patched_open(self, *args, **kwargs):
+        real = real_open(self, *args, **kwargs)
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if "b" in mode:
+            h = _CountingHandle(real)
+            captured["handle"] = h
+            return h
+        return real
+
+    def make_journal(target_bytes, session_id, run_id):
+        path = tmp_path / "_run_journal" / session_id / f"{run_id}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line_tmpl = '{"seq":%d,"event":"token","payload":{"t":"%s"}}\n'
+        seq = 0
+        written = 0
+        with path.open("wb") as fh:
+            while written < target_bytes:
+                chunk = line_tmpl % (seq, "x" * 40)
+                b = chunk.encode("utf-8")
+                fh.write(b)
+                written += len(b)
+                seq += 1
+            done = ('{"seq":%d,"event":"done","terminal":true,'
+                    '"terminal_state":"completed","payload":{"ok":1}}\n' % seq)
+            fh.write(done.encode("utf-8"))
+        return path
+
+    monkeypatch.setattr(Path, "open", patched_open)
+    measured = []
+    for multiple in (8, 12, 16):
+        target = multiple * cap
+        captured.clear()
+        # Each session/run pair is distinct so the summary cache can't short-circuit.
+        sid = f"sess_scale_{multiple}"
+        rid = f"run_scale_{multiple}"
+        make_journal(target, sid, rid)
+        summary = latest_run_summary(sid, rid, session_dir=tmp_path)
+        assert summary["terminal_state"] == "completed", (
+            f"sanity: the run must be completed (got {summary['terminal_state']!r}); "
+            f"if not, the scale test's fixture is broken, not the bound"
+        )
+        handle = captured.get("handle")
+        assert handle is not None, "patched Path.open never returned a binary handle"
+        measured.append(handle.total_returned)
+
+    # The headline assertion: physical read must NOT grow with file size. The
+    # journal grows 8x -> 16x cap (doubling), so physical reads must stay roughly
+    # constant. We assert (a) every measurement is <= 1.5x cap, and (b) the
+    # largest is not meaningfully larger than the smallest (no O(file-size) leak).
+    for i, phys in enumerate(measured):
+        multiple = (8, 12, 16)[i]
+        assert phys <= int(1.5 * cap), (
+            f"latest_run_summary read {phys} bytes ({phys/cap:.2f}x cap) for a "
+            f"{multiple}x-cap journal — exceeds the 1.5x cap bound. Physical reads "
+            f"are NOT bounded by the tail window (#6139 r11 blocker: the discarded "
+            f"head is being scanned for line attribution that summary readers discard)"
+        )
+    # (b) The read must be CONSTANT, not scaling: the 16x journal must not read
+    # meaningfully more than the 8x journal. Allow a small margin (one extra chunk
+    # boundary) for the boundary-record validity proof landing at a slightly
+    # different chunk offset. A mutation that re-adds the head scan makes the
+    # largest ~2x the smallest.
+    assert measured[2] <= measured[0] + 2 * run_journal._SESSION_REPLAY_READ_CHUNK_BYTES, (
+        f"physical reads grew with file size: 8x-cap={measured[0]}, 12x-cap="
+        f"{measured[1]}, 16x-cap={measured[2]} — the read is O(file-size), not "
+        f"bounded by the tail window (#6139 r11 blocker)"
+    )
+
+
+def test_predecessor_recovery_not_starved_by_validity_proof_budget(tmp_path):
+    """Regression (reviewer round 11, secondary): a >=budget invalid oversized
+    boundary record must NOT starve predecessor recovery. Under r10 the boundary
+    lookup, prefix extraction, validity proof, AND the backward predecessor scan
+    shared ONE ``_ReadBudget(2*cap)``. An invalid oversized record ~= the full
+    budget (e.g. an 8 MiB balanced-invalid record against an 8 MiB budget) let
+    the validity proof charge the record's full length, exhausting the meter
+    before the backward predecessor scan could recover the preceding valid
+    terminal ``done`` — so a legitimately COMPLETED run was misreported
+    non-terminal (master ``completed``/last_seq 3 -> candidate ``running``/
+    last_seq 3, because the preceding ``done`` (seq=1) was lost).
+
+    The fix gives predecessor recovery its OWN reserved allowance separate from
+    the validity-proof budget, so a large validity charge can't starve it. This
+    test reproduces the layout: a valid ``done`` (seq=1) followed by an invalid
+    oversized boundary record ~= the full 2*cap budget, followed by a trailing
+    valid token (seq=3) that forces the boundary into the oversized record. The
+    preceding terminal must be recovered (terminal_state == completed)."""
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _read_jsonl,
+        _read_jsonl_tail,
+        latest_run_summary,
+    )
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    budget = 2 * cap  # the shared boundary-recovery budget (r10 size)
+    # A valid terminal done that MUST survive predecessor recovery.
+    valid_done = ('{"seq":1,"event":"done","terminal":true,'
+                  '"terminal_state":"completed","payload":{"ok":1}}\n')
+    # An INVALID oversized record ~= the full budget. Brace-balanced + newline-
+    # terminated but with a trailing comma -> invalid JSON. The validity proof
+    # reads the record's full length, which under r10 exhausted the shared budget.
+    big = "Q" * (budget - 500)
+    invalid_oversized = (
+        '{"seq":2,"event":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"t":"' + big + '"},}\n'
+    )
+    # A trailing valid token so the tail window's boundary lands inside seq=2.
+    trailing = '{"seq":3,"event":"token","payload":{"t":"z"}}\n'
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(valid_done.encode("utf-8"))
+        fh.write(invalid_oversized.encode("utf-8"))
+        fh.write(trailing.encode("utf-8"))
+    assert path.stat().st_size > cap, "sanity: the journal must exceed the tail window"
+
+    # Ground truth: the full reader keeps the valid done (seq=1) + trailing token.
+    full_events, _ = _read_jsonl(path)
+    full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
+    assert 1 in full_seqs and 2 not in full_seqs and 3 in full_seqs, (
+        f"baseline: full reader keeps seq=1 (valid done) + seq=3 (token), rejects "
+        f"seq=2 (invalid); got {full_seqs}"
+    )
+
+    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
+    assert 1 in tail_seqs, (
+        f"the preceding valid terminal (seq=1) was NOT recovered under a "
+        f">=budget invalid oversized boundary record (tail_seqs={tail_seqs}); the "
+        f"validity-proof budget exhausted the predecessor-recovery allowance "
+        f"(#6139 r11 secondary: budget starvation misreports a completed run)"
+    )
+    # The completed run must be reported completed, matching master.
+    summary = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert summary["terminal_state"] == "completed", (
+        f"a completed run with a >=budget invalid oversized tail was misreported "
+        f"as {summary['terminal_state']!r} (expected 'completed'); the preceding "
+        f"terminal done was starved by the validity-proof budget (#6139 r11 secondary)"
+    )
+    assert summary["terminal"] is True, (
+        f"a completed run was misreported non-terminal (terminal={summary['terminal']})"
+    )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -769,7 +769,8 @@ def test_read_jsonl_tail_handles_file_deleted_during_boundary_scan(tmp_path, mon
     summary = run_journal.latest_run_summary("s1", "r1", session_dir=tmp_path)
     assert isinstance(summary, dict), "latest_run_summary must return a dict, not raise"
     assert boundary_calls["n"] >= 1, "the boundary helper must be reached via latest_run_summary too"
-    assert open_calls["n"] == 1, "latest_run_summary must reuse the pinned descriptor"
+    # Round 17: sidecar adds an extra open (JSONL + sidecar = 2 total)
+    assert open_calls["n"] == 2, "latest_run_summary must open JSONL + sidecar (2 opens total)"
 
 
 def test_blank_line_before_oversized_partial_done_recovers_preceding_event(tmp_path, monkeypatch):
@@ -3338,3 +3339,395 @@ def test_transient_rfind_oserror_not_cached_retry_recovers_find_run_summary(tmp_
         f"second call should produce different last_seq than first call (proving no cache), "
         f"but both returned last_seq={first_summary['last_seq']}"
     )
+
+
+# ── Round 17 sidecar tests ─────────────────────────────────────────────────────
+
+
+def test_writer_produces_sidecar_and_summary_matches_full_read(tmp_path):
+    """Test that RunJournalWriter produces a sidecar file and the sidecar-derived
+    summary matches the full read summary field-by-field."""
+    from api.run_journal import _run_path, _summary_sidecar_path, _read_jsonl, _summary_from_events
+    import json
+
+    session_id = "session_s1"
+    run_id = "run_s1"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    # Write token events and a terminal done
+    writer.append_sse_event("token", {"text": "first"})
+    writer.append_sse_event("token", {"text": "second"})
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Sidecar must exist
+    assert sidecar_path.exists(), "sidecar file must exist after writer appends events"
+
+    # Read sidecar directly
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_data = json.load(f)
+
+    # Verify sidecar structure
+    assert sidecar_data["version"] == 1
+    assert sidecar_data["event_count"] == 3
+    assert sidecar_data["last"]["seq"] == 3
+    assert sidecar_data["last"]["event"] == "done"
+    assert sidecar_data["terminal"]["event"] == "done"
+    assert sidecar_data["terminal"]["state"] == "completed"
+
+    # Get sidecar-derived summary via latest_run_summary
+    sidecar_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+
+    # Get full-read summary for comparison
+    full_events, _, _ = _read_jsonl(path)
+    full_summary = _summary_from_events(session_id, run_id, full_events)
+
+    # Field-by-field match
+    assert sidecar_summary["session_id"] == full_summary["session_id"]
+    assert sidecar_summary["run_id"] == full_summary["run_id"]
+    assert sidecar_summary["stream_id"] == full_summary["stream_id"]
+    assert sidecar_summary["event_count"] == full_summary["event_count"]
+    assert sidecar_summary["last_seq"] == full_summary["last_seq"]
+    assert sidecar_summary["last_event_id"] == full_summary["last_event_id"]
+    assert sidecar_summary["terminal"] == full_summary["terminal"]
+    assert sidecar_summary["terminal_state"] == full_summary["terminal_state"]
+    assert sidecar_summary["last_event"] == full_summary["last_event"]
+
+
+def test_oversized_terminal_summary_uses_sidecar_bounded_reads(tmp_path):
+    """Regression test for the #6139 r17 blocker: a cold summary read of a run
+    whose terminal record carries a huge transcript payload must use the compact
+    sidecar (O(1)) instead of walking + scanning the oversized record (O(payload)).
+    Physical bytes read from the JSONL must stay bounded (< 1 MiB) regardless of
+    payload size, and the read must finish well under the UI's 30s API timeout.
+
+    Writer-produced single-terminal-record regression (the maintainer's r17 ask).
+    The payload size defaults to 8 MiB (comfortably > the 4 MiB tail cap, CI-
+    friendly); setting ``HERMES_WEBUI_RUN_JOURNAL_BIG_REGRESSION=144`` runs the
+    exact 144 MiB case the gate measured at 30s+ pre-fix.
+    """
+    import os
+    import time
+    import pathlib
+    from api.run_journal import (
+        _run_path,
+        _summary_sidecar_path,
+        _SUMMARY_CACHE,
+        _SUMMARY_CACHE_LOCK,
+    )
+
+    session_id = "session_os"
+    run_id = "run_os"
+    # Default 8 MiB for CI; env override enables the exact 144 MiB gate case.
+    payload_mib = int(os.environ.get("HERMES_WEBUI_RUN_JOURNAL_BIG_REGRESSION", "8"))
+    jsonl_path = _run_path(session_id, run_id, session_dir=tmp_path)
+
+    # Count PHYSICAL bytes read from the JSONL only (the sidecar is a different
+    # path, so sidecar reads are excluded — proving the payload is never scanned).
+    jsonl_read_bytes = {"bytes": 0}
+    real_path_open = pathlib.Path.open
+
+    class _CountingRead:
+        def __init__(self, fh):
+            self._fh = fh
+
+        def read(self, n=-1):
+            data = self._fh.read(n)
+            jsonl_read_bytes["bytes"] += len(data)
+            return data
+
+        def __getattr__(self, name):
+            return getattr(self._fh, name)
+
+    def selective_open(self, *args, **kwargs):
+        fh = real_path_open(self, *args, **kwargs)
+        # Wrap only positional "rb" opens of the JSONL path. The sidecar is read
+        # via Path.read_bytes() (mode passed as kwarg, different path) so it is
+        # NOT counted — exactly what we want to isolate.
+        if self == jsonl_path and args and args[0] == "rb":
+            return _CountingRead(fh)
+        return fh
+
+    pathlib.Path.open = selective_open
+    try:
+        writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+        writer.append_sse_event("token", {"text": "first"})
+        big_blob = "x" * (payload_mib * 1024 * 1024)
+        writer.append_sse_event(
+            "done",
+            {"terminal_state": "tool_limit_reached", "transcript": big_blob},
+        )
+
+        assert _summary_sidecar_path(jsonl_path).exists(), "writer must produce a sidecar"
+
+        with _SUMMARY_CACHE_LOCK:
+            _SUMMARY_CACHE.clear()
+        t0 = time.perf_counter()
+        summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+        elapsed = time.perf_counter() - t0
+    finally:
+        pathlib.Path.open = real_path_open
+
+    # Terminal identity preserved exactly.
+    assert summary["terminal_state"] == "tool_limit_reached"
+    assert summary["terminal"] is True
+    assert summary["last_seq"] == 2
+
+    # CRITICAL: physical JSONL reads must be bounded (< 1 MiB) regardless of the
+    # payload size — the sidecar is the authority, the transcript is never scanned.
+    assert jsonl_read_bytes["bytes"] < 1 * 1024 * 1024, (
+        f"physical JSONL reads ({jsonl_read_bytes['bytes']} bytes) must be < 1 MiB "
+        f"regardless of the {payload_mib} MiB payload — the sidecar must be used"
+    )
+    # Well under the UI's 30s API timeout (pre-fix this was 30s+ at 144 MiB).
+    assert elapsed < 5.0, (
+        f"cold summary read took {elapsed:.2f}s; must stay fast (not scale with payload)"
+    )
+
+
+def test_sidecar_journal_size_mismatch_falls_back_to_tail(tmp_path):
+    """Test that a stale sidecar (journal_size != current JSONL size) triggers
+    fallback to the tail reader, which recovers the hand-appended event."""
+    from api.run_journal import _run_path, _summary_sidecar_path
+    import json
+
+    session_id = "session_stale"
+    run_id = "run_stale"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    # Write token(seq=1) + done(seq=2) via writer (sidecar created)
+    writer.append_sse_event("token", {"text": "first"})
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Verify sidecar exists and reflects seq=2
+    assert sidecar_path.exists()
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_v1 = json.load(f)
+    assert sidecar_v1["last"]["seq"] == 2
+    original_journal_size = sidecar_v1["journal_size"]
+
+    # Hand-append a seq=3 stream_end line (JSONL grows, sidecar now stale)
+    with path.open("a", encoding="utf-8") as f:
+        seq3_line = json.dumps({
+            "version": 1,
+            "event_id": f"{run_id}:3",
+            "seq": 3,
+            "run_id": run_id,
+            "session_id": session_id,
+            "event": "stream_end",
+            "type": "stream_end",
+            "created_at": 999999.0,
+            "terminal": True,
+            "terminal_state": "closed",
+            "payload": {}
+        }, separators=(",", ":")) + "\n"
+        f.write(seq3_line)
+
+    # Clear cache
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    # latest_run_summary must recover seq=3 via fallback (tail reader)
+    summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert summary["last_seq"] == 3, (
+        f"fallback must recover hand-appended seq=3; got last_seq={summary['last_seq']}"
+    )
+
+    # Sidecar file still exists (not deleted) but is stale
+    assert sidecar_path.exists()
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_stale = json.load(f)
+    assert sidecar_stale["journal_size"] == original_journal_size, (
+        "stale sidecar must not be updated"
+    )
+
+
+def test_sidecar_authoritative_terminal_fold(tmp_path):
+    """Test the fold logic matches select_authoritative_terminal_event across
+    the 5 cases: [done, stream_end], [done, cancel], [stream_end],
+    [stream_end(a), stream_end(b)], [token, token, done(tool_limit_reached)]."""
+    from api.run_journal import _read_jsonl, _summary_from_events
+
+    test_cases = [
+        # (events, expected_terminal_state, description)
+        ([{"event": "done", "terminal": True, "terminal_state": "tool_limit_reached", "seq": 1, "event_id": "r:1", "run_id": "r", "session_id": "s"},
+          {"event": "stream_end", "terminal": True, "terminal_state": "closed", "seq": 2, "event_id": "r:2", "run_id": "r", "session_id": "s"}],
+         "tool_limit_reached", "done(tool_limit_reached) then stream_end -> done wins (stream_end must NOT override a semantic terminal)"),
+
+        ([{"event": "done", "terminal": True, "terminal_state": "completed", "seq": 1, "event_id": "r:1", "run_id": "r", "session_id": "s"},
+          {"event": "cancel", "terminal": True, "terminal_state": "interrupted-by-user", "seq": 2, "event_id": "r:2", "run_id": "r", "session_id": "s"}],
+         "interrupted-by-user", "done then cancel -> cancel wins"),
+
+        ([{"event": "stream_end", "terminal": True, "terminal_state": "closed", "seq": 1, "event_id": "r:1", "run_id": "r", "session_id": "s"}],
+         "completed", "single stream_end -> completed (terminal_state only extracts tool_limit_reached)"),
+
+        ([{"event": "stream_end", "terminal": True, "terminal_state": "closed_a", "seq": 1, "event_id": "r:1", "run_id": "r", "session_id": "s"},
+          {"event": "stream_end", "terminal": True, "terminal_state": "closed_b", "seq": 2, "event_id": "r:2", "run_id": "r", "session_id": "s"}],
+         "completed", "multiple stream_ends -> latest wins (but all resolve to 'completed')"),
+
+        ([{"event": "token", "terminal": False, "seq": 1, "event_id": "r:1", "run_id": "r", "session_id": "s"},
+          {"event": "token", "terminal": False, "seq": 2, "event_id": "r:2", "run_id": "r", "session_id": "s"},
+          {"event": "done", "terminal": True, "terminal_state": "tool_limit_reached", "seq": 3, "event_id": "r:3", "run_id": "r", "session_id": "s"}],
+         "tool_limit_reached", "tokens then done(tool_limit_reached) -> tool_limit_reached"),
+    ]
+
+    for i, (events, expected_state, description) in enumerate(test_cases):
+        session_id = f"session_fold_{i}"
+        run_id = f"run_fold_{i}"
+        writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+        # Append events via writer (builds sidecar)
+        for event in events:
+            payload = {}
+            if event["event"] == "done" and event.get("terminal_state") == "tool_limit_reached":
+                payload = {"terminal_state": "tool_limit_reached"}
+            elif event["event"] == "done":
+                payload = {"session": {"session_id": session_id}}
+            elif event["event"] == "cancel":
+                payload = {"message": "Cancelled"}
+            elif event["event"] == "stream_end":
+                # Pass terminal_state in payload so writer uses it
+                payload = {"terminal_state": event.get("terminal_state", "closed")}
+
+            writer.append_sse_event(event["event"], payload)
+
+        # Get sidecar-derived summary
+        sidecar_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+
+        # Get full-read summary for comparison
+        from api.run_journal import _run_path
+        path = _run_path(session_id, run_id, session_dir=tmp_path)
+        full_events, _, _ = _read_jsonl(path)
+        full_summary = _summary_from_events(session_id, run_id, full_events)
+
+        # Both must agree on expected_state
+        assert sidecar_summary["terminal_state"] == expected_state, (
+            f"case {i} ({description}): sidecar terminal_state={sidecar_summary['terminal_state']}, "
+            f"expected {expected_state}"
+        )
+        assert full_summary["terminal_state"] == expected_state, (
+            f"case {i} ({description}): full terminal_state={full_summary['terminal_state']}, "
+            f"expected {expected_state}"
+        )
+
+        # Sidecar and full must match
+        assert sidecar_summary["terminal_state"] == full_summary["terminal_state"], (
+            f"case {i} ({description}): sidecar and full terminal_state mismatch"
+        )
+
+
+def test_find_run_summary_uses_sidecar(tmp_path):
+    """Test that find_run_summary uses the sidecar and returns the correct summary."""
+    from api.run_journal import _summary_sidecar_path
+
+    session_id = "session_find"
+    run_id = "run_find"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    writer.append_sse_event("token", {"text": "first"})
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = writer._path
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Verify sidecar exists
+    assert sidecar_path.exists()
+
+    # Clear cache
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    # find_run_summary must return the sidecar-derived summary
+    summary = find_run_summary(run_id, session_dir=tmp_path)
+    assert summary is not None
+    assert summary["terminal_state"] == "completed"
+    assert summary["terminal"] is True
+    assert summary["last_seq"] == 2
+    assert "path" in summary
+    assert summary["path"] == str(path)
+
+
+def test_read_run_events_does_not_use_sidecar(tmp_path):
+    """Test that read_run_events returns ALL full events (replay needs full events),
+    not a short-circuited sidecar result."""
+    from api.run_journal import _run_path, _summary_sidecar_path
+
+    session_id = "session_replay"
+    run_id = "run_replay"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    # Write multiple events
+    writer.append_sse_event("token", {"text": "first"})
+    writer.append_sse_event("token", {"text": "second"})
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Verify sidecar exists
+    assert sidecar_path.exists()
+
+    # read_run_events must return ALL 3 events (not sidecar summary)
+    replay = read_run_events(session_id, run_id, session_dir=tmp_path)
+    assert len(replay["events"]) == 3, (
+        f"read_run_events must return all 3 events for replay; got {len(replay['events'])}"
+    )
+
+    # Verify events are full (have payloads)
+    for event in replay["events"]:
+        assert "payload" in event
+        assert isinstance(event["payload"], dict)
+        # The done event should have the session payload
+        if event["event"] == "done":
+            assert "session" in event["payload"]
+
+
+def test_sidecar_absent_falls_back_to_tail_correctness(tmp_path):
+    """Test that a journal with no sidecar (hand-written) still produces a correct
+    summary via the fallback tail reader."""
+    from api.run_journal import _run_path, _summary_sidecar_path
+    import json
+
+    session_id = "session_nosidecar"
+    run_id = "run_nosidecar"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Hand-write journal (no sidecar)
+    events = [
+        {"version": 1, "event_id": f"{run_id}:1", "seq": 1, "run_id": run_id,
+         "session_id": session_id, "event": "token", "type": "token",
+         "terminal": False, "terminal_state": None, "created_at": 100.0,
+         "payload": {"text": "first"}},
+        {"version": 1, "event_id": f"{run_id}:2", "seq": 2, "run_id": run_id,
+         "session_id": session_id, "event": "done", "type": "done",
+         "terminal": True, "terminal_state": "completed", "created_at": 200.0,
+         "payload": {"session": {"session_id": session_id}}},
+    ]
+
+    with path.open("w", encoding="utf-8") as f:
+        for event in events:
+            f.write(json.dumps(event, separators=(",", ":")) + "\n")
+
+    # Verify no sidecar exists
+    sidecar_path = _summary_sidecar_path(path)
+    assert not sidecar_path.exists()
+
+    # Clear cache
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    # latest_run_summary must still produce correct summary via fallback
+    summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert summary["terminal_state"] == "completed"
+    assert summary["terminal"] is True
+    assert summary["last_seq"] == 2
+    assert summary["event_count"] == 2

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -2881,3 +2881,460 @@ def test_oversized_malformed_boundary_rejected_by_streaming_validator_not_suffix
     assert not summary["terminal"], (
         f"a run with only a malformed boundary was marked terminal={summary['terminal']}"
     )
+
+
+def test_oversized_terminal_with_non_standard_number_constants_full_tail_parity(tmp_path):
+    """#6139 r16 FIX 2: full/tail readers agree on NaN/Infinity/-Infinity in oversized
+    terminal records. The writer emits these constants via json.dumps(allow_nan=True),
+    the full reader accepts them via json.loads default behavior, and now the tail
+    reader's _StreamingJsonValidator also accepts them to maintain grammar parity.
+
+    Mutation proof: removing the NaN/Infinity branches from _validate_accumulated_scalar
+    causes these tests to FAIL (tail rejects the record).
+    """
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES
+
+    # Test each non-standard constant
+    test_cases = [
+        (float('nan'), "NaN"),
+        (float('inf'), "Infinity"),
+        (float('-inf'), "-Infinity"),
+    ]
+
+    for constant_value, constant_name in test_cases:
+        session_id = f"session_nan_{constant_name}"
+        run_id = f"run_nan_{constant_name}"
+
+        # Write seq=1: a small valid non-terminal event
+        writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+        writer.append_sse_event("assistant_message", {"content": "test"})
+
+        # Write seq=2: an OVERSIZED terminal done event containing the constant
+        # The payload must be > 4 MiB to trigger boundary record handling
+        huge_payload = {
+            "metric": constant_value,
+            "bulk": "X" * (_SESSION_REPLAY_MAX_BYTES + 100_000)
+        }
+        writer.append_sse_event("done", {
+            "session": {"session_id": session_id},
+            **huge_payload
+        })
+
+        # Full reader should accept the record (json.loads allows these constants)
+        full_result = read_run_events(session_id, run_id, session_dir=tmp_path)
+        full_events = full_result["events"]
+        full_last = full_events[-1] if full_events else None
+
+        assert full_last is not None, f"full reader should return events for {constant_name}"
+        assert full_last.get("seq") == 2, f"full reader last_seq should be 2 for {constant_name}"
+        assert full_last.get("terminal") is True, f"full reader should see terminal=True for {constant_name}"
+        assert full_last.get("terminal_state") == "completed", (
+            f"full reader should see terminal_state='completed' for {constant_name}"
+        )
+
+        # Tail readers (both) should agree with full reader
+        tail_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+        assert tail_summary["last_seq"] == 2, (
+            f"latest_run_summary last_seq should be 2 for {constant_name}, "
+            f"got {tail_summary['last_seq']}"
+        )
+        assert tail_summary["terminal"] is True, (
+            f"latest_run_summary should see terminal=True for {constant_name}, "
+            f"got {tail_summary['terminal']}"
+        )
+        assert tail_summary["terminal_state"] == "completed", (
+            f"latest_run_summary should see terminal_state='completed' for {constant_name}, "
+            f"got {tail_summary['terminal_state']!r}"
+        )
+
+        find_summary = find_run_summary(run_id, session_dir=tmp_path)
+        assert find_summary is not None, f"find_run_summary should find the run for {constant_name}"
+        assert find_summary["last_seq"] == 2, (
+            f"find_run_summary last_seq should be 2 for {constant_name}, "
+            f"got {find_summary['last_seq']}"
+        )
+        assert find_summary["terminal"] is True, (
+            f"find_run_summary should see terminal=True for {constant_name}, "
+            f"got {find_summary['terminal']}"
+        )
+        assert find_summary["terminal_state"] == "completed", (
+            f"find_run_summary should see terminal_state='completed' for {constant_name}, "
+            f"got {find_summary['terminal_state']!r}"
+        )
+
+
+def test_streaming_json_validator_accepts_non_standard_constants(tmp_path):
+    """#6139 r16 FIX 2: _StreamingJsonValidator accepts the three Python non-standard
+    numeric constants (NaN, Infinity, -Infinity) that the writer emits and the full
+    reader accepts.
+
+    The validator must accept ONLY the exact tokens (case-sensitive) and reject
+    malformed variants (Infinite, Nan, -Infinityx, etc.).
+    """
+    from api.run_journal import _StreamingJsonValidator
+
+    # ACCEPT cases (exact tokens)
+    accept_cases = [
+        (b'{"x":NaN}\n', "NaN constant"),
+        (b'{"x":Infinity}\n', "Infinity constant"),
+        (b'{"x":-Infinity}\n', "-Infinity constant"),
+        (b'[NaN,Infinity,-Infinity]\n', "array with all three constants"),
+        (b'{"a":-Infinity,"b":1}\n', "object with -Infinity and normal field"),
+        (b'{"payload":{"data":NaN},"seq":1}\n', "nested NaN"),
+    ]
+
+    for json_bytes, desc in accept_cases:
+        validator = _StreamingJsonValidator()
+        validator.feed(json_bytes)
+        result = validator.finish()
+        assert result is True, (
+            f"Validator should accept non-standard constant: {desc}. "
+            f"Input: {json_bytes!r}"
+        )
+
+    # REJECT cases (malformed variants)
+    reject_cases = [
+        (b'{"x":NaNx}\n', "NaN with trailing text"),
+        (b'{"x":Infinite}\n', "Infinite (wrong spelling)"),
+        (b'{"x":-Infinityx}\n', "-Infinity with trailing text"),
+        (b'{"x":Nan}\n', "Nan (wrong case)"),
+        (b'{"x":infinity}\n', "infinity (wrong case)"),
+        (b'{"x":-nan}\n', "-nan (not a valid token)"),
+    ]
+
+    for json_bytes, desc in reject_cases:
+        validator = _StreamingJsonValidator()
+        validator.feed(json_bytes)
+        result = validator.finish()
+        assert result is False, (
+            f"Validator should reject malformed constant variant: {desc}. "
+            f"Input: {json_bytes!r}"
+        )
+
+
+def test_5mib_predecessor_recovered_before_truncated_boundary(tmp_path):
+    """#6139 r16 FIX 3: a valid predecessor > 4 MiB is recovered before a truncated
+    boundary record. The predecessor's streaming validation gets its OWN budget
+    (line_len + one chunk) instead of charging the shared recovery_budget again,
+    preventing starvation for large predecessors.
+
+    Mutation proof: reverting fix 3 (charging budget_obj again) causes tail
+    last_seq to drop (0 or 1) instead of recovering seq=2.
+    """
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    session_id = "session_5mib_pred"
+    run_id = "run_5mib_pred"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # seq=1: small valid token
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "start"})
+
+    # seq=2: VALID 5 MiB non-terminal event (tool_complete)
+    large_size = _SESSION_REPLAY_MAX_BYTES + 1_000_000  # ~5 MiB
+    large_payload = {"data": "X" * large_size}
+    writer.append_sse_event("tool_complete", large_payload)
+
+    # seq=3: CRASH-TRUNCATED oversized done event (no closing brace + newline)
+    huge_size = _SESSION_REPLAY_MAX_BYTES + 100_000
+    partial_done = (
+        '{"version":1,"event_id":"' + run_id + ':3","seq":3,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * huge_size
+        # NO closing brace, no newline - truncated
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial_done)
+
+    # Full reader should report last_seq=2 (seq=3 is truncated)
+    full_result = read_run_events(session_id, run_id, session_dir=tmp_path)
+    full_events = full_result["events"]
+    full_last_seq = full_events[-1].get("seq") if full_events else 0
+    assert full_last_seq == 2, (
+        f"full reader should report last_seq=2 (seq=3 is truncated), "
+        f"got {full_last_seq}"
+    )
+
+    # Tail reader should ALSO report last_seq=2 (recovering the 5 MiB predecessor)
+    tail_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    tail_last_seq = tail_summary["last_seq"]
+    assert tail_last_seq == 2, (
+        f"tail reader should recover the 5 MiB predecessor and report last_seq=2, "
+        f"got {tail_last_seq} (predecessor lost)"
+    )
+
+    # find_run_summary should agree
+    find_summary = find_run_summary(run_id, session_dir=tmp_path)
+    assert find_summary is not None, "find_run_summary should find the run"
+    assert find_summary["last_seq"] == 2, (
+        f"find_run_summary should report last_seq=2, got {find_summary['last_seq']}"
+    )
+
+
+def test_large_predecessor_above_16mib_recovered(tmp_path):
+    """#6139 r16 FIX 3: stress test with a >16 MiB predecessor to ensure the independent
+    budget approach handles very large predecessors. The validator's budget is
+    line_len + _SESSION_REPLAY_READ_CHUNK_BYTES, so it scales with line size.
+
+    Mutation proof: reverting fix 3 causes this test to fail (predecessor lost).
+    """
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    session_id = "session_16mib_pred"
+    run_id = "run_16mib_pred"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # seq=1: small valid token
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "start"})
+
+    # seq=2: VALID >16 MiB non-terminal event (tool_complete)
+    # Use 17 MiB to clearly exceed any plausible cap
+    large_size = 17 * 1024 * 1024  # 17 MiB
+    large_payload = {"data": "X" * large_size}
+    writer.append_sse_event("tool_complete", large_payload)
+
+    # seq=3: CRASH-TRUNCATED oversized done event
+    huge_size = _SESSION_REPLAY_MAX_BYTES + 100_000
+    partial_done = (
+        '{"version":1,"event_id":"' + run_id + ':3","seq":3,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * huge_size
+        # NO closing brace, no newline - truncated
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial_done)
+
+    # Full reader should report last_seq=2
+    full_result = read_run_events(session_id, run_id, session_dir=tmp_path)
+    full_events = full_result["events"]
+    full_last_seq = full_events[-1].get("seq") if full_events else 0
+    assert full_last_seq == 2, (
+        f"full reader should report last_seq=2, got {full_last_seq}"
+    )
+
+    # Tail reader should recover the 17 MiB predecessor
+    tail_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    tail_last_seq = tail_summary["last_seq"]
+    assert tail_last_seq == 2, (
+        f"tail reader should recover the 17 MiB predecessor and report last_seq=2, "
+        f"got {tail_last_seq} (very large predecessor lost)"
+    )
+
+    find_summary = find_run_summary(run_id, session_dir=tmp_path)
+    assert find_summary is not None, "find_run_summary should find the run"
+    assert find_summary["last_seq"] == 2, (
+        f"find_run_summary should report last_seq=2, got {find_summary['last_seq']}"
+    )
+
+
+def test_transient_rfind_oserror_not_cached_retry_recovers_latest_run_summary(tmp_path):
+    """#6139 r16 FIX 4: _rfind_byte_before propagates fault via fault[0]=True on OSError,
+    so a transient error during backward newline scan is NOT cached as an authoritative
+    "no predecessor" result. A retry succeeds and recovers the correct state.
+
+    Mutation proof: removing fault[0]=True from _rfind_byte_before causes this test to
+    FAIL (the first call's failed result IS cached, second call returns stale data).
+    """
+    import inspect
+    import pathlib
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    session_id = "session_rfind_fault"
+    run_id = "run_rfind_fault"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write seq=1 and seq=2 valid events, then truncated seq=3 boundary
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "first"})
+    writer.append_sse_event("tool_complete", {"result": "ok"})
+
+    # seq=3: truncated oversized boundary
+    huge_size = _SESSION_REPLAY_MAX_BYTES + 100_000
+    partial_done = (
+        '{"version":1,"event_id":"' + run_id + ':3","seq":3,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * huge_size
+        # NO closing brace, no newline - truncated
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial_done)
+
+    # Inject transient OSError on fh.read() when called from _rfind_byte_before
+    # This tests the REAL function's except clause, not the outer one
+    real_path_open = pathlib.Path.open
+    fault_injected = [False]
+    read_calls_while_in_rfind = [0]
+
+    def patched_open(self, *args, **kwargs):
+        # Open the real file handle
+        fh = real_path_open(self, *args, **kwargs)
+        real_read = fh.read
+
+        def maybe_failing_read(size=-1):
+            # Check if _rfind_byte_before is in the call stack
+            stack_names = {frame.frame.f_code.co_name for frame in inspect.stack()}
+            if "_rfind_byte_before" in stack_names and not fault_injected[0]:
+                # First read from _rfind_byte_before: inject transient OSError
+                fault_injected[0] = True
+                read_calls_while_in_rfind[0] += 1
+                raise OSError("Injected transient OSError during _rfind_byte_before read")
+            return real_read(size)
+
+        fh.read = maybe_failing_read
+        return fh
+
+    # Patch Path.open to inject our wrapper
+    original_open = pathlib.Path.open
+    pathlib.Path.open = patched_open
+
+    try:
+        # Clear any existing cache entry for this run
+        from api.run_journal import _SUMMARY_CACHE
+        _SUMMARY_CACHE.pop((session_id, run_id), None)
+
+        # First call during fault should return best-effort (unknown or partial)
+        # It should NOT cache the failed result
+        first_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+
+        # Second call should RE-READ and recover the real completed state
+        # (not return a cached stale "no predecessor" result)
+        second_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    finally:
+        # Restore original Path.open
+        pathlib.Path.open = original_open
+
+    # Verify the fault was indeed injected during _rfind_byte_before
+    assert fault_injected[0], "OSError should have been injected during _rfind_byte_before"
+    assert read_calls_while_in_rfind[0] == 1, (
+        f"exactly one read should have failed while in _rfind_byte_before, "
+        f"got {read_calls_while_in_rfind[0]}"
+    )
+
+    # Assertions:
+    # 1. First call during fault returns best-effort (last_seq=0/1, terminal=False/running)
+    # 2. Second call RECOVERS (last_seq=2) after the OSError clears
+    # 3. The results are DIFFERENT (proving the first wasn't cached)
+
+    # First call may return last_seq=0 or 1 (best-effort during fault)
+    first_last_seq = first_summary["last_seq"]
+    assert first_last_seq in {0, 1}, (
+        f"first call during fault may return best-effort result, got last_seq={first_last_seq}"
+    )
+
+    # Second call should recover the last valid seq (seq=2)
+    # Note: terminal_state may still be "running" because seq=3 is truncated
+    # and seq=2 (tool_complete) is non-terminal. The key is that last_seq advances.
+    assert second_summary["last_seq"] == 2, (
+        f"second call should recover seq=2, got last_seq={second_summary['last_seq']}"
+    )
+
+    # The key assertion: results are DIFFERENT
+    # If fault[0]=True is missing from _rfind_byte_before, the first failed
+    # result would be cached, and both calls would return the SAME stale result.
+    # With fix 4, the second call produces a different result (last_seq advances).
+    assert first_summary["last_seq"] != second_summary["last_seq"], (
+        f"second call should produce different last_seq than first call (proving no cache), "
+        f"but both returned last_seq={first_summary['last_seq']}"
+    )
+
+
+def test_transient_rfind_oserror_not_cached_retry_recovers_find_run_summary(tmp_path):
+    """#6139 r16 FIX 4: same fault propagation test via find_run_summary instead of
+    latest_run_summary, ensuring both summary readers benefit from _rfind_byte_before
+    fault propagation.
+
+    Mutation proof: removing fault[0]=True from _rfind_byte_before causes this test to
+    FAIL (stale cached result instead of recovery).
+    """
+    import inspect
+    import pathlib
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path
+
+    session_id = "session_rfind_find"
+    run_id = "run_rfind_find"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write same shape: valid seq=1, seq=2, truncated seq=3 boundary
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "first"})
+    writer.append_sse_event("tool_complete", {"result": "ok"})
+
+    huge_size = _SESSION_REPLAY_MAX_BYTES + 100_000
+    partial_done = (
+        '{"version":1,"event_id":"' + run_id + ':3","seq":3,'
+        '"event":"done","type":"done","terminal":true,'
+        '"terminal_state":"completed","payload":{"text":"'
+        + "X" * huge_size
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(partial_done)
+
+    # Inject transient OSError on fh.read() when called from _rfind_byte_before
+    real_path_open = pathlib.Path.open
+    fault_injected = [False]
+    read_calls_while_in_rfind = [0]
+
+    def patched_open(self, *args, **kwargs):
+        fh = real_path_open(self, *args, **kwargs)
+        real_read = fh.read
+
+        def maybe_failing_read(size=-1):
+            stack_names = {frame.frame.f_code.co_name for frame in inspect.stack()}
+            if "_rfind_byte_before" in stack_names and not fault_injected[0]:
+                fault_injected[0] = True
+                read_calls_while_in_rfind[0] += 1
+                raise OSError("Injected transient OSError during _rfind_byte_before read")
+            return real_read(size)
+
+        fh.read = maybe_failing_read
+        return fh
+
+    original_open = pathlib.Path.open
+    pathlib.Path.open = patched_open
+
+    try:
+        # Clear cache
+        from api.run_journal import _SUMMARY_CACHE
+        cache_key = (run_id,)  # find_run_summary uses (run_id,) as cache key
+        _SUMMARY_CACHE.pop(cache_key, None)
+
+        # First call during fault
+        first_summary = find_run_summary(run_id, session_dir=tmp_path)
+
+        # Second call should recover
+        second_summary = find_run_summary(run_id, session_dir=tmp_path)
+    finally:
+        pathlib.Path.open = original_open
+
+    # Verify the fault was indeed injected during _rfind_byte_before
+    assert fault_injected[0], "OSError should have been injected during _rfind_byte_before"
+    assert read_calls_while_in_rfind[0] == 1, (
+        f"exactly one read should have failed while in _rfind_byte_before, "
+        f"got {read_calls_while_in_rfind[0]}"
+    )
+
+    assert first_summary is not None, "first call should return a summary"
+    first_last_seq = first_summary["last_seq"]
+    assert first_last_seq in {0, 1}, (
+        f"first call during fault may return best-effort result, got last_seq={first_last_seq}"
+    )
+
+    assert second_summary is not None, "second call should return a summary"
+    assert second_summary["last_seq"] == 2, (
+        f"second call should recover seq=2, got last_seq={second_summary['last_seq']}"
+    )
+
+    # Results must be different (proving no cache)
+    assert first_summary["last_seq"] != second_summary["last_seq"], (
+        f"second call should produce different last_seq than first call (proving no cache), "
+        f"but both returned last_seq={first_summary['last_seq']}"
+    )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -3731,3 +3731,302 @@ def test_sidecar_absent_falls_back_to_tail_correctness(tmp_path):
     assert summary["terminal"] is True
     assert summary["last_seq"] == 2
     assert summary["event_count"] == 2
+
+
+# ── Round 18 regression tests ─────────────────────────────────────────────────────
+
+
+def test_failed_interior_sidecar_commit_not_healed_into_wrong_terminal(tmp_path, monkeypatch):
+    """Regression (Round 18, blocker 1): When a sidecar write fails between appends
+    (e.g. the cancel's sidecar commit OSError), the writer must NOT trust the
+    stale prior sidecar as the fold base for the next append. The stale sidecar's
+    journal_size reflects a pre-append state, so the writer validates it matches
+    the actual JSONL size before folding. A mismatch rebuilds from the tail, not
+    from the stale sidecar. Without this check, the lost cancel event is
+    permanently healed into a wrong 'completed' terminal."""
+    from api.run_journal import _run_path, _summary_sidecar_path, _read_jsonl, _summary_from_events, append_run_event
+    import json
+    from unittest import mock
+
+    session_id = "session_r18_b1"
+    run_id = "run_r18_b1"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Append token(seq=1) — sidecar written successfully
+    append_run_event(session_id, run_id, "token", {"text": "first"}, session_dir=tmp_path)
+
+    # Verify token sidecar
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        token_sidecar = json.load(f)
+    assert token_sidecar["event_count"] == 1
+    token_journal_size = token_sidecar["journal_size"]
+
+    # Now make the NEXT sidecar write fail (cancel) - patch only during this append
+    real_atomic_write = __import__("api.run_journal", fromlist=["_atomic_write_json"])._atomic_write_json
+    failed_once = {"v": False}
+
+    def failing_write(p, payload, *, fsync):
+        if not failed_once["v"]:
+            failed_once["v"] = True
+            raise OSError("Simulated sidecar write failure")
+        return real_atomic_write(p, payload, fsync=fsync)
+
+    # Patch only during the cancel append
+    with mock.patch("api.run_journal._atomic_write_json", failing_write):
+        append_run_event(session_id, run_id, "cancel", {"message": "Cancelled"}, session_dir=tmp_path)
+
+    # After cancel: JSONL has token+cancel, but sidecar is still stale (event_count=1, journal_size=token_size)
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        cancel_sidecar = json.load(f)
+    assert cancel_sidecar["event_count"] == 1, "cancel's sidecar write failed, leaving stale sidecar"
+    assert cancel_sidecar["journal_size"] == token_journal_size, "stale sidecar journal_size unchanged"
+
+    # Append stream_end(seq=3) — sidecar write succeeds (terminal committed)
+    append_run_event(session_id, run_id, "stream_end", {"terminal_state": "closed"}, session_dir=tmp_path)
+
+    # The sidecar must reflect seq=3 (stream_end), not the stale seq=1
+    assert sidecar_path.exists()
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_data = json.load(f)
+    assert sidecar_data["event_count"] == 3, (
+        f"sidecar must count all 3 events; got {sidecar_data['event_count']} — "
+        "stale seq=1 sidecar was incorrectly folded onto"
+    )
+    assert sidecar_data["last"]["seq"] == 3, (
+        f"sidecar last_seq must be 3 (stream_end); got {sidecar_data['last']['seq']} — "
+        "stale sidecar caused wrong terminal"
+    )
+
+    # Clear cache and get cold summary (must match full read)
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    cold_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    full_events, _, _ = _read_jsonl(path)
+    full_summary = _summary_from_events(session_id, run_id, full_events)
+
+    # Cold summary must equal full summary (event_count=3, terminal=interrupted-by-user)
+    assert cold_summary["event_count"] == full_summary["event_count"] == 3, (
+        f"cold summary event_count={cold_summary['event_count']}, "
+        f"full={full_summary['event_count']} — lost cancel event was healed into wrong terminal"
+    )
+    assert cold_summary["terminal_state"] == full_summary["terminal_state"] == "interrupted-by-user", (
+        f"cold terminal_state={cold_summary['terminal_state']}, "
+        f"full={full_summary['terminal_state']} — stale sidecar misreported terminal"
+    )
+
+
+def test_transient_tail_rebuild_fault_not_published_as_authority(tmp_path, monkeypatch):
+    """Regression (Round 18, blocker 2): When a sidecar is absent for an existing run
+    and the writer rebuilds from the tail, a transient fault in _read_jsonl_tail
+    (ok=False) must NOT publish a sidecar. A faulted rebuild could be incomplete
+    (e.g., tail truncated mid-read due to concurrent append), so publishing it as
+    authority would brick the summary readers. The writer honors tail_ok and only
+    publishes when the rebuild succeeded. Readers keep falling back to the tail
+    reader, and a later append retries the rebuild."""
+    from api.run_journal import _run_path, _summary_sidecar_path, _read_jsonl, _summary_from_events
+    import json
+
+    session_id = "session_r18_b2"
+    run_id = "run_r18_b2"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Hand-write a 3-event journal (token, token, cancel) with NO sidecar
+    events = [
+        {"version": 1, "event_id": f"{run_id}:1", "seq": 1, "run_id": run_id,
+         "session_id": session_id, "event": "token", "type": "token",
+         "terminal": False, "terminal_state": None, "created_at": 100.0,
+         "payload": {"text": "first"}},
+        {"version": 1, "event_id": f"{run_id}:2", "seq": 2, "run_id": run_id,
+         "session_id": session_id, "event": "token", "type": "token",
+         "terminal": False, "terminal_state": None, "created_at": 200.0,
+         "payload": {"text": "second"}},
+        {"version": 1, "event_id": f"{run_id}:3", "seq": 3, "run_id": run_id,
+         "session_id": session_id, "event": "cancel", "type": "cancel",
+         "terminal": True, "terminal_state": "interrupted-by-user", "created_at": 300.0,
+         "payload": {"message": "Cancelled"}},
+    ]
+
+    with path.open("w", encoding="utf-8") as f:
+        for event in events:
+            f.write(json.dumps(event, separators=(",", ":")) + "\n")
+
+    # Verify no sidecar exists
+    sidecar_path = _summary_sidecar_path(path)
+    assert not sidecar_path.exists()
+
+    # Monkeypatch _read_jsonl_tail to return ok=False (simulated transient fault)
+    real_read_tail = __import__("api.run_journal", fromlist=["_read_jsonl_tail"])._read_jsonl_tail
+
+    def faulted_tail(path, *, max_bytes, max_rows, attribute_lines):
+        events, malformed, _ok = real_read_tail(
+            path, max_bytes=max_bytes, max_rows=max_rows, attribute_lines=attribute_lines
+        )
+        return events, malformed, False  # Force ok=False
+
+    monkeypatch.setattr("api.run_journal._read_jsonl_tail", faulted_tail)
+
+    # Append a 4th event (stream_end) — this rebuilds from the faulted tail
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("stream_end", {"terminal_state": "closed"})
+
+    # The append must have succeeded (JSONL has 4 lines)
+    with path.open("r", encoding="utf-8") as f:
+        jsonl_lines = [line for line in f if line.strip()]
+    assert len(jsonl_lines) == 4, (
+        f"JSONL must have 4 lines after append; got {len(jsonl_lines)} — "
+        "append may have failed"
+    )
+
+    # The sidecar must NOT have been published (rebuild was faulted)
+    assert not sidecar_path.exists(), (
+        "sidecar must not exist after faulted rebuild — writer must not publish "
+        "untrusted state"
+    )
+
+    # Clear cache
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    # Cold latest_run_summary must still work (tail fallback) and match full read
+    cold_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    full_events, _, _ = _read_jsonl(path)
+    full_summary = _summary_from_events(session_id, run_id, full_events)
+
+    assert cold_summary["event_count"] == full_summary["event_count"] == 4, (
+        f"cold summary event_count={cold_summary['event_count']}, "
+        f"full={full_summary['event_count']} — tail fallback failed"
+    )
+    assert cold_summary["terminal_state"] == full_summary["terminal_state"], (
+        f"cold terminal_state={cold_summary['terminal_state']}, "
+        f"full={full_summary['terminal_state']} — tail fallback misreported terminal"
+    )
+
+
+def test_malformed_matching_size_sidecar_reader_degrades_without_raising(tmp_path, monkeypatch):
+    """Regression (Round 18, blocker 3): A malformed sidecar that passes the
+    journal_size stale check (size matches JSONL) must not raise ValueError or
+    KeyError in the reader or during append. The reader's _validate_sidecar
+    strictly checks schema/types/ranges and returns None on any malformation,
+    degrading to the JSONL fallback. Append must not brick journaling."""
+    from api.run_journal import _run_path, _summary_sidecar_path
+    import json
+
+    session_id = "session_r18_b3_reader"
+    run_id = "run_r18_b3_reader"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    # Append a done event (sidecar written)
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+    jsonl_size = path.stat().st_size
+
+    # Overwrite the sidecar with malformed JSON: event_count is a string, not int
+    malformed_sidecar = {
+        "version": 1,
+        "journal_size": jsonl_size,  # Matches JSONL size (passes stale check)
+        "event_count": "oops",  # WRONG TYPE — must be int
+        "last": None,
+        "terminal": None
+    }
+
+    with sidecar_path.open("w", encoding="utf-8") as f:
+        json.dump(malformed_sidecar, f)
+
+    # Clear cache
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    # latest_run_summary must NOT raise — it degrades to tail fallback
+    summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+
+    # The summary must be correct (recovered via tail fallback)
+    assert summary["terminal_state"] == "completed", (
+        f"summary terminal_state={summary['terminal_state']!r} — malformed sidecar "
+        "should degrade to tail and recover correct terminal"
+    )
+    assert summary["event_count"] == 1, (
+        f"summary event_count={summary['event_count']} — malformed sidecar should "
+        "degrade to tail and recover correct count"
+    )
+
+
+def test_malformed_matching_size_sidecar_append_does_not_brick_journaling(tmp_path, monkeypatch):
+    """Regression (Round 18, blocker 3 follow-up): A malformed sidecar (e.g., missing
+    fold keys like event_count/last/terminal) must not raise KeyError during the
+    next append. The writer's _read_sidecar validates strictly and returns None
+    for malformed sidecars, triggering a rebuild instead of trusting corrupt state.
+    Journaling must continue working — the JSONL line is written, and a new valid
+    sidecar is published."""
+    from api.run_journal import _run_path, _summary_sidecar_path, _read_jsonl, _summary_from_events
+    import json
+
+    session_id = "session_r18_b3_append"
+    run_id = "run_r18_b3_append"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    # Append a done event (sidecar written)
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+    jsonl_size = path.stat().st_size
+
+    # Overwrite the sidecar with incomplete data (missing fold keys)
+    incomplete_sidecar = {
+        "version": 1,
+        "journal_size": jsonl_size,  # Matches JSONL size (passes stale check)
+        # Missing: event_count, last, terminal — MALFORMED
+    }
+
+    with sidecar_path.open("w", encoding="utf-8") as f:
+        json.dump(incomplete_sidecar, f)
+
+    # Clear cache
+    from api.run_journal import _SUMMARY_CACHE, _SUMMARY_CACHE_LOCK
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    # Append stream_end — must NOT raise (malformed sidecar is ignored, rebuilt)
+    writer.append_sse_event("stream_end", {"terminal_state": "closed"})
+
+    # The JSONL must have gained exactly one line (stream_end)
+    with path.open("r", encoding="utf-8") as f:
+        jsonl_lines = [line for line in f if line.strip()]
+    assert len(jsonl_lines) == 2, (
+        f"JSONL must have 2 lines after append; got {len(jsonl_lines)} — "
+        "append may have failed"
+    )
+
+    # The sidecar must now be valid (writer published a new correct sidecar)
+    assert sidecar_path.exists()
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_data = json.load(f)
+    assert sidecar_data["event_count"] == 2, (
+        f"sidecar event_count={sidecar_data['event_count']} — writer must rebuild "
+        "and publish correct sidecar after ignoring malformed one"
+    )
+
+    # Clear cache and verify cold summary matches full read
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.clear()
+
+    cold_summary = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    full_events, _, _ = _read_jsonl(path)
+    full_summary = _summary_from_events(session_id, run_id, full_events)
+
+    assert cold_summary["event_count"] == full_summary["event_count"] == 2, (
+        f"cold summary event_count={cold_summary['event_count']}, "
+        f"full={full_summary['event_count']} — malformed sidecar broke summary"
+    )
+    assert cold_summary["last_seq"] == full_summary["last_seq"] == 2, (
+        f"cold summary last_seq={cold_summary['last_seq']}, "
+        f"full={full_summary['last_seq']} — malformed sidecar broke seq tracking"
+    )

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -22,6 +22,7 @@ from api.run_journal import (
     find_run_summary,
     latest_run_summary,
     read_run_events,
+    append_run_event,
 )
 from api.run_journal import _SESSION_REPLAY_MAX_ROWS
 
@@ -3369,8 +3370,10 @@ def test_writer_produces_sidecar_and_summary_matches_full_read(tmp_path):
     with sidecar_path.open("r", encoding="utf-8") as f:
         sidecar_data = json.load(f)
 
-    # Verify sidecar structure
-    assert sidecar_data["version"] == 1
+    # Verify sidecar structure (b1: v2 schema with session_id/run_id)
+    assert sidecar_data["version"] == 2
+    assert sidecar_data["session_id"] == session_id
+    assert sidecar_data["run_id"] == run_id
     assert sidecar_data["event_count"] == 3
     assert sidecar_data["last"]["seq"] == 3
     assert sidecar_data["last"]["event"] == "done"
@@ -3394,6 +3397,325 @@ def test_writer_produces_sidecar_and_summary_matches_full_read(tmp_path):
     assert sidecar_summary["terminal"] == full_summary["terminal"]
     assert sidecar_summary["terminal_state"] == full_summary["terminal_state"]
     assert sidecar_summary["last_event"] == full_summary["last_event"]
+
+
+def test_foreign_same_size_sidecar_rejected_by_identity(tmp_path):
+    """b1: A v2 sidecar with foreign session_id/run_id (same journal_size) is rejected.
+    Both readers must fall back to the JSONL tail and return the TRUE tuple."""
+    from api.run_journal import _run_path, _summary_sidecar_path, _read_jsonl, _summary_from_events
+    import json
+
+    session_id = "session_1"
+    run_id = "run_foreign"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    # Create a real journal with known events
+    writer.append_sse_event("token", {"text": "real"})
+    writer.append_sse_event("cancel", {})  # terminal_state = interrupted-by-user
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+    journal_size = path.stat().st_size
+
+    # Overwrite sidecar with a FOREIGN one (wrong session_id/run_id, same journal_size, wrong terminal)
+    foreign_sidecar = {
+        "version": 2,
+        "session_id": "wrong_session",
+        "run_id": "wrong_run",
+        "journal_size": journal_size,
+        "event_count": 1,
+        "last": {"seq": 1, "event_id": "wrong_run:1", "event": "done"},
+        "terminal": {"event": "done", "state": "completed", "seq": 1, "event_id": "wrong_run:1"},
+    }
+    with sidecar_path.open("w", encoding="utf-8") as f:
+        json.dump(foreign_sidecar, f)
+
+    # Both readers must reject the foreign sidecar and fall back to JSONL
+    summary_latest = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    summary_find = find_run_summary(run_id, session_dir=tmp_path)
+
+    # Authoritative full read (baseline: must match this)
+    full_events, _, _ = _read_jsonl(path)
+    authoritative = _summary_from_events(session_id, run_id, full_events)
+
+    # Both readers must agree with the full reader (cancel/interrupted-by-user), NOT the foreign done/completed
+    for summary in (summary_latest, summary_find):
+        assert summary["terminal"] is True, "should be terminal (cancel)"
+        assert summary["terminal_state"] == "interrupted-by-user", (
+            f"should report interrupted-by-user, not foreign completed; got {summary['terminal_state']}"
+        )
+        assert summary["last_seq"] == 2, "should have seq 2 (cancel)"
+        assert summary["event_count"] == 2, "should have 2 events"
+
+    # Must match the authoritative full read exactly
+    assert summary_latest["terminal_state"] == authoritative["terminal_state"]
+    assert summary_find["terminal_state"] == authoritative["terminal_state"]
+
+
+def test_pre_state_fault_does_not_publish_sidecar(tmp_path):
+    """b2a: When pre-state fstat raises OSError, pre_size=None, base_trusted=False,
+    so no sidecar is published. JSONL gets the new line, readers return correct result."""
+    from api.run_journal import _run_path, _summary_sidecar_path
+    import json
+
+    session_id = "session_fault"
+    run_id = "run_fault"
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Populate journal + trusted sidecar manually (set up the initial state)
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+    writer.append_sse_event("token", {"text": "existing"})
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    # Verify initial sidecar exists and is trusted
+    assert sidecar_path.exists()
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        initial_sidecar = json.load(f)
+    assert initial_sidecar["event_count"] == 2
+
+    # Fault ONLY the pre-state size read. ``_descriptor_size`` is called exactly
+    # twice per append (pre-state then post-state) and is NOT used by the
+    # cross-process lock, so a one-call counter faults the pre-state read while
+    # leaving the post-state read (and the lock's own fstat) intact. The
+    # post-state MUST succeed, otherwise publish is blocked by ``post_size is
+    # None`` instead of by ``base_trusted`` and the test passes for the wrong
+    # reason.
+    import api.run_journal as rj_module
+    real_descriptor_size = rj_module._descriptor_size
+    calls = {"n": 0}
+
+    def faulting_descriptor_size(fh):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("simulated pre-state fault")
+        return real_descriptor_size(fh)
+
+    rj_module._descriptor_size = faulting_descriptor_size
+    try:
+        # Append one event; pre-state fault must prevent sidecar publication.
+        writer.append_sse_event("token", {"text": "after-fault"})
+    finally:
+        rj_module._descriptor_size = real_descriptor_size  # restore
+
+    # Assert: sidecar NOT republished (should still show event_count=2)
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        final_sidecar = json.load(f)
+    assert final_sidecar["event_count"] == 2, (
+        f"sidecar should NOT be republished after pre-state fault; "
+        f"got event_count={final_sidecar['event_count']} (expected 2)"
+    )
+
+    # JSONL must have the new line (3 total lines)
+    lines = path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 3, f"JSONL should have 3 lines after append; got {len(lines)}"
+
+    # Both readers must return the correct result (event_count=3, not the stale sidecar's 2)
+    summary_latest = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    summary_find = find_run_summary(run_id, session_dir=tmp_path)
+
+    for summary in (summary_latest, summary_find):
+        assert summary["event_count"] == 3, (
+            f"reader should see all 3 events, not stale sidecar count 2; "
+            f"got {summary['event_count']}"
+        )
+        assert summary["last_seq"] == 3, f"last_seq should be 3; got {summary['last_seq']}"
+
+
+def test_sidecar_only_replacement_invalidates_warm_cache(tmp_path):
+    """b1-cache: Replacing ONLY the sidecar (different terminal, same jsonl) changes
+    the cache signature, so warm cache invalidates and next read returns fresh data."""
+    from api.run_journal import _run_path, _summary_sidecar_path
+    import json
+
+    session_id = "session_cache"
+    run_id = "run_cache"
+    writer = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+
+    writer.append_sse_event("token", {"text": "initial"})
+    writer.append_sse_event("done", {"session": {"session_id": session_id}})
+
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    sidecar_path = _summary_sidecar_path(path)
+
+    # Warm the cache via a read
+    summary_1 = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert summary_1["terminal_state"] == "completed"
+
+    # Replace ONLY the sidecar (different terminal, same jsonl)
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_data = json.load(f)
+    sidecar_data["terminal"] = {"event": "cancel", "state": "interrupted-by-user", "seq": 2, "event_id": f"{run_id}:2"}
+    with sidecar_path.open("w", encoding="utf-8") as f:
+        json.dump(sidecar_data, f)
+
+    # Next read must NOT return the stale cached value (must re-read)
+    summary_2 = latest_run_summary(session_id, run_id, session_dir=tmp_path)
+    assert summary_2["terminal_state"] == "interrupted-by-user", (
+        "warm cache must invalidate after sidecar-only replacement; "
+        f"got stale {summary_2['terminal_state']}"
+    )
+
+
+def test_capped_rebuild_not_promoted_to_authority(tmp_path):
+    """b2b: A journal beyond the byte cap (capped rebuild) must NOT publish a sidecar.
+    Rebuild with max_rows=None only trusts when pre_size <= max_bytes."""
+    from api.run_journal import _SESSION_REPLAY_MAX_BYTES, _run_path, _summary_sidecar_path
+    import json
+
+    session_id = "session_capped"
+    run_id = "run_capped"
+
+    # Build an OVERSIZED journal directly (fast): a cancel(seq1) semantic
+    # terminal near the start, followed by a few large events so the total
+    # exceeds the 4 MiB byte cap. No sidecar is written, so the next append must
+    # rebuild from the bounded tail. Raw-written events use the writer's own
+    # record shape so the rebuild fold exercises the real parser.
+    large = "X" * (512 * 1024)  # 512 KiB per token payload
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        specs = [(1, "cancel", {"message": "x"}, "interrupted-by-user")]
+        specs += [(seq, "token", {"text": large}, None) for seq in range(2, 11)]
+        for seq, name, payload, tstate in specs:
+            ev = {
+                "version": 1,
+                "event_id": f"{run_id}:{seq}",
+                "seq": seq,
+                "run_id": run_id,
+                "session_id": session_id,
+                "event": name,
+                "type": name,
+                "created_at": float(seq),
+                "terminal": tstate is not None,
+                "terminal_state": tstate,
+                "payload": payload,
+            }
+            fh.write(json.dumps(ev, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+    sidecar_path = _summary_sidecar_path(path)
+    assert not sidecar_path.exists(), "fixture must start with no sidecar"
+
+    # Sanity: the journal actually exceeds the byte cap (so the rebuild is capped).
+    journal_size = path.stat().st_size
+    assert journal_size > _SESSION_REPLAY_MAX_BYTES, (
+        f"test fixture must exceed byte cap; journal size={journal_size}, cap={_SESSION_REPLAY_MAX_BYTES}"
+    )
+
+    # Append one event (triggers a capped rebuild; must NOT publish a sidecar).
+    append_run_event(session_id, run_id, "token", {"text": "after-rebuild"}, session_dir=tmp_path)
+
+    assert not sidecar_path.exists(), (
+        "sidecar must NOT be published for a capped rebuild; "
+        "journal exceeds byte cap, so the rebuild is incomplete authority"
+    )
+
+    # Both readers must not raise (they fall back to the bounded tail reader).
+    assert latest_run_summary(session_id, run_id, session_dir=tmp_path) is not None
+    assert find_run_summary(run_id, session_dir=tmp_path) is not None
+
+
+def test_writer_free_function_interleaving_no_omission(tmp_path):
+    """b3: RunJournalWriter and free append_run_event() writing to the same journal
+    must not omit events (thread-safety + seq uniqueness). Uses actual threads."""
+    import threading
+    from api.run_journal import _run_path, _read_jsonl
+
+    session_id = "session_interleave"
+    run_id = "run_interleave"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    n = 50  # events per thread
+
+    def writer_thread():
+        w = RunJournalWriter(session_id, run_id, session_dir=tmp_path)
+        for i in range(n):
+            w.append_sse_event("token", {"text": f"writer-{i}"})
+
+    def free_func_thread():
+        for i in range(n):
+            append_run_event(session_id, run_id, "token", {"text": f"free-{i}"}, session_dir=tmp_path)
+
+    t1 = threading.Thread(target=writer_thread)
+    t2 = threading.Thread(target=free_func_thread)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Read JSONL and verify
+    events, _, _ = _read_jsonl(path)
+    assert len(events) == 2 * n, f"expected {2*n} events, got {len(events)}"
+
+    # All seqs must be unique and in [1, 2*n]
+    seqs = sorted([int(e["seq"]) for e in events])
+    assert seqs == list(range(1, 2 * n + 1)), f"seqs not gapless: {seqs[:5]}...{seqs[-5:]}"
+
+
+def test_cross_process_concurrent_append_no_omission(tmp_path):
+    """b3: Two subprocesses appending to the SAME journal must not omit events.
+    Asserts sidecar event_count == durable JSONL line count (ground truth)."""
+    import subprocess
+    import sys
+    import api.run_journal as rj_module
+    from api.run_journal import _run_path, _summary_sidecar_path, _read_jsonl
+    import json
+
+    session_id = "session_crossproc"
+    run_id = "run_crossproc"
+    path = _run_path(session_id, run_id, session_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # The helper runs in a fresh interpreter, so it needs the REPO root (where
+    # the ``api`` package lives) on sys.path -- not tmp_path.
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(rj_module.__file__)))
+    n_events = 30
+
+    helper_code = (
+        "import sys\n"
+        f"sys.path.insert(0, r{chr(34)}{repo_root}{chr(34)})\n"
+        "from api.run_journal import append_run_event\n"
+        f"sid = {session_id!r}\n"
+        f"rid = {run_id!r}\n"
+        f"sd = r{chr(34)}{tmp_path}{chr(34)}\n"
+        f"for i in range({n_events}):\n"
+        "    append_run_event(sid, rid, 'token', {'text': f'proc-{i}'}, session_dir=sd)\n"
+    )
+    helper_file = tmp_path / "cross_proc_helper.py"
+    helper_file.write_text(helper_code, encoding="utf-8")
+
+    # Spawn two subprocesses CONCURRENTLY, capturing stderr so an import/append
+    # failure in the helper surfaces instead of making the test pass vacuously.
+    p1 = subprocess.Popen([sys.executable, str(helper_file)], stderr=subprocess.PIPE)
+    p2 = subprocess.Popen([sys.executable, str(helper_file)], stderr=subprocess.PIPE)
+    out1, err1 = p1.communicate()
+    out2, err2 = p2.communicate()
+    assert p1.returncode == 0, f"helper proc1 failed: {err1.decode('utf-8', 'replace')}"
+    assert p2.returncode == 0, f"helper proc2 failed: {err2.decode('utf-8', 'replace')}"
+
+    # Ground truth: durable JSONL line count.
+    events, _, _ = _read_jsonl(path)
+    durable_count = len(events)
+    assert durable_count == 2 * n_events, (
+        f"expected {2 * n_events} durable events, got {durable_count}; "
+        f"proc1_err={err1.decode('utf-8', 'replace')!r} proc2_err={err2.decode('utf-8', 'replace')!r}"
+    )
+
+    # The published sidecar must agree with the durable line count (no omissions).
+    sidecar_path = _summary_sidecar_path(path)
+    assert sidecar_path.exists(), "trusted sidecar must be published for the concurrent run"
+    with sidecar_path.open("r", encoding="utf-8") as f:
+        sidecar_data = json.load(f)
+    assert sidecar_data["event_count"] == durable_count, (
+        f"sidecar event_count={sidecar_data['event_count']} != durable count={durable_count}; "
+        "cross-process serialization failed - accepted event(s) omitted from the sidecar"
+    )
+
+    # All seqs must be unique and gapless across the two processes.
+    seqs = sorted([int(e["seq"]) for e in events])
+    assert seqs == list(range(1, durable_count + 1)), f"seqs not gapless: {seqs[:5]}...{seqs[-5:]}"
 
 
 def test_oversized_terminal_summary_uses_sidecar_bounded_reads(tmp_path):

--- a/tests/test_run_journal_tail_read.py
+++ b/tests/test_run_journal_tail_read.py
@@ -1794,3 +1794,166 @@ def test_predecessor_recovery_not_starved_by_validity_proof_budget(tmp_path):
     assert summary["terminal"] is True, (
         f"a completed run was misreported non-terminal (terminal={summary['terminal']})"
     )
+
+
+def test_malformed_oversized_boundary_extraction_none_recovers_preceding(tmp_path, monkeypatch):
+    """Regression (reviewer round 12): when ``_extract_boundary_record_summary()``
+    itself returns ``None`` for the straddling oversized boundary record (the record
+    is malformed before the top-level ``payload`` key, e.g. an unquoted token),
+    predecessor recovery must STILL run. The r11 control-flow only recovered when
+    extraction succeeded but validation failed (``boundary_summary is not None and
+    not _record_is_valid_complete(...)``); the extraction-None path skipped the
+    ENTIRE recovery block, so the valid terminal row immediately before the
+    malformed boundary was dropped — the full reader reported ``completed`` while
+    the tail reader reported ``running`` (a completed run misreported non-terminal).
+
+    Layout: valid ``done`` seq=1 (completed), oversized seq=2 malformed before
+    ``payload`` (extraction returns None), trailing valid token seq=3 (forces the
+    boundary into seq=2). The fix recovers the preceding terminal on EITHER
+    rejection path. This is a production-composed regression: it asserts the full
+    reader, tail reader, ``latest_run_summary``, AND ``find_run_summary`` all agree
+    (keep seq=1, report completed, exclude the malformed seq=2); that prefix
+    extraction returned None for the fixture; that predecessor recovery is reached
+    exactly once with a non-empty reserve budget; and that the journal is opened
+    exactly once (no pathname reopen, no O(file-size) head scan)."""
+    from pathlib import Path
+    from api import run_journal
+    from api.run_journal import (
+        _SESSION_REPLAY_MAX_BYTES,
+        _read_jsonl,
+        _read_jsonl_tail,
+        find_run_summary,
+        latest_run_summary,
+    )
+
+    cap = _SESSION_REPLAY_MAX_BYTES
+    # Valid terminal done that MUST survive predecessor recovery.
+    valid_done = ('{"seq":1,"event":"done","terminal":true,'
+                  '"terminal_state":"completed","payload":{"ok":1}}\n')
+    # Oversized straddling boundary record malformed BEFORE the top-level
+    # "payload" key: the bare `bad,` token makes the truncated head invalid JSON,
+    # so _extract_boundary_record_summary returns None (it cannot parse the prefix
+    # up to the payload key). Newline-terminated so the record is a real line.
+    big = "X" * (cap + 50_000)
+    malformed_oversized = (
+        '{"seq":2,"event":"done","terminal":true,bad,'
+        '"payload":{"t":"' + big + '"}}\n'
+    )
+    # Trailing valid token so the tail window's boundary lands inside seq=2.
+    trailing = '{"seq":3,"event":"token","payload":{"t":"z"}}\n'
+    path = tmp_path / "_run_journal" / "s1" / "r1.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as fh:
+        fh.write(valid_done.encode("utf-8"))
+        fh.write(malformed_oversized.encode("utf-8"))
+        fh.write(trailing.encode("utf-8"))
+    assert path.stat().st_size > cap, "sanity: the journal must exceed the tail window"
+
+    # (1) The fixture must actually exercise the extraction-None path: the prefix
+    # extractor returns None for the malformed oversized boundary record. This is
+    # what makes the r11 control-flow skip recovery — a non-None extraction would
+    # take a different branch and the test would not discriminate the r12 fix.
+    import os
+    with path.open("rb") as fh:
+        size = os.fstat(fh.fileno()).st_size
+        record_start = run_journal._find_record_start_before(fh, size, size - cap)
+    with path.open("rb") as fh:
+        extraction = run_journal._extract_boundary_record_summary(fh, record_start)
+    assert extraction is None, (
+        f"fixture precondition: _extract_boundary_record_summary must return None "
+        f"for the malformed-before-payload oversized record (got {extraction!r}); "
+        f"if it returns a summary, the test does not exercise the r12 path"
+    )
+
+    # (2) Ground truth: the full reader keeps the valid done (seq=1) + trailing
+    # token (seq=3) and rejects the malformed seq=2.
+    full_events, _ = _read_jsonl(path)
+    full_seqs = {e.get("seq") for e in full_events if isinstance(e, dict)}
+    assert full_seqs == {1, 3}, (
+        f"baseline: full reader keeps seq=1 (valid done) + seq=3 (token), rejects "
+        f"seq=2 (malformed); got {full_seqs}"
+    )
+
+    # (3) Instrument predecessor recovery and journal opens, scoped to ONE
+    # authoritative _read_jsonl_tail call. The r11 control-flow skipped recovery
+    # on the extraction-None path (count 0); the r12 fix reaches it exactly once.
+    recovery_calls = {"n": 0, "budgets": []}
+    real_recovery = run_journal._read_last_complete_line_before
+
+    # The real signature is (fh, size_arg, end_offset, *, budget). Patch carefully:
+    def patched_recovery_real(fh, size_arg, end_offset, *, budget=None):
+        recovery_calls["n"] += 1
+        recovery_calls["budgets"].append(budget)
+        return real_recovery(fh, size_arg, end_offset, budget=budget)
+
+    monkeypatch.setattr(run_journal, "_read_last_complete_line_before", patched_recovery_real)
+
+    # Count journal opens for this ONE tail read: must be exactly one (single
+    # pinned descriptor; no pathname reopen, no O(file-size) head scan).
+    open_calls = {"n": 0}
+    real_open = Path.open
+
+    def patched_open(self, *args, **kwargs):
+        open_calls["n"] += 1
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", patched_open)
+
+    # (4) The tail reader must keep seq=1 (recovered predecessor) and exclude
+    # seq=2, matching the full reader.
+    tail_events, _ = _read_jsonl_tail(path, max_bytes=cap, max_rows=None)
+    tail_seqs = {e.get("seq") for e in tail_events if isinstance(e, dict)}
+    assert tail_seqs == {1, 3}, (
+        f"the tail reader diverged from the full reader: tail_seqs={tail_seqs} "
+        f"(expected {{1, 3}}); the extraction-None path dropped the preceding "
+        f"terminal (seq=1) by skipping predecessor recovery (#6139 r12 blocker)"
+    )
+    assert 2 not in tail_seqs, "the malformed oversized boundary record was fabricated as a summary"
+
+    # (5) Predecessor recovery was reached exactly ONCE for this single tail read,
+    # with a non-empty reserve budget. A mutation that skips the extraction-None
+    # path makes the count 0; a mutation that double-recovers makes it > 1.
+    assert recovery_calls["n"] == 1, (
+        f"predecessor recovery was reached {recovery_calls['n']} times for a single "
+        f"tail read (expected exactly 1); the extraction-None path must trigger "
+        f"recovery once (#6139 r12: the r11 control-flow skipped it entirely)"
+    )
+    budget = recovery_calls["budgets"][0]
+    assert budget is not None, "predecessor recovery received a None budget (no reserve)"
+    # The reserve is a fresh _ReadBudget(read_bytes_cap); assert it is non-empty.
+    remaining = getattr(budget, "remaining", None)
+    assert remaining is not None and remaining > 0, (
+        f"predecessor recovery's reserve budget was empty or missing "
+        f"(remaining={remaining!r}); a >=budget validity proof must not starve it"
+    )
+
+    # (6) The journal was opened exactly once for this single tail read (single
+    # pinned descriptor; no pathname reopen, no O(file-size) head scan).
+    assert open_calls["n"] == 1, (
+        f"the journal was opened {open_calls['n']} times for a single tail read "
+        f"(expected exactly 1); the tail reader must open once and pin the inode "
+        f"(#6139 r8/r11)"
+    )
+
+    # (7) Production summary readers must report the run completed (end-to-end
+    # correctness, separate from the call-count controls above). Clear the
+    # instrumented counters first so the summary-reader calls don't pollute them.
+    recovery_calls["n"] = 0
+    recovery_calls["budgets"].clear()
+    open_calls["n"] = 0
+    summary = latest_run_summary("s1", "r1", session_dir=tmp_path)
+    assert summary["terminal_state"] == "completed", (
+        f"latest_run_summary reported terminal_state={summary['terminal_state']!r} "
+        f"(expected 'completed'); a completed run was misreported non-terminal "
+        f"because the extraction-None path skipped predecessor recovery (#6139 r12)"
+    )
+    assert summary["terminal"] is True, (
+        f"latest_run_summary marked terminal={summary['terminal']} (expected True)"
+    )
+    found = find_run_summary("r1", session_dir=tmp_path)
+    assert found is not None, "find_run_summary must locate the run"
+    assert found["terminal_state"] == "completed", (
+        f"find_run_summary reported terminal_state={found['terminal_state']!r} "
+        f"(expected 'completed'); the extraction-None path skipped recovery on the "
+        f"find_run_summary path too (#6139 r12)"
+    )


### PR DESCRIPTION
## Thinking Path

- The run journal records SSE events for a turn so they can be replayed after reconnect/restart. Summary readers (`latest_run_summary` / `find_run_summary`) derive `last_seq` / `last_event_id` / `terminal_state` from the journal on every status/sidebar poll.
- `_read_jsonl` read the **WHOLE** journal file via `read_text()` and parsed every line. The replay path (`read_session_run_events`) already had `_SESSION_REPLAY_MAX_BYTES` / `_SESSION_REPLAY_MAX_ROWS` caps + chunked streaming, but the summary readers on the hot poll path did not.
- A turn with heavy tool use / large file reads produced a multi-MB journal fully re-parsed on every status/sidebar poll.

## What Changed

- Give `_read_jsonl` optional `max_bytes`/`max_rows` caps (head cap via the existing `_iter_bounded_raw_jsonl_lines`) and a `tail=` mode.
- The summary readers now read the bounded **TAIL** (seek-to-end + read last `max_bytes`, discard the partial line at the seek boundary, return at most the last `max_rows` events): `last_seq` / `last_event_id` / `terminal_state` are derived from the LAST events, so a tail read keeps them correct for a large COMPLETED run (its terminal marker lives at the end) without parsing the whole history. A naive head cap would misreport such a run as still-running.
- `read_run_events` gains optional `max_bytes`/`max_rows` (forward, head cap) but keeps its default whole-file behavior and `after_seq`/`max_seq` filtering.
- Malformed-line attribution in tail mode counts ACTUAL newlines in the discarded head (streamed in chunks so the head is never materialized twice), then accounts for the dropped partial line at the seek boundary (first whole line = `lines_before_window + 2`). A byte-offset approximation was off by orders of magnitude (a malformed line at real line 181 was reported as ~6892).

## Why It Matters

Run-journal status/sidebar summaries now read a bounded tail of the journal instead of the whole file, capping per-poll memory for large runs. A turn that produced a multi-MB journal no longer gets fully re-parsed on every status poll.

## Verification

- `tests/test_run_journal_tail_read.py` (new, 10 tests): a run with `>_SESSION_REPLAY_MAX_ROWS` events still reports correct `terminal_state`/`last_seq` (proves tail-read, not head-cap); tail respects `max_rows` (newest N) and `max_bytes` (byte window); default unbounded read and `read_run_events` caps/`after_seq` filtering preserved; terminal-state classification unchanged; malformed line numbers are correct across the seek-beyond-cap, rows-cap-trim, and no-seek cases (regression for the byte-offset-vs-line-count bug).
- Existing `test_run_journal.py` / `test_run_journal_seq_cache.py` / `test_run_journal_routes.py` / `test_run_journal_writer_lock_evict.py` / `test_issue3802_delete_session_journals.py` (40 tests) pass unchanged.
- All run via `./scripts/test.sh`.

## Risks / Follow-ups

- `event_count` in the summary is now the tail count, not the authoritative total. Verified that every consumer uses it only as a has-any-events gate (`stale_interrupted_event`) or not at all — no caller treats it as a total. If a future caller needs the true total, it should read it separately rather than relying on the summary.
- The replay path (`read_session_run_events`) is intentionally untouched; only the status-poll summary readers use the tail read.

## Contract Routing

- Task type: memory-bound fix (whole-file journal parse on the poll path).
- Touched areas: run journal summary readers (`api/run_journal.py` `latest_run_summary` / `find_run_summary` / `_read_jsonl`). NOT the replay path.
- Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/rfcs/webui-run-state-consistency-contract.md` (Run journal / replay layer). NOTE: `docs/rfcs/turn-journal.md` governs the separate `_turn_journal/` subsystem (crash-safe turn submission), NOT the `_run_journal/` replay journal touched here; no text in either RFC is changed.
- State layer mutated: **Run journal / replay layer** — but ONLY the status-poll SUMMARY readers. The replay path itself (`read_session_run_events`, the function that rebuilds the live scene after reconnect/restart) is UNCHANGED and still reads forward/bounded.
- Invariant preserved — **Invariant 5 (Replay is idempotent)**: verified against every consumer of the summary fields.
    - `routes.py:_run_journal_status_payload` (~3051) reads only `terminal` / `terminal_state` / `last_seq` / `last_event_id` / `last_event` — all derived from the LAST events, which the tail contains. Unaffected.
    - `routes.py` ~3574 computes `last_seq = max(event_last_seq, summary_last_seq)`; since the tail read makes `summary.last_seq` the true last seq, the max stays correct.
    - `stale_interrupted_event` uses `event_count` only as a has-any-events gate, not an authoritative total. Unaffected.
    - The actual replay path (`read_session_run_events`) is untouched, so replay still rebuilds the same scene without duplicates.
  Regression: `test_latest_run_summary_reads_tail_and_keeps_terminal_state` plus the existing 40-test run_journal suite.
- Scope boundaries: replay idempotency, the turn journal, compression, transcript, and sidebar metadata are all untouched. `read_run_events`' default behavior is unchanged (caps are opt-in kwargs).

Release note: run-journal status/sidebar summaries now read a bounded tail of the journal instead of the whole file, capping per-poll memory for large runs.

## Model Used

builtin:zai-coding-plan/GLM-5.2 (ZCode agent). No AI-specific tool use mattered beyond the repo's standard read/edit/test workflow.
