### PR TITLE
fix(#6240): guard symlink_to with OSError fallback for Windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -915,7 +915,16 @@ def test_server():
     real_skills  = HERMES_HOME / 'skills'
     test_skills  = TEST_STATE_DIR / 'skills'
     if real_skills.exists() and not test_skills.exists():
-        test_skills.symlink_to(real_skills)
+        try:
+            test_skills.symlink_to(real_skills)
+        except OSError:
+            # Native Windows without SeCreateSymbolicLinkPrivilege (Developer Mode
+            # off / non-admin) raises WinError 1314. Fall back to a copy so the
+            # test_server fixture — and the whole suite — still works.
+            if sys.platform == "win32":
+                shutil.copytree(real_skills, test_skills)
+            else:
+                raise
 
     # Isolated cron state
     (TEST_STATE_DIR / 'cron').mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
On native Windows without `SeCreateSymbolicLinkPrivilege` (Developer Mode off, non-admin shell), `Path.symlink_to()` raises `OSError [WinError 1314]`, which blocks the entire test suite at collection time — 88 errors, 0 collected in the bootstrap test files alone.

Wrap the symlink in `try/except OSError`: on win32, fall back to `shutil.copytree()` so the `test_server` fixture — and all dependent tests — still work. On non-Windows, re-raise the OSError to avoid masking real filesystem issues.

Closes #6240.