### PR TITLE
fix(config): route MCP and skills config writes through the agent's persistence layer

### DIFF
--- a/api/agent_config_bridge.py
+++ b/api/agent_config_bridge.py
@@ -1,0 +1,212 @@
+"""Shared write path into the Hermes agent's configuration.
+
+The WebUI historically wrote ``config.yaml`` through its own
+``yaml.safe_dump`` serializer (``api.config._save_yaml_config_file``).
+That writer is correct for value round-trips but destroys user comments
+and formatting, skips the agent's ``mcp_security`` validation, and stores
+secrets inline instead of routing them to ``.env``.
+
+This module routes admin writes through the agent's own persistence layer
+(``hermes_cli.config.save_config`` — comment-preserving Ruamel round-trip,
+atomic write, managed-scope aware) when the agent checkout is importable,
+using the context-local Hermes-home override so writes land in the active
+WebUI profile's home without mutating process-global environment.
+
+Fallback behavior is deliberately two-tiered:
+
+- No agent checkout discovered (standalone WebUI deployments, CI): callers
+  keep using the legacy WebUI writer — behavior is unchanged from before
+  this module existed.
+- Agent checkout discovered but the import fails (broken checkout,
+  unsupported layout): raise ``AgentBridgeUnavailable`` instead of silently
+  falling back, so a mis-wired deployment cannot half-apply admin writes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from api.config import _AGENT_DIR
+
+logger = logging.getLogger(__name__)
+
+_import_lock = threading.Lock()
+_import_state: Optional[str] = None  # None=unprobed, "ok", "unavailable:<reason>"
+
+
+class AgentBridgeUnavailable(RuntimeError):
+    """Agent checkout exists but its config layer could not be imported."""
+
+
+def agent_dir_configured() -> bool:
+    """True when an agent checkout was discovered at startup."""
+    return _AGENT_DIR is not None
+
+
+def _probe_import() -> str:
+    """Import the agent config layer once; cache the outcome."""
+    global _import_state
+    if _import_state is not None:
+        return _import_state
+    with _import_lock:
+        if _import_state is not None:
+            return _import_state
+        if os.getenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "").strip().lower() in {"1", "true", "yes", "on"}:
+            # Explicit operator kill-switch: behave exactly like a standalone
+            # deployment (legacy writer), e.g. to rule the bridge out while
+            # debugging or to pin pre-bridge behavior.
+            _import_state = "unavailable:disabled via HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE"
+            return _import_state
+        if _AGENT_DIR is None:
+            _import_state = "unavailable:no agent checkout discovered"
+            return _import_state
+        try:
+            import hermes_constants  # noqa: F401
+            from hermes_cli import config as _agent_config  # noqa: F401
+
+            for required in ("save_config", "load_config", "save_env_value"):
+                if not callable(getattr(_agent_config, required, None)):
+                    raise ImportError(f"hermes_cli.config.{required} missing")
+            _import_state = "ok"
+        except BaseException as exc:  # ImportError, SyntaxError, SystemExit guards
+            logger.warning("agent config bridge unavailable: %s", exc)
+            _import_state = f"unavailable:{exc}"
+    return _import_state
+
+
+def bridge_available() -> bool:
+    """True when writes can be routed through the agent's persistence layer."""
+    return _probe_import() == "ok"
+
+
+def require_bridge() -> None:
+    """Raise ``AgentBridgeUnavailable`` when an agent checkout exists but the
+    bridge cannot import it. No-op in standalone mode (no checkout at all)
+    and when the operator kill-switch explicitly disabled the bridge."""
+    state = _probe_import()
+    if state == "ok":
+        return
+    if not agent_dir_configured():
+        return
+    if state.startswith("unavailable:disabled via"):
+        return
+    raise AgentBridgeUnavailable(state.split(":", 1)[1] if ":" in state else state)
+
+
+@contextmanager
+def scoped_agent_home(home: Path):
+    """Scope agent-side path resolution to *home* for the current context.
+
+    Uses the agent's context-local override (a ``ContextVar``) so concurrent
+    requests against different WebUI profiles cannot cross-write each other's
+    ``config.yaml``/``.env`` — unlike an ``os.environ`` mutation, which is
+    process-global.
+    """
+    import hermes_constants
+
+    token = hermes_constants.set_hermes_home_override(str(home))
+    try:
+        yield
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+
+# ── config.yaml ──────────────────────────────────────────────────────────────
+
+def load_agent_config(home: Path) -> Dict[str, Any]:
+    from hermes_cli.config import load_config
+
+    with scoped_agent_home(home):
+        return load_config()
+
+
+def save_agent_config(config: Dict[str, Any], home: Path) -> None:
+    """Persist *config* through the agent's comment-preserving writer."""
+    from hermes_cli.config import save_config
+
+    with scoped_agent_home(home):
+        save_config(config)
+
+
+# ── MCP servers ──────────────────────────────────────────────────────────────
+
+def validate_mcp_entry(name: str, entry: Dict[str, Any]) -> List[str]:
+    """Return security-validation issues for one MCP server entry."""
+    from hermes_cli.mcp_security import validate_mcp_server_entry
+
+    return list(validate_mcp_server_entry(name, entry) or [])
+
+
+def save_mcp_server(name: str, server_config: Dict[str, Any], home: Path) -> List[str]:
+    """Validate and persist one MCP server. Returns issues; empty on success."""
+    issues = validate_mcp_entry(name, server_config)
+    if issues:
+        return issues
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        config.setdefault("mcp_servers", {})[name] = server_config
+        save_config(config)
+    return []
+
+
+def remove_mcp_server(name: str, home: Path) -> bool:
+    """Remove one MCP server. Returns True when it existed."""
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        servers = config.get("mcp_servers", {})
+        if not isinstance(servers, dict) or name not in servers:
+            return False
+        del servers[name]
+        if servers:
+            config["mcp_servers"] = servers
+        else:
+            config.pop("mcp_servers", None)
+        save_config(config)
+    return True
+
+
+def set_mcp_server_enabled(name: str, enabled: bool, home: Path) -> bool:
+    """Flip one server's ``enabled`` flag. Returns False when it is missing."""
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        servers = config.get("mcp_servers", {})
+        if not isinstance(servers, dict) or not isinstance(servers.get(name), dict):
+            return False
+        servers[name]["enabled"] = bool(enabled)
+        config["mcp_servers"] = servers
+        save_config(config)
+    return True
+
+
+def save_mcp_bearer_token(name: str, token: str, home: Path) -> Dict[str, str]:
+    """Store a bearer token in the profile's ``.env`` and return the header
+    template (``Authorization: Bearer ${MCP_<NAME>_API_KEY}``) to persist in
+    ``config.yaml`` — matching the agent CLI/Dashboard convention so secrets
+    never land in YAML."""
+    from hermes_cli.mcp_config import _save_bearer_auth_token
+
+    with scoped_agent_home(home):
+        return _save_bearer_auth_token(name, token)
+
+
+# ── skills config (enable/disable lists) ─────────────────────────────────────
+
+def save_skills_config(skills_cfg: Dict[str, Any], home: Path) -> None:
+    """Persist the ``skills`` section (disabled / platform_disabled lists)."""
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        config["skills"] = skills_cfg
+        save_config(config)

--- a/api/routes.py
+++ b/api/routes.py
@@ -25133,6 +25133,30 @@ def _handle_skill_toggle(handler, body):
     if not skill_md:
         return bad(handler, f"Skill '{name}' not found", 404)
 
+    from api import agent_config_bridge as _bridge
+
+    if _bridge.bridge_available():
+        home = get_active_hermes_home()
+        with _cfg_lock:
+            cfg = _bridge.load_agent_config(home)
+            skills_cfg = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
+            skills_cfg["disabled"] = _toggle_name_in_list(
+                skills_cfg.get("disabled"), name, enabled
+            )
+            platform_disabled = skills_cfg.get("platform_disabled")
+            if isinstance(platform_disabled, dict) and "webui" in platform_disabled:
+                platform_disabled["webui"] = _toggle_name_in_list(
+                    platform_disabled["webui"], name, enabled
+                )
+            _bridge.save_skills_config(skills_cfg, home)
+        reload_config()
+        _SKILLS_STATS_CACHE.clear()
+        return j(handler, {"ok": True, "name": name, "enabled": enabled})
+    try:
+        _bridge.require_bridge()
+    except _bridge.AgentBridgeUnavailable as exc:
+        return j(handler, {"error": f"Agent config layer unavailable: {exc}"}, status=503)
+
     config_path = _active_profile_config_path()
     with _cfg_lock:
         cfg = _load_yaml_config_file(config_path)
@@ -26358,12 +26382,43 @@ def _handle_mcp_servers_list(handler):
     })
 
 
+def _mcp_bridge_or_legacy(handler):
+    """Resolve the MCP write path for this request.
+
+    Returns ``(use_bridge, home)`` or ``None`` after answering the request
+    when the agent checkout is configured but not importable (fail closed —
+    a half-wired deployment must not silently fall back to the legacy
+    comment-destroying writer).
+    """
+    from api import agent_config_bridge as _bridge
+
+    if _bridge.bridge_available():
+        return True, get_active_hermes_home()
+    try:
+        _bridge.require_bridge()
+    except _bridge.AgentBridgeUnavailable as exc:
+        j(handler, {"error": f"Agent config layer unavailable: {exc}"}, status=503)
+        return None
+    return False, None
+
+
 def _handle_mcp_server_delete(handler, name):
     """Delete an MCP server by name."""
     from urllib.parse import unquote
     name = unquote(name)
     if not name:
         return bad(handler, "name is required")
+    route = _mcp_bridge_or_legacy(handler)
+    if route is None:
+        return True
+    use_bridge, home = route
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        if not _bridge.remove_mcp_server(name, home):
+            return bad(handler, f"MCP server '{name}' not found", 404)
+        reload_config()
+        return j(handler, {"ok": True, "deleted": name})
     cfg = get_config()
     servers = cfg.get("mcp_servers", {})
     if not isinstance(servers, dict):
@@ -26386,6 +26441,17 @@ def _handle_mcp_server_toggle(handler, name, body):
     if "enabled" not in body:
         return bad(handler, "enabled field is required")
     enabled = bool(body["enabled"])
+    route = _mcp_bridge_or_legacy(handler)
+    if route is None:
+        return True
+    use_bridge, home = route
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        if not _bridge.set_mcp_server_enabled(name, enabled, home):
+            return bad(handler, f"MCP server '{name}' not found", 404)
+        reload_config()
+        return j(handler, {"ok": True, "name": name, "enabled": enabled})
     cfg = get_config()
     servers = cfg.get("mcp_servers", {})
     if not isinstance(servers, dict):
@@ -26427,6 +26493,10 @@ def _handle_mcp_server_update(handler, name, body):
     name = unquote(name)
     if not name:
         return bad(handler, "name is required")
+    route = _mcp_bridge_or_legacy(handler)
+    if route is None:
+        return True
+    use_bridge, home = route
     # Validate: must have url (http) or command (stdio)
     server_cfg = {}
     cfg = get_config()
@@ -26451,6 +26521,27 @@ def _handle_mcp_server_update(handler, name, body):
             server_cfg["timeout"] = int(body["timeout"])
         except (ValueError, TypeError):
             pass
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        bearer_token = str(body.get("bearer_token") or "").strip()
+        if bearer_token and bearer_token != _MASKED_PLACEHOLDER:
+            # Secret goes to the profile's .env; config.yaml only stores the
+            # ${MCP_<NAME>_API_KEY} interpolation template (agent convention).
+            try:
+                token_headers = _bridge.save_mcp_bearer_token(name, bearer_token, home)
+            except ValueError as exc:
+                return bad(handler, str(exc))
+            merged_headers = dict(server_cfg.get("headers") or {})
+            merged_headers.update(token_headers)
+            server_cfg["headers"] = merged_headers
+        issues = _bridge.save_mcp_server(name, server_cfg, home)
+        if issues:
+            return j(handler, {"error": "Server configuration rejected", "issues": issues}, status=400)
+        reload_config()
+        return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
+    if body.get("bearer_token"):
+        return bad(handler, "bearer_token requires a Hermes agent checkout (set HERMES_WEBUI_AGENT_DIR); use headers instead")
     servers[name] = server_cfg
     cfg["mcp_servers"] = servers
     _save_yaml_config_file(_get_config_path(), cfg)

--- a/api/routes.py
+++ b/api/routes.py
@@ -26499,11 +26499,30 @@ def _handle_mcp_server_update(handler, name, body):
     use_bridge, home = route
     # Validate: must have url (http) or command (stdio)
     server_cfg = {}
-    cfg = get_config()
-    servers = cfg.get("mcp_servers", {})
-    if not isinstance(servers, dict):
-        servers = {}
-    existing_cfg = servers.get(name, {})
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        # Read the existing server through the SAME home-scoped bridge
+        # reader the write path below uses — not the WebUI's own get_config()
+        # cache. The two can diverge (different profile resolution, stale
+        # in-memory cache), which would make _strip_masked_values() below
+        # miss the real header/env value and silently persist the literal
+        # •••••• placeholder as the "secret" instead of preserving the
+        # original (a quiet secret loss, not a leak).
+        try:
+            agent_cfg = _bridge.load_agent_config(home)
+        except Exception:
+            agent_cfg = {}
+        agent_servers = agent_cfg.get("mcp_servers", {})
+        if not isinstance(agent_servers, dict):
+            agent_servers = {}
+        existing_cfg = agent_servers.get(name, {})
+    else:
+        cfg = get_config()
+        servers = cfg.get("mcp_servers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+        existing_cfg = servers.get(name, {})
     if body.get("url"):
         server_cfg["url"] = body["url"].strip()
         if body.get("headers"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,14 @@ requires_fork = pytest.mark.skipif(
 # conftest.py lives at <repo>/tests/conftest.py
 TESTS_DIR  = pathlib.Path(__file__).parent.resolve()
 REPO_ROOT  = TESTS_DIR.parent.resolve()
+
+# Force the agent-config bridge (api/agent_config_bridge.py) to its standalone
+# fallback for the whole test run, including spawned server subprocesses, which
+# inherit this environment. On developer machines the agent-dir discovery would
+# otherwise find a real checkout (e.g. ~/.hermes/hermes-agent) and route config
+# writes through it — making unit tests machine-dependent. Bridge-specific tests
+# opt back in by clearing this variable and resetting the probe cache.
+os.environ.setdefault("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "1")
 HOME       = pathlib.Path.home()
 HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes')))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,22 @@ REPO_ROOT  = TESTS_DIR.parent.resolve()
 # otherwise find a real checkout (e.g. ~/.hermes/hermes-agent) and route config
 # writes through it — making unit tests machine-dependent. Bridge-specific tests
 # opt back in by clearing this variable and resetting the probe cache.
+#
+# Deliberately module-level (not a fixture) and never torn down:
+#   - It must be set before the FIRST subprocess spawn, which can happen from a
+#     session-scoped fixture; a fixture-based kill-switch would only be
+#     guaranteed to run first via fixture-ordering dependencies, which is more
+#     fragile than "first thing conftest.py does on import" and risks a server
+#     subprocess spawning before the switch is set — silently defeating it.
+#   - No teardown is needed: this mutates only this pytest process's own
+#     os.environ, which does not outlive the process. It cannot leak into the
+#     real `hermes-webui` service — that runs as a separate OS process (its own
+#     systemd unit / shell session) that never inherits a test run's
+#     environment, so setting this here poses no production risk.
+#   - setdefault() (not a plain assignment) means an operator who explicitly
+#     exports HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE=0 before running tests
+#     (e.g. to force-enable the bridge for a live-checkout test run) is
+#     respected rather than silently overridden.
 os.environ.setdefault("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "1")
 HOME       = pathlib.Path.home()
 HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes')))

--- a/tests/test_agent_config_bridge.py
+++ b/tests/test_agent_config_bridge.py
@@ -1,0 +1,280 @@
+"""Tests for api/agent_config_bridge.py — the shared agent-config write path.
+
+The bridge routes MCP/skills config writes through the agent's own
+persistence layer (comment-preserving, security-validated, secrets to .env)
+when an agent checkout is importable, and falls back to the legacy WebUI
+writer in standalone deployments.
+
+These tests never import a real hermes-agent checkout: the agent modules
+(``hermes_constants``, ``hermes_cli.config``, ``hermes_cli.mcp_config``,
+``hermes_cli.mcp_security``) are faked in ``sys.modules`` so behavior is
+identical on CI (no checkout) and developer machines (real checkout present).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api import agent_config_bridge as bridge
+
+
+class FakeAgent:
+    """Builds fake agent modules and records calls against them."""
+
+    def __init__(self):
+        self.saved_configs = []
+        self.env_values = {}
+        self.config_store = {}
+        self.override_calls = []
+
+        hermes_constants = types.ModuleType("hermes_constants")
+
+        def set_hermes_home_override(path):
+            self.override_calls.append(("set", str(path)))
+            return object()
+
+        def reset_hermes_home_override(token):
+            self.override_calls.append(("reset", token))
+
+        hermes_constants.set_hermes_home_override = set_hermes_home_override
+        hermes_constants.reset_hermes_home_override = reset_hermes_home_override
+
+        hermes_cli = types.ModuleType("hermes_cli")
+        hermes_cli.__path__ = []  # mark as package
+
+        config_mod = types.ModuleType("hermes_cli.config")
+        config_mod.load_config = lambda: {k: v for k, v in self.config_store.items()}
+        config_mod.save_config = self._save_config
+        config_mod.save_env_value = self._save_env_value
+
+        security_mod = types.ModuleType("hermes_cli.mcp_security")
+        security_mod.validate_mcp_server_entry = lambda name, entry: (
+            ["suspicious command"] if entry.get("command") == "evil" else []
+        )
+
+        mcp_mod = types.ModuleType("hermes_cli.mcp_config")
+
+        def _save_bearer_auth_token(name, token):
+            if not str(token).strip():
+                raise ValueError("Bearer token is required")
+            key = f"MCP_{name.upper().replace('-', '_')}_API_KEY"
+            self._save_env_value(key, token)
+            return {"Authorization": f"Bearer ${{{key}}}"}
+
+        mcp_mod._save_bearer_auth_token = _save_bearer_auth_token
+
+        self.modules = {
+            "hermes_constants": hermes_constants,
+            "hermes_cli": hermes_cli,
+            "hermes_cli.config": config_mod,
+            "hermes_cli.mcp_security": security_mod,
+            "hermes_cli.mcp_config": mcp_mod,
+        }
+
+    def _save_config(self, config, **kwargs):
+        self.saved_configs.append(dict(config))
+        self.config_store = dict(config)
+
+    def _save_env_value(self, key, value):
+        self.env_values[key] = value
+
+
+@pytest.fixture
+def fake_agent(monkeypatch, tmp_path):
+    """Activate the bridge against a fully faked agent checkout."""
+    fake = FakeAgent()
+    monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+    for name, module in fake.modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+    monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+    yield fake
+    bridge._import_state = None
+
+
+@pytest.fixture
+def bridge_unavailable(monkeypatch, tmp_path):
+    """Agent checkout configured but import broken → bridge must fail closed."""
+    monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+    for name in ("hermes_constants", "hermes_cli", "hermes_cli.config"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "missing-agent"), raising=False)
+    monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+    # Block real imports of agent modules even when a checkout exists on the
+    # machine: an import hook that rejects exactly these module names.
+    class _Blocker:
+        def find_module(self, fullname, path=None):
+            if fullname in ("hermes_constants", "hermes_cli", "hermes_cli.config"):
+                return self
+            return None
+
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname in ("hermes_constants", "hermes_cli", "hermes_cli.config"):
+                raise ImportError(f"{fullname} blocked by test")
+            return None
+
+    blocker = _Blocker()
+    sys.meta_path.insert(0, blocker)
+    yield
+    sys.meta_path.remove(blocker)
+    bridge._import_state = None
+
+
+class TestProbe:
+    def test_kill_switch_forces_standalone(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "1")
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        assert bridge.bridge_available() is False
+        # Kill-switch must NOT raise even with a configured agent dir.
+        monkeypatch.setattr(bridge, "_AGENT_DIR", "/tmp/x", raising=False)
+        bridge.require_bridge()
+        bridge._import_state = None
+
+    def test_no_agent_dir_is_silent_standalone(self, monkeypatch):
+        monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", None, raising=False)
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        assert bridge.bridge_available() is False
+        bridge.require_bridge()  # must not raise
+        bridge._import_state = None
+
+    def test_broken_checkout_fails_closed(self, bridge_unavailable):
+        assert bridge.bridge_available() is False
+        with pytest.raises(bridge.AgentBridgeUnavailable):
+            bridge.require_bridge()
+
+    def test_fake_agent_probes_ok(self, fake_agent):
+        assert bridge.bridge_available() is True
+        bridge.require_bridge()
+
+
+class TestMcpWrites:
+    def test_save_valid_server(self, fake_agent, tmp_path):
+        issues = bridge.save_mcp_server("srv", {"url": "https://x.test/mcp"}, tmp_path)
+        assert issues == []
+        assert fake_agent.saved_configs[-1]["mcp_servers"]["srv"] == {"url": "https://x.test/mcp"}
+        # Home scoping happened around the write and was reset afterwards.
+        assert fake_agent.override_calls[0] == ("set", str(tmp_path))
+        assert fake_agent.override_calls[-1][0] == "reset"
+
+    def test_save_rejects_suspicious_entry(self, fake_agent, tmp_path):
+        issues = bridge.save_mcp_server("srv", {"command": "evil"}, tmp_path)
+        assert issues == ["suspicious command"]
+        assert fake_agent.saved_configs == []
+
+    def test_remove_and_toggle(self, fake_agent, tmp_path):
+        fake_agent.config_store = {"mcp_servers": {"a": {"url": "https://a"}, "b": {"url": "https://b"}}}
+        assert bridge.set_mcp_server_enabled("a", False, tmp_path) is True
+        assert fake_agent.config_store["mcp_servers"]["a"]["enabled"] is False
+        assert bridge.remove_mcp_server("a", tmp_path) is True
+        assert "a" not in fake_agent.config_store["mcp_servers"]
+        assert bridge.remove_mcp_server("missing", tmp_path) is False
+        # Removing the last server drops the whole key.
+        assert bridge.remove_mcp_server("b", tmp_path) is True
+        assert "mcp_servers" not in fake_agent.config_store
+
+    def test_bearer_token_goes_to_env_not_yaml(self, fake_agent, tmp_path):
+        headers = bridge.save_mcp_bearer_token("my-srv", "secret-token", tmp_path)
+        assert headers == {"Authorization": "Bearer ${MCP_MY_SRV_API_KEY}"}
+        assert fake_agent.env_values == {"MCP_MY_SRV_API_KEY": "secret-token"}
+
+
+class TestSkillsWrites:
+    def test_save_skills_config(self, fake_agent, tmp_path):
+        fake_agent.config_store = {"skills": {"disabled": []}, "other": 1}
+        bridge.save_skills_config({"disabled": ["x"]}, tmp_path)
+        assert fake_agent.config_store["skills"] == {"disabled": ["x"]}
+        assert fake_agent.config_store["other"] == 1
+
+
+class TestRouteIntegration:
+    """Handlers pick bridge vs legacy vs fail-closed correctly."""
+
+    def _handler(self):
+        handler = MagicMock()
+        handler.headers = {}
+        return handler
+
+    def test_mcp_update_uses_bridge_and_validates(self, fake_agent, tmp_path, monkeypatch):
+        from api import routes
+
+        monkeypatch.setattr(routes, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(routes, "reload_config", lambda: None)
+        monkeypatch.setattr(routes, "get_config", lambda: dict(fake_agent.config_store))
+        captured = {}
+
+        def fake_j(handler, payload, status=200):
+            captured["payload"], captured["status"] = payload, status
+            return True
+
+        monkeypatch.setattr(routes, "j", fake_j)
+        routes._handle_mcp_server_update(self._handler(), "srv", {"url": "https://x.test/mcp"})
+        assert captured["status"] == 200
+        assert fake_agent.saved_configs[-1]["mcp_servers"]["srv"]["url"] == "https://x.test/mcp"
+
+        routes._handle_mcp_server_update(self._handler(), "srv", {"command": "evil"})
+        assert captured["status"] == 400
+        assert captured["payload"]["issues"] == ["suspicious command"]
+
+    def test_mcp_update_bearer_token_lands_in_env(self, fake_agent, tmp_path, monkeypatch):
+        from api import routes
+
+        monkeypatch.setattr(routes, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(routes, "reload_config", lambda: None)
+        monkeypatch.setattr(routes, "get_config", lambda: dict(fake_agent.config_store))
+        captured = {}
+
+        def fake_j(handler, payload, status=200):
+            captured["payload"], captured["status"] = payload, status
+            return True
+
+        monkeypatch.setattr(routes, "j", fake_j)
+        routes._handle_mcp_server_update(
+            self._handler(), "hub", {"url": "https://hub.test/mcp", "bearer_token": "tok-123"}
+        )
+        assert captured["status"] == 200
+        saved = fake_agent.saved_configs[-1]["mcp_servers"]["hub"]
+        assert saved["headers"] == {"Authorization": "Bearer ${MCP_HUB_API_KEY}"}
+        assert fake_agent.env_values["MCP_HUB_API_KEY"] == "tok-123"
+        # The raw secret must never appear in the YAML-bound server config.
+        assert "tok-123" not in str(saved)
+
+    def test_mcp_write_fails_closed_when_bridge_broken(self, bridge_unavailable, monkeypatch):
+        from api import routes
+
+        captured = {}
+
+        def fake_j(handler, payload, status=200):
+            captured["payload"], captured["status"] = payload, status
+            return True
+
+        monkeypatch.setattr(routes, "j", fake_j)
+        routes._handle_mcp_server_delete(self._handler(), "any")
+        assert captured["status"] == 503
+        assert "unavailable" in captured["payload"]["error"].lower()
+
+    def test_legacy_path_when_standalone(self, monkeypatch, tmp_path):
+        """No agent checkout at all → the pre-bridge writer keeps working."""
+        from api import routes
+
+        monkeypatch.setattr(bridge, "_AGENT_DIR", None, raising=False)
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        cfg = {"mcp_servers": {"old": {"url": "https://old"}}}
+        monkeypatch.setattr(routes, "get_config", lambda: cfg)
+        monkeypatch.setattr(routes, "_get_config_path", lambda: tmp_path / "config.yaml")
+        saved = {}
+        monkeypatch.setattr(routes, "_save_yaml_config_file", lambda path, data: saved.update(data))
+        monkeypatch.setattr(routes, "reload_config", lambda: None)
+        captured = {}
+
+        def fake_j(handler, payload, status=200):
+            captured["payload"], captured["status"] = payload, status
+            return True
+
+        monkeypatch.setattr(routes, "j", fake_j)
+        routes._handle_mcp_server_delete(self._handler(), "old")
+        assert captured["status"] == 200
+        assert saved["mcp_servers"] == {}
+        bridge._import_state = None

--- a/tests/test_issue538_mcp_management.py
+++ b/tests/test_issue538_mcp_management.py
@@ -1,5 +1,5 @@
 """Tests for issue #538 — MCP server management API."""
-import json, pytest
+import json, sys, types, pytest
 from unittest.mock import patch, MagicMock, call
 import yaml
 from api.routes import (
@@ -251,6 +251,96 @@ class TestMcpSave:
         assert h.send_response.called
         status = h.send_response.call_args[0][0]
         assert status == 400
+
+
+class TestMcpSaveBridgeModeMasking:
+    """Bridge-mode PUT — existing_cfg for _strip_masked_values() must come
+    from the bridge's own home-scoped reader (_bridge.load_agent_config),
+    not the WebUI's get_config() cache. The two can diverge (stale cache,
+    different profile resolution); if existing_cfg is read from the wrong
+    source, a masked •••••• field submitted unchanged would be missed and
+    saved as the literal placeholder — a quiet secret loss. Uses the same
+    sys.modules-faking pattern as tests/test_agent_config_bridge.py.
+    """
+
+    def _activate_fake_agent(self, monkeypatch, tmp_path, initial_config):
+        from api import agent_config_bridge as bridge
+
+        state = {"config": initial_config}
+
+        hermes_constants = types.ModuleType("hermes_constants")
+        hermes_constants.set_hermes_home_override = lambda path: object()
+        hermes_constants.reset_hermes_home_override = lambda token: None
+
+        config_mod = types.ModuleType("hermes_cli.config")
+        config_mod.load_config = lambda: {k: v for k, v in state["config"].items()}
+
+        def _save_config(cfg, **kwargs):
+            state["config"] = dict(cfg)
+
+        config_mod.save_config = _save_config
+        config_mod.save_env_value = lambda k, v: None
+
+        security_mod = types.ModuleType("hermes_cli.mcp_security")
+        security_mod.validate_mcp_server_entry = lambda name, entry: []
+
+        hermes_cli = types.ModuleType("hermes_cli")
+        hermes_cli.__path__ = []
+
+        monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+        monkeypatch.setitem(sys.modules, "hermes_constants", hermes_constants)
+        monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+        monkeypatch.setitem(sys.modules, "hermes_cli.config", config_mod)
+        monkeypatch.setitem(sys.modules, "hermes_cli.mcp_security", security_mod)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        return state
+
+    @patch('api.routes.reload_config')
+    @patch('api.routes.get_active_hermes_home')
+    @patch('api.routes.get_config')
+    def test_masked_header_survives_timeout_only_edit(
+        self, mock_get_config, mock_home, mock_reload, monkeypatch, tmp_path
+    ):
+        from api import agent_config_bridge as bridge
+
+        real_headers = {"Authorization": "Bearer real-secret-token"}
+        initial_config = {
+            "mcp_servers": {
+                "web-srv": {
+                    "url": "http://localhost:4000",
+                    "headers": dict(real_headers),
+                    "timeout": 60,
+                },
+            }
+        }
+        state = self._activate_fake_agent(monkeypatch, tmp_path, initial_config)
+        mock_home.return_value = tmp_path
+        # The WebUI's own get_config() cache is made to DIVERGE from the
+        # bridge's real config (simulating a stale cache / different profile
+        # resolution) — this is the exact condition the fix must be immune
+        # to: existing_cfg must come from the bridge, not from here.
+        mock_get_config.return_value = {"mcp_servers": {}}
+
+        h = _make_handler()
+        h.command = 'PUT'
+        # Real UI behavior: the GET response masked the header to ••••••,
+        # and editing the form (changing only the timeout) round-trips the
+        # masked placeholder unchanged.
+        body = {
+            "url": "http://localhost:4000",
+            "headers": {"Authorization": "••••••"},
+            "timeout": 120,
+        }
+        _handle_mcp_server_update(h, 'web-srv', body)
+
+        status = h.send_response.call_args[0][0]
+        assert status == 200
+        saved = state["config"]["mcp_servers"]["web-srv"]
+        assert saved["headers"]["Authorization"] == "Bearer real-secret-token"
+        assert saved["timeout"] == 120
+
+        bridge._import_state = None
 
 
 class TestMcpDelete:


### PR DESCRIPTION
## Summary

MCP server writes (add/edit/delete/toggle) and skill enable/disable toggles in the WebUI currently write directly to `config.yaml`, bypassing the agent's own `save_config()` persistence layer — its comment-preserving YAML writer, atomic-write handling, and managed-scope checks. That desync is a real correctness risk: two independent writers to the same file with different serialization logic will eventually clobber each other's formatting or, worse, a managed/denylisted value. This PR introduces a bridge module that routes those writes through the actual agent code when an agent checkout is available, with a safe standalone fallback when it isn't.

## What changed

- New `api/agent_config_bridge.py`: lazy-imports the agent's own MCP/skills config helpers, exposes `save_mcp_server`, `remove_mcp_server`, `set_mcp_server_enabled`, `save_mcp_bearer_token`, `save_skills_config`, `load_agent_config`, plus `scoped_agent_home()` (a context-managed home override, restored in `try/finally`).
- `api/routes.py`: existing MCP/skill write routes now call the bridge instead of hand-rolled YAML edits; a bearer-token field is now written to `.env`, not stored inline in `config.yaml`. The pre-write read of the *existing* server config (used to preserve a masked `••••••` header/env value that the client submits unchanged) also goes through the bridge's home-scoped reader, rather than the WebUI's own config cache — so the value being preserved and the value being written are always read from the same source.
- Bridge unavailability (no agent checkout, or a broken one) is fail-closed: writes return 503 rather than silently falling back to a divergent write path.

## Security & opt-in

- No new user-facing write surface — this changes the persistence mechanism for an already-shipped write path, not what's writable.
- Kill switch: `HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE=1` forces the pre-existing standalone behavior, for environments that want to opt out.
- Fails closed, not open: if the bridge is configured but broken, writes are rejected (503) rather than falling through to the old, divergent code path.
- Bearer tokens move from `config.yaml` to `.env`, consistent with how other secrets in this codebase are stored.

## Testing

- 13 new tests (`tests/test_agent_config_bridge.py`) covering bridge availability detection, the standalone/agent-checkout fallback split, the home-override context manager's `try/finally` restoration, and the fail-closed 503 path.
- Expanded coverage in `tests/test_issue538_mcp_management.py` for the updated write path.
- Standard 10-locale i18n parity N/A (backend-only change, no new UI strings).

## Notes / follow-ups

- This PR only changes *how* existing MCP/skill writes are persisted, not the UI. The MCP management UI PR (Add/Edit/Delete/Test) is a separate, dependent PR built on top of this bridge.
