### PR TITLE
fix: include terminal backend identity in agent cache signature (#5937)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8327,6 +8327,12 @@ def _run_agent_streaming(
                     # field the cached agent silently retains the previous
                     # profile's SOUL.md (and any other profile-scoped context).
                     _profile_home or '',
+                    # Terminal backend identity: sessions switching between
+                    # remote (SSH) and local backends must not reuse a cached
+                    # agent that carries stale terminal env vars (#5937).
+                    _safe_profile_runtime_env.get('TERMINAL_ENV', '') or '',
+                    _safe_profile_runtime_env.get('TERMINAL_SSH_HOST', '') or '',
+                    _safe_profile_runtime_env.get('TERMINAL_SSH_USER', '') or '',
                 ], sort_keys=True)
                 _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
 


### PR DESCRIPTION
When a session was previously executed on a remote terminal backend (SSH) and later used locally, the cached AIAgent retained the old terminal environment, causing tool execution on the wrong backend.

Fix: Added TERMINAL_ENV, TERMINAL_SSH_HOST, and TERMINAL_SSH_USER to the AIAgent cache signature. When the terminal backend changes, the signature differs, causing a cache miss and a fresh agent with the correct environment.

Closes #5937