### PR TITLE
fix: catch unhandled exception in POST /api/updates/check (defensive hardening)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13811,7 +13811,14 @@ def handle_post(handler, parsed) -> bool:
             channel = settings.get("update_channel")
         from api.updates import check_for_updates
 
-        return j(handler, check_for_updates(force=force, include_agent=include_agent_updates, channel=channel))
+        logger.info("checking for updates (force=%s, include_agent=%s, channel=%s)", force, include_agent_updates, channel)
+        try:
+            payload = check_for_updates(force=force, include_agent=include_agent_updates, channel=channel)
+        except Exception:
+            logger.exception("update check failed unexpectedly — server would have crashed silently")
+            return bad(handler, "Update check failed, see server log for details", status=500)
+        logger.info("update check completed")
+        return j(handler, payload)
 
     if parsed.path == "/api/extensions/toggle":
         from api.extensions import ExtensionToggleError, set_extension_user_enabled

--- a/api/routes.py
+++ b/api/routes.py
@@ -13812,10 +13812,13 @@ def handle_post(handler, parsed) -> bool:
         from api.updates import check_for_updates
 
         logger.info("checking for updates (force=%s, include_agent=%s, channel=%s)", force, include_agent_updates, channel)
+        # Defensive-only guard: wrap check_for_updates() for consistent
+        # exception protection across all route handlers. Does NOT fix #6086
+        # (root cause is likely signal/process-group reaping, per maintainer analysis).
         try:
             payload = check_for_updates(force=force, include_agent=include_agent_updates, channel=channel)
         except Exception:
-            logger.exception("update check failed unexpectedly — server would have crashed silently")
+            logger.exception("update check failed unexpectedly (defensive guard caught exception)")
             return bad(handler, "Update check failed, see server log for details", status=500)
         logger.info("update check completed")
         return j(handler, payload)


### PR DESCRIPTION
## Summary

Defensive hardening: wraps `POST /api/updates/check` handler with `try/except Exception` + `logger.exception()` as a **belt-and-suspenders** measure. The handler was the only one in `handle_post` without exception protection.

## What it does

- Wraps `check_for_updates()` in a `try/except Exception` block
- Logs the full traceback via `logger.exception()` if something goes wrong
- Returns HTTP 500 instead of crashing

## Does NOT fix #6086

Per maintainer analysis in review, the real root cause of #6086 is likely **signal/process-group reaping** (same class as #6149), not a handler exception:

- Reporter's logs show `200` responses — the handler already returned successfully
- Death is silent — no traceback, no log output
- Also triggered on gateway restart with stale `gateway_state.json`

This PR is purely defensive hardening — ensuring every route handler has consistent exception protection with traceback logging. #6086 remains open for the underlying signal/subprocess root cause.
