### PR TITLE
fix(wakeup): recover process completions after restart

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1365,11 +1365,12 @@ def _drain_loop() -> None:
 def recover_processes_for_webui(process_registry=None, get_session_fn=None) -> int:
     """Recover core background processes and restore WebUI routing metadata.
 
-    The core gateway performs this during gateway startup, but the standalone
-    source WebUI is a different host and previously started only the queue
-    drain. That left checkpointed processes invisible after a WebUI restart.
+    The core gateway performs this during gateway startup, but this WebUI host
+    previously started only the queue drain. That left checkpointed processes
+    invisible after a WebUI restart.
     """
     global _PROCESS_RECOVERY_DONE
+
     if _PROCESS_RECOVERY_DONE:
         return 0
     if process_registry is None:

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1362,7 +1362,7 @@ def _drain_loop() -> None:
             logger.warning("bg_task_complete event handling failed", exc_info=True)
 
 
-def recover_processes_for_webui() -> int:
+def recover_processes_for_webui(process_registry=None, get_session_fn=None) -> int:
     """Recover core background processes and restore WebUI routing metadata.
 
     The core gateway performs this during gateway startup, but the standalone
@@ -1372,7 +1372,17 @@ def recover_processes_for_webui() -> int:
     global _PROCESS_RECOVERY_DONE
     if _PROCESS_RECOVERY_DONE:
         return 0
-    from tools.process_registry import process_registry
+    if process_registry is None:
+        try:
+            from tools.process_registry import process_registry
+        except ImportError:
+            # Hermes Agent is optional in isolated WebUI/test environments.
+            # The drain loop already treats a missing registry as unavailable;
+            # startup recovery must preserve that fail-soft contract.
+            logger.debug("process recovery unavailable: Hermes Agent is not installed")
+            return 0
+    if get_session_fn is None:
+        from api.models import get_session as get_session_fn
 
     recovered = process_registry.recover_from_checkpoint()
     for row in process_registry.list_sessions():
@@ -1380,8 +1390,7 @@ def recover_processes_for_webui() -> int:
         if not session_key:
             continue
         try:
-            from api.models import get_session
-            if get_session(session_key, metadata_only=True) is None:
+            if get_session_fn(session_key, metadata_only=True) is None:
                 continue
         except Exception:
             logger.debug(

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 _DRAIN_THREAD: Optional[threading.Thread] = None
 _DRAIN_STOP = threading.Event()
+_PROCESS_RECOVERY_DONE = False
 
 _REAPER_THREAD: Optional[threading.Thread] = None
 _REAPER_STOP = threading.Event()
@@ -1361,6 +1362,41 @@ def _drain_loop() -> None:
             logger.warning("bg_task_complete event handling failed", exc_info=True)
 
 
+def recover_processes_for_webui() -> int:
+    """Recover core background processes and restore WebUI routing metadata.
+
+    The core gateway performs this during gateway startup, but the standalone
+    source WebUI is a different host and previously started only the queue
+    drain. That left checkpointed processes invisible after a WebUI restart.
+    """
+    global _PROCESS_RECOVERY_DONE
+    if _PROCESS_RECOVERY_DONE:
+        return 0
+    from tools.process_registry import process_registry
+
+    recovered = process_registry.recover_from_checkpoint()
+    for row in process_registry.list_sessions():
+        session_key = str(row.get("session_key") or "")
+        if not session_key:
+            continue
+        try:
+            from api.models import get_session
+            if get_session(session_key, metadata_only=True) is None:
+                continue
+        except Exception:
+            logger.debug(
+                "Could not validate recovered WebUI session %r",
+                session_key,
+                exc_info=True,
+            )
+            continue
+        register_process_session(session_key, session_key)
+    _PROCESS_RECOVERY_DONE = True
+    if recovered:
+        logger.info("Recovered %d background process(es) for WebUI", recovered)
+    return recovered
+
+
 def register_process_session(session_key: str, session_id: str) -> None:
     """Bind a process-registry session_key to a WebUI session_id.
 
@@ -1407,6 +1443,7 @@ def start_drain_thread() -> bool:
     with _THREAD_LIFECYCLE_LOCK:
         if _DRAIN_THREAD is not None and _DRAIN_THREAD.is_alive():
             return False
+        recover_processes_for_webui()
         _DRAIN_STOP.clear()
         _DRAIN_THREAD = threading.Thread(
             target=_drain_loop,

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -1386,16 +1386,18 @@ def recover_processes_for_webui(process_registry=None, get_session_fn=None) -> i
 
     recovered = process_registry.recover_from_checkpoint()
     for row in process_registry.list_sessions():
-        session_key = str(row.get("session_key") or "")
-        if not session_key:
+        process_id = str(row.get("session_id") or "")
+        if not process_id:
             continue
         try:
-            if get_session_fn(session_key, metadata_only=True) is None:
+            proc_session = process_registry.get(process_id)
+            session_key = str(getattr(proc_session, "session_key", "") or "")
+            if not session_key or get_session_fn(session_key, metadata_only=True) is None:
                 continue
         except Exception:
             logger.debug(
-                "Could not validate recovered WebUI session %r",
-                session_key,
+                "Could not resolve recovered WebUI process %r",
+                process_id,
                 exc_info=True,
             )
             continue
@@ -1452,7 +1454,12 @@ def start_drain_thread() -> bool:
     with _THREAD_LIFECYCLE_LOCK:
         if _DRAIN_THREAD is not None and _DRAIN_THREAD.is_alive():
             return False
-        recover_processes_for_webui()
+        try:
+            recover_processes_for_webui()
+        except Exception:
+            # Recovery is best-effort. A corrupt checkpoint or transient I/O
+            # error must not disable notifications for newly spawned tasks.
+            logger.warning("background process recovery failed", exc_info=True)
         _DRAIN_STOP.clear()
         _DRAIN_THREAD = threading.Thread(
             target=_drain_loop,

--- a/tests/test_background_process_restart_recovery.py
+++ b/tests/test_background_process_restart_recovery.py
@@ -1,0 +1,58 @@
+"""Regression coverage for notify_on_complete across a WebUI restart."""
+
+from types import SimpleNamespace
+
+from api import background_process as bp
+
+
+class _FakeThread:
+    def __init__(self, *args, **kwargs):
+        self.started = False
+
+    def is_alive(self):
+        return self.started
+
+    def start(self):
+        self.started = True
+
+
+def test_start_drain_thread_invokes_recovery(monkeypatch):
+    calls = []
+    monkeypatch.setattr(bp, "_DRAIN_THREAD", None)
+    monkeypatch.setattr(bp, "recover_processes_for_webui", lambda: calls.append("recover") or 0)
+    monkeypatch.setattr(bp.threading, "Thread", _FakeThread)
+
+    assert bp.start_drain_thread() is True
+    assert calls == ["recover"]
+
+
+def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
+    calls = {"recover": 0, "registered": []}
+
+    class FakeRegistry:
+        def recover_from_checkpoint(self):
+            calls["recover"] += 1
+            return 1
+
+        def list_sessions(self):
+            return [{
+                "session_id": "proc_recovered",
+                "session_key": "webui-session",
+                "detached": True,
+            }]
+
+    fake_registry = FakeRegistry()
+    monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
+    monkeypatch.setattr(bp, "register_process_session", lambda key, sid: calls["registered"].append((key, sid)))
+
+    import tools.process_registry as pr_mod
+    monkeypatch.setattr(pr_mod, "process_registry", fake_registry)
+    import api.models as models
+    monkeypatch.setattr(models, "get_session", lambda sid, metadata_only=False: SimpleNamespace(id=sid))
+
+    assert bp.recover_processes_for_webui() == 1
+    assert bp.recover_processes_for_webui() == 0
+    assert calls == {
+        "recover": 1,
+        "registered": [("webui-session", "webui-session")],
+    }

--- a/tests/test_background_process_restart_recovery.py
+++ b/tests/test_background_process_restart_recovery.py
@@ -43,16 +43,33 @@ def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
 
     fake_registry = FakeRegistry()
     monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
-    monkeypatch.setattr(bp, "register_process_session", lambda key, sid: calls["registered"].append((key, sid)))
+    monkeypatch.setattr(
+        bp,
+        "register_process_session",
+        lambda key, sid: calls["registered"].append((key, sid)),
+    )
 
-    import tools.process_registry as pr_mod
-    monkeypatch.setattr(pr_mod, "process_registry", fake_registry)
-    import api.models as models
-    monkeypatch.setattr(models, "get_session", lambda sid, metadata_only=False: SimpleNamespace(id=sid))
+    def get_session(sid, metadata_only=False):
+        return SimpleNamespace(id=sid)
 
-    assert bp.recover_processes_for_webui() == 1
-    assert bp.recover_processes_for_webui() == 0
+    assert bp.recover_processes_for_webui(fake_registry, get_session) == 1
+    assert bp.recover_processes_for_webui(fake_registry, get_session) == 0
     assert calls == {
         "recover": 1,
         "registered": [("webui-session", "webui-session")],
     }
+
+
+def test_recovery_is_fail_soft_without_agent(monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tools.process_registry":
+            raise ImportError("Hermes Agent not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    assert bp.recover_processes_for_webui() == 0
+    assert bp._PROCESS_RECOVERY_DONE is False

--- a/tests/test_background_process_restart_recovery.py
+++ b/tests/test_background_process_restart_recovery.py
@@ -16,6 +16,11 @@ class _FakeThread:
         self.started = True
 
 
+class _FakeProcessSession:
+    def __init__(self, session_key):
+        self.session_key = session_key
+
+
 def test_start_drain_thread_invokes_recovery(monkeypatch):
     calls = []
     monkeypatch.setattr(bp, "_DRAIN_THREAD", None)
@@ -24,6 +29,19 @@ def test_start_drain_thread_invokes_recovery(monkeypatch):
 
     assert bp.start_drain_thread() is True
     assert calls == ["recover"]
+
+
+def test_start_drain_thread_survives_recovery_failure(monkeypatch):
+    def fail_recovery():
+        raise OSError("corrupt checkpoint")
+
+    monkeypatch.setattr(bp, "_DRAIN_THREAD", None)
+    monkeypatch.setattr(bp, "recover_processes_for_webui", fail_recovery)
+    monkeypatch.setattr(bp.threading, "Thread", _FakeThread)
+
+    assert bp.start_drain_thread() is True
+    assert bp._DRAIN_THREAD is not None
+    assert bp._DRAIN_THREAD.is_alive()
 
 
 def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
@@ -37,9 +55,12 @@ def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
         def list_sessions(self):
             return [{
                 "session_id": "proc_recovered",
-                "session_key": "webui-session",
                 "detached": True,
             }]
+
+        def get(self, process_id):
+            assert process_id == "proc_recovered"
+            return _FakeProcessSession("webui-session")
 
     fake_registry = FakeRegistry()
     monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)


### PR DESCRIPTION
## Summary

I found that WebUI started the process-completion drain but never recovered checkpointed Hermes Agent background processes after a WebUI restart.

This change:

- calls `ProcessRegistry.recover_from_checkpoint()` before starting the drain thread;
- rebuilds `PROCESS_SESSION_INDEX` from recovered processes whose `session_key` still names a persisted WebUI session;
- keeps startup recovery idempotent.

Together with the companion Hermes Agent change, a `notify_on_complete` process now survives a WebUI restart and wakes its original session when it later exits.

## Root cause

The gateway host already performs process checkpoint recovery during startup, but WebUI only started `api.background_process`'s queue drain. A restarted WebUI therefore had an empty in-memory process registry and no route for the still-running child.

## Validation

- related WebUI wakeup suite: **31 passed**
- focused recovery/notification suite: **15 passed**
- `py_compile` passed for both changed files.
- mutation checks:
  - removing the startup recovery call makes `test_start_drain_thread_invokes_recovery` fail;
  - making a missing Agent import fatal makes `test_recovery_is_fail_soft_without_agent` fail.
- CI initially exposed that isolated WebUI shards do not install Hermes Agent. Commit `2ff238dc` preserved the existing optional-dependency contract by making startup recovery fail-soft when `tools.process_registry` is unavailable; both the direct regression test and the pre-existing concurrent-start test now pass locally.

### End-to-end restart test

I launched a real 300-second background process with `notify_on_complete=True`, restarted WebUI while the child remained alive, and made no polling calls afterward.

- WebUI restart: `15:00:21` to healthy at `15:00:36`
- child completion: `15:04:50`
- autonomous wakeup turn in the original session: `15:04:51`

## Relationship to overlapping PRs

This is complementary to #6185 and #6002, which change completion ownership/routing inside `_process_one`, and to #6159, which adds durable claims for `async_delegation` events.

The hunks are disjoint: those PRs modify routing/claim logic around `_process_one` (roughly lines 822-1266), while this PR adds startup recovery after the drain loop and wires it into `start_drain_thread` (roughly lines 1362-1444).

It is not a duplicate and does not alter async-delegation claim/ack behavior. It restores ordinary checkpointed `proc_*` OS processes and then lets the existing routing/claim paths consume the resulting event.

## Dependency

This PR depends on NousResearch/hermes-agent#66796 for two core guarantees: final notification metadata must be present in the checkpoint, and recovered detached processes must autonomously detect exit. Without the core change, WebUI recovery alone cannot provide the full restart-safe behavior.
