### PR TITLE
fix: Fix kanban scrolling in mobile viewports

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -7024,6 +7024,7 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
   .kanban-modal-overlay{padding:12px;}
   .kanban-modal{padding:16px 16px 14px;border-radius:14px;}
   .kanban-modal-row-inline{flex-direction:column;gap:0;}
+  .kanban-column-body{overscroll-behavior:auto;}
 }
 
 /* ── Logs panel (#1455) ───────────────────────────────────────────────────── */


### PR DESCRIPTION
# Summary
Scrolling vertically (particularly in expanded view) in kanban on a mobile viewport is difficult. The columns have overscroll disabled, meaning tap and drag will only scroll within the column and will not continue to the next section. On desktop it's much easier to get the mouse outside the column div, on mobile you have to deliberately try to tap very close to the edge of the viewport.

The same overscroll setting also often causes the left sidebar to be opened when trying to draft left to right (rather than scrolling it pops the sidebar).

# Fix
Set `overscroll-behavior` to `auto` in the mobile viewport media query for the kanban view.

# Validation
The following is a side by side comparison before and after these changes on desktop. The expectation is that there's no behavior change:
[fix-kanban_overscroll_desktop.webm](https://github.com/user-attachments/assets/3e16c712-142a-4638-a717-188a2485b53c)

The following is a side by side comparison of the before and after on mobile viewports. Note how in the before:
1. Navigating between columns and sections is awkward because of tap targets
2. I end up opening the left nav while scrolled all the way to the right on the board

Both of these  are fixed in the after:
[fix-kanban_overscroll_mobile.webm](https://github.com/user-attachments/assets/a33bc65f-6fd4-4d83-a65e-d70f2b9c0b2d)


Author: Joe Palazzolo <joe@joepalazzolo.net>