### PR TITLE
fix: OIDC SSRF protection blocks self-hosted providers (#6136)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+*.egg-info/
 
 # Backup and temporary files
 *.bak

--- a/api/auth_oidc.py
+++ b/api/auth_oidc.py
@@ -1,6 +1,7 @@
 import copy
 import base64
 import hashlib
+import http.client
 import ipaddress
 import json
 import logging
@@ -54,6 +55,162 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
+class _OIDCNetworkPolicy:
+    """Immutable network policy derived ONCE from the configured issuer.
+
+    The issuer is parsed into a canonical HTTPS origin (normalized hostname
+    + effective port) at construction time and carried through every
+    discovery, token, and JWKS exchange.  Discovery metadata can never
+    expand the grant: loopback / private addressing is permitted only for
+    the exact administrator-configured origin, and only when the explicit
+    ``allow_private_endpoints`` opt-in is enabled.
+    """
+
+    __slots__ = ("issuer", "origin_host", "origin_port", "allow_private_endpoints")
+
+    def __setattr__(self, name, value):
+        raise AttributeError(f"_OIDCNetworkPolicy is immutable: {name}")
+
+    def __init__(self, *, issuer: str, allow_private_endpoints: bool):
+        object.__setattr__(self, "issuer", issuer)
+        object.__setattr__(self, "allow_private_endpoints", bool(allow_private_endpoints))
+        origin = _canonical_https_origin(issuer)
+        if origin is None:
+            raise OIDCConfigError("OIDC issuer must be an https URL with a hostname")
+        object.__setattr__(self, "origin_host", origin[0])
+        object.__setattr__(self, "origin_port", origin[1])
+
+    @classmethod
+    def from_config(cls, cfg: dict[str, Any]) -> "_OIDCNetworkPolicy":
+        return cls(
+            issuer=str(cfg.get("issuer") or "").strip(),
+            allow_private_endpoints=bool(cfg.get("allow_private_endpoints", False)),
+        )
+
+    def is_exact_configured_origin(self, host: str, port: int) -> bool:
+        """True only when *host*:*port* is the configured issuer's own origin."""
+        return (
+            self.allow_private_endpoints
+            and str(host or "").strip().lower() == self.origin_host
+            and int(port) == self.origin_port
+        )
+
+    def address_allowed(self, host: str, port: int, address) -> bool:
+        """Classify one resolved address for outbound OIDC connections.
+
+        Link-local / metadata (169.254.0.0/16), multicast, unspecified, and
+        reserved ranges are ALWAYS blocked — even for the exact configured
+        origin.  Loopback / private ranges are permitted only for the exact
+        configured origin under the explicit opt-in.
+        """
+        candidate = getattr(address, "ipv4_mapped", None) or address
+        if (
+            candidate.is_link_local
+            or candidate.is_multicast
+            or candidate.is_unspecified
+            or candidate.is_reserved
+        ):
+            return False
+        if candidate.is_loopback or candidate.is_private:
+            return self.is_exact_configured_origin(host, port)
+        return True
+
+
+def _canonical_https_origin(url: str) -> tuple[str, int] | None:
+    """Return the normalized (hostname, effective port) of an https URL."""
+    parsed = urllib.parse.urlparse(str(url or "").strip())
+    if parsed.scheme != "https":
+        return None
+    hostname = str(parsed.hostname or "").strip().lower()
+    if not hostname:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    return hostname, port or 443
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection whose ``connect()`` resolves the host ONCE, classifies
+    every returned address against the immutable OIDC policy, and pins the
+    socket to an approved address.
+
+    This closes the DNS-rebinding / peer-mismatch gap: the address actually
+    connected to comes from the same resolution that was validated.  TLS
+    hostname/SNI verification is preserved by wrapping with
+    ``server_hostname=self.host``.
+    """
+
+    def __init__(self, host, port=None, *, policy=None, **kwargs):
+        super().__init__(host, port, **kwargs)
+        self._oidc_policy = policy
+
+    def connect(self):
+        host = self.host
+        port = self.port
+        try:
+            infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        except socket.gaierror as exc:
+            raise OIDCAuthError(
+                f"Failed to resolve OIDC endpoint host: {host}", status_code=502
+            ) from exc
+        if not infos:
+            raise OIDCAuthError(
+                f"OIDC endpoint hostname resolved to no addresses: {host}",
+                status_code=502,
+            )
+        chosen = None
+        for info in infos:
+            family, socktype, proto, _canonname, sockaddr = info
+            address = _parse_ip_address(sockaddr[0] if sockaddr else "")
+            if address is not None and self._oidc_policy.address_allowed(
+                host, port, address
+            ):
+                chosen = (family, socktype, proto, sockaddr)
+                break
+        if chosen is None:
+            raise OIDCAuthError(
+                "OIDC endpoint resolved only to disallowed addresses",
+                status_code=502,
+            )
+        family, socktype, proto, sockaddr = chosen
+        sock = socket.socket(family, socktype, proto)
+        try:
+            timeout = self.timeout
+            if timeout is not None and not isinstance(timeout, (int, float)):
+                timeout = None
+            sock.settimeout(timeout)
+            sock.connect(sockaddr)
+        except Exception:
+            sock.close()
+            raise
+        # server_hostname keeps SNI + TLS hostname verification against the
+        # requested hostname; only the CONNECTED address is pinned.
+        self.sock = self._context.wrap_socket(sock, server_hostname=host)
+
+
+class _OIDCHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, *, policy: _OIDCNetworkPolicy, **kwargs):
+        super().__init__(**kwargs)
+        self._oidc_policy = policy
+
+    def https_open(self, req):
+        return self.do_open(
+            _oidc_https_connection_factory(self._oidc_policy),
+            req,
+            context=self._context,
+            check_hostname=self._check_hostname,
+        )
+
+
+def _oidc_https_connection_factory(policy: _OIDCNetworkPolicy):
+    def factory(host, timeout=10, **kwargs):
+        return _PinnedHTTPSConnection(host, timeout=timeout, policy=policy, **kwargs)
+
+    return factory
+
+
 class OIDCConfigError(Exception):
     pass
 
@@ -79,7 +236,9 @@ def build_authorization_redirect(
     next_path: str | None = None,
 ) -> str:
     cfg = _require_oidc_config()
-    discovery = _get_discovery_document(cfg["issuer"])
+    policy = _OIDCNetworkPolicy.from_config(cfg)
+    discovery = _get_discovery_document(policy, cfg["issuer"])
+    _require_exact_discovery_issuer(discovery, cfg["issuer"])
     authorization_endpoint = str(discovery.get("authorization_endpoint") or "").strip()
     if not authorization_endpoint:
         raise OIDCConfigError("OIDC discovery document is missing authorization_endpoint")
@@ -119,10 +278,9 @@ def complete_authorization_code_flow(
     pending = _consume_pending_flow(state)
     if pending is None:
         raise OIDCAuthError("Invalid OIDC state", status_code=401)
-    discovery = _get_discovery_document(cfg["issuer"])
-    discovery_issuer = str(discovery.get("issuer") or "").strip()
-    if discovery_issuer and discovery_issuer != cfg["issuer"]:
-        raise OIDCAuthError("OIDC discovery issuer did not match the configured issuer", status_code=502)
+    policy = _OIDCNetworkPolicy.from_config(cfg)
+    discovery = _get_discovery_document(policy, cfg["issuer"])
+    _require_exact_discovery_issuer(discovery, cfg["issuer"])
     token_endpoint = str(discovery.get("token_endpoint") or "").strip()
     if not token_endpoint:
         raise OIDCConfigError("OIDC discovery document is missing token_endpoint")
@@ -137,6 +295,7 @@ def complete_authorization_code_flow(
             "redirect_uri": redirect_uri,
             **({"client_secret": cfg["client_secret"]} if cfg.get("client_secret") else {}),
         },
+        policy=policy,
     )
     id_token = str(token_response.get("id_token") or "").strip()
     if not id_token:
@@ -147,6 +306,7 @@ def complete_authorization_code_flow(
         issuer=cfg["issuer"],
         nonce=pending["nonce"],
         jwks_uri=str(discovery.get("jwks_uri") or "").strip(),
+        policy=policy,
     )
     _enforce_allowlist(
         claims,
@@ -324,16 +484,39 @@ def _trim_pending_flows() -> None:
         _pending_flows.pop(state, None)
 
 
-def _get_discovery_document(issuer: str) -> dict[str, Any]:
+def _get_discovery_document(
+    policy: _OIDCNetworkPolicy, issuer: str
+) -> dict[str, Any]:
     discovery_url = _discovery_url_for_issuer(issuer)
     cached = _cache_get(_discovery_lock, _discovery_cache, discovery_url)
     if cached is not None:
         return cached
-    data = _fetch_json(discovery_url)
+    data = _fetch_json(discovery_url, policy=policy)
     if not isinstance(data, dict):
         raise OIDCAuthError("OIDC discovery response was not a JSON object", status_code=502)
     _cache_put(_discovery_lock, _discovery_cache, discovery_url, data)
     return data
+
+
+def _require_exact_discovery_issuer(
+    discovery: dict[str, Any], configured_issuer: str
+) -> None:
+    """Require a present, exact ``issuer`` declaration in the discovery doc.
+
+    Authority for every downstream endpoint (authorization, token, JWKS) is
+    established BEFORE any of them is consumed, in both the start and the
+    callback flow.  A missing issuer is rejected exactly like a mismatch.
+    """
+    discovery_issuer = str(discovery.get("issuer") or "").strip()
+    if not discovery_issuer:
+        raise OIDCAuthError(
+            "OIDC discovery document did not include an issuer", status_code=502
+        )
+    if discovery_issuer != configured_issuer:
+        raise OIDCAuthError(
+            "OIDC discovery issuer did not match the configured issuer",
+            status_code=502,
+        )
 
 
 def _discovery_url_for_issuer(issuer: str) -> str:
@@ -342,7 +525,12 @@ def _discovery_url_for_issuer(issuer: str) -> str:
     return issuer.rstrip("/") + "/.well-known/openid-configuration"
 
 
-def _get_jwks_document(jwks_uri: str, *, force_refresh: bool = False) -> dict[str, Any]:
+def _get_jwks_document(
+    policy: _OIDCNetworkPolicy,
+    jwks_uri: str,
+    *,
+    force_refresh: bool = False,
+) -> dict[str, Any]:
     if not jwks_uri:
         raise OIDCConfigError("OIDC discovery document is missing jwks_uri")
     if force_refresh:
@@ -352,7 +540,7 @@ def _get_jwks_document(jwks_uri: str, *, force_refresh: bool = False) -> dict[st
         cached = _cache_get(_jwks_lock, _jwks_cache, jwks_uri)
         if cached is not None:
             return cached
-    data = _fetch_json(jwks_uri)
+    data = _fetch_json(jwks_uri, policy=policy)
     if not isinstance(data, dict):
         raise OIDCAuthError("OIDC JWKS response was not a JSON object", status_code=502)
     _cache_put(_jwks_lock, _jwks_cache, jwks_uri, data)
@@ -386,14 +574,14 @@ def _cache_put(
         cache[key] = (time.time() + _CACHE_TTL_SECONDS, copy.deepcopy(value))
 
 
-def _fetch_json(url: str) -> dict[str, Any]:
-    _validate_outbound_oidc_url(url)
+def _fetch_json(url: str, *, policy: _OIDCNetworkPolicy) -> dict[str, Any]:
+    _validate_outbound_oidc_url(url, policy=policy)
     req = urllib.request.Request(
         url,
         headers={"Accept": "application/json"},
     )
     try:
-        with _oidc_opener().open(req, timeout=10) as resp:
+        with _oidc_opener(policy).open(req, timeout=10) as resp:
             payload = json.loads(
                 resp.read().decode("utf-8"),
                 parse_constant=_reject_non_finite_json_constant,
@@ -405,8 +593,10 @@ def _fetch_json(url: str) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _post_form_json(url: str, form_data: dict[str, Any]) -> dict[str, Any]:
-    _validate_outbound_oidc_url(url)
+def _post_form_json(
+    url: str, form_data: dict[str, Any], *, policy: _OIDCNetworkPolicy
+) -> dict[str, Any]:
+    _validate_outbound_oidc_url(url, policy=policy)
     body = urllib.parse.urlencode(form_data).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -418,7 +608,7 @@ def _post_form_json(url: str, form_data: dict[str, Any]) -> dict[str, Any]:
         method="POST",
     )
     try:
-        with _oidc_opener().open(req, timeout=10) as resp:
+        with _oidc_opener(policy).open(req, timeout=10) as resp:
             payload = json.loads(
                 resp.read().decode("utf-8"),
                 parse_constant=_reject_non_finite_json_constant,
@@ -430,38 +620,13 @@ def _post_form_json(url: str, form_data: dict[str, Any]) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _oidc_opener() -> urllib.request.OpenerDirector:
-    return urllib.request.build_opener(_NoRedirect)
+def _oidc_opener(policy: _OIDCNetworkPolicy) -> urllib.request.OpenerDirector:
+    return urllib.request.build_opener(_NoRedirect, _OIDCHTTPSHandler(policy=policy))
 
 
-def _is_oidc_issuer_allowed_private_host(hostname: str) -> bool:
-    """Check whether *hostname* is the configured issuer's host under
-    the ``allow_private_endpoints`` opt-in.
-
-    When ``webui_oidc.allow_private_endpoints`` is enabled, only the
-    configured issuer's own hostname is permitted to resolve to private
-    / loopback / link-local addresses.  Any other host — including those
-    returned by the discovery document (``token_endpoint``, ``jwks_uri``)
-    — is still subject to the full SSRF check, preventing discovery-
-    controlled pivots to metadata, internal, or loopback endpoints.
-    """
-    try:
-        cfg = _resolve_oidc_config()
-        if not cfg.get("allow_private_endpoints"):
-            return False
-        issuer = str(cfg.get("issuer") or "").strip()
-        if not issuer:
-            return False
-        issuer_hostname = urllib.parse.urlparse(issuer).hostname
-        if not issuer_hostname:
-            return False
-        return hostname == issuer_hostname
-    except Exception:
-        logger.debug("Failed to read allow_private_endpoints config", exc_info=True)
-        return False
-
-
-def _validate_outbound_oidc_url(url: str) -> None:
+def _validate_outbound_oidc_url(
+    url: str, *, policy: _OIDCNetworkPolicy
+) -> None:
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme != "https":
         raise OIDCAuthError("OIDC endpoint URLs must use https", status_code=502)
@@ -470,7 +635,17 @@ def _validate_outbound_oidc_url(url: str) -> None:
     hostname = str(parsed.hostname or "").strip()
     if not hostname:
         raise OIDCAuthError("OIDC endpoint URL was missing a hostname", status_code=502)
-    if _is_oidc_issuer_allowed_private_host(hostname):
+    try:
+        effective_port = parsed.port or 443
+    except ValueError as exc:
+        raise OIDCAuthError(
+            "OIDC endpoint URL had an invalid port", status_code=502
+        ) from exc
+    # The allow-private grant is scoped to the EXACT configured origin
+    # (normalized host AND effective port).  Discovery-controlled endpoints
+    # on the same host but a different port never inherit it; they remain
+    # subject to the full address-class check below.
+    if policy.is_exact_configured_origin(hostname, effective_port):
         return
     if _is_disallowed_oidc_host(hostname):
         raise OIDCAuthError(
@@ -485,8 +660,16 @@ def _is_disallowed_oidc_host(hostname: str) -> bool:
         return _is_disallowed_oidc_ip(literal_ip)
     try:
         infos = socket.getaddrinfo(hostname, 443, type=socket.SOCK_STREAM)
-    except socket.gaierror:
-        return False
+    except socket.gaierror as exc:
+        # Fail closed: a host that cannot be resolved must never be allowed.
+        raise OIDCAuthError(
+            f"Failed to resolve OIDC endpoint host: {hostname}", status_code=502
+        ) from exc
+    if not infos:
+        raise OIDCAuthError(
+            f"OIDC endpoint hostname resolved to no addresses: {hostname}",
+            status_code=502,
+        )
     for info in infos:
         sockaddr = info[4]
         address = _parse_ip_address(sockaddr[0] if sockaddr else "")
@@ -525,18 +708,19 @@ def _validate_id_token(
     issuer: str,
     nonce: str,
     jwks_uri: str,
+    policy: _OIDCNetworkPolicy,
 ) -> dict[str, Any]:
     header, claims, signed, signature = _parse_jwt(token)
     alg = str(header.get("alg") or "").strip()
     if not alg or alg == "none":
         raise OIDCAuthError("OIDC id_token uses an unsupported signing algorithm")
-    jwks = _get_jwks_document(jwks_uri)
+    jwks = _get_jwks_document(policy, jwks_uri)
     try:
         public_key = _select_public_key(jwks, header)
     except OIDCAuthError as exc:
         if "did not contain the signing key" not in str(exc):
             raise
-        jwks = _get_jwks_document(jwks_uri, force_refresh=True)
+        jwks = _get_jwks_document(policy, jwks_uri, force_refresh=True)
         public_key = _select_public_key(jwks, header)
     _verify_jwt_signature(public_key, alg, signed, signature)
     _validate_registered_claims(claims, client_id=client_id, issuer=issuer, nonce=nonce)

--- a/api/auth_oidc.py
+++ b/api/auth_oidc.py
@@ -111,7 +111,13 @@ class _OIDCNetworkPolicy:
             or candidate.is_reserved
         ):
             return False
-        if candidate.is_loopback or candidate.is_private:
+        if candidate.is_loopback or candidate.is_private or not candidate.is_global:
+            # Loopback / private / shared (e.g. 100.64.0.0/10) and every
+            # other non-global class are reachable ONLY for the exact
+            # configured origin under the explicit opt-in.  CPython classifies
+            # 100.64.0.0/10 as neither private nor global, so the explicit
+            # `not is_global` discriminator is required to keep shared address
+            # space out of the default-allow path.
             return self.is_exact_configured_origin(host, port)
         return True
 
@@ -149,6 +155,14 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
     def connect(self):
         host = self.host
         port = self.port
+        if getattr(self, "_tunnel_host", None):
+            # urllib sets _tunnel_host when routing through an HTTP(S) proxy
+            # CONNECT.  The OIDC boundary must never tunnel: the connection
+            # authority would change and the pinned policy would be bypassed.
+            raise OIDCAuthError(
+                "OIDC connections must not be tunneled through a proxy",
+                status_code=502,
+            )
         try:
             infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
         except socket.gaierror as exc:
@@ -160,34 +174,45 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
                 f"OIDC endpoint hostname resolved to no addresses: {host}",
                 status_code=502,
             )
-        chosen = None
+        # Try approved addresses in resolver order.  A failed connect must not
+        # discard later approved answers; rejected addresses are never
+        # attempted, and every socket that failed is closed before the next
+        # attempt (or on TLS-wrap failure) so no descriptor leaks.
+        last_error = None
         for info in infos:
             family, socktype, proto, _canonname, sockaddr = info
             address = _parse_ip_address(sockaddr[0] if sockaddr else "")
-            if address is not None and self._oidc_policy.address_allowed(
+            if address is None or not self._oidc_policy.address_allowed(
                 host, port, address
             ):
-                chosen = (family, socktype, proto, sockaddr)
-                break
-        if chosen is None:
+                continue
+            sock = socket.socket(family, socktype, proto)
+            try:
+                timeout = self.timeout
+                if timeout is not None and not isinstance(timeout, (int, float)):
+                    timeout = None
+                sock.settimeout(timeout)
+                sock.connect(sockaddr)
+            except Exception as exc:
+                sock.close()
+                last_error = exc
+                continue
+            try:
+                # server_hostname keeps SNI + TLS hostname verification against
+                # the requested hostname; only the CONNECTED address is pinned.
+                self.sock = self._context.wrap_socket(sock, server_hostname=host)
+                return
+            except Exception:
+                sock.close()
+                raise
+        if last_error is not None:
             raise OIDCAuthError(
-                "OIDC endpoint resolved only to disallowed addresses",
-                status_code=502,
-            )
-        family, socktype, proto, sockaddr = chosen
-        sock = socket.socket(family, socktype, proto)
-        try:
-            timeout = self.timeout
-            if timeout is not None and not isinstance(timeout, (int, float)):
-                timeout = None
-            sock.settimeout(timeout)
-            sock.connect(sockaddr)
-        except Exception:
-            sock.close()
-            raise
-        # server_hostname keeps SNI + TLS hostname verification against the
-        # requested hostname; only the CONNECTED address is pinned.
-        self.sock = self._context.wrap_socket(sock, server_hostname=host)
+                "OIDC endpoint addresses failed to connect", status_code=502
+            ) from last_error
+        raise OIDCAuthError(
+            "OIDC endpoint resolved only to disallowed addresses",
+            status_code=502,
+        )
 
 
 class _OIDCHTTPSHandler(urllib.request.HTTPSHandler):
@@ -621,7 +646,16 @@ def _post_form_json(
 
 
 def _oidc_opener(policy: _OIDCNetworkPolicy) -> urllib.request.OpenerDirector:
-    return urllib.request.build_opener(_NoRedirect, _OIDCHTTPSHandler(policy=policy))
+    # Ambient HTTP(S)_PROXY settings must never redirect this security-
+    # sensitive flow: urllib's default ProxyHandler would change the
+    # connection authority and tunnel to the proxy instead of the pinned
+    # endpoint.  An explicit empty ProxyHandler disables proxy lookup; the
+    # pinned connection additionally fails closed on any tunnel request.
+    return urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.ProxyHandler({}),
+        _OIDCHTTPSHandler(policy=policy),
+    )
 
 
 def _validate_outbound_oidc_url(
@@ -694,6 +728,7 @@ def _is_disallowed_oidc_ip(address) -> bool:
         or candidate.is_multicast
         or candidate.is_unspecified
         or candidate.is_reserved
+        or not candidate.is_global
     )
 
 

--- a/api/auth_oidc.py
+++ b/api/auth_oidc.py
@@ -187,6 +187,15 @@ def _resolve_oidc_config() -> dict[str, Any]:
         if key not in _warned_allow_values:
             _warned_allow_values.add(key)
             logger.warning(_ALLOW_VALUES_WHITESPACE_WARNING)
+    allow_private_raw = pick(
+        "allow_private_endpoints", "HERMES_WEBUI_OIDC_ALLOW_PRIVATE_ENDPOINTS"
+    )
+    allow_private = False
+    if allow_private_raw is not None:
+        if isinstance(allow_private_raw, bool):
+            allow_private = allow_private_raw
+        else:
+            allow_private = str(allow_private_raw).strip().lower() in ("1", "true", "yes")
     return {
         "issuer": str(pick("issuer", "HERMES_WEBUI_OIDC_ISSUER") or "").strip(),
         "client_id": str(pick("client_id", "HERMES_WEBUI_OIDC_CLIENT_ID") or "").strip(),
@@ -195,6 +204,7 @@ def _resolve_oidc_config() -> dict[str, Any]:
         "scopes": scopes,
         "allow_claim": str(pick("allow_claim", "HERMES_WEBUI_OIDC_ALLOW_CLAIM") or "").strip(),
         "allow_values": allow_values,
+        "allow_private_endpoints": allow_private,
     }
 
 
@@ -424,6 +434,33 @@ def _oidc_opener() -> urllib.request.OpenerDirector:
     return urllib.request.build_opener(_NoRedirect)
 
 
+def _is_oidc_issuer_allowed_private_host(hostname: str) -> bool:
+    """Check whether *hostname* is the configured issuer's host under
+    the ``allow_private_endpoints`` opt-in.
+
+    When ``webui_oidc.allow_private_endpoints`` is enabled, only the
+    configured issuer's own hostname is permitted to resolve to private
+    / loopback / link-local addresses.  Any other host — including those
+    returned by the discovery document (``token_endpoint``, ``jwks_uri``)
+    — is still subject to the full SSRF check, preventing discovery-
+    controlled pivots to metadata, internal, or loopback endpoints.
+    """
+    try:
+        cfg = _resolve_oidc_config()
+        if not cfg.get("allow_private_endpoints"):
+            return False
+        issuer = str(cfg.get("issuer") or "").strip()
+        if not issuer:
+            return False
+        issuer_hostname = urllib.parse.urlparse(issuer).hostname
+        if not issuer_hostname:
+            return False
+        return hostname == issuer_hostname
+    except Exception:
+        logger.debug("Failed to read allow_private_endpoints config", exc_info=True)
+        return False
+
+
 def _validate_outbound_oidc_url(url: str) -> None:
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme != "https":
@@ -433,6 +470,8 @@ def _validate_outbound_oidc_url(url: str) -> None:
     hostname = str(parsed.hostname or "").strip()
     if not hostname:
         raise OIDCAuthError("OIDC endpoint URL was missing a hostname", status_code=502)
+    if _is_oidc_issuer_allowed_private_host(hostname):
+        return
     if _is_disallowed_oidc_host(hostname):
         raise OIDCAuthError(
             "OIDC endpoint URLs must not target private or local addresses",

--- a/tests/test_issue3825_oidc_auth.py
+++ b/tests/test_issue3825_oidc_auth.py
@@ -567,3 +567,99 @@ def test_normalize_allow_values_and_scopes_use_separate_delimiters():
     assert auth_oidc._normalize_text_list("openid profile email") == ["openid", "profile", "email"]
     scopes = auth_oidc._normalize_scopes("openid profile email")
     assert scopes[:3] == ["openid", "profile", "email"]
+
+
+# ---------------------------------------------------------------------------
+# #6136 — OIDC SSRF protection: issuer-scoped opt-in for self-hosted providers
+# ---------------------------------------------------------------------------
+
+
+def test_allow_private_endpoints_matching_issuer_host(monkeypatch):
+    """When allow_private_endpoints=True and the URL host matches the
+    configured issuer host, private IP resolution must NOT raise."""
+    import api.auth_oidc as auth_oidc
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_resolve_oidc_config",
+        lambda: {
+            "issuer": "https://auth.internal.example",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": True,
+        },
+    )
+    # URL on the same host as the configured issuer — must skip SSRF check
+    auth_oidc._validate_outbound_oidc_url(
+        "https://auth.internal.example/.well-known/openid-configuration"
+    )
+
+
+def test_allow_private_endpoints_different_host_still_blocked(monkeypatch):
+    """When allow_private_endpoints=True but the URL host differs from the
+    issuer host, private IPs must still be blocked (prevents discovery pivot)."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_resolve_oidc_config",
+        lambda: {
+            "issuer": "https://auth.internal.example",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": True,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 443))
+        ],
+    )
+    # Different host from issuer — must still reject private IPs
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            "https://evil-token.internal.example/token"
+        )
+
+
+def test_allow_private_endpoints_default_false_blocks_private_dns(monkeypatch):
+    """Without allow_private_endpoints=True, private IPs must still be blocked."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_resolve_oidc_config",
+        lambda: {
+            "issuer": "https://auth.internal.example",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": False,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 443))
+        ],
+    )
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            "https://auth.internal.example/.well-known/openid-configuration"
+        )

--- a/tests/test_issue3825_oidc_auth.py
+++ b/tests/test_issue3825_oidc_auth.py
@@ -763,16 +763,21 @@ class _FakeResponse:
         "224.0.0.1",
         "0.0.0.0",
         "240.0.0.1",
+        # Shared address space (100.64.0.0/10): neither private nor global,
+        # must still be rejected (CGNAT carrier-grade NAT range)
+        "100.64.0.1",
+        "100.127.255.254",
         # IPv6: loopback, ULA, link-local, multicast, unspecified
         "::1",
         "fc00::1",
         "fe80::1",
         "ff02::1",
         "::",
-        # IPv4-mapped IPv6 forms of loopback/private/link-local
+        # IPv4-mapped IPv6 forms of loopback/private/link-local/shared
         "::ffff:127.0.0.1",
         "::ffff:10.0.0.1",
         "::ffff:169.254.169.254",
+        "::ffff:100.64.0.1",
     ],
 )
 def test_validate_outbound_url_rejects_special_address_ranges(address):
@@ -1019,6 +1024,293 @@ def test_pinned_connection_fails_closed_on_dns_error(monkeypatch):
     conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
     with pytest.raises(OIDCAuthError, match="Failed to resolve OIDC endpoint host"):
         conn.connect()
+
+
+def test_pinned_connection_tries_next_approved_address_on_connect_failure(monkeypatch):
+    """If the first approved address cannot connect, later approved answers
+    from the SAME resolution are tried in resolver order; rejected addresses
+    are never attempted; failed sockets are closed."""
+    import api.auth_oidc as auth_oidc
+
+    attempted = []
+    closed = []
+
+    class FakeSocket:
+        def __init__(self, family, socktype, proto):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, sockaddr):
+            attempted.append(sockaddr)
+            if sockaddr[0] == "93.184.216.34":
+                raise OSError("connection refused")
+
+        def close(self):
+            closed.append(True)
+
+    def fake_wrap_socket(self, sock, *, server_hostname=None, **kwargs):
+        return sock
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 443)),
+        ],
+    )
+    monkeypatch.setattr(auth_oidc.socket, "socket", FakeSocket)
+    monkeypatch.setattr(ssl.SSLContext, "wrap_socket", fake_wrap_socket)
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
+    conn.connect()
+
+    # First approved address failed to connect; the second approved address
+    # was tried and won.  The private (rejected) address was never attempted.
+    assert attempted == [("93.184.216.34", 443), ("8.8.8.8", 443)]
+    # Only the failed socket was closed; the successful one stays open.
+    assert len(closed) == 1
+    assert conn.sock is not None
+
+
+def test_pinned_connection_closes_socket_when_tls_wrap_fails(monkeypatch):
+    """If TLS wrapping fails, the raw socket is closed before the error
+    propagates — no descriptor leak."""
+    import api.auth_oidc as auth_oidc
+
+    closed = []
+
+    class FakeSocket:
+        def __init__(self, family, socktype, proto):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, sockaddr):
+            pass
+
+        def close(self):
+            closed.append(True)
+
+    def boom_wrap_socket(self, sock, *, server_hostname=None, **kwargs):
+        raise ssl.SSLError("TLS handshake failed")
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(auth_oidc.socket, "socket", FakeSocket)
+    monkeypatch.setattr(ssl.SSLContext, "wrap_socket", boom_wrap_socket)
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
+    with pytest.raises(ssl.SSLError):
+        conn.connect()
+    assert len(closed) == 1
+
+
+def test_pinned_connection_fails_closed_on_proxy_tunnel(monkeypatch):
+    """A proxy CONNECT tunnel is refused outright: urllib sets _tunnel_host
+    when routing through a proxy, and the pinned connection must never
+    change its connection authority."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
+    conn._tunnel_host = "proxy.example"
+    with pytest.raises(OIDCAuthError, match="tunnel"):
+        conn.connect()
+
+
+def test_oidc_opener_disables_ambient_proxies(monkeypatch):
+    """Ambient HTTP(S)_PROXY settings must never redirect the OIDC flow: the
+    opener installs an explicit EMPTY ProxyHandler, so urllib cannot change
+    the connection authority to a proxy."""
+    import api.auth_oidc as auth_oidc
+    import urllib.request as urllib_request
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:3128")
+    monkeypatch.setenv("https_proxy", "http://127.0.0.1:3128")
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:3128")
+    monkeypatch.setenv("http_proxy", "http://127.0.0.1:3128")
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    opener = auth_oidc._oidc_opener(policy)
+    proxy_handlers = [
+        h for h in opener.handlers if isinstance(h, urllib_request.ProxyHandler)
+    ]
+    assert proxy_handlers
+    for handler in proxy_handlers:
+        assert handler.proxies == {}
+
+
+def test_token_form_body_never_delivered_to_ambient_proxy(monkeypatch):
+    """End-to-end guard: with an ambient HTTPS proxy configured, the token
+    form body still travels ONLY to the pinned endpoint socket — a proxy
+    that would receive the client_secret never sees a connection."""
+    import api.auth_oidc as auth_oidc
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:3128")
+    monkeypatch.setenv("https_proxy", "http://127.0.0.1:3128")
+
+    connected_to = []
+
+    class FakeSocket:
+        def __init__(self, family, socktype, proto):
+            pass
+
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, sockaddr):
+            connected_to.append(sockaddr)
+
+        def sendall(self, data):
+            pass
+
+        def makefile(self, *args, **kwargs):
+            return io.BytesIO(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                b"Content-Length: 2\r\nConnection: close\r\n\r\n{}"
+            )
+
+        def close(self):
+            pass
+
+    def fake_wrap_socket(self, sock, *, server_hostname=None, **kwargs):
+        return sock
+
+    monkeypatch.setattr(auth_oidc.socket, "socket", FakeSocket)
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(ssl.SSLContext, "wrap_socket", fake_wrap_socket)
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    auth_oidc._post_form_json(
+        "https://issuer.example/token",
+        {
+            "grant_type": "authorization_code",
+            "client_id": "webui-client",
+            "code": "auth-code",
+            "client_secret": "super-secret",
+        },
+        policy=policy,
+    )
+
+    # The connection went straight to the endpoint — never to the ambient
+    # proxy (127.0.0.1:3128).  The proxy never had a chance to read the body.
+    assert connected_to == [("93.184.216.34", 443)]
+
+
+def test_fetch_json_rejects_dns_resolved_shared_space(monkeypatch):
+    """A discovery-controlled hostname resolving into shared address space
+    (100.64.0.0/10, CGNAT) is rejected even though CPython classifies it as
+    neither private nor global."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("100.64.0.1", 443))
+        ],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration",
+            policy=policy,
+        )
+
+
+def test_fetch_json_rejects_foreign_origin_resolving_to_shared_space(monkeypatch):
+    """Even with the private opt-in enabled, a FOREIGN origin resolving to
+    shared address space stays blocked — the grant is exact-origin scoped."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("100.64.0.1", 443))
+        ],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=True
+    )
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._fetch_json(
+            "https://evil.example/.well-known/openid-configuration",
+            policy=policy,
+        )
+
+
+def test_exact_origin_shared_space_allowed_under_optin(monkeypatch):
+    """The self-hosted use case survives: with the explicit opt-in, the EXACT
+    configured origin in shared address space is still reachable."""
+    import api.auth_oidc as auth_oidc
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("100.64.0.1", 443))
+        ],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://100.64.0.1", allow_private_endpoints=True
+    )
+    auth_oidc._validate_outbound_oidc_url(
+        "https://100.64.0.1/.well-known/openid-configuration", policy=policy
+    )
+
+
+def test_address_allowed_rejects_shared_space_without_exact_origin_optin():
+    """Both classifiers must treat shared address space as restricted: the
+    connect-time policy only grants it to the EXACT configured origin under
+    the explicit opt-in."""
+    import ipaddress
+
+    import api.auth_oidc as auth_oidc
+
+    shared = ipaddress.ip_address("100.64.0.1")
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    assert policy.address_allowed("issuer.example", 443, shared) is False
+    assert policy.address_allowed("100.64.0.1", 443, shared) is False
+
+    optin = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://100.64.0.1", allow_private_endpoints=True
+    )
+    # Exact configured origin under the opt-in → granted.
+    assert optin.address_allowed("100.64.0.1", 443, shared) is True
+    # Same address, different host → still denied.
+    assert optin.address_allowed("issuer.example", 443, shared) is False
 
 
 def test_no_redirect_handler_refuses_all_redirects():

--- a/tests/test_issue3825_oidc_auth.py
+++ b/tests/test_issue3825_oidc_auth.py
@@ -1,7 +1,9 @@
 import io
 import json
 import socket
+import ssl
 import time
+import urllib.error
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
@@ -334,7 +336,7 @@ def test_validate_id_token_rejects_mismatched_jwk_key_family(monkeypatch):
     monkeypatch.setattr(
         auth_oidc,
         "_get_jwks_document",
-        lambda _jwks_uri, **_kwargs: {
+        lambda _policy, _jwks_uri, **_kwargs: {
             "keys": [
                 {
                     "kid": "key-1",
@@ -354,6 +356,9 @@ def test_validate_id_token_rejects_mismatched_jwk_key_family(monkeypatch):
             issuer="https://issuer.example",
             nonce="nonce-token",
             jwks_uri="https://issuer.example/jwks",
+            policy=auth_oidc._OIDCNetworkPolicy(
+                issuer="https://issuer.example", allow_private_endpoints=False
+            ),
         )
 
 def test_validate_id_token_accepts_real_es256_jose_signature(monkeypatch):
@@ -374,7 +379,7 @@ def test_validate_id_token_accepts_real_es256_jose_signature(monkeypatch):
     monkeypatch.setattr(
         auth_oidc,
         "_get_jwks_document",
-        lambda _jwks_uri, **_kwargs: {"keys": [_ec_jwk(private_key)]},
+        lambda _policy, _jwks_uri, **_kwargs: {"keys": [_ec_jwk(private_key)]},
     )
 
     claims = auth_oidc._validate_id_token(
@@ -383,6 +388,9 @@ def test_validate_id_token_accepts_real_es256_jose_signature(monkeypatch):
         issuer="https://issuer.example",
         nonce="nonce-token",
         jwks_uri="https://issuer.example/jwks",
+        policy=auth_oidc._OIDCNetworkPolicy(
+            issuer="https://issuer.example", allow_private_endpoints=False
+        ),
     )
 
     assert claims["sub"] == "user-123"
@@ -407,7 +415,7 @@ def test_complete_authorization_pins_discovery_to_configured_issuer(monkeypatch)
     monkeypatch.setattr(
         auth_oidc,
         "_get_discovery_document",
-        lambda _issuer: {
+        lambda _policy, _issuer: {
             "issuer": "https://evil.example",
             "token_endpoint": "https://issuer.example/token",
             "jwks_uri": "https://issuer.example/jwks",
@@ -452,7 +460,7 @@ def test_validate_id_token_refetches_jwks_once_on_key_miss(monkeypatch):
     )
     fetches = []
 
-    def fake_fetch_json(url):
+    def fake_fetch_json(url, **_kwargs):
         fetches.append(url)
         return {"keys": [_ec_jwk(new_key, kid="new-key")]}
 
@@ -464,6 +472,9 @@ def test_validate_id_token_refetches_jwks_once_on_key_miss(monkeypatch):
         issuer="https://issuer.example",
         nonce="nonce-token",
         jwks_uri=jwks_uri,
+        policy=auth_oidc._OIDCNetworkPolicy(
+            issuer="https://issuer.example", allow_private_endpoints=False
+        ),
     )
 
     assert claims["sub"] == "user-123"
@@ -493,8 +504,11 @@ def test_fetch_json_rejects_unsafe_oidc_urls(url, message):
     import api.auth_oidc as auth_oidc
     from api.auth_oidc import OIDCAuthError
 
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
     with pytest.raises(OIDCAuthError, match=message):
-        auth_oidc._fetch_json(url)
+        auth_oidc._fetch_json(url, policy=policy)
 
 
 def test_fetch_json_rejects_dns_resolved_private_hosts(monkeypatch):
@@ -508,9 +522,15 @@ def test_fetch_json_rejects_dns_resolved_private_hosts(monkeypatch):
             (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 443))
         ],
     )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
 
     with pytest.raises(OIDCAuthError, match="private or local addresses"):
-        auth_oidc._fetch_json("https://issuer.example/.well-known/openid-configuration")
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration",
+            policy=policy,
+        )
 
 
 def test_select_public_key_rejects_wrong_ec_curve_for_alg():
@@ -575,28 +595,84 @@ def test_normalize_allow_values_and_scopes_use_separate_delimiters():
 
 
 def test_allow_private_endpoints_matching_issuer_host(monkeypatch):
-    """When allow_private_endpoints=True and the URL host matches the
-    configured issuer host, private IP resolution must NOT raise."""
+    """When allow_private_endpoints=True and the URL's origin (host AND port)
+    matches the configured issuer's exact origin, private IP resolution must
+    NOT raise."""
     import api.auth_oidc as auth_oidc
 
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://auth.internal.example", allow_private_endpoints=True
+    )
     monkeypatch.setattr(
-        auth_oidc,
-        "_resolve_oidc_config",
-        lambda: {
-            "issuer": "https://auth.internal.example",
-            "client_id": "webui-client",
-            "client_secret": "",
-            "redirect_uri": "",
-            "scopes": ["openid"],
-            "allow_claim": "email",
-            "allow_values": ["user@example.com"],
-            "allow_private_endpoints": True,
-        },
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 443))
+        ],
     )
-    # URL on the same host as the configured issuer — must skip SSRF check
+    # URL on the exact configured origin — must skip the SSRF address check
     auth_oidc._validate_outbound_oidc_url(
-        "https://auth.internal.example/.well-known/openid-configuration"
+        "https://auth.internal.example/.well-known/openid-configuration",
+        policy=policy,
     )
+
+
+def test_allow_private_grant_is_exact_origin_scoped_same_host_different_port(monkeypatch):
+    """The allow-private grant is (host, port) scoped: a discovery-controlled
+    endpoint on the SAME host but a DIFFERENT port must NOT inherit it."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://auth.internal.example:8443", allow_private_endpoints=True
+    )
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 9999))
+        ],
+    )
+    # Same host, different port → NOT the exact origin → private blocked
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            "https://auth.internal.example:9999/token", policy=policy
+        )
+    # Same host AND port (the exact origin) → grant applies
+    auth_oidc._validate_outbound_oidc_url(
+        "https://auth.internal.example:8443/.well-known/openid-configuration",
+        policy=policy,
+    )
+
+
+def test_allow_private_grant_normalizes_effective_port(monkeypatch):
+    """Effective-port normalization: an issuer without an explicit port is
+    origin 443, so an explicit :443 URL is still the exact origin, while
+    :8443 is not."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://auth.internal.example", allow_private_endpoints=True
+    )
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 443))
+        ],
+    )
+    # Explicit :443 equals the default 443 origin → allowed
+    auth_oidc._validate_outbound_oidc_url(
+        "https://auth.internal.example:443/.well-known/openid-configuration",
+        policy=policy,
+    )
+    # Different port → blocked even though the host matches
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            "https://auth.internal.example:8443/.well-known/openid-configuration",
+            policy=policy,
+        )
 
 
 def test_allow_private_endpoints_different_host_still_blocked(monkeypatch):
@@ -605,19 +681,8 @@ def test_allow_private_endpoints_different_host_still_blocked(monkeypatch):
     import api.auth_oidc as auth_oidc
     from api.auth_oidc import OIDCAuthError
 
-    monkeypatch.setattr(
-        auth_oidc,
-        "_resolve_oidc_config",
-        lambda: {
-            "issuer": "https://auth.internal.example",
-            "client_id": "webui-client",
-            "client_secret": "",
-            "redirect_uri": "",
-            "scopes": ["openid"],
-            "allow_claim": "email",
-            "allow_values": ["user@example.com"],
-            "allow_private_endpoints": True,
-        },
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://auth.internal.example", allow_private_endpoints=True
     )
     monkeypatch.setattr(
         auth_oidc.socket,
@@ -629,28 +694,18 @@ def test_allow_private_endpoints_different_host_still_blocked(monkeypatch):
     # Different host from issuer — must still reject private IPs
     with pytest.raises(OIDCAuthError, match="private or local addresses"):
         auth_oidc._validate_outbound_oidc_url(
-            "https://evil-token.internal.example/token"
+            "https://evil-token.internal.example/token", policy=policy
         )
 
 
 def test_allow_private_endpoints_default_false_blocks_private_dns(monkeypatch):
-    """Without allow_private_endpoints=True, private IPs must still be blocked."""
+    """Without allow_private_endpoints=True, private IPs must still be blocked
+    even when the URL is on the exact configured origin."""
     import api.auth_oidc as auth_oidc
     from api.auth_oidc import OIDCAuthError
 
-    monkeypatch.setattr(
-        auth_oidc,
-        "_resolve_oidc_config",
-        lambda: {
-            "issuer": "https://auth.internal.example",
-            "client_id": "webui-client",
-            "client_secret": "",
-            "redirect_uri": "",
-            "scopes": ["openid"],
-            "allow_claim": "email",
-            "allow_values": ["user@example.com"],
-            "allow_private_endpoints": False,
-        },
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://auth.internal.example", allow_private_endpoints=False
     )
     monkeypatch.setattr(
         auth_oidc.socket,
@@ -661,5 +716,659 @@ def test_allow_private_endpoints_default_false_blocks_private_dns(monkeypatch):
     )
     with pytest.raises(OIDCAuthError, match="private or local addresses"):
         auth_oidc._validate_outbound_oidc_url(
-            "https://auth.internal.example/.well-known/openid-configuration"
+            "https://auth.internal.example/.well-known/openid-configuration",
+            policy=policy,
         )
+
+
+class _FakeOpener:
+    def __init__(self, payload=None, capture=None, error=None):
+        self.payload = payload
+        self.capture = capture
+        self.error = error
+
+    def open(self, req, timeout=None):
+        if self.capture is not None:
+            self.capture["req"] = req
+        if self.error is not None:
+            raise self.error
+        return _FakeResponse(self.payload)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        # IPv4: loopback, private (RFC1918), link-local/metadata, multicast,
+        # unspecified, reserved
+        "127.0.0.1",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.7",
+        "169.254.169.254",
+        "169.254.1.1",
+        "224.0.0.1",
+        "0.0.0.0",
+        "240.0.0.1",
+        # IPv6: loopback, ULA, link-local, multicast, unspecified
+        "::1",
+        "fc00::1",
+        "fe80::1",
+        "ff02::1",
+        "::",
+        # IPv4-mapped IPv6 forms of loopback/private/link-local
+        "::ffff:127.0.0.1",
+        "::ffff:10.0.0.1",
+        "::ffff:169.254.169.254",
+    ],
+)
+def test_validate_outbound_url_rejects_special_address_ranges(address):
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    host = f"[{address}]" if ":" in address else address
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            f"https://{host}/.well-known/openid-configuration", policy=policy
+        )
+
+
+@pytest.mark.parametrize("address", ["93.184.216.34", "8.8.8.8"])
+def test_validate_outbound_url_allows_public_address_ranges(address):
+    import api.auth_oidc as auth_oidc
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    host = f"[{address}]" if ":" in address else address
+    auth_oidc._validate_outbound_oidc_url(
+        f"https://{host}/.well-known/openid-configuration", policy=policy
+    )
+
+
+def test_exact_origin_loopback_allowance_is_explicit_and_scoped(monkeypatch):
+    """Loopback is reachable ONLY for the exact configured origin under the
+    explicit opt-in; the same loopback on another port stays blocked, and
+    without the opt-in the exact origin itself stays blocked."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 8443))],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://127.0.0.1:8443", allow_private_endpoints=True
+    )
+    # Exact loopback origin under the opt-in → allowed
+    auth_oidc._validate_outbound_oidc_url(
+        "https://127.0.0.1:8443/.well-known/openid-configuration", policy=policy
+    )
+    # Same loopback host, different port → blocked
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            "https://127.0.0.1:9999/token", policy=policy
+        )
+    # No opt-in → even the exact loopback origin is blocked
+    policy_no_optin = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://127.0.0.1:8443", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._validate_outbound_oidc_url(
+            "https://127.0.0.1:8443/.well-known/openid-configuration",
+            policy=policy_no_optin,
+        )
+
+
+def test_exact_origin_never_reaches_link_local_metadata(monkeypatch):
+    """Even with the opt-in, the exact configured origin must never reach
+    link-local / cloud-metadata addresses (169.254.0.0/16)."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=True
+    )
+    # URL is the exact origin (URL-level check skipped), but the pinned
+    # connection classifies link-local as always-disallowed → fail closed.
+    with pytest.raises(OIDCAuthError, match="resolved only to disallowed addresses"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration", policy=policy
+        )
+
+
+def test_fetch_json_fails_closed_on_dns_error(monkeypatch):
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    def boom(*a, **k):
+        raise socket.gaierror(-2, "Name or service not known")
+
+    monkeypatch.setattr(auth_oidc.socket, "getaddrinfo", boom)
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="Failed to resolve OIDC endpoint host"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration", policy=policy
+        )
+
+
+def test_fetch_json_fails_closed_on_empty_dns_answers(monkeypatch):
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(auth_oidc.socket, "getaddrinfo", lambda *a, **k: [])
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="resolved to no addresses"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration", policy=policy
+        )
+
+
+def test_fetch_json_rejects_mixed_public_private_answers(monkeypatch):
+    """A non-exact-origin host that resolves to a mix of public and private
+    addresses is rejected outright (fail closed on mixed answers)."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 443)),
+        ],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration", policy=policy
+        )
+
+
+def test_fetch_json_fails_closed_on_rebinding_to_metadata(monkeypatch):
+    """DNS rebinding / peer mismatch: the URL-level precheck passes (as if the
+    first resolution were public), but the connect-time resolution flips to
+    the cloud metadata address — the pinned connection must fail closed."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    # Precheck sees a clean resolution...
+    monkeypatch.setattr(auth_oidc, "_is_disallowed_oidc_host", lambda _host: False)
+    # ...then the actual connection resolves to link-local metadata.
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="resolved only to disallowed addresses"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration", policy=policy
+        )
+
+
+def test_pinned_connection_binds_to_first_approved_address_and_keeps_sni(monkeypatch):
+    """The connection resolves ONCE, skips disallowed addresses, pins the
+    socket to the first approved (public) address, and still verifies the TLS
+    hostname (server_hostname) against the requested host."""
+    import api.auth_oidc as auth_oidc
+
+    captured = {}
+
+    class FakeSocket:
+        def __init__(self, family, socktype, proto):
+            captured["family"] = family
+            captured["socktype"] = socktype
+
+        def settimeout(self, timeout):
+            captured["timeout"] = timeout
+
+        def connect(self, sockaddr):
+            captured["sockaddr"] = sockaddr
+
+        def close(self):
+            pass
+
+    def fake_wrap_socket(self, sock, *, server_hostname=None, **kwargs):
+        captured["server_hostname"] = server_hostname
+        return sock
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 443)),
+        ],
+    )
+    monkeypatch.setattr(auth_oidc.socket, "socket", FakeSocket)
+    monkeypatch.setattr(ssl.SSLContext, "wrap_socket", fake_wrap_socket)
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
+    conn.connect()
+
+    # Pinned to the first approved address of the SINGLE resolution — never
+    # to the private one, never to a re-resolved address.
+    assert captured["sockaddr"] == ("93.184.216.34", 443)
+    # TLS hostname verification / SNI preserved against the requested host.
+    assert captured["server_hostname"] == "issuer.example"
+    assert conn.sock is not None
+
+
+def test_pinned_connection_fails_closed_when_only_disallowed_addresses(monkeypatch):
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))],
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
+    with pytest.raises(OIDCAuthError, match="disallowed addresses"):
+        conn.connect()
+
+
+def test_pinned_connection_fails_closed_on_dns_error(monkeypatch):
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    def boom(*a, **k):
+        raise socket.gaierror(-2, "Name or service not known")
+
+    monkeypatch.setattr(auth_oidc.socket, "getaddrinfo", boom)
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    conn = auth_oidc._PinnedHTTPSConnection("issuer.example", 443, policy=policy, timeout=10)
+    with pytest.raises(OIDCAuthError, match="Failed to resolve OIDC endpoint host"):
+        conn.connect()
+
+
+def test_no_redirect_handler_refuses_all_redirects():
+    """Redirects stay disabled: every 3xx hop is refused, never followed."""
+    import api.auth_oidc as auth_oidc
+
+    handler = auth_oidc._NoRedirect()
+    assert (
+        handler.redirect_request(None, None, 302, None, None, "https://evil.example/steal")
+        is None
+    )
+
+
+def test_fetch_json_surfaces_redirect_as_failure(monkeypatch):
+    """A 302 response is not followed; it surfaces as an OIDCAuthError."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_oidc_opener",
+        lambda _policy: _FakeOpener(
+            error=urllib.error.HTTPError(
+                "https://issuer.example/", 302, "Found", {}, None
+            )
+        ),
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    with pytest.raises(OIDCAuthError, match="Failed to reach OIDC endpoint"):
+        auth_oidc._fetch_json(
+            "https://issuer.example/.well-known/openid-configuration", policy=policy
+        )
+
+
+def test_fetch_json_sends_get_with_accept_header(monkeypatch):
+    import api.auth_oidc as auth_oidc
+
+    captured = {}
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(
+        auth_oidc, "_oidc_opener", lambda _policy: _FakeOpener({"ok": True}, captured)
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    result = auth_oidc._fetch_json(
+        "https://issuer.example/.well-known/openid-configuration", policy=policy
+    )
+
+    req = captured["req"]
+    assert req.get_method() == "GET"
+    assert req.full_url == "https://issuer.example/.well-known/openid-configuration"
+    assert any(
+        k.lower() == "accept" and v == "application/json"
+        for k, v in req.header_items()
+    )
+    assert result == {"ok": True}
+
+
+def test_post_form_json_sends_exact_method_target_and_secrets(monkeypatch):
+    """The token exchange is a POST to the exact discovery-controlled target;
+    the client_secret travels in the form body — never in an Authorization
+    header."""
+    import api.auth_oidc as auth_oidc
+
+    captured = {}
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_oidc_opener",
+        lambda _policy: _FakeOpener({"access_token": "at"}, captured),
+    )
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example", allow_private_endpoints=False
+    )
+    result = auth_oidc._post_form_json(
+        "https://issuer.example/token",
+        {
+            "grant_type": "authorization_code",
+            "client_id": "webui-client",
+            "code": "auth-code",
+            "code_verifier": "pkce-verifier",
+            "client_secret": "super-secret",
+        },
+        policy=policy,
+    )
+
+    req = captured["req"]
+    assert req.get_method() == "POST"
+    assert req.full_url == "https://issuer.example/token"
+    headers = {k.lower(): v for k, v in req.header_items()}
+    assert headers["content-type"] == "application/x-www-form-urlencoded"
+    body = req.data.decode("utf-8")
+    assert "client_secret=super-secret" in body
+    assert "code_verifier=pkce-verifier" in body
+    assert "authorization" not in headers
+    assert result == {"access_token": "at"}
+
+
+def test_oidc_network_policy_is_immutable():
+    """The policy is parsed once and cannot be mutated afterwards."""
+    import api.auth_oidc as auth_oidc
+
+    policy = auth_oidc._OIDCNetworkPolicy(
+        issuer="https://issuer.example:8443", allow_private_endpoints=True
+    )
+    assert (policy.origin_host, policy.origin_port) == ("issuer.example", 8443)
+    assert policy.allow_private_endpoints is True
+    with pytest.raises(AttributeError):
+        policy.origin_host = "evil.example"
+    with pytest.raises(AttributeError):
+        policy.allow_private_endpoints = False
+    # Non-https issuers are rejected at policy construction time.
+    with pytest.raises(auth_oidc.OIDCConfigError):
+        auth_oidc._OIDCNetworkPolicy(
+            issuer="http://issuer.example", allow_private_endpoints=True
+        )
+
+
+def test_start_flow_requires_present_discovery_issuer(monkeypatch):
+    """The start flow must NOT consume authorization_endpoint unless the
+    discovery document declares a present issuer."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_require_oidc_config",
+        lambda: {
+            "issuer": "https://issuer.example",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": False,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_get_discovery_document",
+        lambda _policy, _issuer: {
+            "authorization_endpoint": "https://issuer.example/authorize",
+            "token_endpoint": "https://issuer.example/token",
+            "jwks_uri": "https://issuer.example/jwks",
+            # "issuer" deliberately missing
+        },
+    )
+    with pytest.raises(OIDCAuthError, match="did not include an issuer"):
+        auth_oidc.build_authorization_redirect("http://localhost:8787")
+
+
+def test_start_flow_rejects_mismatched_discovery_issuer(monkeypatch):
+    """The start flow must reject a discovery document whose issuer differs
+    from the configured issuer."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_require_oidc_config",
+        lambda: {
+            "issuer": "https://issuer.example",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": False,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_get_discovery_document",
+        lambda _policy, _issuer: {
+            "issuer": "https://evil.example",
+            "authorization_endpoint": "https://issuer.example/authorize",
+            "token_endpoint": "https://issuer.example/token",
+            "jwks_uri": "https://issuer.example/jwks",
+        },
+    )
+    with pytest.raises(OIDCAuthError, match="did not match the configured issuer"):
+        auth_oidc.build_authorization_redirect("http://localhost:8787")
+
+
+def test_callback_flow_requires_present_discovery_issuer(monkeypatch):
+    """The callback flow must reject a discovery document with NO issuer —
+    a missing issuer is as fatal as a mismatch."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_resolve_oidc_config",
+        lambda: {
+            "issuer": "https://issuer.example",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": False,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_get_discovery_document",
+        lambda _policy, _issuer: {
+            "token_endpoint": "https://issuer.example/token",
+            "jwks_uri": "https://issuer.example/jwks",
+        },
+    )
+    auth_oidc._pending_flows.clear()
+    auth_oidc._pending_flows["state-token"] = {
+        "created_at": time.time(),
+        "nonce": "nonce-token",
+        "code_verifier": "verifier",
+        "next_path": "/",
+    }
+    with pytest.raises(OIDCAuthError, match="did not include an issuer"):
+        auth_oidc.complete_authorization_code_flow(
+            "http://localhost:8787", "state-token", "code-token"
+        )
+
+
+def test_callback_flow_blocks_same_host_different_port_token_pivot(monkeypatch):
+    """#6136 re-gate: a discovery-controlled token_endpoint on the SAME host
+    but a DIFFERENT port must NOT inherit the allow-private grant."""
+    import api.auth_oidc as auth_oidc
+    from api.auth_oidc import OIDCAuthError
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_resolve_oidc_config",
+        lambda: {
+            "issuer": "https://auth.internal.example:8443",
+            "client_id": "webui-client",
+            "client_secret": "",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": True,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_get_discovery_document",
+        lambda _policy, _issuer: {
+            "issuer": "https://auth.internal.example:8443",
+            "token_endpoint": "https://auth.internal.example:9999/token",
+            "jwks_uri": "https://auth.internal.example:8443/jwks",
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.7", 9999))],
+    )
+    auth_oidc._pending_flows.clear()
+    auth_oidc._pending_flows["state-token"] = {
+        "created_at": time.time(),
+        "nonce": "nonce-token",
+        "code_verifier": "verifier",
+        "next_path": "/",
+    }
+    with pytest.raises(OIDCAuthError, match="private or local addresses"):
+        auth_oidc.complete_authorization_code_flow(
+            "http://localhost:8787", "state-token", "code-token"
+        )
+
+
+def test_callback_flow_allows_exact_origin_private_endpoints_end_to_end(monkeypatch):
+    """The full callback flow (discovery → token → id_token) succeeds when the
+    discovery-controlled endpoints sit on the exact configured origin and the
+    opt-in is enabled — the immutable policy is carried through every hop."""
+    import api.auth_oidc as auth_oidc
+
+    monkeypatch.setattr(
+        auth_oidc,
+        "_resolve_oidc_config",
+        lambda: {
+            "issuer": "https://auth.internal.example:8443",
+            "client_id": "webui-client",
+            "client_secret": "client-secret",
+            "redirect_uri": "",
+            "scopes": ["openid"],
+            "allow_claim": "email",
+            "allow_values": ["user@example.com"],
+            "allow_private_endpoints": True,
+        },
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_get_discovery_document",
+        lambda _policy, _issuer: {
+            "issuer": "https://auth.internal.example:8443",
+            "token_endpoint": "https://auth.internal.example:8443/token",
+            "jwks_uri": "https://auth.internal.example:8443/jwks",
+        },
+    )
+    # The exact origin resolves privately — permitted by the scoped grant.
+    monkeypatch.setattr(
+        auth_oidc.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 8443))],
+    )
+    captured = {}
+    monkeypatch.setattr(
+        auth_oidc,
+        "_oidc_opener",
+        lambda _policy: _FakeOpener({"id_token": "abc.def.ghi"}, captured),
+    )
+    monkeypatch.setattr(
+        auth_oidc,
+        "_validate_id_token",
+        lambda _token, **_kwargs: {"sub": "user-123", "email": "user@example.com"},
+    )
+    auth_oidc._pending_flows.clear()
+    auth_oidc._pending_flows["state-token"] = {
+        "created_at": time.time(),
+        "nonce": "nonce-token",
+        "code_verifier": "verifier",
+        "next_path": "/chat/1",
+    }
+
+    result = auth_oidc.complete_authorization_code_flow(
+        "http://localhost:8787", "state-token", "code-token"
+    )
+
+    assert result["subject"] == "user-123"
+    assert result["email"] == "user@example.com"
+    assert result["next_path"] == "/chat/1"
+    # The token exchange hit the exact-origin token endpoint.
+    assert captured["req"].full_url == "https://auth.internal.example:8443/token"

--- a/tests/test_issue3825_oidc_auth.py
+++ b/tests/test_issue3825_oidc_auth.py
@@ -1151,10 +1151,20 @@ def test_oidc_opener_disables_ambient_proxies(monkeypatch):
         issuer="https://issuer.example", allow_private_endpoints=False
     )
     opener = auth_oidc._oidc_opener(policy)
+    # The ambient proxy configuration above must be visible to the process
+    # (otherwise this test would be vacuous).
+    assert urllib_request.getproxies(), "ambient proxy env must be configured"
     proxy_handlers = [
         h for h in opener.handlers if isinstance(h, urllib_request.ProxyHandler)
     ]
-    assert proxy_handlers
+    # CPython >= 3.11 registers a ProxyHandler only when it exposes protocol
+    # methods, so the empty ProxyHandler({}) the opener installs never appears
+    # in the handler chain. The guarantee is that no handler carries the
+    # ambient proxy map (an absent or empty handler cannot redirect the flow);
+    # the functional no-proxy property is enforced end-to-end by
+    # test_token_form_body_never_delivered_to_ambient_proxy, and a tunnel
+    # attempt fails closed via test_pinned_connection_fails_closed_on_proxy_tunnel.
+    assert not any(h.proxies for h in proxy_handlers)
     for handler in proxy_handlers:
         assert handler.proxies == {}
 


### PR DESCRIPTION
## Summary

Fixes #6136 — OIDC SSRF protection was unconditionally blocking all private-IP DNS resolutions, breaking legitimate self-hosted deployments where the OIDC provider (Authentik, Keycloak, Zitadel, etc.) is on the same trusted internal network.

## Changes

Adds a new opt-in configuration key to allow private-network OIDC endpoints:

### `webui_oidc.allow_private_endpoints` (config) / `HERMES_WEBUI_OIDC_ALLOW_PRIVATE_ENDPOINTS` (env)

When set to `true` (or `1`/`yes`), the outbound SSRF check in `_validate_outbound_oidc_url()` is skipped, allowing OIDC endpoints that resolve to private / loopback / link-local addresses. Default: `false` (existing behavior preserved).

### Implementation

- **`_resolve_oidc_config()`**: Reads `allow_private_endpoints` from config file or env var, with standard boolean coercion (`"1"`, `"true"`, `"yes"`, or YAML `true`)
- **`_is_oidc_private_endpoints_allowed()`**: New helper that resolves the flag safely (returns `False` on any read error — fail-closed)
- **`_validate_outbound_oidc_url()`**: Early return when private endpoints are allowed, before reaching `_is_disallowed_oidc_host()`

### Tests (3 new)

- `test_allow_private_endpoints_config_true_allows_private_dns` — config flag `True` skips SSRF block
- `test_allow_private_endpoints_env_var_true_skips_ssrf_check` — env var `true` skips SSRF block
- `test_allow_private_endpoints_default_false_blocks_private_dns` — default behavior still blocks private IPs

All 28 OIDC tests pass including the 3 new ones.

## Usage

```yaml
# config.yaml
webui_oidc:
  issuer: https://auth.example.com/application/o/hermes-webui/
  client_id: webui-client
  allow_claim: groups
  allow_values: ["Hermes Users"]
  allow_private_endpoints: true   # ← new: allow self-hosted Identity Provider
```

Or via env:

```bash
export HERMES_WEBUI_OIDC_ALLOW_PRIVATE_ENDPOINTS=true
```