### PR TITLE
fix: use durable claims for WebUI async delegation delivery

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -54,6 +54,7 @@ from api.process_event_utils import (
     complete_async_delegation_delivery,
     completion_delivery_id,
     release_async_delegation_delivery,
+    requeue_async_delegation_event,
     schedule_async_delegation_claim_retry,
 )
 
@@ -881,22 +882,48 @@ def _resolve_wakeup_target(
     return owner
 
 
-def _requeue_async_delegation_event(process_registry, evt: dict) -> None:
-    """Best-effort retry path for a claim or dispatch failure."""
-    try:
-        completion_queue = getattr(process_registry, "completion_queue", None)
-        if completion_queue is not None:
-            _DRAIN_STOP.wait(0.5)
-            completion_queue.put(evt)
-    except Exception:
-        logger.warning("Failed to requeue async delegation event", exc_info=True)
+def _requeue_async_delegation_event(
+    process_registry,
+    evt: dict,
+    *,
+    claim=None,
+    delay: float = 0.5,
+) -> bool:
+    """Retry without enqueueing new work once drain shutdown has started."""
+    completion_queue = getattr(process_registry, "completion_queue", None)
+    return requeue_async_delegation_event(
+        evt,
+        completion_queue,
+        delay=delay,
+        stop_event=_DRAIN_STOP,
+        durable=(bool(getattr(claim, "durable", False)) if claim is not None else None),
+    )
+
+
+def _retry_unmapped_async_delegation_event(process_registry, evt: dict) -> None:
+    """Retry durable routing, or one bounded best-effort legacy routing pass."""
+    completion_queue = getattr(process_registry, "completion_queue", None)
+    if schedule_async_delegation_claim_retry(
+        evt,
+        completion_queue,
+        delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+    ):
+        return
+    if evt.get("_webui_routing_retry_attempted"):
+        return
+    retry_evt = dict(evt)
+    retry_evt["_webui_routing_retry_attempted"] = True
+    _requeue_async_delegation_event(
+        process_registry,
+        retry_evt,
+        delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+    )
 
 
 def _record_async_delegation_accepted(
     evt: dict,
     *,
     session_id: str,
-    delegation_id: str,
     claim,
 ) -> None:
     """ACK durable delivery and publish live-view state after turn acceptance."""
@@ -942,7 +969,6 @@ def _start_async_delegation_wakeup_turn(
                 _record_async_delegation_accepted(
                     evt,
                     session_id=session_id,
-                    delegation_id=delegation_id,
                     claim=claim,
                 )
                 logger.info(
@@ -954,7 +980,7 @@ def _start_async_delegation_wakeup_turn(
                 return
 
             release_async_delegation_delivery(evt, claim)
-            _requeue_async_delegation_event(process_registry, evt)
+            _requeue_async_delegation_event(process_registry, evt, claim=claim)
             if status == 409 and (resp or {}).get("error") == "process_wakeup_paused":
                 logger.info(
                     "async delegation wakeup paused for session %s; delivery remains retryable",
@@ -970,7 +996,7 @@ def _start_async_delegation_wakeup_turn(
                 )
         except Exception:
             release_async_delegation_delivery(evt, claim)
-            _requeue_async_delegation_event(process_registry, evt)
+            _requeue_async_delegation_event(process_registry, evt, claim=claim)
             logger.warning(
                 "async delegation wakeup turn failed for session %s; requeued",
                 session_id,
@@ -1014,7 +1040,7 @@ def _process_async_delegation_event(
         # from the shared queue; the core record therefore remains restart-safe.
         if _session_has_active_turn(session_id):
             release_async_delegation_delivery(evt, claim)
-            _requeue_async_delegation_event(process_registry, evt)
+            _requeue_async_delegation_event(process_registry, evt, claim=claim)
             return
 
         _start_async_delegation_wakeup_turn(
@@ -1027,7 +1053,7 @@ def _process_async_delegation_event(
         )
     except Exception:
         release_async_delegation_delivery(evt, claim)
-        _requeue_async_delegation_event(process_registry, evt)
+        _requeue_async_delegation_event(process_registry, evt, claim=claim)
         logger.warning(
             "server-side async delegation dispatch failed for session %s",
             session_id,
@@ -1081,11 +1107,7 @@ def _process_one(evt: dict) -> None:
             process_id,
         )
         if evt.get("type") == "async_delegation":
-            schedule_async_delegation_claim_retry(
-                evt,
-                getattr(_process_registry, "completion_queue", None),
-                delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
-            )
+            _retry_unmapped_async_delegation_event(_process_registry, evt)
         return
     with _cfg.PROCESS_SESSION_INDEX_LOCK:
         session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key)
@@ -1096,11 +1118,7 @@ def _process_one(evt: dict) -> None:
         # registered shortly after process restore.
         logger.debug("process_complete drop: no session mapping for key=%r", session_key)
         if evt.get("type") == "async_delegation":
-            schedule_async_delegation_claim_retry(
-                evt,
-                getattr(_process_registry, "completion_queue", None),
-                delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
-            )
+            _retry_unmapped_async_delegation_event(_process_registry, evt)
         return
     # ── xsession wakeup misroute defense-in-depth (Option 3) ──────────────
     # session_id above came from PROCESS_SESSION_INDEX.get(session_key), and

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -887,6 +887,7 @@ def _requeue_async_delegation_event(
     evt: dict,
     *,
     claim=None,
+    durable: bool | None = None,
     delay: float = 0.5,
 ) -> bool:
     """Retry without enqueueing new work once drain shutdown has started."""
@@ -896,7 +897,11 @@ def _requeue_async_delegation_event(
         completion_queue,
         delay=delay,
         stop_event=_DRAIN_STOP,
-        durable=(bool(getattr(claim, "durable", False)) if claim is not None else None),
+        durable=(
+            durable
+            if durable is not None
+            else (bool(getattr(claim, "durable", False)) if claim is not None else None)
+        ),
     )
 
 
@@ -1022,7 +1027,10 @@ def _process_async_delegation_event(
     try:
         claim = claim_async_delegation_delivery(evt, "webui-background")
     except Exception:
-        _requeue_async_delegation_event(process_registry, evt)
+        # Reaching this branch means the durable claim capability was present
+        # but unavailable. Preserve that knowledge so a simultaneous queue
+        # failure can arm the restore sweep without another store read.
+        _requeue_async_delegation_event(process_registry, evt, durable=True)
         return
     if claim is None:
         completion_queue = getattr(process_registry, "completion_queue", None)

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -48,6 +48,15 @@ import time
 import uuid
 from typing import Any, Optional
 
+from api.process_event_utils import (
+    ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+    claim_async_delegation_delivery,
+    complete_async_delegation_delivery,
+    completion_delivery_id,
+    release_async_delegation_delivery,
+    schedule_async_delegation_claim_retry,
+)
+
 logger = logging.getLogger(__name__)
 
 _DRAIN_THREAD: Optional[threading.Thread] = None
@@ -541,9 +550,9 @@ def _build_payload(evt: dict, session_id: str) -> dict:
       ``(session_id, event_id)`` to dedupe across reconnects.
     """
     # ProcessRegistry completion events use the field name ``session_id`` for
-    # the process id. Alias it locally before exposing it as payload ``task_id``
-    # to avoid confusing that wire-format name with the WebUI session id.
-    process_id = str(evt.get("session_id") or "")
+    # the process id. Async delegation completions carry ``delegation_id``
+    # instead; expose either stable delivery id as payload ``task_id``.
+    process_id = completion_delivery_id(evt)
     payload: dict[str, Any] = {
         "session_id": str(session_id),
         "task_id": process_id,
@@ -872,6 +881,160 @@ def _resolve_wakeup_target(
     return owner
 
 
+def _requeue_async_delegation_event(process_registry, evt: dict) -> None:
+    """Best-effort retry path for a claim or dispatch failure."""
+    try:
+        completion_queue = getattr(process_registry, "completion_queue", None)
+        if completion_queue is not None:
+            _DRAIN_STOP.wait(0.5)
+            completion_queue.put(evt)
+    except Exception:
+        logger.warning("Failed to requeue async delegation event", exc_info=True)
+
+
+def _record_async_delegation_accepted(
+    evt: dict,
+    *,
+    session_id: str,
+    delegation_id: str,
+    claim,
+) -> None:
+    """ACK durable delivery and publish live-view state after turn acceptance."""
+
+    complete_async_delegation_delivery(evt, claim)
+    payload = _build_payload(evt, session_id)
+    try:
+        _emit_bg_task_complete_events_coalesced(session_id, payload)
+    except Exception:
+        logger.debug(
+            "async delegation live-view emit failed for session %s",
+            session_id,
+            exc_info=True,
+        )
+
+
+def _start_async_delegation_wakeup_turn(
+    session_id: str,
+    wakeup_prompt: str,
+    *,
+    delegation_id: str,
+    evt: dict,
+    claim,
+    process_registry,
+) -> None:
+    """Start one autonomous delegation turn and ACK only after acceptance."""
+
+    def _runner() -> None:
+        try:
+            from api.routes import start_session_turn
+
+            resp = start_session_turn(
+                session_id,
+                wakeup_prompt,
+                source="process_wakeup",
+            )
+            raw_status = (resp or {}).get("_status")
+            if raw_status is None:
+                status = 200 if (resp or {}).get("stream_id") else 500
+            else:
+                status = int(raw_status)
+            if 200 <= status < 300:
+                _record_async_delegation_accepted(
+                    evt,
+                    session_id=session_id,
+                    delegation_id=delegation_id,
+                    claim=claim,
+                )
+                logger.info(
+                    "async delegation wakeup turn accepted for session %s "
+                    "(stream_id=%s)",
+                    session_id,
+                    (resp or {}).get("stream_id"),
+                )
+                return
+
+            release_async_delegation_delivery(evt, claim)
+            _requeue_async_delegation_event(process_registry, evt)
+            if status == 409 and (resp or {}).get("error") == "process_wakeup_paused":
+                logger.info(
+                    "async delegation wakeup paused for session %s; delivery remains retryable",
+                    session_id,
+                )
+            else:
+                logger.debug(
+                    "async delegation wakeup not accepted for session %s: "
+                    "status=%s err=%r; requeued",
+                    session_id,
+                    status,
+                    (resp or {}).get("error"),
+                )
+        except Exception:
+            release_async_delegation_delivery(evt, claim)
+            _requeue_async_delegation_event(process_registry, evt)
+            logger.warning(
+                "async delegation wakeup turn failed for session %s; requeued",
+                session_id,
+                exc_info=True,
+            )
+
+    threading.Thread(
+        target=_runner,
+        name=f"hermes-webui-delegation-wakeup-{str(session_id)[:8]}",
+        daemon=True,
+    ).start()
+
+
+def _process_async_delegation_event(
+    evt: dict,
+    *,
+    session_id: str,
+    delegation_id: str,
+    process_registry,
+) -> None:
+    """Claim and route one async completion without private registry markers."""
+
+    try:
+        claim = claim_async_delegation_delivery(evt, "webui-background")
+    except Exception:
+        _requeue_async_delegation_event(process_registry, evt)
+        return
+    if claim is None:
+        completion_queue = getattr(process_registry, "completion_queue", None)
+        schedule_async_delegation_claim_retry(evt, completion_queue)
+        return
+
+    try:
+        wakeup_prompt_raw = format_wakeup_prompt(evt)
+        wakeup_prompt = wakeup_prompt_raw.strip() if wakeup_prompt_raw else ""
+        if not wakeup_prompt:
+            raise RuntimeError("async delegation completion could not be formatted")
+
+        # Do not persist async results in the process-local deferred list. If a
+        # foreground turn owns the session, release the durable claim and retry
+        # from the shared queue; the core record therefore remains restart-safe.
+        if _session_has_active_turn(session_id):
+            release_async_delegation_delivery(evt, claim)
+            _requeue_async_delegation_event(process_registry, evt)
+            return
+
+        _start_async_delegation_wakeup_turn(
+            session_id,
+            wakeup_prompt,
+            delegation_id=delegation_id,
+            evt=evt,
+            claim=claim,
+            process_registry=process_registry,
+        )
+    except Exception:
+        release_async_delegation_delivery(evt, claim)
+        _requeue_async_delegation_event(process_registry, evt)
+        logger.warning(
+            "server-side async delegation dispatch failed for session %s",
+            session_id,
+            exc_info=True,
+        )
+
+
 def _process_one(evt: dict) -> None:
     """Route a single completion_queue event to the matching WebUI session."""
     from api import config as _cfg
@@ -887,7 +1050,7 @@ def _process_one(evt: dict) -> None:
     except Exception:
         _process_registry = None
 
-    process_id = str(evt.get("session_id") or "")
+    process_id = completion_delivery_id(evt)
     session_key = str(evt.get("session_key") or "")
     # Root-cause fix (t_0f447014): the notify_on_complete completion event
     # enqueued by ProcessRegistry._move_to_finished() carries NO "session_key"
@@ -917,13 +1080,27 @@ def _process_one(evt: dict) -> None:
             "process_complete drop: no recoverable session_key for process_id=%r",
             process_id,
         )
+        if evt.get("type") == "async_delegation":
+            schedule_async_delegation_claim_retry(
+                evt,
+                getattr(_process_registry, "completion_queue", None),
+                delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+            )
         return
     with _cfg.PROCESS_SESSION_INDEX_LOCK:
         session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key)
     if not session_id:
         # No mapping — could be a cron/gateway process that uses the same
-        # registry but a non-WebUI session_key. Ignore.
+        # registry but a non-WebUI session_key. Durable delegation events stay
+        # pending and are retried because their WebUI ownership mapping can be
+        # registered shortly after process restore.
         logger.debug("process_complete drop: no session mapping for key=%r", session_key)
+        if evt.get("type") == "async_delegation":
+            schedule_async_delegation_claim_retry(
+                evt,
+                getattr(_process_registry, "completion_queue", None),
+                delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+            )
         return
     # ── xsession wakeup misroute defense-in-depth (Option 3) ──────────────
     # session_id above came from PROCESS_SESSION_INDEX.get(session_key), and
@@ -945,6 +1122,14 @@ def _process_one(evt: dict) -> None:
         session_key_resolved_sid=session_id,
         proc_session=_ps_xs,
     )
+    if evt.get("type") == "async_delegation":
+        _process_async_delegation_event(
+            evt,
+            session_id=session_id,
+            delegation_id=process_id,
+            process_registry=_process_registry,
+        )
+        return
     # ── Idempotency vs the REAL merged upstream #2279 (shared dedupe key) ──
     # The real merged #2279 next-turn drain
     # (api/streaming._drain_webui_process_notifications) dedupes ONLY via
@@ -1056,7 +1241,7 @@ def _process_one(evt: dict) -> None:
         )
 
 
-def record_deferred_wakeup(session_id: str, process_id: str, wakeup_prompt: str) -> None:
+def record_deferred_wakeup(session_id: str, process_id: str, wakeup_prompt: str) -> bool:
     """Persist a deferred process-completion wakeup for later redelivery.
 
     Called from ``_process_one`` when a completion arrives while a turn is
@@ -1068,10 +1253,11 @@ def record_deferred_wakeup(session_id: str, process_id: str, wakeup_prompt: str)
 
     Idempotent per process_id: if the same process_id is already queued for
     this session (kill_process racing the reader thread), it is not appended
-    twice. Best-effort — never raises into the drain loop.
+    twice. Returns whether the prompt is safely queued; never raises into the
+    drain loop.
     """
     if not session_id or not wakeup_prompt:
-        return
+        return False
     from api import config as _cfg
 
     try:
@@ -1080,14 +1266,16 @@ def record_deferred_wakeup(session_id: str, process_id: str, wakeup_prompt: str)
             if process_id and any(
                 e.get("process_id") == process_id for e in entries
             ):
-                return
+                return True
             entries.append(
                 {"process_id": process_id, "wakeup_prompt": wakeup_prompt}
             )
+        return True
     except Exception:
         logger.debug(
             "record_deferred_wakeup failed for session %s", session_id, exc_info=True
         )
+        return False
 
 
 def claim_deferred_wakeups(session_id: str) -> list[dict]:

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -1,0 +1,331 @@
+"""Shared helpers for WebUI completion/delegation delivery."""
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+import logging
+import threading
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Older Hermes Agent builds do not expose durable claim/complete/release APIs.
+# Keep their in-process compatibility dedupe bounded so long-lived WebUI
+# processes cannot retain every delegation id forever.
+LEGACY_ASYNC_DELIVERY_DEDUPE_MAX = 1024
+ASYNC_DELIVERY_CLAIM_RETRY_SECONDS = 301.0
+ASYNC_DELIVERY_ROUTING_RETRY_SECONDS = 5.0
+_LEGACY_ASYNC_DELIVERY_LOCK = threading.Lock()
+_LEGACY_ASYNC_DELIVERY_IDS: OrderedDict[str, None] = OrderedDict()
+_ASYNC_DELIVERY_RETRY_LOCK = threading.Lock()
+_ASYNC_DELIVERY_RETRY_TIMER: threading.Timer | None = None
+_ASYNC_DELIVERY_RETRY_DEADLINE = 0.0
+_ASYNC_DELIVERY_RETRY_QUEUE: Any = None
+_ASYNC_DELIVERY_RETRY_GENERATION = 0
+
+
+@dataclass(frozen=True)
+class AsyncDelegationDeliveryClaim:
+    """Opaque ownership token for one WebUI async-delegation consumer."""
+
+    delegation_id: str
+    claim_id: str
+    durable: bool
+
+
+def completion_delivery_id(evt: Any) -> str:
+    """Return the stable WebUI delivery/dedupe id for a completion event.
+
+    Terminal background-process events use ``session_id`` for the process id.
+    Async ``delegate_task`` completions carry ``delegation_id`` instead, so both
+    WebUI delivery paths must key those events by ``delegation_id``.
+    """
+    if not isinstance(evt, dict):
+        return ""
+    if evt.get("type") == "async_delegation":
+        return str(
+            evt.get("delegation_id")
+            or evt.get("session_id")
+            or evt.get("task_id")
+            or ""
+        ).strip()
+    return str(evt.get("session_id") or "").strip()
+
+
+def _claim_bounded_local(delegation_id: str) -> bool:
+    with _LEGACY_ASYNC_DELIVERY_LOCK:
+        if delegation_id in _LEGACY_ASYNC_DELIVERY_IDS:
+            return False
+        _LEGACY_ASYNC_DELIVERY_IDS[delegation_id] = None
+        while len(_LEGACY_ASYNC_DELIVERY_IDS) > LEGACY_ASYNC_DELIVERY_DEDUPE_MAX:
+            _LEGACY_ASYNC_DELIVERY_IDS.popitem(last=False)
+        return True
+
+
+def _release_bounded_local(delegation_id: str) -> None:
+    with _LEGACY_ASYNC_DELIVERY_LOCK:
+        _LEGACY_ASYNC_DELIVERY_IDS.pop(delegation_id, None)
+
+
+def _arm_async_delegation_restore_sweep(completion_queue: Any, delay: float) -> bool:
+    """Arm one process-wide durable restore sweep at the earliest deadline.
+
+    The durable database is the backlog. Keeping one shared timer avoids both
+    one-thread-per-event growth and lossy eviction of individual retry entries.
+    The sweep restores every still-pending record; atomic claims suppress races
+    and delivered rows are excluded by the core query.
+    """
+    global _ASYNC_DELIVERY_RETRY_TIMER
+    global _ASYNC_DELIVERY_RETRY_DEADLINE
+    global _ASYNC_DELIVERY_RETRY_QUEUE
+    global _ASYNC_DELIVERY_RETRY_GENERATION
+
+    if completion_queue is None:
+        return False
+    retry_delay = max(0.0, float(delay))
+    deadline = time.monotonic() + retry_delay
+
+    with _ASYNC_DELIVERY_RETRY_LOCK:
+        if (
+            _ASYNC_DELIVERY_RETRY_TIMER is not None
+            and deadline >= _ASYNC_DELIVERY_RETRY_DEADLINE
+        ):
+            return True
+        previous = _ASYNC_DELIVERY_RETRY_TIMER
+        if previous is not None:
+            previous.cancel()
+        _ASYNC_DELIVERY_RETRY_GENERATION += 1
+        generation = _ASYNC_DELIVERY_RETRY_GENERATION
+        _ASYNC_DELIVERY_RETRY_DEADLINE = deadline
+        _ASYNC_DELIVERY_RETRY_QUEUE = completion_queue
+
+        def _restore() -> None:
+            global _ASYNC_DELIVERY_RETRY_TIMER
+            global _ASYNC_DELIVERY_RETRY_DEADLINE
+            global _ASYNC_DELIVERY_RETRY_QUEUE
+
+            with _ASYNC_DELIVERY_RETRY_LOCK:
+                if generation != _ASYNC_DELIVERY_RETRY_GENERATION:
+                    return
+                target_queue = _ASYNC_DELIVERY_RETRY_QUEUE
+                _ASYNC_DELIVERY_RETRY_TIMER = None
+                _ASYNC_DELIVERY_RETRY_DEADLINE = 0.0
+                _ASYNC_DELIVERY_RETRY_QUEUE = None
+            try:
+                from tools.async_delegation import restore_undelivered_completions
+
+                restore_undelivered_completions(target_queue)
+            except Exception:
+                logger.warning(
+                    "Failed to restore pending async delegations; retrying sweep",
+                    exc_info=True,
+                )
+                _arm_async_delegation_restore_sweep(
+                    target_queue,
+                    ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+                )
+
+        timer = threading.Timer(retry_delay, _restore)
+        timer.daemon = True
+        _ASYNC_DELIVERY_RETRY_TIMER = timer
+        timer.start()
+    return True
+
+
+def schedule_async_delegation_claim_retry(
+    evt: Any,
+    completion_queue: Any,
+    *,
+    delay: float | None = None,
+) -> bool:
+    """Schedule a durable restore sweep after a claim or routing lease delay."""
+    if not isinstance(evt, dict) or evt.get("type") != "async_delegation":
+        return False
+    delegation_id = str(evt.get("delegation_id") or "").strip()
+    if not delegation_id or completion_queue is None:
+        return False
+    try:
+        from tools.async_delegation import get_durable_delegation
+
+        durable = get_durable_delegation(delegation_id)
+    except (ImportError, AttributeError):
+        return False
+    except Exception:
+        logger.debug(
+            "Failed to inspect durable async delegation %s for retry",
+            delegation_id,
+            exc_info=True,
+        )
+        return False
+    if not isinstance(durable, dict) or durable.get("delivery_state") != "pending":
+        return False
+
+    retry_delay = (
+        ASYNC_DELIVERY_CLAIM_RETRY_SECONDS if delay is None else max(0.0, float(delay))
+    )
+    return _arm_async_delegation_restore_sweep(completion_queue, retry_delay)
+
+
+def _cancel_async_delegation_claim_retry(_delegation_id: str) -> None:
+    # Retry is a shared durable-store sweep, not a per-delegation timer. It must
+    # remain armed because other pending records may rely on the same sweep.
+    return None
+
+
+def async_delivery_retry_timer_count() -> int:
+    with _ASYNC_DELIVERY_RETRY_LOCK:
+        return 1 if _ASYNC_DELIVERY_RETRY_TIMER is not None else 0
+
+
+def claim_async_delegation_delivery(
+    evt: Any,
+    consumer: str,
+) -> AsyncDelegationDeliveryClaim | None:
+    """Atomically claim an async completion for one WebUI delivery path.
+
+    Current Hermes Agent builds provide a durable SQLite-backed claim contract.
+    Older builds fall back to the bounded process-local claim above. The local
+    claim also serializes duplicate legacy events on current cores where no
+    durable row exists yet.
+    """
+    if not isinstance(evt, dict) or evt.get("type") != "async_delegation":
+        return None
+    delegation_id = completion_delivery_id(evt)
+    if not delegation_id or not _claim_bounded_local(delegation_id):
+        return None
+
+    try:
+        from tools.async_delegation import (
+            claim_event_delivery,
+            complete_event_delivery,  # noqa: F401 - capability contract probe
+            release_event_delivery,  # noqa: F401 - capability contract probe
+        )
+    except (ImportError, AttributeError):
+        return AsyncDelegationDeliveryClaim(
+            delegation_id=delegation_id,
+            claim_id="",
+            durable=False,
+        )
+
+    try:
+        claim_id = claim_event_delivery(evt, str(consumer or "webui"))
+    except Exception:
+        _release_bounded_local(delegation_id)
+        logger.warning(
+            "Failed to claim durable async delegation delivery for %s",
+            delegation_id,
+            exc_info=True,
+        )
+        raise
+    if claim_id is None:
+        _release_bounded_local(delegation_id)
+        return None
+    return AsyncDelegationDeliveryClaim(
+        delegation_id=delegation_id,
+        claim_id=str(claim_id or ""),
+        durable=True,
+    )
+
+
+def _mark_legacy_async_delivery_complete(delegation_id: str) -> bool:
+    """Acknowledge completion through progressively older core APIs."""
+    try:
+        from tools import async_delegation as async_delivery
+    except Exception:
+        return False
+
+    marker = getattr(async_delivery, "mark_completion_delivered", None)
+    if callable(marker):
+        try:
+            if marker(delegation_id) is not False:
+                return True
+        except Exception:
+            logger.debug(
+                "mark_completion_delivered failed for %s; trying legacy marker",
+                delegation_id,
+                exc_info=True,
+            )
+
+    legacy_marker = getattr(async_delivery, "mark_async_delegation_consumed", None)
+    if callable(legacy_marker):
+        try:
+            legacy_marker(delegation_id)
+            return True
+        except Exception:
+            logger.debug(
+                "Legacy async delegation marker failed for %s",
+                delegation_id,
+                exc_info=True,
+            )
+    return False
+
+
+def complete_async_delegation_delivery(
+    evt: Any,
+    claim: AsyncDelegationDeliveryClaim,
+) -> None:
+    """Complete a claim after WebUI has accepted the event for delivery."""
+    if claim.durable:
+        from tools.async_delegation import complete_event_delivery
+
+        try:
+            complete_event_delivery(evt, claim.claim_id)
+            _cancel_async_delegation_claim_retry(claim.delegation_id)
+            return
+        except Exception:
+            logger.warning(
+                "Durable async delegation completion ACK failed for %s; "
+                "trying compatibility marker",
+                claim.delegation_id,
+                exc_info=True,
+            )
+            if _mark_legacy_async_delivery_complete(claim.delegation_id):
+                _cancel_async_delegation_claim_retry(claim.delegation_id)
+                return
+            raise
+    _mark_legacy_async_delivery_complete(claim.delegation_id)
+
+
+def release_async_delegation_delivery(
+    evt: Any,
+    claim: AsyncDelegationDeliveryClaim,
+) -> None:
+    """Release a failed claim so a later WebUI consumer can retry it."""
+    try:
+        if claim.durable:
+            from tools.async_delegation import release_event_delivery
+
+            release_event_delivery(evt, claim.claim_id)
+    except Exception:
+        logger.warning(
+            "Failed to release durable async delegation delivery for %s",
+            claim.delegation_id,
+            exc_info=True,
+        )
+    finally:
+        _release_bounded_local(claim.delegation_id)
+
+
+def legacy_async_delivery_dedupe_size() -> int:
+    """Return bounded compatibility-dedupe size for regression coverage."""
+    with _LEGACY_ASYNC_DELIVERY_LOCK:
+        return len(_LEGACY_ASYNC_DELIVERY_IDS)
+
+
+def _reset_legacy_async_delivery_dedupe_for_tests() -> None:
+    global _ASYNC_DELIVERY_RETRY_TIMER
+    global _ASYNC_DELIVERY_RETRY_DEADLINE
+    global _ASYNC_DELIVERY_RETRY_QUEUE
+    global _ASYNC_DELIVERY_RETRY_GENERATION
+
+    with _LEGACY_ASYNC_DELIVERY_LOCK:
+        _LEGACY_ASYNC_DELIVERY_IDS.clear()
+    with _ASYNC_DELIVERY_RETRY_LOCK:
+        timer = _ASYNC_DELIVERY_RETRY_TIMER
+        _ASYNC_DELIVERY_RETRY_TIMER = None
+        _ASYNC_DELIVERY_RETRY_DEADLINE = 0.0
+        _ASYNC_DELIVERY_RETRY_QUEUE = None
+        _ASYNC_DELIVERY_RETRY_GENERATION += 1
+    if timer is not None:
+        timer.cancel()

--- a/api/process_event_utils.py
+++ b/api/process_event_utils.py
@@ -167,6 +167,49 @@ def schedule_async_delegation_claim_retry(
     return _arm_async_delegation_restore_sweep(completion_queue, retry_delay)
 
 
+def requeue_async_delegation_event(
+    evt: Any,
+    completion_queue: Any,
+    *,
+    delay: float = 0.0,
+    stop_event: threading.Event | None = None,
+    durable: bool | None = None,
+) -> bool:
+    """Requeue an async event, falling back to the durable restore sweep.
+
+    Callers pass the queue reference they already resolved so an import failure
+    cannot strand a released durable claim. Legacy events without a durable row
+    still get one best-effort direct requeue; durable events additionally arm a
+    restore sweep when the direct queue write fails.
+    """
+    if not isinstance(evt, dict) or evt.get("type") != "async_delegation":
+        return False
+    if completion_queue is None:
+        return False
+    retry_delay = max(0.0, float(delay))
+    if retry_delay:
+        if stop_event is not None:
+            if stop_event.wait(retry_delay):
+                return False
+        else:
+            time.sleep(retry_delay)
+    try:
+        completion_queue.put(dict(evt))
+        return True
+    except Exception:
+        logger.warning("Failed to requeue async delegation event", exc_info=True)
+        if durable is True:
+            return _arm_async_delegation_restore_sweep(
+                completion_queue,
+                ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+            )
+        return schedule_async_delegation_claim_retry(
+            evt,
+            completion_queue,
+            delay=ASYNC_DELIVERY_ROUTING_RETRY_SECONDS,
+        )
+
+
 def _cancel_async_delegation_claim_retry(_delegation_id: str) -> None:
     # Retry is a shared durable-store sweep, not a per-delegation timer. It must
     # remain armed because other pending records may rely on the same sweep.

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -68,6 +68,7 @@ from api.process_event_utils import (
     complete_async_delegation_delivery,
     completion_delivery_id,
     release_async_delegation_delivery,
+    requeue_async_delegation_event,
     schedule_async_delegation_claim_retry,
 )
 
@@ -2027,6 +2028,7 @@ def _drain_webui_process_notifications(
 
     notifications: list[str] = []
     skipped_events: list[dict] = []
+    async_retry_events: list[tuple[dict, bool]] = []
     completion_queue = getattr(process_registry, 'completion_queue', None)
     if completion_queue is None:
         return []
@@ -2107,7 +2109,9 @@ def _drain_webui_process_notifications(
                     # Stale async events are an explicit terminal disposition.
                     complete_async_delegation_delivery(evt, claim)
                 elif pending_async_acceptances is not None:
-                    pending_async_acceptances.append((evt, claim, notification))
+                    pending_async_acceptances.append(
+                        (evt, claim, notification, completion_queue)
+                    )
                 else:
                     # Direct callers without a live agent turn retain the
                     # historical synchronous acceptance behavior used by
@@ -2117,7 +2121,9 @@ def _drain_webui_process_notifications(
                 if notification_added:
                     notifications.pop()
                 release_async_delegation_delivery(evt, claim)
-                skipped_events.append(evt)
+                async_retry_events.append(
+                    (evt, bool(getattr(claim, "durable", False)))
+                )
                 logger.warning(
                     "Failed to accept async delegation completion for session %s",
                     session_id,
@@ -2148,6 +2154,12 @@ def _drain_webui_process_notifications(
         # replayed forever on later turns.
         _mark_process_completion_consumed(process_registry, evt_sid)
 
+    for evt, durable in async_retry_events:
+        requeue_async_delegation_event(
+            evt,
+            completion_queue,
+            durable=durable,
+        )
     for evt in skipped_events:
         try:
             completion_queue.put(evt)
@@ -2155,6 +2167,32 @@ def _drain_webui_process_notifications(
             logger.debug("Failed to requeue process completion event", exc_info=True)
             break
     return notifications
+
+
+def _accept_pending_async_delegations(
+    pending_async_acceptances: list,
+    *,
+    session_id: str,
+) -> list[str]:
+    """ACK turn-bound delegation claims and return rejected notifications."""
+    rejected_notifications: list[str] = []
+    for evt, claim, notification, completion_queue in pending_async_acceptances:
+        try:
+            complete_async_delegation_delivery(evt, claim)
+        except Exception:
+            release_async_delegation_delivery(evt, claim)
+            requeue_async_delegation_event(
+                evt,
+                completion_queue,
+                durable=bool(getattr(claim, "durable", False)),
+            )
+            rejected_notifications.append(notification)
+            logger.warning(
+                "Async delegation was not accepted into session %s; retrying later",
+                session_id,
+                exc_info=True,
+            )
+    return rejected_notifications
 
 
 def _attachment_name(att) -> str:
@@ -8784,27 +8822,10 @@ def _run_agent_streaming(
             # boundary: immediately before invoking the agent with the message
             # that contains their notifications. A failed ACK is removed from
             # this turn and requeued so retry cannot create a duplicate prompt.
-            _rejected_async_notifications = []
-            for _evt, _claim, _notification in _pending_async_acceptances:
-                try:
-                    complete_async_delegation_delivery(_evt, _claim)
-                except Exception:
-                    release_async_delegation_delivery(_evt, _claim)
-                    try:
-                        from tools.process_registry import process_registry as _process_registry
-
-                        _process_registry.completion_queue.put(_evt)
-                    except Exception:
-                        logger.warning(
-                            "Failed to requeue async delegation after acceptance ACK failure",
-                            exc_info=True,
-                        )
-                    _rejected_async_notifications.append(_notification)
-                    logger.warning(
-                        "Async delegation was not accepted into session %s; retrying later",
-                        session_id,
-                        exc_info=True,
-                    )
+            _rejected_async_notifications = _accept_pending_async_delegations(
+                _pending_async_acceptances,
+                session_id=session_id,
+            )
             if _rejected_async_notifications:
                 for _notification in _rejected_async_notifications:
                     try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2087,7 +2087,9 @@ def _drain_webui_process_notifications(
             try:
                 claim = claim_async_delegation_delivery(evt, "webui-next-turn")
             except Exception:
-                skipped_events.append(evt)
+                # Durable claim capability exists but its store is unavailable.
+                # Keep the durable hint so queue failure still arms a sweep.
+                async_retry_events.append((evt, True))
                 continue
             if claim is None:
                 schedule_async_delegation_claim_retry(evt, completion_queue)
@@ -2169,14 +2171,37 @@ def _drain_webui_process_notifications(
     return notifications
 
 
+def _release_pending_async_delegations(
+    pending_async_acceptances: list,
+    *,
+    session_id: str,
+) -> None:
+    """Release claims prepared for a turn that failed before acceptance."""
+    pending = list(pending_async_acceptances)
+    pending_async_acceptances.clear()
+    for evt, claim, _notification, completion_queue in pending:
+        release_async_delegation_delivery(evt, claim)
+        requeue_async_delegation_event(
+            evt,
+            completion_queue,
+            durable=bool(getattr(claim, "durable", False)),
+        )
+        logger.warning(
+            "Released unaccepted async delegation during session %s teardown",
+            session_id,
+        )
+
+
 def _accept_pending_async_delegations(
     pending_async_acceptances: list,
     *,
     session_id: str,
 ) -> list[str]:
     """ACK turn-bound delegation claims and return rejected notifications."""
+    pending = list(pending_async_acceptances)
+    pending_async_acceptances.clear()
     rejected_notifications: list[str] = []
-    for evt, claim, notification, completion_queue in pending_async_acceptances:
+    for evt, claim, notification, completion_queue in pending:
         try:
             complete_async_delegation_delivery(evt, claim)
         except Exception:
@@ -7359,6 +7384,7 @@ def _run_agent_streaming(
     _checkpoint_stop = None
     _ckpt_thread = None
     _agent_lock = None
+    _pending_async_acceptances = []
     try:
         # Register this stream with the global streaming meter and start the 1 Hz
         # metering ticker. Kept INSIDE the outer try so the outer `finally`'s
@@ -8789,7 +8815,7 @@ def _run_agent_streaming(
             )
             _ckpt_thread.start()
 
-            _pending_async_acceptances = []
+            _pending_async_acceptances.clear()
             _process_notifications = _drain_webui_process_notifications(
                 session_id,
                 pending_async_acceptances=_pending_async_acceptances,
@@ -10692,6 +10718,12 @@ def _run_agent_streaming(
             _error_payload['old_session_id'] = session_id
         put('apperror', _error_payload)
     finally:
+        # A failure after the next-turn drain but before the acceptance helper
+        # must not strand process-local or durable claims removed from the queue.
+        _release_pending_async_delegations(
+            _pending_async_acceptances,
+            session_id=session_id,
+        )
         # #4633/#2476: symmetric metering teardown. begin_session() (top of the
         # outer try) had no paired end_session(), so zero-token turns leaked a
         # _sessions[stream_id] entry that get_stats() pruning never reclaims (its

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -44,6 +44,7 @@ from api.config import (
     parse_reasoning_effort,
     coerce_reasoning_effort_for_model,
     _main_model_request_overrides,
+    PROCESS_SESSION_INDEX, PROCESS_SESSION_INDEX_LOCK,
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
@@ -62,6 +63,13 @@ from api.models import (
     reconciled_state_db_messages_for_session,
 )
 from api.session_ops import mark_session_title_generated, session_has_manual_title
+from api.process_event_utils import (
+    claim_async_delegation_delivery,
+    complete_async_delegation_delivery,
+    completion_delivery_id,
+    release_async_delegation_delivery,
+    schedule_async_delegation_claim_retry,
+)
 
 
 def _session_payload_with_full_messages(session, *, tool_calls=None):
@@ -1947,6 +1955,14 @@ def _format_process_notification(evt: dict) -> str:
     """Format a completed background process notification for agent input."""
     if not isinstance(evt, dict):
         return ''
+    if evt.get('type') == 'async_delegation':
+        try:
+            from tools.process_registry import format_process_notification
+
+            return format_process_notification(evt) or ''
+        except Exception:
+            logger.debug("Failed to format async delegation notification", exc_info=True)
+            return ''
     if evt.get('type') != 'completion':
         return ''
     _sid = evt.get('session_id', '')
@@ -1971,7 +1987,31 @@ def _mark_process_completion_consumed(process_registry, process_id: str) -> None
         logger.debug("Failed to mark process completion consumed", exc_info=True)
 
 
-def _drain_webui_process_notifications(session_id: str) -> list[str]:
+def _completion_event_targets_webui_session(evt_session_key: str, session_id: str) -> bool:
+    """Return whether a completion event belongs to this WebUI session.
+
+    WebUI normally registers ``PROCESS_SESSION_INDEX[session_id] = session_id``.
+    Gateway/agent session keys can differ, so match the direct WebUI case first
+    and otherwise resolve through the same session-key index used by the
+    background wakeup path.
+    """
+    if not evt_session_key or not session_id:
+        return False
+    if evt_session_key == session_id:
+        return True
+    try:
+        with PROCESS_SESSION_INDEX_LOCK:
+            return PROCESS_SESSION_INDEX.get(evt_session_key) == session_id
+    except Exception:
+        logger.debug("Failed to resolve completion event session key", exc_info=True)
+        return False
+
+
+def _drain_webui_process_notifications(
+    session_id: str,
+    *,
+    pending_async_acceptances: list | None = None,
+) -> list[str]:
     """Return completion notifications that belong to this WebUI session.
 
     The agent registry completion queue is process-wide and events do not carry
@@ -2004,17 +2044,26 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
             logger.debug("Failed to drain process completion queue", exc_info=True)
             break
 
-        evt_sid = str(evt.get('session_id') or '') if isinstance(evt, dict) else ''
+        evt_sid = completion_delivery_id(evt) if isinstance(evt, dict) else ''
         if not evt_sid:
             skipped_events.append(evt)
             continue
+        is_async_delegation = (
+            isinstance(evt, dict) and evt.get('type') == 'async_delegation'
+        )
         try:
-            if process_registry.is_completion_consumed(evt_sid):
+            if (
+                not is_async_delegation
+                and process_registry.is_completion_consumed(evt_sid)
+            ):
                 continue
-            proc = process_registry.get(evt_sid)
+            evt_session_key = str(evt.get('session_key') or '') if isinstance(evt, dict) else ''
+            if not evt_session_key:
+                proc = process_registry.get(evt_sid)
+                evt_session_key = str(getattr(proc, 'session_key', '') or '')
         except Exception:
-            proc = None
-        if getattr(proc, 'session_key', None) != session_id:
+            evt_session_key = ''
+        if not _completion_event_targets_webui_session(evt_session_key, session_id):
             skipped_events.append(evt)
             continue
 
@@ -2024,23 +2073,80 @@ def _drain_webui_process_notifications(session_id: str) -> list[str]:
         # completion whose enqueue time is older than the configured cap.
         # Events without a 'completed_at' (older agent builds) are never
         # dropped here, preserving backward-compatible behavior.
+        is_stale = False
+        stale_age = 0.0
         if stale_completion_max_age > 0 and isinstance(evt, dict):
             completed_at = evt.get('completed_at')
             if isinstance(completed_at, (int, float)) and completed_at > 0:
-                age = time.time() - completed_at
-                if age > stale_completion_max_age:
-                    logger.info(
-                        "Dropping stale background-process completion for "
-                        "session %s (age %.0fs > cap %.0fs)",
-                        evt_sid, age, stale_completion_max_age,
-                    )
-                    _mark_process_completion_consumed(process_registry, evt_sid)
-                    continue
+                stale_age = time.time() - completed_at
+                is_stale = stale_age > stale_completion_max_age
+
+        if is_async_delegation:
+            try:
+                claim = claim_async_delegation_delivery(evt, "webui-next-turn")
+            except Exception:
+                skipped_events.append(evt)
+                continue
+            if claim is None:
+                schedule_async_delegation_claim_retry(evt, completion_queue)
+                continue
+            notification_added = False
+            try:
+                if is_stale:
+                    notification = ''
+                else:
+                    notification = _format_process_notification(evt)
+                    if not notification:
+                        raise ValueError(
+                            "async delegation formatter returned an empty notification"
+                        )
+                if notification:
+                    notifications.append(notification)
+                    notification_added = True
+                if is_stale:
+                    # Stale async events are an explicit terminal disposition.
+                    complete_async_delegation_delivery(evt, claim)
+                elif pending_async_acceptances is not None:
+                    pending_async_acceptances.append((evt, claim, notification))
+                else:
+                    # Direct callers without a live agent turn retain the
+                    # historical synchronous acceptance behavior used by
+                    # CLI-style drains.
+                    complete_async_delegation_delivery(evt, claim)
+            except Exception:
+                if notification_added:
+                    notifications.pop()
+                release_async_delegation_delivery(evt, claim)
+                skipped_events.append(evt)
+                logger.warning(
+                    "Failed to accept async delegation completion for session %s",
+                    session_id,
+                    exc_info=True,
+                )
+                continue
+            if is_stale:
+                logger.info(
+                    "Dropping stale async-delegation completion for session %s "
+                    "(age %.0fs > cap %.0fs)",
+                    evt_sid, stale_age, stale_completion_max_age,
+                )
+            continue
+
+        if is_stale:
+            logger.info(
+                "Dropping stale background-process completion for "
+                "session %s (age %.0fs > cap %.0fs)",
+                evt_sid, stale_age, stale_completion_max_age,
+            )
+            _mark_process_completion_consumed(process_registry, evt_sid)
+            continue
 
         notification = _format_process_notification(evt)
         if notification:
             notifications.append(notification)
-            _mark_process_completion_consumed(process_registry, evt_sid)
+        # Matched but unformattable process completions are consumed rather than
+        # replayed forever on later turns.
+        _mark_process_completion_consumed(process_registry, evt_sid)
 
     for evt in skipped_events:
         try:
@@ -8645,7 +8751,11 @@ def _run_agent_streaming(
             )
             _ckpt_thread.start()
 
-            _process_notifications = _drain_webui_process_notifications(session_id)
+            _pending_async_acceptances = []
+            _process_notifications = _drain_webui_process_notifications(
+                session_id,
+                pending_async_acceptances=_pending_async_acceptances,
+            )
             _agent_msg_text = msg_text
             if _process_notifications:
                 _agent_msg_text = "\n\n".join([*_process_notifications, msg_text]).strip()
@@ -8669,6 +8779,51 @@ def _run_agent_streaming(
             # run_conversation() predates the moa_config kwarg.
             if moa_config is not None:
                 _run_conversation_kwargs["moa_config"] = moa_config
+
+            # Finalize durable delegation claims at the current-turn acceptance
+            # boundary: immediately before invoking the agent with the message
+            # that contains their notifications. A failed ACK is removed from
+            # this turn and requeued so retry cannot create a duplicate prompt.
+            _rejected_async_notifications = []
+            for _evt, _claim, _notification in _pending_async_acceptances:
+                try:
+                    complete_async_delegation_delivery(_evt, _claim)
+                except Exception:
+                    release_async_delegation_delivery(_evt, _claim)
+                    try:
+                        from tools.process_registry import process_registry as _process_registry
+
+                        _process_registry.completion_queue.put(_evt)
+                    except Exception:
+                        logger.warning(
+                            "Failed to requeue async delegation after acceptance ACK failure",
+                            exc_info=True,
+                        )
+                    _rejected_async_notifications.append(_notification)
+                    logger.warning(
+                        "Async delegation was not accepted into session %s; retrying later",
+                        session_id,
+                        exc_info=True,
+                    )
+            if _rejected_async_notifications:
+                for _notification in _rejected_async_notifications:
+                    try:
+                        _process_notifications.remove(_notification)
+                    except ValueError:
+                        pass
+                _agent_msg_text = msg_text
+                if _process_notifications:
+                    _agent_msg_text = "\n\n".join(
+                        [*_process_notifications, msg_text]
+                    ).strip()
+                user_message = _build_native_multimodal_message(
+                    workspace_ctx,
+                    _agent_msg_text,
+                    attachments,
+                    workspace,
+                    cfg=_cfg,
+                )
+                _run_conversation_kwargs["user_message"] = user_message
             result = agent.run_conversation(**_run_conversation_kwargs)
             # #4729: the run is done — flush any reasoning tail still in the coalescing
             # buffer (the agent never calls reasoning_callback(None), and a turn can end on

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -1,0 +1,867 @@
+"""Regression coverage for async delegate_task completion routing beyond #4912.
+
+#4912 taught ``format_wakeup_prompt`` how to render ``async_delegation`` events.
+These tests cover the remaining WebUI bridge contract: route those events by
+``session_key``, dedupe by ``delegation_id``, and coordinate with both the
+current durable claim API and bounded compatibility fallbacks.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import queue
+import subprocess
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+from api import background_process as bp
+from api import config as cfg
+from api import process_event_utils as peu
+from api import streaming
+
+
+class _NoopLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeProcessRegistry:
+    def __init__(self):
+        self.completion_queue = queue.Queue()
+        self._completion_consumed: set[str] = set()
+        self._lock = _NoopLock()
+
+    def is_completion_consumed(self, process_id: str) -> bool:
+        return process_id in self._completion_consumed
+
+    def get(self, process_id: str):
+        return None
+
+
+def _install_fake_process_registry(monkeypatch):
+    registry = _FakeProcessRegistry()
+
+    def _format(evt):
+        return f"[ASYNC DELEGATION BATCH COMPLETE — {evt['delegation_id']}]\nbackend summary"
+
+    fake_mod = types.ModuleType("tools.process_registry")
+    fake_mod.process_registry = registry
+    fake_mod.format_process_notification = _format
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake_mod)
+    return registry
+
+
+def _install_fake_durable_delivery_api(monkeypatch):
+    calls = {
+        "claim": [],
+        "complete": [],
+        "release": [],
+        "mark": [],
+        "legacy": [],
+        "delivery_state": "pending",
+        "pending_ids": set(),
+        "restore_failures": 0,
+    }
+    fake_mod = types.ModuleType("tools.async_delegation")
+
+    def _claim(evt, consumer):
+        calls["claim"].append((dict(evt), consumer))
+        return f"claim:{consumer}"
+
+    def _complete(evt, claim_id):
+        calls["complete"].append((dict(evt), claim_id))
+        calls["delivery_state"] = "delivered"
+
+    def _release(evt, claim_id):
+        calls["release"].append((dict(evt), claim_id))
+        calls["delivery_state"] = "pending"
+
+    def _get_durable(delegation_id):
+        if calls["delivery_state"] == "pending":
+            calls["pending_ids"].add(delegation_id)
+        return {"delivery_state": calls["delivery_state"]}
+
+    def _restore(target_queue):
+        if calls["restore_failures"]:
+            calls["restore_failures"] -= 1
+            raise RuntimeError("transient durable-store read failure")
+        if calls["delivery_state"] != "pending":
+            return 0
+        pending = sorted(calls["pending_ids"])
+        for delegation_id in pending:
+            target_queue.put(_async_delegation_event(delegation_id=delegation_id))
+        return len(pending)
+
+    def _mark(delegation_id):
+        calls["mark"].append(delegation_id)
+        return True
+
+    def _legacy(delegation_id):
+        calls["legacy"].append(delegation_id)
+        return True
+
+    fake_mod.claim_event_delivery = _claim
+    fake_mod.complete_event_delivery = _complete
+    fake_mod.release_event_delivery = _release
+    fake_mod.get_durable_delegation = _get_durable
+    fake_mod.restore_undelivered_completions = _restore
+    fake_mod.mark_completion_delivered = _mark
+    fake_mod.mark_async_delegation_consumed = _legacy
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.async_delegation", fake_mod)
+    return calls
+
+
+def _wait_until(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return bool(predicate())
+
+
+def _reset_wakeup_state() -> None:
+    cfg.PROCESS_SESSION_INDEX.clear()
+    cfg.PENDING_BG_TASK_COMPLETIONS.clear()
+    cfg.BG_TASK_COMPLETE_EVENTS_SEEN.clear()
+    cfg.DEFERRED_PROCESS_WAKEUPS.clear()
+    reset = getattr(peu, "_reset_legacy_async_delivery_dedupe_for_tests", None)
+    if reset is not None:
+        reset()
+
+
+def _async_delegation_event(**overrides):
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_test123",
+        "session_key": "webui-session-1",
+        "status": "completed",
+        "is_batch": True,
+        "results": [{"task_index": 0, "status": "completed", "summary": "backend summary"}],
+        "dispatched_at": time.time() - 2,
+        "completed_at": time.time(),
+    }
+    evt.update(overrides)
+    return evt
+
+
+def test_background_wakeup_claims_and_completes_without_registry_growth(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+    started: list[tuple[str, str, str]] = []
+    emitted: list[tuple[str, dict]] = []
+
+    def _accept(
+        session_id,
+        prompt,
+        *,
+        delegation_id,
+        evt,
+        claim,
+        process_registry,
+    ):
+        started.append((session_id, prompt, delegation_id))
+        bp._record_async_delegation_accepted(
+            evt,
+            session_id=session_id,
+            delegation_id=delegation_id,
+            claim=claim,
+        )
+
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda session_id: False)
+    monkeypatch.setattr(bp, "_start_async_delegation_wakeup_turn", _accept)
+    monkeypatch.setattr(
+        bp,
+        "_emit_bg_task_complete_events_coalesced",
+        lambda session_id, payload: emitted.append((session_id, payload)) or 1,
+    )
+
+    bp._process_one(_async_delegation_event())
+
+    assert started == [("webui-session-1", started[0][1], "deleg_test123")]
+    assert "ASYNC DELEGATION BATCH COMPLETE" in started[0][1]
+    assert emitted[0][1]["task_id"] == "deleg_test123"
+    assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+    assert [consumer for _evt, consumer in delivery["claim"]] == ["webui-background"]
+    assert len(delivery["complete"]) == 1
+    assert delivery["release"] == []
+    assert delivery["mark"] == []
+    assert delivery["legacy"] == []
+    assert registry._completion_consumed == set()
+
+
+def test_background_wakeup_releases_claim_when_dispatch_fails(monkeypatch):
+    _reset_wakeup_state()
+    _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda session_id: False)
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    monkeypatch.setattr(
+        bp,
+        "_start_async_delegation_wakeup_turn",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("dispatch failed")),
+    )
+
+    bp._process_one(_async_delegation_event())
+
+    assert len(delivery["claim"]) == 1
+    assert delivery["complete"] == []
+    assert len(delivery["release"]) == 1
+    assert "deleg_test123" not in cfg.BG_TASK_COMPLETE_EVENTS_SEEN.get("webui-session-1", set())
+
+
+def test_background_active_turn_releases_and_requeues_without_in_memory_defer(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: True)
+    monkeypatch.setattr(
+        bp,
+        "_start_async_delegation_wakeup_turn",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must stay deferred")),
+    )
+
+    bp._process_one(_async_delegation_event())
+
+    assert len(delivery["claim"]) == 1
+    assert delivery["complete"] == []
+    assert len(delivery["release"]) == 1
+    assert registry.completion_queue.qsize() == 1
+    assert cfg.DEFERRED_PROCESS_WAKEUPS == {}
+    assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+
+
+@pytest.mark.parametrize("status", [None, 302, 409, 500])
+def test_autonomous_wakeup_only_acks_after_turn_acceptance(monkeypatch, status):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    from api import routes
+
+    monkeypatch.setattr(
+        routes,
+        "start_session_turn",
+        lambda *_args, **_kwargs: {"_status": status, "error": "busy"},
+    )
+    evt = _async_delegation_event()
+    claim = peu.claim_async_delegation_delivery(evt, "webui-background")
+    assert claim is not None
+
+    bp._start_async_delegation_wakeup_turn(
+        "webui-session-1",
+        "delegation result",
+        delegation_id="deleg_test123",
+        evt=evt,
+        claim=claim,
+        process_registry=registry,
+    )
+
+    assert _wait_until(lambda: len(delivery["release"]) == 1)
+    assert delivery["complete"] == []
+    assert _wait_until(lambda: registry.completion_queue.qsize() == 1)
+    assert "deleg_test123" not in cfg.BG_TASK_COMPLETE_EVENTS_SEEN.get("webui-session-1", set())
+
+
+def test_autonomous_wakeup_exception_releases_and_requeues(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    from api import routes
+
+    monkeypatch.setattr(
+        routes,
+        "start_session_turn",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("start failed")),
+    )
+    evt = _async_delegation_event()
+    claim = peu.claim_async_delegation_delivery(evt, "webui-background")
+    assert claim is not None
+
+    bp._start_async_delegation_wakeup_turn(
+        "webui-session-1",
+        "delegation result",
+        delegation_id="deleg_test123",
+        evt=evt,
+        claim=claim,
+        process_registry=registry,
+    )
+
+    assert _wait_until(lambda: len(delivery["release"]) == 1)
+    assert delivery["complete"] == []
+    assert _wait_until(lambda: registry.completion_queue.qsize() == 1)
+
+
+def test_autonomous_wakeup_acks_after_successful_turn_acceptance(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    from api import routes
+
+    monkeypatch.setattr(
+        routes,
+        "start_session_turn",
+        lambda *_args, **_kwargs: {"_status": 200, "stream_id": "stream-1"},
+    )
+    monkeypatch.setattr(bp, "_emit_bg_task_complete_events_coalesced", lambda *_args: 1)
+    evt = _async_delegation_event()
+    claim = peu.claim_async_delegation_delivery(evt, "webui-background")
+    assert claim is not None
+
+    bp._start_async_delegation_wakeup_turn(
+        "webui-session-1",
+        "delegation result",
+        delegation_id="deleg_test123",
+        evt=evt,
+        claim=claim,
+        process_registry=registry,
+    )
+
+    assert _wait_until(lambda: len(delivery["complete"]) == 1)
+    assert delivery["release"] == []
+    assert registry.completion_queue.qsize() == 0
+    assert cfg.BG_TASK_COMPLETE_EVENTS_SEEN == {}
+
+
+def test_background_and_next_turn_consumers_share_one_atomic_claim(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+    evt = _async_delegation_event()
+    registry.completion_queue.put(dict(evt))
+    starts = []
+    notes = []
+    barrier = threading.Barrier(2)
+
+    monkeypatch.setattr(bp, "_session_has_active_turn", lambda _session_id: False)
+    monkeypatch.setattr(
+        bp,
+        "_start_async_delegation_wakeup_turn",
+        lambda *_args, **_kwargs: starts.append("background"),
+    )
+
+    def _background():
+        barrier.wait()
+        bp._process_one(dict(evt))
+
+    def _next_turn():
+        barrier.wait()
+        notes.extend(streaming._drain_webui_process_notifications("webui-session-1"))
+
+    workers = [threading.Thread(target=_background), threading.Thread(target=_next_turn)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=3)
+
+    assert sum((len(starts), len(notes))) == 1
+    assert len(delivery["claim"]) == 1
+    assert registry._completion_consumed == set()
+
+
+def test_legacy_async_event_id_falls_back_to_session_id(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    evt = _async_delegation_event(
+        delegation_id=None,
+        session_id="proc_deleg1",
+        task_id="task-legacy-1",
+    )
+    registry.completion_queue.put(evt)
+
+    notifications = streaming._drain_webui_process_notifications("webui-session-1")
+
+    assert peu.completion_delivery_id(evt) == "proc_deleg1"
+    assert len(notifications) == 1
+    assert len(delivery["claim"]) == 1
+    assert len(delivery["complete"]) == 1
+
+
+def test_streaming_next_turn_claims_and_completes_without_registry_growth(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    registry.completion_queue.put(_async_delegation_event())
+
+    notifications = streaming._drain_webui_process_notifications("webui-session-1")
+
+    assert len(notifications) == 1
+    assert "ASYNC DELEGATION BATCH COMPLETE" in notifications[0]
+    assert [consumer for _evt, consumer in delivery["claim"]] == ["webui-next-turn"]
+    assert len(delivery["complete"]) == 1
+    assert delivery["release"] == []
+    assert registry._completion_consumed == set()
+
+
+def test_streaming_live_turn_defers_ack_until_agent_acceptance_boundary(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    registry.completion_queue.put(_async_delegation_event())
+    pending = []
+
+    notifications = streaming._drain_webui_process_notifications(
+        "webui-session-1",
+        pending_async_acceptances=pending,
+    )
+
+    assert len(notifications) == 1
+    assert len(pending) == 1
+    assert delivery["complete"] == []
+    evt, claim, notification = pending[0]
+    assert notification == notifications[0]
+    peu.complete_async_delegation_delivery(evt, claim)
+    assert len(delivery["complete"]) == 1
+
+
+def test_streaming_formatter_failure_releases_and_requeues(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    process_registry_mod = sys.modules["tools.process_registry"]
+
+    def _fail_formatter(_evt):
+        raise RuntimeError("formatter failed")
+
+    process_registry_mod.format_process_notification = _fail_formatter
+    registry.completion_queue.put(_async_delegation_event())
+    pending = []
+
+    notifications = streaming._drain_webui_process_notifications(
+        "webui-session-1",
+        pending_async_acceptances=pending,
+    )
+
+    assert notifications == []
+    assert pending == []
+    assert len(delivery["claim"]) == 1
+    assert delivery["complete"] == []
+    assert len(delivery["release"]) == 1
+    assert registry.completion_queue.qsize() == 1
+
+
+def test_streaming_next_turn_releases_and_requeues_when_complete_fails(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    async_delivery = sys.modules["tools.async_delegation"]
+
+    def _fail_complete(_evt, _claim_id):
+        raise RuntimeError("complete failed")
+
+    async_delivery.complete_event_delivery = _fail_complete
+    async_delivery.mark_completion_delivered = lambda _delegation_id: False
+    async_delivery.mark_async_delegation_consumed = lambda _delegation_id: (_ for _ in ()).throw(
+        RuntimeError("legacy marker failed")
+    )
+    registry.completion_queue.put(_async_delegation_event())
+
+    notifications = streaming._drain_webui_process_notifications("webui-session-1")
+
+    assert notifications == []
+    assert len(delivery["claim"]) == 1
+    assert len(delivery["release"]) == 1
+    assert registry.completion_queue.qsize() == 1
+    assert registry._completion_consumed == set()
+
+
+def test_streaming_next_turn_drain_routes_via_process_session_index_mapping(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    cfg.PROCESS_SESSION_INDEX["gateway-session-key"] = "webui-session-1"
+    registry.completion_queue.put(_async_delegation_event(session_key="gateway-session-key"))
+
+    wrong_session_notifications = streaming._drain_webui_process_notifications("webui-session-2")
+    right_session_notifications = streaming._drain_webui_process_notifications("webui-session-1")
+
+    assert wrong_session_notifications == []
+    assert len(right_session_notifications) == 1
+    assert "ASYNC DELEGATION BATCH COMPLETE" in right_session_notifications[0]
+    assert len(delivery["claim"]) == 1
+    assert len(delivery["complete"]) == 1
+
+
+def test_claim_held_by_crashed_owner_schedules_retry_instead_of_dropping(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    _install_fake_durable_delivery_api(monkeypatch)
+    async_delivery = sys.modules["tools.async_delegation"]
+    async_delivery.claim_event_delivery = lambda _evt, _consumer: None
+    registry.completion_queue.put(_async_delegation_event())
+
+    try:
+        notifications = streaming._drain_webui_process_notifications("webui-session-1")
+        assert notifications == []
+        assert registry.completion_queue.empty()
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
+
+
+def test_background_unmapped_durable_event_schedules_retry(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    _install_fake_durable_delivery_api(monkeypatch)
+    evt = _async_delegation_event()
+
+    try:
+        bp._process_one(evt)
+        assert registry.completion_queue.empty()
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
+
+
+def test_pending_durable_claim_is_requeued_after_lease_retry(monkeypatch):
+    _reset_wakeup_state()
+    _install_fake_durable_delivery_api(monkeypatch)
+    retry_queue = queue.Queue()
+    evt = _async_delegation_event()
+
+    assert peu.schedule_async_delegation_claim_retry(evt, retry_queue, delay=0.01)
+    assert peu.schedule_async_delegation_claim_retry(evt, retry_queue, delay=0.01)
+    assert peu.async_delivery_retry_timer_count() == 1
+
+    retried = retry_queue.get(timeout=1)
+    assert retried["delegation_id"] == "deleg_test123"
+    assert _wait_until(lambda: peu.async_delivery_retry_timer_count() == 0)
+
+
+def test_delivered_or_legacy_event_is_not_scheduled_for_lease_retry(monkeypatch):
+    _reset_wakeup_state()
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    delivery["delivery_state"] = "delivered"
+    retry_queue = queue.Queue()
+
+    assert not peu.schedule_async_delegation_claim_retry(
+        _async_delegation_event(), retry_queue, delay=0.01
+    )
+    assert not peu.schedule_async_delegation_claim_retry(
+        _async_delegation_event(delegation_id=None), retry_queue, delay=0.01
+    )
+    assert retry_queue.empty()
+    assert peu.async_delivery_retry_timer_count() == 0
+
+
+def test_async_delivery_retry_uses_one_lossless_restore_sweep(monkeypatch):
+    _reset_wakeup_state()
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    retry_queue = queue.Queue()
+    cap = peu.LEGACY_ASYNC_DELIVERY_DEDUPE_MAX
+    try:
+        for index in range(cap + 100):
+            assert peu.schedule_async_delegation_claim_retry(
+                _async_delegation_event(delegation_id=f"deleg_timer_{index}"),
+                retry_queue,
+                delay=0.2,
+            )
+        assert peu.async_delivery_retry_timer_count() == 1
+        assert _wait_until(lambda: retry_queue.qsize() == cap + 100)
+        restored = {
+            retry_queue.get_nowait()["delegation_id"] for _ in range(cap + 100)
+        }
+        assert "deleg_timer_0" in restored
+        assert f"deleg_timer_{cap + 99}" in restored
+        assert restored == delivery["pending_ids"]
+        assert _wait_until(lambda: peu.async_delivery_retry_timer_count() == 0)
+    finally:
+        _reset_wakeup_state()
+
+
+def test_async_delivery_restore_sweep_retries_transient_store_failure(monkeypatch):
+    _reset_wakeup_state()
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    delivery["restore_failures"] = 1
+    retry_queue = queue.Queue()
+    monkeypatch.setattr(peu, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 0.01)
+    try:
+        assert peu.schedule_async_delegation_claim_retry(
+            _async_delegation_event(delegation_id="deleg_transient"),
+            retry_queue,
+            delay=0.01,
+        )
+        retried = retry_queue.get(timeout=1)
+        assert retried["delegation_id"] == "deleg_transient"
+        assert delivery["restore_failures"] == 0
+        assert _wait_until(lambda: peu.async_delivery_retry_timer_count() == 0)
+    finally:
+        _reset_wakeup_state()
+
+
+def test_legacy_completion_prefers_mark_completion_delivered(monkeypatch):
+    _reset_wakeup_state()
+    calls = {"mark": [], "legacy": []}
+    fake_mod = types.ModuleType("tools.async_delegation")
+    fake_mod.mark_completion_delivered = lambda delegation_id: calls["mark"].append(delegation_id) or True
+    fake_mod.mark_async_delegation_consumed = lambda delegation_id: calls["legacy"].append(delegation_id)
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.async_delegation", fake_mod)
+    monkeypatch.setattr(fake_pkg, "async_delegation", fake_mod, raising=False)
+    evt = _async_delegation_event()
+
+    claim = peu.claim_async_delegation_delivery(evt, "legacy-marker-test")
+    assert claim is not None
+    peu.complete_async_delegation_delivery(evt, claim)
+
+    assert calls == {"mark": ["deleg_test123"], "legacy": []}
+
+
+def test_legacy_completion_falls_back_to_old_consumed_marker(monkeypatch):
+    _reset_wakeup_state()
+    calls = {"mark": [], "legacy": []}
+    fake_mod = types.ModuleType("tools.async_delegation")
+    fake_mod.mark_completion_delivered = lambda delegation_id: calls["mark"].append(delegation_id) or False
+    fake_mod.mark_async_delegation_consumed = lambda delegation_id: calls["legacy"].append(delegation_id)
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.async_delegation", fake_mod)
+    monkeypatch.setattr(fake_pkg, "async_delegation", fake_mod, raising=False)
+    evt = _async_delegation_event()
+
+    claim = peu.claim_async_delegation_delivery(evt, "legacy-marker-test")
+    assert claim is not None
+    peu.complete_async_delegation_delivery(evt, claim)
+
+    assert calls == {"mark": ["deleg_test123"], "legacy": ["deleg_test123"]}
+
+
+def test_legacy_async_delivery_dedupe_is_bounded(monkeypatch):
+    _reset_wakeup_state()
+    fake_pkg = sys.modules.get("tools") or types.ModuleType("tools")
+    monkeypatch.setitem(sys.modules, "tools", fake_pkg)
+    monkeypatch.setitem(sys.modules, "tools.async_delegation", types.ModuleType("tools.async_delegation"))
+
+    cap = peu.LEGACY_ASYNC_DELIVERY_DEDUPE_MAX
+    for index in range(5000):
+        evt = _async_delegation_event(delegation_id=f"deleg_legacy_{index}")
+        claim = peu.claim_async_delegation_delivery(evt, "bounded-growth-test")
+        assert claim is not None
+        peu.complete_async_delegation_delivery(evt, claim)
+
+    assert peu.legacy_async_delivery_dedupe_size() == cap
+
+
+def test_real_core_restart_delivers_async_completion_exactly_once(tmp_path):
+    """A real durable core record must not be restored after WebUI accepts it."""
+    try:
+        from tools import async_delegation as ad
+    except Exception as exc:
+        pytest.skip(f"hermes-agent async delegation module unavailable: {exc}")
+    if not all(
+        hasattr(ad, name)
+        for name in ("claim_event_delivery", "complete_event_delivery", "release_event_delivery")
+    ):
+        pytest.skip("installed hermes-agent predates durable completion claims")
+
+    webui_repo = Path(__file__).resolve().parents[1]
+    agent_repo = Path(ad.__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path)
+    env["HERMES_BASE_HOME"] = str(tmp_path)
+    env["HERMES_CONFIG_PATH"] = str(tmp_path / "config.yaml")
+    env["HERMES_WEBUI_STATE_DIR"] = str(tmp_path)
+    env["HERMES_WEBUI_TEST_STATE_DIR"] = str(tmp_path)
+    env["HERMES_WEBUI_NO_DOTENV"] = "1"
+    env["HERMES_WEBUI_AGENT_DIR"] = str(agent_repo)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(webui_repo), str(agent_repo), env.get("PYTHONPATH", "")) if part
+    )
+
+    python_executable = os.environ.get("HERMES_WEBUI_PYTHON") or sys.executable
+    consumer = """
+import json
+import time
+from api import streaming
+from tools import async_delegation as ad
+record = ad.dispatch_async_delegation(
+    goal="restart", context=None, toolsets=None, role="leaf", model="m",
+    session_key="webui-session-1", parent_session_id="durable-parent",
+    runner=lambda: {"status": "completed", "summary": "after restart"},
+)
+deadline = time.time() + 10
+while ad.active_count() and time.time() < deadline:
+    time.sleep(.01)
+assert not ad.active_count()
+notes = streaming._drain_webui_process_notifications("webui-session-1")
+row = ad.get_durable_delegation(record["delegation_id"])
+print(json.dumps({
+    "delegation_id": record["delegation_id"],
+    "deliveries": len(notes),
+    "delivery_state": row["delivery_state"],
+}))
+"""
+    first = subprocess.run(
+        [python_executable, "-c", consumer],
+        cwd=webui_repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert first.returncode == 0, first.stderr
+    accepted = json.loads(first.stdout.strip().splitlines()[-1])
+    assert accepted["deliveries"] == 1
+    assert accepted["delivery_state"] == "delivered"
+
+    restart_probe = """
+from tools.process_registry import process_registry
+print(process_registry.completion_queue.qsize())
+"""
+    second = subprocess.run(
+        [python_executable, "-c", restart_probe],
+        cwd=webui_repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert second.returncode == 0, second.stderr
+    assert second.stdout.strip().splitlines()[-1] == "0"
+
+def test_real_core_active_claim_survives_restart_and_retries_after_lease(tmp_path):
+    """A restored event with a live claim is retried after lease expiry, not lost."""
+    try:
+        from tools import async_delegation as ad
+    except Exception as exc:
+        pytest.skip(f"hermes-agent async delegation module unavailable: {exc}")
+    if not all(
+        hasattr(ad, name)
+        for name in (
+            "claim_event_delivery",
+            "complete_event_delivery",
+            "release_event_delivery",
+            "get_durable_delegation",
+        )
+    ):
+        pytest.skip("installed hermes-agent predates durable completion claims")
+
+    webui_repo = Path(__file__).resolve().parents[1]
+    agent_repo = Path(ad.__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(tmp_path)
+    env["HERMES_BASE_HOME"] = str(tmp_path)
+    env["HERMES_CONFIG_PATH"] = str(tmp_path / "config.yaml")
+    env["HERMES_WEBUI_STATE_DIR"] = str(tmp_path)
+    env["HERMES_WEBUI_TEST_STATE_DIR"] = str(tmp_path)
+    env["HERMES_WEBUI_NO_DOTENV"] = "1"
+    env["HERMES_WEBUI_AGENT_DIR"] = str(agent_repo)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(webui_repo), str(agent_repo), env.get("PYTHONPATH", "")) if part
+    )
+    python_executable = os.environ.get("HERMES_WEBUI_PYTHON") or sys.executable
+
+    producer = """
+import time
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+record = ad.dispatch_async_delegation(
+    goal="lease-restart", context=None, toolsets=None, role="leaf", model="m",
+    session_key="webui-session-1", parent_session_id="durable-parent",
+    runner=lambda: {"status": "completed", "summary": "after lease"},
+)
+deadline = time.time() + 10
+while ad.active_count() and time.time() < deadline:
+    time.sleep(.01)
+assert not ad.active_count()
+evt = process_registry.completion_queue.get_nowait()
+claim = ad.claim_event_delivery(evt, "crashed-owner")
+assert claim
+print(record["delegation_id"])
+"""
+    first = subprocess.run(
+        [python_executable, "-c", producer],
+        cwd=webui_repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert first.returncode == 0, first.stderr
+    delegation_id = next(
+        line.strip()
+        for line in reversed(first.stdout.splitlines())
+        if line.strip().startswith("deleg_")
+    )
+
+    consumer = f"""
+import json
+import time
+from tools import async_delegation as ad
+from api import process_event_utils as peu, streaming
+from tools.process_registry import process_registry
+peu.ASYNC_DELIVERY_CLAIM_RETRY_SECONDS = 0.05
+first_notes = streaming._drain_webui_process_notifications("webui-session-1")
+first_timers = peu.async_delivery_retry_timer_count()
+with ad._DB_LOCK, ad._connect() as conn:
+    conn.execute(
+        "UPDATE async_delegations SET delivery_claimed_at=? WHERE delegation_id=?",
+        (time.time() - 301, {delegation_id!r}),
+    )
+deadline = time.time() + 3
+while process_registry.completion_queue.empty() and time.time() < deadline:
+    time.sleep(.01)
+second_notes = streaming._drain_webui_process_notifications("webui-session-1")
+row = ad.get_durable_delegation({delegation_id!r})
+print(json.dumps({{
+    "first_deliveries": len(first_notes),
+    "scheduled_retries": first_timers,
+    "second_deliveries": len(second_notes),
+    "delivery_state": row["delivery_state"] if row else None,
+}}))
+"""
+    second = subprocess.run(
+        [python_executable, "-c", consumer],
+        cwd=webui_repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert second.returncode == 0, second.stderr
+    result = json.loads(second.stdout.strip().splitlines()[-1])
+    assert result == {
+        "first_deliveries": 0,
+        "scheduled_retries": 1,
+        "second_deliveries": 1,
+        "delivery_state": "delivered",
+    }
+
+    probe = subprocess.run(
+        [
+            python_executable,
+            "-c",
+            "from tools.process_registry import process_registry; print(process_registry.completion_queue.qsize())",
+        ],
+        cwd=webui_repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.strip().splitlines()[-1] == "0"

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -203,6 +203,56 @@ def test_background_wakeup_claims_and_completes_without_registry_growth(monkeypa
     assert registry._completion_consumed == set()
 
 
+def test_claim_failure_and_queue_failure_arm_durable_restore_for_both_consumers(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    _install_fake_durable_delivery_api(monkeypatch)
+    async_delivery = sys.modules["tools.async_delegation"]
+    async_delivery.claim_event_delivery = lambda *_args: (_ for _ in ()).throw(
+        RuntimeError("durable store unavailable")
+    )
+    async_delivery.get_durable_delegation = lambda _delegation_id: (_ for _ in ()).throw(
+        RuntimeError("durable store unavailable")
+    )
+    evt = _async_delegation_event()
+    registry.completion_queue.put(evt)
+    registry.completion_queue.put = lambda _evt: (_ for _ in ()).throw(
+        RuntimeError("queue unavailable")
+    )
+    cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+
+    try:
+        assert streaming._drain_webui_process_notifications("webui-session-1") == []
+        assert peu.async_delivery_retry_timer_count() == 1
+
+        _reset_wakeup_state()
+        cfg.PROCESS_SESSION_INDEX["webui-session-1"] = "webui-session-1"
+        bp._process_one(dict(evt))
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
+
+
+def test_unaccepted_live_turn_claim_is_released_and_requeued_on_teardown(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    evt = _async_delegation_event()
+    claim = peu.claim_async_delegation_delivery(evt, "webui-next-turn")
+    assert claim is not None
+    pending = [(evt, claim, "delegation notification", registry.completion_queue)]
+
+    streaming._release_pending_async_delegations(
+        pending,
+        session_id="webui-session-1",
+    )
+
+    assert pending == []
+    assert len(delivery["release"]) == 1
+    assert registry.completion_queue.qsize() == 1
+    assert peu.legacy_async_delivery_dedupe_size() == 0
+
+
 def test_acceptance_ack_and_queue_failure_schedules_durable_recovery(monkeypatch):
     _reset_wakeup_state()
     delivery = _install_fake_durable_delivery_api(monkeypatch)

--- a/tests/test_async_delegation_webui_bridge.py
+++ b/tests/test_async_delegation_webui_bridge.py
@@ -178,7 +178,6 @@ def test_background_wakeup_claims_and_completes_without_registry_growth(monkeypa
         bp._record_async_delegation_accepted(
             evt,
             session_id=session_id,
-            delegation_id=delegation_id,
             claim=claim,
         )
 
@@ -202,6 +201,96 @@ def test_background_wakeup_claims_and_completes_without_registry_growth(monkeypa
     assert delivery["mark"] == []
     assert delivery["legacy"] == []
     assert registry._completion_consumed == set()
+
+
+def test_acceptance_ack_and_queue_failure_schedules_durable_recovery(monkeypatch):
+    _reset_wakeup_state()
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    async_delivery = sys.modules["tools.async_delegation"]
+
+    async_delivery.complete_event_delivery = lambda *_args: (_ for _ in ()).throw(
+        RuntimeError("ACK failed")
+    )
+    async_delivery.mark_completion_delivered = lambda _delegation_id: False
+    async_delivery.mark_async_delegation_consumed = lambda _delegation_id: (_ for _ in ()).throw(
+        RuntimeError("legacy ACK failed")
+    )
+    async_delivery.get_durable_delegation = lambda _delegation_id: (_ for _ in ()).throw(
+        RuntimeError("durable store temporarily unavailable")
+    )
+
+    class _FailingQueue:
+        def put(self, _evt):
+            raise RuntimeError("queue unavailable")
+
+    evt = _async_delegation_event()
+    delivery["pending_ids"].add(evt["delegation_id"])
+    claim = peu.claim_async_delegation_delivery(evt, "webui-next-turn")
+    assert claim is not None
+
+    try:
+        rejected = streaming._accept_pending_async_delegations(
+            [(evt, claim, "delegation notification", _FailingQueue())],
+            session_id="webui-session-1",
+        )
+        assert rejected == ["delegation notification"]
+        assert len(delivery["release"]) == 1
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
+
+
+def test_requeue_put_failure_arms_durable_restore_sweep(monkeypatch):
+    _reset_wakeup_state()
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+
+    class _FailingQueue:
+        def put(self, _evt):
+            raise RuntimeError("queue unavailable")
+
+    registry = _FakeProcessRegistry()
+    registry.completion_queue = _FailingQueue()
+    evt = _async_delegation_event()
+    delivery["pending_ids"].add(evt["delegation_id"])
+
+    try:
+        bp._requeue_async_delegation_event(registry, evt)
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
+
+
+def test_requeue_stops_without_enqueuing_during_shutdown():
+    _reset_wakeup_state()
+    registry = _FakeProcessRegistry()
+    bp._DRAIN_STOP.set()
+    try:
+        bp._requeue_async_delegation_event(registry, _async_delegation_event())
+        assert registry.completion_queue.empty()
+    finally:
+        bp._DRAIN_STOP.clear()
+
+
+def test_background_unmapped_legacy_event_is_requeued_best_effort(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    _install_fake_durable_delivery_api(monkeypatch)
+    monkeypatch.setattr(bp, "ASYNC_DELIVERY_ROUTING_RETRY_SECONDS", 0.01)
+    evt = _async_delegation_event(
+        delegation_id=None,
+        session_id="proc_legacy_retry",
+        session_key="legacy-unmapped-session",
+    )
+
+    bp._process_one(evt)
+
+    assert _wait_until(lambda: registry.completion_queue.qsize() == 1)
+    retried = registry.completion_queue.get_nowait()
+    assert retried["session_id"] == "proc_legacy_retry"
+    assert retried["_webui_routing_retry_attempted"] is True
+
+    bp._process_one(retried)
+    assert registry.completion_queue.empty()
 
 
 def test_background_wakeup_releases_claim_when_dispatch_fails(monkeypatch):
@@ -426,8 +515,9 @@ def test_streaming_live_turn_defers_ack_until_agent_acceptance_boundary(monkeypa
     assert len(notifications) == 1
     assert len(pending) == 1
     assert delivery["complete"] == []
-    evt, claim, notification = pending[0]
+    evt, claim, notification, completion_queue = pending[0]
     assert notification == notifications[0]
+    assert completion_queue is registry.completion_queue
     peu.complete_async_delegation_delivery(evt, claim)
     assert len(delivery["complete"]) == 1
 
@@ -481,6 +571,36 @@ def test_streaming_next_turn_releases_and_requeues_when_complete_fails(monkeypat
     assert len(delivery["release"]) == 1
     assert registry.completion_queue.qsize() == 1
     assert registry._completion_consumed == set()
+
+
+def test_streaming_synchronous_ack_and_queue_failure_arms_durable_restore(monkeypatch):
+    _reset_wakeup_state()
+    registry = _install_fake_process_registry(monkeypatch)
+    delivery = _install_fake_durable_delivery_api(monkeypatch)
+    async_delivery = sys.modules["tools.async_delegation"]
+
+    async_delivery.complete_event_delivery = lambda *_args: (_ for _ in ()).throw(
+        RuntimeError("complete failed")
+    )
+    async_delivery.mark_completion_delivered = lambda _delegation_id: False
+    async_delivery.mark_async_delegation_consumed = lambda _delegation_id: (_ for _ in ()).throw(
+        RuntimeError("legacy marker failed")
+    )
+    async_delivery.get_durable_delegation = lambda _delegation_id: (_ for _ in ()).throw(
+        RuntimeError("durable store temporarily unavailable")
+    )
+    registry.completion_queue.put(_async_delegation_event())
+    registry.completion_queue.put = lambda _evt: (_ for _ in ()).throw(
+        RuntimeError("queue unavailable")
+    )
+
+    try:
+        notifications = streaming._drain_webui_process_notifications("webui-session-1")
+        assert notifications == []
+        assert len(delivery["release"]) == 1
+        assert peu.async_delivery_retry_timer_count() == 1
+    finally:
+        _reset_wakeup_state()
 
 
 def test_streaming_next_turn_drain_routes_via_process_session_index_mapping(monkeypatch):

--- a/tests/test_notify_on_complete_webui.py
+++ b/tests/test_notify_on_complete_webui.py
@@ -21,6 +21,9 @@ def test_webui_injects_process_notifications_without_persisting_them_as_user_tex
     assert "_process_notifications = _drain_webui_process_notifications(" in src
     assert "pending_async_acceptances=_pending_async_acceptances" in src
     assert "_accept_pending_async_delegations(" in src
+    assert "_pending_async_acceptances = []" in src
+    assert "_release_pending_async_delegations(" in src
+    assert "pending_async_acceptances.clear()" in src
     assert "[*_process_notifications, msg_text]" in src
     assert "_build_native_multimodal_message(workspace_ctx, _agent_msg_text" in src
     assert "persist_user_message=msg_text" in src

--- a/tests/test_notify_on_complete_webui.py
+++ b/tests/test_notify_on_complete_webui.py
@@ -20,9 +20,7 @@ def test_webui_injects_process_notifications_without_persisting_them_as_user_tex
 
     assert "_process_notifications = _drain_webui_process_notifications(" in src
     assert "pending_async_acceptances=_pending_async_acceptances" in src
-    assert src.index("complete_async_delegation_delivery(_evt, _claim)") < src.index(
-        "result = agent.run_conversation(**_run_conversation_kwargs)"
-    )
+    assert "_accept_pending_async_delegations(" in src
     assert "[*_process_notifications, msg_text]" in src
     assert "_build_native_multimodal_message(workspace_ctx, _agent_msg_text" in src
     assert "persist_user_message=msg_text" in src

--- a/tests/test_notify_on_complete_webui.py
+++ b/tests/test_notify_on_complete_webui.py
@@ -4,10 +4,13 @@ from pathlib import Path
 def test_webui_drains_only_matching_background_completion_events():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
 
-    assert "def _drain_webui_process_notifications(session_id: str)" in src
+    assert "def _drain_webui_process_notifications(" in src
+    assert "pending_async_acceptances: list | None = None" in src
     assert "from tools.process_registry import process_registry" in src
     assert "proc = process_registry.get(evt_sid)" in src
-    assert "getattr(proc, 'session_key', None) != session_id" in src
+    assert "def _completion_event_targets_webui_session(evt_session_key: str, session_id: str)" in src
+    assert "PROCESS_SESSION_INDEX.get(evt_session_key) == session_id" in src
+    assert "not _completion_event_targets_webui_session(evt_session_key, session_id)" in src
     assert "skipped_events.append(evt)" in src
     assert "completion_queue.put(evt)" in src
 
@@ -15,7 +18,11 @@ def test_webui_drains_only_matching_background_completion_events():
 def test_webui_injects_process_notifications_without_persisting_them_as_user_text():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
 
-    assert "_process_notifications = _drain_webui_process_notifications(session_id)" in src
+    assert "_process_notifications = _drain_webui_process_notifications(" in src
+    assert "pending_async_acceptances=_pending_async_acceptances" in src
+    assert src.index("complete_async_delegation_delivery(_evt, _claim)") < src.index(
+        "result = agent.run_conversation(**_run_conversation_kwargs)"
+    )
     assert "[*_process_notifications, msg_text]" in src
     assert "_build_native_multimodal_message(workspace_ctx, _agent_msg_text" in src
     assert "persist_user_message=msg_text" in src
@@ -40,8 +47,11 @@ def test_webui_age_gates_stale_background_completion_events():
     assert "HERMES_WEBUI_STALE_COMPLETION_MAX_AGE_SECONDS" in src
     # The drain reads completed_at and drops over-age events without requeueing.
     assert "completed_at = evt.get('completed_at')" in src
-    assert "age = time.time() - completed_at" in src
-    assert "if age > stale_completion_max_age:" in src
-    # Over-age events are consumed (marked), not requeued, so they vanish.
+    assert "stale_age = time.time() - completed_at" in src
+    assert "is_stale = stale_age > stale_completion_max_age" in src
+    assert "if is_stale:" in src
+    # Over-age process events use the registry marker; async delegations finish
+    # their durable delivery claim. Neither path is added to skipped_events.
     assert "_mark_process_completion_consumed(process_registry, evt_sid)" in src
+    assert "complete_async_delegation_delivery(evt, claim)" in src
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI must surface asynchronous `delegate_task` completions through the same fresh-turn model used by CLI/gateway consumers.
- Hermes Agent replaced the removed consumed-marker proposal with durable `claim_event_delivery` / `complete_event_delivery` / `release_event_delivery` APIs.
- The WebUI has two competing consumers (background wakeup and next-turn drain), so both must share the durable claim and acknowledge only at the actual turn-acceptance boundary.
- Recovery must fail closed: a formatter, routing, queue, turn-start, or ACK failure must keep the durable record retryable rather than silently dropping it.

## What Changed

- Added a shared async-delegation delivery layer for stable event IDs, atomic claim/complete/release, bounded older-core compatibility dedupe, and one process-wide durable restore sweep.
- Updated background and next-turn consumers to share that lifecycle without writing `deleg_*` into `ProcessRegistry._completion_consumed`.
- ACKs occur only after a turn is accepted; retryable failures release and requeue.
- Follow-up to review: ACK-failure handling now keeps the already-resolved completion-queue reference. If direct `put()` fails, durable events arm the restore sweep. Shutdown no longer enqueues new retry work.
- A durable claim failure itself now preserves the known durable capability, so a simultaneous queue/store outage still arms recovery without another store read.
- Live-turn claims prepared before message construction are released and requeued from the outer stream teardown if preparation fails before the acceptance helper.
- Legacy events without a durable `delegation_id` use a controlled best-effort direct requeue when session routing is not ready; they are not misrepresented as durable DB records.
- Removed the unused explicit `delegation_id` argument from the post-acceptance helper.

## Why It Matters

This prevents duplicate live-process delivery between the two WebUI drains and prevents pending durable completions from being stranded after a restart, active claim lease, temporary durable-store failure, formatter failure, queue failure, or turn-start failure.

The guarantee is durable at-least-once recovery plus atomic in-process claims. It intentionally does not claim transactional exactly-once across the separate turn-acceptance and durable-ACK stores.

## Delivery Invariants

- Background and next-turn drains share one atomic claim.
- Background wakeups ACK only accepted 2xx responses (or the legacy success shape containing `stream_id`); 3xx/4xx/5xx and exceptions release and requeue.
- Next-turn ACK occurs immediately before `agent.run_conversation()`; ACK failure removes the synthetic notification, releases the claim, and requeues through the held queue reference.
- A failed direct queue write arms the durable restore sweep.
- A restored event with an active prior claim is retried after the lease expires.
- The durable database is the retry backlog; one shared timer restores all pending records and re-arms after transient restore failure.
- Legacy event IDs remain compatible through `delegation_id -> session_id -> task_id` for in-process delivery.
- Ordinary `proc_*` completion behavior is unchanged.

## Contract Routing

Task type: runtime durability/recovery bug fix  
Touched areas: async-delegation completion queue, background wakeup, next-turn injection, durable delivery ACK/retry  
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/GUIDELINES.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`

State layer/invariant: Hermes Agent `state.db` owns the durable pending/delivered record; WebUI owns only the active claim, held queue reference, and one bounded process-wide restore timer. A released durable record remains recoverable until `complete_event_delivery()` succeeds.

Scope boundaries: no UI changes, no new dependencies, no changes to ordinary `proc_*` delivery, and no transactional exactly-once claim across two stores.

## Verification

On current `master` after rebase:

- related async/background/process suite with installed Hermes Agent: `131 passed`
- same suite with the current core checkout: `131 passed`
- repeated ACK-failure + competing-consumer probes: `20/20 passed`
- focused review regressions were observed red before the fix and green afterward (`5 passed`)
- prior full suite for the feature branch: `12889 passed, 116 skipped, 5 deselected, 1 xfailed, 2 xpassed`
- `git diff --check`: passed
- `compileall`: passed
- Ruff on focused changed files: passed
- added-lines security-pattern scan: no findings

GitHub CI for the original head was green across browser smoke, lint, and Python 3.11/3.12/3.13 shards; the pushed follow-up will rerun those checks.

## Risks / Follow-ups

- A crash in the unavoidable gap between external turn acceptance and durable ACK can still produce at-least-once replay; eliminating that requires a transactional outbox or an idempotent turn-acceptance API spanning both stores.
- Older Agent builds without durable APIs remain bounded best-effort only.
- Legacy events without `delegation_id` cannot be restored from the current durable delegation table because that table is keyed by `delegation_id`; they receive direct best-effort requeue instead.

## Release Note

WebUI async delegation completions now use Hermes Agent's durable delivery claims, recover pending results across restart/retry paths, and avoid duplicate delivery between background and next-turn consumers.

## Supersedes

Supersedes #4799, which was correctly closed after Hermes Agent replaced the consumed-marker proposal with durable claim/complete/release.

## Model Used

OpenAI Codex — `gpt-5.6-sol`, via Hermes Agent. Tool-assisted git/GitHub inspection, targeted pytest verification, and independent reviewer subagents were used.
