### PR TITLE
fix(ui): resolve folder download URL against document.baseURI

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -19771,9 +19771,9 @@ function _showFileContextMenu(e, item){
     dlItem.onmouseleave=()=>dlItem.style.background='';
     dlItem.onclick=()=>{
       menu.remove();
-      const url='/api/folder/download?session_id='+encodeURIComponent(S.session.session_id)
+      const rel='/api/folder/download?session_id='+encodeURIComponent(S.session.session_id)
               + '&path='+encodeURIComponent(item.path||'');
-      window.location.href=url;
+      window.location.href=new URL(rel.slice(1), document.baseURI||location.href).href;
     };
     menu.appendChild(dlItem);
   }


### PR DESCRIPTION
When Hermes WebUI is served behind a reverse proxy with a path prefix (e.g. /hermes/), the right-click → "Download Folder" context menu option navigates to a root-absolute URL (/api/folder/download?...), which resolves to the server origin instead of the proxy mount point, causing a 404.

This matches the pattern already used by the workspace.js route helper refactored in v0.52.41 (commit 1a64d7d3).