### PR TITLE
Release: intercept /sessions and /resume slash commands (#6245, @webtecnica)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- **`/sessions` and `/resume` typed in the composer now open the session browser instead of being sent as chat text.** Both commands appeared in the slash-command autocomplete (they're exposed by `/api/commands`) but the WebUI send-time dispatch didn't handle them, so they were posted to the agent as plain text. They now open the native WebUI session browser and clear the composer — on desktop and (via the mobile-aware opener) on phone-width layouts. Thanks @webtecnica. (#6245, #6224)
+
 - **Z.AI GLM models now advertise the correct reasoning controls per version.** The WebUI offered the full `reasoning_effort` ladder (max/xhigh/high/medium/low/minimal) for every GLM model, but per Z.AI's API only GLM-5.2+ supports the effort ladder — GLM-4.5 through 5.1 support the binary `thinking` on/off toggle, and GLM-4.7 forces thinking on (not configurable). Reasoning controls are now gated correctly: GLM-5.2+ keeps the full ladder + None, GLM-4.5/4.6/5.0/5.1 get a two-way On/None thinking toggle (no effort levels), and GLM-4.7 shows forced thinking with no toggle. All three surfaces (config status, effort resolution, composer chip) agree across model tiers, provider aliases, and namespaces. Thanks @rh-id. (#6219)
 
 - **Folder downloads now work when the WebUI is served under a subpath.** The file-tree "Download" context-menu action built an absolute `/api/folder/download?...` URL, which broke behind a reverse proxy that mounts the app under a base path (e.g. `/hermes/`). It now resolves the download URL against `document.baseURI` (matching the pattern the other subpath-aware download paths already use), so it works under any base path and is unchanged on root deployments. Thanks @steezypunk. (#6227)

--- a/static/messages.js
+++ b/static/messages.js
@@ -1465,6 +1465,12 @@ async function send(){
         renderMessages();
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }
+      if(_parsedCmd.name==='sessions' || _parsedCmd.name==='resume'){
+        // Open the native WebUI session browser rather than sending as chat text (#6224)
+        if(typeof expandSidebar==='function') expandSidebar();
+        if(typeof renderSessionList==='function') await renderSessionList();
+        $('msg').value='';autoResize();hideCmdDropdown();return;
+      }
       const _agentCmd=typeof getAgentCommandMetadata==='function'
         ? await getAgentCommandMetadata(_parsedCmd.name)
         : null;

--- a/static/messages.js
+++ b/static/messages.js
@@ -1466,8 +1466,11 @@ async function send(){
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }
       if(_parsedCmd.name==='sessions' || _parsedCmd.name==='resume'){
-        // Open the native WebUI session browser rather than sending as chat text (#6224)
-        if(typeof expandSidebar==='function') expandSidebar();
+        // Open the native WebUI session browser rather than sending as chat text (#6224).
+        // Use the mobile-aware opener so phone-width layouts (where expandSidebar is a
+        // no-op) actually reveal the session drawer.
+        if(typeof _openProfileSwitchSessionBrowser==='function') _openProfileSwitchSessionBrowser();
+        else if(typeof expandSidebar==='function') expandSidebar();
         if(typeof renderSessionList==='function') await renderSessionList();
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }


### PR DESCRIPTION
## Release: intercept /sessions and /resume slash commands (#6245, @webtecnica)

Ships @webtecnica's fix so `/sessions` and `/resume` open the session browser instead of being sent as chat text, gated + hardened for mobile.

### What ships
Both commands appeared in the slash-command autocomplete (exposed by `/api/commands`) but the WebUI send-time dispatch didn't handle them, so they were posted to the agent as plain text. They now open the native WebUI session browser and clear the composer.

### Gate + maintainer fix
Codex verified no agent-side behavior is lost (unmatched slash text goes to `run_conversation`), built-in/CLI/plugin command precedence is intact, and args-ignored (`/resume <id>`) is a noted limitation (WebUI never executed those handlers before), NOT a regression — 34/34 slash tests pass. **One SILENT mobile bug found + fixed (maintainer follow-up, co-authored to @webtecnica):** the intercept called `expandSidebar()` directly, which is a no-op on phone-width layouts, so `/sessions`/`/resume` silently did nothing on mobile. Now uses the mobile-aware `_openProfileSwitchSessionBrowser()` with an `expandSidebar()` fallback.

### Verification
- **Codex adversarial: SAFE (with the mobile fix applied)** — dispatch paths reproduced (bare + args, /pet, CLI-only, agent-runtime, plugin).
- **Full pytest suite: 13,363 passed** (sole failure = known editable-install box artifact); 323 slash/command/send tests pass on the fixed code.

Closes #6245

Credit: @webtecnica.
