### PR TITLE
fix: sanitize mixed Markdown table copies

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1178,6 +1178,20 @@ EXPECT:
   - Paste (Cmd+V) elsewhere shows the full text of that message
 FAIL: No visual feedback, clipboard empty or wrong content.
 
+### T23.3: Copy Mixed Rendered Content with Tables
+SETUP: Use the dark theme and render an assistant response with a heading, prose,
+two Markdown tables, and a bold subtotal cell.
+STEPS:
+  1. Select the complete rendered response, including both tables
+  2. Copy it and paste into a rich-text editor
+  3. Paste it again as plain text
+EXPECT:
+  - Rich text keeps headings, table headers, values, and bold subtotal text
+  - Rich text does not carry Hermes theme colors, spacing, or table controls
+  - Plain text keeps surrounding prose and tab-delimited table rows readable
+FAIL: Theme styling leaks, header cells are blank, formatting disappears, or
+partial table content is missing.
+
 ---
 
 ## Section 24: Inline File Editor (Sprint 5)

--- a/static/messages.js
+++ b/static/messages.js
@@ -482,6 +482,82 @@ function _markdownTableCopyHtmlEscape(value){
     .replace(/>/g,'&gt;');
 }
 
+function _markdownTableCopyHtmlAttributeEscape(value){
+  return _markdownTableCopyHtmlEscape(value)
+    .split('"').join('&quot;')
+    .split("'").join('&#39;');
+}
+
+function _markdownTableCopySafeHref(value){
+  const href=String(value||'').trim();
+  if(!href) return '';
+  if(/^(?:https?:|mailto:|tel:|#|\/(?!\/)|\.\.\/|\.\/)/i.test(href)) return href;
+  return '';
+}
+
+function _markdownTableCopySemanticChildren(node){
+  return _markdownTableNodeChildren(node)
+    .map(_markdownTableCopySemanticHtml)
+    .join('');
+}
+
+function _markdownTableCopySemanticHtml(node){
+  if(!node) return '';
+  if(node.nodeType===3) return _markdownTableCopyHtmlEscape(node.textContent||'');
+  const children=_markdownTableCopySemanticChildren(node);
+  if(node.nodeType!==1||!node.tagName) return children;
+
+  const tag=String(node.tagName).toLowerCase();
+  if(tag==='table'&&node.matches&&node.matches('table[data-markdown-table-enhanced]')){
+    const payload=_markdownTableCopyPayloadForTable(node);
+    return payload?payload.html:'';
+  }
+
+  const blockedTags=[
+    'script','style','button','input','select','textarea','option','svg','canvas',
+    'iframe','object','embed','form','video','audio',
+  ];
+  if(blockedTags.includes(tag)) return '';
+
+  const semanticTags=[
+    'a','abbr','b','blockquote','br','code','dd','del','details','div','dl','dt',
+    'em','h1','h2','h3','h4','h5','h6','hr','i','kbd','li','mark','ol','p',
+    'pre','q','s','samp','small','span','strong','sub','summary','sup','table',
+    'tbody','td','tfoot','th','thead','tr','u','ul','var',
+  ];
+  if(!semanticTags.includes(tag)) return children;
+
+  const getAttribute=(name)=>typeof node.getAttribute==='function'?node.getAttribute(name):null;
+  const attributes=[];
+  if(tag==='a'){
+    const href=_markdownTableCopySafeHref(getAttribute('href'));
+    if(href) attributes.push(`href="${_markdownTableCopyHtmlAttributeEscape(href)}"`);
+  }
+  if(tag==='ol'){
+    const start=getAttribute('start');
+    if(start!==null&&/^-?\d+$/.test(String(start))) attributes.push(`start="${String(start)}"`);
+  }
+  if(tag==='td'||tag==='th'){
+    for(const name of ['colspan','rowspan']){
+      const value=getAttribute(name);
+      if(value!==null&&/^\d+$/.test(String(value))) attributes.push(`${name}="${String(value)}"`);
+    }
+  }
+
+  const opening=`<${tag}${attributes.length?' '+attributes.join(' '):''}>`;
+  if(tag==='br'||tag==='hr') return opening;
+  return `${opening}${children}</${tag}>`;
+}
+
+function _markdownTableCopyCellHtml(cell){
+  if(!cell) return '';
+  const sortButton=cell.querySelector?cell.querySelector('.markdown-table-sort'):null;
+  const sortLabel=sortButton&&sortButton.querySelector
+    ? sortButton.querySelector('.markdown-table-sort-label')
+    : null;
+  return _markdownTableCopySemanticChildren(sortLabel||cell);
+}
+
 function _markdownTableCopyPayloadForTable(table){
   if(!table||!table.rows) return null;
   const rows=Array.from(table.rows||[]);
@@ -499,8 +575,7 @@ function _markdownTableCopyPayloadForTable(table){
       .filter((cell)=>cell&&cell.nodeType===1)
       .map((cell)=>{
         const tag=cellTag(cell);
-        const text=_sanitizeMarkdownTableCellText(cell);
-        return `<${tag}>${_markdownTableCopyHtmlEscape(text)}</${tag}>`;
+        return `<${tag}>${_markdownTableCopyCellHtml(cell)}</${tag}>`;
       })
       .join('');
     return `<tr>${cells}</tr>`;
@@ -598,21 +673,85 @@ function _isFullEnhancedMarkdownTableSelection(range, table){
 }
 
 function _findEnhancedMarkdownTableFromRange(range){
-  if(!range) return null;
-  const found=_findEnhancedMarkdownTable(range.startContainer)
-    || _findEnhancedMarkdownTable(range.endContainer)
-    || _findEnhancedMarkdownTable(range.commonAncestorContainer);
-  if(found) return found;
+  return _findEnhancedMarkdownTablesFromRange(range)[0]||null;
+}
+
+function _findEnhancedMarkdownTablesFromRange(range){
+  if(!range) return [];
+  const tables=[];
+  const add=(table)=>{
+    if(table&&table.matches&&table.matches('table[data-markdown-table-enhanced]')&&!tables.includes(table)){
+      tables.push(table);
+    }
+  };
+  add(_findEnhancedMarkdownTable(range.startContainer));
   const container=range.commonAncestorContainer&&range.commonAncestorContainer.nodeType===3
     ? range.commonAncestorContainer.parentElement
     : range.commonAncestorContainer;
-  if(!container||!container.querySelectorAll||typeof range.intersectsNode!=='function') return null;
-  for(const table of container.querySelectorAll('table[data-markdown-table-enhanced]')){
-    try{
-      if(range.intersectsNode(table)) return table;
-    }catch(_){}
+  add(_findEnhancedMarkdownTable(container));
+  if(container&&container.querySelectorAll&&typeof range.intersectsNode==='function'){
+    for(const table of container.querySelectorAll('table[data-markdown-table-enhanced]')){
+      try{
+        if(range.intersectsNode(table)) add(table);
+      }catch(_){}
+    }
   }
-  return null;
+  add(_findEnhancedMarkdownTable(range.endContainer));
+  return tables;
+}
+
+function _markdownTableCopyPlainText(node){
+  if(!node) return '';
+  if(node.nodeType===3) return String(node.textContent||'');
+  const tag=node.nodeType===1&&node.tagName?String(node.tagName).toLowerCase():'';
+  if(tag==='table'&&node.matches&&node.matches('table[data-markdown-table-enhanced]')){
+    const payload=_markdownTableCopyPayloadForTable(node);
+    return payload?`\n${payload.plain}\n`:'';
+  }
+  const blockedTags=[
+    'script','style','button','input','select','textarea','option','svg','canvas',
+    'iframe','object','embed','form','video','audio',
+  ];
+  if(blockedTags.includes(tag)) return '';
+  if(tag==='br') return '\n';
+  if(tag==='hr') return '\n---\n';
+  const children=_markdownTableNodeChildren(node)
+    .map(_markdownTableCopyPlainText)
+    .join('');
+  if(tag==='li') return `\n- ${children.trim()}\n`;
+  const blockTags=[
+    'blockquote','dd','details','div','dl','dt','h1','h2','h3','h4','h5','h6',
+    'ol','p','pre','summary','table','ul',
+  ];
+  return blockTags.includes(tag)?`\n${children}\n`:children;
+}
+
+function _markdownTableCopyPayloadForMixedRange(range){
+  if(!range||typeof range.cloneContents!=='function') return null;
+  const originalTables=_findEnhancedMarkdownTablesFromRange(range);
+  if(!originalTables.length) return null;
+  const fragment=range.cloneContents();
+  if(!fragment||!fragment.querySelectorAll) return null;
+  const clonedTables=Array.from(fragment.querySelectorAll('table[data-markdown-table-enhanced]'));
+  if(clonedTables.length!==originalTables.length) return null;
+
+  for(let index=0;index<originalTables.length;index++){
+    const originalPayload=_markdownTableCopyPayloadForTable(originalTables[index]);
+    const clonedPayload=_markdownTableCopyPayloadForTable(clonedTables[index]);
+    if(!originalPayload||!clonedPayload) return null;
+    if(originalPayload.html!==clonedPayload.html||originalPayload.plain!==clonedPayload.plain) return null;
+  }
+
+  const html=_markdownTableCopySemanticChildren(fragment).trim();
+  const plain=_markdownTableCopyPlainText(fragment)
+    .replace(/\r/g,'')
+    .split('\n')
+    .map((line)=>line.replace(/[ \t]+$/g,''))
+    .join('\n')
+    .replace(/\n\n\n+/g,'\n\n')
+    .trim();
+  if(!html||!plain) return null;
+  return {html, plain};
 }
 
 function _handleMarkdownTableCopy(event){
@@ -627,11 +766,12 @@ function _handleMarkdownTableCopy(event){
   if(startCell&&endCell&&startCell===endCell) return;
   const table=_findEnhancedMarkdownTableFromRange(range);
   if(!table||!table.matches||!table.matches('table[data-markdown-table-enhanced]')) return;
-  if(!_isFullEnhancedMarkdownTableSelection(range, table)) return;
-  const payload=_markdownTableCopyPayloadForTable(table);
-  if(!payload) return;
   const clipboardData=event.clipboardData||event.originalEvent&&event.originalEvent.clipboardData;
   if(!clipboardData||typeof clipboardData.setData!=='function') return;
+  const payload=_isFullEnhancedMarkdownTableSelection(range, table)
+    ? _markdownTableCopyPayloadForTable(table)
+    : _markdownTableCopyPayloadForMixedRange(range);
+  if(!payload) return;
   if(typeof event.preventDefault==='function') event.preventDefault();
   clipboardData.setData('text/html', payload.html);
   clipboardData.setData('text/plain', payload.plain);

--- a/static/messages.js
+++ b/static/messages.js
@@ -504,8 +504,7 @@ function _markdownTableCopySemanticChildren(node){
 function _markdownTableCopySemanticHtml(node){
   if(!node) return '';
   if(node.nodeType===3) return _markdownTableCopyHtmlEscape(node.textContent||'');
-  const children=_markdownTableCopySemanticChildren(node);
-  if(node.nodeType!==1||!node.tagName) return children;
+  if(node.nodeType!==1||!node.tagName) return _markdownTableCopySemanticChildren(node);
 
   const tag=String(node.tagName).toLowerCase();
   if(tag==='table'&&node.matches&&node.matches('table[data-markdown-table-enhanced]')){
@@ -519,6 +518,7 @@ function _markdownTableCopySemanticHtml(node){
   ];
   if(blockedTags.includes(tag)) return '';
 
+  const children=_markdownTableCopySemanticChildren(node);
   const semanticTags=[
     'a','abbr','b','blockquote','br','code','dd','del','details','div','dl','dt',
     'em','h1','h2','h3','h4','h5','h6','hr','i','kbd','li','mark','ol','p',
@@ -555,7 +555,7 @@ function _markdownTableCopyCellHtml(cell){
   const sortLabel=sortButton&&sortButton.querySelector
     ? sortButton.querySelector('.markdown-table-sort-label')
     : null;
-  return _markdownTableCopySemanticChildren(sortLabel||cell);
+  return _markdownTableCopySemanticChildren(sortLabel||sortButton||cell);
 }
 
 function _markdownTableCopyPayloadForTable(table){

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -75,6 +75,8 @@ function extractFunc(name) {
 
 const required = [
   '_markdownTableCopyHtmlEscape',
+  '_markdownTableCopyHtmlAttributeEscape',
+  '_markdownTableCopySafeHref',
   '_markdownTableText',
   '_markdownTableCellText',
   '_sanitizeMarkdownTableCellText',
@@ -85,13 +87,23 @@ const required = [
   '_markdownTableBoundaryWithinCell',
   '_markdownTableEdgeCell',
   '_isFullEnhancedMarkdownTableSelection',
+  '_findEnhancedMarkdownTablesFromRange',
   '_findEnhancedMarkdownTableFromRange',
+  '_markdownTableCopySemanticChildren',
+  '_markdownTableCopySemanticHtml',
+  '_markdownTableCopyCellHtml',
   '_markdownTableCopyPayloadForTable',
+  '_markdownTableCopyPlainText',
+  '_markdownTableCopyPayloadForMixedRange',
   '_handleMarkdownTableCopy',
 ];
 
 for (const name of required) {
-  eval(extractFunc(name));
+  try {
+    eval(extractFunc(name));
+  } catch (error) {
+    throw new Error(name + ' extraction failed: ' + error.message);
+  }
 }
 
 function toNodeTypeElement(tagName) {
@@ -165,6 +177,10 @@ class FakeElement {
     return Object.prototype.hasOwnProperty.call(this.attrs, name);
   }
 
+  getAttribute(name) {
+    return this.hasAttribute(name) ? this.attrs[name] : null;
+  }
+
   removeAttribute(name) {
     delete this.attrs[name];
   }
@@ -220,6 +236,14 @@ class FakeElement {
 
   set rows(values) {
     this._rows = values || [];
+  }
+}
+
+class FakeFragment extends FakeElement {
+  constructor() {
+    super('fragment');
+    this.nodeType = 11;
+    this.tagName = undefined;
   }
 }
 
@@ -493,7 +517,7 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled }));
     assert out["prevented"] is False
 
 
-def test_mixed_selection_that_crosses_table_leaves_native_copy_unmodified():
+def test_mixed_selection_without_clone_support_leaves_native_copy_unmodified():
     out = _run_js(
         """
 const {root, table, body} = buildEnhancedTableFixture(true);
@@ -646,6 +670,14 @@ const after = makeElement('p');
 after.appendChild(new FakeText('trailing prose'));
 root.appendChild(after);
 
+const partialFragment = new FakeFragment();
+const partial = buildEnhancedTableFixture(false);
+partial.table.rows = [partial.body];
+partialFragment.appendChild(partial.table);
+const clonedAfter = makeElement('p');
+clonedAfter.appendChild(new FakeText('trailing prose'));
+partialFragment.appendChild(clonedAfter);
+
 // Start inside a body cell's text, end in the trailing prose paragraph.
 const range = {
   startContainer: body.cells[0].children[0],
@@ -655,6 +687,9 @@ const range = {
   commonAncestorContainer: root,
   intersectsNode(node) {
     return node === table;
+  },
+  cloneContents() {
+    return partialFragment;
   },
 };
 
@@ -685,3 +720,128 @@ console.log(JSON.stringify({ prevented: event.preventDefaultCalled, data: clipbo
     )
     assert out["prevented"] is False
     assert out["data"] == {}
+
+
+def test_mixed_selection_exports_theme_neutral_semantic_payload():
+    out = _run_js(
+        """
+function appendMixedContent(root, suffix) {
+  const heading = makeElement('h2', {
+    className: 'msg-heading dark-theme',
+    attrs: {style: 'color: white; background: black;'},
+  });
+  heading.appendChild(new FakeText('Monthly Summary'));
+  root.appendChild(heading);
+
+  const first = buildEnhancedTableFixture(true, {
+    headerTexts: ['Product Name', 'Total'],
+    bodyTexts: ['Example Service A', '$10.00'],
+  });
+  root.appendChild(first.table);
+
+  const subheading = makeElement('h3', {className: 'muted'});
+  subheading.appendChild(new FakeText('Example Site B'));
+  root.appendChild(subheading);
+
+  const second = buildEnhancedTableFixture(true, {
+    headerTexts: ['Product Name', 'Total'],
+    bodyTexts: ['Monthly Subtotal', '$40.00'],
+  });
+  const strong = makeElement('strong', {attrs: {style: 'color: gold;'}});
+  strong.appendChild(new FakeText('Monthly Subtotal'));
+  second.body.cells[0].children = [];
+  second.body.cells[0].appendChild(strong);
+  root.appendChild(second.table);
+
+  const trailing = makeElement('p', {
+    className: 'msg-copy-source',
+    attrs: {style: 'font-family: sans-serif;', 'data-copy-id': suffix},
+  });
+  trailing.appendChild(new FakeText('End of report: '));
+  const safeLink = makeElement('a', {
+    className: 'themed-link',
+    attrs: {
+      href: 'https://example.com/report?q=monthly&view=full',
+      style: 'color: cyan;',
+      onclick: 'alert(1)',
+    },
+  });
+  safeLink.appendChild(new FakeText('open report'));
+  trailing.appendChild(safeLink);
+  trailing.appendChild(new FakeText(' / '));
+  const unsafeLink = makeElement('a', {attrs: {href: 'javascript:alert(1)'}});
+  const trailingEnd = new FakeText('unsafe link');
+  unsafeLink.appendChild(trailingEnd);
+  trailing.appendChild(unsafeLink);
+  const hiddenForm = makeElement('form');
+  hiddenForm.appendChild(new FakeText('hidden form value'));
+  trailing.appendChild(hiddenForm);
+  root.appendChild(trailing);
+  return {heading, first, second, trailing, trailingEnd};
+}
+
+const source = makeElement('div');
+const original = appendMixedContent(source, 'source');
+const fragment = new FakeFragment();
+appendMixedContent(fragment, 'clone');
+
+const range = {
+  startContainer: original.heading.children[0],
+  startOffset: 0,
+  endContainer: original.trailingEnd,
+  endOffset: original.trailingEnd.textContent.length,
+  commonAncestorContainer: source,
+  intersectsNode(node) {
+    return node === original.first.table || node === original.second.table;
+  },
+  cloneContents() {
+    return fragment;
+  },
+};
+
+window.getSelection = () => ({
+  isCollapsed: false,
+  rangeCount: 1,
+  getRangeAt: () => range,
+});
+
+const clipboard = {
+  data: {},
+  setData(type, value) {
+    this.data[type] = value;
+  },
+};
+const event = {
+  preventDefaultCalled: false,
+  preventDefault() {
+    this.preventDefaultCalled = true;
+  },
+  clipboardData: clipboard,
+};
+
+_handleMarkdownTableCopy(event);
+console.log(JSON.stringify({prevented: event.preventDefaultCalled, data: clipboard.data}));
+"""
+    )
+
+    assert out["prevented"] is True
+    html = out["data"]["text/html"]
+    plain = out["data"]["text/plain"]
+    assert "<h2>Monthly Summary</h2>" in html
+    assert html.count("<table>") == 2
+    assert html.count("<th>Product Name</th><th>Total</th>") == 2
+    assert "<strong>Monthly Subtotal</strong>" in html
+    assert '<a href="https://example.com/report?q=monthly&amp;view=full">open report</a>' in html
+    assert "<a>unsafe link</a>" in html
+    assert "javascript:" not in html
+    assert "onclick=" not in html
+    assert "style=" not in html
+    assert "class=" not in html
+    assert "data-copy-id" not in html
+    assert "markdown-table-sort" not in html
+    assert "hidden form value" not in html
+    assert "Monthly Summary" in plain
+    assert "Product Name\tTotal" in plain
+    assert "Monthly Subtotal\t$40.00" in plain
+    assert "End of report" in plain
+    assert "hidden form value" not in plain

--- a/tests/test_issue4945_markdown_table_copy.py
+++ b/tests/test_issue4945_markdown_table_copy.py
@@ -347,6 +347,21 @@ console.log(JSON.stringify(payload));
     assert "\nWidget > Basic\t12 & change" in out["plain"]
 
 
+def test_copy_payload_preserves_sort_button_text_when_label_is_missing():
+    out = _run_js(
+        """
+const {table, header} = buildEnhancedTableFixture(false);
+const sortButton = header.cells[0].querySelector('.markdown-table-sort');
+sortButton.children = [];
+sortButton.appendChild(new FakeText('Legacy Product Header'));
+const payload = _markdownTableCopyPayloadForTable(table);
+console.log(JSON.stringify(payload));
+"""
+    )
+    assert "<th>Legacy Product Header</th>" in out["html"]
+    assert out["plain"].startswith("Legacy Product Header\tPrice\n")
+
+
 def test_partial_multi_cell_selection_leaves_native_copy_unmodified():
     out = _run_js(
         """


### PR DESCRIPTION
Closes #6063.

## Thinking Path

The existing copy handler only takes ownership of an isolated full enhanced table. A mixed range therefore falls through to native clipboard serialization, which preserves presentation attributes and can omit enhanced header labels.

The mixed-range path now clones the selected fragment, sanitizes surrounding content into a small semantic allowlist, and replaces each enhanced table with the existing table payload builder. It only takes ownership when every intersected enhanced table is present in full in the clone; partial selections continue to use native browser copy behavior.

## What Changed

- Preserve the existing isolated full-table fast path.
- Add theme-neutral semantic HTML and readable plain-text serialization for mixed heading/prose/table selections.
- Preserve safe inline semantics such as emphasis and safe links while dropping styles, classes, event attributes, controls, unsafe URL schemes, forms, scripts, and media/embed content.
- Compare each cloned table payload with its source table before intercepting the copy event, preventing partial-table truncation.
- Add a Node DOM regression for a heading, two enhanced tables, bold subtotal content, surrounding prose, safe and unsafe links, and hidden form content.
- Add manual test T23.3 for rich-text and plain-text paste behavior.

## Why It Matters

Copying a complete rendered response should not leak dark-theme presentation into another editor or produce blank table headers. The new branch keeps the useful structure and text while maintaining the existing conservative fallback for incomplete selections.

Release note: Mixed-content copies containing complete Markdown tables now produce theme-neutral rich text and readable plain text without blanking table headers.

## Verification

- Red proof on pre-fix `master`: 9 existing clipboard tests passed and the new mixed-range regression failed because the event was not intercepted.
- `./scripts/test.sh tests/test_issue4945_markdown_table_copy.py -q`: 11 passed.
- `./scripts/test.sh`: exit 0 in 707 seconds; 13,138 tests collected, with 5 collection skips and the documented 30 agent-dependent skips because `hermes-agent` is unavailable locally.
- `npm run lint:runtime`: passed.
- `node --check static/messages.js`: passed.
- `git diff --check origin/master...HEAD`: passed.
- Gitleaks v8.30.1 over `origin/master..HEAD`: no leaks found.

## Risks / Follow-ups

- Clipboard HTML intentionally uses an allowlist, so non-semantic presentation markup is flattened rather than copied.
- Only ranges containing complete enhanced tables are intercepted; incomplete tables still fall through to native copy behavior.
- No rendered UI, layout, or interaction control changed, so before/after screenshots are not applicable. The regression asserts the exact HTML and plain-text clipboard payloads instead.

## Contract Routing

- Task type: clipboard/UI behavior bug.
- Touched surfaces: `static/messages.js`, Node DOM regression coverage, and `TESTING.md`.
- Consulted contracts: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, UI/UX guidance, design guidance, and `TESTING.md`.
- Scope boundary: clipboard serialization only; no rendering, persistence, API, or backend behavior changes.

## Model Used

- Provider/model: OpenAI Codex (GPT-5).
- Tools: repository search and review, PowerShell/Git, the project test runner, Node.js syntax and ESLint checks, GitHub CLI, and Gitleaks.
- The generated changes were manually reviewed, security-checked, and tested before publication.
