### PR TITLE
fix: exclude .msg-row from global color transition to prevent hover flicker (#6072)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1489,7 +1489,9 @@
   .agent-activity-thinking[data-live-thinking="1"],
   .agent-activity-thinking[data-live-thinking="1"] *,
   .live-worklog[data-live-worklog-shell="1"],
-  .live-worklog[data-live-worklog-shell="1"] *{transition-property:none!important;transition-duration:0s!important;transition-delay:0s!important;}
+  .live-worklog[data-live-worklog-shell="1"] *,
+  .msg-row,
+  .msg-row *{transition-property:none!important;transition-duration:0s!important;transition-delay:0s!important;}
   :root{--app-titlebar-safe-top:0px;}
   .pwa-standalone{overscroll-behavior:none;}
   .pwa-standalone body{-webkit-tap-highlight-color:transparent;}


### PR DESCRIPTION
Fixes the hover-triggered text-shading flicker on follow-up messages after /continue.

Root cause: A global CSS transition on color/background affects all div elements. The existing exclusion covered live streaming messages and activity-thinking/worklog elements, but not .msg-row for settled messages.

Fix: Adds .msg-row to the transition exclusion block.

Closes #6072