### PR TITLE
fix: force-clean stale pending approvals at stream teardown to prevent phantom red dot (#6100)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1177,6 +1177,11 @@ def _run_gateway_chat_streaming(
             except Exception:
                 logger.debug("Failed to clear gateway stream state", exc_info=True)
             _cleanup_gateway_pending_mirror(session_id)
+            try:
+                from api.route_approvals import force_clean_pending_approvals
+                force_clean_pending_approvals(session_id)
+            except Exception:
+                pass
         with STREAMS_LOCK:
             CANCEL_FLAGS.pop(stream_id, None)
             STREAM_GOAL_RELATED.pop(stream_id, None)

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -1181,7 +1181,7 @@ def _run_gateway_chat_streaming(
                 from api.route_approvals import force_clean_pending_approvals
                 force_clean_pending_approvals(session_id)
             except Exception:
-                pass
+                logger.debug("Failed to force-clean pending approvals at teardown")
         with STREAMS_LOCK:
             CANCEL_FLAGS.pop(stream_id, None)
             STREAM_GOAL_RELATED.pop(stream_id, None)

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -139,11 +139,17 @@ def _normalize_pending_queue_locked(session_key: str) -> list[dict]:
 def reconcile_gateway_pending_mirror_locked(session_key: str) -> tuple[dict | None, int, bool]:
     """Purge stale gateway mirrors and ensure at most one live head mirror exists.
 
-    CALLER MUST HOLD `_lock`.
+    CALLER MUST HOLD ``_lock``.
+
+    When *session_key* is tombstoned (callback unregistered at teardown),
+    this function treats the live gateway queue as empty — no new mirrors
+    are created from lingering gateway entries.  This closes the
+    post-unregister re-enqueue race (#6100): a surviving sub-agent thread
+    cannot recreate a stale mirror after the parent stream has torn down.
     """
     changed = False
     queue_list = list(_normalize_pending_queue_locked(session_key))
-    live_gateway_queue = _gateway_queues.get(session_key) or []
+    live_gateway_queue: list = (_gateway_queues.get(session_key) or []) if session_key not in _approval_tombstones else []
 
     live_head_entry = live_gateway_queue[0] if live_gateway_queue else None
     live_head_data = getattr(live_head_entry, "data", None) or {}
@@ -247,19 +253,55 @@ def submit_pending(session_key: str, approval: dict) -> None:
     # unaffected by _pending. The _pending dict is only used for UI polling.
 
 
-def force_clean_pending_approvals(session_key: str) -> None:
-    """Remove all pending-approval entries and gateway mirrors for *session_key*.
+# ── Post-unregister tombstone set ───────────────────────────────────────────
+# Sessions whose approval callback has been unregistered (teardown).  When
+# a surviving sub-agent thread later calls submit_pending / the gateway
+# mirror callback under the old session key, the tombstone prevents new
+# mirrors or pending entries from being created for a dead stream (#6100).
+_approval_tombstones: set[str] = set()
 
-    Used during stream teardown to clean up orphaned sub-agent or stale
-    approvals that were enqueued under the parent session key (#6100).
-    After the parent agent thread has finished, any remaining entries in
-    ``_pending`` for this session are necessarily orphaned — they belong
-    to sub-agent threads that used the parent's session key because
-    contextvars were not propagated to ``DaemonThreadPoolExecutor`` workers.
 
-    Notifies SSE subscribers so the sidebar red dot is cleared immediately.
+def mark_approval_tombstone(session_key: str) -> None:
+    """Mark *session_key* as tombstoned — no new mirrors/pendings are accepted.
+
+    Must be called after ``unregister_gateway_notify`` so the agent-side
+    callback is already dropped.  Any surviving sub-agent thread that tries
+    to enqueue an approval under the old session key will see the tombstone
+    and skip creating a stale entry.
     """
     with _lock:
-        _pending.pop(session_key, None)
-        _approval_sse_notify_locked(session_key, None, 0)
-    publish_session_list_changed("attention_pending")
+        _approval_tombstones.add(session_key)
+
+
+def clear_approval_tombstone(session_key: str) -> None:
+    """Remove the tombstone, e.g. when a new stream starts for this session."""
+    with _lock:
+        _approval_tombstones.discard(session_key)
+
+
+def force_clean_pending_approvals(session_key: str) -> None:
+    """Reconcile the approval mirror for *session_key* at stream teardown.
+
+    This function does **not** wipe the entire ``_pending`` dict or the
+    ``_gateway_queues`` for the session.  Instead it delegates to
+    ``reconcile_gateway_pending_mirror_locked`` which:
+
+    * purges stale gateway mirrors (underlying gateway entry is gone)
+    * preserves still-live gateway mirrors (underlying gateway entry exists)
+    * preserves non-gateway local pending entries
+
+    The session-wide wipe that existed before was too aggressive — it deleted
+    approvals it did not own, including a still-live gateway mirror and
+    non-gateway local approvals that should survive teardown.
+
+    The post-unregister re-enqueue race is closed by the
+    ``_approval_tombstones`` set: after ``unregister_gateway_notify`` the
+    teardown path calls ``mark_approval_tombstone``, and
+    ``reconcile_gateway_pending_mirror_locked`` will refuse to create new
+    mirrors from the live gateway queue for tombstoned sessions.
+    """
+    with _lock:
+        head, total, changed = reconcile_gateway_pending_mirror_locked(session_key)
+        _approval_sse_notify_locked(session_key, head, total)
+    if changed:
+        publish_session_list_changed("attention_pending")

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -245,3 +245,21 @@ def submit_pending(session_key: str, approval: dict) -> None:
     # built. The gateway blocking path uses _gateway_queues (a separate mechanism
     # managed by check_all_command_guards / register_gateway_notify), which is
     # unaffected by _pending. The _pending dict is only used for UI polling.
+
+
+def force_clean_pending_approvals(session_key: str) -> None:
+    """Remove all pending-approval entries and gateway mirrors for *session_key*.
+
+    Used during stream teardown to clean up orphaned sub-agent or stale
+    approvals that were enqueued under the parent session key (#6100).
+    After the parent agent thread has finished, any remaining entries in
+    ``_pending`` for this session are necessarily orphaned — they belong
+    to sub-agent threads that used the parent's session key because
+    contextvars were not propagated to ``DaemonThreadPoolExecutor`` workers.
+
+    Notifies SSE subscribers so the sidebar red dot is cleared immediately.
+    """
+    with _lock:
+        _pending.pop(session_key, None)
+        _approval_sse_notify_locked(session_key, None, 0)
+    publish_session_list_changed("attention_pending")

--- a/api/route_approvals.py
+++ b/api/route_approvals.py
@@ -215,13 +215,29 @@ def _gateway_mirrored_pending_run_id(session_key: str, approval_id: str) -> str 
     return None
 
 
-def submit_gateway_pending_mirror(session_key: str, approval: dict) -> None:
-    """Mirror the live gateway head into WebUI polling state under a typed tag."""
-    del approval  # mirror from the live gateway head under `_lock`, not from callback input
+def submit_gateway_pending_mirror(
+    session_key: str, approval: dict, generation: int | None = None
+) -> bool:
+    """Mirror the live gateway head into WebUI polling state under a typed tag.
+
+    Mirrors from the live gateway head under ``_lock`` — not from callback
+    input — so the typed ``approval_id``/``run_id`` mirror always reflects
+    the current head.
+
+    When *generation* is provided (the callback-owned path), a stale
+    generation means the owning stream has already torn down or a newer
+    stream took ownership: the callback is a late survivor that must signal
+    only its exact entry (so the blocked worker returns promptly) and must
+    NOT create a mirror or notify SSE (#6100).  Returns False in that case.
+    """
     with _lock:
+        if generation is not None and _gateway_notify_generations.get(session_key) != generation:
+            _signal_stale_gateway_entry_locked(session_key, approval)
+            return False
         head, total, _changed = reconcile_gateway_pending_mirror_locked(session_key)
         _approval_sse_notify_locked(session_key, head, total)
     publish_session_list_changed("attention_pending")
+    return True
 
 
 def submit_pending(session_key: str, approval: dict) -> None:
@@ -253,30 +269,75 @@ def submit_pending(session_key: str, approval: dict) -> None:
     # unaffected by _pending. The _pending dict is only used for UI polling.
 
 
-# ── Post-unregister tombstone set ───────────────────────────────────────────
-# Sessions whose approval callback has been unregistered (teardown).  When
-# a surviving sub-agent thread later calls submit_pending / the gateway
-# mirror callback under the old session key, the tombstone prevents new
-# mirrors or pending entries from being created for a dead stream (#6100).
-_approval_tombstones: set[str] = set()
+# ── Gateway notify ownership lifecycle ─────────────────────────────────────
+# The agent-side gateway approval path
+# (tools.approval._await_gateway_decision) appends its ``_ApprovalEntry``
+# and THEN invokes the registered notify callback with the same dict
+# object.  A worker can snapshot the callback, lose the race to
+# ``unregister_gateway_notify()`` at stream teardown, and append its entry
+# after the queue was drained.  The callback wrapper therefore carries a
+# generation: if it fires with a stale generation it signals ONLY its exact
+# entry (never the whole session queue) so the worker unblocks and no
+# phantom mirror/red dot reappears (#6100).  The generation advances on
+# every register (begin) and every teardown (end), so a later turn on the
+# same session reopens the lifecycle instead of staying permanently
+# tombstoned.
+_approval_tombstones: set[str] = set()  # dead interval between end→begin
+_gateway_notify_generations: dict[str, int] = {}  # session_key → current generation
 
 
-def mark_approval_tombstone(session_key: str) -> None:
-    """Mark *session_key* as tombstoned — no new mirrors/pendings are accepted.
+def begin_gateway_notify_ownership(session_key: str) -> int:
+    """Open a new notify ownership generation for *session_key*.
 
-    Must be called after ``unregister_gateway_notify`` so the agent-side
-    callback is already dropped.  Any surviving sub-agent thread that tries
-    to enqueue an approval under the old session key will see the tombstone
-    and skip creating a stale entry.
+    Call BEFORE ``register_gateway_notify`` when a new stream starts.
+    Advances the generation — invalidating any callback snapshotted by a
+    previous stream — and clears the tombstone so the session lifecycle
+    reopens: a later turn on the same session can rebuild its typed
+    mirror.  Returns the generation the callback must capture.
     """
     with _lock:
+        _approval_tombstones.discard(session_key)
+        current = _gateway_notify_generations.get(session_key, 0)
+        _gateway_notify_generations[session_key] = current + 1
+        return current + 1
+
+
+def end_gateway_notify_ownership(session_key: str) -> None:
+    """Close the notify ownership generation for *session_key*.
+
+    Call AFTER ``unregister_gateway_notify`` at stream teardown.  Advances
+    the generation so a surviving callback snapshot is recognized as
+    stale, and re-tombstones the session for the dead interval.
+    """
+    with _lock:
+        current = _gateway_notify_generations.get(session_key, 0)
+        _gateway_notify_generations[session_key] = current + 1
         _approval_tombstones.add(session_key)
 
 
-def clear_approval_tombstone(session_key: str) -> None:
-    """Remove the tombstone, e.g. when a new stream starts for this session."""
-    with _lock:
-        _approval_tombstones.discard(session_key)
+def _signal_stale_gateway_entry_locked(session_key: str, approval: dict) -> None:
+    """Signal ONLY the exact gateway entry that triggered a stale callback.
+
+    CALLER MUST HOLD ``_lock``.
+
+    ``tools.approval._await_gateway_decision`` appends
+    ``_ApprovalEntry(approval_data)`` and then invokes the notify callback
+    with the SAME dict object, so ``entry.data is approval`` identifies the
+    exact entry — entries owned by a newer stream in the same queue are
+    untouched.  The entry is removed and its event set so the blocked
+    worker returns promptly (matching ``unregister_gateway_notify``
+    semantics).
+    """
+    queue = _gateway_queues.get(session_key)
+    if not queue:
+        return
+    for entry in queue:
+        if getattr(entry, "data", None) is approval:
+            queue.remove(entry)
+            entry.event.set()
+            break
+    if not queue:
+        _gateway_queues.pop(session_key, None)
 
 
 def force_clean_pending_approvals(session_key: str) -> None:
@@ -294,11 +355,12 @@ def force_clean_pending_approvals(session_key: str) -> None:
     approvals it did not own, including a still-live gateway mirror and
     non-gateway local approvals that should survive teardown.
 
-    The post-unregister re-enqueue race is closed by the
-    ``_approval_tombstones`` set: after ``unregister_gateway_notify`` the
-    teardown path calls ``mark_approval_tombstone``, and
-    ``reconcile_gateway_pending_mirror_locked`` will refuse to create new
-    mirrors from the live gateway queue for tombstoned sessions.
+    The post-unregister re-enqueue race is closed by the generation-aware
+    notify ownership: after ``unregister_gateway_notify`` the teardown path
+    calls ``end_gateway_notify_ownership``, and any surviving callback that
+    fires with a stale generation signals only its exact entry.  For the
+    dead interval, ``reconcile_gateway_pending_mirror_locked`` still treats
+    the live gateway queue as empty for tombstoned sessions.
     """
     with _lock:
         head, total, changed = reconcile_gateway_pending_mirror_locked(session_key)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9543,6 +9543,7 @@ from api.route_approvals import (  # noqa: F401 — re-exports for backward comp
     reconcile_gateway_pending_mirror_locked,
     submit_gateway_pending_mirror,
     submit_pending,
+    force_clean_pending_approvals,
 )
 
 # Clarify prompts (optional -- graceful fallback if agent not available)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9544,6 +9544,9 @@ from api.route_approvals import (  # noqa: F401 — re-exports for backward comp
     submit_gateway_pending_mirror,
     submit_pending,
     force_clean_pending_approvals,
+    mark_approval_tombstone,
+    clear_approval_tombstone,
+    _approval_tombstones,
 )
 
 # Clarify prompts (optional -- graceful fallback if agent not available)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9544,8 +9544,8 @@ from api.route_approvals import (  # noqa: F401 — re-exports for backward comp
     submit_gateway_pending_mirror,
     submit_pending,
     force_clean_pending_approvals,
-    mark_approval_tombstone,
-    clear_approval_tombstone,
+    begin_gateway_notify_ownership,
+    end_gateway_notify_ownership,
     _approval_tombstones,
 )
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10159,6 +10159,17 @@ def _run_agent_streaming(
                     _cleanup_gateway_pending_mirror()
                 except Exception:
                     logger.debug("Failed to reconcile gateway approval mirror")
+            # Force-clean any orphaned pending-approval entries left by sub-agent
+            # threads that used the parent session key (#6100). After the parent
+            # agent thread finishes, any remaining approvals for this session are
+            # necessarily orphaned — contextvars weren't propagated to
+            # DaemonThreadPoolExecutor workers, so sub-agents fell back to the
+            # parent's session key from os.environ.
+            try:
+                from api.route_approvals import force_clean_pending_approvals
+                force_clean_pending_approvals(session_id)
+            except Exception:
+                pass
             if _clarify_registered and _unreg_clarify_notify is not None:
                 try:
                     _unreg_clarify_notify(session_id)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10154,22 +10154,26 @@ def _run_agent_streaming(
                     _unreg_notify(session_id)
                 except Exception:
                     logger.debug("Failed to unregister approval callback")
+                try:
+                    from api.route_approvals import mark_approval_tombstone
+                    mark_approval_tombstone(session_id)
+                except Exception:
+                    logger.debug("Failed to mark approval tombstone")
             if _cleanup_gateway_pending_mirror is not None:
                 try:
                     _cleanup_gateway_pending_mirror()
                 except Exception:
                     logger.debug("Failed to reconcile gateway approval mirror")
-            # Force-clean any orphaned pending-approval entries left by sub-agent
-            # threads that used the parent session key (#6100). After the parent
-            # agent thread finishes, any remaining approvals for this session are
-            # necessarily orphaned — contextvars weren't propagated to
-            # DaemonThreadPoolExecutor workers, so sub-agents fell back to the
-            # parent's session key from os.environ.
+            # Reconcile the approval mirror at stream teardown.
+            # Purges stale gateway mirrors while preserving live ones and
+            # non-gateway local entries.  The session-wide wipe that was
+            # here before (force_clean_pending_approvals) was too aggressive
+            # — it deleted approvals it did not own (#6100 / #6208).
             try:
                 from api.route_approvals import force_clean_pending_approvals
                 force_clean_pending_approvals(session_id)
             except Exception:
-                pass
+                logger.debug("Failed to force-clean pending approvals at teardown")
             if _clarify_registered and _unreg_clarify_notify is not None:
                 try:
                     _unreg_clarify_notify(session_id)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7406,10 +7406,25 @@ def _run_agent_streaming(
                 register_gateway_notify as _reg_notify,
                 unregister_gateway_notify as _unreg_notify,
             )
+            # Generation-aware enqueue ownership (#6208): open the notify
+            # ownership generation BEFORE registering the callback so a
+            # callback snapshotted by a worker from a previous stream is
+            # recognized as stale at enqueue time.
+            _approval_gen = None
+            try:
+                from api.route_approvals import begin_gateway_notify_ownership as _begin_gateway_notify_ownership
+                _approval_gen = _begin_gateway_notify_ownership(session_id)
+            except Exception:
+                _approval_gen = None
             def _approval_notify_cb(approval_data):
                 if _submit_pending_for_polling is not None:
                     try:
-                        _submit_pending_for_polling(session_id, approval_data)
+                        if not _submit_pending_for_polling(session_id, approval_data, generation=_approval_gen):
+                            # Stale callback: the owning stream has already
+                            # torn down (or a newer stream took ownership) —
+                            # the exact entry was signaled so the worker
+                            # unblocks; no mirror and no SSE event.
+                            return
                     except Exception:
                         logger.warning("Failed to mirror approval into WebUI polling state", exc_info=True)
                 put('approval', approval_data)
@@ -10155,10 +10170,10 @@ def _run_agent_streaming(
                 except Exception:
                     logger.debug("Failed to unregister approval callback")
                 try:
-                    from api.route_approvals import mark_approval_tombstone
-                    mark_approval_tombstone(session_id)
+                    from api.route_approvals import end_gateway_notify_ownership
+                    end_gateway_notify_ownership(session_id)
                 except Exception:
-                    logger.debug("Failed to mark approval tombstone")
+                    logger.debug("Failed to close approval notify ownership")
             if _cleanup_gateway_pending_mirror is not None:
                 try:
                     _cleanup_gateway_pending_mirror()

--- a/tests/test_approval_generation_ownership.py
+++ b/tests/test_approval_generation_ownership.py
@@ -1,0 +1,212 @@
+"""Regression tests for generation-aware gateway approval enqueue ownership.
+
+PR #6208 re-gate (issue #6100): the previous tombstone design left two
+lifecycle regressions —
+
+1. The callback-snapshot → late-enqueue race stayed open: a worker that
+   snapshotted the notify callback before teardown could append its
+   ``_ApprovalEntry`` AFTER ``unregister_gateway_notify`` drained the queue.
+   The WebUI tombstone hid the mirror but never removed or signaled that
+   agent-side entry, so the worker stayed blocked.
+
+2. The tombstone was never cleared: after the first teardown,
+   ``reconcile_gateway_pending_mirror_locked`` treated the session's gateway
+   queue as empty forever, so a second conversation turn on the same session
+   could not rebuild the typed pending mirror.
+
+The fix replaces the permanent session-id tombstone with generation-aware
+ownership: every register (``begin_gateway_notify_ownership``) and every
+teardown (``end_gateway_notify_ownership``) advances a per-session
+generation; the callback wrapper carries its generation and, when stale,
+signals ONLY its exact entry (``entry.data is approval`` — the agent's
+``_await_gateway_decision`` passes the same dict object to the callback) so
+the worker returns promptly without recreating a queue/mirror.
+"""
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from api import route_approvals as ra
+
+
+def _make_approval(approval_id: str, run_id: str | None = None) -> dict:
+    data = {
+        "command": "rm -rf /tmp/test",
+        "description": f"Approval {approval_id}",
+        "pattern_key": "dangerous_command",
+        "pattern_keys": ["dangerous_command"],
+        "approval_id": approval_id,
+        "choices": ["once", "session", "always", "deny"],
+    }
+    if run_id is not None:
+        data["run_id"] = run_id
+    return data
+
+
+def _drain_gateway_queue(session_key: str) -> None:
+    """Pop + signal all entries — mirrors unregister_gateway_notify's drain."""
+    with ra._lock:
+        entries = ra._gateway_queues.pop(session_key, [])
+    for entry in entries:
+        entry.event.set()
+
+
+def _cleanup(session_key: str) -> None:
+    with ra._lock:
+        ra._gateway_queues.pop(session_key, None)
+        ra._pending.pop(session_key, None)
+        ra._approval_tombstones.discard(session_key)
+        ra._gateway_notify_generations.pop(session_key, None)
+
+
+def test_stale_callback_late_enqueue_signals_exact_entry_no_mirror():
+    """Barrier: callback snapshot → unregister/teardown → late enqueue.
+
+    A worker that snapshotted the callback before teardown and then appends
+    its entry AFTER the queue was drained must not recreate a queue/mirror —
+    the stale callback signals only its exact entry so the worker returns
+    promptly (#6100 re-gate regression #1).
+    """
+    sid = "sess-6208-stale-late"
+    approval_data = _make_approval("appr-6208-stale-late", "run-6208-stale-late")
+    _cleanup(sid)
+
+    try:
+        # Stream start: a generation opens for the session.
+        gen = ra.begin_gateway_notify_ownership(sid)
+        assert gen == 1
+
+        # Deterministic barrier — the worker has ALREADY snapshotted the
+        # callback.  The stream tears down: unregister (pops the callback
+        # and drains the queue) + end ownership.
+        _drain_gateway_queue(sid)
+        ra.end_gateway_notify_ownership(sid)
+        assert sid in ra._approval_tombstones
+
+        # The worker loses the race and appends its entry AFTER the drain.
+        entry = SimpleNamespace(data=dict(approval_data), event=threading.Event(), result=None)
+        with ra._lock:
+            ra._gateway_queues.setdefault(sid, []).append(entry)
+
+        # The stale callback fires (captured generation is now stale).
+        mirrored = ra.submit_gateway_pending_mirror(sid, entry.data, generation=gen)
+
+        assert mirrored is False, "stale callback must not mirror"
+        assert entry.event.is_set(), "stale callback must signal the worker's exact entry"
+        with ra._lock:
+            queue = ra._gateway_queues.get(sid)
+            assert not queue, f"no queue residue expected, got {queue!r}"
+            assert sid not in ra._pending, "no mirror may reappear after teardown"
+    finally:
+        _cleanup(sid)
+
+
+def test_stale_callback_after_newer_stream_takeover_signals_only_own_entry():
+    """A stale callback must never wipe a newer stream's queue or mirror.
+
+    When a newer stream takes ownership of the session, a late callback from
+    the OLD stream must signal only its exact entry — the newer stream's
+    queue entries and typed mirror stay intact (#6208 regression #1, second
+    half).
+    """
+    sid = "sess-6208-newer-stream"
+    old_data = _make_approval("appr-6208-old", "run-6208-old")
+    new_data = _make_approval("appr-6208-new", "run-6208-new")
+    _cleanup(sid)
+
+    try:
+        # Turn 1 (old stream) opens ownership and enqueues.
+        gen_old = ra.begin_gateway_notify_ownership(sid)
+        entry_old = SimpleNamespace(data=dict(old_data), event=threading.Event(), result=None)
+        with ra._lock:
+            ra._gateway_queues.setdefault(sid, []).append(entry_old)
+        # Turn 1 tears down (drain + end ownership).
+        _drain_gateway_queue(sid)
+        ra.end_gateway_notify_ownership(sid)
+
+        # Turn 2 (newer stream) reopens the lifecycle and mirrors its head.
+        gen_new = ra.begin_gateway_notify_ownership(sid)
+        assert gen_new > gen_old
+        assert sid not in ra._approval_tombstones, "tombstone must reopen for the next turn"
+        entry_new = SimpleNamespace(data=dict(new_data), event=threading.Event(), result=None)
+        with ra._lock:
+            ra._gateway_queues.setdefault(sid, []).append(entry_new)
+        assert ra.submit_gateway_pending_mirror(sid, entry_new.data, generation=gen_new) is True
+        with ra._lock:
+            pending = ra._pending[sid]
+            assert pending[0]["approval_id"] == new_data["approval_id"]
+            assert pending[0]["run_id"] == new_data["run_id"]
+            assert pending[0].get(ra._GATEWAY_MIRROR_FLAG) is True
+
+        # The OLD worker's late enqueue now lands in the newer stream's queue.
+        with ra._lock:
+            ra._gateway_queues.setdefault(sid, []).append(entry_old)
+        assert ra.submit_gateway_pending_mirror(sid, entry_old.data, generation=gen_old) is False
+
+        assert entry_old.event.is_set(), "stale entry must be signaled"
+        assert not entry_new.event.is_set(), "newer stream's live entry must be untouched"
+        with ra._lock:
+            queue = ra._gateway_queues.get(sid) or []
+            assert entry_new in queue, "newer stream's entry must survive"
+            assert entry_old not in queue, "stale entry must be removed"
+            pending = ra._pending.get(sid)
+            assert pending and pending[0]["approval_id"] == new_data["approval_id"], (
+                "mirror must still reflect the newer stream's head"
+            )
+    finally:
+        _cleanup(sid)
+
+
+def test_second_turn_same_session_rebuilds_typed_gateway_mirror():
+    """Regression #2: a second sequential turn rebuilds the typed mirror.
+
+    The permanent session-id tombstone made
+    ``reconcile_gateway_pending_mirror_locked`` treat the session's gateway
+    queue as empty forever.  With generation-aware ownership the lifecycle
+    reopens on the next registration, so the second turn can create a typed
+    mirror carrying its own approval_id and run_id.
+    """
+    sid = "sess-6208-two-turns"
+    turn1_data = _make_approval("appr-6208-turn1", "run-6208-turn1")
+    turn2_data = _make_approval("appr-6208-turn2", "run-6208-turn2")
+    _cleanup(sid)
+
+    try:
+        # ── Turn 1: register, enqueue, mirror, teardown ──────────────────
+        gen1 = ra.begin_gateway_notify_ownership(sid)
+        entry1 = SimpleNamespace(data=dict(turn1_data), event=threading.Event(), result=None)
+        with ra._lock:
+            ra._gateway_queues.setdefault(sid, []).append(entry1)
+        assert ra.submit_gateway_pending_mirror(sid, entry1.data, generation=gen1) is True
+        with ra._lock:
+            assert ra._pending[sid][0]["approval_id"] == turn1_data["approval_id"]
+            assert ra._pending[sid][0]["run_id"] == turn1_data["run_id"]
+            assert ra._pending[sid][0].get(ra._GATEWAY_MIRROR_FLAG) is True
+
+        _drain_gateway_queue(sid)
+        ra.end_gateway_notify_ownership(sid)
+        ra.force_clean_pending_approvals(sid)
+        with ra._lock:
+            assert sid not in ra._pending, "turn-1 stale mirror must be purged"
+            assert sid in ra._approval_tombstones
+
+        # ── Turn 2: same session — lifecycle must reopen ─────────────────
+        gen2 = ra.begin_gateway_notify_ownership(sid)
+        assert gen2 > gen1
+        assert sid not in ra._approval_tombstones, (
+            "tombstone must be cleared/advanced before registering the next callback"
+        )
+        entry2 = SimpleNamespace(data=dict(turn2_data), event=threading.Event(), result=None)
+        with ra._lock:
+            ra._gateway_queues.setdefault(sid, []).append(entry2)
+        assert ra.submit_gateway_pending_mirror(sid, entry2.data, generation=gen2) is True
+
+        with ra._lock:
+            pending = ra._pending.get(sid)
+            assert pending, "second turn must rebuild the typed gateway approval mirror"
+            assert pending[0]["approval_id"] == turn2_data["approval_id"]
+            assert pending[0]["run_id"] == turn2_data["run_id"]
+            assert pending[0].get(ra._GATEWAY_MIRROR_FLAG) is True
+    finally:
+        _cleanup(sid)

--- a/tests/test_approval_sse.py
+++ b/tests/test_approval_sse.py
@@ -113,10 +113,12 @@ class TestSSEStaticAnalysis:
         cb_start = streaming_src.find("def _approval_notify_cb(approval_data):")
         cb_end = streaming_src.find("_reg_notify(session_id, _approval_notify_cb)", cb_start)
         cb_body = streaming_src[cb_start:cb_end]
-        assert "_submit_pending_for_polling(session_id, approval_data)" in cb_body, \
+        assert "_submit_pending_for_polling(session_id, approval_data, generation=" in cb_body, \
             "_approval_notify_cb must mirror approval data into polling state before SSE"
         assert "put('approval', approval_data)" in cb_body, \
             "_approval_notify_cb must still emit the approval SSE event"
+        assert cb_body.find("put('approval', approval_data)") > cb_body.find("_submit_pending_for_polling"), \
+            "_approval_notify_cb must mirror polling state before the SSE push"
 
     def test_unsubscribe_in_finally(self):
         """SSE handler must unsubscribe in a finally block."""

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -232,10 +232,12 @@ class TestApprovalModuleExports:
         assert cb_start != -1, "_approval_notify_cb must exist"
         cb_end = STREAMING_SRC.find("_reg_notify(session_id, _approval_notify_cb)", cb_start)
         cb_body = STREAMING_SRC[cb_start:cb_end]
-        assert "_submit_pending_for_polling(session_id, approval_data)" in cb_body, \
+        assert "_submit_pending_for_polling(session_id, approval_data, generation=" in cb_body, \
             "approval notify callback must mirror approval data into polling state"
         assert "put('approval', approval_data)" in cb_body, \
             "approval notify callback must still push the SSE event"
+        assert cb_body.find("put('approval', approval_data)") > cb_body.find("_submit_pending_for_polling"), \
+            "approval notify callback must mirror polling state before the SSE push"
 
 
 # ── HTTP regression tests (test server, port 8788) ───────────────────────────


### PR DESCRIPTION
## Summary

Fixes #6100 — Sub-agent command approvals leaking into parent session's attention queue.

### Root cause

When a sub-agent (spawned via `delegate_task`) encounters a dangerous command in a WebUI/gateway session, the approval request uses the **parent's session key** because `contextvars` aren't propagated to `DaemonThreadPoolExecutor` worker threads. The sub-agent's gateway approval falls back to `os.getenv("HERMES_SESSION_KEY")` which resolves to the parent's session ID.

This creates stale entries in:
1. `_pending[parent_session_id]` (WebUI side)
2. `_gateway_queues[parent_session_id]` (agent side)

After parent stream teardown, these orphan entries persist → phantom red dot.

### Fix

1. **`api/route_approvals.py`** — New `force_clean_pending_approvals()` function that removes all pending-approval entries for a session key under lock and notifies SSE subscribers (clears red dot immediately)
2. **`api/streaming.py`** — Call `force_clean_pending_approvals` at parent stream teardown (after existing `_cleanup_gateway_pending_mirror`)
3. **`api/gateway_chat.py`** — Track agent nature in session metadata to scope sub-agent approvals
4. **`api/routes.py`** — Expose agent nature for UI awareness