### PR TITLE
fix(backend): resolve model prefix through _PROVIDER_ALIASES before matching (#6131)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2957,7 +2957,8 @@ def resolve_model_provider(model_id: str, *, explicitly_picked: bool = False) ->
         # branch (#3872).
         _cp_lower_cross = (config_provider or "").strip().lower()
         _is_custom_cross = _cp_lower_cross == "custom" or _cp_lower_cross.startswith("custom:")
-        if prefix in _PROVIDER_MODELS and prefix != config_provider and not _is_custom_cross:
+        _canon_prefix = _resolve_provider_alias(prefix)
+        if _canon_prefix in _PROVIDER_MODELS and prefix != config_provider and not _is_custom_cross:
             return model_id, "openrouter", None
 
     return model_id, config_provider, config_base_url

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -121,6 +121,25 @@ def test_cross_provider_routes_through_openrouter():
     assert base_url is None  # openrouter uses its own endpoint
 
 
+def test_cross_provider_routes_through_openrouter_with_alias_prefix():
+    """A model whose prefix is a _PROVIDER_ALIASES entry (not itself a
+    _PROVIDER_MODELS key) but resolves to a canonical provider key still
+    routes through the cross-provider OpenRouter branch.
+
+    Regression test for #6131 — before the fix, ``z-ai/glm-5.2`` with
+    config provider ``anthropic`` would fall through and return the stale
+    config provider because ``z-ai`` was checked directly against
+    ``_PROVIDER_MODELS`` instead of being resolved through
+    ``_PROVIDER_ALIASES`` first.
+    """
+    model, provider, base_url = _resolve_with_config(
+        'z-ai/glm-5.2', provider='anthropic',
+    )
+    assert model == 'z-ai/glm-5.2'
+    assert provider == 'openrouter'
+    assert base_url is None  # openrouter uses its own endpoint
+
+
 # ── Bare model names ─────────────────────────────────────────────────────
 
 def test_bare_model_uses_config_provider():


### PR DESCRIPTION
## Summary

Fixes the backend half of the cross-provider model switch bug. When a model ID's prefix differs from the canonical provider slug (e.g. `z-ai/glm-5.2` → provider `nvidia`), `resolve_model_provider()` now normalizes the prefix through `_PROVIDER_ALIASES` before matching against `_PROVIDER_MODELS`.

**Before:** `prefix = "z-ai"` → `"z-ai" not in _PROVIDER_MODELS` → fall through → returns stale `config_provider` (e.g. `anthropic`)  
**After:** `prefix = "z-ai"` → `_resolve_provider_alias("z-ai")` → `"zai"` → `"zai" in _PROVIDER_MODELS` → correctly returns provider

## Related

- **#5907** (open, unmerged) covers the frontend half (`_modelStateForSelect` provider-aware matching). Once both land, the full #6131 flow works end-to-end.
- **Workaround:** `hermes model` CLI or manual `config.yaml` edit

Closes #6131