### PR TITLE
fix: strip MEDIA: and file:// references from public share snapshots (#6126)

### DIFF
--- a/api/shares.py
+++ b/api/shares.py
@@ -104,6 +104,9 @@ def _strip_media_references(text: str) -> str:
       - Bare file:// URLs (whitespace-delimited)
       - Markdown links: [label](file://...)
       - Markdown images: ![alt](file://...)
+      - file:path (no slashes), file:/path (single slash)
+      - file://localhost/path, file://127.0.0.1/path
+      - URL-encoded file:// variants (e.g. file://%2Ftmp%2Ffile)
     while preserving fenced and inline-code regions byte-for-byte (the
     renderer keeps file:// inert inside code/preformatted content).
     """
@@ -129,15 +132,17 @@ def _strip_media_references(text: str) -> str:
     # MEDIA:<path-or-url> tokens (may already have their path redacted)
     text = re.sub(r"MEDIA:\S+", placeholder, text)
 
-    # Markdown images: ![alt](file://...) → placeholder
-    text = re.sub(r"!\[[^\]]*\]\(file://[^\s)]+\)", placeholder, text)
+    # Markdown images: ![alt](file:(?://)?...) → placeholder
+    text = re.sub(r"!\[[^\]]*\]\(file:(?://)?[^\s)]+\)", placeholder, text)
 
-    # Markdown links: [label](file://...) → placeholder
-    text = re.sub(r"\[[^\]]+\]\(file://[^\s)]+\)", placeholder, text)
+    # Markdown links: [label](file:(?://)?...) → placeholder
+    text = re.sub(r"\[[^\]]+\]\(file:(?://)?[^\s)]+\)", placeholder, text)
 
-    # Bare file:// URLs – preserve the leading delimiter instead of consuming
-    # whitespace and unconditionally inserting a space (review feedback).
-    text = re.sub(r"(^|\s)file://[^\s<>\"')\]]+", r"\1" + placeholder, text)
+    # Bare file:(?://)? URLs – preserve the leading delimiter instead of
+    # consuming whitespace and unconditionally inserting a space (review
+    # feedback). The file:(?://)? pattern also catches file:path and
+    # file:/path forms in addition to standard file:// and file:/// variants.
+    text = re.sub(r"(^|\s)file:(?://)?[^\s<>\"')\]]+", r"\1" + placeholder, text)
 
     # Restore stashed code regions.
     for i, s in enumerate(_fenced):

--- a/api/shares.py
+++ b/api/shares.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import secrets
 import tempfile
 import threading
@@ -91,6 +92,62 @@ def _share_message_text(message: dict) -> str:
     return ""
 
 
+def _strip_media_references(text: str) -> str:
+    """Replace local MEDIA: tokens and file:// URLs with inert placeholders.
+
+    Public shares must not emit links to the authenticated /api/media endpoint.
+    MEDIA:<path> sentinel values and file:// URLs that renderMd() would
+    convert into /api/media?path=... URLs are replaced with a non-clickable
+    placeholder so anonymous recipients never see broken auth-gated media links.
+
+    Covers every renderer-recognized file:// form (issue #6285 review):
+      - Bare file:// URLs (whitespace-delimited)
+      - Markdown links: [label](file://...)
+      - Markdown images: ![alt](file://...)
+    while preserving fenced and inline-code regions byte-for-byte (the
+    renderer keeps file:// inert inside code/preformatted content).
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    placeholder = "[Local attachment omitted from public share]"
+
+    # Stash fenced code blocks (```...```) so file:// inside them is preserved.
+    _fenced: list[str] = []
+    text = re.sub(
+        r"```[\s\S]*?```",
+        lambda m: _fenced.append(m.group(0)) or f"\x00F{len(_fenced) - 1}\x00",
+        text,
+    )
+    # Stash inline code spans (`...`) so file:// inside them is preserved.
+    _inline: list[str] = []
+    text = re.sub(
+        r"`[^`\n]+`",
+        lambda m: _inline.append(m.group(0)) or f"\x00I{len(_inline) - 1}\x00",
+        text,
+    )
+
+    # MEDIA:<path-or-url> tokens (may already have their path redacted)
+    text = re.sub(r"MEDIA:\S+", placeholder, text)
+
+    # Markdown images: ![alt](file://...) → placeholder
+    text = re.sub(r"!\[[^\]]*\]\(file://[^\s)]+\)", placeholder, text)
+
+    # Markdown links: [label](file://...) → placeholder
+    text = re.sub(r"\[[^\]]+\]\(file://[^\s)]+\)", placeholder, text)
+
+    # Bare file:// URLs – preserve the leading delimiter instead of consuming
+    # whitespace and unconditionally inserting a space (review feedback).
+    text = re.sub(r"(^|\s)file://[^\s<>\"')\]]+", r"\1" + placeholder, text)
+
+    # Restore stashed code regions.
+    for i, s in enumerate(_fenced):
+        text = text.replace(f"\x00F{i}\x00", s)
+    for i, s in enumerate(_inline):
+        text = text.replace(f"\x00I{i}\x00", s)
+
+    return text
+
+
 def _redact_share_paths(text: str, extra_paths) -> str:
     """Strip known local session/workspace/home paths out of public-share text.
 
@@ -122,6 +179,9 @@ def _sanitize_message(message: dict, *, redact_paths=()) -> dict | None:
     # (1) force credential redaction, (2) strip known local paths.
     text = _force_redact_credentials(text)
     text = _redact_share_paths(text, redact_paths)
+    # Strip MEDIA: / file:// references so the public share never renders
+    # links to the authenticated /api/media endpoint (issue #6126).
+    text = _strip_media_references(text)
     if not text.strip():
         return None
     sanitized = {
@@ -138,10 +198,24 @@ def _public_share_payload(payload: dict) -> dict:
     messages = payload.get("messages")
     if not isinstance(messages, list):
         messages = []
+    # Sanitize each message on read so legacy snapshots stored before the
+    # write-time sanitizer was introduced also have MEDIA:/file:// stripped
+    # (issue #6285 review – "close the legacy-snapshot path").
+    safe_messages = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            content = _strip_media_references(content)
+            if content.strip():
+                safe_messages.append({**msg, "content": content})
+        else:
+            safe_messages.append(msg)
     public = {
         "title": str(payload.get("title") or "Untitled"),
-        "messages": messages,
-        "message_count": int(payload.get("message_count") or len(messages)),
+        "messages": safe_messages,
+        "message_count": int(payload.get("message_count") or len(safe_messages)),
     }
     created_at = payload.get("created_at")
     updated_at = payload.get("updated_at")

--- a/api/shares.py
+++ b/api/shares.py
@@ -109,15 +109,40 @@ def _strip_media_references(text: str) -> str:
       - URL-encoded file:// variants (e.g. file://%2Ftmp%2Ffile)
     while preserving fenced and inline-code regions byte-for-byte (the
     renderer keeps file:// inert inside code/preformatted content).
+
+    Process order matches the real renderer's (ui.js) pipeline:
+      1. CRLF normalisation (renderer normalises before any parsing)
+      2. MEDIA: replacement (renderer converts MEDIA: to media tokens
+         before fenced/inline code processing, so MEDIA: inside code
+         regions is also rendered — matching that here means MEDIA:
+         never survives into a public payload)
+      3. Fenced code stashing (only complete balanced fences — an
+         unmatched opener stays as active prose for sanitisation)
+      4. Inline code stashing
+      5. file:// URL replacement (bare + markdown forms)
+      6. Code restoration
     """
     if not isinstance(text, str) or not text:
         return text
+
+    # (1) Normalise CRLF / bare CR to LF — renderMd() does this first
+    # so the close-fence regex does not miss \r\n-terminated lines.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+
     placeholder = "[Local attachment omitted from public share]"
 
-    # Stash fenced code blocks, matching the renderer's line-anchored
-    # variable-length fence grammar (#6285). Opening fence:
-    # ``^[ ]{0,3}(`{3,})([^`]*)$`` — closing fence:
-    # ``^[ ]{0,3}(`{3,})[ \t]*$`` with length >= opening length.
+    # (2) Replace MEDIA: EVERYWHERE before code stashing — the renderer
+    # converts MEDIA: to media-stash tokens before fenced/inline code
+    # processing, so MEDIA: inside code regions would also be rendered
+    # as /api/media links.
+    text = re.sub(r"MEDIA:\S+", placeholder, text)
+
+    # (3) Stash fenced code blocks.  Match the renderer's line-anchored
+    # variable-length fence grammar exactly.  Only stash a COMPLETE
+    # balanced fence — an unmatched opener (no valid closing fence) stays
+    # as active prose for sanitisation (review #6285 issue 1).
+    # Opening fence: ^[ ]{0,3}(`{3,})([^`]*)$
+    # Closing fence: ^[ ]{0,3}(`{3,})[ \t]*$  (length >= opening length)
     _fenced: list[str] = []
     _lines = text.split("\n")
     _fence_parts: list[str] = []
@@ -128,20 +153,29 @@ def _strip_media_references(text: str) -> str:
             _open_len = len(_om.group(1))
             _start = _i
             _i += 1
+            _found_close = False
             while _i < len(_lines):
                 _cm = re.match(r"^[ ]{0,3}(`{3,})[ \t]*$", _lines[_i])
                 if _cm and len(_cm.group(1)) >= _open_len:
                     _i += 1
+                    _found_close = True
                     break
                 _i += 1
-            _block = "\n".join(_lines[_start:_i])
-            _fenced.append(_block)
-            _fence_parts.append(f"\x00F{len(_fenced) - 1}\x00")
+            if _found_close:
+                _block = "\n".join(_lines[_start:_i])
+                _fenced.append(_block)
+                _fence_parts.append(f"\x00F{len(_fenced) - 1}\x00")
+            else:
+                # No matching close — treat opener and subsequent lines
+                # as active prose (matching renderMd() behaviour).
+                for _j in range(_start, _i):
+                    _fence_parts.append(_lines[_j])
         else:
             _fence_parts.append(_lines[_i])
             _i += 1
     text = "\n".join(_fence_parts)
-    # Stash inline code spans (`...`) so file:// inside them is preserved.
+
+    # (4) Stash inline code spans (`...`) so file:// inside them is preserved.
     _inline: list[str] = []
     text = re.sub(
         r"`[^`\n]+`",
@@ -149,9 +183,7 @@ def _strip_media_references(text: str) -> str:
         text,
     )
 
-    # MEDIA:<path-or-url> tokens (may already have their path redacted)
-    text = re.sub(r"MEDIA:\S+", placeholder, text)
-
+    # (5) file:// URL replacement
     # Markdown images: ![alt](file:(?://)?...) → placeholder
     text = re.sub(r"!\[[^\]]*\]\(file:(?://)?[^\s)]+\)", placeholder, text)
 
@@ -164,7 +196,7 @@ def _strip_media_references(text: str) -> str:
     # file:/path forms in addition to standard file:// and file:/// variants.
     text = re.sub(r"(^|\s)file:(?://)?[^\s<>\"')\]]+", r"\1" + placeholder, text)
 
-    # Restore stashed code regions.
+    # (6) Restore stashed code regions.
     for i, s in enumerate(_fenced):
         text = text.replace(f"\x00F{i}\x00", s)
     for i, s in enumerate(_inline):

--- a/api/shares.py
+++ b/api/shares.py
@@ -114,13 +114,33 @@ def _strip_media_references(text: str) -> str:
         return text
     placeholder = "[Local attachment omitted from public share]"
 
-    # Stash fenced code blocks (```...```) so file:// inside them is preserved.
+    # Stash fenced code blocks, matching the renderer's line-anchored
+    # variable-length fence grammar (#6285). Opening fence:
+    # ``^[ ]{0,3}(`{3,})([^`]*)$`` — closing fence:
+    # ``^[ ]{0,3}(`{3,})[ \t]*$`` with length >= opening length.
     _fenced: list[str] = []
-    text = re.sub(
-        r"```[\s\S]*?```",
-        lambda m: _fenced.append(m.group(0)) or f"\x00F{len(_fenced) - 1}\x00",
-        text,
-    )
+    _lines = text.split("\n")
+    _fence_parts: list[str] = []
+    _i = 0
+    while _i < len(_lines):
+        _om = re.match(r"^[ ]{0,3}(`{3,})([^`]*)$", _lines[_i])
+        if _om:
+            _open_len = len(_om.group(1))
+            _start = _i
+            _i += 1
+            while _i < len(_lines):
+                _cm = re.match(r"^[ ]{0,3}(`{3,})[ \t]*$", _lines[_i])
+                if _cm and len(_cm.group(1)) >= _open_len:
+                    _i += 1
+                    break
+                _i += 1
+            _block = "\n".join(_lines[_start:_i])
+            _fenced.append(_block)
+            _fence_parts.append(f"\x00F{len(_fenced) - 1}\x00")
+        else:
+            _fence_parts.append(_lines[_i])
+            _i += 1
+    text = "\n".join(_fence_parts)
     # Stash inline code spans (`...`) so file:// inside them is preserved.
     _inline: list[str] = []
     text = re.sub(

--- a/api/shares.py
+++ b/api/shares.py
@@ -103,15 +103,20 @@ def _strip_media_references(text: str) -> str:
     Covers every renderer-recognized file:// form (issue #6285 review):
       - Bare file:// URLs (whitespace-delimited)
       - Markdown links: [label](file://...)
-      - Markdown images: ![alt](file://...)
-      - file:path (no slashes), file:/path (single slash)
+      - Markdown images: ![alt](file://...) — including whitespace/newline
+        destinations through the closing ')' (renderer image grammar)
       - file://localhost/path, file://127.0.0.1/path
       - URL-encoded file:// variants (e.g. file://%2Ftmp%2Ffile)
-    while preserving fenced and inline-code regions byte-for-byte (the
-    renderer keeps file:// inert inside code/preformatted content).
+    while preserving fenced code, inline code, raw <pre> blocks, and
+    complete blockquoted fences byte-for-byte (the renderer keeps file://
+    inert inside all of those). Stripping is restricted to the renderer-active
+    lowercase file:// spelling — inert file: and file:/ forms are left as-is.
 
     Process order matches the real renderer's (ui.js) pipeline:
       1. CRLF normalisation (renderer normalises before any parsing)
+      1b. Blockquote pre-pass (renderer groups >-prefixed lines, strips the
+          prefix, recursively renders — mirrors that here; preserves
+          complete blockquoted fences byte-for-byte)
       2. MEDIA: replacement (renderer converts MEDIA: to media tokens
          before fenced/inline code processing, so MEDIA: inside code
          regions is also rendered — matching that here means MEDIA:
@@ -119,8 +124,11 @@ def _strip_media_references(text: str) -> str:
       3. Fenced code stashing (only complete balanced fences — an
          unmatched opener stays as active prose for sanitisation)
       4. Inline code stashing
-      5. file:// URL replacement (bare + markdown forms)
-      6. Code restoration
+      4b. Raw <pre> block stashing (renderer stashes these before its
+          bare file:// pass, so file:// inside them stays inert)
+      5. file:// URL replacement (images with renderer-matched [^\)]+
+         destinations first, then links, then bare URLs)
+      6. Stash restoration (raw <pre>, fences, inline, blockquotes)
     """
     if not isinstance(text, str) or not text:
         return text
@@ -130,6 +138,69 @@ def _strip_media_references(text: str) -> str:
     text = text.replace("\r\n", "\n").replace("\r", "\n")
 
     placeholder = "[Local attachment omitted from public share]"
+
+    # (1b) Blockquote pre-pass — mirror renderMd()'s _applyBlockquotes
+    # (ui.js ~L7115-7162).  The renderer groups consecutive >-prefixed
+    # lines, strips the "> " prefix, and recursively runs the FULL
+    # pipeline on the stripped text.  We do the same: group, strip,
+    # recurse this sanitizer, re-prefix every line, and stash the result
+    # as a \x00Q token so no outer pass re-processes it.  This keeps
+    # file:// inside a COMPLETE blockquoted fence byte-for-byte
+    # (renderer-inert there: the recursion stashes the fence) while still
+    # stripping file:// in blockquote prose (renderer-active there).
+    # Like the renderer, a ">" line that sits inside a non-blockquote
+    # backtick fence is fence content, NOT a blockquote — track fence
+    # state so it passes through untouched.
+    _bq: list[str] = []
+    _lines = text.split("\n")
+    _bq_out: list[str] = []
+    _in_fence = False
+    _fence_len = 0
+
+    def _bq_flush(end):
+        if _bq_start[0] < 0:
+            return
+        _stripped = "\n".join(
+            re.sub(r"^> ?", "", l) for l in _lines[_bq_start[0]:end]
+        )
+        _resanitized = _strip_media_references(_stripped)
+        _reprefixed = "\n".join(
+            ("> " + l) if l else ">" for l in _resanitized.split("\n")
+        )
+        _bq.append(_reprefixed)
+        _bq_out.append("")
+        _bq_out.append(f"\x00Q{len(_bq) - 1}\x00")
+        _bq_out.append("")
+        _bq_start[0] = -1
+
+    _bq_start = [-1]
+    _i = 0
+    while _i < len(_lines):
+        _line = _lines[_i]
+        if _in_fence:
+            _bq_out.append(_line)
+            _cm = re.match(r"^[ ]{0,3}(`{3,})[ \t]*$", _line)
+            if _cm and len(_cm.group(1)) >= _fence_len:
+                _in_fence = False
+            _i += 1
+            continue
+        _om = re.match(r"^[ ]{0,3}(`{3,})([^`]*)$", _line)
+        if _om:
+            _bq_flush(_i)
+            _bq_out.append(_line)
+            _in_fence = True
+            _fence_len = len(_om.group(1))
+            _i += 1
+            continue
+        if _line.startswith(">"):
+            if _bq_start[0] < 0:
+                _bq_start[0] = _i
+        else:
+            _bq_flush(_i)
+            _bq_out.append(_line)
+        _i += 1
+    _bq_flush(len(_lines))
+    text = "\n".join(_bq_out)
 
     # (2) Replace MEDIA: EVERYWHERE before code stashing — the renderer
     # converts MEDIA: to media-stash tokens before fenced/inline code
@@ -183,24 +254,42 @@ def _strip_media_references(text: str) -> str:
         text,
     )
 
-    # (5) file:// URL replacement
-    # Markdown images: ![alt](file:(?://)?...) → placeholder
-    text = re.sub(r"!\[[^\]]*\]\(file:(?://)?[^\s)]+\)", placeholder, text)
+    # (4b) Stash raw <pre> blocks so file:// inside them is preserved.
+    # The renderer stashes raw <pre>...</pre> BEFORE its bare file:// pass
+    # (ui.js ~L7269) and restores it only after all markdown passes, so a
+    # file:// inside a literal <pre> block stays inert text — mirror that.
+    _raw_pre: list[str] = []
+    text = re.sub(
+        r"(<pre\b[^>]*>[\s\S]*?</pre>)",
+        lambda m: _raw_pre.append(m.group(0)) or f"\x00R{len(_raw_pre) - 1}\x00",
+        text,
+        flags=re.IGNORECASE,
+    )
 
-    # Markdown links: [label](file:(?://)?...) → placeholder
-    text = re.sub(r"\[[^\]]+\]\(file:(?://)?[^\s)]+\)", placeholder, text)
+    # (5) file:// URL replacement — grammar matches the renderer (ui.js):
+    #   - Markdown images: destination is [^\)]+ — whitespace AND newline
+    #     destinations are accepted through the closing ')' (L7331/L7473).
+    #     The whole construct is replaced BEFORE the bare-URL pass so a
+    #     space-destination image like ![x](file:///a b.png) can never be
+    #     partially consumed by the bare-URL regex below.
+    #   - Markdown links: destination is [^\s\)]+ — whitespace terminates
+    #     the link destination (L7338/L7479).
+    #   - Bare file:// URLs: whitespace-delimited (L7277).
+    # Restrict to the renderer-active lowercase file:// spelling only —
+    # inert file: / file:/ forms are renderer-inert literals and stay.
+    text = re.sub(r"!\[[^\]]*\]\(file://[^\)]+\)", placeholder, text)
+    text = re.sub(r"\[[^\]]+\]\(file://[^\s\)]+\)", placeholder, text)
+    text = re.sub(r"(^|\s)file://[^\s<>\"')\]]+", r"\1" + placeholder, text)
 
-    # Bare file:(?://)? URLs – preserve the leading delimiter instead of
-    # consuming whitespace and unconditionally inserting a space (review
-    # feedback). The file:(?://)? pattern also catches file:path and
-    # file:/path forms in addition to standard file:// and file:/// variants.
-    text = re.sub(r"(^|\s)file:(?://)?[^\s<>\"')\]]+", r"\1" + placeholder, text)
-
-    # (6) Restore stashed code regions.
+    # (6) Restore stashed regions.
+    for i, s in enumerate(_raw_pre):
+        text = text.replace(f"\x00R{i}\x00", s)
     for i, s in enumerate(_fenced):
         text = text.replace(f"\x00F{i}\x00", s)
     for i, s in enumerate(_inline):
         text = text.replace(f"\x00I{i}\x00", s)
+    for i, s in enumerate(_bq):
+        text = text.replace(f"\x00Q{i}\x00", s)
 
     return text
 

--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -436,16 +436,30 @@ def test_thread_local_env_value_none_default_returns_empty_string(monkeypatch):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_detached_worker_scope_noop_for_default_profile(monkeypatch):
-    """profile_scope_for_detached_worker is a no-op for the default profile."""
+def test_detached_worker_scope_binds_tls_for_default_profile(monkeypatch):
+    """profile_scope_for_detached_worker binds TLS for the default profile (#6326).
+
+    For 'default', the scope must set the request-profile TLS so the worker
+    resolves the default profile's configuration even when the process-wide
+    active profile is a named profile. Env mirroring is skipped (root env
+    is already the process env).
+    """
     monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
     monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
-    # Default/empty name → no TLS set, no env applied.
-    with profiles.profile_scope_for_detached_worker("default", "test"):
-        assert profiles.get_active_profile_name() in ("", "default")
-        assert os.environ.get("ISSUE_3957_WPROBE") is None
+    # Set process-wide active to a named profile to verify TLS overrides it.
+    profiles._active_profile = "work"
+    try:
+        # Default name → TLS bound, env NOT applied.
+        with profiles.profile_scope_for_detached_worker("default", "test"):
+            assert profiles.get_active_profile_name() == "default"
+            assert os.environ.get("ISSUE_3957_WPROBE") is None
+    finally:
+        profiles._active_profile = "default"
+    # Empty name → still no-op.
     with profiles.profile_scope_for_detached_worker("", "test"):
         assert os.environ.get("ISSUE_3957_WPROBE") is None
+    # After the scope, TLS is cleared; falls back to process-wide active.
+    assert profiles.get_active_profile_name() in ("", "default")
 
 
 def test_detached_worker_scope_binds_profile_on_new_thread(monkeypatch, tmp_path):
@@ -872,6 +886,57 @@ def test_detached_worker_scope_scrubs_non_registry_agent_creds(monkeypatch, tmp_
     assert os.environ.get("AZURE_FOUNDRY_API_KEY") == "process-default-foundry-key"
     assert os.environ.get("IDENTITY_ENDPOINT") == "http://169.254.169.254/msi"
     assert os.environ.get("MSI_ENDPOINT") == "http://169.254.169.254/msi"
+
+
+def test_default_detached_worker_isolates_from_named_active_profile(monkeypatch, tmp_path):
+    """Default-scoped detached worker must resolve default, not named active (#6326).
+
+    When the process-wide active profile is a named profile (e.g. 'work'),
+    a detached worker spawned for the 'default' profile must bind the
+    request-profile TLS so that get_active_profile_name() returns 'default',
+    not 'work'. Without this fix, the worker would resolve 'work's
+    provider/model/credentials — breaking profile isolation.
+    """
+    import threading
+
+    base = tmp_path / ".hermes"
+    (base / "profiles" / "work").mkdir(parents=True)
+    (base / "profiles" / "work" / ".env").write_text(
+        "ISSUE_3957_WPROBE=worker-env\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
+    monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
+
+    # Simulate process-wide active profile == 'work'
+    profiles._active_profile = "work"
+
+    out = {}
+
+    def worker():
+        # On this fresh thread, get_active_profile_name() returns 'work'
+        # (process-wide active) because no TLS is set yet.
+        out["before"] = profiles.get_active_profile_name()
+        with profiles.profile_scope_for_detached_worker("default", "test"):
+            out["inside"] = profiles.get_active_profile_name()
+            out["inside_env"] = os.environ.get("ISSUE_3957_WPROBE")
+        out["after"] = profiles.get_active_profile_name()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    # Reset for cleanliness
+    profiles._active_profile = "default"
+
+    # Before scope: process-wide active 'work' is visible on the new thread.
+    assert out["before"] == "work"
+    # Inside scope: TLS bound to 'default' overrides process-wide 'work'.
+    assert out["inside"] == "default"
+    # Env mirroring skipped for root — no worker env applied.
+    assert out["inside_env"] is None
+    # After scope: TLS cleared, falls back to process-wide 'work'.
+    assert out["after"] == "work"
 
 
 def test_expand_env_vars_does_not_leak_process_env_under_block_scope(monkeypatch):

--- a/tests/test_issue3957_profile_providers_models.py
+++ b/tests/test_issue3957_profile_providers_models.py
@@ -436,30 +436,16 @@ def test_thread_local_env_value_none_default_returns_empty_string(monkeypatch):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_detached_worker_scope_binds_tls_for_default_profile(monkeypatch):
-    """profile_scope_for_detached_worker binds TLS for the default profile (#6326).
-
-    For 'default', the scope must set the request-profile TLS so the worker
-    resolves the default profile's configuration even when the process-wide
-    active profile is a named profile. Env mirroring is skipped (root env
-    is already the process env).
-    """
+def test_detached_worker_scope_noop_for_default_profile(monkeypatch):
+    """profile_scope_for_detached_worker is a no-op for the default profile."""
     monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
     monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
-    # Set process-wide active to a named profile to verify TLS overrides it.
-    profiles._active_profile = "work"
-    try:
-        # Default name → TLS bound, env NOT applied.
-        with profiles.profile_scope_for_detached_worker("default", "test"):
-            assert profiles.get_active_profile_name() == "default"
-            assert os.environ.get("ISSUE_3957_WPROBE") is None
-    finally:
-        profiles._active_profile = "default"
-    # Empty name → still no-op.
+    # Default/empty name → no TLS set, no env applied.
+    with profiles.profile_scope_for_detached_worker("default", "test"):
+        assert profiles.get_active_profile_name() in ("", "default")
+        assert os.environ.get("ISSUE_3957_WPROBE") is None
     with profiles.profile_scope_for_detached_worker("", "test"):
         assert os.environ.get("ISSUE_3957_WPROBE") is None
-    # After the scope, TLS is cleared; falls back to process-wide active.
-    assert profiles.get_active_profile_name() in ("", "default")
 
 
 def test_detached_worker_scope_binds_profile_on_new_thread(monkeypatch, tmp_path):
@@ -886,57 +872,6 @@ def test_detached_worker_scope_scrubs_non_registry_agent_creds(monkeypatch, tmp_
     assert os.environ.get("AZURE_FOUNDRY_API_KEY") == "process-default-foundry-key"
     assert os.environ.get("IDENTITY_ENDPOINT") == "http://169.254.169.254/msi"
     assert os.environ.get("MSI_ENDPOINT") == "http://169.254.169.254/msi"
-
-
-def test_default_detached_worker_isolates_from_named_active_profile(monkeypatch, tmp_path):
-    """Default-scoped detached worker must resolve default, not named active (#6326).
-
-    When the process-wide active profile is a named profile (e.g. 'work'),
-    a detached worker spawned for the 'default' profile must bind the
-    request-profile TLS so that get_active_profile_name() returns 'default',
-    not 'work'. Without this fix, the worker would resolve 'work's
-    provider/model/credentials — breaking profile isolation.
-    """
-    import threading
-
-    base = tmp_path / ".hermes"
-    (base / "profiles" / "work").mkdir(parents=True)
-    (base / "profiles" / "work" / ".env").write_text(
-        "ISSUE_3957_WPROBE=worker-env\n", encoding="utf-8"
-    )
-    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
-    monkeypatch.setattr(profiles, "_is_root_profile", lambda n: n in ("", "default"))
-    monkeypatch.delenv("ISSUE_3957_WPROBE", raising=False)
-
-    # Simulate process-wide active profile == 'work'
-    profiles._active_profile = "work"
-
-    out = {}
-
-    def worker():
-        # On this fresh thread, get_active_profile_name() returns 'work'
-        # (process-wide active) because no TLS is set yet.
-        out["before"] = profiles.get_active_profile_name()
-        with profiles.profile_scope_for_detached_worker("default", "test"):
-            out["inside"] = profiles.get_active_profile_name()
-            out["inside_env"] = os.environ.get("ISSUE_3957_WPROBE")
-        out["after"] = profiles.get_active_profile_name()
-
-    t = threading.Thread(target=worker)
-    t.start()
-    t.join()
-
-    # Reset for cleanliness
-    profiles._active_profile = "default"
-
-    # Before scope: process-wide active 'work' is visible on the new thread.
-    assert out["before"] == "work"
-    # Inside scope: TLS bound to 'default' overrides process-wide 'work'.
-    assert out["inside"] == "default"
-    # Env mirroring skipped for root — no worker env applied.
-    assert out["inside_env"] is None
-    # After scope: TLS cleared, falls back to process-wide 'work'.
-    assert out["after"] == "work"
 
 
 def test_expand_env_vars_does_not_leak_process_env_under_block_scope(monkeypatch):

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -803,3 +803,179 @@ class TestBareFileUrlMediaRendering:
         # Labeled anchors keep the normal link path (routed to /api/media as a link,
         # not auto-loaded as an <img>).
         assert "<img" not in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cross-boundary regression: _strip_media_references → renderMd()
+# PR #6285 review: assert sanitized public-share messages never emit
+# api/media?path= when rendered through the ACTUAL renderer.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ruff: noqa: E501 — allow long markdown test strings
+
+
+class TestPublicShareSanitizerThroughRenderer:
+    """Drive _strip_media_references() output through the real renderMd().
+
+    Every message in a public share passes through _strip_media_references()
+    before being stored / served.  If the sanitizer misses any form that the
+    renderer would turn into an api/media?path= link, an anonymous recipient
+    sees a broken auth-gated resource.
+
+    Each test case:
+      1. Takes a raw LLM-like message that contains MEDIA: / file:// refs
+      2. Passes it through _strip_media_references()
+      3. Passes the sanitized text through the real renderMd() via node
+      4. Asserts NO api/media?path= appears in the final HTML
+    """
+
+    @staticmethod
+    def _sanitized_render(driver_path, markdown: str) -> str:
+        """Apply _strip_media_references then renderMd()."""
+        from api.shares import _strip_media_references
+        sanitized = _strip_media_references(markdown)
+        return _render(driver_path, sanitized)
+
+    # ── Prose / bare-url forms (must be replaced) ──────────────────────
+
+    def test_bare_file_url_does_not_survive_sanitizer(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "Data at file:///home/alice/secret.txt",
+        )
+        assert "api/media?path=" not in html, (
+            f"Bare file:// URL survived sanitizer: {html!r}"
+        )
+
+    def test_markdown_link_file_url_does_not_survive(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "[secret](file:///home/alice/secret.txt)",
+        )
+        assert "api/media?path=" not in html, (
+            f"Markdown [label](file://...) survived sanitizer: {html!r}"
+        )
+
+    def test_markdown_image_file_url_does_not_survive(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "![chart](file:///tmp/chart.png)",
+        )
+        assert "api/media?path=" not in html, (
+            f"Markdown ![alt](file://...) survived sanitizer: {html!r}"
+        )
+
+    def test_media_token_does_not_survive(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "Here: MEDIA:/workspace/output.png",
+        )
+        assert "api/media?path=" not in html, (
+            f"MEDIA: token survived sanitizer: {html!r}"
+        )
+
+    # ── Balanced fenced & inline code (file:// must be preserved) ──────
+
+    def test_balanced_fence_preserves_file_url_literal(self, driver_path):
+        from api.shares import _strip_media_references
+        src = "```\nconst p = 'file:///etc/passwd';\n```"
+        sanitized = _strip_media_references(src)
+        assert "file:///etc/passwd" in sanitized, (
+            f"file:// inside balanced fence must be preserved: {sanitized!r}"
+        )
+        html = _render(driver_path, sanitized)
+        assert "api/media?path=" not in html, (
+            f"Sanitised balanced fence must not emit api/media: {html!r}"
+        )
+
+    def test_inline_code_preserves_file_url_literal(self, driver_path):
+        from api.shares import _strip_media_references
+        src = "run `file:///tmp/data.csv` locally"
+        sanitized = _strip_media_references(src)
+        assert "file:///tmp/data.csv" in sanitized, (
+            f"file:// inside inline code must be preserved: {sanitized!r}"
+        )
+        html = _render(driver_path, sanitized)
+        assert "api/media?path=" not in html
+
+    # ── Unmatched fence (opener without close — must NOT stash) ────────
+
+    def test_unmatched_fence_opener_does_not_stash_file_url(self, driver_path):
+        """An opener-like line with no closing fence must stay as active prose,
+        and the file:// ref after it must be replaced by the sanitizer."""
+        html = self._sanitized_render(
+            driver_path,
+            "```\n[secret](file:///home/alice/secret.txt)",
+        )
+        assert "api/media?path=" not in html, (
+            f"Unmatched fence allowed file:// to reach renderer: {html!r}"
+        )
+
+    # ── CRLF blocks (must normalise so close-fence regex matches) ──────
+
+    def test_crlf_fenced_block_does_not_swallow_post_fence_file_url(self, driver_path):
+        """CRLF-terminated fenced block must close properly so a prose
+        file:// after the fence is still sanitised."""
+        html = self._sanitized_render(
+            driver_path,
+            "```\r\ncode line\r\n```\r\nfile:///tmp/leak.csv outside",
+        )
+        assert "api/media?path=" not in html, (
+            f"CRLF fence didn't close; file:// survived: {html!r}"
+        )
+
+    # ── MEDIA: inside code regions (renderer processes first) ─────────
+
+    def test_media_token_inside_fenced_code_is_replaced(self, driver_path):
+        """MEDIA: inside a fence must be replaced because the renderer
+        processes MEDIA: before code stashing."""
+        html = self._sanitized_render(
+            driver_path,
+            "```\nMEDIA:/workspace/secret.png\n```",
+        )
+        assert "api/media?path=" not in html, (
+            f"MEDIA: inside fenced code survived sanitizer: {html!r}"
+        )
+        # The placeholder text should appear (it's prose after sanitization)
+        assert "[Local attachment omitted" in html
+
+    def test_media_token_inside_inline_code_is_replaced(self, driver_path):
+        """MEDIA: inside inline backticks must be replaced."""
+        html = self._sanitized_render(
+            driver_path,
+            "Check `MEDIA:/workspace/secret.png` for details",
+        )
+        assert "api/media?path=" not in html, (
+            f"MEDIA: inside inline code survived sanitizer: {html!r}"
+        )
+
+    # ── Multiple blocks / mixed content ────────────────────────────────
+
+    def test_mixed_content_nothing_leaks(self, driver_path):
+        """A realistic multi-block message with various forms."""
+        src = (
+            "Here is the data:\n\n"
+            "```\n"
+            "const path = 'file:///etc/hosts';\n"
+            "```\n\n"
+            "![chart](file:///tmp/chart.png)\n\n"
+            "Bare file:///tmp/data.csv reference\n\n"
+            "MEDIA:/workspace/photo.png\n\n"
+            "Check `file:///etc/hostname` inline\n\n"
+            "> ```\n"
+            "> file:///blockquote/leak.txt\n"
+            "> ```\n\n"
+            "Done."
+        )
+        html = self._sanitized_render(driver_path, src)
+        assert "api/media?path=" not in html, (
+            f"Mixed content still leaks api/media: {html!r}"
+        )
+        # file:// inside balanced fence and inline code must survive
+        # (renderer keeps them inert)
+        assert "file:///etc/hosts" in html, (
+            "file:// inside balanced fence must survive in HTML"
+        )
+        assert "file:///etc/hostname" in html, (
+            "file:// inside inline code must survive in HTML"
+        )

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -37,24 +37,22 @@ global.document = { createElement: () => ({ innerHTML: '', textContent: '' }), b
 function _sessionUrlForSid(sid) { return '/app/session/' + encodeURIComponent(String(sid || '')); }
 const esc = s => String(s ?? '').replace(/[&<>"']/g, c => (
   {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+// Constants extracted verbatim from ui.js — required by the REAL
+// _inlineMediaHtmlForRef / _mdImageHtml chain that renderMd() delegates to
+// (the file:// → api/media?path= boundary under test).
 const _IMAGE_EXTS=/\.(png|jpg|jpeg|gif|webp|bmp|ico|avif)$/i;
+const _PDF_EXTS=/\.pdf$/i;
+const _HTML_EXTS=/\.(html?|htm)$/i;
 const _SVG_EXTS=/\.svg$/i;
-const _AUDIO_EXTS=/\.(mp3|ogg|wav|m4a|aac|flac|wma|opus|webm)$/i;
+const _AUDIO_EXTS=/\.(mp3|ogg|wav|m4a|aac|flac|wma|opus|webm|oga)$/i;
 const _VIDEO_EXTS=/\.(mp4|webm|mkv|mov|avi|ogv|m4v)$/i;
-// Minimal stand-in for ui.js' _inlineMediaHtmlForRef used when the driver
-// extracts only renderMd(). Mirrors the live UI for the cases the existing
-// tests assert against (https image, bare file:// image). The full renderer
-// (ui.js) is preferred on the real page — these nodes only cover what is
-// reachable from a standalone renderMd() invocation.
-function _inlineMediaHtmlForRef(ref){
-  const r = String(ref || '');
-  if (/^https?:\/\//.test(r)) return `<img class="msg-media-img" src="${esc(r)}" alt="image" loading="lazy">`;
-  if (/^file:\/\//.test(r)){
-    const m = r.replace(/^file:\/\//i, '');
-    return `<img class="msg-media-img" src="api/media?path=${encodeURIComponent(m)}" alt="image" loading="lazy">`;
-  }
-  return `<img class="msg-media-img" src="api/media?path=${encodeURIComponent(r)}" alt="image" loading="lazy">`;
-}
+const _CSV_EXTS=/\.csv$/i;
+const _EXCALIDRAW_EXTS=/\.excalidraw$/i;
+const MEDIA_PLAYBACK_RATES=[0.5,0.75,1,1.25,1.5,2];
+const MEDIA_PLAYBACK_STORAGE_KEY='hermes-media-playback-rate';
+const _DATA_IMAGE_RE=/^data:image\/(?:png|jpe?g|gif|webp|avif)(?:;base64)?,[a-z0-9+/=%._~:@!$&'()*+,;-]*$/i;
+const _DATA_IMAGE_SVG_RE=/^data:image\/svg\+xml;base64,[a-z0-9+/=]+$/i;
+const _DATA_IMAGE_MAX_LEN=2*1024*1024;
 
 function extractFunc(name) {
   const re = new RegExp('function\\s+' + name + '\\s*\\(');
@@ -69,6 +67,17 @@ function extractFunc(name) {
   }
   return src.slice(start, i);
 }
+// REAL renderer helpers — no stubs. The file:// → api/media?path= boundary
+// only exists in the live _inlineMediaHtmlForRef; a stub would make the
+// cross-boundary tests pass trivially without exercising the leak.
+eval(extractFunc('_isSafeDataImageUri'));
+eval(extractFunc('_dataImageHtml'));
+eval(extractFunc('_mediaKindForName'));
+eval(extractFunc('_getStoredMediaPlaybackRate'));
+eval(extractFunc('_mediaSpeedControlsHtml'));
+eval(extractFunc('_mediaPlayerHtml'));
+eval(extractFunc('_inlineMediaHtmlForRef'));
+eval(extractFunc('_mdImageHtml'));
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
 eval(extractFunc('renderMd'));
@@ -863,6 +872,115 @@ class TestPublicShareSanitizerThroughRenderer:
         )
         assert "api/media?path=" not in html, (
             f"Markdown ![alt](file://...) survived sanitizer: {html!r}"
+        )
+
+    # ── Renderer-matched image destinations (re-gate #6285) ────────────
+    # The renderer's image regex accepts [^\)]+ destinations — whitespace
+    # AND newlines through the closing ')' (ui.js L7331/L7473).  The
+    # sanitizer must strip the WHOLE construct so a space-destination image
+    # can never survive into /api/media.  Each case: CONTROL (unsanitized
+    # render shows the private api/media reference EXISTS) → sanitized
+    # render shows it is GONE.
+
+    def test_control_image_no_space_destination_leaks_api_media(self, driver_path):
+        """Control: unsanitized ![x](file:///tmp/chart.png) emits api/media."""
+        html = _render(driver_path, "![chart](file:///tmp/chart.png)")
+        assert "api/media?path=" in html, (
+            f"Control must show the leak before sanitizing: {html!r}"
+        )
+
+    def test_control_image_space_destination_leaks_api_media(self, driver_path):
+        """Control: unsanitized ![x](file:///a b.png) emits api/media."""
+        html = _render(driver_path, "![secret](file:///home/alice/private image.png)")
+        assert "api/media?path=" in html, (
+            f"Control must show the space-destination leak: {html!r}"
+        )
+
+    def test_control_image_multiline_destination_leaks_api_media(self, driver_path):
+        """Control: unsanitized ![x](file:///a\\nb.png) emits api/media."""
+        html = _render(driver_path, "![secret](file:///home/alice/private\nimage.png)")
+        assert "api/media?path=" in html, (
+            f"Control must show the multiline-destination leak: {html!r}"
+        )
+
+    def test_image_no_space_destination_does_not_survive_sanitizer(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "![chart](file:///tmp/chart.png)",
+        )
+        assert "api/media?path=" not in html, (
+            f"No-space image destination survived sanitizer: {html!r}"
+        )
+
+    def test_image_space_destination_does_not_survive_sanitizer(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "![secret](file:///home/alice/private image.png)",
+        )
+        assert "api/media?path=" not in html, (
+            f"Space image destination survived sanitizer: {html!r}"
+        )
+
+    def test_image_multiline_destination_does_not_survive_sanitizer(self, driver_path):
+        html = self._sanitized_render(
+            driver_path,
+            "![secret](file:///home/alice/private\nimage.png)",
+        )
+        assert "api/media?path=" not in html, (
+            f"Multiline image destination survived sanitizer: {html!r}"
+        )
+
+    def test_image_multiline_destination_placeholder_present(self, driver_path):
+        from api.shares import _strip_media_references
+        sanitized = _strip_media_references(
+            "![secret](file:///home/alice/private\nimage.png)"
+        )
+        assert "[Local attachment omitted from public share]" in sanitized, (
+            f"Multiline image construct must be replaced wholesale: {sanitized!r}"
+        )
+
+    # ── Renderer-inert literals: raw <pre> and complete blockquoted fences ──
+
+    def test_raw_pre_block_preserves_file_url_literal(self, driver_path):
+        from api.shares import _strip_media_references
+        src = "<pre>file:///etc/passwd</pre>"
+        sanitized = _strip_media_references(src)
+        assert "file:///etc/passwd" in sanitized, (
+            f"file:// inside raw <pre> must be preserved: {sanitized!r}"
+        )
+        html = _render(driver_path, sanitized)
+        assert "api/media?path=" not in html
+
+    def test_complete_blockquoted_fence_preserves_file_url_literal(self, driver_path):
+        from api.shares import _strip_media_references
+        src = "> ```\n> file:///etc/passwd\n> ```"
+        sanitized = _strip_media_references(src)
+        assert "file:///etc/passwd" in sanitized, (
+            f"file:// inside a complete blockquoted fence must be preserved: {sanitized!r}"
+        )
+        html = _render(driver_path, sanitized)
+        assert "api/media?path=" not in html
+
+    def test_blockquoted_fence_with_space_destination_preserved(self, driver_path):
+        from api.shares import _strip_media_references
+        src = "> ```\n> ![x](file:///home/alice/private image.png)\n> ```"
+        sanitized = _strip_media_references(src)
+        assert "file:///home/alice/private image.png" in sanitized, (
+            f"file:// image inside a complete blockquoted fence must be preserved: {sanitized!r}"
+        )
+        html = _render(driver_path, sanitized)
+        assert "api/media?path=" not in html
+
+    def test_inert_file_single_slash_forms_are_preserved(self, driver_path):
+        """file: and file:/ (renderer-inert) must NOT be stripped."""
+        from api.shares import _strip_media_references
+        src = "see file:relative.txt or file:/single/slash.txt"
+        sanitized = _strip_media_references(src)
+        assert "file:relative.txt" in sanitized, (
+            f"inert file: form must be preserved: {sanitized!r}"
+        )
+        assert "file:/single/slash.txt" in sanitized, (
+            f"inert file:/ form must be preserved: {sanitized!r}"
         )
 
     def test_media_token_does_not_survive(self, driver_path):

--- a/tests/test_session_public_share.py
+++ b/tests/test_session_public_share.py
@@ -226,3 +226,274 @@ def test_share_create_uses_messaging_display_transcript_when_sidecar_has_no_mess
         post("/api/session/delete", {"session_id": sid})
         _remove_test_sessions(conn, sid)
         conn.close()
+
+
+def _make_session_with_media_references():
+    """Create a session whose messages contain MEDIA: tokens and file:// URLs."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "Media Share Test"
+    session.messages = [
+        {"role": "user", "content": "Generate an image."},
+        {
+            "role": "assistant",
+            "content": "Here is the generated image:\nMEDIA:/workspace/output.png\nIt looks great!",
+        },
+    ]
+    session.workspace = "/workspace"
+    session.profile = None
+    session.save()
+    return sid
+
+
+def test_share_strips_media_tokens_from_public_payload():
+    """MEDIA: tokens in shared messages must be replaced with an inert placeholder."""
+    sid = _make_session_with_media_references()
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        assistant_content = shared["share"]["messages"][1]["content"]
+        # MEDIA: must not appear in public share content
+        assert "MEDIA:" not in assistant_content
+        # Placeholder must be present
+        assert "[Local attachment omitted from public share]" in assistant_content
+        # The descriptive text should still be present
+        assert "Here is the generated image:" in assistant_content
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
+def test_share_strips_file_urls_from_public_payload():
+    """file:// URLs in shared messages must be replaced with an inert placeholder."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "File URL Share Test"
+    session.messages = [
+        {"role": "user", "content": "Read this file."},
+        {
+            "role": "assistant",
+            "content": "I found the data at file:///workspace/data.csv\nIt contains 100 rows.",
+        },
+    ]
+    session.workspace = "/workspace"
+    session.profile = None
+    session.save()
+
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        assistant_content = shared["share"]["messages"][1]["content"]
+        # file:// must not appear in public share
+        assert "file://" not in assistant_content
+        # Placeholder must be present
+        assert "[Local attachment omitted from public share]" in assistant_content
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
+def test_share_text_only_messages_unchanged():
+    """Text-only messages without MEDIA: or file:// should pass through unchanged."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "Plain Text Share"
+    session.messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "The answer is **4**."},
+    ]
+    session.workspace = "/workspace"
+    session.profile = None
+    session.save()
+
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        assert shared["share"]["messages"][0]["content"] == "What is 2+2?"
+        assert shared["share"]["messages"][1]["content"] == "The answer is **4**."
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
+# ── Regression tests for PR #6285 review: markdown file:// forms ──────────────
+
+
+def _make_session_with_markdown_file_links():
+    """Create a session with markdown links and images referencing file:// URLs."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "Markdown File Links"
+    session.messages = [
+        {
+            "role": "user",
+            "content": "Check these files.",
+        },
+        {
+            "role": "assistant",
+            "content": (
+                "Here is [the file](file:///tmp/shot.png) you requested.\n"
+                "![annotated chart](file:///tmp/chart.png)\n"
+                "Bare URL: file:///tmp/data.csv\n"
+            ),
+        },
+    ]
+    session.workspace = "/tmp"
+    session.profile = None
+    session.save()
+    return sid
+
+
+def test_share_strips_markdown_file_links():
+    """[label](file://...) markdown links must be stripped from public shares."""
+    sid = _make_session_with_markdown_file_links()
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        content = shared["share"]["messages"][1]["content"]
+        # No file:// anywhere
+        assert "file://" not in content
+        # All three forms replaced with placeholder
+        placeholder = "[Local attachment omitted from public share]"
+        assert content.count(placeholder) == 3
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
+def test_share_preserves_code_regions():
+    """file:// inside fenced and inline code must be preserved byte-for-byte."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "Code Preserve Test"
+    session.messages = [
+        {
+            "role": "user",
+            "content": "Show me the code.",
+        },
+        {
+            "role": "assistant",
+            "content": (
+                "Fenced code:\n"
+                "```\n"
+                "const path = 'file:///etc/passwd';\n"
+                "```\n"
+                "Inline `file:///etc/hosts` code.\n"
+                "Bare file:///tmp/leak.csv outside code.\n"
+            ),
+        },
+    ]
+    session.workspace = "/tmp"
+    session.profile = None
+    session.save()
+
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        content = shared["share"]["messages"][1]["content"]
+        # file:// inside fenced code preserved
+        assert "file:///etc/passwd" in content
+        # file:// inside inline code preserved
+        assert "`file:///etc/hosts`" in content or "file:///etc/hosts" in content
+        # Bare file:// outside code stripped
+        assert "file:///tmp/leak.csv" not in content
+        assert "[Local attachment omitted from public share]" in content
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
+def test_share_preserves_delimiter_before_file_url():
+    """Replacing a bare file:// URL must preserve the leading whitespace/newline."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "Delimiter Test"
+    session.messages = [
+        {"role": "user", "content": "Where is the file?"},
+        {
+            "role": "assistant",
+            "content": "The data is at:\nfile:///tmp/data.csv\n(end of line)",
+        },
+    ]
+    session.workspace = "/tmp"
+    session.profile = None
+    session.save()
+
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        content = shared["share"]["messages"][1]["content"]
+        assert "file://" not in content
+        # The newline before the URL should be preserved
+        assert "at:\n[Local attachment omitted from public share]" in content
+        # The text after should still be present
+        assert "(end of line)" in content
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
+def test_legacy_snapshot_strips_media_on_read():
+    """Pre-fix snapshots with file:// content must be sanitized on read."""
+    # Simulate a legacy snapshot written directly to disk without sanitization.
+    from api.shares import SHARES_DIR, _write_json_atomic, _share_path, load_share
+    import secrets
+
+    token = "test_legacy_" + secrets.token_hex(6)
+    legacy_content = (
+        "[the data](file:///old/path.csv)\n"
+        "![old chart](file:///old/chart.png)\n"
+        "bare file:///old/leak.txt here\n"
+    )
+    payload = {
+        "token": token,
+        "source_session_id": "test-legacy-sid",
+        "title": "Legacy Snapshot",
+        "messages": [
+            {"role": "user", "content": "Read this."},
+            {"role": "assistant", "content": legacy_content},
+        ],
+        "message_count": 2,
+        "created_at": 1000.0,
+        "updated_at": 1000.0,
+        "revoked_at": None,
+    }
+    path = _share_path(token)
+    try:
+        _write_json_atomic(path, payload)
+        # Load through the normal read path — should sanitize.
+        result = load_share(token)
+        assert result is not None
+        content = result["messages"][1]["content"]
+        assert "file://" not in content
+        placeholder = "[Local attachment omitted from public share]"
+        assert content.count(placeholder) == 3
+    finally:
+        try:
+            path.unlink(missing_ok=True)
+        except Exception:
+            pass

--- a/tests/test_session_public_share.py
+++ b/tests/test_session_public_share.py
@@ -457,6 +457,45 @@ def test_share_preserves_delimiter_before_file_url():
         post("/api/session/delete", {"session_id": sid})
 
 
+def test_share_strips_image_destinations_with_spaces_and_newlines():
+    """![alt](file:///path with space.png) and multiline destinations must be
+    stripped — the renderer's image grammar accepts destinations up to the
+    closing ')' including whitespace and newlines."""
+    created, _ = post("/api/session/new", {})
+    sid = created["session"]["session_id"]
+    from api.models import Session
+
+    session = Session.load(sid) or Session(session_id=sid)
+    session.title = "Whitespace Image Destinations"
+    session.messages = [
+        {"role": "user", "content": "Check these files."},
+        {
+            "role": "assistant",
+            "content": (
+                "![secret](file:///home/alice/private image.png)\n"
+                "![secret](file:///home/alice/private\nimage.png)\n"
+                "![chart](file:///tmp/chart.png)\n"
+            ),
+        },
+    ]
+    session.workspace = "/tmp"
+    session.profile = None
+    session.save()
+
+    try:
+        created, _ = post("/api/share/create", {"session_id": sid})
+        token = created["share"]["token"]
+        shared, status, _ = get(f"/api/share/{token}")
+        assert status == 200
+        content = shared["share"]["messages"][1]["content"]
+        # No file:// anywhere — including whitespace/newline destinations
+        assert "file://" not in content
+        placeholder = "[Local attachment omitted from public share]"
+        assert content.count(placeholder) == 3
+    finally:
+        post("/api/session/delete", {"session_id": sid})
+
+
 def test_legacy_snapshot_strips_media_on_read():
     """Pre-fix snapshots with file:// content must be sanitized on read."""
     # Simulate a legacy snapshot written directly to disk without sanitization.
@@ -467,6 +506,8 @@ def test_legacy_snapshot_strips_media_on_read():
     legacy_content = (
         "[the data](file:///old/path.csv)\n"
         "![old chart](file:///old/chart.png)\n"
+        "![private shot](file:///old/private shot.png)\n"
+        "![multi line](file:///old/multi\nline.png)\n"
         "bare file:///old/leak.txt here\n"
     )
     payload = {
@@ -491,7 +532,7 @@ def test_legacy_snapshot_strips_media_on_read():
         content = result["messages"][1]["content"]
         assert "file://" not in content
         placeholder = "[Local attachment omitted from public share]"
-        assert content.count(placeholder) == 3
+        assert content.count(placeholder) == 5
     finally:
         try:
             path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Fixes #6126: Public share pages expose local MEDIA: and file:// artifact references through the authenticated `/api/media` endpoint, causing broken images and download links for anonymous recipients.

## Root Cause

When a share snapshot is created in `api/shares.py`:
1. Local paths are redacted (`/workspace/output.png` → `[redacted-path]`)
2. But `MEDIA:` tokens and `file://` URLs are left intact in the message text
3. `share.js` renders shared messages using the full `renderMd()` pipeline
4. `renderMd()` converts MEDIA: and file:// references into `/api/media?path=...` URLs
5. `/api/media` is authentication-protected, so anonymous viewers get 401/redirects

## Fix

Added `_strip_media_references()` to `api/shares.py`, which replaces:
- `MEDIA:<path-or-url>` tokens with `[Local attachment omitted from public share]`
- Bare `file://` URLs with `[Local attachment omitted from public share]`

Applied in `_sanitize_message()` after credential redaction and path stripping. This ensures public shares never emit links to the auth-protected `/api/media` endpoint.

## Changes

- **`api/shares.py`**: Added `_strip_media_references()` function and `re` import; called from `_sanitize_message()`
- **`tests/test_session_public_share.py`**: Added 3 regression tests for MEDIA: stripping, file:// stripping, and text-only preservation

## Test Results

All 10 tests pass (7 existing + 3 new):

```
tests/test_session_public_share.py::test_share_strips_media_tokens_from_public_payload PASSED
tests/test_session_public_share.py::test_share_strips_file_urls_from_public_payload PASSED
tests/test_session_public_share.py::test_share_text_only_messages_unchanged PASSED
```

## Verification

- Public shares containing `MEDIA:/workspace/output.png` no longer render `/api/media` links
- Public shares containing `file:///workspace/data.csv` no longer render `/api/media` links
- Text-only public shares are unchanged
- `/api/media` endpoint remains authentication-protected