### PR TITLE
fix: intercept /sessions and /resume slash commands in WebUI (#6224)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1465,6 +1465,12 @@ async function send(){
         renderMessages();
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }
+      if(_parsedCmd.name==='sessions' || _parsedCmd.name==='resume'){
+        // Open the native WebUI session browser rather than sending as chat text (#6224)
+        if(typeof expandSidebar==='function') expandSidebar();
+        if(typeof renderSessionList==='function') await renderSessionList();
+        $('msg').value='';autoResize();hideCmdDropdown();return;
+      }
       const _agentCmd=typeof getAgentCommandMetadata==='function'
         ? await getAgentCommandMetadata(_parsedCmd.name)
         : null;


### PR DESCRIPTION
## Problem
When typing `/sessions` or `/resume` in the WebUI composer, the autocomplete popup shows them as valid commands (they're exposed by `/api/commands`), but they get sent as plain text to the agent instead of executing. This is because the agent command registry exposes both as non-`cli_only` commands, but the WebUI send-time dispatch in `static/messages.js` had no branch to catch them.

## Fix
Add a native-intercept branch in the `_parsedCmd && !_cmd` block of `send()` (alongside the `/pet` special-case at ~line 1451). When the user types `/sessions` or `/resume`:

1. Expand the sidebar (to show the session browser)
2. Refresh the session list via `renderSessionList()`
3. Clear the composer

This follows the same guard pattern used by other branches in this block, with `typeof` checks before calling any function.

## Root cause analysis (per maintainer)
- `api/commands.py:96-108` `list_commands()` emits every registry entry not marked `gateway_only` or in `_NEVER_EXPOSE`
- `sessions` and `resume` are registered without `cli_only`, so they pass the filter
- `_AGENT_COMMANDS_RUN_ON_WEBUI` (line 1136) contains `reload-mcp`, `reload-skills`, `codex-runtime`, `credits` — but NOT `sessions` or `resume`
- None of the branches in the dispatch match, so the block falls through to the normal send path

## Alternative considered
Marking them `cli_only=True` on the agent side would make the existing `cli_only` branch fire, but that's worse UX given the WebUI genuinely supports session browsing/resuming.

Closes #6224