### PR TITLE
fix: decode chunked request bodies so proxied POSTs (Cloudflare Tunnel) authenticate

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -654,9 +654,9 @@ def _read_chunked_body(handler, max_bytes: int) -> bytes:
         size_token = size_line.split(b';', 1)[0].strip()
         try:
             size = int(size_token, 16)
-        except ValueError:
+        except ValueError as err:
             handler.close_connection = True
-            raise ValueError(f'Malformed chunk size: {size_token!r}')
+            raise ValueError(f'Malformed chunk size: {size_token!r}') from err
         if size == 0:
             # Consume optional trailer headers up to the terminating blank line.
             while True:

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -623,8 +623,72 @@ def redact_session_data(session_dict: dict) -> dict:
     return result
 
 
+def _read_exact(rfile, n: int) -> bytes:
+    """Read exactly n bytes, tolerating short reads from the socket buffer."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = rfile.read(n - len(buf))
+        if not chunk:
+            break  # premature EOF
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _read_chunked_body(handler, max_bytes: int) -> bytes:
+    """Decode a ``Transfer-Encoding: chunked`` request body.
+
+    Python's ``http.server`` never populates Content-Length for chunked
+    requests and does not decode them, so ``rfile.read(Content-Length)`` reads
+    nothing. Reverse proxies that stream an HTTP/2 client request to an
+    HTTP/1.1 origin — notably Cloudflare Tunnel (cloudflared) — forward request
+    bodies this way, so without decoding here the server sees an empty body on
+    every proxied POST (login, settings, message send, …). See RFC 7230 §4.1.
+    """
+    rfile = handler.rfile
+    out = bytearray()
+    while True:
+        size_line = rfile.readline(65536)
+        if not size_line:
+            break  # premature EOF — return what we have
+        # A chunk-size line may carry ';'-delimited chunk extensions; drop them.
+        size_token = size_line.split(b';', 1)[0].strip()
+        try:
+            size = int(size_token, 16)
+        except ValueError:
+            handler.close_connection = True
+            raise ValueError(f'Malformed chunk size: {size_token!r}')
+        if size == 0:
+            # Consume optional trailer headers up to the terminating blank line.
+            while True:
+                trailer = rfile.readline(65536)
+                if trailer in (b'\r\n', b'\n', b''):
+                    break
+            break
+        if len(out) + size > max_bytes:
+            handler.close_connection = True
+            raise ValueError(f'Request body too large (> {max_bytes} bytes)')
+        out.extend(_read_exact(rfile, size))
+        rfile.readline(3)  # consume the CRLF that terminates the chunk data
+    return bytes(out)
+
+
 def read_body(handler) -> dict:
-    """Read and JSON-parse a POST request body (capped at 20MB)."""
+    """Read and JSON-parse a POST request body (capped at 20MB).
+
+    Handles both ``Content-Length`` and ``Transfer-Encoding: chunked`` framing.
+    The latter is required for bodies proxied by cloudflared / any HTTP/2 front
+    end, which forward to the HTTP/1.1 origin without a Content-Length header.
+    """
+    # RFC 7230 §3.3.3: Transfer-Encoding takes precedence over Content-Length;
+    # a chunked body has no Content-Length to read.
+    transfer_encoding = handler.headers.get('Transfer-Encoding', '') or ''
+    if 'chunked' in transfer_encoding.lower():
+        raw = _read_chunked_body(handler, MAX_BODY_BYTES) or b'{}'
+        try:
+            return _json.loads(raw)
+        except Exception:
+            return {}
+
     raw_length = handler.headers.get('Content-Length', 0)
     try:
         length = int(raw_length)

--- a/tests/test_chunked_request_body.py
+++ b/tests/test_chunked_request_body.py
@@ -1,0 +1,93 @@
+"""read_body() decodes Transfer-Encoding: chunked request bodies.
+
+Reverse proxies that stream an HTTP/2 client request to an HTTP/1.1 origin —
+notably Cloudflare Tunnel (cloudflared) — forward request bodies with
+``Transfer-Encoding: chunked`` and no ``Content-Length``. Before the fix,
+``read_body()`` only honoured ``Content-Length``, so every proxied POST
+arrived with an empty body. For JSON login that meant the parsed password was
+``""`` and the server returned 401 "Invalid password" no matter what the user
+typed; other POSTs (settings, message send) silently lost their payload too.
+
+These tests assert the observable behaviour of ``read_body`` — the decoded
+dict — not a source string. The chunked cases fail against the pre-fix code
+(they get ``{}`` back) and pass after it.
+"""
+import email.message
+import io
+import json
+
+from api.helpers import read_body
+
+
+class _FakeHandler:
+    """Minimal stand-in for BaseHTTPRequestHandler's body-reading surface.
+
+    Uses a real ``email.message.Message`` so header lookups are
+    case-insensitive, exactly as ``http.server`` delivers them (cloudflared
+    sends the header lowercased as ``transfer-encoding``).
+    """
+
+    def __init__(self, raw: bytes, headers: dict):
+        self.rfile = io.BytesIO(raw)
+        msg = email.message.Message()
+        for key, value in headers.items():
+            msg[key] = value
+        self.headers = msg
+        self.close_connection = False
+
+
+def _one_chunk(body: bytes) -> bytes:
+    """Frame *body* as a single HTTP chunk followed by the terminator."""
+    return b"%x\r\n%s\r\n0\r\n\r\n" % (len(body), body)
+
+
+def test_chunked_body_is_decoded_lowercase_header():
+    payload = {"password": "correct horse battery staple", "n": 42}
+    body = json.dumps(payload).encode()
+    # cloudflared casing: lowercase header name, and NO Content-Length.
+    handler = _FakeHandler(
+        _one_chunk(body),
+        {"transfer-encoding": "chunked", "content-type": "application/json"},
+    )
+    assert read_body(handler) == payload
+
+
+def test_chunked_body_reassembled_across_multiple_chunks():
+    # A body split across several chunks must be reassembled in order; a
+    # single-chunk test could not catch a reader that drops all but one chunk.
+    payload = {"blob": "x" * 5000, "tail": "end"}
+    body = json.dumps(payload).encode()
+    p1, p2, p3 = body[:100], body[100:3000], body[3000:]
+    raw = (
+        b"%x\r\n%s\r\n" % (len(p1), p1)
+        + b"%x\r\n%s\r\n" % (len(p2), p2)
+        + b"%x\r\n%s\r\n" % (len(p3), p3)
+        + b"0\r\n\r\n"
+    )
+    handler = _FakeHandler(raw, {"Transfer-Encoding": "chunked"})
+    assert read_body(handler) == payload
+
+
+def test_chunked_with_extension_on_size_line():
+    # Chunk-size lines may carry ';'-delimited extensions; they must be ignored.
+    payload = {"ok": True}
+    body = json.dumps(payload).encode()
+    raw = b"%x;ext=1\r\n%s\r\n0\r\n\r\n" % (len(body), body)
+    handler = _FakeHandler(raw, {"Transfer-Encoding": "chunked"})
+    assert read_body(handler) == payload
+
+
+def test_content_length_body_still_works():
+    # The existing Content-Length path must be unchanged.
+    payload = {"password": "correct horse battery staple"}
+    body = json.dumps(payload).encode()
+    handler = _FakeHandler(
+        body,
+        {"Content-Length": str(len(body)), "Content-Type": "application/json"},
+    )
+    assert read_body(handler) == payload
+
+
+def test_empty_body_returns_empty_dict():
+    handler = _FakeHandler(b"", {})
+    assert read_body(handler) == {}


### PR DESCRIPTION
> **⚠️ Disclaimer — AI-authored, submitted on a maintainer's behalf.** This PR was written by an AI agent (Claude Code) working on behalf of a user who hit this bug running Hermes WebUI behind a Cloudflare Tunnel. They don't have time to shepherd it through review, so **please feel free to close it with zero friction if that's easier for you — genuinely no hard feelings.** It's offered as a ready-to-use fix + reproduction in case it's useful; the diagnosis and verification below are real and reproducible either way.

## Thinking Path

- Hermes WebUI is meant to run comfortably behind a reverse proxy / tunnel (the README and env docs cover `HERMES_WEBUI_ALLOWED_ORIGINS`, `TRUST_FORWARDED_*`, Docker, etc.).
- A common deployment is Cloudflare Tunnel (`cloudflared`) in front of the origin. Browsers speak HTTP/2 to the Cloudflare edge; `cloudflared` then **streams** that request to the HTTP/1.1 origin.
- When a proxy streams a body whose length it doesn't know up front, it forwards it with `Transfer-Encoding: chunked` and **no `Content-Length`**. This is normal, spec-compliant proxy behavior.
- `api/helpers.py:read_body()` read the body as `rfile.read(int(Content-Length))`. With no `Content-Length`, it read **nothing** and returned `{}`.
- So every authenticated/data POST through the tunnel arrived with an empty body. The most visible symptom: **login always failed** — `body.get("password","")` was `""`, so `verify_password("")` returned false and the server answered `401 "Invalid password"` no matter what the user typed. (A second tell: the server left the un-read chunked bytes in the socket, which the keep-alive handler then parsed as a bogus follow-up request — the phantom `"method": "-", "status": 400` lines in the access log.)
- This PR teaches `read_body()` to decode chunked bodies, so proxied POSTs carry their payload and authenticate normally.

## What Changed

- `api/helpers.py`
  - `read_body()` now checks `Transfer-Encoding` first. If it contains `chunked`, the body is decoded via a new `_read_chunked_body()` helper (RFC 7230 §4.1: `Transfer-Encoding` takes precedence over `Content-Length`). Otherwise the existing `Content-Length` path runs **unchanged**.
  - `_read_chunked_body()` reads chunk-size lines (ignoring `;`-delimited chunk extensions), reassembles chunk data in order, consumes the terminating zero-size chunk + trailers, and enforces the same `MAX_BODY_BYTES` (20 MB) cap. Malformed chunk sizes / oversize bodies raise `ValueError` and set `close_connection = True`, matching the existing error contract.
  - `_read_exact()` helper guards against short reads from the socket buffer.
- `tests/test_chunked_request_body.py` (new) — behavior tests for `read_body()`.

Fix is at the **shared chokepoint** (`read_body()` — all 6 JSON POST call sites), not per-endpoint.

## Why It Matters

Without this, Hermes WebUI is effectively unusable behind any HTTP/2 front end that streams request bodies (Cloudflare Tunnel is the common one): you can load the page and do GETs, but **cannot log in or submit any POST**, with a misleading "Invalid password" error that sends people chasing a credential problem that doesn't exist.

## Verification

Local, Python 3.11 venv.

**Unit — the test bites (rule 6):**
- Against **pre-fix** `read_body()`: the 3 chunked tests **fail** (they get `{}` back); the `Content-Length` and empty-body tests pass. → `3 failed, 2 passed`
- Against **post-fix**: `5 passed`.

**Neighboring sweep (no regressions):**
```
pytest tests/test_chunked_request_body.py tests/test_issue1855_request_diagnostics.py \
  tests/test_issue3582_tts_content_length.py tests/test_trusted_header_auth.py \
  tests/test_1560_password_env_var_no_op.py tests/test_auth_settings_safety.py \
  tests/test_cors_preflight_allowlist.py tests/test_security_review_fixes.py
→ 110 passed
```

**Integration — real socket against a running server (the actual user symptom):**
| Request framing | password | Before fix | After fix |
|---|---|---|---|
| `Content-Length` | correct | 200 | 200 |
| `Transfer-Encoding: chunked` | correct | **401** | **200** |
| `Transfer-Encoding: chunked` | wrong | 401 | 401 |

The last row confirms auth is not weakened — a wrong password over a chunked request is still rejected.

## Risks / Follow-ups

- **Scope / known siblings left out (rule 1):** the multipart **upload** handlers in `api/upload.py` also read bodies via `Content-Length` (lines ~210/388/420/604) and would likewise mis-read a chunked upload. I deliberately left those out of scope — they're a separate, larger change (streaming multipart parse) with different risk, and I didn't want to widen this diff. Flagging them explicitly rather than hiding the gap.
- Chunked **trailers** are consumed and discarded (Hermes doesn't use trailer headers).
- Non-compliant bare-LF chunk framing isn't specially handled; `cloudflared` and standard proxies use CRLF.
- I could **not** verify end-to-end through an actual live Cloudflare Access-gated tunnel from CI (the headless environment can't pass the Access challenge); the chunked **socket reproduction** stands in for that path and is a faithful byte-level match of what `cloudflared` sends.

## Release note

> Fix: request bodies sent with `Transfer-Encoding: chunked` (e.g. via Cloudflare Tunnel / any HTTP/2 reverse proxy) are now decoded correctly. Previously such POSTs — including login — arrived empty, causing a spurious "Invalid password" / lost-payload behavior behind a tunnel.

(Left `CHANGELOG.md` untouched per CONTRIBUTING.)

## Model Used / AI Usage Disclosure

- **Provider:** Anthropic
- **Model:** Claude Opus 4.8 (1M context) — model ID `claude-opus-4-8[1m]`
- **Tooling:** Claude Code (agentic CLI). Diagnosis was done by reproducing the failure at the socket level against a live instance, then reading `read_body()`; the fix and tests were authored and verified by the agent. A human directed the work and reviewed the outcome but did not hand-review every line — see the disclaimer at the top.
