### PR TITLE
Release: remove dead rowIndex param from settled-scene pushRow (#6258, @webtecnica)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Changed
 
+- **Internal: removed a dead `rowIndex` parameter from the settled-scene row projector.** `attachLiveStream`'s `pushRow` helper carried an unused positional index left over from before final-segment eligibility moved to a row-identity `WeakSet`; dropping it is a pure no-op refactor (differential execution confirms byte-identical settled scenes — ordering, dedupe, final-prefix suppression, and sequence assignment all unchanged). Thanks @webtecnica. (#6258)
+
 - **Docs: reconciled the assistant-reply lifecycle RFCs/contracts with shipped behavior.** The Stable Assistant Turn Anchors and Live-to-Final RFCs, `docs/CONTRACTS.md`, and the Phase 0 architecture inventory were updated from "proposed/scaffold" framing to "accepted/implemented" to match what actually ships (single assistant-turn owner projecting one `activity_scene_v1` into Compact Worklog / Transparent Stream / Final answer). Documentation-only — no runtime behavior or CI-gate change; the one code touch is a corrected comment header in `static/assistant_turn_anchors.js`. Remaining hardening stays tracked under #3400. Thanks @franksong2702. (#6144)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -3586,7 +3586,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(idx>lastProjectedToolIndex&&row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')) finalSegmentLiveProseRows.add(row);
     });
     const rowIsLiveTokenFinalPrefix=(row,textKey,finalSegmentEligible)=>finalSegmentEligible&&row&&row.role==='prose'&&row.kind==='process_prose'&&String(row.source_event_type||'')==='token'&&String(row.local_id||'').startsWith('live-prose:')&&textKey&&finalKey&&textKey.length<finalKey.length&&finalKey.startsWith(textKey);
-    const pushRow=(row,rowIndex)=>{
+    const pushRow=(row)=>{
       if(!row||typeof row!=='object') return;
       const finalSegmentEligible=finalSegmentLiveProseRows.has(row);
       row=_anchorSceneSettleLiveRunningRow(row,hasSettledThinking);
@@ -3607,7 +3607,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         seq:rows.length,
       });
     };
-    orderedRows.forEach((row,idx)=>pushRow(row,idx));
+    orderedRows.forEach((row)=>pushRow(row));
     const scene={
       ...base,
       version:'activity_scene_v1',

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -931,7 +931,7 @@ def test_settled_anchor_scene_preserves_live_projected_order_before_backfill():
     projected_push_idx = complete.index("orderedRows.push(row);", ordered_idx)
     backfill_idx = complete.index("for(let idx=turnStart+1;idx<=lastAsstIndex;idx+=1)", projected_push_idx)
     terminal_idx = complete.index("if(row&&row.role==='terminal') orderedRows.push(row);", backfill_idx)
-    replay_idx = complete.index("orderedRows.forEach((row,idx)=>pushRow(row,idx));", terminal_idx)
+    replay_idx = complete.index("orderedRows.forEach((row)=>pushRow(row));", terminal_idx)
     assert projected_idx < ordered_idx < projected_push_idx < backfill_idx < terminal_idx < replay_idx
 
     assert "const seenTextKeys=[];" in complete


### PR DESCRIPTION
## Release: remove dead rowIndex param from settled-scene pushRow (#6258, @webtecnica)

Ships @webtecnica's dead-code cleanup, gated with a differential-execution proof.

### What ships
`attachLiveStream`'s `pushRow` helper carried an unused positional `rowIndex` parameter, left over from before final-segment eligibility moved to a row-identity `WeakSet`. Removed the param and its pass-through at the single call site.

### Verification
- **Codex adversarial: SAFE TO SHIP** — the removed param was never read; final-segment eligibility uses `finalSegmentLiveProseRows.has(row)` (WeakSet by identity), `order_index`/`seq` derive from `rows.length`. **Differential execution of the actual old/new extracted settlement functions produced identical scenes** (ordering, dedupe, final-prefix suppression, sequence assignment all unchanged). One definition + one call site.
- **Activity-stream regression gate: all layers pass.**
- **Full pytest suite: 13,364 passed** (sole failure = known editable-install box artifact); 63 focused live-to-final tests pass.

Closes #6258

Credit: @webtecnica.
