### PR TITLE
perf: make repeated conversation switching responsive

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,6 +235,24 @@ Session is a plain Python class (not a dataclass, not SQLAlchemy):
 title_from(): takes messages list, finds first user message, returns first 64 chars.
 Called after run_conversation() completes to set the session title retroactively.
 
+Initial session-tail response cache:
+
+- `GET /api/session?messages=1&msg_limit=N&resolve_model=0` keeps a bounded
+  process-local LRU of final redacted response payloads for idle native WebUI
+  sessions.
+- The cache is a presentation optimization only. Session JSON plus profile
+  `state.db` remain authoritative; `context_messages` and transcript recovery
+  semantics are unchanged.
+- Keys include stat signatures for the session sidecar, active-profile
+  `state.db`/WAL/SHM files, `settings.json`, and the active profile's
+  `config.yaml`. Any source write produces a miss automatically.
+- Active/pending runs, messaging/CLI/read-only sessions, truncation state, and
+  compression/fork lineage bypass the cache and use the established full
+  reconciliation path.
+- The cache is capped by both entry count and serialized payload bytes. It is
+  intentionally process-local: restart drops it safely, and a miss is always a
+  performance cost rather than a correctness failure.
+
 ### 4.3 SSE Streaming Engine
 
 This is the most architecturally interesting part. Two endpoints cooperate:
@@ -446,10 +464,14 @@ Chat:
     removeThinking()      Removes thinking dots (called on first token or on error)
 
 Rendering:
-    renderMessages()      Full rebuild of #msgInner from S.messages
+    renderMessages()      Reuses a per-session HTML LRU on unchanged cross-session
+                          navigation; otherwise rebuilds #msgInner from S.messages
     renderMd(raw)         Homegrown markdown renderer (see 5.4 for known gaps)
     syncTopbar()          Updates topbar title, meta, model chip, workspace chip
     renderTray()          Updates attach tray showing pending files
+
+The HTML LRU is bounded to eight entries, 2 MiB per entry, and 8 MiB total
+(estimated as UTF-16 browser heap). Cache hits refresh insertion/LRU order.
 
 Approval:
     showApprovalCard(p)   Shows the approval card with command/description text

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -461,8 +461,9 @@ When the all-profiles sidebar opens an existing conversation owned by another
 profile, the profile cookie still switches before `loadSession()`, but the
 already-complete all-profiles list stays visible and is reused from browser
 cache. That path does not synchronously refetch projects/sessions or start the
-generic model-catalog refresh; `loadSession()` performs the single deferred
-session-specific model refresh after transcript first paint.
+generic model-catalog refresh. Session navigation marks the model catalog stale
+without fetching it; opening the model picker performs the bounded
+session-specific freshness check on demand.
 
 Chat:
     send()                Main action: upload files, POST /api/chat/start, open EventSource

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -457,6 +457,13 @@ Session management:
     deleteSession(sid)    POST /api/session/delete, handle active/inactive cases correctly
     renderSessionList()   GET /api/sessions, rebuild #sessionList DOM
 
+When the all-profiles sidebar opens an existing conversation owned by another
+profile, the profile cookie still switches before `loadSession()`, but the
+already-complete all-profiles list stays visible and is reused from browser
+cache. That path does not synchronously refetch projects/sessions or start the
+generic model-catalog refresh; `loadSession()` performs the single deferred
+session-specific model refresh after transcript first paint.
+
 Chat:
     send()                Main action: upload files, POST /api/chat/start, open EventSource
     uploadPendingFiles()  Upload each file in S.pendingFiles, return filenames array

--- a/api/routes.py
+++ b/api/routes.py
@@ -9378,7 +9378,7 @@ def _session_detail_tail_cache_get(key: tuple | None) -> dict | None:
         if entry is None:
             return None
         _SESSION_DETAIL_TAIL_CACHE.move_to_end(key)
-        return entry[0]
+        return dict(entry[0])
 
 
 def _session_detail_tail_cache_set(key: tuple | None, payload: dict) -> None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -28,7 +28,7 @@ import time
 import uuid
 import http.client
 import socket as _socket
-from collections import defaultdict, deque
+from collections import OrderedDict, defaultdict, deque
 from pathlib import Path
 from contextlib import closing
 from urllib.parse import parse_qs, quote, unquote, urljoin, urlsplit
@@ -9265,6 +9265,155 @@ from api.models import (
 )
 
 
+# Initial transcript tails are expensive to rebuild for large, tool-heavy
+# sessions even after Session.load() is warm: the route still reconciles
+# sidecar/state.db rows, derives todo/tool state, redacts the payload, and
+# serializes hundreds of KB. Cache only the final, already-redacted response for
+# the ordinary idle native-WebUI path. The cache is a presentation optimization,
+# never a state source: every key includes the source files' stat signatures and
+# any active/pending, messaging, lineage, or recovery shape bypasses it.
+_SESSION_DETAIL_TAIL_CACHE_VERSION = 1
+_SESSION_DETAIL_TAIL_CACHE_MAX_ENTRIES = 24
+_SESSION_DETAIL_TAIL_CACHE_MAX_BYTES = 24 * 1024 * 1024
+_SESSION_DETAIL_TAIL_CACHE_MAX_ENTRY_BYTES = 2 * 1024 * 1024
+_SESSION_DETAIL_TAIL_CACHE: "OrderedDict[tuple, tuple[dict, int]]" = OrderedDict()
+_SESSION_DETAIL_TAIL_CACHE_BYTES = 0
+_SESSION_DETAIL_TAIL_CACHE_LOCK = threading.Lock()
+
+
+def _session_detail_tail_path_stamp(path) -> tuple | None:
+    try:
+        path = Path(path)
+        st = path.stat()
+    except (OSError, TypeError, ValueError):
+        return None
+    return (
+        str(path),
+        int(getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000))),
+        int(st.st_size),
+        int(getattr(st, "st_ctime_ns", int(st.st_ctime * 1_000_000_000))),
+    )
+
+
+def _session_detail_tail_source_stamp(sid: str) -> tuple | None:
+    if not is_safe_session_id(sid):
+        return None
+    sidecar_stamp = _session_detail_tail_path_stamp(SESSION_DIR / f"{sid}.json")
+    if sidecar_stamp is None:
+        return None
+    try:
+        state_db_path = Path(_active_state_db_path())
+    except Exception:
+        state_db_path = None
+    state_stamps = ()
+    if state_db_path is not None:
+        state_stamps = tuple(
+            _session_detail_tail_path_stamp(path)
+            for path in (
+                state_db_path,
+                Path(f"{state_db_path}-wal"),
+                Path(f"{state_db_path}-shm"),
+            )
+        )
+    try:
+        profile_config_path = _active_profile_config_path()
+    except Exception:
+        profile_config_path = None
+    return (
+        sidecar_stamp,
+        state_stamps,
+        _session_detail_tail_path_stamp(SETTINGS_FILE),
+        _session_detail_tail_path_stamp(profile_config_path),
+    )
+
+
+def _session_detail_tail_cache_eligible(session) -> bool:
+    if session is None:
+        return False
+    if getattr(session, "active_stream_id", None):
+        return False
+    if getattr(session, "pending_user_message", None) or getattr(session, "pending_started_at", None):
+        return False
+    if getattr(session, "parent_session_id", None) or getattr(session, "pre_compression_snapshot", False):
+        return False
+    if getattr(session, "truncation_watermark", None) not in (None, ""):
+        return False
+    if getattr(session, "truncation_boundary", None) not in (None, ""):
+        return False
+    if getattr(session, "read_only", False) or getattr(session, "is_cli_session", False):
+        return False
+    if _is_messaging_session_record(session) or _session_requires_cli_metadata_lookup(session):
+        return False
+    source = str(getattr(session, "session_source", "") or "").strip().lower()
+    return source in ("", "webui")
+
+
+def _session_detail_tail_cache_key(
+    session,
+    *,
+    msg_limit: int,
+    expand_renderable: bool,
+) -> tuple | None:
+    if not _session_detail_tail_cache_eligible(session):
+        return None
+    sid = str(getattr(session, "session_id", "") or "")
+    source_stamp = _session_detail_tail_source_stamp(sid)
+    if source_stamp is None:
+        return None
+    return (
+        _SESSION_DETAIL_TAIL_CACHE_VERSION,
+        sid,
+        str(getattr(session, "profile", "") or ""),
+        max(1, int(msg_limit)),
+        bool(expand_renderable),
+        source_stamp,
+    )
+
+
+def _session_detail_tail_cache_get(key: tuple | None) -> dict | None:
+    if key is None:
+        return None
+    with _SESSION_DETAIL_TAIL_CACHE_LOCK:
+        entry = _SESSION_DETAIL_TAIL_CACHE.get(key)
+        if entry is None:
+            return None
+        _SESSION_DETAIL_TAIL_CACHE.move_to_end(key)
+        return entry[0]
+
+
+def _session_detail_tail_cache_set(key: tuple | None, payload: dict) -> None:
+    global _SESSION_DETAIL_TAIL_CACHE_BYTES
+    if key is None or not isinstance(payload, dict):
+        return
+    try:
+        entry_bytes = len(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        )
+    except (TypeError, ValueError):
+        return
+    if entry_bytes > _SESSION_DETAIL_TAIL_CACHE_MAX_ENTRY_BYTES:
+        return
+    with _SESSION_DETAIL_TAIL_CACHE_LOCK:
+        previous = _SESSION_DETAIL_TAIL_CACHE.pop(key, None)
+        if previous is not None:
+            _SESSION_DETAIL_TAIL_CACHE_BYTES -= previous[1]
+        _SESSION_DETAIL_TAIL_CACHE[key] = (payload, entry_bytes)
+        _SESSION_DETAIL_TAIL_CACHE_BYTES += entry_bytes
+        while (
+            len(_SESSION_DETAIL_TAIL_CACHE) > _SESSION_DETAIL_TAIL_CACHE_MAX_ENTRIES
+            or _SESSION_DETAIL_TAIL_CACHE_BYTES > _SESSION_DETAIL_TAIL_CACHE_MAX_BYTES
+        ):
+            _old_key, (_old_payload, old_bytes) = _SESSION_DETAIL_TAIL_CACHE.popitem(last=False)
+            _SESSION_DETAIL_TAIL_CACHE_BYTES -= old_bytes
+
+
+def _clear_session_detail_tail_cache() -> None:
+    global _SESSION_DETAIL_TAIL_CACHE_BYTES
+    with _SESSION_DETAIL_TAIL_CACHE_LOCK:
+        _SESSION_DETAIL_TAIL_CACHE.clear()
+        _SESSION_DETAIL_TAIL_CACHE_BYTES = 0
+
+
 _COMPRESSION_RECOVERY_START_LOCK = threading.Lock()
 
 
@@ -12421,7 +12570,17 @@ def handle_get(handler, parsed) -> bool:
         try:
             _t1 = _time.monotonic()
             if _diag: _diag.stage("t1_after_get_session_check")
-            s = get_session(sid, metadata_only=(not load_messages))
+            _detail_cache_candidate = (
+                load_messages
+                and msg_limit is not None
+                and msg_before is None
+                and not resolve_model
+            )
+            _detail_cache_key = None
+            s = get_session(
+                sid,
+                metadata_only=(not load_messages) or _detail_cache_candidate,
+            )
             _session_profile = getattr(s, 'profile', None) or None
             if not _session_visible_to_active_profile(_session_profile, handler):
                 if _session_profile:
@@ -12443,6 +12602,27 @@ def handle_get(handler, parsed) -> bool:
                 return bad(handler, "Session not found", 404)
             original_stream_id = getattr(s, "active_stream_id", None)
             _clear_stale_stream_state(s)
+            if _detail_cache_candidate:
+                _detail_cache_key = _session_detail_tail_cache_key(
+                    s,
+                    msg_limit=msg_limit,
+                    expand_renderable=expand_renderable,
+                )
+                _cached_detail_payload = _session_detail_tail_cache_get(_detail_cache_key)
+                if _cached_detail_payload is not None:
+                    if _diag:
+                        _diag.stage("session_detail_tail_cache_hit")
+                        _diag.finish()
+                    return j(handler, _cached_detail_payload)
+                if _diag:
+                    _diag.stage("session_detail_tail_cache_miss")
+                if getattr(s, "_loaded_metadata_only", False):
+                    s = get_session(sid, metadata_only=False)
+                    _session_profile = getattr(s, 'profile', None) or None
+                # A full cached object may have changed while the metadata-only
+                # read was in flight. Re-evaluate eligibility before storing.
+                if not _session_detail_tail_cache_eligible(s):
+                    _detail_cache_key = None
             cli_meta = _lookup_cli_session_metadata(sid) if _session_requires_cli_metadata_lookup(s) else {}
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
             cli_messages = []
@@ -12757,7 +12937,19 @@ def handle_get(handler, parsed) -> bool:
             redact = redact_session_data(raw)
             _t5 = _time.monotonic()
             if _diag: _diag.stage("t5_after_redact")
-            resp = j(handler, {"session": redact})
+            _response_payload = {"session": redact}
+            if _detail_cache_key is not None:
+                _fresh_detail_cache_key = _session_detail_tail_cache_key(
+                    s,
+                    msg_limit=msg_limit,
+                    expand_renderable=expand_renderable,
+                )
+                # The response was derived between two independent filesystem
+                # snapshots. Store it only when no authoritative input changed
+                # during reconciliation/redaction (TOCTOU stale-cache guard).
+                if _fresh_detail_cache_key == _detail_cache_key:
+                    _session_detail_tail_cache_set(_detail_cache_key, _response_payload)
+            resp = j(handler, _response_payload)
             _t6 = _time.monotonic()
             if _diag: _diag.stage("t6_after_json_write")
             _total_ms = (_t6 - _t0) * 1000

--- a/static/boot.js
+++ b/static/boot.js
@@ -3547,23 +3547,37 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     }
     if(S.session) syncTopbar();
     else if(typeof syncReasoningChip==='function') syncReasoningChip();
-  }).catch(e=>{
-    window._modelDropdownReady=null;
-    throw e;
   });
+  let _modelDropdownReadyFreshness=null;
+  const _trackModelDropdownReady=(promise,freshness=null)=>{
+    const tracked=Promise.resolve(promise).catch(e=>{
+      if(window._modelDropdownReady===tracked){
+        window._modelDropdownReady=null;
+        _modelDropdownReadyFreshness=null;
+      }
+      throw e;
+    });
+    window._modelDropdownReady=tracked;
+    _modelDropdownReadyFreshness=freshness||null;
+    return tracked;
+  };
   const _startModelDropdown=(opts={})=>{
+    const requestedFreshness=opts&&opts.freshness?opts.freshness:null;
     const ready=window._modelDropdownReady;
-    if(ready&&typeof ready.then==='function') return ready;
-    const next=_hydrateModelDropdown(opts);
-    window._modelDropdownReady=next;
-    return next;
+    if(ready&&typeof ready.then==='function'){
+      if(!requestedFreshness||_modelDropdownReadyFreshness===requestedFreshness) return ready;
+      const queued=Promise.resolve(ready).catch(()=>{}).then(()=>_hydrateModelDropdown(opts));
+      return _trackModelDropdownReady(queued,requestedFreshness);
+    }
+    return _trackModelDropdownReady(_hydrateModelDropdown(opts),requestedFreshness);
   };
   const _startBootModelDropdown=()=>{
     const ready=window._modelDropdownReady;
     if(ready&&typeof ready.then==='function') return ready;
-    const next=_hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth});
-    window._modelDropdownReady=next;
-    return next;
+    return _trackModelDropdownReady(
+      _hydrateModelDropdown({redirectIfUnauth:_redirectBootModelDropdownIfUnauth}),
+      null,
+    );
   };
   window._modelDropdownReady=null;
   window._startBootModelDropdown=_startBootModelDropdown;

--- a/static/boot.js
+++ b/static/boot.js
@@ -3508,9 +3508,10 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     }
     return true;
   };
-  const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({
+  const _hydrateModelDropdown=({redirectIfUnauth=null,freshness=null}={})=>populateModelDropdown({
     preferProfileDefaultOnFreshBoot:true,
     ...(redirectIfUnauth?{redirectIfUnauth}:{}),
+    ...(freshness?{freshness}:{}),
   }).then(()=>{
     const sessionModelState=S.session&&S.session.model
       ? {model:S.session.model,model_provider:S.session.model_provider||null}
@@ -3550,10 +3551,10 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     window._modelDropdownReady=null;
     throw e;
   });
-  const _startModelDropdown=()=>{
+  const _startModelDropdown=(opts={})=>{
     const ready=window._modelDropdownReady;
     if(ready&&typeof ready.then==='function') return ready;
-    const next=_hydrateModelDropdown();
+    const next=_hydrateModelDropdown(opts);
     window._modelDropdownReady=next;
     return next;
   };

--- a/static/panels.js
+++ b/static/panels.js
@@ -6543,7 +6543,15 @@ async function _profileSwitchPanelLoad(){
 
 function _refreshProfileSwitchBackground(gen){
   window._modelDropdownReady=null;
-  if (typeof window._ensureModelDropdownReady === 'function') {
+  // A cross-profile sidebar click immediately calls loadSession(), whose
+  // post-paint session_visit refresh is the authoritative model-catalog load.
+  // Starting the generic profile refresh here as well duplicates a potentially
+  // multi-second /api/models rebuild while the conversation is opening.
+  const openingExistingSidebarSession = !!(
+    typeof _profileSwitchOpeningExistingSession !== 'undefined'
+    && _profileSwitchOpeningExistingSession
+  );
+  if (!openingExistingSidebarSession && typeof window._ensureModelDropdownReady === 'function') {
     Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{});
   }
   Promise.resolve(loadWorkspaceList()).then(()=>{
@@ -6941,6 +6949,13 @@ async function switchToProfile(name) {
   const _prevProfileName = S.activeProfile || 'default';
   const _switchGen = ++_profileSwitchGeneration;
   const _openingExistingSidebarSession = !!(typeof _profileSwitchOpeningExistingSession !== 'undefined' && _profileSwitchOpeningExistingSession);
+  // In all-profiles mode the sidebar cache already contains the clicked target
+  // profile. Keep those valid rows visible while only the per-client profile
+  // cookie changes; loadSession() will patch the active row from cache after the
+  // target conversation arrives.
+  const _preserveAllProfilesSidebar = _openingExistingSidebarSession
+    && typeof _showAllProfiles !== 'undefined'
+    && _showAllProfiles;
   if (_chip) { _chip.classList.add('switching'); _chip.disabled = true; }
   if (_titlebarBtn) { _titlebarBtn.classList.add('switching'); _titlebarBtn.disabled = true; }
   // Optimistic name update — shows the target name right away
@@ -6987,12 +7002,14 @@ async function switchToProfile(name) {
     // so a pre-switch /api/sessions response (old profile's rows, issued before the
     // switch) can't resolve, pass the generation guard, clear the skeleton flag, and
     // paint stale rows. Must precede showSessionListSkeleton().
-    if (typeof _invalidateSessionListRenders === 'function') _invalidateSessionListRenders();
-    // ...and set the embargo so a render that STARTS during the switch window (after the
-    // skeleton, before the new-profile cookie is set) also can't paint the old profile's
-    // rows. Cleared right before the switch-owned renderSessionList() and on failure.
-    if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(true);
-    if (typeof showSessionListSkeleton === 'function') showSessionListSkeleton(name);
+    if (!_preserveAllProfilesSidebar) {
+      if (typeof _invalidateSessionListRenders === 'function') _invalidateSessionListRenders();
+      // ...and set the embargo so a render that STARTS during the switch window (after the
+      // skeleton, before the new-profile cookie is set) also can't paint the old profile's
+      // rows. Cleared right before the switch-owned renderSessionList() and on failure.
+      if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(true);
+      if (typeof showSessionListSkeleton === 'function') showSessionListSkeleton(name);
+    }
     // invalidate any in-flight workspace-tree load UNCONDITIONALLY at switch start — even
     // when the panel is closed, loadDir('.') still runs later, and an empty-session switch
     // reuses the same session_id so loadDir's id guard alone can't reject a stale
@@ -7118,15 +7135,22 @@ async function switchToProfile(name) {
     // ── Session ────────────────────────────────────────────────────────────
     // Keep the all-profiles sidebar scope sticky across profile switches. It is
     // a navigation preference shared by the browser session, not a per-profile flag.
-    if (typeof animateNextSessionListRefresh === 'function') animateNextSessionListRefresh();
+    if (!_preserveAllProfilesSidebar && typeof animateNextSessionListRefresh === 'function') {
+      animateNextSessionListRefresh();
+    }
 
     if (sessionInProgress && _openingExistingSidebarSession) {
       // The caller will immediately load the clicked session after this profile
-      // cookie switch. Avoid creating/retagging an intermediate blank chat.
+      // cookie switch. Avoid creating/retagging an intermediate blank chat. In
+      // all-profiles mode the cached list remains authoritative across this
+      // cookie-only switch, so do not block the transcript behind another
+      // projects + sessions round trip.
       const workspaceVisible = typeof _workspacePanelMode !== 'undefined' && _workspacePanelMode !== 'closed';
-      if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
-      await renderSessionList();
-      if (_switchGen !== _profileSwitchGeneration) return false;
+      if (!_preserveAllProfilesSidebar) {
+        if (typeof _setProfileSwitchListEmbargo === 'function') _setProfileSwitchListEmbargo(false);
+        await renderSessionList();
+        if (_switchGen !== _profileSwitchGeneration) return false;
+      }
       if (workspaceVisible && typeof clearWorkspaceTreeSkeleton === 'function') clearWorkspaceTreeSkeleton();
       showToast(t('profile_switched', name));
     } else if (sessionInProgress) {

--- a/static/panels.js
+++ b/static/panels.js
@@ -6543,10 +6543,10 @@ async function _profileSwitchPanelLoad(){
 
 function _refreshProfileSwitchBackground(gen){
   window._modelDropdownReady=null;
-  // A cross-profile sidebar click immediately calls loadSession(), whose
-  // post-paint session_visit refresh is the authoritative model-catalog load.
-  // Starting the generic profile refresh here as well duplicates a potentially
-  // multi-second /api/models rebuild while the conversation is opening.
+  // A cross-profile sidebar click immediately calls loadSession(), which marks
+  // the model catalog stale; the picker performs its bounded freshness check on
+  // demand. Starting the generic profile refresh here would instead trigger a
+  // potentially multi-second /api/models rebuild while the conversation opens.
   const openingExistingSidebarSession = !!(
     typeof _profileSwitchOpeningExistingSession !== 'undefined'
     && _profileSwitchOpeningExistingSession

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1906,20 +1906,18 @@ async function loadSession(sid){
   // Loading a real existing session abandons any pre-session toolset override
   // staged on the empty composer before any deferred refresh work runs.
   S._pendingSessionToolsets=null;
-  if(typeof populateModelDropdown==='function'){
-    const modelRefreshSid=sid;
-    const isActiveModelRefreshSession=()=>!!(S.session&&S.session.session_id===modelRefreshSid);
-    if(!S._bootReady&&typeof window!=='undefined'&&typeof window._startBootModelDropdown==='function'){
+  if(typeof window!=='undefined'){
+    if(!S._bootReady&&typeof window._startBootModelDropdown==='function'){
       Promise.resolve().then(()=>{
-        if(!isActiveModelRefreshSession()) return undefined;
+        if(!S.session||S.session.session_id!==sid) return undefined;
         return window._startBootModelDropdown();
       }).catch(()=>{});
     }else{
-      const modelRefreshPromise=_deferSessionSideEffect(modelRefreshSid,()=>{
-        if(!isActiveModelRefreshSession()) return undefined;
-        return populateModelDropdown({freshness:'session_visit'});
-      }).catch(()=>{});
-      if(typeof window!=='undefined') window._modelDropdownReady=modelRefreshPromise;
+      // Session metadata already carries the active model, and syncTopbar()
+      // injects a missing session-scoped option into the select. Mark the
+      // provider catalog stale here, but defer its bounded freshness check
+      // until the user actually opens the model picker.
+      window._modelDropdownReady=null;
     }
   }
   if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);

--- a/static/ui.js
+++ b/static/ui.js
@@ -14342,6 +14342,10 @@ function renderCompressionUi(){
 // Keyed by session_id. Only used on cross-session navigation, never for
 // in-session updates (new messages, edits, stream events).
 const _sessionHtmlCache=new Map();
+const _SESSION_HTML_CACHE_MAX_ENTRIES=8;
+const _SESSION_HTML_CACHE_MAX_ENTRY_BYTES=2*1024*1024;
+const _SESSION_HTML_CACHE_MAX_TOTAL_BYTES=8*1024*1024;
+let _sessionHtmlCacheBytes=0;
 let _sessionHtmlCacheSid=null; // session_id currently rendered in the DOM
 // #5966 (Codex F3): persist which capped Transparent-Stream turns the user has
 // revealed, keyed by `${session_id}:${ownerRawIdx}`, so a switch-away/back or a
@@ -14353,9 +14357,46 @@ const _transparentRevealedTurns=new Set();
 function _transparentRevealKey(sessionId, ownerIdx){
   return String(sessionId||(S.session&&S.session.session_id)||'')+':'+String(ownerIdx);
 }
+function _sessionHtmlCacheEntryBytes(html){
+  // JS strings are UTF-16 in memory. This deliberately budgets the retained
+  // browser heap rather than UTF-8 wire size.
+  return String(html||'').length*2;
+}
+function _sessionHtmlCacheDelete(sid){
+  const cached=_sessionHtmlCache.get(sid);
+  if(!cached) return false;
+  _sessionHtmlCacheBytes=Math.max(0,_sessionHtmlCacheBytes-Number(cached.bytes||0));
+  return _sessionHtmlCache.delete(sid);
+}
+function _sessionHtmlCacheGet(sid){
+  const cached=_sessionHtmlCache.get(sid);
+  if(!cached) return null;
+  // Map insertion order is the LRU order; a successful read becomes newest.
+  _sessionHtmlCache.delete(sid);
+  _sessionHtmlCache.set(sid,cached);
+  return cached;
+}
+function _sessionHtmlCacheSet(sid,entry){
+  const bytes=_sessionHtmlCacheEntryBytes(entry&&entry.html);
+  _sessionHtmlCacheDelete(sid);
+  if(bytes>_SESSION_HTML_CACHE_MAX_ENTRY_BYTES) return false;
+  const cached={...entry,bytes};
+  _sessionHtmlCache.set(sid,cached);
+  _sessionHtmlCacheBytes+=bytes;
+  while(
+    _sessionHtmlCache.size>_SESSION_HTML_CACHE_MAX_ENTRIES||
+    _sessionHtmlCacheBytes>_SESSION_HTML_CACHE_MAX_TOTAL_BYTES
+  ){
+    const oldestSid=_sessionHtmlCache.keys().next().value;
+    if(oldestSid===undefined) break;
+    _sessionHtmlCacheDelete(oldestSid);
+  }
+  return _sessionHtmlCache.has(sid);
+}
 function clearMessageRenderCache(){
   _clearRenderCache();
   _sessionHtmlCache.clear();
+  _sessionHtmlCacheBytes=0;
   _sessionHtmlCacheSid=null;
   clearVisibleMessageRowCache();
   _clearMessageVirtualHeightCache();
@@ -15186,7 +15227,7 @@ function _maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualW
   if(!preserveScroll||!virtualWindow||!virtualWindow.virtualized||!!(options&&options._virtualFallback)) return false;
   if(_messageViewportIntersectsRenderedRow()) return false;
   if(_sessionHtmlCacheSid&&S.session&&S.session.session_id===_sessionHtmlCacheSid){
-    _sessionHtmlCache.delete(_sessionHtmlCacheSid);
+    _sessionHtmlCacheDelete(_sessionHtmlCacheSid);
   }
   _messageVirtualWindowKey='';
   renderMessages({preserveScroll:true,_virtualFallback:true});
@@ -15247,7 +15288,7 @@ function renderMessages(options){
   if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
     const renderSignature=_messageRenderCacheSignature();
     cachedRenderSignature=renderSignature;
-    const cached=_sessionHtmlCache.get(sid);
+    const cached=_sessionHtmlCacheGet(sid);
     if(cached&&cached.msgCount===msgCount&&cached.renderWindowKey===renderWindowKey&&cached.signature===renderSignature){
       inner.innerHTML=cached.html;
       _messageVirtualWindowKey=renderWindowKey;
@@ -16745,12 +16786,8 @@ function renderMessages(options){
   const _keepOpenArmed=(typeof _isKeepSettledWorklogOpenArmed==='function')&&_isKeepSettledWorklogOpenArmed();
   if(sid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi&&!_keepOpenArmed){
     const _html=inner.innerHTML;
-    // Only cache sessions with <300KB rendered HTML; evict oldest beyond 8 sessions.
-    if(_html.length<300_000){
-      const renderSignature=cachedRenderSignature===null?_messageRenderCacheSignature():cachedRenderSignature;
-      _sessionHtmlCache.set(sid,{html:_html,msgCount,renderWindowKey,signature:renderSignature});
-      if(_sessionHtmlCache.size>8){_sessionHtmlCache.delete(_sessionHtmlCache.keys().next().value);}
-    }
+    const renderSignature=cachedRenderSignature===null?_messageRenderCacheSignature():cachedRenderSignature;
+    _sessionHtmlCacheSet(sid,{html:_html,msgCount,renderWindowKey,signature:renderSignature});
   }
   _updateMessageVirtualMeasurements(renderVisWithIdx, renderVisibleIdxs, virtualWindow);
   // Kill the pinned/tail-follower mid-stream jitter. Schedule the re-anchor in a MICROTASK,

--- a/static/ui.js
+++ b/static/ui.js
@@ -4603,7 +4603,7 @@ async function toggleModelDropdown(){
   if(typeof closeReasoningDropdown==='function') closeReasoningDropdown();
   if(typeof closeToolsetsDropdown==='function') closeToolsetsDropdown();
   if(typeof window._ensureModelDropdownReady==='function'){
-    const ready=window._ensureModelDropdownReady();
+    const ready=window._ensureModelDropdownReady({freshness:'session_visit'});
     if(ready&&typeof ready.catch==='function') ready.catch(()=>{});
   }
   if(dd.classList.contains('open')) return;

--- a/tests/test_issue2613_render_cache_signature.py
+++ b/tests/test_issue2613_render_cache_signature.py
@@ -24,3 +24,24 @@ def test_render_signature_tracks_message_content_and_settled_tool_cards():
 def test_documentation_no_longer_allows_same_count_stale_html():
     assert "Known limitation: cache key is session_id + message count" not in UI_JS
     assert "mutate message content without changing the count will serve stale HTML" not in UI_JS
+
+
+def test_large_session_html_cache_uses_bounded_memory_lru():
+    assert "_SESSION_HTML_CACHE_MAX_ENTRY_BYTES=2*1024*1024" in UI_JS
+    assert "_SESSION_HTML_CACHE_MAX_TOTAL_BYTES=8*1024*1024" in UI_JS
+    assert "function _sessionHtmlCacheEntryBytes(html)" in UI_JS
+    assert "function _sessionHtmlCacheSet(sid,entry)" in UI_JS
+    assert "_sessionHtmlCacheBytes>_SESSION_HTML_CACHE_MAX_TOTAL_BYTES" in UI_JS
+    assert "_sessionHtmlCacheDelete(oldestSid)" in UI_JS
+    assert "_html.length<300_000" not in UI_JS
+
+
+def test_session_html_cache_hit_refreshes_lru_order_and_budgeted_delete():
+    get_fn = UI_JS[
+        UI_JS.index("function _sessionHtmlCacheGet(sid)"):
+        UI_JS.index("function _sessionHtmlCacheSet(sid,entry)")
+    ]
+    assert "_sessionHtmlCache.delete(sid)" in get_fn
+    assert "_sessionHtmlCache.set(sid,cached)" in get_fn
+    assert "const cached=_sessionHtmlCacheGet(sid);" in UI_JS
+    assert "_sessionHtmlCacheDelete(_sessionHtmlCacheSid);" in UI_JS

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -670,39 +670,29 @@ def test_populate_model_dropdown_accepts_session_visit_freshness_and_guards_stal
     assert live_tail.count("requestSeq!==null&&requestSeq!==_modelDropdownRequestSeq") >= 4
 
 
-def test_load_session_schedules_session_visit_model_refresh_before_message_load():
+def test_load_session_invalidates_picker_catalog_without_fetching_models():
     body = _extract_function_body(_read_static("sessions.js"), "async function loadSession(")
 
     assign_idx = body.index("S.session=data.session")
     message_load_idx = body.index("await _ensureMessagesLoaded(sid", assign_idx)
-    failure_return_idx = body.index("return;", message_load_idx)
-    model_block_idx = body.index("if(typeof populateModelDropdown==='function')", assign_idx)
-    guard_helper_idx = body.index("const isActiveModelRefreshSession", model_block_idx)
-    promise_idx = body.index("const modelRefreshPromise=_deferSessionSideEffect", model_block_idx)
-    ready_idx = body.index("window._modelDropdownReady=modelRefreshPromise", promise_idx)
-    refresh_idx = body.index("populateModelDropdown({freshness:'session_visit'})", promise_idx)
+    model_block_idx = body.index("if(typeof window!=='undefined')", assign_idx)
+    invalidate_idx = body.index("window._modelDropdownReady=null", model_block_idx)
 
-    assert assign_idx < model_block_idx < message_load_idx < failure_return_idx
-    assert model_block_idx < promise_idx < refresh_idx < ready_idx
-    assert guard_helper_idx < promise_idx
-    assert "_loadingSessionId!==modelRefreshSid" not in body[model_block_idx:ready_idx], (
-        "deferred model refresh must guard on the active session, not _loadingSessionId, "
-        "because loadSession clears _loadingSessionId when the first paint is complete"
-    )
+    assert assign_idx < model_block_idx < invalidate_idx < message_load_idx
+    assert "populateModelDropdown({freshness:'session_visit'})" not in body
+    assert "const modelRefreshPromise=_deferSessionSideEffect" not in body
+    assert "window._startBootModelDropdown()" in body
 
 
-def test_session_visit_model_refresh_is_deferred_until_after_first_paint():
-    sessions = _read_static("sessions.js")
-    defer_helper = _extract_function_body(sessions, "function _afterSessionFirstPaint(")
-    side_effect_helper = _extract_function_body(sessions, "function _deferSessionSideEffect(")
-    load_body = _extract_function_body(sessions, "async function loadSession(")
+def test_session_visit_model_refresh_runs_when_picker_opens():
+    ui = _read_static("ui.js")
+    boot = _read_static("boot.js")
+    toggle_body = _extract_function_body(ui, "async function toggleModelDropdown(")
 
-    assert "requestAnimationFrame(()=>requestAnimationFrame(run))" in defer_helper
-    assert "requestIdleCallback(invoke,{timeout:1500})" in defer_helper
-    assert "return _afterSessionFirstPaint(()=>" in side_effect_helper
-    assert "const modelRefreshPromise=_deferSessionSideEffect" in load_body
-    assert "isActiveModelRefreshSession()" in load_body
-    assert "return populateModelDropdown({freshness:'session_visit'});" in load_body
+    assert "window._ensureModelDropdownReady({freshness:'session_visit'})" in toggle_body
+    assert "const _startModelDropdown=(opts={})=>" in boot
+    assert "const next=_hydrateModelDropdown(opts)" in boot
+    assert "...(freshness?{freshness}:{})" in boot
 
 
 def test_boot_model_dropdown_clears_cached_ready_on_401():

--- a/tests/test_issue4756_session_visit_model_refresh.py
+++ b/tests/test_issue4756_session_visit_model_refresh.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import io
 import json
 import os
+import shutil
+import subprocess
 import time
 from pathlib import Path
 from urllib.parse import urlparse
@@ -691,8 +693,69 @@ def test_session_visit_model_refresh_runs_when_picker_opens():
 
     assert "window._ensureModelDropdownReady({freshness:'session_visit'})" in toggle_body
     assert "const _startModelDropdown=(opts={})=>" in boot
-    assert "const next=_hydrateModelDropdown(opts)" in boot
+    assert "const requestedFreshness=opts&&opts.freshness?opts.freshness:null" in boot
+    assert "_modelDropdownReadyFreshness===requestedFreshness" in boot
+    assert "then(()=>_hydrateModelDropdown(opts))" in boot
     assert "...(freshness?{freshness}:{})" in boot
+
+
+def test_picker_freshness_is_queued_behind_incompatible_model_load():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        import pytest
+
+        pytest.skip("node not available")
+
+    boot = _read_static("boot.js")
+    definitions_start = boot.index(
+        "const _trackModelDropdownReady=(promise,freshness=null)=>"
+    )
+    definitions_end = boot.index(
+        "const _startBootModelDropdown=()=>",
+        definitions_start,
+    )
+    definitions = boot[definitions_start:definitions_end]
+    harness = f"""
+const window={{_modelDropdownReady:null}};
+let _modelDropdownReadyFreshness=null;
+const calls=[];
+let releaseGeneric;
+const genericGate=new Promise((resolve)=>{{releaseGeneric=resolve;}});
+const _hydrateModelDropdown=(opts={{}})=>{{
+  calls.push(opts.freshness||null);
+  return calls.length===1?genericGate:Promise.resolve();
+}};
+{definitions}
+(async()=>{{
+  const generic=_startModelDropdown();
+  const picker=_startModelDropdown({{freshness:'session_visit'}});
+  const duplicatePicker=_startModelDropdown({{freshness:'session_visit'}});
+  releaseGeneric();
+  await picker;
+  process.stdout.write(JSON.stringify({{
+    calls,
+    pickerQueued:picker!==generic,
+    duplicateCoalesced:duplicatePicker===picker,
+    readyIsPicker:window._modelDropdownReady===picker,
+  }}));
+}})().catch((error)=>{{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    proc = subprocess.run(
+        [node, "-e", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert json.loads(proc.stdout) == {
+        "calls": [None, "session_visit"],
+        "pickerQueued": True,
+        "duplicateCoalesced": True,
+        "readyIsPicker": True,
+    }
 
 
 def test_boot_model_dropdown_clears_cached_ready_on_401():

--- a/tests/test_issue734_message_windowing.py
+++ b/tests/test_issue734_message_windowing.py
@@ -38,7 +38,7 @@ def test_windowed_render_keeps_streaming_and_tool_activity_anchored_to_rendered_
 def test_window_state_participates_in_cache_and_cached_button_is_rewired():
     assert "cached.renderWindowKey===renderWindowKey" in UI_JS
     assert "cached.signature===renderSignature" in UI_JS
-    assert "_sessionHtmlCache.set(sid,{html:_html,msgCount,renderWindowKey,signature:renderSignature})" in UI_JS
+    assert "_sessionHtmlCacheSet(sid,{html:_html,msgCount,renderWindowKey,signature:renderSignature})" in UI_JS
     assert "_messageVirtualWindowKey=renderWindowKey" in UI_JS
     assert "function _wireMessageWindowLoadEarlierButton()" in UI_JS
     assert "_wireMessageWindowLoadEarlierButton();" in UI_JS

--- a/tests/test_model_default_boot_precedence.py
+++ b/tests/test_model_default_boot_precedence.py
@@ -179,7 +179,7 @@ def test_boot_settings_applies_default_without_deleting_browser_model_state():
 
 
 def test_boot_model_dropdown_explicitly_requests_profile_default_precedence():
-    assert "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({" in BOOT_JS
+    assert "const _hydrateModelDropdown=({redirectIfUnauth=null,freshness=null}={})=>populateModelDropdown({" in BOOT_JS
     assert "preferProfileDefaultOnFreshBoot:true" in BOOT_JS
     # #2726 invariant: boot path must keep profile/server default ahead of stale
     # browser-persisted state when a default exists. Post-#2716 cherry-pick onto

--- a/tests/test_profile_switch_ux.py
+++ b/tests/test_profile_switch_ux.py
@@ -128,6 +128,42 @@ class TestParallelizedFetches:
         )
         assert "existingDefaultOpt.dataset.provider = providerId" in fn
 
+    def test_all_profiles_existing_chat_keeps_sidebar_cache_during_cookie_switch(self):
+        """Cross-profile chat navigation must not blank/refetch a complete all-profile list."""
+        fn = self._get_switch_fn()
+        preserve_idx = fn.find("const _preserveAllProfilesSidebar =")
+        assert preserve_idx != -1
+        assert "_openingExistingSidebarSession" in fn[preserve_idx: preserve_idx + 300]
+        assert "_showAllProfiles" in fn[preserve_idx: preserve_idx + 300]
+
+        setup_guard = fn.find("if (!_preserveAllProfilesSidebar) {", preserve_idx)
+        switch_post = fn.find("await api('/api/profile/switch'")
+        assert preserve_idx < setup_guard < switch_post
+        guarded_setup = fn[setup_guard:switch_post]
+        assert "_invalidateSessionListRenders()" in guarded_setup
+        assert "_setProfileSwitchListEmbargo(true)" in guarded_setup
+        assert "showSessionListSkeleton(name)" in guarded_setup
+
+        branch_start = fn.find("if (sessionInProgress && _openingExistingSidebarSession)")
+        branch_end = fn.find("} else if (sessionInProgress)", branch_start)
+        branch = fn[branch_start:branch_end]
+        assert "if (!_preserveAllProfilesSidebar) {" in branch
+        assert "await renderSessionList();" in branch
+        assert "projects + sessions round trip" in branch
+
+    def test_existing_chat_profile_switch_defers_to_session_model_refresh(self):
+        """Opening a concrete chat must not start a second generic model rebuild."""
+        start = self.JS.find("function _refreshProfileSwitchBackground(gen)")
+        end = self.JS.find("\n}", start)
+        assert start != -1 and end != -1
+        helper = self.JS[start:end]
+        assert "openingExistingSidebarSession" in helper
+        assert "_profileSwitchOpeningExistingSession" in helper
+        assert (
+            "if (!openingExistingSidebarSession && "
+            "typeof window._ensureModelDropdownReady === 'function')"
+        ) in helper
+
     def test_workspace_load_is_awaited_only_when_visible(self):
         """Profile switches should not duplicate workspace-tree loads."""
         fn = self._get_switch_fn()

--- a/tests/test_session_detail_tail_cache.py
+++ b/tests/test_session_detail_tail_cache.py
@@ -149,3 +149,21 @@ def test_active_and_lineage_sessions_never_use_detail_tail_cache():
     child = _session("lineage_cache_001", [])
     child.parent_session_id = "parent_001"
     assert routes._session_detail_tail_cache_eligible(child) is False
+
+
+def test_detail_tail_cache_hit_is_isolated_from_top_level_response_mutation():
+    key = ("detail-cache-copy",)
+    payload = {"session": {"session_id": "copy_001"}, "cached": True}
+    routes._clear_session_detail_tail_cache()
+    try:
+        routes._session_detail_tail_cache_set(key, payload)
+
+        first_hit = routes._session_detail_tail_cache_get(key)
+        assert first_hit is not None
+        first_hit["request_only"] = True
+
+        second_hit = routes._session_detail_tail_cache_get(key)
+        assert second_hit is not None
+        assert "request_only" not in second_hit
+    finally:
+        routes._clear_session_detail_tail_cache()

--- a/tests/test_session_detail_tail_cache.py
+++ b/tests/test_session_detail_tail_cache.py
@@ -1,0 +1,151 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import api.models as models
+import api.routes as routes
+
+
+def _session(sid, messages):
+    session = models.Session(
+        session_id=sid,
+        title="Cached tail",
+        workspace="/tmp",
+        model="test-model",
+        messages=messages,
+        context_length=32_000,
+    )
+    session.session_source = "webui"
+    return session
+
+
+def _metadata_stub(session):
+    stub = models.Session(
+        session_id=session.session_id,
+        title=session.title,
+        workspace=session.workspace,
+        model=session.model,
+        profile=session.profile,
+        context_length=session.context_length,
+    )
+    stub.session_source = "webui"
+    stub._metadata_message_count = len(session.messages)
+    stub._loaded_metadata_only = True
+    return stub
+
+
+def _invoke_twice(tmp_path, monkeypatch):
+    sid = "detail_cache_001"
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    sidecar = session_dir / f"{sid}.json"
+    sidecar.write_text('{"version":1}', encoding="utf-8")
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}", encoding="utf-8")
+    config = tmp_path / "config.yaml"
+    config.write_text("model: {}\n", encoding="utf-8")
+    state_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SETTINGS_FILE", settings)
+    monkeypatch.setattr(routes, "_active_state_db_path", lambda: state_db)
+    monkeypatch.setattr(routes, "_active_profile_config_path", lambda: config)
+    routes._clear_session_detail_tail_cache()
+
+    full = _session(
+        sid,
+        [
+            {"role": "user", "content": "question", "timestamp": 1.0},
+            {"role": "assistant", "content": "answer", "timestamp": 2.0},
+        ],
+    )
+    metadata = _metadata_stub(full)
+    load_modes = []
+    responses = []
+
+    def fake_get_session(_sid, metadata_only=False):
+        assert _sid == sid
+        load_modes.append(bool(metadata_only))
+        return metadata if metadata_only else full
+
+    def fake_j(_handler, payload, status=200, extra_headers=None, **_kwargs):
+        responses.append((status, payload))
+        return payload
+
+    parsed = urlparse(
+        f"/api/session?session_id={sid}&messages=1&resolve_model=0"
+        "&msg_limit=30&expand_renderable=1"
+    )
+    common_patches = (
+        patch.object(routes, "get_session", side_effect=fake_get_session),
+        patch.object(routes, "_session_visible_to_active_profile", return_value=True),
+        patch.object(routes, "_clear_stale_stream_state", return_value=False),
+        patch.object(routes, "_lookup_cli_session_metadata", return_value={}),
+        patch.object(routes, "get_state_db_session_messages", return_value=[]),
+        patch.object(routes, "redact_session_data", side_effect=lambda raw: raw),
+        patch.object(routes, "_active_stream_ids", return_value=set()),
+        patch.object(routes, "j", side_effect=fake_j),
+    )
+    for context in common_patches:
+        context.start()
+    try:
+        routes.handle_get(SimpleNamespace(), parsed)
+        routes.handle_get(SimpleNamespace(), parsed)
+    finally:
+        for context in reversed(common_patches):
+            context.stop()
+
+    return sidecar, parsed, full, metadata, load_modes, responses
+
+
+def test_second_initial_tail_request_skips_full_session_load(tmp_path, monkeypatch):
+    _sidecar, _parsed, _full, _metadata, load_modes, responses = _invoke_twice(
+        tmp_path,
+        monkeypatch,
+    )
+
+    assert load_modes == [True, False, True]
+    assert len(responses) == 2
+    assert responses[0][1] == responses[1][1]
+    assert responses[1][1]["session"]["messages"][-1]["content"] == "answer"
+
+
+def test_sidecar_change_invalidates_cached_initial_tail(tmp_path, monkeypatch):
+    sidecar, parsed, full, metadata, load_modes, _responses = _invoke_twice(
+        tmp_path,
+        monkeypatch,
+    )
+    sidecar.write_text('{"version":2,"changed":true}', encoding="utf-8")
+
+    def fake_get_session(_sid, metadata_only=False):
+        load_modes.append(bool(metadata_only))
+        return metadata if metadata_only else full
+
+    captured = []
+
+    def fake_j(_handler, payload, status=200, extra_headers=None, **_kwargs):
+        captured.append(payload)
+        return payload
+
+    with patch.object(routes, "get_session", side_effect=fake_get_session), \
+         patch.object(routes, "_session_visible_to_active_profile", return_value=True), \
+         patch.object(routes, "_clear_stale_stream_state", return_value=False), \
+         patch.object(routes, "_lookup_cli_session_metadata", return_value={}), \
+         patch.object(routes, "get_state_db_session_messages", return_value=[]), \
+         patch.object(routes, "redact_session_data", side_effect=lambda raw: raw), \
+         patch.object(routes, "_active_stream_ids", return_value=set()), \
+         patch.object(routes, "j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(), parsed)
+
+    assert load_modes[-2:] == [True, False]
+    assert captured
+
+
+def test_active_and_lineage_sessions_never_use_detail_tail_cache():
+    active = _session("active_cache_001", [])
+    active.active_stream_id = "stream-1"
+    assert routes._session_detail_tail_cache_eligible(active) is False
+
+    child = _session("lineage_cache_001", [])
+    child.parent_session_id = "parent_001"
+    assert routes._session_detail_tail_cache_eligible(child) is False

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -72,7 +72,7 @@ def test_boot_does_not_block_session_restore_on_model_catalog():
 
     assert "if(s.default_model){" in src
     assert "window._defaultModel=s.default_model;" in src
-    assert "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({" in src
+    assert "const _hydrateModelDropdown=({redirectIfUnauth=null,freshness=null}={})=>populateModelDropdown({" in src
     assert "window._modelDropdownReady=null;" in src
     assert "window._startBootModelDropdown=_startBootModelDropdown;" in src
     assert "window._ensureModelDropdownReady=_startModelDropdown;" in src
@@ -109,7 +109,7 @@ def test_failed_boot_model_catalog_prime_is_retryable():
     src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
     # #2726 parameterized the call: populateModelDropdown({preferProfileDefaultOnFreshBoot:true})
     # Match either signature shape — empty args (legacy) OR opts arg (post-#2726).
-    needle = "const _hydrateModelDropdown=({redirectIfUnauth=null}={})=>populateModelDropdown({"
+    needle = "const _hydrateModelDropdown=({redirectIfUnauth=null,freshness=null}={})=>populateModelDropdown({"
     start = src.index(needle)
     end = src.index("const _startBootModelDropdown=()=>", start)
     block = src[start:end]


### PR DESCRIPTION
## Thinking Path

- Conversation switching should reach first paint without waiting for work that is unrelated to the selected transcript.
- Runtime traces showed three repeat costs: rebuilding the initial transcript tail, rebuilding rendered DOM for a recently visited chat, and starting sidebar/model-catalog refreshes during cross-profile navigation.
- The largest tail came from `/api/models?freshness=session_visit`: the measured run made 22 of those requests across 24 chat opens, with a roughly four-second median.
- The fix keeps authoritative session state untouched. It caches only validated presentation responses/markup, preserves an already-complete all-profiles sidebar during its cookie-only profile switch, and moves model-catalog freshness work to the point where the user opens the model picker.

## What Changed

- Add a bounded, lock-guarded server cache for the final redacted initial transcript-tail response of eligible idle native WebUI sessions.
  - Keys include sidecar, `state.db`/WAL/SHM, settings, profile config, pagination, and render-expansion stamps.
  - A second source snapshot prevents storing a response if authoritative inputs changed while it was assembled.
  - Active, pending, CLI/messaging, compression-lineage, recovery, and read-only session shapes bypass the cache.
  - Limits: 24 entries, 24 MiB total, 2 MiB per entry.
- Make the browser transcript HTML cache a bounded LRU (8 entries, 8 MiB total, 2 MiB per entry) so recently visited conversations can restore without repeating Markdown and DOM construction.
- Preserve the cached all-profiles sidebar when an existing chat click only needs to switch the profile cookie; avoid the intermediate skeleton and projects/sessions round trip.
- Skip the duplicate generic model-catalog refresh on that cross-profile path.
- Mark model options stale when a session opens and run the existing `session_visit` freshness check only when the model picker is opened.
- Preserve requested picker freshness across concurrent model loads: a stronger `session_visit` load queues behind an incompatible in-flight load, while duplicate picker calls share the queued promise.
- Document the navigation/cache contract in `ARCHITECTURE.md` and add regression coverage for cache eligibility/invalidation, render-cache bounds/signatures, profile switching, and picker-triggered model refresh.

## Why It Matters

Measured on the same live local WebUI click flow before and after the change:

| Signal | Before | After |
|---|---:|---:|
| Cross-profile switch median | 2,766.7 ms | 121.3 ms |
| Cross-profile switch maximum | 4,139.3 ms | 467.9 ms |
| Transcript-tail median | 123.5 ms | 97.3 ms |
| Transcript-tail p90 | 248.5 ms | 152.9 ms |
| Transcript-tail maximum | 2,345.4 ms | 610.2 ms |
| `session_visit` model requests during chat opens | 22 / 24 opens | 0 / 21 opens |

The measured profile-switch median is about 23x faster, and the recurring four-second model request is no longer part of conversation navigation.

There are no visual or layout changes, so before/after screenshots would be identical. The relevant UI evidence is the request count and latency comparison above; the sidebar remains visually stable during the optimized profile switch.

## Contract Routing

Task type: focused session-navigation performance fix.

Touched areas:

- `GET /api/session` initial transcript-tail presentation response
- browser transcript render cache
- all-profiles sidebar navigation across profile ownership
- model-picker catalog freshness

Relevant public docs:

- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `ARCHITECTURE.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`

State layer and invariant: only bounded presentation caches are added. Session sidecars and `state.db` remain authoritative; volatile/recovery shapes bypass the server cache, source stamps invalidate cached responses, and a cache miss follows the existing full reconciliation/redaction path.

Evidence: automated cache/profile/model-refresh regressions plus a restarted live-instance click trace covering 21 conversation opens and 12 cross-profile switches.

## Contract Change

Previous behavior:

- A loaded session scheduled a `session_visit` model-catalog refresh even when the user did not interact with model selection.
- An existing-chat click across profiles could rebuild the sidebar even when the all-profiles cache already contained the target row.

New behavior:

- Session navigation marks the model catalog stale; opening the model picker performs the bounded freshness check on demand.
- An all-profiles existing-chat click keeps the complete cached sidebar visible across the profile-cookie switch.

Compatibility rationale: session metadata still supplies the active model and `syncTopbar()` injects a missing session-scoped option. The authoritative catalog is refreshed before model-picker interaction, while chat first paint no longer depends on provider discovery or a redundant sidebar request.

## Verification

- `./scripts/test.sh tests/test_issue2613_render_cache_signature.py tests/test_session_detail_tail_cache.py tests/test_profile_switch_ux.py tests/test_issue4756_session_visit_model_refresh.py -q`
  - 48 passed after rebasing onto current `master`
- Ruff on all four changed test files
  - passed
- `git diff --check origin/master...HEAD`
  - passed
- Manual live-instance verification after restart
  - 21 conversation opens
  - 12 cross-profile switches
  - zero `/api/models?freshness=session_visit` calls during chat navigation

## Risks / Follow-ups

- The server cache is per-process and intentionally conservative; CLI/messaging and recovery-sensitive sessions still take the full path.
- The model catalog may remain stale until the picker is opened. The picker already triggers the freshness check, so send/start correctness is unchanged.
- #6038 addresses latency inside the model-catalog refresh itself and remains complementary: this PR removes that refresh from navigation, while #6038 can make the eventual on-demand refresh faster and more resilient.
- No dependencies, build tooling, visual styling, storage formats, or authoritative session-state semantics change.

Release-note-ready wording:

> Conversation switching is faster by reusing validated transcript/render caches, preserving the all-profiles sidebar across chat-owned profile switches, and deferring model-catalog refresh until the picker is opened.

## Model Used

Provider: OpenAI

Model: GPT-5 (Codex agent)

Notable use: AI-assisted code-path and runtime-log tracing, implementation, regression-test updates, upstream rebase/conflict review, and PR preparation through local terminal tooling.

Refs #2168, #6135, and #6038.
