### PR TITLE
fix(stream): preserve prose fade nodes to prevent scroll bounce

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4586,7 +4586,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     el.addEventListener('animationend',e=>{
       const span=e.target;
       if(!span||!span.classList||!span.classList.contains('stream-fade-word')) return;
-      span.replaceWith(document.createTextNode(span.textContent||''));
+      // Keep the animated inline node stable for the lifetime of the live turn.
+      // Replacing each word with a fresh text node makes native scroll anchoring
+      // choose a new anchor while the transcript is still growing, producing a
+      // visible vertical bounce. Final settlement rebuilds plain persisted DOM.
+      span.classList.remove('is-new');
+      if(span.style) span.style.removeProperty('--stream-fade-ms');
     });
   }
   function _streamFadeRenderer(el){

--- a/static/ui.js
+++ b/static/ui.js
@@ -13398,7 +13398,13 @@ function _bindTransparentFadeCleanup(body){
   body.addEventListener('animationend', e=>{
     const span = e.target;
     if(!span || !span.classList || !span.classList.contains('stream-fade-word')) return;
-    span.replaceWith(document.createTextNode(span.textContent || ''));
+    // Keep the animated inline node stable for the lifetime of the live turn,
+    // exactly like _streamFadeBindCleanup() in messages.js. Replacing each word
+    // with a fresh text node makes native scroll anchoring choose a new anchor
+    // while the transparent prose row is still growing, producing a visible
+    // vertical bounce. Final settlement rebuilds plain persisted DOM.
+    span.classList.remove('is-new');
+    if(span.style) span.style.removeProperty('--stream-fade-ms');
   });
 }
 

--- a/tests/test_smooth_text_fade.py
+++ b/tests/test_smooth_text_fade.py
@@ -8,6 +8,7 @@ CONFIG_PY = (REPO / "api" / "config.py").read_text(encoding="utf-8")
 INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 I18N_JS = (REPO / "static" / "i18n.js").read_text(encoding="utf-8")
@@ -389,6 +390,61 @@ if(span.replacements!==0) throw new Error('fade cleanup replaced the active scro
 if(span.classList.contains('is-new')) throw new Error('fade animation class was not cleared');
 if(!span.classList.contains('stream-fade-word')) throw new Error('stable fade node lost its identity');
 if(span.style.removed.join('|')!=='--stream-fade-ms') throw new Error('fade timing override was not cleared');
+"""
+    run_node(script)
+
+
+def test_transparent_fade_cleanup_preserves_the_animated_node_as_the_scroll_anchor():
+    """The transparent-activity fade path must share the messages.js cleanup.
+
+    `_bindTransparentFadeCleanup()` in ui.js is the visible transparent_stream
+    sibling of `_streamFadeBindCleanup()` in messages.js.  It used to replace
+    every animated word span with a fresh text node on animationend, which made
+    native scroll anchoring pick a new anchor while the transparent prose row
+    was still growing.  Both live prose paths must keep the node stable: only
+    the transient `is-new` class and the `--stream-fade-ms` timing override are
+    removed; final settlement rebuilds the persisted DOM as plain text.
+    """
+    cleanup = function_block(UI_JS, "_bindTransparentFadeCleanup")
+    assert_contains_all(
+        cleanup,
+        [
+            "animationend",
+            "span.classList.remove('is-new')",
+            "span.style.removeProperty('--stream-fade-ms')",
+        ],
+    )
+    assert "span.replaceWith" not in cleanup
+    script = r"""
+class FakeClassList {
+  constructor(names){ this.names=new Set(names); }
+  contains(name){ return this.names.has(name); }
+  remove(name){ this.names.delete(name); }
+}
+const listeners={};
+const document={createTextNode(text){ return {textContent:String(text)}; }};
+const body={
+  _transparentFadeCleanupBound:false,
+  addEventListener(name,fn){ listeners[name]=fn; },
+};
+""" + cleanup + r"""
+_bindTransparentFadeCleanup(body);
+if(body._transparentFadeCleanupBound!==true) throw new Error('transparent fade cleanup was not bound');
+const span={
+  textContent:'stable anchor',
+  classList:new FakeClassList(['stream-fade-word','is-new']),
+  style:{
+    removed:[],
+    removeProperty(name){ this.removed.push(name); },
+  },
+  replacements:0,
+  replaceWith(){ this.replacements += 1; },
+};
+listeners.animationend({target:span});
+if(span.replacements!==0) throw new Error('transparent fade cleanup replaced the active scroll-anchor node');
+if(span.classList.contains('is-new')) throw new Error('transparent fade animation class was not cleared');
+if(!span.classList.contains('stream-fade-word')) throw new Error('stable transparent fade node lost its identity');
+if(span.style.removed.join('|')!=='--stream-fade-ms') throw new Error('transparent fade timing override was not cleared');
 """
     run_node(script)
 

--- a/tests/test_smooth_text_fade.py
+++ b/tests/test_smooth_text_fade.py
@@ -224,8 +224,9 @@ def test_stream_fade_uses_incremental_renderer_without_changing_default_path():
     )
     assert_contains_all(
         cleanup_block,
-        ["animationend", "span.replaceWith(document.createTextNode"],
+        ["animationend", "span.classList.remove('is-new')"],
     )
+    assert "span.replaceWith" not in cleanup_block
     assert "_wrapStreamingFadeWords" not in MESSAGES_JS
     assert "animationDelay" not in renderer_block
     assert "_STREAM_FADE_STAGGER_MS" not in MESSAGES_JS
@@ -347,6 +348,48 @@ window._fadeTextEffect=true;
 if(!_shouldUseLiveProseFade()) throw new Error('regular fade preference should work when motion is allowed');
 """
     )
+    run_node(script)
+
+
+def test_fade_cleanup_preserves_the_animated_node_as_the_scroll_anchor():
+    """Animation cleanup must not replace inline nodes during a live stream.
+
+    Replacing every word node on animationend makes the browser choose a new
+    native scroll anchor while the transcript is still growing.  The opacity
+    animation can finish by removing its transient class; final settlement will
+    rebuild the persisted answer as plain text.
+    """
+    cleanup = function_block(MESSAGES_JS, "_streamFadeBindCleanup")
+    script = r"""
+class FakeClassList {
+  constructor(names){ this.names=new Set(names); }
+  contains(name){ return this.names.has(name); }
+  remove(name){ this.names.delete(name); }
+}
+const listeners={};
+const document={createTextNode(text){ return {textContent:String(text)}; }};
+const body={
+  _streamFadeCleanupBound:false,
+  addEventListener(name,fn){ listeners[name]=fn; },
+};
+""" + cleanup + r"""
+_streamFadeBindCleanup(body);
+const span={
+  textContent:'stable anchor',
+  classList:new FakeClassList(['stream-fade-word','is-new']),
+  style:{
+    removed:[],
+    removeProperty(name){ this.removed.push(name); },
+  },
+  replacements:0,
+  replaceWith(){ this.replacements += 1; },
+};
+listeners.animationend({target:span});
+if(span.replacements!==0) throw new Error('fade cleanup replaced the active scroll-anchor node');
+if(span.classList.contains('is-new')) throw new Error('fade animation class was not cleared');
+if(!span.classList.contains('stream-fade-word')) throw new Error('stable fade node lost its identity');
+if(span.style.removed.join('|')!=='--stream-fade-ms') throw new Error('fade timing override was not cleared');
+"""
     run_node(script)
 
 


### PR DESCRIPTION
## Summary

- preserve each `.stream-fade-word` node after its opacity animation finishes
- clear only the transient `is-new` class and per-word timing override
- keep Transparent Stream's prose fade introduced for #5493 while avoiding repeated live DOM replacement
- add a behavioral regression test that verifies animation cleanup preserves the active node identity

## Problem

Transparent Stream intentionally wraps incoming prose words in temporary spans to provide the prose fade restored by #5493. The `animationend` handler currently replaces every finished span with a fresh text node while the response is still growing.

Those repeated node replacements can make the browser select a new native scroll anchor. During a long streamed conclusion this presents as a visible vertical bounce, even though the opacity animation itself does not change layout.

## Fix

Keep the inline span stable for the lifetime of the live assistant turn. When its animation ends, remove `is-new` and the temporary `--stream-fade-ms` override instead of replacing the node. Final stream settlement already rebuilds the persisted response DOM, so completed messages still normalize without carrying live animation state.

This does not change the fade policy, disable Transparent Stream animation, or modify the existing pinned-tail and unpinned-reader scroll protections.

## Validation

- `node --check static/messages.js`
- `./scripts/test.sh tests/test_smooth_text_fade.py tests/test_issue5367_transparent_live_row_reconcile.py tests/test_issue3877_midstream_flicker.py tests/test_pinned_tail_midstream_jitter.py tests/test_issue3479_ios_stream_scroll_jump.py tests/test_live_to_final_anchor_visible_order.py tests/test_markdown_table_cell_spacing.py -q`
  - `109 passed`
- Browser run with Transparent Stream and prose fade enabled:
  - 1,960-character streamed conclusion plus an 8x4 Markdown table
  - 942 active animation frames sampled
  - 419 fade spans observed; up to 39 actively animating
  - one stable prose row and body node throughout the stream
  - 0 negative scroll movements
  - final heading and Markdown table rendered correctly
  - 0 JavaScript console errors

## Scope

Two files only:

- `static/messages.js`
- `tests/test_smooth_text_fade.py`
