### PR TITLE
fix(server): reap exited children via SIGCHLD handler to prevent zombie accumulation (#6145)

### DIFF
--- a/server.py
+++ b/server.py
@@ -16,6 +16,23 @@ _SIGPIPE = getattr(signal, "SIGPIPE", None)
 if _SIGPIPE is not None:
     signal.signal(_SIGPIPE, signal.SIG_IGN)
 
+# Reap exited children via SIGCHLD so subprocess zombies never accumulate.
+# Without this, any async spawn whose reaper thread is lost (server reload,
+# exception, etc.) leaves a [hermes] <defunct> zombie lingering forever.
+# The loop calls waitpid(-1, WNOHANG) until no more exited children remain;
+# it is non-blocking and never disturbs running subprocesses.
+def _reap_children(_signo, _frame):
+    """Reap any exited child so they never linger as zombies."""
+    try:
+        while True:
+            pid, _status = os.waitpid(-1, os.WNOHANG)
+            if pid == 0:
+                break
+    except ChildProcessError:
+        pass
+
+signal.signal(signal.SIGCHLD, _reap_children)
+
 # Test-mode network isolation keeps subprocess-backed tests hermetic.
 if os.environ.get("HERMES_WEBUI_TEST_NETWORK_BLOCK", "").strip() in ("1", "true", "yes"):
     _REAL_CREATE_CONN = socket.create_connection


### PR DESCRIPTION
## Resumo

Adiciona um handler global `SIGCHLD` em `server.py` para eliminar processos zumbis filhos que se acumulam sob `hermes-webui.service`.

## Contexto

A issue #6145 reporta que processos `[hermes] <defunct>` (zumbis) se acumulam quando `api/gateway_restart.py::restart_active_profile_gateway` executa `hermes gateway restart` via `subprocess.Popen` no caminho não-bloqueante (>2s). Nesse caminho, a coleta do processo filho é delegada a uma daemon thread `_wait_and_release`. Se essa thread é perdida (recarga do servidor, exceção, etc.), o filho nunca é coletado e vira um zumbi.

## O que foi feito

Adicionado um handler `SIGCHLD` global em `server.py` (imediatamente após o handler `SIGPIPE` existente) que coleta **qualquer** filho já terminado via `os.waitpid(-1, os.WNOHANG)`. Isso garante que nenhum processo filho órfão ou com thread de coleta perdida se torne um zumbi.

## Mudanças

- **`server.py`**: Nova função `_reap_children()` registrada como handler `signal.SIGCHLD`. A função usa `waitpid(-1, WNOHANG)` em loop para coletar todos os filhos já terminados de forma não-bloqueante.

## Verificação

1. `ps -eo pid,ppid,stat,comm | awk '$3 ~ /Z/'` → mostra `[hermes] <defunct>` com PPID = `server.py` (antes)
2. Após aplicar o patch e reiniciar `hermes-webui.service`, acionar `hermes gateway restart` da WebUI
3. `ps` → nenhum `[hermes] <defunct>` deve permanecer (depois)

Closes #6145