### PR TITLE
feat: add durable active-run indicator visible across session switches (#6025)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2,6 +2,8 @@
 // These run during script evaluation to handle server-stopped state
 // and cross-tab shutdown broadcasts as early as possible.
 (function(){
+  // Restore active run state from session storage across page reloads (#6025)
+  try{_restoreActiveRunState();}catch(e){}
   // Clear stale stop-server flag on successful page load (server is reachable)
   try{localStorage.removeItem('hermes-webui-server-stopped');}catch(_){}
   // Listen for shutdown broadcast from other tabs

--- a/static/index.html
+++ b/static/index.html
@@ -122,7 +122,7 @@
   <div class="app-titlebar-left">
     <button class="app-titlebar-profile" id="titlebarProfileBtn" type="button" onclick="toggleProfileDropdown(event)" aria-label="Switch profile" style="display:none">
       <span class="app-titlebar-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>
-      <span class="app-titlebar-profile-label" id="titlebarProfileLabel">default</span>
+      <span class="app-titlebar-profile-label" id="titlebarProfileLabel">default</span><span id="activeRunDot" class="active-run-dot-hidden"></span>
       <span class="app-titlebar-profile-chevron" aria-hidden="true"><svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>
     </button>
     <button class="app-titlebar-hamburger has-tooltip has-tooltip--bottom" id="btnHamburger" onclick="toggleMobileSidebar()" type="button" data-tooltip="Menu" aria-label="Menu">

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2074,6 +2074,12 @@ async function loadSession(sid){
     }
     // Refresh todos from cold-load or persisted INFLIGHT before painting.
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
+    // Carry forward restored active-run state when the server snapshot does not
+    // report an active stream for a session we persisted as running (#6025).
+    if(!activeStreamId && S._restoredActiveSessionId === sid){
+      activeStreamId = S.activeStreamId || null;
+    }
+    delete S._restoredActiveSessionId;
     S.busy=!!activeStreamId;_updateActiveRunDot();_persistActiveRunState();  // #4354: Only assert busy if server confirms active stream.
     // appendLiveToolCard() is guarded by S.activeStreamId; restore it before
     // replaying persisted live tools so the compact Activity count survives
@@ -9252,7 +9258,7 @@ function _persistActiveRunState() {
         sessionStorage.setItem('hermes-webui-active-run', JSON.stringify({
             busy: !!S.busy,
             activeStreamId: S.activeStreamId || null,
-            sessionId: (S.session && S.session.session_id) || null,
+            activeSessionId: (S.session && S.session.session_id) || null,
             timestamp: Date.now()
         }));
     } catch(e) {}
@@ -9266,7 +9272,7 @@ function _restoreActiveRunState() {
             S.busy = true;
             _updateActiveRunDot();
             if (state.activeStreamId) S.activeStreamId = state.activeStreamId;
-            if (state.sessionId) S._restoredActiveSessionId = state.sessionId;
+            if (state.activeSessionId) S._restoredActiveSessionId = state.activeSessionId;
         }
         sessionStorage.removeItem('hermes-webui-active-run');
     } catch(e) {}
@@ -9274,7 +9280,11 @@ function _restoreActiveRunState() {
 function _updateActiveRunDot() {
     var dot = document.getElementById('activeRunDot');
     if (!dot) return;
-    if (S.busy) {
+    // Dot reflects *any* active run, not just the current session's busy state (#6025).
+    // A session switch to an idle tab must not hide the indicator while a background
+    // session is still streaming.
+    var anyActive = !!S.busy || (typeof INFLIGHT !== 'undefined' && INFLIGHT && Object.keys(INFLIGHT).length > 0);
+    if (anyActive) {
         dot.className = 'active-run-dot';
         dot.title = 'Agent is running';
     } else {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -843,7 +843,7 @@ function _reconcileActiveSessionIdleStateFromList(serverRows) {
   if (!serverRow) return false;
   if (!_isServerIdleSessionRow(serverRow)) return false;
   let changed=false;
-  if (S.busy) { S.busy=false; changed=true; }
+  if (S.busy) { S.busy=false;_updateActiveRunDot(); changed=true; }
   if (S.activeStreamId) { S.activeStreamId=null; changed=true; }
   if (INFLIGHT&&INFLIGHT[sid]) {
     delete INFLIGHT[sid];
@@ -1483,7 +1483,7 @@ async function newSession(flash, options={}){
     }
     // Reset per-session visual state: a fresh chat is idle even if another
     // conversation is still streaming in the background.
-    S.busy=false;
+    S.busy=false;_updateActiveRunDot();
     S.activeStreamId=null;
     updateSendBtn();
     setStatus('');
@@ -1961,7 +1961,7 @@ async function loadSession(sid){
   // precede the acknowledge repaint.)
   if(!activeStreamId){
     S.activeStreamId=null;
-    S.busy=false;
+    S.busy=false;_updateActiveRunDot();
     if(INFLIGHT[sid]){
       delete INFLIGHT[sid];
       if(typeof clearInflightState==='function') clearInflightState(sid);
@@ -2074,7 +2074,7 @@ async function loadSession(sid){
     }
     // Refresh todos from cold-load or persisted INFLIGHT before painting.
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
-    S.busy=!!activeStreamId;  // #4354: Only assert busy if server confirms active stream.
+    S.busy=!!activeStreamId;_updateActiveRunDot();_persistActiveRunState();  // #4354: Only assert busy if server confirms active stream.
     // appendLiveToolCard() is guarded by S.activeStreamId; restore it before
     // replaying persisted live tools so the compact Activity count survives
     // switching away from and back to an active chat (#1715).
@@ -2223,7 +2223,7 @@ async function loadSession(sid){
     activeStreamId = activeStreamId || ((S.activeStreamId && S.session && S.session.session_id===sid) ? S.activeStreamId : null);
 
     if(activeStreamId){
-      S.busy=true;
+      S.busy=true;_updateActiveRunDot();_persistActiveRunState();
       S.activeStreamId=activeStreamId;
       if(typeof attachLiveStream==='function') attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
       else if(typeof watchInflightSession==='function') watchInflightSession(sid, activeStreamId);
@@ -2249,7 +2249,7 @@ async function loadSession(sid){
       if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
       if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
     }else{
-      S.busy=false;
+      S.busy=false;_updateActiveRunDot();
       S.activeStreamId=null;
       updateSendBtn();
       setStatus('');
@@ -9245,3 +9245,39 @@ document.addEventListener('keydown',(e)=>{
   e.preventDefault();
   navigateSession(e.key==='j'?1:-1);
 });
+
+/* Active-run indicator persistence - visible across session switches (#6025) */
+function _persistActiveRunState() {
+    try {
+        sessionStorage.setItem('hermes-webui-active-run', JSON.stringify({
+            busy: !!S.busy,
+            activeStreamId: S.activeStreamId || null,
+            sessionId: (S.session && S.session.session_id) || null,
+            timestamp: Date.now()
+        }));
+    } catch(e) {}
+}
+function _restoreActiveRunState() {
+    try {
+        var raw = sessionStorage.getItem('hermes-webui-active-run');
+        if (!raw) return;
+        var state = JSON.parse(raw);
+        if (state.busy && state.timestamp && (Date.now() - state.timestamp) < 30000) {
+            S.busy = true;
+            _updateActiveRunDot();
+            if (state.activeStreamId) S.activeStreamId = state.activeStreamId;
+            if (state.sessionId) S._restoredActiveSessionId = state.sessionId;
+        }
+        sessionStorage.removeItem('hermes-webui-active-run');
+    } catch(e) {}
+}
+function _updateActiveRunDot() {
+    var dot = document.getElementById('activeRunDot');
+    if (!dot) return;
+    if (S.busy) {
+        dot.className = 'active-run-dot';
+        dot.title = 'Agent is running';
+    } else {
+        dot.className = 'active-run-dot-hidden';
+    }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -7235,3 +7235,8 @@ html[data-conversation-outline="enabled"] #outlineToggleBtn:not([hidden]){displa
 /* Settings field highlight (mirrors msg-question-highlight / _highlightQuestionRow pattern) */
 .settings-field-highlight { animation: settings-field-pulse 1.6s ease-out; }
 @keyframes settings-field-pulse { 0% { box-shadow: 0 0 0 0 var(--focus-ring); } 35% { box-shadow: 0 0 0 4px var(--focus-ring); } 100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); } }
+
+/* Active-run indicator dot - green pulsing animation (#6025) */
+#activeRunDot.active-run-dot{display:inline-block;width:8px;height:8px;border-radius:50%;background:#2ecc71;margin:0 6px 0 2px;vertical-align:middle;position:relative;box-shadow:0 0 4px rgba(46,204,113,.6);animation:active-run-pulse 2s ease-in-out infinite}
+#activeRunDot.active-run-dot-hidden{display:none!important}
+@keyframes active-run-pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.85)}}

--- a/static/ui.js
+++ b/static/ui.js
@@ -7764,6 +7764,8 @@ async function handleComposerPrimaryAction(){
 
 function setBusy(v){
   S.busy=v;
+  try{_updateActiveRunDot();}catch(_){}
+  try{_persistActiveRunState();}catch(_){}
   updateSendBtn();
   if(!v){
     if(typeof _clearActivityElapsedTimer==='function') _clearActivityElapsedTimer();

--- a/tests/test_6176_active_run_indicator.py
+++ b/tests/test_6176_active_run_indicator.py
@@ -1,0 +1,209 @@
+"""Regression checks for PR #6176 active-run indicator."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+class TestActiveRunDotElement:
+    """The dot element exists in the DOM and has CSS styling."""
+
+    def test_html_contains_active_run_dot_span(self):
+        assert 'id="activeRunDot"' in INDEX_HTML, "activeRunDot span missing from index.html"
+
+    def test_html_dot_is_sibling_of_profile_label(self):
+        assert 'id="titlebarProfileLabel"' in INDEX_HTML
+        assert 'id="activeRunDot"' in INDEX_HTML
+        # dot must appear after the profile label span
+        label_idx = INDEX_HTML.index('id="titlebarProfileLabel"')
+        dot_idx = INDEX_HTML.index('id="activeRunDot"')
+        assert dot_idx > label_idx, "activeRunDot must follow titlebarProfileLabel in HTML"
+
+    def test_css_defines_active_run_dot_visible_class(self):
+        assert '#activeRunDot.active-run-dot{' in STYLE_CSS.replace(' ', ''), \
+            "Missing .active-run-dot CSS rule for visible dot"
+
+    def test_css_defines_active_run_dot_hidden_class(self):
+        assert '#activeRunDot.active-run-dot-hidden{' in STYLE_CSS.replace(' ', ''), \
+            "Missing .active-run-dot-hidden CSS rule"
+
+    def test_css_defines_pulse_animation(self):
+        # @keyframes active-run-pulse with spaces collapsed
+        css_no_spaces = STYLE_CSS.replace(' ', '').replace('\n', '').replace('\t', '')
+        assert '@keyframesactive-run-pulse' in css_no_spaces, \
+            "Missing @keyframes active-run-pulse animation"
+
+
+class TestSetBusyChokepoint:
+    """setBusy() is the single chokepoint that drives _updateActiveRunDot() and _persistActiveRunState()."""
+
+    def test_setbusy_calls_update_active_run_dot(self):
+        # setBusy must call _updateActiveRunDot() after S.busy = v
+        assert 'try{_updateActiveRunDot();}catch(_){}' in UI_JS, \
+            "setBusy must call _updateActiveRunDot()"
+
+    def test_setbusy_calls_persist_active_run_state(self):
+        # setBusy must call _persistActiveRunState() after S.busy = v
+        assert 'try{_persistActiveRunState();}catch(_){}' in UI_JS, \
+            "setBusy must call _persistActiveRunState()"
+
+    def test_setbusy_calls_update_before_persist(self):
+        # _updateActiveRunDot must appear before _persistActiveRunState in setBusy
+        update_idx = UI_JS.index('_updateActiveRunDot')
+        persist_idx = UI_JS.index('_persistActiveRunState')
+        assert update_idx < persist_idx, \
+            "_updateActiveRunDot must be called before _persistActiveRunState in setBusy"
+
+
+class TestUpdateActiveRunDot:
+    """_updateActiveRunDot() reflects ANY active run, not just S.busy."""
+
+    def test_update_active_run_dot_exists(self):
+        assert 'function _updateActiveRunDot()' in SESSIONS_JS, \
+            "_updateActiveRunDot() function must exist in sessions.js"
+
+    def test_checks_s_busy(self):
+        assert '!!S.busy' in SESSIONS_JS, "_updateActiveRunDot must check S.busy"
+
+    def test_checks_inflight_for_any_active_run(self):
+        # Must check INFLIGHT for any active run, not just S.busy
+        assert "typeof INFLIGHT !== 'undefined'" in SESSIONS_JS, \
+            "_updateActiveRunDot must guard INFLIGHT access"
+        assert "Object.keys(INFLIGHT).length > 0" in SESSIONS_JS, \
+            "_updateActiveRunDot must check INFLIGHT for background runs"
+
+    def test_sets_active_run_dot_class_when_active(self):
+        assert "dot.className = 'active-run-dot'" in SESSIONS_JS, \
+            "Must set active-run-dot class when active"
+
+    def test_sets_hidden_class_when_inactive(self):
+        assert "dot.className = 'active-run-dot-hidden'" in SESSIONS_JS, \
+            "Must set active-run-dot-hidden class when inactive"
+
+    def test_sets_title_agent_is_running(self):
+        assert "dot.title = 'Agent is running'" in SESSIONS_JS, \
+            "Must set title attribute for accessibility"
+
+
+class TestPersistActiveRunState:
+    """_persistActiveRunState() writes correct state to sessionStorage."""
+
+    def test_persist_uses_correct_session_id_accessor(self):
+        # Must use S.session && S.session.session_id, never the phantom S.sessionId
+        assert "S.session && S.session.session_id" in SESSIONS_JS, \
+            "_persistActiveRunState must use S.session && S.session.session_id"
+        assert "S.sessionId" not in SESSIONS_JS, \
+            "Phantom S.sessionId must not appear in the codebase"
+
+    def test_persist_key_is_active_session_id(self):
+        assert 'activeSessionId:' in SESSIONS_JS, \
+            "sessionStorage key must be activeSessionId (not the misleading sessionId)"
+
+    def test_persist_includes_busy_flag(self):
+        assert 'busy: !!S.busy' in SESSIONS_JS
+
+    def test_persist_includes_active_stream_id(self):
+        assert 'activeStreamId:' in SESSIONS_JS
+
+    def test_persist_includes_timestamp(self):
+        assert 'timestamp: Date.now()' in SESSIONS_JS
+
+    def test_persist_wraps_in_try_catch(self):
+        # sessionStorage access may throw (quota, private browsing); must be guarded
+        func_start = SESSIONS_JS.index('function _persistActiveRunState()')
+        func_end = func_start + 500  # reasonable window
+        func_text = SESSIONS_JS[func_start:func_end]
+        assert 'try {' in func_text and 'catch(e) {}' in func_text, \
+            "_persistActiveRunState must wrap in try/catch"
+
+
+class TestRestoreActiveRunState:
+    """_restoreActiveRunState() restores and paints from sessionStorage."""
+
+    def test_restore_exists(self):
+        assert 'function _restoreActiveRunState()' in SESSIONS_JS, \
+            "_restoreActiveRunState() function must exist"
+
+    def test_restore_calls_update_active_run_dot(self):
+        func_start = SESSIONS_JS.index('function _restoreActiveRunState()')
+        func_end = SESSIONS_JS.index('function _updateActiveRunDot()')
+        func_text = SESSIONS_JS[func_start:func_end]
+        assert '_updateActiveRunDot()' in func_text, \
+            "_restoreActiveRunState must call _updateActiveRunDot() to paint the dot"
+
+    def test_restore_sets_s_busy_true(self):
+        func_start = SESSIONS_JS.index('function _restoreActiveRunState()')
+        func_end = SESSIONS_JS.index('function _updateActiveRunDot()')
+        func_text = SESSIONS_JS[func_start:func_end]
+        assert 'S.busy = true' in func_text, \
+            "_restoreActiveRunState must set S.busy = true"
+
+    def test_restore_reads_active_session_id(self):
+        func_start = SESSIONS_JS.index('function _restoreActiveRunState()')
+        func_end = SESSIONS_JS.index('function _updateActiveRunDot()')
+        func_text = SESSIONS_JS[func_start:func_end]
+        assert 'state.activeSessionId' in func_text, \
+            "_restoreActiveRunState must read state.activeSessionId"
+
+    def test_restore_checks_thirty_second_window(self):
+        assert '(Date.now() - state.timestamp) < 30000' in SESSIONS_JS, \
+            "_restoreActiveRunState must enforce 30-second recency window"
+
+    def test_restore_clears_session_storage_after_read(self):
+        assert "sessionStorage.removeItem('hermes-webui-active-run')" in SESSIONS_JS, \
+            "_restoreActiveRunState must remove the item to prevent stale restores"
+
+    def test_restore_wraps_in_try_catch(self):
+        func_start = SESSIONS_JS.index('function _restoreActiveRunState()')
+        func_end = SESSIONS_JS.index('function _updateActiveRunDot()')
+        func_text = SESSIONS_JS[func_start:func_end]
+        assert 'try {' in func_text and 'catch(e) {}' in func_text, \
+            "_restoreActiveRunState must wrap in try/catch"
+
+
+class TestBootIntegration:
+    """boot.js calls _restoreActiveRunState() early."""
+
+    def test_boot_calls_restore(self):
+        assert '_restoreActiveRunState()' in BOOT_JS, \
+            "boot.js must call _restoreActiveRunState() for cross-reload persistence"
+
+    def test_boot_restore_wrapped_in_try_catch(self):
+        assert "try{_restoreActiveRunState();}catch(e){}" in BOOT_JS, \
+            "boot.js restore call must be wrapped in try/catch"
+
+
+class TestLoadSessionSurvival:
+    """loadSession carries forward restored active-run state for matching session."""
+
+    def test_loadsession_carries_forward_restored_stream(self):
+        # When server doesn't report activeStreamId but restore has one for this sid,
+        # loadSession must carry it forward.
+        assert 'S._restoredActiveSessionId === sid' in SESSIONS_JS, \
+            "loadSession must check restored session ID before clobbering busy state"
+
+    def test_loadsession_clears_restored_flag_after_use(self):
+        assert 'delete S._restoredActiveSessionId' in SESSIONS_JS, \
+            "loadSession must clear S._restoredActiveSessionId after consuming it"
+
+
+class TestPerAssignmentSites:
+    """The 6 per-assignment _updateActiveRunDot() calls in sessions.js remain as guardrails."""
+
+    def test_reconcile_idle_calls_update_dot(self):
+        assert "S.busy=false;_updateActiveRunDot();" in SESSIONS_JS
+
+    def test_new_session_calls_update_dot(self):
+        # newSession should call _updateActiveRunDot after S.busy=false
+        assert "S.busy=false;_updateActiveRunDot();" in SESSIONS_JS
+
+    def test_loadsession_busy_path_calls_update_and_persist(self):
+        assert "S.busy=true;_updateActiveRunDot();_persistActiveRunState();" in SESSIONS_JS
+
+    def test_loadsession_active_stream_path_calls_update_and_persist(self):
+        assert "S.busy=!!activeStreamId;_updateActiveRunDot();_persistActiveRunState();" in SESSIONS_JS

--- a/tests/test_6176_active_run_indicator_js_behaviour.py
+++ b/tests/test_6176_active_run_indicator_js_behaviour.py
@@ -1,0 +1,513 @@
+"""Behavioural tests for the active-run indicator dot — execute the actual
+_updateActiveRunDot(), _persistActiveRunState(), _restoreActiveRunState(),
+and setBusy() functions via Node.js against mocked DOM/S/storage.
+
+The static checks in test_6176_active_run_indicator.py confirm structural
+properties (call sites exist, correct accessors, CSS rules present), but
+they pass even if the runtime logic is inverted — e.g. if the dot hides
+when it should show, or persist writes a stale busy flag after stream-finish.
+
+This file pins the actual rendered className/title for every state so the
+indicator's show/hide/inflight contract cannot silently regress.
+
+Tests cover:
+  - Dot shows on setBusy(true)
+  - Dot clears on setBusy(false)
+  - No stale dot / stale persist after stream-finish
+  - Dot reflects background run after switching sessions (INFLIGHT non-empty)
+  - Persist/restore round-trip survives a simulated reload
+  - Restore paints the dot via _updateActiveRunDot()
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS_PATH = str(REPO_ROOT / "static" / "sessions.js")
+UI_JS_PATH = str(REPO_ROOT / "static" / "ui.js")
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+# ── Node.js driver ──────────────────────────────────────────────────────────
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const sessionsSrc = fs.readFileSync(process.argv[2], 'utf8');
+const uiSrc = fs.readFileSync(process.argv[3], 'utf8');
+
+// ── Mock DOM element (analogous to makeEl() in reasoning tests) ──
+function makeDot() {
+    return {
+        className: 'active-run-dot-hidden',
+        title: '',
+    };
+}
+
+// ── Mock global state S (matches ui.js const S = {...}) ──
+global.S = {
+    busy: false,
+    session: null,
+    activeStreamId: null,
+};
+
+// ── Mock INFLIGHT (global map of active streams) ──
+global.INFLIGHT = {};
+
+// ── Mock document (getElementById for the dot) ──
+const dot = makeDot();
+global.document = {
+    getElementById: function(id) {
+        if (id === 'activeRunDot') return dot;
+        return null;
+    },
+    addEventListener: function() {},
+    querySelectorAll: function() { return []; },
+    querySelector: function() { return null; },
+};
+
+// ── Mock sessionStorage ──
+let _storage = {};
+global.sessionStorage = {
+    getItem: function(k) { return _storage.hasOwnProperty(k) ? _storage[k] : null; },
+    setItem: function(k, v) { _storage[k] = String(v); },
+    removeItem: function(k) { delete _storage[k]; },
+};
+
+// ── Mock other globals touched by setBusy ──
+global.updateSendBtn = function() {};
+global._queueDrainSid = null;
+global.setStatus = function() {};
+global.setComposerStatus = function() {};
+global.updateQueueBadge = function() {};
+global.shiftQueuedSessionMessage = function() { return null; };
+global._clearActivityElapsedTimer = function() {};
+
+// ── Globals needed by sessions.js but not relevant here ──
+global.window = {};
+global.ICONS = {};
+global._loadingSessionId = null;
+global._loadSessionGeneration = 0;
+global._autoLoadContinuation = null;
+global._pendingCarryForwardSnapshot = null;
+global._draftSaveTimer = null;
+global._NEW_CHAT_DRAFT_SESSION_KEY = null;
+global.__ = function() {};
+
+// ── Extract a named function from source ──
+function extractFunc(src, name) {
+    const re = new RegExp('function\\s+' + name + '\\s*\\(');
+    const start = src.search(re);
+    if (start < 0) throw new Error(name + ' not found');
+    let i = src.indexOf('{', start);
+    let depth = 1; i++;
+    while (depth > 0 && i < src.length) {
+        if (src[i] === '{') depth++;
+        else if (src[i] === '}') depth--;
+        i++;
+    }
+    return src.slice(start, i);
+}
+
+// Evaluate the functions from sessions.js
+eval(extractFunc(sessionsSrc, '_persistActiveRunState'));
+eval(extractFunc(sessionsSrc, '_restoreActiveRunState'));
+eval(extractFunc(sessionsSrc, '_updateActiveRunDot'));
+
+// Evaluate setBusy from ui.js
+eval(extractFunc(uiSrc, 'setBusy'));
+
+// ── Read the command from argv[4] ──
+const cmd = JSON.parse(process.argv[4]);
+
+// Apply state mutations before executing
+if (cmd.S_busy !== undefined) S.busy = cmd.S_busy;
+if (cmd.S_session !== undefined) S.session = cmd.S_session;
+if (cmd.S_activeStreamId !== undefined) S.activeStreamId = cmd.S_activeStreamId;
+if (cmd.S__restoredActiveSessionId !== undefined) S._restoredActiveSessionId = cmd.S__restoredActiveSessionId;
+if (cmd.INFLIGHT !== undefined) INFLIGHT = cmd.INFLIGHT;
+if (cmd._queueDrainSid !== undefined) _queueDrainSid = cmd._queueDrainSid;
+if (cmd.storageSeed !== undefined && Array.isArray(cmd.storageSeed)) {
+    cmd.storageSeed.forEach(function(e) {
+        sessionStorage.setItem(e.k, e.v);
+    });
+}
+
+let result = {};
+
+if (cmd.action === 'updateActiveRunDot') {
+    _updateActiveRunDot();
+    result.dotClassName = dot.className;
+    result.dotTitle = dot.title;
+}
+
+if (cmd.action === 'persistActiveRunState') {
+    _persistActiveRunState();
+    const raw = sessionStorage.getItem('hermes-webui-active-run');
+    result.persisted = raw ? JSON.parse(raw) : null;
+}
+
+if (cmd.action === 'restoreActiveRunState') {
+    _restoreActiveRunState();
+    result.S_busy = S.busy;
+    result.S__restoredActiveSessionId = S._restoredActiveSessionId;
+    result.dotClassName = dot.className;
+    result.dotTitle = dot.title;
+    result.storageCleared = sessionStorage.getItem('hermes-webui-active-run') === null;
+}
+
+if (cmd.action === 'setBusy') {
+    setBusy(cmd.busyValue);
+    result.S_busy = S.busy;
+    result.dotClassName = dot.className;
+    result.dotTitle = dot.title;
+    const raw = sessionStorage.getItem('hermes-webui-active-run');
+    result.persisted = raw ? JSON.parse(raw) : null;
+}
+
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("active_run_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _run(driver_path, cmd):
+    """Execute the driver with the given command object."""
+    result = subprocess.run(
+        [NODE, driver_path, SESSIONS_JS_PATH, UI_JS_PATH, json.dumps(cmd)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed (rc={result.returncode}):\n{result.stderr}")
+    return json.loads(result.stdout)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# _updateActiveRunDot() — single-source-of-truth for dot visibility
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestUpdateActiveRunDotBehaviour:
+    """_updateActiveRunDot() sets the dot's className and title based on
+    S.busy and the INFLIGHT map."""
+
+    def test_dot_shows_when_s_busy_is_true(self, driver_path):
+        out = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": True,
+            "INFLIGHT": {},
+        })
+        assert out["dotClassName"] == "active-run-dot", \
+            f"Dot must show when S.busy=true, got {out}"
+        assert out["dotTitle"] == "Agent is running"
+
+    def test_dot_hides_when_s_busy_is_false_and_inflight_empty(self, driver_path):
+        out = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": False,
+            "INFLIGHT": {},
+        })
+        assert out["dotClassName"] == "active-run-dot-hidden", \
+            f"Dot must hide when S.busy=false and INFLIGHT empty, got {out}"
+
+    def test_dot_shows_when_inflight_has_entries_even_if_s_busy_false(self, driver_path):
+        """After switching to an idle session, the dot must still reflect a
+        background run that is still streaming. INFLIGHT non-empty → dot stays lit."""
+        out = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": False,
+            "INFLIGHT": {"stream-abc": {}},
+        })
+        assert out["dotClassName"] == "active-run-dot", \
+            f"Dot must show when INFLIGHT has entries (background run), got {out}"
+        assert out["dotTitle"] == "Agent is running"
+
+    def test_dot_shows_when_both_s_busy_and_inflight_have_runs(self, driver_path):
+        out = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": True,
+            "INFLIGHT": {"stream-1": {}, "stream-2": {}},
+        })
+        assert out["dotClassName"] == "active-run-dot", \
+            f"Dot must show when both S.busy and INFLIGHT indicate runs, got {out}"
+
+    def test_inflight_undefined_is_handled_gracefully(self, driver_path):
+        """When INFLIGHT is undefined (not yet initialised), the dot should
+        still work based on S.busy alone."""
+        out = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": False,
+            "INFLIGHT": None,  # Force undefined via null (driver sets if !== undefined)
+        })
+        # With INFLIGHT forced to null, only S.busy matters
+        assert out["dotClassName"] == "active-run-dot-hidden", \
+            f"Dot must hide when S.busy=false and INFLIGHT undefined/null, got {out}"
+
+    def test_inflight_null_treated_as_no_runs(self, driver_path):
+        """INFLIGHT might be null during early boot."""
+        # We need to test with INFLIGHT explicitly undefined.
+        # Use a special command that doesn't set INFLIGHT.
+        out = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": True,
+        })
+        assert out["dotClassName"] == "active-run-dot", \
+            f"Dot must show when S.busy=true regardless of INFLIGHT state, got {out}"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# _persistActiveRunState() — writes correct snapshot to sessionStorage
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPersistActiveRunStateBehaviour:
+    """_persistActiveRunState() writes busy, activeStreamId, activeSessionId,
+    and timestamp to sessionStorage."""
+
+    def test_persist_writes_busy_true_with_session(self, driver_path):
+        out = _run(driver_path, {
+            "action": "persistActiveRunState",
+            "S_busy": True,
+            "S_session": {"session_id": "ses-abc-123"},
+            "S_activeStreamId": "stream-xyz",
+        })
+        assert out["persisted"] is not None, "Must write to sessionStorage"
+        assert out["persisted"]["busy"] is True
+        assert out["persisted"]["activeStreamId"] == "stream-xyz"
+        assert out["persisted"]["activeSessionId"] == "ses-abc-123"
+        assert isinstance(out["persisted"]["timestamp"], (int, float))
+
+    def test_persist_writes_busy_false_after_stream_finish(self, driver_path):
+        """When a stream finishes, persist must write busy=false so a reload
+        doesn't flash a stale dot. This is the fix for the false-positive
+        flash on reload (#6176 review comment)."""
+        out = _run(driver_path, {
+            "action": "persistActiveRunState",
+            "S_busy": False,
+            "S_session": {"session_id": "ses-abc-123"},
+            "S_activeStreamId": None,
+        })
+        assert out["persisted"]["busy"] is False, \
+            "Must persist busy=false after stream-finish to prevent stale flash on reload"
+        assert out["persisted"]["activeStreamId"] is None
+
+    def test_persist_handles_null_session_gracefully(self, driver_path):
+        """S.session may be null early in boot or during new-session flow."""
+        out = _run(driver_path, {
+            "action": "persistActiveRunState",
+            "S_busy": True,
+            "S_session": None,
+            "S_activeStreamId": "stream-xyz",
+        })
+        assert out["persisted"]["activeSessionId"] is None, \
+            "Must coerce null session to null activeSessionId"
+
+    def test_persist_handles_missing_session_id_gracefully(self, driver_path):
+        out = _run(driver_path, {
+            "action": "persistActiveRunState",
+            "S_busy": True,
+            "S_session": {},
+            "S_activeStreamId": "stream-xyz",
+        })
+        assert out["persisted"]["activeSessionId"] is None, \
+            "Must handle S.session without session_id"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# _restoreActiveRunState() — reads from sessionStorage and paints the dot
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRestoreActiveRunStateBehaviour:
+    """_restoreActiveRunState() reads the persisted state, sets S.busy,
+    paints the dot via _updateActiveRunDot(), and clears sessionStorage."""
+
+    def _seed_storage(self, driver_path, busy=True, activeStreamId="stream-1",
+                      activeSessionId="ses-1", timestamp=None):
+        if timestamp is None:
+            import time
+            timestamp = int(time.time() * 1000)
+        return _run(driver_path, {
+            "action": "restoreActiveRunState",
+            "storageSeed": [{
+                "k": "hermes-webui-active-run",
+                "v": json.dumps({
+                    "busy": busy,
+                    "activeStreamId": activeStreamId,
+                    "activeSessionId": activeSessionId,
+                    "timestamp": timestamp,
+                }),
+            }],
+        })
+
+    def test_restore_sets_s_busy_true_and_paints_dot(self, driver_path):
+        out = self._seed_storage(driver_path)
+        assert out["S_busy"] is True, "Restore must set S.busy = true"
+        assert out["dotClassName"] == "active-run-dot", \
+            "Restore must paint the dot via _updateActiveRunDot()"
+        assert out["dotTitle"] == "Agent is running", \
+            "Restore must set accessibility title"
+
+    def test_restore_sets_restored_active_session_id(self, driver_path):
+        out = self._seed_storage(driver_path, activeSessionId="ses-abc")
+        assert out["S__restoredActiveSessionId"] == "ses-abc", \
+            "Restore must preserve session ID for loadSession carry-forward"
+
+    def test_restore_clears_storage_after_read(self, driver_path):
+        out = self._seed_storage(driver_path)
+        assert out["storageCleared"] is True, \
+            "Restore must remove the item to prevent stale restores"
+
+    def test_restore_ignores_stale_timestamp_outside_30s_window(self, driver_path):
+        import time
+        stale_ts = int((time.time() - 60) * 1000)  # 60 seconds ago
+        out = self._seed_storage(driver_path, timestamp=stale_ts)
+        assert out["S_busy"] is False, \
+            "Restore must ignore entries older than 30 seconds"
+
+    def test_restore_ignores_busy_false_entry(self, driver_path):
+        out = self._seed_storage(driver_path, busy=False)
+        assert out["S_busy"] is False, \
+            "Restore must NOT set S.busy=true when persisted busy=false"
+        # Dot should remain hidden (default state)
+        # After restore sets nothing, dot stays at its initial hidden state
+        assert out["dotClassName"] == "active-run-dot-hidden"
+
+    def test_restore_no_storage_does_nothing(self, driver_path):
+        out = _run(driver_path, {"action": "restoreActiveRunState"})
+        assert out["S_busy"] is False, "No storage → no restore"
+        assert out["dotClassName"] == "active-run-dot-hidden"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# setBusy() — the single chokepoint that drives update + persist
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSetBusyChokepointBehaviour:
+    """setBusy(v) is the single chokepoint that MUST call both
+    _updateActiveRunDot() and _persistActiveRunState()."""
+
+    def test_setbusy_true_shows_dot_and_persists(self, driver_path):
+        out = _run(driver_path, {
+            "action": "setBusy",
+            "busyValue": True,
+            "S_session": {"session_id": "ses-1"},
+        })
+        assert out["dotClassName"] == "active-run-dot", \
+            "setBusy(true) must show the dot"
+        assert out["persisted"] is not None, \
+            "setBusy(true) must persist state"
+        assert out["persisted"]["busy"] is True
+
+    def test_setbusy_false_hides_dot_and_persists(self, driver_path):
+        """After stream-finish, setBusy(false) must hide the dot AND persist
+        busy=false so a reload doesn't flash a stale dot."""
+        # Start with dot visible
+        pre = _run(driver_path, {
+            "action": "updateActiveRunDot",
+            "S_busy": True,
+            "INFLIGHT": {},
+        })
+        assert pre["dotClassName"] == "active-run-dot"
+
+        out = _run(driver_path, {
+            "action": "setBusy",
+            "busyValue": False,
+            "S_session": {"session_id": "ses-1"},
+            "INFLIGHT": {},  # No background runs
+        })
+        assert out["dotClassName"] == "active-run-dot-hidden", \
+            "setBusy(false) must hide the dot when no background runs"
+        assert out["persisted"]["busy"] is False, \
+            "setBusy(false) must persist busy=false to prevent stale flash on reload"
+
+    def test_setbusy_false_keeps_dot_when_inflight_has_runs(self, driver_path):
+        """When a background session is still running, calling setBusy(false)
+        on the foreground session must NOT hide the dot because INFLIGHT still
+        has active streams."""
+        out = _run(driver_path, {
+            "action": "setBusy",
+            "busyValue": False,
+            "S_session": {"session_id": "ses-1"},
+            "INFLIGHT": {"stream-bg": {}},  # Background run still active
+        })
+        assert out["dotClassName"] == "active-run-dot", \
+            "setBusy(false) must NOT hide dot when background runs are active"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Persist/Restore round-trip — simulates a page reload
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPersistRestoreRoundTrip:
+    """A full persist → restore cycle simulates a page reload and verifies
+    the dot survives the round-trip."""
+
+    def test_roundtrip_survives_reload(self, driver_path):
+        """1. setBusy(true) → persist
+           2. Simulate reload: read from storage, restore
+           3. Dot should be visible after restore
+        """
+        # Step 1: Start a run
+        out1 = _run(driver_path, {
+            "action": "setBusy",
+            "busyValue": True,
+            "S_session": {"session_id": "ses-roundtrip"},
+            "S_activeStreamId": "stream-rt",
+        })
+        assert out1["dotClassName"] == "active-run-dot"
+        persisted = out1["persisted"]
+        assert persisted["busy"] is True
+
+        # Step 2: Simulate reload by seeding storage and restoring
+        out2 = _run(driver_path, {
+            "action": "restoreActiveRunState",
+            "storageSeed": [{
+                "k": "hermes-webui-active-run",
+                "v": json.dumps(persisted),
+            }],
+        })
+        assert out2["S_busy"] is True, \
+            "After restore, S.busy must be true"
+        assert out2["dotClassName"] == "active-run-dot", \
+            "After restore, dot must be visible"
+        assert out2["S__restoredActiveSessionId"] == "ses-roundtrip", \
+            "After restore, session ID must be carried forward"
+
+    def test_roundtrip_preserves_cleared_state(self, driver_path):
+        """1. setBusy(false) → persist busy=false
+           2. Simulate reload
+           3. Dot should NOT appear (busy=false in storage → no restore)
+        """
+        # Step 1: Finish a run
+        out1 = _run(driver_path, {
+            "action": "setBusy",
+            "busyValue": False,
+            "S_session": {"session_id": "ses-roundtrip"},
+            "S_activeStreamId": None,
+            "INFLIGHT": {},
+        })
+        assert out1["persisted"]["busy"] is False
+
+        # Step 2: Simulate reload
+        out2 = _run(driver_path, {
+            "action": "restoreActiveRunState",
+            "storageSeed": [{
+                "k": "hermes-webui-active-run",
+                "v": json.dumps(out1["persisted"]),
+            }],
+        })
+        assert out2["S_busy"] is False, \
+            "After stream-finish reload, S.busy must be false"
+        assert out2["dotClassName"] == "active-run-dot-hidden", \
+            "After stream-finish reload, dot must be hidden"


### PR DESCRIPTION
Adds a green pulsing dot indicator next to the active profile name that shows when the agent is running. The indicator persists across session switches and tab reloads via sessionStorage.

## Changes
- CSS: green pulsing dot animation ()
- HTML: dot element inserted after profile name in titlebar
- sessions.js: , ,  - wires into all  assignment sites
- boot.js: restore call at startup to detect previously active runs

Closes #6025