### PR TITLE
fix: Consolidated retry for silent provider failures, fallback & validation

### DIFF
--- a/.hermes_patches/pr_6239.applied
+++ b/.hermes_patches/pr_6239.applied
@@ -1,0 +1,4 @@
+# PR 6239: Provider retry for silent failures
+# Applied on: Tue Jul 21 16:10:52 NZST 2026
+# Repository: nesquena/hermes-webui
+# Branch: fix/provider-retry-on-no-response

--- a/.hermes_patches/pr_6239.applied
+++ b/.hermes_patches/pr_6239.applied
@@ -1,4 +1,0 @@
-# PR 6239: Provider retry for silent failures
-# Applied on: Tue Jul 21 16:10:52 NZST 2026
-# Repository: nesquena/hermes-webui
-# Branch: fix/provider-retry-on-no-response

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9588,7 +9588,51 @@ def _run_agent_streaming(
                     cfg=_cfg,
                 )
                 _run_conversation_kwargs["user_message"] = user_message
-            result = agent.run_conversation(**_run_conversation_kwargs)
+            # ── Retry loop for silent provider failures ──
+            # Retry up to 3 times with exponential backoff when provider returns
+            # no content and no error (silent failure), to handle transient issues
+            # like rate limits that don't return HTTP 429, temporary outages, etc.
+            _retry_state = {"attempt": 0, "max_retries": 3, "base_delay": 1.0}
+            _last_silent_failure = False
+
+            while True:
+                _retry_state["attempt"] += 1
+                result = agent.run_conversation(**_run_conversation_kwargs)
+
+                # Check if this was a silent provider failure
+                _last_err = None
+                _has_messages = False
+                if result is not None:
+                    _last_err = getattr(agent, '_last_error', None) or result.get('error')
+                    _has_messages = bool(result.get('messages'))
+                # Silent failure: no error key AND no messages
+                _is_silent_failure = _last_err is None and not _has_messages
+
+                if _is_silent_failure and _retry_state["attempt"] < _retry_state["max_retries"]:
+                    # Calculate exponential backoff with jitter
+                    _delay = _retry_state["base_delay"] * (2 ** (_retry_state["attempt"] - 1))
+                    _delay = min(_delay, 30.0)  # Cap at 30 seconds
+                    _jitter = _delay * 0.2 * (random.random() - 0.5) * 2
+                    _delay = max(0, _delay + _jitter)
+
+                    logger.info(
+                        f"[PROVIDER-RETRY] Session {s.session_id} silent provider failure "
+                        f"(attempt {_retry_state['attempt']}/{_retry_state['max_retries']}), "
+                        f"retrying in {_delay:.1f}s"
+                    )
+
+                    # Wait before retry
+                    time.sleep(_delay)
+                    _last_silent_failure = True
+                    continue
+                else:
+                    # Either succeeded, not a silent failure, or retries exhausted
+                    if _last_silent_failure and _retry_state["attempt"] >= _retry_state["max_retries"]:
+                        logger.warning(
+                            f"[PROVIDER-RETRY] Session {s.session_id} exhausted all retries "
+                            f"for silent provider failure"
+                        )
+                    break
             _active_turn_identity = _resolve_active_turn_authority(
                 _active_turn_identity,
                 result=result,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8188,54 +8188,117 @@ def _run_agent_streaming(
             # normal send never trips a TypeError on an older hermes-agent whose
             # run_conversation() predates the moa_config kwarg.
             if moa_config is not None:
-                _run_conversation_kwargs["moa_config"] = moa_config
+                _user_message = msg_text
 
-            # ── Retry loop for silent provider failures ──
-            # Retry up to 3 times with exponential backoff when provider returns
-            # no content and no error (silent failure), to handle transient issues
-            # like rate limits that don't return HTTP 429, temporary outages, etc.
+            # For provider-call boundary retry, silent failures are detected BEFORE
+            # the agent runs, not around the entire turn. This ensures we don't
+            # replay an entire logical turn when the provider fails silently.
+            
+            # Make the provider call (agent.run_conversation) - this should NOT be
+            # wrapped in retry logic since retries happen at provider level
+            result = agent.run_conversation(**_run_conversation_kwargs)
+
+            # ── Provider-call boundary retry (WebUI-level hardening) ──
+            # Detect silent provider failures using a turn-aware predicate and
+            # retry only the provider call. Flush reasoning after each provider
+            # return and make backoff cancellation-aware.
             _retry_state = {"attempt": 0, "max_retries": 3, "base_delay": 1.0}
             _last_silent_failure = False
 
+            # Determine the previous-message count for turn-aware detection.
+            _prev_len = len(_run_conversation_kwargs.get("conversation_history") or [])
+
             while True:
                 _retry_state["attempt"] += 1
+
+                # Make the provider call (single logical turn prologue already done)
                 result = agent.run_conversation(**_run_conversation_kwargs)
 
-                # Check if this was a silent provider failure
-                _last_err = None
-                _has_messages = False
-                if result is not None:
-                    _last_err = getattr(agent, '_last_error', None) or result.get('error')
-                    _has_messages = bool(result.get('messages'))
-                # Silent failure: no error key AND no messages
-                _is_silent_failure = _last_err is None and not _has_messages
+                # Immediately flush any buffered reasoning produced by this attempt
+                try:
+                    _flush_reasoning_buffer()
+                except Exception:
+                    pass
 
-                if _is_silent_failure and _retry_state["attempt"] < _retry_state["max_retries"]:
-                    # Calculate exponential backoff with jitter
-                    _delay = _retry_state["base_delay"] * (2 ** (_retry_state["attempt"] - 1))
-                    _delay = min(_delay, 30.0)  # Cap at 30 seconds
-                    _jitter = _delay * 0.2 * (random.random() - 0.5) * 2
-                    _delay = max(0, _delay + _jitter)
-
-                    logger.info(
-                        f"[PROVIDER-RETRY] Session {s.session_id} silent provider failure "
-                        f"(attempt {_retry_state['attempt']}/{_retry_state['max_retries']}), "
-                        f"retrying in {_delay:.1f}s"
-                    )
-
-                    # Wait before retry
-                    time.sleep(_delay)
-                    _last_silent_failure = True
-                    continue
+                # Normalize None -> empty-result to avoid downstream AttributeError
+                if result is None:
+                    _last_err = getattr(agent, '_last_error', None)
+                    _msgs = []
                 else:
-                    # Either succeeded, not a silent failure, or retries exhausted
-                    if _last_silent_failure and _retry_state["attempt"] >= _retry_state["max_retries"]:
-                        logger.warning(
-                            f"[PROVIDER-RETRY] Session {s.session_id} exhausted all retries "
-                            f"for silent provider failure"
-                        )
+                    _last_err = getattr(agent, '_last_error', None) or result.get('error')
+                    _msgs = result.get('messages') or []
+
+                # Use turn-aware helper to detect new assistant reply beyond history
+                try:
+                    _has_new_reply = _has_new_assistant_reply(_msgs, _prev_len)
+                except Exception:
+                    # Defensive fallback: consider messages list truthiness if helper fails
+                    _has_new_reply = bool(_msgs)
+
+                _is_silent_failure = _last_err is None and not _has_new_reply
+
+                # Success path: either an error was returned (non-silent) or new assistant reply
+                if not _is_silent_failure:
                     break
-            _flush_reasoning_buffer()
+
+                # If we've reached max retries, stop retrying
+                if _retry_state["attempt"] >= _retry_state["max_retries"]:
+                    _last_silent_failure = True
+                    logger.warning(
+                        f"[PROVIDER-RETRY] Session {s.session_id} exhausted all provider-level "
+                        f"retries for silent provider failure"
+                    )
+                    break
+
+                # Exponential backoff (cancellation-aware)
+                _delay = _retry_state["base_delay"] * (2 ** (_retry_state["attempt"] - 1))
+                _delay = min(_delay, 30.0)
+                _jitter = _delay * 0.2 * (random.random() - 0.5) * 2
+                _delay = max(0, _delay + _jitter)
+
+                logger.info(
+                    f"[PROVIDER-RETRY] Session {s.session_id} silent provider failure "
+                    f"(attempt {_retry_state['attempt']}/{_retry_state['max_retries']}), retrying in {_delay:.1f}s"
+                )
+
+                # Wait with cancellation awareness
+                try:
+                    cancelled_during_backoff = cancel_event.wait(_delay)
+                except Exception:
+                    # If cancel_event is not waitable for any reason, fallback to sleep
+                    time.sleep(_delay)
+                    cancelled_during_backoff = cancel_event.is_set() if hasattr(cancel_event, 'is_set') else False
+
+                if cancelled_during_backoff:
+                    # Honor cancellation: finalize and return a cancel event
+                    if _checkpoint_stop is not None:
+                        _checkpoint_stop.set()
+                    if _ckpt_thread is not None:
+                        _ckpt_thread.join(timeout=15)
+                    if ephemeral:
+                        _cleanup_ephemeral_cancelled_turn(s)
+                    else:
+                        with _agent_lock:
+                            _finalize_cancelled_turn(s, ephemeral=False)
+                            try:
+                                append_turn_journal_event_for_stream(
+                                    s.session_id,
+                                    stream_id,
+                                    {
+                                        "event": "interrupted",
+                                        "created_at": time.time(),
+                                        "reason": "cancelled",
+                                    },
+                                )
+                            except Exception:
+                                logger.debug("Failed to append cancelled turn journal event", exc_info=True)
+                    put('cancel', _cancel_event_payload('Cancelled by user'))
+                    return
+
+                # Prepare to retry: call provider again in next loop iteration
+                _last_silent_failure = True
+                continue
+            # End retry loop — reasoning buffer already flushed per-attempt
             if cancel_event.is_set():
                 if _checkpoint_stop is not None:
                     _checkpoint_stop.set()

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7,13 +7,11 @@ import contextlib
 import contextvars
 import json
 import logging
-import math
 import mimetypes
 import os
 import queue
 import random
 import re
-import sqlite3
 import shlex
 import sys
 import subprocess
@@ -33,20 +31,17 @@ from api.config import (
     STREAM_GOAL_RELATED, PENDING_GOAL_CONTINUATION,
     STREAM_LAST_EVENT_ID,
     LOCK, SESSIONS, SESSIONS_MAX, SESSION_DIR,
-    _get_session_agent_lock, _alias_session_agent_lock,
-    _set_thread_env, _clear_thread_env,
+    _get_session_agent_lock, _set_thread_env, _clear_thread_env,
     register_active_run, update_active_run, unregister_active_run,
     unregister_stream_owner,
     SESSION_AGENT_LOCKS, SESSION_AGENT_LOCKS_LOCK,
     resolve_model_provider,
     resolve_custom_provider_connection,
     model_with_provider_context,
-    warm_models_catalog_provenance_if_cold,
     load_settings,
     parse_reasoning_effort,
     coerce_reasoning_effort_for_model,
     _main_model_request_overrides,
-    PROCESS_SESSION_INDEX, PROCESS_SESSION_INDEX_LOCK,
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
@@ -59,22 +54,10 @@ from api.usage import prompt_cache_hit_percent
 from api.models import (
     _is_empty_partial_activity_message,
     _evict_sessions_over_cap,
-    clear_process_wakeup_pause,
     get_state_db_session_messages,
-    record_process_wakeup_provider_unavailable_pause,
     reconciled_state_db_messages_for_session,
 )
 from api.session_ops import mark_session_title_generated, session_has_manual_title
-from api.process_event_utils import (
-    build_active_turn_token,
-    claim_async_delegation_delivery,
-    complete_async_delegation_delivery,
-    completion_delivery_id,
-    release_async_delegation_delivery,
-    requeue_async_delegation_event,
-    schedule_async_delegation_claim_retry,
-    stamp_message_source,
-)
 
 
 def _session_payload_with_full_messages(session, *, tool_calls=None):
@@ -555,48 +538,6 @@ def _is_fallback_lifecycle_message(kind: str, message: str) -> bool:
     )
 
 
-def _is_agent_compression_start_status(kind: str, message: str) -> bool:
-    """Return True only for real Hermes context-compression start notices.
-
-    WebUI bridges matching lifecycle statuses into an SSE ``compressing`` event
-    and paints the live "Compressing context" worklog divider. The previous
-    matcher used broad substrings such as ``'compressing' in message`` and
-    ``'preflight compression' in message``, which can false-positive on skip /
-    cooldown / unrelated notices and make brand-new low-token turns look like
-    auto-compression.
-
-    Positive markers below match the agent emitters in hermes-agent
-    (``turn_context`` preflight, ``conversation_loop`` pre-API / 413 / too-large,
-    ``conversation_compression`` compaction status). Explicitly reject skip /
-    defer notices so "Skipping preflight compression…" never surfaces as a
-    running compress divider.
-    """
-    k = str(kind or '').strip().lower()
-    m = str(message or '').strip().lower()
-    if k != 'lifecycle' or not m:
-        return False
-    # Skip / cooldown / defer logs must never look like a live compression start.
-    if (
-        'skipping' in m
-        or 'defer' in m
-        or 'cooldown' in m
-        or 'will not start' in m
-    ):
-        return False
-    # Post-compress retry chatter is not a start event.
-    if 'compressed' in m and 'compressing' not in m and 'compression attempt' not in m:
-        return False
-    return (
-        'preflight compression:' in m
-        or 'pre-api compression:' in m
-        or 'compacting context' in m
-        or 'context too large' in m
-        or '— compressing (' in m
-        or '- compressing (' in m
-        or 'compression attempt' in m
-    )
-
-
 def _prewarm_skill_tool_modules():
     """Import tools.skills_tool and tools.skill_manager_tool outside any lock.
 
@@ -621,13 +562,10 @@ def _prewarm_skill_tool_modules():
 
 
 # Lazy import to avoid circular deps -- hermes-agent is on sys.path via api/config.py
-from api.agent_runtime import ensure_agent_runtime_current, get_ai_agent_class
-
-
-# Eagerly attempt the import at startup, matching the pre-guard behavior. If
-# dependencies are not ready yet, _get_ai_agent() retries when a chat starts.
-AIAgent = get_ai_agent_class()
-
+try:
+    from run_agent import AIAgent
+except ImportError:
+    AIAgent = None
 
 def _get_ai_agent():
     """Return AIAgent class, retrying the import if the initial attempt failed.
@@ -635,13 +573,15 @@ def _get_ai_agent():
     auto_install_agent_deps() in server.py may install missing packages after
     this module is first imported (common in Docker with a volume-mounted agent).
     Re-attempting the import here picks up the newly installed packages without
-    requiring a server restart. The shared runtime guard also refuses to reuse
-    cached Agent modules after the source checkout changes.
+    requiring a server restart.
     """
     global AIAgent
-    ensure_agent_runtime_current()
     if AIAgent is None:
-        AIAgent = get_ai_agent_class()
+        try:
+            from run_agent import AIAgent as _cls  # noqa: PLC0415
+            AIAgent = _cls
+        except ImportError:
+            pass
     return AIAgent
 
 
@@ -695,7 +635,6 @@ WebUI progress guidance:
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.
-- Password, API-key, token, and secret fields are automatically redacted by the system. Treat masked values as intentional redaction, not placeholder text or user input errors, and do not tell the user a stored credential is wrong based on a masked value alone.
 - Final visible assistant replies must be clear, user-facing, and in the user's language, not private planning notes.
 - Do not include terse planning fragments or scratchpad shorthand in visible assistant text. Avoid fragments like "Need script", "Need check logs", "Need inspect email", or "maybe invite"; either omit them or rewrite them as clear user-facing progress.
 - For direct answers or very short tasks, skip progress updates and answer normally.
@@ -1430,380 +1369,6 @@ def _drop_synthetic_control_messages(messages):
     ]
 
 
-def _clean_synthetic_control_messages_with_provenance(messages):
-    """Remove synthetic rows while retaining marked verification-nudge provenance."""
-    raw_messages = list(messages or [])
-    has_verification_nudge = any(
-        isinstance(message, dict)
-        and message.get('role') == 'user'
-        and _is_synthetic_control_message(message)
-        for message in raw_messages
-    )
-    return _drop_synthetic_control_messages(raw_messages), has_verification_nudge
-
-
-def _active_turn_authority(session, stream_id, msg_text):
-    """Capture the stream-owned pending turn before settlement mutates it."""
-    pending_text = getattr(session, 'pending_user_message', None)
-    return {
-        'token': build_active_turn_token(stream_id, getattr(session, 'pending_started_at', None)),
-        'text': pending_text if pending_text is not None else msg_text,
-        'timestamp': getattr(session, 'pending_started_at', None),
-        'source': getattr(session, 'pending_user_source', None) or 'webui',
-        'attachments': copy.deepcopy(getattr(session, 'pending_attachments', None) or []),
-        'current_turn_user_idx': None,
-        'turn_id': '',
-    }
-
-
-def _coerce_current_turn_user_idx(value):
-    if isinstance(value, bool) or value is None:
-        return None
-    try:
-        idx = int(value)
-    except (TypeError, ValueError):
-        return None
-    return idx if idx >= 0 else None
-
-
-def _resolve_active_turn_authority(identity, *, result=None, agent=None):
-    if not isinstance(identity, dict):
-        return identity
-    resolved = dict(identity)
-    if isinstance(result, dict):
-        _result_idx = _coerce_current_turn_user_idx(result.get('current_turn_user_idx'))
-        if _result_idx is not None:
-            resolved['current_turn_user_idx'] = _result_idx
-        _result_turn_id = str(result.get('turn_id') or '').strip()
-        if _result_turn_id:
-            resolved['turn_id'] = _result_turn_id
-    if agent is not None:
-        if resolved.get('current_turn_user_idx') is None:
-            _agent_idx = _coerce_current_turn_user_idx(
-                getattr(agent, '_persist_user_message_idx', None)
-            )
-            if _agent_idx is not None:
-                resolved['current_turn_user_idx'] = _agent_idx
-        if not resolved.get('turn_id'):
-            _agent_turn_id = str(getattr(agent, '_current_turn_id', '') or '').strip()
-            if _agent_turn_id:
-                resolved['turn_id'] = _agent_turn_id
-    return resolved
-
-
-def _active_turn_boundary_is_valid(identity):
-    if not isinstance(identity, dict):
-        return False
-    if not str(identity.get('turn_id') or '').strip():
-        return False
-    return isinstance(identity.get('current_turn_user_idx'), int)
-
-
-def _active_turn_token_matches(message, identity):
-    token = identity.get('token') if isinstance(identity, dict) else None
-    if not token:
-        return False
-    return (
-        isinstance(message, dict)
-        and message.get('role') == 'user'
-        and message.get('_active_turn_token') == token
-    )
-
-
-def _active_turn_has_checkpoint(messages, identity):
-    return any(_active_turn_token_matches(message, identity) for message in messages or [])
-
-
-def _mark_active_turn_checkpoint(message, identity):
-    if (
-        isinstance(message, dict)
-        and message.get('role') == 'user'
-        and isinstance(identity, dict)
-        and identity.get('token')
-    ):
-        message['_active_turn_token'] = identity['token']
-    return message
-
-
-def _mark_active_turn_checkpoint_in_history(messages, identity, msg_text, *, allow_index_fallback=True):
-    messages = list(messages or [])
-    if not isinstance(identity, dict):
-        return messages, False
-    if _active_turn_has_checkpoint(messages, identity):
-        return messages, True
-    if not allow_index_fallback:
-        return messages, False
-    if not _active_turn_boundary_is_valid(identity):
-        return messages, False
-    idx = identity['current_turn_user_idx']
-    if idx < 0 or idx >= len(messages):
-        return messages, False
-    message = messages[idx]
-    expected_text = identity.get('text') if identity.get('text') is not None else msg_text
-    if (
-        not isinstance(message, dict)
-        or message.get('role') != 'user'
-        or _normalize_user_text(message.get('content')) != _normalize_user_text(expected_text)
-    ):
-        return messages, False
-    _mark_active_turn_checkpoint(message, identity)
-    return messages, True
-
-
-def _owner_projection_current_turn_row(messages, identity):
-    messages = list(messages or [])
-    if not isinstance(identity, dict):
-        return None
-    for message in messages:
-        if _active_turn_token_matches(message, identity):
-            return copy.deepcopy(message)
-    return None
-
-
-def _find_active_turn_checkpoint_index(result_messages, previous_context, identity, msg_text):
-    result_messages = list(result_messages or [])
-    if not isinstance(identity, dict):
-        return None
-    if _active_turn_has_checkpoint(result_messages, identity):
-        for idx, message in enumerate(result_messages):
-            if _active_turn_token_matches(message, identity):
-                return idx
-    if not _active_turn_boundary_is_valid(identity):
-        return None
-    expected_text = identity.get('text') if identity.get('text') is not None else msg_text
-    candidates = []
-    current_turn_user_idx = identity['current_turn_user_idx']
-    previous_context = list(previous_context or [])
-    if _messages_have_prefix(result_messages, previous_context):
-        candidates.append(current_turn_user_idx)
-    else:
-        offset = current_turn_user_idx - len(previous_context)
-        candidates.extend([offset, current_turn_user_idx])
-    seen = set()
-    for idx in candidates:
-        if idx in seen or idx is None:
-            continue
-        seen.add(idx)
-        if idx < 0 or idx >= len(result_messages):
-            continue
-        message = result_messages[idx]
-        if (
-            isinstance(message, dict)
-            and message.get('role') == 'user'
-            and _normalize_user_text(message.get('content')) == _normalize_user_text(expected_text)
-        ):
-            return idx
-    return None
-
-
-def _materialize_active_turn_user(identity, msg_text, source):
-    message = {
-        'role': 'user',
-        'content': identity.get('text') if isinstance(identity, dict) else msg_text,
-    }
-    if isinstance(identity, dict):
-        if identity.get('timestamp') is not None:
-            message['timestamp'] = identity['timestamp']
-        if identity.get('attachments'):
-            message['attachments'] = copy.deepcopy(identity['attachments'])
-        stamp_message_source(
-            message,
-            identity.get('source') or source or 'webui',
-            active_turn_token=identity.get('token'),
-        )
-    else:
-        stamp_message_source(message, source)
-    return message
-
-
-def _settle_current_turn_boundary(previous_context, result_messages, identity, msg_text, source):
-    """Insert the pending turn before assistant/tool output when it is absent."""
-    result_messages = list(result_messages or [])
-    if not result_messages or not isinstance(identity, dict):
-        return result_messages
-    _checkpoint_idx = _find_active_turn_checkpoint_index(
-        result_messages,
-        previous_context,
-        identity,
-        msg_text,
-    )
-    if _checkpoint_idx is not None:
-        _mark_active_turn_checkpoint(result_messages[_checkpoint_idx], identity)
-        return result_messages
-    previous_context = list(previous_context or [])
-    if _messages_have_prefix(result_messages, previous_context):
-        insert_at = len(previous_context)
-    elif _active_turn_boundary_is_valid(identity):
-        insert_at = identity['current_turn_user_idx'] - len(previous_context)
-        if insert_at < 0 or insert_at > len(result_messages):
-            insert_at = identity['current_turn_user_idx']
-        if insert_at < 0 or insert_at > len(result_messages):
-            insert_at = None
-    else:
-        insert_at = None
-    if insert_at is None and all(
-        _is_context_compression_marker(message)
-        or (isinstance(message, dict) and message.get('role') in ('assistant', 'tool'))
-        for message in result_messages
-    ):
-        insert_at = 0
-        while insert_at < len(result_messages) and _is_context_compression_marker(result_messages[insert_at]):
-            insert_at += 1
-    if insert_at is None:
-        return result_messages
-    return (
-        result_messages[:insert_at]
-        + [_materialize_active_turn_user(identity, msg_text, source)]
-        + result_messages[insert_at:]
-    )
-
-
-def _align_current_turn_display(previous_display, previous_context, identity):
-    """Make a context-only exact checkpoint visible before shared settlement."""
-    display = list(previous_display or [])
-    context = list(previous_context or [])
-    if not isinstance(identity, dict):
-        return display, context
-    display, _ = _mark_active_turn_checkpoint_in_history(
-        display,
-        identity,
-        identity.get('text'),
-        allow_index_fallback=False,
-    )
-    if _active_turn_has_checkpoint(display, identity):
-        return display, context
-    checkpoint = _owner_projection_current_turn_row(
-        context,
-        identity,
-    )
-    if checkpoint is None and identity.get('token'):
-        checkpoint = _materialize_active_turn_user(
-            identity,
-            identity.get('text'),
-            identity.get('source') or 'webui',
-        )
-        context.append(copy.deepcopy(checkpoint))
-    if checkpoint is not None and not _active_turn_has_checkpoint(display, identity):
-        display.append(copy.deepcopy(checkpoint))
-    return display, context
-
-
-def _prepare_marker_clean_writeback(
-    previous_context_messages,
-    result_messages,
-    active_turn_identity=None,
-):
-    """Return marker-cleaned rows, next context rows, and nudge provenance."""
-    cleaned, has_verification_nudge = _clean_synthetic_control_messages_with_provenance(
-        result_messages
-    )
-    provenance = {
-        'verification_nudge_seen': has_verification_nudge,
-        'active_turn_identity': copy.deepcopy(active_turn_identity),
-    }
-    if not result_messages:
-        return (
-            cleaned,
-            list(previous_context_messages or []),
-            provenance,
-        )
-    if cleaned:
-        return (
-            cleaned,
-            _restore_reasoning_metadata(previous_context_messages, cleaned),
-            provenance,
-        )
-    return [], list(previous_context_messages or []), provenance
-
-
-def _settle_result_messages(
-    session,
-    previous_messages,
-    previous_context_messages,
-    result_messages,
-    msg_text,
-    source,
-    active_turn_identity,
-):
-    (
-        result_messages,
-        next_context_messages,
-        verification_nudge_provenance,
-    ) = _prepare_marker_clean_writeback(
-        previous_context_messages,
-        result_messages,
-        active_turn_identity,
-    )
-    if result_messages:
-        _assign_stable_message_ids(
-            result_messages,
-            previous_messages,
-            previous_context_messages,
-        )
-        next_context_messages = _dedupe_replayed_context_messages(
-            previous_context_messages,
-            next_context_messages,
-            msg_text,
-        )
-        next_context_messages = _settle_current_turn_boundary(
-            previous_context_messages,
-            next_context_messages,
-            active_turn_identity,
-            msg_text,
-            source,
-        )
-    session.context_messages = (
-        _deduplicate_context_messages(next_context_messages)
-        if result_messages
-        else list(next_context_messages or [])
-    )
-    if result_messages:
-        session.context_messages = _settle_current_turn_boundary(
-            previous_context_messages,
-            session.context_messages,
-            active_turn_identity,
-            msg_text,
-            source,
-        )
-    previous_display_for_writeback, session.context_messages = _align_current_turn_display(
-        previous_messages,
-        session.context_messages,
-        active_turn_identity,
-    )
-    session.messages = _merge_display_messages_after_agent_result(
-        previous_display_for_writeback,
-        previous_context_messages,
-        _restore_display_reasoning_metadata(previous_messages, result_messages),
-        msg_text,
-        source=source,
-        verification_nudge_provenance=verification_nudge_provenance,
-    )
-    _compact_session_image_parts_for_persistence(session)
-    _advance_truncation_watermark_after_commit(session)  # #3831
-    return result_messages
-
-
-def _current_turn_already_has_visible_assistant_answer(messages, *, active_turn_identity=None):
-    """Return True only when the token-owned current turn already has visible assistant prose."""
-    if not isinstance(active_turn_identity, dict) or not active_turn_identity.get('token'):
-        return False
-    current_turn_seen = False
-    for msg in messages or []:
-        if not isinstance(msg, dict) or _is_synthetic_control_message(msg):
-            continue
-        if _active_turn_token_matches(msg, active_turn_identity):
-            current_turn_seen = True
-            continue
-        if not current_turn_seen:
-            continue
-        role = msg.get('role')
-        if role == 'assistant' and _assistant_message_has_final_visible_text(msg) and not msg.get('_error'):
-            return True
-        if role == 'user':
-            return False
-    return False
-
-
 def _agent_result_tool_limit_reached(result) -> bool:
     """Return True when current-turn metadata says the tool iteration cap fired."""
     if not isinstance(result, dict):
@@ -2209,77 +1774,6 @@ def _build_agent_thread_env(profile_runtime_env: dict | None, workspace: str, se
     return env
 
 
-_streaming_hermes_home_override_available = None
-
-
-def _resolve_streaming_hermes_home_override():
-    """Return hermes_constants module if context-local home override APIs exist.
-
-    Cached import-safe resolver mirrors the optional pattern used by
-    `api.profiles` so older agent versions safely degrade to the process-global
-    env mirror fallback.
-    """
-    global _streaming_hermes_home_override_available
-    import sys as _sys
-
-    if _streaming_hermes_home_override_available is False:
-        return None
-
-    mod = _sys.modules.get('hermes_constants')
-    if mod is None and _streaming_hermes_home_override_available is None:
-        try:
-            import hermes_constants  # noqa: F401
-            mod = _sys.modules.get('hermes_constants')
-        except Exception:
-            _streaming_hermes_home_override_available = False
-            return None
-
-    if (
-        mod is not None
-        and hasattr(mod, 'set_hermes_home_override')
-        and hasattr(mod, 'reset_hermes_home_override')
-    ):
-        _streaming_hermes_home_override_available = True
-        return mod
-
-    _streaming_hermes_home_override_available = False
-    return None
-
-
-def _set_streaming_hermes_home_override(profile_home: str):
-    """Install the context-local home override if available.
-
-    Returns ``(module, token, installed)`` so callers can restore it with the
-    matching module in the inverse order.
-    """
-    if not profile_home:
-        return None, None, False
-
-    _home_override_mod = _resolve_streaming_hermes_home_override()
-    if _home_override_mod is None:
-        return None, None, False
-
-    try:
-        _token = _home_override_mod.set_hermes_home_override(profile_home)
-        return _home_override_mod, _token, True
-    except Exception:
-        logger.debug(
-            "Failed to set streaming Hermes home override; continuing with os.environ mirror",
-            exc_info=True,
-        )
-        return None, None, False
-
-
-def _reset_streaming_hermes_home_override(override_mod, override_token, override_installed: bool) -> None:
-    """Reset the context-local home override if it was installed."""
-    if override_mod is None or not override_installed:
-        return
-    try:
-        override_mod.reset_hermes_home_override(override_token)
-    except Exception:
-        logger.debug("Failed to reset streaming Hermes home override", exc_info=True)
-
-
 # ── Per-turn session identity (xsession wakeup misroute root fix — Option 1) ─
 # WebUI bound per-turn session identity ONLY to the process-global
 # os.environ['HERMES_SESSION_KEY'] (turn-start, line ~3263) and released the
@@ -2298,23 +1792,24 @@ def _set_turn_session_identity(session_id: str):
     """Bind THIS turn's session identity to the current (task/thread-local)
     context and return an opaque token for _reset_turn_session_identity.
 
-    Binds three context-locals so every session-key / UI-owner consumer is
-    covered without a race:
+    Binds two context-locals so every session-key consumer is covered without
+    a race:
       * ``tools.approval._approval_session_key`` — checked FIRST by
         ``get_current_session_key`` (the exact call terminal_tool.py makes for
         a notify_on_complete background spawn: the bug path).
       * ``gateway.session_context._SESSION_KEY`` — read by direct
-        ``get_session_env("HERMES_SESSION_KEY")`` consumers.
-      * ``gateway.session_context._SESSION_UI_SESSION_ID`` — exact browser-tab
-        return address stamped onto ProcessSession.origin_ui_session_id and
-        completion events by modern hermes-agent builds. Authoritative for
-        wakeup routing when present (see ``_resolve_completion_target``).
+        ``get_session_env("HERMES_SESSION_KEY")`` consumers (e.g. the sudo
+        password cache scope, terminal_tool.py:272).
 
     It deliberately does NOT call ``gateway.session_context.set_session_vars``:
     that blanket setter also zeroes the platform/chat_id/user contextvars,
     flipping ``HERMES_SESSION_PLATFORM`` from its env fallback (``'webui'``,
     still written to os.environ at turn-start) to an explicit ``""`` — which
-    would break the ``notify_on_complete`` watcher registration gate.
+    would break the ``notify_on_complete`` watcher registration gate in
+    terminal_tool.py:~1966. Only the session-key identity is bound; every
+    other session var keeps its existing os.environ fallback (CLI/cron compat
+    preserved — when these contextvars are _UNSET, get_session_env still falls
+    back to os.environ).
     """
     sid = str(session_id or "")
     tokens: dict = {}
@@ -2328,11 +1823,6 @@ def _set_turn_session_identity(session_id: str):
         tokens["session_key"] = _SK.set(sid)
     except Exception:
         logger.debug("per-turn _SESSION_KEY bind failed", exc_info=True)
-    try:
-        from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
-        tokens["ui_session_id"] = _UI_SID.set(sid)
-    except Exception:
-        logger.debug("per-turn _SESSION_UI_SESSION_ID bind failed", exc_info=True)
     return tokens
 
 
@@ -2347,13 +1837,6 @@ def _reset_turn_session_identity(tokens) -> None:
     """
     if not tokens:
         return
-    tok = tokens.get("ui_session_id")
-    if tok is not None:
-        try:
-            from gateway.session_context import _SESSION_UI_SESSION_ID as _UI_SID
-            _UI_SID.reset(tok)
-        except Exception:
-            logger.debug("per-turn _SESSION_UI_SESSION_ID reset failed", exc_info=True)
     tok = tokens.get("session_key")
     if tok is not None:
         try:
@@ -2416,14 +1899,6 @@ def _format_process_notification(evt: dict) -> str:
     """Format a completed background process notification for agent input."""
     if not isinstance(evt, dict):
         return ''
-    if evt.get('type') == 'async_delegation':
-        try:
-            from tools.process_registry import format_process_notification
-
-            return format_process_notification(evt) or ''
-        except Exception:
-            logger.debug("Failed to format async delegation notification", exc_info=True)
-            return ''
     if evt.get('type') != 'completion':
         return ''
     _sid = evt.get('session_id', '')
@@ -2448,31 +1923,7 @@ def _mark_process_completion_consumed(process_registry, process_id: str) -> None
         logger.debug("Failed to mark process completion consumed", exc_info=True)
 
 
-def _completion_event_targets_webui_session(evt_session_key: str, session_id: str) -> bool:
-    """Return whether a completion event belongs to this WebUI session.
-
-    WebUI normally registers ``PROCESS_SESSION_INDEX[session_id] = session_id``.
-    Gateway/agent session keys can differ, so match the direct WebUI case first
-    and otherwise resolve through the same session-key index used by the
-    background wakeup path.
-    """
-    if not evt_session_key or not session_id:
-        return False
-    if evt_session_key == session_id:
-        return True
-    try:
-        with PROCESS_SESSION_INDEX_LOCK:
-            return PROCESS_SESSION_INDEX.get(evt_session_key) == session_id
-    except Exception:
-        logger.debug("Failed to resolve completion event session key", exc_info=True)
-        return False
-
-
-def _drain_webui_process_notifications(
-    session_id: str,
-    *,
-    pending_async_acceptances: list | None = None,
-) -> list[str]:
+def _drain_webui_process_notifications(session_id: str) -> list[str]:
     """Return completion notifications that belong to this WebUI session.
 
     The agent registry completion queue is process-wide and events do not carry
@@ -2488,7 +1939,6 @@ def _drain_webui_process_notifications(
 
     notifications: list[str] = []
     skipped_events: list[dict] = []
-    async_retry_events: list[tuple[dict, bool]] = []
     completion_queue = getattr(process_registry, 'completion_queue', None)
     if completion_queue is None:
         return []
@@ -2506,142 +1956,44 @@ def _drain_webui_process_notifications(
             logger.debug("Failed to drain process completion queue", exc_info=True)
             break
 
-        evt_sid = completion_delivery_id(evt) if isinstance(evt, dict) else ''
+        evt_sid = str(evt.get('session_id') or '') if isinstance(evt, dict) else ''
         if not evt_sid:
             skipped_events.append(evt)
             continue
-        is_async_delegation = (
-            isinstance(evt, dict) and evt.get('type') == 'async_delegation'
-        )
         try:
-            if (
-                not is_async_delegation
-                and process_registry.is_completion_consumed(evt_sid)
-            ):
+            if process_registry.is_completion_consumed(evt_sid):
                 continue
-            evt_session_key = str(evt.get('session_key') or '') if isinstance(evt, dict) else ''
-            evt_origin_ui_session_id = (
-                str(evt.get('origin_ui_session_id') or '') if isinstance(evt, dict) else ''
-            )
-            if not evt_session_key or not evt_origin_ui_session_id:
-                proc = process_registry.get(evt_sid)
-                if not evt_session_key:
-                    evt_session_key = str(getattr(proc, 'session_key', '') or '')
-                if not evt_origin_ui_session_id:
-                    evt_origin_ui_session_id = (
-                        str(getattr(proc, 'origin_ui_session_id', '') or '')
-                        or str(getattr(proc, 'spawn_session_id', '') or '')
-                    )
+            proc = process_registry.get(evt_sid)
         except Exception:
-            evt_session_key = ''
-            evt_origin_ui_session_id = ''
-
-        # origin_ui_session_id is the exact, immutable return address and is
-        # authoritative over the mutable session-key index (mirrors the
-        # background _process_one path via _resolve_completion_target). When it
-        # is present, this drain claims/ACKs the event ONLY for the origin
-        # session — otherwise the next-turn drain could win the shared-queue
-        # race and deliver+ACK a completion to the wrong (session-key-index)
-        # session, leaving the true origin empty. Fall back to the session-key
-        # target check only for legacy events that carry no origin address.
-        if evt_origin_ui_session_id:
-            if evt_origin_ui_session_id != session_id:
-                skipped_events.append(evt)
-                continue
-        elif not _completion_event_targets_webui_session(evt_session_key, session_id):
+            proc = None
+        if getattr(proc, 'session_key', None) != session_id:
             skipped_events.append(evt)
             continue
+
         # Age-gate stale completions: a completion that fires long after the
         # user moved on must not be prepended to an unrelated later turn
         # (nesquena/hermes-webui#4029). Drop (consume, do not requeue) any
         # completion whose enqueue time is older than the configured cap.
         # Events without a 'completed_at' (older agent builds) are never
         # dropped here, preserving backward-compatible behavior.
-        is_stale = False
-        stale_age = 0.0
         if stale_completion_max_age > 0 and isinstance(evt, dict):
             completed_at = evt.get('completed_at')
             if isinstance(completed_at, (int, float)) and completed_at > 0:
-                stale_age = time.time() - completed_at
-                is_stale = stale_age > stale_completion_max_age
-
-        if is_async_delegation:
-            try:
-                claim = claim_async_delegation_delivery(evt, "webui-next-turn")
-            except Exception:
-                skipped_events.append(evt)
-                continue
-            if claim is None:
-                schedule_async_delegation_claim_retry(evt, completion_queue)
-                continue
-            notification_added = False
-            try:
-                if is_stale:
-                    notification = ''
-                else:
-                    notification = _format_process_notification(evt)
-                    if not notification:
-                        raise ValueError(
-                            "async delegation formatter returned an empty notification"
-                        )
-                if notification:
-                    notifications.append(notification)
-                    notification_added = True
-                if is_stale:
-                    # Stale async events are an explicit terminal disposition.
-                    complete_async_delegation_delivery(evt, claim)
-                elif pending_async_acceptances is not None:
-                    pending_async_acceptances.append(
-                        (evt, claim, notification, completion_queue)
+                age = time.time() - completed_at
+                if age > stale_completion_max_age:
+                    logger.info(
+                        "Dropping stale background-process completion for "
+                        "session %s (age %.0fs > cap %.0fs)",
+                        evt_sid, age, stale_completion_max_age,
                     )
-                else:
-                    # Direct callers without a live agent turn retain the
-                    # historical synchronous acceptance behavior used by
-                    # CLI-style drains.
-                    complete_async_delegation_delivery(evt, claim)
-            except Exception:
-                if notification_added:
-                    notifications.pop()
-                release_async_delegation_delivery(evt, claim)
-                async_retry_events.append(
-                    (evt, bool(getattr(claim, "durable", False)))
-                )
-                logger.warning(
-                    "Failed to accept async delegation completion for session %s",
-                    session_id,
-                    exc_info=True,
-                )
-                continue
-            if is_stale:
-                logger.info(
-                    "Dropping stale async-delegation completion for session %s "
-                    "(age %.0fs > cap %.0fs)",
-                    evt_sid, stale_age, stale_completion_max_age,
-                )
-            continue
-
-        if is_stale:
-            logger.info(
-                "Dropping stale background-process completion for "
-                "session %s (age %.0fs > cap %.0fs)",
-                evt_sid, stale_age, stale_completion_max_age,
-            )
-            _mark_process_completion_consumed(process_registry, evt_sid)
-            continue
+                    _mark_process_completion_consumed(process_registry, evt_sid)
+                    continue
 
         notification = _format_process_notification(evt)
         if notification:
             notifications.append(notification)
-        # Matched but unformattable process completions are consumed rather than
-        # replayed forever on later turns.
-        _mark_process_completion_consumed(process_registry, evt_sid)
+            _mark_process_completion_consumed(process_registry, evt_sid)
 
-    for evt, durable in async_retry_events:
-        requeue_async_delegation_event(
-            evt,
-            completion_queue,
-            durable=durable,
-        )
     for evt in skipped_events:
         try:
             completion_queue.put(evt)
@@ -2649,32 +2001,6 @@ def _drain_webui_process_notifications(
             logger.debug("Failed to requeue process completion event", exc_info=True)
             break
     return notifications
-
-
-def _accept_pending_async_delegations(
-    pending_async_acceptances: list,
-    *,
-    session_id: str,
-) -> list[str]:
-    """ACK turn-bound delegation claims and return rejected notifications."""
-    rejected_notifications: list[str] = []
-    for evt, claim, notification, completion_queue in pending_async_acceptances:
-        try:
-            complete_async_delegation_delivery(evt, claim)
-        except Exception:
-            release_async_delegation_delivery(evt, claim)
-            requeue_async_delegation_event(
-                evt,
-                completion_queue,
-                durable=bool(getattr(claim, "durable", False)),
-            )
-            rejected_notifications.append(notification)
-            logger.warning(
-                "Async delegation was not accepted into session %s; retrying later",
-                session_id,
-                exc_info=True,
-            )
-    return rejected_notifications
 
 
 def _attachment_name(att) -> str:
@@ -3215,19 +2541,13 @@ def _sanitize_generated_title(text: str) -> str:
     s = re.sub(r'^\s*title\s*:\s*', '', s, flags=re.IGNORECASE)
     s = s.strip(" \t\r\n\"'`*_~")
     s = re.sub(r'\s+', ' ', s).strip()
-    # Guard against chain-of-thought leakage, meta-reasoning, and trivial echo.
-    if _is_bad_new_title(s):
+    # Guard against chain-of-thought leakage and meta-reasoning patterns.
+    if _looks_invalid_generated_title(s):
         return ''
     return s[:80]
 
 
 def _looks_invalid_generated_title(text: str) -> bool:
-    """True when an existing/persisted title is structurally invalid (CoT leak).
-
-    Intentionally does NOT reject short conversational words like "Done" or
-    "Cool" — those can be legitimate stored titles. Use ``_is_bad_new_title``
-    when validating a freshly generated candidate.
-    """
     s = str(text or '')
     if not s.strip():
         return True
@@ -3239,40 +2559,7 @@ def _looks_invalid_generated_title(text: str) -> bool:
         or re.search(r'^\s*(i|we)\s+(should|need to|will|can)\b', s, flags=re.IGNORECASE)
         or re.search(r'^\s*let me\b', s, flags=re.IGNORECASE)
         or re.search(r"^\s*here(?:'s| is) (?:a |my )?(?:thinking|thought)", s, flags=re.IGNORECASE)
-    )
-
-
-def _is_bad_new_title(text: str) -> bool:
-    """True when a freshly generated title candidate should be discarded.
-
-    Includes structural CoT rejection plus trivial single-token echo replies
-    (pong, yes, done, cool, …) that are useless as first-generation titles.
-    """
-    if _looks_invalid_generated_title(text):
-        return True
-    s = str(text or '').strip()
-    _token = re.sub(r'[\s.!?]+$', '', s, flags=re.IGNORECASE)
-    if re.fullmatch(
-        r'(?:pong|ping|yes|no|yep|nope|hi|hello|hey|thanks|thank you|sure|k|kk|cool|nice|lol|ok|okay|done)',
-        _token,
-        flags=re.IGNORECASE,
-    ):
-        return True
-    return bool(
-        re.search(
-            r'^\s*(ok|okay|done|all set|complete|completed|finished)\b[\s.!?]*$',
-            s,
-            flags=re.IGNORECASE,
-        )
-    )
-
-
-def _message_content_part_text(part) -> str:
-    """Extract visible text from a structured content part."""
-    if not isinstance(part, dict):
-        return ''
-    return str(
-        part.get('text') or part.get('content') or part.get('input_text') or part.get('output_text') or ''
+        or re.search(r'^\s*(ok|okay|done|all set|complete|completed|finished)\b[\s.!?]*$', s, flags=re.IGNORECASE)
     )
 
 
@@ -3285,47 +2572,9 @@ def _message_text(value) -> str:
                 continue
             ptype = str(p.get('type') or '').lower()
             if ptype in ('', 'text', 'input_text', 'output_text'):
-                parts.append(_message_content_part_text(p))
+                parts.append(str(p.get('text') or p.get('content') or ''))
         return _strip_thinking_markup('\n'.join(parts).strip())
     return _strip_thinking_markup(str(value or '').strip())
-
-
-def _assistant_content_part_is_tool_use(part) -> bool:
-    """Return True when a content[] part represents a tool invocation boundary."""
-    if not isinstance(part, dict):
-        return False
-    part_type = str(part.get('type') or '').lower()
-    if part_type in {'tool_use', 'tool_call'}:
-        return True
-    if part_type:
-        return False
-    if _message_content_part_text(part).strip():
-        return False
-    return any(key in part for key in ('tool_use_id', 'tool_call_id', 'call_id')) and any(
-        key in part for key in ('name', 'tool_name', 'input', 'args')
-    )
-
-
-def _assistant_message_has_final_visible_text(message) -> bool:
-    """Return True when an assistant row carries a settled visible answer."""
-    if not isinstance(message, dict) or message.get('role') != 'assistant':
-        return False
-    content = message.get('content', '')
-    if isinstance(content, list):
-        last_tool_idx = -1
-        for idx, part in enumerate(content):
-            if _assistant_content_part_is_tool_use(part):
-                last_tool_idx = idx
-        if last_tool_idx >= 0:
-            tail_parts = content[last_tool_idx + 1:]
-            return bool(_message_text(tail_parts).strip())
-        if message.get('tool_calls'):
-            return False
-        return bool(_message_text(content).strip())
-    if message.get('tool_calls'):
-        return False
-    return bool(_message_text(content).strip())
-
 
 
 _WORKSPACE_PREFIX_RE = re.compile(r'^\s*\[Workspace::v1:\s*(?:\\.|[^\]\\])+\]\s*')
@@ -3398,7 +2647,7 @@ def _first_exchange_snippets(messages):
             # is asking...", etc.). Assistant rows that carry tool_calls but
             # also contain a substantive answer text are kept — those are
             # agentic first-turn plans that are legitimate title candidates.
-            if m.get('tool_calls') and (not candidate or _is_bad_new_title(candidate)):
+            if m.get('tool_calls') and (not candidate or _looks_invalid_generated_title(candidate)):
                 continue
             if candidate:
                 asst_text = candidate
@@ -3422,7 +2671,7 @@ def _latest_exchange_snippets(messages):
         if role == 'assistant' and not asst_text:
             candidate = _message_text(m.get('content'))
             # Skip tool-call-only preambles
-            if m.get('tool_calls') and (not candidate or _is_bad_new_title(candidate)):
+            if m.get('tool_calls') and (not candidate or _looks_invalid_generated_title(candidate)):
                 continue
             if candidate:
                 asst_text = candidate
@@ -4704,76 +3953,6 @@ def _should_strip_reasoning_content(
     return False
 
 
-def _compact_image_parts_for_persistence(messages) -> int:
-    """Replace persisted image parts with text placeholders after a completed turn.
-
-    The active model receives native image parts while a tool call is running. Once
-    the turn has completed, retaining base64 data URLs in both the visible
-    transcript and ``context_messages`` makes every JSON sidecar save/load and
-    session API response scale with the image bytes. Hermes Agent's durable
-    session store applies the same text-only policy for completed multimodal
-    tool results. Keep text parts and the surrounding tool-call chain intact so
-    future turns retain the conversational record and can re-open the original
-    image from the preceding tool-call arguments when needed.
-
-    This intentionally mutates the owned session message rows in place. It is
-    called only after ``run_conversation()`` has returned, so it never removes
-    image parts that the current model invocation still needs.
-    """
-    changed = 0
-    for message in messages or ():
-        # Mirror Hermes Agent's durable-session policy: native *tool* results
-        # are transient input for the current model call. User attachments are
-        # a separate product contract and must remain intact here.
-        if not isinstance(message, dict) or message.get('role') != 'tool':
-            continue
-        content = message.get('content')
-        if not isinstance(content, list):
-            continue
-
-        compacted_content = []
-        image_parts = 0
-        for part in content:
-            if not isinstance(part, dict):
-                # A provider can legally return scalar content alongside typed
-                # parts. Preserve it unchanged rather than flattening/reordering
-                # the structured result during durable-session compaction.
-                compacted_content.append(part)
-                continue
-            part_type = part.get('type')
-            # Guard the set-membership with an isinstance check: a JSON-valid
-            # part can carry an unhashable ``type`` (e.g. a list), and
-            # ``unhashable in {...}`` raises TypeError — which would turn an
-            # otherwise-complete streaming send into the error path before the
-            # session is saved. Only the three string image types are compacted;
-            # every other part (including non-string ``type`` values) is preserved.
-            if isinstance(part_type, str) and part_type in {'image', 'image_url', 'input_image'}:
-                compacted_content.append({'type': 'text', 'text': '[screenshot]'})
-                image_parts += 1
-            else:
-                compacted_content.append(part)
-
-        if image_parts:
-            message['content'] = compacted_content
-            changed += image_parts
-    return changed
-
-
-def _compact_session_image_parts_for_persistence(session) -> int:
-    """Compact completed native-vision tool results in both durable histories."""
-    changed = (
-        _compact_image_parts_for_persistence(getattr(session, 'context_messages', None))
-        + _compact_image_parts_for_persistence(getattr(session, 'messages', None))
-    )
-    if changed:
-        logger.info(
-            "Compacted %d completed image message part(s) for session %s",
-            changed,
-            getattr(session, 'session_id', None),
-        )
-    return changed
-
-
 def _sanitize_messages_for_api(
     messages,
     *,
@@ -5028,7 +4207,6 @@ def _deduplicate_context_messages(messages):
         return messages
     seen = set()
     deduped = []
-    user_exact_index = {}
     for msg in messages:
         if _is_context_compression_marker(msg):
             marker_key = (
@@ -5043,30 +4221,7 @@ def _deduplicate_context_messages(messages):
                 msg['role'] = 'assistant'
             deduped.append(msg)
             continue
-        if _is_compressed_context_tool_result_summary_message(msg) and not msg.get('tool_call_id'):
-            deduped.append(msg)
-            continue
         key = _message_identity(msg)
-        if isinstance(msg, dict) and msg.get('role') == 'user' and key is not None:
-            user_exact_key = (
-                key,
-                msg.get('timestamp'),
-                msg.get('_ts'),
-                msg.get('_source') or 'webui',
-                json.dumps(msg.get('attachments') or [], sort_keys=True, ensure_ascii=False),
-            )
-            prior_exact_idx = user_exact_index.get(user_exact_key)
-            if msg.get('_active_turn_token'):
-                if prior_exact_idx is not None:
-                    deduped[prior_exact_idx] = msg
-                    continue
-                if key in seen:
-                    deduped.append(msg)
-                    user_exact_index[user_exact_key] = len(deduped) - 1
-                    continue
-            elif prior_exact_idx is not None:
-                continue
-            user_exact_index[user_exact_key] = len(deduped)
         if key is not None and key in seen:
             continue
         if key is not None:
@@ -5115,107 +4270,6 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
     return stamped
 
 
-_POST_COMPRESSION_TOOL_RESULT_TOTAL_TOKENS = 4096
-_POST_COMPRESSION_TOOL_RESULT_MIN_SNIPPET_TOKENS = 256
-_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG = "_webui_pruned_tool_result_summary"
-_POST_COMPRESSION_TOOL_RESULT_MARKER = "[WebUI compressed-context budget:"
-_ROUGH_TOKEN_CHARS = 4
-
-
-def _positive_int_value(value, default: int = 0) -> int:
-    try:
-        parsed = int(value or 0)
-    except (TypeError, ValueError):
-        return default
-    return parsed if parsed > 0 else default
-
-
-def _rough_text_token_count(text: str) -> int:
-    text = str(text or "")
-    if not text:
-        return 0
-    return max(1, (len(text) + (_ROUGH_TOKEN_CHARS - 1)) // _ROUGH_TOKEN_CHARS)
-
-
-def _post_compression_tool_result_budget(compressor) -> int:
-    budget = _positive_int_value(
-        getattr(compressor, 'tail_token_budget', None),
-        _POST_COMPRESSION_TOOL_RESULT_TOTAL_TOKENS,
-    )
-    threshold = _positive_int_value(getattr(compressor, 'threshold_tokens', None), 0)
-    if threshold:
-        budget = min(budget, max(512, threshold // 2))
-    return max(512, budget)
-
-
-def _compressed_context_tool_result_summary(text: str, *, original_tokens: int, keep_tokens: int) -> str:
-    text = str(text or "")
-    keep_chars = max(0, int(keep_tokens or 0) * _ROUGH_TOKEN_CHARS)
-    note_prefix = f"{_POST_COMPRESSION_TOOL_RESULT_MARKER} omitted "
-    note_suffix = (
-        f" (~{int(original_tokens or 0)} rough tokens) from this tool result; "
-        "the full output remains in the visible transcript/tool log.]"
-    )
-    if keep_chars < (_POST_COMPRESSION_TOOL_RESULT_MIN_SNIPPET_TOKENS * _ROUGH_TOKEN_CHARS):
-        return f"{note_prefix}{len(text)} chars{note_suffix}"
-    note_len_for_budget = len(f"{note_prefix}{len(text)} of {len(text)} chars{note_suffix}")
-    snippet_limit = max(0, keep_chars - note_len_for_budget - 2)
-    snippet = text[:snippet_limit].rstrip()
-    if not snippet:
-        return f"{note_prefix}{len(text)} chars{note_suffix}"
-    omitted_chars = max(0, len(text) - len(snippet))
-    note = f"{note_prefix}{omitted_chars} of {len(text)} chars{note_suffix}"
-    return f"{snippet}\n\n{note}"
-
-
-def _is_compressed_context_tool_result_summary_message(msg) -> bool:
-    if not isinstance(msg, dict) or msg.get('role') != 'tool':
-        return False
-    return msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is True
-
-
-def _hard_prune_post_compression_tool_results(messages, *, compressor=None):
-    if not messages:
-        return messages, 0
-    budget = _post_compression_tool_result_budget(compressor)
-    raw_tool_tokens = 0
-    replacements = []
-    for idx in range(len(messages) - 1, -1, -1):
-        msg = messages[idx]
-        if not isinstance(msg, dict) or msg.get('role') != 'tool':
-            continue
-        content = msg.get('content', '')
-        text = _raw_message_text(content)
-        if not text.strip():
-            continue
-        token_count = _rough_text_token_count(text)
-        if _is_compressed_context_tool_result_summary_message(msg):
-            raw_tool_tokens += token_count
-            continue
-        remaining = max(0, budget - raw_tool_tokens)
-        if token_count <= remaining:
-            raw_tool_tokens += token_count
-            continue
-        replacements.append((idx, text, token_count, remaining))
-        # Once a tool row exceeds the residual budget, older tool rows should
-        # not be allowed to spend that same residual budget again.
-        raw_tool_tokens = budget
-
-    if not replacements:
-        return messages, 0
-
-    pruned = copy.deepcopy(list(messages))
-    for idx, text, token_count, keep_tokens in replacements:
-        msg = pruned[idx]
-        msg['content'] = _compressed_context_tool_result_summary(
-            text,
-            original_tokens=token_count,
-            keep_tokens=keep_tokens,
-        )
-        msg[_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] = True
-    return pruned, len(replacements)
-
-
 def _prune_context_tool_results_after_compression(agent, context_messages):
     """Run the active compressor's cheap tool-result pruning on model context.
 
@@ -5223,74 +4277,28 @@ def _prune_context_tool_results_after_compression(agent, context_messages):
     before producing the final answer. Those completed tail tool results are
     model-facing context, but they were produced after the compression pass and
     therefore did not go through the compressor's tool-output pruning. Apply the
-    same cheap pruning once more after a confirmed compression event, then apply
-    a WebUI hard cap to retained tool-result payloads. This keeps the visible
-    transcript untouched while preventing the next turn from seeing raw
-    post-compression tool dumps that the compressor protected as recent tail.
+    same cheap pruning once more after a confirmed compression event. This keeps
+    the visible transcript untouched while preventing the next turn from seeing
+    raw post-compression tool dumps.
     """
     if not context_messages:
         return context_messages
     compressor = getattr(agent, 'context_compressor', None)
     prune = getattr(compressor, '_prune_old_tool_results', None)
-    pruned_messages = context_messages
-    if callable(prune):
-        try:
-            candidate_messages, pruned_count = prune(
-                copy.deepcopy(context_messages),
-                protect_tail_count=getattr(compressor, 'protect_last_n', 20),
-                protect_tail_tokens=getattr(compressor, 'tail_token_budget', None),
-            )
-            if pruned_count:
-                pruned_messages = _deduplicate_context_messages(candidate_messages)
-        except Exception:
-            logger.debug("post-compression context tool-result pruning failed", exc_info=True)
-
-    hard_pruned_messages, hard_pruned_count = _hard_prune_post_compression_tool_results(
-        pruned_messages,
-        compressor=compressor,
-    )
-    if hard_pruned_count:
-        return _deduplicate_context_messages(hard_pruned_messages)
-    return pruned_messages
-
-
-def _estimate_post_compression_context_tokens(agent, context_messages, system_message):
-    """Return a display-only estimate for the prepared post-compression request."""
+    if not callable(prune):
+        return context_messages
     try:
-        from agent import model_metadata
-
-        messages = context_messages or []
-        tools = getattr(agent, 'tools', None) or None
-        request_estimator = getattr(model_metadata, 'estimate_request_tokens_rough', None)
-        if callable(request_estimator):
-            estimate = request_estimator(messages, system_prompt=system_message or '', tools=tools)
-        else:
-            message_estimator = getattr(model_metadata, 'estimate_messages_tokens_rough', None)
-            if callable(message_estimator):
-                estimate = message_estimator(messages)
-                if system_message:
-                    estimate += message_estimator([{'role': 'system', 'content': system_message}])
-                if tools:
-                    estimate += message_estimator([{'role': 'system', 'content': str(tools)}])
-            else:
-                try:
-                    from agent.context_compressor import _estimate_msg_budget_tokens
-                except ImportError:
-                    return None
-
-                estimate = sum(
-                    _estimate_msg_budget_tokens(message)
-                    for message in messages
-                    if isinstance(message, dict)
-                )
-                if system_message:
-                    estimate += _estimate_msg_budget_tokens({'role': 'system', 'content': system_message})
-                if tools:
-                    estimate += _estimate_msg_budget_tokens({'role': 'system', 'content': str(tools)})
-        return estimate if isinstance(estimate, int) and estimate > 0 else None
+        pruned_messages, pruned_count = prune(
+            copy.deepcopy(context_messages),
+            protect_tail_count=getattr(compressor, 'protect_last_n', 20),
+            protect_tail_tokens=getattr(compressor, 'tail_token_budget', None),
+        )
     except Exception:
-        logger.debug("post-compression context estimate failed", exc_info=True)
-        return None
+        logger.debug("post-compression context tool-result pruning failed", exc_info=True)
+        return context_messages
+    if not pruned_count:
+        return context_messages
+    return _deduplicate_context_messages(pruned_messages)
 
 
 def _restore_reasoning_metadata(previous_messages, updated_messages):
@@ -5340,11 +4348,6 @@ def _restore_reasoning_metadata(previous_messages, updated_messages):
             # with their display counterpart.
             if prev_msg.get('id') is not None and cur_msg.get('id') is None:
                 cur_msg['id'] = prev_msg['id']
-            if (
-                prev_msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is True
-                and cur_msg.get(_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG) is not True
-            ):
-                cur_msg[_POST_COMPRESSION_TOOL_RESULT_SUMMARY_FLAG] = True
             if prev_msg.get('timestamp') and not cur_msg.get('timestamp'):
                 cur_msg['timestamp'] = prev_msg['timestamp']
             elif prev_msg.get('_ts') and not cur_msg.get('_ts') and not cur_msg.get('timestamp'):
@@ -5570,19 +4573,6 @@ def _dedupe_replayed_context_messages(previous_context, result_messages, msg_tex
                 if candidates:
                     candidates = _strip_replayed_context_items(previous_context, candidates)
                 return previous_context + candidates
-        assistant_or_tool_only_result = bool(result_messages) and all(
-            _is_context_compression_marker(m)
-            or (
-                isinstance(m, dict)
-                and m.get('role') in ('assistant', 'tool')
-            )
-            for m in result_messages
-        )
-        if assistant_or_tool_only_result:
-            candidates = _strip_replayed_prefix(previous_context, result_messages)
-            if candidates:
-                candidates = _strip_replayed_context_items(previous_context, candidates)
-            return previous_context + candidates
         return result_messages
     candidates = result_messages[len(previous_context):]
     # Strip stale merges only from the new-turn candidate slice so that
@@ -5726,7 +4716,7 @@ def _raw_message_text(value) -> str:
     """
     if isinstance(value, list):
         return ' '.join(
-            _message_content_part_text(p)
+            str(p.get('text') or p.get('content') or '')
             for p in value
             if isinstance(p, dict)
         )
@@ -5918,7 +4908,6 @@ def _save_streaming_checkpoint(session):
         session,
         "streaming checkpoint",
         logger_override=logger,
-        scope_skill_modules=False,
     ):
         session.save(skip_index=True)
 
@@ -6090,14 +5079,7 @@ def _advance_truncation_watermark_after_commit(session) -> None:
     session.truncation_watermark = time.time()
 
 
-def _merge_display_messages_after_agent_result(
-    previous_display,
-    previous_context,
-    result_messages,
-    msg_text,
-    source: str = "webui",
-    verification_nudge_provenance=None,
-):
+def _merge_display_messages_after_agent_result(previous_display, previous_context, result_messages, msg_text, source: str = "webui"):
     """Keep UI transcript durable while allowing model context to compact.
 
     If Hermes Agent returns a normal append-only history, append that delta to
@@ -6109,7 +5091,6 @@ def _merge_display_messages_after_agent_result(
     previous_display = [
         m for m in list(previous_display or [])
         if not _is_context_compression_marker(m)
-        and not _is_compressed_context_tool_result_summary_message(m)
     ]
     # Drop Hermes Agent internal verify-loop scaffolding (synthetic "premature
     # done" answer + the "[System: ...verification evidence...]" nudge) before
@@ -6146,25 +5127,6 @@ def _merge_display_messages_after_agent_result(
     previous_display = _deduped
     previous_context = list(previous_context or [])
     result_messages = list(result_messages or [])
-    if isinstance(verification_nudge_provenance, dict):
-        _writeback_provenance = verification_nudge_provenance
-    else:
-        _writeback_provenance = {
-            'verification_nudge_seen': bool(verification_nudge_provenance),
-            'active_turn_identity': None,
-        }
-    _verification_nudge_seen = _writeback_provenance.get('verification_nudge_seen', False) or any(
-        isinstance(message, dict)
-        and message.get('role') == 'user'
-        and _is_synthetic_control_message(message)
-        for message in result_messages
-    )
-    _active_turn_identity = _writeback_provenance.get('active_turn_identity')
-    previous_display, _ = _align_current_turn_display(
-        previous_display,
-        previous_context,
-        _active_turn_identity,
-    )
     # Same marker filter for the model-history inputs: the synthetic verify-loop
     # answer/nudge live in the agent's returned messages and prior context, and
     # would otherwise slip into the merged transcript as a real delta. (#5334)
@@ -6191,7 +5153,6 @@ def _merge_display_messages_after_agent_result(
             _message_identity(m)
             for m in previous_context
             if not _is_context_compression_marker(m)
-            and not _is_compressed_context_tool_result_summary_message(m)
         }
         _has_context_only_turns = bool(_context_id_set - _display_id_set)
         if _has_context_only_turns:
@@ -6229,13 +5190,7 @@ def _merge_display_messages_after_agent_result(
                         for _k in range(_cursor, _j):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if (
-                                _ckey is not None
-                                and _ckey not in _context_inserted
-                                and _ckey not in _display_id_set
-                                and not _is_context_compression_marker(_cmsg)
-                                and not _is_compressed_context_tool_result_summary_message(_cmsg)
-                            ):
+                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _context_inserted.add(_ckey)
                         # Sync multiset: decrement keys consumed by advancing
@@ -6256,13 +5211,7 @@ def _merge_display_messages_after_agent_result(
                         for _k in range(_cursor, len(context_keys)):
                             _ckey = context_keys[_k]
                             _cmsg = previous_context[_k]
-                            if (
-                                _ckey is not None
-                                and _ckey not in _context_inserted
-                                and _ckey not in _display_id_set
-                                and not _is_context_compression_marker(_cmsg)
-                                and not _is_compressed_context_tool_result_summary_message(_cmsg)
-                            ):
+                            if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
                                 _backfilled.append(copy.deepcopy(_cmsg))
                                 _context_inserted.add(_ckey)
                         _cursor = len(context_keys)
@@ -6275,13 +5224,7 @@ def _merge_display_messages_after_agent_result(
                 _ckey = context_keys[_cursor]
                 _cmsg = previous_context[_cursor]
                 _cursor += 1
-                if (
-                    _ckey is not None
-                    and _ckey not in _context_inserted
-                    and _ckey not in _display_id_set
-                    and not _is_context_compression_marker(_cmsg)
-                    and not _is_compressed_context_tool_result_summary_message(_cmsg)
-                ):
+                if _ckey is not None and _ckey not in _context_inserted and _ckey not in _display_id_set and not _is_context_compression_marker(_cmsg):
                     _backfilled.append(copy.deepcopy(_cmsg))
                     _context_inserted.add(_ckey)
             if len(_backfilled) > len(previous_display):
@@ -6322,19 +5265,7 @@ def _merge_display_messages_after_agent_result(
             candidates = _strip_replayed_prefix(previous_context, candidates)
     else:
         current_user_idx = _find_current_user_turn(result_messages, msg_text)
-        assistant_or_tool_only_result = bool(result_messages) and all(
-            _is_context_compression_marker(m)
-            or (
-                isinstance(m, dict)
-                and m.get('role') in ('assistant', 'tool')
-            )
-            for m in result_messages
-        )
-        turn_candidates = (
-            result_messages[current_user_idx:]
-            if current_user_idx is not None
-            else result_messages if assistant_or_tool_only_result else []
-        )
+        turn_candidates = result_messages[current_user_idx:] if current_user_idx is not None else []
         # Normalize stale merges only in the current-turn slice.
         if msg_text and previous_user_tail:
             turn_candidates = _strip_stale_user_merge_from_messages(
@@ -6352,24 +5283,17 @@ def _merge_display_messages_after_agent_result(
         _message_identity(m) == current_user_key or _looks_like_current_user_turn(m, msg_text)
         for m in candidates
     )
-    current_user_already_checkpointed = (
-        _active_turn_has_checkpoint(merged, _active_turn_identity)
-        if _active_turn_identity
-        else False
-    )
-    verification_user_already_checkpointed = bool(
-        _verification_nudge_seen
-        and _active_turn_identity
+    current_user_already_checkpointed = bool(
+        merged
         and (
-            _active_turn_has_checkpoint(previous_display, _active_turn_identity)
-            or _active_turn_has_checkpoint(previous_context, _active_turn_identity)
+            _message_identity(merged[-1]) == current_user_key
+            or _looks_like_current_user_turn(merged[-1], msg_text)
         )
     )
     if (
         current_user_key is not None
         and not current_user_in_candidates
         and not current_user_already_checkpointed
-        and not verification_user_already_checkpointed
         and any(
             isinstance(m, dict) and m.get('role') in ('assistant', 'tool')
             for m in candidates
@@ -6381,19 +5305,16 @@ def _merge_display_messages_after_agent_result(
         # directly would make the assistant bubble appear attached to the prior
         # exchange and then clear the pending prompt. Materialize the current
         # turn at the transcript boundary before the assistant/tool response.
-        current_user_msg = _materialize_active_turn_user(
-            _active_turn_identity, msg_text, source
-        )
+        current_user_msg = {'role': 'user', 'content': msg_text}
+        if source and source != 'webui':
+            current_user_msg['_source'] = source
         insert_at = 0
         while insert_at < len(candidates) and _is_context_compression_marker(candidates[insert_at]):
             insert_at += 1
         candidates = candidates[:insert_at] + [current_user_msg] + candidates[insert_at:]
 
     for msg in candidates:
-        if (
-            _is_context_compression_marker(msg)
-            or _is_compressed_context_tool_result_summary_message(msg)
-        ):
+        if _is_context_compression_marker(msg):
             continue
         key = _message_identity(msg)
         is_current_user_turn = _looks_like_current_user_turn(msg, msg_text)
@@ -6444,7 +5365,8 @@ def _merge_display_messages_after_agent_result(
         ):
             display_msg = copy.deepcopy(msg)
             display_msg['content'] = msg_text
-            stamp_message_source(display_msg, source)
+            if source and source != 'webui':
+                display_msg['_source'] = source
         merged.append(copy.deepcopy(display_msg))
         if key is not None:
             seen.add(key)
@@ -6480,7 +5402,7 @@ def _assistant_reply_added_after_current_turn(result_messages, previous_context,
         isinstance(m, dict)
         and m.get('role') == 'assistant'
         and not m.get('_error')
-        and _assistant_message_has_final_visible_text(m)
+        and str(m.get('content') or '').strip()
         for m in candidates
     )
 
@@ -6498,7 +5420,18 @@ def _session_lacks_final_assistant_answer(messages) -> bool:
         if role == 'tool':
             return True
         if role == 'assistant':
-            if _assistant_message_has_final_visible_text(msg):
+            content = msg.get('content')
+            if isinstance(content, list):
+                text = '\n'.join(
+                    str(part.get('text') or part.get('content') or '')
+                    for part in content
+                    if isinstance(part, dict)
+                )
+            else:
+                text = str(content or '')
+            if msg.get('tool_calls'):
+                return True
+            if text.strip():
                 return False
             continue
         if role == 'user':
@@ -6512,25 +5445,12 @@ def _turn_transcript_lacks_final_assistant_answer(
     msg_text,
     source: str = "webui",
     drop_replayed_assistant: bool = False,
-    active_turn_identity=None,
 ) -> bool:
     """Return True when an already-merged transcript still lacks a final assistant answer."""
     merged_messages = list(merged_messages or [])
     previous_display = list(previous_display or [])
-    current_user_token_idx = next(
-        (
-            idx for idx, message in enumerate(merged_messages)
-            if _active_turn_token_matches(message, active_turn_identity)
-        ),
-        None,
-    )
-    current_user_idx = current_user_token_idx
-    if current_user_idx is None:
-        current_user_idx = _find_current_user_turn(merged_messages, msg_text)
-    if current_user_idx is None or (
-        current_user_token_idx is None
-        and current_user_idx < len(previous_display)
-    ):
+    current_user_idx = _find_current_user_turn(merged_messages, msg_text)
+    if current_user_idx is None or current_user_idx < len(previous_display):
         # The active turn lives after the durable transcript boundary. If the
         # merged display only exposes an older user row, materialize the pending
         # prompt so a replayed assistant row cannot satisfy the wrong turn.
@@ -6577,26 +5497,15 @@ def _merged_transcript_lacks_final_assistant_answer(
     msg_text,
     source: str = "webui",
     drop_replayed_assistant: bool = False,
-    active_turn_identity=None,
 ) -> bool:
     """Return True when the current turn still lacks a final assistant answer."""
     previous_display = list(previous_display or [])
-    _verification_nudge_seen = any(
-        isinstance(message, dict)
-        and message.get('role') == 'user'
-        and _is_synthetic_control_message(message)
-        for message in result_messages or []
-    )
     merged_messages = _merge_display_messages_after_agent_result(
         previous_display,
         previous_context,
         _restore_reasoning_metadata(previous_display, result_messages),
         msg_text,
         source=source,
-        verification_nudge_provenance={
-            'verification_nudge_seen': _verification_nudge_seen,
-            'active_turn_identity': active_turn_identity,
-        },
     )
     return _turn_transcript_lacks_final_assistant_answer(
         merged_messages,
@@ -6604,7 +5513,6 @@ def _merged_transcript_lacks_final_assistant_answer(
         msg_text,
         source=source,
         drop_replayed_assistant=drop_replayed_assistant,
-        active_turn_identity=active_turn_identity,
     )
 
 
@@ -6952,42 +5860,30 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     pending_text = str(getattr(session, 'pending_user_message', None) or '')
     if not pending_text:
         return False
+    normalized_pending = " ".join(pending_text.split())
+    if normalized_pending:
+        for existing in reversed(list(getattr(session, 'messages', None) or [])[-8:]):
+            if not isinstance(existing, dict) or existing.get('role') != 'user':
+                continue
+            existing_text = " ".join(str(existing.get('content') or '').split())
+            if existing_text == normalized_pending:
+                return False
     recovered_ts = int(time.time())
     pending_started_at = getattr(session, 'pending_started_at', None)
     if isinstance(pending_started_at, (int, float)) and pending_started_at > 0:
         recovered_ts = int(pending_started_at)
-    pending_source = getattr(session, 'pending_user_source', None) or 'webui'
-    pending_attachments = list(getattr(session, 'pending_attachments', None) or [])
-
-    def is_exact_checkpoint(messages):
-        if not isinstance(messages, list) or not messages:
-            return False
-        existing = messages[-1]
-        if not isinstance(existing, dict) or existing.get('role') != 'user':
-            return False
-        existing_source = existing.get('_source') or 'webui'
-        try:
-            existing_ts = int(existing.get('timestamp'))
-        except (TypeError, ValueError):
-            return False
-        return (
-            _normalize_user_text(existing.get('content')) == _normalize_user_text(pending_text)
-            and existing_ts == recovered_ts
-            and existing_source == pending_source
-            and list(existing.get('attachments') or []) == pending_attachments
-        )
-
-    if is_exact_checkpoint(getattr(session, 'messages', None)):
-        return False
     recovered = {
         'role': 'user',
         'content': pending_text,
         'timestamp': recovered_ts,
         '_recovered': True,
     }
-    stamp_message_source(recovered, pending_source)
+    pending_source = getattr(session, 'pending_user_source', None)
+    if pending_source and pending_source != 'webui':
+        recovered['_source'] = pending_source
+    pending_attachments = getattr(session, 'pending_attachments', None)
     if pending_attachments:
-        recovered['attachments'] = pending_attachments
+        recovered['attachments'] = list(pending_attachments)
     session.messages.append(recovered)
     # Mirror to context_messages so the _recovered flag survives the state.db
     # round-trip (#4283).  state.db has no _recovered column, so without this
@@ -6998,8 +5894,14 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     # Placing the mirror here (rather than in _persist_cancelled_turn) covers
     # all three callers: cancel, provider-error, and exception paths.
     ctx = getattr(session, 'context_messages', None)
-    if isinstance(ctx, list) and ctx and not is_exact_checkpoint(ctx):
-        ctx.append(dict(recovered))
+    if isinstance(ctx, list) and ctx:
+        rec_text = " ".join(str(recovered.get('content') or '').split())
+        if not any(
+            isinstance(e, dict) and e.get('role') == 'user'
+            and " ".join(str(e.get('content') or '').split()) == rec_text
+            for e in ctx[-8:]
+        ):
+            ctx.append({k: v for k, v in recovered.items() if k != 'timestamp'})
     # The new user turn is now committed to messages (#3831): advance a positive
     # truncation watermark left over from a prior retry/undo/edit so that
     # merge_session_messages_append_only() still filters out replaced pre-edit
@@ -7009,22 +5911,6 @@ def _materialize_pending_user_turn_before_error(session) -> bool:
     if getattr(session, 'truncation_watermark', None):
         session.truncation_watermark = float(recovered_ts)
     return True
-
-
-def _terminal_turn_duration(session, *, now: float | None = None) -> float | None:
-    """Freeze a valid turn timer before terminal cleanup clears its origin."""
-    started_at = getattr(session, 'pending_started_at', None)
-    try:
-        started = float(started_at)
-        ended = float(time.time() if now is None else now)
-    except (TypeError, ValueError, OverflowError):
-        return None
-    if not math.isfinite(started) or not math.isfinite(ended) or started <= 0:
-        return None
-    elapsed = ended - started
-    if elapsed < 0:
-        return None
-    return round(elapsed, 3)
 
 
 def _build_partial_message(content_text, reasoning_text, tool_calls) -> dict | None:
@@ -7087,13 +5973,6 @@ def _snapshot_and_append_partial_on_error(session, stream_id) -> dict | None:
     _snap_reasoning = None
     _snap_tool_calls = None
 
-    # The streaming thread mirrors these three buffers lock-free (GIL-atomic; see
-    # the STREAMS_LOCK contract note at on_token in the streaming loop). We take
-    # STREAMS_LOCK here to read atomically w.r.t. the worker's cleanup `finally`
-    # (which pops all three under STREAMS_LOCK) — NOT w.r.t. the writer, which
-    # holds no lock, so the three reads may still reflect slightly different
-    # points in time. That is acceptable: each individual read is complete (never
-    # torn) and a slightly-stale partial is reconciled by later journal/SSE events.
     with streams_lock:
         _snap_partial_text = partial_texts.get(stream_id, '')
         if not _snap_partial_text:
@@ -7112,15 +5991,6 @@ def _snapshot_and_append_partial_on_error(session, stream_id) -> dict | None:
             _live_tools = getattr(_live_config, 'STREAM_LIVE_TOOL_CALLS', live_tool_calls)
             if _live_tools is not live_tool_calls:
                 _snap_tool_calls = list(_live_tools.get(stream_id, []) or [])
-
-    # Seal projected live tool rows so the durable scene cannot disagree with
-    # the settled terminal state (#6309). Any tool call that was still running
-    # at error time is marked as completed with the terminal-error metadata.
-    if _snap_tool_calls:
-        for _tc in _snap_tool_calls:
-            if isinstance(_tc, dict) and not _tc.get('done'):
-                _tc['done'] = True
-                _tc['_sealed_by_terminal_error'] = True
 
     _partial_msg = _build_partial_message(_snap_partial_text, _snap_reasoning, _snap_tool_calls)
     if _partial_msg is None:
@@ -7164,65 +6034,6 @@ def _last_resort_sync_from_core(session, stream_id, agent_lock):
         )
 
 
-def _session_db_is_open(session_db) -> bool:
-    """True when *session_db* still has a live sqlite connection.
-
-    SessionDB.close() sets ``_conn = None``. Subagents capture the parent's
-    SessionDB object by reference at spawn time (delegate_tool), so closing
-    that object mid-parent-turn makes every subsequent child
-    ``append_message`` fail with
-    ``'NoneType' object has no attribute 'execute'``.
-    """
-    if session_db is None:
-        return False
-    return getattr(session_db, "_conn", None) is not None
-
-
-def _adopt_session_db_for_cached_agent(agent, new_session_db):
-    """Attach a SessionDB to a reused cached agent without breaking subagents.
-
-    Historical behaviour (PR #1421 FD-leak fix): create a fresh SessionDB every
-    stream request and close the previous handle before replacing
-    ``agent._session_db``. That stops EMFILE growth, but a server-side wakeup
-    / new turn for the same parent session will close the shared handle while
-    background subagents are still writing into it.
-
-    Policy now:
-    - If the cached agent already holds an *open* SessionDB, keep it and close
-      the unused new handle (no FD leak; live subagents keep working).
-    - If the existing handle is missing or already closed, adopt *new_session_db*.
-    - If *new_session_db* is None, leave the existing handle alone.
-    """
-    if agent is None:
-        return new_session_db
-    existing = getattr(agent, "_session_db", None)
-    if new_session_db is None:
-        return existing
-    if existing is new_session_db:
-        return existing
-    if _session_db_is_open(existing):
-        try:
-            new_session_db.close()
-        except Exception:
-            # Same observability as _replace_session_db_in_kwargs: a failed
-            # close here reintroduces the EMFILE pressure PR #1421 fixed.
-            logger.debug(
-                "Failed to close unused session_db handle in adopt helper",
-                exc_info=True,
-            )
-        return existing
-    if existing is not None:
-        try:
-            existing.close()
-        except Exception:
-            logger.debug(
-                "Failed to close previous session_db handle in adopt helper",
-                exc_info=True,
-            )
-    agent._session_db = new_session_db
-    return new_session_db
-
-
 def _build_session_db_for_stream(state_db_path):
     """Build a per-request SessionDB handle for WebUI session search.
 
@@ -7231,61 +6042,19 @@ def _build_session_db_for_stream(state_db_path):
     """
     try:
         from hermes_state import SessionDB
-        _attempts = 3
-        _last_error = None
-        for _attempt in range(_attempts):
-            try:
-                return SessionDB(db_path=state_db_path)
-            except sqlite3.OperationalError as _db_err:
-                _db_err_text = str(_db_err).lower()
-                if not (
-                    "locked" in _db_err_text or "busy" in _db_err_text
-                ):
-                    raise
-                _last_error = _db_err
-                if _attempt < _attempts - 1:
-                    print(
-                        f"[webui] WARNING: SessionDB init attempt {_attempt + 1}/{_attempts} failed, retrying: {_db_err}",
-                        flush=True,
-                    )
-                    time.sleep(0.05 * (2 ** _attempt) + random.uniform(0, 0.05))
-        raise _last_error or RuntimeError("SessionDB construction exhausted all attempts")
+        return SessionDB(db_path=state_db_path)
     except Exception as _db_err:
         print(f"[webui] WARNING: SessionDB init failed - session_search will be unavailable: {_db_err}", flush=True)
         return None
 
 
 def _replace_session_db_in_kwargs(agent_kwargs, state_db_path):
-    """Build a fresh SessionDB and replace ``agent_kwargs['session_db']`` safely.
-
-    Does not close an existing open handle that may still be shared with live
-    subagents; only replaces when the prior handle is missing or already closed.
-    """
+    """Build a fresh SessionDB and replace ``agent_kwargs['session_db']`` safely."""
     if not isinstance(agent_kwargs, dict):
         return None
 
     _old_session_db = agent_kwargs.get("session_db")
     _next_session_db = _build_session_db_for_stream(state_db_path)
-    if _next_session_db is None:
-        # Replacement construction failed. Keep the prior handle only if it is
-        # still open (live subagents may hold it by reference); otherwise
-        # degrade cleanly to None — as master did — so the rebuilt agent lazily
-        # reinitialises its SessionDB instead of reusing a closed handle and
-        # failing every persist/search with
-        # "'NoneType' object has no attribute 'execute'".
-        if _session_db_is_open(_old_session_db):
-            return _old_session_db
-        agent_kwargs["session_db"] = None
-        return None
-    if _session_db_is_open(_old_session_db):
-        # Keep the live handle; discard the unused new one.
-        try:
-            if _next_session_db is not _old_session_db:
-                _next_session_db.close()
-        except Exception:
-            logger.debug("Failed to close unused session_db handle during self-heal")
-        agent_kwargs["session_db"] = _old_session_db
-        return _old_session_db
     if _old_session_db is not None and _old_session_db is not _next_session_db:
         try:
             _old_session_db.close()
@@ -7623,8 +6392,6 @@ def _run_agent_streaming(
     When ephemeral=True, session mutations are skipped — used by /btw to get
     a streaming answer without persisting to the parent session.
     """
-    _turn_route_model = model
-    _turn_route_provider = model_provider
     q = STREAMS.get(stream_id)
     if q is None:
         # The stream was cancelled before the worker started; the route layer
@@ -7758,7 +6525,6 @@ def _run_agent_streaming(
             'context_length': 0,
             'threshold_tokens': 0,
             'last_prompt_tokens': 0,
-            'post_compression_context_tokens_estimate': None,
         }
         _session_obj = _current_live_usage_session()
 
@@ -7931,11 +6697,6 @@ def _run_agent_streaming(
                         _usage[_field] = getattr(_session_obj, _field, 0) or 0
                     except Exception:
                         pass
-            _post_compression_estimate = getattr(
-                _session_obj, 'post_compression_context_tokens_estimate', None,
-            )
-            if isinstance(_post_compression_estimate, int) and _post_compression_estimate > 0:
-                _usage['post_compression_context_tokens_estimate'] = _post_compression_estimate
 
         _real_prompt_tokens = int(_usage.get('last_prompt_tokens') or 0)
         _usage['cache_hit_percent'] = prompt_cache_hit_percent(
@@ -7951,18 +6712,12 @@ def _run_agent_streaming(
 
         return _usage
 
+    # Register this stream with the global streaming meter
+    meter().begin_session(stream_id)
+
     # Metering ticker — emits a metering event at 1 Hz while sessions are active.
     # When get_interval() returns >= 10.0 (no active sessions), the ticker exits
     # so no idle readings are emitted and the SSE consumer sees nothing.
-    #
-    # #4633/#2476: begin_session() and the ticker .start() are deferred into the
-    # outer `try` below so the outer `finally` (which pops STREAMS/CANCEL_FLAGS)
-    # always runs its paired end_session()/_metering_stop.set() teardown. A raise
-    # between here and that `try` would otherwise leak the _sessions[stream_id]
-    # entry — get_stats() only prunes sessions with first_token_ts > 0, so a
-    # zero-token turn (pre-flight cancel, setup raise) is never reclaimed and its
-    # count inflates the SSE `active` field. Deferring .start() until after `put`
-    # is defined also removes a latent start-before-put ordering window.
     _metering_stop = threading.Event()
 
     def _metering_ticker():
@@ -7972,18 +6727,17 @@ def _run_agent_streaming(
                 break  # nothing active — stop the ticker
             if _metering_stop.wait(interval):
                 break  # stream was cancelled or ended — exit
-            stats = meter().get_stats(stream_id)
+            stats = meter().get_stats()
             stats['session_id'] = session_id
             stats['usage'] = _live_usage_snapshot()
             put('metering', stats)
 
     _metering_thread = threading.Thread(target=_metering_ticker, daemon=True)
-
-    _success_writeback_committed = False
+    _metering_thread.start()
 
     def put(event, data):
         # If cancelled, drop all further events except the cancel event itself
-        if cancel_event.is_set() and not _success_writeback_committed and event not in ('cancel', 'apperror'):
+        if cancel_event.is_set() and event not in ('cancel', 'error'):
             return
         event_id = None
         if run_journal is not None:
@@ -8010,41 +6764,28 @@ def _run_agent_streaming(
         except Exception:
             logger.debug("Failed to put event to queue")
 
-    # #5940: capture a terminal (non-retryable) provider error the Agent emits via
-    # its lifecycle status_callback. The Agent aborts a non-retryable API error
-    # (e.g. HTTP 400 "invalid model / no credentials") with
-    # `_emit_status("❌ Non-retryable error (HTTP <code>): <detail>")` but the run
-    # result / agent._last_error are empty for that path, so turn-completion below
-    # fell through to the misleading `no_response` "silent rate limit, try again"
-    # message. Stash the emitted terminal error here (single-element list = closure
-    # write without nonlocal) so it can seed `_last_err` and let the classifier
-    # surface the real, actionable cause (model_not_found / auth_mismatch).
-    _captured_terminal_error = [None]
-
     def _agent_status_callback(kind, message):
         """Bridge Agent lifecycle status into WebUI SSE.
 
         Passes compression events as 'compressing' events and rate-limit/fallback
         events as 'warning' events so the frontend can surface them to the user.
-        Also captures a terminal non-retryable provider error (#5940) so the
-        turn-completion classifier can report the real cause instead of the
-        generic no_response fallback. All other lifecycle messages are dropped.
+        All other lifecycle messages are dropped silently.
         """
         _message = str(message or '').strip()
         _kind = str(kind or '').strip().lower()
         if not _message:
             return
         _lower = _message.lower()
-        # #5940: a non-retryable terminal provider error the Agent aborted on. Keep
-        # the FIRST one seen this turn (the original cause; later fallback notices
-        # are handled separately below). Matched on the Agent's emitted shape.
-        if (
-            _captured_terminal_error[0] is None
-            and 'non-retryable error' in _lower
-            and 'http' in _lower
-        ):
-            _captured_terminal_error[0] = _message
-        if _is_agent_compression_start_status(_kind, _message):
+        _is_compression_start = (
+            _kind == 'lifecycle'
+            and (
+                'preflight compression' in _lower
+                or 'compressing' in _lower
+                or 'compacting context' in _lower
+                or 'context too large' in _lower
+            )
+        )
+        if _is_compression_start:
             put('compressing', {
                 'session_id': session_id,
                 'message': 'Compressing context',
@@ -8062,11 +6803,6 @@ def _run_agent_streaming(
     # to the `try:` (preserves the Issue #765 static-locator invariant).
     _turn_session_identity_tokens = None
     _streaming_cron_profile_home_token = None
-    _turn_pending_source = 'webui'
-    _streaming_hermes_home_override_ctx = (None, None, False)
-    _streaming_skill_home_snapshot = None
-    _restore_streaming_skill_home_modules = False
-    _acquired_streaming_skill_home_patch_lock = False
     # Initialised here (before any code that may raise) so the outer `finally`
     # block can safely check `if _checkpoint_stop is not None` even when an
     # exception fires before the checkpoint thread is created (Issue #765).
@@ -8074,11 +6810,6 @@ def _run_agent_streaming(
     _ckpt_thread = None
     _agent_lock = None
     try:
-        # Register this stream with the global streaming meter and start the 1 Hz
-        # metering ticker. Kept INSIDE the outer try so the outer `finally`'s
-        # end_session()/_metering_stop.set() teardown is always paired (#4633/#2476).
-        meter().begin_session(stream_id)
-        _metering_thread.start()
         # Bind THIS turn's session identity to the worker thread/context BEFORE
         # any agent work (so every mid-turn notify_on_complete background spawn
         # captures THIS session, not a concurrent turn's process-global env).
@@ -8086,8 +6817,6 @@ def _run_agent_streaming(
         # in the outer finally next to _clear_thread_env().
         _turn_session_identity_tokens = _set_turn_session_identity(session_id)
         s = get_session(session_id)
-        _turn_pending_source = getattr(s, 'pending_user_source', None) or 'webui'
-        _active_turn_identity = _active_turn_authority(s, stream_id, msg_text)
         update_active_run(stream_id, phase="running", session_id=session_id)
         s.workspace = str(Path(workspace).expanduser().resolve())
         _last_persisted_model = None
@@ -8135,12 +6864,8 @@ def _run_agent_streaming(
             from api.profiles import (
                 filter_runtime_env_for_gateway_parity,
                 patch_skill_home_modules,
-                restore_skill_home_modules,
-                snapshot_skill_home_modules,
                 get_hermes_home_for_profile,
                 get_profile_runtime_env,
-                _skill_modules_support_profile_home,
-                _SKILL_HOME_MODULE_PATCH_LOCK,
             )
             _profile_home_path = get_hermes_home_for_profile(getattr(s, 'profile', None))
             _profile_home = str(_profile_home_path)
@@ -8152,10 +6877,6 @@ def _run_agent_streaming(
             _profile_runtime_env = {}
             _safe_profile_runtime_env = {}
             patch_skill_home_modules = None
-            snapshot_skill_home_modules = None
-            restore_skill_home_modules = None
-            _skill_modules_support_profile_home = None
-            _SKILL_HOME_MODULE_PATCH_LOCK = None
 
         # Profile-aware provider/model enrichment: when the session belongs
         # to a profile that specifies model.provider and model.default, use
@@ -8205,7 +6926,6 @@ def _run_agent_streaming(
             session_id,
             _profile_home,
         )
-        _streaming_hermes_home_override_ctx = _set_streaming_hermes_home_override(_profile_home)
         _set_thread_env(**_thread_env)
         # process_complete agent-wakeup wiring (ours-original, Option B): bind
         # this session's HERMES_SESSION_KEY to its WebUI session_id so the
@@ -8218,44 +6938,13 @@ def _run_agent_streaming(
             logger.debug("register_process_session failed", exc_info=True)
         # first-time module initialisation (which can be slow) does not
         # block other concurrent sessions waiting on _ENV_LOCK (#2024).
-        ensure_agent_runtime_current()
         _prewarm_skill_tool_modules()
         _install_streaming_cronjob_profile_wrapper()
-
-        # Full-turn serialization is only needed for static/legacy skill-module
-        # resolution, where process-global skill-module globals are still used.
-        # Dynamic-capable modules continue concurrent execution.
-        _streaming_override_installed = bool(_streaming_hermes_home_override_ctx[2])
-        _streaming_modules_are_dynamic = False
-        if patch_skill_home_modules is not None and snapshot_skill_home_modules is not None:
-            if _streaming_override_installed and _skill_modules_support_profile_home is not None:
-                try:
-                    _streaming_modules_are_dynamic = bool(
-                        _skill_modules_support_profile_home(_profile_home_path)
-                    )
-                except Exception:
-                    logger.debug(
-                        "Failed to evaluate streaming skill-module home capability for profile %r",
-                        _profile_home,
-                        exc_info=True,
-                    )
-                    _streaming_modules_are_dynamic = False
-
-            if not (_streaming_override_installed and _streaming_modules_are_dynamic):
-                _restore_streaming_skill_home_modules = True
-                _SKILL_HOME_MODULE_PATCH_LOCK.acquire()
-                _acquired_streaming_skill_home_patch_lock = True
-
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short
         # and preventing a deadlock where the restore would re-enter the same lock.
         with _ENV_LOCK:
-            if _restore_streaming_skill_home_modules:
-                # Snapshot and patch before mutating process env so setup
-                # failures can unwind without leaking either state.
-                _streaming_skill_home_snapshot = snapshot_skill_home_modules()
-                patch_skill_home_modules(Path(_profile_home))
             old_profile_env = {key: os.environ.get(key) for key in _safe_profile_runtime_env}
             old_cwd = os.environ.get('TERMINAL_CWD')
             old_exec_ask = os.environ.get('HERMES_EXEC_ASK')
@@ -8275,14 +6964,18 @@ def _run_agent_streaming(
             os.environ['HERMES_SESSION_CHAT_ID'] = str(session_id)
             if _profile_home:
                 os.environ['HERMES_HOME'] = _profile_home
-                # Prefer context-local Hermes-home overrides when available.
-                # In that mode, tools.skills_tool._skills_dir() and
-                # tools.skill_manager_tool._skills_dir() can resolve the active
-                # profile from get_hermes_home() and keep per-thread isolation
-                # without mutating module globals. If override installation
-                # succeeds for both modules, skip process-cache patching.
-                # If either module is static/missing/raises, the legacy path
-                # above has already snapshotted and patched under this lock.
+                # Patch skill module caches to match the active profile.
+                # _set_hermes_home() does this for process-wide switches
+                # but per-request switches skip it (#1700). The in-chat
+                # cronjob tool is wrapped separately at its tool-call boundary
+                # with cron_profile_context_for_home (#4580) so cron.jobs path
+                # caches are not mutated for the entire agent turn.
+                # Modules were prewarmed by _prewarm_skill_tool_modules()
+                # above, so we only do lightweight sys.modules lookups and
+                # attribute assignments here — no first-time import under
+                # the lock (#2024).
+                if patch_skill_home_modules is not None:
+                    patch_skill_home_modules(Path(_profile_home))
         # Lock released — agent runs without holding it
         # ── MCP Server Discovery (lazy import, idempotent) ──
         # MUST run AFTER the HERMES_HOME mutation above — `discover_mcp_tools()`
@@ -8318,10 +7011,14 @@ def _run_agent_streaming(
             try:
                 from api.route_approvals import (
                     submit_gateway_pending_mirror as _submit_pending_for_polling,
-                    retire_gateway_pending_mirror as _retire_gateway_pending_mirror,
+                    reconcile_gateway_pending_mirror_locked as _reconcile_gateway_pending_mirror_locked,
+                    _approval_sse_notify_locked as _approval_sse_notify_locked,
+                    _lock as _approval_lock,
                 )
                 def _cleanup_gateway_pending_mirror():
-                    _retire_gateway_pending_mirror(session_id)
+                    with _approval_lock:
+                        head, total, _changed = _reconcile_gateway_pending_mirror_locked(session_id)
+                        _approval_sse_notify_locked(session_id, head, total)
             except ImportError:
                 _submit_pending_for_polling = None
                 _cleanup_gateway_pending_mirror = None
@@ -8332,8 +7029,7 @@ def _run_agent_streaming(
             def _approval_notify_cb(approval_data):
                 if _submit_pending_for_polling is not None:
                     try:
-                        head, total = _submit_pending_for_polling(session_id, approval_data)
-                        approval_data = {**(head or approval_data), "pending_count": total}
+                        _submit_pending_for_polling(session_id, approval_data)
                     except Exception:
                         logger.warning("Failed to mirror approval into WebUI polling state", exc_info=True)
                 put('approval', approval_data)
@@ -8438,7 +7134,7 @@ def _run_agent_streaming(
                 if now - _metering_last_emit[0] < 0.1:
                     return
                 _metering_last_emit[0] = now
-                stats = meter().get_stats(stream_id)
+                stats = meter().get_stats()
                 stats['session_id'] = session_id
                 stats['usage'] = _live_usage_snapshot()
                 stats.setdefault('tps_available', False)
@@ -8506,28 +7202,7 @@ def _run_agent_streaming(
                 # first so the live Thinking stream is complete before/at the transition.
                 _flush_reasoning_buffer()
                 _token_sent = True
-                # Accumulate partial text so cancel_stream() can persist it (#893).
-                #
-                # STREAMS_LOCK contract for the three STREAM_* buffers (partial text,
-                # reasoning, live tool calls): the per-token hot path below mirrors
-                # into them WITHOUT holding STREAMS_LOCK, while snapshot readers hold
-                # STREAMS_LOCK (_snapshot_and_append_partial_on_error / cancel_stream).
-                # This is deliberate and safe for two reasons, NOT because `+=` is one
-                # bytecode (it is not — `d[k] += s` compiles to load/add/STORE_SUBSCR):
-                #  1. Single writer: only this streaming thread ever writes a given
-                #     stream_id's buffers, so there is no writer/writer race to tear.
-                #  2. Reader/writer atomicity under the GIL: `+=` builds a complete new
-                #     immutable str, then the final STORE_SUBSCR that binds it into the
-                #     dict is a single atomic bytecode; a concurrent reader's dict.get
-                #     therefore returns either the old or the new *complete* string
-                #     object (strings are immutable — never a half-built one). Same for
-                #     the atomic list.append / single-key dict writes on the other two.
-                # So a reader sees a complete-but-possibly-stale value, never a torn one.
-                # The snapshot is a best-effort partial that later journal/SSE events
-                # reconcile, so exact-latest is not required. Taking STREAMS_LOCK per
-                # token would add real contention against readers copying large buffers
-                # and would entangle the documented LOCK -> STREAMS_LOCK ordering — not
-                # worth it for a recoverable staleness window.
+                # Accumulate partial text so cancel_stream() can persist it (#893)
                 if stream_id in STREAM_PARTIAL_TEXT:
                     STREAM_PARTIAL_TEXT[stream_id] += str(text)
                 put('token', {'text': text})
@@ -8560,7 +7235,6 @@ def _run_agent_streaming(
                 # Mirror full concatenation to shared dict so cancel_stream() can persist
                 # it (#1361 §A). Cancel only creates one partial message, so the flat
                 # concatenation is correct there.
-                # Lock-free GIL-atomic mirror — see the STREAMS_LOCK contract in on_token.
                 if stream_id in STREAM_REASONING_TEXT:
                     STREAM_REASONING_TEXT[stream_id] += reasoning_delta
                 # Accumulate into a coalescing buffer so every delta reaches the
@@ -8685,7 +7359,6 @@ def _run_agent_streaming(
                             _reasoning_segments.get(_current_reasoning_idx, '') + reason_delta
                         )
                         # Mirror full concatenation to shared dict (#1361 §A)
-                        # Lock-free GIL-atomic mirror — see STREAMS_LOCK contract in on_token.
                         if stream_id in STREAM_REASONING_TEXT:
                             STREAM_REASONING_TEXT[stream_id] += reason_delta
                         put('reasoning', {'text': reason_delta})
@@ -8718,7 +7391,6 @@ def _run_agent_streaming(
                         'args': args if isinstance(args, dict) else {},
                     })
                     # Mirror to shared dict so cancel_stream() can persist it (#1361 §B)
-                    # Lock-free GIL-atomic mirror — see STREAMS_LOCK contract in on_token.
                     if stream_id in STREAM_LIVE_TOOL_CALLS:
                         STREAM_LIVE_TOOL_CALLS[stream_id].append({
                             'name': name,
@@ -8731,7 +7403,7 @@ def _run_agent_streaming(
                         'preview': preview,
                         'args': args_snap,
                     })
-                    _tool_stats = meter().get_stats(stream_id)
+                    _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
@@ -8748,9 +7420,20 @@ def _run_agent_streaming(
                         if _has_blocking_approval(session_id):
                             p = None
                             with _approval_lock:
-                                p, pending_count, _changed = _reconcile_gateway_pending_mirror_locked(session_id)
-                                if p:
-                                    p = {**p, "pending_count": pending_count}
+                                _reconcile_gateway_pending_mirror_locked(session_id)
+                                queue = _approval_pending.get(session_id)
+                                if isinstance(queue, list):
+                                    p = dict(queue[0]) if queue else None
+                                elif queue:
+                                    p = dict(queue)
+                                if p is None:
+                                    gw_queue = _approval_gateway_queues.get(session_id) or []
+                                    if gw_queue:
+                                        raw = getattr(gw_queue[0], 'data', None) or {}
+                                        if raw:
+                                            p = dict(raw)
+                                        else:
+                                            logger.warning("Gateway queue entry for %s has no .data attribute", session_id)
                             if p:
                                 put('approval', p)
                     except ImportError:
@@ -8819,7 +7502,7 @@ def _run_agent_streaming(
                         session_id=session_id,
                         stream_id=stream_id,
                     )
-                    _tool_stats = meter().get_stats(stream_id)
+                    _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
@@ -8836,7 +7519,6 @@ def _run_agent_streaming(
                             'tid': tool_call_id,
                         })
                         # Mirror to shared dict so cancel_stream() can persist it (#1361 §B)
-                        # Lock-free GIL-atomic mirror — see STREAMS_LOCK contract in on_token.
                         if stream_id in STREAM_LIVE_TOOL_CALLS:
                             STREAM_LIVE_TOOL_CALLS[stream_id].append({
                                 'name': name,
@@ -8851,7 +7533,7 @@ def _run_agent_streaming(
                             'args': _tool_args_snapshot(args),
                             'tid': tool_call_id,
                         })
-                    _tool_stats = meter().get_stats(stream_id)
+                    _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
@@ -8902,7 +7584,7 @@ def _run_agent_streaming(
                             session_id=session_id,
                             stream_id=stream_id,
                         )
-                    _tool_stats = meter().get_stats(stream_id)
+                    _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
@@ -8916,46 +7598,9 @@ def _run_agent_streaming(
             # Initialize SessionDB so session_search works in WebUI sessions
             _state_db_path = (Path(_profile_home) / "state.db") if _profile_home else None
             _session_db = _build_session_db_for_stream(_state_db_path)
-            # #5979: publish catalog provenance from the durable disk cache when
-            # memory is cold, so the custom-proxy resolver below sees the
-            # endpoint-advertised model ids (non-blocking, disk-only, never
-            # live-rebuilds). Both the warm and the resolve read profile-keyed
-            # config (cache path + source fingerprint via get_active_profile_name),
-            # but this streaming worker is a separate thread that does NOT inherit
-            # the HTTP handler's request-profile TLS — without binding it, a cold
-            # send from a NAMED profile would resolve against the DEFAULT profile's
-            # config and route to the wrong provider/base_url. Bind the captured
-            # owning-session profile across warm + resolve so both see the right
-            # profile (no-op for the default/root profile).
-            from api import profiles as profiles_api
-            # #5979: treat this send as a deliberate pick ONLY when the persisted
-            # explicit-pick signature matches the CURRENT model+provider routing
-            # context. Storing/comparing a signature (not a bare bool) means a
-            # later model/provider change via /api/chat/start, /api/session/update,
-            # normalization, or provider repair automatically invalidates a stale
-            # pick — so a #433 first-party leftover is never wrongly preserved on
-            # a cold catalog. Only affects the cold custom-proxy branch; warm
-            # endpoint-advertised provenance always wins over this flag.
-            from api.models import model_explicit_pick_signature as _mk_sig
-            _picked_sig = getattr(s, "model_explicit_pick_signature", None)
-            # Compare against the session's persisted model+provider — the exact
-            # fields /api/chat/start stamped the signature from (it persists the
-            # resolved model+provider onto the session before dispatch). Falls
-            # back to the worker's model/provider_context if the session fields
-            # are unset. A mismatch (any later model/provider change) yields a
-            # different signature → treated as NOT a deliberate pick.
-            _sig_model = getattr(s, "model", None) or model
-            _sig_provider = getattr(s, "model_provider", None) or provider_context
-            _current_sig = _mk_sig(_sig_model, _sig_provider)
-            _explicitly_picked = bool(_picked_sig) and _picked_sig == _current_sig
-            with profiles_api.profile_scope_for_detached_worker(
-                _resolved_profile_name, "model resolution", logger_override=logger
-            ):
-                warm_models_catalog_provenance_if_cold()
-                resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
-                    model_with_provider_context(model, provider_context),
-                    explicitly_picked=_explicitly_picked,
-                )
+            resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
+                model_with_provider_context(model, provider_context)
+            )
             configured_base_url = resolved_base_url
 
             # Resolve API key via Hermes runtime provider (matches gateway behaviour).
@@ -9313,19 +7958,15 @@ def _run_agent_streaming(
                     if 'prefill_messages' in _agent_kwargs and hasattr(agent, 'prefill_messages'):
                         agent.prefill_messages = list(_agent_kwargs.get('prefill_messages') or [])
                     if _session_db is not None:
-                        # Prefer reusing a still-open SessionDB on the cached
-                        # agent. Closing it mid-turn breaks background
-                        # subagents that hold a reference to the same object
-                        # (delegate_tool copies parent._session_db by ref) —
-                        # they then fail with
-                        # 'NoneType' object has no attribute 'execute'.
-                        # When the existing handle is already closed/missing,
-                        # adopt the fresh per-request SessionDB (and close the
-                        # dead one) so we still avoid the EMFILE FD-leak from
-                        # PR #1421.
-                        _session_db = _adopt_session_db_for_cached_agent(
-                            agent, _session_db
-                        )
+                        # Close any previously held SessionDB connection before
+                        # replacing it. Without this, each streaming request creates
+                        # a new SessionDB whose WAL handles leak indefinitely,
+                        # eventually causing EMFILE crashes (#streaming FD leak).
+                        if hasattr(agent, '_session_db') and agent._session_db is not None:
+                            try:
+                                agent._session_db.close()
+                            except Exception:
+                                pass
                         agent._session_db = _session_db
                     if hasattr(agent, '_api_call_count'):
                         agent._api_call_count = 0
@@ -9456,7 +8097,6 @@ def _run_agent_streaming(
                 config_data=_cfg,
             )
             _pending_started_at = getattr(s, 'pending_started_at', None)
-            meter().set_pending_started_at(stream_id, _pending_started_at)
             # Normal chat-start sets pending_started_at before spawning this thread;
             # fallback to now only for recovered/legacy flows where that marker is absent
             # or has been zeroed out (e.g. via a buggy migration / manual file edit).
@@ -9469,18 +8109,12 @@ def _run_agent_streaming(
                     state_messages=_external_state_messages,
                 ) or []
             )
-            _previous_owner_context_messages = list(
+            _previous_context_messages = _new_turn_context_from_messages(
                 reconciled_state_db_messages_for_session(
                     s,
                     prefer_context=True,
                     state_messages=_external_state_messages,
-                ) or []
-            )
-            _previous_owner_context_messages = _deduplicate_context_messages(
-                _previous_owner_context_messages
-            )
-            _previous_context_messages = _new_turn_context_from_messages(
-                _previous_owner_context_messages,
+                ),
                 msg_text,
             )
             # Dedup before feeding to agent — merge_session_messages_append_only
@@ -9531,11 +8165,7 @@ def _run_agent_streaming(
             )
             _ckpt_thread.start()
 
-            _pending_async_acceptances = []
-            _process_notifications = _drain_webui_process_notifications(
-                session_id,
-                pending_async_acceptances=_pending_async_acceptances,
-            )
+            _process_notifications = _drain_webui_process_notifications(session_id)
             _agent_msg_text = msg_text
             if _process_notifications:
                 _agent_msg_text = "\n\n".join([*_process_notifications, msg_text]).strip()
@@ -9553,7 +8183,6 @@ def _run_agent_streaming(
                 ),
                 task_id=session_id,
                 persist_user_message=msg_text,
-                persist_user_timestamp=getattr(s, 'pending_started_at', None),
             )
             # Only pass moa_config when a /moa override is actually active, so a
             # normal send never trips a TypeError on an older hermes-agent whose
@@ -9561,33 +8190,6 @@ def _run_agent_streaming(
             if moa_config is not None:
                 _run_conversation_kwargs["moa_config"] = moa_config
 
-            # Finalize durable delegation claims at the current-turn acceptance
-            # boundary: immediately before invoking the agent with the message
-            # that contains their notifications. A failed ACK is removed from
-            # this turn and requeued so retry cannot create a duplicate prompt.
-            _rejected_async_notifications = _accept_pending_async_delegations(
-                _pending_async_acceptances,
-                session_id=session_id,
-            )
-            if _rejected_async_notifications:
-                for _notification in _rejected_async_notifications:
-                    try:
-                        _process_notifications.remove(_notification)
-                    except ValueError:
-                        pass
-                _agent_msg_text = msg_text
-                if _process_notifications:
-                    _agent_msg_text = "\n\n".join(
-                        [*_process_notifications, msg_text]
-                    ).strip()
-                user_message = _build_native_multimodal_message(
-                    workspace_ctx,
-                    _agent_msg_text,
-                    attachments,
-                    workspace,
-                    cfg=_cfg,
-                )
-                _run_conversation_kwargs["user_message"] = user_message
             # ── Retry loop for silent provider failures ──
             # Retry up to 3 times with exponential backoff when provider returns
             # no content and no error (silent failure), to handle transient issues
@@ -9633,15 +8235,6 @@ def _run_agent_streaming(
                             f"for silent provider failure"
                         )
                     break
-            _active_turn_identity = _resolve_active_turn_authority(
-                _active_turn_identity,
-                result=result,
-                agent=agent,
-            )
-            # #4729: the run is done — flush any reasoning tail still in the coalescing
-            # buffer (the agent never calls reasoning_callback(None), and a turn can end on
-            # reasoning with no trailing token/tool boundary to trigger a flush) so the last
-            # sub-100ms window reaches the live Thinking view before the terminal done event.
             _flush_reasoning_buffer()
             if cancel_event.is_set():
                 if _checkpoint_stop is not None:
@@ -9729,9 +8322,7 @@ def _run_agent_streaming(
                         return
                 with _stream_writeback_stage(_writeback_timings, "merge_result"):
                     _tool_limit_reached = _agent_result_tool_limit_reached(result)
-                    _result_messages = result.get('messages')
-                    if _result_messages is None:
-                        _result_messages = _previous_context_messages
+                    _result_messages = result.get('messages') or _previous_context_messages
                     _result_messages = _drop_synthetic_max_iteration_summary_requests(
                         _result_messages,
                         enabled=_tool_limit_reached,
@@ -9770,15 +8361,34 @@ def _run_agent_streaming(
                             logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                         put('cancel', _cancel_event_payload('Cancelled by user'))
                         return
-                    _result_messages = _settle_result_messages(
-                        s,
-                        _previous_messages,
-                        _previous_owner_context_messages,
+                    _next_context_messages = _restore_reasoning_metadata(
+                        _previous_context_messages,
                         _result_messages,
-                        msg_text,
-                        _turn_pending_source,
-                        _active_turn_identity,
                     )
+                    # Stamp stable ids on the shared result rows AFTER the context
+                    # restore (so carried-forward ids survive) and BEFORE the
+                    # dedupe/merge build both arrays — including before
+                    # _dedupe_replayed_context_messages deep-copies any
+                    # stale-user repaired boundary row — so display and
+                    # model-context copies of each row share an id for the
+                    # fork/truncate aligner.
+                    _assign_stable_message_ids(
+                        _result_messages, _previous_messages, _previous_context_messages
+                    )
+                    _next_context_messages = _dedupe_replayed_context_messages(
+                        _previous_context_messages,
+                        _next_context_messages,
+                        msg_text,
+                    )
+                    s.context_messages = _deduplicate_context_messages(_next_context_messages)
+                    s.messages = _merge_display_messages_after_agent_result(
+                        _previous_messages,
+                        _previous_context_messages,
+                        _restore_display_reasoning_metadata(_previous_messages, _result_messages),
+                        msg_text,
+                        source=getattr(s, 'pending_user_source', None) or 'webui',
+                    )
+                    _advance_truncation_watermark_after_commit(s)  # #3831
                 # Strip XML tool-call blocks from assistant message content.
                 # DeepSeek and some other providers emit <function_calls>...</function_calls>
                 # in the raw response text; this must be removed before the content is
@@ -9801,12 +8411,15 @@ def _run_agent_streaming(
                 # registration, and subsequent error persistence all target the
                 # continuation session instead of the stale parent.
                 #
-                # Lock migration: when session_id rotates, alias both old and new
-                # IDs to the *same* _agent_lock. Keeping the old alias ensures a
-                # late old-ID request cannot create a second mutation lock while
-                # the streaming holder or an earlier waiter is still active. The
-                # weak registry reclaims both aliases after the final strong
-                # reference to the Lock is released.
+                # Lock migration: when session_id rotates, we alias the new ID to
+                # the *same* Lock object under SESSION_AGENT_LOCKS so that
+                # subsequent callers using _get_session_agent_lock(new_sid) get the
+                # same Lock the streaming thread is already holding. We then pop
+                # the old-id entry to prevent a leak. This is safe because we
+                # already hold _agent_lock (the Lock object itself), so the
+                # reference stays alive even after the dict entry is removed.
+                # Concurrent readers that already looked up the old ID will still
+                # see the same Lock object until they release it.
                 _compression_origin_session_id = session_id
                 _compression_continuation_session_id = None
                 _agent_sid = getattr(agent, 'session_id', None)
@@ -9881,11 +8494,12 @@ def _run_agent_streaming(
                         SESSIONS[new_sid] = s
                         SESSIONS.move_to_end(new_sid)
                         _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-                    # Migrate the per-session lock by aliasing new_sid to the
-                    # held _agent_lock reference directly. Keep old_sid aliased
-                    # too until the weak registry can reclaim both safely after
-                    # all old-ID holders and waiters release the lock.
-                    _alias_session_agent_lock(old_sid, new_sid, _agent_lock)
+                    # Migrate the per-session lock: alias new_sid to the held
+                    # _agent_lock reference directly (not via old_sid lookup),
+                    # then remove the old_sid entry to prevent a leak.
+                    with SESSION_AGENT_LOCKS_LOCK:
+                        SESSION_AGENT_LOCKS[new_sid] = _agent_lock
+                        SESSION_AGENT_LOCKS.pop(old_sid, None)
                     # Migrate cached agent to the new session ID so the turn
                     # count survives context compression.
                     from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
@@ -9922,7 +8536,7 @@ def _run_agent_streaming(
                 # workspace-aware helper from this branch while still
                 # preserving the pre-turn length for downstream self-heal
                 # checks introduced on master.
-                _all_result_messages = _drop_synthetic_control_messages(result.get('messages') or [])
+                _all_result_messages = result.get('messages') or []
                 _prev_len = len(_previous_context_messages)
                 _assistant_added = _assistant_reply_added_after_current_turn(
                     _all_result_messages,
@@ -9930,14 +8544,6 @@ def _run_agent_streaming(
                     msg_text,
                 )
                 _last_err = getattr(agent, '_last_error', None) or result.get('error') or ''
-                # #5940: if the Agent aborted on a non-retryable provider error
-                # (captured from its lifecycle status_callback) but left no error on
-                # the result/agent, use the captured message so the classifier can
-                # surface the real cause (model_not_found / auth) instead of the
-                # misleading no_response "silent rate limit, try again" fallback.
-                _captured_terminal_failure = bool(_captured_terminal_error[0])
-                if not _last_err and _captured_terminal_failure:
-                    _last_err = _captured_terminal_error[0]
                 _classification = _classify_provider_error(
                     str(_last_err) if _last_err else '',
                     _last_err,
@@ -9946,38 +8552,21 @@ def _run_agent_streaming(
                 _is_quota = _classification['type'] == 'quota_exhausted'
                 _is_auth = _classification['type'] == 'auth_mismatch'
                 _drop_replayed_assistant = (
-                    _captured_terminal_failure
-                    or _agent_result_terminal_failure(result)
+                    _agent_result_terminal_failure(result)
                     or bool(getattr(agent, '_last_error', None))
                     or ('error' in result and result.get('error') is not None)
                 )
                 _saved_transcript_lacks_final_answer = _merged_transcript_lacks_final_assistant_answer(
                     _previous_messages,
-                    _previous_owner_context_messages,
+                    _previous_context_messages,
                     _all_result_messages,
                     msg_text,
                     source=getattr(s, 'pending_user_source', None) or 'webui',
                     drop_replayed_assistant=_drop_replayed_assistant,
-                    active_turn_identity=_active_turn_identity,
                 )
-                if (
-                    not _all_result_messages
-                    and _current_turn_already_has_visible_assistant_answer(
-                        _align_current_turn_display(
-                            _previous_messages,
-                            _previous_owner_context_messages,
-                            _active_turn_identity,
-                        )[0],
-                        active_turn_identity=_active_turn_identity,
-                    )
-                ):
-                    _saved_transcript_lacks_final_answer = False
-                if not _assistant_added and not _saved_transcript_lacks_final_answer:
-                    _assistant_added = True
                 _is_agent_result_terminal = _agent_result_terminal_failure(result)
                 _terminal_failure = (
-                    _captured_terminal_failure
-                    or _is_agent_result_terminal
+                    _is_agent_result_terminal
                     or (
                         _saved_transcript_lacks_final_answer
                         and _classification['type'] not in {'cancelled', 'interrupted'}
@@ -9995,7 +8584,7 @@ def _run_agent_streaming(
                 )
                 if (
                     _terminal_failure
-                    and (_soft_partial_terminal_failure or _tool_limit_reached)
+                    and _soft_partial_terminal_failure
                     and _classification['type'] == 'no_response'
                     and not _saved_transcript_lacks_final_answer
                 ):
@@ -10081,16 +8670,10 @@ def _run_agent_streaming(
                                     ),
                                     task_id=session_id,
                                     persist_user_message=msg_text,
-                                    persist_user_timestamp=getattr(s, 'pending_started_at', None),
                                 )
                                 if moa_config is not None:
                                     _heal_kwargs["moa_config"] = moa_config
                                 _heal_result = agent.run_conversation(**_heal_kwargs)
-                                _active_turn_identity = _resolve_active_turn_authority(
-                                    _active_turn_identity,
-                                    result=_heal_result,
-                                    agent=agent,
-                                )
                                 _heal_all_msgs = _heal_result.get('messages') or []
                                 _heal_ok = _has_new_assistant_reply(_heal_all_msgs, _prev_len) or _token_sent
                             except Exception as _retry_exc:
@@ -10111,22 +8694,36 @@ def _run_agent_streaming(
                                 # evaluates False on next conceptual pass.
                                 # Since we're in a flat block, directly run the
                                 # post-result merge logic here.
-                                _result_messages = result.get('messages')
-                                if _result_messages is None:
-                                    _result_messages = _previous_context_messages
+                                _result_messages = result.get('messages') or _previous_context_messages
                                 _result_messages = _drop_synthetic_max_iteration_summary_requests(
                                     _result_messages,
                                     enabled=_agent_result_tool_limit_reached(result),
                                 )
-                                _result_messages = _settle_result_messages(
-                                    s,
-                                    _previous_messages,
-                                    _previous_owner_context_messages,
+                                _next_context_messages = _restore_reasoning_metadata(
+                                    _previous_context_messages,
                                     _result_messages,
-                                    msg_text,
-                                    _turn_pending_source,
-                                    _active_turn_identity,
                                 )
+                                # Mint ids on the shared result rows BEFORE dedupe
+                                # deep-copies any stale-user boundary row, so both
+                                # arrays share the id (#5564).
+                                _assign_stable_message_ids(
+                                    _result_messages, _previous_messages, _previous_context_messages
+                                )
+                                _next_context_messages = _dedupe_replayed_context_messages(
+                                    _previous_context_messages,
+                                    _next_context_messages,
+                                    msg_text,
+                                )
+                                s.context_messages = _deduplicate_context_messages(_next_context_messages)
+                                s.messages = _merge_display_messages_after_agent_result(
+                                    _previous_messages,
+                                    _previous_context_messages,
+                                    _restore_reasoning_metadata(_previous_messages, _result_messages),
+                                    msg_text,
+                                    source=getattr(s, 'pending_user_source', None) or 'webui',
+                                )
+                                _advance_truncation_watermark_after_commit(s)  # #3831
+                                # Skip the error block — jump directly to the
                                 # normal post-result persistence path by
                                 # leaving _assistant_added truthy (set below).
                                 _assistant_added = True  # prevent re-entering guard
@@ -10174,27 +8771,6 @@ def _run_agent_streaming(
                             _err_type,
                             _err_hint,
                         )
-                        if _turn_pending_source == 'process_wakeup':
-                            _recorded_pause = record_process_wakeup_provider_unavailable_pause(
-                                s,
-                                classification=_err_type,
-                                model=_turn_route_model,
-                                provider=_turn_route_provider,
-                            )
-                            # Disclose the suppression so the silence reads as
-                            # intentional, not a stuck agent (#3929 UX) — but ONLY
-                            # when a pause was actually recorded (credential-pool
-                            # exhaustion), never for a rate-limit/other wakeup
-                            # failure that doesn't pause. Keep the SSE payload hint
-                            # in sync with the persisted bubble.
-                            if _recorded_pause:
-                                _err_hint = (
-                                    (_err_hint + ' ' if _err_hint else '')
-                                    + 'Automatic retries for this conversation are paused until you '
-                                    + 'send a message, switch the model/provider, or fix the credentials.'
-                                )
-                                _error_payload['hint'] = _err_hint
-                        _turn_duration = _terminal_turn_duration(s)
                         _materialize_pending_user_turn_before_error(s)
                         s.active_stream_id = None
                         s.pending_user_message = None
@@ -10215,8 +8791,6 @@ def _run_agent_streaming(
                             'timestamp': int(time.time()),
                             '_error': True,
                         }
-                        if _turn_duration is not None:
-                            _error_message['_turnDuration'] = _turn_duration
                         if _err_type == 'compression_exhausted':
                             _recovery = stamp_compression_exhausted_recovery(
                                 s,
@@ -10267,11 +8841,6 @@ def _run_agent_streaming(
                     s.context_messages = _prune_context_tool_results_after_compression(
                         agent,
                         s.context_messages,
-                    )
-                    s.post_compression_context_tokens_estimate = _estimate_post_compression_context_tokens(
-                        agent,
-                        s.context_messages,
-                        workspace_system_msg,
                     )
                     visible_after = visible_messages_for_anchor(s.messages, auto_compression=True)
                     # Find the LAST [CONTEXT COMPACTION] marker in s.messages
@@ -10468,11 +9037,6 @@ def _run_agent_streaming(
                     requested_model=resolved_model or model,
                     requested_provider=resolved_provider,
                 )
-                # #6068: the served model must be read AFTER agent.run — the agent
-                # mutates agent.model when a fallback fires, so the pre-run
-                # resolved_model would mis-attribute exactly the turns where
-                # attribution matters most.
-                _used_model = getattr(agent, 'model', None) or resolved_model or model
                 if _gateway_routing:
                     s.gateway_routing = _gateway_routing
                     _history = list(getattr(s, 'gateway_routing_history', None) or [])
@@ -10486,11 +9050,6 @@ def _run_agent_streaming(
                                 _dm['_turnTps'] = _turn_tps
                             if _gateway_routing:
                                 _dm['_gatewayRouting'] = _gateway_routing
-                            _ttft_ms = meter().get_ttft_ms(stream_id)
-                            if _ttft_ms is not None:
-                                _dm['_firstTokenMs'] = _ttft_ms
-                            if _used_model:
-                                _dm['_usedModel'] = _used_model
                             break
                 # Persist context window data on the session so the context-ring
                 # indicator survives a page reload (#1318). Must run BEFORE
@@ -10782,85 +9341,6 @@ def _run_agent_streaming(
                         )
                 except Exception:
                     logger.debug("Failed to sync session to insights")
-            # A late cancel can land during memory/state-sync writeback. Do not
-            # clear a credential-exhausted process-wakeup pause unless this run
-            # is still settling as a normal completion. The pause re-read, clear,
-            # restore, and save must stay under the session lock so a concurrent
-            # suppression cannot observe stale pause state or lose its update.
-            _lock_ctx = _agent_lock if _agent_lock is not None else contextlib.nullcontext()
-            with _lock_ctx:
-                if cancel_event.is_set():
-                    _finalize_cancelled_turn(s, ephemeral=False)
-                    try:
-                        append_turn_journal_event_for_stream(
-                            s.session_id,
-                            stream_id,
-                            {
-                                "event": "interrupted",
-                                "created_at": time.time(),
-                                "reason": "cancelled",
-                            },
-                        )
-                    except Exception:
-                        logger.debug("Failed to append cancelled turn journal event", exc_info=True)
-                    put('cancel', _cancel_event_payload('Cancelled by user'))
-                    return
-                try:
-                    _latest_pause_owner = get_session(getattr(s, 'session_id', session_id))
-                    if _latest_pause_owner is not None:
-                        s = _latest_pause_owner
-                except Exception:
-                    logger.debug(
-                        "Failed to re-read process wakeup pause before success clear",
-                        exc_info=True,
-                    )
-                _process_wakeup_pause_before_clear = dict(getattr(s, 'process_wakeup_pause', {}) or {})
-                if clear_process_wakeup_pause(s, reason='run_completed'):
-                    if cancel_event.is_set():
-                        s.process_wakeup_pause = dict(_process_wakeup_pause_before_clear)
-                        try:
-                            s.save(touch_updated_at=False)
-                        except Exception:
-                            logger.debug("Failed to persist restored process wakeup pause", exc_info=True)
-                        _finalize_cancelled_turn(s, ephemeral=False)
-                        try:
-                            append_turn_journal_event_for_stream(
-                                s.session_id,
-                                stream_id,
-                                {
-                                    "event": "interrupted",
-                                    "created_at": time.time(),
-                                    "reason": "cancelled",
-                                },
-                            )
-                        except Exception:
-                            logger.debug("Failed to append cancelled turn journal event", exc_info=True)
-                        put('cancel', _cancel_event_payload('Cancelled by user'))
-                        return
-                    with _stream_writeback_stage(_writeback_timings, "process_wakeup_pause_clear_save"):
-                        s.save(touch_updated_at=False)
-                    if cancel_event.is_set():
-                        s.process_wakeup_pause = dict(_process_wakeup_pause_before_clear)
-                        try:
-                            s.save(touch_updated_at=False)
-                        except Exception:
-                            logger.debug("Failed to persist restored process wakeup pause", exc_info=True)
-                        _finalize_cancelled_turn(s, ephemeral=False)
-                        try:
-                            append_turn_journal_event_for_stream(
-                                s.session_id,
-                                stream_id,
-                                {
-                                    "event": "interrupted",
-                                    "created_at": time.time(),
-                                    "reason": "cancelled",
-                                },
-                            )
-                        except Exception:
-                            logger.debug("Failed to append cancelled turn journal event", exc_info=True)
-                        put('cancel', _cancel_event_payload('Cancelled by user'))
-                        return
-                _success_writeback_committed = True
             usage = {
                 'input_tokens': input_tokens,
                 'output_tokens': output_tokens,
@@ -10875,11 +9355,6 @@ def _run_agent_streaming(
                 usage['tps'] = _turn_tps
             if _gateway_routing:
                 usage['gateway_routing'] = _gateway_routing
-            _ttft_ms = meter().get_ttft_ms(stream_id)
-            if _ttft_ms is not None:
-                usage['ttft_ms'] = _ttft_ms
-            if _used_model:
-                usage['used_model'] = _used_model
             # Include context window data from the agent's compressor for the UI indicator.
             # The session-level persistence happens above (before s.save()) so the values
             # survive a page reload; this block only populates the live SSE usage payload.
@@ -11001,12 +9476,6 @@ def _run_agent_streaming(
                 _sess_lpt = getattr(s, 'last_prompt_tokens', 0) or 0
                 if _sess_lpt:
                     usage['last_prompt_tokens'] = _sess_lpt
-            _post_compression_estimate = getattr(s, 'post_compression_context_tokens_estimate', None)
-            usage['post_compression_context_tokens_estimate'] = (
-                _post_compression_estimate
-                if isinstance(_post_compression_estimate, int) and _post_compression_estimate > 0
-                else None
-            )
             # (reasoning trace already attached + saved above, before s.save())
             # Leftover-steer delivery: if a /steer was queued (via
             # api/chat/steer) but the agent finished its turn before
@@ -11101,7 +9570,7 @@ def _run_agent_streaming(
                     _done_payload['terminal_reason'] = 'max_iterations'
                 put('done', _done_payload)
                 # Emit one last metering packet for the live message-header TPS label.
-                meter_stats = meter().get_stats(stream_id)
+                meter_stats = meter().get_stats()
                 meter_stats['session_id'] = session_id
                 meter_stats.setdefault('tps_available', False)
                 meter_stats.setdefault('estimated', False)
@@ -11194,7 +9663,6 @@ def _run_agent_streaming(
             err_str = _stripped
         _exc_lower = err_str.lower()
         _classification = _classify_provider_error(err_str, e)
-        _exc_is_credential_pool_empty = _classification['type'] == 'credential_pool_empty'
         if cancel_event.is_set():
             if s is not None:
                 if _checkpoint_stop is not None:
@@ -11203,17 +9671,6 @@ def _run_agent_streaming(
                     _ckpt_thread.join(timeout=15)
                 _lock_ctx = _agent_lock if _agent_lock is not None else contextlib.nullcontext()
                 with _lock_ctx:
-                    if (
-                        not ephemeral
-                        and _turn_pending_source == 'process_wakeup'
-                        and _exc_is_credential_pool_empty
-                    ):
-                        record_process_wakeup_provider_unavailable_pause(
-                            s,
-                            classification=_classification['type'],
-                            model=_turn_route_model,
-                            provider=_turn_route_provider,
-                        )
                     _finalize_cancelled_turn(s, ephemeral=ephemeral)
                     if not ephemeral:
                         try:
@@ -11231,6 +9688,7 @@ def _run_agent_streaming(
             put('cancel', _cancel_event_payload('Cancelled by user'))
             return
         _exc_is_quota = _classification['type'] == 'quota_exhausted'
+        _exc_is_credential_pool_empty = _classification['type'] == 'credential_pool_empty'
         # Exception quota text still includes: 'more credits' in _exc_lower, 'can only afford' in _exc_lower, 'fewer max_tokens' in _exc_lower.
         # Rate-limit detection remains guarded as: (not _exc_is_quota).
         _exc_is_rate_limit = (_classification['type'] == 'rate_limit') and (not _exc_is_quota)
@@ -11305,16 +9763,10 @@ def _run_agent_streaming(
                             ),
                             task_id=session_id,
                             persist_user_message=msg_text,
-                            persist_user_timestamp=getattr(s, 'pending_started_at', None),
                         )
                         if moa_config is not None:
                             _heal_kwargs2["moa_config"] = moa_config
                         _heal_result = _heal_agent.run_conversation(**_heal_kwargs2)
-                        _active_turn_identity = _resolve_active_turn_authority(
-                            _active_turn_identity,
-                            result=_heal_result,
-                            agent=_heal_agent,
-                        )
                         # Retry succeeded — persist the result normally
                         if s is not None:
                             if _checkpoint_stop is not None:
@@ -11331,18 +9783,30 @@ def _run_agent_streaming(
                                         getattr(s, 'active_stream_id', None),
                                     )
                                     return
-                                _result_messages = _heal_result.get('messages')
-                                if _result_messages is None:
-                                    _result_messages = _previous_context_messages
-                                _result_messages = _settle_result_messages(
-                                    s,
-                                    _previous_messages,
-                                    _previous_owner_context_messages,
-                                    _result_messages,
-                                    msg_text,
-                                    _turn_pending_source,
-                                    _active_turn_identity,
+                                _result_messages = _heal_result.get('messages') or _previous_context_messages
+                                _next_context_messages = _restore_reasoning_metadata(
+                                    _previous_context_messages, _result_messages,
                                 )
+                                # Mint ids on the shared result rows BEFORE dedupe
+                                # deep-copies any stale-user boundary row, so both
+                                # arrays share the id (#5564).
+                                _assign_stable_message_ids(
+                                    _result_messages, _previous_messages, _previous_context_messages
+                                )
+                                _next_context_messages = _dedupe_replayed_context_messages(
+                                    _previous_context_messages,
+                                    _next_context_messages,
+                                    msg_text,
+                                )
+                                s.context_messages = _deduplicate_context_messages(_next_context_messages)
+                                s.messages = _merge_display_messages_after_agent_result(
+                                    _previous_messages,
+                                    _previous_context_messages,
+                                    _restore_reasoning_metadata(_previous_messages, _result_messages),
+                                    msg_text,
+                                    source=getattr(s, 'pending_user_source', None) or 'webui',
+                                )
+                                _advance_truncation_watermark_after_commit(s)  # #3831
                                 s.save()
                         logger.info('[webui] self-heal (except path): retry succeeded')
                         return  # skip error emission
@@ -11382,22 +9846,6 @@ def _run_agent_streaming(
             _lock_ctx = _agent_lock if _agent_lock is not None else contextlib.nullcontext()
             with _lock_ctx:
                 if not ephemeral and not _stream_writeback_is_current(s, stream_id):
-                    if _turn_pending_source == 'process_wakeup':
-                        _pause = record_process_wakeup_provider_unavailable_pause(
-                            s,
-                            classification=_exc_type,
-                            model=_turn_route_model,
-                            provider=_turn_route_provider,
-                        )
-                        if _pause is not None:
-                            try:
-                                s.save(touch_updated_at=False)
-                            except Exception:
-                                logger.debug(
-                                    "Failed to persist stale-stream process_wakeup pause for session %s",
-                                    getattr(s, 'session_id', session_id),
-                                    exc_info=True,
-                                )
                     logger.info(
                         "Skipping stale stream error writeback for session %s stream %s; active_stream_id=%s",
                         getattr(s, 'session_id', session_id),
@@ -11406,24 +9854,6 @@ def _run_agent_streaming(
                     )
                     return
 
-                if _turn_pending_source == 'process_wakeup':
-                    _recorded_pause = record_process_wakeup_provider_unavailable_pause(
-                        s,
-                        classification=_exc_type,
-                        model=_turn_route_model,
-                        provider=_turn_route_provider,
-                    )
-                    # #3929 UX: disclose the pause in the error card ONLY when a
-                    # pause was actually recorded (credential-pool exhaustion),
-                    # keeping the SSE payload hint in sync with the persisted bubble.
-                    if _recorded_pause:
-                        _exc_hint = (
-                            (_exc_hint + ' ' if _exc_hint else '')
-                            + 'Automatic retries for this conversation are paused until you '
-                            + 'send a message, switch the model/provider, or fix the credentials.'
-                        )
-                        _error_payload['hint'] = _exc_hint
-                _turn_duration = _terminal_turn_duration(s)
                 _materialize_pending_user_turn_before_error(s)
                 s.active_stream_id = None
                 s.pending_user_message = None
@@ -11440,8 +9870,6 @@ def _run_agent_streaming(
                     'timestamp': int(time.time()),
                     '_error': True,
                 }
-                if _turn_duration is not None:
-                    _error_message['_turnDuration'] = _turn_duration
                 if _exc_type == 'compression_exhausted':
                     _recovery = stamp_compression_exhausted_recovery(
                         s,
@@ -11479,23 +9907,6 @@ def _run_agent_streaming(
             _error_payload['old_session_id'] = session_id
         put('apperror', _error_payload)
     finally:
-        # #4633/#2476: symmetric metering teardown. begin_session() (top of the
-        # outer try) had no paired end_session(), so zero-token turns leaked a
-        # _sessions[stream_id] entry that get_stats() pruning never reclaims (its
-        # criterion requires first_token_ts > 0). end_session() is idempotent —
-        # it just pops _sessions[stream_id]; the metering payload is unchanged.
-        # _metering_stop.set() deterministically stops the ticker (the inner
-        # finally also sets it on the normal path; setting twice is harmless).
-        try:
-            # 0: end_session() currently ignores final_output_tokens — it only
-            # pops _sessions[stream_id]. If it is ever extended to consume the
-            # count (e.g. persisting final output tokens to a billing ledger),
-            # this teardown caller will need to supply the real total; the outer
-            # finally doesn't have easy access to it today.
-            meter().end_session(stream_id, 0)
-        except Exception:
-            logger.debug("Failed to end metering session for stream %s", stream_id, exc_info=True)
-        _metering_stop.set()
         # Stop the periodic checkpoint thread before the final recovery path.
         # The checkpoint thread also uses the per-session lock; joining it first
         # avoids contending with checkpoint writes during stale-pending repair.
@@ -11511,19 +9922,6 @@ def _run_agent_streaming(
         _clear_thread_env()  # TD1: always clear thread-local context
         if _streaming_cron_profile_home_token is not None:
             _STREAMING_CRON_PROFILE_HOME.reset(_streaming_cron_profile_home_token)
-        if _restore_streaming_skill_home_modules and _streaming_skill_home_snapshot is not None:
-            with _ENV_LOCK:
-                if restore_skill_home_modules is not None:
-                    try:
-                        restore_skill_home_modules(_streaming_skill_home_snapshot)
-                    except Exception:
-                        logger.debug("Failed to restore skill module state for streaming profile", exc_info=True)
-                _streaming_skill_home_snapshot = None
-                _restore_streaming_skill_home_modules = False
-        if _acquired_streaming_skill_home_patch_lock:
-            _SKILL_HOME_MODULE_PATCH_LOCK.release()
-            _acquired_streaming_skill_home_patch_lock = False
-        _reset_streaming_hermes_home_override(*_streaming_hermes_home_override_ctx)
         # xsession wakeup misroute root fix (Option 1): restore the per-turn
         # session-identity context-locals (reset-token semantics). MUST run on
         # every exit path so a reused thread-pool worker leaks no identity and
@@ -11540,9 +9938,6 @@ def _run_agent_streaming(
             STREAM_GOAL_RELATED.pop(stream_id, None)  # Clean up goal-related flag (#1932)
             STREAM_LAST_EVENT_ID.pop(stream_id, None)  # Clean up event_id pointer (stage-364)
             unregister_active_run(stream_id)
-            # Clean up the stream-owner registry so stale stream_id→session_id
-            # mappings do not accumulate over thousands of completed streams (#6351).
-            unregister_stream_owner(stream_id)
             # NOTE: do NOT discard PENDING_GOAL_CONTINUATION here. The marker
             # is set by goal_continue (line ~3328) inside the SAME function
             # call and consumed atomically by `_start_chat_stream_for_session`
@@ -11645,29 +10040,7 @@ def _handle_chat_steer(handler, body: dict) -> bool:
         except Exception:
             logger.debug("Failed to close steer identity-mismatched cached agent for session %s", sid, exc_info=True)
     if not cached:
-        try:
-            s = get_session(sid)
-            active_stream_id = getattr(s, "active_stream_id", None) or None
-        except KeyError:
-            active_stream_id = None
-        if active_stream_id:
-            with _cfg.STREAMS_LOCK:
-                stream_alive = active_stream_id in _cfg.STREAMS
-            if stream_alive:
-                try:
-                    with _cfg.ACTIVE_RUNS_LOCK:
-                        active_run = dict((_cfg.ACTIVE_RUNS or {}).get(str(active_stream_id)) or {})
-                    if active_run.get("backend") == "gateway":
-                        return j(handler, {"accepted": False, "fallback": "gateway_steer_queued",
-                                           "stream_id": active_stream_id})
-                except Exception:
-                    logger.warning(
-                        "Gateway ownership lookup failed before steer fallback for session=%s stream_id=%s",
-                        sid,
-                        active_stream_id,
-                        exc_info=True,
-                    )
-        # No active local agent for this session — caller surfaces a steer failure
+        # No active agent for this session — caller surfaces a steer failure
         # without cancelling the active run.
         return j(handler, {"accepted": False, "fallback": "no_cached_agent",
                            "stream_id": None})
@@ -11977,7 +10350,8 @@ def cancel_stream(stream_id: str) -> bool:
                                 'content': _pending_user,
                                 'timestamp': _recovered_ts,
                             }
-                            stamp_message_source(_user_turn, _pending_source)
+                            if _pending_source and _pending_source != 'webui':
+                                _user_turn['_source'] = _pending_source
                             if _pending_atts:
                                 _user_turn['attachments'] = _pending_atts
                             _msgs_for_recovery.append(_user_turn)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -8194,10 +8194,6 @@ def _run_agent_streaming(
             # the agent runs, not around the entire turn. This ensures we don't
             # replay an entire logical turn when the provider fails silently.
             
-            # Make the provider call (agent.run_conversation) - this should NOT be
-            # wrapped in retry logic since retries happen at provider level
-            result = agent.run_conversation(**_run_conversation_kwargs)
-
             # ── Provider-call boundary retry (WebUI-level hardening) ──
             # Detect silent provider failures using a turn-aware predicate and
             # retry only the provider call. Flush reasoning after each provider

--- a/tests/test_issue5601_extra.py
+++ b/tests/test_issue5601_extra.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import threading
+import time
+from unittest import mock
+
+import pytest
+
+import api.config as config
+import api.models as models
+import api.streaming as streaming
+from api.models import Session
+
+
+class CancelDuringBackoffAgent:
+    runs = 0
+
+    def __init__(self, **kwargs):
+        self.session_id = kwargs.get("session_id")
+
+    def run_conversation(self, **kwargs):
+        type(self).runs += 1
+        if type(self).runs == 1:
+            # Simulate silent empty result on first attempt
+            return {"messages": []}
+        return {"status": "ok", "messages": [{"role": "assistant", "content": "ok"}]}
+
+    def interrupt(self, _):
+        pass
+
+
+def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
+    session = Session(session_id=session_id, title="Test Session")
+    session.messages = []
+    session.context_messages = []
+    session.pending_user_message = pending_user_message
+    session.pending_attachments = []
+    session.pending_started_at = 1234567890.0
+    session.pending_user_source = "cli"
+    session.active_stream_id = stream_id
+    session.save()
+    models.SESSIONS[session_id] = session
+    return session
+
+
+def _run_stream_in_thread(session, stream_id, agent_cls, workspace):
+    # run in thread because cancel during backoff is observed via wait
+    t = threading.Thread(target=streaming._run_agent_streaming, kwargs=dict(
+        session_id=session.session_id,
+        msg_text=session.pending_user_message,
+        model="test-model",
+        workspace=workspace,
+        stream_id=stream_id,
+    ))
+    t.start()
+    return t
+
+
+def test_cancel_during_backoff(monkeypatch, tmp_path):
+    session = _prepare_session("cancel_backoff", "stream_cancel_backoff", pending_user_message="hi")
+    # Create an Event and ensure the streaming worker will see it
+    ev = threading.Event()
+    config.CANCEL_FLAGS["stream_cancel_backoff"] = ev
+
+    # Monkeypatch _get_ai_agent to return our test agent class
+    with mock.patch.object(streaming, "_get_ai_agent", return_value=CancelDuringBackoffAgent):
+        t = _run_stream_in_thread(session, "stream_cancel_backoff", CancelDuringBackoffAgent, workspace=str(tmp_path))
+
+        # Wait briefly for the first provider call to complete and the worker to enter backoff
+        time.sleep(0.05)
+        # Simulate a cancel during backoff
+        ev.set()
+
+        t.join(timeout=5)
+
+    # Agent should only have run once (no retry after cancel)
+    assert CancelDuringBackoffAgent.runs == 1
+
+
+def test_none_result_is_handled(monkeypatch, tmp_path):
+    # Ensure None results are coerced and don't crash the downstream code
+    class NoneFirstAgent:
+        runs = 0
+
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            if type(self).runs < 3:
+                return None
+            return {"status": "ok", "messages": [{"role": "assistant", "content": "ok"}]}
+
+        def interrupt(self, _):
+            pass
+
+    session = _prepare_session("none_result", "stream_none_result", pending_user_message="hi")
+    config.CANCEL_FLAGS["stream_none_result"] = threading.Event()
+
+    with mock.patch.object(streaming, "_get_ai_agent", return_value=NoneFirstAgent):
+        fake_queue = streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text=session.pending_user_message,
+            model="test-model",
+            workspace=str(tmp_path),
+            stream_id="stream_none_result",
+        )
+
+    # Agent should have attempted multiple times and eventually produced messages
+    assert NoneFirstAgent.runs == 3
+    saved = Session.load("none_result")
+    assert saved is not None
+    assert any(m.get("role") == "assistant" for m in saved.messages)

--- a/tests/test_issue5601_extra.py
+++ b/tests/test_issue5601_extra.py
@@ -10,23 +10,16 @@ import api.config as config
 import api.models as models
 import api.streaming as streaming
 from api.models import Session
+# Reuse the existing helper from the main test file for consistent mocking
+from tests.test_issue5601_silent_provider_retry import _run_stream
 
 
-class CancelDuringBackoffAgent:
+# Reuse test agents from the main test file so mocking/patching behaves identically
+from tests.test_issue5601_silent_provider_retry import SilentRetryAgent, NoneRetryAgent
+
+
+class CancelDuringBackoffAgent(SilentRetryAgent):
     runs = 0
-
-    def __init__(self, **kwargs):
-        self.session_id = kwargs.get("session_id")
-
-    def run_conversation(self, **kwargs):
-        type(self).runs += 1
-        if type(self).runs == 1:
-            # Simulate silent empty result on first attempt
-            return {"messages": []}
-        return {"status": "ok", "messages": [{"role": "assistant", "content": "ok"}]}
-
-    def interrupt(self, _):
-        pass
 
 
 def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
@@ -58,70 +51,29 @@ def _run_stream_in_thread(session, stream_id, agent_cls, workspace):
 
 def test_cancel_during_backoff(monkeypatch, tmp_path):
     session = _prepare_session("cancel_backoff", "stream_cancel_backoff", pending_user_message="hi")
-    # Create an Event and ensure the streaming worker will see it
-    ev = threading.Event()
-    config.CANCEL_FLAGS["stream_cancel_backoff"] = ev
+    CancelDuringBackoffAgent.runs = 0
 
-    # Simulate cancellation during backoff by making wait() return True
-    def _always_true(timeout=None):
-        return True
-    ev.wait = _always_true
-
-    # Monkeypatch dependencies and run synchronously like other tests
-    with mock.patch.object(streaming, "get_session", return_value=session), \
-         mock.patch.object(streaming, "_get_ai_agent", return_value=CancelDuringBackoffAgent), \
-         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+    with mock.patch("api.streaming.time.sleep"), \
+         mock.patch("api.streaming.threading.Event.wait", return_value=True), \
          mock.patch("api.config.get_config", return_value={}), \
          mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
-        fake_queue = streaming._run_agent_streaming(
-            session_id=session.session_id,
-            msg_text=session.pending_user_message,
-            model="test-model",
-            workspace=str(tmp_path),
-            stream_id="stream_cancel_backoff",
-        )
+        fake_queue = _run_stream(monkeypatch, session, "stream_cancel_backoff", CancelDuringBackoffAgent, workspace=str(tmp_path))
 
-    # Agent should only have run once (no retry after cancel)
     assert CancelDuringBackoffAgent.runs == 1
-    events = [(e[0], e[1]) for e in list(fake_queue.queue)]
+    events = [(ev_name, payload) for ev_name, payload in list(fake_queue.queue)]
     assert any(ev_name == "cancel" for ev_name, _ in events)
 
 
 def test_none_result_is_handled(monkeypatch, tmp_path):
-    # Ensure None results are coerced and don't crash the downstream code
-    class NoneFirstAgent:
-        runs = 0
-
-        def __init__(self, **kwargs):
-            pass
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            if type(self).runs < 3:
-                return None
-            return {"status": "ok", "messages": [{"role": "assistant", "content": "ok"}]}
-
-        def interrupt(self, _):
-            pass
-
     session = _prepare_session("none_result", "stream_none_result", pending_user_message="hi")
     config.CANCEL_FLAGS["stream_none_result"] = threading.Event()
 
-    with mock.patch.object(streaming, "get_session", return_value=session), \
-         mock.patch.object(streaming, "_get_ai_agent", return_value=NoneFirstAgent), \
-         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+    with mock.patch("api.streaming.time.sleep"), \
          mock.patch("api.config.get_config", return_value={}), \
          mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
-        fake_queue = streaming._run_agent_streaming(
-            session_id=session.session_id,
-            msg_text=session.pending_user_message,
-            model="test-model",
-            workspace=str(tmp_path),
-            stream_id="stream_none_result",
-        )
+        fake_queue = _run_stream(monkeypatch, session, "stream_none_result", NoneRetryAgent, workspace=str(tmp_path))
 
-    # Agent should have attempted multiple times and eventually produced messages
-    assert NoneFirstAgent.runs == 3
+    assert NoneRetryAgent.runs == 3
     saved = Session.load("none_result")
     assert saved is not None
     assert any(m.get("role") == "assistant" for m in saved.messages)

--- a/tests/test_issue5601_extra.py
+++ b/tests/test_issue5601_extra.py
@@ -62,19 +62,29 @@ def test_cancel_during_backoff(monkeypatch, tmp_path):
     ev = threading.Event()
     config.CANCEL_FLAGS["stream_cancel_backoff"] = ev
 
-    # Monkeypatch _get_ai_agent to return our test agent class
-    with mock.patch.object(streaming, "_get_ai_agent", return_value=CancelDuringBackoffAgent):
-        t = _run_stream_in_thread(session, "stream_cancel_backoff", CancelDuringBackoffAgent, workspace=str(tmp_path))
+    # Simulate cancellation during backoff by making wait() return True
+    def _always_true(timeout=None):
+        return True
+    ev.wait = _always_true
 
-        # Wait briefly for the first provider call to complete and the worker to enter backoff
-        time.sleep(0.05)
-        # Simulate a cancel during backoff
-        ev.set()
-
-        t.join(timeout=5)
+    # Monkeypatch dependencies and run synchronously like other tests
+    with mock.patch.object(streaming, "get_session", return_value=session), \
+         mock.patch.object(streaming, "_get_ai_agent", return_value=CancelDuringBackoffAgent), \
+         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+         mock.patch("api.config.get_config", return_value={}), \
+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
+        fake_queue = streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text=session.pending_user_message,
+            model="test-model",
+            workspace=str(tmp_path),
+            stream_id="stream_cancel_backoff",
+        )
 
     # Agent should only have run once (no retry after cancel)
     assert CancelDuringBackoffAgent.runs == 1
+    events = [(e[0], e[1]) for e in list(fake_queue.queue)]
+    assert any(ev_name == "cancel" for ev_name, _ in events)
 
 
 def test_none_result_is_handled(monkeypatch, tmp_path):
@@ -97,7 +107,11 @@ def test_none_result_is_handled(monkeypatch, tmp_path):
     session = _prepare_session("none_result", "stream_none_result", pending_user_message="hi")
     config.CANCEL_FLAGS["stream_none_result"] = threading.Event()
 
-    with mock.patch.object(streaming, "_get_ai_agent", return_value=NoneFirstAgent):
+    with mock.patch.object(streaming, "get_session", return_value=session), \
+         mock.patch.object(streaming, "_get_ai_agent", return_value=NoneFirstAgent), \
+         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+         mock.patch("api.config.get_config", return_value={}), \
+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
         fake_queue = streaming._run_agent_streaming(
             session_id=session.session_id,
             msg_text=session.pending_user_message,

--- a/tests/test_issue5601_silent_provider_retry.py
+++ b/tests/test_issue5601_silent_provider_retry.py
@@ -1,261 +1,280 @@
-"""Regression tests for silent provider failure retry in streaming.
+commit b6ae470d67925ae64d421407ad5024f4030a9908
+Author: Lincoln <lincoln@hermes.local>
+Date:   Sat Jul 18 22:52:26 2026 +1200
 
-Silent provider failures occur when the API returns no error AND no messages
-(empty response body, provider timeout without HTTP error, rate limits without
-HTTP 429). The streaming layer retries up to 3 times with exponential backoff.
-"""
+    test: add regression tests for silent provider failure retry
+    
+    Test silent provider failures (no error, no messages) trigger retry:
+    - Silent failure with empty messages triggers retry
+    - None result triggers retry
+    - Retry exhaustion after 3 attempts
+    - Normal success without retry
 
-from __future__ import annotations
-
-import queue
-import sys
-import types
-from unittest import mock
-
-import pytest
-
-import api.config as config
-import api.models as models
-import api.streaming as streaming
-from api.models import Session
-
-
-@pytest.fixture(autouse=True)
-def _isolate_session_dir(tmp_path, monkeypatch):
-    session_dir = tmp_path / "sessions"
-    session_dir.mkdir()
-    index_file = session_dir / "_index.json"
-    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
-    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
-    models.SESSIONS.clear()
-    yield
-    models.SESSIONS.clear()
-
-
-@pytest.fixture(autouse=True)
-def _isolate_stream_state():
-    config.STREAMS.clear()
-    config.CANCEL_FLAGS.clear()
-    config.AGENT_INSTANCES.clear()
-    config.STREAM_PARTIAL_TEXT.clear()
-    if hasattr(config, "STREAM_REASONING_TEXT"):
-        config.STREAM_REASONING_TEXT.clear()
-    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
-        config.STREAM_LIVE_TOOL_CALLS.clear()
-    yield
-    config.STREAMS.clear()
-    config.CANCEL_FLAGS.clear()
-    config.AGENT_INSTANCES.clear()
-    config.STREAM_PARTIAL_TEXT.clear()
-    if hasattr(config, "STREAM_REASONING_TEXT"):
-        config.STREAM_REASONING_TEXT.clear()
-    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
-        config.STREAM_LIVE_TOOL_CALLS.clear()
-
-
-@pytest.fixture(autouse=True)
-def _isolate_agent_locks():
-    config.SESSION_AGENT_LOCKS.clear()
-    yield
-    config.SESSION_AGENT_LOCKS.clear()
-
-
-@pytest.fixture(autouse=True)
-def _mock_hermes_modules(monkeypatch):
-    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
-    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
-        "provider": requested or "test-provider",
-        "api_key": "synthetic-key",
-        "base_url": None,
-    }
-    fake_hermes_cli = types.ModuleType("hermes_cli")
-    fake_hermes_cli.runtime_provider = fake_runtime_module
-    fake_hermes_state = types.ModuleType("hermes_state")
-    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
-
-    injected = {
-        "hermes_cli": fake_hermes_cli,
-        "hermes_cli.runtime_provider": fake_runtime_module,
-        "hermes_state": fake_hermes_state,
-    }
-    missing = object()
-    saved = {k: sys.modules.get(k, missing) for k in injected}
-    sys.modules.update(injected)
-    yield
-    for name, prev in saved.items():
-        if prev is missing:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = prev
-
-
-class MockAgent:
-    def __init__(self, **kwargs):
-        self.session_id = kwargs.get("session_id")
-        self.stream_delta_callback = kwargs.get("stream_delta_callback")
-        self.reasoning_callback = kwargs.get("reasoning_callback")
-        self.tool_progress_callback = kwargs.get("tool_progress_callback")
-        self.session_prompt_tokens = 0
-        self.session_completion_tokens = 0
-        self.session_estimated_cost_usd = 0.0
-        self.context_compressor = None
-        self._last_error = None
-        self.ephemeral_system_prompt = None
-
-    def run_conversation(self, **kwargs):
-        raise NotImplementedError
-
-    def interrupt(self, _message):
-        pass
-
-
-def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
-    session = Session(session_id=session_id, title="Test Session")
-    session.messages = []
-    session.context_messages = []
-    session.pending_user_message = pending_user_message
-    session.pending_attachments = []
-    session.pending_started_at = 1234567890.0
-    session.pending_user_source = "cli"
-    session.active_stream_id = stream_id
-    session.save()
-    models.SESSIONS[session_id] = session
-    return session
-
-
-def _queue_events(fake_queue):
-    return [(item[0], item[1]) for item in list(fake_queue.queue)]
-
-
-def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
-    fake_queue = queue.Queue()
-    streaming.STREAMS[stream_id] = fake_queue
-    config.STREAM_PARTIAL_TEXT[stream_id] = ""
-
-    with mock.patch.object(streaming, "get_session", return_value=session), \
-         mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
-         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
-         mock.patch("api.config.get_config", return_value={}), \
-         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
-        streaming._run_agent_streaming(
-            session_id=session.session_id,
-            msg_text=session.pending_user_message,
-            model="test-model",
-            workspace=workspace,
-            stream_id=stream_id,
-        )
-
-    return fake_queue
-
-
-def _build_silent_failure_agent(success_on_attempt: int = 2):
-    """Agent that returns empty result (no messages, no error key) for first N-1 attempts."""
-    class SilentFailureAgent(MockAgent):
-        runs = 0
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            history = list(kwargs.get("conversation_history") or [])
-            if type(self).runs < success_on_attempt:
-                # Silent failure: no error key, no messages
-                return {}
-            return {
-                "status": "ok",
-                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
-            }
-
-    return SilentFailureAgent
-
-
-def _build_none_result_agent(success_on_attempt: int = 2):
-    """Agent that returns None for first N-1 attempts."""
-    class NoneResultAgent(MockAgent):
-        runs = 0
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            history = list(kwargs.get("conversation_history") or [])
-            if type(self).runs < success_on_attempt:
-                return None
-            return {
-                "status": "ok",
-                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
-            }
-
-    return NoneResultAgent
-
-
-def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
-    """Silent failure on attempt 1 should retry and succeed on attempt 2."""
-    session = _prepare_session("silent_retry", "stream_silent_retry", pending_user_message="Test message")
-    agent_cls = _build_silent_failure_agent(success_on_attempt=2)
-
-    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", agent_cls, workspace=str(tmp_path))
-
-    assert agent_cls.runs == 2  # Two attempts: initial + one retry
-    saved = Session.load("silent_retry")
-    assert saved is not None
-    assert saved.messages[-1]["role"] == "assistant"
-    assert saved.messages[-1]["content"] == "Success after retry"
-
-    events = _queue_events(fake_queue)
-    assert any(event == "done" for event, _ in events)
-
-
-def test_silent_provider_failure_none_result_retries_and_succeeds(tmp_path, monkeypatch):
-    """None result should also trigger retry and succeed."""
-    session = _prepare_session("silent_none", "stream_silent_none", pending_user_message="Test message")
-    agent_cls = _build_none_result_agent(success_on_attempt=3)
-
-    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", agent_cls, workspace=str(tmp_path))
-
-    assert agent_cls.runs == 3  # Three attempts: initial + two retries
-    saved = Session.load("silent_none")
-    assert saved is not None
-    assert saved.messages[-1]["role"] == "assistant"
-
-
-def test_silent_provider_failure_all_retries_exhausted(tmp_path, monkeypatch):
-    """After 3 retries exhausted, should return empty response to user."""
-    session = _prepare_session("silent_exhausted", "stream_silent_exhausted", pending_user_message="Test message")
-    agent_cls = _build_silent_failure_agent(success_on_attempt=10)  # Never succeeds
-
-    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", agent_cls, workspace=str(tmp_path))
-
-    assert agent_cls.runs == 3  # Only 3 attempts max
-    saved = Session.load("silent_exhausted")
-    assert saved is not None
-    # After retries exhausted, should have empty response
-    assert any(msg.get("role") == "assistant" for msg in saved.messages)
-
-
-def test_silent_provider_failure_no_error_field_succeeds_first_try(tmp_path, monkeypatch):
-    """Normal success with content should not trigger retry."""
-    session = _prepare_session("no_error_success", "stream_no_error_success", pending_user_message="Test message")
-
-    class ImmediateSuccessAgent(MockAgent):
-        runs = 0
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            history = list(kwargs.get("conversation_history") or [])
-            return {
-                "status": "ok",
-                "messages": history + [{"role": "assistant", "content": "Immediate success"}],
-            }
-
-    agent_cls = ImmediateSuccessAgent
-
-    with mock.patch("api.streaming.time.sleep"):
-        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", agent_cls, workspace=str(tmp_path))
-
-    assert agent_cls.runs == 1  # Only one attempt
-    saved = Session.load("no_error_success")
-    assert saved is not None
-    assert saved.messages[-1]["content"] == "Immediate success"
-
-    events = _queue_events(fake_queue)
-    assert any(event == "done" for event, _ in events)
+diff --git a/tests/test_issue5601_silent_provider_retry.py b/tests/test_issue5601_silent_provider_retry.py
+new file mode 100644
+index 00000000..e742a950
+--- /dev/null
++++ b/tests/test_issue5601_silent_provider_retry.py
+@@ -0,0 +1,261 @@
++"""Regression tests for silent provider failure retry in streaming.
++
++Silent provider failures occur when the API returns no error AND no messages
++(empty response body, provider timeout without HTTP error, rate limits without
++HTTP 429). The streaming layer retries up to 3 times with exponential backoff.
++"""
++
++from __future__ import annotations
++
++import queue
++import sys
++import types
++from unittest import mock
++
++import pytest
++
++import api.config as config
++import api.models as models
++import api.streaming as streaming
++from api.models import Session
++
++
++@pytest.fixture(autouse=True)
++def _isolate_session_dir(tmp_path, monkeypatch):
++    session_dir = tmp_path / "sessions"
++    session_dir.mkdir()
++    index_file = session_dir / "_index.json"
++    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
++    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
++    models.SESSIONS.clear()
++    yield
++    models.SESSIONS.clear()
++
++
++@pytest.fixture(autouse=True)
++def _isolate_stream_state():
++    config.STREAMS.clear()
++    config.CANCEL_FLAGS.clear()
++    config.AGENT_INSTANCES.clear()
++    config.STREAM_PARTIAL_TEXT.clear()
++    if hasattr(config, "STREAM_REASONING_TEXT"):
++        config.STREAM_REASONING_TEXT.clear()
++    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
++        config.STREAM_LIVE_TOOL_CALLS.clear()
++    yield
++    config.STREAMS.clear()
++    config.CANCEL_FLAGS.clear()
++    config.AGENT_INSTANCES.clear()
++    config.STREAM_PARTIAL_TEXT.clear()
++    if hasattr(config, "STREAM_REASONING_TEXT"):
++        config.STREAM_REASONING_TEXT.clear()
++    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
++        config.STREAM_LIVE_TOOL_CALLS.clear()
++
++
++@pytest.fixture(autouse=True)
++def _isolate_agent_locks():
++    config.SESSION_AGENT_LOCKS.clear()
++    yield
++    config.SESSION_AGENT_LOCKS.clear()
++
++
++@pytest.fixture(autouse=True)
++def _mock_hermes_modules(monkeypatch):
++    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
++    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
++        "provider": requested or "test-provider",
++        "api_key": "synthetic-key",
++        "base_url": None,
++    }
++    fake_hermes_cli = types.ModuleType("hermes_cli")
++    fake_hermes_cli.runtime_provider = fake_runtime_module
++    fake_hermes_state = types.ModuleType("hermes_state")
++    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
++
++    injected = {
++        "hermes_cli": fake_hermes_cli,
++        "hermes_cli.runtime_provider": fake_runtime_module,
++        "hermes_state": fake_hermes_state,
++    }
++    missing = object()
++    saved = {k: sys.modules.get(k, missing) for k in injected}
++    sys.modules.update(injected)
++    yield
++    for name, prev in saved.items():
++        if prev is missing:
++            sys.modules.pop(name, None)
++        else:
++            sys.modules[name] = prev
++
++
++class MockAgent:
++    def __init__(self, **kwargs):
++        self.session_id = kwargs.get("session_id")
++        self.stream_delta_callback = kwargs.get("stream_delta_callback")
++        self.reasoning_callback = kwargs.get("reasoning_callback")
++        self.tool_progress_callback = kwargs.get("tool_progress_callback")
++        self.session_prompt_tokens = 0
++        self.session_completion_tokens = 0
++        self.session_estimated_cost_usd = 0.0
++        self.context_compressor = None
++        self._last_error = None
++        self.ephemeral_system_prompt = None
++
++    def run_conversation(self, **kwargs):
++        raise NotImplementedError
++
++    def interrupt(self, _message):
++        pass
++
++
++def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
++    session = Session(session_id=session_id, title="Test Session")
++    session.messages = []
++    session.context_messages = []
++    session.pending_user_message = pending_user_message
++    session.pending_attachments = []
++    session.pending_started_at = 1234567890.0
++    session.pending_user_source = "cli"
++    session.active_stream_id = stream_id
++    session.save()
++    models.SESSIONS[session_id] = session
++    return session
++
++
++def _queue_events(fake_queue):
++    return [(item[0], item[1]) for item in list(fake_queue.queue)]
++
++
++def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
++    fake_queue = queue.Queue()
++    streaming.STREAMS[stream_id] = fake_queue
++    config.STREAM_PARTIAL_TEXT[stream_id] = ""
++
++    with mock.patch.object(streaming, "get_session", return_value=session), \
++         mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
++         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
++         mock.patch("api.config.get_config", return_value={}), \
++         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
++        streaming._run_agent_streaming(
++            session_id=session.session_id,
++            msg_text=session.pending_user_message,
++            model="test-model",
++            workspace=workspace,
++            stream_id=stream_id,
++        )
++
++    return fake_queue
++
++
++def _build_silent_failure_agent(success_on_attempt: int = 2):
++    """Agent that returns empty result (no messages, no error key) for first N-1 attempts."""
++    class SilentFailureAgent(MockAgent):
++        runs = 0
++
++        def run_conversation(self, **kwargs):
++            type(self).runs += 1
++            history = list(kwargs.get("conversation_history") or [])
++            if type(self).runs < success_on_attempt:
++                # Silent failure: no error key, no messages
++                return {}
++            return {
++                "status": "ok",
++                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
++            }
++
++    return SilentFailureAgent
++
++
++def _build_none_result_agent(success_on_attempt: int = 2):
++    """Agent that returns None for first N-1 attempts."""
++    class NoneResultAgent(MockAgent):
++        runs = 0
++
++        def run_conversation(self, **kwargs):
++            type(self).runs += 1
++            history = list(kwargs.get("conversation_history") or [])
++            if type(self).runs < success_on_attempt:
++                return None
++            return {
++                "status": "ok",
++                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
++            }
++
++    return NoneResultAgent
++
++
++def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
++    """Silent failure on attempt 1 should retry and succeed on attempt 2."""
++    session = _prepare_session("silent_retry", "stream_silent_retry", pending_user_message="Test message")
++    agent_cls = _build_silent_failure_agent(success_on_attempt=2)
++
++    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
++        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", agent_cls, workspace=str(tmp_path))
++
++    assert agent_cls.runs == 2  # Two attempts: initial + one retry
++    saved = Session.load("silent_retry")
++    assert saved is not None
++    assert saved.messages[-1]["role"] == "assistant"
++    assert saved.messages[-1]["content"] == "Success after retry"
++
++    events = _queue_events(fake_queue)
++    assert any(event == "done" for event, _ in events)
++
++
++def test_silent_provider_failure_none_result_retries_and_succeeds(tmp_path, monkeypatch):
++    """None result should also trigger retry and succeed."""
++    session = _prepare_session("silent_none", "stream_silent_none", pending_user_message="Test message")
++    agent_cls = _build_none_result_agent(success_on_attempt=3)
++
++    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
++        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", agent_cls, workspace=str(tmp_path))
++
++    assert agent_cls.runs == 3  # Three attempts: initial + two retries
++    saved = Session.load("silent_none")
++    assert saved is not None
++    assert saved.messages[-1]["role"] == "assistant"
++
++
++def test_silent_provider_failure_all_retries_exhausted(tmp_path, monkeypatch):
++    """After 3 retries exhausted, should return empty response to user."""
++    session = _prepare_session("silent_exhausted", "stream_silent_exhausted", pending_user_message="Test message")
++    agent_cls = _build_silent_failure_agent(success_on_attempt=10)  # Never succeeds
++
++    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
++        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", agent_cls, workspace=str(tmp_path))
++
++    assert agent_cls.runs == 3  # Only 3 attempts max
++    saved = Session.load("silent_exhausted")
++    assert saved is not None
++    # After retries exhausted, should have empty response
++    assert any(msg.get("role") == "assistant" for msg in saved.messages)
++
++
++def test_silent_provider_failure_no_error_field_succeeds_first_try(tmp_path, monkeypatch):
++    """Normal success with content should not trigger retry."""
++    session = _prepare_session("no_error_success", "stream_no_error_success", pending_user_message="Test message")
++
++    class ImmediateSuccessAgent(MockAgent):
++        runs = 0
++
++        def run_conversation(self, **kwargs):
++            type(self).runs += 1
++            history = list(kwargs.get("conversation_history") or [])
++            return {
++                "status": "ok",
++                "messages": history + [{"role": "assistant", "content": "Immediate success"}],
++            }
++
++    agent_cls = ImmediateSuccessAgent
++
++    with mock.patch("api.streaming.time.sleep"):
++        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", agent_cls, workspace=str(tmp_path))
++
++    assert agent_cls.runs == 1  # Only one attempt
++    saved = Session.load("no_error_success")
++    assert saved is not None
++    assert saved.messages[-1]["content"] == "Immediate success"
++
++    events = _queue_events(fake_queue)
++    assert any(event == "done" for event, _ in events)
+\ No newline at end of file

--- a/tests/test_issue5601_silent_provider_retry.py
+++ b/tests/test_issue5601_silent_provider_retry.py
@@ -1,0 +1,261 @@
+"""Regression tests for silent provider failure retry in streaming.
+
+Silent provider failures occur when the API returns no error AND no messages
+(empty response body, provider timeout without HTTP error, rate limits without
+HTTP 429). The streaming layer retries up to 3 times with exponential backoff.
+"""
+
+from __future__ import annotations
+
+import queue
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+import api.config as config
+import api.models as models
+import api.streaming as streaming
+from api.models import Session
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    models.SESSIONS.clear()
+    yield
+    models.SESSIONS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_stream_state():
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    if hasattr(config, "STREAM_REASONING_TEXT"):
+        config.STREAM_REASONING_TEXT.clear()
+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
+        config.STREAM_LIVE_TOOL_CALLS.clear()
+    yield
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    if hasattr(config, "STREAM_REASONING_TEXT"):
+        config.STREAM_REASONING_TEXT.clear()
+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
+        config.STREAM_LIVE_TOOL_CALLS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agent_locks():
+    config.SESSION_AGENT_LOCKS.clear()
+    yield
+    config.SESSION_AGENT_LOCKS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _mock_hermes_modules(monkeypatch):
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
+        "provider": requested or "test-provider",
+        "api_key": "synthetic-key",
+        "base_url": None,
+    }
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.runtime_provider = fake_runtime_module
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
+
+    injected = {
+        "hermes_cli": fake_hermes_cli,
+        "hermes_cli.runtime_provider": fake_runtime_module,
+        "hermes_state": fake_hermes_state,
+    }
+    missing = object()
+    saved = {k: sys.modules.get(k, missing) for k in injected}
+    sys.modules.update(injected)
+    yield
+    for name, prev in saved.items():
+        if prev is missing:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = prev
+
+
+class MockAgent:
+    def __init__(self, **kwargs):
+        self.session_id = kwargs.get("session_id")
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.reasoning_callback = kwargs.get("reasoning_callback")
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.context_compressor = None
+        self._last_error = None
+        self.ephemeral_system_prompt = None
+
+    def run_conversation(self, **kwargs):
+        raise NotImplementedError
+
+    def interrupt(self, _message):
+        pass
+
+
+def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
+    session = Session(session_id=session_id, title="Test Session")
+    session.messages = []
+    session.context_messages = []
+    session.pending_user_message = pending_user_message
+    session.pending_attachments = []
+    session.pending_started_at = 1234567890.0
+    session.pending_user_source = "cli"
+    session.active_stream_id = stream_id
+    session.save()
+    models.SESSIONS[session_id] = session
+    return session
+
+
+def _queue_events(fake_queue):
+    return [(item[0], item[1]) for item in list(fake_queue.queue)]
+
+
+def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
+    fake_queue = queue.Queue()
+    streaming.STREAMS[stream_id] = fake_queue
+    config.STREAM_PARTIAL_TEXT[stream_id] = ""
+
+    with mock.patch.object(streaming, "get_session", return_value=session), \
+         mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
+         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+         mock.patch("api.config.get_config", return_value={}), \
+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
+        streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text=session.pending_user_message,
+            model="test-model",
+            workspace=workspace,
+            stream_id=stream_id,
+        )
+
+    return fake_queue
+
+
+def _build_silent_failure_agent(success_on_attempt: int = 2):
+    """Agent that returns empty result (no messages, no error key) for first N-1 attempts."""
+    class SilentFailureAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            if type(self).runs < success_on_attempt:
+                # Silent failure: no error key, no messages
+                return {}
+            return {
+                "status": "ok",
+                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
+            }
+
+    return SilentFailureAgent
+
+
+def _build_none_result_agent(success_on_attempt: int = 2):
+    """Agent that returns None for first N-1 attempts."""
+    class NoneResultAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            if type(self).runs < success_on_attempt:
+                return None
+            return {
+                "status": "ok",
+                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
+            }
+
+    return NoneResultAgent
+
+
+def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
+    """Silent failure on attempt 1 should retry and succeed on attempt 2."""
+    session = _prepare_session("silent_retry", "stream_silent_retry", pending_user_message="Test message")
+    agent_cls = _build_silent_failure_agent(success_on_attempt=2)
+
+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 2  # Two attempts: initial + one retry
+    saved = Session.load("silent_retry")
+    assert saved is not None
+    assert saved.messages[-1]["role"] == "assistant"
+    assert saved.messages[-1]["content"] == "Success after retry"
+
+    events = _queue_events(fake_queue)
+    assert any(event == "done" for event, _ in events)
+
+
+def test_silent_provider_failure_none_result_retries_and_succeeds(tmp_path, monkeypatch):
+    """None result should also trigger retry and succeed."""
+    session = _prepare_session("silent_none", "stream_silent_none", pending_user_message="Test message")
+    agent_cls = _build_none_result_agent(success_on_attempt=3)
+
+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 3  # Three attempts: initial + two retries
+    saved = Session.load("silent_none")
+    assert saved is not None
+    assert saved.messages[-1]["role"] == "assistant"
+
+
+def test_silent_provider_failure_all_retries_exhausted(tmp_path, monkeypatch):
+    """After 3 retries exhausted, should return empty response to user."""
+    session = _prepare_session("silent_exhausted", "stream_silent_exhausted", pending_user_message="Test message")
+    agent_cls = _build_silent_failure_agent(success_on_attempt=10)  # Never succeeds
+
+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 3  # Only 3 attempts max
+    saved = Session.load("silent_exhausted")
+    assert saved is not None
+    # After retries exhausted, should have empty response
+    assert any(msg.get("role") == "assistant" for msg in saved.messages)
+
+
+def test_silent_provider_failure_no_error_field_succeeds_first_try(tmp_path, monkeypatch):
+    """Normal success with content should not trigger retry."""
+    session = _prepare_session("no_error_success", "stream_no_error_success", pending_user_message="Test message")
+
+    class ImmediateSuccessAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            return {
+                "status": "ok",
+                "messages": history + [{"role": "assistant", "content": "Immediate success"}],
+            }
+
+    agent_cls = ImmediateSuccessAgent
+
+    with mock.patch("api.streaming.time.sleep"):
+        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 1  # Only one attempt
+    saved = Session.load("no_error_success")
+    assert saved is not None
+    assert saved.messages[-1]["content"] == "Immediate success"
+
+    events = _queue_events(fake_queue)
+    assert any(event == "done" for event, _ in events)

--- a/tests/test_issue5601_silent_provider_retry.py
+++ b/tests/test_issue5601_silent_provider_retry.py
@@ -1,280 +1,261 @@
-commit b6ae470d67925ae64d421407ad5024f4030a9908
-Author: Lincoln <lincoln@hermes.local>
-Date:   Sat Jul 18 22:52:26 2026 +1200
+"""Regression tests for silent provider failure retry in streaming.
 
-    test: add regression tests for silent provider failure retry
-    
-    Test silent provider failures (no error, no messages) trigger retry:
-    - Silent failure with empty messages triggers retry
-    - None result triggers retry
-    - Retry exhaustion after 3 attempts
-    - Normal success without retry
+Silent provider failures occur when the API returns no error AND no messages
+(empty response body, provider timeout without HTTP error, rate limits without
+HTTP 429). The streaming layer retries up to 3 times with exponential backoff.
+"""
 
-diff --git a/tests/test_issue5601_silent_provider_retry.py b/tests/test_issue5601_silent_provider_retry.py
-new file mode 100644
-index 00000000..e742a950
---- /dev/null
-+++ b/tests/test_issue5601_silent_provider_retry.py
-@@ -0,0 +1,261 @@
-+"""Regression tests for silent provider failure retry in streaming.
-+
-+Silent provider failures occur when the API returns no error AND no messages
-+(empty response body, provider timeout without HTTP error, rate limits without
-+HTTP 429). The streaming layer retries up to 3 times with exponential backoff.
-+"""
-+
-+from __future__ import annotations
-+
-+import queue
-+import sys
-+import types
-+from unittest import mock
-+
-+import pytest
-+
-+import api.config as config
-+import api.models as models
-+import api.streaming as streaming
-+from api.models import Session
-+
-+
-+@pytest.fixture(autouse=True)
-+def _isolate_session_dir(tmp_path, monkeypatch):
-+    session_dir = tmp_path / "sessions"
-+    session_dir.mkdir()
-+    index_file = session_dir / "_index.json"
-+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
-+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
-+    models.SESSIONS.clear()
-+    yield
-+    models.SESSIONS.clear()
-+
-+
-+@pytest.fixture(autouse=True)
-+def _isolate_stream_state():
-+    config.STREAMS.clear()
-+    config.CANCEL_FLAGS.clear()
-+    config.AGENT_INSTANCES.clear()
-+    config.STREAM_PARTIAL_TEXT.clear()
-+    if hasattr(config, "STREAM_REASONING_TEXT"):
-+        config.STREAM_REASONING_TEXT.clear()
-+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
-+        config.STREAM_LIVE_TOOL_CALLS.clear()
-+    yield
-+    config.STREAMS.clear()
-+    config.CANCEL_FLAGS.clear()
-+    config.AGENT_INSTANCES.clear()
-+    config.STREAM_PARTIAL_TEXT.clear()
-+    if hasattr(config, "STREAM_REASONING_TEXT"):
-+        config.STREAM_REASONING_TEXT.clear()
-+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
-+        config.STREAM_LIVE_TOOL_CALLS.clear()
-+
-+
-+@pytest.fixture(autouse=True)
-+def _isolate_agent_locks():
-+    config.SESSION_AGENT_LOCKS.clear()
-+    yield
-+    config.SESSION_AGENT_LOCKS.clear()
-+
-+
-+@pytest.fixture(autouse=True)
-+def _mock_hermes_modules(monkeypatch):
-+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
-+    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
-+        "provider": requested or "test-provider",
-+        "api_key": "synthetic-key",
-+        "base_url": None,
-+    }
-+    fake_hermes_cli = types.ModuleType("hermes_cli")
-+    fake_hermes_cli.runtime_provider = fake_runtime_module
-+    fake_hermes_state = types.ModuleType("hermes_state")
-+    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
-+
-+    injected = {
-+        "hermes_cli": fake_hermes_cli,
-+        "hermes_cli.runtime_provider": fake_runtime_module,
-+        "hermes_state": fake_hermes_state,
-+    }
-+    missing = object()
-+    saved = {k: sys.modules.get(k, missing) for k in injected}
-+    sys.modules.update(injected)
-+    yield
-+    for name, prev in saved.items():
-+        if prev is missing:
-+            sys.modules.pop(name, None)
-+        else:
-+            sys.modules[name] = prev
-+
-+
-+class MockAgent:
-+    def __init__(self, **kwargs):
-+        self.session_id = kwargs.get("session_id")
-+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
-+        self.reasoning_callback = kwargs.get("reasoning_callback")
-+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
-+        self.session_prompt_tokens = 0
-+        self.session_completion_tokens = 0
-+        self.session_estimated_cost_usd = 0.0
-+        self.context_compressor = None
-+        self._last_error = None
-+        self.ephemeral_system_prompt = None
-+
-+    def run_conversation(self, **kwargs):
-+        raise NotImplementedError
-+
-+    def interrupt(self, _message):
-+        pass
-+
-+
-+def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
-+    session = Session(session_id=session_id, title="Test Session")
-+    session.messages = []
-+    session.context_messages = []
-+    session.pending_user_message = pending_user_message
-+    session.pending_attachments = []
-+    session.pending_started_at = 1234567890.0
-+    session.pending_user_source = "cli"
-+    session.active_stream_id = stream_id
-+    session.save()
-+    models.SESSIONS[session_id] = session
-+    return session
-+
-+
-+def _queue_events(fake_queue):
-+    return [(item[0], item[1]) for item in list(fake_queue.queue)]
-+
-+
-+def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
-+    fake_queue = queue.Queue()
-+    streaming.STREAMS[stream_id] = fake_queue
-+    config.STREAM_PARTIAL_TEXT[stream_id] = ""
-+
-+    with mock.patch.object(streaming, "get_session", return_value=session), \
-+         mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
-+         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
-+         mock.patch("api.config.get_config", return_value={}), \
-+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
-+        streaming._run_agent_streaming(
-+            session_id=session.session_id,
-+            msg_text=session.pending_user_message,
-+            model="test-model",
-+            workspace=workspace,
-+            stream_id=stream_id,
-+        )
-+
-+    return fake_queue
-+
-+
-+def _build_silent_failure_agent(success_on_attempt: int = 2):
-+    """Agent that returns empty result (no messages, no error key) for first N-1 attempts."""
-+    class SilentFailureAgent(MockAgent):
-+        runs = 0
-+
-+        def run_conversation(self, **kwargs):
-+            type(self).runs += 1
-+            history = list(kwargs.get("conversation_history") or [])
-+            if type(self).runs < success_on_attempt:
-+                # Silent failure: no error key, no messages
-+                return {}
-+            return {
-+                "status": "ok",
-+                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
-+            }
-+
-+    return SilentFailureAgent
-+
-+
-+def _build_none_result_agent(success_on_attempt: int = 2):
-+    """Agent that returns None for first N-1 attempts."""
-+    class NoneResultAgent(MockAgent):
-+        runs = 0
-+
-+        def run_conversation(self, **kwargs):
-+            type(self).runs += 1
-+            history = list(kwargs.get("conversation_history") or [])
-+            if type(self).runs < success_on_attempt:
-+                return None
-+            return {
-+                "status": "ok",
-+                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
-+            }
-+
-+    return NoneResultAgent
-+
-+
-+def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
-+    """Silent failure on attempt 1 should retry and succeed on attempt 2."""
-+    session = _prepare_session("silent_retry", "stream_silent_retry", pending_user_message="Test message")
-+    agent_cls = _build_silent_failure_agent(success_on_attempt=2)
-+
-+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", agent_cls, workspace=str(tmp_path))
-+
-+    assert agent_cls.runs == 2  # Two attempts: initial + one retry
-+    saved = Session.load("silent_retry")
-+    assert saved is not None
-+    assert saved.messages[-1]["role"] == "assistant"
-+    assert saved.messages[-1]["content"] == "Success after retry"
-+
-+    events = _queue_events(fake_queue)
-+    assert any(event == "done" for event, _ in events)
-+
-+
-+def test_silent_provider_failure_none_result_retries_and_succeeds(tmp_path, monkeypatch):
-+    """None result should also trigger retry and succeed."""
-+    session = _prepare_session("silent_none", "stream_silent_none", pending_user_message="Test message")
-+    agent_cls = _build_none_result_agent(success_on_attempt=3)
-+
-+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", agent_cls, workspace=str(tmp_path))
-+
-+    assert agent_cls.runs == 3  # Three attempts: initial + two retries
-+    saved = Session.load("silent_none")
-+    assert saved is not None
-+    assert saved.messages[-1]["role"] == "assistant"
-+
-+
-+def test_silent_provider_failure_all_retries_exhausted(tmp_path, monkeypatch):
-+    """After 3 retries exhausted, should return empty response to user."""
-+    session = _prepare_session("silent_exhausted", "stream_silent_exhausted", pending_user_message="Test message")
-+    agent_cls = _build_silent_failure_agent(success_on_attempt=10)  # Never succeeds
-+
-+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", agent_cls, workspace=str(tmp_path))
-+
-+    assert agent_cls.runs == 3  # Only 3 attempts max
-+    saved = Session.load("silent_exhausted")
-+    assert saved is not None
-+    # After retries exhausted, should have empty response
-+    assert any(msg.get("role") == "assistant" for msg in saved.messages)
-+
-+
-+def test_silent_provider_failure_no_error_field_succeeds_first_try(tmp_path, monkeypatch):
-+    """Normal success with content should not trigger retry."""
-+    session = _prepare_session("no_error_success", "stream_no_error_success", pending_user_message="Test message")
-+
-+    class ImmediateSuccessAgent(MockAgent):
-+        runs = 0
-+
-+        def run_conversation(self, **kwargs):
-+            type(self).runs += 1
-+            history = list(kwargs.get("conversation_history") or [])
-+            return {
-+                "status": "ok",
-+                "messages": history + [{"role": "assistant", "content": "Immediate success"}],
-+            }
-+
-+    agent_cls = ImmediateSuccessAgent
-+
-+    with mock.patch("api.streaming.time.sleep"):
-+        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", agent_cls, workspace=str(tmp_path))
-+
-+    assert agent_cls.runs == 1  # Only one attempt
-+    saved = Session.load("no_error_success")
-+    assert saved is not None
-+    assert saved.messages[-1]["content"] == "Immediate success"
-+
-+    events = _queue_events(fake_queue)
-+    assert any(event == "done" for event, _ in events)
-\ No newline at end of file
+from __future__ import annotations
+
+import queue
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+import api.config as config
+import api.models as models
+import api.streaming as streaming
+from api.models import Session
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    models.SESSIONS.clear()
+    yield
+    models.SESSIONS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_stream_state():
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    if hasattr(config, "STREAM_REASONING_TEXT"):
+        config.STREAM_REASONING_TEXT.clear()
+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
+        config.STREAM_LIVE_TOOL_CALLS.clear()
+    yield
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    if hasattr(config, "STREAM_REASONING_TEXT"):
+        config.STREAM_REASONING_TEXT.clear()
+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
+        config.STREAM_LIVE_TOOL_CALLS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agent_locks():
+    config.SESSION_AGENT_LOCKS.clear()
+    yield
+    config.SESSION_AGENT_LOCKS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _mock_hermes_modules(monkeypatch):
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
+        "provider": requested or "test-provider",
+        "api_key": "synthetic-key",
+        "base_url": None,
+    }
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.runtime_provider = fake_runtime_module
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
+
+    injected = {
+        "hermes_cli": fake_hermes_cli,
+        "hermes_cli.runtime_provider": fake_runtime_module,
+        "hermes_state": fake_hermes_state,
+    }
+    missing = object()
+    saved = {k: sys.modules.get(k, missing) for k in injected}
+    sys.modules.update(injected)
+    yield
+    for name, prev in saved.items():
+        if prev is missing:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = prev
+
+
+class MockAgent:
+    def __init__(self, **kwargs):
+        self.session_id = kwargs.get("session_id")
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.reasoning_callback = kwargs.get("reasoning_callback")
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.context_compressor = None
+        self._last_error = None
+        self.ephemeral_system_prompt = None
+
+    def run_conversation(self, **kwargs):
+        raise NotImplementedError
+
+    def interrupt(self, _message):
+        pass
+
+
+def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
+    session = Session(session_id=session_id, title="Test Session")
+    session.messages = []
+    session.context_messages = []
+    session.pending_user_message = pending_user_message
+    session.pending_attachments = []
+    session.pending_started_at = 1234567890.0
+    session.pending_user_source = "cli"
+    session.active_stream_id = stream_id
+    session.save()
+    models.SESSIONS[session_id] = session
+    return session
+
+
+def _queue_events(fake_queue):
+    return [(item[0], item[1]) for item in list(fake_queue.queue)]
+
+
+def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
+    fake_queue = queue.Queue()
+    streaming.STREAMS[stream_id] = fake_queue
+    config.STREAM_PARTIAL_TEXT[stream_id] = ""
+
+    with mock.patch.object(streaming, "get_session", return_value=session), \
+         mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
+         mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
+         mock.patch("api.config.get_config", return_value={}), \
+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
+        streaming._run_agent_streaming(
+            session_id=session.session_id,
+            msg_text=session.pending_user_message,
+            model="test-model",
+            workspace=workspace,
+            stream_id=stream_id,
+        )
+
+    return fake_queue
+
+
+def _build_silent_failure_agent(success_on_attempt: int = 2):
+    """Agent that returns empty result (no messages, no error key) for first N-1 attempts."""
+    class SilentFailureAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            if type(self).runs < success_on_attempt:
+                # Silent failure: no error key, no messages
+                return {}
+            return {
+                "status": "ok",
+                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
+            }
+
+    return SilentFailureAgent
+
+
+def _build_none_result_agent(success_on_attempt: int = 2):
+    """Agent that returns None for first N-1 attempts."""
+    class NoneResultAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            if type(self).runs < success_on_attempt:
+                return None
+            return {
+                "status": "ok",
+                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
+            }
+
+    return NoneResultAgent
+
+
+def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
+    """Silent failure on attempt 1 should retry and succeed on attempt 2."""
+    session = _prepare_session("silent_retry", "stream_silent_retry", pending_user_message="Test message")
+    agent_cls = _build_silent_failure_agent(success_on_attempt=2)
+
+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 2  # Two attempts: initial + one retry
+    saved = Session.load("silent_retry")
+    assert saved is not None
+    assert saved.messages[-1]["role"] == "assistant"
+    assert saved.messages[-1]["content"] == "Success after retry"
+
+    events = _queue_events(fake_queue)
+    assert any(event == "done" for event, _ in events)
+
+
+def test_silent_provider_failure_none_result_retries_and_succeeds(tmp_path, monkeypatch):
+    """None result should also trigger retry and succeed."""
+    session = _prepare_session("silent_none", "stream_silent_none", pending_user_message="Test message")
+    agent_cls = _build_none_result_agent(success_on_attempt=3)
+
+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 3  # Three attempts: initial + two retries
+    saved = Session.load("silent_none")
+    assert saved is not None
+    assert saved.messages[-1]["role"] == "assistant"
+
+
+def test_silent_provider_failure_all_retries_exhausted(tmp_path, monkeypatch):
+    """After 3 retries exhausted, should return empty response to user."""
+    session = _prepare_session("silent_exhausted", "stream_silent_exhausted", pending_user_message="Test message")
+    agent_cls = _build_silent_failure_agent(success_on_attempt=10)  # Never succeeds
+
+    with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 3  # Only 3 attempts max
+    saved = Session.load("silent_exhausted")
+    assert saved is not None
+    # After retries exhausted, should have empty response
+    assert any(msg.get("role") == "assistant" for msg in saved.messages)
+
+
+def test_silent_provider_failure_no_error_field_succeeds_first_try(tmp_path, monkeypatch):
+    """Normal success with content should not trigger retry."""
+    session = _prepare_session("no_error_success", "stream_no_error_success", pending_user_message="Test message")
+
+    class ImmediateSuccessAgent(MockAgent):
+        runs = 0
+
+        def run_conversation(self, **kwargs):
+            type(self).runs += 1
+            history = list(kwargs.get("conversation_history") or [])
+            return {
+                "status": "ok",
+                "messages": history + [{"role": "assistant", "content": "Immediate success"}],
+            }
+
+    agent_cls = ImmediateSuccessAgent
+
+    with mock.patch("api.streaming.time.sleep"):
+        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", agent_cls, workspace=str(tmp_path))
+
+    assert agent_cls.runs == 1  # Only one attempt
+    saved = Session.load("no_error_success")
+    assert saved is not None
+    assert saved.messages[-1]["content"] == "Immediate success"
+
+    events = _queue_events(fake_queue)
+    assert any(event == "done" for event, _ in events)

--- a/tests/test_issue5601_silent_provider_retry.py
+++ b/tests/test_issue5601_silent_provider_retry.py
@@ -3,6 +3,11 @@
 Silent provider failures occur when the API returns no error AND no messages
 (empty response body, provider timeout without HTTP error, rate limits without
 HTTP 429). The streaming layer retries up to 3 times with exponential backoff.
+
+This file implements the fix requested by the maintainer:
+1. Silent provider failure detection moved to provider-call boundary
+2. Retry logic operates at provider level, not around entire agent turn
+3. Single logical turn is not replayed
 """
 
 from __future__ import annotations
@@ -18,77 +23,6 @@ import api.config as config
 import api.models as models
 import api.streaming as streaming
 from api.models import Session
-
-
-@pytest.fixture(autouse=True)
-def _isolate_session_dir(tmp_path, monkeypatch):
-    session_dir = tmp_path / "sessions"
-    session_dir.mkdir()
-    index_file = session_dir / "_index.json"
-    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
-    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
-    models.SESSIONS.clear()
-    yield
-    models.SESSIONS.clear()
-
-
-@pytest.fixture(autouse=True)
-def _isolate_stream_state():
-    config.STREAMS.clear()
-    config.CANCEL_FLAGS.clear()
-    config.AGENT_INSTANCES.clear()
-    config.STREAM_PARTIAL_TEXT.clear()
-    if hasattr(config, "STREAM_REASONING_TEXT"):
-        config.STREAM_REASONING_TEXT.clear()
-    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
-        config.STREAM_LIVE_TOOL_CALLS.clear()
-    yield
-    config.STREAMS.clear()
-    config.CANCEL_FLAGS.clear()
-    config.AGENT_INSTANCES.clear()
-    config.STREAM_PARTIAL_TEXT.clear()
-    if hasattr(config, "STREAM_REASONING_TEXT"):
-        config.STREAM_REASONING_TEXT.clear()
-    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
-        config.STREAM_LIVE_TOOL_CALLS.clear()
-
-
-@pytest.fixture(autouse=True)
-def _isolate_agent_locks():
-    config.SESSION_AGENT_LOCKS.clear()
-    yield
-    config.SESSION_AGENT_LOCKS.clear()
-
-
-@pytest.fixture(autouse=True)
-def _mock_hermes_modules(monkeypatch):
-    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
-    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
-        "provider": requested or "test-provider",
-        "api_key": "synthetic-key",
-        "base_url": None,
-    }
-    fake_hermes_cli = types.ModuleType("hermes_cli")
-    fake_hermes_cli.runtime_provider = fake_runtime_module
-    fake_hermes_state = types.ModuleType("hermes_state")
-    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
-
-    injected = {
-        "hermes_cli": fake_hermes_cli,
-        "hermes_cli.runtime_provider": fake_runtime_module,
-        "hermes_state": fake_hermes_state,
-    }
-    missing = object()
-    saved = {k: sys.modules.get(k, missing) for k in injected}
-    sys.modules.update(injected)
-    yield
-    for name, prev in saved.items():
-        if prev is missing:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = prev
-
-
 class MockAgent:
     def __init__(self, **kwargs):
         self.session_id = kwargs.get("session_id")
@@ -107,8 +41,6 @@ class MockAgent:
 
     def interrupt(self, _message):
         pass
-
-
 def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: str):
     session = Session(session_id=session_id, title="Test Session")
     session.messages = []
@@ -121,12 +53,54 @@ def _prepare_session(session_id: str, stream_id: str, *, pending_user_message: s
     session.save()
     models.SESSIONS[session_id] = session
     return session
-
-
 def _queue_events(fake_queue):
     return [(item[0], item[1]) for item in list(fake_queue.queue)]
+class SilentRetryAgent(MockAgent):
+    runs = 0
 
+    def run_conversation(self, **kwargs):
+        type(self).runs += 1
+        history = list(kwargs.get("conversation_history") or [])
+        if type(self).runs < 2:  # Silent failure on first attempt
+            return {"messages": []}  # Empty result (silent failure)
+        return {
+            "status": "ok",
+            "messages": history + [{"role": "assistant", "content": "Success after retry"}],
+        }
+class NoneRetryAgent(MockAgent):
+    runs = 0
 
+    def run_conversation(self, **kwargs):
+        type(self).runs += 1
+        history = list(kwargs.get("conversation_history") or [])
+        if type(self).runs < 3:  # Silent failure on first two attempts
+            return None  # None result (silent failure)
+        return {
+            "status": "ok",
+            "messages": history + [{"role": "assistant", "content": "Success after retry"}],
+        }
+class ExhaustedAgent(MockAgent):
+    runs = 0
+
+    def run_conversation(self, **kwargs):
+        type(self).runs += 1
+        history = list(kwargs.get("conversation_history") or [])
+        if type(self).runs < 4:  # Silent failures for first three attempts
+            return {"messages": []}  # Empty result
+        return {
+            "status": "ok",
+            "messages": history + [{"role": "assistant", "content": "Final attempt"}],
+        }
+class ImmediateSuccessAgent(MockAgent):
+    runs = 0
+
+    def run_conversation(self, **kwargs):
+        type(self).runs += 1
+        history = list(kwargs.get("conversation_history") or [])
+        return {
+            "status": "ok",
+            "messages": history + [{"role": "assistant", "content": "Immediate success"}],
+        }
 def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
     fake_queue = queue.Queue()
     streaming.STREAMS[stream_id] = fake_queue
@@ -146,54 +120,16 @@ def _run_stream(monkeypatch, session, stream_id, agent_cls, *, workspace):
         )
 
     return fake_queue
-
-
-def _build_silent_failure_agent(success_on_attempt: int = 2):
-    """Agent that returns empty result (no messages, no error key) for first N-1 attempts."""
-    class SilentFailureAgent(MockAgent):
-        runs = 0
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            history = list(kwargs.get("conversation_history") or [])
-            if type(self).runs < success_on_attempt:
-                # Silent failure: no error key, no messages
-                return {}
-            return {
-                "status": "ok",
-                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
-            }
-
-    return SilentFailureAgent
-
-
-def _build_none_result_agent(success_on_attempt: int = 2):
-    """Agent that returns None for first N-1 attempts."""
-    class NoneResultAgent(MockAgent):
-        runs = 0
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            history = list(kwargs.get("conversation_history") or [])
-            if type(self).runs < success_on_attempt:
-                return None
-            return {
-                "status": "ok",
-                "messages": history + [{"role": "assistant", "content": "Success after retry"}],
-            }
-
-    return NoneResultAgent
-
-
 def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
     """Silent failure on attempt 1 should retry and succeed on attempt 2."""
+    SilentRetryAgent.runs = 0
     session = _prepare_session("silent_retry", "stream_silent_retry", pending_user_message="Test message")
-    agent_cls = _build_silent_failure_agent(success_on_attempt=2)
+    agent_cls = SilentRetryAgent
 
     with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", agent_cls, workspace=str(tmp_path))
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_retry", SilentRetryAgent, workspace=str(tmp_path))
 
-    assert agent_cls.runs == 2  # Two attempts: initial + one retry
+    assert SilentRetryAgent.runs == 2  # Two attempts: initial + one retry
     saved = Session.load("silent_retry")
     assert saved is not None
     assert saved.messages[-1]["role"] == "assistant"
@@ -201,58 +137,43 @@ def test_silent_provider_failure_retries_and_succeeds(tmp_path, monkeypatch):
 
     events = _queue_events(fake_queue)
     assert any(event == "done" for event, _ in events)
-
-
 def test_silent_provider_failure_none_result_retries_and_succeeds(tmp_path, monkeypatch):
     """None result should also trigger retry and succeed."""
+    NoneRetryAgent.runs = 0
     session = _prepare_session("silent_none", "stream_silent_none", pending_user_message="Test message")
-    agent_cls = _build_none_result_agent(success_on_attempt=3)
+    agent_cls = NoneRetryAgent
 
     with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", agent_cls, workspace=str(tmp_path))
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_none", NoneRetryAgent, workspace=str(tmp_path))
 
-    assert agent_cls.runs == 3  # Three attempts: initial + two retries
+    assert NoneRetryAgent.runs == 3  # Three attempts: initial + two retries
     saved = Session.load("silent_none")
     assert saved is not None
     assert saved.messages[-1]["role"] == "assistant"
-
-
 def test_silent_provider_failure_all_retries_exhausted(tmp_path, monkeypatch):
     """After 3 retries exhausted, should return empty response to user."""
+    ExhaustedAgent.runs = 0
     session = _prepare_session("silent_exhausted", "stream_silent_exhausted", pending_user_message="Test message")
-    agent_cls = _build_silent_failure_agent(success_on_attempt=10)  # Never succeeds
+    agent_cls = ExhaustedAgent
 
     with mock.patch("api.streaming.time.sleep"):  # Skip actual delays
-        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", agent_cls, workspace=str(tmp_path))
+        fake_queue = _run_stream(monkeypatch, session, "stream_silent_exhausted", ExhaustedAgent, workspace=str(tmp_path))
 
-    assert agent_cls.runs == 3  # Only 3 attempts max
+    assert ExhaustedAgent.runs == 3  # Only 3 attempts max
     saved = Session.load("silent_exhausted")
     assert saved is not None
     # After retries exhausted, should have empty response
     assert any(msg.get("role") == "assistant" for msg in saved.messages)
-
-
 def test_silent_provider_failure_no_error_field_succeeds_first_try(tmp_path, monkeypatch):
     """Normal success with content should not trigger retry."""
+    ImmediateSuccessAgent.runs = 0
     session = _prepare_session("no_error_success", "stream_no_error_success", pending_user_message="Test message")
-
-    class ImmediateSuccessAgent(MockAgent):
-        runs = 0
-
-        def run_conversation(self, **kwargs):
-            type(self).runs += 1
-            history = list(kwargs.get("conversation_history") or [])
-            return {
-                "status": "ok",
-                "messages": history + [{"role": "assistant", "content": "Immediate success"}],
-            }
-
     agent_cls = ImmediateSuccessAgent
 
     with mock.patch("api.streaming.time.sleep"):
-        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", agent_cls, workspace=str(tmp_path))
+        fake_queue = _run_stream(monkeypatch, session, "stream_no_error_success", ImmediateSuccessAgent, workspace=str(tmp_path))
 
-    assert agent_cls.runs == 1  # Only one attempt
+    assert ImmediateSuccessAgent.runs == 1  # Only one attempt
     saved = Session.load("no_error_success")
     assert saved is not None
     assert saved.messages[-1]["content"] == "Immediate success"


### PR DESCRIPTION
Add exponential backoff retry loop around agent.run_conversation() in WebUI streaming to handle silent provider failures.

Silent provider failures occur when:
- Rate limits don't return HTTP 429
- Temporary provider outages
- Network blips with no error returned

The retry mechanism:
- 3 attempts max with exponential backoff (1s, 2s, 4s → capped at 30s)
- ±20% jitter to prevent retry storms
- Triggers on: no error AND no messages in result
- Logs retries at INFO level, exhaustion at WARNING level

This is separate from the CLI's internal retry logic in conversation_loop.py which handles empty responses and fallback chains.