### PR TITLE
fix: prevent child-streaming CSS class reflow on parent sidebar row (#6027)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7823,7 +7823,7 @@ function renderSessionListFromCache(){
     const attention=_sessionAttentionState(s)||_sessionAttentionState({_child:true,attention:s._child_session_attention});
     const attentionClass=attention?(attention.kind==='approval'?' attention-approval':(attention.kind==='clarify'?' attention-clarify':' attention-attention')):'';
     const readOnly=_isReadOnlySession(s);
-    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'')+(attention?' needs-attention':'')+attentionClass;
+    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(ownStreaming?' streaming':'')+(hasUnread?' unread':'')+(attention?' needs-attention':'')+attentionClass;
     const swipeReturnOffset=_sessionSwipeReturnOffsets.get(s.session_id);
     if(swipeReturnOffset!==undefined){
       _sessionSwipeReturnOffsets.delete(s.session_id);


### PR DESCRIPTION
## Summary

Closes #6027 — residual sidebar reflow when a delegated/subagent child session starts or stops streaming, after the #5699 fix (which only closed the date-bucket-jump vector).

## Root cause

`bubbleSidebarState` sets `parentRow._child_session_streaming = true` when a child streams. In `_renderOneSession`, the composite `isStreaming = ownStreaming || !!s._child_session_streaming` was used for the `.streaming` CSS class on the parent row. The CSS `.streaming` class (style.css lines 1595, 1648, 1716) toggles `padding-right` and `color` transitions — causing visible visual reflow on the parent row whenever a child starts or stops streaming, even though the parent's sort position never changed.

## Fix

**1-line change** in `static/sessions.js` line 7826:

```diff
- el.className='session-item'+...+(isStreaming?' streaming':'')+...;
+ el.className='session-item'+...+(ownStreaming?' streaming':'')+...;
```

Use `ownStreaming` (the parent's OWN streaming state, from `_isSessionEffectivelyStreaming(s)`) for the `.streaming` CSS class instead of the composite `isStreaming` (ownStreaming || child_session_streaming).

This means:
- ✅ The parent's own `.streaming` class still reflects when it is actively generating
- ✅ Child-streaming state still bubbles via `_child_session_streaming` for the attention badge/indicator
- ❌ Child-streaming no longer toggles `.streaming` CSS transitions on the parent row
- ✅ No position/sort change — the parent stays put in its date bucket
- ✅ All 64 existing sidebar tests pass (53 lineage + 7 subagent flicker + 4 partition)

## What this does NOT change

- `_child_session_streaming`, `_child_session_has_unread`, `_child_session_attention` still bubble up to the parent for the attention indicator
- `_rememberRenderedStreamingState` still uses `ownStreaming` (not `isStreaming`) — already correct from #5699
- `hasAttentionState` and the state indicator still use `isStreaming` (includes child streaming)
- Parent sort rank is unchanged — no boost when child streams (intentional: the issue asks the parent to stay put)

## Testing

All 64 related tests pass:
```
tests/test_5306_subagent_sidebar_flicker.py ................ 7 passed
tests/test_session_lineage_collapse.py ................... 53 passed
tests/test_sidebar_session_partition.py ................. 4 passed
```

## Related

- #5699 (fixed date-bucket-jump vector, this is the residual CSS reflow vector)
- #5306 (subagent sidebar flicker — child retention during parent's active turn)
