### PR TITLE
fix: show file name first in Artifacts tab, clip directory path (#6067)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6429,7 +6429,8 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .workspace-artifact-empty{padding:16px 8px;color:var(--muted);font-size:12px;line-height:1.5;text-align:center;}
 .workspace-artifact-item{display:block;width:100%;text-align:left;background:var(--surface-subtle);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:8px 10px;margin-bottom:6px;cursor:pointer;}
 .workspace-artifact-item:hover{border-color:var(--accent);}
-.workspace-artifact-path{font-family:'SF Mono',ui-monospace,monospace;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.workspace-artifact-name{font-family:'SF Mono',ui-monospace,monospace;font-size:13px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--text);}
+.workspace-artifact-dir{font-family:'SF Mono',ui-monospace,monospace;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--muted);margin-top:1px;}
 .workspace-artifact-meta{margin-top:3px;color:var(--muted);font-size:11px;}
 .workspace-artifacts-count{opacity:.65;font-size:11px;}
 .rightpanel[data-active-tab="artifacts"] .breadcrumb-bar,.rightpanel[data-active-tab="artifacts"] .file-tree,.rightpanel[data-active-tab="artifacts"] #wsEmptyState{display:none!important;}

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -586,7 +586,17 @@ function renderSessionArtifacts(){
     if(normWs && p.startsWith(normWs)) return p.slice(normWs.length);
     return p;
   };
-  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(displayPath(item.path))}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
+  root.innerHTML = items.map(item => {
+    const dPath = displayPath(item.path);
+    const idx = dPath.lastIndexOf('/');
+    const fileName = idx >= 0 ? dPath.slice(idx + 1) : dPath;
+    const dirPath = idx >= 0 ? dPath.slice(0, idx) : '';
+    return `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)">
+      <div class="workspace-artifact-name">${esc(fileName)}</div>
+      ${dirPath ? `<div class="workspace-artifact-dir">${esc(dirPath)}</div>` : ''}
+      <div class="workspace-artifact-meta">${esc(item.source || 'session')}</div>
+    </button>`;
+  }).join('');
 }
 
 async function _workspacePathExists(path){


### PR DESCRIPTION
## Summary

Fixes #6067 — in the workspace **Artifacts** tab, long paths (e.g. `src/api/routes/users.py`) were rendered as a single ellipsised line, cutting off the identifying file name first.

### Before

Every artifact row showed the full path on one line. Deep paths truncated the file name (`…`), making it impossible to identify files at a glance.

### After

Each artifact row now has a **two-line layout**:

| Element | CSS class | Style |
|---|---|---|
| **File name** (last path segment) | `.workspace-artifact-name` | `font-size: 13px; font-weight: 600;` — bold, always visible |
| Directory prefix | `.workspace-artifact-dir` | `font-size: 11px; color: var(--muted);` — truncates with ellipsis when too long |
| Source badge | `.workspace-artifact-meta` | unchanged |

### Changes

- **`static/workspace.js`**: Split `displayPath()` into `fileName` (last `/` segment) and `dirPath` (prefix). Modified the template to render `.workspace-artifact-name` + `.workspace-artifact-dir` + `.workspace-artifact-meta`.
- **`static/style.css`**: Replaced `.workspace-artifact-path` with `.workspace-artifact-name` (bold filename) and `.workspace-artifact-dir` (muted, truncatable directory).

### Verification

- ✅ Single-segment paths render with just the file name (no directory line)
- ✅ Deep paths show the file name prominently, directory clipped with `text-overflow: ellipsis`
- ✅ Source badge still visible
- ✅ Click-through to Files tab works unchanged (uses `data-artifact-path`)
- ✅ Backward compatible — no API changes, no new dependencies