### PR TITLE
fix(wakeup): recover terminal process completions after restart

### DIFF
--- a/api/background_process.py
+++ b/api/background_process.py
@@ -63,6 +63,8 @@ logger = logging.getLogger(__name__)
 _DRAIN_THREAD: Optional[threading.Thread] = None
 _DRAIN_STOP = threading.Event()
 _PROCESS_RECOVERY_DONE = False
+_PROCESS_CHECKPOINT_RECOVERED = False
+_PROCESS_RECOVERY_LOCK = threading.Lock()
 
 _REAPER_THREAD: Optional[threading.Thread] = None
 _REAPER_STOP = threading.Event()
@@ -1625,10 +1627,7 @@ def recover_processes_for_webui(process_registry=None, get_session_fn=None) -> i
     previously started only the queue drain. That left checkpointed processes
     invisible after a WebUI restart.
     """
-    global _PROCESS_RECOVERY_DONE
-
-    if _PROCESS_RECOVERY_DONE:
-        return 0
+    global _PROCESS_CHECKPOINT_RECOVERED, _PROCESS_RECOVERY_DONE
     if process_registry is None:
         try:
             from tools.process_registry import process_registry
@@ -1641,28 +1640,36 @@ def recover_processes_for_webui(process_registry=None, get_session_fn=None) -> i
     if get_session_fn is None:
         from api.models import get_session as get_session_fn
 
-    recovered = process_registry.recover_from_checkpoint()
-    for row in process_registry.list_sessions():
-        process_id = str(row.get("session_id") or "")
-        if not process_id:
-            continue
-        try:
-            proc_session = process_registry.get(process_id)
-            session_key = str(getattr(proc_session, "session_key", "") or "")
-            if not session_key or get_session_fn(session_key, metadata_only=True) is None:
+    with _PROCESS_RECOVERY_LOCK:
+        if _PROCESS_RECOVERY_DONE:
+            return 0
+
+        recovered = 0
+        if not _PROCESS_CHECKPOINT_RECOVERED:
+            recovered = process_registry.recover_from_checkpoint()
+            _PROCESS_CHECKPOINT_RECOVERED = True
+
+        for row in process_registry.list_sessions():
+            process_id = str(row.get("session_id") or "")
+            if not process_id:
                 continue
-        except Exception:
-            logger.debug(
-                "Could not resolve recovered WebUI process %r",
-                process_id,
-                exc_info=True,
-            )
-            continue
-        register_process_session(session_key, session_key)
-    _PROCESS_RECOVERY_DONE = True
-    if recovered:
-        logger.info("Recovered %d background process(es) for WebUI", recovered)
-    return recovered
+            try:
+                proc_session = process_registry.get(process_id)
+                session_key = str(getattr(proc_session, "session_key", "") or "")
+                if not session_key or get_session_fn(session_key, metadata_only=True) is None:
+                    continue
+            except Exception:
+                logger.warning(
+                    "Could not resolve recovered WebUI process %r",
+                    process_id,
+                    exc_info=True,
+                )
+                continue
+            register_process_session(session_key, session_key)
+        _PROCESS_RECOVERY_DONE = True
+        if recovered:
+            logger.info("Recovered %d background process(es) for WebUI", recovered)
+        return recovered
 
 
 def register_process_session(session_key: str, session_id: str) -> None:

--- a/api/background_process.py
+++ b/api/background_process.py
@@ -62,6 +62,7 @@ logger = logging.getLogger(__name__)
 
 _DRAIN_THREAD: Optional[threading.Thread] = None
 _DRAIN_STOP = threading.Event()
+_PROCESS_RECOVERY_DONE = False
 
 _REAPER_THREAD: Optional[threading.Thread] = None
 _REAPER_STOP = threading.Event()
@@ -1617,6 +1618,53 @@ def _drain_loop() -> None:
             logger.warning("bg_task_complete event handling failed", exc_info=True)
 
 
+def recover_processes_for_webui(process_registry=None, get_session_fn=None) -> int:
+    """Recover core background processes and restore WebUI routing metadata.
+
+    The core gateway performs this during gateway startup, but this WebUI host
+    previously started only the queue drain. That left checkpointed processes
+    invisible after a WebUI restart.
+    """
+    global _PROCESS_RECOVERY_DONE
+
+    if _PROCESS_RECOVERY_DONE:
+        return 0
+    if process_registry is None:
+        try:
+            from tools.process_registry import process_registry
+        except ImportError:
+            # Hermes Agent is optional in isolated WebUI/test environments.
+            # The drain loop already treats a missing registry as unavailable;
+            # startup recovery must preserve that fail-soft contract.
+            logger.debug("process recovery unavailable: Hermes Agent is not installed")
+            return 0
+    if get_session_fn is None:
+        from api.models import get_session as get_session_fn
+
+    recovered = process_registry.recover_from_checkpoint()
+    for row in process_registry.list_sessions():
+        process_id = str(row.get("session_id") or "")
+        if not process_id:
+            continue
+        try:
+            proc_session = process_registry.get(process_id)
+            session_key = str(getattr(proc_session, "session_key", "") or "")
+            if not session_key or get_session_fn(session_key, metadata_only=True) is None:
+                continue
+        except Exception:
+            logger.debug(
+                "Could not resolve recovered WebUI process %r",
+                process_id,
+                exc_info=True,
+            )
+            continue
+        register_process_session(session_key, session_key)
+    _PROCESS_RECOVERY_DONE = True
+    if recovered:
+        logger.info("Recovered %d background process(es) for WebUI", recovered)
+    return recovered
+
+
 def register_process_session(session_key: str, session_id: str) -> None:
     """Bind a process-registry session_key to a WebUI session_id.
 
@@ -1663,6 +1711,12 @@ def start_drain_thread() -> bool:
     with _THREAD_LIFECYCLE_LOCK:
         if _DRAIN_THREAD is not None and _DRAIN_THREAD.is_alive():
             return False
+        try:
+            recover_processes_for_webui()
+        except Exception:
+            # Recovery is best-effort. A corrupt checkpoint or transient I/O
+            # error must not disable notifications for newly spawned tasks.
+            logger.warning("background process recovery failed", exc_info=True)
         _DRAIN_STOP.clear()
         _DRAIN_THREAD = threading.Thread(
             target=_drain_loop,

--- a/tests/test_background_process_restart_recovery.py
+++ b/tests/test_background_process_restart_recovery.py
@@ -1,0 +1,96 @@
+"""Regression coverage for notify_on_complete across a WebUI restart."""
+
+from types import SimpleNamespace
+
+from api import background_process as bp
+
+
+class _FakeThread:
+    def __init__(self, *args, **kwargs):
+        self.started = False
+
+    def is_alive(self):
+        return self.started
+
+    def start(self):
+        self.started = True
+
+
+class _FakeProcessSession:
+    def __init__(self, session_key):
+        self.session_key = session_key
+
+
+def test_start_drain_thread_invokes_recovery(monkeypatch):
+    calls = []
+    monkeypatch.setattr(bp, "_DRAIN_THREAD", None)
+    monkeypatch.setattr(bp, "recover_processes_for_webui", lambda: calls.append("recover") or 0)
+    monkeypatch.setattr(bp.threading, "Thread", _FakeThread)
+
+    assert bp.start_drain_thread() is True
+    assert calls == ["recover"]
+
+
+def test_start_drain_thread_survives_recovery_failure(monkeypatch):
+    def fail_recovery():
+        raise OSError("corrupt checkpoint")
+
+    monkeypatch.setattr(bp, "_DRAIN_THREAD", None)
+    monkeypatch.setattr(bp, "recover_processes_for_webui", fail_recovery)
+    monkeypatch.setattr(bp.threading, "Thread", _FakeThread)
+
+    assert bp.start_drain_thread() is True
+    assert bp._DRAIN_THREAD is not None
+    assert bp._DRAIN_THREAD.is_alive()
+
+
+def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
+    calls = {"recover": 0, "registered": []}
+
+    class FakeRegistry:
+        def recover_from_checkpoint(self):
+            calls["recover"] += 1
+            return 1
+
+        def list_sessions(self):
+            return [{
+                "session_id": "proc_recovered",
+                "detached": True,
+            }]
+
+        def get(self, process_id):
+            assert process_id == "proc_recovered"
+            return _FakeProcessSession("webui-session")
+
+    fake_registry = FakeRegistry()
+    monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
+    monkeypatch.setattr(
+        bp,
+        "register_process_session",
+        lambda key, sid: calls["registered"].append((key, sid)),
+    )
+
+    def get_session(sid, metadata_only=False):
+        return SimpleNamespace(id=sid)
+
+    assert bp.recover_processes_for_webui(fake_registry, get_session) == 1
+    assert bp.recover_processes_for_webui(fake_registry, get_session) == 0
+    assert calls == {
+        "recover": 1,
+        "registered": [("webui-session", "webui-session")],
+    }
+
+
+def test_recovery_is_fail_soft_without_agent(monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tools.process_registry":
+            raise ImportError("Hermes Agent not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    assert bp.recover_processes_for_webui() == 0
+    assert bp._PROCESS_RECOVERY_DONE is False

--- a/tests/test_background_process_restart_recovery.py
+++ b/tests/test_background_process_restart_recovery.py
@@ -1,6 +1,10 @@
 """Regression coverage for notify_on_complete across a WebUI restart."""
 
+import threading
+import time
 from types import SimpleNamespace
+
+import pytest
 
 from api import background_process as bp
 
@@ -63,6 +67,7 @@ def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
             return _FakeProcessSession("webui-session")
 
     fake_registry = FakeRegistry()
+    monkeypatch.setattr(bp, "_PROCESS_CHECKPOINT_RECOVERED", False)
     monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
     monkeypatch.setattr(
         bp,
@@ -81,6 +86,65 @@ def test_recovery_runs_once_and_rebuilds_session_mapping(monkeypatch):
     }
 
 
+def test_partial_recovery_retry_does_not_repeat_checkpoint_adoption(monkeypatch):
+    calls = {"recover": 0, "list": 0}
+
+    class FlakyRegistry:
+        def recover_from_checkpoint(self):
+            calls["recover"] += 1
+            return 1
+
+        def list_sessions(self):
+            calls["list"] += 1
+            if calls["list"] == 1:
+                raise OSError("transient list failure")
+            return []
+
+    registry = FlakyRegistry()
+    monkeypatch.setattr(bp, "_PROCESS_CHECKPOINT_RECOVERED", False)
+    monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
+
+    with pytest.raises(OSError, match="transient list failure"):
+        bp.recover_processes_for_webui(registry, lambda *_args, **_kwargs: None)
+
+    assert bp.recover_processes_for_webui(registry, lambda *_args, **_kwargs: None) == 0
+    assert calls == {"recover": 1, "list": 2}
+
+
+def test_concurrent_direct_recovery_runs_once(monkeypatch):
+    calls = {"recover": 0}
+
+    class FakeRegistry:
+        def recover_from_checkpoint(self):
+            time.sleep(0.02)
+            calls["recover"] += 1
+            return 1
+
+        def list_sessions(self):
+            return []
+
+    monkeypatch.setattr(bp, "_PROCESS_CHECKPOINT_RECOVERED", False)
+    monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
+    registry = FakeRegistry()
+    barrier = threading.Barrier(8)
+    results = []
+
+    def recover():
+        barrier.wait()
+        results.append(
+            bp.recover_processes_for_webui(registry, lambda *_args, **_kwargs: None)
+        )
+
+    workers = [threading.Thread(target=recover) for _ in range(8)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert calls["recover"] == 1
+    assert sorted(results) == [0] * 7 + [1]
+
+
 def test_recovery_is_fail_soft_without_agent(monkeypatch):
     real_import = __import__
 
@@ -89,6 +153,7 @@ def test_recovery_is_fail_soft_without_agent(monkeypatch):
             raise ImportError("Hermes Agent not installed")
         return real_import(name, *args, **kwargs)
 
+    monkeypatch.setattr(bp, "_PROCESS_CHECKPOINT_RECOVERED", False)
     monkeypatch.setattr(bp, "_PROCESS_RECOVERY_DONE", False)
     monkeypatch.setattr("builtins.__import__", fake_import)
 


### PR DESCRIPTION
## Summary

A `terminal(background=True, notify_on_complete=True)` child can outlive a WebUI restart, but the restarted WebUI never calls `ProcessRegistry.recover_from_checkpoint()`. Its in-memory process registry and `PROCESS_SESSION_INDEX` therefore start empty, so the eventual ordinary `proc_*` completion cannot wake its original session.

This change:

- performs best-effort core process recovery before starting the completion drain;
- rebuilds `PROCESS_SESSION_INDEX` from each recovered `ProcessSession.session_key`;
- validates that the owning WebUI session still exists before restoring the route;
- keeps recovery idempotent and fail-soft, so a corrupt checkpoint or missing optional Agent package cannot disable notifications for newly spawned tasks.

## Distinction from #6283

#6283 correctly shipped restart-safe durable delivery for `async_delegation` records through `tools.async_delegation`.

This PR covers a separate path: ordinary terminal `proc_*` processes tracked by `tools.process_registry`. Current `master` (`6ad84d7d`) has no `recover_from_checkpoint()` call in `api/background_process.py`, and NousResearch/hermes-agent#31980 ("Background terminal processes lose tracking after gateway restart") remains open.

This is the clean current-master replacement for closed #6225, which was marked superseded by #6283. The two fixes are complementary rather than duplicates.

## Companion core PR

Depends on NousResearch/hermes-agent#66796, which:

- persists final `notify_on_complete` metadata after terminal spawn configuration;
- monitors recovered detached processes so their exit autonomously enqueues a completion without requiring a later `poll` or `list` call.

## Validation

On current `master`, after #6283:

- related wakeup/delegation suite: **79 passed**
- focused replacement suite: **4 passed**
- `py_compile`: passed
- `git diff --check`: passed
- mutation checks:
  - skipping startup process recovery fails;
  - removing the real `ProcessSession` owner lookup fails;
  - allowing a recovery exception to escape and block drain startup fails.

## End-to-end restart test

I launched a real 300-second terminal process with `notify_on_complete=True`, restarted the WebUI while the child remained alive, and made no polling calls afterward.

- WebUI healthy again at `15:00:36`
- child completed at `15:04:50`
- original session autonomously started its wakeup turn at `15:04:51`

The test exercises the ordinary terminal-process registry path, not async delegation.