### PR TITLE
perf(session): durable composer-draft sidecars and clear recovery

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -25,6 +25,11 @@ try:  # pragma: no cover - platform-specific imports.
 except ImportError:  # pragma: no cover
     _msvcrt = None
 
+try:  # optional fast JSON codec for the session-save hotpath (big sessions)
+    import orjson as _orjson
+except ImportError:  # pragma: no cover - environment without orjson
+    _orjson = None
+
 import api.config as _cfg
 from api.compression_anchor import is_context_compression_marker
 from api.config import (
@@ -1078,6 +1083,42 @@ def _read_file_head(path: Path, max_prefix_bytes: int = 4096) -> str:
         return fp.read(max_prefix_bytes).decode('utf-8', errors='ignore')
 
 
+def _json_dumps_session(obj) -> str:
+    """Serialize a session payload compactly (big-session hotpath, 2026-07-13).
+
+    Session files used to be written with ``indent=2``; on multi-MB sessions
+    the pretty-printing alone costs hundreds of milliseconds per save and
+    inflates the file (and every subsequent parse) by ~30-40%. Compact output
+    is byte-for-byte JSON-compatible with every reader (json.loads and the
+    metadata-prefix scanner are both whitespace-agnostic).
+
+    orjson is used when available and silently falls back to the stdlib for
+    payloads it cannot encode. Note one deliberate normalization: orjson
+    writes non-finite floats (NaN/Infinity) as ``null``, which is valid JSON,
+    while the stdlib emits the non-standard ``NaN`` literal.
+    """
+    if _orjson is not None:
+        try:
+            return _orjson.dumps(obj, option=_orjson.OPT_NON_STR_KEYS).decode('utf-8')
+        except Exception:
+            pass
+    return json.dumps(obj, ensure_ascii=False, separators=(',', ':'))
+
+
+def _json_loads_session(text):
+    """Parse session JSON, preferring orjson with a stdlib fallback.
+
+    The fallback also covers legacy files containing the non-standard ``NaN``
+    literal, which the stdlib accepts but orjson rejects.
+    """
+    if _orjson is not None:
+        try:
+            return _orjson.loads(text)
+        except Exception:
+            pass
+    return json.loads(text)
+
+
 def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
     """Read only the metadata portion before the large arrays.
 
@@ -1111,10 +1152,136 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
     return None
 
 
+# ── Composer-draft sidecar store (big-session hotpath, 2026-07-13) ─────────
+# Keystroke autosaves used to persist the draft by rewriting the entire
+# session JSON via Session.save(); on a multi-MB session that turns every
+# debounced draft POST into a multi-second full-file parse+serialize and
+# starves the whole server. Drafts now live in a tiny per-session sidecar
+# file under SESSION_DIR/_drafts/ (mirroring the _turn_journal convention so
+# top-level '*.json' session scans never see it). The legacy composer_draft
+# field inside the session JSON remains as a read fallback for drafts saved
+# before the sidecar existed, and keeps being persisted opportunistically
+# with regular session saves.
+
+_DRAFT_SIDECAR_DIRNAME = '_drafts'
+_DRAFT_SIDECAR_CACHE: dict = {}
+_DRAFT_SIDECAR_LOCK = threading.Lock()
+_COMPOSER_DRAFT_LOCKS: dict = {}
+
+
+def get_composer_draft_lock(sid) -> threading.Lock:
+    """Per-session lock for draft read-merge-write; deliberately decoupled
+    from the session/agent locks so drafts never queue behind turn machinery."""
+    key = str(sid)
+    with _DRAFT_SIDECAR_LOCK:
+        lock = _COMPOSER_DRAFT_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _COMPOSER_DRAFT_LOCKS[key] = lock
+        return lock
+
+
+def composer_draft_sidecar_path(sid):
+    if not is_safe_session_id(str(sid or '')):
+        return None
+    return SESSION_DIR / _DRAFT_SIDECAR_DIRNAME / f'{sid}.json'
+
+
+def read_composer_draft_sidecar(sid):
+    """Return the sidecar draft dict for *sid*, or None when absent/unreadable.
+
+    None means "no sidecar" (caller falls back to the legacy in-file field);
+    an existing sidecar with an empty draft is a real, authoritative value —
+    that distinction is what lets a cleared draft win over a stale legacy one.
+    """
+    p = composer_draft_sidecar_path(sid)
+    if p is None:
+        return None
+    try:
+        st = p.stat()
+    except OSError:
+        return None
+    stat_key = (st.st_mtime_ns, st.st_size)
+    key = str(sid)
+    with _DRAFT_SIDECAR_LOCK:
+        cached = _DRAFT_SIDECAR_CACHE.get(key)
+        if cached is not None and cached[0] == stat_key:
+            return copy.deepcopy(cached[1])
+    try:
+        data = _json_loads_session(p.read_text(encoding='utf-8'))
+    except Exception:
+        return None
+    draft = data.get('draft') if isinstance(data, dict) else None
+    if not isinstance(draft, dict):
+        return None
+    with _DRAFT_SIDECAR_LOCK:
+        _DRAFT_SIDECAR_CACHE[key] = (stat_key, copy.deepcopy(draft))
+    return draft
+
+
+def write_composer_draft_sidecar(sid, draft) -> dict:
+    """Atomically persist *draft* to the sidecar and return the stored dict."""
+    p = composer_draft_sidecar_path(sid)
+    if p is None:
+        raise ValueError(f'Unsafe session_id {sid!r}; refusing to write draft sidecar')
+    draft = dict(draft) if isinstance(draft, dict) else {}
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = _json_dumps_session({'draft': draft, 'updated_at': time.time()})
+    tmp = p.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+    try:
+        with open(tmp, 'w', encoding='utf-8') as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, p)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+    try:
+        st = p.stat()
+        with _DRAFT_SIDECAR_LOCK:
+            _DRAFT_SIDECAR_CACHE[str(sid)] = ((st.st_mtime_ns, st.st_size), copy.deepcopy(draft))
+    except OSError:
+        pass
+    return draft
+
+
+def delete_composer_draft_sidecar(sid) -> None:
+    p = composer_draft_sidecar_path(sid)
+    with _DRAFT_SIDECAR_LOCK:
+        _DRAFT_SIDECAR_CACHE.pop(str(sid), None)
+    if p is None:
+        return
+    try:
+        p.unlink(missing_ok=True)
+    except OSError:
+        logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
+
+
+def resolve_composer_draft(sid, legacy=None) -> dict:
+    """Sidecar draft when present, else the legacy in-file composer_draft."""
+    sidecar = read_composer_draft_sidecar(sid)
+    if sidecar is not None:
+        return sidecar
+    return legacy if isinstance(legacy, dict) else {}
+
+
+def update_cached_composer_draft(sid, draft) -> None:
+    """Keep an already-cached full Session object's composer_draft in sync so
+    code paths that still read the attribute directly see the sidecar value."""
+    with LOCK:
+        cached = SESSIONS.get(sid)
+    if cached is not None and str(getattr(cached, 'session_id', '') or '') == str(sid):
+        cached.composer_draft = dict(draft) if isinstance(draft, dict) else {}
+
+
 def _load_session_from_path(path: Path) -> "Session | None":
     """Load a session from an explicit JSON path without consulting SESSION_DIR."""
     try:
-        data = json.loads(path.read_text(encoding='utf-8'))
+        data = _json_loads_session(path.read_text(encoding='utf-8'))
     except Exception:
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
@@ -1418,7 +1585,39 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        payload = _json_dumps_session({**meta, **extra})
+
+        # ── No-op save skip (big-session hotpath, 2026-07-13) ───────────
+        # Several periodic callers re-save byte-identical content (observed
+        # as full 23 MB rewrites every ~15-30s on an idle large session).
+        # If this object produced the exact same payload it last wrote AND
+        # the on-disk file is untouched since that write (so no other
+        # writer's state can be clobbered or masked), skip the disk write.
+        # touch_updated_at=True saves always differ (updated_at changed),
+        # so recency semantics are unaffected.
+        payload_digest = hashlib.sha256(payload.encode('utf-8')).hexdigest()
+        if payload_digest == getattr(self, '_last_saved_digest', None):
+            try:
+                st = os.stat(self.path)
+                disk_unchanged = (
+                    (st.st_mtime_ns, st.st_size) == getattr(self, '_last_saved_stat', None)
+                )
+            except OSError:
+                disk_unchanged = False
+            if disk_unchanged:
+                if not skip_index:
+                    _write_session_index(updates=[self])
+                if self.messages:
+                    try:
+                        _clear_webui_zero_message_orphan_tombstone(self.session_id)
+                        _clear_webui_deleted_session_tombstone(self.session_id)
+                    except Exception:
+                        logger.debug(
+                            "Failed to clear webui tombstone for %s",
+                            self.session_id,
+                            exc_info=True,
+                        )
+                return
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -1434,13 +1633,39 @@ class Session:
         # their .bak get restored automatically.
         try:
             if self.path.exists():
-                existing_text = self.path.read_text(encoding='utf-8')
-                try:
-                    existing = json.loads(existing_text)
-                    existing_msg_count = len(existing.get('messages') or [])
-                except (json.JSONDecodeError, ValueError):
-                    existing_msg_count = -1  # corrupt → always back up
                 incoming_msg_count = len(self.messages or [])
+                # Fast path (big-session hotpath, 2026-07-13): modern session
+                # files carry an accurate message_count in the metadata prefix
+                # (written by this method before the messages array). Reading
+                # that prefix costs a few KB instead of parsing the entire
+                # multi-MB file. The full read+parse only happens when the
+                # prefix is unavailable (legacy/corrupt layout) or when it
+                # signals a shrink — the case that needs existing_text for
+                # the .bak snapshot anyway.
+                existing_text = None
+                existing_msg_count = None
+                try:
+                    prefix = _read_metadata_json_prefix(self.path)
+                except Exception:
+                    prefix = None
+                if prefix:
+                    try:
+                        existing_msg_count = _parse_nonnegative_int(
+                            json.loads(prefix).get('message_count')
+                        )
+                    except (json.JSONDecodeError, ValueError):
+                        existing_msg_count = None
+                if (
+                    existing_msg_count is None
+                    or existing_msg_count > incoming_msg_count
+                    or (existing_msg_count > 0 and incoming_msg_count == 0)
+                ):
+                    existing_text = self.path.read_text(encoding='utf-8')
+                    try:
+                        existing = _json_loads_session(existing_text)
+                        existing_msg_count = len(existing.get('messages') or [])
+                    except Exception:
+                        existing_msg_count = -1  # corrupt → always back up
                 if (
                     existing_msg_count > 0
                     and incoming_msg_count == 0
@@ -1496,6 +1721,14 @@ class Session:
             except Exception:
                 pass
             raise
+        # Record what this object wrote so the no-op skip above can prove
+        # "same payload, file untouched since" on the next save.
+        self._last_saved_digest = payload_digest
+        try:
+            st = os.stat(self.path)
+            self._last_saved_stat = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            self._last_saved_stat = None
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1537,7 +1770,7 @@ class Session:
         # cache write is only committed if the file didn't change under us
         # during the parse (TOCTOU guard against an atomic replace mid-read).
         _pre_read_sig = _sidecar_stat_signature(p)
-        data = json.loads(p.read_text(encoding='utf-8'))
+        data = _json_loads_session(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
         if _collapsed_partials:
@@ -1772,7 +2005,13 @@ class Session:
             'source_label': self.source_label,
             'read_only': self.read_only,
             'enabled_toolsets': self.enabled_toolsets,
-            'composer_draft': self.composer_draft if isinstance(self.composer_draft, dict) else {},
+            # Sidecar draft wins over the in-file field (big-session save
+            # hotpath): draft autosaves no longer rewrite the session JSON,
+            # so the sidecar is the authoritative, freshest copy.
+            'composer_draft': resolve_composer_draft(
+                self.session_id,
+                self.composer_draft if isinstance(self.composer_draft, dict) else {},
+            ),
             'process_wakeup_pause': self.process_wakeup_pause if isinstance(self.process_wakeup_pause, dict) else {},
             'share_token': self.share_token,
             'share_created_at': self.share_created_at,

--- a/api/models.py
+++ b/api/models.py
@@ -1302,7 +1302,7 @@ def write_composer_draft_sidecar(sid, draft) -> dict:
             f.write(payload)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(tmp, p)
+        _safe_replace(tmp, p)
     except Exception:
         try:
             tmp.unlink(missing_ok=True)
@@ -1736,38 +1736,18 @@ class Session:
         try:
             if self.path.exists():
                 incoming_msg_count = len(self.messages or [])
-                # Fast path (big-session hotpath, 2026-07-13): modern session
-                # files carry an accurate message_count in the metadata prefix
-                # (written by this method before the messages array). Reading
-                # that prefix costs a few KB instead of parsing the entire
-                # multi-MB file. The full read+parse only happens when the
-                # prefix is unavailable (legacy/corrupt layout) or when it
-                # signals a shrink — the case that needs existing_text for
-                # the .bak snapshot anyway.
-                existing_text = None
-                existing_msg_count = None
+                # ``message_count`` is an accelerator written by this class,
+                # not a generation/integrity proof for legacy or external
+                # writers.  A stale low count must never make a real shrink
+                # overwrite history without a parseable recovery backup.
+                # Therefore read and verify the existing payload before every
+                # overwrite; grow still avoids making a backup.
+                existing_text = self.path.read_text(encoding='utf-8')
                 try:
-                    prefix = _read_metadata_json_prefix(self.path)
+                    existing = _json_loads_session(existing_text)
+                    existing_msg_count = len(existing.get('messages') or [])
                 except Exception:
-                    prefix = None
-                if prefix:
-                    try:
-                        existing_msg_count = _parse_nonnegative_int(
-                            json.loads(prefix).get('message_count')
-                        )
-                    except (json.JSONDecodeError, ValueError):
-                        existing_msg_count = None
-                if (
-                    existing_msg_count is None
-                    or existing_msg_count > incoming_msg_count
-                    or (existing_msg_count > 0 and incoming_msg_count == 0)
-                ):
-                    existing_text = self.path.read_text(encoding='utf-8')
-                    try:
-                        existing = _json_loads_session(existing_text)
-                        existing_msg_count = len(existing.get('messages') or [])
-                    except Exception:
-                        existing_msg_count = -1  # corrupt → always back up
+                    existing_msg_count = -1  # corrupt → never infer a safe shrink
                 if (
                     existing_msg_count > 0
                     and incoming_msg_count == 0

--- a/api/models.py
+++ b/api/models.py
@@ -1318,16 +1318,24 @@ def write_composer_draft_sidecar(sid, draft) -> dict:
     return draft
 
 
-def delete_composer_draft_sidecar(sid) -> None:
+def delete_composer_draft_sidecar(sid) -> bool:
+    """Remove a draft sidecar and report whether no authoritative copy remains.
+
+    Callers that tell the browser a draft was cleared must fail closed when an
+    unlink error leaves the sidecar in place: sidecars override the legacy
+    in-session draft on the next load.
+    """
     p = composer_draft_sidecar_path(sid)
     with _DRAFT_SIDECAR_LOCK:
         _DRAFT_SIDECAR_CACHE.pop(str(sid), None)
     if p is None:
-        return
+        return True
     try:
         p.unlink(missing_ok=True)
     except OSError:
         logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
+        return False
+    return not p.exists()
 
 
 def migrate_composer_draft_sidecar(old_sid, new_sid) -> None:

--- a/api/models.py
+++ b/api/models.py
@@ -1088,6 +1088,24 @@ def _read_file_head(path: Path, max_prefix_bytes: int = 4096) -> str:
         return fp.read(max_prefix_bytes).decode('utf-8', errors='ignore')
 
 
+def _read_top_level_json_value_from_head(text: str, key: str):
+    """Decode one top-level value from a bounded, possibly incomplete JSON prefix."""
+    key_pos = _find_top_level_json_key(text, key)
+    if key_pos is None:
+        return None
+    colon_pos = text.find(':', key_pos + len(json.dumps(key)))
+    if colon_pos < 0:
+        return None
+    value_pos = colon_pos + 1
+    while value_pos < len(text) and text[value_pos] in ' \t\r\n':
+        value_pos += 1
+    try:
+        value, _end = json.JSONDecoder().raw_decode(text, value_pos)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return value
+
+
 def _json_dumps_session(obj) -> str:
     """Serialize a session payload compactly (big-session hotpath, 2026-07-13).
 
@@ -1310,6 +1328,27 @@ def delete_composer_draft_sidecar(sid) -> None:
         p.unlink(missing_ok=True)
     except OSError:
         logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
+
+
+def migrate_composer_draft_sidecar(old_sid, new_sid) -> None:
+    """Move draft ownership across a session-id rotation without clobbering a newer draft."""
+    old_sid = str(old_sid or '')
+    new_sid = str(new_sid or '')
+    if old_sid == new_sid or not is_safe_session_id(old_sid) or not is_safe_session_id(new_sid):
+        return
+    locks = sorted(
+        ((old_sid, get_composer_draft_lock(old_sid)), (new_sid, get_composer_draft_lock(new_sid))),
+        key=lambda item: item[0],
+    )
+    with locks[0][1]:
+        with locks[1][1]:
+            old_draft = read_composer_draft_sidecar(old_sid)
+            if old_draft is None:
+                return
+            if read_composer_draft_sidecar(new_sid) is None:
+                write_composer_draft_sidecar(new_sid, old_draft)
+                update_cached_composer_draft(new_sid, old_draft)
+            delete_composer_draft_sidecar(old_sid)
 
 
 def resolve_composer_draft(sid, legacy=None) -> dict:
@@ -3687,7 +3726,6 @@ def _has_compression_continuation(session) -> bool:
     # shallow JSON metadata scan; session files write parent_session_id before
     # the messages array, so this avoids loading multi-MB transcripts.
     try:
-        needle = f'"parent_session_id": "{sid}"'
         for path in SESSION_DIR.glob('*.json'):
             if path.name.startswith('_') or path.stem == sid:
                 continue
@@ -3701,7 +3739,7 @@ def _has_compression_continuation(session) -> bool:
                 head = _read_file_head(path, max_prefix_bytes=16384)[:4096]
             except OSError:
                 continue
-            if needle in head:
+            if _read_top_level_json_value_from_head(head, 'parent_session_id') == sid:
                 return True
     except Exception:
         logger.debug("Failed to scan session files for compression continuation", exc_info=True)

--- a/api/models.py
+++ b/api/models.py
@@ -2,6 +2,7 @@
 import collections
 import copy
 import datetime
+import errno
 import hashlib
 import inspect
 import json
@@ -1276,22 +1277,33 @@ def _composer_draft_sidecar_signature(stat_result):
     )
 
 
-def _fsync_composer_draft_parent(path: Path) -> None:
-    """Best-effort directory durability after a draft replace or unlink."""
-    try:
-        flags = getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_RDONLY", 0)
-        directory_fd = os.open(path.parent, flags)
-    except OSError:
+def _fsync_composer_draft_directory(path: Path) -> None:
+    """Durably publish a directory entry where the platform supports it."""
+    # Windows does not provide portable directory handles for ``os.fsync``.
+    # Sidecar writes still use fsynced files plus atomic replace; directory fsync
+    # is an unsupported extra durability step, not a reason to reject drafts.
+    if os.name == "nt":
         return
+    flags = getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_RDONLY", 0)
+    try:
+        directory_fd = os.open(path, flags)
+    except OSError as exc:
+        if exc.errno in {errno.EINVAL, errno.ENOTSUP, getattr(errno, "EOPNOTSUPP", errno.ENOTSUP)}:
+            return
+        raise
     try:
         os.fsync(directory_fd)
-    except OSError:
-        pass
+    except OSError as exc:
+        if exc.errno in {errno.EINVAL, errno.ENOTSUP, getattr(errno, "EOPNOTSUPP", errno.ENOTSUP)}:
+            return
+        raise
     finally:
-        try:
-            os.close(directory_fd)
-        except OSError:
-            pass
+        os.close(directory_fd)
+
+
+def _fsync_composer_draft_parent(path: Path) -> None:
+    """Durably publish a draft replace or unlink in its parent directory."""
+    _fsync_composer_draft_directory(path.parent)
 
 
 def composer_draft_sidecar_path(sid):
@@ -1346,7 +1358,10 @@ def write_composer_draft_sidecar(sid, draft) -> dict:
     if p is None:
         raise ValueError(f'Unsafe session_id {sid!r}; refusing to write draft sidecar')
     draft = dict(draft) if isinstance(draft, dict) else {}
+    drafts_dir_created = not p.parent.exists()
     p.parent.mkdir(parents=True, exist_ok=True)
+    if drafts_dir_created:
+        _fsync_composer_draft_directory(SESSION_DIR)
     payload = _json_dumps_session({'draft': draft, 'updated_at': time.time()})
     tmp = p.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
     try:
@@ -1383,7 +1398,9 @@ def delete_composer_draft_sidecar(sid) -> bool:
     if p is None:
         return True
     try:
-        p.unlink(missing_ok=True)
+        if not p.exists():
+            return True
+        p.unlink()
         _fsync_composer_draft_parent(p)
     except OSError:
         logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
@@ -1417,27 +1434,17 @@ def migrate_composer_draft_sidecar(old_sid, new_sid, *, finalize_source: bool = 
             return False
         if old_state == "absent":
             return True
-        old_path = composer_draft_sidecar_path(old_sid)
-        new_path = composer_draft_sidecar_path(new_sid)
-        if old_path is None or new_path is None:
-            return False
         copied_destination = False
         if new_state == "absent":
             write_composer_draft_sidecar(new_sid, old_draft)
             update_cached_composer_draft(new_sid, old_draft)
             copied_destination = True
         elif old_draft != new_draft:
-            # A failed prior move can leave a stale destination sidecar. If the
-            # retained source changed after that copy, it remains authoritative
-            # and must refresh the destination before source deletion.
-            try:
-                old_mtime = old_path.stat().st_mtime_ns
-                new_mtime = new_path.stat().st_mtime_ns
-            except OSError:
-                return False
-            if old_mtime > new_mtime:
-                write_composer_draft_sidecar(new_sid, old_draft)
-                update_cached_composer_draft(new_sid, old_draft)
+            # The old session remains the explicit owner until this operation
+            # succeeds, so its current draft is authoritative even when files
+            # share an mtime on coarse/coalesced filesystems.
+            write_composer_draft_sidecar(new_sid, old_draft)
+            update_cached_composer_draft(new_sid, old_draft)
         if not finalize_source:
             return True
         if delete_composer_draft_sidecar(old_sid):
@@ -1465,6 +1472,47 @@ def update_cached_composer_draft(sid, draft) -> None:
         cached = SESSIONS.get(sid)
         if cached is not None and str(getattr(cached, 'session_id', '') or '') == str(sid):
             cached.composer_draft = copy.deepcopy(draft) if isinstance(draft, dict) else {}
+
+
+def _recover_staged_session_owner(sid, path: Path) -> Path:
+    """Restore a staged delete owner after its rollback failed.
+
+    Callers only invoke this after the primary owner path is absent. Acquiring
+    the draft stripe prevents a concurrent delete from being resurrected while
+    it still owns the staged file; once that delete releases the lock, a leftover
+    stage is an incomplete deletion and must be made discoverable again.
+    """
+    with get_composer_draft_lock(sid):
+        if path.exists():
+            return path
+        staged_candidates = sorted(path.parent.glob(f'.{path.name}.deleting-*'))
+        if not staged_candidates:
+            return path
+        try:
+            os.replace(staged_candidates[-1], path)
+            _fsync_composer_draft_directory(path.parent)
+        except OSError:
+            logger.exception("Failed to recover staged session owner for %s", sid)
+    return path
+
+
+def _recover_all_staged_session_owners() -> None:
+    """Make rollback leftovers visible before a sidebar/index scan."""
+    try:
+        staged_paths = list(SESSION_DIR.glob('.*.json.deleting-*'))
+    except OSError:
+        logger.debug("Failed to scan staged session owners", exc_info=True)
+        return
+    for staged_path in staged_paths:
+        name = staged_path.name
+        prefix = '.'
+        marker = '.json.deleting-'
+        if not name.startswith(prefix) or marker not in name:
+            continue
+        sid = name[len(prefix):].split(marker, 1)[0]
+        if not is_safe_session_id(sid):
+            continue
+        _recover_staged_session_owner(sid, SESSION_DIR / f'{sid}.json')
 
 
 def _load_session_from_path(path: Path) -> "Session | None":
@@ -1946,6 +1994,8 @@ class Session:
             return None
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():
+            p = _recover_staged_session_owner(sid, p)
+        if not p.exists():
             return None
         # #5854: snapshot the stat signature BEFORE reading so a legacy-facts
         # cache write is only committed if the file didn't change under us
@@ -1999,6 +2049,8 @@ class Session:
         if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
+        if not p.exists():
+            p = _recover_staged_session_owner(sid, p)
         if not p.exists():
             return None
         try:
@@ -6172,6 +6224,7 @@ def _diag_stage(diag, name: str) -> None:
 
 
 def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
+    _recover_all_staged_session_owners()
     _diag_stage(diag, "all_sessions.active_streams")
     active_stream_ids = _active_stream_ids()
     # Phase C: try index first for O(1) read; fall back to full scan

--- a/api/models.py
+++ b/api/models.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import re
+import stat
 import threading
 import time
 import uuid
@@ -1138,11 +1139,30 @@ def _json_loads_session(text):
 
 
 def _stream_file_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
-    """Hash a file without materializing a second multi-MB payload in memory."""
+    """Hash one stable regular-file generation without buffering it in memory."""
+    def identity(file_stat):
+        return (
+            file_stat.st_dev,
+            file_stat.st_ino,
+            stat.S_IFMT(file_stat.st_mode),
+            file_stat.st_size,
+            file_stat.st_mtime_ns,
+            file_stat.st_ctime_ns,
+        )
+
     digest = hashlib.sha256()
     with path.open('rb') as handle:
+        before = os.fstat(handle.fileno())
+        if not stat.S_ISREG(before.st_mode):
+            raise OSError(f'refusing to hash non-regular session file: {path}')
         while chunk := handle.read(chunk_size):
             digest.update(chunk)
+        after = os.fstat(handle.fileno())
+        if identity(before) != identity(after):
+            raise OSError(f'session file changed while hashing: {path}')
+        current = os.stat(path, follow_symlinks=False)
+        if identity(after) != identity(current):
+            raise OSError(f'session file identity changed while hashing: {path}')
     return digest.hexdigest()
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -13,7 +13,7 @@ import stat
 import threading
 import time
 import uuid
-from contextlib import closing, contextmanager
+from contextlib import ExitStack, closing, contextmanager
 from pathlib import Path
 
 try:  # pragma: no cover - platform-specific imports.
@@ -1233,21 +1233,36 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
 # with regular session saves.
 
 _DRAFT_SIDECAR_DIRNAME = '_drafts'
-_DRAFT_SIDECAR_CACHE: dict = {}
+# Drafts are small, but a server can see arbitrarily many session ids. Keep the
+# cache bounded just like the other sidecar caches in this module; the sidecar
+# stat signature remains the freshness authority on a cache miss.
+_DRAFT_SIDECAR_CACHE: "collections.OrderedDict[str, tuple]" = collections.OrderedDict()
+_DRAFT_SIDECAR_CACHE_MAX = 256
 _DRAFT_SIDECAR_LOCK = threading.Lock()
-_COMPOSER_DRAFT_LOCKS: dict = {}
+# Use fixed lock stripes instead of retaining one lock per historical session.
+# A stripe collision merely serializes two unrelated draft writes; it cannot
+# merge drafts because each operation still addresses its own sidecar path.
+# RLock keeps a same-stripe old/new pair safe during draft migration.
+_COMPOSER_DRAFT_LOCK_STRIPES = tuple(threading.RLock() for _ in range(64))
 
 
-def get_composer_draft_lock(sid) -> threading.Lock:
-    """Per-session lock for draft read-merge-write; deliberately decoupled
-    from the session/agent locks so drafts never queue behind turn machinery."""
+def _composer_draft_lock_stripe_index(sid) -> int:
+    return hash(str(sid)) % len(_COMPOSER_DRAFT_LOCK_STRIPES)
+
+
+def get_composer_draft_lock(sid):
+    """Return a bounded lock stripe for draft read-merge-write operations."""
+    return _COMPOSER_DRAFT_LOCK_STRIPES[_composer_draft_lock_stripe_index(sid)]
+
+
+def _cache_composer_draft_sidecar(sid, stat_key, draft) -> None:
+    """Store a draft cache entry and evict least-recently-used stale entries."""
     key = str(sid)
     with _DRAFT_SIDECAR_LOCK:
-        lock = _COMPOSER_DRAFT_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _COMPOSER_DRAFT_LOCKS[key] = lock
-        return lock
+        _DRAFT_SIDECAR_CACHE[key] = (stat_key, copy.deepcopy(draft))
+        _DRAFT_SIDECAR_CACHE.move_to_end(key)
+        while len(_DRAFT_SIDECAR_CACHE) > _DRAFT_SIDECAR_CACHE_MAX:
+            _DRAFT_SIDECAR_CACHE.popitem(last=False)
 
 
 def composer_draft_sidecar_path(sid):
@@ -1275,6 +1290,7 @@ def read_composer_draft_sidecar(sid):
     with _DRAFT_SIDECAR_LOCK:
         cached = _DRAFT_SIDECAR_CACHE.get(key)
         if cached is not None and cached[0] == stat_key:
+            _DRAFT_SIDECAR_CACHE.move_to_end(key)
             return copy.deepcopy(cached[1])
     try:
         data = _json_loads_session(p.read_text(encoding='utf-8'))
@@ -1283,8 +1299,7 @@ def read_composer_draft_sidecar(sid):
     draft = data.get('draft') if isinstance(data, dict) else None
     if not isinstance(draft, dict):
         return None
-    with _DRAFT_SIDECAR_LOCK:
-        _DRAFT_SIDECAR_CACHE[key] = (stat_key, copy.deepcopy(draft))
+    _cache_composer_draft_sidecar(sid, stat_key, draft)
     return draft
 
 
@@ -1311,8 +1326,7 @@ def write_composer_draft_sidecar(sid, draft) -> dict:
         raise
     try:
         st = p.stat()
-        with _DRAFT_SIDECAR_LOCK:
-            _DRAFT_SIDECAR_CACHE[str(sid)] = ((st.st_mtime_ns, st.st_size), copy.deepcopy(draft))
+        _cache_composer_draft_sidecar(sid, (st.st_mtime_ns, st.st_size), draft)
     except OSError:
         pass
     return draft
@@ -1344,19 +1358,23 @@ def migrate_composer_draft_sidecar(old_sid, new_sid) -> None:
     new_sid = str(new_sid or '')
     if old_sid == new_sid or not is_safe_session_id(old_sid) or not is_safe_session_id(new_sid):
         return
-    locks = sorted(
-        ((old_sid, get_composer_draft_lock(old_sid)), (new_sid, get_composer_draft_lock(new_sid))),
-        key=lambda item: item[0],
-    )
-    with locks[0][1]:
-        with locks[1][1]:
-            old_draft = read_composer_draft_sidecar(old_sid)
-            if old_draft is None:
-                return
-            if read_composer_draft_sidecar(new_sid) is None:
-                write_composer_draft_sidecar(new_sid, old_draft)
-                update_cached_composer_draft(new_sid, old_draft)
-            delete_composer_draft_sidecar(old_sid)
+    # Acquire unique fixed stripes by stripe index, not by session id. Two
+    # unrelated migrations can map their old/new ids to the same pair of
+    # stripes in inverse SID order; a global stripe order prevents deadlock.
+    stripe_indexes = sorted({
+        _composer_draft_lock_stripe_index(old_sid),
+        _composer_draft_lock_stripe_index(new_sid),
+    })
+    with ExitStack() as lock_stack:
+        for stripe_index in stripe_indexes:
+            lock_stack.enter_context(_COMPOSER_DRAFT_LOCK_STRIPES[stripe_index])
+        old_draft = read_composer_draft_sidecar(old_sid)
+        if old_draft is None:
+            return
+        if read_composer_draft_sidecar(new_sid) is None:
+            write_composer_draft_sidecar(new_sid, old_draft)
+            update_cached_composer_draft(new_sid, old_draft)
+        delete_composer_draft_sidecar(old_sid)
 
 
 def resolve_composer_draft(sid, legacy=None) -> dict:

--- a/api/models.py
+++ b/api/models.py
@@ -1265,42 +1265,79 @@ def _cache_composer_draft_sidecar(sid, stat_key, draft) -> None:
             _DRAFT_SIDECAR_CACHE.popitem(last=False)
 
 
+def _composer_draft_sidecar_signature(stat_result):
+    """Return an identity-sensitive cache token for a derived draft sidecar."""
+    return (
+        int(getattr(stat_result, "st_dev", 0)),
+        int(getattr(stat_result, "st_ino", 0)),
+        int(stat_result.st_size),
+        int(stat_result.st_mtime_ns),
+        int(getattr(stat_result, "st_ctime_ns", 0)),
+    )
+
+
+def _fsync_composer_draft_parent(path: Path) -> None:
+    """Best-effort directory durability after a draft replace or unlink."""
+    try:
+        flags = getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_RDONLY", 0)
+        directory_fd = os.open(path.parent, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(directory_fd)
+        except OSError:
+            pass
+
+
 def composer_draft_sidecar_path(sid):
     if not is_safe_session_id(str(sid or '')):
         return None
     return SESSION_DIR / _DRAFT_SIDECAR_DIRNAME / f'{sid}.json'
 
 
-def read_composer_draft_sidecar(sid):
-    """Return the sidecar draft dict for *sid*, or None when absent/unreadable.
+def composer_draft_sidecar_state(sid) -> tuple[str, dict | None]:
+    """Return ``present``, ``absent``, or ``unreadable`` without conflating loss.
 
-    None means "no sidecar" (caller falls back to the legacy in-file field);
-    an existing sidecar with an empty draft is a real, authoritative value —
-    that distinction is what lets a cleared draft win over a stale legacy one.
+    Destructive operations must not treat a malformed or temporarily unreadable
+    authoritative draft as absent; only callers that intentionally display the
+    legacy fallback should use ``read_composer_draft_sidecar`` below.
     """
     p = composer_draft_sidecar_path(sid)
     if p is None:
-        return None
+        return "unreadable", None
     try:
         st = p.stat()
+    except FileNotFoundError:
+        return "absent", None
     except OSError:
-        return None
-    stat_key = (st.st_mtime_ns, st.st_size)
+        return "unreadable", None
+    stat_key = _composer_draft_sidecar_signature(st)
     key = str(sid)
     with _DRAFT_SIDECAR_LOCK:
         cached = _DRAFT_SIDECAR_CACHE.get(key)
         if cached is not None and cached[0] == stat_key:
             _DRAFT_SIDECAR_CACHE.move_to_end(key)
-            return copy.deepcopy(cached[1])
+            return "present", copy.deepcopy(cached[1])
     try:
         data = _json_loads_session(p.read_text(encoding='utf-8'))
+        draft = data.get('draft') if isinstance(data, dict) else None
+        if not isinstance(draft, dict):
+            raise ValueError("draft sidecar has invalid shape")
     except Exception:
-        return None
-    draft = data.get('draft') if isinstance(data, dict) else None
-    if not isinstance(draft, dict):
-        return None
+        return "unreadable", None
     _cache_composer_draft_sidecar(sid, stat_key, draft)
-    return draft
+    return "present", draft
+
+
+def read_composer_draft_sidecar(sid):
+    """Return the sidecar draft dict for display, or None when not usable."""
+    state, draft = composer_draft_sidecar_state(sid)
+    return draft if state == "present" else None
 
 
 def write_composer_draft_sidecar(sid, draft) -> dict:
@@ -1318,6 +1355,7 @@ def write_composer_draft_sidecar(sid, draft) -> dict:
             f.flush()
             os.fsync(f.fileno())
         _safe_replace(tmp, p)
+        _fsync_composer_draft_parent(p)
     except Exception:
         try:
             tmp.unlink(missing_ok=True)
@@ -1326,7 +1364,7 @@ def write_composer_draft_sidecar(sid, draft) -> dict:
         raise
     try:
         st = p.stat()
-        _cache_composer_draft_sidecar(sid, (st.st_mtime_ns, st.st_size), draft)
+        _cache_composer_draft_sidecar(sid, _composer_draft_sidecar_signature(st), draft)
     except OSError:
         pass
     return draft
@@ -1346,18 +1384,23 @@ def delete_composer_draft_sidecar(sid) -> bool:
         return True
     try:
         p.unlink(missing_ok=True)
+        _fsync_composer_draft_parent(p)
     except OSError:
         logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
         return False
     return not p.exists()
 
 
-def migrate_composer_draft_sidecar(old_sid, new_sid) -> None:
-    """Move draft ownership across a session-id rotation without clobbering a newer draft."""
+def migrate_composer_draft_sidecar(old_sid, new_sid, *, finalize_source: bool = True) -> bool:
+    """Move/copy a draft across a session-id rotation.
+
+    With ``finalize_source=False`` the destination is made durable but the old
+    owner remains authoritative until its continuation session JSON is saved.
+    """
     old_sid = str(old_sid or '')
     new_sid = str(new_sid or '')
     if old_sid == new_sid or not is_safe_session_id(old_sid) or not is_safe_session_id(new_sid):
-        return
+        return True
     # Acquire unique fixed stripes by stripe index, not by session id. Two
     # unrelated migrations can map their old/new ids to the same pair of
     # stripes in inverse SID order; a global stripe order prevents deadlock.
@@ -1368,13 +1411,43 @@ def migrate_composer_draft_sidecar(old_sid, new_sid) -> None:
     with ExitStack() as lock_stack:
         for stripe_index in stripe_indexes:
             lock_stack.enter_context(_COMPOSER_DRAFT_LOCK_STRIPES[stripe_index])
-        old_draft = read_composer_draft_sidecar(old_sid)
-        if old_draft is None:
-            return
-        if read_composer_draft_sidecar(new_sid) is None:
+        old_state, old_draft = composer_draft_sidecar_state(old_sid)
+        new_state, new_draft = composer_draft_sidecar_state(new_sid)
+        if old_state == "unreadable" or new_state == "unreadable":
+            return False
+        if old_state == "absent":
+            return True
+        old_path = composer_draft_sidecar_path(old_sid)
+        new_path = composer_draft_sidecar_path(new_sid)
+        if old_path is None or new_path is None:
+            return False
+        copied_destination = False
+        if new_state == "absent":
             write_composer_draft_sidecar(new_sid, old_draft)
             update_cached_composer_draft(new_sid, old_draft)
-        delete_composer_draft_sidecar(old_sid)
+            copied_destination = True
+        elif old_draft != new_draft:
+            # A failed prior move can leave a stale destination sidecar. If the
+            # retained source changed after that copy, it remains authoritative
+            # and must refresh the destination before source deletion.
+            try:
+                old_mtime = old_path.stat().st_mtime_ns
+                new_mtime = new_path.stat().st_mtime_ns
+            except OSError:
+                return False
+            if old_mtime > new_mtime:
+                write_composer_draft_sidecar(new_sid, old_draft)
+                update_cached_composer_draft(new_sid, old_draft)
+        if not finalize_source:
+            return True
+        if delete_composer_draft_sidecar(old_sid):
+            return True
+        if copied_destination:
+            # Do not leave a partial move when the source remains authoritative.
+            # Best effort only: a second filesystem error still reports failure
+            # and the caller will keep the original session ownership.
+            delete_composer_draft_sidecar(new_sid)
+        return False
 
 
 def resolve_composer_draft(sid, legacy=None) -> dict:
@@ -1390,8 +1463,8 @@ def update_cached_composer_draft(sid, draft) -> None:
     code paths that still read the attribute directly see the sidecar value."""
     with LOCK:
         cached = SESSIONS.get(sid)
-    if cached is not None and str(getattr(cached, 'session_id', '') or '') == str(sid):
-        cached.composer_draft = dict(draft) if isinstance(draft, dict) else {}
+        if cached is not None and str(getattr(cached, 'session_id', '') or '') == str(sid):
+            cached.composer_draft = copy.deepcopy(draft) if isinstance(draft, dict) else {}
 
 
 def _load_session_from_path(path: Path) -> "Session | None":

--- a/api/models.py
+++ b/api/models.py
@@ -752,13 +752,13 @@ def _load_webui_deleted_session_tombstone() -> frozenset[str]:
     )
 
 
-def _save_webui_deleted_session_tombstone(ids) -> None:
+def _save_webui_deleted_session_tombstone(ids) -> bool:
     try:
         sorted_ids = sorted(set(
             str(sid).strip() for sid in (ids or []) if str(sid or "").strip()
         ))
     except TypeError:
-        return
+        return False
     if len(sorted_ids) > WEBUI_DELETED_SESSION_TOMBSTONE_CAP:
         sorted_ids = sorted_ids[-WEBUI_DELETED_SESSION_TOMBSTONE_CAP:]
     payload = {
@@ -777,6 +777,8 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
             f.flush()
             os.fsync(f.fileno())
         os.replace(_tmp, p)
+        _fsync_composer_draft_directory(SESSION_DIR)
+        return True
     except Exception:
         logger.debug("Failed to save webui deleted-session tombstone", exc_info=True)
         if _tmp is not None:
@@ -784,18 +786,19 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
                 _tmp.unlink(missing_ok=True)
             except Exception:
                 pass
+        return False
 
 
-def _record_webui_deleted_session_tombstone(sid: str) -> None:
+def _record_webui_deleted_session_tombstone(sid: str) -> bool:
     sid = str(sid or "").strip()
     if not sid:
-        return
+        return False
     with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
         current = set(_load_webui_deleted_session_tombstone())
         if sid in current:
-            return
+            return True
         current.add(sid)
-        _save_webui_deleted_session_tombstone(current)
+        return _save_webui_deleted_session_tombstone(current)
 
 
 def _clear_webui_deleted_session_tombstone(sid: str) -> None:
@@ -1751,9 +1754,26 @@ class Session:
         with _session_save_lock(self.session_id):
             self._save_locked(touch_updated_at=touch_updated_at, skip_index=skip_index)
 
-    def _save_locked(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+    def _save_locked(
+        self,
+        touch_updated_at: bool = True,
+        skip_index: bool = False,
+        *,
+        allow_deleted_session_restore: bool = False,
+    ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
+        # Session deletion records a durable tombstone while holding this same
+        # save stripe. A stale Session object queued behind deletion must not
+        # recreate its owner file after the delete endpoint has acknowledged
+        # success. Fresh sessions receive new IDs; explicit recovery paths own
+        # tombstone clearing before they persist a restored owner.
+        if (
+            not allow_deleted_session_restore
+            and not self.path.exists()
+            and self.session_id in _load_webui_deleted_session_tombstone()
+        ):
+            raise RuntimeError(f"Refusing to save deleted session {self.session_id!r}")
         # ── #1558 P0 guard ──────────────────────────────────────────────
         # Refuse to save a session that was loaded with metadata_only=True.
         # Such sessions have messages=[] (it's the whole point of the partial

--- a/api/models.py
+++ b/api/models.py
@@ -183,6 +183,10 @@ def _safe_replace(src: Path, dst: Path) -> None:
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
+# Serialize each session's complete check/backup/replace sequence without an
+# unbounded per-session lock cache. A rare stripe collision only delays an
+# unrelated save and cannot affect correctness.
+_SESSION_SAVE_LOCK_STRIPES = tuple(threading.RLock() for _ in range(64))
 _SESSION_INDEX_REBUILD_LOCK = threading.Lock()
 _SESSION_INDEX_REBUILD_THREAD = None
 _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
@@ -1093,16 +1097,30 @@ def _json_dumps_session(obj) -> str:
     metadata-prefix scanner are both whitespace-agnostic).
 
     orjson is used when available and silently falls back to the stdlib for
-    payloads it cannot encode. Note one deliberate normalization: orjson
-    writes non-finite floats (NaN/Infinity) as ``null``, which is valid JSON,
-    while the stdlib emits the non-standard ``NaN`` literal.
+    payloads it cannot encode. Legacy session files may contain the stdlib's
+    non-standard NaN/Infinity literals; keep those float values stable instead
+    of letting orjson silently rewrite them to ``null``.
     """
-    if _orjson is not None:
+    if _orjson is not None and not _contains_nonfinite_float(obj):
         try:
             return _orjson.dumps(obj, option=_orjson.OPT_NON_STR_KEYS).decode('utf-8')
         except Exception:
             pass
     return json.dumps(obj, ensure_ascii=False, separators=(',', ':'))
+
+
+def _contains_nonfinite_float(value) -> bool:
+    """Return whether a JSON-shaped value contains NaN or either infinity."""
+    if isinstance(value, float):
+        return not math.isfinite(value)
+    if isinstance(value, dict):
+        return any(
+            _contains_nonfinite_float(key) or _contains_nonfinite_float(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_nonfinite_float(item) for item in value)
+    return False
 
 
 def _json_loads_session(text):
@@ -1117,6 +1135,19 @@ def _json_loads_session(text):
         except Exception:
             pass
     return json.loads(text)
+
+
+def _stream_file_sha256(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    """Hash a file without materializing a second multi-MB payload in memory."""
+    digest = hashlib.sha256()
+    with path.open('rb') as handle:
+        while chunk := handle.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _session_save_lock(session_id):
+    return _SESSION_SAVE_LOCK_STRIPES[hash(str(session_id)) % len(_SESSION_SAVE_LOCK_STRIPES)]
 
 
 def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
@@ -1511,6 +1542,10 @@ class Session:
         return SESSION_DIR / f'{self.session_id}.json'
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        with _session_save_lock(self.session_id):
+            self._save_locked(touch_updated_at=touch_updated_at, skip_index=skip_index)
+
+    def _save_locked(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
@@ -1590,21 +1625,29 @@ class Session:
         # ── No-op save skip (big-session hotpath, 2026-07-13) ───────────
         # Several periodic callers re-save byte-identical content (observed
         # as full 23 MB rewrites every ~15-30s on an idle large session).
-        # If this object produced the exact same payload it last wrote AND
-        # the on-disk file is untouched since that write (so no other
-        # writer's state can be clobbered or masked), skip the disk write.
+        # If this object produced the exact same payload it last wrote, verify
+        # the real on-disk bytes before skipping. The stat tuple is only a cache
+        # hint: same-size replacements can preserve/coarsen mtime, including an
+        # in-place overwrite. A freshly-loaded object has no digest cache, so it
+        # also verifies once and can retain the no-op optimization after restart.
         # touch_updated_at=True saves always differ (updated_at changed),
         # so recency semantics are unaffected.
-        payload_digest = hashlib.sha256(payload.encode('utf-8')).hexdigest()
-        if payload_digest == getattr(self, '_last_saved_digest', None):
+        payload_bytes = payload.encode('utf-8')
+        payload_digest = hashlib.sha256(payload_bytes).hexdigest()
+        last_saved_digest = getattr(self, '_last_saved_digest', None)
+        if last_saved_digest is None or payload_digest == last_saved_digest:
+            verified_stat = None
             try:
-                st = os.stat(self.path)
+                verified_stat = os.stat(self.path)
                 disk_unchanged = (
-                    (st.st_mtime_ns, st.st_size) == getattr(self, '_last_saved_stat', None)
+                    verified_stat.st_size == len(payload_bytes)
+                    and _stream_file_sha256(self.path) == payload_digest
                 )
             except OSError:
                 disk_unchanged = False
-            if disk_unchanged:
+            if disk_unchanged and verified_stat is not None:
+                self._last_saved_digest = payload_digest
+                self._last_saved_stat = (verified_stat.st_mtime_ns, verified_stat.st_size)
                 if not skip_index:
                     _write_session_index(updates=[self])
                 if self.messages:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2130,10 +2130,19 @@ def _prune_orphaned_webui_zero_message_sessions(rows, *, diag_stage=None):
                 # Re-read ownership at the destructive boundary. A WebUI
                 # session can intentionally have no transcript yet while its
                 # sidecar holds the user's durable composer draft.
-                owner = Session.load(_sid)
-                draft = resolve_composer_draft(
-                    _sid, getattr(owner, "composer_draft", None) if owner else None
-                )
+                try:
+                    owner = Session.load(_sid)
+                    draft = resolve_composer_draft(
+                        _sid, getattr(owner, "composer_draft", None) if owner else None
+                    )
+                except Exception:
+                    logger.warning(
+                        "Retaining webui zero-message row %s because durable owner reload failed",
+                        _sid,
+                        exc_info=True,
+                    )
+                    missing_webui_orphan_ids.discard(_sid)
+                    continue
                 has_draft = bool(
                     isinstance(draft, dict)
                     and (str(draft.get("text") or "") or draft.get("files"))

--- a/api/routes.py
+++ b/api/routes.py
@@ -9458,6 +9458,7 @@ from api.models import (
     write_composer_draft_sidecar,
     delete_composer_draft_sidecar,
     get_composer_draft_lock,
+    _session_save_lock,
     _fsync_composer_draft_directory,
     update_cached_composer_draft,
 )
@@ -14975,16 +14976,16 @@ def handle_post(handler, parsed) -> bool:
         # lock used by POST /api/session/draft. Whichever operation wins, the
         # final state cannot contain a draft without an owning session.
         sidecar_deleted = False
-        with get_composer_draft_lock(sid):
+        with get_composer_draft_lock(sid), _session_save_lock(sid):
             sidecar_state, _sidecar_draft = composer_draft_sidecar_state(sid)
             if sidecar_state == "unreadable":
                 return bad(handler, "Saved draft is unreadable; session was retained", 500)
             owner = None
             try:
                 owner = Session.load(sid)
-                if owner is None:
-                    raise FileNotFoundError(p)
                 if sidecar_state == "present":
+                    if owner is None:
+                        return bad(handler, "Saved draft has no session owner; session was retained", 500)
                     # A failed unlink may mean ``unlink()`` succeeded but its
                     # parent directory fsync did not. Persist the authoritative
                     # draft in the legacy owner before staging so either outcome
@@ -14998,14 +14999,16 @@ def handle_post(handler, parsed) -> bool:
             # Stage the owner under the same directory first. That lets a
             # sidecar-delete failure restore the owner atomically rather than
             # orphaning the authoritative draft after a partial delete.
-            staged_owner = p.with_name(f".{p.name}.deleting-{uuid.uuid4().hex}")
-            try:
-                os.replace(p, staged_owner)
-            except FileNotFoundError:
-                staged_owner = None
-            except Exception:
-                logger.debug("Failed to stage session file for deletion %s", p, exc_info=True)
-                return bad(handler, "Failed to remove session; saved draft was retained", 500)
+            staged_owner = None
+            if owner is not None:
+                staged_owner = p.with_name(f".{p.name}.deleting-{uuid.uuid4().hex}")
+                try:
+                    os.replace(p, staged_owner)
+                except FileNotFoundError:
+                    staged_owner = None
+                except Exception:
+                    logger.debug("Failed to stage session file for deletion %s", p, exc_info=True)
+                    return bad(handler, "Failed to remove session; saved draft was retained", 500)
             if not delete_composer_draft_sidecar(sid):
                 if staged_owner is not None:
                     try:
@@ -15014,6 +15017,20 @@ def handle_post(handler, parsed) -> bool:
                     except Exception:
                         logger.exception("Failed to restore session owner after draft-delete failure: %s", sid)
                 return bad(handler, "Failed to remove saved draft; session was retained", 500)
+            backup_path = p.with_suffix('.json.bak')
+            try:
+                if backup_path.exists():
+                    backup_path.unlink()
+                    _fsync_composer_draft_directory(SESSION_DIR)
+            except Exception:
+                logger.exception("Failed to remove session backup for %s", sid)
+                try:
+                    if staged_owner is not None:
+                        os.replace(staged_owner, p)
+                        _fsync_composer_draft_directory(SESSION_DIR)
+                except Exception:
+                    logger.exception("Failed to restore session after backup-delete failure: %s", sid)
+                return bad(handler, "Failed to remove session backup; session was retained", 500)
             try:
                 if staged_owner is not None:
                     staged_owner.unlink(missing_ok=True)
@@ -15042,24 +15059,31 @@ def handle_post(handler, parsed) -> bool:
                     logger.exception("Failed to restore session after final directory fsync failure: %s", sid)
                 return bad(handler, "Failed to finalize session deletion; session was retained", 500)
             sidecar_deleted = True
+            if not is_messaging_session and not _record_webui_deleted_session_tombstone(sid):
+                logger.error("Failed to record delete tombstone for %s", sid)
+                try:
+                    if sidecar_state == "present":
+                        write_composer_draft_sidecar(sid, _sidecar_draft)
+                    if owner is not None:
+                        owner._save_locked(
+                            touch_updated_at=False,
+                            skip_index=True,
+                            allow_deleted_session_restore=True,
+                        )
+                    _fsync_composer_draft_directory(SESSION_DIR)
+                except Exception:
+                    logger.exception("Failed to restore session after tombstone failure: %s", sid)
+                return bad(handler, "Failed to finalize session deletion; session was retained", 500)
             with LOCK:
                 SESSIONS.pop(sid, None)
             # Evict cached agent so turn count doesn't leak into a recycled session
             from api.config import _evict_session_agent
             _evict_session_agent(sid)
-            try:
-                p.with_suffix('.json.bak').unlink(missing_ok=True)
-            except Exception:
-                logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
+
         try:
             prune_session_from_index(sid)
         except Exception:
             logger.debug("Failed to prune deleted session from index: %s", sid, exc_info=True)
-        if sidecar_deleted and not is_messaging_session:
-            try:
-                _record_webui_deleted_session_tombstone(sid)
-            except Exception:
-                logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         try:
             from api.upload import _session_attachment_dir
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -9438,7 +9438,7 @@ from api.models import (
     process_wakeup_pause_credential_state_changed,
     suppress_process_wakeup_for_provider_pause,
     resolve_composer_draft,
-    read_composer_draft_sidecar,
+    composer_draft_sidecar_state,
     write_composer_draft_sidecar,
     delete_composer_draft_sidecar,
     get_composer_draft_lock,
@@ -14764,8 +14764,10 @@ def handle_post(handler, parsed) -> bool:
                 s_meta = get_session(sid, metadata_only=True)
             except KeyError:
                 return bad(handler, "Session not found", 404)
-            sidecar_draft = read_composer_draft_sidecar(sid)
-            if sidecar_draft is not None:
+            sidecar_state, sidecar_draft = composer_draft_sidecar_state(sid)
+            if sidecar_state == "unreadable":
+                return bad(handler, "Saved draft is unreadable; refusing to overwrite it", status=500)
+            if sidecar_state == "present":
                 current_draft = dict(sidecar_draft)
             else:
                 current_draft = dict(getattr(s_meta, "composer_draft", {}) or {})
@@ -14957,24 +14959,39 @@ def handle_post(handler, parsed) -> bool:
         # final state cannot contain a draft without an owning session.
         sidecar_deleted = False
         with get_composer_draft_lock(sid):
+            # Stage the owner under the same directory first. That lets a
+            # sidecar-delete failure restore the owner atomically rather than
+            # orphaning the authoritative draft after a partial delete.
+            staged_owner = p.with_name(f".{p.name}.deleting-{uuid.uuid4().hex}")
+            try:
+                os.replace(p, staged_owner)
+            except FileNotFoundError:
+                staged_owner = None
+            except Exception:
+                logger.debug("Failed to stage session file for deletion %s", p, exc_info=True)
+                return bad(handler, "Failed to remove session; saved draft was retained", 500)
+            if not delete_composer_draft_sidecar(sid):
+                if staged_owner is not None:
+                    try:
+                        os.replace(staged_owner, p)
+                    except Exception:
+                        logger.exception("Failed to restore session owner after draft-delete failure: %s", sid)
+                return bad(handler, "Failed to remove saved draft; session was retained", 500)
+            try:
+                if staged_owner is not None:
+                    staged_owner.unlink(missing_ok=True)
+            except Exception:
+                logger.warning("Failed to finalize staged session deletion for %s", sid, exc_info=True)
+            sidecar_deleted = True
             with LOCK:
                 SESSIONS.pop(sid, None)
             # Evict cached agent so turn count doesn't leak into a recycled session
             from api.config import _evict_session_agent
             _evict_session_agent(sid)
             try:
-                p.unlink(missing_ok=True)
-            except Exception:
-                logger.debug("Failed to unlink session file %s", p)
-            sidecar_deleted = not p.exists()
-            try:
                 p.with_suffix('.json.bak').unlink(missing_ok=True)
             except Exception:
                 logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
-            try:
-                delete_composer_draft_sidecar(sid)
-            except Exception:
-                logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
         try:
             prune_session_from_index(sid)
         except Exception:
@@ -20791,7 +20808,18 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
         for draft_path in drafts_dir.glob('*.json'):
             sid = draft_path.stem
             with get_composer_draft_lock(sid):
-                owner_exists = (SESSION_DIR / f'{sid}.json').exists()
+                owner_path = SESSION_DIR / f'{sid}.json'
+                # Recover a rare failed delete rollback before deciding this
+                # draft is orphaned. The staging name is same-directory and
+                # contains the authoritative owner JSON.
+                if not owner_path.exists():
+                    staged_candidates = sorted(SESSION_DIR.glob(f'.{sid}.json.deleting-*'))
+                    if staged_candidates:
+                        try:
+                            os.replace(staged_candidates[-1], owner_path)
+                        except OSError:
+                            logger.warning("Failed to restore staged session owner for draft cleanup: %s", sid)
+                owner_exists = owner_path.exists()
                 with LOCK:
                     in_memory_owner = sid in SESSIONS
                 if not owner_exists and not in_memory_owner:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2125,8 +2125,22 @@ def _prune_orphaned_webui_zero_message_sessions(rows, *, diag_stage=None):
                 )
         _diag("self_heal_webui_zero_message_orphan")
     if missing_webui_orphan_ids:
-        for _sid in missing_webui_orphan_ids:
+        for _sid in missing_webui_orphan_ids.copy():
             with get_composer_draft_lock(_sid):
+                # Re-read ownership at the destructive boundary. A WebUI
+                # session can intentionally have no transcript yet while its
+                # sidecar holds the user's durable composer draft.
+                owner = Session.load(_sid)
+                draft = resolve_composer_draft(
+                    _sid, getattr(owner, "composer_draft", None) if owner else None
+                )
+                has_draft = bool(
+                    isinstance(draft, dict)
+                    and (str(draft.get("text") or "") or draft.get("files"))
+                )
+                if owner is not None and has_draft:
+                    missing_webui_orphan_ids.discard(_sid)
+                    continue
                 delete_composer_draft_sidecar(_sid)
             try:
                 prune_session_from_index(_sid)

--- a/api/routes.py
+++ b/api/routes.py
@@ -20795,8 +20795,8 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 with LOCK:
                     in_memory_owner = sid in SESSIONS
                 if not owner_exists and not in_memory_owner:
-                    delete_composer_draft_sidecar(sid)
-                    cleaned += 1
+                    if delete_composer_draft_sidecar(sid):
+                        cleaned += 1
     except Exception:
         logger.debug("Failed to clean up draft-sidecar orphans", exc_info=True)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -14698,6 +14698,20 @@ def handle_post(handler, parsed) -> bool:
         # via the 400ms debounced auto-save.
         _MAX_DRAFT_TEXT = 50_000  # 50 KB cap on textarea content
         _MAX_DRAFT_FILES = 50  # max number of attached file references
+
+        def _canonical_draft(value):
+            value = value if isinstance(value, dict) else {}
+            draft_text = value.get("text")
+            if not isinstance(draft_text, str):
+                draft_text = ""
+            draft_files = value.get("files")
+            if not isinstance(draft_files, list):
+                draft_files = []
+            return {
+                "text": draft_text[:_MAX_DRAFT_TEXT],
+                "files": draft_files[:_MAX_DRAFT_FILES],
+            }
+
         if text is not None and not isinstance(text, str):
             text = ""
         if isinstance(text, str) and len(text) > _MAX_DRAFT_TEXT:
@@ -14732,9 +14746,15 @@ def handle_post(handler, parsed) -> bool:
                 current_draft = dict(sidecar_draft)
             else:
                 current_draft = dict(getattr(s_meta, "composer_draft", {}) or {})
-            if clear_requested and isinstance(clear_expected, dict) and current_draft != clear_expected:
+            current_clear_draft = _canonical_draft(current_draft)
+            expected_clear_draft = _canonical_draft(clear_expected)
+            if (
+                clear_requested
+                and isinstance(clear_expected, dict)
+                and current_clear_draft != expected_clear_draft
+            ):
                 unchanged = True
-                saved_draft = current_draft
+                saved_draft = current_clear_draft
             elif clear_requested:
                 saved_draft = {"text": "", "files": []}
                 owner = get_session(sid)

--- a/api/routes.py
+++ b/api/routes.py
@@ -14780,10 +14780,30 @@ def handle_post(handler, parsed) -> bool:
                 saved_draft = current_clear_draft
             elif clear_requested:
                 saved_draft = {"text": "", "files": []}
+                # Clearing crosses two durable stores: the sidecar is
+                # authoritative while present, but the legacy session payload
+                # takes over after unlink. Checkpoint the current draft first,
+                # so either later operation can fail without losing it.
                 owner = get_session(sid)
+                owner.composer_draft = dict(current_clear_draft)
+                try:
+                    owner.save(touch_updated_at=False, skip_index=True)
+                except Exception:
+                    logger.debug("Failed to checkpoint composer draft before clear for %s", sid, exc_info=True)
+                    update_cached_composer_draft(sid, current_clear_draft)
+                    return bad(handler, "Failed to clear the saved draft", status=500)
+                if not delete_composer_draft_sidecar(sid):
+                    update_cached_composer_draft(sid, current_clear_draft)
+                    return bad(handler, "Failed to clear the saved draft", status=500)
                 owner.composer_draft = dict(saved_draft)
-                owner.save(touch_updated_at=False)
-                delete_composer_draft_sidecar(sid)
+                try:
+                    owner.save(touch_updated_at=False, skip_index=True)
+                except Exception:
+                    # The durable checkpoint above remains on disk. Restore the
+                    # in-memory view before reporting the failed clear.
+                    logger.debug("Failed to finalize composer draft clear for %s", sid, exc_info=True)
+                    update_cached_composer_draft(sid, current_clear_draft)
+                    return bad(handler, "Failed to clear the saved draft", status=500)
                 update_cached_composer_draft(sid, saved_draft)
             else:
                 next_draft = dict(current_draft)

--- a/api/routes.py
+++ b/api/routes.py
@@ -7852,6 +7852,17 @@ def _is_subagent_child_session_id(sid: str) -> bool:
     return _state_db_session_source(sid) == "subagent"
 
 
+def _session_source_marks_subagent(s) -> bool:
+    """True when a session object's source fields tag it as a delegated
+    subagent child. Works on metadata-only stubs (the source fields live in
+    the metadata prefix), so callers on hot paths can avoid a full load."""
+    src = (
+        str(getattr(s, "source_tag", "") or getattr(s, "raw_source", "")
+            or getattr(s, "session_source", "") or "").strip().lower()
+    )
+    return src == "subagent"
+
+
 def _session_is_subagent_view_only(sid: str) -> bool:
     """Return True when ``sid`` is a delegated subagent child by ANY signal —
     state.db source OR a persisted WebUI sidecar tagged subagent.
@@ -7869,11 +7880,7 @@ def _session_is_subagent_view_only(sid: str) -> bool:
         s = get_session(sid)
     except Exception:
         return False
-    src = (
-        str(getattr(s, "source_tag", "") or getattr(s, "raw_source", "")
-            or getattr(s, "session_source", "") or "").strip().lower()
-    )
-    return src == "subagent"
+    return _session_source_marks_subagent(s)
 
 
 def _is_claimable_cli_source(cli_meta: dict, state_db_source: str = "") -> tuple[bool, str]:
@@ -9405,6 +9412,12 @@ from api.models import (
     process_wakeup_credential_state_fingerprint,
     process_wakeup_pause_credential_state_changed,
     suppress_process_wakeup_for_provider_pause,
+    resolve_composer_draft,
+    read_composer_draft_sidecar,
+    write_composer_draft_sidecar,
+    delete_composer_draft_sidecar,
+    get_composer_draft_lock,
+    update_cached_composer_draft,
 )
 
 
@@ -14353,8 +14366,11 @@ def handle_post(handler, parsed) -> bool:
                 # Preserve LLM-generated title flag so we don't regenerate title on duplicate.
                 llm_title_generated=getattr(session, "llm_title_generated", False),
                 manual_title=getattr(session, "manual_title", False),
-                # Composer draft — preserve per-session draft state.
-                composer_draft=copy.deepcopy(getattr(session, "composer_draft", None) or {}),
+                # Composer draft — preserve per-session draft state. Resolve
+                # through the sidecar store so the freshest draft is copied.
+                composer_draft=copy.deepcopy(resolve_composer_draft(
+                    session.session_id, getattr(session, "composer_draft", None)
+                ) or {}),
                 # Context engine state — preserve so the duplicate's context engine
                 # starts from the same point as the original.
                 context_engine=getattr(session, "context_engine", None),
@@ -14638,6 +14654,14 @@ def handle_post(handler, parsed) -> bool:
         # GET ?session_id=X  → return current draft
         # POST body          → save draft { session_id, text?, files? }
         # HTTP method is in handler.command (e.g. "POST", "GET"), parsed has no .method
+        #
+        # Big-session save hotpath: drafts persist to a tiny per-session sidecar
+        # file (models.write_composer_draft_sidecar) instead of Session.save().
+        # On a multi-MB session, every 400ms-debounced keystroke autosave used to
+        # rewrite the entire session JSON (~1s CPU each) behind the session lock,
+        # and the queued POSTs made the whole server unresponsive. This route now
+        # only ever does a metadata-prefix load for validation plus a small atomic
+        # file write. The legacy in-file composer_draft remains as a read fallback.
         import time as _draft_time
         _draft_t0 = _draft_time.monotonic()
         _draft_stages = []
@@ -14651,10 +14675,10 @@ def handle_post(handler, parsed) -> bool:
             if not sid:
                 return bad(handler, "session_id is required", 400)
             try:
-                s = get_session(sid)
+                s = get_session(sid, metadata_only=True)
             except KeyError:
                 return bad(handler, "Session not found", 404)
-            draft = getattr(s, "composer_draft", {}) or {}
+            draft = resolve_composer_draft(sid, getattr(s, "composer_draft", None))
             return j(handler, {"draft": draft})
         # POST
         try:
@@ -14662,8 +14686,6 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         sid = body["session_id"]
-        if _session_is_subagent_view_only(sid):
-            return bad(handler, "Subagent sessions are view-only and cannot store a draft from WebUI", 400)
         text = body.get("text")
         files = body.get("files")
         # Stage-326 hardening (per Opus advisor): size + type validation on
@@ -14681,32 +14703,42 @@ def handle_post(handler, parsed) -> bool:
         if isinstance(files, list) and len(files) > _MAX_DRAFT_FILES:
             files = files[:_MAX_DRAFT_FILES]
         try:
-            s = get_session(sid)
+            s_meta = get_session(sid, metadata_only=True)
         except KeyError:
             return bad(handler, "Session not found", 404)
         _draft_mark("after_get_session")
+        # Same #5307 view-only guard as before, evaluated on the (possibly
+        # metadata-only) session object so the check never forces a full
+        # multi-MB transcript load just to store a draft.
+        if _is_subagent_child_session_id(sid) or _session_source_marks_subagent(s_meta):
+            return bad(handler, "Subagent sessions are view-only and cannot store a draft from WebUI", 400)
         unchanged = False
-        with _get_session_agent_lock(sid):
+        # Dedicated per-session draft lock: drafts must never queue behind the
+        # session/agent lock a running turn may hold.
+        with get_composer_draft_lock(sid):
             _draft_mark("acquired_lock")
-            current_draft = dict(getattr(s, "composer_draft", {}) or {})
+            sidecar_draft = read_composer_draft_sidecar(sid)
+            if sidecar_draft is not None:
+                current_draft = dict(sidecar_draft)
+            else:
+                current_draft = dict(getattr(s_meta, "composer_draft", {}) or {})
             next_draft = dict(current_draft)
             if text is not None:
                 next_draft["text"] = text
             if files is not None:
                 next_draft["files"] = files
-            if next_draft == current_draft:
+            if next_draft == current_draft and sidecar_draft is not None:
                 unchanged = True
                 saved_draft = current_draft
             else:
-                s.composer_draft = next_draft
-                # Draft persistence is not conversation activity. Touching updated_at
-                # here makes the active-session external-refresh poll force-reload the
-                # current chat every few seconds while the user is typing, and that
-                # delayed reload can restore an older draft over newer local input.
+                # Draft persistence is not conversation activity: the sidecar
+                # write touches neither the session JSON, its updated_at, nor
+                # the sidebar index, so active-session external-refresh polls
+                # never force-reload the chat while the user is typing.
                 _draft_mark("before_save")
-                s.save(touch_updated_at=False, skip_index=True)
+                saved_draft = write_composer_draft_sidecar(sid, next_draft)
+                update_cached_composer_draft(sid, saved_draft)
                 _draft_mark("after_save")
-                saved_draft = s.composer_draft
         _draft_mark("released_lock")
         payload = {"ok": True, "draft": saved_draft}
         if unchanged:
@@ -14846,6 +14878,10 @@ def handle_post(handler, parsed) -> bool:
             p.with_suffix('.json.bak').unlink(missing_ok=True)
         except Exception:
             logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
+        try:
+            delete_composer_draft_sidecar(sid)
+        except Exception:
+            logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
         try:
             prune_session_from_index(sid)
         except Exception:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2132,8 +2132,18 @@ def _prune_orphaned_webui_zero_message_sessions(rows, *, diag_stage=None):
                 # sidecar holds the user's durable composer draft.
                 try:
                     owner = Session.load(_sid)
-                    draft = resolve_composer_draft(
-                        _sid, getattr(owner, "composer_draft", None) if owner else None
+                    sidecar_state, sidecar_draft = composer_draft_sidecar_state(_sid)
+                    if sidecar_state == "unreadable":
+                        logger.warning(
+                            "Retaining webui zero-message row %s because its draft sidecar is unreadable",
+                            _sid,
+                        )
+                        missing_webui_orphan_ids.discard(_sid)
+                        continue
+                    draft = (
+                        sidecar_draft
+                        if sidecar_state == "present"
+                        else getattr(owner, "composer_draft", None) if owner else None
                     )
                 except Exception:
                     logger.warning(
@@ -2150,7 +2160,13 @@ def _prune_orphaned_webui_zero_message_sessions(rows, *, diag_stage=None):
                 if owner is not None and has_draft:
                     missing_webui_orphan_ids.discard(_sid)
                     continue
-                delete_composer_draft_sidecar(_sid)
+                if not delete_composer_draft_sidecar(_sid):
+                    logger.warning(
+                        "Retaining webui zero-message row %s because its draft sidecar could not be removed",
+                        _sid,
+                    )
+                    missing_webui_orphan_ids.discard(_sid)
+                    continue
             try:
                 prune_session_from_index(_sid)
                 _diag("prune_orphaned_webui_zero_message")
@@ -9442,6 +9458,7 @@ from api.models import (
     write_composer_draft_sidecar,
     delete_composer_draft_sidecar,
     get_composer_draft_lock,
+    _fsync_composer_draft_directory,
     update_cached_composer_draft,
 )
 
@@ -14959,6 +14976,25 @@ def handle_post(handler, parsed) -> bool:
         # final state cannot contain a draft without an owning session.
         sidecar_deleted = False
         with get_composer_draft_lock(sid):
+            sidecar_state, _sidecar_draft = composer_draft_sidecar_state(sid)
+            if sidecar_state == "unreadable":
+                return bad(handler, "Saved draft is unreadable; session was retained", 500)
+            owner = None
+            try:
+                owner = Session.load(sid)
+                if owner is None:
+                    raise FileNotFoundError(p)
+                if sidecar_state == "present":
+                    # A failed unlink may mean ``unlink()`` succeeded but its
+                    # parent directory fsync did not. Persist the authoritative
+                    # draft in the legacy owner before staging so either outcome
+                    # is readable.
+                    owner.composer_draft = copy.deepcopy(_sidecar_draft)
+                    owner.save(touch_updated_at=False, skip_index=True)
+                    _fsync_composer_draft_directory(SESSION_DIR)
+            except Exception:
+                logger.exception("Failed to checkpoint draft before session deletion: %s", sid)
+                return bad(handler, "Failed to preserve saved draft; session was retained", 500)
             # Stage the owner under the same directory first. That lets a
             # sidecar-delete failure restore the owner atomically rather than
             # orphaning the authoritative draft after a partial delete.
@@ -14974,6 +15010,7 @@ def handle_post(handler, parsed) -> bool:
                 if staged_owner is not None:
                     try:
                         os.replace(staged_owner, p)
+                        _fsync_composer_draft_directory(SESSION_DIR)
                     except Exception:
                         logger.exception("Failed to restore session owner after draft-delete failure: %s", sid)
                 return bad(handler, "Failed to remove saved draft; session was retained", 500)
@@ -14981,7 +15018,29 @@ def handle_post(handler, parsed) -> bool:
                 if staged_owner is not None:
                     staged_owner.unlink(missing_ok=True)
             except Exception:
-                logger.warning("Failed to finalize staged session deletion for %s", sid, exc_info=True)
+                logger.exception("Failed to finalize staged session deletion for %s", sid)
+                try:
+                    if staged_owner is not None:
+                        os.replace(staged_owner, p)
+                        _fsync_composer_draft_directory(SESSION_DIR)
+                except Exception:
+                    logger.exception("Failed to restore staged session after unlink failure: %s", sid)
+                return bad(handler, "Failed to finalize session deletion; session was retained", 500)
+            try:
+                if staged_owner is not None:
+                    _fsync_composer_draft_directory(SESSION_DIR)
+            except Exception:
+                logger.exception("Failed to durably finalize staged session deletion for %s", sid)
+                # unlink succeeded but its directory entry is not confirmed
+                # durable. Recreate the canonical owner from the loaded snapshot.
+                try:
+                    if sidecar_state == "present":
+                        write_composer_draft_sidecar(sid, _sidecar_draft)
+                    owner.save(touch_updated_at=False, skip_index=True)
+                    _fsync_composer_draft_directory(SESSION_DIR)
+                except Exception:
+                    logger.exception("Failed to restore session after final directory fsync failure: %s", sid)
+                return bad(handler, "Failed to finalize session deletion; session was retained", 500)
             sidecar_deleted = True
             with LOCK:
                 SESSIONS.pop(sid, None)
@@ -20698,8 +20757,15 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 # same lock as POST/delete so cleanup cannot delete its owner
                 # between validation and a draft write.
                 s = Session.load(sid)
-                draft = resolve_composer_draft(
-                    sid, getattr(s, "composer_draft", None) if s else None
+                sidecar_state, sidecar_draft = composer_draft_sidecar_state(sid)
+                # Cleanup is destructive: a malformed or transiently unreadable
+                # authoritative sidecar is retention, never an empty fallback.
+                if sidecar_state == "unreadable":
+                    continue
+                draft = (
+                    sidecar_draft
+                    if sidecar_state == "present"
+                    else getattr(s, "composer_draft", None) if s else None
                 )
                 has_draft = bool(
                     str(draft.get("text") or "") or draft.get("files")
@@ -20712,11 +20778,54 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                         and not has_draft
                     )
                 if should_delete:
+                    if sidecar_state == "present":
+                        try:
+                            s.composer_draft = copy.deepcopy(sidecar_draft)
+                            s.save(touch_updated_at=False, skip_index=True)
+                            _fsync_composer_draft_directory(SESSION_DIR)
+                        except Exception:
+                            logger.exception("Failed to checkpoint draft before cleanup: %s", sid)
+                            continue
+                    staged_owner = p.with_name(f".{p.name}.deleting-{uuid.uuid4().hex}")
+                    try:
+                        os.replace(p, staged_owner)
+                    except FileNotFoundError:
+                        continue
+                    except OSError:
+                        logger.warning("Failed to stage session file for cleanup: %s", sid, exc_info=True)
+                        continue
+                    if not delete_composer_draft_sidecar(sid):
+                        try:
+                            os.replace(staged_owner, p)
+                            _fsync_composer_draft_directory(SESSION_DIR)
+                        except OSError:
+                            logger.exception("Failed to restore staged session owner after cleanup failure: %s", sid)
+                        continue
+                    try:
+                        staged_owner.unlink()
+                    except OSError:
+                        logger.exception("Failed to finalize staged session cleanup: %s", sid)
+                        try:
+                            os.replace(staged_owner, p)
+                            _fsync_composer_draft_directory(SESSION_DIR)
+                        except OSError:
+                            logger.exception("Failed to restore staged cleanup owner after unlink failure: %s", sid)
+                        continue
+                    try:
+                        _fsync_composer_draft_directory(SESSION_DIR)
+                    except OSError:
+                        logger.exception("Failed to durably finalize staged session cleanup: %s", sid)
+                        try:
+                            if sidecar_state == "present":
+                                write_composer_draft_sidecar(sid, sidecar_draft)
+                            s.save(touch_updated_at=False, skip_index=True)
+                            _fsync_composer_draft_directory(SESSION_DIR)
+                        except OSError:
+                            logger.exception("Failed to restore cleanup state after final directory fsync failure: %s", sid)
+                        continue
                     with LOCK:
                         SESSIONS.pop(sid, None)
-                    p.unlink(missing_ok=True)
                     p.with_suffix('.json.bak').unlink(missing_ok=True)
-                    delete_composer_draft_sidecar(sid)
                     cleaned += 1
                     phase1_removed_ids.add(sid)
         except Exception:
@@ -20823,6 +20932,9 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 with LOCK:
                     in_memory_owner = sid in SESSIONS
                 if not owner_exists and not in_memory_owner:
+                    sidecar_state, _sidecar_draft = composer_draft_sidecar_state(sid)
+                    if sidecar_state == "unreadable":
+                        continue
                     if delete_composer_draft_sidecar(sid):
                         cleaned += 1
     except Exception:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2126,6 +2126,8 @@ def _prune_orphaned_webui_zero_message_sessions(rows, *, diag_stage=None):
         _diag("self_heal_webui_zero_message_orphan")
     if missing_webui_orphan_ids:
         for _sid in missing_webui_orphan_ids:
+            with get_composer_draft_lock(_sid):
+                delete_composer_draft_sidecar(_sid)
             try:
                 prune_session_from_index(_sid)
                 _diag("prune_orphaned_webui_zero_message")
@@ -14688,6 +14690,8 @@ def handle_post(handler, parsed) -> bool:
         sid = body["session_id"]
         text = body.get("text")
         files = body.get("files")
+        clear_requested = body.get("clear") is True
+        clear_expected = body.get("expected")
         # Stage-326 hardening (per Opus advisor): size + type validation on
         # the draft inputs. Without this, a misbehaving or malicious client
         # can persist multi-MB strings into the session JSON on every keystroke
@@ -14717,28 +14721,51 @@ def handle_post(handler, parsed) -> bool:
         # session/agent lock a running turn may hold.
         with get_composer_draft_lock(sid):
             _draft_mark("acquired_lock")
+            # Validation before this lock can race delete. Re-resolve ownership
+            # at the point of use so a late POST cannot recreate an orphan.
+            try:
+                s_meta = get_session(sid, metadata_only=True)
+            except KeyError:
+                return bad(handler, "Session not found", 404)
             sidecar_draft = read_composer_draft_sidecar(sid)
             if sidecar_draft is not None:
                 current_draft = dict(sidecar_draft)
             else:
                 current_draft = dict(getattr(s_meta, "composer_draft", {}) or {})
-            next_draft = dict(current_draft)
-            if text is not None:
-                next_draft["text"] = text
-            if files is not None:
-                next_draft["files"] = files
-            if next_draft == current_draft and sidecar_draft is not None:
+            if clear_requested and isinstance(clear_expected, dict) and current_draft != clear_expected:
                 unchanged = True
                 saved_draft = current_draft
-            else:
-                # Draft persistence is not conversation activity: the sidecar
-                # write touches neither the session JSON, its updated_at, nor
-                # the sidebar index, so active-session external-refresh polls
-                # never force-reload the chat while the user is typing.
-                _draft_mark("before_save")
-                saved_draft = write_composer_draft_sidecar(sid, next_draft)
+            elif clear_requested:
+                saved_draft = {"text": "", "files": []}
+                owner = get_session(sid)
+                owner.composer_draft = dict(saved_draft)
+                owner.save(touch_updated_at=False)
+                delete_composer_draft_sidecar(sid)
                 update_cached_composer_draft(sid, saved_draft)
-                _draft_mark("after_save")
+            else:
+                next_draft = dict(current_draft)
+                if text is not None:
+                    next_draft["text"] = text
+                if files is not None:
+                    next_draft["files"] = files
+                if next_draft == current_draft and sidecar_draft is not None:
+                    unchanged = True
+                    saved_draft = current_draft
+                else:
+                    # A memory-only new chat needs one durable owner record or
+                    # its sidecar becomes undiscoverable after restart.
+                    if not (SESSION_DIR / f"{sid}.json").exists() and (
+                        str(next_draft.get("text") or "") or next_draft.get("files")
+                    ):
+                        owner = get_session(sid)
+                        owner.composer_draft = dict(next_draft)
+                        owner.save(touch_updated_at=False)
+                    # Draft persistence is not conversation activity: existing
+                    # session JSON and sidebar metadata remain untouched.
+                    _draft_mark("before_save")
+                    saved_draft = write_composer_draft_sidecar(sid, next_draft)
+                    update_cached_composer_draft(sid, saved_draft)
+                    _draft_mark("after_save")
         _draft_mark("released_lock")
         payload = {"ok": True, "draft": saved_draft}
         if unchanged:
@@ -14857,31 +14884,34 @@ def handle_post(handler, parsed) -> bool:
         except Exception:
             logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
             event_profile = None
-        # Delete from WebUI session store
-        with LOCK:
-            SESSIONS.pop(sid, None)
-        # Evict cached agent so turn count doesn't leak into a recycled session
-        from api.config import _evict_session_agent
-        _evict_session_agent(sid)
         try:
             p = (SESSION_DIR / f"{sid}.json").resolve()
             p.relative_to(SESSION_DIR.resolve())
         except Exception:
             return bad(handler, "Invalid session_id", 400)
+        # Delete from WebUI session store and its draft under the same draft
+        # lock used by POST /api/session/draft. Whichever operation wins, the
+        # final state cannot contain a draft without an owning session.
         sidecar_deleted = False
-        try:
-            p.unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Failed to unlink session file %s", p)
-        sidecar_deleted = not p.exists()
-        try:
-            p.with_suffix('.json.bak').unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
-        try:
-            delete_composer_draft_sidecar(sid)
-        except Exception:
-            logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
+        with get_composer_draft_lock(sid):
+            with LOCK:
+                SESSIONS.pop(sid, None)
+            # Evict cached agent so turn count doesn't leak into a recycled session
+            from api.config import _evict_session_agent
+            _evict_session_agent(sid)
+            try:
+                p.unlink(missing_ok=True)
+            except Exception:
+                logger.debug("Failed to unlink session file %s", p)
+            sidecar_deleted = not p.exists()
+            try:
+                p.with_suffix('.json.bak').unlink(missing_ok=True)
+            except Exception:
+                logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
+            try:
+                delete_composer_draft_sidecar(sid)
+            except Exception:
+                logger.debug("Failed to unlink draft sidecar for %s", sid, exc_info=True)
         try:
             prune_session_from_index(sid)
         except Exception:

--- a/api/routes.py
+++ b/api/routes.py
@@ -20632,17 +20632,33 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
         if p.name.startswith("_"):
             continue
         try:
-            s = Session.load(p.stem)
-            if zero_only:
-                should_delete = s and len(s.messages) == 0
-            else:
-                should_delete = s and s.title == "Untitled" and len(s.messages) == 0
-            if should_delete:
-                with LOCK:
-                    SESSIONS.pop(p.stem, None)
-                p.unlink(missing_ok=True)
-                cleaned += 1
-                phase1_removed_ids.add(p.stem)
+            sid = p.stem
+            with get_composer_draft_lock(sid):
+                # The draft sidecar is durable user state.  Check it under the
+                # same lock as POST/delete so cleanup cannot delete its owner
+                # between validation and a draft write.
+                s = Session.load(sid)
+                draft = resolve_composer_draft(
+                    sid, getattr(s, "composer_draft", None) if s else None
+                )
+                has_draft = bool(
+                    str(draft.get("text") or "") or draft.get("files")
+                ) if isinstance(draft, dict) else False
+                if zero_only:
+                    should_delete = s and len(s.messages) == 0 and not has_draft
+                else:
+                    should_delete = (
+                        s and s.title == "Untitled" and len(s.messages) == 0
+                        and not has_draft
+                    )
+                if should_delete:
+                    with LOCK:
+                        SESSIONS.pop(sid, None)
+                    p.unlink(missing_ok=True)
+                    p.with_suffix('.json.bak').unlink(missing_ok=True)
+                    delete_composer_draft_sidecar(sid)
+                    cleaned += 1
+                    phase1_removed_ids.add(sid)
         except Exception:
             logger.debug("Failed to clean up session file %s", p)
 
@@ -20722,6 +20738,24 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
     # correct, so keep it (avoids a wasteful rebuild).
     if phase1_touched and not phase2_rewrote_index and SESSION_INDEX_FILE.exists():
         SESSION_INDEX_FILE.unlink(missing_ok=True)
+
+    # A sidecar with neither a persisted nor in-memory owner is an orphan.
+    # Do this after the owner/index passes and recheck ownership while holding
+    # the draft lock; a draft-only new session writes owner then sidecar under
+    # that lock, so cleanup must never delete an in-flight legitimate draft.
+    drafts_dir = SESSION_DIR / '_drafts'
+    try:
+        for draft_path in drafts_dir.glob('*.json'):
+            sid = draft_path.stem
+            with get_composer_draft_lock(sid):
+                owner_exists = (SESSION_DIR / f'{sid}.json').exists()
+                with LOCK:
+                    in_memory_owner = sid in SESSIONS
+                if not owner_exists and not in_memory_owner:
+                    delete_composer_draft_sidecar(sid)
+                    cleaned += 1
+    except Exception:
+        logger.debug("Failed to clean up draft-sidecar orphans", exc_info=True)
 
     return j(handler, {"ok": True, "cleaned": cleaned})
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -15058,7 +15058,6 @@ def handle_post(handler, parsed) -> bool:
                 except Exception:
                     logger.exception("Failed to restore session after final directory fsync failure: %s", sid)
                 return bad(handler, "Failed to finalize session deletion; session was retained", 500)
-            sidecar_deleted = True
             if not is_messaging_session and not _record_webui_deleted_session_tombstone(sid):
                 logger.error("Failed to record delete tombstone for %s", sid)
                 try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3890,16 +3890,26 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     return None, llm_status or 'empty_title', raw_preview
 
 
-def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
+def _preserve_pre_compression_snapshot(
+    s,
+    old_sid: str,
+    *,
+    draft_already_migrated: bool = False,
+) -> None:
     """Persist old_sid as a read-only pre-compression snapshot.
 
     Context compression rotates the active WebUI session id from old_sid to the
     agent's new continuation id. The old JSON must remain on disk for lineage
     traversal, but it should not continue to appear as an active sidebar row.
     """
-    from api.models import migrate_composer_draft_sidecar
+    if not draft_already_migrated:
+        from api.models import migrate_composer_draft_sidecar
 
-    migrate_composer_draft_sidecar(old_sid, s.session_id)
+        if not migrate_composer_draft_sidecar(old_sid, s.session_id):
+            logger.warning(
+                "Refusing to archive compression snapshot %s because its draft sidecar did not migrate", old_sid
+            )
+            return
     old_path = SESSION_DIR / f'{old_sid}.json'
     if not old_path.exists():
         return
@@ -9083,8 +9093,28 @@ def _run_agent_streaming(
                 _compression_origin_session_id = session_id
                 _compression_continuation_session_id = None
                 _agent_sid = getattr(agent, 'session_id', None)
-                _compressed = False
+                _draft_migration_ready = True
                 if _agent_sid and _agent_sid != session_id:
+                    # Move the authoritative draft before committing any
+                    # WebUI-side session-ID rotation. A corrupt/unreadable
+                    # sidecar must leave the current owner intact instead of
+                    # creating a continuation that cannot recover its draft.
+                    from api.models import migrate_composer_draft_sidecar
+                    try:
+                        _draft_migration_ready = migrate_composer_draft_sidecar(
+                            session_id,
+                            _agent_sid,
+                            finalize_source=False,
+                        )
+                    except Exception:
+                        _draft_migration_ready = False
+                        logger.exception(
+                            "Failed to migrate composer draft before compression rotation: old_sid=%s new_sid=%s",
+                            session_id,
+                            _agent_sid,
+                        )
+                _compressed = False
+                if _agent_sid and _agent_sid != session_id and _draft_migration_ready:
                     old_sid = session_id
                     new_sid = _agent_sid
                     _compression_origin_session_id = old_sid
@@ -9119,7 +9149,11 @@ def _run_agent_streaming(
                     # compression removes messages from the model's context. Skip
                     # the write when the file already contains up-to-date data
                     # (i.e. it was just saved by a checkpoint).
-                    _preserve_pre_compression_snapshot(s, old_sid)
+                    _preserve_pre_compression_snapshot(
+                        s,
+                        old_sid,
+                        draft_already_migrated=True,
+                    )
                     # The continuation is the live/tip session, not another archived
                     # snapshot. If the in-memory object was itself loaded from a
                     # pre-compression snapshot (possible on repeated compression chains
@@ -9184,6 +9218,24 @@ def _run_agent_streaming(
                         except Exception:
                             logger.debug("Failed to close skipped compression-migration cached agent for session %s", old_sid, exc_info=True)
                     _compressed = True
+                elif _agent_sid and _agent_sid != session_id:
+                    # The agent has already rotated internally, but WebUI must
+                    # retain the old owner until its authoritative draft can
+                    # move with it. Restore the agent identity before ordinary
+                    # finalization writes the current session.
+                    try:
+                        agent.session_id = session_id
+                    except Exception:
+                        logger.exception(
+                            "Failed to restore agent session identity after aborted compression rotation: old_sid=%s new_sid=%s",
+                            session_id,
+                            _agent_sid,
+                        )
+                    logger.error(
+                        "Aborted WebUI compression rotation because composer draft migration did not complete: old_sid=%s new_sid=%s",
+                        session_id,
+                        _agent_sid,
+                    )
 
                 # ── Detect silent agent failure (no assistant reply produced) ──
                 # When the agent catches an auth/network error internally it may return
@@ -9951,6 +10003,26 @@ def _run_agent_streaming(
                     return
                 with _stream_writeback_stage(_writeback_timings, "session_save"):
                     s.save()
+                if _compressed:
+                    # The continuation owner is now durable. Only now may the
+                    # preflight copy retire the preserved source draft.
+                    try:
+                        from api.models import migrate_composer_draft_sidecar
+                        if not migrate_composer_draft_sidecar(
+                            _compression_origin_session_id,
+                            s.session_id,
+                        ):
+                            logger.warning(
+                                "Retained pre-compression draft source after continuation save failed to finalize migration: old_sid=%s new_sid=%s",
+                                _compression_origin_session_id,
+                                s.session_id,
+                            )
+                    except Exception:
+                        logger.exception(
+                            "Failed to finalize composer draft migration after continuation save: old_sid=%s new_sid=%s",
+                            _compression_origin_session_id,
+                            s.session_id,
+                        )
                 if cancel_event.is_set():
                     _finalize_cancelled_turn(s, ephemeral=False)
                     try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3897,6 +3897,9 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
     agent's new continuation id. The old JSON must remain on disk for lineage
     traversal, but it should not continue to appear as an active sidebar row.
     """
+    from api.models import migrate_composer_draft_sidecar
+
+    migrate_composer_draft_sidecar(old_sid, s.session_id)
     old_path = SESSION_DIR / f'{old_sid}.json'
     if not old_path.exists():
         return

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -330,6 +330,9 @@ function _clearComposerDraft(sid, text, files) {
   else _suppressComposerDraftRestoreAfterSubmit(sid);
   return api('/api/session/draft', {
     method: 'POST',
+    retries: 2,
+    retryTimeouts: true,
+    retryStatuses: [429, 500, 502, 503, 504],
     body: JSON.stringify({
       session_id: sid,
       clear: true,
@@ -345,7 +348,13 @@ function _clearComposerDraft(sid, text, files) {
       confirmed && typeof confirmed.text === 'string' ? confirmed.text : '',
       confirmed && Array.isArray(confirmed.files) ? confirmed.files : [],
     );
-  }).catch(() => {});
+  }).catch((error) => {
+    console.warn('[composer-draft] clear failed after retries', error);
+    if (typeof showToast === 'function') {
+      showToast('Could not clear the saved draft. It may reappear after reload.', 5000, 'warning');
+    }
+    return null;
+  });
 }
 
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -353,7 +353,7 @@ function _clearComposerDraft(sid, text, files) {
     if (typeof showToast === 'function') {
       showToast('Could not clear the saved draft. It may reappear after reload.', 5000, 'warning');
     }
-    return null;
+    throw error;
   });
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -330,9 +330,21 @@ function _clearComposerDraft(sid, text, files) {
   else _suppressComposerDraftRestoreAfterSubmit(sid);
   return api('/api/session/draft', {
     method: 'POST',
-    body: JSON.stringify({ session_id: sid, text: '' }),
-  }).then(() => {
-    _rememberComposerDraftPayloadState(sid, '', []);
+    body: JSON.stringify({
+      session_id: sid,
+      clear: true,
+      expected: {
+        text: String(text || ''),
+        files: _composerDraftFilesForPersist(files),
+      },
+    }),
+  }).then((result) => {
+    const confirmed = result && result.draft;
+    _rememberComposerDraftPayloadState(
+      sid,
+      confirmed && typeof confirmed.text === 'string' ? confirmed.text : '',
+      confirmed && Array.isArray(confirmed.files) ? confirmed.files : [],
+    );
   }).catch(() => {});
 }
 

--- a/tests/test_bigsession_save_hotpath.py
+++ b/tests/test_bigsession_save_hotpath.py
@@ -1,0 +1,186 @@
+"""Big-session save-hotpath regression tests (2026-07-13).
+
+Covers the changes that keep a multi-MB session usable:
+
+1. Session.save() writes compact JSON (no indent) that every existing reader —
+   full json.loads and the metadata-prefix scanner — still parses.
+2. The #1558 backup safeguard takes the metadata-prefix fast path on normal
+   grow-the-conversation saves and still produces a .bak on shrink.
+3. Byte-identical re-saves skip the disk write entirely (no-op skip).
+4. Composer drafts persist to a tiny sidecar file instead of rewriting the
+   whole session JSON; sidecar wins over the legacy in-file field.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import api.config as _cfg
+import api.models as _models
+from api.models import (
+    Session,
+    composer_draft_sidecar_path,
+    delete_composer_draft_sidecar,
+    read_composer_draft_sidecar,
+    resolve_composer_draft,
+    write_composer_draft_sidecar,
+)
+
+
+@pytest.fixture
+def session_store(tmp_path, monkeypatch):
+    """Isolated SESSION_DIR + index + caches, mirroring test_session_duplicate_edit."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    index_file = sessions_dir / "_index.json"
+    # api.models imports SESSION_DIR/SESSION_INDEX_FILE at module level, so
+    # patch BOTH api.config and api.models bindings.
+    monkeypatch.setattr(_cfg, "SESSION_DIR", sessions_dir)
+    monkeypatch.setattr(_models, "SESSION_DIR", sessions_dir)
+    monkeypatch.setattr(_cfg, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(_models, "SESSION_INDEX_FILE", index_file)
+    with _models.LOCK:
+        _models.SESSIONS.clear()
+    _models._DRAFT_SIDECAR_CACHE.clear()
+    yield sessions_dir
+    with _models.LOCK:
+        _models.SESSIONS.clear()
+    _models._DRAFT_SIDECAR_CACHE.clear()
+
+
+def _msg(role, content, idx):
+    return {"id": f"m{idx}", "role": role, "content": content, "timestamp": float(idx)}
+
+
+def _make_session(sid, n_messages):
+    s = Session(session_id=sid, title="hotpath test")
+    s.messages = [_msg("user" if i % 2 == 0 else "assistant", f"msg {i}", i) for i in range(n_messages)]
+    return s
+
+
+def test_save_writes_compact_json_metadata_prefix_still_readable(session_store):
+    s = _make_session("hotpath1", 4)
+    s.save(skip_index=True)
+    text = (session_store / "hotpath1.json").read_text(encoding="utf-8")
+    # Compact output: no pretty-print newlines (escaped \n inside strings is fine).
+    assert text.count("\n") == 0, "session JSON should be compact, not indented"
+    parsed = json.loads(text)
+    assert len(parsed["messages"]) == 4
+    assert parsed["message_count"] == 4
+    # The metadata-prefix scanner must still work on the compact layout.
+    meta = Session.load_metadata_only("hotpath1")
+    assert meta is not None
+    assert getattr(meta, "_loaded_metadata_only", False) is True
+    assert meta._metadata_message_count == 4
+    assert meta.messages == []
+    # And a full load round-trips.
+    full = Session.load("hotpath1")
+    assert len(full.messages) == 4
+
+
+def test_backup_guard_grow_makes_no_bak_shrink_makes_bak(session_store):
+    s = _make_session("hotpath2", 3)
+    s.save(skip_index=True)
+    s.messages.append(_msg("user", "grow", 3))
+    s.save(skip_index=True)
+    bak = session_store / "hotpath2.json.bak"
+    assert not bak.exists(), "grow-the-conversation saves must not produce a backup"
+    # Shrink → .bak snapshot of the pre-shrink state.
+    s2 = Session.load("hotpath2")
+    s2.messages = s2.messages[:1]
+    s2.save(skip_index=True)
+    assert bak.exists(), "a shrinking save must leave a recoverable .bak"
+    assert len(json.loads(bak.read_text(encoding="utf-8"))["messages"]) == 4
+    assert len(json.loads((session_store / "hotpath2.json").read_text(encoding="utf-8"))["messages"]) == 1
+
+
+def test_backup_guard_refuses_empty_overwrite_with_active_stream(session_store):
+    s = _make_session("hotpath3", 2)
+    s.save(skip_index=True)
+    stub = Session(session_id="hotpath3", title="stub")
+    stub.messages = []
+    stub.active_stream_id = "stream-x"
+    stub.save(skip_index=True)
+    on_disk = json.loads((session_store / "hotpath3.json").read_text(encoding="utf-8"))
+    assert len(on_disk["messages"]) == 2, (
+        "an empty active/pending snapshot must not overwrite a populated session"
+    )
+
+
+def test_noop_resave_skips_disk_write(session_store):
+    s = _make_session("hotpath4", 2)
+    s.save(skip_index=True)
+    p = session_store / "hotpath4.json"
+    st1 = os.stat(p)
+    # Identical content, no updated_at touch → must not rewrite the file.
+    s.save(touch_updated_at=False, skip_index=True)
+    st2 = os.stat(p)
+    assert (st1.st_mtime_ns, st1.st_size) == (st2.st_mtime_ns, st2.st_size), (
+        "byte-identical re-save should skip the disk write"
+    )
+    # Real change → must write.
+    s.title = "changed"
+    s.save(touch_updated_at=False, skip_index=True)
+    st3 = os.stat(p)
+    assert st3.st_mtime_ns != st1.st_mtime_ns
+    assert json.loads(p.read_text(encoding="utf-8"))["title"] == "changed"
+
+
+def test_noop_skip_defers_to_external_writer(session_store):
+    s = _make_session("hotpath5", 1)
+    s.save(skip_index=True)
+    p = session_store / "hotpath5.json"
+    # Another writer replaces the file (different Session object / process).
+    other = Session.load("hotpath5")
+    other.title = "external"
+    other.save(skip_index=True)
+    # The original object's payload is unchanged, but the file on disk moved on:
+    # the skip must not fire, and this save must win with its own content.
+    s.save(touch_updated_at=False, skip_index=True)
+    assert json.loads(p.read_text(encoding="utf-8"))["title"] == "hotpath test"
+
+
+def test_draft_sidecar_roundtrip_and_precedence(session_store):
+    sid = "hotpath6"
+    s = _make_session(sid, 1)
+    s.composer_draft = {"text": "legacy draft", "files": []}
+    s.save(skip_index=True)
+    # No sidecar yet → legacy field resolves.
+    assert resolve_composer_draft(sid, s.composer_draft)["text"] == "legacy draft"
+    # Sidecar write does NOT touch the session file.
+    st1 = os.stat(session_store / f"{sid}.json")
+    stored = write_composer_draft_sidecar(sid, {"text": "sidecar draft", "files": []})
+    st2 = os.stat(session_store / f"{sid}.json")
+    assert (st1.st_mtime_ns, st1.st_size) == (st2.st_mtime_ns, st2.st_size)
+    assert stored["text"] == "sidecar draft"
+    assert composer_draft_sidecar_path(sid).exists()
+    assert read_composer_draft_sidecar(sid)["text"] == "sidecar draft"
+    # Sidecar wins over legacy — including an EMPTY sidecar (cleared draft).
+    assert resolve_composer_draft(sid, s.composer_draft)["text"] == "sidecar draft"
+    write_composer_draft_sidecar(sid, {"text": "", "files": []})
+    assert resolve_composer_draft(sid, s.composer_draft)["text"] == ""
+    # compact() serves the sidecar value.
+    assert s.compact()["composer_draft"]["text"] == ""
+    # Delete → falls back to legacy again.
+    delete_composer_draft_sidecar(sid)
+    assert resolve_composer_draft(sid, s.composer_draft)["text"] == "legacy draft"
+
+
+def test_draft_sidecar_rejects_unsafe_session_ids(session_store):
+    assert composer_draft_sidecar_path("../evil") is None
+    assert read_composer_draft_sidecar("../evil") is None
+    with pytest.raises(ValueError):
+        write_composer_draft_sidecar("../evil", {"text": "x"})
+
+
+def test_draft_sidecar_not_picked_up_as_session(session_store):
+    sid = "hotpath7"
+    _make_session(sid, 1).save(skip_index=True)
+    write_composer_draft_sidecar(sid, {"text": "draft"})
+    top_level = {p.name for p in session_store.glob("*.json")}
+    assert f"{sid}.json" in top_level
+    assert not any("_drafts" in str(p) for p in session_store.glob("*.json")), (
+        "draft sidecars must live outside the top-level *.json session scan"
+    )

--- a/tests/test_bigsession_save_hotpath.py
+++ b/tests/test_bigsession_save_hotpath.py
@@ -125,6 +125,25 @@ def test_backup_guard_grow_makes_no_bak_shrink_makes_bak(session_store):
     assert len(json.loads((session_store / "hotpath2.json").read_text(encoding="utf-8"))["messages"]) == 1
 
 
+def test_backup_guard_does_not_trust_stale_message_count_on_shrink(session_store):
+    """External/legacy writers may leave a derived prefix count stale."""
+    s = _make_session("hotpath-stale-count", 3)
+    s.save(skip_index=True)
+    payload = json.loads(s.path.read_text(encoding="utf-8"))
+    payload["message_count"] = 1  # stale low count, but three real messages
+    s.path.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+
+    incoming = Session.load("hotpath-stale-count")
+    assert incoming is not None
+    incoming.messages = incoming.messages[:1]
+    incoming.save(skip_index=True)
+
+    backup = s.path.with_suffix(".json.bak")
+    assert backup.exists()
+    assert len(json.loads(backup.read_text(encoding="utf-8"))["messages"]) == 3
+    assert len(json.loads(s.path.read_text(encoding="utf-8"))["messages"]) == 1
+
+
 def test_backup_guard_refuses_empty_overwrite_with_active_stream(session_store):
     s = _make_session("hotpath3", 2)
     s.save(skip_index=True)
@@ -425,6 +444,19 @@ def test_draft_sidecar_roundtrip_and_precedence(session_store):
     # Delete → falls back to legacy again.
     delete_composer_draft_sidecar(sid)
     assert resolve_composer_draft(sid, s.composer_draft)["text"] == "legacy draft"
+
+
+def test_draft_sidecar_uses_safe_replace(session_store, monkeypatch):
+    calls = []
+    original = _models._safe_replace
+
+    def tracked_replace(src, dst):
+        calls.append((src, dst))
+        return original(src, dst)
+
+    monkeypatch.setattr(_models, "_safe_replace", tracked_replace)
+    write_composer_draft_sidecar("hotpath-safe-replace", {"text": "draft", "files": []})
+    assert calls, "draft sidecars must retain the platform-safe replacement path"
 
 
 def test_draft_sidecar_rejects_unsafe_session_ids(session_store):

--- a/tests/test_bigsession_save_hotpath.py
+++ b/tests/test_bigsession_save_hotpath.py
@@ -16,6 +16,7 @@ import json
 import math
 import os
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -198,6 +199,109 @@ def test_noop_skip_detects_same_stat_external_replacement(session_store, replace
 
     s.save(touch_updated_at=False, skip_index=True)
     assert json.loads(p.read_text(encoding="utf-8"))["title"] == "owned-title"
+
+
+def test_noop_skip_detects_atomic_replacement_after_digest_read(
+    session_store, monkeypatch
+):
+    s = _make_session("digest-race-atomic", 2)
+    s.title = "owned-A"
+    s.save(touch_updated_at=False, skip_index=True)
+    p = s.path
+    owned = p.read_bytes()
+    original_stat = p.stat()
+    replacement = owned.replace(b"owned-A", b"owned-B")
+    assert len(replacement) == len(owned)
+
+    original_open = Path.open
+    replacement_injected = False
+
+    class ReplaceAtDigestEof:
+        def __init__(self, stream):
+            self._stream = stream
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return self._stream.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self._stream, name)
+
+        def read(self, *args, **kwargs):
+            nonlocal replacement_injected
+            chunk = self._stream.read(*args, **kwargs)
+            if chunk == b"" and not replacement_injected:
+                replacement_injected = True
+                external = p.with_suffix(".external")
+                external.write_bytes(replacement)
+                os.replace(external, p)
+                os.utime(p, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+            return chunk
+
+    def injecting_open(path, *args, **kwargs):
+        stream = original_open(path, *args, **kwargs)
+        if path == p and args and args[0] == "rb" and not replacement_injected:
+            return ReplaceAtDigestEof(stream)
+        return stream
+
+    monkeypatch.setattr(Path, "open", injecting_open)
+    s.save(touch_updated_at=False, skip_index=True)
+
+    assert replacement_injected, "test must replace the file after digest EOF"
+    assert p.read_bytes() == owned
+
+
+def test_noop_skip_detects_in_place_change_during_digest_read(
+    session_store, monkeypatch
+):
+    s = _make_session("digest-race-in-place", 2)
+    s.title = "owned-A"
+    s.messages[0]["content"] = "x" * (1024 * 1024 + 128)
+    s.save(touch_updated_at=False, skip_index=True)
+    p = s.path
+    owned = p.read_bytes()
+    original_stat = p.stat()
+    replacement = owned.replace(b"owned-A", b"owned-B")
+    assert len(replacement) == len(owned) > 1024 * 1024
+
+    original_open = Path.open
+    replacement_injected = False
+
+    class ReplaceAfterFirstChunk:
+        def __init__(self, stream):
+            self._stream = stream
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return self._stream.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self._stream, name)
+
+        def read(self, *args, **kwargs):
+            nonlocal replacement_injected
+            chunk = self._stream.read(*args, **kwargs)
+            if chunk and not replacement_injected:
+                replacement_injected = True
+                p.write_bytes(replacement)
+                os.utime(p, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+            return chunk
+
+    def injecting_open(path, *args, **kwargs):
+        stream = original_open(path, *args, **kwargs)
+        if path == p and args and args[0] == "rb" and not replacement_injected:
+            return ReplaceAfterFirstChunk(stream)
+        return stream
+
+    monkeypatch.setattr(Path, "open", injecting_open)
+    s.save(touch_updated_at=False, skip_index=True)
+
+    assert replacement_injected, "test must replace the file during chunked digesting"
+    assert p.read_bytes() == owned
 
 
 def test_noop_resave_after_reload_skips_disk_write(session_store, monkeypatch):

--- a/tests/test_bigsession_save_hotpath.py
+++ b/tests/test_bigsession_save_hotpath.py
@@ -446,6 +446,26 @@ def test_draft_sidecar_roundtrip_and_precedence(session_store):
     assert resolve_composer_draft(sid, s.composer_draft)["text"] == "legacy draft"
 
 
+
+def test_draft_locks_are_fixed_stripes_and_cache_is_lru_bounded(session_store, monkeypatch):
+    # New session ids must reuse a fixed number of lock objects rather than
+    # retaining one lock for every historical draft owner.
+    locks = {_models.get_composer_draft_lock(f"draft-lock-{index}") for index in range(4096)}
+    assert len(locks) <= len(_models._COMPOSER_DRAFT_LOCK_STRIPES)
+
+    monkeypatch.setattr(_models, "_DRAFT_SIDECAR_CACHE_MAX", 2)
+    for sid in ("draft-cache-a", "draft-cache-b", "draft-cache-c"):
+        write_composer_draft_sidecar(sid, {"text": sid, "files": []})
+
+    assert list(_models._DRAFT_SIDECAR_CACHE) == ["draft-cache-b", "draft-cache-c"]
+    # A cache hit refreshes recency, so the next insertion evicts b, not c.
+    cached = read_composer_draft_sidecar("draft-cache-b")
+    assert cached is not None
+    assert cached["text"] == "draft-cache-b"
+    write_composer_draft_sidecar("draft-cache-d", {"text": "d", "files": []})
+    assert list(_models._DRAFT_SIDECAR_CACHE) == ["draft-cache-b", "draft-cache-d"]
+
+
 def test_draft_sidecar_uses_safe_replace(session_store, monkeypatch):
     calls = []
     original = _models._safe_replace

--- a/tests/test_bigsession_save_hotpath.py
+++ b/tests/test_bigsession_save_hotpath.py
@@ -13,7 +13,9 @@ Covers the changes that keep a multi-MB session usable:
 from __future__ import annotations
 
 import json
+import math
 import os
+import threading
 
 import pytest
 
@@ -58,6 +60,32 @@ def _make_session(sid, n_messages):
     s = Session(session_id=sid, title="hotpath test")
     s.messages = [_msg("user" if i % 2 == 0 else "assistant", f"msg {i}", i) for i in range(n_messages)]
     return s
+
+
+class _NullingFastJson:
+    """Minimal orjson-shaped codec that exposes its non-finite behaviour."""
+
+    OPT_NON_STR_KEYS = 1
+
+    @staticmethod
+    def dumps(obj, option=0):
+        def normalize(value):
+            if isinstance(value, float) and not math.isfinite(value):
+                return None
+            if isinstance(value, list):
+                return [normalize(item) for item in value]
+            if isinstance(value, dict):
+                return {key: normalize(item) for key, item in value.items()}
+            return value
+
+        return json.dumps(normalize(obj), separators=(",", ":")).encode("utf-8")
+
+    @staticmethod
+    def loads(text):
+        def reject_nonfinite(value):
+            raise ValueError(f"non-finite literal {value}")
+
+        return json.loads(text, parse_constant=reject_nonfinite)
 
 
 def test_save_writes_compact_json_metadata_prefix_still_readable(session_store):
@@ -140,6 +168,133 @@ def test_noop_skip_defers_to_external_writer(session_store):
     # the skip must not fire, and this save must win with its own content.
     s.save(touch_updated_at=False, skip_index=True)
     assert json.loads(p.read_text(encoding="utf-8"))["title"] == "hotpath test"
+
+
+@pytest.mark.parametrize("replacement", ["atomic", "inplace"])
+def test_noop_skip_detects_same_stat_external_replacement(session_store, replacement):
+    s = _make_session(f"hotpath_same_stat_{replacement}", 1)
+    s.title = "owned-title"
+    s.save(touch_updated_at=False, skip_index=True)
+    p = s.path
+    original_stat = p.stat()
+    external = p.read_text(encoding="utf-8").replace("owned-title", "other-title")
+    assert len(external.encode("utf-8")) == original_stat.st_size
+
+    if replacement == "atomic":
+        replacement_path = p.with_suffix(".external")
+        replacement_path.write_text(external, encoding="utf-8")
+        os.replace(replacement_path, p)
+    else:
+        with p.open("r+", encoding="utf-8") as handle:
+            handle.write(external)
+            handle.flush()
+            os.fsync(handle.fileno())
+    os.utime(p, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+    same_stat = p.stat()
+    assert (same_stat.st_mtime_ns, same_stat.st_size) == (
+        original_stat.st_mtime_ns,
+        original_stat.st_size,
+    )
+
+    s.save(touch_updated_at=False, skip_index=True)
+    assert json.loads(p.read_text(encoding="utf-8"))["title"] == "owned-title"
+
+
+def test_noop_resave_after_reload_skips_disk_write(session_store, monkeypatch):
+    _make_session("hotpath_restart", 2).save(touch_updated_at=False, skip_index=True)
+    reloaded = Session.load("hotpath_restart")
+    assert reloaded is not None
+    assert not hasattr(reloaded, "_last_saved_digest")
+
+    def unexpected_replace(*_args, **_kwargs):
+        raise AssertionError("a true no-op after cache loss must not rewrite the session")
+
+    monkeypatch.setattr(_models, "_safe_replace", unexpected_replace)
+    reloaded.save(touch_updated_at=False, skip_index=True)
+
+
+def test_same_session_saves_are_serialized(session_store, monkeypatch):
+    seed = _make_session("hotpath_locked", 1)
+    seed.save(touch_updated_at=False, skip_index=True)
+    first = Session.load("hotpath_locked")
+    second = Session.load("hotpath_locked")
+    assert first is not None and second is not None
+    first.title = "first-writer"
+    second.title = "second-writer"
+
+    original_replace = _models._safe_replace
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    call_lock = threading.Lock()
+    calls = 0
+
+    def controlled_replace(src, dst):
+        nonlocal calls
+        with call_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        return original_replace(src, dst)
+
+    monkeypatch.setattr(_models, "_safe_replace", controlled_replace)
+    errors = []
+
+    def save(session):
+        try:
+            session.save(touch_updated_at=False, skip_index=True)
+        except Exception as exc:
+            errors.append(exc)
+
+    first_thread = threading.Thread(target=save, args=(first,))
+    second_thread = threading.Thread(target=save, args=(second,))
+    first_thread.start()
+    assert first_entered.wait(timeout=5)
+    second_thread.start()
+    assert not second_entered.wait(timeout=0.2), (
+        "a second writer for the same session must wait for the first save"
+    )
+    release_first.set()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not errors
+    assert second_entered.is_set()
+    assert json.loads(seed.path.read_text(encoding="utf-8"))["title"] == "second-writer"
+
+
+@pytest.mark.parametrize("fast_codec", [None, _NullingFastJson], ids=["stdlib", "fast-codec"])
+def test_nested_nonfinite_values_roundtrip_deterministically(session_store, monkeypatch, fast_codec):
+    monkeypatch.setattr(_models, "_orjson", fast_codec)
+    session = _make_session(f"hotpath_nonfinite_{'fast' if fast_codec else 'stdlib'}", 1)
+    session.estimated_cost = float("nan")
+    session.messages[0]["metrics"] = {
+        "positive": float("inf"),
+        "nested": [1.25, {"negative": float("-inf")}],
+    }
+    session.save(touch_updated_at=False, skip_index=True)
+    first_bytes = session.path.read_bytes()
+
+    reloaded = Session.load(session.session_id)
+    assert reloaded is not None
+    assert isinstance(reloaded.estimated_cost, float)
+    assert math.isnan(reloaded.estimated_cost)
+    assert reloaded.messages[0]["metrics"]["positive"] == float("inf")
+    assert reloaded.messages[0]["metrics"]["nested"][0] == 1.25
+    assert reloaded.messages[0]["metrics"]["nested"][1]["negative"] == float("-inf")
+    reloaded.save(touch_updated_at=False, skip_index=True)
+    assert reloaded.path.read_bytes() == first_bytes
+
+
+@pytest.mark.parametrize("fast_codec", [None, _NullingFastJson], ids=["stdlib", "fast-codec"])
+def test_malformed_session_json_fails_consistently(monkeypatch, fast_codec):
+    monkeypatch.setattr(_models, "_orjson", fast_codec)
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        _models._json_loads_session('{"messages": [}')
 
 
 def test_draft_sidecar_roundtrip_and_precedence(session_store):

--- a/tests/test_bigsession_save_hotpath.py
+++ b/tests/test_bigsession_save_hotpath.py
@@ -157,22 +157,24 @@ def test_backup_guard_refuses_empty_overwrite_with_active_stream(session_store):
     )
 
 
-def test_noop_resave_skips_disk_write(session_store):
+def test_noop_resave_skips_disk_write(session_store, monkeypatch):
     s = _make_session("hotpath4", 2)
     s.save(skip_index=True)
     p = session_store / "hotpath4.json"
-    st1 = os.stat(p)
+    replace_calls = []
+    real_replace = _models._safe_replace
+    monkeypatch.setattr(
+        _models,
+        "_safe_replace",
+        lambda source, destination: (replace_calls.append((source, destination)), real_replace(source, destination))[1],
+    )
     # Identical content, no updated_at touch → must not rewrite the file.
     s.save(touch_updated_at=False, skip_index=True)
-    st2 = os.stat(p)
-    assert (st1.st_mtime_ns, st1.st_size) == (st2.st_mtime_ns, st2.st_size), (
-        "byte-identical re-save should skip the disk write"
-    )
-    # Real change → must write.
+    assert replace_calls == [], "byte-identical re-save should skip the disk write"
+    # Real change → must publish through the atomic writer.
     s.title = "changed"
     s.save(touch_updated_at=False, skip_index=True)
-    st3 = os.stat(p)
-    assert st3.st_mtime_ns != st1.st_mtime_ns
+    assert len(replace_calls) == 1
     assert json.loads(p.read_text(encoding="utf-8"))["title"] == "changed"
 
 

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -28,6 +28,49 @@ def test_clear_composer_draft_suppresses_same_session_stale_restore():
     assert "const confirmed = result && result.draft;" in clear_body
 
 
+def test_clear_composer_draft_rejects_after_terminal_retry_failure():
+    """The send-error recovery path must be able to observe a terminal clear failure."""
+    import shutil
+    import subprocess
+    import textwrap
+
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        import pytest
+        pytest.skip("node not available")
+
+    clear_fn = _block(
+        SESSIONS_JS,
+        "function _clearComposerDraft(sid, text, files)",
+        "const SESSION_VIEWED_COUNTS_KEY",
+    )
+    harness = textwrap.dedent(
+        """
+        let _draftSaveTimer = 0;
+        let warned = false;
+        function clearTimeout() {}
+        function _clearRememberedNewChatDraftSession() {}
+        function _suppressComposerDraftRestoreAfterSubmit() {}
+        function _composerDraftFilesForPersist(files) { return files || []; }
+        function _rememberComposerDraftPayloadState() {}
+        function showToast() { warned = true; }
+        function api() { return Promise.reject(new Error('terminal clear failure')); }
+
+        %(clear_fn)s
+
+        _clearComposerDraft('sid-1', 'submitted', []).then(
+          () => console.log(JSON.stringify({ fulfilled: true, warned })),
+          () => console.log(JSON.stringify({ fulfilled: false, warned })),
+        );
+        """
+    ) % {"clear_fn": clear_fn}
+    result = subprocess.run([node, "-e", harness], check=True, text=True, capture_output=True)
+    import json
+    observed = json.loads(result.stdout)
+
+    assert observed == {"fulfilled": False, "warned": True}
+
+
 def test_non_empty_draft_save_clears_submit_restore_suppression():
     save_body = _block(SESSIONS_JS, "function _saveComposerDraft(sid, text, files)", "function _composerDraftHasPayload")
     assert "_clearComposerDraftRestoreSuppression(sid);" in save_body

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -22,6 +22,10 @@ def test_clear_composer_draft_suppresses_same_session_stale_restore():
     suppress_idx = clear_body.index("_suppressComposerDraftRestoreAfterSubmit(sid, text, files);")
     post_idx = clear_body.index("api('/api/session/draft'")
     assert suppress_idx < post_idx, "restore suppression must be local and immediate before async POST"
+    assert "clear: true" in clear_body
+    assert "text: String(text || '')" in clear_body
+    assert "files: _composerDraftFilesForPersist(files)" in clear_body
+    assert "const confirmed = result && result.draft;" in clear_body
 
 
 def test_non_empty_draft_save_clears_submit_restore_suppression():

--- a/tests/test_compression_snapshot_runtime_clear.py
+++ b/tests/test_compression_snapshot_runtime_clear.py
@@ -34,6 +34,30 @@ class FakeSession:
         path.write_text(json.dumps(self.saved_payload), encoding="utf-8")
 
 
+
+def test_preserve_snapshot_skips_duplicate_draft_migration_after_preflight(tmp_path, monkeypatch):
+    from api import streaming
+
+    class SnapshotSession:
+        session_id = "continuation"
+        messages = []
+
+    monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
+    (tmp_path / "parent.json").write_text(json.dumps({"messages": []}), encoding="utf-8")
+
+    def unexpected_migration(*_args):
+        raise AssertionError("preflight-successful rotation must not migrate drafts twice")
+
+    import api.models as models
+    monkeypatch.setattr(models, "migrate_composer_draft_sidecar", unexpected_migration)
+
+    streaming._preserve_pre_compression_snapshot(
+        SnapshotSession(),
+        "parent",
+        draft_already_migrated=True,
+    )
+
+
 def test_preserve_pre_compression_snapshot_clears_runtime_fields_while_restoring_continuation_state(tmp_path, monkeypatch):
     monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
     (tmp_path / "old_session.json").write_text(json.dumps({"messages": []}), encoding="utf-8")

--- a/tests/test_issue2057_worktree_lifecycle.py
+++ b/tests/test_issue2057_worktree_lifecycle.py
@@ -126,15 +126,7 @@ def test_delete_session_records_tombstone_when_state_db_delete_fails(tmp_path, m
     def fail_delete(value):
         raise RuntimeError("state.db locked")
 
-    real_unlink = Path.unlink
-
-    def fail_backup_unlink(path, *args, **kwargs):
-        if path.name == f"{sid}.json.bak":
-            raise PermissionError("backup locked")
-        return real_unlink(path, *args, **kwargs)
-
     monkeypatch.setattr(models, "delete_cli_session", fail_delete)
-    monkeypatch.setattr(Path, "unlink", fail_backup_unlink)
 
     assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
 

--- a/tests/test_issue4985_orphaned_webui_zero_message.py
+++ b/tests/test_issue4985_orphaned_webui_zero_message.py
@@ -255,6 +255,8 @@ def _payload_for_rows_webui(
     zero_message_ids,
     existing_ids=None,
     cli_existing_ids=None,
+    sidecar_state=None,
+    sidecar_delete_success=True,
 ):
     """Variant of #3238's ``_payload_for_rows`` for the #4985 path.
 
@@ -288,9 +290,18 @@ def _payload_for_rows_webui(
         lambda ids, profile=None: frozenset(zero_message_ids or []),
     )
     monkeypatch.setattr(
+        routes,
+        "composer_draft_sidecar_state",
+        lambda _sid: sidecar_state or ("absent", None),
+    )
+    monkeypatch.setattr(
+        routes,
+        "delete_composer_draft_sidecar",
+        lambda _sid: sidecar_delete_success,
+    )
+    monkeypatch.setattr(
         routes, "prune_session_from_index", lambda sid: pruned.append(sid)
     )
-
     payload = routes._build_session_list_cache_payload(
         active_profile="default",
         all_profiles=False,
@@ -330,7 +341,60 @@ def test_webui_titled_orphan_in_state_db_is_pruned(monkeypatch):
     assert pruned == ["webui-orphan"]
 
 
-# 2. Titled Webui row with state.db.messages NON-empty -> RETAINED. The gate
+def test_webui_zero_message_orphan_is_retained_when_draft_sidecar_delete_fails(monkeypatch):
+    row = {
+        "session_id": "webui-orphan-sidecar-delete-failure",
+        "title": "Native WebUI",
+        "profile": "default",
+        "updated_at": 20,
+        "last_message_at": 20,
+        "message_count": 0,
+        "read_only": False,
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "source_label": "WebUI",
+        "is_cli_session": False,
+    }
+
+    payload, pruned = _payload_for_rows_webui(
+        monkeypatch,
+        [row],
+        zero_message_ids=["webui-orphan-sidecar-delete-failure"],
+        sidecar_delete_success=False,
+    )
+
+    assert [session["session_id"] for session in payload["sessions"]] == [
+        "webui-orphan-sidecar-delete-failure"
+    ]
+    assert pruned == []
+
+
+def test_webui_zero_message_orphan_with_unreadable_draft_is_retained(monkeypatch):
+    row = {
+        "session_id": "webui-unreadable-draft",
+        "title": "Native WebUI",
+        "profile": "default",
+        "updated_at": 20,
+        "last_message_at": 20,
+        "message_count": 0,
+        "read_only": False,
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "source_label": "WebUI",
+        "is_cli_session": False,
+    }
+
+    payload, pruned = _payload_for_rows_webui(
+        monkeypatch,
+        [row],
+        zero_message_ids=["webui-unreadable-draft"],
+        sidecar_state=("unreadable", None),
+    )
+
+    assert [session["session_id"] for session in payload["sessions"]] == ["webui-unreadable-draft"]
+    assert pruned == []
 #    fires, the helper confirms messages exist, the row is NOT in the missing
 #    set, prune_session_from_index is NOT called.
 def test_webui_titled_row_with_messages_in_state_db_is_retained(monkeypatch):

--- a/tests/test_issue5572_messaging_clear_semantics.py
+++ b/tests/test_issue5572_messaging_clear_semantics.py
@@ -196,15 +196,19 @@ def test_session_clear_preserves_imported_messaging_transcript_and_blocks_state_
     assert loaded.pending_user_source is None
     assert loaded.title == "Untitled"
 
-    persisted = loaded.path.read_text(encoding="utf-8")
-    assert '"messages": []' in persisted
-    assert '"context_messages": []' in persisted
-    assert '"tool_calls": []' in persisted
-    assert '"truncation_watermark": 0.0' in persisted
-    assert '"truncation_boundary": 0.0' in persisted
-    assert '"pending_user_message": null' in persisted
-    assert '"pending_started_at": null' in persisted
-    assert '"pending_user_source": null' in persisted
+    # Assert on the parsed on-disk payload rather than substring-matching a
+    # specific whitespace layout: session files are now written as compact
+    # JSON (big-session save hotpath, 2026-07-13), so '"messages": []' with a
+    # space no longer appears verbatim while the semantics are unchanged.
+    persisted = json.loads(loaded.path.read_text(encoding="utf-8"))
+    assert persisted["messages"] == []
+    assert persisted["context_messages"] == []
+    assert persisted["tool_calls"] == []
+    assert persisted["truncation_watermark"] == 0.0
+    assert persisted["truncation_boundary"] == 0.0
+    assert persisted["pending_user_message"] is None
+    assert persisted["pending_started_at"] is None
+    assert persisted["pending_user_source"] is None
 
     state_db_messages = get_cli_session_messages(sid)
     assert [(m["role"], m["content"], m["timestamp"]) for m in state_db_messages] == [

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -278,30 +278,31 @@ class TestIssue765FollowupHardening:
     """
 
     def test_same_session_concurrent_saves_use_distinct_temp_files(self, monkeypatch):
-        """Two concurrent saves of the same session must not collide on one tmp path.
+        """Two contending saves must serialize without reusing one tmp path.
 
         The key regression guard here is that each save call should reach os.replace()
         with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
-        threads would target the same path and the second replace would deterministically
-        fail once the first consume/remove happened.
+        threads could target the same path and the second replace would fail once the
+        first consumed it. The save lock now serializes replacement, so coordinate the
+        callers before save rather than requiring simultaneous replace calls.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
 
         original_replace = models.os.replace
-        barrier = threading.Barrier(2)
+        start = threading.Barrier(3)
         replace_sources = []
         errors = []
 
-        def _replace_with_barrier(src, dst):
+        def _record_replace(src, dst):
             replace_sources.append(str(src))
-            barrier.wait(timeout=5)
             return original_replace(src, dst)
 
-        monkeypatch.setattr(models.os, "replace", _replace_with_barrier)
+        monkeypatch.setattr(models.os, "replace", _record_replace)
 
         def _save_worker():
             try:
+                start.wait(timeout=5)
                 s.save(skip_index=True)
             except Exception as e:
                 errors.append(e)
@@ -310,6 +311,7 @@ class TestIssue765FollowupHardening:
         t2 = threading.Thread(target=_save_worker)
         t1.start()
         t2.start()
+        start.wait(timeout=5)
         t1.join(timeout=5)
         t2.join(timeout=5)
 

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -154,6 +154,14 @@ def test_restorable_candidate_rejects_in_flight_worktree_and_cross_profile_sessi
 
 
 def test_clear_composer_draft_forgets_same_new_chat_candidate():
+    suppress_start = SESSIONS_JS.find("function _suppressComposerDraftRestoreAfterSubmit(")
+    suppress_end = SESSIONS_JS.find("function _clearComposerDraftRestoreSuppression", suppress_start)
+    assert suppress_start != -1 and suppress_end != -1, "submit suppression helper not found"
+    suppress_body = SESSIONS_JS[suppress_start:suppress_end]
+    assert "_rememberComposerDraftPayloadState(sid, '', []);" in suppress_body, (
+        "submit suppression must immediately clear local draft-payload tracking before the async POST"
+    )
+
     start = SESSIONS_JS.find("function _clearComposerDraft(")
     end = SESSIONS_JS.find("const SESSION_VIEWED_COUNTS_KEY", start)
     assert start != -1 and end != -1, "_clearComposerDraft block not found"
@@ -164,8 +172,17 @@ def test_clear_composer_draft_forgets_same_new_chat_candidate():
     assert "return api('/api/session/draft'" in body, (
         "clear path should return its POST promise for callers/tests that need to await it"
     )
-    assert "_rememberComposerDraftPayloadState(sid, '', []);" in body, (
-        "clear path must also clear local draft-payload tracking so send-then-switch can skip redundant empty flushes"
+    suppress_idx = body.find("_suppressComposerDraftRestoreAfterSubmit(sid, text, files);")
+    post_idx = body.find("return api('/api/session/draft'")
+    confirmed_idx = body.find("const confirmed = result && result.draft;")
+    remember_idx = body.find("_rememberComposerDraftPayloadState(", confirmed_idx)
+    assert -1 not in (suppress_idx, post_idx, confirmed_idx, remember_idx)
+    assert suppress_idx < post_idx < confirmed_idx < remember_idx, (
+        "clear must reset local tracking before POST, then remember the server-confirmed draft"
+    )
+    assert "confirmed && typeof confirmed.text === 'string' ? confirmed.text : ''" in body
+    assert "confirmed && Array.isArray(confirmed.files) ? confirmed.files : []" in body, (
+        "a newer draft preserved by the server must replace the optimistic empty local state"
     )
 
 

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -172,6 +172,35 @@ def test_bulk_zero_message_prune_preserves_nonempty_draft_owner(session_env, mon
     assert tombstoned == []
 
 
+def test_bulk_zero_message_prune_retains_corrupt_durable_owner(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "draft-bulk-corrupt-owner"
+    sidecar = {"text": "keep this sidecar despite corrupt owner", "files": []}
+    (session_dir / f"{sid}.json").write_text("{not valid json", encoding="utf-8")
+    models.write_composer_draft_sidecar(sid, sidecar)
+
+    pruned = []
+    tombstoned = []
+    monkeypatch.setattr(routes, "agent_session_zero_message_sids", lambda *_a, **_k: {sid})
+    monkeypatch.setattr(routes, "_load_webui_zero_message_orphan_tombstone", lambda: set())
+    monkeypatch.setattr(routes, "prune_session_from_index", pruned.append)
+    monkeypatch.setattr(routes, "_record_webui_zero_message_orphan_tombstone", tombstoned.append)
+
+    rows = [{
+        "session_id": sid,
+        "title": "Corrupt durable owner",
+        "message_count": 1,
+        "session_source": "webui",
+        "source_tag": "webui",
+    }]
+    assert routes._prune_orphaned_webui_zero_message_sessions(rows) == rows
+    assert models.read_composer_draft_sidecar(sid) == sidecar
+    assert pruned == []
+    assert tombstoned == []
+
+
 def test_bulk_zero_message_prune_removes_empty_owner_and_tombstones(session_env, monkeypatch):
     from api import models, routes
 

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -189,6 +189,34 @@ def test_clear_is_canonical_durable_and_does_not_clobber_newer_draft(session_env
     assert models.read_composer_draft_sidecar(sid) == newer
 
 
+def test_clear_canonicalizes_legacy_draft_without_files(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    sid = "draft-clear-legacy"
+    session = models.Session(
+        session_id=sid,
+        title="Legacy clear",
+        composer_draft={"text": "submitted"},
+    )
+    session.save(skip_index=True)
+
+    response = _post_draft(
+        monkeypatch,
+        {
+            "session_id": sid,
+            "clear": True,
+            "expected": {"text": "submitted", "files": []},
+        },
+    )
+
+    assert response["status"] == 200
+    assert response["payload"]["draft"] == {"text": "", "files": []}
+    assert "unchanged" not in response["payload"]
+    assert models.Session.load(sid).composer_draft == {"text": "", "files": []}
+    assert models.read_composer_draft_sidecar(sid) is None
+
+
 def test_compact_session_json_still_drives_parent_recovery_reader(session_env):
     from api import models
 

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -229,3 +229,40 @@ def test_compact_session_json_still_drives_parent_recovery_reader(session_env):
     raw = child.path.read_text(encoding="utf-8")
     assert f'"parent_session_id":"{parent_sid}"' in raw
     assert models._has_compression_continuation(models.Session(session_id=parent_sid)) is True
+
+
+@pytest.mark.parametrize("zero_only", [False, True], ids=["untitled", "zero-message"])
+def test_cleanup_preserves_nonempty_draft_owner_and_removes_empty_owner_and_ghost(
+    session_env, monkeypatch, zero_only
+):
+    """Both cleanup endpoints must treat a nonempty draft as durable user state."""
+    from api import models, routes
+
+    session_dir, sessions = session_env
+    keep_sid = f"cleanup-keep-{zero_only}"
+    keep = models.Session(session_id=keep_sid, title="Untitled")
+    keep.save(skip_index=True)
+    models.write_composer_draft_sidecar(keep_sid, {"text": "keep me", "files": []})
+
+    remove_sid = f"cleanup-remove-{zero_only}"
+    remove = models.Session(session_id=remove_sid, title="Untitled")
+    remove.save(skip_index=True)
+    models.write_composer_draft_sidecar(remove_sid, {"text": "", "files": []})
+
+    ghost_sid = f"cleanup-ghost-{zero_only}"
+    models.write_composer_draft_sidecar(ghost_sid, {"text": "orphan", "files": []})
+    sessions.pop(ghost_sid, None)
+
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=zero_only) is True
+
+    assert (session_dir / f"{keep_sid}.json").exists()
+    sessions.clear()
+    restarted = models.Session.load(keep_sid)
+    assert restarted is not None
+    assert models.resolve_composer_draft(keep_sid, restarted.composer_draft)["text"] == "keep me"
+    assert not (session_dir / f"{remove_sid}.json").exists()
+    assert models.read_composer_draft_sidecar(remove_sid) is None
+    assert models.read_composer_draft_sidecar(ghost_sid) is None
+    assert captured["ok"] is True

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -1,0 +1,203 @@
+"""Lifecycle regressions for PR #6011 composer-draft sidecars."""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from contextlib import contextmanager
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.requires_agent_modules
+
+
+@pytest.fixture
+def session_env(monkeypatch, tmp_path):
+    from api import config, models, routes
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    index_file.write_text("[]", encoding="utf-8")
+    sessions = OrderedDict()
+
+    for module in (config, models, routes):
+        monkeypatch.setattr(module, "SESSION_DIR", session_dir, raising=False)
+        monkeypatch.setattr(module, "SESSION_INDEX_FILE", index_file, raising=False)
+    monkeypatch.setattr(models, "SESSIONS", sessions, raising=False)
+    monkeypatch.setattr(routes, "SESSIONS", sessions, raising=False)
+    monkeypatch.setattr(config, "_evict_session_agent", lambda _sid: None, raising=False)
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    models._DRAFT_SIDECAR_CACHE.clear()
+    models._COMPOSER_DRAFT_LOCKS.clear()
+    yield session_dir, sessions
+    models._DRAFT_SIDECAR_CACHE.clear()
+    models._COMPOSER_DRAFT_LOCKS.clear()
+
+
+def _post_draft(monkeypatch, payload):
+    from api import routes
+
+    raw = json.dumps(payload).encode("utf-8")
+    captured = {}
+
+    def fake_j(_handler, body, status=200, extra_headers=None):
+        captured.update(payload=body, status=status, extra_headers=extra_headers)
+        return True
+
+    monkeypatch.setattr(routes, "j", fake_j)
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda handler, message, status=400: fake_j(handler, {"error": message}, status=status),
+    )
+    handler = SimpleNamespace(
+        command="POST",
+        headers={"Content-Length": str(len(raw))},
+        rfile=BytesIO(raw),
+        _safe_webui_print=lambda *_args, **_kwargs: None,
+    )
+    assert routes.handle_post(handler, SimpleNamespace(path="/api/session/draft")) is True
+    return captured
+
+
+def test_first_nonempty_draft_persists_restartable_session_record(session_env, monkeypatch):
+    from api import models
+
+    session_dir, sessions = session_env
+    session = models.new_session()
+    sid = session.session_id
+    assert not (session_dir / f"{sid}.json").exists()
+
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "text": "survive restart", "files": []},
+    )
+
+    assert response["status"] == 200
+    assert models.composer_draft_sidecar_path(sid).exists()
+    assert (session_dir / f"{sid}.json").exists(), "first payload draft must anchor the session"
+
+    sessions.clear()
+    restarted = models.Session.load(sid)
+    assert restarted is not None
+    assert models.resolve_composer_draft(sid, restarted.composer_draft) == {
+        "text": "survive restart",
+        "files": [],
+    }
+
+
+def test_compression_rotation_moves_draft_to_continuation_owner(session_env):
+    from api import models, streaming
+
+    _session_dir, _sessions = session_env
+    old_sid = "draft-rotation-old"
+    new_sid = "draft-rotation-new"
+    session = models.Session(session_id=old_sid, title="Before compression")
+    session.save(skip_index=True)
+    models.write_composer_draft_sidecar(
+        old_sid,
+        {"text": "continue after compression", "files": [{"name": "notes.txt"}]},
+    )
+
+    session.session_id = new_sid
+    streaming._preserve_pre_compression_snapshot(session, old_sid)
+
+    assert models.read_composer_draft_sidecar(old_sid) is None
+    assert models.read_composer_draft_sidecar(new_sid) == {
+        "text": "continue after compression",
+        "files": [{"name": "notes.txt"}],
+    }
+
+
+def test_delete_race_and_bulk_prune_cannot_leave_orphan_drafts(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, sessions = session_env
+    sid = "draft-delete-race"
+    session = models.Session(session_id=sid, title="Delete race")
+    session.save(skip_index=True)
+
+    real_lock = models.get_composer_draft_lock(sid)
+
+    @contextmanager
+    def delete_wins_before_draft_lock(_sid):
+        with real_lock:
+            sessions.pop(sid, None)
+            (session_dir / f"{sid}.json").unlink(missing_ok=True)
+            models.delete_composer_draft_sidecar(sid)
+            yield
+
+    monkeypatch.setattr(routes, "get_composer_draft_lock", delete_wins_before_draft_lock)
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "text": "must not resurrect", "files": []},
+    )
+    assert response["status"] == 404
+    assert models.read_composer_draft_sidecar(sid) is None
+
+    bulk_sid = "draft-bulk-orphan"
+    bulk = models.Session(session_id=bulk_sid, title="Stale titled row")
+    bulk.save(skip_index=True)
+    models.write_composer_draft_sidecar(bulk_sid, {"text": "orphan", "files": []})
+    monkeypatch.setattr(routes, "agent_session_zero_message_sids", lambda *_a, **_k: {bulk_sid})
+    monkeypatch.setattr(routes, "_load_webui_zero_message_orphan_tombstone", lambda: set())
+    monkeypatch.setattr(routes, "prune_session_from_index", lambda _sid: None)
+    monkeypatch.setattr(routes, "_record_webui_zero_message_orphan_tombstone", lambda _sid: None)
+
+    rows = [{
+        "session_id": bulk_sid,
+        "title": "Stale titled row",
+        "message_count": 1,
+        "session_source": "webui",
+        "source_tag": "webui",
+    }]
+    assert routes._prune_orphaned_webui_zero_message_sessions(rows) == []
+    assert models.read_composer_draft_sidecar(bulk_sid) is None
+
+
+def test_clear_is_canonical_durable_and_does_not_clobber_newer_draft(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    sid = "draft-clear"
+    old_draft = {"text": "submitted", "files": [{"name": "old.txt"}]}
+    session = models.Session(session_id=sid, title="Clear", composer_draft=dict(old_draft))
+    session.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, old_draft)
+
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "clear": True, "expected": old_draft},
+    )
+    assert response["status"] == 200
+    assert response["payload"]["draft"] == {"text": "", "files": []}
+    assert models.read_composer_draft_sidecar(sid) is None
+    assert models.Session.load(sid).composer_draft == {"text": "", "files": []}
+
+    newer = {"text": "typed after submit", "files": [{"name": "new.txt"}]}
+    models.write_composer_draft_sidecar(sid, newer)
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "clear": True, "expected": old_draft},
+    )
+    assert response["status"] == 200
+    assert response["payload"]["draft"] == newer
+    assert response["payload"]["unchanged"] is True
+    assert models.read_composer_draft_sidecar(sid) == newer
+
+
+def test_compact_session_json_still_drives_parent_recovery_reader(session_env):
+    from api import models
+
+    _session_dir, sessions = session_env
+    parent_sid = "compact-parent"
+    child = models.Session(session_id="compact-child", parent_session_id=parent_sid)
+    child.save(touch_updated_at=False, skip_index=True)
+    sessions.clear()
+
+    raw = child.path.read_text(encoding="utf-8")
+    assert f'"parent_session_id":"{parent_sid}"' in raw
+    assert models._has_compression_continuation(models.Session(session_id=parent_sid)) is True

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -112,7 +112,7 @@ def test_compression_rotation_moves_draft_to_continuation_owner(session_env):
     }
 
 
-def test_delete_race_and_bulk_prune_cannot_leave_orphan_drafts(session_env, monkeypatch):
+def test_delete_race_cannot_leave_orphan_drafts(session_env, monkeypatch):
     from api import models, routes
 
     session_dir, sessions = session_env
@@ -138,24 +138,67 @@ def test_delete_race_and_bulk_prune_cannot_leave_orphan_drafts(session_env, monk
     assert response["status"] == 404
     assert models.read_composer_draft_sidecar(sid) is None
 
-    bulk_sid = "draft-bulk-orphan"
-    bulk = models.Session(session_id=bulk_sid, title="Stale titled row")
-    bulk.save(skip_index=True)
-    models.write_composer_draft_sidecar(bulk_sid, {"text": "orphan", "files": []})
-    monkeypatch.setattr(routes, "agent_session_zero_message_sids", lambda *_a, **_k: {bulk_sid})
+
+def test_bulk_zero_message_prune_preserves_nonempty_draft_owner(session_env, monkeypatch):
+    from api import models, routes
+
+    _session_dir, sessions = session_env
+    sid = "draft-bulk-owner"
+    owner = models.Session(session_id=sid, title="Draft-only conversation")
+    owner.save(skip_index=True)
+    draft = {"text": "keep this durable draft", "files": []}
+    models.write_composer_draft_sidecar(sid, draft)
+    sessions.clear()
+
+    pruned = []
+    tombstoned = []
+    monkeypatch.setattr(routes, "agent_session_zero_message_sids", lambda *_a, **_k: {sid})
     monkeypatch.setattr(routes, "_load_webui_zero_message_orphan_tombstone", lambda: set())
-    monkeypatch.setattr(routes, "prune_session_from_index", lambda _sid: None)
-    monkeypatch.setattr(routes, "_record_webui_zero_message_orphan_tombstone", lambda _sid: None)
+    monkeypatch.setattr(routes, "prune_session_from_index", pruned.append)
+    monkeypatch.setattr(routes, "_record_webui_zero_message_orphan_tombstone", tombstoned.append)
 
     rows = [{
-        "session_id": bulk_sid,
-        "title": "Stale titled row",
+        "session_id": sid,
+        "title": "Draft-only conversation",
+        "message_count": 1,
+        "session_source": "webui",
+        "source_tag": "webui",
+    }]
+    assert routes._prune_orphaned_webui_zero_message_sessions(rows) == rows
+    restarted = models.Session.load(sid)
+    assert restarted is not None
+    assert models.resolve_composer_draft(sid, restarted.composer_draft) == draft
+    assert pruned == []
+    assert tombstoned == []
+
+
+def test_bulk_zero_message_prune_removes_empty_owner_and_tombstones(session_env, monkeypatch):
+    from api import models, routes
+
+    _session_dir, _sessions = session_env
+    sid = "draft-bulk-empty-owner"
+    owner = models.Session(session_id=sid, title="Empty stale conversation")
+    owner.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, {"text": "", "files": []})
+
+    pruned = []
+    tombstoned = []
+    monkeypatch.setattr(routes, "agent_session_zero_message_sids", lambda *_a, **_k: {sid})
+    monkeypatch.setattr(routes, "_load_webui_zero_message_orphan_tombstone", lambda: set())
+    monkeypatch.setattr(routes, "prune_session_from_index", pruned.append)
+    monkeypatch.setattr(routes, "_record_webui_zero_message_orphan_tombstone", tombstoned.append)
+
+    rows = [{
+        "session_id": sid,
+        "title": "Empty stale conversation",
         "message_count": 1,
         "session_source": "webui",
         "source_tag": "webui",
     }]
     assert routes._prune_orphaned_webui_zero_message_sessions(rows) == []
-    assert models.read_composer_draft_sidecar(bulk_sid) is None
+    assert models.read_composer_draft_sidecar(sid) is None
+    assert pruned == [sid]
+    assert tombstoned == [sid]
 
 
 def test_clear_is_canonical_durable_and_does_not_clobber_newer_draft(session_env, monkeypatch):

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -134,6 +134,163 @@ def test_delete_restores_owner_when_authoritative_draft_unlink_fails(session_env
     assert models.read_composer_draft_sidecar(sid) == draft
 
 
+
+def test_delete_fsync_failure_after_sidecar_unlink_keeps_legacy_draft(session_env, monkeypatch):
+    from api import models
+
+    session_dir, _sessions = session_env
+    sid = "delete-sidecar-fsync-failure"
+    owner = models.Session(session_id=sid, title="Retain latest draft")
+    owner.save(skip_index=True)
+    draft = {"text": "latest durable draft", "files": []}
+    models.write_composer_draft_sidecar(sid, draft)
+    monkeypatch.setattr(
+        models,
+        "_fsync_composer_draft_parent",
+        lambda _path: (_ for _ in ()).throw(OSError("simulated directory EIO")),
+    )
+
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert (session_dir / f"{sid}.json").exists()
+    assert models.Session.load(sid).composer_draft == draft
+
+
+def test_delete_refuses_sidecar_unlink_when_checkpoint_directory_fsync_fails(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "delete-checkpoint-directory-fsync-failure"
+    owner = models.Session(session_id=sid, title="Retain draft")
+    owner.save(skip_index=True)
+    draft = {"text": "draft remains authoritative", "files": []}
+    models.write_composer_draft_sidecar(sid, draft)
+    monkeypatch.setattr(
+        routes,
+        "_fsync_composer_draft_directory",
+        lambda _path: (_ for _ in ()).throw(OSError("simulated checkpoint EIO")),
+    )
+    unlink_attempted = []
+    monkeypatch.setattr(
+        routes,
+        "delete_composer_draft_sidecar",
+        lambda _sid: unlink_attempted.append(_sid) or True,
+    )
+
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert unlink_attempted == []
+    assert (session_dir / f"{sid}.json").exists()
+    assert models.read_composer_draft_sidecar(sid) == draft
+
+
+def test_delete_rollback_failure_is_recovered_by_next_session_load(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, sessions = session_env
+    sid = "delete-rollback-load-recovery"
+    owner = models.Session(session_id=sid, title="Retain after rollback failure")
+    owner.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, {"text": "durable", "files": []})
+    owner_path = session_dir / f"{sid}.json"
+    staged_prefix = str(session_dir / f".{sid}.json.deleting-")
+    original_replace = routes.os.replace
+    failed_restore = []
+
+    def fail_first_rollback(source, destination):
+        if (
+            str(source).startswith(staged_prefix)
+            and str(destination) == str(owner_path)
+            and not failed_restore
+        ):
+            failed_restore.append(True)
+            raise OSError("simulated delete rollback failure")
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(routes, "delete_composer_draft_sidecar", lambda _sid: False)
+    monkeypatch.setattr(routes.os, "replace", fail_first_rollback)
+
+    response = _post_session_delete(monkeypatch, sid)
+    sessions.clear()
+    listed = models.all_sessions()
+    metadata = models.Session.load_metadata_only(sid)
+    reloaded = models.Session.load(sid)
+
+    assert response["status"] == 500
+    assert failed_restore == [True]
+    assert owner_path.exists()
+    assert sid in {entry["session_id"] for entry in listed}
+    assert metadata is not None
+    assert metadata.session_id == sid
+    assert reloaded is not None
+    assert reloaded.session_id == sid
+
+
+def test_delete_returns_error_when_final_owner_unlink_directory_fsync_fails(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "delete-final-owner-fsync-failure"
+    owner = models.Session(session_id=sid, title="Delete only after durable unlink")
+    owner.save(skip_index=True)
+    monkeypatch.setattr(
+        routes,
+        "_fsync_composer_draft_directory",
+        lambda _path: (_ for _ in ()).throw(OSError("simulated final unlink EIO")),
+    )
+
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert (session_dir / f"{sid}.json").exists()
+    assert models.Session.load(sid) is not None
+
+
+def test_delete_final_owner_unlink_failure_restores_staged_owner(session_env, monkeypatch):
+    from api import models
+
+    session_dir, _sessions = session_env
+    sid = "delete-final-owner-unlink-failure"
+    owner = models.Session(session_id=sid, title="Retain after unlink failure")
+    owner.save(skip_index=True)
+    owner_path = session_dir / f"{sid}.json"
+    original_unlink = type(owner_path).unlink
+
+    def fail_staged_unlink(path, *args, **kwargs):
+        if path.name.startswith(f".{sid}.json.deleting-"):
+            raise OSError("simulated staged owner unlink failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(owner_path), "unlink", fail_staged_unlink)
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert owner_path.exists()
+    assert not list(session_dir.glob(f".{sid}.json.deleting-*"))
+
+
+def test_delete_refuses_to_remove_unreadable_authoritative_draft(session_env, monkeypatch):
+    from api import models
+
+    session_dir, _sessions = session_env
+    sid = "draft-delete-unreadable"
+    session = models.Session(session_id=sid, title="Retain unreadable draft")
+    session.save(skip_index=True)
+    owner_path = session_dir / f"{sid}.json"
+    sidecar_path = models.composer_draft_sidecar_path(sid)
+    assert sidecar_path is not None
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text("{malformed", encoding="utf-8")
+
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert owner_path.exists()
+    assert sidecar_path.read_text(encoding="utf-8") == "{malformed"
+
+
 def test_compression_rotation_moves_draft_to_continuation_owner(session_env):
     from api import models, streaming
 
@@ -551,6 +708,70 @@ def test_clear_skips_index_write_to_keep_checkpoint_and_final_save_durable(sessi
     assert models.Session.load(sid).composer_draft == {"text": "", "files": []}
 
 
+
+def test_draft_directory_fsync_is_noop_on_windows(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    open_calls = []
+    monkeypatch.setattr(models.os, "name", "nt")
+    monkeypatch.setattr(models.os, "open", lambda *_args, **_kwargs: open_calls.append(True) or 0)
+
+    models._fsync_composer_draft_directory(models.SESSION_DIR)
+
+    assert open_calls == []
+
+
+def test_write_draft_rejects_parent_directory_fsync_failure(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    monkeypatch.setattr(
+        models,
+        "_fsync_composer_draft_parent",
+        lambda _path: (_ for _ in ()).throw(OSError("simulated directory EIO")),
+    )
+
+    with pytest.raises(OSError, match="directory EIO"):
+        models.write_composer_draft_sidecar("draft-parent-fsync-eio", {"text": "x", "files": []})
+
+
+def test_delete_draft_reports_parent_directory_fsync_failure(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    sid = "draft-delete-parent-fsync-eio"
+    models.write_composer_draft_sidecar(sid, {"text": "x", "files": []})
+    monkeypatch.setattr(
+        models,
+        "_fsync_composer_draft_parent",
+        lambda _path: (_ for _ in ()).throw(OSError("simulated directory EIO")),
+    )
+
+    assert models.delete_composer_draft_sidecar(sid) is False
+
+
+def test_migration_uses_retained_source_when_drafts_differ_with_equal_mtime(session_env):
+    from api import models
+    import os
+
+    _session_dir, _sessions = session_env
+    old_sid = "draft-equal-time-source"
+    new_sid = "draft-equal-time-destination"
+    models.write_composer_draft_sidecar(old_sid, {"text": "source", "files": []})
+    models.write_composer_draft_sidecar(new_sid, {"text": "destination", "files": []})
+    old_path = models.composer_draft_sidecar_path(old_sid)
+    new_path = models.composer_draft_sidecar_path(new_sid)
+    assert old_path is not None and new_path is not None
+    timestamp = 1_700_000_000_000_000_000
+    os.utime(old_path, ns=(timestamp, timestamp))
+    os.utime(new_path, ns=(timestamp, timestamp))
+
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid) is True
+    assert models.read_composer_draft_sidecar(old_sid) is None
+    assert models.read_composer_draft_sidecar(new_sid) == {"text": "source", "files": []}
+
+
 def test_delete_draft_sidecar_reports_unlink_failure(session_env, monkeypatch):
     from api import models
 
@@ -588,6 +809,126 @@ def test_cleanup_does_not_count_failed_orphan_sidecar_delete(session_env, monkey
 
     assert captured == {"ok": True, "cleaned": 0}
     assert (session_dir / "_drafts" / f"{sid}.json").exists()
+
+
+
+def test_cleanup_retains_owner_when_draft_sidecar_delete_fails(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "cleanup-owner-sidecar-delete-failure"
+    owner = models.Session(session_id=sid, title="Untitled")
+    owner.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, {"text": "", "files": []})
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+    monkeypatch.setattr(routes, "delete_composer_draft_sidecar", lambda _sid: False)
+
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=False) is True
+
+    assert captured == {"ok": True, "cleaned": 0}
+    assert (session_dir / f"{sid}.json").exists()
+    assert models.read_composer_draft_sidecar(sid) == {"text": "", "files": []}
+
+
+def test_cleanup_fsync_failure_after_sidecar_unlink_keeps_legacy_draft(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "cleanup-sidecar-fsync-failure"
+    owner = models.Session(session_id=sid, title="Untitled")
+    owner.save(skip_index=True)
+    draft = {"text": "", "files": []}
+    models.write_composer_draft_sidecar(sid, draft)
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+    monkeypatch.setattr(
+        models,
+        "_fsync_composer_draft_parent",
+        lambda _path: (_ for _ in ()).throw(OSError("simulated directory EIO")),
+    )
+
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=False) is True
+
+    assert captured == {"ok": True, "cleaned": 0}
+    assert (session_dir / f"{sid}.json").exists()
+    assert models.Session.load(sid).composer_draft == draft
+
+
+def test_cleanup_recovers_staged_owner_after_sidecar_delete_rollback_failure(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "cleanup-sidecar-delete-rollback-failure"
+    owner = models.Session(session_id=sid, title="Untitled")
+    owner.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, {"text": "", "files": []})
+    owner_path = session_dir / f"{sid}.json"
+    staged_prefix = str(session_dir / f".{sid}.json.deleting-")
+    original_replace = routes.os.replace
+    failed_restore = []
+
+    def fail_first_rollback(source, destination):
+        if (
+            str(source).startswith(staged_prefix)
+            and str(destination) == str(owner_path)
+            and not failed_restore
+        ):
+            failed_restore.append(True)
+            raise OSError("simulated cleanup rollback failure")
+        return original_replace(source, destination)
+
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+    monkeypatch.setattr(routes, "delete_composer_draft_sidecar", lambda _sid: False)
+    monkeypatch.setattr(routes.os, "replace", fail_first_rollback)
+
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=False) is True
+
+    assert failed_restore == [True]
+    assert captured == {"ok": True, "cleaned": 0}
+    assert owner_path.exists()
+    assert models.read_composer_draft_sidecar(sid) == {"text": "", "files": []}
+
+
+def test_cleanup_retains_unreadable_orphan_sidecar(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, sessions = session_env
+    sid = "cleanup-unreadable-orphan"
+    sidecar_path = models.composer_draft_sidecar_path(sid)
+    assert sidecar_path is not None
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text("{malformed", encoding="utf-8")
+    sessions.pop(sid, None)
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=False) is True
+
+    assert captured == {"ok": True, "cleaned": 0}
+    assert sidecar_path.read_text(encoding="utf-8") == "{malformed"
+
+
+def test_cleanup_retains_owner_when_sidecar_is_unreadable(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "cleanup-unreadable-owner"
+    owner = models.Session(session_id=sid, title="Untitled")
+    owner.save(skip_index=True)
+    sidecar_path = models.composer_draft_sidecar_path(sid)
+    assert sidecar_path is not None
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text("{malformed", encoding="utf-8")
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=False) is True
+
+    assert captured == {"ok": True, "cleaned": 0}
+    assert (session_dir / f"{sid}.json").exists()
+    assert sidecar_path.read_text(encoding="utf-8") == "{malformed"
 
 
 def test_clear_canonicalizes_legacy_draft_without_files(session_env, monkeypatch):

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -61,6 +61,33 @@ def _post_draft(monkeypatch, payload):
     return captured
 
 
+
+def _post_session_delete(monkeypatch, sid):
+    from api import routes
+
+    raw = json.dumps({"session_id": sid}).encode("utf-8")
+    captured = {}
+
+    def fake_j(_handler, body, status=200, extra_headers=None):
+        captured.update(payload=body, status=status, extra_headers=extra_headers)
+        return True
+
+    monkeypatch.setattr(routes, "j", fake_j)
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda handler, message, status=400: fake_j(handler, {"error": message}, status=status),
+    )
+    handler = SimpleNamespace(
+        command="POST",
+        headers={"Content-Length": str(len(raw))},
+        rfile=BytesIO(raw),
+        _safe_webui_print=lambda *_args, **_kwargs: None,
+    )
+    assert routes.handle_post(handler, SimpleNamespace(path="/api/session/delete")) is True
+    return captured
+
+
 def test_first_nonempty_draft_persists_restartable_session_record(session_env, monkeypatch):
     from api import models
 
@@ -85,6 +112,26 @@ def test_first_nonempty_draft_persists_restartable_session_record(session_env, m
         "text": "survive restart",
         "files": [],
     }
+
+
+
+def test_delete_restores_owner_when_authoritative_draft_unlink_fails(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "draft-delete-sidecar-failure"
+    session = models.Session(session_id=sid, title="Retain draft")
+    session.save(skip_index=True)
+    draft = {"text": "latest durable text", "files": []}
+    models.write_composer_draft_sidecar(sid, draft)
+    owner_path = session_dir / f"{sid}.json"
+
+    monkeypatch.setattr(routes, "delete_composer_draft_sidecar", lambda _sid: False)
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert owner_path.exists()
+    assert models.read_composer_draft_sidecar(sid) == draft
 
 
 def test_compression_rotation_moves_draft_to_continuation_owner(session_env):
@@ -275,6 +322,122 @@ def test_bulk_zero_message_prune_removes_empty_owner_and_tombstones(session_env,
     assert models.read_composer_draft_sidecar(sid) is None
     assert pruned == [sid]
     assert tombstoned == [sid]
+
+
+
+def test_draft_post_refuses_to_overwrite_unreadable_authoritative_sidecar(session_env, monkeypatch):
+    from api import models
+
+    session_dir, _sessions = session_env
+    sid = "draft-unreadable-sidecar"
+    session = models.Session(session_id=sid, title="Corrupt draft")
+    session.save(skip_index=True)
+    draft_path = models.composer_draft_sidecar_path(sid)
+    draft_path.parent.mkdir(parents=True, exist_ok=True)
+    draft_path.write_text("{not json", encoding="utf-8")
+
+    response = _post_draft(monkeypatch, {"session_id": sid, "text": "must not overwrite", "files": []})
+
+    assert response["status"] == 500
+    assert draft_path.read_text(encoding="utf-8") == "{not json"
+
+
+def test_draft_cache_rejects_same_size_mtime_atomic_replacement(session_env):
+    from api import models
+    import os
+
+    sid = "draft-cache-identity"
+    models.write_composer_draft_sidecar(sid, {"text": "old", "files": []})
+    path = models.composer_draft_sidecar_path(sid)
+    original = path.stat()
+    assert models.read_composer_draft_sidecar(sid)["text"] == "old"
+
+    replacement = path.with_suffix(".replacement")
+    replacement.write_text(
+        path.read_text(encoding="utf-8").replace('"old"', '"new"'),
+        encoding="utf-8",
+    )
+    assert replacement.stat().st_size == original.st_size
+    os.replace(replacement, path)
+    os.utime(path, ns=(original.st_atime_ns, original.st_mtime_ns))
+
+    assert models.read_composer_draft_sidecar(sid) == {"text": "new", "files": []}
+
+
+
+
+def test_draft_preflight_copy_keeps_source_until_continuation_owner_is_saved(session_env):
+    from api import models
+
+    old_sid = "draft-preflight-old"
+    new_sid = "draft-preflight-new"
+    draft = {"text": "do not orphan", "files": []}
+    models.write_composer_draft_sidecar(old_sid, draft)
+
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid, finalize_source=False) is True
+    assert models.read_composer_draft_sidecar(old_sid) == draft
+    assert models.read_composer_draft_sidecar(new_sid) == draft
+
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid) is True
+    assert models.read_composer_draft_sidecar(old_sid) is None
+
+
+def test_draft_migration_rolls_back_new_sidecar_when_source_delete_fails(session_env, monkeypatch):
+    from api import models
+
+    old_sid = "draft-rollback-old"
+    new_sid = "draft-rollback-new"
+    draft = {"text": "keep old ownership", "files": []}
+    models.write_composer_draft_sidecar(old_sid, draft)
+    real_delete = models.delete_composer_draft_sidecar
+
+    def fail_only_source_delete(sid):
+        return False if sid == old_sid else real_delete(sid)
+
+    monkeypatch.setattr(models, "delete_composer_draft_sidecar", fail_only_source_delete)
+
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid) is False
+    assert models.read_composer_draft_sidecar(old_sid) == draft
+    assert models.read_composer_draft_sidecar(new_sid) is None
+
+
+
+def test_draft_migration_refreshes_stale_destination_after_failed_rollback(session_env, monkeypatch):
+    from api import models
+    import os
+
+    old_sid = "draft-stale-source"
+    new_sid = "draft-stale-destination"
+    models.write_composer_draft_sidecar(old_sid, {"text": "first", "files": []})
+    original_delete = models.delete_composer_draft_sidecar
+
+    monkeypatch.setattr(models, "delete_composer_draft_sidecar", lambda _sid: False)
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid) is False
+    old_path = models.composer_draft_sidecar_path(old_sid)
+    new_path = models.composer_draft_sidecar_path(new_sid)
+    assert old_path is not None and new_path is not None
+    models.write_composer_draft_sidecar(old_sid, {"text": "newest", "files": []})
+    newer_ns = max(old_path.stat().st_mtime_ns, new_path.stat().st_mtime_ns + 1)
+    os.utime(old_path, ns=(newer_ns, newer_ns))
+
+    monkeypatch.setattr(models, "delete_composer_draft_sidecar", original_delete)
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid) is True
+    assert models.read_composer_draft_sidecar(new_sid) == {"text": "newest", "files": []}
+    assert models.read_composer_draft_sidecar(old_sid) is None
+
+
+def test_draft_migration_fails_closed_when_old_sidecar_is_unreadable(session_env):
+    from api import models
+
+    old_sid = "draft-corrupt-source"
+    new_sid = "draft-corrupt-destination"
+    old_path = models.composer_draft_sidecar_path(old_sid)
+    old_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.write_text("{not json", encoding="utf-8")
+
+    assert models.migrate_composer_draft_sidecar(old_sid, new_sid) is False
+    assert old_path.exists()
+    assert models.composer_draft_sidecar_path(new_sid).exists() is False
 
 
 def test_clear_is_canonical_durable_and_does_not_clobber_newer_draft(session_env, monkeypatch):

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -261,6 +261,107 @@ def test_clear_is_canonical_durable_and_does_not_clobber_newer_draft(session_env
     assert models.read_composer_draft_sidecar(sid) == newer
 
 
+def test_clear_returns_error_when_authoritative_draft_sidecar_cannot_be_removed(
+    session_env, monkeypatch
+):
+    from api import models, routes
+
+    _session_dir, _sessions = session_env
+    sid = "draft-clear-unlink-failure"
+    old_draft = {"text": "must not be falsely cleared", "files": []}
+    session = models.Session(session_id=sid, title="Clear unlink failure")
+    session.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, old_draft)
+
+    monkeypatch.setattr(routes, "delete_composer_draft_sidecar", lambda _sid: False)
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "clear": True, "expected": old_draft},
+    )
+
+    assert response["status"] == 500
+    assert "clear" in response["payload"]["error"].lower()
+    assert models.read_composer_draft_sidecar(sid) == old_draft
+    # A failed clear must retain a durable legacy fallback as well as the
+    # authoritative sidecar; a later sidecar loss must not discard the draft.
+    assert models.Session.load(sid).composer_draft == old_draft
+
+
+def test_clear_preserves_fallback_when_empty_legacy_save_fails(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    sid = "draft-clear-empty-save-failure"
+    old_draft = {"text": "must survive empty save failure", "files": []}
+    session = models.Session(session_id=sid, title="Clear empty save failure")
+    session.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, old_draft)
+    real_save = models.Session.save
+
+    def fail_only_empty_draft_save(self, *args, **kwargs):
+        if self.session_id == sid and self.composer_draft == {"text": "", "files": []}:
+            raise OSError("simulated empty legacy draft save failure")
+        return real_save(self, *args, **kwargs)
+
+    monkeypatch.setattr(models.Session, "save", fail_only_empty_draft_save)
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "clear": True, "expected": old_draft},
+    )
+
+    assert response["status"] == 500
+    assert "clear" in response["payload"]["error"].lower()
+    # The sidecar was removed, so the pre-unlink legacy checkpoint is now the
+    # only durable copy and must restore the submitted draft.
+    assert models.read_composer_draft_sidecar(sid) is None
+    assert models.Session.load(sid).composer_draft == old_draft
+
+
+def test_clear_skips_index_write_to_keep_checkpoint_and_final_save_durable(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    sid = "draft-clear-index-failure"
+    old_draft = {"text": "must not depend on index write", "files": []}
+    session = models.Session(session_id=sid, title="Clear index failure")
+    session.save(skip_index=True)
+    models.write_composer_draft_sidecar(sid, old_draft)
+
+    def fail_index_write(*_args, **_kwargs):
+        raise OSError("simulated session index write failure")
+
+    monkeypatch.setattr(models, "_write_session_index", fail_index_write)
+    response = _post_draft(
+        monkeypatch,
+        {"session_id": sid, "clear": True, "expected": old_draft},
+    )
+
+    assert response["status"] == 200
+    assert models.read_composer_draft_sidecar(sid) is None
+    assert models.Session.load(sid).composer_draft == {"text": "", "files": []}
+
+
+def test_delete_draft_sidecar_reports_unlink_failure(session_env, monkeypatch):
+    from api import models
+
+    _session_dir, _sessions = session_env
+    sid = "draft-sidecar-unlink-failure"
+    models.write_composer_draft_sidecar(sid, {"text": "preserve me", "files": []})
+    sidecar_path = models.composer_draft_sidecar_path(sid)
+    assert sidecar_path is not None
+    original_unlink = type(sidecar_path).unlink
+
+    def fail_sidecar_unlink(path, *args, **kwargs):
+        if path == sidecar_path:
+            raise OSError("simulated draft-sidecar unlink failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(sidecar_path), "unlink", fail_sidecar_unlink)
+
+    assert models.delete_composer_draft_sidecar(sid) is False
+    assert sidecar_path.exists()
+
+
 def test_clear_canonicalizes_legacy_draft_without_files(session_env, monkeypatch):
     from api import models
 

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -31,10 +31,8 @@ def session_env(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "_evict_session_agent", lambda _sid: None, raising=False)
     monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
     models._DRAFT_SIDECAR_CACHE.clear()
-    models._COMPOSER_DRAFT_LOCKS.clear()
     yield session_dir, sessions
     models._DRAFT_SIDECAR_CACHE.clear()
-    models._COMPOSER_DRAFT_LOCKS.clear()
 
 
 def _post_draft(monkeypatch, payload):
@@ -110,6 +108,55 @@ def test_compression_rotation_moves_draft_to_continuation_owner(session_env):
         "text": "continue after compression",
         "files": [{"name": "notes.txt"}],
     }
+
+
+
+def test_draft_migration_handles_old_and_new_ids_on_same_lock_stripe(session_env, monkeypatch):
+    from api import models
+
+    old_sid = "draft-same-stripe-old"
+    new_sid = "draft-same-stripe-new"
+    models.write_composer_draft_sidecar(old_sid, {"text": "move me", "files": []})
+    # Force the pair onto one lock. RLock makes the existing ordered nested
+    # migration protocol safe even when two ids share a stripe.
+    monkeypatch.setattr(models, "_COMPOSER_DRAFT_LOCK_STRIPES", (models.threading.RLock(),))
+
+    models.migrate_composer_draft_sidecar(old_sid, new_sid)
+
+    assert models.read_composer_draft_sidecar(old_sid) is None
+    assert models.read_composer_draft_sidecar(new_sid) == {"text": "move me", "files": []}
+
+
+
+def test_draft_migration_orders_distinct_stripes_independent_of_sid_order(session_env, monkeypatch):
+    from api import models
+
+    acquired = []
+
+    class RecordingLock:
+        def __init__(self, stripe_index):
+            self.stripe_index = stripe_index
+
+        def __enter__(self):
+            acquired.append(self.stripe_index)
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    # Invert the session-id order relative to stripe order. Both migrations must
+    # still acquire 0 then 1, preventing cross-migration lock-order inversion.
+    monkeypatch.setattr(models, "_COMPOSER_DRAFT_LOCK_STRIPES", (RecordingLock(0), RecordingLock(1)))
+    monkeypatch.setattr(
+        models,
+        "_composer_draft_lock_stripe_index",
+        lambda sid: {"draft-a": 1, "draft-b": 0}[sid],
+    )
+
+    models.migrate_composer_draft_sidecar("draft-a", "draft-b")
+    models.migrate_composer_draft_sidecar("draft-b", "draft-a")
+
+    assert acquired == [0, 1, 0, 1]
 
 
 def test_delete_race_cannot_leave_orphan_drafts(session_env, monkeypatch):
@@ -360,6 +407,24 @@ def test_delete_draft_sidecar_reports_unlink_failure(session_env, monkeypatch):
 
     assert models.delete_composer_draft_sidecar(sid) is False
     assert sidecar_path.exists()
+
+
+
+def test_cleanup_does_not_count_failed_orphan_sidecar_delete(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, sessions = session_env
+    sid = "cleanup-orphan-unlink-failure"
+    models.write_composer_draft_sidecar(sid, {"text": "orphan", "files": []})
+    sessions.pop(sid, None)
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.update(payload) or True)
+    monkeypatch.setattr(routes, "delete_composer_draft_sidecar", lambda _sid: False)
+
+    assert routes._handle_sessions_cleanup(SimpleNamespace(), {}, zero_only=False) is True
+
+    assert captured == {"ok": True, "cleaned": 0}
+    assert (session_dir / "_drafts" / f"{sid}.json").exists()
 
 
 def test_clear_canonicalizes_legacy_draft_without_files(session_env, monkeypatch):

--- a/tests/test_pr6011_draft_lifecycle.py
+++ b/tests/test_pr6011_draft_lifecycle.py
@@ -135,6 +135,74 @@ def test_delete_restores_owner_when_authoritative_draft_unlink_fails(session_env
 
 
 
+def test_delete_without_owner_or_sidecar_is_idempotent(session_env, monkeypatch):
+    """A never-persisted session has no draft state to checkpoint before delete."""
+    response = _post_session_delete(monkeypatch, "draft-delete-never-persisted")
+
+    assert response["status"] == 200
+    assert response["payload"]["ok"] is True
+
+
+
+def test_delete_retains_owner_when_backup_unlink_fails(session_env, monkeypatch):
+    from api import models
+
+    session_dir, _sessions = session_env
+    sid = "draft-delete-backup-unlink-failure"
+    owner = models.Session(session_id=sid, title="Retain after backup failure")
+    owner.save(skip_index=True)
+    owner_path = session_dir / f"{sid}.json"
+    backup_path = owner_path.with_suffix(".json.bak")
+    backup_path.write_text(owner_path.read_text(encoding="utf-8"), encoding="utf-8")
+    original_unlink = type(backup_path).unlink
+
+    def fail_backup_unlink(path, *args, **kwargs):
+        if path == backup_path:
+            raise OSError("simulated backup unlink failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(backup_path), "unlink", fail_backup_unlink)
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert owner_path.exists()
+    assert backup_path.exists()
+
+
+
+def test_deleted_session_rejects_stale_save(session_env, monkeypatch):
+    from api import models
+
+    session_dir, _sessions = session_env
+    sid = "draft-delete-stale-save"
+    owner = models.Session(session_id=sid, title="Must not resurrect")
+    owner.save(skip_index=True)
+
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 200
+    with pytest.raises(RuntimeError, match="deleted"):
+        owner.save(skip_index=True)
+    assert not (session_dir / f"{sid}.json").exists()
+
+
+
+def test_delete_restores_owner_when_tombstone_write_fails(session_env, monkeypatch):
+    from api import models, routes
+
+    session_dir, _sessions = session_env
+    sid = "draft-delete-tombstone-failure"
+    owner = models.Session(session_id=sid, title="Retain without tombstone")
+    owner.save(skip_index=True)
+    monkeypatch.setattr(routes, "_record_webui_deleted_session_tombstone", lambda _sid: False)
+
+    response = _post_session_delete(monkeypatch, sid)
+
+    assert response["status"] == 500
+    assert (session_dir / f"{sid}.json").exists()
+
+
+
 def test_delete_fsync_failure_after_sidecar_unlink_keeps_legacy_draft(session_env, monkeypatch):
     from api import models
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -369,7 +369,12 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+2400]
+    clear_idx = max(
+        routes_src.find("if parsed.path == '/api/session/clear':", delete_idx),
+        routes_src.find('if parsed.path == "/api/session/clear":', delete_idx),
+    )
+    assert clear_idx > delete_idx, "session/delete handler boundary not found"
+    delete_block = routes_src[delete_idx:clear_idx]
     assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
         "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -344,9 +344,19 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             text.find('if parsed.path == "/api/session/delete":'),
         )
         if delete_idx >= 0:
-            delete_block = text[delete_idx:delete_idx+2400]
-            assert "prune_session_from_index(sid)" in delete_block, \
-                f"{label} session/delete must prune SESSION_INDEX_FILE"
+            clear_idx = max(
+                text.find("if parsed.path == '/api/session/clear':", delete_idx),
+                text.find('if parsed.path == "/api/session/clear":', delete_idx),
+            )
+            assert clear_idx > delete_idx, f"{label} session/delete handler boundary not found"
+            delete_block = text[delete_idx:clear_idx]
+            lock_idx = delete_block.find("with get_composer_draft_lock(sid):")
+            draft_delete_idx = delete_block.find("delete_composer_draft_sidecar(sid)")
+            prune_idx = delete_block.find("prune_session_from_index(sid)")
+            assert -1 not in (lock_idx, draft_delete_idx, prune_idx), \
+                f"{label} session/delete must lock drafts, remove the sidecar, and prune SESSION_INDEX_FILE"
+            assert lock_idx < draft_delete_idx < prune_idx, \
+                f"{label} session/delete must prune only after draft-locked sidecar cleanup"
             return
     assert False, "session/delete handler not found in server.py or api/routes.py"
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -350,7 +350,7 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             )
             assert clear_idx > delete_idx, f"{label} session/delete handler boundary not found"
             delete_block = text[delete_idx:clear_idx]
-            lock_idx = delete_block.find("with get_composer_draft_lock(sid):")
+            lock_idx = delete_block.find("with get_composer_draft_lock(sid), _session_save_lock(sid):")
             draft_delete_idx = delete_block.find("delete_composer_draft_sidecar(sid)")
             prune_idx = delete_block.find("prune_session_from_index(sid)")
             assert -1 not in (lock_idx, draft_delete_idx, prune_idx), \
@@ -375,8 +375,9 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
     )
     assert clear_idx > delete_idx, "session/delete handler boundary not found"
     delete_block = routes_src[delete_idx:clear_idx]
-    assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
-        "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
+    assert "backup_path = p.with_suffix('.json.bak')" in delete_block
+    assert "backup_path.unlink()" in delete_block, \
+        "session/delete must unlink <sid>.json.bak before acknowledging deletion"
 
 # ── R9: Token/tool SSE events write to wrong session after switch ─────────────
 

--- a/tests/test_stage326_composer_draft_validation.py
+++ b/tests/test_stage326_composer_draft_validation.py
@@ -77,11 +77,13 @@ def test_draft_files_type_coerced_to_list():
 
 
 def test_draft_validation_appears_before_persist():
-    """The validation must run BEFORE the lock acquire / save, not after."""
+    """The validation must run BEFORE the sidecar persist, not after."""
     src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
     # Anchor on the unique POST-validation comment marker.
     marker_idx = src.find("Stage-326 hardening (per Opus advisor)")
-    persist_idx = src.find("s.composer_draft = next_draft\n                # Draft persistence is not conversation activity")
+    # Big-session hotpath (2026-07-13): drafts persist to a sidecar file,
+    # not via Session.save() — the persist site is the sidecar write.
+    persist_idx = src.find("saved_draft = write_composer_draft_sidecar(sid, next_draft)")
     assert marker_idx != -1 and persist_idx != -1, (
         "could not locate validation marker or persist site"
     )
@@ -96,23 +98,35 @@ def test_draft_save_does_not_touch_session_updated_at():
     If POST /api/session/draft bumps updated_at, the frontend's active-session
     external refresh poll treats every keystroke autosave as a remote session
     update and force-reloads the current chat a few seconds later.
+
+    Big-session hotpath (2026-07-13): the guarantee got stronger — the draft
+    POST must not call Session.save() AT ALL (which used to rewrite the whole
+    multi-MB session JSON per keystroke autosave). Drafts go to a tiny sidecar
+    file that touches neither the session JSON, its updated_at, nor the index.
     """
     src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    persist_idx = src.find("s.composer_draft = next_draft")
-    assert persist_idx != -1, "could not locate composer draft persist site"
-    save_idx = src.find("s.save(touch_updated_at=False, skip_index=True)", persist_idx)
-    assert save_idx != -1, "composer draft save must preserve session updated_at and skip index churn"
+    route_idx = src.find('if parsed.path == "/api/session/draft":')
+    assert route_idx != -1, "could not locate draft route"
+    end_idx = src.find('payload = {"ok": True, "draft": saved_draft}', route_idx)
+    assert end_idx != -1, "could not locate draft route response site"
+    route_body = src[route_idx:end_idx]
+    assert "write_composer_draft_sidecar" in route_body, (
+        "draft POST must persist via the sidecar store"
+    )
+    assert "s.save(" not in route_body and "s_meta.save(" not in route_body, (
+        "draft POST must never rewrite the session JSON via Session.save()"
+    )
 
 
 def test_draft_save_skips_unchanged_payload_before_persist():
-    """Duplicate debounced draft POSTs should not rewrite the full session JSON."""
+    """Duplicate debounced draft POSTs should not rewrite the draft sidecar."""
     src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    draft_idx = src.find('current_draft = dict(getattr(s, "composer_draft", {}) or {})')
-    unchanged_idx = src.find("if next_draft == current_draft", draft_idx)
-    save_idx = src.find("s.save(touch_updated_at=False, skip_index=True)", draft_idx)
+    draft_idx = src.find("sidecar_draft = read_composer_draft_sidecar(sid)")
+    unchanged_idx = src.find("if next_draft == current_draft and sidecar_draft is not None", draft_idx)
+    save_idx = src.find("saved_draft = write_composer_draft_sidecar(sid, next_draft)", draft_idx)
 
-    assert draft_idx != -1, "draft route should snapshot current composer_draft"
+    assert draft_idx != -1, "draft route should snapshot the current sidecar draft"
     assert unchanged_idx != -1, "draft route should no-op unchanged normalized payloads"
-    assert save_idx != -1, "draft route should still save changed drafts"
-    assert unchanged_idx < save_idx, "unchanged guard must run before full session save"
+    assert save_idx != -1, "draft route should still persist changed drafts"
+    assert unchanged_idx < save_idx, "unchanged guard must run before the sidecar persist"
     assert 'payload["unchanged"] = True' in src

--- a/tests/test_stage326_composer_draft_validation.py
+++ b/tests/test_stage326_composer_draft_validation.py
@@ -121,7 +121,7 @@ def test_draft_save_does_not_touch_session_updated_at():
 def test_draft_save_skips_unchanged_payload_before_persist():
     """Duplicate debounced draft POSTs should not rewrite the draft sidecar."""
     src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    draft_idx = src.find("sidecar_draft = read_composer_draft_sidecar(sid)")
+    draft_idx = src.find("sidecar_state, sidecar_draft = composer_draft_sidecar_state(sid)")
     unchanged_idx = src.find("if next_draft == current_draft and sidecar_draft is not None", draft_idx)
     save_idx = src.find("saved_draft = write_composer_draft_sidecar(sid, next_draft)", draft_idx)
 


### PR DESCRIPTION
Closes #6242

## Standalone rebase / attribution

This is a standalone `master`-based PR. It rebases and preserves the nine
commits authored by **@ai-ag2026** in #6011, then adds the draft-clear durability
fix from #6242 as the final commit. It supersedes my former stacked follow-up
at ai-ag2026/hermes-webui#1, which is closed after this PR is created.

## Problem

Large sessions are rewritten repeatedly for tiny composer-draft edits. The
underlying sidecar design prevents those multi-MiB rewrites, but clear must
remain durable across two stores: the authoritative draft sidecar and the
legacy session JSON fallback.

## What changed

- Persist composer drafts in small per-session sidecars and avoid unnecessary
  session rewrites (rebased #6011 work, commits preserved with original author).
- Preserve drafts across session lifecycle, recovery, deletion, compression, and
  no-op save paths.
- Make authoritative sidecar deletion report success/failure.
- Use a fail-closed clear protocol:
  1. checkpoint the current draft into legacy session JSON;
  2. remove the authoritative sidecar;
  3. persist the canonical empty legacy draft.
- Clear-specific session writes use `skip_index=True`: draft persistence does
  not change sidebar/index metadata, avoiding an unnecessary index write and a
  post-session-write failure source.

## Durability contract

A `200` clear response is returned only after the sidecar is absent and the
canonical empty legacy draft is durable. If checkpointing, unlinking, or final
persistence fails, the endpoint returns `500` without falsely reporting that a
draft was cleared. A durable pre-clear fallback survives a final-save failure.

## Verification

- Rebased all commits cleanly from #6011's previous base onto current upstream
  `master` (`d195b094`).
- Focused composer-draft/session regression suite: **59 passed**.
- `python -m py_compile api/models.py api/routes.py api/streaming.py tests/test_pr6011_draft_lifecycle.py`
- `python scripts/ruff_lint.py --diff origin/master`: **0 new violations**.
- `git diff --check origin/master...HEAD`: clean.

## Explicit regressions

The suite covers:

- sidecar unlink failure retains an authoritative and legacy fallback copy;
- final empty legacy-save failure still restores the original draft after the
  sidecar has been removed;
- forced session-index write failure cannot affect clear durability because
  clear-specific saves skip index writes;
- stale client clear requests do not clobber newer drafts;
- first non-empty drafts, session rotation, deletion races, and zero-message
  cleanup retain valid draft owners.

## Scope / release note

Avoid multi-MiB session rewrites for normal composer draft edits and prevent
false-success or data-loss paths when clearing drafts.

## Model Used

OpenAI `gpt-5.6-terra` via Hermes Agent. Work used isolated worktrees, rebase
verification, focused regression tests, py-compile, and diff linting.
