### PR TITLE
perf(run-journal): cache unchanged run summaries

### DIFF
--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -10,6 +10,7 @@ import os
 import re
 import threading
 import time
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -27,6 +28,14 @@ _WRITER_LOCKS_GUARD = threading.Lock()
 # ``_reserve_next_seq`` and ``delete_run_journal`` (which evicts stale entries).
 _SEQ_CACHE: dict[str, int] = {}
 _SEQ_CACHE_LOCK = threading.Lock()
+# Summary callers only need terminal state and the latest cursor. Re-parsing a
+# completed journal's full payload (which can include multi-megabyte tool or
+# session results) on every status/reconnect probe is needless. This process
+# cache is keyed by a complete stat identity, so it is never used after an
+# atomic replacement, append, truncate, or same-path file recreation.
+_SUMMARY_CACHE_MAX_ENTRIES = 128
+_SUMMARY_CACHE: OrderedDict[str, tuple[tuple[int, int, int, int], dict]] = OrderedDict()
+_SUMMARY_CACHE_LOCK = threading.Lock()
 _TERMINAL_SSE_EVENTS = {"done", "cancel", "apperror", "error", "stream_end"}
 _FSYNC_MODE_ENV = "HERMES_WEBUI_RUN_JOURNAL_FSYNC"
 _FSYNC_MODE_EAGER = "eager"
@@ -69,6 +78,54 @@ def _lock_for(path: Path) -> threading.Lock:
             lock = threading.Lock()
             _WRITER_LOCKS[key] = lock
         return lock
+
+
+def _summary_cache_signature(path: Path) -> tuple[int, int, int, int] | None:
+    """Return the complete filesystem identity used for summary-cache validity."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (int(stat.st_dev), int(stat.st_ino), int(stat.st_size), int(stat.st_mtime_ns))
+
+
+def _get_cached_summary(path: Path) -> dict | None:
+    signature = _summary_cache_signature(path)
+    if signature is None:
+        return None
+    key = str(path)
+    with _SUMMARY_CACHE_LOCK:
+        cached = _SUMMARY_CACHE.get(key)
+        if cached is None:
+            return None
+        cached_signature, summary = cached
+        if cached_signature != signature:
+            _SUMMARY_CACHE.pop(key, None)
+            return None
+        _SUMMARY_CACHE.move_to_end(key)
+        return dict(summary)
+
+
+def _cache_summary(
+    path: Path,
+    summary: dict,
+    *,
+    expected_signature: tuple[int, int, int, int] | None = None,
+) -> None:
+    signature = _summary_cache_signature(path)
+    if signature is None or (expected_signature is not None and signature != expected_signature):
+        return
+    key = str(path)
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE[key] = (signature, dict(summary))
+        _SUMMARY_CACHE.move_to_end(key)
+        while len(_SUMMARY_CACHE) > _SUMMARY_CACHE_MAX_ENTRIES:
+            _SUMMARY_CACHE.popitem(last=False)
+
+
+def _discard_cached_summary(path: Path) -> None:
+    with _SUMMARY_CACHE_LOCK:
+        _SUMMARY_CACHE.pop(str(path), None)
 
 
 def _read_jsonl(path: Path) -> tuple[list[dict], list[dict]]:
@@ -351,6 +408,7 @@ def append_run_event(
             fh.flush()
             if _should_fsync_event(terminal_state):
                 os.fsync(fh.fileno())
+        _discard_cached_summary(path)
         if created_file:
             _fsync_parent_dir(path)
         return event
@@ -427,8 +485,15 @@ def _summary_from_events(session_id: str, run_id: str, events: Iterable[dict]) -
 
 
 def latest_run_summary(session_id: str, run_id: str, *, session_dir: Path | None = None) -> dict:
-    journal = read_run_events(session_id, run_id, session_dir=session_dir)
-    return _summary_from_events(session_id, run_id, journal.get("events") or [])
+    path = _run_path(session_id, run_id, session_dir=session_dir)
+    cached = _get_cached_summary(path)
+    if cached is not None:
+        return cached
+    pre_read_signature = _summary_cache_signature(path)
+    events, _malformed = _read_jsonl(path)
+    summary = _summary_from_events(session_id, run_id, events)
+    _cache_summary(path, summary, expected_signature=pre_read_signature)
+    return summary
 
 
 def session_journal_fingerprint(session_id: str, *, session_dir: Path | None = None) -> tuple[int, float, int]:
@@ -471,8 +536,12 @@ def find_run_summary(run_id: str, *, session_dir: Path | None = None) -> dict | 
     journal_root = root / RUN_JOURNAL_DIR_NAME
     for path in journal_root.glob(f"*/{rid}.jsonl"):
         session_id = path.parent.name
-        events, _malformed = _read_jsonl(path)
-        summary = _summary_from_events(session_id, rid, events)
+        summary = _get_cached_summary(path)
+        if summary is None:
+            pre_read_signature = _summary_cache_signature(path)
+            events, _malformed = _read_jsonl(path)
+            summary = _summary_from_events(session_id, rid, events)
+            _cache_summary(path, summary, expected_signature=pre_read_signature)
         summary["path"] = str(path)
         return summary
     return None
@@ -640,8 +709,11 @@ def delete_run_journal(session_id: str, *, session_dir: Path | None = None) -> b
         # ``_note_assigned_seq`` take — so a concurrent append on another path
         # cannot mutate the dict mid-iteration (``dictionary changed size``).
         with _SEQ_CACHE_LOCK:
-            for key in [k for k in _SEQ_CACHE if str(Path(k).parent) == dir_key]:
-                del _SEQ_CACHE[key]
+            for cache_key in [entry for entry in _SEQ_CACHE if str(Path(entry).parent) == dir_key]:
+                del _SEQ_CACHE[cache_key]
+        with _SUMMARY_CACHE_LOCK:
+            for cache_key in [entry for entry in _SUMMARY_CACHE if str(Path(entry).parent) == dir_key]:
+                del _SUMMARY_CACHE[cache_key]
     return removed
 
 

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -113,7 +113,10 @@ def _cache_summary(
     expected_signature: tuple[int, int, int, int] | None = None,
 ) -> None:
     signature = _summary_cache_signature(path)
-    if signature is None or (expected_signature is not None and signature != expected_signature):
+    # The pre-read signature is an enforced TOCTOU precondition. In particular,
+    # a journal created after a missing-file read has ``None -> signature`` and
+    # must not cache the empty/unknown result under the new file's identity.
+    if signature is None or signature != expected_signature:
         return
     key = str(path)
     with _SUMMARY_CACHE_LOCK:

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -104,6 +104,49 @@ def test_latest_summary_and_find_run_summary_classify_terminal_state(tmp_path):
     assert found["terminal_state"] == "interrupted-by-user"
 
 
+def test_latest_summary_reuses_unchanged_journal_summary_without_reparsing(tmp_path, monkeypatch):
+    append_run_event("session_1", "run_1", "token", {"text": "ok"}, session_dir=tmp_path)
+    append_run_event("session_1", "run_1", "done", {"session": {}}, session_dir=tmp_path)
+
+    first = latest_run_summary("session_1", "run_1", session_dir=tmp_path)
+
+    monkeypatch.setattr(
+        "api.run_journal._read_jsonl",
+        lambda _path: (_ for _ in ()).throw(AssertionError("unchanged journal was reparsed")),
+    )
+    repeated = latest_run_summary("session_1", "run_1", session_dir=tmp_path)
+
+    assert repeated == first
+
+
+def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tmp_path, monkeypatch):
+    append_run_event("session_1", "run_1", "token", {"text": "ok"}, session_dir=tmp_path)
+    append_run_event("session_1", "run_1", "done", {"session": {}}, session_dir=tmp_path)
+
+    import api.run_journal as run_journal
+
+    original_read = run_journal._read_jsonl
+
+    def append_after_read(path):
+        events, malformed = original_read(path)
+        append_run_event(
+            "session_1",
+            "run_1",
+            "cancel",
+            {"message": "Cancelled by user"},
+            session_dir=tmp_path,
+        )
+        return events, malformed
+
+    monkeypatch.setattr(run_journal, "_read_jsonl", append_after_read)
+
+    first = latest_run_summary("session_1", "run_1", session_dir=tmp_path)
+    second = latest_run_summary("session_1", "run_1", session_dir=tmp_path)
+
+    assert first["terminal_state"] == "completed"
+    assert second["terminal_state"] == "interrupted-by-user"
+
+
 def test_terminal_state_classification_distinguishes_crash_from_user_cancel(tmp_path):
     append_run_event("session_1", "run_cancelled", "cancel", {"message": "Cancelled by user"}, session_dir=tmp_path)
     append_run_event("session_1", "run_crashed", "apperror", {"type": "interrupted"}, session_dir=tmp_path)

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -147,6 +147,38 @@ def test_summary_cache_does_not_store_result_when_journal_changes_during_read(tm
     assert second["terminal_state"] == "interrupted-by-user"
 
 
+
+def test_summary_cache_rejects_first_append_that_races_missing_journal_read(tmp_path, monkeypatch):
+    import api.run_journal as run_journal
+
+    original_read = run_journal._read_jsonl
+    appended = False
+
+    def append_after_missing_read(path):
+        nonlocal appended
+        events, malformed = original_read(path)
+        if not appended:
+            appended = True
+            append_run_event(
+                "session_1",
+                "run_first_append",
+                "done",
+                {"session": {}},
+                session_dir=tmp_path,
+            )
+        return events, malformed
+
+    monkeypatch.setattr(run_journal, "_read_jsonl", append_after_missing_read)
+
+    raced = latest_run_summary("session_1", "run_first_append", session_dir=tmp_path)
+    refreshed = latest_run_summary("session_1", "run_first_append", session_dir=tmp_path)
+
+    assert raced["terminal_state"] == "unknown"
+    assert refreshed["terminal_state"] == "completed"
+    assert refreshed["last_seq"] == 1
+    assert refreshed["last_event_id"] == "run_first_append:1"
+
+
 def test_terminal_state_classification_distinguishes_crash_from_user_cancel(tmp_path):
     append_run_event("session_1", "run_cancelled", "cancel", {"message": "Cancelled by user"}, session_dir=tmp_path)
     append_run_event("session_1", "run_crashed", "apperror", {"type": "interrupted"}, session_dir=tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to #6241: avoid repeatedly parsing an unchanged run journal in status/ownership summary paths.

- Add a bounded 128-entry, process-local LRU cache for run summaries.
- Validate every cache hit with `(device, inode, size, mtime_ns)` and return a defensive copy.
- Invalidate after every local append; reject a cache write if the journal changed while it was being read.
- Evict per-session summary entries with existing journal deletion cleanup.

Journal replay remains authoritative and unchanged. Cache misses, external mutation, append, truncate, replacement, recreation, or a concurrent write during read continue to take the full existing parse path.

## Why

Large active sessions can accumulate multi-megabyte JSONL journal files. `latest_run_summary()` and `find_run_summary()` previously reparsed their complete payloads for each unchanged summary probe, adding avoidable Python CPU/GIL and allocation pressure to reconnect/recovery paths that contribute to #6241.

## Tests

- `HERMES_WEBUI_TEST_PYTHON=/home/heeho3/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/bin/python3 ./scripts/test.sh tests/test_run_journal.py tests/test_run_journal_seq_cache.py tests/test_issue3802_delete_session_journals.py tests/test_run_journal_routes.py -q`
  - `40 passed`
- `./.venv/bin/python -m py_compile api/run_journal.py`
- `./.venv/bin/ruff check api/run_journal.py tests/test_run_journal.py`
  - `All checks passed`
- Independent review: no blocking correctness, concurrency, invalidation, durability, or scope findings.

## Full suite note

`./scripts/test.sh -q` completed with `13,365 passed`, `132 skipped`, but has 5 pre-existing/local-environment failures outside this diff:

- 4 dotenv bootstrap tests see launcher-provided `HERMES_WEBUI_PORT=8787` / host values instead of fixture values.
- 1 context-compression test imports a locally installed Hermes Agent whose `agent.auxiliary_client` lacks `call_llm`.
