### PR TITLE
perf(providers): parallelize cold provider discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@
 > Python 3.11, 3.12, and 3.13 (3 parallel shards each) against every PR, plus a ruff
 > lint gate, a headless browser smoke test, and a Docker smoke test.
 >
-> Notable architecture state: the bootstrap and first-run onboarding flow own setup discovery; the default WebUI state directory is `~/.hermes/webui`; `ctl.sh` provides a daemon wrapper for homelab installs; chat streaming is still WebUI-owned SSE with stream-ownership guards, cancellation, async manual compression, and turn-journal audit plumbing; provider/model discovery is profile-aware with live-model cache invalidation and custom-provider scoping. (Version/test-count numbers above are a periodic snapshot — the authoritative source is the latest git tag and `pytest --collect-only`.)
+> Notable architecture state: the bootstrap and first-run onboarding flow own setup discovery; the default WebUI state directory is `~/.hermes/webui`; `ctl.sh` provides a daemon wrapper for homelab installs; chat streaming is still WebUI-owned SSE with stream-ownership guards, cancellation, async manual compression, and turn-journal audit plumbing; provider/model discovery is profile-aware and deadline-bounded, with keyed singleflight/cache invalidation, live-model refresh, and custom-provider scoping. (Version/test-count numbers above are a periodic snapshot — the authoritative source is the latest git tag and `pytest --collect-only`.)
 
 ---
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import atexit
 import base64
 import copy
+import contextvars
 import hashlib
 import json
 import logging
@@ -21,6 +22,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -139,11 +141,23 @@ _account_usage_status_cache: dict[tuple[str, str, str], tuple[float, Any]] = {}
 _account_usage_status_cache_lock = threading.Lock()
 _providers_cache: dict[tuple[Any, ...], tuple[float, dict[str, Any]]] = {}
 _providers_cache_lock = threading.Lock()
+_providers_build_inflight: dict[tuple[Any, ...], "_ProvidersBuildInFlight"] = {}
 _account_usage_worker_pool: dict[str, list["_AccountUsageProbeWorker"]] = {}
 _account_usage_worker_pool_lock = threading.Lock()
+_providers_cache_generation = 0
+_PROVIDERS_MAX_WORKERS = 8
+_providers_executor = ThreadPoolExecutor(max_workers=_PROVIDERS_MAX_WORKERS)
 
 # Per-home worker pool configuration for probe tail-latency reduction (#3787)
 _ACCOUNT_USAGE_WORKERS_PER_HOME = 2
+
+
+class _ProvidersBuildInFlight:
+    def __init__(self, generation: int):
+        self.generation = generation
+        self.event = threading.Event()
+        self.result: dict[str, Any] | None = None
+        self.exception: BaseException | None = None
 
 
 def _get_account_usage_probe_semaphore() -> threading.BoundedSemaphore:
@@ -775,6 +789,27 @@ def _provider_credential_env_vars() -> tuple[str, ...]:
     return tuple(sorted(names))
 
 
+_BEDROCK_SINGLE_CREDENTIAL_ENV_SIGNALS = (
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_PROFILE",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+)
+
+
+def _provider_has_structural_bedrock_credentials() -> bool:
+    """Return True when Bedrock credential signals are available without probing."""
+    access_key = _thread_local_env_value("AWS_ACCESS_KEY_ID").strip()
+    secret_key = _thread_local_env_value("AWS_SECRET_ACCESS_KEY").strip()
+    if access_key and secret_key:
+        return True
+    for env_name in _BEDROCK_SINGLE_CREDENTIAL_ENV_SIGNALS:
+        if _thread_local_env_value(env_name).strip():
+            return True
+    return False
+
+
 _PROVIDER_CREDENTIAL_ENV_VARS = _provider_credential_env_vars()
 
 # Providers that use OAuth or token flows — their credentials are managed
@@ -1037,6 +1072,114 @@ def _providers_cache_key(cfg: Any) -> tuple[Any, ...]:
     )
 
 
+def _acquire_provider_build_state(
+    cache_key: tuple[Any, ...],
+) -> tuple[str, dict[str, Any] | None, _ProvidersBuildInFlight | None]:
+    now = time.monotonic()
+    with _providers_cache_lock:
+        cached = _providers_cache.get(cache_key)
+        if cached is not None:
+            ts, payload = cached
+            if now - ts < _PROVIDERS_CACHE_TTL_SECONDS:
+                return "cached", copy.deepcopy(payload), None
+            _providers_cache.pop(cache_key, None)
+
+        generation = _providers_cache_generation
+        in_flight = _providers_build_inflight.get(cache_key)
+        if in_flight is not None:
+            if in_flight.generation == generation:
+                return "wait", None, in_flight
+            _providers_build_inflight.pop(cache_key, None)
+
+        state = _ProvidersBuildInFlight(generation)
+        _providers_build_inflight[cache_key] = state
+        return "build", None, state
+
+
+def _complete_provider_build(
+    cache_key: tuple[Any, ...],
+    state: _ProvidersBuildInFlight,
+    payload: dict[str, Any] | None = None,
+    *,
+    error: BaseException | None = None,
+) -> dict[str, Any] | None:
+    completion_error: BaseException | None = error
+    completed_result: dict[str, Any] | None = None
+    published_cache_entry: tuple[float, dict[str, Any]] | None = None
+    try:
+        if completion_error is None:
+            if payload is not None:
+                state.result = copy.deepcopy(payload)
+            else:
+                state.result = None
+        else:
+            state.exception = completion_error
+            state.result = None
+
+        if (
+            completion_error is None
+            and state.result is not None
+        ):
+            with _providers_cache_lock:
+                if state.generation == _providers_cache_generation:
+                    published_cache_entry = (
+                        time.monotonic(),
+                        copy.deepcopy(state.result),
+                    )
+                    _providers_cache.clear()
+                    _providers_cache[cache_key] = published_cache_entry
+
+        if completion_error is None:
+            completed_result = copy.deepcopy(state.result)
+    except BaseException as exc:
+        if completion_error is None:
+            completion_error = exc
+            state.exception = exc
+        else:
+            state.exception = completion_error
+    finally:
+        try:
+            if completion_error is not None and published_cache_entry is not None:
+                try:
+                    with _providers_cache_lock:
+                        if _providers_cache.get(cache_key) is published_cache_entry:
+                            _providers_cache.pop(cache_key, None)
+                except BaseException:
+                    logger.debug(
+                        "Failed to rollback provider cache publication for %s",
+                        cache_key,
+                        exc_info=True,
+                    )
+            with _providers_cache_lock:
+                if _providers_build_inflight.get(cache_key) is state:
+                    _providers_build_inflight.pop(cache_key, None)
+        except BaseException:
+            logger.debug(
+                "Failed to remove provider build state for %s",
+                cache_key,
+                exc_info=True,
+            )
+        state.event.set()
+
+    if completion_error is not None:
+        if error is None:
+            raise completion_error
+        return None
+    return completed_result
+
+
+def _wait_provider_build(state: _ProvidersBuildInFlight, cache_key: tuple[Any, ...]) -> dict[str, Any]:
+    state.event.wait()
+    if state.exception is not None:
+        raise state.exception
+    if state.result is not None:
+        return copy.deepcopy(state.result)
+    cached = _get_cached_providers(cache_key)
+    if cached is not None:
+        return cached
+    raise RuntimeError("Provider build did not produce payload")
+
+
 def _get_cached_providers(cache_key: tuple[Any, ...]) -> dict[str, Any] | None:
     now = time.monotonic()
     with _providers_cache_lock:
@@ -1050,20 +1193,29 @@ def _get_cached_providers(cache_key: tuple[Any, ...]) -> dict[str, Any] | None:
         return copy.deepcopy(payload)
 
 
-def _store_cached_providers(cache_key: tuple[Any, ...], payload: dict[str, Any]) -> dict[str, Any]:
+def _store_cached_providers(
+    cache_key: tuple[Any, ...],
+    payload: dict[str, Any],
+    generation: int | None = None,
+) -> dict[str, Any]:
     with _providers_cache_lock:
+        if generation is not None and generation != _providers_cache_generation:
+            return copy.deepcopy(payload)
         # Single-entry by design: /api/providers is cacheable only for the
         # active profile/config snapshot, so clear older snapshots to avoid
         # retaining unbounded provider metadata across profile switches.
         _providers_cache.clear()
         _providers_cache[cache_key] = (time.monotonic(), copy.deepcopy(payload))
-    return payload
+    return copy.deepcopy(payload)
 
 
 def invalidate_providers_cache() -> None:
     """Clear cached ``GET /api/providers`` responses."""
+    global _providers_cache_generation
     with _providers_cache_lock:
+        _providers_cache_generation += 1
         _providers_cache.clear()
+        _providers_build_inflight.clear()
 
 
 def _load_env_file(env_path: Path) -> dict[str, str]:
@@ -1081,6 +1233,23 @@ def _load_env_file(env_path: Path) -> dict[str, str]:
     except Exception:
         return {}
     return values
+
+
+def _provider_entry_env_key_source(provider_id: str, env_values: dict[str, Any]) -> str:
+    """Resolve an env-backed key source label for a provider card."""
+    env_var = _provider_env_var_for(provider_id)
+    if not env_var:
+        return "none"
+    if _provider_value_counts_as_api_key(provider_id, env_values.get(env_var)):
+        return "env_file"
+    if _provider_value_counts_as_api_key(provider_id, _thread_local_env_value(env_var)):
+        return "env_var"
+    for alias in _PROVIDER_ENV_VAR_ALIASES.get(provider_id, ()) or ():
+        if _provider_value_counts_as_api_key(provider_id, env_values.get(alias)):
+            return "env_file"
+        if _provider_value_counts_as_api_key(provider_id, _thread_local_env_value(alias)):
+            return "env_var"
+    return "none"
 
 
 def _decode_jwt_claims_unverified(token: str) -> dict[str, Any]:
@@ -1977,7 +2146,12 @@ def _close_account_usage_probe_workers_async(*, provider_id: str | None = None) 
     thread.start()
 
 
+def _close_providers_executor() -> None:
+    _providers_executor.shutdown(wait=False)
+
+
 atexit.register(_close_account_usage_probe_workers)
+atexit.register(_close_providers_executor)
 
 
 def _account_usage_cache_key(provider: str, home: Path, api_key: str | None) -> tuple[str, str, str]:
@@ -2546,45 +2720,67 @@ def get_provider_cost_history(provider_id: str | None = None, days: int = 7) -> 
 # SECTION: Public API
 
 
-def get_providers() -> dict[str, Any]:
-    """Return a list of all known providers with their configuration status.
+def _build_provider_entry(
+    provider_id: str,
+    initial_has_key: bool,
+    providers_cfg: dict[str, Any],
+    active_profile_name: str,
+    request_thread_env: dict[str, Any],
+    block_process_env_fallback: bool,
+) -> dict[str, Any] | None:
+    """Build one provider entry using request-scoped profile/thread-local context."""
+    pid = str(provider_id or "").strip()
+    if not pid:
+        return None
 
-    Each entry contains:
-    - ``id``: canonical provider slug
-    - ``display_name``: human-readable name
-    - ``has_key``: whether an API key is configured
-    - ``configurable``: whether the key can be set from the WebUI
-    - ``key_source``: where the key was found (``env_file``, ``env_var``,
-      ``config_yaml``, ``oauth``, ``none``)
-    - ``models``: list of known model IDs for this provider
-    """
-    # Collect all known provider IDs from multiple sources
-    known_ids = set(_PROVIDER_DISPLAY.keys()) | set(_PROVIDER_MODELS.keys())
-    known_ids.update(plugin_model_provider_ids())
+    display_name = effective_provider_display_name(pid, _PROVIDER_DISPLAY)
+    is_oauth = _provider_is_oauth(pid)
+    providers_cfg = providers_cfg if isinstance(providers_cfg, dict) else {}
+    thread_env = dict(request_thread_env or {})
 
-    # Also detect providers from config.yaml providers section
-    cfg = get_config()
-    cache_key = _providers_cache_key(cfg)
-    cached = _get_cached_providers(cache_key)
-    if cached is not None:
-        return cached
+    import api.config as cfg
+    import api.profiles as profiles
 
-    providers = []
-    providers_cfg = cfg.get("providers") or {}
-    if isinstance(providers_cfg, dict):
-        known_ids.update(providers_cfg.keys())
+    has_key = bool(initial_has_key)
+    is_bedrock = pid == "bedrock"
+    auth_error = None
+    key_source = "none"
 
-    # Add OAuth providers even if not in _PROVIDER_DISPLAY
-    known_ids.update(_OAUTH_PROVIDERS)
+    previous_thread_env = dict(getattr(cfg._thread_ctx, "env", {}))
+    previous_block = bool(getattr(cfg._thread_ctx, "block_process_env_fallback", False))
 
-    for pid in sorted(known_ids):
-        display_name = effective_provider_display_name(pid, _PROVIDER_DISPLAY)
-        is_oauth = _provider_is_oauth(pid)
-        has_key = _provider_has_key(pid)
+    try:
+        if active_profile_name:
+            profiles.set_request_profile(active_profile_name)
+        else:
+            profiles.clear_request_profile()
+        cfg._set_thread_env(**thread_env)
+        cfg._thread_ctx.block_process_env_fallback = block_process_env_fallback
+
+        if has_key:
+            if is_bedrock:
+                if _provider_has_structural_bedrock_credentials():
+                    key_source = "env_var"
+                else:
+                    key_source = "config_yaml"
+            elif is_oauth:
+                key_source = "oauth"
+            else:
+                env_var = _provider_env_var_for(pid)
+                if env_var:
+                    env_path = _get_hermes_home() / ".env"
+                    env_values = _load_env_file(env_path)
+                    key_source = _provider_entry_env_key_source(pid, env_values)
+                    if key_source == "none":
+                        key_source = "config_yaml"
+                else:
+                    key_source = "config_yaml"
+
         plugin_auth_status: dict[str, Any] | None = None
         if not has_key and is_plugin_model_provider(pid):
             try:
                 from hermes_cli.auth import get_auth_status as _gas_plugin
+
                 _plugin_status = _gas_plugin(pid)
                 if isinstance(_plugin_status, dict) and (
                     _plugin_status.get("logged_in") or _plugin_status.get("configured")
@@ -2594,10 +2790,17 @@ def get_providers() -> dict[str, Any]:
             except Exception:
                 logger.debug("Plugin provider auth check failed for %s", pid, exc_info=True)
 
-        # Determine key source
-        key_source = "none"
-        auth_error = None
-        if is_oauth:
+        if is_bedrock:
+            # Bedrock auth must stay structural-only on the settings path (#2720/#6010).
+            # Use the same env-signal family consumed by the runtime adapter path,
+            # but do not invoke hermes_cli.auth or botocore-like resolution.
+            if _provider_has_structural_bedrock_credentials() and not has_key:
+                has_key = True
+                if key_source == "none":
+                    key_source = "env_var"
+            if key_source == "none" and has_key:
+                key_source = "env_var"
+        elif is_oauth:
             key_source = "oauth"
             # Check if actually authenticated via hermes_cli.
             # IMPORTANT: do not unconditionally overwrite has_key from _provider_has_key().
@@ -2606,6 +2809,7 @@ def get_providers() -> dict[str, Any]:
             # or refresh token consumed by native Codex CLI / VS Code extension).
             try:
                 from hermes_cli.auth import get_auth_status as _gas
+
                 status = _gas(pid)
                 if isinstance(status, dict) and status.get("logged_in"):
                     has_key = True
@@ -2628,32 +2832,14 @@ def get_providers() -> dict[str, Any]:
             if env_var:
                 env_path = _get_hermes_home() / ".env"
                 env_values = _load_env_file(env_path)
-                if _provider_value_counts_as_api_key(pid, env_values.get(env_var)):
-                    key_source = "env_file"
-                elif _provider_value_counts_as_api_key(pid, _thread_local_env_value(env_var)):
-                    key_source = "env_var"
-                else:
-                    # Canonical name not set; check legacy aliases (e.g. lmstudio's
-                    # pre-#1500 LMSTUDIO_API_KEY) so existing users see "env_file"
-                    # instead of being misreported as "config_yaml" when the key
-                    # actually lives in .env under the old name.
-                    aliased = False
-                    for alias in _PROVIDER_ENV_VAR_ALIASES.get(pid, ()) or ():
-                        if _provider_value_counts_as_api_key(pid, env_values.get(alias)):
-                            key_source = "env_file"
-                            aliased = True
-                            break
-                        if _provider_value_counts_as_api_key(pid, _thread_local_env_value(alias)):
-                            key_source = "env_var"
-                            aliased = True
-                            break
-                    if not aliased:
-                        _plugin_ks = (
-                            str(plugin_auth_status.get("key_source") or "").strip()
-                            if isinstance(plugin_auth_status, dict)
-                            else ""
-                        )
-                        key_source = _plugin_ks or "config_yaml"
+                key_source = _provider_entry_env_key_source(pid, env_values)
+                if key_source == "none":
+                    _plugin_ks = (
+                        str(plugin_auth_status.get("key_source") or "").strip()
+                        if isinstance(plugin_auth_status, dict)
+                        else ""
+                    )
+                    key_source = _plugin_ks or "config_yaml"
             else:
                 _plugin_ks = (
                     str(plugin_auth_status.get("key_source") or "").strip()
@@ -2663,32 +2849,34 @@ def get_providers() -> dict[str, Any]:
                 key_source = _plugin_ks or "config_yaml"
         elif not _provider_env_var_for(pid):
             # Fallback: provider is not a known API-key provider and not in
-            # the hardcoded _OAUTH_PROVIDERS set.  It may be a custom or
+            # the hardcoded _OAUTH_PROVIDERS set. It may be a custom or
             # newly-added OAuth provider (e.g. Anthropic connected via OAuth).
             # Check live auth status so the Providers tab agrees with the
             # model picker (#1212).
             #
             # IMPORTANT: we skip providers with a known API-key env var because
             # they are pure API-key providers — calling get_auth_status() for
-            # every unconfigured API-key provider would add unnecessary latency
-            # (network round-trip per provider) on the Settings page.
-            # Validate pid looks like a real provider before probing
+            # every unconfigured API-key provider would add unnecessary latency.
             import re as _re
-            if _re.match(r'^[a-z][a-z0-9_-]{0,63}$', pid):
+
+            if _re.match(r"^[a-z][a-z0-9_-]{0,63}$", pid):
                 try:
                     from hermes_cli.auth import get_auth_status as _gas
+
                     status = _gas(pid)
                     if isinstance(status, dict) and status.get("logged_in"):
                         has_key = True
-                        # Constrain key_source to a known-safe closed set
+                        # Constrain key_source to a known-safe closed set.
                         _raw_ks = status.get("key_source", "")
-                        key_source = _raw_ks if _raw_ks in {"oauth", "env", "config", "token"} else "oauth"
+                        key_source = (
+                            _raw_ks if _raw_ks in {"oauth", "env", "config", "token"} else "oauth"
+                        )
                         is_oauth = True
                 except Exception:
                     pass
 
         if pid == "openai" and not has_key and _provider_has_shadowed_codex_oauth_value(pid):
-            continue
+            return None
 
         models = list(_PROVIDER_MODELS.get(pid, []))
         models_total = len(models)
@@ -2723,7 +2911,7 @@ def get_providers() -> dict[str, Any]:
         # Nous Portal: prefer the live catalog so the providers card matches
         # the dropdown picker (#1538). Same fallback shape as the static-only
         # case below — when hermes_cli is unavailable or its lookup raises,
-        # we keep the four-entry curated list.
+        # we keep the curated list.
         #
         # On large-tier accounts (#1567 reporter Deor saw 396 entries), we
         # render the same featured subset the picker uses so the providers
@@ -2750,7 +2938,7 @@ def get_providers() -> dict[str, Any]:
             except Exception:
                 logger.debug("Failed to load Nous Portal models from hermes_cli")
         # LM Studio: fetch live locally-loaded models so the providers card
-        # matches what's actually available on the user's server (#WebUI).
+        # matches what's actually available on your server (#WebUI).
         if pid == "lmstudio":
             try:
                 from hermes_cli.models import provider_model_ids as _pmi
@@ -2776,7 +2964,7 @@ def get_providers() -> dict[str, Any]:
                     pid,
                     exc_info=True,
                 )
-        # Also include models from config.yaml providers section
+        # Also include models from config.yaml providers section.
         if isinstance(providers_cfg, dict):
             provider_cfg = providers_cfg.get(pid, {})
             if isinstance(provider_cfg, dict) and "models" in provider_cfg:
@@ -2796,11 +2984,12 @@ def get_providers() -> dict[str, Any]:
         is_self_hosted = pid in _SELF_HOSTED_PROVIDER_IDS
         try:
             from api.config import _get_provider_base_url
+
             provider_base_url = _get_provider_base_url(pid) if is_self_hosted else None
         except Exception:
             provider_base_url = None
         _is_plugin = is_plugin_model_provider(pid)
-        providers.append({
+        return {
             "id": pid,
             "display_name": display_name,
             "has_key": has_key,
@@ -2814,13 +3003,114 @@ def get_providers() -> dict[str, Any]:
             "models": models,
             # models_total reflects the complete catalog size (e.g. 396 for
             # an enterprise Nous Portal account), even when "models" is
-            # trimmed to a featured subset for UI scannability. The frontend
-            # uses this for the header text "396 models · OAuth" so users
-            # know the full catalog exists and is reachable via the slash
-            # command. For providers that don't trim, models_total ==
-            # len(models) and the frontend behaves identically to before.
+            # trimmed to a featured subset for UI scannability. For providers
+            # that don't trim, models_total equals len(models) and the
+            # frontend behaves identically to before.
             "models_total": models_total,
-        })
+        }
+    except Exception:
+        logger.debug("Failed to build provider entry for %s", pid, exc_info=True)
+        models = list(_PROVIDER_MODELS.get(pid, []))
+        models_total = len(models)
+        if isinstance(providers_cfg, dict):
+            provider_cfg = providers_cfg.get(pid, {})
+            if isinstance(provider_cfg, dict) and "models" in provider_cfg:
+                cfg_models = provider_cfg["models"]
+                if isinstance(cfg_models, dict):
+                    models = models + [{"id": k, "label": k} for k in cfg_models.keys()]
+                elif isinstance(cfg_models, list):
+                    models = models + [{"id": k, "label": k} for k in cfg_models]
+                if pid != "nous":
+                    models_total = len(models)
+        is_self_hosted = pid in _SELF_HOSTED_PROVIDER_IDS
+        try:
+            from api.config import _get_provider_base_url
+
+            provider_base_url = _get_provider_base_url(pid) if is_self_hosted else None
+        except Exception:
+            provider_base_url = None
+        if pid == "openai" and not has_key and _provider_has_shadowed_codex_oauth_value(pid):
+            return None
+        return {
+            "id": pid,
+            "display_name": display_name,
+            "has_key": has_key,
+            "configurable": not is_oauth and bool(_provider_env_var_for(pid)),
+            "is_self_hosted": is_self_hosted,
+            "base_url": provider_base_url,
+            "is_plugin_provider": is_plugin_model_provider(pid),
+            "is_oauth": is_oauth,
+            "key_source": key_source if has_key else "none",
+            "auth_error": auth_error,
+            "models": models,
+            "models_total": models_total,
+        }
+    finally:
+        cfg._thread_ctx.block_process_env_fallback = previous_block
+        if previous_thread_env:
+            cfg._set_thread_env(**previous_thread_env)
+        else:
+            cfg._clear_thread_env()
+        profiles.clear_request_profile()
+
+
+def _build_providers_payload(
+    cfg: dict[str, Any],
+    sorted_known_ids: list[str],
+    active_profile_name: str,
+    request_thread_env: dict[str, Any],
+    request_block_process_env_fallback: bool,
+    providers_cfg: dict[str, Any],
+) -> dict[str, Any]:
+    providers = []
+
+    # Credential-pool discovery uses a shared process cache that predates this
+    # endpoint's worker fan-out. Keep those reads on the request thread; the
+    # expensive independent auth/model enrichment below is what benefits from
+    # bounded parallelism.
+    initial_has_keys: dict[str, bool] = {}
+    for pid in sorted_known_ids:
+        provider_id = str(pid or "").strip()
+        try:
+            has_key = _provider_has_key(provider_id)
+            if provider_id.lower() == "bedrock":
+                has_key = has_key or _provider_has_structural_bedrock_credentials()
+            initial_has_keys[provider_id] = has_key
+        except Exception:
+            logger.debug("Failed reading local provider credentials for %s", pid, exc_info=True)
+            initial_has_keys[provider_id] = False
+
+    provider_entries: dict[str, dict[str, Any]] = {}
+    # Bound parallel provider work to avoid a DNS/auth-probe stampede when many
+    # providers need live enrichment on the same cold request.
+    futures = {}
+    for pid in sorted_known_ids:
+        context = contextvars.copy_context()
+        future = _providers_executor.submit(
+            context.run,
+            _build_provider_entry,
+            pid,
+            initial_has_keys.get(str(pid or "").strip(), False),
+            providers_cfg,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+        )
+        futures[future] = pid
+
+    for future, pid in list(futures.items()):
+        try:
+            entry = future.result()
+        except Exception:
+            logger.debug("Failed building provider entry for %s", pid, exc_info=True)
+            entry = None
+        if isinstance(entry, dict):
+            provider_entries[pid] = entry
+
+    for pid in sorted_known_ids:
+        entry = provider_entries.get(pid)
+        if entry is not None:
+            providers.append(entry)
 
     # Scan custom_providers from config.yaml (e.g. glmcode, timicc)
     custom_providers_cfg = cfg.get("custom_providers", [])
@@ -2861,6 +3151,7 @@ def get_providers() -> dict[str, Any]:
             if not cp_has_key:
                 try:
                     from api.config import _has_explicit_pool_credentials
+
                     if _has_explicit_pool_credentials(cp_id):
                         cp_has_key = True
                 except ImportError:
@@ -2894,11 +3185,70 @@ def get_providers() -> dict[str, Any]:
         return (3, pid)
     providers.sort(key=_provider_sort_key)
 
-    result = {
+    return {
         "providers": providers,
         "active_provider": active_provider,
     }
-    return _store_cached_providers(cache_key, result)
+
+
+def get_providers() -> dict[str, Any]:
+    """Return a list of all known providers with their configuration status.
+
+    Each entry contains:
+    - ``id``: canonical provider slug
+    - ``display_name``: human-readable name
+    - ``has_key``: whether an API key is configured
+    - ``configurable``: whether the key can be set from the WebUI
+    - ``key_source``: where the key was found (``env_file``, ``env_var``,
+      ``config_yaml``, ``oauth``, ``none``)
+    - ``models``: list of known model IDs for this provider
+    """
+    # Collect all known provider IDs from multiple sources
+    known_ids = set(_PROVIDER_DISPLAY.keys()) | set(_PROVIDER_MODELS.keys())
+    known_ids.update(plugin_model_provider_ids())
+
+    # Also detect providers from config.yaml providers section
+    cfg = get_config()
+    cache_key = _providers_cache_key(cfg)
+    state, cached, in_flight = _acquire_provider_build_state(cache_key)
+    if state == "cached" and cached is not None:
+        return cached
+    if state == "wait" and in_flight is not None:
+        return _wait_provider_build(in_flight, cache_key)
+
+    providers_cfg: dict[str, Any] = cfg.get("providers") or {}
+    if isinstance(providers_cfg, dict):
+        known_ids.update(providers_cfg.keys())
+
+    # Add OAuth providers even if not in _PROVIDER_DISPLAY
+    known_ids.update(_OAUTH_PROVIDERS)
+
+    sorted_known_ids = sorted(known_ids)
+    import api.config as config_module
+    import api.profiles as profiles
+
+    active_profile_name = profiles.get_active_profile_name()
+    request_thread_env = dict(getattr(config_module._thread_ctx, "env", {}))
+    request_block_process_env_fallback = bool(
+        getattr(config_module._thread_ctx, "block_process_env_fallback", False),
+    )
+
+    if in_flight is None:
+        raise RuntimeError("Failed to claim provider build state")
+
+    try:
+        result = _build_providers_payload(
+            cfg=cfg,
+            sorted_known_ids=sorted_known_ids,
+            active_profile_name=active_profile_name,
+            request_thread_env=request_thread_env,
+            request_block_process_env_fallback=request_block_process_env_fallback,
+            providers_cfg=providers_cfg,
+        )
+    except BaseException as exc:
+        _complete_provider_build(cache_key, in_flight, error=exc)
+        raise
+    return _complete_provider_build(cache_key, in_flight, payload=result)
 
 
 def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:

--- a/api/providers.py
+++ b/api/providers.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import logging
 import os
+import queue
 import signal
 import subprocess
 import sys
@@ -22,7 +23,6 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -146,7 +146,14 @@ _account_usage_worker_pool: dict[str, list["_AccountUsageProbeWorker"]] = {}
 _account_usage_worker_pool_lock = threading.Lock()
 _providers_cache_generation = 0
 _PROVIDERS_MAX_WORKERS = 8
-_providers_executor = ThreadPoolExecutor(max_workers=_PROVIDERS_MAX_WORKERS)
+_PROVIDERS_MAX_ACTIVE_TASKS = 64
+_PROVIDERS_BUILD_TIMEOUT_SECONDS = 15.0
+_PROVIDERS_FOLLOWER_TIMEOUT_SECONDS = 20.0
+_providers_runner_lock = threading.Lock()
+_providers_runner_condition = threading.Condition(_providers_runner_lock)
+_providers_active_runners: set["_ProvidersBuildRunner"] = set()
+_providers_active_tasks: dict[tuple[str, str], "_ProvidersBuildRunner"] = {}
+_providers_shutdown = threading.Event()
 
 # Per-home worker pool configuration for probe tail-latency reduction (#3787)
 _ACCOUNT_USAGE_WORKERS_PER_HOME = 2
@@ -158,6 +165,201 @@ class _ProvidersBuildInFlight:
         self.event = threading.Event()
         self.result: dict[str, Any] | None = None
         self.exception: BaseException | None = None
+
+
+class _ProvidersBuildRunner:
+    """Own one bounded provider build without reusable non-daemon workers.
+
+    Provider plugins and live catalog callbacks do not all expose a terminating
+    timeout.  Running them in a process-wide ``ThreadPoolExecutor`` therefore
+    lets one stuck callback permanently consume reusable capacity and makes the
+    interpreter join that worker at exit.  Each cold build instead owns up to
+    ``_PROVIDERS_MAX_WORKERS`` daemon workers and returns at a hard build
+    deadline.  A process-wide task registry prevents a timed-out
+    ``(Hermes home, provider)`` callback from being started again while the old
+    invocation is still alive, and the active-task cap bounds total detached
+    work across profiles.
+
+    Python cannot terminate an arbitrary running thread safely.  Timed-out
+    callbacks are therefore quarantined rather than falsely reported as
+    cancelled; queued work is dropped and cannot start after ``stop()``.
+    """
+
+    def __init__(
+        self,
+        home_key: str,
+        jobs: list[tuple[str, str, contextvars.Context, tuple[Any, ...]]],
+        worker_fn,
+    ):
+        self.home_key = home_key
+        self._jobs: queue.Queue[
+            tuple[str, str, contextvars.Context, tuple[Any, ...]]
+        ] = queue.Queue()
+        for job in jobs:
+            self._jobs.put(job)
+        self._worker_fn = worker_fn
+        self._stop = threading.Event()
+        self._done = threading.Event()
+        self._wake = threading.Event()
+        self._result_lock = threading.Lock()
+        self._remaining = len(jobs)
+        self._results: dict[str, Any] = {}
+        self._deadline = 0.0
+        self.timed_out = False
+        self.skipped_quarantined = False
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._wake.set()
+        # Synchronize with task admission so no queued callback can be claimed
+        # after stop() returns.
+        with _providers_runner_condition:
+            _providers_runner_condition.notify_all()
+        # Drop queued contexts immediately.  A stuck running callback retains
+        # only its own context instead of pinning every cancelled job forever.
+        while True:
+            try:
+                self._jobs.get_nowait()
+            except queue.Empty:
+                break
+            self._finish_job()
+
+    def _finish_job(self) -> None:
+        with self._result_lock:
+            self._remaining -= 1
+            if self._remaining <= 0:
+                self._done.set()
+                self._wake.set()
+
+    def _claim_task(
+        self,
+        active_id: str,
+    ) -> tuple[str, tuple[str, str] | None]:
+        task_key = (self.home_key, active_id)
+        with _providers_runner_condition:
+            if self._stop.is_set() or _providers_shutdown.is_set():
+                return "stop", None
+            if time.monotonic() >= self._deadline:
+                self.timed_out = True
+                _providers_runner_condition.notify_all()
+                return "deadline", None
+            owner = _providers_active_tasks.get(task_key)
+            if owner is not None:
+                if owner.timed_out:
+                    return "quarantined", None
+                return "retry", None
+            if len(_providers_active_tasks) >= _PROVIDERS_MAX_ACTIVE_TASKS:
+                return "retry", None
+            _providers_active_tasks[task_key] = self
+            return "claimed", task_key
+
+    def _release_task(self, task_key: tuple[str, str]) -> None:
+        with _providers_runner_condition:
+            if _providers_active_tasks.get(task_key) is self:
+                _providers_active_tasks.pop(task_key, None)
+            _providers_runner_condition.notify_all()
+
+    def _requeue_and_wait(
+        self,
+        job: tuple[str, str, contextvars.Context, tuple[Any, ...]],
+    ) -> bool:
+        with _providers_runner_condition:
+            if self._stop.is_set() or _providers_shutdown.is_set():
+                return False
+            remaining = self._deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            self._jobs.put(job)
+            _providers_runner_condition.wait(timeout=min(remaining, 0.05))
+            return True
+
+    def _worker(self) -> None:
+        while not self._stop.is_set():
+            try:
+                job = self._jobs.get_nowait()
+            except queue.Empty:
+                return
+            result_id, active_id, context, args = job
+
+            task_key: tuple[str, str] | None = None
+            finish_job = True
+            try:
+                claim, task_key = self._claim_task(active_id)
+                if claim == "retry":
+                    if self._requeue_and_wait(job):
+                        finish_job = False
+                    continue
+                if claim == "quarantined":
+                    self.skipped_quarantined = True
+                    continue
+                if claim == "deadline":
+                    self.stop()
+                    continue
+                if claim != "claimed" or task_key is None:
+                    continue
+                entry = context.run(self._worker_fn, *args)
+                if isinstance(entry, dict) and not self._stop.is_set():
+                    with self._result_lock:
+                        if not self._stop.is_set():
+                            self._results[result_id] = entry
+            except BaseException:
+                logger.debug("Failed building provider work item %s", result_id, exc_info=True)
+            finally:
+                if task_key is not None:
+                    self._release_task(task_key)
+                if finish_job:
+                    self._finish_job()
+
+    def run(self, deadline: float) -> dict[str, Any]:
+        if self._remaining == 0:
+            return {}
+        self._deadline = deadline
+        if deadline <= time.monotonic():
+            with _providers_runner_condition:
+                self.timed_out = True
+                _providers_runner_condition.notify_all()
+            self.stop()
+            return {}
+        with _providers_runner_condition:
+            if _providers_shutdown.is_set():
+                return {}
+            _providers_active_runners.add(self)
+
+        worker_count = min(_PROVIDERS_MAX_WORKERS, self._remaining)
+        try:
+            for index in range(worker_count):
+                threading.Thread(
+                    target=self._worker,
+                    name=f"provider-build-{index + 1}",
+                    daemon=True,
+                ).start()
+            remaining = max(0.0, deadline - time.monotonic())
+            if not self._wake.wait(remaining):
+                with _providers_runner_condition:
+                    self.timed_out = True
+                    _providers_runner_condition.notify_all()
+                self.stop()
+            with self._result_lock:
+                return dict(self._results)
+        finally:
+            self.stop()
+            with _providers_runner_condition:
+                _providers_active_runners.discard(self)
+                _providers_runner_condition.notify_all()
+
+
+def shutdown_provider_build_runners() -> None:
+    """Stop admitting provider work during orderly server shutdown.
+
+    Running callbacks may be third-party code that Python cannot safely kill.
+    Runner threads are daemonized, so shutdown signals every active runner and
+    returns without joining callbacks that ignore cancellation.
+    """
+    _providers_shutdown.set()
+    with _providers_runner_lock:
+        runners = list(_providers_active_runners)
+    for runner in runners:
+        runner.stop()
 
 
 def _get_account_usage_probe_semaphore() -> threading.BoundedSemaphore:
@@ -1102,6 +1304,7 @@ def _complete_provider_build(
     payload: dict[str, Any] | None = None,
     *,
     error: BaseException | None = None,
+    cache_payload: bool = True,
 ) -> dict[str, Any] | None:
     completion_error: BaseException | None = error
     completed_result: dict[str, Any] | None = None
@@ -1119,6 +1322,7 @@ def _complete_provider_build(
         if (
             completion_error is None
             and state.result is not None
+            and cache_payload
         ):
             with _providers_cache_lock:
                 if state.generation == _providers_cache_generation:
@@ -1169,7 +1373,12 @@ def _complete_provider_build(
 
 
 def _wait_provider_build(state: _ProvidersBuildInFlight, cache_key: tuple[Any, ...]) -> dict[str, Any]:
-    state.event.wait()
+    if not state.event.wait(_PROVIDERS_FOLLOWER_TIMEOUT_SECONDS):
+        # Bound this caller without stealing ownership from the leader.  The
+        # leader may still publish a valid result; removing its state here
+        # would let a replacement build race and then be overwritten by that
+        # late completion.
+        raise TimeoutError("Timed out waiting for provider discovery")
     if state.exception is not None:
         raise state.exception
     if state.result is not None:
@@ -2130,12 +2339,7 @@ def _close_account_usage_probe_workers_async(*, provider_id: str | None = None) 
     thread.start()
 
 
-def _close_providers_executor() -> None:
-    _providers_executor.shutdown(wait=False)
-
-
 atexit.register(_close_account_usage_probe_workers)
-atexit.register(_close_providers_executor)
 
 
 def _account_usage_cache_key(provider: str, home: Path, api_key: str | None) -> tuple[str, str, str]:
@@ -3038,6 +3242,59 @@ def _build_provider_entry(
         profiles.clear_request_profile()
 
 
+def _scan_provider_has_keys(
+    provider_ids: list[str],
+    custom_provider_ids: list[str],
+    active_profile_name: str,
+    request_thread_env: dict[str, Any],
+    block_process_env_fallback: bool,
+) -> dict[str, bool]:
+    """Run serialized credential-pool discovery inside the build deadline."""
+    import api.config as config_module
+    import api.profiles as profiles
+
+    previous_thread_env = dict(getattr(config_module._thread_ctx, "env", {}))
+    previous_block = bool(
+        getattr(config_module._thread_ctx, "block_process_env_fallback", False)
+    )
+    try:
+        if active_profile_name:
+            profiles.set_request_profile(active_profile_name)
+        else:
+            profiles.clear_request_profile()
+        config_module._set_thread_env(**dict(request_thread_env or {}))
+        config_module._thread_ctx.block_process_env_fallback = block_process_env_fallback
+
+        results: dict[str, bool] = {}
+        custom_ids = set(custom_provider_ids)
+        for provider_id in provider_ids:
+            try:
+                if provider_id in custom_ids:
+                    from api.config import _has_explicit_pool_credentials
+
+                    has_key = _has_explicit_pool_credentials(provider_id)
+                else:
+                    has_key = _provider_has_key(provider_id)
+                if provider_id.lower() == "bedrock":
+                    has_key = has_key or _provider_has_structural_bedrock_credentials()
+                results[provider_id] = has_key
+            except Exception:
+                logger.debug(
+                    "Failed reading local provider credentials for %s",
+                    provider_id,
+                    exc_info=True,
+                )
+                results[provider_id] = False
+        return results
+    finally:
+        config_module._thread_ctx.block_process_env_fallback = previous_block
+        if previous_thread_env:
+            config_module._set_thread_env(**previous_thread_env)
+        else:
+            config_module._clear_thread_env()
+        profiles.clear_request_profile()
+
+
 def _build_providers_payload(
     cfg: dict[str, Any],
     sorted_known_ids: list[str],
@@ -3045,51 +3302,86 @@ def _build_providers_payload(
     request_thread_env: dict[str, Any],
     request_block_process_env_fallback: bool,
     providers_cfg: dict[str, Any],
-) -> dict[str, Any]:
+    deadline: float,
+) -> tuple[dict[str, Any], bool]:
     providers = []
 
-    # Credential-pool discovery uses a shared process cache that predates this
-    # endpoint's worker fan-out. Keep those reads on the request thread; the
-    # expensive independent auth/model enrichment below is what benefits from
-    # bounded parallelism.
-    initial_has_keys: dict[str, bool] = {}
-    for pid in sorted_known_ids:
-        provider_id = str(pid or "").strip()
-        try:
-            has_key = _provider_has_key(provider_id)
-            if provider_id.lower() == "bedrock":
-                has_key = has_key or _provider_has_structural_bedrock_credentials()
-            initial_has_keys[provider_id] = has_key
-        except Exception:
-            logger.debug("Failed reading local provider credentials for %s", pid, exc_info=True)
-            initial_has_keys[provider_id] = False
+    try:
+        home_key = str(_get_hermes_home().resolve())
+    except OSError:
+        home_key = str(_get_hermes_home())
 
-    provider_entries: dict[str, dict[str, Any]] = {}
-    # Bound parallel provider work to avoid a DNS/auth-probe stampede when many
-    # providers need live enrichment on the same cold request.
-    futures = {}
+    custom_providers_cfg = cfg.get("custom_providers", [])
+    custom_provider_ids = []
+    if isinstance(custom_providers_cfg, list):
+        custom_provider_ids = [
+            _custom_provider_slug_from_name(str(cp.get("name") or "").strip())
+            for cp in custom_providers_cfg
+            if isinstance(cp, dict) and cp.get("name")
+        ]
+    credential_scan_ids = list(dict.fromkeys([
+        *(str(pid or "").strip() for pid in sorted_known_ids),
+        *(pid for pid in custom_provider_ids if pid),
+    ]))
+
+    # Credential-pool discovery mutates a shared process cache, so it stays
+    # serialized as one work item while still sharing the leader's deadline.
+    preflight_runner = _ProvidersBuildRunner(
+        home_key,
+        [(
+            "credentials",
+            "__credential_preflight__",
+            contextvars.copy_context(),
+            (
+                credential_scan_ids,
+                custom_provider_ids,
+                active_profile_name,
+                request_thread_env,
+                request_block_process_env_fallback,
+            ),
+        )],
+        _scan_provider_has_keys,
+    )
+    preflight_results = preflight_runner.run(deadline)
+    initial_has_keys = preflight_results.get("credentials", {})
+    if not isinstance(initial_has_keys, dict):
+        initial_has_keys = {}
+    preflight_complete = (
+        "credentials" in preflight_results
+        and not preflight_runner.timed_out
+        and not preflight_runner.skipped_quarantined
+    )
+
+    # Potentially unbounded plugin/live callbacks run only in this build's
+    # daemonized runner.  A hard build deadline drops queued work, while the
+    # process-wide task registry quarantines any callback that remains stuck.
+    jobs = []
     for pid in sorted_known_ids:
         context = contextvars.copy_context()
-        future = _providers_executor.submit(
-            context.run,
-            _build_provider_entry,
-            pid,
-            initial_has_keys.get(str(pid or "").strip(), False),
-            providers_cfg,
-            active_profile_name,
-            request_thread_env,
-            request_block_process_env_fallback,
-        )
-        futures[future] = pid
+        provider_id = str(pid or "").strip()
+        jobs.append((
+            provider_id,
+            provider_id,
+            context,
+            (
+                pid,
+                initial_has_keys.get(provider_id, False),
+                providers_cfg,
+                active_profile_name,
+                request_thread_env,
+                request_block_process_env_fallback,
+            ),
+        ))
 
-    for future, pid in list(futures.items()):
-        try:
-            entry = future.result()
-        except Exception:
-            logger.debug("Failed building provider entry for %s", pid, exc_info=True)
-            entry = None
-        if isinstance(entry, dict):
-            provider_entries[pid] = entry
+    runner = _ProvidersBuildRunner(home_key, jobs, _build_provider_entry)
+    provider_entries = runner.run(deadline)
+    if runner.timed_out:
+        logger.warning(
+            "Provider discovery exceeded %.1fs; returning %d/%d completed entries",
+            _PROVIDERS_BUILD_TIMEOUT_SECONDS,
+            len(provider_entries),
+            len(jobs),
+        )
 
     for pid in sorted_known_ids:
         entry = provider_entries.get(pid)
@@ -3097,7 +3389,6 @@ def _build_providers_payload(
             providers.append(entry)
 
     # Scan custom_providers from config.yaml (e.g. glmcode, timicc)
-    custom_providers_cfg = cfg.get("custom_providers", [])
     if isinstance(custom_providers_cfg, list):
         for cp in custom_providers_cfg:
             if not isinstance(cp, dict) or not cp.get("name"):
@@ -3131,15 +3422,8 @@ def _build_providers_payload(
             if cp_api_key.startswith("${") and cp_api_key.endswith("}"):
                 env_var = cp_api_key[2:-1]
                 cp_has_key = bool(_thread_local_env_value(env_var).strip())
-            # Fallback: check credential pool (key added via hermes auth add)
-            if not cp_has_key:
-                try:
-                    from api.config import _has_explicit_pool_credentials
-
-                    if _has_explicit_pool_credentials(cp_id):
-                        cp_has_key = True
-                except ImportError:
-                    pass
+            # The serialized preflight includes credential-pool keys.
+            cp_has_key = cp_has_key or bool(initial_has_keys.get(cp_id, False))
             providers.append({
                 "id": cp_id,
                 "display_name": cp_name,
@@ -3169,10 +3453,15 @@ def _build_providers_payload(
         return (3, pid)
     providers.sort(key=_provider_sort_key)
 
-    return {
-        "providers": providers,
-        "active_provider": active_provider,
-    }
+    return (
+        {
+            "providers": providers,
+            "active_provider": active_provider,
+        },
+        preflight_complete
+        and not runner.timed_out
+        and not runner.skipped_quarantined,
+    )
 
 
 def get_providers() -> dict[str, Any]:
@@ -3203,6 +3492,7 @@ def get_providers() -> dict[str, Any]:
     if in_flight is None:
         raise RuntimeError("Failed to claim provider build state")
 
+    deadline = time.monotonic() + _PROVIDERS_BUILD_TIMEOUT_SECONDS
     try:
         providers_cfg: dict[str, Any] = cfg.get("providers") or {}
         if isinstance(providers_cfg, dict):
@@ -3221,18 +3511,27 @@ def get_providers() -> dict[str, Any]:
             getattr(config_module._thread_ctx, "block_process_env_fallback", False),
         )
 
-        result = _build_providers_payload(
+        result, cache_payload = _build_providers_payload(
             cfg=cfg,
             sorted_known_ids=sorted_known_ids,
             active_profile_name=active_profile_name,
             request_thread_env=request_thread_env,
             request_block_process_env_fallback=request_block_process_env_fallback,
             providers_cfg=providers_cfg,
+            deadline=deadline,
         )
     except BaseException as exc:
         _complete_provider_build(cache_key, in_flight, error=exc)
         raise
-    return _complete_provider_build(cache_key, in_flight, payload=result)
+    completed = _complete_provider_build(
+        cache_key,
+        in_flight,
+        payload=result,
+        cache_payload=cache_payload,
+    )
+    if completed is None:
+        raise RuntimeError("Provider build did not produce payload")
+    return completed
 
 
 def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:

--- a/api/providers.py
+++ b/api/providers.py
@@ -3186,7 +3186,7 @@ def _build_provider_entry(
             "base_url": provider_base_url,
             "is_plugin_provider": _is_plugin,
             "is_oauth": is_oauth,
-            "key_source": key_source,
+            "key_source": key_source if has_key else "none",
             "auth_error": auth_error,
             "models": models,
             # models_total reflects the complete catalog size (e.g. 396 for

--- a/api/providers.py
+++ b/api/providers.py
@@ -1193,22 +1193,6 @@ def _get_cached_providers(cache_key: tuple[Any, ...]) -> dict[str, Any] | None:
         return copy.deepcopy(payload)
 
 
-def _store_cached_providers(
-    cache_key: tuple[Any, ...],
-    payload: dict[str, Any],
-    generation: int | None = None,
-) -> dict[str, Any]:
-    with _providers_cache_lock:
-        if generation is not None and generation != _providers_cache_generation:
-            return copy.deepcopy(payload)
-        # Single-entry by design: /api/providers is cacheable only for the
-        # active profile/config snapshot, so clear older snapshots to avoid
-        # retaining unbounded provider metadata across profile switches.
-        _providers_cache.clear()
-        _providers_cache[cache_key] = (time.monotonic(), copy.deepcopy(payload))
-    return copy.deepcopy(payload)
-
-
 def invalidate_providers_cache() -> None:
     """Clear cached ``GET /api/providers`` responses."""
     global _providers_cache_generation
@@ -3216,27 +3200,27 @@ def get_providers() -> dict[str, Any]:
     if state == "wait" and in_flight is not None:
         return _wait_provider_build(in_flight, cache_key)
 
-    providers_cfg: dict[str, Any] = cfg.get("providers") or {}
-    if isinstance(providers_cfg, dict):
-        known_ids.update(providers_cfg.keys())
-
-    # Add OAuth providers even if not in _PROVIDER_DISPLAY
-    known_ids.update(_OAUTH_PROVIDERS)
-
-    sorted_known_ids = sorted(known_ids)
-    import api.config as config_module
-    import api.profiles as profiles
-
-    active_profile_name = profiles.get_active_profile_name()
-    request_thread_env = dict(getattr(config_module._thread_ctx, "env", {}))
-    request_block_process_env_fallback = bool(
-        getattr(config_module._thread_ctx, "block_process_env_fallback", False),
-    )
-
     if in_flight is None:
         raise RuntimeError("Failed to claim provider build state")
 
     try:
+        providers_cfg: dict[str, Any] = cfg.get("providers") or {}
+        if isinstance(providers_cfg, dict):
+            known_ids.update(providers_cfg.keys())
+
+        # Add OAuth providers even if not in _PROVIDER_DISPLAY
+        known_ids.update(_OAUTH_PROVIDERS)
+
+        sorted_known_ids = sorted(known_ids)
+        import api.config as config_module
+        import api.profiles as profiles
+
+        active_profile_name = profiles.get_active_profile_name()
+        request_thread_env = dict(getattr(config_module._thread_ctx, "env", {}))
+        request_block_process_env_fallback = bool(
+            getattr(config_module._thread_ctx, "block_process_env_fallback", False),
+        )
+
         result = _build_providers_payload(
             cfg=cfg,
             sorted_known_ids=sorted_known_ids,

--- a/server.py
+++ b/server.py
@@ -691,17 +691,9 @@ def main() -> None:
     print(f'  Then open:     {scheme}://localhost:{PORT}', flush=True)
     print('', flush=True)
 
-    # ctl.sh stops the WebUI with SIGTERM. Python's default SIGTERM handler
-    # terminates the process WITHOUT unwinding the try/finally around
-    # serve_forever(), so drain_all_on_shutdown() (which flushes in-flight
-    # fire-and-forget memory commits) would never run on the normal managed
-    # stop. Install a handler that requests an orderly shutdown so
-    # serve_forever() returns and the existing `finally` block drains cleanly.
-    #
-    # httpd.shutdown() blocks until serve_forever() has exited and MUST NOT be
-    # called from the thread running serve_forever() (it would deadlock), so we
-    # dispatch it from a short-lived helper thread. The handler is idempotent
-    # and guards against double-shutdown (e.g. repeated SIGTERM/SIGINT).
+    # ctl.sh uses SIGTERM, whose default handler skips this function's finally.
+    # Request orderly shutdown from a helper thread: shutdown() blocks until
+    # serve_forever() exits, and the event makes repeated signals idempotent.
     _shutdown_requested = threading.Event()
 
     def _request_shutdown(signum, _frame):

--- a/server.py
+++ b/server.py
@@ -724,6 +724,11 @@ def main() -> None:
         httpd.serve_forever()
     finally:
         httpd.server_close()
+        try:
+            from api.providers import shutdown_provider_build_runners
+            shutdown_provider_build_runners()
+        except Exception:
+            logger.debug("Failed to stop provider build runners during shutdown", exc_info=True)
         _log_shutdown_audit()
         try:
             from api.gateway_watcher import stop_watcher

--- a/static/panels.js
+++ b/static/panels.js
@@ -10955,6 +10955,7 @@ const _SELF_HOSTED_DEFAULT_BASE_URLS = Object.freeze({
   ollama: 'http://localhost:11434/v1',
   lmstudio: 'http://localhost:1234/v1',
 });
+let _providersPanelLoadGeneration = 0;
 
 async function _fetchProviderQuotaStatus(force=false){
   const endpoint=force?`/api/provider/quota?refresh=1&ts=${Date.now()}`:'/api/provider/quota';
@@ -10967,20 +10968,19 @@ async function loadProvidersPanel(){
   const list=$('providersList');
   const empty=$('providersEmpty');
   if(!list) return;
+  const generation=++_providersPanelLoadGeneration;
+  const providersPromise = api('/api/providers');
+  const quotaPromise = _fetchProviderQuotaStatus(false).catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||t('provider_quota_unavailable'),client_fetched_at:new Date().toISOString()}));
   try{
-    const data=await api('/api/providers');
-    const quota=await _fetchProviderQuotaStatus(false).catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||t('provider_quota_unavailable'),client_fetched_at:new Date().toISOString()}));
+    const data=await providersPromise;
+    if(generation!==_providersPanelLoadGeneration) return;
     const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider||p.is_self_hosted);
     list.innerHTML='';
     _providerCardEls.clear();
-    const quotaCard=_buildProviderQuotaCard(quota);
-    if(quotaCard){
-      list.appendChild(quotaCard);
-      renderProviderCostChart(quotaCard); // async, fire-and-forget
-    }
     if(providers.length===0){
       list.style.display='none';
       if(empty) empty.style.display='';
+      await quotaPromise;
       return;
     }
     if(empty) empty.style.display='none';
@@ -10988,7 +10988,20 @@ async function loadProvidersPanel(){
     for(const p of providers){
       list.appendChild(_buildProviderCard(p));
     }
+    const quota = await quotaPromise;
+    if(generation!==_providersPanelLoadGeneration) return;
+    const quotaCard=_buildProviderQuotaCard(quota);
+    if(quotaCard){
+      const currentQuotaCard=list.querySelector('.provider-quota-card');
+      if(currentQuotaCard){
+        currentQuotaCard.replaceWith(quotaCard);
+      }else{
+        list.prepend(quotaCard);
+      }
+      renderProviderCostChart(quotaCard); // async, fire-and-forget
+    }
   }catch(e){
+    if(generation!==_providersPanelLoadGeneration) return;
     list.innerHTML='<div style="color:var(--error);padding:12px;font-size:13px">Failed to load providers: '+esc(e.message||String(e))+'</div>';
   }
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -10956,6 +10956,7 @@ const _SELF_HOSTED_DEFAULT_BASE_URLS = Object.freeze({
   lmstudio: 'http://localhost:1234/v1',
 });
 let _providersPanelLoadGeneration = 0;
+let _providersPanelCurrentLoad = null;
 
 async function _fetchProviderQuotaStatus(force=false){
   const endpoint=force?`/api/provider/quota?refresh=1&ts=${Date.now()}`:'/api/provider/quota';
@@ -10971,39 +10972,52 @@ async function loadProvidersPanel(){
   const generation=++_providersPanelLoadGeneration;
   const providersPromise = api('/api/providers');
   const quotaPromise = _fetchProviderQuotaStatus(false).catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||t('provider_quota_unavailable'),client_fetched_at:new Date().toISOString()}));
-  try{
-    const data=await providersPromise;
-    if(generation!==_providersPanelLoadGeneration) return;
-    const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider||p.is_self_hosted);
-    list.innerHTML='';
-    _providerCardEls.clear();
-    if(providers.length===0){
-      list.style.display='none';
-      if(empty) empty.style.display='';
-      await quotaPromise;
-      return;
+  const load={generation,promise:null};
+  const awaitWinningLoad=async()=>{
+    while(_providersPanelCurrentLoad&&_providersPanelCurrentLoad!==load){
+      const winner=_providersPanelCurrentLoad;
+      await winner.promise;
+      if(_providersPanelCurrentLoad===winner) return;
     }
-    if(empty) empty.style.display='none';
-    list.style.display='';
-    for(const p of providers){
-      list.appendChild(_buildProviderCard(p));
-    }
-    const quota = await quotaPromise;
-    if(generation!==_providersPanelLoadGeneration) return;
-    const quotaCard=_buildProviderQuotaCard(quota);
-    if(quotaCard){
-      const currentQuotaCard=list.querySelector('.provider-quota-card');
-      if(currentQuotaCard){
-        currentQuotaCard.replaceWith(quotaCard);
-      }else{
-        list.prepend(quotaCard);
+  };
+  load.promise=(async()=>{
+    try{
+      const data=await providersPromise;
+      if(generation!==_providersPanelLoadGeneration){await awaitWinningLoad();return;}
+      const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth||p.is_custom||p.is_plugin_provider||p.is_self_hosted);
+      list.innerHTML='';
+      _providerCardEls.clear();
+      if(providers.length===0){
+        list.style.display='none';
+        if(empty) empty.style.display='';
+        await quotaPromise;
+        if(generation!==_providersPanelLoadGeneration) await awaitWinningLoad();
+        return;
       }
-      renderProviderCostChart(quotaCard); // async, fire-and-forget
+      if(empty) empty.style.display='none';
+      list.style.display='';
+      for(const p of providers){
+        list.appendChild(_buildProviderCard(p));
+      }
+      const quota = await quotaPromise;
+      if(generation!==_providersPanelLoadGeneration){await awaitWinningLoad();return;}
+      const quotaCard=_buildProviderQuotaCard(quota);
+      if(quotaCard){
+        const currentQuotaCard=list.querySelector('.provider-quota-card');
+        if(currentQuotaCard){
+          currentQuotaCard.replaceWith(quotaCard);
+        }else{
+          list.prepend(quotaCard);
+        }
+        renderProviderCostChart(quotaCard); // async, fire-and-forget
+      }
+    }catch(e){
+      if(generation!==_providersPanelLoadGeneration){await awaitWinningLoad();return;}
+      list.innerHTML='<div style="color:var(--error);padding:12px;font-size:13px">Failed to load providers: '+esc(e.message||String(e))+'</div>';
     }
-  }catch(e){
-    if(generation!==_providersPanelLoadGeneration) return;
-    list.innerHTML='<div style="color:var(--error);padding:12px;font-size:13px">Failed to load providers: '+esc(e.message||String(e))+'</div>';
-  }
+  })();
+  _providersPanelCurrentLoad=load;
+  return load.promise;
 }
 
 async function _refreshProviderQuota(card,button){

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -9,9 +9,22 @@ import os
 import sys
 import types
 
+import pytest
+
 import api.config as config
 import api.profiles as profiles
 from tests._pytest_port import BASE
+
+
+@pytest.fixture(autouse=True)
+def _isolate_in_memory_provider_config(monkeypatch):
+    """Keep direct ``config.cfg`` fixtures independent of loader/cache state."""
+    from api import providers
+
+    providers.invalidate_providers_cache()
+    monkeypatch.setattr(providers, "get_config", lambda: config.cfg)
+    yield
+    providers.invalidate_providers_cache()
 
 
 def _install_fake_hermes_cli(monkeypatch):
@@ -166,6 +179,35 @@ class TestCustomProvidersInGetProviders:
             assert len(cp) == 1
             assert cp[0]["has_key"] is False
             assert cp[0]["key_source"] == "none"
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+    def test_custom_provider_key_from_credential_pool(self, monkeypatch, tmp_path):
+        """Custom providers still inherit keys stored by ``hermes auth add``."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            config,
+            "_has_explicit_pool_credentials",
+            lambda provider_id: provider_id == "custom:pool-only",
+        )
+
+        old_cfg, old_mtime = self._setup_cfg([
+            {
+                "name": "pool-only",
+                "base_url": "https://pool.example/v1",
+                "api_key": "",
+            },
+        ])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            provider = next(
+                item for item in result["providers"]
+                if item["id"] == "custom:pool-only"
+            )
+            assert provider["has_key"] is True
         finally:
             self._restore_cfg(old_cfg, old_mtime)
 

--- a/tests/test_issue2545_xai_oauth_provider.py
+++ b/tests/test_issue2545_xai_oauth_provider.py
@@ -1,4 +1,6 @@
 import copy
+import sys
+import types
 
 import api.config as config
 import api.profiles as profiles
@@ -31,6 +33,22 @@ def test_xai_oauth_is_known_oauth_provider():
 
 
 def test_xai_oauth_provider_card_uses_oauth_status_and_models(monkeypatch, tmp_path):
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda pid: (
+        ["grok-4.20"] if pid == "xai-oauth" else []
+    )
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda pid: {
+        "logged_in": pid == "xai-oauth",
+        "key_source": "oauth" if pid == "xai-oauth" else "none",
+    }
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
     restore = _with_config(
         monkeypatch,
         tmp_path,
@@ -51,6 +69,7 @@ def test_xai_oauth_provider_card_uses_oauth_status_and_models(monkeypatch, tmp_p
         assert grok["display_name"] == "xAI Grok OAuth"
         assert grok["is_oauth"] is True
         assert grok["configurable"] is False
+        assert grok["has_key"] is True
         assert grok["key_source"] == "oauth"
         assert grok["models"] == [{"id": "grok-4.20", "label": "Grok 4.20"}]
         assert grok["models_total"] == 1

--- a/tests/test_provider_cost_chart_ui.py
+++ b/tests/test_provider_cost_chart_ui.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
+from tests.js_source_extract import extract_function
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+LOAD_PROVIDERS_PANEL_JS = extract_function(PANELS_JS, "loadProvidersPanel", prefix="async function")
+NODE = shutil.which("node")
 
 
 def test_provider_cost_chart_ui_guards_are_present():
-    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    panels_js = PANELS_JS
     style_css = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
     # function is defined
@@ -28,3 +35,276 @@ def test_provider_cost_chart_ui_guards_are_present():
 
     # null delta guard for the oldest snapshot
     assert "s.delta!=null" in panels_js
+
+
+def _run_load_panel_harness(scenario):
+    if NODE is None:  # pragma: no cover
+        import pytest
+
+        pytest.skip("node is unavailable in this test environment")
+
+    driver = r"""
+const { performance } = require('perf_hooks');
+
+const scenario = JSON.parse(process.argv[1] || '{}');
+const loadProvidersPanelSource = process.argv[2] || '';
+if (!loadProvidersPanelSource) {
+  process.exit(1);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeElement(className = '') {
+  const element = {
+    className,
+    children: [],
+    style: {},
+    dataset: {},
+    _parent: null,
+    _innerHTML: '',
+    classList: {
+      contains(name) {
+        return element.className.split(' ').includes(name);
+      },
+    },
+    prepend(child) {
+      child._parent = element;
+      element.children.unshift(child);
+    },
+    appendChild(child) {
+      child._parent = element;
+      element.children.push(child);
+    },
+    replaceWith(newNode) {
+      if (!this._parent) return;
+      const idx = this._parent.children.indexOf(this);
+      if (idx < 0) return;
+      this._parent.children[idx] = newNode;
+      newNode._parent = this._parent;
+      this._parent = null;
+    },
+    querySelector(selector) {
+      if (selector === '.provider-quota-card') {
+        return element.children.find((child) => child.className.includes('provider-quota-card')) || null;
+      }
+      return null;
+    },
+  };
+
+  Object.defineProperty(element, 'innerHTML', {
+    get() {
+      return element._innerHTML;
+    },
+    set(value) {
+      element._innerHTML = value;
+      if (value === '') {
+        element.children = [];
+      }
+    },
+  });
+
+  return element;
+}
+
+let providersPaintedAt = null;
+let quotaPaintedAt = null;
+const events = [];
+const t0 = performance.now();
+const toMs = () => Number((performance.now() - t0).toFixed(3));
+let providersCalls = 0;
+let quotaCalls = 0;
+
+const providers = scenario.providersList !== undefined ? scenario.providersList : [
+  {
+    id: 'provider-a',
+    display_name: 'Provider A',
+    has_key: false,
+    configurable: true,
+    is_oauth: false,
+    is_custom: false,
+    is_plugin_provider: false,
+    is_self_hosted: false,
+    key_source: 'none',
+    models: [],
+    models_total: 0,
+  },
+];
+
+const list = makeElement();
+const empty = makeElement();
+globalThis.$ = (id) => ({ providersList: list, providersEmpty: empty }[id] || null);
+globalThis.esc = (value) => String(value || '');
+globalThis.t = (value) => String(value || '');
+globalThis._providerCardEls = new Map();
+globalThis._providersPanelLoadGeneration = 0;
+globalThis._buildProviderCard = () => {
+  if (providersPaintedAt === null) providersPaintedAt = toMs();
+  return makeElement('provider-card');
+};
+globalThis._buildProviderQuotaCard = (status) => {
+  if (quotaPaintedAt === null) quotaPaintedAt = toMs();
+  const node = makeElement('provider-quota-card');
+  const marker = status ? (status.quotaMarker || status.status || status.message || '') : '';
+  node.textContent = String(marker || '');
+  return node;
+};
+globalThis.renderProviderCostChart = () => {};
+globalThis.api = async (url) => {
+  if (url !== '/api/providers') return { providers: [] };
+  providersCalls += 1;
+  const delay = (scenario.providersDelays && scenario.providersDelays[providersCalls]) || scenario.providersDelay || 0;
+  await sleep(delay);
+  events.push({ type: 'providers-resolve', call: providersCalls, at: toMs() });
+  return { providers };
+};
+globalThis._fetchProviderQuotaStatus = async () => {
+  quotaCalls += 1;
+  const delay = (scenario.quotaDelays && scenario.quotaDelays[quotaCalls]) || scenario.quotaDelay || 0;
+  await sleep(delay);
+  if (scenario.quotaRejects && scenario.quotaRejects[quotaCalls]) {
+    const message = scenario.quotaRejectMessages && scenario.quotaRejectMessages[quotaCalls]
+      ? scenario.quotaRejectMessages[quotaCalls]
+      : `quota-reject-${quotaCalls}`;
+    events.push({ type: 'quota-reject', call: quotaCalls, marker: message, at: toMs() });
+    throw new Error(message);
+  }
+  const marker = scenario.quotaMarkers && scenario.quotaMarkers[quotaCalls]
+    ? scenario.quotaMarkers[quotaCalls]
+    : `call-${quotaCalls}`;
+  events.push({ type: 'quota-resolve', call: quotaCalls, marker, at: toMs() });
+  return { ok: true, status: 'available', quotaMarker: marker };
+};
+
+eval(loadProvidersPanelSource);
+
+(async () => {
+  if (scenario.doubleLoad) {
+    const first = loadProvidersPanel();
+    if (scenario.secondLoadOffsetMs) {
+      await sleep(scenario.secondLoadOffsetMs);
+    }
+    await Promise.all([first, loadProvidersPanel()]);
+  } else {
+    await loadProvidersPanel();
+  }
+  await sleep(scenario.postDelayMs || 0);
+  const quotaCards = list.children.filter((child) => child.className.includes('provider-quota-card'));
+  const providerCards = list.children.filter((child) => child.className === 'provider-card');
+  console.log(JSON.stringify({
+    providersCalls,
+    quotaCalls,
+    providersPaintedAt,
+    quotaPaintedAt,
+    providerCards: providerCards.length,
+    quotaCards: quotaCards.length,
+    quotaMarker: quotaCards.length ? quotaCards[0].textContent : null,
+    events,
+    listLength: list.children.length,
+    listDisplay: list.style.display || '',
+    emptyDisplay: empty.style.display || '',
+  }));
+})();
+"""
+
+    proc = subprocess.run(
+        [NODE, "-e", driver, json.dumps(scenario), LOAD_PROVIDERS_PANEL_JS],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"node harness failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    return json.loads(proc.stdout.strip())
+
+
+def test_load_providers_panel_renders_providers_without_waiting_for_quota():
+    """Provider cards should paint before quota status, since quota is now concurrent."""
+    result = _run_load_panel_harness({
+        "providersDelay": 5,
+        "quotaDelay": 50,
+        "postDelayMs": 75,
+    })
+    assert result["providerCards"] > 0
+    assert result["providersPaintedAt"] is not None
+    assert result["quotaPaintedAt"] is not None
+    assert result["providersPaintedAt"] <= result["quotaPaintedAt"]
+
+
+def test_load_providers_panel_avoids_stale_quota_updates_with_generation_guard():
+    """A late quota response from an older load must not duplicate/update a stale card."""
+    result = _run_load_panel_harness({
+        "providersDelay": 5,
+        "quotaDelays": {1: 150, 2: 25},
+        "quotaMarkers": {1: "first-load", 2: "second-load"},
+        "doubleLoad": True,
+        "secondLoadOffsetMs": 5,
+        "postDelayMs": 250,
+    })
+    assert result["quotaCards"] == 1
+    assert result["quotaMarker"] == "second-load"
+    assert result["providersCalls"] >= 2
+    assert result["quotaCalls"] >= 2
+
+
+def test_load_providers_panel_starts_providers_and_quota_requests_in_parallel():
+    """Source-level contract: quota + providers requests are started before the await."""
+    panels = PANELS_JS
+    assert "providersPromise = api('/api/providers')" in LOAD_PROVIDERS_PANEL_JS
+    assert "quotaPromise = _fetchProviderQuotaStatus(false)" in LOAD_PROVIDERS_PANEL_JS
+    assert ".then((quota)=>" not in LOAD_PROVIDERS_PANEL_JS
+    assert LOAD_PROVIDERS_PANEL_JS.count("}catch(e){") == 1
+    assert "await quotaPromise" in LOAD_PROVIDERS_PANEL_JS
+    assert "_providersPanelLoadGeneration" in panels
+    assert "generation!==_providersPanelLoadGeneration" in LOAD_PROVIDERS_PANEL_JS
+
+
+def test_load_providers_panel_shows_unavailable_quota_card_when_quota_rejects():
+    """Quota fetch rejection should still render provider cards and an unavailable quota card."""
+    result = _run_load_panel_harness({
+        "providersDelay": 5,
+        "quotaDelay": 2,
+        "quotaRejects": {1: True},
+        "postDelayMs": 75,
+    })
+    assert result["providerCards"] > 0
+    assert result["quotaCards"] == 1
+    assert result["quotaMarker"] == "unavailable"
+    assert any(event["type"] == "quota-reject" for event in result["events"])
+
+
+def test_load_providers_panel_builds_provider_cards_before_quota_dom_insertion_even_when_quota_resolves_first():
+    """Quota DOM insertion always follows provider-card insertion in code order, even when the quota fetch itself settles first."""
+    result = _run_load_panel_harness({
+        "providersDelay": 40,
+        "quotaDelay": 2,
+        "postDelayMs": 75,
+    })
+    assert result["providerCards"] > 0
+    assert result["quotaCards"] == 1
+    assert result["providersPaintedAt"] is not None
+    assert result["quotaPaintedAt"] is not None
+    # Quota's own fetch resolved first, but the quota card is still only ever
+    # built after the provider cards, because that is where the code puts it.
+    assert result["providersPaintedAt"] <= result["quotaPaintedAt"]
+
+
+def test_load_providers_panel_awaits_quota_before_returning_on_zero_providers():
+    """Awaiting loadProvidersPanel() must include the quota fetch even when the provider list is empty."""
+    result = _run_load_panel_harness({
+        "providersList": [],
+        "providersDelay": 5,
+        "quotaDelay": 40,
+        "postDelayMs": 0,
+    })
+    assert result["providerCards"] == 0
+    assert result["quotaCards"] == 0
+    # By the time `await loadProvidersPanel()` returns (postDelayMs=0), the
+    # slower quota fetch must already have settled.
+    assert result["quotaCalls"] == 1
+    quota_events = [e for e in result["events"] if e["type"] == "quota-resolve"]
+    assert len(quota_events) == 1
+    # Empty-state visibility must be unchanged by the added await.
+    assert result["listDisplay"] == "none"
+    assert result["emptyDisplay"] == ""

--- a/tests/test_provider_cost_chart_ui.py
+++ b/tests/test_provider_cost_chart_ui.py
@@ -139,9 +139,11 @@ globalThis.esc = (value) => String(value || '');
 globalThis.t = (value) => String(value || '');
 globalThis._providerCardEls = new Map();
 globalThis._providersPanelLoadGeneration = 0;
-globalThis._buildProviderCard = () => {
+globalThis._buildProviderCard = (provider) => {
   if (providersPaintedAt === null) providersPaintedAt = toMs();
-  return makeElement('provider-card');
+  const node = makeElement('provider-card');
+  node.textContent = String((provider && provider.id) || '');
+  return node;
 };
 globalThis._buildProviderQuotaCard = (status) => {
   if (quotaPaintedAt === null) quotaPaintedAt = toMs();
@@ -153,39 +155,55 @@ globalThis._buildProviderQuotaCard = (status) => {
 globalThis.renderProviderCostChart = () => {};
 globalThis.api = async (url) => {
   if (url !== '/api/providers') return { providers: [] };
-  providersCalls += 1;
-  const delay = (scenario.providersDelays && scenario.providersDelays[providersCalls]) || scenario.providersDelay || 0;
+  const call = ++providersCalls;
+  const delay = (scenario.providersDelays && scenario.providersDelays[call]) || scenario.providersDelay || 0;
   await sleep(delay);
-  events.push({ type: 'providers-resolve', call: providersCalls, at: toMs() });
-  return { providers };
+  events.push({ type: 'providers-resolve', call, at: toMs() });
+  const selectedProviders = scenario.providersLists && scenario.providersLists[call]
+    ? scenario.providersLists[call]
+    : providers;
+  return { providers: selectedProviders };
 };
 globalThis._fetchProviderQuotaStatus = async () => {
-  quotaCalls += 1;
-  const delay = (scenario.quotaDelays && scenario.quotaDelays[quotaCalls]) || scenario.quotaDelay || 0;
+  const call = ++quotaCalls;
+  const delay = (scenario.quotaDelays && scenario.quotaDelays[call]) || scenario.quotaDelay || 0;
   await sleep(delay);
-  if (scenario.quotaRejects && scenario.quotaRejects[quotaCalls]) {
-    const message = scenario.quotaRejectMessages && scenario.quotaRejectMessages[quotaCalls]
-      ? scenario.quotaRejectMessages[quotaCalls]
-      : `quota-reject-${quotaCalls}`;
-    events.push({ type: 'quota-reject', call: quotaCalls, marker: message, at: toMs() });
+  if (scenario.quotaRejects && scenario.quotaRejects[call]) {
+    const message = scenario.quotaRejectMessages && scenario.quotaRejectMessages[call]
+      ? scenario.quotaRejectMessages[call]
+      : `quota-reject-${call}`;
+    events.push({ type: 'quota-reject', call, marker: message, at: toMs() });
     throw new Error(message);
   }
-  const marker = scenario.quotaMarkers && scenario.quotaMarkers[quotaCalls]
-    ? scenario.quotaMarkers[quotaCalls]
-    : `call-${quotaCalls}`;
-  events.push({ type: 'quota-resolve', call: quotaCalls, marker, at: toMs() });
+  const marker = scenario.quotaMarkers && scenario.quotaMarkers[call]
+    ? scenario.quotaMarkers[call]
+    : `call-${call}`;
+  events.push({ type: 'quota-resolve', call, marker, at: toMs() });
   return { ok: true, status: 'available', quotaMarker: marker };
 };
 
 eval(loadProvidersPanelSource);
 
 (async () => {
+  let firstAwaitSnapshot = null;
   if (scenario.doubleLoad) {
     const first = loadProvidersPanel();
     if (scenario.secondLoadOffsetMs) {
       await sleep(scenario.secondLoadOffsetMs);
     }
-    await Promise.all([first, loadProvidersPanel()]);
+    const second = loadProvidersPanel();
+    if (scenario.awaitOnlyFirst) {
+      await first;
+      const firstQuotaCards = list.children.filter((child) => child.className.includes('provider-quota-card'));
+      firstAwaitSnapshot = {
+        at: toMs(),
+        providerMarkers: list.children.filter((child) => child.className === 'provider-card').map((child) => child.textContent),
+        quotaMarker: firstQuotaCards.length ? firstQuotaCards[0].textContent : null,
+      };
+      await second;
+    } else {
+      await Promise.all([first, second]);
+    }
   } else {
     await loadProvidersPanel();
   }
@@ -200,6 +218,8 @@ eval(loadProvidersPanelSource);
     providerCards: providerCards.length,
     quotaCards: quotaCards.length,
     quotaMarker: quotaCards.length ? quotaCards[0].textContent : null,
+    providerMarkers: providerCards.map((child) => child.textContent),
+    firstAwaitSnapshot,
     events,
     listLength: list.children.length,
     listDisplay: list.style.display || '',
@@ -246,6 +266,27 @@ def test_load_providers_panel_avoids_stale_quota_updates_with_generation_guard()
     assert result["quotaMarker"] == "second-load"
     assert result["providersCalls"] >= 2
     assert result["quotaCalls"] >= 2
+
+
+def test_superseded_provider_load_awaits_winning_generation_before_settling():
+    """Awaiting stale load A must not resolve until winning load B has painted."""
+    result = _run_load_panel_harness({
+        "providersLists": {
+            1: [{"id": "provider-a", "configurable": True}],
+            2: [{"id": "provider-b", "configurable": True}],
+        },
+        "providersDelays": {1: 10, 2: 60},
+        "quotaDelays": {1: 5, 2: 80},
+        "quotaMarkers": {1: "quota-a", 2: "quota-b"},
+        "doubleLoad": True,
+        "awaitOnlyFirst": True,
+        "secondLoadOffsetMs": 1,
+    })
+
+    assert result["firstAwaitSnapshot"]["providerMarkers"] == ["provider-b"]
+    assert result["firstAwaitSnapshot"]["quotaMarker"] == "quota-b"
+    assert result["providerMarkers"] == ["provider-b"]
+    assert result["quotaMarker"] == "quota-b"
 
 
 def test_load_providers_panel_starts_providers_and_quota_requests_in_parallel():

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -1312,6 +1312,44 @@ class TestGetProviders:
         assert entry["has_key"] is True
         assert entry["key_source"] == "config_yaml"
 
+    def test_build_provider_entry_logged_out_oauth_normalizes_key_source(self, monkeypatch, tmp_path):
+        """Logged-out OAuth cards cannot claim an OAuth credential source."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(
+            prov,
+            "_PROVIDER_DISPLAY",
+            {"openai-codex": "OpenAI Codex"},
+        )
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai-codex": []})
+        monkeypatch.setattr(
+            prov,
+            "_OAUTH_PROVIDERS",
+            frozenset({"openai-codex"}),
+        )
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(
+            sys.modules["hermes_cli.auth"],
+            "get_auth_status",
+            lambda _pid: {"logged_in": False},
+        )
+
+        entry = prov._build_provider_entry(
+            provider_id="openai-codex",
+            initial_has_key=False,
+            providers_cfg={},
+            active_profile_name="",
+            request_thread_env={},
+            block_process_env_fallback=False,
+        )
+
+        assert entry is not None
+        assert entry["has_key"] is False
+        assert entry["key_source"] == "none"
+
     def test_build_provider_entry_cleans_up_request_context_after_setup_error(self, monkeypatch, tmp_path):
         """Partial request-context setup failure must not leave thread-local/profile residue."""
         _install_fake_hermes_cli(monkeypatch)

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -546,6 +546,126 @@ class TestGetProviders:
         finally:
             prov.invalidate_providers_cache()
 
+    def test_post_registration_build_setup_error_clears_inflight_and_retries(self, monkeypatch, tmp_path):
+        """Setup failure after claiming build should wake waiters and allow retry."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+
+        setup_blocked = threading.Event()
+        release_setup = threading.Event()
+        build_payload_calls = {"value": 0}
+        original_get_active_profile_name = profiles.get_active_profile_name
+
+        def broken_active_profile_name():
+            setup_blocked.set()
+            release_setup.wait(2)
+            raise RuntimeError("post-registration setup failure")
+
+        def succeed_payload(
+            cfg,
+            sorted_known_ids,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+            providers_cfg,
+        ):
+            build_payload_calls["value"] += 1
+            return {
+                "providers": [{
+                    "id": "openai",
+                    "display_name": "OpenAI",
+                    "has_key": False,
+                    "configurable": True,
+                    "key_source": "none",
+                    "is_self_hosted": False,
+                    "base_url": None,
+                    "is_plugin_provider": False,
+                    "is_oauth": False,
+                    "auth_error": None,
+                    "models": [],
+                    "models_total": 0,
+                }],
+                "active_provider": "openai",
+            }
+
+        monkeypatch.setattr(profiles, "get_active_profile_name", broken_active_profile_name)
+        monkeypatch.setattr(prov, "_build_providers_payload", succeed_payload)
+
+        waiter = threading.Event()
+        real_wait_provider_build = prov._wait_provider_build
+
+        def spy_wait_provider_build(state, cache_key):
+            waiter.set()
+            return real_wait_provider_build(state, cache_key)
+
+        monkeypatch.setattr(prov, "_wait_provider_build", spy_wait_provider_build)
+
+        errors = {}
+
+        def call_get_providers(label):
+            try:
+                prov.get_providers()
+            except BaseException as exc:
+                errors[label] = exc
+
+        lead_started = False
+        follower_started = False
+        lead = threading.Thread(target=call_get_providers, args=("lead",))
+        follower = threading.Thread(target=call_get_providers, args=("waiter",))
+
+        try:
+            lead.start()
+            lead_started = True
+            assert setup_blocked.wait(2)
+
+            follower.start()
+            follower_started = True
+            assert waiter.wait(2)
+
+            cache_key = prov._providers_cache_key(prov.get_config())
+            assert cache_key in prov._providers_build_inflight
+
+            release_setup.set()
+
+            lead.join(2)
+            follower.join(2)
+
+            assert not lead.is_alive()
+            assert not follower.is_alive()
+            assert isinstance(errors.get("lead"), RuntimeError)
+            assert isinstance(errors.get("waiter"), RuntimeError)
+            assert errors["lead"].args == errors["waiter"].args == ("post-registration setup failure",)
+
+            assert cache_key not in prov._providers_build_inflight
+            assert cache_key not in prov._providers_cache
+
+            monkeypatch.setattr(
+                profiles,
+                "get_active_profile_name",
+                original_get_active_profile_name,
+            )
+            result = prov.get_providers()
+            ids = {entry["id"] for entry in result["providers"]}
+            assert ids == {"openai"}
+            assert build_payload_calls["value"] == 1
+        finally:
+            release_setup.set()
+            if lead_started:
+                lead.join(2)
+            if follower_started:
+                follower.join(2)
+            monkeypatch.setattr(profiles, "get_active_profile_name", original_get_active_profile_name)
+            if hasattr(prov, "invalidate_providers_cache"):
+                prov.invalidate_providers_cache()
+
     def test_complete_provider_build_cache_publication_lock_error_wakes_waiter_and_clears_inflight(self, monkeypatch, tmp_path):
         """Cache publication lock failure must wake waiters and be recoverable."""
         _install_fake_hermes_cli(monkeypatch)

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -5,7 +5,10 @@ Part of #604 — multi-provider model picker support.
 """
 
 import json
+import os
+import subprocess
 import threading
+import textwrap
 import time
 import sys
 import types
@@ -174,7 +177,9 @@ class TestGetProviders:
         assert ids == {"openai-codex", "xai-oauth", "nous"}
         assert barrier.broken is False
         assert set(started.keys()) == set(delays)
-        assert set(credential_threads) == {request_thread_id}
+        credential_thread_ids = set(credential_threads)
+        assert len(credential_thread_ids) == 1
+        assert request_thread_id not in credential_thread_ids
 
     def test_get_providers_bedrock_entry_uses_structural_credentials_without_live_probe(self, monkeypatch, tmp_path):
         """Bedrock card construction should use structural env signals, not live auth probes."""
@@ -394,6 +399,354 @@ class TestGetProviders:
         third = prov.get_providers()
         assert third["providers"] is not outputs["first"]["providers"]
 
+    def test_blocked_provider_build_times_out_wakes_follower_and_does_not_poison_next_key(
+        self, monkeypatch, tmp_path,
+    ):
+        """A stuck build is bounded, drops queued work, and cannot poison later builds."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        prov.invalidate_providers_cache()
+        provider_ids = [f"provider-{i:02d}" for i in range(12)]
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {pid: pid for pid in provider_ids})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {pid: [] for pid in provider_ids})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "_provider_has_key", lambda _pid: False)
+        monkeypatch.setattr(prov, "_PROVIDERS_BUILD_TIMEOUT_SECONDS", 0.15, raising=False)
+        monkeypatch.setattr(prov, "_PROVIDERS_FOLLOWER_TIMEOUT_SECONDS", 0.5, raising=False)
+
+        mode = {"value": "blocked"}
+        monkeypatch.setattr(
+            prov,
+            "get_config",
+            lambda: {"model": {}, "providers": {}},
+        )
+
+        release = threading.Event()
+        eight_started = threading.Event()
+        follower_entered = threading.Event()
+        lock = threading.Lock()
+        started = []
+
+        def fake_build_entry(
+            pid,
+            initial_has_key,
+            providers_cfg,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+        ):
+            marker = mode["value"]
+            with lock:
+                started.append((marker, str(pid)))
+                blocked_count = sum(1 for seen_marker, _ in started if seen_marker == "blocked")
+                if blocked_count >= prov._PROVIDERS_MAX_WORKERS:
+                    eight_started.set()
+            if marker == "blocked":
+                release.wait()
+            return {
+                "id": str(pid),
+                "display_name": str(pid),
+                "has_key": bool(initial_has_key),
+                "configurable": True,
+                "is_self_hosted": False,
+                "base_url": None,
+                "is_plugin_provider": False,
+                "is_oauth": False,
+                "key_source": "none",
+                "auth_error": None,
+                "models": [],
+                "models_total": 0,
+            }
+
+        monkeypatch.setattr(prov, "_build_provider_entry", fake_build_entry)
+        real_wait = prov._wait_provider_build
+
+        def spy_wait(state, cache_key):
+            follower_entered.set()
+            return real_wait(state, cache_key)
+
+        monkeypatch.setattr(prov, "_wait_provider_build", spy_wait)
+
+        outputs = {}
+        errors = {}
+
+        def call(label):
+            try:
+                outputs[label] = prov.get_providers()
+            except BaseException as exc:
+                errors[label] = exc
+
+        leader = threading.Thread(target=call, args=("leader",), daemon=True)
+        follower = threading.Thread(target=call, args=("follower",), daemon=True)
+        later = threading.Thread(target=call, args=("later",), daemon=True)
+
+        try:
+            leader.start()
+            assert eight_started.wait(2)
+            follower.start()
+            assert follower_entered.wait(2)
+
+            leader.join(1)
+            follower.join(1)
+            assert not leader.is_alive()
+            assert not follower.is_alive()
+            assert not errors
+            with prov._providers_cache_lock:
+                assert not prov._providers_cache
+
+            # The four jobs queued behind the blocked workers must not start
+            # after the build deadline expires.
+            time.sleep(0.1)
+            blocked_ids = {pid for marker, pid in started if marker == "blocked"}
+            assert blocked_ids == set(provider_ids[:prov._PROVIDERS_MAX_WORKERS])
+
+            # The timed-out partial payload is visible to its followers but is
+            # not cached.  The same key therefore gets fresh capacity while
+            # the old provider callbacks remain quarantined.
+            mode["value"] = "fast"
+            later.start()
+            later.join(1)
+            assert not later.is_alive()
+            assert not errors
+            assert {
+                entry["id"] for entry in outputs["later"]["providers"]
+            } == set(provider_ids[prov._PROVIDERS_MAX_WORKERS:])
+            with prov._providers_cache_lock:
+                assert not prov._providers_cache
+
+            # Releasing callbacks after the deadline must not drain the old
+            # runner's cancelled queue.  It should only clear quarantine keys.
+            release.set()
+            cleanup_deadline = time.monotonic() + 2
+            while time.monotonic() < cleanup_deadline:
+                with prov._providers_runner_lock:
+                    if not prov._providers_active_tasks:
+                        break
+                time.sleep(0.01)
+            with prov._providers_runner_lock:
+                assert not prov._providers_active_tasks
+            blocked_ids_after_release = {
+                pid for marker, pid in started if marker == "blocked"
+            }
+            assert blocked_ids_after_release == set(
+                provider_ids[:prov._PROVIDERS_MAX_WORKERS]
+            )
+
+            recovered = prov.get_providers()
+            assert {entry["id"] for entry in recovered["providers"]} == set(provider_ids)
+            with prov._providers_cache_lock:
+                assert prov._providers_cache
+        finally:
+            release.set()
+            leader.join(2)
+            follower.join(2)
+            if later.ident is not None:
+                later.join(2)
+            prov.invalidate_providers_cache()
+
+    def test_follower_timeout_does_not_abandon_leader_state(self, monkeypatch):
+        """A bounded follower may leave, but cannot invalidate its live leader."""
+        from api import providers as prov
+
+        cache_key = ("home", 0, 0, "cfg")
+        state = prov._ProvidersBuildInFlight(prov._providers_cache_generation)
+        monkeypatch.setattr(prov, "_PROVIDERS_FOLLOWER_TIMEOUT_SECONDS", 0.05)
+        with prov._providers_cache_lock:
+            prov._providers_build_inflight[cache_key] = state
+
+        started = time.monotonic()
+        try:
+            with pytest.raises(TimeoutError, match="provider discovery"):
+                prov._wait_provider_build(state, cache_key)
+            assert time.monotonic() - started < 0.5
+            with prov._providers_cache_lock:
+                assert prov._providers_build_inflight.get(cache_key) is state
+            assert not state.event.is_set()
+        finally:
+            with prov._providers_cache_lock:
+                if prov._providers_build_inflight.get(cache_key) is state:
+                    prov._providers_build_inflight.pop(cache_key, None)
+
+    def test_credential_preflight_uses_the_leader_deadline(
+        self, monkeypatch, tmp_path,
+    ):
+        """A blocked credential-pool read cannot extend the total build deadline."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        prov.invalidate_providers_cache()
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setattr(prov, "_PROVIDERS_BUILD_TIMEOUT_SECONDS", 0.15)
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocked_has_key(_provider_id):
+            entered.set()
+            release.wait(5)
+            return False
+
+        monkeypatch.setattr(prov, "_provider_has_key", blocked_has_key)
+
+        try:
+            started = time.monotonic()
+            result = prov.get_providers()
+            elapsed = time.monotonic() - started
+
+            assert entered.is_set()
+            assert elapsed < 0.75
+            assert result["providers"] == []
+            with prov._providers_cache_lock:
+                assert not prov._providers_cache
+        finally:
+            release.set()
+            prov.invalidate_providers_cache()
+
+    def test_overlapping_healthy_build_waits_for_provider_admission(
+        self, monkeypatch, tmp_path,
+    ):
+        """Temporary overlap retries the provider instead of caching an omission."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        prov.invalidate_providers_cache()
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "_provider_has_key", lambda _pid: False)
+        monkeypatch.setattr(prov, "_PROVIDERS_BUILD_TIMEOUT_SECONDS", 2.0)
+
+        marker = {"value": "old"}
+        monkeypatch.setattr(
+            prov,
+            "get_config",
+            lambda: {
+                "model": {},
+                "providers": {"openai": {"marker": marker["value"]}},
+            },
+        )
+
+        old_entered = threading.Event()
+        release_old = threading.Event()
+
+        def build_entry(pid, _has_key, providers_cfg, *_args):
+            value = providers_cfg["openai"]["marker"]
+            if value == "old":
+                old_entered.set()
+                release_old.wait(5)
+            return {
+                "id": pid,
+                "display_name": "OpenAI",
+                "has_key": False,
+                "configurable": True,
+                "is_self_hosted": False,
+                "is_plugin_provider": False,
+                "is_oauth": False,
+                "key_source": "none",
+                "auth_error": None,
+                "models": [],
+                "models_total": 0,
+                "marker": value,
+            }
+
+        monkeypatch.setattr(prov, "_build_provider_entry", build_entry)
+        outputs = {}
+        errors = []
+
+        def run(name):
+            try:
+                outputs[name] = prov.get_providers()
+            except BaseException as exc:
+                errors.append(exc)
+
+        old = threading.Thread(target=run, args=("old",))
+        newer = threading.Thread(target=run, args=("new",))
+        try:
+            old.start()
+            assert old_entered.wait(1)
+            marker["value"] = "new"
+            prov.invalidate_providers_cache()
+            newer.start()
+            time.sleep(0.1)
+            assert newer.is_alive()
+            assert "new" not in outputs
+
+            release_old.set()
+            old.join(2)
+            newer.join(2)
+
+            assert not old.is_alive()
+            assert not newer.is_alive()
+            assert not errors
+            assert len(outputs["new"]["providers"]) == 1
+            assert outputs["new"]["providers"][0]["marker"] == "new"
+        finally:
+            release_old.set()
+            if old.ident is not None:
+                old.join(2)
+            if newer.ident is not None:
+                newer.join(2)
+            prov.invalidate_providers_cache()
+
+    def test_stuck_provider_worker_does_not_block_process_exit(self):
+        """Provider work that never returns must not participate in interpreter joining."""
+        script = textwrap.dedent("""
+            import pathlib
+            import threading
+            from api import profiles
+            from api import providers as prov
+
+            home = pathlib.Path('/tmp/hermes-provider-exit-test')
+            profiles.get_active_hermes_home = lambda: home
+            prov._PROVIDER_DISPLAY = {'blocked': 'Blocked'}
+            prov._PROVIDER_MODELS = {'blocked': []}
+            prov._OAUTH_PROVIDERS = frozenset()
+            prov.plugin_model_provider_ids = lambda: set()
+            prov._provider_has_key = lambda _pid: False
+            prov.get_config = lambda: {'model': {}, 'providers': {}}
+            prov._PROVIDERS_BUILD_TIMEOUT_SECONDS = 30
+            prov._PROVIDERS_FOLLOWER_TIMEOUT_SECONDS = 0.3
+
+            started = threading.Event()
+            never = threading.Event()
+
+            def blocked(*_args, **_kwargs):
+                started.set()
+                never.wait()
+
+            prov._build_provider_entry = blocked
+            request = threading.Thread(target=prov.get_providers, daemon=True)
+            request.start()
+            assert started.wait(2)
+            prov.shutdown_provider_build_runners()
+            request.join(1)
+            assert not request.is_alive()
+        """)
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(os.path.dirname(os.path.dirname(__file__)))
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+
     def test_invalidate_during_blocked_build_starts_new_generation_and_ignores_stale_completion(
         self, monkeypatch, tmp_path,
     ):
@@ -423,6 +776,7 @@ class TestGetProviders:
             request_thread_env,
             request_block_process_env_fallback,
             providers_cfg,
+            deadline,
         ):
             with lock:
                 call_id = len(build_calls)
@@ -433,7 +787,7 @@ class TestGetProviders:
             else:
                 new_entered.set()
                 release_new.wait(2)
-            return {
+            return ({
                 "providers": [{
                     "id": "openai",
                     "display_name": "OpenAI",
@@ -443,7 +797,7 @@ class TestGetProviders:
                     "call_id": call_id,
                 }],
                 "active_provider": None,
-            }
+            }, True)
 
         monkeypatch.setattr(prov, "_build_providers_payload", fake_build)
 
@@ -514,11 +868,12 @@ class TestGetProviders:
             request_thread_env,
             request_block_process_env_fallback,
             providers_cfg,
+            deadline,
         ):
             attempt["value"] += 1
             if attempt["value"] == 1:
                 raise RuntimeError("simulated aggregate build failure")
-            return {
+            return ({
                 "providers": [{
                     "id": "openai",
                     "display_name": "OpenAI",
@@ -527,7 +882,7 @@ class TestGetProviders:
                     "key_source": "none",
                 }],
                 "active_provider": None,
-            }
+            }, True)
 
         monkeypatch.setattr(prov, "_build_providers_payload", flaky_build)
 
@@ -576,9 +931,10 @@ class TestGetProviders:
             request_thread_env,
             request_block_process_env_fallback,
             providers_cfg,
+            deadline,
         ):
             build_payload_calls["value"] += 1
-            return {
+            return ({
                 "providers": [{
                     "id": "openai",
                     "display_name": "OpenAI",
@@ -594,7 +950,7 @@ class TestGetProviders:
                     "models_total": 0,
                 }],
                 "active_provider": "openai",
-            }
+            }, True)
 
         monkeypatch.setattr(profiles, "get_active_profile_name", broken_active_profile_name)
         monkeypatch.setattr(prov, "_build_providers_payload", succeed_payload)
@@ -691,11 +1047,12 @@ class TestGetProviders:
             request_thread_env,
             request_block_process_env_fallback,
             providers_cfg,
+            deadline,
         ):
             build_calls["value"] += 1
             payload_begun.set()
             release.wait(2)
-            return {
+            return ({
                 "providers": [{
                     "id": "openai",
                     "display_name": "OpenAI",
@@ -711,7 +1068,7 @@ class TestGetProviders:
                     "models_total": 0,
                 }],
                 "active_provider": "openai",
-            }
+            }, True)
 
         monkeypatch.setattr(prov, "_build_providers_payload", flaky_build_payload)
 

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -5,10 +5,14 @@ Part of #604 — multi-provider model picker support.
 """
 
 import json
+import threading
+import time
 import sys
 import types
 import urllib.error
 import urllib.request
+
+import pytest
 
 import api.config as config
 import api.profiles as profiles
@@ -99,6 +103,864 @@ class TestGetProviders:
             assert first == second
             assert calls == ["openai"]
         finally:
+            if hasattr(prov, "invalidate_providers_cache"):
+                prov.invalidate_providers_cache()
+
+    def test_get_providers_cold_path_parallelizes_provider_probes(self, monkeypatch, tmp_path):
+        """Cold providers path should complete in roughly max-provider latency, not sum."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        delays = {
+            "openai-codex": 0.25,
+            "xai-oauth": 0.25,
+            "nous": 0.25,
+        }
+        started = {}
+        started_lock = threading.Lock()
+        request_thread_id = threading.get_ident()
+        credential_threads = []
+        barrier = threading.Barrier(len(delays))
+
+        def _fake_read_live_provider_model_ids(pid: str):
+            delay = delays.get(pid)
+            if delay is not None:
+                with started_lock:
+                    started[pid] = time.perf_counter()
+                try:
+                    barrier.wait(timeout=0.5)
+                except threading.BrokenBarrierError:
+                    pass
+                time.sleep(delay)
+                return [f"{pid}-live"]
+            return []
+
+        fake_models = sys.modules["hermes_cli.models"]
+        fake_models.provider_model_ids = lambda pid: (
+            _fake_read_live_provider_model_ids(pid) if pid in delays else []
+        )
+        fake_auth = sys.modules["hermes_cli.auth"]
+        fake_auth.get_auth_status = lambda _pid: {}
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {
+            "openai-codex": "OpenAI Codex",
+            "xai-oauth": "xAI",
+            "nous": "Nous",
+        })
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {
+            "openai-codex": [],
+            "xai-oauth": [],
+            "nous": [],
+        })
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset({"openai-codex", "xai-oauth", "nous"}))
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(
+            prov,
+            "_provider_has_key",
+            lambda _pid: credential_threads.append(threading.get_ident()) or False,
+        )
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setattr(prov, "_read_live_provider_model_ids", _fake_read_live_provider_model_ids)
+
+        try:
+            result = prov.get_providers()
+        finally:
+            if hasattr(prov, "invalidate_providers_cache"):
+                prov.invalidate_providers_cache()
+
+        ids = {entry["id"] for entry in result["providers"]}
+        assert ids == {"openai-codex", "xai-oauth", "nous"}
+        assert barrier.broken is False
+        assert set(started.keys()) == set(delays)
+        assert set(credential_threads) == {request_thread_id}
+
+    def test_get_providers_bedrock_entry_uses_structural_credentials_without_live_probe(self, monkeypatch, tmp_path):
+        """Bedrock card construction should use structural env signals, not live auth probes."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        tmp_path.joinpath(".env").write_text(
+            "AWS_ACCESS_KEY_ID=provider-path-id\n"
+            "AWS_SECRET_ACCESS_KEY=provider-path-secret\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", raising=False)
+        monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", raising=False)
+        monkeypatch.delenv("AWS_WEB_IDENTITY_TOKEN_FILE", raising=False)
+
+        calls = []
+
+        fake_auth = sys.modules["hermes_cli.auth"]
+        fake_auth.get_auth_status = lambda pid: calls.append(pid) or {
+            "logged_in": True,
+            "key_source": "env",
+        }
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {
+            "bedrock": "AWS Bedrock",
+            "openai": "OpenAI",
+        })
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {
+            "bedrock": [{"id": "bedrock-model", "label": "Bedrock Model"}],
+            "openai": [],
+        })
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "process-id")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "process-secret")
+        result = None
+        try:
+            result = prov.get_providers()
+        finally:
+            if hasattr(prov, "invalidate_providers_cache"):
+                prov.invalidate_providers_cache()
+        assert result is not None
+
+        ids = {entry["id"]: entry for entry in result["providers"]}
+        assert ids["bedrock"]["has_key"] is True
+        assert ids["bedrock"]["key_source"] == "env_var"
+        assert calls == []
+
+    def test_get_providers_workers_inherit_request_context(self, monkeypatch, tmp_path):
+        """Context-variable overrides propagate from request thread into worker providers."""
+        _install_fake_hermes_cli(monkeypatch)
+
+        hermes_constants = pytest.importorskip("hermes_constants")
+        secret_scope = pytest.importorskip("agent.secret_scope")
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"strange": "Strange"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"strange": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset({"strange"}))
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setattr(prov, "_provider_has_key", lambda _pid: False)
+
+        captured = []
+
+        def fake_auth_status(_pid):
+            captured.append((
+                hermes_constants.get_hermes_home(),
+                dict(secret_scope.current_secret_scope() or {}),
+            ))
+            return {"logged_in": True, "key_source": "env"}
+
+        fake_auth = sys.modules["hermes_cli.auth"]
+        fake_auth.get_auth_status = fake_auth_status
+
+        def _run_scenario(home_path, secret_map):
+            home_token = hermes_constants.set_hermes_home_override(home_path)
+            scope_token = secret_scope.set_secret_scope(dict(secret_map))
+            try:
+                return prov.get_providers()
+            finally:
+                secret_scope.reset_secret_scope(scope_token)
+                hermes_constants.reset_hermes_home_override(home_token)
+                prov.invalidate_providers_cache()
+
+        home_a = tmp_path / "home-a"
+        home_a.mkdir()
+        home_b = tmp_path / "home-b"
+        home_b.mkdir()
+        secrets_a = {"HOME_A_SENTINEL": "value-from-a"}
+        secrets_b = {"HOME_B_SENTINEL": "value-from-b"}
+
+        prov.invalidate_providers_cache()
+        try:
+            # Exercise two distinct homes/secret maps sequentially, invalidating
+            # the providers cache between runs so each actually rebuilds and
+            # calls the worker-thread auth probe again (#3957).
+            captured.clear()
+            result_a = _run_scenario(home_a, secrets_a)
+            ids_a = {entry["id"]: entry for entry in result_a["providers"]}
+            assert ids_a["strange"]["has_key"] is True
+            assert captured == [(home_a, secrets_a)]
+
+            captured.clear()
+            result_b = _run_scenario(home_b, secrets_b)
+            ids_b = {entry["id"]: entry for entry in result_b["providers"]}
+            assert ids_b["strange"]["has_key"] is True
+            assert captured == [(home_b, secrets_b)]
+
+            # No leakage: the second run's captured scope/home must not carry
+            # any trace of the first run's home or secrets.
+            assert captured[0][0] != home_a
+            assert "HOME_A_SENTINEL" not in captured[0][1]
+        finally:
+            prov.invalidate_providers_cache()
+
+    def test_get_providers_singleflight_reuses_inflight_build(self, monkeypatch, tmp_path):
+        """Concurrent callers for the same cache key share one provider build."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        provider_ids = [f"provider-{i:02d}" for i in range(24)]
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {pid: pid for pid in provider_ids})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {pid: [] for pid in provider_ids})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setattr(prov, "_provider_has_key", lambda _pid: False)
+
+        started = threading.Event()
+        release = threading.Event()
+        lock = threading.Lock()
+        seen = set()
+        active = {"value": 0}
+        max_active = {"value": 0}
+        call_count = {"value": 0}
+
+        def fake_build_entry(
+            pid,
+            initial_has_key,
+            providers_cfg,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+        ):
+            with lock:
+                call_count["value"] += 1
+                active["value"] += 1
+                if active["value"] > max_active["value"]:
+                    max_active["value"] = active["value"]
+                seen.add(str(pid))
+                if active["value"] >= prov._PROVIDERS_MAX_WORKERS:
+                    started.set()
+            try:
+                release.wait()
+            finally:
+                with lock:
+                    active["value"] -= 1
+            return {
+                "id": str(pid),
+                "display_name": str(pid),
+                "has_key": bool(initial_has_key),
+                "configurable": True,
+                "is_self_hosted": False,
+                "base_url": None,
+                "is_plugin_provider": False,
+                "is_oauth": False,
+                "key_source": "none",
+                "auth_error": None,
+                "models": [],
+                "models_total": 0,
+            }
+
+        monkeypatch.setattr(prov, "_build_provider_entry", fake_build_entry)
+
+        waiter_entered = threading.Event()
+        real_wait_provider_build = prov._wait_provider_build
+
+        def spy_wait_provider_build(state, cache_key):
+            waiter_entered.set()
+            return real_wait_provider_build(state, cache_key)
+
+        monkeypatch.setattr(prov, "_wait_provider_build", spy_wait_provider_build)
+
+        outputs = {}
+        def first_call():
+            outputs["first"] = prov.get_providers()
+
+        def second_call():
+            outputs["second"] = prov.get_providers()
+
+        t1 = threading.Thread(target=first_call)
+        t2 = threading.Thread(target=second_call)
+        t1.start()
+        assert started.wait(2)
+        t2.start()
+        assert waiter_entered.wait(2)
+        release.set()
+        t1.join()
+        t2.join()
+
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+        assert call_count["value"] == len(provider_ids)
+        assert max_active["value"] <= prov._PROVIDERS_MAX_WORKERS
+        assert outputs["first"]["providers"] != []
+        assert outputs["second"]["providers"] is not outputs["first"]["providers"]
+
+        third = prov.get_providers()
+        assert third["providers"] is not outputs["first"]["providers"]
+
+    def test_invalidate_during_blocked_build_starts_new_generation_and_ignores_stale_completion(
+        self, monkeypatch, tmp_path,
+    ):
+        """Invalidating mid-build bumps the generation so a late-completing stale build cannot clobber a newer cached result (#6010)."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+
+        lock = threading.Lock()
+        build_calls = []
+        old_entered = threading.Event()
+        release_old = threading.Event()
+        new_entered = threading.Event()
+        release_new = threading.Event()
+
+        def fake_build(
+            cfg,
+            sorted_known_ids,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+            providers_cfg,
+        ):
+            with lock:
+                call_id = len(build_calls)
+                build_calls.append(call_id)
+            if call_id == 0:
+                old_entered.set()
+                release_old.wait(2)
+            else:
+                new_entered.set()
+                release_new.wait(2)
+            return {
+                "providers": [{
+                    "id": "openai",
+                    "display_name": "OpenAI",
+                    "has_key": False,
+                    "configurable": True,
+                    "key_source": "none",
+                    "call_id": call_id,
+                }],
+                "active_provider": None,
+            }
+
+        monkeypatch.setattr(prov, "_build_providers_payload", fake_build)
+
+        outputs = {}
+
+        def _old_call():
+            outputs["old"] = prov.get_providers()
+
+        try:
+            t_old = threading.Thread(target=_old_call)
+            t_old.start()
+            assert old_entered.wait(2)
+
+            # Invalidate while the old build is still blocked — this must bump
+            # the generation and drop the old build's in-flight registration so
+            # a concurrent caller starts a brand-new build rather than waiting
+            # on the now-stale one.
+            prov.invalidate_providers_cache()
+
+            def _new_call():
+                outputs["new"] = prov.get_providers()
+
+            t_new = threading.Thread(target=_new_call)
+            t_new.start()
+            assert new_entered.wait(2)
+
+            # Complete the NEW build first, then let the stale OLD build finish.
+            release_new.set()
+            t_new.join(2)
+            release_old.set()
+            t_old.join(2)
+
+            assert outputs["new"]["providers"][0]["call_id"] == 1
+            assert outputs["old"]["providers"][0]["call_id"] == 0
+
+            # A subsequent cached read must reflect the new build, not the
+            # late-completing stale one.
+            cached = prov.get_providers()
+            assert cached["providers"][0]["call_id"] == 1
+        finally:
+            prov.invalidate_providers_cache()
+
+    def test_failed_aggregate_build_clears_inflight_state_and_retries_succeed(
+        self, monkeypatch, tmp_path,
+    ):
+        """A build that raises must not leave stale in-flight/cache state (#6010).
+
+        A subsequent request for the same cache key should retry the build
+        (not hang waiting on a dead in-flight entry) and succeed.
+        """
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+
+        attempt = {"value": 0}
+
+        def flaky_build(
+            cfg,
+            sorted_known_ids,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+            providers_cfg,
+        ):
+            attempt["value"] += 1
+            if attempt["value"] == 1:
+                raise RuntimeError("simulated aggregate build failure")
+            return {
+                "providers": [{
+                    "id": "openai",
+                    "display_name": "OpenAI",
+                    "has_key": False,
+                    "configurable": True,
+                    "key_source": "none",
+                }],
+                "active_provider": None,
+            }
+
+        monkeypatch.setattr(prov, "_build_providers_payload", flaky_build)
+
+        try:
+            with pytest.raises(RuntimeError, match="simulated aggregate build failure"):
+                prov.get_providers()
+
+            cache_key = prov._providers_cache_key(prov.get_config())
+            assert cache_key not in prov._providers_build_inflight
+            assert cache_key not in prov._providers_cache
+
+            result = prov.get_providers()
+            ids = {entry["id"] for entry in result["providers"]}
+            assert ids == {"openai"}
+            assert attempt["value"] == 2
+        finally:
+            prov.invalidate_providers_cache()
+
+    def test_complete_provider_build_cache_publication_lock_error_wakes_waiter_and_clears_inflight(self, monkeypatch, tmp_path):
+        """Cache publication lock failure must wake waiters and be recoverable."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+        monkeypatch.setattr(prov, "_provider_has_key", lambda _pid: False)
+
+        payload_begun = threading.Event()
+        release = threading.Event()
+        build_calls = {"value": 0}
+
+        def flaky_build_payload(
+            cfg,
+            sorted_known_ids,
+            active_profile_name,
+            request_thread_env,
+            request_block_process_env_fallback,
+            providers_cfg,
+        ):
+            build_calls["value"] += 1
+            payload_begun.set()
+            release.wait(2)
+            return {
+                "providers": [{
+                    "id": "openai",
+                    "display_name": "OpenAI",
+                    "has_key": False,
+                    "configurable": True,
+                    "is_self_hosted": False,
+                    "base_url": None,
+                    "is_plugin_provider": False,
+                    "is_oauth": False,
+                    "key_source": "none",
+                    "auth_error": None,
+                    "models": [],
+                    "models_total": 0,
+                }],
+                "active_provider": "openai",
+            }
+
+        monkeypatch.setattr(prov, "_build_providers_payload", flaky_build_payload)
+
+        original_cache_lock = prov._providers_cache_lock
+        exit_counter = {"count": 0}
+        injected_failures = {"count": 0}
+        armed = threading.Event()
+        completion_error = RuntimeError("cache publication failed")
+
+        class _OneShotFailingCacheLock:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __enter__(self):
+                return self._inner.__enter__()
+
+            def __exit__(self, exc_type, exc, tb):
+                exit_counter["count"] += 1
+                self._inner.__exit__(exc_type, exc, tb)
+                if armed.is_set() and injected_failures["count"] == 0:
+                    injected_failures["count"] += 1
+                    raise completion_error
+
+        failing_cache_lock = _OneShotFailingCacheLock(original_cache_lock)
+        monkeypatch.setattr(prov, "_providers_cache_lock", failing_cache_lock)
+
+        waiter = threading.Event()
+        real_wait_provider_build = prov._wait_provider_build
+
+        def spy_wait_provider_build(state, cache_key):
+            waiter.set()
+            return real_wait_provider_build(state, cache_key)
+
+        monkeypatch.setattr(prov, "_wait_provider_build", spy_wait_provider_build)
+        errors = {}
+
+        def call_get_providers(label):
+            try:
+                prov.get_providers()
+            except BaseException as exc:
+                errors[label] = exc
+
+        lead = threading.Thread(target=call_get_providers, args=("lead",))
+        follower = threading.Thread(target=call_get_providers, args=("waiter",))
+        lead_started = False
+        follower_started = False
+
+        try:
+            lead.start()
+            lead_started = True
+            assert payload_begun.wait(2)
+            follower.start()
+            follower_started = True
+            assert waiter.wait(2)
+            armed.set()
+
+            release.set()
+            lead.join(2)
+            follower.join(2)
+
+            assert not lead.is_alive()
+            assert not follower.is_alive()
+            assert isinstance(errors.get("lead"), RuntimeError)
+            assert isinstance(errors.get("waiter"), RuntimeError)
+            assert errors["lead"].args == errors["waiter"].args == completion_error.args
+            assert injected_failures["count"] == 1
+            assert exit_counter["count"] >= 1
+
+            assert "cache publication failed" in str(errors["lead"])
+            monkeypatch.setattr(prov, "_providers_cache_lock", original_cache_lock)
+
+            cache_key = prov._providers_cache_key(prov.get_config())
+            assert cache_key not in prov._providers_build_inflight
+
+            result = prov.get_providers()
+            ids = {entry["id"] for entry in result["providers"]}
+            assert ids == {"openai"}
+            assert build_calls["value"] == 2
+        finally:
+            release.set()
+            if lead_started:
+                lead.join(2)
+            if follower_started:
+                follower.join(2)
+            monkeypatch.setattr(prov, "_providers_cache_lock", original_cache_lock)
+            if hasattr(prov, "invalidate_providers_cache"):
+                prov.invalidate_providers_cache()
+
+    def test_complete_provider_build_skips_stale_publication_after_generation_bump(self, monkeypatch, tmp_path):
+        """TOCTOU generation bump between pre-check and lock must not cache stale completion."""
+        _install_fake_hermes_cli(monkeypatch)
+        from api import providers as prov
+
+        cache_key = ("toctou-generation", "providers")
+        stale_payload = {
+            "providers": [{"id": "stale", "display_name": "Stale", "has_key": False}],
+            "active_provider": None,
+        }
+        fresh_cache_value = (999.0, {"providers": [{"id": "fresh"}], "active_provider": "fresh"})
+        original_cache_lock = prov._providers_cache_lock
+        original_generation = prov._providers_cache_generation
+
+        prov._providers_cache.clear()
+        prov._providers_cache[cache_key] = fresh_cache_value
+        prov._providers_cache_generation = 0
+        bump_state = {"count": 0}
+
+        class _GenerationBumpCacheLock:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __enter__(self):
+                if bump_state["count"] == 0:
+                    prov._providers_cache_generation += 1
+                    bump_state["count"] += 1
+                return self._inner.__enter__()
+
+            def __exit__(self, exc_type, exc, tb):
+                return self._inner.__exit__(exc_type, exc, tb)
+
+        bumping_lock = _GenerationBumpCacheLock(original_cache_lock)
+        monkeypatch.setattr(prov, "_providers_cache_lock", bumping_lock)
+
+        stale_state = prov._ProvidersBuildInFlight(0)
+
+        try:
+            cached_before = prov._providers_cache[cache_key]
+            result = prov._complete_provider_build(cache_key, stale_state, payload=stale_payload)
+
+            assert result == stale_payload
+            assert prov._providers_cache.get(cache_key) is cached_before
+            assert prov._providers_cache[cache_key] == fresh_cache_value
+            assert bump_state["count"] == 1
+            assert prov._providers_cache_generation == 1
+        finally:
+            monkeypatch.setattr(prov, "_providers_cache_lock", original_cache_lock)
+            prov._providers_cache_generation = original_generation
+            if hasattr(prov, "invalidate_providers_cache"):
+                prov.invalidate_providers_cache()
+
+    def test_build_provider_entry_outer_fallback_preserves_env_key_source(self, monkeypatch, tmp_path):
+        """Outer catch should retain env key source for configured API-key providers."""
+        _install_fake_hermes_cli(monkeypatch)
+        (tmp_path / ".env").write_text("LM_API_KEY=lmstudio-fallback-key\n", encoding="utf-8")
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"lmstudio": "LM Studio"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"lmstudio": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+
+        plugin_probe_calls = {"value": 0}
+
+        def _raise_plugin_probe(_provider_id):
+            plugin_probe_calls["value"] += 1
+            if plugin_probe_calls["value"] == 1:
+                raise RuntimeError("forcing fallback")
+            return False
+
+        monkeypatch.setattr(prov, "is_plugin_model_provider", _raise_plugin_probe)
+
+        entry = prov._build_provider_entry(
+            provider_id="lmstudio",
+            initial_has_key=True,
+            providers_cfg={},
+            active_profile_name="",
+            request_thread_env={},
+            block_process_env_fallback=False,
+        )
+
+        assert entry is not None
+        assert entry["has_key"] is True
+        assert entry["key_source"] == "env_file"
+        assert plugin_probe_calls["value"] >= 2
+
+    def test_build_provider_entry_initial_bedrock_key_source_prefers_env_var_for_structural_credentials(self, monkeypatch, tmp_path):
+        """Initial bedrock credentials from structural signals should report env_var."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"bedrock": "AWS Bedrock"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"bedrock": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+
+        entry = prov._build_provider_entry(
+            provider_id="bedrock",
+            initial_has_key=True,
+            providers_cfg={},
+            active_profile_name="",
+            request_thread_env={
+                "AWS_ACCESS_KEY_ID": "thread-access-key",
+                "AWS_SECRET_ACCESS_KEY": "thread-secret-key",
+            },
+            block_process_env_fallback=False,
+        )
+
+        assert entry is not None
+        assert entry["has_key"] is True
+        assert entry["key_source"] == "env_var"
+        assert "thread-access-key" not in str(entry)
+        assert "thread-secret-key" not in str(entry)
+
+    def test_build_provider_entry_initial_bedrock_key_source_falls_back_config_yaml(self, monkeypatch, tmp_path):
+        """Initial bedrock credentials without structural signals should report config_yaml."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        for env_name in (
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "AWS_PROFILE",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+        ):
+            monkeypatch.delenv(env_name, raising=False)
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"bedrock": "AWS Bedrock"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"bedrock": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+
+        entry = prov._build_provider_entry(
+            provider_id="bedrock",
+            initial_has_key=True,
+            providers_cfg={},
+            active_profile_name="",
+            request_thread_env={},
+            block_process_env_fallback=False,
+        )
+
+        assert entry is not None
+        assert entry["has_key"] is True
+        assert entry["key_source"] == "config_yaml"
+
+    def test_build_provider_entry_cleans_up_request_context_after_setup_error(self, monkeypatch, tmp_path):
+        """Partial request-context setup failure must not leave thread-local/profile residue."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        from api import providers as prov
+        from api import config as provider_cfg
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"openai": "OpenAI"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"openai": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+
+        original_clear_thread_env = provider_cfg._clear_thread_env
+        clear_thread_env_calls = {"value": 0}
+        set_thread_env_calls = {"value": 0}
+
+        original_set_thread_env = provider_cfg._set_thread_env
+
+        def flaky_set_thread_env(**kwargs):
+            set_thread_env_calls["value"] += 1
+            if set_thread_env_calls["value"] == 1:
+                # Partially apply caller state, then fail to prove the finally
+                # cleanup still runs and restores worker-local context.
+                provider_cfg._thread_ctx.env = dict(kwargs)
+                raise RuntimeError("simulated context setup failure")
+            return original_set_thread_env(**kwargs)
+
+        def tracked_clear_thread_env():
+            clear_thread_env_calls["value"] += 1
+            return original_clear_thread_env()
+
+        try:
+            profiles.clear_request_profile()
+            provider_cfg._clear_thread_env()
+            provider_cfg._thread_ctx.block_process_env_fallback = False
+            assert getattr(profiles._tls, "profile", None) is None
+            assert provider_cfg._thread_ctx.env == {}
+            assert provider_cfg._thread_ctx.block_process_env_fallback is False
+
+            monkeypatch.setattr(provider_cfg, "_set_thread_env", flaky_set_thread_env)
+            monkeypatch.setattr(provider_cfg, "_clear_thread_env", tracked_clear_thread_env)
+
+            entry = prov._build_provider_entry(
+                provider_id="openai",
+                initial_has_key=True,
+                providers_cfg={},
+                active_profile_name="quarantine-profile",
+                request_thread_env={"THREAD_ENV_KEY": "thread-env-value"},
+                block_process_env_fallback=False,
+            )
+
+            assert entry is not None
+            assert set_thread_env_calls["value"] == 1
+            assert clear_thread_env_calls["value"] == 1
+            assert getattr(profiles._tls, "profile", None) is None
+            assert provider_cfg._thread_ctx.env == {}
+            assert provider_cfg._thread_ctx.block_process_env_fallback is False
+        finally:
+            # Ensure this test never leaves request/thread state on the shared
+            # pytest worker thread, even on assertion failure.
+            monkeypatch.setattr(provider_cfg, "_set_thread_env", original_set_thread_env)
+            monkeypatch.setattr(provider_cfg, "_clear_thread_env", original_clear_thread_env)
+            profiles.clear_request_profile()
+            provider_cfg._clear_thread_env()
+            provider_cfg._thread_ctx.block_process_env_fallback = False
+
+    def test_bedrock_structural_credentials_require_complete_access_key_pair(self, monkeypatch):
+        """A lone AWS access-key field is not a usable Bedrock credential signal."""
+        from api import providers as prov
+
+        for env_name in (
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            *prov._BEDROCK_SINGLE_CREDENTIAL_ENV_SIGNALS,
+        ):
+            monkeypatch.delenv(env_name, raising=False)
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "access-key-without-secret")
+        assert prov._provider_has_structural_bedrock_credentials() is False
+
+    def test_get_providers_bedrock_structural_credentials_respect_profile_thread_local(self, monkeypatch, tmp_path):
+        """Bedrock should read process-thread credentials, not raw process env, in named profiles."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", tmp_path)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "process-id")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "process-secret")
+        profile_home = tmp_path / "profiles" / "work"
+        profile_home.mkdir(parents=True)
+        (tmp_path / ".env").write_text(
+            "OTHER_SHARED_KEY=from-process-file\n",
+            encoding="utf-8",
+        )
+        (profile_home / ".env").write_text(
+            "OTHER_PROFILE_KEY=from-profile\n",
+            encoding="utf-8",
+        )
+
+        from api import providers as prov
+
+        monkeypatch.setattr(prov, "_PROVIDER_DISPLAY", {"bedrock": "AWS Bedrock"})
+        monkeypatch.setattr(prov, "_PROVIDER_MODELS", {"bedrock": []})
+        monkeypatch.setattr(prov, "_OAUTH_PROVIDERS", frozenset())
+        monkeypatch.setattr(prov, "plugin_model_provider_ids", lambda: set())
+        monkeypatch.setattr(prov, "get_config", lambda: {"model": {}, "providers": {}})
+
+        profiles.set_request_profile("work")
+        try:
+            with profiles.profile_env_for_active_request_readonly("test"):
+                no_profile_keys = prov.get_providers()
+            bedrock = next((p for p in no_profile_keys["providers"] if p["id"] == "bedrock"), None)
+            assert bedrock is not None
+            assert bedrock["has_key"] is False
+
+            (profile_home / ".env").write_text(
+                "AWS_ACCESS_KEY_ID=profile-id\nAWS_SECRET_ACCESS_KEY=profile-secret\n",
+                encoding="utf-8",
+            )
+            with profiles.profile_env_for_active_request_readonly("test"):
+                result = prov.get_providers()
+            bedrock = next((p for p in result["providers"] if p["id"] == "bedrock"), None)
+            assert bedrock is not None
+            assert bedrock["has_key"] is True
+
+        finally:
+            profiles.clear_request_profile()
             if hasattr(prov, "invalidate_providers_cache"):
                 prov.invalidate_providers_cache()
 


### PR DESCRIPTION
## Thinking Path

- PR #6013 made repeat `/api/providers` requests fast by caching the response.
- The first uncached request remained slow because it checked provider credentials and models one provider at a time.
- This delay matters on phones. The mobile footer does not show the compact quota chip, so users often open Providers to check usage and credential-pool status for services such as OpenAI Codex.
- Provider checks must keep the active profile's home, environment, and credentials. Moving them to worker threads without that context could read data from the wrong profile.
- This PR runs independent checks in deadline-bound per-build daemon runners, limits process-wide active work, and makes callers for the same profile share one build.
- It also lets provider cards appear before the quota request finishes.

## What Changed

- Runs serialized credential discovery and parallel provider probes under one absolute 15-second leader deadline, using per-build daemon runners capped at eight workers.
- Quarantines callbacks that outlive a build, caps process-wide active work, drops queued contexts at the deadline, and stops admitting provider work during orderly server shutdown.
- Copies the request's profile and credential context into each worker.
- Makes concurrent requests for the same cache key share one provider build.
- Bounds follower waits and keeps timed-out or quarantined partial results out of the response cache so recovered providers are retried immediately.
- Prevents an old build from replacing newer data after cache invalidation.
- Wakes waiting callers when a build or cache publication fails, rolls back the failed publication, and lets a later request retry.
- Preserves the best-known credential source when provider discovery falls back after an unexpected error.
- Detects Bedrock credentials from explicit AWS settings instead of running the live AWS metadata credential chain when the Providers page loads, while distinguishing environment signals from config or pool credentials.
- Starts the provider and quota requests together. It renders provider cards when provider data arrives, then adds quota data when ready.
- Adds tests for parallel work, the worker limit, shared builds, cache invalidation, failed-build retries, profile isolation, Bedrock credentials, and both provider-first and quota-first completion.

## Why It Matters

- Under the same test conditions, the mean time for the first uncached provider response fell from **5.855 seconds to 0.791 seconds** across five alternating runs. That is **86.5% less time**, or a **7.40× speedup**.
- Provider cards no longer wait for quota data before they appear.
- This makes provider usage checks faster on mobile, where the composer does not show the compact quota chip.
- The lifecycle change preserves the 47-provider catalog. The final review follow-up intentionally normalizes a logged-out OAuth card from `key_source: "oauth"` to `key_source: "none"` when `has_key` is false.
- Keyed shared builds avoid duplicate same-profile checks, while per-build daemon runners prevent a stuck callback from poisoning reusable process-wide worker capacity or blocking interpreter exit.
- Each worker keeps the correct profile and credential context.

## Verification

Targeted provider, quota, plugin, profile, and mobile tests:

`python -m pytest tests/test_provider_management.py tests/test_provider_cost_chart_ui.py tests/test_provider_quota_status.py tests/test_credential_pool_providers.py tests/test_plugin_model_providers.py tests/test_issue3957_profile_providers_models.py tests/test_mobile_layout.py -q -o addopts=`

Result: `242 passed`

Focused concurrency, profile, Bedrock, invalidation, and frontend tests:

`python -m pytest tests/test_provider_management.py -k 'singleflight or invalidate_during_blocked_build or failed_aggregate_build or workers_inherit_request_context or bedrock_structural' -q -o addopts=`

Result: `6 passed`

`python -m pytest tests/test_provider_cost_chart_ui.py -q -o addopts=`

Result: `6 passed`

Post-review lifecycle and stale-load validation on exact head `0367de66`:

`./scripts/test.sh tests/test_provider_management.py tests/test_provider_cost_chart_ui.py tests/test_provider_quota_status.py tests/test_provider_cost_history.py tests/test_provider_cost_budget.py tests/test_provider_sort_order.py tests/test_custom_providers_in_panel.py -q -o addopts=`

Result: `152 passed`

`./scripts/test.sh tests/test_issue2545_xai_oauth_provider.py tests/test_provider_management.py::TestGetProviders::test_build_provider_entry_logged_out_oauth_normalizes_key_source -q -o addopts=`

Result: `4 passed`

The permanently blocked provider, absolute credential-preflight deadline, healthy overlapping-build admission, process-exit shutdown, and stale frontend await-contract regressions were repeated 15 times each.

Result: `75 passed`

Orderly shutdown coverage: `5 passed`

Before the intentional OAuth metadata normalization, the rebased pre-fix parent and lifecycle head returned byte-equivalent JSON for all 47 providers (`2.419s` vs `2.411s` in the local plugin-limited environment).

Syntax and formatting checks:

`node --check static/panels.js`

`python -m py_compile api/providers.py tests/test_provider_management.py tests/test_provider_cost_chart_ui.py`

`git diff --check`

All passed.

The performance test ran the upstream and updated versions five times each in alternating, separate Python processes. Each run cleared the provider-response cache first.

- Upstream: **5.646–6.289 seconds**
- Updated: **0.733–0.896 seconds**

The change does not alter the page layout or provider data, so screenshots would not show the improvement.

## Risks / Follow-ups

- The Providers page now treats explicit AWS settings as evidence that Bedrock has credentials. Explicit provider authentication and test actions still run the full AWS credential check.
- Provider discovery returns the entries completed by the 15-second deadline. Timed-out or quarantined partial results are not cached, so later requests retry as soon as the stuck callback releases its quarantine key.
- Python cannot safely terminate arbitrary third-party thread callbacks. Those callbacks run only in daemonized per-build runners, remain globally capped and keyed while alive, and cannot block interpreter exit.

## Model Used

- Nous Research / Hermes Agent `gpt-5.6-sol` for investigation, implementation planning, corrections, and verification.
- OpenAI / Codex `gpt-5.3-codex-spark` (`xhigh`) for implementation and final review.
- Anthropic / Claude Code `claude-sonnet-5` for concurrency lifecycle changes and test corrections.
- Anthropic / Claude Code `claude-opus-4-8` for follow-up concurrency lifecycle review.
- Greptile (model undisclosed) for automated final review and the logged-out OAuth metadata correction.






