### PR TITLE
fix(#6108): retry transient SessionDB init for WebUI session_search

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -12,6 +12,7 @@ import os
 import queue
 import random
 import re
+import sqlite3
 import shlex
 import sys
 import subprocess
@@ -6339,7 +6340,12 @@ def _build_session_db_for_stream(state_db_path):
         for _attempt in range(_attempts):
             try:
                 return SessionDB(db_path=state_db_path)
-            except Exception as _db_err:
+            except sqlite3.OperationalError as _db_err:
+                _db_err_text = str(_db_err).lower()
+                if not (
+                    "locked" in _db_err_text or "busy" in _db_err_text
+                ):
+                    raise
                 _last_error = _db_err
                 if _attempt < _attempts - 1:
                     print(
@@ -6347,7 +6353,7 @@ def _build_session_db_for_stream(state_db_path):
                         flush=True,
                     )
                     time.sleep(0.05 * (2 ** _attempt) + random.uniform(0, 0.05))
-        raise _last_error
+        raise _last_error or RuntimeError("SessionDB construction exhausted all attempts")
     except Exception as _db_err:
         print(f"[webui] WARNING: SessionDB init failed - session_search will be unavailable: {_db_err}", flush=True)
         return None

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10,6 +10,7 @@ import logging
 import mimetypes
 import os
 import queue
+import random
 import re
 import shlex
 import sys
@@ -6333,7 +6334,20 @@ def _build_session_db_for_stream(state_db_path):
     """
     try:
         from hermes_state import SessionDB
-        return SessionDB(db_path=state_db_path)
+        _attempts = 3
+        _last_error = None
+        for _attempt in range(_attempts):
+            try:
+                return SessionDB(db_path=state_db_path)
+            except Exception as _db_err:
+                _last_error = _db_err
+                if _attempt < _attempts - 1:
+                    print(
+                        f"[webui] WARNING: SessionDB init attempt {_attempt + 1}/{_attempts} failed, retrying: {_db_err}",
+                        flush=True,
+                    )
+                    time.sleep(0.05 * (2 ** _attempt) + random.uniform(0, 0.05))
+        raise _last_error
     except Exception as _db_err:
         print(f"[webui] WARNING: SessionDB init failed - session_search will be unavailable: {_db_err}", flush=True)
         return None

--- a/tests/test_issue3548_sessiondb_self_heal.py
+++ b/tests/test_issue3548_sessiondb_self_heal.py
@@ -47,7 +47,7 @@ def test_session_db_helper_retries_transient_constructor_failure():
     fake_state.SessionDB = mock.Mock(
         side_effect=[
             sqlite3.OperationalError("database is locked"),
-            sqlite3.OperationalError("database is locked"),
+            sqlite3.OperationalError("database is busy"),
             created,
         ]
     )
@@ -93,6 +93,48 @@ def test_session_db_helper_returns_none_after_exhausted_retries():
         mock.call(db_path=state_db_path),
     ]
     assert sleep.call_args_list == [mock.call(0.05), mock.call(0.1)]
+
+
+def test_session_db_helper_does_not_retry_permanent_constructor_failure():
+    import api.streaming as streaming
+
+    state_db_path = Path("/tmp/profile/state.db")
+    permanent_error = TypeError("unsupported SessionDB argument")
+    fake_state = types.ModuleType("hermes_state")
+    fake_state.SessionDB = mock.Mock(side_effect=permanent_error)
+
+    with (
+        mock.patch.dict(sys.modules, {"hermes_state": fake_state}),
+        mock.patch.object(streaming, "random", mock.Mock(), create=True) as random,
+        mock.patch.object(streaming.time, "sleep") as sleep,
+    ):
+        db = streaming._build_session_db_for_stream(state_db_path)
+
+    assert db is None
+    fake_state.SessionDB.assert_called_once_with(db_path=state_db_path)
+    random.uniform.assert_not_called()
+    sleep.assert_not_called()
+
+
+def test_session_db_helper_does_not_retry_noncontention_operational_error():
+    import api.streaming as streaming
+
+    state_db_path = Path("/tmp/profile/state.db")
+    permanent_error = sqlite3.OperationalError("locking protocol")
+    fake_state = types.ModuleType("hermes_state")
+    fake_state.SessionDB = mock.Mock(side_effect=permanent_error)
+
+    with (
+        mock.patch.dict(sys.modules, {"hermes_state": fake_state}),
+        mock.patch.object(streaming, "random", mock.Mock(), create=True) as random,
+        mock.patch.object(streaming.time, "sleep") as sleep,
+    ):
+        db = streaming._build_session_db_for_stream(state_db_path)
+
+    assert db is None
+    fake_state.SessionDB.assert_called_once_with(db_path=state_db_path)
+    random.uniform.assert_not_called()
+    sleep.assert_not_called()
 
 
 def test_self_heal_session_db_handle_is_replaced_safely():

--- a/tests/test_issue3548_sessiondb_self_heal.py
+++ b/tests/test_issue3548_sessiondb_self_heal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sqlite3
 import sys
 import types
 from unittest import mock
@@ -22,28 +23,76 @@ def test_session_db_helper_uses_request_state_db_path():
     fake_state = types.ModuleType("hermes_state")
     fake_state.SessionDB = FakeSessionDB
 
-    with mock.patch.dict(sys.modules, {"hermes_state": fake_state}):
+    with (
+        mock.patch.dict(sys.modules, {"hermes_state": fake_state}),
+        mock.patch.object(streaming.time, "sleep") as sleep,
+    ):
         state_db_path = Path("/tmp/profile") / "state.db"
         db = streaming._build_session_db_for_stream(state_db_path)
 
     assert db is not None
     assert calls["db_path"] == state_db_path
     assert isinstance(db, FakeSessionDB)
+    sleep.assert_not_called()
 
 
-def test_session_db_helper_returns_none_when_constructor_fails():
+def test_session_db_helper_retries_transient_constructor_failure():
     import api.streaming as streaming
 
-    def failing_session_db(db_path=None):
-        raise RuntimeError("SessionDB unavailable")
-
+    state_db_path = Path("/tmp/profile/state.db")
+    created = mock.Mock(name="session_db")
     fake_state = types.ModuleType("hermes_state")
-    fake_state.SessionDB = mock.Mock(side_effect=failing_session_db)
+    fake_random = mock.Mock()
+    fake_random.uniform.return_value = 0.0
+    fake_state.SessionDB = mock.Mock(
+        side_effect=[
+            sqlite3.OperationalError("database is locked"),
+            sqlite3.OperationalError("database is locked"),
+            created,
+        ]
+    )
 
-    with mock.patch.dict(sys.modules, {"hermes_state": fake_state}):
-        db = streaming._build_session_db_for_stream(Path("/tmp/profile/state.db"))
+    with (
+        mock.patch.dict(sys.modules, {"hermes_state": fake_state}),
+        mock.patch.object(streaming, "random", fake_random, create=True),
+        mock.patch.object(streaming.time, "sleep") as sleep,
+    ):
+        db = streaming._build_session_db_for_stream(state_db_path)
+
+    assert db is created
+    assert fake_state.SessionDB.call_args_list == [
+        mock.call(db_path=state_db_path),
+        mock.call(db_path=state_db_path),
+        mock.call(db_path=state_db_path),
+    ]
+    assert sleep.call_args_list == [mock.call(0.05), mock.call(0.1)]
+
+
+def test_session_db_helper_returns_none_after_exhausted_retries():
+    import api.streaming as streaming
+
+    state_db_path = Path("/tmp/profile/state.db")
+    fake_state = types.ModuleType("hermes_state")
+    fake_random = mock.Mock()
+    fake_random.uniform.return_value = 0.0
+    fake_state.SessionDB = mock.Mock(
+        side_effect=sqlite3.OperationalError("database is locked")
+    )
+
+    with (
+        mock.patch.dict(sys.modules, {"hermes_state": fake_state}),
+        mock.patch.object(streaming, "random", fake_random, create=True),
+        mock.patch.object(streaming.time, "sleep") as sleep,
+    ):
+        db = streaming._build_session_db_for_stream(state_db_path)
 
     assert db is None
+    assert fake_state.SessionDB.call_args_list == [
+        mock.call(db_path=state_db_path),
+        mock.call(db_path=state_db_path),
+        mock.call(db_path=state_db_path),
+    ]
+    assert sleep.call_args_list == [mock.call(0.05), mock.call(0.1)]
 
 
 def test_self_heal_session_db_handle_is_replaced_safely():

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -71,6 +71,15 @@ class TestSessionDBInjection(unittest.TestCase):
             "SessionDB init helper must use try/except for non-fatal error handling",
         )
 
+    def test_sessiondb_retry_only_targets_transient_sqlite_errors(self):
+        """Permanent constructor errors must leave the retry loop immediately."""
+        helper_start = STREAMING_PY.find("def _build_session_db_for_stream")
+        helper_end = STREAMING_PY.find("\n\ndef _attempt_credential_self_heal", helper_start)
+        helper_src = STREAMING_PY[helper_start:helper_end]
+        self.assertIn("except sqlite3.OperationalError as _db_err", helper_src)
+        self.assertIn('"locked" in _db_err_text or "busy" in _db_err_text', helper_src)
+        self.assertIn("raise _last_error or RuntimeError", helper_src)
+
     def test_sessiondb_failure_logs_warning(self):
         """A failure initializing SessionDB must print a WARNING (not silently drop the error)."""
         self.assertIn(


### PR DESCRIPTION
## Thinking Path

- The intermittent `count: 0` reports in [#6108](https://github.com/nesquena/hermes-webui/issues/6108) come from the WebUI path, where `_build_session_db_for_stream()` drops the first raised `SessionDB` constructor failure to `None`.
- Maintainer review on July 16, 2026 in [#6109](https://github.com/nesquena/hermes-webui/pull/6109#issuecomment-4988832111) narrowed the surviving fix to that helper: retry raised constructor failures, keep the import failure graceful, and leave `_fts_enabled` out of the retry loop.
- Greptile's July 17, 2026 follow-up showed that the first retry patch still treated every constructor exception as transient, so the rework keeps the same helper seam but narrows retries to real SQLite lock or busy contention and makes the exhausted raise explicit.

## What Changed

- `api/streaming.py`: retry only transient `sqlite3.OperationalError` constructor failures whose message contains `locked` or `busy`, keep the helper's outer fail-open warning path, and guard the exhausted raise with `raise _last_error or RuntimeError(...)`.
- `tests/test_issue3548_sessiondb_self_heal.py`: cover retry-to-success, exhausted-failure fallback, the no-final-sleep rule, a permanent non-SQLite constructor failure, and a non-contention SQLite constructor failure that must not retry.
- `tests/test_sprint42.py`: pin the helper's broad outer try/except contract, the narrowed transient retry classifier, and the explicit exhausted-raise fallback.

## Why It Matters

Transient `state.db` open races stop looking like real empty search results, so WebUI session recall is more reliable under active gateway writes. Permanent constructor failures still degrade cleanly, and they now skip the extra retry delay and misleading retry warnings.

## Verification

The helper retry regressions fail on July 17, 2026 `origin/master` `92ebc10c` and pass on this branch for the transient-retry and exhausted-failure paths, the permanent non-SQLite and non-contention SQLite no-retry regressions pass here, the immediate-success preservation row passes on both base and head, and the sprint42 helper-shape guard still passes on both sides. The focused helper plus sprint42 pack passes locally here, and CI runs the broader matrix.

## Risks / Follow-ups

Retries still add a small stream-start delay when lock contention persists, and this slice still leaves startup-level SessionDB reuse out of scope. If real installs still surface false 0-result searches after the helper retry, the next investigation should revisit shared handle ownership separately.

## Upstream

Closes #6108.

## Model Used

GPT 5 via Codex CLI, with a same-provider adversarial diff review and explicit base/head proof rows for the helper retry seam
