### PR TITLE
fix(frontend): route msg_limit-heavy paths around the server ceiling (#6152)

### DIFF
--- a/static/outline.js
+++ b/static/outline.js
@@ -104,10 +104,16 @@ function _jumpToMessage(rawIdx) {
   }
 
   // Row is outside the render window — reload the full session and retry.
+  // Use the bare messages=1 path (no msg_limit) so the server returns the
+  // COMPLETE transcript: the target row is addressed by absolute index
+  // (msg-user-<rawIdx>), so a bounded tail window would miss early rows.
+  // (A previous version sent msg_limit=9999 as a "give me everything" hack,
+  // but the server now clamps msg_limit, so the bare path is the correct way
+  // to request the full transcript here.)
   if (typeof api !== 'function') return;
   if (S.busy || S.activeStreamId) return;
   api('/api/session?session_id=' + encodeURIComponent(sid) +
-      '&messages=1&resolve_model=0&msg_limit=9999')
+      '&messages=1&resolve_model=0')
     .then(function(data) {
       if (!data || !data.session) return;
       if (!S.session || S.session.session_id !== sid) return;  // session switched

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2928,6 +2928,19 @@ let _messagesTruncated = false;
 // server-bounded and do not consume the visible-message budget.
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
+// ============================================================================
+// COUPLED CONSTANT — keep in sync with api/routes.py:_MAX_MSG_LIMIT.
+// ============================================================================
+// This is a hand-mirrored copy of the backend's GET /api/session ?msg_limit=
+// ceiling. _loadOlderMessages grows its msg_limit tail window by
+// +_INITIAL_MSG_LIMIT each load; once growth would exceed this ceiling the
+// server clamps and the tail stops growing, so we switch to msg_before paging
+// (a fixed-size backward page keyed off _oldestIdx) instead. If you change the
+// backend _MAX_MSG_LIMIT, change this value to match — otherwise load-older
+// silently stalls again for long sessions. The durable fix (so this mirror
+// isn't needed) is to expose the ceiling in the /api/session metadata response
+// and read it here; see tracking issue for that follow-up.
+const _MSG_LIMIT_MAX = 500;
 let _sameSessionForceReloadHint = null;
 
 function _currentLoadedRenderableMessageCount(){
@@ -3531,18 +3544,34 @@ async function _loadOlderMessages() {
   // rebuilt transcript (#1937).
   const startGeneration = _messagesGeneration;
   try {
-    // Ask the server for a larger authoritative tail window instead of a
-    // separate msg_before page. The same /api/session contract handles both —
-    // post-#2716 the backend always runs the full append-only merge, so a
-    // larger msg_limit on the same call produces the same merged transcript
-    // we'd get by stitching pages, but without client-side index bookkeeping.
-    // Cumulative growth: each "load more" asks for currentLoaded + 30, and the
-    // newly exposed head is what we expose to the user.
+    // Two strategies, chosen by whether the growing tail window still fits under
+    // the server's msg_limit ceiling (_MSG_LIMIT_MAX, mirroring backend
+    // _MAX_MSG_LIMIT):
+    //
+    //  - Below the ceiling: ask for a larger authoritative tail window
+    //    (currentLoaded + _INITIAL_MSG_LIMIT). Post-#2716 the backend runs the
+    //    full append-only merge, so a larger msg_limit produces the same merged
+    //    transcript we'd get by stitching pages, without client-side index
+    //    bookkeeping. The newly exposed head is what we expose to the user.
+    //
+    //  - At/above the ceiling: the server clamps msg_limit, so the tail window
+    //    stops growing and this strategy would stall (the same clamped tail is
+    //    returned, olderMsgs -> 0). Switch to msg_before paging — a fixed
+    //    _INITIAL_MSG_LIMIT backward page keyed off _oldestIdx — which is
+    //    bounded and never hits the ceiling, so the head stays reachable for
+    //    arbitrarily long transcripts. (This is the same paging request the
+    //    race-fallback below uses, proven correct there.)
     const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, (S.messages || []).length + _INITIAL_MSG_LIMIT);
-    const data = await api(
-      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,
-      {timeoutMs:120000}
-    );
+    const useBeforePaging = requestedLimit >= _MSG_LIMIT_MAX;
+    const data = useBeforePaging
+      ? await api(
+          `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,
+          {timeoutMs:120000}
+        )
+      : await api(
+          `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,
+          {timeoutMs:120000}
+        );
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) { _loadingOlder = false; return; }
     //  - response shape sane
@@ -3583,18 +3612,22 @@ async function _loadOlderMessages() {
     let olderMsgs = expandedMsgs.slice(0, olderCount);
     let nextMessages = expandedMsgs;
     if (!tailMatches) {
-      // Race fallback: keep the legacy index-page request as the
-      // correctness-preserving alternative. Same guards reapplied because
-      // we just awaited again.
-      const fallback = await api(
-        `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,
-        {timeoutMs:120000}
-      );
-      if (!fallback || !fallback.session) { _loadingOlder = false; return; }
-      if (!S.session || S.session.session_id !== sid) return;
-      if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
-      if (_messagesGeneration !== startGeneration) return;
-      responseSession = fallback.session;
+      // Race fallback (or the over-ceiling msg_before primary path): keep the
+      // legacy index-page request as the correctness-preserving alternative.
+      // When useBeforePaging is true we already fetched a msg_before page as
+      // the primary `data`, so reuse it instead of re-fetching. Same guards
+      // reapplied because we just awaited again (skipped for the reuse case).
+      if (!useBeforePaging) {
+        const fallback = await api(
+          `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,
+          {timeoutMs:120000}
+        );
+        if (!fallback || !fallback.session) { _loadingOlder = false; return; }
+        if (!S.session || S.session.session_id !== sid) return;
+        if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
+        if (_messagesGeneration !== startGeneration) return;
+        responseSession = fallback.session;
+      }
       olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
       nextMessages = [...olderMsgs, ...S.messages];
     }

--- a/tests/test_api_timeout.py
+++ b/tests/test_api_timeout.py
@@ -230,17 +230,16 @@ def test_session_message_loads_keep_explicit_longer_timeouts():
         "      {timeoutMs:120000}\n"
         "    )"
     ) in src
+    # _loadOlderMessages now picks between two strategies (tail-growth vs
+    # msg_before paging) via a useBeforePaging ternary, but both keep the long
+    # timeoutMs:120000. Assert each URL + timeout survives in the source.
     assert (
-        "api(\n"
-        "      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,\n"
-        "      {timeoutMs:120000}\n"
-        "    )"
+        "`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,\n"
+        "          {timeoutMs:120000}"
     ) in src
     assert (
-        "api(\n"
-        "        `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,\n"
-        "        {timeoutMs:120000}\n"
-        "      )"
+        "`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,\n"
+        "          {timeoutMs:120000}"
     ) in src
 
 


### PR DESCRIPTION
## Thinking Path

- PR #6152 clamps `GET /api/session ?msg_limit=` to a max of 500 server-side — a correct memory fix, but I shipped it without tracing the frontend paths that relied on unbounded `msg_limit`.
- Review of the frontend revealed two paths that **silently break for sessions > 500 visible rows**: the outline "jump to message" feature and endless scroll / "Load earlier". This PR is the frontend follow-up that makes the clamp safe.

## What Changed

**1. `static/outline.js` — outline jump-to-message (was silently no-op for long sessions)**

`_jumpToMessage` sent `msg_limit=9999` as a "give me everything" hack so it could scroll to any message by absolute index (`msg-user-<rawIdx>`). Clamped to 500, the target row's DOM id doesn't exist for early messages in long sessions, and line 119's `if (r)` silently does nothing — the outline panel's core function failed invisibly.

Fix: drop `msg_limit=9999`, use the bare `messages=1` path. PR #6152 deliberately left the bare path unbounded for exactly this kind of caller; this restores the pre-#6152 behavior.

**2. `static/sessions.js` — endless scroll / "Load earlier" (was stalling at 500 rows)**

`_loadOlderMessages` grows `msg_limit` by `+_INITIAL_MSG_LIMIT` each load (30 → 60 → … → 500 → clamped). Past 500 the server returns the same clamped tail, `olderMsgs` shrinks to 0, and the load-more loop silently gives up — the head becomes unreachable for long sessions.

Fix: added `_MSG_LIMIT_MAX = 500` (mirroring backend `_MAX_MSG_LIMIT`, documented as kept-in-sync). Once the grown `requestedLimit` meets/exceeds it, the primary fetch switches to `msg_before` paging — a fixed `_INITIAL_MSG_LIMIT` backward page keyed off `_oldestIdx`. This is the **same bounded paging request the existing race-fallback uses** (proven correct there), so the head stays reachable for arbitrarily long transcripts. The response is handled by the existing prepend path (`tailMatches` is naturally false for a page, so the `!tailMatches` branch reuses the already-fetched `data` — no double fetch).

## Why It Matters

Without this, #6152's memory fix silently degrades two features for exactly the long sessions that motivated the memory work in the first place. With it, the clamp is safe: the only callers that legitimately need more than 500 rows now use either the unbounded bare path (outline) or proper bounded paging (load-older).

## Verification

- `node --check` passes on both edited files.
- Backend window-contract tests still pass: `test_session_tail_payload.py` (9) + `test_session_message_window_renderable_tail.py` (10).
- **No JS test harness exists in this repo** (vanilla JS, manually verified per `TESTING.md`). I could not run the browser here. The manual verification a maintainer should do:
  1. Open a session with > 500 messages.
  2. Click an outline entry pointing at an early message → confirm it scrolls to and flashes that message (was silently no-op).
  3. Scroll to the top → confirm "Load earlier" / endless scroll keeps producing older messages past the 500-row mark without stalling (was stalling).

## Risks / Follow-ups

- The `_MSG_LIMIT_MAX` JS constant must stay in sync with the backend `_MAX_MSG_LIMIT` (500). They're documented as a pair; if the backend ceiling changes, this mirror must too. (A future improvement could expose the ceiling via the `/api/session` metadata response so the frontend doesn't hardcode it — out of scope here.)
- The outline bare-path fetch loads the full transcript into `S.messages` for the jump — that's the same cost as before #6152 (the `msg_limit=9999` was effectively doing the same), so no regression, just worth noting it's the one remaining "load everything" path and is inherent to absolute-index addressing.

## Contract Routing

- Task type: frontend follow-up to a backend memory fix (#6152).
- Touched areas: outline jump-to-message (`static/outline.js`), endless-scroll / load-older (`static/sessions.js` `_loadOlderMessages`).
- Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`.
- State layer mutated: client-side `S.messages` (the active-session transcript), same as the existing load-older path. No backend state change.
- Scope boundaries: does not weaken the #6152 clamp. The bare `messages=1` path (outline) was intentionally left unbounded by #6152; the `msg_before` paging path (load-older) is bounded by `_INITIAL_MSG_LIMIT` and never hits the ceiling.

Release note: fixes outline jump-to-message and endless scroll silently breaking on sessions longer than 500 messages after the server-side `msg_limit` ceiling (companion to #6152).

## Model Used

builtin:zai-coding-plan/GLM-5.2 (ZCode agent). No AI-specific tool use mattered beyond the repo's standard read/edit/test workflow.
