### PR TITLE
fix: add OIDC_SSRF_ALLOW_PRIVATE env var to bypass SSRF check for self-hosted OIDC (#6136)

### DIFF
--- a/api/auth_oidc.py
+++ b/api/auth_oidc.py
@@ -400,6 +400,14 @@ def _validate_outbound_oidc_url(url: str) -> None:
     hostname = str(parsed.hostname or "").strip()
     if not hostname:
         raise OIDCAuthError("OIDC endpoint URL was missing a hostname", status_code=502)
+    _ssrf_bypass = os.getenv("OIDC_SSRF_ALLOW_PRIVATE", "").strip().lower()
+    if _ssrf_bypass in ("1", "true", "yes"):
+        logger.warning(
+            "OIDC_SSRF_ALLOW_PRIVATE is enabled — SSRF protection bypassed for %s. "
+            "This reduces security; only use on trusted networks.",
+            url,
+        )
+        return
     if _is_disallowed_oidc_host(hostname):
         raise OIDCAuthError(
             "OIDC endpoint URLs must not target private or local addresses",


### PR DESCRIPTION
## Summary

Adds `OIDC_SSRF_ALLOW_PRIVATE` environment variable as an opt-out for the OIDC SSRF private-IP check (Option A from the issue).

## Problem

Issue #6136 — The OIDC SSRF hardening (RFC1918 check) blocks legitimate self-hosted deployments where Authentik, Keycloak, or Zitadel run on internal/private networks.

When the hostname resolves to a private IP (e.g. `10.5.5.7`), the SSRF check rejects it:
```
OIDC SSRF check rejected auth.example.com because it resolved to private address 10.5.5.7
```

## Solution

Sets `OIDC_SSRF_ALLOW_PRIVATE=true` (or `1`, `yes`) to skip the private-IP check in `_validate_outbound_oidc_url()`.

- Keeps the current protection **by default** — no behavioral change for existing deployments
- Logs a `logger.warning(...)` when the bypass is active, so operators are aware
- Accepts `"true"`, `"1"`, or `"yes"` (case-insensitive)

## Usage

```bash
OIDC_SSRF_ALLOW_PRIVATE=true ./bootstrap.py
```

Or set in your environment / `.env` file:
```
OIDC_SSRF_ALLOW_PRIVATE=true
```

## Changes

Modified one file:
- `api/auth_oidc.py` — added env var check before `_is_disallowed_oidc_host()` call

## Verification

- [x] Python parse verified: `ast.parse(open('api/auth_oidc.py').read())`
- [x] No merge markers or truncation
- [x] Diff is minimal (+8 lines, single responsibility)