### PR TITLE
fix: fix scrolling on new task dialog in kanban on mobile viewports

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -7022,7 +7022,7 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
   }
   /* Modal scales to viewport width on phones with reasonable padding.
      Ensure it's on screen and scrollable */
-  .kanban-modal-overlay{align-items:flex-start;overflow-y:auto;padding:12px;}
+  .kanban-modal-overlay{align-items:safe center;overflow-y:auto;padding:12px;}
   .kanban-modal{padding:16px 16px 14px;border-radius:14px;}
   .kanban-modal-row-inline{flex-direction:column;gap:0;}
 }

--- a/static/style.css
+++ b/static/style.css
@@ -7021,10 +7021,10 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
     max-width:calc(100vw - 24px);
   }
   /* Modal scales to viewport width on phones with reasonable padding.
-	   Ensure it's on screen and scrollable */
-	.kanban-modal-overlay{align-items:flex-start;overflow-y:auto;padding:12px;}
-	.kanban-modal{padding:16px 16px 14px;border-radius:14px;}
-	.kanban-modal-row-inline{flex-direction:column;gap:0;}
+     Ensure it's on screen and scrollable */
+  .kanban-modal-overlay{align-items:flex-start;overflow-y:auto;padding:12px;}
+  .kanban-modal{padding:16px 16px 14px;border-radius:14px;}
+  .kanban-modal-row-inline{flex-direction:column;gap:0;}
 }
 
 /* ── Logs panel (#1455) ───────────────────────────────────────────────────── */

--- a/static/style.css
+++ b/static/style.css
@@ -7020,10 +7020,11 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
     min-width:min(280px, calc(100vw - 24px));
     max-width:calc(100vw - 24px);
   }
-  /* Modal scales to viewport width on phones with reasonable padding. */
-  .kanban-modal-overlay{padding:12px;}
-  .kanban-modal{padding:16px 16px 14px;border-radius:14px;}
-  .kanban-modal-row-inline{flex-direction:column;gap:0;}
+  /* Modal scales to viewport width on phones with reasonable padding.
+	   Ensure it's on screen and scrollable */
+	.kanban-modal-overlay{align-items:flex-start;overflow-y:auto;padding:12px;}
+	.kanban-modal{padding:16px 16px 14px;border-radius:14px;}
+	.kanban-modal-row-inline{flex-direction:column;gap:0;}
 }
 
 /* ── Logs panel (#1455) ───────────────────────────────────────────────────── */

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -815,6 +815,22 @@ def test_kanban_review_feedback_static_ui_fixes_exist():
     assert "kanban-stats-grid" in PANELS
 
 
+def test_kanban_modal_mobile_responsive_css():
+    """On narrow phones (<=640px) a tall kanban modal must stay reachable: the
+    overlay scrolls (overflow-y:auto) and top-aligns its content
+    (align-items:flex-start) so nothing is clipped above the fold."""
+    # Each @media (max-width: 640px) block closes with a "\n}" at column 0
+    # (interior rules are indented), so this cleanly isolates each block.
+    blocks = re.findall(r"@media\s*\(max-width:\s*640px\)\s*\{(.*?)\n\}", STYLE, flags=re.S)
+    block = next((b for b in blocks if ".kanban-modal-overlay" in b), None)
+    assert block, "kanban-modal-overlay has no mobile (<=640px) rules"
+
+    overlay = re.search(r"\.kanban-modal-overlay\s*\{([^}]*)\}", block)
+    props = overlay.group(1)
+    assert "overflow-y:auto" in props, f"overlay must be scrollable. Got: {props}"
+    assert "align-items:flex-start" in props, f"overlay must top-align content. Got: {props}"
+
+
 def test_kanban_task_detail_renderer_executes_with_log_and_formats_feedback():
     import json
     import subprocess

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -826,6 +826,7 @@ def test_kanban_modal_mobile_responsive_css():
     assert block, "kanban-modal-overlay has no mobile (<=640px) rules"
 
     overlay = re.search(r"\.kanban-modal-overlay\s*\{([^}]*)\}", block)
+    assert overlay, "kanban-modal-overlay rule not parseable in mobile block"
     props = overlay.group(1)
     assert "overflow-y:auto" in props, f"overlay must be scrollable. Got: {props}"
     assert "align-items:flex-start" in props, f"overlay must top-align content. Got: {props}"

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -817,19 +817,23 @@ def test_kanban_review_feedback_static_ui_fixes_exist():
 
 def test_kanban_modal_mobile_responsive_css():
     """On narrow phones (<=640px) a tall kanban modal must stay reachable: the
-    overlay scrolls (overflow-y:auto) and top-aligns its content
-    (align-items:flex-start) so nothing is clipped above the fold."""
-    # Each @media (max-width: 640px) block closes with a "\n}" at column 0
-    # (interior rules are indented), so this cleanly isolates each block.
-    blocks = re.findall(r"@media\s*\(max-width:\s*640px\)\s*\{(.*?)\n\}", STYLE, flags=re.S)
-    block = next((b for b in blocks if ".kanban-modal-overlay" in b), None)
-    assert block, "kanban-modal-overlay has no mobile (<=640px) rules"
-
-    overlay = re.search(r"\.kanban-modal-overlay\s*\{([^}]*)\}", block)
-    assert overlay, "kanban-modal-overlay rule not parseable in mobile block"
-    props = overlay.group(1)
-    assert "overflow-y:auto" in props, f"overlay must be scrollable. Got: {props}"
-    assert "align-items:flex-start" in props, f"overlay must top-align content. Got: {props}"
+    overlay scrolls (overflow-y:auto) and safe-centers its content
+    (align-items:safe center) so an overflowing modal is never clipped above
+    the fold where its top can't be scrolled back into view."""
+    # There are several `.kanban-modal-overlay{...}` rules (skin override, base
+    # desktop, and the mobile <=640px override, which is last in the file).
+    # Match against COMPACT_STYLE — whitespace-stripped, like the sibling CSS
+    # tests — and take the last rule to isolate the mobile override, instead of
+    # depending on brittle @media-block bracket matching.
+    overlay_rules = re.findall(r"\.kanban-modal-overlay\{([^}]*)\}", COMPACT_STYLE)
+    assert overlay_rules, "no .kanban-modal-overlay rule found in style.css"
+    mobile = overlay_rules[-1]
+    assert "overflow-y:auto" in mobile, f"mobile overlay must be scrollable. Got: {mobile}"
+    # `align-items:safe center` compacts to `align-items:safecenter`.
+    assert "align-items:safecenter" in mobile, (
+        f"mobile overlay must safe-center its content so an overflowing modal "
+        f"is never clipped above the fold. Got: {mobile}"
+    )
 
 
 def test_kanban_task_detail_renderer_executes_with_log_and_formats_feedback():


### PR DESCRIPTION
# Summary
Interacting with Kanban > New Task opens a dialog for you to enter information to create a new kanban task. On mobile viewports this dialog was both:
1. Not scrollable
2. Not properly aligned with it's parent element causing some of it to be outside your viewport

This PR simply adds two classes to the media query for mobile viewports to fix the issue.

# The Problem
Without this PR the new task dialog is unusable on mobile devices:
[fix-kaban_newtask_old.webm](https://github.com/user-attachments/assets/e2c8fc54-2a84-4dcb-b89d-af0133a663ad)

With the two CSS properties the entire modal is scrollable and viewable within the viewport:
[fix-kanban_newtask_new.webm](https://github.com/user-attachments/assets/737347df-08d5-417d-b3ab-23dbff82ff30)

# Fix
Simply adding:
* `overflow-y: auto` to make the `.kanban-modal-overlay` scrollable
* `align-items: flex-start` to ensure the `.kanban-modal` is placed properly within the parent

# Validation
- See videos attached above
- Added a test case asserting that `.kanban-modal-overlay` is in fact scrollable and it's content is positioned properly within and `.venv/bin/python -m pytest tests/test_kanban_ui_static.py -k mobile_responsive -q`