### PR TITLE
fix: generate non-empty approval_id when gateway approval.request omits it (#6008)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -6,6 +6,7 @@ import logging
 import os
 import threading
 import time
+import uuid
 import urllib.error
 import urllib.request
 from typing import Any
@@ -334,6 +335,8 @@ def _gateway_runs_approval_event(payload: dict) -> dict | None:
     args = payload.get("args") if isinstance(payload.get("args"), (list, dict)) else []
     run_id = str(payload.get("run_id") or "").strip()
     approval_id = str(payload.get("approval_id") or payload.get("id") or "").strip()
+    if not approval_id:
+        approval_id = uuid.uuid4().hex
     risk = str(payload.get("risk_level") or "high").strip()
     choices = payload.get("choices") if isinstance(payload.get("choices"), list) else []
     allow_permanent = payload.get("allow_permanent")


### PR DESCRIPTION
Closes #6008

## Problem

When Hermes Agent emits an `approval.request` SSE event without an `approval_id` or `id` field, `_gateway_runs_approval_event()` in `api/gateway_chat.py` produces an empty string for `approval_id`. This causes:

1. The frontend approval card displays with `approval_id: ""`
2. User clicks Allow/Deny → `POST /api/approval/respond` with empty `approval_id`
3. The route handler rejects: `if not approval_id: return bad(...)`
4. The run remains permanently blocked

## Root cause

The Hermes Agent API server emits `approval.request` events with only `run_id`, `timestamp`, `choices` — but **no** `approval_id`:

```python
# In hermes-agent gateway/platforms/api_server.py
{
    "event": "approval.request",
    "run_id": run_id,
    "timestamp": time.time(),
    "choices": ["once", "session", "always", "deny"],
    # no approval_id field
}
```

The WebUI adapter then does:
```python
approval_id = str(payload.get("approval_id") or payload.get("id") or "").strip()
  → ""
```

## Fix

Generate a `uuid.uuid4().hex` as the local `approval_id` when the upstream payload provides neither `approval_id` nor `id`. This is consistent with how `route_approvals.submit_pending` already handles the same situation for local approvals:

```python
entry.setdefault("approval_id", uuid.uuid4().hex)
```

The Hermes Agent resolves approvals by `run_id`, not `approval_id`, so this ID is purely a WebUI-local correlation key.

## Verification

- 55 tests pass (pre-existing skips: 23)
- All gateway approval, SSE, and runs-API tests green