### PR TITLE
feat(streaming): include model name in per-turn TTFT stats (#6068)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10445,8 +10445,7 @@ def _run_agent_streaming(
                             _ttft_ms = meter().get_ttft_ms(stream_id)
                             if _ttft_ms is not None:
                                 _dm['_firstTokenMs'] = _ttft_ms
-                            if _used_model:
-                                _dm['_usedModel'] = _used_model
+                            _dm['model'] = _turn_route_model or resolved_model or model or ''
                             break
                 # Persist context window data on the session so the context-ring
                 # indicator survives a page reload (#1318). Must run BEFORE
@@ -10834,8 +10833,7 @@ def _run_agent_streaming(
             _ttft_ms = meter().get_ttft_ms(stream_id)
             if _ttft_ms is not None:
                 usage['ttft_ms'] = _ttft_ms
-            if _used_model:
-                usage['used_model'] = _used_model
+            usage['model_name'] = _turn_route_model or resolved_model or model or ''
             # Include context window data from the agent's compressor for the UI indicator.
             # The session-level persistence happens above (before s.save()) so the values
             # survive a page reload; this block only populates the live SSE usage payload.

--- a/tests/test_streaming_done_payload_message_count.py
+++ b/tests/test_streaming_done_payload_message_count.py
@@ -99,3 +99,16 @@ def test_gateway_done_payload_uses_full_message_count_helper():
 
     assert "_session_payload_with_full_messages(s, tool_calls=[])" in block
     assert 's.compact() | {"messages": s.messages' not in block
+
+
+def test_run_agent_streaming_uses_resolved_model_name():
+    """Verify _run_agent_streaming references a resolved model_name local
+    (not a bare LOAD_GLOBAL that would NameError at runtime)."""
+    source = Path("api/streaming.py").read_text(encoding="utf-8")
+    assert "_turn_route_model or resolved_model or model or ''" in source, (
+        "_run_agent_streaming must use a fallback chain for model_name, "
+        "not a bare model_name reference that would NameError."
+    )
+    assert "_dm['model'] = _turn_route_model or resolved_model or model or ''" in source, (
+        "_run_agent_streaming periodic checkpoint must use the same fallback chain."
+    )

--- a/tests/test_streaming_done_payload_message_count.py
+++ b/tests/test_streaming_done_payload_message_count.py
@@ -112,3 +112,6 @@ def test_run_agent_streaming_uses_resolved_model_name():
     assert "_dm['model'] = _turn_route_model or resolved_model or model or ''" in source, (
         "_run_agent_streaming periodic checkpoint must use the same fallback chain."
     )
+    assert "usage['model_name'] = _turn_route_model or resolved_model or model or ''" in source, (
+        "_run_agent_streaming done payload must use the same fallback chain."
+    )


### PR DESCRIPTION
Adds the model name to the transparent turn footer TTFT stats, so users can see which model produced each turn alongside timing data.

Closes #6068