### PR TITLE
fix: Fix height of consolidated kanban board

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -2526,6 +2526,7 @@ function _kanbanRenderBoard(){
     board.innerHTML = _kanbanEmptyBoardHtml();
     return;
   }
+  board.classList.toggle('kanban-board-consolidated', !_kanbanLanesByProfile);
   const columns = _kanbanVisibleTasks();
   const total = columns.reduce((n, col) => n + (col.tasks || []).length, 0);
   if ($('kanbanSummary')) $('kanbanSummary').textContent = String(t('kanban_visible_tasks')).replace('{0}', total);

--- a/static/style.css
+++ b/static/style.css
@@ -6695,10 +6695,12 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .kanban-list-title{font-size:13px;font-weight:600;line-height:1.35;}
 .kanban-board-wrap{flex:1;min-height:0;overflow:auto;padding:16px;background:var(--bg);}
 .kanban-board{display:flex;gap:12px;min-height:100%;overflow-x:auto;padding-bottom:8px;}
+.kanban-board.kanban-board-consolidated{height:100%;}
 .kanban-column{display:flex;flex-direction:column;min-width:260px;max-width:320px;flex:1;background:var(--panel);border:1px solid var(--border);border-radius:10px;min-height:240px;}
 .kanban-column-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:10px 12px;border-bottom:1px solid var(--border);font-size:13px;font-weight:600;color:var(--text);}
 .kanban-count{font-size:11px;color:var(--muted);background:var(--input-bg);border:1px solid var(--border);border-radius:999px;padding:1px 7px;}
 .kanban-column-body{display:flex;flex-direction:column;gap:8px;padding:10px;min-height:0;max-height:min(68vh,720px);overflow-y:auto;overscroll-behavior:contain;scrollbar-gutter:stable;}
+.kanban-board-consolidated .kanban-column-body{height:100%;max-height:unset;overscroll-behavior:auto;}
 .kanban-card{border:1px solid var(--border);border-radius:9px;background:var(--bg);padding:10px;cursor:pointer;box-shadow:var(--shadow-sm);}
 .kanban-card:hover,.kanban-card.selected{border-color:var(--accent);}
 .kanban-card-title{font-size:13px;font-weight:650;color:var(--text);line-height:1.35;margin-bottom:6px;}

--- a/tests/test_kanban_board_ui.py
+++ b/tests/test_kanban_board_ui.py
@@ -25,3 +25,30 @@ def test_kanban_columns_render_scrollable_card_lists():
     assert "overflow-y:auto" in rule
     assert "overscroll-behavior:contain" in rule
     assert "scrollbar-gutter:stable" in rule
+
+
+def test_kanban_consolidated_board_fills_viewport_height():
+    """The consolidated (single-board) view must stretch to fill the viewport
+    instead of leaving empty space below the columns on desktop.
+
+    Both the board element and its column bodies drop their capped heights and
+    take height:100% so the columns extend to the bottom of the board wrap.
+    """
+    board_rule = _css_rule(".kanban-board.kanban-board-consolidated")
+    assert "height:100%" in board_rule
+
+    body_rule = _css_rule(".kanban-board-consolidated .kanban-column-body")
+    assert "height:100%" in body_rule
+    assert "max-height:unset" in body_rule
+    # The consolidated view owns its own full-height scroll container, so it opts
+    # out of the scroll-chaining lock the capped lane view uses.
+    assert "overscroll-behavior:auto" in body_rule
+
+
+def test_kanban_consolidated_class_toggled_by_lane_mode():
+    """The consolidated-height CSS only takes effect when the board element
+    carries the `kanban-board-consolidated` class, which the renderer adds only
+    in the single-board (non-lanes) view. Pin the wiring so a render refactor
+    can't silently strip the class and reintroduce the empty-space regression.
+    """
+    assert "classList.toggle('kanban-board-consolidated'" in PANELS_JS


### PR DESCRIPTION
# Summary
The consolidated Kanban board view has incorrect column heights and leaves empty space below the cards. This PR adjusts the CSS between the consolidated and per-profile view to make proper use of the column vertical spacing.

# The Issue
The consolidated kanban view keeps a `min-height` property on the columns, which causes them to not fill the vertical space properly:
<img width="354" height="1207" alt="Screenshot_20260718_235408" src="https://github.com/user-attachments/assets/523b149f-c2be-4dbe-914f-c168d42fcc5b" />

# The Fix
The fix requires applying CSS to two elements when in the consolidated view:
1. `kanban-board` needs a fixed `height: 100%` to fill it's parent (and thus filling the vertical space)
2. `kanban-column-body` needs it's `max-height` property removed (this sets the height of the profile rows in the per-profile view) and it's `height` set to 100% to fill the outer `kanban-board`

To target these the JS that toggles the board view now also toggles a `kanban-board-consolidated` so we can target it in the CSS rules and override the default behavior used by the profile view.

# Validation
Manual testing on desktop and mobile layouts shows the consolidated view filling the viewport as expected:
<img width="563" height="1231" alt="Screenshot_20260719_000124" src="https://github.com/user-attachments/assets/cd030f7b-5dba-4cad-89de-708366d36178" />
<img width="464" height="951" alt="Screenshot_20260719_000204" src="https://github.com/user-attachments/assets/29a0df5b-dc44-4660-a542-e6390e780264" />

The per-profile layout still has it's proper profile-lane heights as expected:
<img width="956" height="1263" alt="Screenshot_20260719_000256" src="https://github.com/user-attachments/assets/501a81f4-a908-4f31-bdd3-168d9a810397" />

Added a test case and ran kanban related tests: 
```
find tests -type f -iname "*kanban*.py" | xargs .venv/bin/python -m pytest -q
```