### PR TITLE
perf: keep WebUI reconnect responsive for large active sessions (#6241)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8522,6 +8522,10 @@ def _parse_msg_limit(raw):
     return max(1, min(value, _MAX_MSG_LIMIT))
 
 
+# If a sidecar JSON file exceeds this threshold, the display-path tail
+# optimization fires regardless of message count.  Sessions with few messages
+# but large tool outputs (multi-MB JSON) should not force a full-scan merge.
+_SIDECAR_BYTE_TAIL_THRESHOLD = 500_000  # 500 KB
 # Defensive row backstop for the GET /api/session display path's state.db read.
 # This is NOT a semantic window (the display window counts visible rows
 # post-reconciliation via _message_window_for_display); it is a safety net so a
@@ -8641,6 +8645,16 @@ def _limited_webui_messages_for_display_with_sidecar(session, sidecar_messages, 
     )
 
 
+def _sidecar_file_exceeds_threshold(session_id, threshold_bytes) -> bool:
+    """Check if the sidecar JSON file for ``session_id`` exceeds ``threshold_bytes``."""
+    from api.config import SESSION_DIR
+    try:
+        p = SESSION_DIR / f"{session_id}.json"
+        return os.path.isfile(p) and os.path.getsize(p) > threshold_bytes
+    except Exception:
+        return False
+
+
 def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before=None):
     """Return (timestamp floor, sidecar messages) for bounded state.db tail reads.
 
@@ -8671,7 +8685,9 @@ def _state_db_since_timestamp_for_limited_display(session, msg_limit, msg_before
         return None, sidecar_messages
     raw_budget = max(300, limit * 10)
     if len(sidecar_messages) <= raw_budget:
-        return None, sidecar_messages
+        _sid = getattr(session, "session_id", "") or ""
+        if not _sid or not _sidecar_file_exceeds_threshold(_sid, _SIDECAR_BYTE_TAIL_THRESHOLD):
+            return None, sidecar_messages
 
     floor = min(sidecar_timestamps[-raw_budget:])
     sidecar_before_count = sum(1 for ts in sidecar_timestamps if ts < floor)


### PR DESCRIPTION
## Problem

Reopening a WebUI tab after a large active session with many tool calls is slow — bootstrap requests can take tens of seconds. The root cause is that the display-path tail optimization in `_state_db_since_timestamp_for_limited_display` only fires based on message count (`len(sidecar_messages) <= raw_budget`). Sessions with few messages but large tool outputs (multi-MB JSON per message) skip the optimization entirely, forcing a full-scan state.db merge on every reconnect.

## Fix

Added a secondary file-size threshold trigger: when the sidecar JSON file exceeds **500 KB**, the tail optimization fires regardless of message count, bounding the state.db query to only recent rows.

### Changes

- `_sidecar_file_exceeds_threshold(session_id, threshold_bytes)` — checks sidecar file size without loading it
- `_SIDECAR_BYTE_TAIL_THRESHOLD = 500_000` — 500 KB threshold
- Modified the guard in `_state_db_since_timestamp_for_limited_display` to check file size when message count is within budget

`+17/-1` in `api/routes.py`

Closes #6241