### PR TITLE
fix(stream): preserve prose fade nodes to prevent scroll bounce

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4262,7 +4262,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     el.addEventListener('animationend',e=>{
       const span=e.target;
       if(!span||!span.classList||!span.classList.contains('stream-fade-word')) return;
-      span.replaceWith(document.createTextNode(span.textContent||''));
+      // Keep the animated inline node stable for the lifetime of the live turn.
+      // Replacing each word with a fresh text node makes native scroll anchoring
+      // choose a new anchor while the transcript is still growing, producing a
+      // visible vertical bounce. Final settlement rebuilds plain persisted DOM.
+      span.classList.remove('is-new');
+      if(span.style) span.style.removeProperty('--stream-fade-ms');
     });
   }
   function _streamFadeRenderer(el){

--- a/static/ui.js
+++ b/static/ui.js
@@ -12906,7 +12906,12 @@ function _bindTransparentFadeCleanup(body){
   body.addEventListener('animationend', e=>{
     const span = e.target;
     if(!span || !span.classList || !span.classList.contains('stream-fade-word')) return;
-    span.replaceWith(document.createTextNode(span.textContent || ''));
+    // Keep the animated inline node stable for the lifetime of the live turn.
+    // Replacing each word with a fresh text node makes native scroll anchoring
+    // choose a new anchor while the transcript is still growing, producing a
+    // visible vertical bounce. Final settlement rebuilds plain persisted DOM.
+    span.classList.remove('is-new');
+    if(span.style) span.style.removeProperty('--stream-fade-ms');
   });
 }
 

--- a/tests/test_issue5367_transparent_live_row_reconcile.py
+++ b/tests/test_issue5367_transparent_live_row_reconcile.py
@@ -1666,6 +1666,67 @@ global._anchorSceneTransparentNodeForRow = (row) => makeToolRow(row.version);
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_transparent_fade_cleanup_preserves_the_animated_node_as_the_scroll_anchor():
+    """Animation cleanup in transparent-activity path must not replace inline nodes.
+
+    The _bindTransparentFadeCleanup handler fires on animationend for every
+    .stream-fade-word.is-new span inside a transparent-activity prose row.
+    Replacing each word with a fresh text node makes native scroll anchoring
+    choose a new anchor while the transcript is still growing.  The cleanup
+    must keep the span identity, remove is-new, and clear --stream-fade-ms.
+    """
+    script = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.env.UI_JS_PATH, 'utf8');
+function extractFunc(name){
+  const marker = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(marker);
+  if(start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start) + 1;
+  let depth = 1;
+  while(depth > 0 && i < src.length){
+    if(src[i] === '{') depth += 1;
+    else if(src[i] === '}') depth -= 1;
+    i += 1;
+  }
+  return src.slice(start, i);
+}
+const cleanup = extractFunc('_bindTransparentFadeCleanup');
+class FakeClassList {
+  constructor(names){ this.names=new Set(names); }
+  contains(name){ return this.names.has(name); }
+  remove(name){ this.names.delete(name); }
+}
+const listeners={};
+const document={createTextNode(text){ return {textContent:String(text)}; }};
+const body={
+  _transparentFadeCleanupBound:false,
+  addEventListener(name,fn){ listeners[name]=fn; },
+};
+eval(cleanup);
+_bindTransparentFadeCleanup(body);
+const span={
+  textContent:'stable anchor',
+  classList:new FakeClassList(['stream-fade-word','is-new']),
+  style:{
+    removed:[],
+    removeProperty(name){ this.removed.push(name); },
+  },
+  replacements:0,
+  replaceWith(){ this.replacements += 1; },
+};
+listeners.animationend({target:span});
+if(span.replacements!==0) throw new Error('fade cleanup replaced the active scroll-anchor node');
+if(span.classList.contains('is-new')) throw new Error('fade animation class was not cleared');
+if(!span.classList.contains('stream-fade-word')) throw new Error('stable fade node lost its identity');
+if(span.style.removed.join('|')!=='--stream-fade-ms') throw new Error('fade timing override was not cleared');
+process.stdout.write(JSON.stringify({passed:true}));
+"""
+    data = _run_node_script(script, str(ROOT / "static" / "ui.js"))
+    assert data["passed"] is True
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_transparent_live_thinking_refresh_preserves_scroll_container():
     script = """
 const fs = require('fs');

--- a/tests/test_smooth_text_fade.py
+++ b/tests/test_smooth_text_fade.py
@@ -203,8 +203,9 @@ def test_stream_fade_uses_incremental_renderer_without_changing_default_path():
     )
     assert_contains_all(
         cleanup_block,
-        ["animationend", "span.replaceWith(document.createTextNode"],
+        ["animationend", "span.classList.remove('is-new')"],
     )
+    assert "span.replaceWith" not in cleanup_block
     assert "_wrapStreamingFadeWords" not in MESSAGES_JS
     assert "animationDelay" not in renderer_block
     assert "_STREAM_FADE_STAGGER_MS" not in MESSAGES_JS
@@ -325,6 +326,48 @@ window._fadeTextEffect=true;
 if(!_shouldUseLiveProseFade()) throw new Error('regular fade preference should work when motion is allowed');
 """
     )
+    run_node(script)
+
+
+def test_fade_cleanup_preserves_the_animated_node_as_the_scroll_anchor():
+    """Animation cleanup must not replace inline nodes during a live stream.
+
+    Replacing every word node on animationend makes the browser choose a new
+    native scroll anchor while the transcript is still growing.  The opacity
+    animation can finish by removing its transient class; final settlement will
+    rebuild the persisted answer as plain text.
+    """
+    cleanup = function_block(MESSAGES_JS, "_streamFadeBindCleanup")
+    script = r"""
+class FakeClassList {
+  constructor(names){ this.names=new Set(names); }
+  contains(name){ return this.names.has(name); }
+  remove(name){ this.names.delete(name); }
+}
+const listeners={};
+const document={createTextNode(text){ return {textContent:String(text)}; }};
+const body={
+  _streamFadeCleanupBound:false,
+  addEventListener(name,fn){ listeners[name]=fn; },
+};
+""" + cleanup + r"""
+_streamFadeBindCleanup(body);
+const span={
+  textContent:'stable anchor',
+  classList:new FakeClassList(['stream-fade-word','is-new']),
+  style:{
+    removed:[],
+    removeProperty(name){ this.removed.push(name); },
+  },
+  replacements:0,
+  replaceWith(){ this.replacements += 1; },
+};
+listeners.animationend({target:span});
+if(span.replacements!==0) throw new Error('fade cleanup replaced the active scroll-anchor node');
+if(span.classList.contains('is-new')) throw new Error('fade animation class was not cleared');
+if(!span.classList.contains('stream-fade-word')) throw new Error('stable fade node lost its identity');
+if(span.style.removed.join('|')!=='--stream-fade-ms') throw new Error('fade timing override was not cleared');
+"""
     run_node(script)
 
 


### PR DESCRIPTION
## Summary

- Preserve each `.stream-fade-word` node after its opacity animation finishes
- Clear only the transient `is-new` class and per-word timing override `--stream-fade-ms`
- Keep Transparent Stream's prose fade introduced for #5493 while avoiding repeated live DOM replacement
- Add a behavioral regression test that verifies animation cleanup preserves the active node identity

## Problem

Transparent Stream intentionally wraps incoming prose words in temporary spans to provide the prose fade restored by #5493. The `animationend` handler currently replaces every finished span with a fresh text node while the response is still growing.

Those repeated node replacements can make the browser select a new native scroll anchor. During a long streamed conclusion this presents as a visible vertical bounce, even though the opacity animation itself does not change layout.

## Fix

Keep the inline span stable for the lifetime of the live assistant turn. When its animation ends, remove `is-new` and the temporary `--stream-fade-ms` override instead of replacing the node. Final stream settlement already rebuilds the persisted response DOM, so completed messages still normalize without carrying live animation state.

This does not change the fade policy, disable Transparent Stream animation, or modify the existing pinned-tail and unpinned-reader scroll protections.

## Scope

Two files only:

- `static/messages.js`
- `tests/test_smooth_text_fade.py`

Closes #6257