### PR TITLE
feat: expose msg_limit ceiling in /api/session metadata, remove hardcoded _MSG_LIMIT_MAX from frontend (#6177)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8446,6 +8446,34 @@ def _message_window_for_display(messages, msg_limit=None, msg_before=None, expan
 
 
 _LIMITED_TOOL_CONTENT_MAX_CHARS = 4096
+# Server-side ceiling on the ?msg_limit= tail-window size. A client could
+# otherwise request msg_limit=1000000 and force the server to assemble and
+# serialize an unbounded message payload (the frontend's own pagination grows
+# by ~30 at a time, with one outline-jump path asking for 9999). The ceiling is
+# generous — far above any legitimate visible-row window — so real pagination is
+# unaffected; it only caps the pathological/oversized request. When the request
+# exceeds the ceiling the response is silently clamped and _messages_truncated
+# is set (the existing truncation signal already covers "more rows exist").
+_MAX_MSG_LIMIT = 500
+
+
+def _parse_msg_limit(raw):
+    """Parse and clamp the ``?msg_limit=`` query value.
+
+    Returns a positive int clamped to ``[1, _MAX_MSG_LIMIT]``, or ``None`` when
+    the value is absent/empty/malformed (the bare no-``msg_limit`` path, which
+    intentionally returns the full transcript for callers that need it).
+    Extracted from the handler so the clamp expression has direct test coverage.
+    """
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return max(1, min(value, _MAX_MSG_LIMIT))
+
+
 # Defensive row backstop for the GET /api/session display path's state.db read.
 # This is NOT a semantic window (the display window counts visible rows
 # post-reconciliation via _message_window_for_display); it is a safety net so a
@@ -12400,11 +12428,13 @@ def handle_get(handler, parsed) -> bool:
         # transcript rows. Hidden tool-result rows do not consume the budget;
         # they are included only when they sit inside the selected window and
         # are bounded before serialization. Older rows load on-demand.
-        _msg_limit = query.get("msg_limit", [None])[0]
-        try:
-            msg_limit = max(1, int(_msg_limit)) if _msg_limit else None
-        except (ValueError, TypeError):
-            msg_limit = None
+        # Clamp to _MAX_MSG_LIMIT so an oversized request (e.g. msg_limit=9999
+        # from an outline jump, or a hostile value) can't force an unbounded
+        # payload; the existing _messages_truncated signal covers the clamped
+        # case (the client sees there are more rows than returned). Parsing +
+        # clamping live in _parse_msg_limit so the expression has direct test
+        # coverage; None means the bare no-msg_limit path (full transcript).
+        msg_limit = _parse_msg_limit(query.get("msg_limit", [None])[0])
         # ?msg_before=N — 0-based index into the full message array.
         # Returns messages before this index (for scroll-to-top lazy loading).
         # Combined with msg_limit for paging.
@@ -12739,6 +12769,7 @@ def handle_get(handler, parsed) -> bool:
             _truncated = load_messages and msg_limit is not None and _messages_offset > 0
             raw["_messages_truncated"] = _truncated
             raw["_messages_offset"] = _messages_offset
+            raw["_msg_limit_max"] = _MAX_MSG_LIMIT
             _t4 = _time.monotonic()
             if _diag: _diag.stage("t4_after_compact_and_merge")
             if effective_model:

--- a/static/outline.js
+++ b/static/outline.js
@@ -104,10 +104,16 @@ function _jumpToMessage(rawIdx) {
   }
 
   // Row is outside the render window — reload the full session and retry.
+  // Use the bare messages=1 path (no msg_limit) so the server returns the
+  // COMPLETE transcript: the target row is addressed by absolute index
+  // (msg-user-<rawIdx>), so a bounded tail window would miss early rows.
+  // (A previous version sent msg_limit=9999 as a "give me everything" hack,
+  // but the server now clamps msg_limit, so the bare path is the correct way
+  // to request the full transcript here.)
   if (typeof api !== 'function') return;
   if (S.busy || S.activeStreamId) return;
   api('/api/session?session_id=' + encodeURIComponent(sid) +
-      '&messages=1&resolve_model=0&msg_limit=9999')
+      '&messages=1&resolve_model=0')
     .then(function(data) {
       if (!data || !data.session) return;
       if (!S.session || S.session.session_id !== sid) return;  // session switched

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2928,6 +2928,20 @@ let _messagesTruncated = false;
 // server-bounded and do not consume the visible-message budget.
 // Older messages are loaded on-demand via _loadOlderMessages().
 const _INITIAL_MSG_LIMIT = 30;
+// ============================================================================
+// COUPLED CONSTANT — keep in sync with api/routes.py:_MAX_MSG_LIMIT.
+// ============================================================================
+// This is a hand-mirrored fallback copy of the backend's GET /api/session
+// ?msg_limit= ceiling. The durable fix (issue #6177) is to read the ceiling
+// from /api/session metadata (_msg_limit_max) so the frontend dynamically
+// follows the server's actual value. The constant below is only the default
+// for older servers that don't expose the field; once _msg_limit_max is
+// available from the API response, _msgLimitMax is updated and this constant
+// is no longer used.
+const _MSG_LIMIT_MAX = 500;
+// Live ceiling: read from /api/session response _msg_limit_max when available,
+// fall back to _MSG_LIMIT_MAX for older servers without the metadata field.
+let _msgLimitMax = _MSG_LIMIT_MAX;
 let _sameSessionForceReloadHint = null;
 
 function _currentLoadedRenderableMessageCount(){
@@ -3051,6 +3065,7 @@ async function _ensureMessagesLoaded(sid, opts) {
   if (!data || !data.session) return;
   _messagesTruncated = !!data.session._messages_truncated;
   _oldestIdx = data.session._messages_offset || 0;
+  _msgLimitMax = data.session._msg_limit_max || _MSG_LIMIT_MAX;
   // #3162: `msgs` is reassigned below by the #3018 ephemeral-field carry-forward,
   // so it must be `let`, not `const`. The `const` form threw a TypeError inside
   // _ensureMessagesLoaded() that surfaced as a "Failed to load conversation messages"
@@ -3531,18 +3546,34 @@ async function _loadOlderMessages() {
   // rebuilt transcript (#1937).
   const startGeneration = _messagesGeneration;
   try {
-    // Ask the server for a larger authoritative tail window instead of a
-    // separate msg_before page. The same /api/session contract handles both —
-    // post-#2716 the backend always runs the full append-only merge, so a
-    // larger msg_limit on the same call produces the same merged transcript
-    // we'd get by stitching pages, but without client-side index bookkeeping.
-    // Cumulative growth: each "load more" asks for currentLoaded + 30, and the
-    // newly exposed head is what we expose to the user.
+    // Two strategies, chosen by whether the growing tail window still fits under
+    // the server's msg_limit ceiling (_msgLimitMax, read from /api/session
+    // _msg_limit_max metadata, falling back to _MSG_LIMIT_MAX for older servers):
+    //
+    //  - Below the ceiling: ask for a larger authoritative tail window
+    //    (currentLoaded + _INITIAL_MSG_LIMIT). Post-#2716 the backend runs the
+    //    full append-only merge, so a larger msg_limit produces the same merged
+    //    transcript we'd get by stitching pages, without client-side index
+    //    bookkeeping. The newly exposed head is what we expose to the user.
+    //
+    //  - At/above the ceiling: the server clamps msg_limit, so the tail window
+    //    stops growing and this strategy would stall (the same clamped tail is
+    //    returned, olderMsgs -> 0). Switch to msg_before paging — a fixed
+    //    _INITIAL_MSG_LIMIT backward page keyed off _oldestIdx — which is
+    //    bounded and never hits the ceiling, so the head stays reachable for
+    //    arbitrarily long transcripts. (This is the same paging request the
+    //    race-fallback below uses, proven correct there.)
     const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, (S.messages || []).length + _INITIAL_MSG_LIMIT);
-    const data = await api(
-      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,
-      {timeoutMs:120000}
-    );
+    const useBeforePaging = requestedLimit >= _msgLimitMax;
+    const data = useBeforePaging
+      ? await api(
+          `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,
+          {timeoutMs:120000}
+        )
+      : await api(
+          `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,
+          {timeoutMs:120000}
+        );
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) { _loadingOlder = false; return; }
     //  - response shape sane
@@ -3583,18 +3614,22 @@ async function _loadOlderMessages() {
     let olderMsgs = expandedMsgs.slice(0, olderCount);
     let nextMessages = expandedMsgs;
     if (!tailMatches) {
-      // Race fallback: keep the legacy index-page request as the
-      // correctness-preserving alternative. Same guards reapplied because
-      // we just awaited again.
-      const fallback = await api(
-        `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,
-        {timeoutMs:120000}
-      );
-      if (!fallback || !fallback.session) { _loadingOlder = false; return; }
-      if (!S.session || S.session.session_id !== sid) return;
-      if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
-      if (_messagesGeneration !== startGeneration) return;
-      responseSession = fallback.session;
+      // Race fallback (or the over-ceiling msg_before primary path): keep the
+      // legacy index-page request as the correctness-preserving alternative.
+      // When useBeforePaging is true we already fetched a msg_before page as
+      // the primary `data`, so reuse it instead of re-fetching. Same guards
+      // reapplied because we just awaited again (skipped for the reuse case).
+      if (!useBeforePaging) {
+        const fallback = await api(
+          `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,
+          {timeoutMs:120000}
+        );
+        if (!fallback || !fallback.session) { _loadingOlder = false; return; }
+        if (!S.session || S.session.session_id !== sid) return;
+        if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
+        if (_messagesGeneration !== startGeneration) return;
+        responseSession = fallback.session;
+      }
       olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
       nextMessages = [...olderMsgs, ...S.messages];
     }
@@ -3637,6 +3672,7 @@ async function _loadOlderMessages() {
     _messageRenderWindowSize=_currentMessageRenderWindowSize()+Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT);
     _messagesTruncated = !!responseSession._messages_truncated;
     _oldestIdx = responseSession._messages_offset || 0;
+    _msgLimitMax = responseSession._msg_limit_max || _MSG_LIMIT_MAX;
     renderMessages({ preserveScroll: true });
     if (container) {
       // Prepending older messages must not teleport the reader. Anchor to the

--- a/tests/test_api_timeout.py
+++ b/tests/test_api_timeout.py
@@ -230,17 +230,16 @@ def test_session_message_loads_keep_explicit_longer_timeouts():
         "      {timeoutMs:120000}\n"
         "    )"
     ) in src
+    # _loadOlderMessages now picks between two strategies (tail-growth vs
+    # msg_before paging) via a useBeforePaging ternary, but both keep the long
+    # timeoutMs:120000. Assert each URL + timeout survives in the source.
     assert (
-        "api(\n"
-        "      `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,\n"
-        "      {timeoutMs:120000}\n"
-        "    )"
+        "`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,\n"
+        "          {timeoutMs:120000}"
     ) in src
     assert (
-        "api(\n"
-        "        `/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`,\n"
-        "        {timeoutMs:120000}\n"
-        "      )"
+        "`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`,\n"
+        "          {timeoutMs:120000}"
     ) in src
 
 

--- a/tests/test_msg_limit_ceiling_drift.py
+++ b/tests/test_msg_limit_ceiling_drift.py
@@ -1,0 +1,72 @@
+"""Stopgap drift guard: the frontend ``_MSG_LIMIT_MAX`` fallback must match the
+backend ``_MAX_MSG_LIMIT`` ceiling.
+
+PR #6152 introduced the server-side ``_MAX_MSG_LIMIT`` ceiling on
+``GET /api/session ?msg_limit=``. PR #6154 added a hand-mirrored
+``_MSG_LIMIT_MAX`` in ``static/sessions.js`` so the frontend knows when to
+switch from the growing-tail strategy to ``msg_before`` paging. If the two
+drift, load-older silently stalls at the old value — the exact regression #6154
+fixed. The durable fix (#6177) exposes the ceiling via ``/api/session`` metadata
+(``_msg_limit_max`` field) so the frontend reads it dynamically and the
+``_MSG_LIMIT_MAX`` becomes just a fallback for older servers. Until the metadata
+field is universally available, this static-source assertion catches the drift.
+
+Placement note: this test ships in #6152 (where ``_MAX_MSG_LIMIT`` is defined).
+The frontend ``_MSG_LIMIT_MAX`` only exists once #6154 lands, so the assertion
+SKIPS when the JS constant is absent — it activates automatically once both
+branches are on master, and bites if the two values ever diverge.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _backend_max_msg_limit() -> int:
+    """Extract ``_MAX_MSG_LIMIT = <int>`` from api/routes.py."""
+    src = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+    m = re.search(r"^_MAX_MSG_LIMIT\s*=\s*(\d+)\s*$", src, re.MULTILINE)
+    assert m, "_MAX_MSG_LIMIT not found in api/routes.py"
+    return int(m.group(1))
+
+
+def _frontend_msg_limit_max():
+    """Extract ``_MSG_LIMIT_MAX = <int>`` from static/sessions.js, or return
+    None when the constant is absent (PR #6154 not yet landed)."""
+    sessions = ROOT / "static" / "sessions.js"
+    if not sessions.exists():
+        return None
+    src = sessions.read_text(encoding="utf-8")
+    m = re.search(r"const\s+_MSG_LIMIT_MAX\s*=\s*(\d+)\s*;", src)
+    return int(m.group(1)) if m else None
+
+
+def test_frontend_msg_limit_max_matches_backend_ceiling():
+    """When both constants exist (i.e. #6152 + #6154 have both landed), the
+    frontend fallback MUST equal the backend ceiling or load-older silently
+    stalls for long sessions. Skips gracefully when the JS constant is absent
+    (the #6152-only state) so this test ships atomically with the backend
+    constant without depending on the #6154 branch."""
+    backend = _backend_max_msg_limit()
+    frontend = _frontend_msg_limit_max()
+    if frontend is None:
+        # PR #6154 (the frontend mirror) hasn't landed yet — skip rather than
+        # fail. Once both are on master this branch is exercised and bites on
+        # any drift.
+        import pytest
+        pytest.skip("_MSG_LIMIT_MAX not yet present in static/sessions.js "
+                    "(lands in #6154); drift guard activates once both are on master")
+    assert frontend == backend, (
+        f"frontend _MSG_LIMIT_MAX ({frontend}) != backend _MAX_MSG_LIMIT ({backend}): "
+        f"load-older will silently stall at the wrong value. Update both together, "
+        f"or land #6177 (metadata-exposure) to retire the mirror."
+    )
+
+
+def test_backend_max_msg_limit_is_reasonable():
+    """The backend ceiling must exist and stay in a sane range (the frontend's
+    real pagination grows by ~30, so anything in [100, 2000] is generous)."""
+    backend = _backend_max_msg_limit()
+    assert 100 <= backend <= 2000, f"_MAX_MSG_LIMIT out of expected range: {backend}"

--- a/tests/test_session_msg_limit_ceiling.py
+++ b/tests/test_session_msg_limit_ceiling.py
@@ -1,0 +1,66 @@
+"""Tests: server-side ``msg_limit`` ceiling on ``GET /api/session``.
+
+A client could request ``msg_limit=1000000`` (or the frontend's
+``msg_limit=9999`` outline-jump path) and force the server to assemble and
+serialize an unbounded message payload. The handler now clamps ``msg_limit`` to
+``_MAX_MSG_LIMIT`` (generous — far above any legitimate visible-row window) so
+real pagination is unaffected while the pathological/oversized request is
+bounded. The existing ``_messages_truncated`` signal covers the clamped case.
+
+The parse+clamp lives in ``_parse_msg_limit`` so the clamping expression has
+direct test coverage (driving the handler end-to-end would require a live
+session + state.db; the helper is the unit under test).
+"""
+from __future__ import annotations
+
+from api.routes import _MAX_MSG_LIMIT, _parse_msg_limit
+
+
+def test_max_msg_limit_constant_is_reasonable():
+    """The ceiling must exist and be well above legitimate pagination sizes
+    (the frontend grows windows by ~30, initial load is 30) but finite."""
+    assert isinstance(_MAX_MSG_LIMIT, int)
+    assert 100 <= _MAX_MSG_LIMIT <= 2000, _MAX_MSG_LIMIT
+
+
+def test_parse_msg_limit_none_when_absent_or_empty():
+    """No value (the bare no-msg_limit path) returns None — intentionally the
+    'full transcript' escape hatch for branch/undo/jump-to-start flows."""
+    assert _parse_msg_limit(None) is None
+    assert _parse_msg_limit("") is None
+
+
+def test_parse_msg_limit_none_when_malformed():
+    """A non-numeric value returns None rather than raising (matches the
+    pre-fix behavior where a ValueError fell through to msg_limit=None)."""
+    assert _parse_msg_limit("not-a-number") is None
+    assert _parse_msg_limit("abc") is None
+
+
+def test_parse_msg_limit_passes_legit_sizes_unchanged():
+    """Legitimate pagination sizes (5/30/60/100) are returned verbatim — the
+    ceiling only caps oversized requests."""
+    for legit in (1, 5, 30, 60, 100):
+        if legit > _MAX_MSG_LIMIT:
+            continue
+        assert _parse_msg_limit(str(legit)) == legit, f"legit {legit} altered"
+
+
+def test_parse_msg_limit_clamps_oversized_to_ceiling():
+    """An over-ceiling request (the outline-jump 9999, or a hostile 1000000) is
+    clamped down to _MAX_MSG_LIMIT — exactly the regression this PR fixes."""
+    assert _parse_msg_limit("9999") == _MAX_MSG_LIMIT
+    assert _parse_msg_limit("1000000") == _MAX_MSG_LIMIT
+    assert _parse_msg_limit(str(_MAX_MSG_LIMIT + 1)) == _MAX_MSG_LIMIT
+
+
+def test_parse_msg_limit_ceiling_boundary_itself_passes():
+    """A request exactly at the ceiling is allowed (clamp is inclusive)."""
+    assert _parse_msg_limit(str(_MAX_MSG_LIMIT)) == _MAX_MSG_LIMIT
+
+
+def test_parse_msg_limit_zero_and_negative_clamp_to_one():
+    """Non-positive values clamp to the minimum (1), not None — a caller asking
+    for msg_limit=0 gets a 1-row window, not the full transcript."""
+    assert _parse_msg_limit("0") == 1
+    assert _parse_msg_limit("-5") == 1


### PR DESCRIPTION
## Summary

Fixes #6177: instead of hand-mirroring `_MSG_LIMIT_MAX` in the frontend, the backend now exposes its `msg_limit` ceiling via the `/api/session` response metadata, and the frontend reads it dynamically.

This PR bundles the changes from #6152 and #6154 (which are still open and introduce the `_MAX_MSG_LIMIT`/`_MSG_LIMIT_MAX` constants) plus the #6177 metadata exposure that removes the coupling.

## Changes

### Backend (`api/routes.py`)
- **Add `_MAX_MSG_LIMIT = 500`** ceiling constant (from #6152)
- **Add `_parse_msg_limit()`** helper to clamp `?msg_limit=` to `[1, _MAX_MSG_LIMIT]` (from #6152)
- **Replace inline parsing** with `_parse_msg_limit` call (from #6152)
- **Expose `_msg_limit_max`** in GET /api/session response metadata alongside `_messages_truncated`/`_messages_offset` — this is the #6177 change

### Frontend (`static/sessions.js`)
- **Add `_MSG_LIMIT_MAX = 500`** as a fallback constant for older servers (from #6154)
- **Add `_msgLimitMax` variable**, populated from API response `_msg_limit_max` with fallback to `_MSG_LIMIT_MAX`
- **Replace hardcoded constant** use with dynamic `_msgLimitMax` in `_loadOlderMessages` (the #6177 change)
- **Implement two-strategy load-older** (from #6154): growing tail window below ceiling, `msg_before` paging at/above ceiling
- **Reuse primary fetch** when `useBeforePaging` already made a `msg_before` request, avoids double fetch

### Frontend (`static/outline.js`)
- **Remove `msg_limit=9999`** hack from jump-to-message URL, use bare `messages=1` path (from #6154)

### Tests
- **`test_session_msg_limit_ceiling.py`** (new): unit tests for `_parse_msg_limit` (from #6152)
- **`test_msg_limit_ceiling_drift.py`** (new): static-source assertion that frontend fallback matches backend ceiling (from #6152)
- **`test_api_timeout.py`**: updated for new two-strategy code pattern (from #6154)

## Verification

- `python3 -m py_compile api/routes.py` ✅
- `node --check static/sessions.js` ✅
- `node --check static/outline.js` ✅
- `./scripts/test.sh tests/test_session_msg_limit_ceiling.py` — 7 passed ✅
- `./scripts/test.sh tests/test_msg_limit_ceiling_drift.py` — 2 passed ✅
- Existing window/renderable tests (10 + 9 = 19) — all pass ✅
- `./scripts/test.sh tests/test_api_timeout.py` — 8 passed ✅

## Contract Change (additive, backward-compatible)

The `/api/session` response now includes a `_msg_limit_max` field alongside the existing `_messages_truncated`/`_messages_offset`. The frontend reads this field when available and falls back to `_MSG_LIMIT_MAX = 500` for older servers. The field is a plain integer; no new query params or route changes.

Release note: `GET /api/session` now exposes `_msg_limit_max` in the response metadata so the frontend reads the `msg_limit` ceiling dynamically instead of hand-mirroring it.