### PR TITLE
feat(settings): add option to disable auto-scroll during responses (#6132)

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -661,8 +661,8 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Load older messages while scrolling up',
 
     settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
-    settings_label_auto_scroll_follow: 'Auto-follow new content',
-    settings_desc_auto_scroll_follow: 'When enabled, the view scrolls to the bottom as new tokens stream in. When disabled, you control the scroll position manually.',
+    settings_label_auto_scroll_follow: 'Auto-scroll to new content',
+    settings_desc_auto_scroll_follow: 'When enabled, the view auto-scrolls to the bottom as new tokens stream in. Uncheck to disable auto-scrolling and control the scroll position manually.',
     settings_label_render_user_markdown: 'Render markdown in user messages',
     settings_label_show_titlebar_profile: 'Show profile switcher in titlebar',
     settings_desc_show_titlebar_profile: 'When enabled, a profile switcher button appears in the top-left app titlebar so you can change profiles from any tab. Off by default; the composer footer always has a profile switcher regardless of this setting.',

--- a/static/index.html
+++ b/static/index.html
@@ -1068,9 +1068,9 @@
             <div class="settings-field" style="margin-top:8px">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
                 <input type="checkbox" id="settingsAutoScrollFollow" style="width:15px;height:15px;accent-color:var(--accent)">
-                <span data-i18n="settings_label_auto_scroll_follow">Auto-follow new content</span>
+                <span data-i18n="settings_label_auto_scroll_follow">Auto-scroll to new content</span>
               </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_auto_scroll_follow">When enabled, the view scrolls to the bottom as new tokens stream in. When disabled, you control the scroll position manually.</div>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_auto_scroll_follow">When enabled, the view auto-scrolls to the bottom as new tokens stream in. Uncheck to disable auto-scrolling and control the scroll position manually.</div>
             </div>
             <div class="settings-field" style="margin-top:8px">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">


### PR DESCRIPTION
Closes #6132

## Summary

This PR adds a user-facing option to disable automatic scrolling during AI response streaming. When the assistant generates a long response, the page auto-scrolls to the newest content — this can make reading earlier parts frustrating.

The **"Auto-scroll to new content"** toggle in **Settings → Preferences** lets users opt out of auto-follow behavior. When unchecked, the scroll position stays wherever the user places it, even as new tokens stream in.

## What's already in place

The full implementation was completed in prior work (PR #4006). The core infrastructure is already wired:

- **Backend**: `auto_scroll_follow` config key in `api/config.py` (default: `true`, part of `_SETTINGS_BOOLEANS`)
- **UI**: Checkbox with id `settingsAutoScrollFollow` in `index.html`
- **Persistence**: Saved/loaded via the settings API endpoint in `panels.js` and `boot.js`
- **Gating**: `scrollIfPinned()` in `ui.js` checks `window._autoScrollFollow` at entry — when false, all streaming auto-scroll is suppressed
- **i18n**: Labels in all 18 locales

## This PR

Minor label refinements:
- Label: "Auto-follow new content" → "Auto-scroll to new content"  
- Description: clarified that unchecking disables auto-scrolling

These text changes make the feature more discoverable for users looking for an "auto-scroll" option, which is the terminology used in the issue.

## Testing

- Toggle is at **Settings → Preferences → Auto-scroll to new content**
- Default: checked (auto-scroll enabled)
- Uncheck → scroll position stays fixed during streaming
- Setting persists across page reloads via backend API