### PR TITLE
test: isolate state-dir probes from user state

### DIFF
--- a/tests/test_issue4449_state_dir_contract.py
+++ b/tests/test_issue4449_state_dir_contract.py
@@ -12,6 +12,7 @@ truly isolated import and can't pollute the test process.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -19,20 +20,27 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-_PROBE = (
-    "import api.config as c; "
-    "print(c.STATE_DIR)"
-)
+_PROBE = "import api.config as c; print(c.STATE_DIR)"
 
 
-def _state_dir_for_env(**env_overrides) -> Path:
+def _state_dir_for_env(platform_home: Path, **env_overrides) -> Path:
     """Import api.config in a fresh subprocess under the given env and return
     the resolved STATE_DIR it computes. None-valued overrides unset the var."""
     env = dict(os.environ)
-    # Start from a clean slate for the two vars under test so the parent
-    # process's pytest values don't bleed in.
+    # Keep every probe inside fixture-owned platform paths. Inheriting the real
+    # user home lets an import-only probe reconcile pytest workspace defaults
+    # into the user's settings.json before it prints STATE_DIR.
+    env["HOME"] = str(platform_home)
+    env["USERPROFILE"] = str(platform_home)
+    env["LOCALAPPDATA"] = str(platform_home / "AppData" / "Local")
+    # Start from a clean slate for the vars that can redirect state or trigger
+    # startup settings reconciliation in the child process.
     env.pop("HERMES_HOME", None)
+    env.pop("HERMES_BASE_HOME", None)
     env.pop("HERMES_WEBUI_STATE_DIR", None)
+    env.pop("HERMES_WEBUI_TEST_STATE_DIR", None)
+    env.pop("HERMES_WEBUI_DEFAULT_WORKSPACE", None)
+    env.pop("HERMES_CONFIG_PATH", None)
     for key, value in env_overrides.items():
         if value is None:
             env.pop(key, None)
@@ -50,20 +58,51 @@ def _state_dir_for_env(**env_overrides) -> Path:
     return Path(out.stdout.strip()).resolve()
 
 
-def _platform_default_state_dir() -> Path:
+def _platform_default_state_dir(platform_home: Path) -> Path:
     """What STATE_DIR resolves to with HERMES_HOME + STATE_DIR both unset."""
-    return _state_dir_for_env()
+    return _state_dir_for_env(platform_home)
+
+
+def test_state_dir_probe_does_not_mutate_platform_default_settings(
+    tmp_path, monkeypatch
+):
+    """The subprocess probe must not reconcile pytest defaults into user state."""
+    platform_home = tmp_path / "platform-home"
+    if os.name == "nt":
+        settings_file = (
+            platform_home / "AppData" / "Local" / "hermes" / "webui" / "settings.json"
+        )
+    else:
+        settings_file = platform_home / ".hermes" / "webui" / "settings.json"
+    settings_file.parent.mkdir(parents=True)
+    persisted_workspace = tmp_path / "persisted-workspace"
+    persisted_workspace.mkdir()
+    original = (
+        json.dumps({"default_workspace": str(persisted_workspace)}) + "\n"
+    ).encode()
+    settings_file.write_bytes(original)
+
+    monkeypatch.setenv("HOME", str(platform_home))
+    monkeypatch.setenv("USERPROFILE", str(platform_home))
+    monkeypatch.setenv(
+        "HERMES_WEBUI_DEFAULT_WORKSPACE", str(tmp_path / "pytest-workspace")
+    )
+
+    state_dir = _platform_default_state_dir(platform_home)
+
+    assert settings_file.read_bytes() == original
+    assert state_dir == settings_file.parent.resolve()
 
 
 def test_config_state_dir_defaults_to_hermes_home_webui(tmp_path):
     hermes_home = tmp_path / ".hermes" / "profiles" / "isolated"
     hermes_home.mkdir(parents=True)
 
-    state_dir = _state_dir_for_env(HERMES_HOME=hermes_home)
+    state_dir = _state_dir_for_env(tmp_path / "platform-home", HERMES_HOME=hermes_home)
     assert state_dir == (hermes_home / "webui").resolve()
 
 
-def test_config_state_dir_unchanged_for_normal_install_hermes_home_unset():
+def test_config_state_dir_unchanged_for_normal_install_hermes_home_unset(tmp_path):
     """Backward-compat: with HERMES_HOME unset, STATE_DIR stays at the platform
     default `<~/.hermes>/webui` — a normal install's state must NOT relocate
     (the #4449/#4454 state-dir move only affects an explicitly-set HERMES_HOME).
@@ -71,12 +110,14 @@ def test_config_state_dir_unchanged_for_normal_install_hermes_home_unset():
     Cross-check: the unset-HERMES_HOME result must NOT equal the result of
     pointing HERMES_HOME at an arbitrary other base — i.e. the default is
     genuinely the platform home, not whatever the test environment injected."""
-    default = _platform_default_state_dir()
+    platform_home = tmp_path / "platform-home"
+    default = _platform_default_state_dir(platform_home)
     assert default.name == "webui"
     # Pointing HERMES_HOME elsewhere produces a DIFFERENT dir, proving the unset
     # case resolves to the platform default rather than echoing an injected base.
-    elsewhere = _state_dir_for_env(HERMES_HOME="/tmp/hermes-4449-elsewhere-base")
-    assert elsewhere == Path("/tmp/hermes-4449-elsewhere-base/webui").resolve()
+    elsewhere_base = tmp_path / "elsewhere-base"
+    elsewhere = _state_dir_for_env(platform_home, HERMES_HOME=elsewhere_base)
+    assert elsewhere == (elsewhere_base / "webui").resolve()
     assert default != elsewhere
 
 
@@ -88,6 +129,7 @@ def test_config_state_dir_explicit_override_takes_precedence(tmp_path):
     explicit = tmp_path / "custom-state"
 
     state_dir = _state_dir_for_env(
+        tmp_path / "platform-home",
         HERMES_HOME=hermes_home,
         HERMES_WEBUI_STATE_DIR=explicit,
     )


### PR DESCRIPTION
## Thinking Path

- The state-dir contract tests import `api.config` in fresh subprocesses.
- Pytest injects state and workspace overrides into the parent environment for suite isolation.
- The normal-install probe removed `HERMES_HOME` and `HERMES_WEBUI_STATE_DIR`, but still inherited the pytest workspace override while using the platform user home.
- Import-time settings reconciliation could therefore write the pytest workspace into a production-like `settings.json`.
- This PR keeps every probe inside fixture-owned platform paths and removes all parent state/config redirects before import.

## Contract Routing

Task type: test-isolation bug fix; no intentional product-contract change.

Touched areas:
- `tests/test_issue4449_state_dir_contract.py`
- subprocess environment isolation for WebUI state/config probes

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `TESTING.md`

Scope boundaries:
- No runtime product code changes.
- No production settings or existing sessions are repaired by this PR.

Evidence needed before claiming done:
- A sentinel platform-default `settings.json` remains byte-for-byte unchanged.
- All resolved state paths remain fixture-owned.
- Existing explicit/unset state-dir precedence tests still pass.

## What Changed

- Require each subprocess probe to receive a fixture-owned platform home.
- Set `HOME`, `USERPROFILE`, and `LOCALAPPDATA` inside the child environment.
- Clear inherited Hermes home/base-home, WebUI state/test-state/default-workspace, and config-path overrides before applying the variables under test.
- Add a regression test that preserves the active platform-default sentinel `settings.json` byte-for-byte, including `%LOCALAPPDATA%\hermes\webui` on native Windows.
- Use `json.dumps` so the sentinel remains valid on Windows paths.

## Why It Matters

A test that only intends to inspect `STATE_DIR` must never read or reconcile pytest defaults into real user state. The isolation now models a normal install without touching the operator's home on Linux, macOS, or Windows.

## Verification

- RED before the isolation fix: the new sentinel test failed and showed `settings.json` rewritten with the pytest workspace (`1 failed, 3 passed`).
- `./scripts/test.sh tests/test_issue4449_state_dir_contract.py tests/test_pytest_state_isolation.py tests/test_issue2698_isolated_hermes_home.py tests/test_bootstrap_foreground.py -q`
  - `78 passed`
- `ruff check tests/test_issue4449_state_dir_contract.py`
  - passed
- `ruff format --check tests/test_issue4449_state_dir_contract.py`
  - passed
- `python scripts/ruff_lint.py --diff origin/master`
  - 0 findings on added/modified lines
- `git diff --check`
  - passed
- Full `./scripts/test.sh`
  - `13348 passed, 104 skipped, 1 xfailed, 2 xpassed, 34 subtests passed`
  - one unrelated existing environment/order-dependent failure remained in `test_issue4685_post_compression_context_metering.py`: importing the external Hermes Agent `agent.context_compressor` saw an incomplete `agent.auxiliary_client` stub and could not import `call_llm`. The same failure occurred in both isolated PR worktrees and is outside this test-only diff.

## Risks / Follow-ups

- Risk is limited to test harness behavior; runtime code is unchanged.
- This does not repair already-persisted settings or stale session workspaces. Those are intentionally separate concerns.
- No docs update is needed because the product contract is unchanged; this enforces the repository's existing isolated-test-state rule.

## Model Used

- Provider: OpenAI Codex
- Model: `gpt-5.6-sol`
- Reasoning mode: `medium`
- Notable tools: Hermes Agent repository inspection, isolated Git worktrees, official test runner, and independent read-only review agents.
