### PR TITLE
fix(transparent-stream): remove dead rowIndex param from pushRow (#6189 follow-up)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3586,7 +3586,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(idx>lastProjectedToolIndex&&row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')) finalSegmentLiveProseRows.add(row);
     });
     const rowIsLiveTokenFinalPrefix=(row,textKey,finalSegmentEligible)=>finalSegmentEligible&&row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
-    const pushRow=(row,rowIndex)=>{
+    const pushRow=(row)=>{
       if(!row||typeof row!=='object') return;
       const finalSegmentEligible=finalSegmentLiveProseRows.has(row);
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
@@ -3607,7 +3607,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         seq:rows.length,
       });
     };
-    orderedRows.forEach((row,idx)=>pushRow(row,idx));
+    orderedRows.forEach((row)=>pushRow(row));
     const scene={
       ...base,
       version:'activity_scene_v1',

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -931,7 +931,7 @@ def test_settled_anchor_scene_preserves_live_projected_order_before_backfill():
     projected_push_idx = complete.index("orderedRows.push(row);", ordered_idx)
     backfill_idx = complete.index("for(let idx=turnStart+1;idx<=lastAsstIndex;idx+=1)", projected_push_idx)
     terminal_idx = complete.index("if(row&&row.role==='terminal') orderedRows.push(row);", backfill_idx)
-    replay_idx = complete.index("orderedRows.forEach((row,idx)=>pushRow(row,idx));", terminal_idx)
+    replay_idx = complete.index("orderedRows.forEach((row)=>pushRow(row));", terminal_idx)
     assert projected_idx < ordered_idx < projected_push_idx < backfill_idx < terminal_idx < replay_idx
 
     assert "const seenTextKeys=[];" in complete


### PR DESCRIPTION
## Summary

Follow-up to #6217 (which shipped the fix from #6189): removes the dead `rowIndex` parameter from the `pushRow` closure inside `_completeSettledAnchorSceneForTurn`.

In #6189/#6217 the final-segment eligibility was migrated from an index comparison (`rowIndex > lastNonTerminalWorkRowIndex`) to a `WeakSet` lookup (`finalSegmentLiveProseRows.has(row)`). The `rowIndex` parameter on `pushRow` became dead code — it's declared but never read. The call-site at `orderedRows.forEach((row,idx)=>pushRow(row,idx))` still passes `idx`, which is harmless but adds noise.

This addresses the [greptile review feedback](https://github.com/nesquena/hermes-webui/pull/6189#discussion_r3604203897) on the original PR.

## Changes

- **`static/messages.js`**: Remove `rowIndex` from `pushRow` signature, simplify call-site to `orderedRows.forEach((row)=>pushRow(row))`
- **`tests/test_live_to_final_anchor_visible_order.py`**: Update assertion that checks the call-site string to match new shape

## Verification

- All 81 tests in the transparent-stream prefix-dedupe, anchor-scene client, live-to-final visible order, and live-row reconcile suites pass.
- No other test files reference the old `pushRow(row,idx)` pattern.

Closes #6189