### PR TITLE
fix(wakeup): route background completions by origin_ui_session_id

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -822,7 +822,12 @@ def _mark_registry_completion_consumed(process_id: str) -> None:
 # registry, pre-Option-1 spawns) it is a PURE PASS-THROUGH — it never
 # suppresses a legitimate Option Z wakeup on uncertainty (Option Z must keep
 # working).
-_ENV_IMMUNE_OWNER_ATTRS = ("spawn_session_id", "owner_session_id", "turn_session_id")
+_ENV_IMMUNE_OWNER_ATTRS = (
+    "origin_ui_session_id",  # modern hermes-agent exact browser-tab return address
+    "spawn_session_id",
+    "owner_session_id",
+    "turn_session_id",
+)
 
 
 def _env_immune_spawn_owner(proc_session) -> str:
@@ -872,6 +877,32 @@ def _resolve_wakeup_target(
     return owner
 
 
+def _resolve_completion_target(
+    *,
+    session_key_resolved_sid: str,
+    origin_ui_session_id: str,
+) -> str:
+    """Return the WebUI session that owns a detached completion event.
+
+    Modern Hermes Agent events carry ``origin_ui_session_id`` as an exact,
+    immutable return address captured from the commissioning browser turn.
+    It is authoritative over the mutable/legacy session-key index. Older
+    Agent events omit it and retain the existing session-key fallback.
+    """
+    resolved = str(session_key_resolved_sid or "")
+    owner = str(origin_ui_session_id or "")
+    if not owner:
+        return resolved
+    if resolved and resolved != owner:
+        logger.error(
+            "cross-session completion route BLOCKED: session_key resolved to %r "
+            "but exact origin_ui_session_id is %r; routing to the exact owner",
+            resolved,
+            owner,
+        )
+    return owner
+
+
 def _process_one(evt: dict) -> None:
     """Route a single completion_queue event to the matching WebUI session."""
     from api import config as _cfg
@@ -889,53 +920,51 @@ def _process_one(evt: dict) -> None:
 
     process_id = str(evt.get("session_id") or "")
     session_key = str(evt.get("session_key") or "")
+    origin_ui_session_id = str(evt.get("origin_ui_session_id") or "")
     # Root-cause fix (t_0f447014): the notify_on_complete completion event
-    # enqueued by ProcessRegistry._move_to_finished() carries NO "session_key"
-    # field — only the watch_match enqueue includes one. Without it the old
-    # `evt.get("session_key") or process_id` fell back to the process id
-    # ("proc_xxxx"), which is never a PROCESS_SESSION_INDEX key (only
-    # webui_session_id -> webui_session_id is registered at chat-start), so
-    # every wakeup was silently dropped here and the frontend never POSTed an
-    # ack. Recover the spawn-time session_key from the process registry's
-    # ProcessSession: the terminal tool captured it synchronously at spawn
-    # (while the turn's env was active), so it survives the turn-end env
-    # restore and is the WebUI session_id for WebUI-spawned processes.
-    if not session_key and process_id:
+    # enqueued by ProcessRegistry._move_to_finished() historically carried NO
+    # "session_key" field — only the watch_match enqueue included one. Without
+    # it the old `evt.get("session_key") or process_id` fell back to the
+    # process id ("proc_xxxx"), which is never a PROCESS_SESSION_INDEX key.
+    # Recover spawn-time routing metadata from the process registry.
+    if process_id and (not session_key or not origin_ui_session_id):
         try:
             if _process_registry is not None:
                 _ps = _process_registry.get(process_id)
-                if _ps is not None and getattr(_ps, "session_key", ""):
-                    session_key = str(_ps.session_key)
+                if _ps is not None:
+                    if not session_key and getattr(_ps, "session_key", ""):
+                        session_key = str(_ps.session_key)
+                    if not origin_ui_session_id:
+                        origin_ui_session_id = (
+                            str(getattr(_ps, "origin_ui_session_id", "") or "")
+                            or str(getattr(_ps, "spawn_session_id", "") or "")
+                        )
         except Exception:
             logger.debug(
-                "session_key recovery from process registry failed for %r",
+                "session ownership recovery from process registry failed for %r",
                 process_id,
                 exc_info=True,
             )
-    if not session_key:
+    if not session_key and not origin_ui_session_id:
         logger.debug(
-            "process_complete drop: no recoverable session_key for process_id=%r",
+            "process_complete drop: no recoverable session_key or exact UI owner "
+            "for process_id=%r",
             process_id,
         )
         return
-    with _cfg.PROCESS_SESSION_INDEX_LOCK:
-        session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key)
-    if not session_id:
+    session_id = ""
+    if session_key:
+        with _cfg.PROCESS_SESSION_INDEX_LOCK:
+            session_id = _cfg.PROCESS_SESSION_INDEX.get(session_key) or ""
+    if not session_id and not origin_ui_session_id:
         # No mapping — could be a cron/gateway process that uses the same
         # registry but a non-WebUI session_key. Ignore.
         logger.debug("process_complete drop: no session mapping for key=%r", session_key)
         return
     # ── xsession wakeup misroute defense-in-depth (Option 3) ──────────────
-    # session_id above came from PROCESS_SESSION_INDEX.get(session_key), and
-    # session_key was captured by the terminal tool from the (historically
-    # racy) process-global env at spawn. Option 1 binds the per-turn identity
-    # to a contextvar so that capture is no longer racy — but as an INDEPENDENT
-    # safety net, cross-check the resolved target against the env-immune
-    # spawn owner (when the core ProcessSession exposes one). On a positive
-    # mismatch this re-routes the wakeup (and the live-view emit + dedupe
-    # markers below) to the TRUE owner instead of waking the wrong session.
-    # Pure pass-through when no env-immune owner is available (today's core,
-    # cron/CLI procs, pre-Option-1 spawns) — never suppresses a valid wakeup.
+    # First retain the process-registry spawn-owner cross-check for legacy
+    # terminal events. Then apply origin_ui_session_id as the final authority;
+    # that exact owner is shared by process and async-delegation completions.
     try:
         _ps_xs = _process_registry.get(process_id) if (_process_registry is not None and process_id) else None
     except Exception:
@@ -945,6 +974,13 @@ def _process_one(evt: dict) -> None:
         session_key_resolved_sid=session_id,
         proc_session=_ps_xs,
     )
+    session_id = _resolve_completion_target(
+        session_key_resolved_sid=session_id,
+        origin_ui_session_id=origin_ui_session_id,
+    )
+    if not session_id:
+        logger.debug("process_complete drop: completion target resolved empty")
+        return
     # ── Idempotency vs the REAL merged upstream #2279 (shared dedupe key) ──
     # The real merged #2279 next-turn drain
     # (api/streaming._drain_webui_process_notifications) dedupes ONLY via

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1798,24 +1798,23 @@ def _set_turn_session_identity(session_id: str):
     """Bind THIS turn's session identity to the current (task/thread-local)
     context and return an opaque token for _reset_turn_session_identity.
 
-    Binds two context-locals so every session-key consumer is covered without
-    a race:
+    Binds three context-locals so every session-key / UI-owner consumer is
+    covered without a race:
       * ``tools.approval._approval_session_key`` — checked FIRST by
         ``get_current_session_key`` (the exact call terminal_tool.py makes for
         a notify_on_complete background spawn: the bug path).
       * ``gateway.session_context._SESSION_KEY`` — read by direct
-        ``get_session_env("HERMES_SESSION_KEY")`` consumers (e.g. the sudo
-        password cache scope, terminal_tool.py:272).
+        ``get_session_env("HERMES_SESSION_KEY")`` consumers.
+      * ``gateway.session_context._SESSION_UI_SESSION_ID`` — exact browser-tab
+        return address stamped onto ProcessSession.origin_ui_session_id and
+        completion events by modern hermes-agent builds. Authoritative for
+        wakeup routing when present (see ``_resolve_completion_target``).
 
     It deliberately does NOT call ``gateway.session_context.set_session_vars``:
     that blanket setter also zeroes the platform/chat_id/user contextvars,
     flipping ``HERMES_SESSION_PLATFORM`` from its env fallback (``'webui'``,
     still written to os.environ at turn-start) to an explicit ``""`` — which
-    would break the ``notify_on_complete`` watcher registration gate in
-    terminal_tool.py:~1966. Only the session-key identity is bound; every
-    other session var keeps its existing os.environ fallback (CLI/cron compat
-    preserved — when these contextvars are _UNSET, get_session_env still falls
-    back to os.environ).
+    would break the ``notify_on_complete`` watcher registration gate.
     """
     sid = str(session_id or "")
     tokens: dict = {}
@@ -1829,6 +1828,11 @@ def _set_turn_session_identity(session_id: str):
         tokens["session_key"] = _SK.set(sid)
     except Exception:
         logger.debug("per-turn _SESSION_KEY bind failed", exc_info=True)
+    try:
+        from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
+        tokens["ui_session_id"] = _UI_SID.set(sid)
+    except Exception:
+        logger.debug("per-turn _SESSION_UI_SESSION_ID bind failed", exc_info=True)
     return tokens
 
 
@@ -1843,6 +1847,13 @@ def _reset_turn_session_identity(tokens) -> None:
     """
     if not tokens:
         return
+    tok = tokens.get("ui_session_id")
+    if tok is not None:
+        try:
+            from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
+            _UI_SID.reset(tok)
+        except Exception:
+            logger.debug("per-turn _SESSION_UI_SESSION_ID reset failed", exc_info=True)
     tok = tokens.get("session_key")
     if tok is not None:
         try:

--- a/tests/test_xsession_wakeup_misroute.py
+++ b/tests/test_xsession_wakeup_misroute.py
@@ -257,3 +257,53 @@ def test_resolve_wakeup_target_passthrough_when_owner_unknown():
         session_key_resolved_sid=sid,
         proc_session=None,
     ) == sid
+
+
+# ---------------------------------------------------------------------------
+# Exact origin_ui_session_id ownership (complements Option 3)
+# ---------------------------------------------------------------------------
+
+def test_resolve_completion_target_prefers_origin_ui_session_id():
+    """When session_key resolves to B but origin_ui_session_id is A, route to A."""
+    bp = importlib.import_module("api.background_process")
+    assert hasattr(bp, "_resolve_completion_target"), (
+        "missing _resolve_completion_target — exact-owner routing not implemented"
+    )
+    SESS_A = "webui-tab-A"
+    SESS_B = "webui-tab-B"
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid=SESS_B,
+        origin_ui_session_id=SESS_A,
+    ) == SESS_A
+
+
+def test_resolve_completion_target_fallback_without_origin():
+    bp = importlib.import_module("api.background_process")
+    sid = "legacy-only"
+    assert bp._resolve_completion_target(
+        session_key_resolved_sid=sid,
+        origin_ui_session_id="",
+    ) == sid
+
+
+def test_env_immune_owner_prefers_origin_ui_session_id():
+    bp = importlib.import_module("api.background_process")
+    ps = _fake_ps(session_key="B", spawn_session_id="spawn-B")
+    # Duck-typed modern field wins over legacy spawn_session_id.
+    ps.origin_ui_session_id = "tab-A"
+    assert bp._env_immune_spawn_owner(ps) == "tab-A"
+
+
+def test_turn_identity_binder_sets_ui_session_id():
+    """Option 1 must also bind HERMES_UI_SESSION_ID so terminal_tool can stamp
+    origin_ui_session_id on notify_on_complete spawns."""
+    streaming = importlib.import_module("api.streaming")
+    pytest.importorskip("gateway.session_context", reason="hermes-agent not installed")
+    from gateway import session_context as sc
+
+    bind = streaming._bind_turn_session_identity
+    assert sc._SESSION_UI_SESSION_ID.get() is sc._UNSET
+    with bind("webui-sid-42"):
+        assert sc._SESSION_UI_SESSION_ID.get() == "webui-sid-42"
+        assert sc.get_session_env("HERMES_UI_SESSION_ID", "") == "webui-sid-42"
+    assert sc._SESSION_UI_SESSION_ID.get() is sc._UNSET


### PR DESCRIPTION
## Summary

Fixes **Background wakeup** events landing in the wrong Hermes WebUI chat.

Root cause: server-side `notify_on_complete` routing trusted the legacy `session_key → session_id` index. Concurrent turns / temporary subagent keys can contaminate that key. Modern hermes-agent stamps an exact `origin_ui_session_id` (commissioning browser tab); this PR makes that field authoritative.

### Changes
- Bind `HERMES_UI_SESSION_ID` in `_set_turn_session_identity` / reset (alongside approval + `_SESSION_KEY`)
- `_resolve_completion_target`: prefer `origin_ui_session_id` over session-key resolution
- Recover `origin_ui_session_id` / `spawn_session_id` from `ProcessSession` when the event lacks it
- Keep legacy session-key fallback for older agent builds without exact owner metadata
- Option-3 env-immune owner attrs now include `origin_ui_session_id` first

### Companion PR
Agent-side stamp: opened in parallel against `NousResearch/hermes-agent` (`fix/webui-bg-wakeup-origin-routing`).

Related: #6002, #2968.

## Test plan
- [x] `PYTHONPATH=<hermes-agent> pytest tests/test_xsession_wakeup_misroute.py` (11 passed)
- [ ] Manual: two open WebUI sessions; spawn `notify_on_complete` process in A; confirm server-side wakeup only in A