### PR TITLE
fix(session): externalize large native media

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -245,13 +245,22 @@ extraction under `attachments/`; changing `HERMES_WEBUI_ATTACHMENT_DIR` does not
 move or change private-media authority. A deployment that moves WebUI state must
 move the complete `STATE_DIR` together.
 
-Private-media reads and writes are anchored to opened directory handles, reject
-symlink components, verify extension/MIME, raster magic, and SHA-256, and publish
-only fully synced files. New-session lineage operations clone all referenced
-blobs transactionally before publishing the new session id. Model requests and
-portable exports must hydrate every reference through the strict reader and
-must reject any private URI that remains; plain JSON imports containing private
-URIs are rejected. Legacy files under
+On platforms with `dir_fd` support, private-media reads and writes are anchored
+to opened directory handles and reject symlink components. Native Windows uses
+a capability-selected pathname backend with the same content verification,
+atomic publication, clone rollback, and removal contract. Both backends verify
+extension/MIME, raster magic, and SHA-256 before a reference can be retained.
+`Session.save()` and session deletion share a per-session publication lock:
+save verifies every retained reference immediately before JSON replacement,
+while deletion tombstones publication before removing JSON and media. A stale
+worker therefore cannot recreate a deleted session or publish a dangling ref.
+
+New-session lineage operations clone all referenced blobs transactionally
+before publishing the new session id. Ephemeral `/btw` sessions retire JSON,
+cache, stream ownership, tracking, and private media on success, cancellation,
+or startup failure. Model requests and portable exports must hydrate every
+reference through the strict reader and must reject any private URI that
+remains; plain JSON imports containing private URIs are rejected. Legacy files under
 `attachments/<session_id>/session-media` are verified and migrated into the
 state-owned store on first read. Session deletion removes both upload and
 private-media namespaces.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -337,8 +337,11 @@ Private-media deletion first atomically renames the exact held SID directory to
 a random quarantine entry under the cross-process SID authority and syncs the
 media parent. Because current POSIX/Python backends cannot retire a held inode
 without a pathname race, recursive retirement keeps child and SID quarantine
-entries and reports a retryable integrity residual instead of deleting an
-unrelated replacement. Truncate/retry/undo and backup restore prune blobs by
+entries and reports an integrity residual instead of deleting an unrelated
+replacement. A retry detects the existing SID-specific quarantine and leaves
+it in place rather than recursively creating further quarantine entries;
+operators can retain that durable authority until an identity-bound retirement
+backend is available. Truncate/retry/undo and backup restore prune blobs by
 reachability across both the live sidecar and any recovery backup. A successful
 clear removes its stale backup and then removes or reachability-prunes the
 private-media namespace, including when the live transcript was already empty;

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,12 @@ retryable integrity failure.
 Deletion retires the active lease and tombstones publication before removing
 artifacts; an intentional same-SID recreation receives a new lease, so an old
 `Session` in this or another process remains stale even after the SID becomes
-valid again. Save validates the complete final payload and verifies every
+valid again. An unreadable aggregate deletion tombstone remains fail-closed
+for an absent SID without a matching claim. It is left byte-for-byte in place,
+but a fresh exclusive destination reservation may publish through it because
+its durable, SID-scoped incarnation claim proves an intentional recreation;
+corruption in the aggregate therefore cannot disable unrelated new sessions.
+Save validates the complete final payload and verifies every
 private reference immediately before JSON replacement. Compact references are
 permitted only in canonical image parts below `messages` and
 `context_messages`; every other serialized field is private-reference-free. A

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -262,7 +262,11 @@ destination claim. Shared index and tombstone RMW operations and sharded
 cleanup-residual writes have their own cross-process file locks and random
 exclusive staging names. Session, index, tombstone, cleanup residual, and
 destructive directory-entry changes are not acknowledged until their
-containing-directory durability barrier succeeds.
+containing-directory durability barrier succeeds. File unlink and directory
+removal use type-aware commit guards on the held quarantined inode and verify
+through that still-open handle that the exact inode lost its final link; an
+entry replaced after the earlier traversal check is retained and reported as a
+retryable integrity failure.
 Deletion retires the active lease and tombstones publication before removing
 artifacts; an intentional same-SID recreation receives a new lease, so an old
 `Session` in this or another process remains stale even after the SID becomes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -285,9 +285,12 @@ or publish a dangling ref.
 New-session lineage operations exclusively reserve the destination SID and
 prove its sidecar, media, attachment, journal, index, cache, and runtime
 namespaces unowned before publishing. Duplicate, branch, `/btw`, portable JSON
-import, focused recovery, and compression continuation creation use this same
-publish-or-rollback transaction. Rollback removes only artifacts created while
-that reservation is held. Before compression mutates either identity, it holds
+import, focused recovery, compression continuation creation, and external-session
+share metadata sidecars use this same publish-or-rollback transaction. Share
+create/revoke holds the reservation through sidecar save, so a failed save
+cannot retain an incarnation claim that blocks future share operations.
+Rollback removes only artifacts created while that reservation is held. Before
+compression mutates either identity, it holds
 both SID authorities plus the global index writer, records durable intent, and
 stores digest-bound exact-byte backups of the source sidecar and index. It then
 archives the source, publishes the continuation JSON/index, and migrates cache,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -256,7 +256,10 @@ check followed by a separately resolved write or destructive removal.
 
 The anchored backend verifies extension/MIME, raster magic, and SHA-256 before
 a reference can be retained. `Session.save()` and destructive session cleanup
-share a per-session publication lock plus a process-local incarnation lease.
+share a permanent per-SID cross-process file lock, an in-process publication
+lock, and a process-local incarnation lease. Session, index, tombstone, cleanup
+residual, and destructive directory-entry changes are not acknowledged until
+their containing-directory durability barrier succeeds.
 Deletion retires the active lease and tombstones publication before removing
 artifacts; an intentional same-SID recreation receives a new lease, so an old
 in-process `Session` remains stale even after the SID becomes valid again.
@@ -264,11 +267,13 @@ Save verifies every retained reference immediately before JSON replacement.
 A stale worker therefore cannot recreate a deleted session or publish a
 dangling ref.
 
-New-session lineage operations clone all referenced blobs transactionally
-before publishing the new session id. Duplicate and branch publication does
-not enter `SESSIONS` until media, JSON, and index publication succeed; any
-post-clone failure retires the destination and removes its JSON, index residue,
-and media namespace.
+New-session lineage operations exclusively reserve the destination SID and
+prove its sidecar, media, attachment, journal, index, cache, and runtime
+namespaces unowned before publishing. Duplicate, branch, `/btw`, portable JSON
+import, focused recovery, and compression continuation creation use this same
+publish-or-rollback transaction. Rollback removes only artifacts created while
+that reservation is held. Compression publishes the continuation JSON/index
+before moving cache or agent-lock ownership.
 
 Every destructive session path uses the same idempotent artifact cleanup. It
 verifies absence of JSON, backup and crashed-save temporaries, attachments,
@@ -300,6 +305,14 @@ containing private URIs are rejected. Legacy files under
 `attachments/<session_id>/session-media` are verified and migrated into the
 state-owned store on first read. Session deletion removes both upload and
 private-media namespaces.
+
+Private-media deletion first atomically renames the exact held SID directory to
+a random quarantine entry, syncs the media parent, and deletes only that held
+quarantine identity. Truncate/retry/undo and backup restore prune blobs by
+reachability across both the live sidecar and any recovery backup. A successful
+clear removes its stale backup before removing the complete private-media
+namespace; an already-empty session with no prior clear generation keeps an
+independently recoverable backup.
 
 ### 4.3 SSE Streaming Engine
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -262,11 +262,12 @@ destination claim. Shared index and tombstone RMW operations and sharded
 cleanup-residual writes have their own cross-process file locks and random
 exclusive staging names. Session, index, tombstone, cleanup residual, and
 destructive directory-entry changes are not acknowledged until their
-containing-directory durability barrier succeeds. File unlink and directory
-removal use type-aware commit guards on the held quarantined inode and verify
-through that still-open handle that the exact inode lost its final link; an
-entry replaced after the earlier traversal check is retained and reported as a
-retryable integrity failure.
+containing-directory durability barrier succeeds. POSIX exposes final file
+unlink and directory removal only by mutable pathname; it has no portable
+held-FD identity-bound removal primitive. Private-media cleanup therefore
+renames entries into durable quarantine but fails closed before the final
+unlink/rmdir, retaining that quarantine as retry authority rather than risking
+deletion of a replacement installed in the final check-to-delete gap.
 Deletion retires the active lease and tombstones publication before removing
 artifacts; an intentional same-SID recreation receives a new lease, so an old
 `Session` in this or another process remains stale even after the SID becomes
@@ -333,14 +334,17 @@ state-owned store on first read. Session deletion removes both upload and
 private-media namespaces.
 
 Private-media deletion first atomically renames the exact held SID directory to
-a random quarantine entry under the cross-process SID authority, syncs the
-media parent, and recursively quarantines child entries before deleting only
-their held identities. Truncate/retry/undo and backup restore prune blobs by
+a random quarantine entry under the cross-process SID authority and syncs the
+media parent. Because current POSIX/Python backends cannot retire a held inode
+without a pathname race, recursive retirement keeps child and SID quarantine
+entries and reports a retryable integrity residual instead of deleting an
+unrelated replacement. Truncate/retry/undo and backup restore prune blobs by
 reachability across both the live sidecar and any recovery backup. A successful
-clear always removes its stale backup and then removes or reachability-prunes
-the private-media namespace, including when the live transcript was already
-empty. Clear, prune, and focused recovery keep the per-SID process lock through
-retirement. Reachability cleanup runs after the transcript and recovery
+clear removes its stale backup and then removes or reachability-prunes the
+private-media namespace, including when the live transcript was already empty;
+on the current backend media retirement instead reports the retained quarantine
+as an incomplete clear. Clear, prune, and focused recovery keep the per-SID
+process lock through retirement. Reachability cleanup runs after the transcript and recovery
 authority are durably committed; a failure persists an operation-typed cleanup
 residual that `/api/sessions/cleanup` can retry. A committed transcript response
 may remain successful only after that retry authority is durable.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -245,22 +245,54 @@ extraction under `attachments/`; changing `HERMES_WEBUI_ATTACHMENT_DIR` does not
 move or change private-media authority. A deployment that moves WebUI state must
 move the complete `STATE_DIR` together.
 
-On platforms with `dir_fd` support, private-media reads and writes are anchored
-to opened directory handles and reject symlink components. Native Windows uses
-a capability-selected pathname backend with the same content verification,
-atomic publication, clone rollback, and removal contract. Both backends verify
-extension/MIME, raster magic, and SHA-256 before a reference can be retained.
-`Session.save()` and session deletion share a per-session publication lock:
-save verifies every retained reference immediately before JSON replacement,
-while deletion tombstones publication before removing JSON and media. A stale
-worker therefore cannot recreate a deleted session or publish a dangling ref.
+Private-media support is enabled only when every required handle-relative
+operation is available (`open`, `mkdir`, `stat`, `unlink`, `rmdir`, `link`,
+`replace`, and directory listing). Reads, writes, clone publication/rollback,
+and removal stay anchored to opened directory handles and reject symlink
+components. A platform without that complete contract (including native
+Windows today) keeps large data URLs inline and refuses to hydrate, clone, or
+remove a pre-existing compact reference; it never falls back to a pathname
+check followed by a separately resolved write or destructive removal.
+
+The anchored backend verifies extension/MIME, raster magic, and SHA-256 before
+a reference can be retained. `Session.save()` and destructive session cleanup
+share a per-session publication lock plus a process-local incarnation lease.
+Deletion retires the active lease and tombstones publication before removing
+artifacts; an intentional same-SID recreation receives a new lease, so an old
+in-process `Session` remains stale even after the SID becomes valid again.
+Save verifies every retained reference immediately before JSON replacement.
+A stale worker therefore cannot recreate a deleted session or publish a
+dangling ref.
 
 New-session lineage operations clone all referenced blobs transactionally
-before publishing the new session id. Ephemeral `/btw` sessions retire JSON,
-cache, stream ownership, tracking, and private media on success, cancellation,
-or startup failure. Model requests and portable exports must hydrate every
-reference through the strict reader and must reject any private URI that
-remains; plain JSON imports containing private URIs are rejected. Legacy files under
+before publishing the new session id. Duplicate and branch publication does
+not enter `SESSIONS` until media, JSON, and index publication succeed; any
+post-clone failure retires the destination and removes its JSON, index residue,
+and media namespace.
+
+Every destructive session path uses the same idempotent artifact cleanup. It
+verifies absence of JSON, backup and crashed-save temporaries, attachments,
+private media, turn/run journals, sidebar index state, and (where WebUI owns it)
+`state.db` state before returning success. Failures return machine-readable
+residual artifact names and persist
+`sessions/_session_cleanup_residuals.json` so a later delete or cleanup request
+can retry them. Each marker retains the original tombstone and `state.db`
+ownership policy, so retrying cleanup cannot turn a messaging-sidecar delete
+into deletion of the externally owned messaging transcript. The generic
+`/api/media` file server hard-denies the complete `session-media` subtree.
+
+Ephemeral `/btw` sessions register an exact
+`{parent_session_id, ephemeral_session_id, stream_id}` owner before the stream
+is exposed. Success, cancellation (including cancel-before-worker), and startup
+failure compare-and-delete only that owner and retire JSON/backup, cache,
+stream/active-owner maps, run/turn journals, agent locks/cache, state DB state,
+and private media. A failed retirement leaves both the durable residual marker
+and the matching in-process owner marked cleanup-pending; an older completion
+cannot erase a newer `/btw` owner for the same parent.
+
+Model requests and portable exports must hydrate every reference through the
+strict reader and must reject any private URI that remains; plain JSON imports
+containing private URIs are rejected. Legacy files under
 `attachments/<session_id>/session-media` are verified and migrated into the
 state-owned store on first read. Session deletion removes both upload and
 private-media namespaces.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,23 +257,33 @@ check followed by a separately resolved write or destructive removal.
 The anchored backend verifies extension/MIME, raster magic, and SHA-256 before
 a reference can be retained. `Session.save()` and destructive session cleanup
 share a permanent per-SID cross-process file lock, an in-process publication
-lock, and a process-local incarnation lease. Session, index, tombstone, cleanup
-residual, and destructive directory-entry changes are not acknowledged until
-their containing-directory durability barrier succeeds.
+lock, and an incarnation token persisted in both the sidecar and any pre-save
+destination claim. Shared index and tombstone RMW operations and sharded
+cleanup-residual writes have their own cross-process file locks and random
+exclusive staging names. Session, index, tombstone, cleanup residual, and
+destructive directory-entry changes are not acknowledged until their
+containing-directory durability barrier succeeds.
 Deletion retires the active lease and tombstones publication before removing
 artifacts; an intentional same-SID recreation receives a new lease, so an old
-in-process `Session` remains stale even after the SID becomes valid again.
-Save verifies every retained reference immediately before JSON replacement.
-A stale worker therefore cannot recreate a deleted session or publish a
-dangling ref.
+`Session` in this or another process remains stale even after the SID becomes
+valid again. Save validates the complete final payload and verifies every
+private reference immediately before JSON replacement. Compact references are
+permitted only in canonical image parts below `messages` and
+`context_messages`; every other serialized field is private-reference-free. A
+stale worker therefore cannot recreate a deleted session, redirect ownership,
+or publish a dangling ref.
 
 New-session lineage operations exclusively reserve the destination SID and
 prove its sidecar, media, attachment, journal, index, cache, and runtime
 namespaces unowned before publishing. Duplicate, branch, `/btw`, portable JSON
 import, focused recovery, and compression continuation creation use this same
 publish-or-rollback transaction. Rollback removes only artifacts created while
-that reservation is held. Compression publishes the continuation JSON/index
-before moving cache or agent-lock ownership.
+that reservation is held. Compression records a durable transaction intent,
+publishes the continuation JSON/index, migrates cache, agent lock/cache, stream
+owner, active-run, and agent identity state while the reservation remains held,
+and commits only after every migration succeeds. Startup recovery finalizes a
+matching published incarnation or rolls back a prepared destination with no
+sidecar.
 
 Every destructive session path uses the same idempotent artifact cleanup. It
 verifies absence of JSON, backup and crashed-save temporaries, attachments,
@@ -307,15 +317,17 @@ state-owned store on first read. Session deletion removes both upload and
 private-media namespaces.
 
 Private-media deletion first atomically renames the exact held SID directory to
-a random quarantine entry, syncs the media parent, and deletes only that held
-quarantine identity. Truncate/retry/undo and backup restore prune blobs by
+a random quarantine entry under the cross-process SID authority, syncs the
+media parent, and recursively quarantines child entries before deleting only
+their held identities. Truncate/retry/undo and backup restore prune blobs by
 reachability across both the live sidecar and any recovery backup. A successful
-clear removes its stale backup before removing the complete private-media
-namespace; an already-empty session with no prior clear generation keeps an
-independently recoverable backup. Reachability pruning runs after the transcript
-and recovery authority are durably committed; a pruning error is logged and can
-be retried by the next pruning mutation without falsely reporting the committed
-transcript write as failed.
+clear always removes its stale backup and then removes or reachability-prunes
+the private-media namespace, including when the live transcript was already
+empty. Clear, prune, and focused recovery keep the per-SID process lock through
+retirement. Reachability cleanup runs after the transcript and recovery
+authority are durably committed; a failure persists an operation-typed cleanup
+residual that `/api/sessions/cleanup` can retry. A committed transcript response
+may remain successful only after that retry authority is durable.
 
 ### 4.3 SSE Streaming Engine
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -278,12 +278,16 @@ prove its sidecar, media, attachment, journal, index, cache, and runtime
 namespaces unowned before publishing. Duplicate, branch, `/btw`, portable JSON
 import, focused recovery, and compression continuation creation use this same
 publish-or-rollback transaction. Rollback removes only artifacts created while
-that reservation is held. Compression records a durable transaction intent,
-publishes the continuation JSON/index, migrates cache, agent lock/cache, stream
-owner, active-run, and agent identity state while the reservation remains held,
-and commits only after every migration succeeds. Startup recovery finalizes a
-matching published incarnation or rolls back a prepared destination with no
-sidecar.
+that reservation is held. Before compression mutates either identity, it holds
+both SID authorities plus the global index writer, records durable intent, and
+stores digest-bound exact-byte backups of the source sidecar and index. It then
+archives the source, publishes the continuation JSON/index, and migrates cache,
+agent lock/cache, stream owner, active-run, and agent identity state while the
+reservation remains held. Commit occurs only after every migration succeeds.
+Any earlier failure restores the source bytes and runtime identity and removes
+the reserved destination. Startup recovery finalizes only a matching
+`migrations_complete` incarnation; every earlier durable phase restores the
+source and rolls back the destination deterministically.
 
 Every destructive session path uses the same idempotent artifact cleanup. It
 verifies absence of JSON, backup and crashed-save temporaries, attachments,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,6 +235,27 @@ Session is a plain Python class (not a dataclass, not SQLAlchemy):
 title_from(): takes messages list, finds first user message, returns first 64 chars.
 Called after run_conversation() completes to set the session title retroactively.
 
+#### 4.2.1 Private Session Media
+
+Large native raster data URLs are externalized from `messages` and
+`context_messages` into the state-owned `STATE_DIR/session-media/<session_id>`
+store. Session JSON retains content-addressed `webui-media://<sha256>.<ext>`
+references. This namespace is separate from ordinary uploads and archive
+extraction under `attachments/`; changing `HERMES_WEBUI_ATTACHMENT_DIR` does not
+move or change private-media authority. A deployment that moves WebUI state must
+move the complete `STATE_DIR` together.
+
+Private-media reads and writes are anchored to opened directory handles, reject
+symlink components, verify extension/MIME, raster magic, and SHA-256, and publish
+only fully synced files. New-session lineage operations clone all referenced
+blobs transactionally before publishing the new session id. Model requests and
+portable exports must hydrate every reference through the strict reader and
+must reject any private URI that remains; plain JSON imports containing private
+URIs are rejected. Legacy files under
+`attachments/<session_id>/session-media` are verified and migrated into the
+state-owned store on first read. Session deletion removes both upload and
+private-media namespaces.
+
 ### 4.3 SSE Streaming Engine
 
 This is the most architecturally interesting part. Two endpoints cooperate:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -247,10 +247,13 @@ prune, rollback, and recovery unsafe.
 `webui-media://<sha256>.<ext>` remains a read-only compatibility format for
 sidecars written by an earlier experimental build. The reader anchors the
 directory handles, rejects symlink components, and verifies extension/MIME,
-raster magic, and SHA-256 before it expands a reference to a data URL. A normal
-`Session.save()` writes that verified value back inline; duplicate, branch,
-`/btw`, and compression continuation do the same before the destination can
-commit. Missing or corrupt media fails closed and leaves the current sidecar
+raster magic, and SHA-256 before it expands a reference to a data URL. It is
+not a persistence compatibility path: `Session.save()`, backup/recovery,
+duplicate, branch, `/btw`, and compression continuation reject a compact
+reference before a destination can commit. An operator must run an explicit
+offline migration which reads and verifies the legacy blob, writes an inline
+payload, then retires the old namespace using an identity-bound backend.
+Missing or corrupt media also fails closed and leaves the current sidecar
 untouched. Portable imports continue to reject private references.
 
 No automatic write, clone, migration, prune, or deletion operation creates a
@@ -264,10 +267,10 @@ path; it requires an identity-bound backend/operator migration. The generic
 
 Session publication and deletion share permanent per-SID cross-process and
 in-process locks plus an incarnation token. Tokenless legacy loads hold that
-authority from signature validation through lease registration, and a save
-rechecks the bound sidecar signature immediately before publishing. Backups,
-focused recovery, and compression-source restore verify every private reference
-before they can retain or publish their payload.
+authority from no-follow regular-FD validation through lease registration, and
+a save rechecks the bound device/inode signature immediately before publishing.
+Backups, focused recovery, and compression-source restore validate the exact
+bytes they will retain or publish and reject every private reference.
 
 ### 4.3 SSE Streaming Engine
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,120 +237,37 @@ Called after run_conversation() completes to set the session title retroactively
 
 #### 4.2.1 Private Session Media
 
-Large native raster data URLs are externalized from `messages` and
-`context_messages` into the state-owned `STATE_DIR/session-media/<session_id>`
-store. Session JSON retains content-addressed `webui-media://<sha256>.<ext>`
-references. This namespace is separate from ordinary uploads and archive
-extraction under `attachments/`; changing `HERMES_WEBUI_ATTACHMENT_DIR` does not
-move or change private-media authority. A deployment that moves WebUI state must
-move the complete `STATE_DIR` together.
+Large native raster data URLs remain inline in session JSON. New private-media
+externalization is disabled because POSIX/Python exposes final `unlink` and
+`rmdir` only by mutable pathname; it has no portable operation that retires the
+inode held by an opened descriptor. A final stat check cannot close the
+replacement window, so enabling creation would make ordinary delete, clear,
+prune, rollback, and recovery unsafe.
 
-Private-media support is enabled only when every required handle-relative
-operation is available (`open`, `mkdir`, `stat`, `unlink`, `rmdir`, `link`,
-`replace`, and directory listing). Reads, writes, clone publication/rollback,
-and removal stay anchored to opened directory handles and reject symlink
-components. A platform without that complete contract (including native
-Windows today) keeps large data URLs inline and refuses to hydrate, clone, or
-remove a pre-existing compact reference; it never falls back to a pathname
-check followed by a separately resolved write or destructive removal.
+`webui-media://<sha256>.<ext>` remains a read-only compatibility format for
+sidecars written by an earlier experimental build. The reader anchors the
+directory handles, rejects symlink components, and verifies extension/MIME,
+raster magic, and SHA-256 before it expands a reference to a data URL. A normal
+`Session.save()` writes that verified value back inline; duplicate, branch,
+`/btw`, and compression continuation do the same before the destination can
+commit. Missing or corrupt media fails closed and leaves the current sidecar
+untouched. Portable imports continue to reject private references.
 
-The anchored backend verifies extension/MIME, raster magic, and SHA-256 before
-a reference can be retained. `Session.save()` and destructive session cleanup
-share a permanent per-SID cross-process file lock, an in-process publication
-lock, and an incarnation token persisted in both the sidecar and any pre-save
-destination claim. Shared index and tombstone RMW operations and sharded
-cleanup-residual writes have their own cross-process file locks and random
-exclusive staging names. Session, index, tombstone, cleanup residual, and
-destructive directory-entry changes are not acknowledged until their
-containing-directory durability barrier succeeds. POSIX exposes final file
-unlink and directory removal only by mutable pathname; it has no portable
-held-FD identity-bound removal primitive. Private-media cleanup therefore
-renames entries into durable quarantine but fails closed before the final
-unlink/rmdir, retaining that quarantine as retry authority rather than risking
-deletion of a replacement installed in the final check-to-delete gap.
-Deletion retires the active lease and tombstones publication before removing
-artifacts; an intentional same-SID recreation receives a new lease, so an old
-`Session` in this or another process remains stale even after the SID becomes
-valid again. An unreadable aggregate deletion tombstone remains fail-closed
-for an absent SID without a matching claim. It is left byte-for-byte in place,
-but a fresh exclusive destination reservation may publish through it because
-its durable, SID-scoped incarnation claim proves an intentional recreation;
-corruption in the aggregate therefore cannot disable unrelated new sessions.
-Save validates the complete final payload and verifies every
-private reference immediately before JSON replacement. Compact references are
-permitted only in canonical image parts below `messages` and
-`context_messages`; every other serialized field is private-reference-free. A
-stale worker therefore cannot recreate a deleted session, redirect ownership,
-or publish a dangling ref.
-
-New-session lineage operations exclusively reserve the destination SID and
-prove its sidecar, media, attachment, journal, index, cache, and runtime
-namespaces unowned before publishing. Duplicate, branch, `/btw`, portable JSON
-import, focused recovery, compression continuation creation, and external-session
-share metadata sidecars use this same publish-or-rollback transaction. Share
-create/revoke holds the reservation through sidecar save, so a failed save
-cannot retain an incarnation claim that blocks future share operations.
-Rollback removes only artifacts created while that reservation is held. Before
-compression mutates either identity, it holds
-both SID authorities plus the global index writer, records durable intent, and
-stores digest-bound exact-byte backups of the source sidecar and index. It then
-archives the source, publishes the continuation JSON/index, and migrates cache,
-agent lock/cache, stream owner, active-run, and agent identity state while the
-reservation remains held. Commit occurs only after every migration succeeds.
-Any earlier failure restores the source bytes and runtime identity and removes
-the reserved destination. Startup recovery finalizes only a matching
-`migrations_complete` incarnation; every earlier durable phase restores the
-source and rolls back the destination deterministically.
-
-Every destructive session path uses the same idempotent artifact cleanup. It
-verifies absence of JSON, backup and crashed-save temporaries, attachments,
-private media, turn/run journals, sidebar index state, and (where WebUI owns it)
-`state.db` state before returning success. Failures return machine-readable
-residual artifact names and persist
-`sessions/_session_cleanup_residuals/<session_id>.json` so a later delete or
-cleanup request can retry them. Residual authority is sharded by SID: a corrupt
-or future-version record fails closed for its owning SID without preventing
-unrelated sessions from being created or other valid cleanup records from being
-retried. The corrupt record remains in place and is returned as a cleanup
-residual for operator repair. Each marker retains the original tombstone and
-`state.db` ownership policy, so retrying cleanup cannot turn a messaging-sidecar
-delete into deletion of the externally owned messaging transcript. The generic
+No automatic write, clone, migration, prune, or deletion operation creates a
+new private-media entry. Existing canonical directories and durable
+`.delete-<sid-hash>-...` quarantines remain SID owners, including the crash
+window before a cleanup residual is written, so a same-ID reservation cannot
+adopt or collide with detached private data. Automatic retirement of such old
+experimental data is intentionally refused rather than deleting a mutable
+path; it requires an identity-bound backend/operator migration. The generic
 `/api/media` file server hard-denies the complete `session-media` subtree.
 
-Ephemeral `/btw` sessions register an exact
-`{parent_session_id, ephemeral_session_id, stream_id}` owner before the stream
-is exposed. Success, cancellation (including cancel-before-worker), and startup
-failure compare-and-delete only that owner and retire JSON/backup, cache,
-stream/active-owner maps, run/turn journals, agent locks/cache, state DB state,
-and private media. A failed retirement leaves both the durable residual marker
-and the matching in-process owner marked cleanup-pending; an older completion
-cannot erase a newer `/btw` owner for the same parent.
-
-Model requests and portable exports must hydrate every reference through the
-strict reader and must reject any private URI that remains; plain JSON imports
-containing private URIs are rejected. Legacy files under
-`attachments/<session_id>/session-media` are verified and migrated into the
-state-owned store on first read. Session deletion removes both upload and
-private-media namespaces.
-
-Private-media deletion first atomically renames the exact held SID directory to
-a random quarantine entry under the cross-process SID authority and syncs the
-media parent. Because current POSIX/Python backends cannot retire a held inode
-without a pathname race, recursive retirement keeps child and SID quarantine
-entries and reports an integrity residual instead of deleting an unrelated
-replacement. A retry detects the existing SID-specific quarantine and leaves
-it in place rather than recursively creating further quarantine entries;
-operators can retain that durable authority until an identity-bound retirement
-backend is available. Truncate/retry/undo and backup restore prune blobs by
-reachability across both the live sidecar and any recovery backup. A successful
-clear removes its stale backup and then removes or reachability-prunes the
-private-media namespace, including when the live transcript was already empty;
-on the current backend media retirement instead reports the retained quarantine
-as an incomplete clear. Clear, prune, and focused recovery keep the per-SID
-process lock through retirement. Reachability cleanup runs after the transcript and recovery
-authority are durably committed; a failure persists an operation-typed cleanup
-residual that `/api/sessions/cleanup` can retry. A committed transcript response
-may remain successful only after that retry authority is durable.
+Session publication and deletion share permanent per-SID cross-process and
+in-process locks plus an incarnation token. Tokenless legacy loads hold that
+authority from signature validation through lease registration, and a save
+rechecks the bound sidecar signature immediately before publishing. Backups,
+focused recovery, and compression-source restore verify every private reference
+before they can retain or publish their payload.
 
 ### 4.3 SSE Streaming Engine
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -312,7 +312,10 @@ quarantine identity. Truncate/retry/undo and backup restore prune blobs by
 reachability across both the live sidecar and any recovery backup. A successful
 clear removes its stale backup before removing the complete private-media
 namespace; an already-empty session with no prior clear generation keeps an
-independently recoverable backup.
+independently recoverable backup. Reachability pruning runs after the transcript
+and recovery authority are durably committed; a pruning error is logged and can
+be retried by the next pruning mutation without falsely reporting the committed
+transcript write as failed.
 
 ### 4.3 SSE Streaming Engine
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -275,11 +275,14 @@ verifies absence of JSON, backup and crashed-save temporaries, attachments,
 private media, turn/run journals, sidebar index state, and (where WebUI owns it)
 `state.db` state before returning success. Failures return machine-readable
 residual artifact names and persist
-`sessions/_session_cleanup_residuals.json` so a later delete or cleanup request
-can retry them. Each marker retains the original tombstone and `state.db`
-ownership policy, so retrying cleanup cannot turn a messaging-sidecar delete
-into deletion of the externally owned messaging transcript. The generic
-`/api/media` file server hard-denies the complete `session-media` subtree.
+`sessions/_session_cleanup_residuals/<session_id>.json` so a later delete or
+cleanup request can retry them. Residual authority is sharded by SID: a corrupt
+or future-version record fails closed for its owning SID without preventing
+unrelated sessions from being created. Each marker retains the original
+tombstone and `state.db` ownership policy, so retrying cleanup cannot turn a
+messaging-sidecar delete into deletion of the externally owned messaging
+transcript. The generic `/api/media` file server hard-denies the complete
+`session-media` subtree.
 
 Ephemeral `/btw` sessions register an exact
 `{parent_session_id, ephemeral_session_id, stream_id}` owner before the stream

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -278,11 +278,12 @@ residual artifact names and persist
 `sessions/_session_cleanup_residuals/<session_id>.json` so a later delete or
 cleanup request can retry them. Residual authority is sharded by SID: a corrupt
 or future-version record fails closed for its owning SID without preventing
-unrelated sessions from being created. Each marker retains the original
-tombstone and `state.db` ownership policy, so retrying cleanup cannot turn a
-messaging-sidecar delete into deletion of the externally owned messaging
-transcript. The generic `/api/media` file server hard-denies the complete
-`session-media` subtree.
+unrelated sessions from being created or other valid cleanup records from being
+retried. The corrupt record remains in place and is returned as a cleanup
+residual for operator repair. Each marker retains the original tombstone and
+`state.db` ownership policy, so retrying cleanup cannot turn a messaging-sidecar
+delete into deletion of the externally owned messaging transcript. The generic
+`/api/media` file server hard-denies the complete `session-media` subtree.
 
 Ephemeral `/btw` sessions register an exact
 `{parent_session_id, ephemeral_session_id, stream_id}` owner before the stream

--- a/api/background.py
+++ b/api/background.py
@@ -13,8 +13,10 @@ _lock = threading.Lock()
 # parent_session_id -> list of task dicts
 _BACKGROUND_TASKS: dict[str, list[dict[str, Any]]] = {}
 
-# btw ephemeral session tracking: parent_sid -> {ephemeral_sid, stream_id, question}
-_BTW_TRACKING: dict[str, dict[str, Any]] = {}
+# btw ephemeral ownership: (parent_sid, ephemeral_sid, stream_id) -> record.
+# A parent may have overlapping side questions; each lifecycle stays independently
+# consumable so an older completion cannot erase or hide a newer owner.
+_BTW_TRACKING: dict[tuple[str, str, str], dict[str, Any]] = {}
 
 
 def track_background(parent_sid: str, bg_sid: str, stream_id: str,
@@ -33,13 +35,16 @@ def track_background(parent_sid: str, bg_sid: str, stream_id: str,
 
 
 def track_btw(parent_sid: str, ephemeral_sid: str, stream_id: str,
-              question: str) -> None:
+              question: str) -> dict[str, Any]:
     with _lock:
-        _BTW_TRACKING[parent_sid] = {
+        record = {
+            "parent_session_id": parent_sid,
             "ephemeral_session_id": ephemeral_sid,
             "stream_id": stream_id,
             "question": question,
         }
+        _BTW_TRACKING[(parent_sid, ephemeral_sid, stream_id)] = record
+        return dict(record)
 
 
 def complete_background(parent_sid: str, task_id: str, answer: str) -> None:
@@ -81,7 +86,43 @@ def get_background_tasks(parent_sid: str) -> list[dict[str, Any]]:
         return list(_BACKGROUND_TASKS.get(parent_sid, []))
 
 
-def cleanup_btw(parent_sid: str) -> dict[str, Any] | None:
-    """Remove and return btw tracking for a parent session."""
+def find_btw_owner(ephemeral_sid: str, stream_id: str) -> dict[str, Any] | None:
+    """Return the exact owned lifecycle record for an ephemeral stream."""
     with _lock:
-        return _BTW_TRACKING.pop(parent_sid, None)
+        for record in _BTW_TRACKING.values():
+            if (
+                record.get("ephemeral_session_id") == ephemeral_sid
+                and record.get("stream_id") == stream_id
+            ):
+                return dict(record)
+    return None
+
+
+def mark_btw_cleanup_pending(
+    parent_sid: str,
+    ephemeral_sid: str,
+    stream_id: str,
+    residuals: list[dict],
+) -> bool:
+    """Keep the exact owner visible as a retryable in-process residual."""
+    with _lock:
+        current = _BTW_TRACKING.get((parent_sid, ephemeral_sid, stream_id))
+        if not current:
+            return False
+        current["cleanup_pending"] = True
+        current["cleanup_residuals"] = list(residuals)
+        return True
+
+
+def cleanup_btw(
+    parent_sid: str,
+    ephemeral_sid: str,
+    stream_id: str,
+) -> dict[str, Any] | None:
+    """Compare-and-delete one exact parent/ephemeral/stream owner record."""
+    with _lock:
+        key = (parent_sid, ephemeral_sid, stream_id)
+        current = _BTW_TRACKING.get(key)
+        if not current:
+            return None
+        return _BTW_TRACKING.pop(key, None)

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -499,7 +499,14 @@ def _run_gateway_runs_api_streaming(
 
         instructions_parts = []
         conversation_history = []
-        for entry in getattr(session, "context_messages", None) or []:
+        stored_history = getattr(session, "context_messages", None) or []
+        try:
+            from api.session_media import hydrate_session_media_urls
+
+            stored_history = hydrate_session_media_urls(stored_history, session_id)
+        except Exception:
+            logger.warning("Could not hydrate gateway session media for %s", session_id, exc_info=True)
+        for entry in stored_history:
             if not isinstance(entry, dict):
                 continue
             role = str(entry.get("role") or "").strip().lower()

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -500,12 +500,12 @@ def _run_gateway_runs_api_streaming(
         instructions_parts = []
         conversation_history = []
         stored_history = getattr(session, "context_messages", None) or []
-        try:
-            from api.session_media import hydrate_session_media_urls
+        from api.session_media import (
+            assert_no_session_media_references,
+            hydrate_session_media_urls,
+        )
 
-            stored_history = hydrate_session_media_urls(stored_history, session_id)
-        except Exception:
-            logger.warning("Could not hydrate gateway session media for %s", session_id, exc_info=True)
+        stored_history = hydrate_session_media_urls(stored_history, session_id)
         for entry in stored_history:
             if not isinstance(entry, dict):
                 continue
@@ -545,6 +545,7 @@ def _run_gateway_runs_api_streaming(
             run_body["instructions"] = "\n\n".join(part for part in instructions_parts if part)
         if conversation_history:
             run_body["conversation_history"] = conversation_history
+        assert_no_session_media_references(run_body, context="Gateway /v1/runs request")
         req = urllib.request.Request(
             url_runs,
             data=json.dumps(run_body).encode("utf-8"),

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1023,6 +1023,10 @@ def redact_session_data(session_dict: dict) -> dict:
     from api.config import load_settings
     _enabled = bool(load_settings().get("api_redact_enabled", True))
     result = dict(session_dict)
+    # Process-local lifecycle authority is neither serializable nor part of any
+    # response/export contract. Keep it private even when callers pass a raw
+    # Session.__dict__ instead of Session.compact().
+    result.pop('_publication_generation', None)
     if isinstance(result.get('title'), str):
         result['title'] = _redact_text(result['title'], _enabled=_enabled)
     if 'messages' in result:

--- a/api/models.py
+++ b/api/models.py
@@ -2805,7 +2805,7 @@ class Session:
         from api.session_media import (
             assert_no_session_media_references,
             externalize_large_session_media,
-            hydrate_session_media_urls,
+            inline_legacy_session_media_urls,
             verify_serialized_session_media_payload,
         )
 
@@ -2821,8 +2821,10 @@ class Session:
         # read only through the verifier, then written back as portable data
         # URLs.  New externalization is disabled until private entries can be
         # retired by immutable identity rather than mutable pathname.
-        hydrated_messages = hydrate_session_media_urls(self.messages, self.session_id)
-        hydrated_context_messages = hydrate_session_media_urls(
+        hydrated_messages = inline_legacy_session_media_urls(
+            self.messages, self.session_id
+        )
+        hydrated_context_messages = inline_legacy_session_media_urls(
             self.context_messages, self.session_id
         )
         self.messages = hydrated_messages

--- a/api/models.py
+++ b/api/models.py
@@ -1599,6 +1599,11 @@ def model_explicit_pick_signature(model, model_provider) -> str:
 
 
 class Session:
+    # Keep lifecycle authority out of ``__dict__``. A few supported internal
+    # and test utilities serialize that mapping directly, while the generation
+    # object is deliberately process-local and non-serializable.
+    __slots__ = ("_publication_generation", "__dict__", "__weakref__")
+
     def __init__(self, session_id: str=None, title: str='Untitled',
                  workspace=str(DEFAULT_WORKSPACE), model=DEFAULT_MODEL,
                  model_provider=None,
@@ -1649,9 +1654,9 @@ class Session:
                  share_created_at=None,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
-        # Process-local incarnation lease. Every load of the current SID shares
-        # this token; an intentional same-SID recreation rotates it so old
-        # in-process Session objects can never regain publication authority.
+        # Process-local incarnation lease stored in the class slot above. Every
+        # load of the current SID shares this token; an intentional same-SID
+        # recreation rotates it so old objects never regain publication authority.
         self._publication_generation = _session_publication_generation(self.session_id)
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())

--- a/api/models.py
+++ b/api/models.py
@@ -2421,16 +2421,27 @@ class Session:
         if prune_media:
             from api.session_media import prune_session_media
 
-            retained_values = [self.messages, self.context_messages]
-            backup_path = self.path.with_suffix('.json.bak')
-            if _path_entry_exists(backup_path):
-                backup_payload = json.loads(backup_path.read_bytes())
-                if not isinstance(backup_payload, dict):
-                    raise ValueError("Invalid session backup while pruning media")
-                if backup_payload.get("session_id") != self.session_id:
-                    raise ValueError("Session backup identity mismatch while pruning media")
-                retained_values.append(backup_payload)
-            prune_session_media(self.session_id, retained_values)
+            try:
+                retained_values = [self.messages, self.context_messages]
+                backup_path = self.path.with_suffix('.json.bak')
+                if _path_entry_exists(backup_path):
+                    backup_payload = json.loads(backup_path.read_bytes())
+                    if not isinstance(backup_payload, dict):
+                        raise ValueError("Invalid session backup while pruning media")
+                    if backup_payload.get("session_id") != self.session_id:
+                        raise ValueError("Session backup identity mismatch while pruning media")
+                    retained_values.append(backup_payload)
+                prune_session_media(self.session_id, retained_values)
+            except Exception:
+                # The sidecar and index are already durably committed above.
+                # Pruning is retention-only because every live/recovery
+                # reference is kept, so a cleanup error must not turn that
+                # committed transcript mutation into a false HTTP failure.
+                logger.warning(
+                    "Could not prune session media after transcript truncation for %s",
+                    self.session_id,
+                    exc_info=True,
+                )
 
         # #4985 belt-and-suspenders self-heal: a successful save with at
         # least one real message on the sidecar is unconditional proof the

--- a/api/models.py
+++ b/api/models.py
@@ -10,6 +10,7 @@ import math
 import os
 import re
 import secrets
+import stat
 import threading
 import time
 import uuid
@@ -2805,7 +2806,6 @@ class Session:
         from api.session_media import (
             assert_no_session_media_references,
             externalize_large_session_media,
-            inline_legacy_session_media_urls,
             verify_serialized_session_media_payload,
         )
 
@@ -2817,18 +2817,14 @@ class Session:
             },
             context="session payload outside messages/context_messages",
         )
-        # Compact references created by an unreleased experimental build are
-        # read only through the verifier, then written back as portable data
-        # URLs.  New externalization is disabled until private entries can be
-        # retired by immutable identity rather than mutable pathname.
-        hydrated_messages = inline_legacy_session_media_urls(
-            self.messages, self.session_id
+        # New private media creation is disabled. Do not silently migrate an
+        # experimental compact reference to inline JSON: its old namespace
+        # cannot be retired safely on this backend, so a successful save would
+        # strand private data and make later lifecycle cleanup non-convergent.
+        assert_no_session_media_references(
+            [self.messages, self.context_messages],
+            context="session save; use an explicit offline media migration",
         )
-        hydrated_context_messages = inline_legacy_session_media_urls(
-            self.context_messages, self.session_id
-        )
-        self.messages = hydrated_messages
-        self.context_messages = hydrated_context_messages
         externalize_large_session_media(self.messages, self.session_id)
         externalize_large_session_media(self.context_messages, self.session_id)
         # Write metadata fields first so load_metadata_only() can read them
@@ -2908,10 +2904,14 @@ class Session:
                     existing = json.loads(existing_text)
                     if not isinstance(existing, dict) or existing.get("session_id") != self.session_id:
                         raise RuntimeError("Existing session sidecar identity mismatch")
-                    # A backup remains a recovery publication candidate.  Do
-                    # not retain one that points at missing/corrupt private
-                    # media, even though the incoming sidecar is portable.
-                    verify_serialized_session_media_payload(existing, self.session_id)
+                    # A backup remains a recovery publication candidate. It
+                    # must be portable too: compact refs require an explicit
+                    # offline migration rather than silently retaining bytes
+                    # whose namespace cannot be retired safely.
+                    assert_no_session_media_references(
+                        existing,
+                        context="session backup; use an explicit offline media migration",
+                    )
                     existing_msg_count = len(existing.get('messages') or [])
                 except json.JSONDecodeError:
                     existing_msg_count = -1  # corrupt → always back up
@@ -3075,17 +3075,24 @@ class Session:
         with _session_publication_authority(sid):
             if not p.exists():
                 return None
-            _pre_read_sig = _sidecar_stat_signature(p)
             try:
-                data = _load_and_validate_session_payload(p, sid)
+                # Tokenless files have no persisted generation. Bind their
+                # lease to the exact regular inode read through this held
+                # no-follow descriptor, not to a pathname/time heuristic.
+                candidate = _load_and_validate_session_payload(p, sid)
+                if candidate.get("publication_incarnation"):
+                    data = candidate
+                    _post_read_sig = None
+                else:
+                    data, _post_read_sig = _read_tokenless_sidecar_with_signature(p, sid)
             except (OSError, ValueError, json.JSONDecodeError):
                 logger.warning("Rejecting invalid or identity-mismatched session sidecar for %s", sid)
                 return None
-            _post_read_sig = _sidecar_stat_signature(p)
-            if _pre_read_sig is None or _post_read_sig is None or _pre_read_sig != _post_read_sig:
-                logger.warning("Session sidecar changed during validated load for %s", sid)
-                return None
             data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+            # A tokenless payload was read from this exact held descriptor;
+            # modern payloads still use the current no-follow regular-file
+            # signature for the legacy metadata cache below.
+            _pre_read_sig = _post_read_sig or _sidecar_stat_signature(p)
             session = cls(**data)
             if not data.get("publication_incarnation"):
                 _register_validated_legacy_session_generation(session, _post_read_sig)
@@ -5428,11 +5435,46 @@ def _sidecar_stat_signature(path):
     cached entry keyed by this signature is auto-invalidated on the next write.
     """
     try:
-        st = path.stat()
+        st = os.stat(path, follow_symlinks=False)
     except OSError:
         return None
-    return (str(path), int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
-            int(st.st_size), int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))))
+    if not stat.S_ISREG(st.st_mode):
+        return None
+    return (
+        str(path),
+        int(st.st_dev),
+        int(st.st_ino),
+        int(getattr(st, 'st_mtime_ns', int(st.st_mtime * 1_000_000_000))),
+        int(st.st_size),
+        int(getattr(st, 'st_ctime_ns', int(st.st_ctime * 1_000_000_000))),
+    )
+
+
+def _read_tokenless_sidecar_with_signature(path: Path, expected_session_id: str) -> tuple[dict, tuple]:
+    """Read one regular sidecar through a held no-follow descriptor."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:
+        raise ValueError("Tokenless legacy sidecars require no-follow file descriptors")
+    fd = os.open(str(path), os.O_RDONLY | nofollow)
+    try:
+        held = os.fstat(fd)
+        if not stat.S_ISREG(held.st_mode):
+            raise ValueError("Tokenless legacy sidecar is not a regular file")
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            raw = handle.read()
+        signature = (
+            str(path),
+            int(held.st_dev),
+            int(held.st_ino),
+            int(getattr(held, 'st_mtime_ns', int(held.st_mtime * 1_000_000_000))),
+            int(held.st_size),
+            int(getattr(held, 'st_ctime_ns', int(held.st_ctime * 1_000_000_000))),
+        )
+        return _validate_session_payload_identity(
+            json.loads(raw), expected_session_id, source_name=path.name
+        ), signature
+    finally:
+        os.close(fd)
 
 
 def _legacy_sidecar_facts_get(sid):

--- a/api/models.py
+++ b/api/models.py
@@ -1365,6 +1365,17 @@ class Session:
             )
         if touch_updated_at:
             self.updated_at = time.time()
+        # A large native image otherwise occurs in both messages and
+        # context_messages, so every session read and JSON response repeats its
+        # base64 work. Persist a private reference and hydrate only when a later
+        # model call needs the original data URL.
+        try:
+            from api.session_media import externalize_large_session_media
+
+            externalize_large_session_media(self.messages, self.session_id)
+            externalize_large_session_media(self.context_messages, self.session_id)
+        except Exception:
+            logger.warning("Could not externalize session media for %s", self.session_id, exc_info=True)
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.

--- a/api/models.py
+++ b/api/models.py
@@ -935,44 +935,85 @@ def _session_has_cleanup_residual(session_id: str) -> bool:
     return True
 
 
-def _load_session_cleanup_residuals() -> dict[str, dict]:
+def _read_session_cleanup_residual_record(path: Path) -> tuple[str, dict]:
+    sid = path.stem
+    if path.is_symlink():
+        raise ValueError("Invalid session cleanup residual symlink")
+    raw = json.loads(path.read_bytes())
+    if (
+        not is_safe_session_id(sid)
+        or not isinstance(raw, dict)
+        or raw.get("version") != SESSION_CLEANUP_RESIDUAL_VERSION
+        or raw.get("session_id") != sid
+    ):
+        raise ValueError("Invalid session cleanup residual entry")
+    items = raw.get("residuals")
+    delete_state_db = raw.get("delete_state_db")
+    durable_tombstone = raw.get("durable_tombstone")
+    if (
+        not isinstance(items, list)
+        or not isinstance(delete_state_db, bool)
+        or not isinstance(durable_tombstone, bool)
+    ):
+        raise ValueError("Invalid session cleanup residual policy")
+    if not all(
+        isinstance(item, dict) and isinstance(item.get("artifact"), str)
+        for item in items
+    ):
+        raise ValueError("Invalid session cleanup residual artifact")
+    return sid, {
+        "residuals": list(items),
+        "delete_state_db": delete_state_db,
+        "durable_tombstone": durable_tombstone,
+    }
+
+
+def _scan_session_cleanup_residuals() -> tuple[dict[str, dict], list[dict]]:
+    """Load valid SID records and report invalid records independently."""
     root = _session_cleanup_residual_dir()
     try:
-        paths = list(root.glob("*.json"))
-    except OSError:
-        raise
+        paths = sorted(
+            (path for path in root.iterdir() if path.suffix == ".json"),
+            key=lambda path: path.name,
+        )
+    except FileNotFoundError:
+        return {}, []
     if not paths:
-        return {}
+        return {}, []
     validated = {}
+    invalid = []
     for path in paths:
         sid = path.stem
-        raw = json.loads(path.read_bytes())
-        if (
-            not is_safe_session_id(sid)
-            or not isinstance(raw, dict)
-            or raw.get("version") != SESSION_CLEANUP_RESIDUAL_VERSION
-            or raw.get("session_id") != sid
-        ):
-            raise ValueError("Invalid session cleanup residual entry")
-        items = raw.get("residuals")
-        delete_state_db = raw.get("delete_state_db")
-        durable_tombstone = raw.get("durable_tombstone")
-        if (
-            not isinstance(items, list)
-            or not isinstance(delete_state_db, bool)
-            or not isinstance(durable_tombstone, bool)
-        ):
-            raise ValueError("Invalid session cleanup residual policy")
-        if not all(
-            isinstance(item, dict) and isinstance(item.get("artifact"), str)
-            for item in items
-        ):
-            raise ValueError("Invalid session cleanup residual artifact")
-        validated[sid] = {
-            "residuals": list(items),
-            "delete_state_db": delete_state_db,
-            "durable_tombstone": durable_tombstone,
-        }
+        try:
+            loaded_sid, policy = _read_session_cleanup_residual_record(path)
+        except (OSError, ValueError) as exc:
+            logger.warning(
+                "Could not read session cleanup residual record %s",
+                path,
+                exc_info=True,
+            )
+            failure = {
+                "artifacts": [
+                    {
+                        "artifact": "cleanup_residual_record",
+                        "error": type(exc).__name__,
+                    }
+                ]
+            }
+            if is_safe_session_id(sid):
+                failure["session_id"] = sid
+            invalid.append(failure)
+            continue
+        validated[loaded_sid] = policy
+    return validated, invalid
+
+
+def _load_session_cleanup_residuals() -> dict[str, dict]:
+    validated, invalid = _scan_session_cleanup_residuals()
+    if invalid:
+        raise ValueError(
+            f"Invalid session cleanup residual records: {len(invalid)}"
+        )
     return validated
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -358,6 +358,26 @@ def _session_publication_generation(
         return generation
 
 
+def _register_published_session_generation(session) -> None:
+    """Make a successfully persisted lease authoritative in this process.
+
+    Bare constructors deliberately begin with an unshared token so they cannot
+    inherit a live sidecar. Once their own sidecar has passed the final
+    publication check and is durably replaced, future deletion/load paths must
+    recognize that exact object as the current generation.
+    """
+    sid = str(getattr(session, "session_id", "") or "")
+    generation = getattr(session, "_publication_generation", None)
+    if generation is None:
+        raise RuntimeError(f"Missing publication generation for {sid!r}")
+    key = _session_publication_store_key(sid)
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        current = _SESSION_PUBLICATION_GENERATIONS.get(key)
+        if current is not None and current != generation:
+            raise RuntimeError(f"Refusing to replace live session generation {sid!r}")
+        _SESSION_PUBLICATION_GENERATIONS[key] = generation
+
+
 def _activate_session_publication_generation(session) -> _SessionPublicationGeneration:
     """Bind *session* to a fresh lease for an intentional SID recreation."""
     sid = str(getattr(session, "session_id", "") or "")
@@ -385,7 +405,24 @@ def _mark_session_deleted_for_publication(
     with _SESSION_PUBLICATION_LOCKS_GUARD:
         generation = _SESSION_PUBLICATION_GENERATIONS.get(key)
         if generation is None:
-            generation = _SessionPublicationGeneration()
+            # An ephemeral object that has never materialized a sidecar or
+            # claim may still need exact lifecycle cleanup. Its unshared
+            # constructor lease is safe to retire only while no durable
+            # publication authority exists for this SID. A bare constructor
+            # must never use this branch to delete an existing session.
+            sidecar = SESSION_DIR / f"{sid}.json"
+            has_durable_authority = _path_entry_exists(sidecar) or _path_entry_exists(
+                sidecar.with_suffix(".json.bak")
+            )
+            if not has_durable_authority:
+                try:
+                    has_durable_authority = _read_session_incarnation_claim(sid) is not None
+                except Exception:
+                    has_durable_authority = True
+            if expected_generation is not None and not has_durable_authority:
+                generation = expected_generation
+            else:
+                generation = _SessionPublicationGeneration()
             _SESSION_PUBLICATION_GENERATIONS[key] = generation
         if expected_generation is not None and expected_generation != generation:
             raise RuntimeError(f"Refusing to delete stale session generation {sid!r}")
@@ -2487,28 +2524,20 @@ class Session:
                  publication_incarnation=None,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
-        # Process-local incarnation lease stored in the class slot above. Every
-        # load of the current SID shares this token; an intentional same-SID
-        # recreation rotates it so old objects never regain publication authority.
-        if publication_incarnation is None and is_safe_session_id(self.session_id):
-            claim_token = _read_session_incarnation_claim(self.session_id)
-            sidecar_token = None
-            sidecar = SESSION_DIR / f"{self.session_id}.json"
-            if _path_entry_exists(sidecar):
-                persisted = _load_and_validate_session_payload(
-                    sidecar,
-                    self.session_id,
-                )
-                sidecar_token = persisted.get("publication_incarnation")
-            if claim_token and sidecar_token and claim_token != sidecar_token:
-                raise RuntimeError(
-                    f"Session incarnation authorities disagree for {self.session_id!r}"
-                )
-            publication_incarnation = sidecar_token or claim_token
-        self._publication_generation = _session_publication_generation(
-            self.session_id,
-            str(publication_incarnation) if publication_incarnation else None,
-        )
+        # Process-local incarnation lease stored in the class slot above. A
+        # constructor is not a load path: it must never read a live sidecar or
+        # pre-save claim and thereby adopt another object's publication
+        # authority. Validated loaders pass the persisted token explicitly;
+        # intentional same-SID creation receives a fresh token when its
+        # destination reservation binds it. A bare constructor gets an
+        # unshared token, which the save-time sidecar/claim comparison rejects.
+        if publication_incarnation is None:
+            self._publication_generation = _SessionPublicationGeneration()
+        else:
+            self._publication_generation = _session_publication_generation(
+                self.session_id,
+                str(publication_incarnation),
+            )
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())
         self.model = model
@@ -2881,6 +2910,7 @@ class Session:
                 )
             _safe_replace(tmp, self.path)
             _fsync_parent_directory(self.path)
+            _register_published_session_generation(self)
         except Exception:
             try:
                 tmp.unlink(missing_ok=True)

--- a/api/models.py
+++ b/api/models.py
@@ -510,7 +510,13 @@ def _session_publication_rejection_reason(
             # be published only by an object returned through a validated load
             # path, which registers its otherwise process-local generation.
             # A bare constructor after restart has no such authority.
-            if current_generation is None or generation != current_generation:
+            signature = _SESSION_PUBLICATION_LEGACY_SIGNATURES.get(key)
+            if (
+                current_generation is None
+                or generation != current_generation
+                or signature is None
+                or _sidecar_stat_signature(path) != signature
+            ):
                 return "unvalidated session generation"
     else:
         try:
@@ -794,13 +800,12 @@ def _session_destination_owners(session_id: str) -> list[str]:
         _read_session_incarnation_claim(sid)
         owners.append("session_incarnation_claim")
 
-    from api.session_media import _session_media_dir
+    from api.session_media import session_media_destination_owners
     from api.upload import _session_attachment_dir
     from api.turn_journal import TURN_JOURNAL_DIR_NAME
     from api.run_journal import RUN_JOURNAL_DIR_NAME
 
-    if _path_entry_exists(_session_media_dir(sid)):
-        owners.append("session_media")
+    owners.extend(session_media_destination_owners(sid))
     if _path_entry_exists(_session_attachment_dir(sid)):
         owners.append("attachments")
     turn_root = SESSION_DIR / TURN_JOURNAL_DIR_NAME
@@ -2800,6 +2805,7 @@ class Session:
         from api.session_media import (
             assert_no_session_media_references,
             externalize_large_session_media,
+            hydrate_session_media_urls,
             verify_serialized_session_media_payload,
         )
 
@@ -2811,6 +2817,16 @@ class Session:
             },
             context="session payload outside messages/context_messages",
         )
+        # Compact references created by an unreleased experimental build are
+        # read only through the verifier, then written back as portable data
+        # URLs.  New externalization is disabled until private entries can be
+        # retired by immutable identity rather than mutable pathname.
+        hydrated_messages = hydrate_session_media_urls(self.messages, self.session_id)
+        hydrated_context_messages = hydrate_session_media_urls(
+            self.context_messages, self.session_id
+        )
+        self.messages = hydrated_messages
+        self.context_messages = hydrated_context_messages
         externalize_large_session_media(self.messages, self.session_id)
         externalize_large_session_media(self.context_messages, self.session_id)
         # Write metadata fields first so load_metadata_only() can read them
@@ -2890,6 +2906,10 @@ class Session:
                     existing = json.loads(existing_text)
                     if not isinstance(existing, dict) or existing.get("session_id") != self.session_id:
                         raise RuntimeError("Existing session sidecar identity mismatch")
+                    # A backup remains a recovery publication candidate.  Do
+                    # not retain one that points at missing/corrupt private
+                    # media, even though the incoming sidecar is portable.
+                    verify_serialized_session_media_payload(existing, self.session_id)
                     existing_msg_count = len(existing.get('messages') or [])
                 except json.JSONDecodeError:
                     existing_msg_count = -1  # corrupt → always back up
@@ -3047,32 +3067,26 @@ class Session:
         if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
-        if not p.exists():
-            return None
-        # #5854: snapshot the stat signature BEFORE reading so a legacy-facts
-        # cache write is only committed if the file didn't change under us
-        # during the parse (TOCTOU guard against an atomic replace mid-read).
-        _pre_read_sig = _sidecar_stat_signature(p)
-        try:
-            data = _load_and_validate_session_payload(p, sid)
-        except (OSError, ValueError, json.JSONDecodeError):
-            logger.warning("Rejecting invalid or identity-mismatched session sidecar for %s", sid)
-            return None
-        # Do not attach a tokenless legacy lease to a sidecar that changed
-        # while it was being parsed. A caller can retry the complete validated
-        # load; accepting this snapshot would authorize an unknown replacement.
-        _post_read_sig = _sidecar_stat_signature(p)
-        if _pre_read_sig is None or _post_read_sig is None or _pre_read_sig != _post_read_sig:
-            logger.warning("Session sidecar changed during validated load for %s", sid)
-            return None
-        data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
-        session = cls(**data)
-        if not data.get("publication_incarnation"):
-            # Legacy sidecars have no durable incarnation token.  A complete,
-            # identity-validated load is the only safe way to establish their
-            # in-process authority; a bare ``Session(session_id=sid)`` must
-            # remain unable to adopt the same sidecar.
-            _register_validated_legacy_session_generation(session, _post_read_sig)
+        # The validation snapshot, tokenless-lease binding, and registry
+        # publication are one authority transaction.  A recovery replacement
+        # cannot land between validation and registration.
+        with _session_publication_authority(sid):
+            if not p.exists():
+                return None
+            _pre_read_sig = _sidecar_stat_signature(p)
+            try:
+                data = _load_and_validate_session_payload(p, sid)
+            except (OSError, ValueError, json.JSONDecodeError):
+                logger.warning("Rejecting invalid or identity-mismatched session sidecar for %s", sid)
+                return None
+            _post_read_sig = _sidecar_stat_signature(p)
+            if _pre_read_sig is None or _post_read_sig is None or _pre_read_sig != _post_read_sig:
+                logger.warning("Session sidecar changed during validated load for %s", sid)
+                return None
+            data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+            session = cls(**data)
+            if not data.get("publication_incarnation"):
+                _register_validated_legacy_session_generation(session, _post_read_sig)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching

--- a/api/models.py
+++ b/api/models.py
@@ -421,6 +421,7 @@ def _session_publication_rejection_reason(
         if key in _SESSION_PUBLICATION_DELETED:
             return "deleted session"
     generation_token = getattr(generation, "token", None)
+    claim_token = None
     if _path_entry_exists(path):
         try:
             persisted = json.loads(path.read_bytes())
@@ -444,8 +445,27 @@ def _session_publication_rejection_reason(
             return "stale session generation"
     # A live sidecar beats a stale durable tombstone after restart. An absent
     # sidecar plus tombstone is authoritative and must reject a late save.
-    if not path.exists() and sid in _load_webui_deleted_session_tombstone():
-        return "deleted session"
+    #
+    # A malformed aggregate tombstone cannot be treated as empty: that would
+    # authorize a stale cross-process object after deletion. A matching,
+    # durable incarnation claim is the one safe exception. It proves an
+    # exclusive destination reservation intentionally recreated this SID, so
+    # corruption affecting an unrelated entry must not disable every new
+    # session first-save.
+    if not path.exists():
+        try:
+            deleted_session_ids = _load_webui_deleted_session_tombstone()
+        except (OSError, ValueError):
+            if claim_token != generation_token or claim_token is None:
+                return "unreadable deleted-session authority"
+            logger.warning(
+                "Ignoring unreadable deleted-session tombstone for newly reserved %s",
+                sid,
+                exc_info=True,
+            )
+            deleted_session_ids = frozenset()
+        if sid in deleted_session_ids:
+            return "deleted session"
     return None
 
 
@@ -802,7 +822,18 @@ class _SessionDestinationReservation:
                 self.generation.token,
             )
             self._claim_created = True
-            _clear_webui_deleted_session_tombstone(self.session_id)
+            try:
+                _clear_webui_deleted_session_tombstone(self.session_id)
+            except (OSError, ValueError):
+                # The just-persisted incarnation claim is durable and scoped
+                # to this exclusive reservation. Keep an unreadable aggregate
+                # tombstone in place for operator recovery; the matching claim
+                # lets only this intentional recreation publish through it.
+                logger.warning(
+                    "Could not clear deleted-session tombstone while reserving %s",
+                    self.session_id,
+                    exc_info=True,
+                )
             key = _session_publication_store_key(self.session_id)
             with _SESSION_PUBLICATION_LOCKS_GUARD:
                 _SESSION_PUBLICATION_GENERATIONS[key] = self.generation

--- a/api/models.py
+++ b/api/models.py
@@ -291,7 +291,10 @@ _CROSS_PROCESS_LOCKS_HELD = threading.local()
 class _SessionPublicationGeneration:
     """Lease for one SID incarnation, persisted with the owning sidecar."""
 
-    def __init__(self, token: str | None = None) -> None:
+    def __init__(
+        self,
+        token: str | None = None,
+    ) -> None:
         self.token = str(token or secrets.token_hex(16))
 
 
@@ -303,6 +306,12 @@ _SESSION_INCARNATION_TOKEN_RE = re.compile(r"^[a-f0-9]{32}$")
 
 def _is_session_incarnation_token(value) -> bool:
     return isinstance(value, str) and bool(_SESSION_INCARNATION_TOKEN_RE.fullmatch(value))
+
+
+def _session_publication_store_key(session_id: str) -> str:
+    """Scope process-local leases to the configured session store and SID."""
+    store = str(Path(SESSION_DIR).expanduser().absolute())
+    return f"{store}\0{str(session_id or '')}"
 
 
 def _get_session_publication_lock(session_id: str) -> threading.RLock:
@@ -322,17 +331,19 @@ def _session_publication_generation(
 ) -> _SessionPublicationGeneration:
     """Return the lease shared by loaded objects for one persisted incarnation."""
     sid = str(session_id or "")
+    key = _session_publication_store_key(sid)
     with _SESSION_PUBLICATION_LOCKS_GUARD:
-        generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
+        generation = _SESSION_PUBLICATION_GENERATIONS.get(key)
         if generation is None or (token is not None and generation.token != token):
             generation = _SessionPublicationGeneration(token)
-            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
+            _SESSION_PUBLICATION_GENERATIONS[key] = generation
         return generation
 
 
 def _activate_session_publication_generation(session) -> _SessionPublicationGeneration:
     """Bind *session* to a fresh lease for an intentional SID recreation."""
     sid = str(getattr(session, "session_id", "") or "")
+    key = _session_publication_store_key(sid)
     with _session_publication_authority(sid):
         if _session_has_cleanup_residual(sid):
             raise RuntimeError(
@@ -340,8 +351,8 @@ def _activate_session_publication_generation(session) -> _SessionPublicationGene
             )
         generation = _SessionPublicationGeneration()
         with _SESSION_PUBLICATION_LOCKS_GUARD:
-            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
-            _SESSION_PUBLICATION_DELETED.discard(sid)
+            _SESSION_PUBLICATION_GENERATIONS[key] = generation
+            _SESSION_PUBLICATION_DELETED.discard(key)
         session._publication_generation = generation
         return generation
 
@@ -352,14 +363,15 @@ def _mark_session_deleted_for_publication(
     expected_generation: _SessionPublicationGeneration | None = None,
 ) -> _SessionPublicationGeneration:
     sid = str(session_id or "")
+    key = _session_publication_store_key(sid)
     with _SESSION_PUBLICATION_LOCKS_GUARD:
-        generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
+        generation = _SESSION_PUBLICATION_GENERATIONS.get(key)
         if generation is None:
             generation = _SessionPublicationGeneration()
-            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
+            _SESSION_PUBLICATION_GENERATIONS[key] = generation
         if expected_generation is not None and expected_generation != generation:
             raise RuntimeError(f"Refusing to delete stale session generation {sid!r}")
-        _SESSION_PUBLICATION_DELETED.add(sid)
+        _SESSION_PUBLICATION_DELETED.add(key)
         return generation
 
 
@@ -369,6 +381,7 @@ def _session_publication_rejection_reason(
     generation: _SessionPublicationGeneration | None,
 ) -> str | None:
     sid = str(session_id or "")
+    key = _session_publication_store_key(sid)
     try:
         residual_path = _session_cleanup_residual_file(sid)
         if _path_entry_exists(residual_path):
@@ -380,14 +393,14 @@ def _session_publication_rejection_reason(
     except Exception:
         return "unreadable cleanup authority for session"
     with _SESSION_PUBLICATION_LOCKS_GUARD:
-        current_generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
+        current_generation = _SESSION_PUBLICATION_GENERATIONS.get(key)
         if (
             generation is not None
             and current_generation is not None
             and generation != current_generation
         ):
             return "stale session generation"
-        if sid in _SESSION_PUBLICATION_DELETED:
+        if key in _SESSION_PUBLICATION_DELETED:
             return "deleted session"
     generation_token = getattr(generation, "token", None)
     if _path_entry_exists(path):
@@ -758,9 +771,10 @@ class _SessionDestinationReservation:
             )
             self._claim_created = True
             _clear_webui_deleted_session_tombstone(self.session_id)
+            key = _session_publication_store_key(self.session_id)
             with _SESSION_PUBLICATION_LOCKS_GUARD:
-                _SESSION_PUBLICATION_GENERATIONS[self.session_id] = self.generation
-                _SESSION_PUBLICATION_DELETED.discard(self.session_id)
+                _SESSION_PUBLICATION_GENERATIONS[key] = self.generation
+                _SESSION_PUBLICATION_DELETED.discard(key)
             _active_destination_reservations()[self.session_id] = self.token
             self._entered = True
             return self
@@ -856,9 +870,10 @@ def rollback_reserved_session_destination(session_id: str, token: str) -> dict:
                 f"Refusing to roll back unproven session incarnation {sid!r}"
             )
         generation = _SessionPublicationGeneration(token)
+        key = _session_publication_store_key(sid)
         with _SESSION_PUBLICATION_LOCKS_GUARD:
-            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
-            _SESSION_PUBLICATION_DELETED.discard(sid)
+            _SESSION_PUBLICATION_GENERATIONS[key] = generation
+            _SESSION_PUBLICATION_DELETED.discard(key)
         return delete_session_artifacts(
             sid,
             expected_generation=generation,
@@ -2393,10 +2408,21 @@ class Session:
         # Process-local incarnation lease stored in the class slot above. Every
         # load of the current SID shares this token; an intentional same-SID
         # recreation rotates it so old objects never regain publication authority.
-        if publication_incarnation is None:
-            publication_incarnation = _read_session_incarnation_claim(
-                self.session_id
-            )
+        if publication_incarnation is None and is_safe_session_id(self.session_id):
+            claim_token = _read_session_incarnation_claim(self.session_id)
+            sidecar_token = None
+            sidecar = SESSION_DIR / f"{self.session_id}.json"
+            if _path_entry_exists(sidecar):
+                persisted = _load_and_validate_session_payload(
+                    sidecar,
+                    self.session_id,
+                )
+                sidecar_token = persisted.get("publication_incarnation")
+            if claim_token and sidecar_token and claim_token != sidecar_token:
+                raise RuntimeError(
+                    f"Session incarnation authorities disagree for {self.session_id!r}"
+                )
+            publication_incarnation = sidecar_token or claim_token
         self._publication_generation = _session_publication_generation(
             self.session_id,
             str(publication_incarnation) if publication_incarnation else None,
@@ -2556,6 +2582,24 @@ class Session:
             with LOCK:
                 if SESSIONS.get(self.session_id) is self:
                     owners = [owner for owner in owners if owner != "session_cache"]
+            # Direct first-save is a backwards-compatible materialization path.
+            # Production creators reserve before any runtime namespace exists;
+            # repair/checkpoint callers may legitimately establish locks and
+            # journals before their first sidecar publication.
+            owners = [
+                owner
+                for owner in owners
+                if owner
+                not in {
+                    "turn_journal",
+                    "run_journal",
+                    "stream_registry",
+                    "stream_owner_registry",
+                    "active_run_registry",
+                    "agent_cache",
+                    "agent_lock",
+                }
+            ]
             if owners:
                 raise SessionDestinationCollisionError(
                     f"Session destination {self.session_id!r} is already owned: "
@@ -10450,6 +10494,16 @@ def _delete_cli_session_locked(sid, hermes_home) -> bool:
             columns = {
                 row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
             }
+            if not columns:
+                return stale_cleanup_complete
+            if "id" not in columns:
+                return False
+            if conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
+                (sid,),
+            ).fetchone() is None:
+                conn.commit()
+                return stale_cleanup_complete
             if not {"id", "parent_session_id"}.issubset(columns):
                 return False
 

--- a/api/models.py
+++ b/api/models.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import re
+import secrets
 import threading
 import time
 import uuid
@@ -280,18 +281,28 @@ _SESSION_PUBLICATION_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = 
     weakref.WeakValueDictionary()
 )
 _SESSION_PUBLICATION_DELETED: set[str] = set()
+_CROSS_PROCESS_LOCKS_GUARD = threading.Lock()
+_CROSS_PROCESS_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
+    weakref.WeakValueDictionary()
+)
+_CROSS_PROCESS_LOCKS_HELD = threading.local()
 
 
 class _SessionPublicationGeneration:
-    """Weakly-owned lease for one live in-process SID incarnation."""
+    """Lease for one SID incarnation, persisted with the owning sidecar."""
 
-    def __init__(self) -> None:
-        self.token = uuid.uuid4().hex
+    def __init__(self, token: str | None = None) -> None:
+        self.token = str(token or secrets.token_hex(16))
 
 
 _SESSION_PUBLICATION_GENERATIONS: weakref.WeakValueDictionary[
     str, _SessionPublicationGeneration
 ] = weakref.WeakValueDictionary()
+_SESSION_INCARNATION_TOKEN_RE = re.compile(r"^[a-f0-9]{32}$")
+
+
+def _is_session_incarnation_token(value) -> bool:
+    return isinstance(value, str) and bool(_SESSION_INCARNATION_TOKEN_RE.fullmatch(value))
 
 
 def _get_session_publication_lock(session_id: str) -> threading.RLock:
@@ -305,13 +316,16 @@ def _get_session_publication_lock(session_id: str) -> threading.RLock:
         return lock
 
 
-def _session_publication_generation(session_id: str) -> _SessionPublicationGeneration:
-    """Return the process-local lease shared by one live SID incarnation."""
+def _session_publication_generation(
+    session_id: str,
+    token: str | None = None,
+) -> _SessionPublicationGeneration:
+    """Return the lease shared by loaded objects for one persisted incarnation."""
     sid = str(session_id or "")
     with _SESSION_PUBLICATION_LOCKS_GUARD:
         generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
-        if generation is None:
-            generation = _SessionPublicationGeneration()
+        if generation is None or (token is not None and generation.token != token):
+            generation = _SessionPublicationGeneration(token)
             _SESSION_PUBLICATION_GENERATIONS[sid] = generation
         return generation
 
@@ -355,6 +369,16 @@ def _session_publication_rejection_reason(
     generation: _SessionPublicationGeneration | None,
 ) -> str | None:
     sid = str(session_id or "")
+    try:
+        residual_path = _session_cleanup_residual_file(sid)
+        if _path_entry_exists(residual_path):
+            _residual_sid, residual_policy = _read_session_cleanup_residual_record(
+                residual_path
+            )
+            if residual_policy.get("operation") == "delete":
+                return "deleted session with destructive cleanup pending"
+    except Exception:
+        return "unreadable cleanup authority for session"
     with _SESSION_PUBLICATION_LOCKS_GUARD:
         current_generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
         if (
@@ -365,6 +389,28 @@ def _session_publication_rejection_reason(
             return "stale session generation"
         if sid in _SESSION_PUBLICATION_DELETED:
             return "deleted session"
+    generation_token = getattr(generation, "token", None)
+    if _path_entry_exists(path):
+        try:
+            persisted = json.loads(path.read_bytes())
+        except Exception:
+            return "unreadable session incarnation"
+        persisted_token = (
+            persisted.get("publication_incarnation")
+            if isinstance(persisted, dict)
+            else None
+        )
+        if not isinstance(persisted, dict) or persisted.get("session_id") != sid:
+            return "session identity mismatch"
+        if persisted_token and persisted_token != generation_token:
+            return "stale session generation"
+    else:
+        try:
+            claim_token = _read_session_incarnation_claim(sid)
+        except Exception:
+            return "unreadable session incarnation claim"
+        if claim_token is not None and claim_token != generation_token:
+            return "stale session generation"
     # A live sidecar beats a stale durable tombstone after restart. An absent
     # sidecar plus tombstone is authoritative and must reject a late save.
     if not path.exists() and sid in _load_webui_deleted_session_tombstone():
@@ -396,6 +442,28 @@ def is_safe_session_id(sid) -> bool:
     return all(c in _SAFE_SID_CHARS for c in sid)
 
 
+def _load_and_validate_session_payload(
+    path: Path,
+    expected_session_id: str,
+) -> dict:
+    """Load one sidecar/backup without allowing its outer SID to redirect ownership."""
+    sid = str(expected_session_id or "")
+    if not is_safe_session_id(sid):
+        raise ValueError("Invalid expected session_id")
+    data = json.loads(path.read_bytes())
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid session payload: {path.name}")
+    if data.get("session_id") != sid:
+        raise ValueError(
+            f"Session payload identity mismatch: expected {sid!r}, "
+            f"found {data.get('session_id')!r}"
+        )
+    token = data.get("publication_incarnation")
+    if token is not None and not _is_session_incarnation_token(token):
+        raise ValueError("Invalid session publication incarnation")
+    return data
+
+
 _SESSION_DESTINATION_RESERVATIONS = threading.local()
 
 
@@ -407,40 +475,74 @@ def _active_destination_reservations() -> dict[str, str]:
     return active
 
 
+def _cross_process_lock(name: str) -> threading.RLock:
+    with _CROSS_PROCESS_LOCKS_GUARD:
+        lock = _CROSS_PROCESS_LOCKS.get(name)
+        if lock is None:
+            lock = threading.RLock()
+            _CROSS_PROCESS_LOCKS[name] = lock
+        return lock
+
+
+@contextmanager
+def _cross_process_file_lock(name: str):
+    """Serialize one file-backed authority across threads and processes."""
+    if not name or any(c not in _SAFE_SID_CHARS for c in name):
+        raise ValueError("Invalid cross-process lock name")
+    with _cross_process_lock(name):
+        held = getattr(_CROSS_PROCESS_LOCKS_HELD, "counts", None)
+        if held is None:
+            held = {}
+            _CROSS_PROCESS_LOCKS_HELD.counts = held
+        if held.get(name, 0):
+            held[name] += 1
+            try:
+                yield
+            finally:
+                held[name] -= 1
+            return
+
+        lock_root = SESSION_DIR / "_cross_process_locks"
+        lock_root.mkdir(parents=True, exist_ok=True)
+        lock_path = lock_root / f"{name}.lock"
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        with os.fdopen(fd, "r+b", buffering=0) as lock_file:
+            if _fcntl is not None:
+                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+
+                def unlock():
+                    _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+            elif _msvcrt is not None:
+                if os.fstat(lock_file.fileno()).st_size == 0:
+                    lock_file.write(b"\0")
+                lock_file.seek(0)
+                _msvcrt.locking(  # type: ignore[attr-defined]
+                    lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
+                )
+
+                def unlock():
+                    lock_file.seek(0)
+                    _msvcrt.locking(  # type: ignore[attr-defined]
+                        lock_file.fileno(), _msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+                    )
+            else:
+                raise RuntimeError("cross-process file locking is unavailable")
+            held[name] = 1
+            try:
+                yield
+            finally:
+                held.pop(name, None)
+                unlock()
+
+
 @contextmanager
 def _session_publication_process_lock(session_id: str):
     """Hold the permanent cross-process publication lock for one SID."""
     sid = str(session_id or "")
     if not is_safe_session_id(sid):
         raise ValueError("Invalid session_id")
-    lock_root = SESSION_DIR / "_session_publication_locks"
-    lock_root.mkdir(parents=True, exist_ok=True)
-    lock_path = lock_root / f"{sid}.lock"
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-    with os.fdopen(fd, "r+b", buffering=0) as lock_file:
-        if _fcntl is not None:
-            _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
-            return
-        if _msvcrt is not None:
-            if os.fstat(lock_file.fileno()).st_size == 0:
-                lock_file.write(b"\0")
-            lock_file.seek(0)
-            _msvcrt.locking(  # type: ignore[attr-defined]
-                lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
-            )
-            try:
-                yield
-            finally:
-                lock_file.seek(0)
-                _msvcrt.locking(  # type: ignore[attr-defined]
-                    lock_file.fileno(), _msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
-                )
-            return
-        raise RuntimeError("cross-process session publication locking is unavailable")
+    with _cross_process_file_lock(f"session-{sid}"):
+        yield
 
 
 @contextmanager
@@ -468,6 +570,72 @@ class SessionDestinationCollisionError(RuntimeError):
     pass
 
 
+SESSION_INCARNATION_CLAIM_VERSION = 1
+
+
+def _session_incarnation_claim_file(session_id: str) -> Path:
+    sid = str(session_id or "")
+    if not is_safe_session_id(sid):
+        raise ValueError("Invalid session_id")
+    return SESSION_DIR / "_session_incarnation_claims" / f"{sid}.json"
+
+
+def _read_session_incarnation_claim(session_id: str) -> str | None:
+    path = _session_incarnation_claim_file(session_id)
+    try:
+        raw = json.loads(path.read_bytes())
+    except FileNotFoundError:
+        return None
+    if (
+        not isinstance(raw, dict)
+        or raw.get("version") != SESSION_INCARNATION_CLAIM_VERSION
+        or raw.get("session_id") != session_id
+        or not _is_session_incarnation_token(raw.get("token"))
+    ):
+        raise ValueError(f"Invalid session incarnation claim for {session_id!r}")
+    return raw["token"]
+
+
+def _persist_session_incarnation_claim(session_id: str, token: str) -> None:
+    path = _session_incarnation_claim_file(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _fsync_parent_directory(path.parent)
+    tmp = path.with_name(f".{path.name}.tmp.{uuid.uuid4().hex}")
+    try:
+        with open(tmp, "x", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "version": SESSION_INCARNATION_CLAIM_VERSION,
+                    "session_id": session_id,
+                    "token": token,
+                },
+                handle,
+                ensure_ascii=False,
+                indent=2,
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+        _safe_replace(tmp, path)
+        _fsync_parent_directory(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _clear_session_incarnation_claim(
+    session_id: str,
+    *,
+    expected_token: str | None = None,
+) -> None:
+    path = _session_incarnation_claim_file(session_id)
+    token = _read_session_incarnation_claim(session_id)
+    if token is None:
+        return
+    if expected_token is not None and token != expected_token:
+        raise RuntimeError(f"Session incarnation claim changed for {session_id!r}")
+    _durable_unlink(path)
+
+
 def _session_destination_owners(session_id: str) -> list[str]:
     """Return every known owner of a destination SID, failing closed."""
     sid = str(session_id or "")
@@ -480,6 +648,10 @@ def _session_destination_owners(session_id: str) -> list[str]:
         SESSION_DIR.glob(f"{sid}.json.bak.tmp.*")
     ):
         owners.append("session_temporary_files")
+    if _path_entry_exists(_session_incarnation_claim_file(sid)):
+        # Invalid claims are owners too: uncertainty must not authorize reuse.
+        _read_session_incarnation_claim(sid)
+        owners.append("session_incarnation_claim")
 
     from api.session_media import _session_media_dir
     from api.upload import _session_attachment_dir
@@ -497,7 +669,7 @@ def _session_destination_owners(session_id: str) -> list[str]:
         owners.append("run_journal")
 
     if _path_entry_exists(SESSION_INDEX_FILE):
-        with _INDEX_WRITE_LOCK:
+        with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
             rows = json.loads(SESSION_INDEX_FILE.read_bytes())
         if not isinstance(rows, list):
             raise RuntimeError("Cannot reserve a SID while the session index is invalid")
@@ -556,6 +728,7 @@ class _SessionDestinationReservation:
         self._committed = False
         self._entered = False
         self._bound_session_ref = None
+        self._claim_created = False
 
     def __enter__(self):
         if not is_safe_session_id(self.session_id):
@@ -579,6 +752,12 @@ class _SessionDestinationReservation:
                     f"Refusing to reserve session {self.session_id!r} while cleanup residuals remain"
                 )
             self.generation = _SessionPublicationGeneration()
+            _persist_session_incarnation_claim(
+                self.session_id,
+                self.generation.token,
+            )
+            self._claim_created = True
+            _clear_webui_deleted_session_tombstone(self.session_id)
             with _SESSION_PUBLICATION_LOCKS_GUARD:
                 _SESSION_PUBLICATION_GENERATIONS[self.session_id] = self.generation
                 _SESSION_PUBLICATION_DELETED.discard(self.session_id)
@@ -586,6 +765,18 @@ class _SessionDestinationReservation:
             self._entered = True
             return self
         except BaseException:
+            if self._claim_created and self.generation is not None:
+                try:
+                    _clear_session_incarnation_claim(
+                        self.session_id,
+                        expected_token=self.generation.token,
+                    )
+                except Exception:
+                    logger.error(
+                        "Could not roll back failed incarnation claim for %s",
+                        self.session_id,
+                        exc_info=True,
+                    )
             self._release()
             raise
 
@@ -647,6 +838,33 @@ class _SessionDestinationReservation:
 
 def reserve_session_destination(session_id: str) -> _SessionDestinationReservation:
     return _SessionDestinationReservation(session_id)
+
+
+def rollback_reserved_session_destination(session_id: str, token: str) -> dict:
+    """Crash-recovery rollback that may remove only one proven incarnation."""
+    sid = str(session_id or "")
+    with _session_publication_authority(sid):
+        sidecar = SESSION_DIR / f"{sid}.json"
+        persisted_token = None
+        if _path_entry_exists(sidecar):
+            payload = _load_and_validate_session_payload(sidecar, sid)
+            persisted_token = payload.get("publication_incarnation")
+        claim_token = _read_session_incarnation_claim(sid)
+        observed = persisted_token or claim_token
+        if observed != token:
+            raise RuntimeError(
+                f"Refusing to roll back unproven session incarnation {sid!r}"
+            )
+        generation = _SessionPublicationGeneration(token)
+        with _SESSION_PUBLICATION_LOCKS_GUARD:
+            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
+            _SESSION_PUBLICATION_DELETED.discard(sid)
+        return delete_session_artifacts(
+            sid,
+            expected_generation=generation,
+            durable_tombstone=False,
+            delete_state_db=False,
+        )
 
 
 def _cleanup_stale_tmp_files() -> None:
@@ -794,9 +1012,9 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
     """
     session_dir = session_dir or SESSION_DIR
     session_index_file = session_index_file or SESSION_INDEX_FILE
-    _tmp = session_index_file.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+    _tmp = session_index_file.with_suffix(f'.tmp.{uuid.uuid4().hex}')
 
-    with _INDEX_WRITE_LOCK:
+    with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
         # Lazy full-rebuild path — used when index doesn't exist yet.
         if updates is None or not session_index_file.exists():
             _cleanup_stale_tmp_files()  # best-effort sweep on startup / first call
@@ -918,10 +1136,10 @@ def prune_session_from_index(session_id: str) -> None:
     if not SESSION_INDEX_FILE.exists():
         _fsync_parent_directory(SESSION_INDEX_FILE)
         return
-    _tmp = SESSION_INDEX_FILE.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+    _tmp = SESSION_INDEX_FILE.with_suffix(f'.tmp.{uuid.uuid4().hex}')
 
     _fallback = False
-    with _INDEX_WRITE_LOCK:
+    with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
         try:
             with LOCK:
                 existing = json.loads(SESSION_INDEX_FILE.read_bytes())
@@ -1066,9 +1284,7 @@ def _save_webui_zero_message_orphan_tombstone(ids) -> None:
     _tmp = None
     try:
         SESSION_DIR.mkdir(parents=True, exist_ok=True)
-        _tmp = p.with_suffix(
-            f'.tmp.{os.getpid()}.{threading.current_thread().ident}'
-        )
+        _tmp = p.with_suffix(f'.tmp.{uuid.uuid4().hex}')
         with open(_tmp, 'w', encoding='utf-8') as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
@@ -1107,7 +1323,10 @@ def _record_webui_zero_message_orphan_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    with _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK:
+    with (
+        _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK,
+        _cross_process_file_lock("zero-message-tombstone"),
+    ):
         current = set(_load_webui_zero_message_orphan_tombstone())
         if sid in current:
             return
@@ -1134,7 +1353,10 @@ def _clear_webui_zero_message_orphan_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    with _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK:
+    with (
+        _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK,
+        _cross_process_file_lock("zero-message-tombstone"),
+    ):
         current = set(_load_webui_zero_message_orphan_tombstone())
         if sid not in current:
             return
@@ -1157,26 +1379,26 @@ def _webui_deleted_session_tombstone_file() -> "Path":
 
 def _load_webui_deleted_session_tombstone() -> frozenset[str]:
     p = _webui_deleted_session_tombstone_file()
-    if not p.exists():
+    if not _path_entry_exists(p):
         return frozenset()
     try:
         raw = json.loads(p.read_text(encoding='utf-8'))
-    except Exception:
-        logger.debug("Failed to load webui deleted-session tombstone", exc_info=True)
-        return frozenset()
+    except Exception as exc:
+        raise ValueError("Invalid webui deleted-session tombstone") from exc
     if not isinstance(raw, dict):
-        return frozenset()
+        raise ValueError("Invalid webui deleted-session tombstone")
     try:
-        if int(raw.get("version", 0)) != WEBUI_DELETED_SESSION_TOMBSTONE_VERSION:
-            return frozenset()
-    except (TypeError, ValueError):
-        return frozenset()
+        version = int(raw.get("version", 0))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid webui deleted-session tombstone version") from exc
+    if version != WEBUI_DELETED_SESSION_TOMBSTONE_VERSION:
+        raise ValueError("Invalid webui deleted-session tombstone version")
     ids = raw.get("ids", [])
-    if not isinstance(ids, list):
-        return frozenset()
-    return frozenset(
-        str(sid).strip() for sid in ids if str(sid or "").strip()
-    )
+    if not isinstance(ids, list) or not all(
+        isinstance(sid, str) and is_safe_session_id(sid.strip()) for sid in ids
+    ):
+        raise ValueError("Invalid webui deleted-session tombstone ids")
+    return frozenset(sid.strip() for sid in ids)
 
 
 def _save_webui_deleted_session_tombstone(ids) -> None:
@@ -1193,9 +1415,7 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
     _tmp = None
     try:
         SESSION_DIR.mkdir(parents=True, exist_ok=True)
-        _tmp = p.with_suffix(
-            f'.tmp.{os.getpid()}.{threading.current_thread().ident}'
-        )
+        _tmp = p.with_suffix(f'.tmp.{uuid.uuid4().hex}')
         with open(_tmp, 'w', encoding='utf-8') as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
@@ -1215,7 +1435,10 @@ def _record_webui_deleted_session_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
+    with (
+        _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK,
+        _cross_process_file_lock("deleted-session-tombstone"),
+    ):
         current = set(_load_webui_deleted_session_tombstone())
         if sid in current:
             _fsync_parent_directory(_webui_deleted_session_tombstone_file())
@@ -1228,7 +1451,10 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
+    with (
+        _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK,
+        _cross_process_file_lock("deleted-session-tombstone"),
+    ):
         current = set(_load_webui_deleted_session_tombstone())
         if sid not in current:
             return
@@ -1284,10 +1510,12 @@ def _read_session_cleanup_residual_record(path: Path) -> tuple[str, dict]:
     items = raw.get("residuals")
     delete_state_db = raw.get("delete_state_db")
     durable_tombstone = raw.get("durable_tombstone")
+    operation = raw.get("operation", "delete")
     if (
         not isinstance(items, list)
         or not isinstance(delete_state_db, bool)
         or not isinstance(durable_tombstone, bool)
+        or operation not in {"delete", "prune", "clear"}
     ):
         raise ValueError("Invalid session cleanup residual policy")
     if not all(
@@ -1299,6 +1527,7 @@ def _read_session_cleanup_residual_record(path: Path) -> tuple[str, dict]:
         "residuals": list(items),
         "delete_state_db": delete_state_db,
         "durable_tombstone": durable_tombstone,
+        "operation": operation,
     }
 
 
@@ -1357,20 +1586,28 @@ def _persist_session_cleanup_residuals(
     *,
     durable_tombstone: bool,
     delete_state_db: bool,
+    operation: str = "delete",
 ) -> None:
     """Persist retryable artifact names until an idempotent cleanup succeeds."""
     sid = str(session_id or "")
     path = _session_cleanup_residual_file(sid)
-    with _SESSION_CLEANUP_RESIDUAL_LOCK:
+    if operation not in {"delete", "prune", "clear"}:
+        raise ValueError("Invalid session cleanup operation")
+    with (
+        _SESSION_CLEANUP_RESIDUAL_LOCK,
+        _cross_process_file_lock(f"cleanup-residual-{sid}"),
+    ):
         if not residuals:
+            if operation != "delete" and _path_entry_exists(path):
+                _existing_sid, existing_policy = _read_session_cleanup_residual_record(path)
+                if existing_policy.get("operation") != operation:
+                    return
             _durable_unlink(path)
             return
         root = _session_cleanup_residual_dir()
         root.mkdir(parents=True, exist_ok=True)
         _fsync_parent_directory(root)
-        tmp = path.with_suffix(
-            f".tmp.{os.getpid()}.{threading.current_thread().ident}"
-        )
+        tmp = path.with_suffix(f".tmp.{uuid.uuid4().hex}")
         try:
             with open(tmp, "w", encoding="utf-8") as handle:
                 json.dump(
@@ -1380,6 +1617,7 @@ def _persist_session_cleanup_residuals(
                         "residuals": list(residuals),
                         "delete_state_db": bool(delete_state_db),
                         "durable_tombstone": bool(durable_tombstone),
+                        "operation": operation,
                     },
                     handle,
                     ensure_ascii=False,
@@ -1392,6 +1630,58 @@ def _persist_session_cleanup_residuals(
         except BaseException:
             tmp.unlink(missing_ok=True)
             raise
+
+
+def retry_session_retention_cleanup(session_id: str, operation: str) -> dict:
+    """Retry reachability cleanup without deleting the live session owner."""
+    sid = str(session_id or "")
+    if operation not in {"prune", "clear"}:
+        raise ValueError("Invalid retention cleanup operation")
+    residuals = []
+    with _session_publication_authority(sid):
+        sidecar = SESSION_DIR / f"{sid}.json"
+        try:
+            current = _load_and_validate_session_payload(sidecar, sid)
+        except Exception as exc:
+            residuals.append({"artifact": "session_json", "error": type(exc).__name__})
+            current = None
+        backup = sidecar.with_suffix(".json.bak")
+        retained = [current] if current is not None else []
+        if operation == "clear":
+            try:
+                _durable_unlink(backup)
+            except Exception as exc:
+                residuals.append({"artifact": "session_backup", "error": type(exc).__name__})
+        elif _path_entry_exists(backup):
+            try:
+                retained.append(_load_and_validate_session_payload(backup, sid))
+            except Exception as exc:
+                residuals.append({"artifact": "session_backup", "error": type(exc).__name__})
+        if current is not None and not residuals:
+            try:
+                from api.session_media import (
+                    _collect_reference_filenames,
+                    prune_session_media,
+                    remove_session_media,
+                )
+
+                live_refs = _collect_reference_filenames(
+                    [current.get("messages", []), current.get("context_messages", [])]
+                )
+                if operation == "clear" and not live_refs:
+                    remove_session_media(sid)
+                else:
+                    prune_session_media(sid, retained)
+            except Exception as exc:
+                residuals.append({"artifact": "session_media", "error": type(exc).__name__})
+        _persist_session_cleanup_residuals(
+            sid,
+            residuals,
+            durable_tombstone=False,
+            delete_state_db=False,
+            operation=operation,
+        )
+    return {"ok": not residuals, "session_id": sid, "residuals": residuals}
 
 
 def delete_session_artifacts(
@@ -1472,7 +1762,10 @@ def delete_session_artifacts(
         except Exception as exc:
             residual("active_run_registry", exc)
             active_run = True
-        if active_run:
+        # A destination reservation rollback owns the not-yet-committed SID
+        # and may need to retire it after an in-transaction registry migration.
+        # Ordinary destructive requests still defer while any run is active.
+        if active_run and _reservation_token is None:
             residual("active_run")
         if residuals:
             try:
@@ -1498,6 +1791,16 @@ def delete_session_artifacts(
                 residual(artifact, exc)
             if _path_entry_exists(path):
                 residual(artifact)
+
+        try:
+            _clear_session_incarnation_claim(
+                sid,
+                expected_token=retired_generation.token,
+            )
+        except Exception as exc:
+            residual("session_incarnation_claim", exc)
+        if _path_entry_exists(_session_incarnation_claim_file(sid)):
+            residual("session_incarnation_claim")
 
         # Session.save() normally removes its own failed staging files, but a
         # process crash can leave transcript-bearing JSON/backup temporaries.
@@ -1583,32 +1886,36 @@ def delete_session_artifacts(
             except Exception as exc:
                 residual("state_db", exc)
 
-        try:
-            from api.config import (
-                SESSION_AGENT_LOCKS,
-                SESSION_AGENT_LOCKS_LOCK,
-                _evict_session_agent,
-            )
+        # Reservation owners roll back any pre-commit registry migration in
+        # their outer transaction. Evicting here could close a migrated agent
+        # before that undo restores it under the source SID.
+        if _reservation_token is None:
+            try:
+                from api.config import (
+                    SESSION_AGENT_LOCKS,
+                    SESSION_AGENT_LOCKS_LOCK,
+                    _evict_session_agent,
+                )
 
-            _evict_session_agent(sid)
-            with SESSION_AGENT_LOCKS_LOCK:
-                SESSION_AGENT_LOCKS.pop(sid, None)
-        except Exception as exc:
-            residual("agent_runtime_cache", exc)
+                _evict_session_agent(sid)
+                with SESSION_AGENT_LOCKS_LOCK:
+                    SESSION_AGENT_LOCKS.pop(sid, None)
+            except Exception as exc:
+                residual("agent_runtime_cache", exc)
 
-        try:
-            from api.background_process import forget_bg_task_completion_dedup
+            try:
+                from api.background_process import forget_bg_task_completion_dedup
 
-            forget_bg_task_completion_dedup(sid)
-        except Exception as exc:
-            residual("background_completion_registry", exc)
+                forget_bg_task_completion_dedup(sid)
+            except Exception as exc:
+                residual("background_completion_registry", exc)
 
-        try:
-            from api.terminal import close_terminal
+            try:
+                from api.terminal import close_terminal
 
-            close_terminal(sid)
-        except Exception as exc:
-            residual("terminal", exc)
+                close_terminal(sid)
+            except Exception as exc:
+                residual("terminal", exc)
 
         try:
             _persist_session_cleanup_residuals(
@@ -1942,25 +2249,21 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
 
 def _load_session_from_path(path: Path) -> "Session | None":
     """Load a session from an explicit JSON path without consulting SESSION_DIR."""
-    try:
-        data = json.loads(path.read_text(encoding='utf-8'))
-    except Exception:
-        return None
-    if not isinstance(data, dict):
-        return None
-    embedded_sid = str(data.get("session_id") or "")
-    expected_sids = {path.stem}
+    expected_sids = [path.stem]
     # Legacy Hermes sidecars were named ``session_<sid>.json``. Keep that
     # format readable, but never let an arbitrary outer filename redirect the
     # loaded object to another session's cache/index/media namespace.
     if path.stem.startswith("session_"):
-        expected_sids.add(path.stem[len("session_"):])
-    if embedded_sid not in expected_sids:
-        logger.warning(
-            "Rejecting session sidecar identity mismatch: path=%s embedded=%r",
-            path,
-            embedded_sid,
-        )
+        expected_sids.insert(0, path.stem[len("session_"):])
+    data = None
+    for expected_sid in expected_sids:
+        try:
+            data = _load_and_validate_session_payload(path, expected_sid)
+            break
+        except Exception:
+            continue
+    if data is None:
+        logger.warning("Rejecting invalid or identity-mismatched session sidecar: %s", path)
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
     return Session(**data)
@@ -2084,12 +2387,20 @@ class Session:
                  process_wakeup_pause=None,
                  share_token=None,
                  share_created_at=None,
+                 publication_incarnation=None,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
         # Process-local incarnation lease stored in the class slot above. Every
         # load of the current SID shares this token; an intentional same-SID
         # recreation rotates it so old objects never regain publication authority.
-        self._publication_generation = _session_publication_generation(self.session_id)
+        if publication_incarnation is None:
+            publication_incarnation = _read_session_incarnation_claim(
+                self.session_id
+            )
+        self._publication_generation = _session_publication_generation(
+            self.session_id,
+            str(publication_incarnation) if publication_incarnation else None,
+        )
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())
         self.model = model
@@ -2234,6 +2545,26 @@ class Session:
             raise RuntimeError(
                 f"Refusing to publish {rejection} {self.session_id!r}"
             )
+        if not _path_entry_exists(self.path) and _read_session_incarnation_claim(
+            self.session_id
+        ) is None:
+            if _session_has_cleanup_residual(self.session_id):
+                raise RuntimeError(
+                    f"Refusing to publish session {self.session_id!r} while cleanup residuals remain"
+                )
+            owners = _session_destination_owners(self.session_id)
+            with LOCK:
+                if SESSIONS.get(self.session_id) is self:
+                    owners = [owner for owner in owners if owner != "session_cache"]
+            if owners:
+                raise SessionDestinationCollisionError(
+                    f"Session destination {self.session_id!r} is already owned: "
+                    + ", ".join(owners)
+                )
+            _persist_session_incarnation_claim(
+                self.session_id,
+                self._publication_generation.token,
+            )
         # ── #1558 P0 guard ──────────────────────────────────────────────
         # Refuse to save a session that was loaded with metadata_only=True.
         # Such sessions have messages=[] (it's the whole point of the partial
@@ -2258,10 +2589,19 @@ class Session:
         # base64 work. Persist a private reference and hydrate only when a later
         # model call needs the original data URL.
         from api.session_media import (
+            assert_no_session_media_references,
             externalize_large_session_media,
-            verify_session_media_references,
+            verify_serialized_session_media_payload,
         )
 
+        assert_no_session_media_references(
+            {
+                key: value
+                for key, value in self.__dict__.items()
+                if key not in {"messages", "context_messages"}
+            },
+            context="session payload outside messages/context_messages",
+        )
         externalize_large_session_media(self.messages, self.session_id)
         externalize_large_session_media(self.context_messages, self.session_id)
         # Write metadata fields first so load_metadata_only() can read them
@@ -2294,6 +2634,7 @@ class Session:
             'share_token', 'share_created_at',
         ]
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
+        meta['publication_incarnation'] = self._publication_generation.token
         # #5854: message_count and a compact anchor-scene fingerprint go in the
         # metadata prefix (BEFORE messages) so load_metadata_only() and the
         # sidebar-poll freshness check never have to parse the full (250-480KB)
@@ -2317,7 +2658,9 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        payload_data = {**meta, **extra}
+        verify_serialized_session_media_payload(payload_data, self.session_id)
+        payload = json.dumps(payload_data, ensure_ascii=False, indent=2)
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -2336,8 +2679,10 @@ class Session:
                 existing_text = self.path.read_text(encoding='utf-8')
                 try:
                     existing = json.loads(existing_text)
+                    if not isinstance(existing, dict) or existing.get("session_id") != self.session_id:
+                        raise RuntimeError("Existing session sidecar identity mismatch")
                     existing_msg_count = len(existing.get('messages') or [])
-                except (json.JSONDecodeError, ValueError):
+                except json.JSONDecodeError:
                     existing_msg_count = -1  # corrupt → always back up
                 incoming_msg_count = len(self.messages or [])
                 if (
@@ -2366,7 +2711,7 @@ class Session:
                     # land at all.
                     try:
                         bak_tmp = bak_path.with_suffix(
-                            f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
+                            f'.bak.tmp.{uuid.uuid4().hex}'
                         )
                         with open(bak_tmp, 'w', encoding='utf-8') as bf:
                             bf.write(existing_text)
@@ -2383,7 +2728,7 @@ class Session:
         except OSError:
             pass
 
-        tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
+        tmp = self.path.with_suffix(f'.tmp.{uuid.uuid4().hex}')
         try:
             with open(tmp, 'w', encoding='utf-8') as f:
                 f.write(payload)
@@ -2392,8 +2737,8 @@ class Session:
             # Verify the exact retained media authority at the publication
             # boundary. A missing or corrupt blob must leave the previous JSON
             # untouched even when serialization and backup work took time.
-            verify_session_media_references(
-                [self.messages, self.context_messages],
+            verify_serialized_session_media_payload(
+                json.loads(payload),
                 self.session_id,
             )
             # Delete and save share the publication lock, but keep the
@@ -2418,6 +2763,10 @@ class Session:
             raise
         if not skip_index:
             _write_session_index(updates=[self])
+        _clear_session_incarnation_claim(
+            self.session_id,
+            expected_token=self._publication_generation.token,
+        )
         if prune_media:
             from api.session_media import prune_session_media
 
@@ -2432,15 +2781,28 @@ class Session:
                         raise ValueError("Session backup identity mismatch while pruning media")
                     retained_values.append(backup_payload)
                 prune_session_media(self.session_id, retained_values)
-            except Exception:
+                _persist_session_cleanup_residuals(
+                    self.session_id,
+                    [],
+                    durable_tombstone=False,
+                    delete_state_db=False,
+                    operation="prune",
+                )
+            except Exception as exc:
                 # The sidecar and index are already durably committed above.
-                # Pruning is retention-only because every live/recovery
-                # reference is kept, so a cleanup error must not turn that
-                # committed transcript mutation into a false HTTP failure.
+                # Preserve a durable, machine-readable retry authority before
+                # allowing callers to treat the transcript commit as complete.
                 logger.warning(
                     "Could not prune session media after transcript truncation for %s",
                     self.session_id,
                     exc_info=True,
+                )
+                _persist_session_cleanup_residuals(
+                    self.session_id,
+                    [{"artifact": "session_media", "error": type(exc).__name__}],
+                    durable_tombstone=False,
+                    delete_state_db=False,
+                    operation="prune",
                 )
 
         # #4985 belt-and-suspenders self-heal: a successful save with at
@@ -2481,9 +2843,10 @@ class Session:
         # cache write is only committed if the file didn't change under us
         # during the parse (TOCTOU guard against an atomic replace mid-read).
         _pre_read_sig = _sidecar_stat_signature(p)
-        data = json.loads(p.read_text(encoding='utf-8'))
-        if not isinstance(data, dict) or data.get('session_id') != sid:
-            logger.warning("Rejecting session sidecar identity mismatch for %s", sid)
+        try:
+            data = _load_and_validate_session_payload(p, sid)
+        except (OSError, ValueError, json.JSONDecodeError):
+            logger.warning("Rejecting invalid or identity-mismatched session sidecar for %s", sid)
             return None
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
@@ -5655,27 +6018,16 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None, p
         worktree_created_at=wt.get('created_at') if wt else None,
         enabled_toolsets=enabled_toolsets,
     )
-    _activate_session_publication_generation(s)
-    # #4985: defensive — auto-generated uuids don't collide with the
-    # tombstone, but if a future caller ever passes an explicit id that
-    # was previously pruned, clear the entry so the new session isn't
-    # shadowed on the next poll. Wrapped because a tombstone failure
-    # must never block new-session creation.
-    try:
+    with reserve_session_destination(s.session_id) as reservation:
+        reservation.bind(s)
         _clear_webui_zero_message_orphan_tombstone(s.session_id)
-        _clear_webui_deleted_session_tombstone(s.session_id)
-    except Exception:
-        logger.debug(
-            "Failed to clear webui tombstone for %s",
-            s.session_id,
-            exc_info=True,
-        )
-    with LOCK:
-        SESSIONS[s.session_id] = s
-        SESSIONS.move_to_end(s.session_id)
-        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-    if wt:
-        s.save()
+        with LOCK:
+            SESSIONS[s.session_id] = s
+            SESSIONS.move_to_end(s.session_id)
+            _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+        if wt:
+            s.save()
+        reservation.commit()
     return s
 
 def _hide_from_default_sidebar(session: dict, *, show_cron: bool = False, show_webhook: bool = False) -> bool:
@@ -7186,22 +7538,11 @@ def import_cli_session(
         updated_at=updated_at,
         parent_session_id=parent_session_id,
     )
-    _activate_session_publication_generation(s)
-    # #4985: import_cli_session uses an explicit sid (the CLI sidecar's id).
-    # If that sid was previously tombstoned as a webui zero-message orphan,
-    # clear the tombstone entry so the freshly-imported session is visible
-    # on the next poll. Wrapped because a tombstone failure must never block
-    # an import.
-    try:
+    with reserve_session_destination(s.session_id) as reservation:
+        reservation.bind(s)
         _clear_webui_zero_message_orphan_tombstone(s.session_id)
-        _clear_webui_deleted_session_tombstone(s.session_id)
-    except Exception:
-        logger.debug(
-            "Failed to clear webui tombstone for %s",
-            s.session_id,
-            exc_info=True,
-        )
-    s.save(touch_updated_at=False)
+        s.save(touch_updated_at=False)
+        reservation.commit()
     return s
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -319,6 +319,11 @@ class _SessionPublicationGeneration:
 _SESSION_PUBLICATION_GENERATIONS: weakref.WeakValueDictionary[
     str, _SessionPublicationGeneration
 ] = weakref.WeakValueDictionary()
+# Legacy sidecars predate durable incarnation tokens.  This tracks the exact
+# stat signature that a validated loader used to establish their process-local
+# lease, so concurrent validated readers can share it without letting a bare
+# constructor inherit authority.
+_SESSION_PUBLICATION_LEGACY_SIGNATURES: dict[str, tuple] = {}
 _SESSION_INCARNATION_TOKEN_RE = re.compile(r"^[a-f0-9]{32}$")
 
 
@@ -355,6 +360,8 @@ def _session_publication_generation(
         if generation is None or (token is not None and generation.token != token):
             generation = _SessionPublicationGeneration(token)
             _SESSION_PUBLICATION_GENERATIONS[key] = generation
+        if token is not None:
+            _SESSION_PUBLICATION_LEGACY_SIGNATURES.pop(key, None)
         return generation
 
 
@@ -376,6 +383,30 @@ def _register_published_session_generation(session) -> None:
         if current is not None and current != generation:
             raise RuntimeError(f"Refusing to replace live session generation {sid!r}")
         _SESSION_PUBLICATION_GENERATIONS[key] = generation
+        _SESSION_PUBLICATION_LEGACY_SIGNATURES.pop(key, None)
+
+
+def _register_validated_legacy_session_generation(session, signature: tuple) -> None:
+    """Bind a verified tokenless sidecar to one process-local generation.
+
+    A legacy JSON file has no durable incarnation field.  Two full loaders can
+    therefore race while reading the same immutable sidecar; they must share a
+    lease, while a loader that observes a replacement must supersede the old
+    lease so its stale object cannot publish.  Bare constructors never call
+    this helper.
+    """
+    sid = str(getattr(session, "session_id", "") or "")
+    generation = getattr(session, "_publication_generation", None)
+    if generation is None:
+        raise RuntimeError(f"Missing publication generation for {sid!r}")
+    key = _session_publication_store_key(sid)
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        current = _SESSION_PUBLICATION_GENERATIONS.get(key)
+        if current is not None and _SESSION_PUBLICATION_LEGACY_SIGNATURES.get(key) == signature:
+            session._publication_generation = current
+            return
+        _SESSION_PUBLICATION_GENERATIONS[key] = generation
+        _SESSION_PUBLICATION_LEGACY_SIGNATURES[key] = signature
 
 
 def _activate_session_publication_generation(session) -> _SessionPublicationGeneration:
@@ -390,6 +421,7 @@ def _activate_session_publication_generation(session) -> _SessionPublicationGene
         generation = _SessionPublicationGeneration()
         with _SESSION_PUBLICATION_LOCKS_GUARD:
             _SESSION_PUBLICATION_GENERATIONS[key] = generation
+            _SESSION_PUBLICATION_LEGACY_SIGNATURES.pop(key, None)
             _SESSION_PUBLICATION_DELETED.discard(key)
         session._publication_generation = generation
         return generation
@@ -2422,13 +2454,7 @@ def _load_session_from_path(path: Path) -> "Session | None":
         logger.warning("Rejecting invalid or identity-mismatched session sidecar: %s", path)
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
-    session = Session(**data)
-    if not data.get("publication_incarnation"):
-        # A legacy payload has no durable token. Register only after its path
-        # and embedded SID have been validated above, never from a constructor
-        # that merely names the same SID.
-        _register_published_session_generation(session)
-    return session
+    return Session(**data)
 
 
 def _lookup_index_message_count(session_id):
@@ -3032,6 +3058,13 @@ class Session:
         except (OSError, ValueError, json.JSONDecodeError):
             logger.warning("Rejecting invalid or identity-mismatched session sidecar for %s", sid)
             return None
+        # Do not attach a tokenless legacy lease to a sidecar that changed
+        # while it was being parsed. A caller can retry the complete validated
+        # load; accepting this snapshot would authorize an unknown replacement.
+        _post_read_sig = _sidecar_stat_signature(p)
+        if _pre_read_sig is None or _post_read_sig is None or _pre_read_sig != _post_read_sig:
+            logger.warning("Session sidecar changed during validated load for %s", sid)
+            return None
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
         if not data.get("publication_incarnation"):
@@ -3039,7 +3072,7 @@ class Session:
             # identity-validated load is the only safe way to establish their
             # in-process authority; a bare ``Session(session_id=sid)`` must
             # remain unable to adopt the same sidecar.
-            _register_published_session_generation(session)
+            _register_validated_legacy_session_generation(session, _post_read_sig)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching

--- a/api/models.py
+++ b/api/models.py
@@ -1151,7 +1151,7 @@ def delete_session_artifacts(
         try:
             prune_session_from_index(sid)
             if SESSION_INDEX_FILE.exists():
-                rows = json.loads(SESSION_INDEX_FILE.read_text(encoding="utf-8"))
+                rows = json.loads(SESSION_INDEX_FILE.read_bytes())
                 if not isinstance(rows, list) or any(
                     isinstance(row, dict) and row.get("session_id") == sid
                     for row in rows

--- a/api/models.py
+++ b/api/models.py
@@ -177,6 +177,83 @@ def _safe_replace(src: Path, dst: Path) -> None:
             delay *= 2  # 50 -> 100 -> 200 -> 400 -> 800 ms
 
 
+def _path_entry_exists(path: Path) -> bool:
+    """Return whether *path* names an entry, including a broken symlink."""
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _fsync_directory(path: Path) -> None:
+    """Durably commit prior entry changes made in one directory."""
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        create_file = ctypes.windll.kernel32.CreateFileW
+        create_file.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        create_file.restype = wintypes.HANDLE
+        handle = create_file(
+            str(path),
+            0x80000000 | 0x40000000,  # GENERIC_READ | GENERIC_WRITE
+            0x00000001 | 0x00000002 | 0x00000004,  # share read/write/delete
+            None,
+            3,  # OPEN_EXISTING
+            0x02000000,  # FILE_FLAG_BACKUP_SEMANTICS
+            None,
+        )
+        invalid_handle = wintypes.HANDLE(-1).value
+        if handle == invalid_handle:
+            raise ctypes.WinError()
+        try:
+            if not ctypes.windll.kernel32.FlushFileBuffers(handle):
+                raise ctypes.WinError()
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+        return
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    fd = os.open(path, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_parent_directory(path: Path) -> None:
+    _fsync_directory(path.parent)
+
+
+def _durable_unlink(path: Path, *, missing_ok: bool = True) -> None:
+    """Unlink one entry and durably commit its absence.
+
+    The parent is synced even when the entry is already absent. This makes a
+    retry able to complete a deletion whose earlier unlink succeeded but whose
+    directory barrier failed.
+    """
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        if not missing_ok:
+            raise
+    parent = path.parent
+    while not parent.exists() and parent != parent.parent:
+        parent = parent.parent
+    _fsync_directory(parent)
+
+
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
@@ -242,7 +319,7 @@ def _session_publication_generation(session_id: str) -> _SessionPublicationGener
 def _activate_session_publication_generation(session) -> _SessionPublicationGeneration:
     """Bind *session* to a fresh lease for an intentional SID recreation."""
     sid = str(getattr(session, "session_id", "") or "")
-    with _get_session_publication_lock(sid):
+    with _session_publication_authority(sid):
         if _session_has_cleanup_residual(sid):
             raise RuntimeError(
                 f"Refusing to recreate session {sid!r} while cleanup residuals remain"
@@ -317,6 +394,259 @@ def is_safe_session_id(sid) -> bool:
     if not sid or not isinstance(sid, str):
         return False
     return all(c in _SAFE_SID_CHARS for c in sid)
+
+
+_SESSION_DESTINATION_RESERVATIONS = threading.local()
+
+
+def _active_destination_reservations() -> dict[str, str]:
+    active = getattr(_SESSION_DESTINATION_RESERVATIONS, "active", None)
+    if active is None:
+        active = {}
+        _SESSION_DESTINATION_RESERVATIONS.active = active
+    return active
+
+
+@contextmanager
+def _session_publication_process_lock(session_id: str):
+    """Hold the permanent cross-process publication lock for one SID."""
+    sid = str(session_id or "")
+    if not is_safe_session_id(sid):
+        raise ValueError("Invalid session_id")
+    lock_root = SESSION_DIR / "_session_publication_locks"
+    lock_root.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_root / f"{sid}.lock"
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    with os.fdopen(fd, "r+b", buffering=0) as lock_file:
+        if _fcntl is not None:
+            _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+            return
+        if _msvcrt is not None:
+            if os.fstat(lock_file.fileno()).st_size == 0:
+                lock_file.write(b"\0")
+            lock_file.seek(0)
+            _msvcrt.locking(  # type: ignore[attr-defined]
+                lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
+            )
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                _msvcrt.locking(  # type: ignore[attr-defined]
+                    lock_file.fileno(), _msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+                )
+            return
+        raise RuntimeError("cross-process session publication locking is unavailable")
+
+
+@contextmanager
+def _session_publication_authority(
+    session_id: str,
+    *,
+    reservation_token: str | None = None,
+):
+    """Serialize publication/deletion unless this thread owns a reservation."""
+    sid = str(session_id or "")
+    with _get_session_publication_lock(sid):
+        active_token = _active_destination_reservations().get(sid)
+        if active_token is not None:
+            if reservation_token != active_token:
+                raise RuntimeError(
+                    f"Session destination {sid!r} is owned by another publication transaction"
+                )
+            yield
+            return
+        with _session_publication_process_lock(sid):
+            yield
+
+
+class SessionDestinationCollisionError(RuntimeError):
+    pass
+
+
+def _session_destination_owners(session_id: str) -> list[str]:
+    """Return every known owner of a destination SID, failing closed."""
+    sid = str(session_id or "")
+    owners: list[str] = []
+    sidecar = SESSION_DIR / f"{sid}.json"
+    candidates = [sidecar, sidecar.with_suffix(".json.bak")]
+    if any(_path_entry_exists(path) for path in candidates):
+        owners.append("session_sidecar")
+    if any(SESSION_DIR.glob(f"{sid}.tmp.*")) or any(
+        SESSION_DIR.glob(f"{sid}.json.bak.tmp.*")
+    ):
+        owners.append("session_temporary_files")
+
+    from api.session_media import _session_media_dir
+    from api.upload import _session_attachment_dir
+    from api.turn_journal import TURN_JOURNAL_DIR_NAME
+    from api.run_journal import RUN_JOURNAL_DIR_NAME
+
+    if _path_entry_exists(_session_media_dir(sid)):
+        owners.append("session_media")
+    if _path_entry_exists(_session_attachment_dir(sid)):
+        owners.append("attachments")
+    turn_root = SESSION_DIR / TURN_JOURNAL_DIR_NAME
+    if any(turn_root.glob(f"{sid}~*.jsonl")) or _path_entry_exists(turn_root / f"{sid}.jsonl"):
+        owners.append("turn_journal")
+    if _path_entry_exists(SESSION_DIR / RUN_JOURNAL_DIR_NAME / sid):
+        owners.append("run_journal")
+
+    if _path_entry_exists(SESSION_INDEX_FILE):
+        with _INDEX_WRITE_LOCK:
+            rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+        if not isinstance(rows, list):
+            raise RuntimeError("Cannot reserve a SID while the session index is invalid")
+        if any(isinstance(row, dict) and row.get("session_id") == sid for row in rows):
+            owners.append("session_index")
+
+    with LOCK:
+        if sid in SESSIONS:
+            owners.append("session_cache")
+    with STREAMS_LOCK:
+        if any(
+            str((entry or {}).get("session_id") or "") == sid
+            for entry in STREAMS.values()
+            if isinstance(entry, dict)
+        ):
+            owners.append("stream_registry")
+    with _cfg.STREAM_SESSION_OWNERS_LOCK:
+        if sid in {
+            str(owner_sid or "")
+            for owner_sid in _cfg.STREAM_SESSION_OWNERS.values()
+        }:
+            owners.append("stream_owner_registry")
+    with _cfg.ACTIVE_RUNS_LOCK:
+        if any(
+            str((entry or {}).get("session_id") or "") == sid
+            for entry in _cfg.ACTIVE_RUNS.values()
+            if isinstance(entry, dict)
+        ):
+            owners.append("active_run_registry")
+    with _cfg.SESSION_AGENT_CACHE_LOCK:
+        if sid in _cfg.SESSION_AGENT_CACHE:
+            owners.append("agent_cache")
+    with _cfg.SESSION_AGENT_LOCKS_LOCK:
+        if sid in _cfg.SESSION_AGENT_LOCKS:
+            owners.append("agent_lock")
+    # Agent state.db is intentionally not an ownership namespace here. Agent
+    # compression creates its continuation row before the WebUI publishes the
+    # corresponding sidecar, and ordinary WebUI sessions can acquire a row on
+    # first turn. The reservation exclusively governs WebUI-owned artifacts.
+    return owners
+
+
+class _SessionDestinationReservation:
+    """Exclusive publish-or-rollback transaction for a previously unused SID."""
+
+    def __init__(
+        self: "_SessionDestinationReservation",
+        session_id: str,
+    ) -> None:
+        self.session_id = str(session_id or "")
+        self.token = uuid.uuid4().hex
+        self.generation: _SessionPublicationGeneration | None = None
+        self._thread_lock = None
+        self._process_lock = None
+        self._process_lock_entered = False
+        self._committed = False
+        self._entered = False
+        self._bound_session_ref = None
+
+    def __enter__(self):
+        if not is_safe_session_id(self.session_id):
+            raise ValueError("Invalid session_id")
+        self._thread_lock = _get_session_publication_lock(self.session_id)
+        self._thread_lock.acquire()
+        try:
+            self._process_lock = _session_publication_process_lock(self.session_id)
+            self._process_lock.__enter__()
+            self._process_lock_entered = True
+            if self.session_id in _active_destination_reservations():
+                raise RuntimeError("Nested destination reservation for the same SID")
+            owners = _session_destination_owners(self.session_id)
+            if owners:
+                raise SessionDestinationCollisionError(
+                    f"Session destination {self.session_id!r} is already owned: "
+                    + ", ".join(owners)
+                )
+            if _session_has_cleanup_residual(self.session_id):
+                raise RuntimeError(
+                    f"Refusing to reserve session {self.session_id!r} while cleanup residuals remain"
+                )
+            self.generation = _SessionPublicationGeneration()
+            with _SESSION_PUBLICATION_LOCKS_GUARD:
+                _SESSION_PUBLICATION_GENERATIONS[self.session_id] = self.generation
+                _SESSION_PUBLICATION_DELETED.discard(self.session_id)
+            _active_destination_reservations()[self.session_id] = self.token
+            self._entered = True
+            return self
+        except BaseException:
+            self._release()
+            raise
+
+    def bind(self, session) -> None:
+        if not self._entered or str(getattr(session, "session_id", "") or "") != self.session_id:
+            raise RuntimeError("Destination reservation/session identity mismatch")
+        session._publication_generation = self.generation
+        session._destination_reservation_token = self.token
+        self._bound_session_ref = weakref.ref(session)
+
+    def commit(self) -> None:
+        if not self._entered:
+            raise RuntimeError("Destination reservation is not active")
+        self._committed = True
+
+    def _release(self) -> None:
+        if self._bound_session_ref is not None:
+            bound_session = self._bound_session_ref()
+            if (
+                bound_session is not None
+                and getattr(bound_session, "_destination_reservation_token", None)
+                == self.token
+            ):
+                bound_session.__dict__.pop("_destination_reservation_token", None)
+            self._bound_session_ref = None
+        _active_destination_reservations().pop(self.session_id, None)
+        if self._process_lock is not None and self._process_lock_entered:
+            self._process_lock.__exit__(None, None, None)
+        self._process_lock = None
+        self._process_lock_entered = False
+        if self._thread_lock is not None:
+            self._thread_lock.release()
+            self._thread_lock = None
+
+    def __exit__(self, exc_type, exc, tb):
+        rollback_error = None
+        try:
+            if self._entered and not self._committed:
+                result = delete_session_artifacts(
+                    self.session_id,
+                    expected_generation=self.generation,
+                    durable_tombstone=False,
+                    delete_state_db=False,
+                    _reservation_token=self.token,
+                )
+                if not result.get("ok"):
+                    rollback_error = RuntimeError(
+                        f"Could not roll back reserved session {self.session_id!r}: "
+                        f"{result.get('residuals')!r}"
+                    )
+        finally:
+            self._release()
+        if rollback_error is not None:
+            if exc is not None:
+                raise rollback_error from exc
+            raise rollback_error
+        return False
+
+
+def reserve_session_destination(session_id: str) -> _SessionDestinationReservation:
+    return _SessionDestinationReservation(session_id)
 
 
 def _cleanup_stale_tmp_files() -> None:
@@ -509,6 +839,7 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
                     f.flush()
                     os.fsync(f.fileno())
                 _safe_replace(_tmp, session_index_file)
+                _fsync_parent_directory(session_index_file)
             except Exception:
                 # Best-effort cleanup of stale tmp on failure
                 try:
@@ -556,6 +887,7 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
                     f.flush()
                     os.fsync(f.fileno())
                 _safe_replace(_tmp, session_index_file)
+                _fsync_parent_directory(session_index_file)
             except Exception:
                 try:
                     _tmp.unlink(missing_ok=True)
@@ -581,7 +913,10 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
 def prune_session_from_index(session_id: str) -> None:
     """Remove one session row from the persisted sidebar index if present."""
     sid = str(session_id or "")
-    if not sid or not SESSION_INDEX_FILE.exists():
+    if not sid:
+        return
+    if not SESSION_INDEX_FILE.exists():
+        _fsync_parent_directory(SESSION_INDEX_FILE)
         return
     _tmp = SESSION_INDEX_FILE.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
 
@@ -594,6 +929,7 @@ def prune_session_from_index(session_id: str) -> None:
                     raise ValueError("session index must be a list")
                 pruned = [e for e in existing if e.get('session_id') != sid]
                 if len(pruned) == len(existing):
+                    _fsync_parent_directory(SESSION_INDEX_FILE)
                     return
                 _payload = json.dumps(pruned, ensure_ascii=False, indent=2)
 
@@ -603,6 +939,7 @@ def prune_session_from_index(session_id: str) -> None:
                     f.flush()
                     os.fsync(f.fileno())
                 _safe_replace(_tmp, SESSION_INDEX_FILE)
+                _fsync_parent_directory(SESSION_INDEX_FILE)
             except Exception:
                 try:
                     _tmp.unlink(missing_ok=True)
@@ -736,7 +1073,8 @@ def _save_webui_zero_message_orphan_tombstone(ids) -> None:
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(_tmp, p)
+        _safe_replace(_tmp, p)
+        _fsync_parent_directory(p)
     except Exception:
         logger.debug(
             "Failed to save webui zero-message orphan tombstone",
@@ -805,7 +1143,7 @@ def _clear_webui_zero_message_orphan_tombstone(sid: str) -> None:
             _save_webui_zero_message_orphan_tombstone(current)
             return
         try:
-            _webui_zero_message_orphan_tombstone_file().unlink(missing_ok=True)
+            _durable_unlink(_webui_zero_message_orphan_tombstone_file())
         except Exception:
             logger.debug(
                 "Failed to remove empty webui zero-message orphan tombstone",
@@ -842,12 +1180,9 @@ def _load_webui_deleted_session_tombstone() -> frozenset[str]:
 
 
 def _save_webui_deleted_session_tombstone(ids) -> None:
-    try:
-        sorted_ids = sorted(set(
-            str(sid).strip() for sid in (ids or []) if str(sid or "").strip()
-        ))
-    except TypeError:
-        return
+    sorted_ids = sorted(set(
+        str(sid).strip() for sid in (ids or []) if str(sid or "").strip()
+    ))
     if len(sorted_ids) > WEBUI_DELETED_SESSION_TOMBSTONE_CAP:
         sorted_ids = sorted_ids[-WEBUI_DELETED_SESSION_TOMBSTONE_CAP:]
     payload = {
@@ -865,14 +1200,15 @@ def _save_webui_deleted_session_tombstone(ids) -> None:
             json.dump(payload, f, ensure_ascii=False, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(_tmp, p)
+        _safe_replace(_tmp, p)
+        _fsync_parent_directory(p)
     except Exception:
-        logger.debug("Failed to save webui deleted-session tombstone", exc_info=True)
         if _tmp is not None:
             try:
                 _tmp.unlink(missing_ok=True)
             except Exception:
                 pass
+        raise
 
 
 def _record_webui_deleted_session_tombstone(sid: str) -> None:
@@ -882,6 +1218,7 @@ def _record_webui_deleted_session_tombstone(sid: str) -> None:
     with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
         current = set(_load_webui_deleted_session_tombstone())
         if sid in current:
+            _fsync_parent_directory(_webui_deleted_session_tombstone_file())
             return
         current.add(sid)
         _save_webui_deleted_session_tombstone(current)
@@ -899,10 +1236,7 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
         if current:
             _save_webui_deleted_session_tombstone(current)
             return
-        try:
-            _webui_deleted_session_tombstone_file().unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Failed to remove empty webui deleted-session tombstone", exc_info=True)
+        _durable_unlink(_webui_deleted_session_tombstone_file())
 
 
 def _session_cleanup_residual_dir() -> Path:
@@ -1029,10 +1363,11 @@ def _persist_session_cleanup_residuals(
     path = _session_cleanup_residual_file(sid)
     with _SESSION_CLEANUP_RESIDUAL_LOCK:
         if not residuals:
-            path.unlink(missing_ok=True)
+            _durable_unlink(path)
             return
         root = _session_cleanup_residual_dir()
         root.mkdir(parents=True, exist_ok=True)
+        _fsync_parent_directory(root)
         tmp = path.with_suffix(
             f".tmp.{os.getpid()}.{threading.current_thread().ident}"
         )
@@ -1053,6 +1388,7 @@ def _persist_session_cleanup_residuals(
                 handle.flush()
                 os.fsync(handle.fileno())
             _safe_replace(tmp, path)
+            _fsync_parent_directory(path)
         except BaseException:
             tmp.unlink(missing_ok=True)
             raise
@@ -1064,6 +1400,7 @@ def delete_session_artifacts(
     expected_generation: _SessionPublicationGeneration | None = None,
     durable_tombstone: bool = True,
     delete_state_db: bool = True,
+    _reservation_token: str | None = None,
 ) -> dict:
     """Retire one SID incarnation and verify every private artifact is absent.
 
@@ -1087,7 +1424,10 @@ def delete_session_artifacts(
             residuals.append(item)
 
     retired_generation = None
-    with _get_session_publication_lock(sid):
+    with _session_publication_authority(
+        sid,
+        reservation_token=_reservation_token,
+    ):
         retired_generation = _mark_session_deleted_for_publication(
             sid,
             expected_generation=expected_generation,
@@ -1153,10 +1493,10 @@ def delete_session_artifacts(
 
         for artifact, path in (("session_json", sidecar), ("session_backup", backup)):
             try:
-                path.unlink(missing_ok=True)
+                _durable_unlink(path)
             except Exception as exc:
                 residual(artifact, exc)
-            if path.exists():
+            if _path_entry_exists(path):
                 residual(artifact)
 
         # Session.save() normally removes its own failed staging files, but a
@@ -1167,7 +1507,8 @@ def delete_session_artifacts(
         try:
             for pattern in temporary_patterns:
                 for temp_path in SESSION_DIR.glob(pattern):
-                    temp_path.unlink(missing_ok=True)
+                    temp_path.unlink()
+            _fsync_directory(SESSION_DIR)
             if any(
                 any(SESSION_DIR.glob(pattern))
                 for pattern in temporary_patterns
@@ -1181,7 +1522,7 @@ def delete_session_artifacts(
 
             remove_session_media(sid)
             media_dir = _session_media_dir(sid)
-            if media_dir.exists():
+            if _path_entry_exists(media_dir):
                 residual("session_media")
         except Exception as exc:
             residual("session_media", exc)
@@ -1190,9 +1531,11 @@ def delete_session_artifacts(
             from api.upload import _session_attachment_dir
 
             attachment_dir = _session_attachment_dir(sid)
-            if attachment_dir.exists():
+            if _path_entry_exists(attachment_dir):
                 shutil.rmtree(attachment_dir)
-            if attachment_dir.exists():
+            if attachment_dir.parent.exists():
+                _fsync_directory(attachment_dir.parent)
+            if _path_entry_exists(attachment_dir):
                 residual("attachments")
         except Exception as exc:
             residual("attachments", exc)
@@ -1202,6 +1545,8 @@ def delete_session_artifacts(
 
             delete_turn_journal(sid, session_dir=SESSION_DIR)
             turn_root = SESSION_DIR / TURN_JOURNAL_DIR_NAME
+            if turn_root.exists():
+                _fsync_directory(turn_root)
             if list(turn_root.glob(f"{sid}~*.jsonl")) or (turn_root / f"{sid}.jsonl").exists():
                 residual("turn_journal")
         except Exception as exc:
@@ -1211,7 +1556,10 @@ def delete_session_artifacts(
             from api.run_journal import RUN_JOURNAL_DIR_NAME, delete_run_journal
 
             delete_run_journal(sid, session_dir=SESSION_DIR)
-            if (SESSION_DIR / RUN_JOURNAL_DIR_NAME / sid).exists():
+            run_root = SESSION_DIR / RUN_JOURNAL_DIR_NAME
+            if run_root.exists():
+                _fsync_directory(run_root)
+            if _path_entry_exists(run_root / sid):
                 residual("run_journal")
         except Exception as exc:
             residual("run_journal", exc)
@@ -1598,6 +1946,22 @@ def _load_session_from_path(path: Path) -> "Session | None":
         data = json.loads(path.read_text(encoding='utf-8'))
     except Exception:
         return None
+    if not isinstance(data, dict):
+        return None
+    embedded_sid = str(data.get("session_id") or "")
+    expected_sids = {path.stem}
+    # Legacy Hermes sidecars were named ``session_<sid>.json``. Keep that
+    # format readable, but never let an arbitrary outer filename redirect the
+    # loaded object to another session's cache/index/media namespace.
+    if path.stem.startswith("session_"):
+        expected_sids.add(path.stem[len("session_"):])
+    if embedded_sid not in expected_sids:
+        logger.warning(
+            "Rejecting session sidecar identity mismatch: path=%s embedded=%r",
+            path,
+            embedded_sid,
+        )
+        return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
     return Session(**data)
 
@@ -1833,17 +2197,31 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
-        with _get_session_publication_lock(self.session_id):
+    def save(
+        self,
+        touch_updated_at: bool = True,
+        skip_index: bool = False,
+        prune_media: bool = False,
+    ) -> None:
+        with _session_publication_authority(
+            self.session_id,
+            reservation_token=getattr(
+                self,
+                "_destination_reservation_token",
+                None,
+            ),
+        ):
             return self._save_under_publication_lock(
                 touch_updated_at=touch_updated_at,
                 skip_index=skip_index,
+                prune_media=prune_media,
             )
 
     def _save_under_publication_lock(
         self,
         touch_updated_at: bool = True,
         skip_index: bool = False,
+        prune_media: bool = False,
     ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
@@ -1995,6 +2373,7 @@ class Session:
                             bf.flush()
                             os.fsync(bf.fileno())
                         _safe_replace(bak_tmp, bak_path)
+                        _fsync_parent_directory(bak_path)
                     except OSError:
                         # Backup is best-effort; main save proceeds regardless.
                         try:
@@ -2030,6 +2409,7 @@ class Session:
                     f"Refusing to publish {rejection} {self.session_id!r}"
                 )
             _safe_replace(tmp, self.path)
+            _fsync_parent_directory(self.path)
         except Exception:
             try:
                 tmp.unlink(missing_ok=True)
@@ -2038,6 +2418,19 @@ class Session:
             raise
         if not skip_index:
             _write_session_index(updates=[self])
+        if prune_media:
+            from api.session_media import prune_session_media
+
+            retained_values = [self.messages, self.context_messages]
+            backup_path = self.path.with_suffix('.json.bak')
+            if _path_entry_exists(backup_path):
+                backup_payload = json.loads(backup_path.read_bytes())
+                if not isinstance(backup_payload, dict):
+                    raise ValueError("Invalid session backup while pruning media")
+                if backup_payload.get("session_id") != self.session_id:
+                    raise ValueError("Session backup identity mismatch while pruning media")
+                retained_values.append(backup_payload)
+            prune_session_media(self.session_id, retained_values)
 
         # #4985 belt-and-suspenders self-heal: a successful save with at
         # least one real message on the sidecar is unconditional proof the
@@ -2078,6 +2471,9 @@ class Session:
         # during the parse (TOCTOU guard against an atomic replace mid-read).
         _pre_read_sig = _sidecar_stat_signature(p)
         data = json.loads(p.read_text(encoding='utf-8'))
+        if not isinstance(data, dict) or data.get('session_id') != sid:
+            logger.warning("Rejecting session sidecar identity mismatch for %s", sid)
+            return None
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
         if _collapsed_partials:
@@ -2132,6 +2528,9 @@ class Session:
             if not prefix:
                 return cls.load(sid)
             parsed = json.loads(prefix)
+            if not isinstance(parsed, dict) or parsed.get('session_id') != sid:
+                logger.warning("Rejecting session sidecar identity mismatch for %s", sid)
+                return None
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
                 return cls.load(sid)

--- a/api/models.py
+++ b/api/models.py
@@ -197,11 +197,24 @@ _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
 # load-modify-write/unlink sequence in both helpers.
 _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK = threading.Lock()
 _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK = threading.Lock()
+_SESSION_CLEANUP_RESIDUAL_LOCK = threading.Lock()
 _SESSION_PUBLICATION_LOCKS_GUARD = threading.Lock()
 _SESSION_PUBLICATION_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
     weakref.WeakValueDictionary()
 )
 _SESSION_PUBLICATION_DELETED: set[str] = set()
+
+
+class _SessionPublicationGeneration:
+    """Weakly-owned lease for one live in-process SID incarnation."""
+
+    def __init__(self) -> None:
+        self.token = uuid.uuid4().hex
+
+
+_SESSION_PUBLICATION_GENERATIONS: weakref.WeakValueDictionary[
+    str, _SessionPublicationGeneration
+] = weakref.WeakValueDictionary()
 
 
 def _get_session_publication_lock(session_id: str) -> threading.RLock:
@@ -215,24 +228,73 @@ def _get_session_publication_lock(session_id: str) -> threading.RLock:
         return lock
 
 
-def _mark_session_deleted_for_publication(session_id: str) -> None:
-    with _SESSION_PUBLICATION_LOCKS_GUARD:
-        _SESSION_PUBLICATION_DELETED.add(str(session_id or ""))
-
-
-def _unmark_session_deleted_for_publication(session_id: str) -> None:
-    with _SESSION_PUBLICATION_LOCKS_GUARD:
-        _SESSION_PUBLICATION_DELETED.discard(str(session_id or ""))
-
-
-def _session_is_deleted_for_publication(session_id: str, path: Path) -> bool:
+def _session_publication_generation(session_id: str) -> _SessionPublicationGeneration:
+    """Return the process-local lease shared by one live SID incarnation."""
     sid = str(session_id or "")
     with _SESSION_PUBLICATION_LOCKS_GUARD:
+        generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
+        if generation is None:
+            generation = _SessionPublicationGeneration()
+            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
+        return generation
+
+
+def _activate_session_publication_generation(session) -> _SessionPublicationGeneration:
+    """Bind *session* to a fresh lease for an intentional SID recreation."""
+    sid = str(getattr(session, "session_id", "") or "")
+    with _get_session_publication_lock(sid):
+        pending_cleanup = _load_session_cleanup_residuals()
+        if sid in pending_cleanup:
+            raise RuntimeError(
+                f"Refusing to recreate session {sid!r} while cleanup residuals remain"
+            )
+        generation = _SessionPublicationGeneration()
+        with _SESSION_PUBLICATION_LOCKS_GUARD:
+            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
+            _SESSION_PUBLICATION_DELETED.discard(sid)
+        session._publication_generation = generation
+        return generation
+
+
+def _mark_session_deleted_for_publication(
+    session_id: str,
+    *,
+    expected_generation: _SessionPublicationGeneration | None = None,
+) -> _SessionPublicationGeneration:
+    sid = str(session_id or "")
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
+        if generation is None:
+            generation = _SessionPublicationGeneration()
+            _SESSION_PUBLICATION_GENERATIONS[sid] = generation
+        if expected_generation is not None and expected_generation != generation:
+            raise RuntimeError(f"Refusing to delete stale session generation {sid!r}")
+        _SESSION_PUBLICATION_DELETED.add(sid)
+        return generation
+
+
+def _session_publication_rejection_reason(
+    session_id: str,
+    path: Path,
+    generation: _SessionPublicationGeneration | None,
+) -> str | None:
+    sid = str(session_id or "")
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        current_generation = _SESSION_PUBLICATION_GENERATIONS.get(sid)
+        if (
+            generation is not None
+            and current_generation is not None
+            and generation != current_generation
+        ):
+            return "stale session generation"
         if sid in _SESSION_PUBLICATION_DELETED:
-            return True
+            return "deleted session"
     # A live sidecar beats a stale durable tombstone after restart. An absent
     # sidecar plus tombstone is authoritative and must reject a late save.
-    return not path.exists() and sid in _load_webui_deleted_session_tombstone()
+    if not path.exists() and sid in _load_webui_deleted_session_tombstone():
+        return "deleted session"
+    return None
+
 
 # Path-safety contract for session IDs.  Accept alphanumerics, underscore, and
 # hyphen so API/gateway-issued ids (``api-*``, ``reachy-voice-*``) round-trip
@@ -588,6 +650,7 @@ WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_CAP = 500
 WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_VERSION = 1
 WEBUI_DELETED_SESSION_TOMBSTONE_CAP = 1000
 WEBUI_DELETED_SESSION_TOMBSTONE_VERSION = 1
+SESSION_CLEANUP_RESIDUAL_VERSION = 2
 
 
 def _webui_zero_message_orphan_tombstone_file() -> "Path":
@@ -829,11 +892,6 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
-    # Explicit new-session/import paths call this before their first save.
-    # Retire the process-local deletion marker together with its durable peer
-    # so deliberately recreating the same identity remains supported. A stale
-    # worker cannot reach this helper because save rejects the marker first.
-    _unmark_session_deleted_for_publication(sid)
     with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
         current = set(_load_webui_deleted_session_tombstone())
         if sid not in current:
@@ -846,6 +904,319 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
             _webui_deleted_session_tombstone_file().unlink(missing_ok=True)
         except Exception:
             logger.debug("Failed to remove empty webui deleted-session tombstone", exc_info=True)
+
+
+def _session_cleanup_residual_file() -> Path:
+    return SESSION_DIR / "_session_cleanup_residuals.json"
+
+
+def _load_session_cleanup_residuals() -> dict[str, dict]:
+    path = _session_cleanup_residual_file()
+    if not path.exists():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or raw.get("version") != SESSION_CLEANUP_RESIDUAL_VERSION:
+        raise ValueError("Invalid session cleanup residual manifest")
+    entries = raw.get("sessions")
+    if not isinstance(entries, dict):
+        raise ValueError("Invalid session cleanup residual entries")
+    validated = {}
+    for raw_sid, record in entries.items():
+        sid = str(raw_sid or "")
+        if not is_safe_session_id(sid) or not isinstance(record, dict):
+            raise ValueError("Invalid session cleanup residual entry")
+        items = record.get("residuals")
+        delete_state_db = record.get("delete_state_db")
+        durable_tombstone = record.get("durable_tombstone")
+        if (
+            not isinstance(items, list)
+            or not isinstance(delete_state_db, bool)
+            or not isinstance(durable_tombstone, bool)
+        ):
+            raise ValueError("Invalid session cleanup residual policy")
+        if not all(
+            isinstance(item, dict) and isinstance(item.get("artifact"), str)
+            for item in items
+        ):
+            raise ValueError("Invalid session cleanup residual artifact")
+        validated[sid] = {
+            "residuals": list(items),
+            "delete_state_db": delete_state_db,
+            "durable_tombstone": durable_tombstone,
+        }
+    return validated
+
+
+def _persist_session_cleanup_residuals(
+    session_id: str,
+    residuals: list[dict],
+    *,
+    durable_tombstone: bool,
+    delete_state_db: bool,
+) -> None:
+    """Persist retryable artifact names until an idempotent cleanup succeeds."""
+    sid = str(session_id or "")
+    path = _session_cleanup_residual_file()
+    with _SESSION_CLEANUP_RESIDUAL_LOCK:
+        entries = _load_session_cleanup_residuals()
+        if residuals:
+            entries[sid] = {
+                "residuals": list(residuals),
+                "delete_state_db": bool(delete_state_db),
+                "durable_tombstone": bool(durable_tombstone),
+            }
+        else:
+            entries.pop(sid, None)
+        if not entries:
+            path.unlink(missing_ok=True)
+            return
+        SESSION_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(
+            f".tmp.{os.getpid()}.{threading.current_thread().ident}"
+        )
+        try:
+            with open(tmp, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {"version": SESSION_CLEANUP_RESIDUAL_VERSION, "sessions": entries},
+                    handle,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            _safe_replace(tmp, path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+
+
+def delete_session_artifacts(
+    session_id: str,
+    *,
+    expected_generation: _SessionPublicationGeneration | None = None,
+    durable_tombstone: bool = True,
+    delete_state_db: bool = True,
+) -> dict:
+    """Retire one SID incarnation and verify every private artifact is absent.
+
+    The publication lock covers the generation transition, durable tombstone,
+    filesystem cleanup, index mutation, and state.db cleanup. A same-SID
+    recreation cannot begin until this transaction releases the lock, and its
+    fresh generation prevents any old Session object from publishing later.
+    """
+    import shutil
+
+    sid = str(session_id or "")
+    if not is_safe_session_id(sid):
+        raise ValueError("Invalid session_id")
+    residuals: list[dict] = []
+
+    def residual(artifact: str, exc: BaseException | None = None) -> None:
+        item = {"artifact": artifact}
+        if exc is not None:
+            item["error"] = type(exc).__name__
+        if item not in residuals:
+            residuals.append(item)
+
+    retired_generation = None
+    with _get_session_publication_lock(sid):
+        retired_generation = _mark_session_deleted_for_publication(
+            sid,
+            expected_generation=expected_generation,
+        )
+        sidecar = SESSION_DIR / f"{sid}.json"
+        backup = sidecar.with_suffix(".json.bak")
+
+        if durable_tombstone:
+            try:
+                _record_webui_deleted_session_tombstone(sid)
+                if sid not in _load_webui_deleted_session_tombstone():
+                    residual("deleted_session_tombstone")
+            except Exception as exc:
+                residual("deleted_session_tombstone", exc)
+            # Do not remove the authoritative sidecar unless crash recovery is
+            # already guaranteed to remember this destructive intent.
+            if residuals:
+                try:
+                    _persist_session_cleanup_residuals(
+                        sid,
+                        residuals,
+                        durable_tombstone=durable_tombstone,
+                        delete_state_db=delete_state_db,
+                    )
+                except Exception as exc:
+                    residual("cleanup_residual_manifest", exc)
+                return {
+                    "ok": False,
+                    "session_id": sid,
+                    "residuals": residuals,
+                    "generation": retired_generation.token,
+                }
+
+        try:
+            from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK
+
+            with ACTIVE_RUNS_LOCK:
+                active_run = any(
+                    str((entry or {}).get("session_id") or "") == sid
+                    for entry in ACTIVE_RUNS.values()
+                )
+        except Exception as exc:
+            residual("active_run_registry", exc)
+            active_run = True
+        if active_run:
+            residual("active_run")
+        if residuals:
+            try:
+                _persist_session_cleanup_residuals(
+                    sid,
+                    residuals,
+                    durable_tombstone=durable_tombstone,
+                    delete_state_db=delete_state_db,
+                )
+            except Exception as exc:
+                residual("cleanup_residual_manifest", exc)
+            return {
+                "ok": False,
+                "session_id": sid,
+                "residuals": residuals,
+                "generation": retired_generation.token,
+            }
+
+        for artifact, path in (("session_json", sidecar), ("session_backup", backup)):
+            try:
+                path.unlink(missing_ok=True)
+            except Exception as exc:
+                residual(artifact, exc)
+            if path.exists():
+                residual(artifact)
+
+        # Session.save() normally removes its own failed staging files, but a
+        # process crash can leave transcript-bearing JSON/backup temporaries.
+        # They are SID-scoped, so cleanup can remove and verify them without
+        # touching another session's in-flight publication.
+        temporary_patterns = (f"{sid}.tmp.*", f"{sid}.json.bak.tmp.*")
+        try:
+            for pattern in temporary_patterns:
+                for temp_path in SESSION_DIR.glob(pattern):
+                    temp_path.unlink(missing_ok=True)
+            if any(
+                any(SESSION_DIR.glob(pattern))
+                for pattern in temporary_patterns
+            ):
+                residual("session_temporary_files")
+        except Exception as exc:
+            residual("session_temporary_files", exc)
+
+        try:
+            from api.session_media import remove_session_media, _session_media_dir
+
+            remove_session_media(sid)
+            media_dir = _session_media_dir(sid)
+            if media_dir.exists():
+                residual("session_media")
+        except Exception as exc:
+            residual("session_media", exc)
+
+        try:
+            from api.upload import _session_attachment_dir
+
+            attachment_dir = _session_attachment_dir(sid)
+            if attachment_dir.exists():
+                shutil.rmtree(attachment_dir)
+            if attachment_dir.exists():
+                residual("attachments")
+        except Exception as exc:
+            residual("attachments", exc)
+
+        try:
+            from api.turn_journal import TURN_JOURNAL_DIR_NAME, delete_turn_journal
+
+            delete_turn_journal(sid, session_dir=SESSION_DIR)
+            turn_root = SESSION_DIR / TURN_JOURNAL_DIR_NAME
+            if list(turn_root.glob(f"{sid}~*.jsonl")) or (turn_root / f"{sid}.jsonl").exists():
+                residual("turn_journal")
+        except Exception as exc:
+            residual("turn_journal", exc)
+
+        try:
+            from api.run_journal import RUN_JOURNAL_DIR_NAME, delete_run_journal
+
+            delete_run_journal(sid, session_dir=SESSION_DIR)
+            if (SESSION_DIR / RUN_JOURNAL_DIR_NAME / sid).exists():
+                residual("run_journal")
+        except Exception as exc:
+            residual("run_journal", exc)
+
+        try:
+            prune_session_from_index(sid)
+            if SESSION_INDEX_FILE.exists():
+                rows = json.loads(SESSION_INDEX_FILE.read_text(encoding="utf-8"))
+                if not isinstance(rows, list) or any(
+                    isinstance(row, dict) and row.get("session_id") == sid
+                    for row in rows
+                ):
+                    residual("session_index")
+        except Exception as exc:
+            residual("session_index", exc)
+
+        if delete_state_db:
+            try:
+                if not delete_cli_session(sid):
+                    residual("state_db")
+            except Exception as exc:
+                residual("state_db", exc)
+
+        try:
+            from api.config import (
+                SESSION_AGENT_LOCKS,
+                SESSION_AGENT_LOCKS_LOCK,
+                _evict_session_agent,
+            )
+
+            _evict_session_agent(sid)
+            with SESSION_AGENT_LOCKS_LOCK:
+                SESSION_AGENT_LOCKS.pop(sid, None)
+        except Exception as exc:
+            residual("agent_runtime_cache", exc)
+
+        try:
+            from api.background_process import forget_bg_task_completion_dedup
+
+            forget_bg_task_completion_dedup(sid)
+        except Exception as exc:
+            residual("background_completion_registry", exc)
+
+        try:
+            from api.terminal import close_terminal
+
+            close_terminal(sid)
+        except Exception as exc:
+            residual("terminal", exc)
+
+        try:
+            _persist_session_cleanup_residuals(
+                sid,
+                residuals,
+                durable_tombstone=durable_tombstone,
+                delete_state_db=delete_state_db,
+            )
+        except Exception as exc:
+            residual("cleanup_residual_manifest", exc)
+
+    # Do not pop a same-SID replacement that activated immediately after the
+    # publication lock was released. Cache eviction is generation-conditional.
+    with LOCK:
+        cached = SESSIONS.get(sid)
+        if cached is not None and getattr(cached, "_publication_generation", None) == retired_generation:
+            SESSIONS.pop(sid, None)
+
+    return {
+        "ok": not residuals,
+        "session_id": sid,
+        "residuals": residuals,
+        "generation": retired_generation.token,
+    }
 
 
 def _content_has_reasoning_only_parts(content) -> bool:
@@ -1278,6 +1649,10 @@ class Session:
                  share_created_at=None,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
+        # Process-local incarnation lease. Every load of the current SID shares
+        # this token; an intentional same-SID recreation rotates it so old
+        # in-process Session objects can never regain publication authority.
+        self._publication_generation = _session_publication_generation(self.session_id)
         self.title = title
         self.workspace = str(Path(workspace).expanduser().resolve())
         self.model = model
@@ -1399,9 +1774,14 @@ class Session:
     ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
-        if _session_is_deleted_for_publication(self.session_id, self.path):
+        rejection = _session_publication_rejection_reason(
+            self.session_id,
+            self.path,
+            getattr(self, "_publication_generation", None),
+        )
+        if rejection:
             raise RuntimeError(
-                f"Refusing to publish deleted session {self.session_id!r}"
+                f"Refusing to publish {rejection} {self.session_id!r}"
             )
         # ── #1558 P0 guard ──────────────────────────────────────────────
         # Refuse to save a session that was loaded with metadata_only=True.
@@ -1567,9 +1947,14 @@ class Session:
             # Delete and save share the publication lock, but keep the
             # authoritative deletion check directly adjacent to replace so a
             # future refactor cannot reintroduce a check-then-publish gap.
-            if _session_is_deleted_for_publication(self.session_id, self.path):
+            rejection = _session_publication_rejection_reason(
+                self.session_id,
+                self.path,
+                getattr(self, "_publication_generation", None),
+            )
+            if rejection:
                 raise RuntimeError(
-                    f"Refusing to publish deleted session {self.session_id!r}"
+                    f"Refusing to publish {rejection} {self.session_id!r}"
                 )
             _safe_replace(tmp, self.path)
         except Exception:
@@ -4787,6 +5172,7 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None, p
         worktree_created_at=wt.get('created_at') if wt else None,
         enabled_toolsets=enabled_toolsets,
     )
+    _activate_session_publication_generation(s)
     # #4985: defensive — auto-generated uuids don't collide with the
     # tombstone, but if a future caller ever passes an explicit id that
     # was previously pruned, clear the entry so the new session isn't
@@ -6317,6 +6703,7 @@ def import_cli_session(
         updated_at=updated_at,
         parent_session_id=parent_session_id,
     )
+    _activate_session_publication_generation(s)
     # #4985: import_cli_session uses an explicit sid (the CLI sidecar's id).
     # If that sid was previously tombstoned as a webui zero-message orphan,
     # clear the tombstone entry so the freshly-imported session is visible
@@ -9223,7 +9610,8 @@ def _delete_cli_session_locked(sid, hermes_home) -> bool:
 
     db_path = hermes_home / 'state.db'
     if not db_path.exists():
-        return False
+        # Idempotent deletion: an absent database cannot retain this session.
+        return stale_cleanup_complete
 
     try:
         with closing(sqlite3.connect(str(db_path))) as conn:

--- a/api/models.py
+++ b/api/models.py
@@ -612,6 +612,30 @@ def _validate_session_payload_identity(
     return data
 
 
+def _read_portable_session_payload_bytes(
+    payload_bytes: bytes,
+    expected_session_id: str,
+    *,
+    source_name: str,
+    context: str,
+) -> dict:
+    """Parse one exact sidecar buffer and reject non-portable media refs.
+
+    Backups and recovery are alternate publication authorities.  They must
+    validate the same bytes they retain or restore, never an equivalent value
+    reconstructed through a text-mode read/write path.
+    """
+    payload = _validate_session_payload_identity(
+        json.loads(payload_bytes),
+        expected_session_id,
+        source_name=source_name,
+    )
+    from api.session_media import assert_no_session_media_references
+
+    assert_no_session_media_references(payload, context=context)
+    return payload
+
+
 _SESSION_DESTINATION_RESERVATIONS = threading.local()
 
 
@@ -2899,17 +2923,16 @@ class Session:
         # their .bak get restored automatically.
         try:
             if self.path.exists():
-                existing_text = self.path.read_text(encoding='utf-8')
+                existing_bytes = self.path.read_bytes()
                 try:
-                    existing = json.loads(existing_text)
-                    if not isinstance(existing, dict) or existing.get("session_id") != self.session_id:
-                        raise RuntimeError("Existing session sidecar identity mismatch")
                     # A backup remains a recovery publication candidate. It
                     # must be portable too: compact refs require an explicit
                     # offline migration rather than silently retaining bytes
                     # whose namespace cannot be retired safely.
-                    assert_no_session_media_references(
-                        existing,
+                    existing = _read_portable_session_payload_bytes(
+                        existing_bytes,
+                        self.session_id,
+                        source_name=self.path.name,
                         context="session backup; use an explicit offline media migration",
                     )
                     existing_msg_count = len(existing.get('messages') or [])
@@ -2932,30 +2955,15 @@ class Session:
                     return
                 if existing_msg_count > incoming_msg_count:
                     bak_path = self.path.with_suffix('.json.bak')
-                    # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,
-                    # mirroring the main save() pattern below. Prevents a
-                    # torn .bak from a crash mid-write or a concurrent
-                    # backup-producing save. Recovery defends against a
-                    # torn .bak (JSONDecodeError → no_action), so the
-                    # failure mode pre-fix was "backup is lost"; with
-                    # this fix the backup either lands cleanly or doesn't
-                    # land at all.
+                    # Retain exactly the byte buffer that was parsed and
+                    # validated above. Text mode would normalize CRLF/lone-CR
+                    # whitespace and turn the recovery authority into a
+                    # different payload.
                     try:
-                        bak_tmp = bak_path.with_suffix(
-                            f'.bak.tmp.{uuid.uuid4().hex}'
-                        )
-                        with open(bak_tmp, 'w', encoding='utf-8') as bf:
-                            bf.write(existing_text)
-                            bf.flush()
-                            os.fsync(bf.fileno())
-                        _safe_replace(bak_tmp, bak_path)
-                        _fsync_parent_directory(bak_path)
+                        _durable_replace_bytes(bak_path, existing_bytes)
                     except OSError:
                         # Backup is best-effort; main save proceeds regardless.
-                        try:
-                            bak_tmp.unlink(missing_ok=True)
-                        except Exception:
-                            pass
+                        pass
         except OSError:
             pass
 

--- a/api/models.py
+++ b/api/models.py
@@ -243,8 +243,7 @@ def _activate_session_publication_generation(session) -> _SessionPublicationGene
     """Bind *session* to a fresh lease for an intentional SID recreation."""
     sid = str(getattr(session, "session_id", "") or "")
     with _get_session_publication_lock(sid):
-        pending_cleanup = _load_session_cleanup_residuals()
-        if sid in pending_cleanup:
+        if _session_has_cleanup_residual(sid):
             raise RuntimeError(
                 f"Refusing to recreate session {sid!r} while cleanup residuals remain"
             )
@@ -906,28 +905,58 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
             logger.debug("Failed to remove empty webui deleted-session tombstone", exc_info=True)
 
 
-def _session_cleanup_residual_file() -> Path:
-    return SESSION_DIR / "_session_cleanup_residuals.json"
+def _session_cleanup_residual_dir() -> Path:
+    return SESSION_DIR / "_session_cleanup_residuals"
+
+
+def _session_cleanup_residual_file(session_id: str) -> Path:
+    sid = str(session_id or "")
+    if not is_safe_session_id(sid):
+        raise ValueError("Invalid session_id")
+    return _session_cleanup_residual_dir() / f"{sid}.json"
+
+
+def _session_has_cleanup_residual(session_id: str) -> bool:
+    """Return whether one SID has a retry marker, failing closed per SID.
+
+    Residual authority is deliberately sharded by session ID. A corrupt or
+    future-version record therefore blocks recreation of its owning SID but
+    cannot make every unrelated new-session path unavailable.
+    """
+    path = _session_cleanup_residual_file(session_id)
+    try:
+        os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not inspect cleanup residuals for session {session_id!r}"
+        ) from exc
+    return True
 
 
 def _load_session_cleanup_residuals() -> dict[str, dict]:
-    path = _session_cleanup_residual_file()
-    if not path.exists():
+    root = _session_cleanup_residual_dir()
+    try:
+        paths = list(root.glob("*.json"))
+    except OSError:
+        raise
+    if not paths:
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(raw, dict) or raw.get("version") != SESSION_CLEANUP_RESIDUAL_VERSION:
-        raise ValueError("Invalid session cleanup residual manifest")
-    entries = raw.get("sessions")
-    if not isinstance(entries, dict):
-        raise ValueError("Invalid session cleanup residual entries")
     validated = {}
-    for raw_sid, record in entries.items():
-        sid = str(raw_sid or "")
-        if not is_safe_session_id(sid) or not isinstance(record, dict):
+    for path in paths:
+        sid = path.stem
+        raw = json.loads(path.read_bytes())
+        if (
+            not is_safe_session_id(sid)
+            or not isinstance(raw, dict)
+            or raw.get("version") != SESSION_CLEANUP_RESIDUAL_VERSION
+            or raw.get("session_id") != sid
+        ):
             raise ValueError("Invalid session cleanup residual entry")
-        items = record.get("residuals")
-        delete_state_db = record.get("delete_state_db")
-        durable_tombstone = record.get("durable_tombstone")
+        items = raw.get("residuals")
+        delete_state_db = raw.get("delete_state_db")
+        durable_tombstone = raw.get("durable_tombstone")
         if (
             not isinstance(items, list)
             or not isinstance(delete_state_db, bool)
@@ -956,28 +985,26 @@ def _persist_session_cleanup_residuals(
 ) -> None:
     """Persist retryable artifact names until an idempotent cleanup succeeds."""
     sid = str(session_id or "")
-    path = _session_cleanup_residual_file()
+    path = _session_cleanup_residual_file(sid)
     with _SESSION_CLEANUP_RESIDUAL_LOCK:
-        entries = _load_session_cleanup_residuals()
-        if residuals:
-            entries[sid] = {
-                "residuals": list(residuals),
-                "delete_state_db": bool(delete_state_db),
-                "durable_tombstone": bool(durable_tombstone),
-            }
-        else:
-            entries.pop(sid, None)
-        if not entries:
+        if not residuals:
             path.unlink(missing_ok=True)
             return
-        SESSION_DIR.mkdir(parents=True, exist_ok=True)
+        root = _session_cleanup_residual_dir()
+        root.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(
             f".tmp.{os.getpid()}.{threading.current_thread().ident}"
         )
         try:
             with open(tmp, "w", encoding="utf-8") as handle:
                 json.dump(
-                    {"version": SESSION_CLEANUP_RESIDUAL_VERSION, "sessions": entries},
+                    {
+                        "version": SESSION_CLEANUP_RESIDUAL_VERSION,
+                        "session_id": sid,
+                        "residuals": list(residuals),
+                        "delete_state_db": bool(delete_state_db),
+                        "durable_tombstone": bool(durable_tombstone),
+                    },
                     handle,
                     ensure_ascii=False,
                     indent=2,

--- a/api/models.py
+++ b/api/models.py
@@ -473,6 +473,13 @@ def _session_publication_rejection_reason(
             return "session identity mismatch"
         if persisted_token and persisted_token != generation_token:
             return "stale session generation"
+        if not persisted_token:
+            # Legacy sidecars predate persisted incarnation tokens. They may
+            # be published only by an object returned through a validated load
+            # path, which registers its otherwise process-local generation.
+            # A bare constructor after restart has no such authority.
+            if current_generation is None or generation != current_generation:
+                return "unvalidated session generation"
     else:
         try:
             claim_token = _read_session_incarnation_claim(sid)
@@ -771,8 +778,23 @@ def _session_destination_owners(session_id: str) -> list[str]:
         owners.append("run_journal")
 
     if _path_entry_exists(SESSION_INDEX_FILE):
-        with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
-            rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+        try:
+            with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
+                rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+        except (OSError, ValueError, json.JSONDecodeError):
+            # The index is an acceleration structure, not the authority for
+            # ownership. Rebuild it from validated sidecars before deciding a
+            # new destination is free; treating a corrupt index as empty
+            # would fail open, while permanently rejecting every new SID
+            # would turn a recoverable cache failure into an outage.
+            try:
+                _write_session_index()
+                with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
+                    rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                raise RuntimeError(
+                    "Cannot rebuild the session index while reserving a destination"
+                ) from exc
         if not isinstance(rows, list):
             raise RuntimeError("Cannot reserve a SID while the session index is invalid")
         if any(isinstance(row, dict) and row.get("session_id") == sid for row in rows):
@@ -2400,7 +2422,13 @@ def _load_session_from_path(path: Path) -> "Session | None":
         logger.warning("Rejecting invalid or identity-mismatched session sidecar: %s", path)
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
-    return Session(**data)
+    session = Session(**data)
+    if not data.get("publication_incarnation"):
+        # A legacy payload has no durable token. Register only after its path
+        # and embedded SID have been validated above, never from a constructor
+        # that merely names the same SID.
+        _register_published_session_generation(session)
+    return session
 
 
 def _lookup_index_message_count(session_id):
@@ -3006,6 +3034,12 @@ class Session:
             return None
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
+        if not data.get("publication_incarnation"):
+            # Legacy sidecars have no durable incarnation token.  A complete,
+            # identity-validated load is the only safe way to establish their
+            # in-process authority; a bare ``Session(session_id=sid)`` must
+            # remain unable to adopt the same sidecar.
+            _register_published_session_generation(session)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching

--- a/api/models.py
+++ b/api/models.py
@@ -12,6 +12,7 @@ import re
 import threading
 import time
 import uuid
+import weakref
 from contextlib import closing, contextmanager
 from pathlib import Path
 
@@ -196,6 +197,42 @@ _SESSION_INDEX_REBUILD_THREAD_TARGET: tuple[Path, Path] | None = None
 # load-modify-write/unlink sequence in both helpers.
 _WEBUI_ZERO_MESSAGE_ORPHAN_TOMBSTONE_LOCK = threading.Lock()
 _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK = threading.Lock()
+_SESSION_PUBLICATION_LOCKS_GUARD = threading.Lock()
+_SESSION_PUBLICATION_LOCKS: weakref.WeakValueDictionary[str, threading.RLock] = (
+    weakref.WeakValueDictionary()
+)
+_SESSION_PUBLICATION_DELETED: set[str] = set()
+
+
+def _get_session_publication_lock(session_id: str) -> threading.RLock:
+    """Return the lock shared by JSON save and destructive session cleanup."""
+    sid = str(session_id or "")
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        lock = _SESSION_PUBLICATION_LOCKS.get(sid)
+        if lock is None:
+            lock = threading.RLock()
+            _SESSION_PUBLICATION_LOCKS[sid] = lock
+        return lock
+
+
+def _mark_session_deleted_for_publication(session_id: str) -> None:
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        _SESSION_PUBLICATION_DELETED.add(str(session_id or ""))
+
+
+def _unmark_session_deleted_for_publication(session_id: str) -> None:
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        _SESSION_PUBLICATION_DELETED.discard(str(session_id or ""))
+
+
+def _session_is_deleted_for_publication(session_id: str, path: Path) -> bool:
+    sid = str(session_id or "")
+    with _SESSION_PUBLICATION_LOCKS_GUARD:
+        if sid in _SESSION_PUBLICATION_DELETED:
+            return True
+    # A live sidecar beats a stale durable tombstone after restart. An absent
+    # sidecar plus tombstone is authoritative and must reject a late save.
+    return not path.exists() and sid in _load_webui_deleted_session_tombstone()
 
 # Path-safety contract for session IDs.  Accept alphanumerics, underscore, and
 # hyphen so API/gateway-issued ids (``api-*``, ``reachy-voice-*``) round-trip
@@ -792,6 +829,11 @@ def _clear_webui_deleted_session_tombstone(sid: str) -> None:
     sid = str(sid or "").strip()
     if not sid:
         return
+    # Explicit new-session/import paths call this before their first save.
+    # Retire the process-local deletion marker together with its durable peer
+    # so deliberately recreating the same identity remains supported. A stale
+    # worker cannot reach this helper because save rejects the marker first.
+    _unmark_session_deleted_for_publication(sid)
     with _WEBUI_DELETED_SESSION_TOMBSTONE_LOCK:
         current = set(_load_webui_deleted_session_tombstone())
         if sid not in current:
@@ -1344,8 +1386,23 @@ class Session:
         return SESSION_DIR / f'{self.session_id}.json'
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        with _get_session_publication_lock(self.session_id):
+            return self._save_under_publication_lock(
+                touch_updated_at=touch_updated_at,
+                skip_index=skip_index,
+            )
+
+    def _save_under_publication_lock(
+        self,
+        touch_updated_at: bool = True,
+        skip_index: bool = False,
+    ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
+        if _session_is_deleted_for_publication(self.session_id, self.path):
+            raise RuntimeError(
+                f"Refusing to publish deleted session {self.session_id!r}"
+            )
         # ── #1558 P0 guard ──────────────────────────────────────────────
         # Refuse to save a session that was loaded with metadata_only=True.
         # Such sessions have messages=[] (it's the whole point of the partial
@@ -1369,13 +1426,13 @@ class Session:
         # context_messages, so every session read and JSON response repeats its
         # base64 work. Persist a private reference and hydrate only when a later
         # model call needs the original data URL.
-        try:
-            from api.session_media import externalize_large_session_media
+        from api.session_media import (
+            externalize_large_session_media,
+            verify_session_media_references,
+        )
 
-            externalize_large_session_media(self.messages, self.session_id)
-            externalize_large_session_media(self.context_messages, self.session_id)
-        except Exception:
-            logger.warning("Could not externalize session media for %s", self.session_id, exc_info=True)
+        externalize_large_session_media(self.messages, self.session_id)
+        externalize_large_session_media(self.context_messages, self.session_id)
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -1500,6 +1557,20 @@ class Session:
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())
+            # Verify the exact retained media authority at the publication
+            # boundary. A missing or corrupt blob must leave the previous JSON
+            # untouched even when serialization and backup work took time.
+            verify_session_media_references(
+                [self.messages, self.context_messages],
+                self.session_id,
+            )
+            # Delete and save share the publication lock, but keep the
+            # authoritative deletion check directly adjacent to replace so a
+            # future refactor cannot reintroduce a check-then-publish gap.
+            if _session_is_deleted_for_publication(self.session_id, self.path):
+                raise RuntimeError(
+                    f"Refusing to publish deleted session {self.session_id!r}"
+                )
             _safe_replace(tmp, self.path)
         except Exception:
             try:

--- a/api/models.py
+++ b/api/models.py
@@ -255,6 +255,24 @@ def _durable_unlink(path: Path, *, missing_ok: bool = True) -> None:
     _fsync_directory(parent)
 
 
+def _durable_replace_bytes(path: Path, payload: bytes) -> None:
+    """Atomically replace one file and durably commit the exact byte payload."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _fsync_parent_directory(path.parent)
+    tmp = path.with_name(f".{path.name}.tmp.{uuid.uuid4().hex}")
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _safe_replace(tmp, path)
+        _fsync_parent_directory(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
@@ -460,12 +478,26 @@ def _load_and_validate_session_payload(
     expected_session_id: str,
 ) -> dict:
     """Load one sidecar/backup without allowing its outer SID to redirect ownership."""
+    data = json.loads(path.read_bytes())
+    return _validate_session_payload_identity(
+        data,
+        expected_session_id,
+        source_name=path.name,
+    )
+
+
+def _validate_session_payload_identity(
+    data,
+    expected_session_id: str,
+    *,
+    source_name: str = "session payload",
+) -> dict:
+    """Bind one already-read payload to its authoritative outer SID."""
     sid = str(expected_session_id or "")
     if not is_safe_session_id(sid):
         raise ValueError("Invalid expected session_id")
-    data = json.loads(path.read_bytes())
     if not isinstance(data, dict):
-        raise ValueError(f"Invalid session payload: {path.name}")
+        raise ValueError(f"Invalid session payload: {source_name}")
     if data.get("session_id") != sid:
         raise ValueError(
             f"Session payload identity mismatch: expected {sid!r}, "
@@ -854,7 +886,12 @@ def reserve_session_destination(session_id: str) -> _SessionDestinationReservati
     return _SessionDestinationReservation(session_id)
 
 
-def rollback_reserved_session_destination(session_id: str, token: str) -> dict:
+def rollback_reserved_session_destination(
+    session_id: str,
+    token: str,
+    *,
+    durable_intent_path: Path | None = None,
+) -> dict:
     """Crash-recovery rollback that may remove only one proven incarnation."""
     sid = str(session_id or "")
     with _session_publication_authority(sid):
@@ -865,7 +902,21 @@ def rollback_reserved_session_destination(session_id: str, token: str) -> dict:
             persisted_token = payload.get("publication_incarnation")
         claim_token = _read_session_incarnation_claim(sid)
         observed = persisted_token or claim_token
-        if observed != token:
+        intent_authorizes_missing_incarnation = False
+        if observed is None and durable_intent_path is not None:
+            expected_intent = SESSION_DIR / "_compression_transactions" / f"{sid}.json"
+            if Path(durable_intent_path).absolute() != expected_intent.absolute():
+                raise RuntimeError("Compression rollback intent path mismatch")
+            raw_intent = json.loads(durable_intent_path.read_bytes())
+            intent_authorizes_missing_incarnation = (
+                isinstance(raw_intent, dict)
+                and raw_intent.get("version") == 2
+                and raw_intent.get("new_session_id") == sid
+                and raw_intent.get("incarnation_token") == token
+                and raw_intent.get("phase")
+                in {"reserved", "source_archived", "sidecar_published"}
+            )
+        if observed != token and not intent_authorizes_missing_incarnation:
             raise RuntimeError(
                 f"Refusing to roll back unproven session incarnation {sid!r}"
             )

--- a/api/routes.py
+++ b/api/routes.py
@@ -9430,7 +9430,7 @@ from api.models import (
     _record_webui_zero_message_orphan_tombstone,
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
-    _load_session_cleanup_residuals,
+    _scan_session_cleanup_residuals,
     _activate_session_publication_generation,
     _clear_webui_deleted_session_tombstone,
     delete_session_artifacts,
@@ -20652,10 +20652,12 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
     phase1_removed_ids = set()
     cleanup_residuals = []
 
-    # Retry any previously incomplete destructive operation first. The durable
-    # manifest is keyed by SID and every cleanup step is idempotent.
+    # Retry any previously incomplete destructive operation first. Durable
+    # records are keyed by SID and every cleanup step is idempotent.
     try:
-        pending_cleanup = _load_session_cleanup_residuals()
+        pending_cleanup, invalid_cleanup_records = (
+            _scan_session_cleanup_residuals()
+        )
     except Exception as exc:
         logger.warning("Could not read session cleanup residual manifest", exc_info=True)
         return j(
@@ -20666,6 +20668,13 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
             },
             status=500,
         )
+    cleanup_residuals.extend(invalid_cleanup_records)
+    reserved_cleanup_ids = set(pending_cleanup)
+    reserved_cleanup_ids.update(
+        item["session_id"]
+        for item in invalid_cleanup_records
+        if item.get("session_id")
+    )
     for sid, policy in pending_cleanup.items():
         result = delete_session_artifacts(
             sid,
@@ -20685,7 +20694,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
         # A residual entry already owns this SID's retry lifecycle. Avoid a
         # second delete attempt in the same request (and duplicate residual
         # rows) when the retry above deliberately left its sidecar in place.
-        if p.stem in pending_cleanup:
+        if p.stem in reserved_cleanup_ids:
             continue
         try:
             s = Session.load(p.stem)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9432,6 +9432,8 @@ from api.models import (
     _load_webui_deleted_session_tombstone,
     _scan_session_cleanup_residuals,
     _activate_session_publication_generation,
+    reserve_session_destination,
+    _durable_unlink,
     _clear_webui_deleted_session_tombstone,
     delete_session_artifacts,
     ensure_cron_project,
@@ -14444,49 +14446,36 @@ def handle_post(handler, parsed) -> bool:
                 updated_at=time.time(),
             )
 
+            media_cloned = False
             try:
                 from api.session_media import clone_session_media_references
 
-                clone_session_media_references(
-                    [copied_session.messages, copied_session.context_messages],
-                    session.session_id,
-                    copied_session.session_id,
-                )
-            except (OSError, ValueError):
-                delete_session_artifacts(
-                    copied_session.session_id,
-                    expected_generation=getattr(copied_session, "_publication_generation", None),
-                    durable_tombstone=False,
-                    delete_state_db=False,
-                )
-                logger.warning(
-                    "Could not clone session media from %s to %s",
-                    session.session_id,
-                    copied_session.session_id,
-                    exc_info=True,
-                )
-                return bad(handler, "Could not copy session media", 500)
-
-            try:
-                # Persist JSON + index before exposing the destination in the
-                # cache. Any failure after media clone retires the whole new-ID
-                # transaction, including JSON, index residue, and private media.
-                copied_session.save()
-                with LOCK:
-                    SESSIONS[copied_session.session_id] = copied_session
-                    SESSIONS.move_to_end(copied_session.session_id)
-                    _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+                with reserve_session_destination(copied_session.session_id) as reservation:
+                    reservation.bind(copied_session)
+                    clone_session_media_references(
+                        [copied_session.messages, copied_session.context_messages],
+                        session.session_id,
+                        copied_session.session_id,
+                    )
+                    media_cloned = True
+                    copied_session.save()
+                    with LOCK:
+                        SESSIONS[copied_session.session_id] = copied_session
+                        SESSIONS.move_to_end(copied_session.session_id)
+                        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+                    reservation.commit()
             except Exception:
-                cleanup = delete_session_artifacts(
-                    copied_session.session_id,
-                    expected_generation=getattr(copied_session, "_publication_generation", None),
-                    durable_tombstone=False,
-                    delete_state_db=False,
-                )
+                if not media_cloned:
+                    logger.warning(
+                        "Could not clone session media from %s to %s",
+                        session.session_id,
+                        copied_session.session_id,
+                        exc_info=True,
+                    )
+                    return bad(handler, "Could not copy session media", 500)
                 logger.warning(
-                    "Could not publish duplicated session %s; rollback residuals=%s",
+                    "Could not publish duplicated session %s",
                     copied_session.session_id,
-                    cleanup["residuals"],
                     exc_info=True,
                 )
                 return bad(handler, "Could not publish duplicated session", 500)
@@ -14987,6 +14976,7 @@ def handle_post(handler, parsed) -> bool:
         sid = body["session_id"]
         with _get_session_agent_lock(sid):
             had_sidecar_messages = bool(s.messages or [])
+            prior_clear_generation = getattr(s, "clear_generation", None)
             # Clear is a full truncate-to-empty: route through the SAME helper the
             # /api/session/truncate handler uses (single source of truth) so the
             # display + context arrays are emptied AND the truncation watermark is
@@ -15028,14 +15018,25 @@ def handle_post(handler, parsed) -> bool:
             s.pending_attachments = []
             s.pending_started_at = None
             s.pending_user_source = None
-            s.clear_generation = uuid.uuid4().hex if had_sidecar_messages else None
+            s.clear_generation = (
+                uuid.uuid4().hex
+                if had_sidecar_messages
+                else prior_clear_generation
+            )
+            destructive_clear = had_sidecar_messages or bool(prior_clear_generation)
             # Reset the title via the rename helper so clearing a manually-named
             # session also clears manual_title/llm_title_generated — otherwise the
             # reused session keeps its manual-title protection and never auto-names
             # again (#3542 lifecycle gap).
             from api.session_ops import apply_session_title_rename
             apply_session_title_rename(s, "Untitled")
-            s.save()
+            clear_residuals = []
+            try:
+                s.save()
+            except Exception as exc:
+                clear_residuals.append(
+                    {"artifact": "session_json", "error": type(exc).__name__}
+                )
             persisted_clear = False
             try:
                 persisted = json.loads(s.path.read_text(encoding="utf-8"))
@@ -15053,11 +15054,33 @@ def handle_post(handler, parsed) -> bool:
                 )
             except (OSError, json.JSONDecodeError, ValueError):
                 logger.warning("session clear could not verify persisted empty state for %s", sid, exc_info=True)
-            if had_sidecar_messages and persisted_clear:
+            if not persisted_clear:
+                clear_residuals.append({"artifact": "session_json_verification"})
+            if persisted_clear and destructive_clear:
                 try:
-                    s.path.with_suffix('.json.bak').unlink(missing_ok=True)
-                except OSError:
+                    # The backup can retain references to the removed history;
+                    # commit its absence before deleting the media namespace.
+                    _durable_unlink(s.path.with_suffix('.json.bak'))
+                except Exception as exc:
+                    clear_residuals.append(
+                        {"artifact": "session_backup", "error": type(exc).__name__}
+                    )
                     logger.warning("session clear could not remove stale backup for %s", sid, exc_info=True)
+                if not clear_residuals:
+                    try:
+                        from api.session_media import remove_session_media
+
+                        remove_session_media(sid)
+                    except Exception as exc:
+                        clear_residuals.append(
+                            {"artifact": "session_media", "error": type(exc).__name__}
+                        )
+            if clear_residuals:
+                return j(
+                    handler,
+                    {"error": "Session clear incomplete", "residuals": clear_residuals},
+                    status=500,
+                )
         # Evict cached agent outside the per-session lock.  Eviction may run a
         # boundary memory commit for batch-extraction providers, and provider
         # I/O must not hold the session mutation lock.
@@ -15095,7 +15118,7 @@ def handle_post(handler, parsed) -> bool:
             from api.session_ops import truncate_session_at_keep
 
             old_msg_count, old_ctx_count = truncate_session_at_keep(s, keep)
-            s.save()
+            s.save(prune_media=True)
             logger.info(
                 "truncate %s: messages %d→%d, context_messages %d→%d, watermark=%.2f",
                 body["session_id"], old_msg_count, len(s.messages or []),
@@ -15201,48 +15224,38 @@ def handle_post(handler, parsed) -> bool:
             parent_session_id=source.session_id,
             session_source="fork",
         )
+        media_cloned = False
         try:
             from api.session_media import clone_session_media_references
 
-            clone_session_media_references(
-                [branch.messages, branch.context_messages],
-                source.session_id,
-                branch.session_id,
-            )
-        except (OSError, ValueError):
-            delete_session_artifacts(
-                branch.session_id,
-                expected_generation=getattr(branch, "_publication_generation", None),
-                durable_tombstone=False,
-                delete_state_db=False,
-            )
-            logger.warning(
-                "Could not clone session media from %s to %s",
-                source.session_id,
-                branch.session_id,
-                exc_info=True,
-            )
-            return bad(handler, "Could not copy session media", 500)
-        try:
-            # Persist only if there are messages (matches new_session pattern),
-            # and never cache a messageful branch before durable publication.
-            if forked_messages:
+            with reserve_session_destination(branch.session_id) as reservation:
+                reservation.bind(branch)
+                clone_session_media_references(
+                    [branch.messages, branch.context_messages],
+                    source.session_id,
+                    branch.session_id,
+                )
+                media_cloned = True
+                # Even an empty fork publishes its sidecar before becoming
+                # observable; otherwise the reservation has no durable owner.
                 branch.save()
-            with LOCK:
-                SESSIONS[branch.session_id] = branch
-                SESSIONS.move_to_end(branch.session_id)
-                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+                with LOCK:
+                    SESSIONS[branch.session_id] = branch
+                    SESSIONS.move_to_end(branch.session_id)
+                    _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+                reservation.commit()
         except Exception:
-            cleanup = delete_session_artifacts(
-                branch.session_id,
-                expected_generation=getattr(branch, "_publication_generation", None),
-                durable_tombstone=False,
-                delete_state_db=False,
-            )
+            if not media_cloned:
+                logger.warning(
+                    "Could not clone session media from %s to %s",
+                    source.session_id,
+                    branch.session_id,
+                    exc_info=True,
+                )
+                return bad(handler, "Could not copy session media", 500)
             logger.warning(
-                "Could not publish branched session %s; rollback residuals=%s",
+                "Could not publish branched session %s",
                 branch.session_id,
-                cleanup["residuals"],
                 exc_info=True,
             )
             return bad(handler, "Could not publish branched session", 500)
@@ -20893,24 +20906,26 @@ def _handle_btw(handler, body):
     try:
         from api.session_media import clone_session_media_references
 
-        clone_session_media_references(
-            [ephemeral.messages, ephemeral.context_messages],
-            s.session_id,
-            ephemeral.session_id,
-        )
-    except (OSError, ValueError):
-        _cleanup_ephemeral_session(ephemeral)
+        with reserve_session_destination(ephemeral.session_id) as reservation:
+            reservation.bind(ephemeral)
+            clone_session_media_references(
+                [ephemeral.messages, ephemeral.context_messages],
+                s.session_id,
+                ephemeral.session_id,
+            )
+            ephemeral.save()
+            reservation.commit()
+    except Exception:
         logger.warning(
-            "Could not clone session media from %s to btw session %s",
+            "Could not publish btw session copied from %s to %s",
             s.session_id,
             ephemeral.session_id,
             exc_info=True,
         )
-        return bad(handler, "Could not copy session media", 500)
+        return bad(handler, "Could not publish side-question session", 500)
     stream_id = uuid.uuid4().hex
     ephemeral.active_stream_id = stream_id
     try:
-        ephemeral.save()
         stream = create_stream_channel()
         thr = threading.Thread(
             target=_run_agent_streaming,
@@ -21997,15 +22012,17 @@ def _handle_session_compression_recovery_start(handler, body):
             copied_session.context_messages = []
             copied_session.composer_draft = {"text": "", "files": []}
             try:
-                copied_session.save()
+                with reserve_session_destination(copied_session.session_id) as reservation:
+                    reservation.bind(copied_session)
+                    copied_session.save()
+                    with LOCK:
+                        SESSIONS[copied_session.session_id] = copied_session
+                        SESSIONS.move_to_end(copied_session.session_id)
+                        _evict_sessions_over_cap()
+                    reservation.commit()
             except Exception as e:
                 logger.exception("failed to persist compression recovery session for %s", sid)
                 return bad(handler, f"Failed to start compression recovery: {_sanitize_error(e)}", 500)
-
-            with LOCK:
-                SESSIONS[copied_session.session_id] = copied_session
-                SESSIONS.move_to_end(copied_session.session_id)
-                _evict_sessions_over_cap()
             created = True
     if created:
         publish_session_list_changed(
@@ -26226,13 +26243,21 @@ def _handle_session_import(handler, body):
         profile=get_active_profile_name(),
     )
     s.pinned = body.get("pinned", False)
-    # Save first: Session.save externalizes portable inline media under the new
-    # id.  Only then may the imported session become observable from the cache.
-    s.save()
-    with LOCK:
-        SESSIONS[s.session_id] = s
-        SESSIONS.move_to_end(s.session_id)
-        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+    # Externalization, sidecar/index publication, and cache exposure are one
+    # reserved transaction. A failed save cannot orphan imported media, and a
+    # generated-ID collision cannot overwrite or roll back an existing owner.
+    try:
+        with reserve_session_destination(s.session_id) as reservation:
+            reservation.bind(s)
+            s.save()
+            with LOCK:
+                SESSIONS[s.session_id] = s
+                SESSIONS.move_to_end(s.session_id)
+                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+            reservation.commit()
+    except Exception as exc:
+        logger.warning("Could not publish imported session %s", s.session_id, exc_info=True)
+        return bad(handler, f"Could not import session: {_sanitize_error(exc)}", 500)
     publish_session_list_changed("session_import")
     return j(handler, {"ok": True, "session": s.compact() | {"messages": s.messages}})
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2809,8 +2809,6 @@ from api.config import (
     unregister_stream_owner,
     CHAT_LOCK,
     _get_session_agent_lock,
-    SESSION_AGENT_LOCKS,
-    SESSION_AGENT_LOCKS_LOCK,
     CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS,
     load_settings,
     persisted_speech_settings_keys,
@@ -5094,6 +5092,8 @@ def _get_or_materialize_session(sid: str, *, refresh_cli_messages: bool = False)
             created_at=cli_meta.get("created_at"),
             updated_at=cli_meta.get("updated_at"),
         )
+        _activate_session_publication_generation(s)
+        _clear_webui_deleted_session_tombstone(s.session_id)
         _apply_source_meta(s)
         s.save(touch_updated_at=False)
     else:
@@ -5174,6 +5174,8 @@ def _build_share_metadata_sidecar(
         updated_at=cli_meta.get("updated_at") or getattr(snapshot_session, "updated_at", None),
         profile=cli_meta.get("profile") or getattr(snapshot_session, "profile", None),
     )
+    _activate_session_publication_generation(session)
+    _clear_webui_deleted_session_tombstone(session.session_id)
     session.is_cli_session = bool(
         getattr(snapshot_session, "is_cli_session", False)
         or is_cli_session_row(cli_meta)
@@ -8194,7 +8196,10 @@ def _claim_or_synthesize_cli_session(sid: str, cli_meta: dict = None):
                           is_cli_flag=not _sa_child),
             "not_claimable",
         )
-    return build_session(sid, cli_meta, msgs, read_only_flag=False), "materialized"
+    materialized = build_session(sid, cli_meta, msgs, read_only_flag=False)
+    _activate_session_publication_generation(materialized)
+    _clear_webui_deleted_session_tombstone(materialized.session_id)
+    return materialized, "materialized"
 
 
 def _request_wants_all_profiles_import(body) -> bool:
@@ -9425,10 +9430,10 @@ from api.models import (
     _record_webui_zero_message_orphan_tombstone,
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
-    _record_webui_deleted_session_tombstone,
-    _get_session_publication_lock,
-    _mark_session_deleted_for_publication,
-    _unmark_session_deleted_for_publication,
+    _load_session_cleanup_residuals,
+    _activate_session_publication_generation,
+    _clear_webui_deleted_session_tombstone,
+    delete_session_artifacts,
     ensure_cron_project,
     _profile_has_user_projects,
     is_cron_session,
@@ -14448,6 +14453,12 @@ def handle_post(handler, parsed) -> bool:
                     copied_session.session_id,
                 )
             except (OSError, ValueError):
+                delete_session_artifacts(
+                    copied_session.session_id,
+                    expected_generation=getattr(copied_session, "_publication_generation", None),
+                    durable_tombstone=False,
+                    delete_state_db=False,
+                )
                 logger.warning(
                     "Could not clone session media from %s to %s",
                     session.session_id,
@@ -14456,20 +14467,34 @@ def handle_post(handler, parsed) -> bool:
                 )
                 return bad(handler, "Could not copy session media", 500)
 
-            with LOCK:
-                SESSIONS[copied_session.session_id] = copied_session
-                SESSIONS.move_to_end(copied_session.session_id)
-                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-            # Persist immediately. The pre-PR flow (/api/session/new + /api/session/rename)
-            # accidentally avoided this because `/api/session/rename` calls `s.save()`.
-            # Without this explicit save, the duplicate is in-memory only — if the user
-            # refreshes before sending a turn, the duplicate vanishes.
-            copied_session.save()
-            publish_session_list_changed(
-                "session_duplicate",
-                profile=getattr(copied_session, "profile", None),
-                session_id=getattr(copied_session, "session_id", None),
-            )
+            try:
+                # Persist JSON + index before exposing the destination in the
+                # cache. Any failure after media clone retires the whole new-ID
+                # transaction, including JSON, index residue, and private media.
+                copied_session.save()
+                with LOCK:
+                    SESSIONS[copied_session.session_id] = copied_session
+                    SESSIONS.move_to_end(copied_session.session_id)
+                    _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+                publish_session_list_changed(
+                    "session_duplicate",
+                    profile=getattr(copied_session, "profile", None),
+                    session_id=getattr(copied_session, "session_id", None),
+                )
+            except Exception:
+                cleanup = delete_session_artifacts(
+                    copied_session.session_id,
+                    expected_generation=getattr(copied_session, "_publication_generation", None),
+                    durable_tombstone=False,
+                    delete_state_db=False,
+                )
+                logger.warning(
+                    "Could not publish duplicated session %s; rollback residuals=%s",
+                    copied_session.session_id,
+                    cleanup["residuals"],
+                    exc_info=True,
+                )
+                return bad(handler, "Could not publish duplicated session", 500)
 
             return j(handler, {"session": copied_session.compact() | {"messages": copied_session.messages}})
         except Exception as e:
@@ -14923,132 +14948,27 @@ def handle_post(handler, parsed) -> bool:
             p.relative_to(SESSION_DIR.resolve())
         except Exception:
             return bad(handler, "Invalid session_id", 400)
-        # Session JSON publication and destructive cleanup share one authority.
-        # Mark deletion before unlinking so a worker holding a stale Session
-        # cannot publish after this critical section completes.
-        media_cleanup_error = None
-        storage_cleanup_error = None
-        with _get_session_publication_lock(sid):
-            _mark_session_deleted_for_publication(sid)
-            try:
-                p.unlink(missing_ok=True)
-            except Exception:
-                _unmark_session_deleted_for_publication(sid)
-                logger.warning("Failed to unlink session file %s", p, exc_info=True)
-                return bad(handler, "Could not delete session storage", 500)
-            sidecar_deleted = not p.exists()
-            if not sidecar_deleted:
-                _unmark_session_deleted_for_publication(sid)
-                return bad(handler, "Could not delete session storage", 500)
-            if not is_messaging_session:
-                try:
-                    _record_webui_deleted_session_tombstone(sid)
-                    tombstone_persisted = (
-                        sid in _load_webui_deleted_session_tombstone()
-                    )
-                except Exception:
-                    tombstone_persisted = False
-                    logger.warning(
-                        "Failed to tombstone deleted WebUI session %s",
-                        sid,
-                        exc_info=True,
-                    )
-                if not tombstone_persisted:
-                    storage_cleanup_error = RuntimeError(
-                        "Could not persist deleted-session tombstone"
-                    )
-            try:
-                p.with_suffix('.json.bak').unlink(missing_ok=True)
-            except Exception:
-                logger.debug(
-                    "Failed to unlink session backup file %s",
-                    p.with_suffix('.json.bak'),
-                    exc_info=True,
-                )
-            try:
-                from api.session_media import remove_session_media
-
-                remove_session_media(sid)
-            except Exception as exc:
-                media_cleanup_error = exc
-                logger.warning(
-                    "Failed to clean private media for deleted session %s",
-                    sid,
-                    exc_info=True,
-                )
-        # Cache eviction happens after the publication lock is released to avoid
-        # reversing LOCK -> publication-lock order used by existing save paths.
-        with LOCK:
-            SESSIONS.pop(sid, None)
-        # Evict cached agent so turn count doesn't leak into a recycled session.
-        from api.config import _evict_session_agent
-        _evict_session_agent(sid)
-        try:
-            prune_session_from_index(sid)
-        except Exception:
-            logger.debug("Failed to prune deleted session from index: %s", sid, exc_info=True)
-        try:
-            from api.upload import _session_attachment_dir
-
-            shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
-        except Exception:
-            logger.debug("Failed to clean attachment dir for deleted session %s", sid)
-        # Remove the turn-journal shards and the run-journal directory so a
-        # deleted conversation is not recoverable from disk. The session JSON +
-        # state.db rows are cleared above, but these journals retain the user's
-        # messages (turn journal) and the full request/response payloads (run
-        # journal) in plaintext. (#3802)
-        try:
-            from api.turn_journal import delete_turn_journal
-
-            delete_turn_journal(sid)
-        except Exception:
-            logger.debug("Failed to delete turn journal for deleted session %s", sid)
-        try:
-            from api.run_journal import delete_run_journal
-
-            delete_run_journal(sid)
-        except Exception:
-            logger.debug("Failed to delete run journal for deleted session %s", sid)
-        # Prune the per-session agent lock so deleted sessions don't leak
-        # Lock entries in SESSION_AGENT_LOCKS forever.
-        with SESSION_AGENT_LOCKS_LOCK:
-            SESSION_AGENT_LOCKS.pop(sid, None)
-        # Prune the completion-dedup entry too. The reaper sweeps it once the
-        # completion is delivered (drained from PENDING); a session deleted
-        # while a completion is still pending would otherwise keep its entry.
-        try:
-            from api.background_process import forget_bg_task_completion_dedup
-
-            forget_bg_task_completion_dedup(sid)
-        except Exception:
-            logger.debug("Failed to prune bg-task dedup entry for deleted session %s", sid)
-        try:
-            from api.terminal import close_terminal
-            close_terminal(sid)
-        except Exception:
-            logger.debug("Failed to close workspace terminal for deleted session %s", sid)
-        # Also delete from CLI state.db for CLI sessions shown in sidebar,
-        # but never erase external messaging channel memory via WebUI delete.
-        state_db_cleanup_failed = False
-        if not is_messaging_session:
-            try:
-                from api.models import delete_cli_session
-
-                state_db_cleanup_failed = not delete_cli_session(sid)
-            except Exception:
-                state_db_cleanup_failed = True
-                logger.warning("Failed to delete CLI session %s", sid, exc_info=True)
+        cleanup = delete_session_artifacts(
+            sid,
+            durable_tombstone=not is_messaging_session,
+            delete_state_db=not is_messaging_session,
+        )
+        if not cleanup["ok"]:
+            return j(
+                handler,
+                {
+                    "error": "Session cleanup incomplete",
+                    "residuals": cleanup["residuals"],
+                    **worktree_retained,
+                },
+                status=500,
+            )
         _publish_session_list_changed("session_delete", profile=event_profile)
-        if media_cleanup_error is not None:
-            return bad(handler, "Session deleted but private media cleanup failed", 500)
-        if storage_cleanup_error is not None:
-            return bad(handler, "Session deleted but storage cleanup failed", 500)
         return j(
             handler,
             {
                 "ok": True,
-                "state_db_cleanup_failed": state_db_cleanup_failed,
+                "state_db_cleanup_failed": False,
                 **worktree_retained,
             },
         )
@@ -15290,6 +15210,12 @@ def handle_post(handler, parsed) -> bool:
                 branch.session_id,
             )
         except (OSError, ValueError):
+            delete_session_artifacts(
+                branch.session_id,
+                expected_generation=getattr(branch, "_publication_generation", None),
+                durable_tombstone=False,
+                delete_state_db=False,
+            )
             logger.warning(
                 "Could not clone session media from %s to %s",
                 source.session_id,
@@ -15297,19 +15223,35 @@ def handle_post(handler, parsed) -> bool:
                 exc_info=True,
             )
             return bad(handler, "Could not copy session media", 500)
-        with LOCK:
-            SESSIONS[branch.session_id] = branch
-            SESSIONS.move_to_end(branch.session_id)
-            _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-
-        # Persist only if there are messages (matches new_session pattern)
-        if forked_messages:
-            branch.save()
-            publish_session_list_changed(
-                "session_branch",
-                profile=getattr(branch, "profile", None),
-                session_id=getattr(branch, "session_id", None),
+        try:
+            # Persist only if there are messages (matches new_session pattern),
+            # and never cache a messageful branch before durable publication.
+            if forked_messages:
+                branch.save()
+            with LOCK:
+                SESSIONS[branch.session_id] = branch
+                SESSIONS.move_to_end(branch.session_id)
+                _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
+            if forked_messages:
+                publish_session_list_changed(
+                    "session_branch",
+                    profile=getattr(branch, "profile", None),
+                    session_id=getattr(branch, "session_id", None),
+                )
+        except Exception:
+            cleanup = delete_session_artifacts(
+                branch.session_id,
+                expected_generation=getattr(branch, "_publication_generation", None),
+                durable_tombstone=False,
+                delete_state_db=False,
             )
+            logger.warning(
+                "Could not publish branched session %s; rollback residuals=%s",
+                branch.session_id,
+                cleanup["residuals"],
+                exc_info=True,
+            )
+            return bad(handler, "Could not publish branched session", 500)
 
         return j(handler, {
             "session_id": branch.session_id,
@@ -16074,6 +16016,8 @@ def handle_post(handler, parsed) -> bool:
                     created_at=cli_meta.get("created_at"),
                     updated_at=cli_meta.get("updated_at"),
                 )
+                _activate_session_publication_generation(s)
+                _clear_webui_deleted_session_tombstone(s.session_id)
                 s.is_cli_session = is_cli_session_row(cli_meta)
                 s.source_tag = cli_meta.get("source_tag")
                 s.raw_source = cli_meta.get("raw_source") or cli_meta.get("source_tag")
@@ -19052,7 +18996,7 @@ def _handle_media(handler, parsed):
     # secrets are blocked without 403-ing a named-profile workspace. (#3234.)
     _DENY_SUBDIRS = (
         "sessions", "memories", "cron", "logs",
-        "checkpoints", "backups",
+        "checkpoints", "backups", "session-media",
     )
     _state_dir = None
     try:
@@ -20706,10 +20650,42 @@ def _handle_memory_read(handler, parsed=None):
 def _handle_sessions_cleanup(handler, body, zero_only=False):
     cleaned = 0
     phase1_removed_ids = set()
+    cleanup_residuals = []
+
+    # Retry any previously incomplete destructive operation first. The durable
+    # manifest is keyed by SID and every cleanup step is idempotent.
+    try:
+        pending_cleanup = _load_session_cleanup_residuals()
+    except Exception as exc:
+        logger.warning("Could not read session cleanup residual manifest", exc_info=True)
+        return j(
+            handler,
+            {
+                "error": "Session cleanup manifest could not be read",
+                "residuals": [{"artifact": "cleanup_residual_manifest", "error": type(exc).__name__}],
+            },
+            status=500,
+        )
+    for sid, policy in pending_cleanup.items():
+        result = delete_session_artifacts(
+            sid,
+            durable_tombstone=policy["durable_tombstone"],
+            delete_state_db=policy["delete_state_db"],
+        )
+        if result["ok"]:
+            cleaned += 1
+            phase1_removed_ids.add(sid)
+        else:
+            cleanup_residuals.append({"session_id": sid, "artifacts": result["residuals"]})
 
     # Phase 1: Clean orphan session files (existing behavior).
     for p in SESSION_DIR.glob("*.json"):
         if p.name.startswith("_"):
+            continue
+        # A residual entry already owns this SID's retry lifecycle. Avoid a
+        # second delete attempt in the same request (and duplicate residual
+        # rows) when the retry above deliberately left its sidecar in place.
+        if p.stem in pending_cleanup:
             continue
         try:
             s = Session.load(p.stem)
@@ -20718,16 +20694,37 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
             else:
                 should_delete = s and s.title == "Untitled" and len(s.messages) == 0
             if should_delete:
-                with LOCK:
-                    SESSIONS.pop(p.stem, None)
-                p.unlink(missing_ok=True)
-                cleaned += 1
-                phase1_removed_ids.add(p.stem)
+                result = delete_session_artifacts(
+                    p.stem,
+                    expected_generation=getattr(s, "_publication_generation", None),
+                )
+                if result["ok"]:
+                    cleaned += 1
+                    phase1_removed_ids.add(p.stem)
+                else:
+                    cleanup_residuals.append(
+                        {"session_id": p.stem, "artifacts": result["residuals"]}
+                    )
         except Exception:
-            logger.debug("Failed to clean up session file %s", p)
+            logger.debug("Failed to clean up session file %s", p, exc_info=True)
+            cleanup_residuals.append(
+                {"session_id": p.stem, "artifacts": [{"artifact": "session_cleanup"}]}
+            )
 
     phase1_touched = bool(cleaned)
+    phase1_reconciled_index = False
+    if phase1_removed_ids and SESSION_INDEX_FILE.exists():
+        try:
+            phase1_index_rows = json.loads(SESSION_INDEX_FILE.read_bytes())
+            phase1_reconciled_index = isinstance(phase1_index_rows, list) and not any(
+                isinstance(entry, dict)
+                and entry.get("session_id") in phase1_removed_ids
+                for entry in phase1_index_rows
+            )
+        except Exception:
+            phase1_reconciled_index = False
     phase2_rewrote_index = False
+    phase2_candidate_ids = []
 
     # Phase 2: Index-only ghost sweep (#5331).
     # Remove index entries that have no backing .json file and no
@@ -20769,10 +20766,10 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                         if sid in phase1_removed_ids:
                             continue
                         # Index-only ghost — no backing file, not in memory.
-                        cleaned += 1
+                        phase2_candidate_ids.append(sid)
                         # Ghost not added to survivors — removed from index.
 
-                    if cleaned > 0 and len(survivors) < len(index_file_data):
+                    if phase2_candidate_ids and len(survivors) < len(index_file_data):
                         _tmp = SESSION_INDEX_FILE.with_suffix(
                             f".tmp.{os.getpid()}.{threading.current_thread().ident}"
                         )
@@ -20784,25 +20781,55 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                                 os.fsync(f.fileno())
                             _safe_replace(_tmp, SESSION_INDEX_FILE)
                             phase2_rewrote_index = True
+                            cleaned += len(phase2_candidate_ids)
                         except Exception:
                             try:
                                 _tmp.unlink(missing_ok=True)
                             except Exception:
                                 pass
                             raise
-        except Exception:
+        except Exception as exc:
             logger.debug(
                 "Failed to clean up index-only session entries", exc_info=True
             )
+            # A parse failure has not identified a safe deletion target. Once
+            # candidates are known, however, failure to publish the survivor
+            # index is an incomplete destructive operation: do not count it as
+            # cleaned or return success. The unchanged index is the durable,
+            # idempotent retry source for the next cleanup request.
+            for sid in phase2_candidate_ids:
+                cleanup_residuals.append(
+                    {
+                        "session_id": sid,
+                        "artifacts": [
+                            {"artifact": "session_index", "error": type(exc).__name__}
+                        ],
+                    }
+                )
 
     # Post-cleanup index invalidation.
     # When Phase 1 removed files and Phase 2 didn't already clean the
     # index, delete the index to force a fresh rebuild from disk on the
     # next sidebar poll.  When Phase 2 succeeded the index is already
     # correct, so keep it (avoids a wasteful rebuild).
-    if phase1_touched and not phase2_rewrote_index and SESSION_INDEX_FILE.exists():
+    if (
+        phase1_touched
+        and not phase1_reconciled_index
+        and not phase2_rewrote_index
+        and SESSION_INDEX_FILE.exists()
+    ):
         SESSION_INDEX_FILE.unlink(missing_ok=True)
 
+    if cleanup_residuals:
+        return j(
+            handler,
+            {
+                "error": "Session cleanup incomplete",
+                "cleaned": cleaned,
+                "residuals": cleanup_residuals,
+            },
+            status=500,
+        )
     return j(handler, {"ok": True, "cleaned": cleaned})
 
 
@@ -20882,6 +20909,11 @@ def _handle_btw(handler, body):
             kwargs={"ephemeral": True, "model_provider": model_provider},
             daemon=True,
         )
+        # Establish the exact lifecycle owner before any stream/cache registry
+        # makes the ephemeral session observable to another in-process actor.
+        from api.background import track_btw
+
+        track_btw(body["session_id"], ephemeral.session_id, stream_id, question)
         register_stream_owner(stream_id, ephemeral.session_id)
         with STREAMS_LOCK:
             STREAMS[stream_id] = stream
@@ -20889,9 +20921,6 @@ def _handle_btw(handler, body):
             SESSIONS[ephemeral.session_id] = ephemeral
             SESSIONS.move_to_end(ephemeral.session_id)
             _evict_sessions_over_cap()
-        from api.background import track_btw
-
-        track_btw(body["session_id"], ephemeral.session_id, stream_id, question)
         thr.start()
     except Exception:
         _cleanup_ephemeral_session(ephemeral, stream_id=stream_id)

--- a/api/routes.py
+++ b/api/routes.py
@@ -14466,7 +14466,21 @@ def handle_post(handler, parsed) -> bool:
 
             media_cloned = False
             try:
-                from api.session_media import clone_session_media_references
+                from api.session_media import (
+                    clone_session_media_references,
+                    hydrate_session_media_urls,
+                )
+
+                # Older experimental sidecars may still contain compact refs.
+                # Copy their verified bytes into portable history before the
+                # new session is reserved; disabled externalization must never
+                # create destination private media.
+                copied_session.messages = hydrate_session_media_urls(
+                    copied_session.messages, session.session_id
+                )
+                copied_session.context_messages = hydrate_session_media_urls(
+                    copied_session.context_messages, session.session_id
+                )
 
                 with reserve_session_destination(copied_session.session_id) as reservation:
                     reservation.bind(copied_session)
@@ -15221,7 +15235,17 @@ def handle_post(handler, parsed) -> bool:
         )
         media_cloned = False
         try:
-            from api.session_media import clone_session_media_references
+            from api.session_media import (
+                clone_session_media_references,
+                hydrate_session_media_urls,
+            )
+
+            branch.messages = hydrate_session_media_urls(
+                branch.messages, source.session_id
+            )
+            branch.context_messages = hydrate_session_media_urls(
+                branch.context_messages, source.session_id
+            )
 
             with reserve_session_destination(branch.session_id) as reservation:
                 reservation.bind(branch)
@@ -20904,7 +20928,15 @@ def _handle_btw(handler, body):
     ephemeral.title = f"btw: {question[:60]}"
     ephemeral.parent_session_id = s.session_id
     try:
-        from api.session_media import clone_session_media_references
+        from api.session_media import (
+            clone_session_media_references,
+            hydrate_session_media_urls,
+        )
+
+        ephemeral.messages = hydrate_session_media_urls(ephemeral.messages, s.session_id)
+        ephemeral.context_messages = hydrate_session_media_urls(
+            ephemeral.context_messages, s.session_id
+        )
 
         with reserve_session_destination(ephemeral.session_id) as reservation:
             reservation.bind(ephemeral)

--- a/api/routes.py
+++ b/api/routes.py
@@ -14950,6 +14950,12 @@ def handle_post(handler, parsed) -> bool:
             shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
         except Exception:
             logger.debug("Failed to clean attachment dir for deleted session %s", sid)
+        try:
+            from api.session_media import remove_session_media
+
+            remove_session_media(sid)
+        except Exception:
+            logger.debug("Failed to clean private media for deleted session %s", sid)
         # Remove the turn-journal shards and the run-journal directory so a
         # deleted conversation is not recoverable from disk. The session JSON +
         # state.db rows are cleared above, but these journals retain the user's
@@ -16796,6 +16802,20 @@ def _handle_session_export(handler, parsed):
     if not _profiles_match(getattr(s, "profile", None), active_profile):
         return bad(handler, "Session not found", 404)
     safe = redact_session_data(s.__dict__)
+    try:
+        from api.session_media import (
+            assert_no_session_media_references,
+            hydrate_session_media_urls,
+        )
+
+        # Exports are portable documents, not handles into this installation's
+        # private store.  Inline verified media before serializing so importing
+        # the file under a new id can establish fresh ownership.
+        safe = hydrate_session_media_urls(safe, sid)
+        assert_no_session_media_references(safe, context="session export")
+    except (OSError, ValueError) as exc:
+        logger.warning("Could not create a portable export for session %s", sid, exc_info=True)
+        return bad(handler, str(exc), 409)
     qs = parse_qs(parsed.query)
     fmt = qs.get("format", ["json"])[0].lower()
     if fmt == "html":
@@ -20775,19 +20795,54 @@ def _handle_btw(handler, body):
             if current_stream_id in STREAMS:
                 return j(handler, {"error": "session already has an active stream"}, status=409)
         s.active_stream_id = None
-    # Create ephemeral hidden session inheriting context
-    from api.models import new_session as _new_session
+    # Create the ephemeral session privately.  Do not use new_session() here:
+    # that publishes the new id in SESSIONS before copied media ownership has
+    # been established.
     model_provider = getattr(s, 'model_provider', None)
-    ephemeral = _new_session(
+    ephemeral = Session(
         workspace=s.workspace,
         model=s.model,
         model_provider=model_provider,
         profile=getattr(s, 'profile', None),
     )
-    # Copy conversation history for context (agent reads from messages)
-    ephemeral.messages = list(s.messages or [])
+    # Copy both display and authoritative model history.  Clone every compact
+    # media reference transactionally before the first save/cache publication.
+    ephemeral.messages = copy.deepcopy(s.messages or [])
+    ephemeral.context_messages = copy.deepcopy(
+        getattr(s, "context_messages", None) or []
+    )
     ephemeral.title = f"btw: {question[:60]}"
-    ephemeral.save()
+    try:
+        from api.session_media import clone_session_media_references
+
+        clone_session_media_references(
+            [ephemeral.messages, ephemeral.context_messages],
+            s.session_id,
+            ephemeral.session_id,
+        )
+    except (OSError, ValueError):
+        logger.warning(
+            "Could not clone session media from %s to btw session %s",
+            s.session_id,
+            ephemeral.session_id,
+            exc_info=True,
+        )
+        return bad(handler, "Could not copy session media", 500)
+    try:
+        ephemeral.save()
+    except Exception:
+        try:
+            from api.session_media import remove_session_media
+
+            remove_session_media(ephemeral.session_id)
+        except Exception:
+            logger.debug("Failed to roll back btw session media", exc_info=True)
+        logger.warning("Could not persist btw session %s", ephemeral.session_id, exc_info=True)
+        return bad(handler, "Could not create side-question session", 500)
+    with LOCK:
+        SESSIONS[ephemeral.session_id] = ephemeral
+        SESSIONS.move_to_end(ephemeral.session_id)
+        _evict_sessions_over_cap()
     stream_id = uuid.uuid4().hex
     ephemeral.active_stream_id = stream_id
     ephemeral.save()
@@ -22497,10 +22552,10 @@ def _handle_chat_sync(handler, body):
             _previous_messages = list(s.messages or [])
             _previous_context_messages = list(_context_messages_for_new_turn(s, msg))
 
-            result = agent.run_conversation(
-                user_message=workspace_ctx + msg,
-                system_message=workspace_system_msg,
-                conversation_history=_sanitize_messages_for_api(
+            _run_kwargs = {
+                "user_message": workspace_ctx + msg,
+                "system_message": workspace_system_msg,
+                "conversation_history": _sanitize_messages_for_api(
                     _previous_context_messages,
                     cfg=get_config(),
                     session_id=s.session_id,
@@ -22508,9 +22563,13 @@ def _handle_chat_sync(handler, body):
                     effective_provider=_provider,
                     effective_base_url=_base_url,
                 ),
-                task_id=s.session_id,
-                persist_user_message=msg,
-            )
+                "task_id": s.session_id,
+                "persist_user_message": msg,
+            }
+            from api.streaming import _assert_model_request_has_no_private_media
+
+            _assert_model_request_has_no_private_media(_run_kwargs)
+            result = agent.run_conversation(**_run_kwargs)
     finally:
         with _ENV_LOCK:
             if old_cwd is None:
@@ -26058,6 +26117,19 @@ def _handle_session_import(handler, body):
     messages = body.get("messages")
     if not isinstance(messages, list):
         return bad(handler, 'JSON must contain a "messages" array')
+    try:
+        from api.session_media import assert_no_session_media_references
+
+        # A private URI is meaningful only inside the source installation and
+        # session id.  Portable exports contain verified inline data URLs;
+        # reject hand-authored/legacy JSON that tries to retain private handles.
+        assert_no_session_media_references(body, context="session import")
+    except ValueError:
+        return bad(
+            handler,
+            "JSON import contains a private session media reference; export the source session again to create a portable file",
+            400,
+        )
     title = body.get("title", "Imported session")
     try:
         workspace = str(resolve_trusted_workspace(body.get("workspace", str(DEFAULT_WORKSPACE))))
@@ -26068,16 +26140,23 @@ def _handle_session_import(handler, body):
         title=title,
         workspace=workspace,
         model=model,
-        messages=messages,
-        tool_calls=body.get("tool_calls", []),
+        messages=copy.deepcopy(messages),
+        context_messages=copy.deepcopy(
+            body.get("context_messages")
+            if isinstance(body.get("context_messages"), list)
+            else []
+        ),
+        tool_calls=copy.deepcopy(body.get("tool_calls", [])),
         profile=get_active_profile_name(),
     )
     s.pinned = body.get("pinned", False)
+    # Save first: Session.save externalizes portable inline media under the new
+    # id.  Only then may the imported session become observable from the cache.
+    s.save()
     with LOCK:
         SESSIONS[s.session_id] = s
         SESSIONS.move_to_end(s.session_id)
         _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-    s.save()
     publish_session_list_changed("session_import")
     return j(handler, {"ok": True, "session": s.compact() | {"messages": s.messages}})
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -5092,10 +5092,11 @@ def _get_or_materialize_session(sid: str, *, refresh_cli_messages: bool = False)
             created_at=cli_meta.get("created_at"),
             updated_at=cli_meta.get("updated_at"),
         )
-        _activate_session_publication_generation(s)
-        _clear_webui_deleted_session_tombstone(s.session_id)
-        _apply_source_meta(s)
-        s.save(touch_updated_at=False)
+        with reserve_session_destination(s.session_id) as reservation:
+            reservation.bind(s)
+            _apply_source_meta(s)
+            s.save(touch_updated_at=False)
+            reservation.commit()
     else:
         # Regular CLI/agent sessions: import full message history
         msgs = get_cli_session_messages(sid)
@@ -5174,8 +5175,6 @@ def _build_share_metadata_sidecar(
         updated_at=cli_meta.get("updated_at") or getattr(snapshot_session, "updated_at", None),
         profile=cli_meta.get("profile") or getattr(snapshot_session, "profile", None),
     )
-    _activate_session_publication_generation(session)
-    _clear_webui_deleted_session_tombstone(session.session_id)
     session.is_cli_session = bool(
         getattr(snapshot_session, "is_cli_session", False)
         or is_cli_session_row(cli_meta)
@@ -5213,6 +5212,9 @@ def _build_share_metadata_sidecar(
             value = getattr(snapshot_session, attr, None)
         if value is not None:
             setattr(session, attr, value)
+    with reserve_session_destination(session.session_id) as reservation:
+        reservation.bind(session)
+        reservation.commit()
     return session
 
 
@@ -7844,7 +7846,10 @@ def _session_deleted_tombstone_marks_was_webui(sid: str) -> bool:
     try:
         return sid in _load_webui_deleted_session_tombstone()
     except Exception:
-        return False
+        # This decision gates whether a missing sidecar may be claimed as a
+        # foreign session. An unreadable deletion authority is not proof that
+        # the SID is safe to reclaim.
+        return True
 
 
 def _state_db_session_source(sid: str) -> str:
@@ -8196,10 +8201,7 @@ def _claim_or_synthesize_cli_session(sid: str, cli_meta: dict = None):
                           is_cli_flag=not _sa_child),
             "not_claimable",
         )
-    materialized = build_session(sid, cli_meta, msgs, read_only_flag=False)
-    _activate_session_publication_generation(materialized)
-    _clear_webui_deleted_session_tombstone(materialized.session_id)
-    return materialized, "materialized"
+    return build_session(sid, cli_meta, msgs, read_only_flag=False), "materialized"
 
 
 def _request_wants_all_profiles_import(body) -> bool:
@@ -9431,11 +9433,11 @@ from api.models import (
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
     _scan_session_cleanup_residuals,
-    _activate_session_publication_generation,
+    retry_session_retention_cleanup,
     reserve_session_destination,
-    _durable_unlink,
-    _clear_webui_deleted_session_tombstone,
+    _fsync_parent_directory,
     delete_session_artifacts,
+    _session_publication_authority,
     ensure_cron_project,
     _profile_has_user_projects,
     is_cron_session,
@@ -14974,9 +14976,7 @@ def handle_post(handler, parsed) -> bool:
         except KeyError:
             return bad(handler, "Session not found", 404)
         sid = body["session_id"]
-        with _get_session_agent_lock(sid):
-            had_sidecar_messages = bool(s.messages or [])
-            prior_clear_generation = getattr(s, "clear_generation", None)
+        with _get_session_agent_lock(sid), _session_publication_authority(sid):
             # Clear is a full truncate-to-empty: route through the SAME helper the
             # /api/session/truncate handler uses (single source of truth) so the
             # display + context arrays are emptied AND the truncation watermark is
@@ -15018,12 +15018,7 @@ def handle_post(handler, parsed) -> bool:
             s.pending_attachments = []
             s.pending_started_at = None
             s.pending_user_source = None
-            s.clear_generation = (
-                uuid.uuid4().hex
-                if had_sidecar_messages
-                else prior_clear_generation
-            )
-            destructive_clear = had_sidecar_messages or bool(prior_clear_generation)
+            s.clear_generation = uuid.uuid4().hex
             # Reset the title via the rename helper so clearing a manually-named
             # session also clears manual_title/llm_title_generated — otherwise the
             # reused session keeps its manual-title protection and never auto-names
@@ -15056,25 +15051,9 @@ def handle_post(handler, parsed) -> bool:
                 logger.warning("session clear could not verify persisted empty state for %s", sid, exc_info=True)
             if not persisted_clear:
                 clear_residuals.append({"artifact": "session_json_verification"})
-            if persisted_clear and destructive_clear:
-                try:
-                    # The backup can retain references to the removed history;
-                    # commit its absence before deleting the media namespace.
-                    _durable_unlink(s.path.with_suffix('.json.bak'))
-                except Exception as exc:
-                    clear_residuals.append(
-                        {"artifact": "session_backup", "error": type(exc).__name__}
-                    )
-                    logger.warning("session clear could not remove stale backup for %s", sid, exc_info=True)
-                if not clear_residuals:
-                    try:
-                        from api.session_media import remove_session_media
-
-                        remove_session_media(sid)
-                    except Exception as exc:
-                        clear_residuals.append(
-                            {"artifact": "session_media", "error": type(exc).__name__}
-                        )
+            if persisted_clear:
+                cleanup = retry_session_retention_cleanup(sid, "clear")
+                clear_residuals.extend(cleanup["residuals"])
             if clear_residuals:
                 return j(
                     handler,
@@ -16029,20 +16008,21 @@ def handle_post(handler, parsed) -> bool:
                     created_at=cli_meta.get("created_at"),
                     updated_at=cli_meta.get("updated_at"),
                 )
-                _activate_session_publication_generation(s)
-                _clear_webui_deleted_session_tombstone(s.session_id)
-                s.is_cli_session = is_cli_session_row(cli_meta)
-                s.source_tag = cli_meta.get("source_tag")
-                s.raw_source = cli_meta.get("raw_source") or cli_meta.get("source_tag")
-                s.session_source = cli_meta.get("session_source")
-                s.source_label = cli_meta.get("source_label")
-                s.user_id = cli_meta.get("user_id")
-                s.chat_id = cli_meta.get("chat_id")
-                s.chat_type = cli_meta.get("chat_type")
-                s.thread_id = cli_meta.get("thread_id")
-                s.session_key = cli_meta.get("session_key")
-                s.platform = cli_meta.get("platform")
-                s.save(touch_updated_at=False)
+                with reserve_session_destination(s.session_id) as reservation:
+                    reservation.bind(s)
+                    s.is_cli_session = is_cli_session_row(cli_meta)
+                    s.source_tag = cli_meta.get("source_tag")
+                    s.raw_source = cli_meta.get("raw_source") or cli_meta.get("source_tag")
+                    s.session_source = cli_meta.get("session_source")
+                    s.source_label = cli_meta.get("source_label")
+                    s.user_id = cli_meta.get("user_id")
+                    s.chat_id = cli_meta.get("chat_id")
+                    s.chat_type = cli_meta.get("chat_type")
+                    s.thread_id = cli_meta.get("thread_id")
+                    s.session_key = cli_meta.get("session_key")
+                    s.platform = cli_meta.get("platform")
+                    s.save(touch_updated_at=False)
+                    reservation.commit()
             else:
                 msgs = get_cli_session_messages(sid)
                 if not msgs:
@@ -20689,14 +20669,19 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
         if item.get("session_id")
     )
     for sid, policy in pending_cleanup.items():
-        result = delete_session_artifacts(
-            sid,
-            durable_tombstone=policy["durable_tombstone"],
-            delete_state_db=policy["delete_state_db"],
-        )
+        operation = policy.get("operation", "delete")
+        if operation in {"prune", "clear"}:
+            result = retry_session_retention_cleanup(sid, operation)
+        else:
+            result = delete_session_artifacts(
+                sid,
+                durable_tombstone=policy["durable_tombstone"],
+                delete_state_db=policy["delete_state_db"],
+            )
         if result["ok"]:
             cleaned += 1
-            phase1_removed_ids.add(sid)
+            if operation == "delete":
+                phase1_removed_ids.add(sid)
         else:
             cleanup_residuals.append({"session_id": sid, "artifacts": result["residuals"]})
 
@@ -20733,7 +20718,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 {"session_id": p.stem, "artifacts": [{"artifact": "session_cleanup"}]}
             )
 
-    phase1_touched = bool(cleaned)
+    phase1_touched = bool(phase1_removed_ids)
     phase1_reconciled_index = False
     if phase1_removed_ids and SESSION_INDEX_FILE.exists():
         try:
@@ -20761,9 +20746,9 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
     # prevent races with concurrent Session.save() / prune_session_from_index().
     if SESSION_INDEX_FILE.exists():
         try:
-            from api.models import _INDEX_WRITE_LOCK, _safe_replace
+            from api.models import _INDEX_WRITE_LOCK, _cross_process_file_lock, _safe_replace
 
-            with _INDEX_WRITE_LOCK:
+            with _INDEX_WRITE_LOCK, _cross_process_file_lock("session-index"):
                 index_file_data = json.loads(
                     SESSION_INDEX_FILE.read_bytes()
                 )
@@ -20792,9 +20777,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                         # Ghost not added to survivors — removed from index.
 
                     if phase2_candidate_ids and len(survivors) < len(index_file_data):
-                        _tmp = SESSION_INDEX_FILE.with_suffix(
-                            f".tmp.{os.getpid()}.{threading.current_thread().ident}"
-                        )
+                        _tmp = SESSION_INDEX_FILE.with_suffix(f".tmp.{uuid.uuid4().hex}")
                         _payload = json.dumps(survivors, ensure_ascii=False, indent=2)
                         try:
                             with open(_tmp, "w", encoding="utf-8") as f:
@@ -20802,6 +20785,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                                 f.flush()
                                 os.fsync(f.fileno())
                             _safe_replace(_tmp, SESSION_INDEX_FILE)
+                            _fsync_parent_directory(SESSION_INDEX_FILE)
                             phase2_rewrote_index = True
                             cleaned += len(phase2_candidate_ids)
                         except Exception:
@@ -22246,7 +22230,13 @@ def _handle_chat_start(handler, body, diag=None):
                     403,
                 )
             try:
-                synth.save()
+                with reserve_session_destination(synth.session_id) as reservation:
+                    reservation.bind(synth)
+                    synth.save()
+                    with LOCK:
+                        SESSIONS[synth.session_id] = synth
+                        SESSIONS.move_to_end(synth.session_id)
+                    reservation.commit()
             except Exception as _save_err:
                 # Persisting the sidecar failed: surface a generic 500 to
                 # the client (paths sanitised, see _sanitize_error) and log
@@ -22264,15 +22254,6 @@ def _handle_chat_start(handler, body, diag=None):
                     500,
                 )
             s = synth
-            try:
-                with LOCK:
-                    SESSIONS[s.session_id] = s
-                    SESSIONS.move_to_end(s.session_id)
-            except Exception:
-                # If the in-memory LRU refuses the new session, fall through
-                # with the just-persisted sidecar; _start_run will load it
-                # from disk if needed.
-                pass
         except PermissionError:
             return bad(handler, "Read-only imported sessions cannot be continued from WebUI", 403)
         diag.stage("validate_profile") if diag else None

--- a/api/routes.py
+++ b/api/routes.py
@@ -22470,6 +22470,7 @@ def _handle_chat_sync(handler, body):
                 conversation_history=_sanitize_messages_for_api(
                     _previous_context_messages,
                     cfg=get_config(),
+                    session_id=s.session_id,
                     effective_model=_model,
                     effective_provider=_provider,
                     effective_base_url=_base_url,
@@ -24605,7 +24606,7 @@ def _handle_session_compress(handler, body):
     try:
         from api.streaming import _sanitize_messages_for_api
 
-        messages = _sanitize_messages_for_api(s.messages)
+        messages = _sanitize_messages_for_api(s.messages, session_id=s.session_id)
         if len(messages) < 4:
             return bad(handler, "Not enough conversation to compress (need at least 4 messages).")
 
@@ -24766,7 +24767,7 @@ def _handle_session_compress(handler, body):
             )
             if current_stream_state != original_stream_state:
                 return bad(handler, "Session stream state changed during compression; please retry.", 409)
-            if _sanitize_messages_for_api(s.messages) != original_messages:
+            if _sanitize_messages_for_api(s.messages, session_id=s.session_id) != original_messages:
                 return bad(handler, "Session was modified during compression; please retry.", 409)
 
             from api.session_ops import _truncation_watermark_for

--- a/api/routes.py
+++ b/api/routes.py
@@ -9426,6 +9426,9 @@ from api.models import (
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
     _record_webui_deleted_session_tombstone,
+    _get_session_publication_lock,
+    _mark_session_deleted_for_publication,
+    _unmark_session_deleted_for_publication,
     ensure_cron_project,
     _profile_has_user_projects,
     is_cron_session,
@@ -9656,6 +9659,7 @@ from api.streaming import (
     _sse,
     _sse_set_write_deadline,
     _run_agent_streaming,
+    _cleanup_ephemeral_session,
     cancel_stream,
     _materialize_pending_user_turn_before_error,
     generate_session_title_for_session,
@@ -14914,48 +14918,81 @@ def handle_post(handler, parsed) -> bool:
         except Exception:
             logger.debug("Failed to resolve profile for deleted session %s", sid, exc_info=True)
             event_profile = None
-        # Delete from WebUI session store
-        with LOCK:
-            SESSIONS.pop(sid, None)
-        # Evict cached agent so turn count doesn't leak into a recycled session
-        from api.config import _evict_session_agent
-        _evict_session_agent(sid)
         try:
             p = (SESSION_DIR / f"{sid}.json").resolve()
             p.relative_to(SESSION_DIR.resolve())
         except Exception:
             return bad(handler, "Invalid session_id", 400)
-        sidecar_deleted = False
-        try:
-            p.unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Failed to unlink session file %s", p)
-        sidecar_deleted = not p.exists()
-        try:
-            p.with_suffix('.json.bak').unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Failed to unlink session backup file %s", p.with_suffix('.json.bak'))
+        # Session JSON publication and destructive cleanup share one authority.
+        # Mark deletion before unlinking so a worker holding a stale Session
+        # cannot publish after this critical section completes.
+        media_cleanup_error = None
+        storage_cleanup_error = None
+        with _get_session_publication_lock(sid):
+            _mark_session_deleted_for_publication(sid)
+            try:
+                p.unlink(missing_ok=True)
+            except Exception:
+                _unmark_session_deleted_for_publication(sid)
+                logger.warning("Failed to unlink session file %s", p, exc_info=True)
+                return bad(handler, "Could not delete session storage", 500)
+            sidecar_deleted = not p.exists()
+            if not sidecar_deleted:
+                _unmark_session_deleted_for_publication(sid)
+                return bad(handler, "Could not delete session storage", 500)
+            if not is_messaging_session:
+                try:
+                    _record_webui_deleted_session_tombstone(sid)
+                    tombstone_persisted = (
+                        sid in _load_webui_deleted_session_tombstone()
+                    )
+                except Exception:
+                    tombstone_persisted = False
+                    logger.warning(
+                        "Failed to tombstone deleted WebUI session %s",
+                        sid,
+                        exc_info=True,
+                    )
+                if not tombstone_persisted:
+                    storage_cleanup_error = RuntimeError(
+                        "Could not persist deleted-session tombstone"
+                    )
+            try:
+                p.with_suffix('.json.bak').unlink(missing_ok=True)
+            except Exception:
+                logger.debug(
+                    "Failed to unlink session backup file %s",
+                    p.with_suffix('.json.bak'),
+                    exc_info=True,
+                )
+            try:
+                from api.session_media import remove_session_media
+
+                remove_session_media(sid)
+            except Exception as exc:
+                media_cleanup_error = exc
+                logger.warning(
+                    "Failed to clean private media for deleted session %s",
+                    sid,
+                    exc_info=True,
+                )
+        # Cache eviction happens after the publication lock is released to avoid
+        # reversing LOCK -> publication-lock order used by existing save paths.
+        with LOCK:
+            SESSIONS.pop(sid, None)
+        # Evict cached agent so turn count doesn't leak into a recycled session.
+        from api.config import _evict_session_agent
+        _evict_session_agent(sid)
         try:
             prune_session_from_index(sid)
         except Exception:
             logger.debug("Failed to prune deleted session from index: %s", sid, exc_info=True)
-        if sidecar_deleted and not is_messaging_session:
-            try:
-                _record_webui_deleted_session_tombstone(sid)
-            except Exception:
-                logger.debug("Failed to tombstone deleted WebUI session %s", sid, exc_info=True)
         try:
             from api.upload import _session_attachment_dir
 
             shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
         except Exception:
             logger.debug("Failed to clean attachment dir for deleted session %s", sid)
-        try:
-            from api.session_media import remove_session_media
-
-            remove_session_media(sid)
-        except Exception:
-            logger.debug("Failed to clean private media for deleted session %s", sid)
         # Remove the turn-journal shards and the run-journal directory so a
         # deleted conversation is not recoverable from disk. The session JSON +
         # state.db rows are cleared above, but these journals retain the user's
@@ -15003,6 +15040,10 @@ def handle_post(handler, parsed) -> bool:
                 state_db_cleanup_failed = True
                 logger.warning("Failed to delete CLI session %s", sid, exc_info=True)
         _publish_session_list_changed("session_delete", profile=event_profile)
+        if media_cleanup_error is not None:
+            return bad(handler, "Session deleted but private media cleanup failed", 500)
+        if storage_cleanup_error is not None:
+            return bad(handler, "Session deleted but storage cleanup failed", 500)
         return j(
             handler,
             {
@@ -20812,6 +20853,7 @@ def _handle_btw(handler, body):
         getattr(s, "context_messages", None) or []
     )
     ephemeral.title = f"btw: {question[:60]}"
+    ephemeral.parent_session_id = s.session_id
     try:
         from api.session_media import clone_session_media_references
 
@@ -20821,6 +20863,7 @@ def _handle_btw(handler, body):
             ephemeral.session_id,
         )
     except (OSError, ValueError):
+        _cleanup_ephemeral_session(ephemeral)
         logger.warning(
             "Could not clone session media from %s to btw session %s",
             s.session_id,
@@ -20828,37 +20871,32 @@ def _handle_btw(handler, body):
             exc_info=True,
         )
         return bad(handler, "Could not copy session media", 500)
-    try:
-        ephemeral.save()
-    except Exception:
-        try:
-            from api.session_media import remove_session_media
-
-            remove_session_media(ephemeral.session_id)
-        except Exception:
-            logger.debug("Failed to roll back btw session media", exc_info=True)
-        logger.warning("Could not persist btw session %s", ephemeral.session_id, exc_info=True)
-        return bad(handler, "Could not create side-question session", 500)
-    with LOCK:
-        SESSIONS[ephemeral.session_id] = ephemeral
-        SESSIONS.move_to_end(ephemeral.session_id)
-        _evict_sessions_over_cap()
     stream_id = uuid.uuid4().hex
     ephemeral.active_stream_id = stream_id
-    ephemeral.save()
-    stream = create_stream_channel()
-    register_stream_owner(stream_id, ephemeral.session_id)
-    with STREAMS_LOCK:
-        STREAMS[stream_id] = stream
-    from api.background import track_btw
-    track_btw(body["session_id"], ephemeral.session_id, stream_id, question)
-    thr = threading.Thread(
-        target=_run_agent_streaming,
-        args=(ephemeral.session_id, question, s.model, s.workspace, stream_id, None),
-        kwargs={"ephemeral": True, "model_provider": model_provider},
-        daemon=True,
-    )
-    thr.start()
+    try:
+        ephemeral.save()
+        stream = create_stream_channel()
+        thr = threading.Thread(
+            target=_run_agent_streaming,
+            args=(ephemeral.session_id, question, s.model, s.workspace, stream_id, None),
+            kwargs={"ephemeral": True, "model_provider": model_provider},
+            daemon=True,
+        )
+        register_stream_owner(stream_id, ephemeral.session_id)
+        with STREAMS_LOCK:
+            STREAMS[stream_id] = stream
+        with LOCK:
+            SESSIONS[ephemeral.session_id] = ephemeral
+            SESSIONS.move_to_end(ephemeral.session_id)
+            _evict_sessions_over_cap()
+        from api.background import track_btw
+
+        track_btw(body["session_id"], ephemeral.session_id, stream_id, question)
+        thr.start()
+    except Exception:
+        _cleanup_ephemeral_session(ephemeral, stream_id=stream_id)
+        logger.warning("Could not start btw session %s", ephemeral.session_id, exc_info=True)
+        return bad(handler, "Could not start side-question session", 500)
     return j(handler, {"stream_id": stream_id, "session_id": ephemeral.session_id, "parent_session_id": body["session_id"]})
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -14468,18 +14468,6 @@ def handle_post(handler, parsed) -> bool:
             try:
                 from api.session_media import (
                     clone_session_media_references,
-                    inline_legacy_session_media_urls,
-                )
-
-                # Older experimental sidecars may still contain compact refs.
-                # Copy their verified bytes into portable history before the
-                # new session is reserved; disabled externalization must never
-                # create destination private media.
-                copied_session.messages = inline_legacy_session_media_urls(
-                    copied_session.messages, session.session_id
-                )
-                copied_session.context_messages = inline_legacy_session_media_urls(
-                    copied_session.context_messages, session.session_id
                 )
 
                 with reserve_session_destination(copied_session.session_id) as reservation:
@@ -15237,14 +15225,6 @@ def handle_post(handler, parsed) -> bool:
         try:
             from api.session_media import (
                 clone_session_media_references,
-                inline_legacy_session_media_urls,
-            )
-
-            branch.messages = inline_legacy_session_media_urls(
-                branch.messages, source.session_id
-            )
-            branch.context_messages = inline_legacy_session_media_urls(
-                branch.context_messages, source.session_id
             )
 
             with reserve_session_destination(branch.session_id) as reservation:
@@ -20930,12 +20910,6 @@ def _handle_btw(handler, body):
     try:
         from api.session_media import (
             clone_session_media_references,
-            inline_legacy_session_media_urls,
-        )
-
-        ephemeral.messages = inline_legacy_session_media_urls(ephemeral.messages, s.session_id)
-        ephemeral.context_messages = inline_legacy_session_media_urls(
-            ephemeral.context_messages, s.session_id
         )
 
         with reserve_session_destination(ephemeral.session_id) as reservation:

--- a/api/routes.py
+++ b/api/routes.py
@@ -14476,11 +14476,6 @@ def handle_post(handler, parsed) -> bool:
                     SESSIONS[copied_session.session_id] = copied_session
                     SESSIONS.move_to_end(copied_session.session_id)
                     _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-                publish_session_list_changed(
-                    "session_duplicate",
-                    profile=getattr(copied_session, "profile", None),
-                    session_id=getattr(copied_session, "session_id", None),
-                )
             except Exception:
                 cleanup = delete_session_artifacts(
                     copied_session.session_id,
@@ -14496,6 +14491,11 @@ def handle_post(handler, parsed) -> bool:
                 )
                 return bad(handler, "Could not publish duplicated session", 500)
 
+            publish_session_list_changed(
+                "session_duplicate",
+                profile=getattr(copied_session, "profile", None),
+                session_id=getattr(copied_session, "session_id", None),
+            )
             return j(handler, {"session": copied_session.compact() | {"messages": copied_session.messages}})
         except Exception as e:
             return bad(handler, str(e))
@@ -15232,12 +15232,6 @@ def handle_post(handler, parsed) -> bool:
                 SESSIONS[branch.session_id] = branch
                 SESSIONS.move_to_end(branch.session_id)
                 _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-            if forked_messages:
-                publish_session_list_changed(
-                    "session_branch",
-                    profile=getattr(branch, "profile", None),
-                    session_id=getattr(branch, "session_id", None),
-                )
         except Exception:
             cleanup = delete_session_artifacts(
                 branch.session_id,
@@ -15253,6 +15247,12 @@ def handle_post(handler, parsed) -> bool:
             )
             return bad(handler, "Could not publish branched session", 500)
 
+        if forked_messages:
+            publish_session_list_changed(
+                "session_branch",
+                profile=getattr(branch, "profile", None),
+                session_id=getattr(branch, "session_id", None),
+            )
         return j(handler, {
             "session_id": branch.session_id,
             "title": branch_title,

--- a/api/routes.py
+++ b/api/routes.py
@@ -5212,9 +5212,6 @@ def _build_share_metadata_sidecar(
             value = getattr(snapshot_session, attr, None)
         if value is not None:
             setattr(session, attr, value)
-    with reserve_session_destination(session.session_id) as reservation:
-        reservation.bind(session)
-        reservation.commit()
     return session
 
 
@@ -14175,9 +14172,16 @@ def handle_post(handler, parsed) -> bool:
                 snapshot_session,
                 cli_meta=cli_meta,
             )
-        persisted_session.share_token = share_meta["share_token"]
-        persisted_session.share_created_at = share_meta["share_created_at"]
-        persisted_session.save(touch_updated_at=False)
+            with reserve_session_destination(sid) as reservation:
+                reservation.bind(persisted_session)
+                persisted_session.share_token = share_meta["share_token"]
+                persisted_session.share_created_at = share_meta["share_created_at"]
+                persisted_session.save(touch_updated_at=False)
+                reservation.commit()
+        else:
+            persisted_session.share_token = share_meta["share_token"]
+            persisted_session.share_created_at = share_meta["share_created_at"]
+            persisted_session.save(touch_updated_at=False)
         _publish_session_list_changed(
             "session_share_create",
             profile=getattr(persisted_session, "profile", None),
@@ -14219,12 +14223,24 @@ def handle_post(handler, parsed) -> bool:
                 snapshot_session,
                 cli_meta=cli_meta,
             )
-            target_session.share_token = token
-            target_session.share_created_at = getattr(snapshot_session, "share_created_at", None)
-        revoke_share(target_session)
-        target_session.share_token = None
-        target_session.share_created_at = None
-        target_session.save(touch_updated_at=False)
+            with reserve_session_destination(sid) as reservation:
+                reservation.bind(target_session)
+                target_session.share_token = token
+                target_session.share_created_at = getattr(
+                    snapshot_session,
+                    "share_created_at",
+                    None,
+                )
+                revoke_share(target_session)
+                target_session.share_token = None
+                target_session.share_created_at = None
+                target_session.save(touch_updated_at=False)
+                reservation.commit()
+        else:
+            revoke_share(target_session)
+            target_session.share_token = None
+            target_session.share_created_at = None
+            target_session.save(touch_updated_at=False)
         _publish_session_list_changed(
             "session_share_revoke",
             profile=getattr(target_session, "profile", None),

--- a/api/routes.py
+++ b/api/routes.py
@@ -14435,6 +14435,23 @@ def handle_post(handler, parsed) -> bool:
                 updated_at=time.time(),
             )
 
+            try:
+                from api.session_media import clone_session_media_references
+
+                clone_session_media_references(
+                    [copied_session.messages, copied_session.context_messages],
+                    session.session_id,
+                    copied_session.session_id,
+                )
+            except (OSError, ValueError):
+                logger.warning(
+                    "Could not clone session media from %s to %s",
+                    session.session_id,
+                    copied_session.session_id,
+                    exc_info=True,
+                )
+                return bad(handler, "Could not copy session media", 500)
+
             with LOCK:
                 SESSIONS[copied_session.session_id] = copied_session
                 SESSIONS.move_to_end(copied_session.session_id)
@@ -15217,6 +15234,22 @@ def handle_post(handler, parsed) -> bool:
             parent_session_id=source.session_id,
             session_source="fork",
         )
+        try:
+            from api.session_media import clone_session_media_references
+
+            clone_session_media_references(
+                [branch.messages, branch.context_messages],
+                source.session_id,
+                branch.session_id,
+            )
+        except (OSError, ValueError):
+            logger.warning(
+                "Could not clone session media from %s to %s",
+                source.session_id,
+                branch.session_id,
+                exc_info=True,
+            )
+            return bad(handler, "Could not copy session media", 500)
         with LOCK:
             SESSIONS[branch.session_id] = branch
             SESSIONS.move_to_end(branch.session_id)

--- a/api/routes.py
+++ b/api/routes.py
@@ -14468,17 +14468,17 @@ def handle_post(handler, parsed) -> bool:
             try:
                 from api.session_media import (
                     clone_session_media_references,
-                    hydrate_session_media_urls,
+                    inline_legacy_session_media_urls,
                 )
 
                 # Older experimental sidecars may still contain compact refs.
                 # Copy their verified bytes into portable history before the
                 # new session is reserved; disabled externalization must never
                 # create destination private media.
-                copied_session.messages = hydrate_session_media_urls(
+                copied_session.messages = inline_legacy_session_media_urls(
                     copied_session.messages, session.session_id
                 )
-                copied_session.context_messages = hydrate_session_media_urls(
+                copied_session.context_messages = inline_legacy_session_media_urls(
                     copied_session.context_messages, session.session_id
                 )
 
@@ -15237,13 +15237,13 @@ def handle_post(handler, parsed) -> bool:
         try:
             from api.session_media import (
                 clone_session_media_references,
-                hydrate_session_media_urls,
+                inline_legacy_session_media_urls,
             )
 
-            branch.messages = hydrate_session_media_urls(
+            branch.messages = inline_legacy_session_media_urls(
                 branch.messages, source.session_id
             )
-            branch.context_messages = hydrate_session_media_urls(
+            branch.context_messages = inline_legacy_session_media_urls(
                 branch.context_messages, source.session_id
             )
 
@@ -20930,11 +20930,11 @@ def _handle_btw(handler, body):
     try:
         from api.session_media import (
             clone_session_media_references,
-            hydrate_session_media_urls,
+            inline_legacy_session_media_urls,
         )
 
-        ephemeral.messages = hydrate_session_media_urls(ephemeral.messages, s.session_id)
-        ephemeral.context_messages = hydrate_session_media_urls(
+        ephemeral.messages = inline_legacy_session_media_urls(ephemeral.messages, s.session_id)
+        ephemeral.context_messages = inline_legacy_session_media_urls(
             ephemeral.context_messages, s.session_id
         )
 

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -169,6 +169,25 @@ def _assert_entry_still_names_fd(parent_fd: int, name: str, child_fd: int) -> No
         raise SessionMediaIntegrityError("Private media directory changed during operation")
 
 
+def _assert_regular_entry_still_names_fd(
+    parent_fd: int,
+    name: str,
+    entry_fd: int,
+) -> None:
+    held = os.fstat(entry_fd)
+    try:
+        current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise SessionMediaIntegrityError(
+            "Private media file changed during operation"
+        ) from exc
+    if not stat.S_ISREG(current.st_mode) or (held.st_dev, held.st_ino) != (
+        current.st_dev,
+        current.st_ino,
+    ):
+        raise SessionMediaIntegrityError("Private media file changed during operation")
+
+
 def _assert_private_handles(state_fd: int, media_fd: int, session_fd: int, sid: str) -> None:
     _assert_entry_still_names_fd(state_fd, _PRIVATE_ROOT_NAME, media_fd)
     _assert_entry_still_names_fd(media_fd, sid, session_fd)
@@ -785,18 +804,23 @@ def _remove_tree_at(parent_fd: int, name: str, *, expected_fd: int | None = None
                     dst_dir_fd=child_fd,
                 )
                 _fsync_dir(child_fd)
-                _assert_entry_still_names_fd(
-                    child_fd,
-                    quarantine_name,
-                    entry_fd,
-                )
                 if stat.S_ISDIR(held.st_mode):
+                    _assert_entry_still_names_fd(
+                        child_fd,
+                        quarantine_name,
+                        entry_fd,
+                    )
                     _remove_tree_at(
                         child_fd,
                         quarantine_name,
                         expected_fd=entry_fd,
                     )
                 else:
+                    _assert_regular_entry_still_names_fd(
+                        child_fd,
+                        quarantine_name,
+                        entry_fd,
+                    )
                     os.unlink(quarantine_name, dir_fd=child_fd)
                     _fsync_dir(child_fd)
             finally:
@@ -937,7 +961,7 @@ def prune_session_media(session_id: str, retained_values) -> int:
                                 dst_dir_fd=directory_fd,
                             )
                             _fsync_dir(directory_fd)
-                            _assert_entry_still_names_fd(
+                            _assert_regular_entry_still_names_fd(
                                 directory_fd,
                                 quarantine,
                                 entry_fd,

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -8,8 +8,9 @@ from the user-controlled attachment/archive extraction namespace.
 References do not encode a filesystem root.  Moving the complete WebUI state
 directory therefore moves their authority with it; changing only
 ``HERMES_WEBUI_ATTACHMENT_DIR`` does not.  Files written by the earlier
-attachment-root layout are read through a strict compatibility path and
-migrated into the state-owned store on first use.
+attachment-root layout are read through a strict compatibility path only.
+Persisting them requires an explicit offline migration with an identity-bound
+retirement backend.
 """
 import base64
 import binascii
@@ -30,8 +31,8 @@ _MIN_EXTERNALIZED_BYTES = 64 * 1024
 # retire the inode held by an open descriptor, so a replacement can always win
 # between a final identity check and the destructive syscall.  Do not create a
 # private reference until the storage backend has an identity-bound retirement
-# primitive.  Existing references remain read-compatible and are migrated back
-# to portable data URLs by Session.save().
+# primitive. Existing references remain read-compatible, but all persistence
+# paths fail closed until an explicit offline migration is performed.
 _PRIVATE_MEDIA_EXTERNALIZATION_ENABLED = False
 _MEDIA_SCHEME = "webui-media://"
 _PRIVATE_ROOT_NAME = "session-media"

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -1,0 +1,187 @@
+"""Private, file-backed storage for large native image content parts.
+
+Keeping a multi-megabyte ``data:image/...;base64`` string in both ``messages``
+and ``context_messages`` makes every session read and JSON response pay for the
+same bytes again. This module stores only verified raster images as immutable
+session attachments and leaves a small, opaque ``webui-media://`` reference in
+the transcript. The reference is expanded only at the model-call boundary.
+"""
+import base64
+import binascii
+import hashlib
+import os
+import re
+import threading
+from pathlib import Path
+
+from api.config import STATE_DIR
+
+
+_MIN_EXTERNALIZED_BYTES = 64 * 1024
+_MEDIA_SCHEME = "webui-media://"
+_REF_RE = re.compile(r"^webui-media://([a-f0-9]{64}\.(?:png|jpe?g|gif|webp|bmp))$")
+_MIME_EXTENSIONS = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/bmp": "bmp",
+}
+
+
+def _attachment_root() -> Path:
+    """Mirror the upload inbox root without importing api.upload circularly."""
+    override = os.getenv("HERMES_WEBUI_ATTACHMENT_DIR", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (STATE_DIR / "attachments").resolve()
+
+
+def _session_media_dir(session_id: str) -> Path:
+    """Return the private artifact directory shared with session uploads."""
+    safe_id = re.sub(r"[^\w.\-]", "_", str(session_id or "session"))[:120]
+    root = _attachment_root()
+    target = (root / safe_id / "session-media").resolve()
+    if not target.is_relative_to(root):
+        raise ValueError("Invalid session media directory")
+    return target
+
+
+def _is_expected_raster_bytes(mime: str, raw: bytes) -> bool:
+    if mime == "image/png":
+        return raw.startswith(b"\x89PNG\r\n\x1a\n")
+    if mime == "image/jpeg":
+        return raw.startswith(b"\xff\xd8\xff")
+    if mime == "image/gif":
+        return raw.startswith((b"GIF87a", b"GIF89a"))
+    if mime == "image/webp":
+        return len(raw) >= 12 and raw[:4] == b"RIFF" and raw[8:12] == b"WEBP"
+    if mime == "image/bmp":
+        return raw.startswith(b"BM")
+    return False
+
+
+def _decode_raster_data_uri(url):
+    """Return ``(mime, bytes)`` for a valid raster base64 data URI, else None."""
+    if not isinstance(url, str) or not url[:5].lower() == "data:":
+        return None
+    try:
+        header, encoded = url.split(",", 1)
+    except ValueError:
+        return None
+    tokens = header[5:].split(";")
+    if not tokens or "base64" not in {token.strip().lower() for token in tokens[1:]}:
+        return None
+    mime = tokens[0].strip().lower()
+    if mime not in _MIME_EXTENSIONS:
+        return None
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    if not _is_expected_raster_bytes(mime, raw):
+        return None
+    return mime, raw
+
+
+def _write_media(session_id: str, mime: str, raw: bytes) -> str:
+    """Persist immutable media and return its opaque reference URL."""
+    digest = hashlib.sha256(raw).hexdigest()
+    filename = f"{digest}.{_MIME_EXTENSIONS[mime]}"
+    root = _session_media_dir(session_id)
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / filename
+    if not target.exists():
+        tmp = root / f".{filename}.{os.getpid()}.{threading.get_ident()}.tmp"
+        try:
+            with open(tmp, "xb") as handle:
+                handle.write(raw)
+                handle.flush()
+                os.fsync(handle.fileno())
+            # Same digest means same bytes, so replacing a concurrent writer is
+            # safe and avoids a partially written stable filename.
+            os.replace(tmp, target)
+        except FileExistsError:
+            pass
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+    return _MEDIA_SCHEME + filename
+
+
+def externalize_large_session_media(value, session_id: str, *, min_bytes: int = _MIN_EXTERNALIZED_BYTES) -> int:
+    """Replace large structured raster data URLs in *value* in place.
+
+    Only canonical OpenAI-style ``image_url`` content parts are touched. Plain
+    text, SVG and malformed/foreign data URLs remain byte-for-byte unchanged.
+    Returns the number of parts externalized.
+    """
+    changed = 0
+
+    def visit(node):
+        nonlocal changed
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        image = node.get("image_url")
+        if node.get("type") == "image_url" and isinstance(image, dict):
+            decoded = _decode_raster_data_uri(image.get("url"))
+            if decoded is not None:
+                mime, raw = decoded
+                if len(raw) >= min_bytes:
+                    image["url"] = _write_media(session_id, mime, raw)
+                    changed += 1
+                    return
+        for child in node.values():
+            visit(child)
+
+    visit(value)
+    return changed
+
+
+def hydrate_session_media_urls(value, session_id: str):
+    """Return a deep copy whose valid private references are data URLs again."""
+    import copy
+
+    hydrated = copy.deepcopy(value)
+    root = _session_media_dir(session_id)
+
+    def visit(node):
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        image = node.get("image_url")
+        if node.get("type") == "image_url" and isinstance(image, dict):
+            url = image.get("url")
+            match = _REF_RE.fullmatch(url) if isinstance(url, str) else None
+            if match:
+                path = (root / match.group(1)).resolve()
+                try:
+                    if path.is_relative_to(root) and path.is_file():
+                        raw = path.read_bytes()
+                        mime = {
+                            ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                            ".gif": "image/gif", ".webp": "image/webp", ".bmp": "image/bmp",
+                        }.get(path.suffix.lower())
+                        if mime and _is_expected_raster_bytes(mime, raw):
+                            image["url"] = "data:%s;base64,%s" % (
+                                mime, base64.b64encode(raw).decode("ascii")
+                            )
+                except OSError:
+                    # Preserve a missing/corrupt reference rather than replacing
+                    # it with unrelated bytes.
+                    pass
+                return
+        for child in node.values():
+            visit(child)
+
+    visit(hydrated)
+    return hydrated

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -17,7 +17,6 @@ import hashlib
 import os
 import re
 import secrets
-import shutil
 import stat
 import threading
 from contextlib import contextmanager
@@ -48,15 +47,35 @@ _EXTENSION_MIMES = {
 }
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
-_DIR_FD_OK = all(
-    function in getattr(os, "supports_dir_fd", set())
-    for function in (os.open, os.mkdir, os.stat, os.unlink, os.rmdir, os.link)
-) and os.listdir in getattr(os, "supports_fd", set())
+_DIR_FD_CAPABILITIES = {
+    "open": os.open in getattr(os, "supports_dir_fd", set()),
+    "mkdir": os.mkdir in getattr(os, "supports_dir_fd", set()),
+    "stat": os.stat in getattr(os, "supports_dir_fd", set()),
+    "unlink": os.unlink in getattr(os, "supports_dir_fd", set()),
+    "rmdir": os.rmdir in getattr(os, "supports_dir_fd", set()),
+    "link": os.link in getattr(os, "supports_dir_fd", set()),
+    # CPython exposes os.replace(src_dir_fd=..., dst_dir_fd=...) through the
+    # same platform primitive as os.rename, but only os.rename is listed in
+    # supports_dir_fd. Key the replace capability to that authoritative entry.
+    "replace": os.name != "nt" and os.rename in getattr(os, "supports_dir_fd", set()),
+    "listdir": os.listdir in getattr(os, "supports_fd", set()),
+}
+_DIR_FD_OK = all(_DIR_FD_CAPABILITIES.values())
 _MEDIA_IO_LOCK = threading.RLock()
 
 
 class SessionMediaIntegrityError(ValueError):
     """A private reference cannot be proven safe and complete."""
+
+
+def _unsupported_backend_error() -> SessionMediaIntegrityError:
+    missing = ", ".join(
+        name for name, supported in _DIR_FD_CAPABILITIES.items() if not supported
+    ) or "anchored directory handles"
+    return SessionMediaIntegrityError(
+        "Private session media is unsupported on this filesystem backend "
+        f"because safe anchored operations are unavailable ({missing})"
+    )
 
 
 def _validated_session_id(session_id: str) -> str:
@@ -83,131 +102,6 @@ def _attachment_root() -> Path:
 def _session_media_dir(session_id: str) -> Path:
     """Return the state-owned private media path (diagnostics/tests only)."""
     return _state_root() / _PRIVATE_ROOT_NAME / _validated_session_id(session_id)
-
-
-def _ensure_path_directory(session_id: str, *, create: bool) -> tuple[Path, bool]:
-    """Return a safe pathname-backend directory for platforms without dir_fd."""
-    sid = _validated_session_id(session_id)
-    root = _state_root()
-    media_root = root / _PRIVATE_ROOT_NAME
-    session_root = media_root / sid
-    created_session = False
-    for candidate in (media_root, session_root):
-        try:
-            info = candidate.lstat()
-        except FileNotFoundError:
-            if not create:
-                raise
-            candidate.mkdir(mode=0o700)
-            if candidate == session_root:
-                created_session = True
-            info = candidate.lstat()
-        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
-            raise SessionMediaIntegrityError("Private media path is not a safe directory")
-        try:
-            candidate.resolve().relative_to(root)
-        except ValueError as exc:
-            raise SessionMediaIntegrityError("Private media path escaped state root") from exc
-    return session_root, created_session
-
-
-def _fsync_path_directory(path: Path) -> None:
-    """Sync a pathname directory where the platform exposes directory handles."""
-    try:
-        fd = os.open(str(path), os.O_RDONLY | _O_DIRECTORY)
-    except OSError:
-        # Native Windows cannot open directories this way. File flush+fsync and
-        # atomic replace still provide the strongest available local contract.
-        return
-    try:
-        os.fsync(fd)
-    except OSError:
-        if os.name != "nt":
-            raise
-    finally:
-        os.close(fd)
-
-
-def _read_and_verify_path(directory: Path, filename: str) -> tuple[str, bytes]:
-    target = directory / filename
-    before = target.lstat()
-    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
-        raise SessionMediaIntegrityError("Stored session image is not a regular file")
-    with open(target, "rb") as handle:
-        held = os.fstat(handle.fileno())
-        raw = handle.read()
-    after = target.lstat()
-    if (held.st_dev, held.st_ino) != (before.st_dev, before.st_ino) or (
-        held.st_dev,
-        held.st_ino,
-    ) != (after.st_dev, after.st_ino):
-        raise SessionMediaIntegrityError("Stored session image changed during read")
-    return _verify_media_bytes(filename, raw)
-
-
-def _write_media_path(session_id: str, mime: str, raw: bytes, filename: str) -> str:
-    with _MEDIA_IO_LOCK:
-        directory, session_created = _ensure_path_directory(session_id, create=True)
-        target = directory / filename
-        temp = directory / _new_temp_name(filename)
-        published = False
-        try:
-            try:
-                _read_and_verify_path(directory, filename)
-                return _MEDIA_SCHEME + filename
-            except FileNotFoundError:
-                pass
-            except SessionMediaIntegrityError:
-                pass
-            with open(temp, "xb") as handle:
-                handle.write(raw)
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(temp, target)
-            published = True
-            _fsync_path_directory(directory)
-            _read_and_verify_path(directory, filename)
-        except BaseException:
-            temp.unlink(missing_ok=True)
-            if published:
-                target.unlink(missing_ok=True)
-                _fsync_path_directory(directory)
-            if session_created:
-                try:
-                    directory.rmdir()
-                except OSError:
-                    pass
-            raise
-        finally:
-            temp.unlink(missing_ok=True)
-    return _MEDIA_SCHEME + filename
-
-
-def _read_verified_media_reference_path(
-    session_id: str,
-    filename: str,
-) -> tuple[str, bytes]:
-    try:
-        directory, _ = _ensure_path_directory(session_id, create=False)
-        return _read_and_verify_path(directory, filename)
-    except FileNotFoundError as private_missing:
-        for legacy_path in _legacy_session_media_dirs(session_id):
-            try:
-                info = legacy_path.lstat()
-                if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
-                    continue
-                mime, raw = _read_and_verify_path(legacy_path, filename)
-                _write_media(session_id, mime, raw)
-                return mime, raw
-            except FileNotFoundError:
-                continue
-        raise SessionMediaIntegrityError(
-            f"Stored session image is missing: {filename}. Restore it or re-attach the image."
-        ) from private_missing
-    except OSError as exc:
-        raise SessionMediaIntegrityError(
-            f"Stored session image could not be read safely: {filename}. Restore it or re-attach the image."
-        ) from exc
 
 
 def _legacy_session_media_dirs(session_id: str) -> list[Path]:
@@ -439,7 +333,7 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
     digest = hashlib.sha256(raw).hexdigest()
     filename = f"{digest}.{_MIME_EXTENSIONS[mime]}"
     if not _DIR_FD_OK:
-        return _write_media_path(session_id, mime, raw, filename)
+        raise _unsupported_backend_error()
     temp_name = None
     published = False
     with _MEDIA_IO_LOCK:
@@ -512,7 +406,7 @@ def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str,
     """Read through one anchored handle and verify type, magic and digest."""
     _reference_filename(_MEDIA_SCHEME + filename)
     if not _DIR_FD_OK:
-        return _read_verified_media_reference_path(session_id, filename)
+        raise _unsupported_backend_error()
     try:
         with _open_private_session(session_id, create=False) as (
             state_fd,
@@ -595,18 +489,15 @@ def clone_session_media_references(value, source_session_id: str, destination_se
     if not filenames:
         return 0
 
+    if not _DIR_FD_OK:
+        raise _unsupported_backend_error()
+
     # Preflight every source before creating the destination namespace.  A bad
     # later reference therefore cannot leave an earlier destination blob behind.
     payloads = {
         filename: _read_verified_media_reference(source_session_id, filename)
         for filename in filenames
     }
-    if not _DIR_FD_OK:
-        return _clone_session_media_references_path(
-            filenames,
-            payloads,
-            destination_session_id,
-        )
     staged = {}
     created = []
     with _MEDIA_IO_LOCK:
@@ -690,67 +581,6 @@ def clone_session_media_references(value, source_session_id: str, destination_se
     return len(filenames)
 
 
-def _clone_session_media_references_path(
-    filenames: list[str],
-    payloads: dict[str, tuple[str, bytes]],
-    destination_session_id: str,
-) -> int:
-    """Transactional clone fallback for platforms without directory-fd APIs."""
-    staged: dict[str, Path] = {}
-    created: list[Path] = []
-    with _MEDIA_IO_LOCK:
-        directory, session_created = _ensure_path_directory(
-            destination_session_id,
-            create=True,
-        )
-        try:
-            for filename, (mime, raw) in payloads.items():
-                expected = f"{hashlib.sha256(raw).hexdigest()}.{_MIME_EXTENSIONS[mime]}"
-                if expected != filename:
-                    raise SessionMediaIntegrityError("Session media identity changed while cloning")
-                try:
-                    _read_and_verify_path(directory, filename)
-                    continue
-                except FileNotFoundError:
-                    pass
-                except SessionMediaIntegrityError as exc:
-                    raise SessionMediaIntegrityError(
-                        f"Destination already contains corrupt session media: {filename}"
-                    ) from exc
-                temp = directory / _new_temp_name(filename)
-                with open(temp, "xb") as handle:
-                    handle.write(raw)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                staged[filename] = temp
-
-            for filename, temp in staged.items():
-                target = directory / filename
-                if target.exists():
-                    _read_and_verify_path(directory, filename)
-                    temp.unlink(missing_ok=True)
-                    continue
-                os.replace(temp, target)
-                created.append(target)
-            staged.clear()
-            _fsync_path_directory(directory)
-            for filename in filenames:
-                _read_and_verify_path(directory, filename)
-        except BaseException:
-            for target in reversed(created):
-                target.unlink(missing_ok=True)
-            for temp in staged.values():
-                temp.unlink(missing_ok=True)
-            _fsync_path_directory(directory)
-            if session_created:
-                try:
-                    directory.rmdir()
-                except OSError:
-                    pass
-            raise
-    return len(filenames)
-
-
 def externalize_large_session_media(
     value,
     session_id: str,
@@ -758,6 +588,11 @@ def externalize_large_session_media(
     min_bytes: int = _MIN_EXTERNALIZED_BYTES,
 ) -> int:
     """Replace large structured raster data URLs in *value* in place."""
+    # Unsupported platforms keep portable data URLs inline. No compact private
+    # reference is ever persisted unless every operation needed to read, clone,
+    # commit, roll back, and remove it has an anchored handle implementation.
+    if not _DIR_FD_OK:
+        return 0
     changed = 0
 
     def visit(node):
@@ -858,22 +693,13 @@ def remove_session_media(session_id: str) -> None:
     """Delete the state-owned private media namespace for one session."""
     sid = _validated_session_id(session_id)
     if not _DIR_FD_OK:
-        with _MEDIA_IO_LOCK:
-            media_root = _state_root() / _PRIVATE_ROOT_NAME
-            session_root = media_root / sid
-            try:
-                info = session_root.lstat()
-            except FileNotFoundError:
-                return
-            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
-                raise SessionMediaIntegrityError("Private media path is not a safe directory")
-            try:
-                session_root.resolve().relative_to(_state_root())
-            except ValueError as exc:
-                raise SessionMediaIntegrityError("Private media path escaped state root") from exc
-            shutil.rmtree(session_root)
-            _fsync_path_directory(media_root)
-        return
+        # A platform that never had the capability cannot create this tree via
+        # this implementation. Absence is therefore a safe no-op; presence is
+        # not deleted through a mutable pathname because that would reintroduce
+        # the check-then-use parent-swap vulnerability this guard prevents.
+        if not (_state_root() / _PRIVATE_ROOT_NAME).exists():
+            return
+        raise _unsupported_backend_error()
     try:
         state_fd = _open_root_fd(_state_root())
         try:

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -193,17 +193,18 @@ def _unlink_quarantined_regular_entry(
     name: str,
     entry_fd: int,
 ) -> None:
-    """Commit unlink only for the regular inode held in private quarantine."""
+    """Retire only the regular inode held in private quarantine.
+
+    POSIX exposes ``unlinkat`` only by mutable directory entry.  Even after an
+    inode comparison, another writer can replace that entry before the unlink,
+    so no portable Python/POSIX primitive can prove that unlink removes this
+    held inode rather than the replacement.  Keep the quarantined entry as the
+    durable retry authority instead of risking deletion of unrelated data.
+    """
     _assert_regular_entry_still_names_fd(parent_fd, name, entry_fd)
-    links_before = os.fstat(entry_fd).st_nlink
-    if links_before < 1:
-        raise SessionMediaIntegrityError("Private media file has no removable link")
-    os.unlink(name, dir_fd=parent_fd)
-    _fsync_dir(parent_fd)
-    if os.fstat(entry_fd).st_nlink != links_before - 1:
-        raise SessionMediaIntegrityError(
-            "Private media file replacement prevented exact removal"
-        )
+    raise SessionMediaIntegrityError(
+        "Exact private media file retirement is unavailable; retaining quarantine"
+    )
 
 
 def _rmdir_quarantined_directory_entry(
@@ -211,14 +212,16 @@ def _rmdir_quarantined_directory_entry(
     name: str,
     entry_fd: int,
 ) -> None:
-    """Commit rmdir only for the empty directory inode held in quarantine."""
+    """Retire only the empty directory inode held in private quarantine.
+
+    See :func:`_unlink_quarantined_regular_entry`: ``rmdir`` has the same
+    pathname-only final operation, so retaining the already-hidden quarantine
+    is the only fail-closed behavior on this backend.
+    """
     _assert_entry_still_names_fd(parent_fd, name, entry_fd)
-    os.rmdir(name, dir_fd=parent_fd)
-    _fsync_dir(parent_fd)
-    if os.fstat(entry_fd).st_nlink != 0:
-        raise SessionMediaIntegrityError(
-            "Private media directory replacement prevented exact removal"
-        )
+    raise SessionMediaIntegrityError(
+        "Exact private media directory retirement is unavailable; retaining quarantine"
+    )
 
 
 def _assert_private_handles(state_fd: int, media_fd: int, session_fd: int, sid: str) -> None:

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -188,6 +188,36 @@ def _assert_regular_entry_still_names_fd(
         raise SessionMediaIntegrityError("Private media file changed during operation")
 
 
+def _unlink_quarantined_regular_entry(
+    parent_fd: int,
+    name: str,
+    entry_fd: int,
+) -> None:
+    """Commit unlink only for the regular inode held in private quarantine."""
+    _assert_regular_entry_still_names_fd(parent_fd, name, entry_fd)
+    os.unlink(name, dir_fd=parent_fd)
+    _fsync_dir(parent_fd)
+    if os.fstat(entry_fd).st_nlink != 0:
+        raise SessionMediaIntegrityError(
+            "Private media file replacement prevented exact removal"
+        )
+
+
+def _rmdir_quarantined_directory_entry(
+    parent_fd: int,
+    name: str,
+    entry_fd: int,
+) -> None:
+    """Commit rmdir only for the empty directory inode held in quarantine."""
+    _assert_entry_still_names_fd(parent_fd, name, entry_fd)
+    os.rmdir(name, dir_fd=parent_fd)
+    _fsync_dir(parent_fd)
+    if os.fstat(entry_fd).st_nlink != 0:
+        raise SessionMediaIntegrityError(
+            "Private media directory replacement prevented exact removal"
+        )
+
+
 def _assert_private_handles(state_fd: int, media_fd: int, session_fd: int, sid: str) -> None:
     _assert_entry_still_names_fd(state_fd, _PRIVATE_ROOT_NAME, media_fd)
     _assert_entry_still_names_fd(media_fd, sid, session_fd)
@@ -821,16 +851,18 @@ def _remove_tree_at(parent_fd: int, name: str, *, expected_fd: int | None = None
                         quarantine_name,
                         entry_fd,
                     )
-                    os.unlink(quarantine_name, dir_fd=child_fd)
-                    _fsync_dir(child_fd)
+                    _unlink_quarantined_regular_entry(
+                        child_fd,
+                        quarantine_name,
+                        entry_fd,
+                    )
             finally:
                 os.close(entry_fd)
         # Keep the authoritative handle open through the last identity check
         # and rmdir. In particular, never close it and then resolve ``name``
         # again as the old implementation did.
         _assert_entry_still_names_fd(parent_fd, name, child_fd)
-        os.rmdir(name, dir_fd=parent_fd)
-        _fsync_dir(parent_fd)
+        _rmdir_quarantined_directory_entry(parent_fd, name, child_fd)
     finally:
         if owns_fd and child_fd is not None:
             os.close(child_fd)
@@ -966,8 +998,11 @@ def prune_session_media(session_id: str, retained_values) -> int:
                                 quarantine,
                                 entry_fd,
                             )
-                            os.unlink(quarantine, dir_fd=directory_fd)
-                            _fsync_dir(directory_fd)
+                            _unlink_quarantined_regular_entry(
+                                directory_fd,
+                                quarantine,
+                                entry_fd,
+                            )
                             removed += 1
                     finally:
                         os.close(entry_fd)

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -27,6 +27,14 @@ _MIME_EXTENSIONS = {
     "image/webp": "webp",
     "image/bmp": "bmp",
 }
+_EXTENSION_MIMES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+}
 
 
 def _attachment_root() -> Path:
@@ -95,7 +103,17 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
     root = _session_media_dir(session_id)
     root.mkdir(parents=True, exist_ok=True)
     target = root / filename
-    if not target.exists():
+    target_is_verified = False
+    try:
+        if target.is_file():
+            existing = target.read_bytes()
+            target_is_verified = (
+                hashlib.sha256(existing).hexdigest() == digest
+                and _is_expected_raster_bytes(mime, existing)
+            )
+    except OSError:
+        target_is_verified = False
+    if not target_is_verified:
         tmp = root / f".{filename}.{os.getpid()}.{threading.get_ident()}.tmp"
         try:
             with open(tmp, "wb") as handle:
@@ -111,6 +129,63 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
             except OSError:
                 pass
     return _MEDIA_SCHEME + filename
+
+
+def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str, bytes]:
+    """Read one reference and verify its type and content-addressed name."""
+    match = _REF_RE.fullmatch(_MEDIA_SCHEME + filename)
+    if not match:
+        raise ValueError("Invalid session media reference")
+    root = _session_media_dir(session_id)
+    path = (root / match.group(1)).resolve()
+    if not path.is_relative_to(root):
+        raise ValueError("Invalid session media path")
+    raw = path.read_bytes()
+    mime = _EXTENSION_MIMES.get(path.suffix.lower().lstrip("."))
+    if not mime or not _is_expected_raster_bytes(mime, raw):
+        raise ValueError(f"Session media type verification failed for {filename}")
+    expected_digest = filename.split(".", 1)[0]
+    if hashlib.sha256(raw).hexdigest() != expected_digest:
+        raise ValueError(f"Session media digest verification failed for {filename}")
+    return mime, raw
+
+
+def clone_session_media_references(value, source_session_id: str, destination_session_id: str) -> int:
+    """Give *destination_session_id* verified ownership of compact references.
+
+    The structured value is not mutated. Callers must invoke this before
+    committing copied history under a different session id so every persisted
+    ``webui-media://`` reference resolves independently of the source session.
+    """
+    if source_session_id == destination_session_id:
+        return 0
+    filenames = set()
+
+    def visit(node):
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        image = node.get("image_url")
+        if node.get("type") == "image_url" and isinstance(image, dict):
+            url = image.get("url")
+            match = _REF_RE.fullmatch(url) if isinstance(url, str) else None
+            if match:
+                filenames.add(match.group(1))
+                return
+        for child in node.values():
+            visit(child)
+
+    visit(value)
+    for filename in sorted(filenames):
+        mime, raw = _read_verified_media_reference(source_session_id, filename)
+        cloned_reference = _write_media(destination_session_id, mime, raw)
+        if cloned_reference != _MEDIA_SCHEME + filename:
+            raise ValueError(f"Session media reference changed while cloning {filename}")
+        _read_verified_media_reference(destination_session_id, filename)
+    return len(filenames)
 
 
 def externalize_large_session_media(value, session_id: str, *, min_bytes: int = _MIN_EXTERNALIZED_BYTES) -> int:
@@ -169,10 +244,7 @@ def hydrate_session_media_urls(value, session_id: str):
                 try:
                     if path.is_relative_to(root) and path.is_file():
                         raw = path.read_bytes()
-                        mime = {
-                            ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
-                            ".gif": "image/gif", ".webp": "image/webp", ".bmp": "image/bmp",
-                        }.get(path.suffix.lower())
+                        mime = _EXTENSION_MIMES.get(path.suffix.lower().lstrip("."))
                         if mime and _is_expected_raster_bytes(mime, raw):
                             image["url"] = "data:%s;base64,%s" % (
                                 mime, base64.b64encode(raw).decode("ascii")

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -195,9 +195,12 @@ def _unlink_quarantined_regular_entry(
 ) -> None:
     """Commit unlink only for the regular inode held in private quarantine."""
     _assert_regular_entry_still_names_fd(parent_fd, name, entry_fd)
+    links_before = os.fstat(entry_fd).st_nlink
+    if links_before < 1:
+        raise SessionMediaIntegrityError("Private media file has no removable link")
     os.unlink(name, dir_fd=parent_fd)
     _fsync_dir(parent_fd)
-    if os.fstat(entry_fd).st_nlink != 0:
+    if os.fstat(entry_fd).st_nlink != links_before - 1:
         raise SessionMediaIntegrityError(
             "Private media file replacement prevented exact removal"
         )

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -670,12 +670,15 @@ def hydrate_session_media_urls(value, session_id: str):
     return hydrated
 
 
-def _remove_tree_at(parent_fd: int, name: str) -> None:
-    """Remove one child tree without following symlinks."""
-    try:
-        child_fd = os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd)
-    except FileNotFoundError:
-        return
+def _remove_tree_at(parent_fd: int, name: str, *, expected_fd: int | None = None) -> None:
+    """Remove exactly one held child tree without following replacements."""
+    child_fd = expected_fd
+    owns_fd = child_fd is None
+    if child_fd is None:
+        try:
+            child_fd = os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd)
+        except FileNotFoundError:
+            return
     try:
         for entry_name in os.listdir(child_fd):
             info = os.stat(entry_name, dir_fd=child_fd, follow_symlinks=False)
@@ -683,10 +686,21 @@ def _remove_tree_at(parent_fd: int, name: str) -> None:
                 _remove_tree_at(child_fd, entry_name)
             else:
                 os.unlink(entry_name, dir_fd=child_fd)
+        # Keep the authoritative handle open through the last identity check
+        # and rmdir. In particular, never close it and then resolve ``name``
+        # again as the old implementation did.
+        _assert_entry_still_names_fd(parent_fd, name, child_fd)
+        os.rmdir(name, dir_fd=parent_fd)
+        _fsync_dir(parent_fd)
     finally:
-        os.close(child_fd)
-    os.rmdir(name, dir_fd=parent_fd)
-    _fsync_dir(parent_fd)
+        if owns_fd and child_fd is not None:
+            os.close(child_fd)
+
+
+def _deletion_quarantine_prefix(session_id: str) -> str:
+    # Hashing makes the ownership prefix unambiguous: SID ``a`` must never
+    # match a quarantine belonging to sibling SID ``a-b`` during retry.
+    return f".delete-{hashlib.sha256(session_id.encode('utf-8')).hexdigest()}-"
 
 
 def remove_session_media(session_id: str) -> None:
@@ -697,18 +711,99 @@ def remove_session_media(session_id: str) -> None:
         # this implementation. Absence is therefore a safe no-op; presence is
         # not deleted through a mutable pathname because that would reintroduce
         # the check-then-use parent-swap vulnerability this guard prevents.
-        if not (_state_root() / _PRIVATE_ROOT_NAME).exists():
+        try:
+            os.lstat(_state_root() / _PRIVATE_ROOT_NAME)
+        except FileNotFoundError:
             return
         raise _unsupported_backend_error()
-    try:
-        state_fd = _open_root_fd(_state_root())
+    with _MEDIA_IO_LOCK:
         try:
-            media_fd, _ = _open_child_dir(state_fd, _PRIVATE_ROOT_NAME, create=False)
+            state_fd = _open_root_fd(_state_root())
             try:
-                _remove_tree_at(media_fd, sid)
+                media_fd, _ = _open_child_dir(state_fd, _PRIVATE_ROOT_NAME, create=False)
+                try:
+                    quarantine_prefix = _deletion_quarantine_prefix(sid)
+                    for entry_name in os.listdir(media_fd):
+                        if entry_name.startswith(quarantine_prefix):
+                            _remove_tree_at(media_fd, entry_name)
+                    try:
+                        session_fd = os.open(
+                            sid,
+                            os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW,
+                            dir_fd=media_fd,
+                        )
+                    except FileNotFoundError:
+                        # Retry the durability barrier even when a prior call
+                        # already completed the rename/remove operations.
+                        _fsync_dir(media_fd)
+                        return
+                    quarantine = f"{quarantine_prefix}{secrets.token_hex(16)}"
+                    try:
+                        os.replace(
+                            sid,
+                            quarantine,
+                            src_dir_fd=media_fd,
+                            dst_dir_fd=media_fd,
+                        )
+                        _fsync_dir(media_fd)
+                        _assert_entry_still_names_fd(media_fd, quarantine, session_fd)
+                        _remove_tree_at(
+                            media_fd,
+                            quarantine,
+                            expected_fd=session_fd,
+                        )
+                    finally:
+                        os.close(session_fd)
+                finally:
+                    os.close(media_fd)
             finally:
-                os.close(media_fd)
-        finally:
-            os.close(state_fd)
-    except FileNotFoundError:
-        return
+                os.close(state_fd)
+        except FileNotFoundError:
+            return
+
+
+def _retained_media_filenames(values) -> set[str]:
+    retained: set[str] = set()
+
+    def visit(node) -> None:
+        if isinstance(node, dict):
+            for child in node.values():
+                visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+        elif isinstance(node, str) and node.startswith(_MEDIA_SCHEME):
+            retained.add(_reference_filename(node))
+
+    visit(values)
+    return retained
+
+
+def prune_session_media(session_id: str, retained_values) -> int:
+    """Durably remove blobs unreachable from current and recovery payloads."""
+    sid = _validated_session_id(session_id)
+    retained = _retained_media_filenames(retained_values)
+    if not _DIR_FD_OK:
+        try:
+            os.lstat(_state_root() / _PRIVATE_ROOT_NAME)
+        except FileNotFoundError:
+            return 0
+        raise _unsupported_backend_error()
+    removed = 0
+    with _MEDIA_IO_LOCK:
+        try:
+            with _open_private_session(sid, create=False) as handles:
+                directory_fd = handles[2]
+                for filename in os.listdir(directory_fd):
+                    info = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+                    if not stat.S_ISREG(info.st_mode):
+                        raise SessionMediaIntegrityError(
+                            "Unexpected entry in private session media directory"
+                        )
+                    if filename not in retained:
+                        os.unlink(filename, dir_fd=directory_fd)
+                        removed += 1
+                _fsync_dir(directory_fd)
+        except FileNotFoundError:
+            return 0
+    return removed

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -85,6 +85,15 @@ def _validated_session_id(session_id: str) -> str:
     return sid
 
 
+@contextmanager
+def _session_media_authority(session_id: str):
+    """Share the durable SID mutation boundary with sidecar publication."""
+    from api.models import _session_publication_process_lock
+
+    with _session_publication_process_lock(_validated_session_id(session_id)):
+        yield
+
+
 def _state_root() -> Path:
     root = Path(STATE_DIR).expanduser()
     root.mkdir(parents=True, exist_ok=True)
@@ -336,8 +345,8 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
         raise _unsupported_backend_error()
     temp_name = None
     published = False
-    with _MEDIA_IO_LOCK:
-        sid = _validated_session_id(session_id)
+    sid = _validated_session_id(session_id)
+    with _session_media_authority(sid), _MEDIA_IO_LOCK:
         with _open_private_session(sid, create=True) as (
             state_fd,
             media_fd,
@@ -408,7 +417,10 @@ def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str,
     if not _DIR_FD_OK:
         raise _unsupported_backend_error()
     try:
-        with _open_private_session(session_id, create=False) as (
+        with _session_media_authority(session_id), _open_private_session(
+            session_id,
+            create=False,
+        ) as (
             state_fd,
             media_fd,
             directory_fd,
@@ -481,6 +493,74 @@ def verify_session_media_references(value, session_id: str) -> int:
     return len(filenames)
 
 
+def verify_serialized_session_media_payload(payload: dict, session_id: str) -> int:
+    """Validate private refs across the complete sidecar schema.
+
+    Compact references are sanctioned only inside the two transcript fields,
+    and only in canonical ``type=image_url`` parts. Every other serialized
+    field must remain portable and free of private ownership handles.
+    """
+    if not isinstance(payload, dict):
+        raise SessionMediaIntegrityError("Session payload must be an object")
+    filenames = set()
+
+    def reject_private_refs(value) -> None:
+        assert_no_session_media_references(
+            value,
+            context="session transcript outside an image part",
+        )
+
+    for field in ("messages", "context_messages"):
+        transcript = payload.get(field, [])
+        if not isinstance(transcript, list):
+            reject_private_refs(transcript)
+            continue
+        for message in transcript:
+            if not isinstance(message, dict):
+                reject_private_refs(message)
+                continue
+            reject_private_refs(
+                {key: value for key, value in message.items() if key != "content"}
+            )
+            content = message.get("content")
+            if not isinstance(content, list):
+                reject_private_refs(content)
+                continue
+            for part in content:
+                image = part.get("image_url") if isinstance(part, dict) else None
+                if (
+                    isinstance(part, dict)
+                    and part.get("type") == "image_url"
+                    and isinstance(image, dict)
+                ):
+                    url = image.get("url")
+                    if isinstance(url, str) and url.startswith(_MEDIA_SCHEME):
+                        filenames.add(_reference_filename(url))
+                    reject_private_refs(
+                        {
+                            **{key: value for key, value in part.items() if key != "image_url"},
+                            "image_url": {
+                                key: value for key, value in image.items() if key != "url"
+                            },
+                        }
+                    )
+                    continue
+                reject_private_refs(part)
+
+    outside = {
+        key: value
+        for key, value in payload.items()
+        if key not in {"messages", "context_messages"}
+    }
+    assert_no_session_media_references(
+        outside,
+        context="session payload outside messages/context_messages",
+    )
+    for filename in sorted(filenames):
+        _read_verified_media_reference(session_id, filename)
+    return len(filenames)
+
+
 def clone_session_media_references(value, source_session_id: str, destination_session_id: str) -> int:
     """Transactionally give a new session verified ownership of all references."""
     if source_session_id == destination_session_id:
@@ -500,8 +580,8 @@ def clone_session_media_references(value, source_session_id: str, destination_se
     }
     staged = {}
     created = []
-    with _MEDIA_IO_LOCK:
-        destination_sid = _validated_session_id(destination_session_id)
+    destination_sid = _validated_session_id(destination_session_id)
+    with _session_media_authority(destination_sid), _MEDIA_IO_LOCK:
         with _open_private_session(destination_sid, create=True) as (
             state_fd,
             media_fd,
@@ -681,11 +761,46 @@ def _remove_tree_at(parent_fd: int, name: str, *, expected_fd: int | None = None
             return
     try:
         for entry_name in os.listdir(child_fd):
-            info = os.stat(entry_name, dir_fd=child_fd, follow_symlinks=False)
-            if stat.S_ISDIR(info.st_mode):
-                _remove_tree_at(child_fd, entry_name)
-            else:
-                os.unlink(entry_name, dir_fd=child_fd)
+            try:
+                entry_fd = os.open(
+                    entry_name,
+                    os.O_RDONLY | _O_NOFOLLOW | getattr(os, "O_NONBLOCK", 0),
+                    dir_fd=child_fd,
+                )
+            except OSError as exc:
+                raise SessionMediaIntegrityError(
+                    "Could not hold private media entry for removal"
+                ) from exc
+            held = os.fstat(entry_fd)
+            quarantine_name = f".remove-{secrets.token_hex(16)}"
+            try:
+                if not (stat.S_ISDIR(held.st_mode) or stat.S_ISREG(held.st_mode)):
+                    raise SessionMediaIntegrityError(
+                        "Unexpected entry in private session media directory"
+                    )
+                os.replace(
+                    entry_name,
+                    quarantine_name,
+                    src_dir_fd=child_fd,
+                    dst_dir_fd=child_fd,
+                )
+                _fsync_dir(child_fd)
+                _assert_entry_still_names_fd(
+                    child_fd,
+                    quarantine_name,
+                    entry_fd,
+                )
+                if stat.S_ISDIR(held.st_mode):
+                    _remove_tree_at(
+                        child_fd,
+                        quarantine_name,
+                        expected_fd=entry_fd,
+                    )
+                else:
+                    os.unlink(quarantine_name, dir_fd=child_fd)
+                    _fsync_dir(child_fd)
+            finally:
+                os.close(entry_fd)
         # Keep the authoritative handle open through the last identity check
         # and rmdir. In particular, never close it and then resolve ``name``
         # again as the old implementation did.
@@ -716,7 +831,7 @@ def remove_session_media(session_id: str) -> None:
         except FileNotFoundError:
             return
         raise _unsupported_backend_error()
-    with _MEDIA_IO_LOCK:
+    with _session_media_authority(sid), _MEDIA_IO_LOCK:
         try:
             state_fd = _open_root_fd(_state_root())
             try:
@@ -790,19 +905,48 @@ def prune_session_media(session_id: str, retained_values) -> int:
             return 0
         raise _unsupported_backend_error()
     removed = 0
-    with _MEDIA_IO_LOCK:
+    with _session_media_authority(sid), _MEDIA_IO_LOCK:
         try:
             with _open_private_session(sid, create=False) as handles:
                 directory_fd = handles[2]
                 for filename in os.listdir(directory_fd):
-                    info = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
-                    if not stat.S_ISREG(info.st_mode):
-                        raise SessionMediaIntegrityError(
-                            "Unexpected entry in private session media directory"
+                    try:
+                        entry_fd = os.open(
+                            filename,
+                            os.O_RDONLY
+                            | _O_NOFOLLOW
+                            | getattr(os, "O_NONBLOCK", 0),
+                            dir_fd=directory_fd,
                         )
-                    if filename not in retained:
-                        os.unlink(filename, dir_fd=directory_fd)
-                        removed += 1
+                    except OSError as exc:
+                        raise SessionMediaIntegrityError(
+                            "Could not hold private media entry for pruning"
+                        ) from exc
+                    try:
+                        held = os.fstat(entry_fd)
+                        if not stat.S_ISREG(held.st_mode):
+                            raise SessionMediaIntegrityError(
+                                "Unexpected entry in private session media directory"
+                            )
+                        if filename not in retained:
+                            quarantine = f".prune-{secrets.token_hex(16)}"
+                            os.replace(
+                                filename,
+                                quarantine,
+                                src_dir_fd=directory_fd,
+                                dst_dir_fd=directory_fd,
+                            )
+                            _fsync_dir(directory_fd)
+                            _assert_entry_still_names_fd(
+                                directory_fd,
+                                quarantine,
+                                entry_fd,
+                            )
+                            os.unlink(quarantine, dir_fd=directory_fd)
+                            _fsync_dir(directory_fd)
+                            removed += 1
+                    finally:
+                        os.close(entry_fd)
                 _fsync_dir(directory_fd)
         except FileNotFoundError:
             return 0

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -26,6 +26,13 @@ from api.config import STATE_DIR
 
 
 _MIN_EXTERNALIZED_BYTES = 64 * 1024
+# POSIX only exposes unlink/rmdir by a mutable directory entry.  It cannot
+# retire the inode held by an open descriptor, so a replacement can always win
+# between a final identity check and the destructive syscall.  Do not create a
+# private reference until the storage backend has an identity-bound retirement
+# primitive.  Existing references remain read-compatible and are migrated back
+# to portable data URLs by Session.save().
+_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED = False
 _MEDIA_SCHEME = "webui-media://"
 _PRIVATE_ROOT_NAME = "session-media"
 _REF_RE = re.compile(r"^webui-media://([a-f0-9]{64}\.(?:png|jpe?g|gif|webp|bmp))$")
@@ -111,6 +118,43 @@ def _attachment_root() -> Path:
 def _session_media_dir(session_id: str) -> Path:
     """Return the state-owned private media path (diagnostics/tests only)."""
     return _state_root() / _PRIVATE_ROOT_NAME / _validated_session_id(session_id)
+
+
+def session_media_destination_owners(session_id: str) -> list[str]:
+    """Return durable private-media owners for *session_id* without mutating.
+
+    A crash may leave a renamed ``.delete-<sid-hash>-...`` quarantine before a
+    cleanup residual is persisted.  It is still private data for that SID and
+    must block reuse just like the canonical directory does.
+    """
+    sid = _validated_session_id(session_id)
+    root = _state_root() / _PRIVATE_ROOT_NAME
+    try:
+        root_stat = os.lstat(root)
+    except FileNotFoundError:
+        return []
+    except OSError:
+        return ["session_media_unknown"]
+    if not stat.S_ISDIR(root_stat.st_mode):
+        return ["session_media_unknown"]
+    owners = []
+    try:
+        if _path_entry_exists(_session_media_dir(sid)):
+            owners.append("session_media")
+        prefix = _deletion_quarantine_prefix(sid)
+        if any(path.name.startswith(prefix) for path in root.iterdir()):
+            owners.append("session_media_quarantine")
+    except OSError:
+        return ["session_media_unknown"]
+    return owners
+
+
+def _path_entry_exists(path: Path) -> bool:
+    try:
+        os.lstat(path)
+        return True
+    except FileNotFoundError:
+        return False
 
 
 def _legacy_session_media_dirs(session_id: str) -> list[Path]:
@@ -494,9 +538,10 @@ def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str,
             try:
                 with _open_legacy_session(legacy_path) as legacy_fd:
                     mime, raw = _read_and_verify_at(legacy_fd, filename)
-                # Migration is part of the successful compatibility read.  Do
-                # not keep serving from an attachment root that may move later.
-                _write_media(session_id, mime, raw)
+                # Compatibility is deliberately read-only.  Publishing a new
+                # private copy would recreate the retirement problem this
+                # module now fails closed on; Session.save() instead inlines
+                # the verified bytes into the next durable sidecar write.
                 return mime, raw
             except FileNotFoundError:
                 continue
@@ -624,6 +669,11 @@ def clone_session_media_references(value, source_session_id: str, destination_se
     if not filenames:
         return 0
 
+    if not _PRIVATE_MEDIA_EXTERNALIZATION_ENABLED:
+        raise SessionMediaIntegrityError(
+            "Private session media creation is disabled; hydrate legacy references first"
+        )
+
     if not _DIR_FD_OK:
         raise _unsupported_backend_error()
 
@@ -723,6 +773,11 @@ def externalize_large_session_media(
     min_bytes: int = _MIN_EXTERNALIZED_BYTES,
 ) -> int:
     """Replace large structured raster data URLs in *value* in place."""
+    # Portable session JSON is the only enabled write format.  Keep this
+    # no-op as the centralized save hook so callers cannot accidentally revive
+    # compact reference creation while exact retirement is unavailable.
+    if not _PRIVATE_MEDIA_EXTERNALIZATION_ENABLED:
+        return 0
     # Unsupported platforms keep portable data URLs inline. No compact private
     # reference is ever persisted unless every operation needed to read, clone,
     # commit, roll back, and remove it has an anchored handle implementation.
@@ -883,6 +938,14 @@ def _deletion_quarantine_prefix(session_id: str) -> str:
 def remove_session_media(session_id: str) -> None:
     """Delete the state-owned private media namespace for one session."""
     sid = _validated_session_id(session_id)
+    if not _PRIVATE_MEDIA_EXTERNALIZATION_ENABLED:
+        owners = session_media_destination_owners(sid)
+        if owners:
+            raise SessionMediaIntegrityError(
+                "Private session media predates disabled externalization; "
+                "automatic retirement is unavailable"
+            )
+        return
     if not _DIR_FD_OK:
         # A platform that never had the capability cannot create this tree via
         # this implementation. Absence is therefore a safe no-op; presence is
@@ -971,6 +1034,14 @@ def _retained_media_filenames(values) -> set[str]:
 def prune_session_media(session_id: str, retained_values) -> int:
     """Durably remove blobs unreachable from current and recovery payloads."""
     sid = _validated_session_id(session_id)
+    if not _PRIVATE_MEDIA_EXTERNALIZATION_ENABLED:
+        owners = session_media_destination_owners(sid)
+        if owners:
+            raise SessionMediaIntegrityError(
+                "Private session media predates disabled externalization; "
+                "automatic retirement is unavailable"
+            )
+        return 0
     retained = _retained_media_filenames(retained_values)
     if not _DIR_FD_OK:
         try:

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -61,7 +61,7 @@ def _is_expected_raster_bytes(mime: str, raw: bytes) -> bool:
     return False
 
 
-def _decode_raster_data_uri(url):
+def _decode_raster_data_uri(url, *, min_bytes: int = 0):
     """Return ``(mime, bytes)`` for a valid raster base64 data URI, else None."""
     if not isinstance(url, str) or not url[:5].lower() == "data:":
         return None
@@ -74,6 +74,10 @@ def _decode_raster_data_uri(url):
         return None
     mime = tokens[0].strip().lower()
     if mime not in _MIME_EXTENSIONS:
+        return None
+    # Standard base64 is four characters per three input bytes. Avoid decoding
+    # a small image only to discover that it stays inline below the threshold.
+    if min_bytes and len(encoded) < 4 * ((min_bytes + 2) // 3):
         return None
     try:
         raw = base64.b64decode(encoded, validate=True)
@@ -94,15 +98,13 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
     if not target.exists():
         tmp = root / f".{filename}.{os.getpid()}.{threading.get_ident()}.tmp"
         try:
-            with open(tmp, "xb") as handle:
+            with open(tmp, "wb") as handle:
                 handle.write(raw)
                 handle.flush()
                 os.fsync(handle.fileno())
             # Same digest means same bytes, so replacing a concurrent writer is
             # safe and avoids a partially written stable filename.
             os.replace(tmp, target)
-        except FileExistsError:
-            pass
         finally:
             try:
                 tmp.unlink(missing_ok=True)
@@ -130,7 +132,7 @@ def externalize_large_session_media(value, session_id: str, *, min_bytes: int = 
             return
         image = node.get("image_url")
         if node.get("type") == "image_url" and isinstance(image, dict):
-            decoded = _decode_raster_data_uri(image.get("url"))
+            decoded = _decode_raster_data_uri(image.get("url"), min_bytes=min_bytes)
             if decoded is not None:
                 mime, raw = decoded
                 if len(raw) >= min_bytes:

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -860,6 +860,13 @@ def hydrate_session_media_urls(value, session_id: str):
     return hydrated
 
 
+def inline_legacy_session_media_urls(value, session_id: str):
+    """Migrate compact refs only when present, preserving ordinary object identity."""
+    if not _collect_reference_filenames(value):
+        return value
+    return hydrate_session_media_urls(value, session_id)
+
+
 def _remove_tree_at(parent_fd: int, name: str, *, expected_fd: int | None = None) -> None:
     """Remove exactly one held child tree without following replacements."""
     child_fd = expected_fd

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -538,10 +538,10 @@ def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str,
             try:
                 with _open_legacy_session(legacy_path) as legacy_fd:
                     mime, raw = _read_and_verify_at(legacy_fd, filename)
-                # Compatibility is deliberately read-only.  Publishing a new
+                # Compatibility is deliberately read-only. Publishing a new
                 # private copy would recreate the retirement problem this
-                # module now fails closed on; Session.save() instead inlines
-                # the verified bytes into the next durable sidecar write.
+                # module now fails closed on; persisted migration requires an
+                # explicit offline tool with a safe retirement backend.
                 return mime, raw
             except FileNotFoundError:
                 continue
@@ -858,13 +858,6 @@ def hydrate_session_media_urls(value, session_id: str):
     visit(hydrated)
     assert_no_session_media_references(hydrated, context="hydrated session history")
     return hydrated
-
-
-def inline_legacy_session_media_urls(value, session_id: str):
-    """Migrate compact refs only when present, preserving ordinary object identity."""
-    if not _collect_reference_filenames(value):
-        return value
-    return hydrate_session_media_urls(value, session_id)
 
 
 def _remove_tree_at(parent_fd: int, name: str, *, expected_fd: int | None = None) -> None:

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -17,6 +17,7 @@ import hashlib
 import os
 import re
 import secrets
+import shutil
 import stat
 import threading
 from contextlib import contextmanager
@@ -47,6 +48,10 @@ _EXTENSION_MIMES = {
 }
 _O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_DIR_FD_OK = all(
+    function in getattr(os, "supports_dir_fd", set())
+    for function in (os.open, os.mkdir, os.stat, os.unlink, os.rmdir, os.link)
+)
 _MEDIA_IO_LOCK = threading.RLock()
 
 
@@ -78,6 +83,131 @@ def _attachment_root() -> Path:
 def _session_media_dir(session_id: str) -> Path:
     """Return the state-owned private media path (diagnostics/tests only)."""
     return _state_root() / _PRIVATE_ROOT_NAME / _validated_session_id(session_id)
+
+
+def _ensure_path_directory(session_id: str, *, create: bool) -> tuple[Path, bool]:
+    """Return a safe pathname-backend directory for platforms without dir_fd."""
+    sid = _validated_session_id(session_id)
+    root = _state_root()
+    media_root = root / _PRIVATE_ROOT_NAME
+    session_root = media_root / sid
+    created_session = False
+    for candidate in (media_root, session_root):
+        try:
+            info = candidate.lstat()
+        except FileNotFoundError:
+            if not create:
+                raise
+            candidate.mkdir(mode=0o700)
+            if candidate == session_root:
+                created_session = True
+            info = candidate.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            raise SessionMediaIntegrityError("Private media path is not a safe directory")
+        try:
+            candidate.resolve().relative_to(root)
+        except ValueError as exc:
+            raise SessionMediaIntegrityError("Private media path escaped state root") from exc
+    return session_root, created_session
+
+
+def _fsync_path_directory(path: Path) -> None:
+    """Sync a pathname directory where the platform exposes directory handles."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY | _O_DIRECTORY)
+    except OSError:
+        # Native Windows cannot open directories this way. File flush+fsync and
+        # atomic replace still provide the strongest available local contract.
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        if os.name != "nt":
+            raise
+    finally:
+        os.close(fd)
+
+
+def _read_and_verify_path(directory: Path, filename: str) -> tuple[str, bytes]:
+    target = directory / filename
+    before = target.lstat()
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise SessionMediaIntegrityError("Stored session image is not a regular file")
+    with open(target, "rb") as handle:
+        held = os.fstat(handle.fileno())
+        raw = handle.read()
+    after = target.lstat()
+    if (held.st_dev, held.st_ino) != (before.st_dev, before.st_ino) or (
+        held.st_dev,
+        held.st_ino,
+    ) != (after.st_dev, after.st_ino):
+        raise SessionMediaIntegrityError("Stored session image changed during read")
+    return _verify_media_bytes(filename, raw)
+
+
+def _write_media_path(session_id: str, mime: str, raw: bytes, filename: str) -> str:
+    with _MEDIA_IO_LOCK:
+        directory, session_created = _ensure_path_directory(session_id, create=True)
+        target = directory / filename
+        temp = directory / _new_temp_name(filename)
+        published = False
+        try:
+            try:
+                _read_and_verify_path(directory, filename)
+                return _MEDIA_SCHEME + filename
+            except FileNotFoundError:
+                pass
+            except SessionMediaIntegrityError:
+                pass
+            with open(temp, "xb") as handle:
+                handle.write(raw)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp, target)
+            published = True
+            _fsync_path_directory(directory)
+            _read_and_verify_path(directory, filename)
+        except BaseException:
+            temp.unlink(missing_ok=True)
+            if published:
+                target.unlink(missing_ok=True)
+                _fsync_path_directory(directory)
+            if session_created:
+                try:
+                    directory.rmdir()
+                except OSError:
+                    pass
+            raise
+        finally:
+            temp.unlink(missing_ok=True)
+    return _MEDIA_SCHEME + filename
+
+
+def _read_verified_media_reference_path(
+    session_id: str,
+    filename: str,
+) -> tuple[str, bytes]:
+    try:
+        directory, _ = _ensure_path_directory(session_id, create=False)
+        return _read_and_verify_path(directory, filename)
+    except FileNotFoundError as private_missing:
+        for legacy_path in _legacy_session_media_dirs(session_id):
+            try:
+                info = legacy_path.lstat()
+                if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                    continue
+                mime, raw = _read_and_verify_path(legacy_path, filename)
+                _write_media(session_id, mime, raw)
+                return mime, raw
+            except FileNotFoundError:
+                continue
+        raise SessionMediaIntegrityError(
+            f"Stored session image is missing: {filename}. Restore it or re-attach the image."
+        ) from private_missing
+    except OSError as exc:
+        raise SessionMediaIntegrityError(
+            f"Stored session image could not be read safely: {filename}. Restore it or re-attach the image."
+        ) from exc
 
 
 def _legacy_session_media_dirs(session_id: str) -> list[Path]:
@@ -160,7 +290,6 @@ def _open_private_session(session_id: str, *, create: bool):
         media_fd, _ = _open_child_dir(state_fd, _PRIVATE_ROOT_NAME, create=create)
         session_fd, session_created = _open_child_dir(media_fd, sid, create=create)
         yield state_fd, media_fd, session_fd, session_created
-        _assert_private_handles(state_fd, media_fd, session_fd, sid)
     finally:
         for fd in (session_fd, media_fd, state_fd):
             if fd is not None:
@@ -309,6 +438,8 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
         raise SessionMediaIntegrityError("Refusing to store unverified session media")
     digest = hashlib.sha256(raw).hexdigest()
     filename = f"{digest}.{_MIME_EXTENSIONS[mime]}"
+    if not _DIR_FD_OK:
+        return _write_media_path(session_id, mime, raw, filename)
     temp_name = None
     published = False
     with _MEDIA_IO_LOCK:
@@ -322,13 +453,20 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
             try:
                 try:
                     _read_and_verify_at(directory_fd, filename)
-                    return _MEDIA_SCHEME + filename
                 except FileNotFoundError:
                     pass
                 except SessionMediaIntegrityError:
                     # A corrupt same-name target is replaced only after the new
                     # bytes are fully written and synced.
                     pass
+                else:
+                    _assert_private_handles(
+                        state_fd,
+                        media_fd,
+                        directory_fd,
+                        sid,
+                    )
+                    return _MEDIA_SCHEME + filename
                 temp_name = _write_temp_at(directory_fd, filename, raw)
                 os.replace(
                     temp_name,
@@ -373,9 +511,23 @@ def _write_media(session_id: str, mime: str, raw: bytes) -> str:
 def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str, bytes]:
     """Read through one anchored handle and verify type, magic and digest."""
     _reference_filename(_MEDIA_SCHEME + filename)
+    if not _DIR_FD_OK:
+        return _read_verified_media_reference_path(session_id, filename)
     try:
-        with _open_private_session(session_id, create=False) as (_, _, directory_fd, _):
-            return _read_and_verify_at(directory_fd, filename)
+        with _open_private_session(session_id, create=False) as (
+            state_fd,
+            media_fd,
+            directory_fd,
+            _,
+        ):
+            result = _read_and_verify_at(directory_fd, filename)
+            _assert_private_handles(
+                state_fd,
+                media_fd,
+                directory_fd,
+                _validated_session_id(session_id),
+            )
+            return result
     except FileNotFoundError as private_missing:
         for legacy_path in _legacy_session_media_dirs(session_id):
             try:
@@ -427,6 +579,14 @@ def _collect_reference_filenames(value) -> list[str]:
     return sorted(filenames)
 
 
+def verify_session_media_references(value, session_id: str) -> int:
+    """Fail closed unless every retained private reference is owned and intact."""
+    filenames = _collect_reference_filenames(value)
+    for filename in filenames:
+        _read_verified_media_reference(session_id, filename)
+    return len(filenames)
+
+
 def clone_session_media_references(value, source_session_id: str, destination_session_id: str) -> int:
     """Transactionally give a new session verified ownership of all references."""
     if source_session_id == destination_session_id:
@@ -441,6 +601,12 @@ def clone_session_media_references(value, source_session_id: str, destination_se
         filename: _read_verified_media_reference(source_session_id, filename)
         for filename in filenames
     }
+    if not _DIR_FD_OK:
+        return _clone_session_media_references_path(
+            filenames,
+            payloads,
+            destination_session_id,
+        )
     staged = {}
     created = []
     with _MEDIA_IO_LOCK:
@@ -452,6 +618,12 @@ def clone_session_media_references(value, source_session_id: str, destination_se
             session_created,
         ):
             try:
+                _assert_private_handles(
+                    state_fd,
+                    media_fd,
+                    directory_fd,
+                    destination_sid,
+                )
                 for filename, (mime, raw) in payloads.items():
                     expected = f"{hashlib.sha256(raw).hexdigest()}.{_MIME_EXTENSIONS[mime]}"
                     if expected != filename:
@@ -515,6 +687,67 @@ def clone_session_media_references(value, source_session_id: str, destination_se
                     except OSError:
                         pass
                 raise
+    return len(filenames)
+
+
+def _clone_session_media_references_path(
+    filenames: list[str],
+    payloads: dict[str, tuple[str, bytes]],
+    destination_session_id: str,
+) -> int:
+    """Transactional clone fallback for platforms without directory-fd APIs."""
+    staged: dict[str, Path] = {}
+    created: list[Path] = []
+    with _MEDIA_IO_LOCK:
+        directory, session_created = _ensure_path_directory(
+            destination_session_id,
+            create=True,
+        )
+        try:
+            for filename, (mime, raw) in payloads.items():
+                expected = f"{hashlib.sha256(raw).hexdigest()}.{_MIME_EXTENSIONS[mime]}"
+                if expected != filename:
+                    raise SessionMediaIntegrityError("Session media identity changed while cloning")
+                try:
+                    _read_and_verify_path(directory, filename)
+                    continue
+                except FileNotFoundError:
+                    pass
+                except SessionMediaIntegrityError as exc:
+                    raise SessionMediaIntegrityError(
+                        f"Destination already contains corrupt session media: {filename}"
+                    ) from exc
+                temp = directory / _new_temp_name(filename)
+                with open(temp, "xb") as handle:
+                    handle.write(raw)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                staged[filename] = temp
+
+            for filename, temp in staged.items():
+                target = directory / filename
+                if target.exists():
+                    _read_and_verify_path(directory, filename)
+                    temp.unlink(missing_ok=True)
+                    continue
+                os.replace(temp, target)
+                created.append(target)
+            staged.clear()
+            _fsync_path_directory(directory)
+            for filename in filenames:
+                _read_and_verify_path(directory, filename)
+        except BaseException:
+            for target in reversed(created):
+                target.unlink(missing_ok=True)
+            for temp in staged.values():
+                temp.unlink(missing_ok=True)
+            _fsync_path_directory(directory)
+            if session_created:
+                try:
+                    directory.rmdir()
+                except OSError:
+                    pass
+            raise
     return len(filenames)
 
 
@@ -625,6 +858,23 @@ def _remove_tree_at(parent_fd: int, name: str) -> None:
 def remove_session_media(session_id: str) -> None:
     """Delete the state-owned private media namespace for one session."""
     sid = _validated_session_id(session_id)
+    if not _DIR_FD_OK:
+        with _MEDIA_IO_LOCK:
+            media_root = _state_root() / _PRIVATE_ROOT_NAME
+            session_root = media_root / sid
+            try:
+                info = session_root.lstat()
+            except FileNotFoundError:
+                return
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                raise SessionMediaIntegrityError("Private media path is not a safe directory")
+            try:
+                session_root.resolve().relative_to(_state_root())
+            except ValueError as exc:
+                raise SessionMediaIntegrityError("Private media path escaped state root") from exc
+            shutil.rmtree(session_root)
+            _fsync_path_directory(media_root)
+        return
     try:
         state_fd = _open_root_fd(_state_root())
         try:

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -900,9 +900,21 @@ def remove_session_media(session_id: str) -> None:
                 media_fd, _ = _open_child_dir(state_fd, _PRIVATE_ROOT_NAME, create=False)
                 try:
                     quarantine_prefix = _deletion_quarantine_prefix(sid)
-                    for entry_name in os.listdir(media_fd):
-                        if entry_name.startswith(quarantine_prefix):
-                            _remove_tree_at(media_fd, entry_name)
+                    existing_quarantines = [
+                        entry_name
+                        for entry_name in os.listdir(media_fd)
+                        if entry_name.startswith(quarantine_prefix)
+                    ]
+                    if existing_quarantines:
+                        # A prior call already detached this SID from its
+                        # public namespace. Retrying a pathname deletion of
+                        # that held quarantine would reintroduce the same
+                        # identity race (and recursively create more
+                        # quarantines). Preserve the single durable retry
+                        # authority and make the incomplete cleanup explicit.
+                        raise SessionMediaIntegrityError(
+                            "Exact private media retirement is unavailable; retaining quarantine"
+                        )
                     try:
                         session_fd = os.open(
                             sid,

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -1,17 +1,25 @@
 """Private, file-backed storage for large native image content parts.
 
-Keeping a multi-megabyte ``data:image/...;base64`` string in both ``messages``
-and ``context_messages`` makes every session read and JSON response pay for the
-same bytes again. This module stores only verified raster images as immutable
-session attachments and leaves a small, opaque ``webui-media://`` reference in
-the transcript. The reference is expanded only at the model-call boundary.
+Large raster data URLs are stored as immutable, content-addressed files and
+represented in session JSON by ``webui-media://`` references.  The private
+store is owned by ``STATE_DIR/session-media`` and is deliberately separate
+from the user-controlled attachment/archive extraction namespace.
+
+References do not encode a filesystem root.  Moving the complete WebUI state
+directory therefore moves their authority with it; changing only
+``HERMES_WEBUI_ATTACHMENT_DIR`` does not.  Files written by the earlier
+attachment-root layout are read through a strict compatibility path and
+migrated into the state-owned store on first use.
 """
 import base64
 import binascii
 import hashlib
 import os
 import re
+import secrets
+import stat
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 
 from api.config import STATE_DIR
@@ -19,7 +27,9 @@ from api.config import STATE_DIR
 
 _MIN_EXTERNALIZED_BYTES = 64 * 1024
 _MEDIA_SCHEME = "webui-media://"
+_PRIVATE_ROOT_NAME = "session-media"
 _REF_RE = re.compile(r"^webui-media://([a-f0-9]{64}\.(?:png|jpe?g|gif|webp|bmp))$")
+_SAFE_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,120}$")
 _MIME_EXTENSIONS = {
     "image/png": "png",
     "image/jpeg": "jpg",
@@ -35,24 +45,151 @@ _EXTENSION_MIMES = {
     "webp": "image/webp",
     "bmp": "image/bmp",
 }
+_O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_MEDIA_IO_LOCK = threading.RLock()
+
+
+class SessionMediaIntegrityError(ValueError):
+    """A private reference cannot be proven safe and complete."""
+
+
+def _validated_session_id(session_id: str) -> str:
+    sid = str(session_id or "")
+    if not _SAFE_SESSION_ID_RE.fullmatch(sid) or sid in {".", ".."}:
+        raise SessionMediaIntegrityError("Invalid session id for private media")
+    return sid
+
+
+def _state_root() -> Path:
+    root = Path(STATE_DIR).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    return root.resolve()
 
 
 def _attachment_root() -> Path:
-    """Mirror the upload inbox root without importing api.upload circularly."""
+    """Return the legacy upload-inbox root for read compatibility only."""
     override = os.getenv("HERMES_WEBUI_ATTACHMENT_DIR", "").strip()
     if override:
         return Path(override).expanduser().resolve()
-    return (STATE_DIR / "attachments").resolve()
+    return (_state_root() / "attachments").resolve()
 
 
 def _session_media_dir(session_id: str) -> Path:
-    """Return the private artifact directory shared with session uploads."""
-    safe_id = re.sub(r"[^\w.\-]", "_", str(session_id or "session"))[:120]
-    root = _attachment_root()
-    target = (root / safe_id / "session-media").resolve()
-    if not target.is_relative_to(root):
-        raise ValueError("Invalid session media directory")
-    return target
+    """Return the state-owned private media path (diagnostics/tests only)."""
+    return _state_root() / _PRIVATE_ROOT_NAME / _validated_session_id(session_id)
+
+
+def _legacy_session_media_dirs(session_id: str) -> list[Path]:
+    sid = _validated_session_id(session_id)
+    roots = [_attachment_root(), (_state_root() / "attachments").resolve()]
+    out = []
+    for root in roots:
+        candidate = root / sid / _PRIVATE_ROOT_NAME
+        if candidate not in out:
+            out.append(candidate)
+    return out
+
+
+def _fsync_dir(fd: int) -> None:
+    os.fsync(fd)
+
+
+def _open_root_fd(path: Path) -> int:
+    return os.open(str(path), os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW)
+
+
+def _open_child_dir(parent_fd: int, name: str, *, create: bool) -> tuple[int, bool]:
+    try:
+        return os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd), False
+    except FileNotFoundError:
+        if not create:
+            raise
+    try:
+        os.mkdir(name, 0o700, dir_fd=parent_fd)
+        created = True
+        try:
+            _fsync_dir(parent_fd)
+        except BaseException:
+            try:
+                os.rmdir(name, dir_fd=parent_fd)
+            except OSError:
+                pass
+            raise
+    except FileExistsError:
+        created = False
+    return os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd), created
+
+
+def _assert_entry_still_names_fd(parent_fd: int, name: str, child_fd: int) -> None:
+    held = os.fstat(child_fd)
+    try:
+        current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise SessionMediaIntegrityError(
+            "Private media directory changed during operation"
+        ) from exc
+    if not stat.S_ISDIR(current.st_mode) or (held.st_dev, held.st_ino) != (
+        current.st_dev,
+        current.st_ino,
+    ):
+        raise SessionMediaIntegrityError("Private media directory changed during operation")
+
+
+def _assert_private_handles(state_fd: int, media_fd: int, session_fd: int, sid: str) -> None:
+    _assert_entry_still_names_fd(state_fd, _PRIVATE_ROOT_NAME, media_fd)
+    _assert_entry_still_names_fd(media_fd, sid, session_fd)
+    try:
+        current_state = os.stat(_state_root(), follow_symlinks=True)
+    except OSError as exc:
+        raise SessionMediaIntegrityError(
+            "WebUI state directory changed during operation"
+        ) from exc
+    held_state = os.fstat(state_fd)
+    if (current_state.st_dev, current_state.st_ino) != (held_state.st_dev, held_state.st_ino):
+        raise SessionMediaIntegrityError("WebUI state directory changed during operation")
+
+
+@contextmanager
+def _open_private_session(session_id: str, *, create: bool):
+    sid = _validated_session_id(session_id)
+    state_fd = media_fd = session_fd = None
+    state_root = _state_root()
+    try:
+        state_fd = _open_root_fd(state_root)
+        media_fd, _ = _open_child_dir(state_fd, _PRIVATE_ROOT_NAME, create=create)
+        session_fd, session_created = _open_child_dir(media_fd, sid, create=create)
+        yield state_fd, media_fd, session_fd, session_created
+        _assert_private_handles(state_fd, media_fd, session_fd, sid)
+    finally:
+        for fd in (session_fd, media_fd, state_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+
+@contextmanager
+def _open_legacy_session(path: Path):
+    """Open legacy ``<attachment-root>/<sid>/session-media`` without symlinks."""
+    root = path.parents[1]
+    sid = path.parent.name
+    root_fd = session_fd = media_fd = None
+    try:
+        root_fd = _open_root_fd(root)
+        session_fd, _ = _open_child_dir(root_fd, sid, create=False)
+        media_fd, _ = _open_child_dir(session_fd, _PRIVATE_ROOT_NAME, create=False)
+        yield media_fd
+        _assert_entry_still_names_fd(root_fd, sid, session_fd)
+        _assert_entry_still_names_fd(session_fd, _PRIVATE_ROOT_NAME, media_fd)
+    finally:
+        for fd in (media_fd, session_fd, root_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
 
 def _is_expected_raster_bytes(mime: str, raw: bytes) -> bool:
@@ -83,8 +220,6 @@ def _decode_raster_data_uri(url, *, min_bytes: int = 0):
     mime = tokens[0].strip().lower()
     if mime not in _MIME_EXTENSIONS:
         return None
-    # Standard base64 is four characters per three input bytes. Avoid decoding
-    # a small image only to discover that it stays inline below the threshold.
     if min_bytes and len(encoded) < 4 * ((min_bytes + 2) // 3):
         return None
     try:
@@ -96,69 +231,172 @@ def _decode_raster_data_uri(url, *, min_bytes: int = 0):
     return mime, raw
 
 
+def _reference_filename(url: str) -> str:
+    match = _REF_RE.fullmatch(url) if isinstance(url, str) else None
+    if not match:
+        raise SessionMediaIntegrityError("Invalid private session media reference")
+    return match.group(1)
+
+
+def _verify_media_bytes(filename: str, raw: bytes) -> tuple[str, bytes]:
+    _reference_filename(_MEDIA_SCHEME + filename)
+    mime = _EXTENSION_MIMES.get(filename.rsplit(".", 1)[-1].lower())
+    if not mime or not _is_expected_raster_bytes(mime, raw):
+        raise SessionMediaIntegrityError(
+            f"Stored session image has an invalid type: {filename}. Restore it or re-attach the image."
+        )
+    if hashlib.sha256(raw).hexdigest() != filename.split(".", 1)[0]:
+        raise SessionMediaIntegrityError(
+            f"Stored session image failed digest verification: {filename}. Restore it or re-attach the image."
+        )
+    return mime, raw
+
+
+def _read_file_at(directory_fd: int, filename: str) -> bytes:
+    fd = os.open(filename, os.O_RDONLY | _O_NOFOLLOW, dir_fd=directory_fd)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise SessionMediaIntegrityError("Stored session image is not a regular file")
+        chunks = []
+        while True:
+            chunk = os.read(fd, 1024 * 1024)
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+
+
+def _read_and_verify_at(directory_fd: int, filename: str) -> tuple[str, bytes]:
+    return _verify_media_bytes(filename, _read_file_at(directory_fd, filename))
+
+
+def _new_temp_name(filename: str) -> str:
+    return f".{filename}.{secrets.token_hex(16)}.tmp"
+
+
+def _write_temp_at(directory_fd: int, filename: str, raw: bytes) -> str:
+    temp_name = _new_temp_name(filename)
+    fd = os.open(
+        temp_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | _O_NOFOLLOW,
+        0o600,
+        dir_fd=directory_fd,
+    )
+    try:
+        view = memoryview(raw)
+        while view:
+            written = os.write(fd, view)
+            if written <= 0:
+                raise OSError("Could not write private session media")
+            view = view[written:]
+        os.fsync(fd)
+    except BaseException:
+        try:
+            os.unlink(temp_name, dir_fd=directory_fd)
+        except OSError:
+            pass
+        raise
+    finally:
+        os.close(fd)
+    return temp_name
+
+
 def _write_media(session_id: str, mime: str, raw: bytes) -> str:
-    """Persist immutable media and return its opaque reference URL."""
+    """Durably persist immutable media and return its opaque reference URL."""
+    if mime not in _MIME_EXTENSIONS or not _is_expected_raster_bytes(mime, raw):
+        raise SessionMediaIntegrityError("Refusing to store unverified session media")
     digest = hashlib.sha256(raw).hexdigest()
     filename = f"{digest}.{_MIME_EXTENSIONS[mime]}"
-    root = _session_media_dir(session_id)
-    root.mkdir(parents=True, exist_ok=True)
-    target = root / filename
-    target_is_verified = False
-    try:
-        if target.is_file():
-            existing = target.read_bytes()
-            target_is_verified = (
-                hashlib.sha256(existing).hexdigest() == digest
-                and _is_expected_raster_bytes(mime, existing)
-            )
-    except OSError:
-        target_is_verified = False
-    if not target_is_verified:
-        tmp = root / f".{filename}.{os.getpid()}.{threading.get_ident()}.tmp"
-        try:
-            with open(tmp, "wb") as handle:
-                handle.write(raw)
-                handle.flush()
-                os.fsync(handle.fileno())
-            # Same digest means same bytes, so replacing a concurrent writer is
-            # safe and avoids a partially written stable filename.
-            os.replace(tmp, target)
-        finally:
+    temp_name = None
+    published = False
+    with _MEDIA_IO_LOCK:
+        sid = _validated_session_id(session_id)
+        with _open_private_session(sid, create=True) as (
+            state_fd,
+            media_fd,
+            directory_fd,
+            session_created,
+        ):
             try:
-                tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
+                try:
+                    _read_and_verify_at(directory_fd, filename)
+                    return _MEDIA_SCHEME + filename
+                except FileNotFoundError:
+                    pass
+                except SessionMediaIntegrityError:
+                    # A corrupt same-name target is replaced only after the new
+                    # bytes are fully written and synced.
+                    pass
+                temp_name = _write_temp_at(directory_fd, filename, raw)
+                os.replace(
+                    temp_name,
+                    filename,
+                    src_dir_fd=directory_fd,
+                    dst_dir_fd=directory_fd,
+                )
+                temp_name = None
+                published = True
+                _fsync_dir(directory_fd)
+                _read_and_verify_at(directory_fd, filename)
+                _assert_private_handles(state_fd, media_fd, directory_fd, sid)
+            except BaseException:
+                if temp_name is not None:
+                    try:
+                        os.unlink(temp_name, dir_fd=directory_fd)
+                    except OSError:
+                        pass
+                    temp_name = None
+                if published:
+                    try:
+                        os.unlink(filename, dir_fd=directory_fd)
+                        _fsync_dir(directory_fd)
+                    except OSError:
+                        pass
+                if session_created:
+                    try:
+                        os.rmdir(sid, dir_fd=media_fd)
+                        _fsync_dir(media_fd)
+                    except OSError:
+                        pass
+                raise
+            finally:
+                if temp_name is not None:
+                    try:
+                        os.unlink(temp_name, dir_fd=directory_fd)
+                    except OSError:
+                        pass
     return _MEDIA_SCHEME + filename
 
 
 def _read_verified_media_reference(session_id: str, filename: str) -> tuple[str, bytes]:
-    """Read one reference and verify its type and content-addressed name."""
-    match = _REF_RE.fullmatch(_MEDIA_SCHEME + filename)
-    if not match:
-        raise ValueError("Invalid session media reference")
-    root = _session_media_dir(session_id)
-    path = (root / match.group(1)).resolve()
-    if not path.is_relative_to(root):
-        raise ValueError("Invalid session media path")
-    raw = path.read_bytes()
-    mime = _EXTENSION_MIMES.get(path.suffix.lower().lstrip("."))
-    if not mime or not _is_expected_raster_bytes(mime, raw):
-        raise ValueError(f"Session media type verification failed for {filename}")
-    expected_digest = filename.split(".", 1)[0]
-    if hashlib.sha256(raw).hexdigest() != expected_digest:
-        raise ValueError(f"Session media digest verification failed for {filename}")
-    return mime, raw
+    """Read through one anchored handle and verify type, magic and digest."""
+    _reference_filename(_MEDIA_SCHEME + filename)
+    try:
+        with _open_private_session(session_id, create=False) as (_, _, directory_fd, _):
+            return _read_and_verify_at(directory_fd, filename)
+    except FileNotFoundError as private_missing:
+        for legacy_path in _legacy_session_media_dirs(session_id):
+            try:
+                with _open_legacy_session(legacy_path) as legacy_fd:
+                    mime, raw = _read_and_verify_at(legacy_fd, filename)
+                # Migration is part of the successful compatibility read.  Do
+                # not keep serving from an attachment root that may move later.
+                _write_media(session_id, mime, raw)
+                return mime, raw
+            except FileNotFoundError:
+                continue
+        raise SessionMediaIntegrityError(
+            f"Stored session image is missing: {filename}. Restore it or re-attach the image."
+        ) from private_missing
+    except OSError as exc:
+        raise SessionMediaIntegrityError(
+            f"Stored session image could not be read safely: {filename}. Restore it or re-attach the image."
+        ) from exc
 
 
-def clone_session_media_references(value, source_session_id: str, destination_session_id: str) -> int:
-    """Give *destination_session_id* verified ownership of compact references.
-
-    The structured value is not mutated. Callers must invoke this before
-    committing copied history under a different session id so every persisted
-    ``webui-media://`` reference resolves independently of the source session.
-    """
-    if source_session_id == destination_session_id:
-        return 0
+def _collect_reference_filenames(value) -> list[str]:
     filenames = set()
 
     def visit(node):
@@ -167,34 +405,126 @@ def clone_session_media_references(value, source_session_id: str, destination_se
                 visit(item)
             return
         if not isinstance(node, dict):
+            if isinstance(node, str) and node.startswith(_MEDIA_SCHEME):
+                raise SessionMediaIntegrityError("Private media reference is outside an image part")
             return
         image = node.get("image_url")
         if node.get("type") == "image_url" and isinstance(image, dict):
             url = image.get("url")
-            match = _REF_RE.fullmatch(url) if isinstance(url, str) else None
-            if match:
-                filenames.add(match.group(1))
-                return
+            if isinstance(url, str) and url.startswith(_MEDIA_SCHEME):
+                filenames.add(_reference_filename(url))
+            for key, child in node.items():
+                if key != "image_url":
+                    visit(child)
+            for key, child in image.items():
+                if key != "url":
+                    visit(child)
+            return
         for child in node.values():
             visit(child)
 
     visit(value)
-    for filename in sorted(filenames):
-        mime, raw = _read_verified_media_reference(source_session_id, filename)
-        cloned_reference = _write_media(destination_session_id, mime, raw)
-        if cloned_reference != _MEDIA_SCHEME + filename:
-            raise ValueError(f"Session media reference changed while cloning {filename}")
-        _read_verified_media_reference(destination_session_id, filename)
+    return sorted(filenames)
+
+
+def clone_session_media_references(value, source_session_id: str, destination_session_id: str) -> int:
+    """Transactionally give a new session verified ownership of all references."""
+    if source_session_id == destination_session_id:
+        return 0
+    filenames = _collect_reference_filenames(value)
+    if not filenames:
+        return 0
+
+    # Preflight every source before creating the destination namespace.  A bad
+    # later reference therefore cannot leave an earlier destination blob behind.
+    payloads = {
+        filename: _read_verified_media_reference(source_session_id, filename)
+        for filename in filenames
+    }
+    staged = {}
+    created = []
+    with _MEDIA_IO_LOCK:
+        destination_sid = _validated_session_id(destination_session_id)
+        with _open_private_session(destination_sid, create=True) as (
+            state_fd,
+            media_fd,
+            directory_fd,
+            session_created,
+        ):
+            try:
+                for filename, (mime, raw) in payloads.items():
+                    expected = f"{hashlib.sha256(raw).hexdigest()}.{_MIME_EXTENSIONS[mime]}"
+                    if expected != filename:
+                        raise SessionMediaIntegrityError("Session media identity changed while cloning")
+                    try:
+                        _read_and_verify_at(directory_fd, filename)
+                        continue
+                    except FileNotFoundError:
+                        staged[filename] = _write_temp_at(directory_fd, filename, raw)
+                    except SessionMediaIntegrityError as exc:
+                        raise SessionMediaIntegrityError(
+                            f"Destination already contains corrupt session media: {filename}"
+                        ) from exc
+
+                # Hard-link fully-synced staging files into their immutable names.
+                # Link publication is exclusive, so a check-then-use race cannot
+                # overwrite a different writer.
+                for filename, temp_name in staged.items():
+                    try:
+                        os.link(
+                            temp_name,
+                            filename,
+                            src_dir_fd=directory_fd,
+                            dst_dir_fd=directory_fd,
+                            follow_symlinks=False,
+                        )
+                        created.append(filename)
+                    except FileExistsError:
+                        _read_and_verify_at(directory_fd, filename)
+                for temp_name in staged.values():
+                    os.unlink(temp_name, dir_fd=directory_fd)
+                staged.clear()
+                _fsync_dir(directory_fd)
+                for filename in filenames:
+                    _read_and_verify_at(directory_fd, filename)
+                _assert_private_handles(
+                    state_fd,
+                    media_fd,
+                    directory_fd,
+                    destination_sid,
+                )
+            except BaseException:
+                for filename in reversed(created):
+                    try:
+                        os.unlink(filename, dir_fd=directory_fd)
+                    except OSError:
+                        pass
+                for temp_name in staged.values():
+                    try:
+                        os.unlink(temp_name, dir_fd=directory_fd)
+                    except OSError:
+                        pass
+                try:
+                    _fsync_dir(directory_fd)
+                except OSError:
+                    pass
+                if session_created:
+                    try:
+                        os.rmdir(destination_sid, dir_fd=media_fd)
+                        _fsync_dir(media_fd)
+                    except OSError:
+                        pass
+                raise
     return len(filenames)
 
 
-def externalize_large_session_media(value, session_id: str, *, min_bytes: int = _MIN_EXTERNALIZED_BYTES) -> int:
-    """Replace large structured raster data URLs in *value* in place.
-
-    Only canonical OpenAI-style ``image_url`` content parts are touched. Plain
-    text, SVG and malformed/foreign data URLs remain byte-for-byte unchanged.
-    Returns the number of parts externalized.
-    """
+def externalize_large_session_media(
+    value,
+    session_id: str,
+    *,
+    min_bytes: int = _MIN_EXTERNALIZED_BYTES,
+) -> int:
+    """Replace large structured raster data URLs in *value* in place."""
     changed = 0
 
     def visit(node):
@@ -211,7 +541,9 @@ def externalize_large_session_media(value, session_id: str, *, min_bytes: int = 
             if decoded is not None:
                 mime, raw = decoded
                 if len(raw) >= min_bytes:
-                    image["url"] = _write_media(session_id, mime, raw)
+                    # Mutate only after durable publication succeeds.
+                    reference = _write_media(session_id, mime, raw)
+                    image["url"] = reference
                     changed += 1
                     return
         for child in node.values():
@@ -221,12 +553,28 @@ def externalize_large_session_media(value, session_id: str, *, min_bytes: int = 
     return changed
 
 
+def assert_no_session_media_references(value, *, context: str = "outbound payload") -> None:
+    """Recursively reject any private URI that survived a serialization boundary."""
+    def visit(node):
+        if isinstance(node, dict):
+            for child in node.values():
+                visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+        elif isinstance(node, str) and node.startswith(_MEDIA_SCHEME):
+            raise SessionMediaIntegrityError(
+                f"Private session media reference remained in {context}"
+            )
+
+    visit(value)
+
+
 def hydrate_session_media_urls(value, session_id: str):
-    """Return a deep copy whose valid private references are data URLs again."""
+    """Return a deep copy with every private image strictly verified and expanded."""
     import copy
 
     hydrated = copy.deepcopy(value)
-    root = _session_media_dir(session_id)
 
     def visit(node):
         if isinstance(node, list):
@@ -238,24 +586,54 @@ def hydrate_session_media_urls(value, session_id: str):
         image = node.get("image_url")
         if node.get("type") == "image_url" and isinstance(image, dict):
             url = image.get("url")
-            match = _REF_RE.fullmatch(url) if isinstance(url, str) else None
-            if match:
-                path = (root / match.group(1)).resolve()
-                try:
-                    if path.is_relative_to(root) and path.is_file():
-                        raw = path.read_bytes()
-                        mime = _EXTENSION_MIMES.get(path.suffix.lower().lstrip("."))
-                        if mime and _is_expected_raster_bytes(mime, raw):
-                            image["url"] = "data:%s;base64,%s" % (
-                                mime, base64.b64encode(raw).decode("ascii")
-                            )
-                except OSError:
-                    # Preserve a missing/corrupt reference rather than replacing
-                    # it with unrelated bytes.
-                    pass
+            if isinstance(url, str) and url.startswith(_MEDIA_SCHEME):
+                filename = _reference_filename(url)
+                mime, raw = _read_verified_media_reference(session_id, filename)
+                image["url"] = "data:%s;base64,%s" % (
+                    mime,
+                    base64.b64encode(raw).decode("ascii"),
+                )
                 return
         for child in node.values():
             visit(child)
 
     visit(hydrated)
+    assert_no_session_media_references(hydrated, context="hydrated session history")
     return hydrated
+
+
+def _remove_tree_at(parent_fd: int, name: str) -> None:
+    """Remove one child tree without following symlinks."""
+    try:
+        child_fd = os.open(name, os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW, dir_fd=parent_fd)
+    except FileNotFoundError:
+        return
+    try:
+        with os.scandir(child_fd) as entries:
+            for entry in entries:
+                info = entry.stat(follow_symlinks=False)
+                if stat.S_ISDIR(info.st_mode):
+                    _remove_tree_at(child_fd, entry.name)
+                else:
+                    os.unlink(entry.name, dir_fd=child_fd)
+    finally:
+        os.close(child_fd)
+    os.rmdir(name, dir_fd=parent_fd)
+    _fsync_dir(parent_fd)
+
+
+def remove_session_media(session_id: str) -> None:
+    """Delete the state-owned private media namespace for one session."""
+    sid = _validated_session_id(session_id)
+    try:
+        state_fd = _open_root_fd(_state_root())
+        try:
+            media_fd, _ = _open_child_dir(state_fd, _PRIVATE_ROOT_NAME, create=False)
+            try:
+                _remove_tree_at(media_fd, sid)
+            finally:
+                os.close(media_fd)
+        finally:
+            os.close(state_fd)
+    except FileNotFoundError:
+        return

--- a/api/session_media.py
+++ b/api/session_media.py
@@ -51,7 +51,7 @@ _O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 _DIR_FD_OK = all(
     function in getattr(os, "supports_dir_fd", set())
     for function in (os.open, os.mkdir, os.stat, os.unlink, os.rmdir, os.link)
-)
+) and os.listdir in getattr(os, "supports_fd", set())
 _MEDIA_IO_LOCK = threading.RLock()
 
 
@@ -842,13 +842,12 @@ def _remove_tree_at(parent_fd: int, name: str) -> None:
     except FileNotFoundError:
         return
     try:
-        with os.scandir(child_fd) as entries:
-            for entry in entries:
-                info = entry.stat(follow_symlinks=False)
-                if stat.S_ISDIR(info.st_mode):
-                    _remove_tree_at(child_fd, entry.name)
-                else:
-                    os.unlink(entry.name, dir_fd=child_fd)
+        for entry_name in os.listdir(child_fd):
+            info = os.stat(entry_name, dir_fd=child_fd, follow_symlinks=False)
+            if stat.S_ISDIR(info.st_mode):
+                _remove_tree_at(child_fd, entry_name)
+            else:
+                os.unlink(entry_name, dir_fd=child_fd)
     finally:
         os.close(child_fd)
     os.rmdir(name, dir_fd=parent_fd)

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -470,7 +470,7 @@ def retry_last(session_id: str) -> dict[str, Any]:
                 truncated_context = _truncate_at_last_user(s.context_messages)
                 if truncated_context is not None:
                     s.context_messages = truncated_context
-        s.save()
+        s.save(prune_media=True)
     return {'last_user_text': last_user_text, 'removed_count': removed_count}
 
 
@@ -512,7 +512,7 @@ def undo_last(session_id: str) -> dict[str, Any]:
                 truncated_context = _truncate_at_last_user(s.context_messages)
                 if truncated_context is not None:
                     s.context_messages = truncated_context
-        s.save()  # outside LOCK -- save() re-acquires LOCK via _write_session_index()
+        s.save(prune_media=True)  # outside LOCK -- save() re-acquires LOCK via _write_session_index()
     preview = (removed_text[:40] + '...') if len(removed_text) > 40 else removed_text
     return {
         'removed_count': removed_count,

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -26,6 +26,8 @@ Three integration points:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -43,6 +45,212 @@ from api.turn_journal import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+_COMPRESSION_TRANSACTION_VERSION = 2
+_COMPRESSION_TRANSACTION_PHASES = {
+    "initializing",
+    "prepared",
+    "reserved",
+    "source_archived",
+    "sidecar_published",
+    "migrations_complete",
+    "source_restored",
+}
+
+
+def _compression_transaction_paths(session_dir: Path, new_sid: str) -> dict[str, Path]:
+    root = session_dir / "_compression_transactions"
+    return {
+        "root": root,
+        "intent": root / f"{new_sid}.json",
+        "sidecar_backup": root / f"{new_sid}.source-sidecar.bak",
+        "index_backup": root / f"{new_sid}.source-index.bak",
+    }
+
+
+def _write_compression_transaction_intent(
+    session_dir: Path,
+    intent: dict,
+) -> dict:
+    from api.models import _durable_replace_bytes
+
+    validated = _validate_compression_transaction_intent(
+        session_dir,
+        intent,
+    )
+    paths = _compression_transaction_paths(
+        session_dir,
+        validated["new_session_id"],
+    )
+    _durable_replace_bytes(
+        paths["intent"],
+        json.dumps(validated, ensure_ascii=False, indent=2).encode("utf-8"),
+    )
+    return validated
+
+
+def _validate_compression_transaction_intent(
+    session_dir: Path,
+    intent: dict,
+    *,
+    expected_new_sid: str | None = None,
+) -> dict:
+    from api.models import _is_session_incarnation_token, is_safe_session_id
+
+    if not isinstance(intent, dict) or intent.get("version") != _COMPRESSION_TRANSACTION_VERSION:
+        raise ValueError("invalid compression transaction version")
+    old_sid = intent.get("old_session_id")
+    new_sid = intent.get("new_session_id")
+    if (
+        not isinstance(old_sid, str)
+        or not isinstance(new_sid, str)
+        or not is_safe_session_id(old_sid)
+        or not is_safe_session_id(new_sid)
+        or old_sid == new_sid
+        or (expected_new_sid is not None and new_sid != expected_new_sid)
+    ):
+        raise ValueError("invalid compression transaction identity")
+    phase = intent.get("phase")
+    if phase not in _COMPRESSION_TRANSACTION_PHASES:
+        raise ValueError("invalid compression transaction phase")
+    token = intent.get("incarnation_token")
+    if token is not None and not _is_session_incarnation_token(token):
+        raise ValueError("invalid compression transaction incarnation")
+    if phase not in {"initializing", "prepared"} and token is None:
+        raise ValueError("compression transaction phase requires an incarnation")
+    source = intent.get("source")
+    if not isinstance(source, dict):
+        raise ValueError("invalid compression transaction source backup")
+    paths = _compression_transaction_paths(session_dir, new_sid)
+    expected = {
+        "sidecar": paths["sidecar_backup"].name,
+        "index": paths["index_backup"].name,
+    }
+    for key in ("sidecar", "index"):
+        record = source.get(key)
+        if not isinstance(record, dict) or not isinstance(record.get("existed"), bool):
+            raise ValueError("invalid compression transaction backup record")
+        if record.get("backup") != expected[key]:
+            raise ValueError("compression transaction backup path mismatch")
+        digest = record.get("sha256")
+        if record["existed"]:
+            if (
+                not isinstance(digest, str)
+                or len(digest) != 64
+                or any(char not in "0123456789abcdef" for char in digest)
+            ):
+                raise ValueError("invalid compression transaction backup digest")
+        elif digest is not None:
+            raise ValueError("absent compression source cannot have a digest")
+    return dict(intent)
+
+
+def _stage_compression_transaction_source(
+    session_dir: Path,
+    old_sid: str,
+    new_sid: str,
+) -> dict:
+    """Durably record exact source bytes before either session identity mutates."""
+    from api.models import (
+        _durable_replace_bytes,
+        _path_entry_exists,
+        _validate_session_payload_identity,
+    )
+
+    paths = _compression_transaction_paths(session_dir, new_sid)
+    sidecar = session_dir / f"{old_sid}.json"
+    index = session_dir / "_index.json"
+    if not _path_entry_exists(sidecar):
+        raise RuntimeError("Compression source sidecar is missing")
+    sidecar_bytes = sidecar.read_bytes()
+    _validate_session_payload_identity(
+        json.loads(sidecar_bytes),
+        old_sid,
+        source_name=sidecar.name,
+    )
+    index_existed = _path_entry_exists(index)
+    index_bytes = index.read_bytes() if index_existed else b""
+    intent = {
+        "version": _COMPRESSION_TRANSACTION_VERSION,
+        "old_session_id": old_sid,
+        "new_session_id": new_sid,
+        "incarnation_token": None,
+        "phase": "initializing",
+        "source": {
+            "sidecar": {
+                "existed": True,
+                "backup": paths["sidecar_backup"].name,
+                "sha256": hashlib.sha256(sidecar_bytes).hexdigest(),
+            },
+            "index": {
+                "existed": index_existed,
+                "backup": paths["index_backup"].name,
+                "sha256": (
+                    hashlib.sha256(index_bytes).hexdigest()
+                    if index_existed
+                    else None
+                ),
+            },
+        },
+    }
+    intent = _write_compression_transaction_intent(session_dir, intent)
+    _durable_replace_bytes(paths["sidecar_backup"], sidecar_bytes)
+    if index_existed:
+        _durable_replace_bytes(paths["index_backup"], index_bytes)
+    intent["phase"] = "prepared"
+    return _write_compression_transaction_intent(session_dir, intent)
+
+
+def _advance_compression_transaction(
+    session_dir: Path,
+    intent: dict,
+    phase: str,
+    *,
+    token: str | None = None,
+) -> dict:
+    updated = dict(intent)
+    updated["phase"] = phase
+    if token is not None:
+        updated["incarnation_token"] = token
+    return _write_compression_transaction_intent(session_dir, updated)
+
+
+def _restore_compression_transaction_source(
+    session_dir: Path,
+    intent: dict,
+) -> None:
+    """Restore the old sidecar and global index byte-for-byte from durable backups."""
+    from api.models import _durable_replace_bytes, _durable_unlink
+
+    validated = _validate_compression_transaction_intent(session_dir, intent)
+    paths = _compression_transaction_paths(
+        session_dir,
+        validated["new_session_id"],
+    )
+    targets = {
+        "sidecar": session_dir / f"{validated['old_session_id']}.json",
+        "index": session_dir / "_index.json",
+    }
+    for key in ("sidecar", "index"):
+        record = validated["source"][key]
+        if not record["existed"]:
+            _durable_unlink(targets[key])
+            continue
+        backup = paths[f"{key}_backup"]
+        payload = backup.read_bytes()
+        if hashlib.sha256(payload).hexdigest() != record["sha256"]:
+            raise RuntimeError("Compression source backup digest mismatch")
+        _durable_replace_bytes(targets[key], payload)
+
+
+def _retire_compression_transaction(session_dir: Path, new_sid: str) -> None:
+    from api.models import _durable_unlink
+
+    paths = _compression_transaction_paths(session_dir, new_sid)
+    _durable_unlink(paths["sidecar_backup"])
+    _durable_unlink(paths["index_backup"])
+    _durable_unlink(paths["intent"])
 
 
 def _read_recovery_payload(path: Path, expected_sid: str) -> dict:
@@ -1028,8 +1236,11 @@ def recover_incomplete_compression_transactions(session_dir: Path) -> dict:
     from api.models import (
         SESSION_DIR,
         Session,
+        _INDEX_WRITE_LOCK,
         _clear_session_incarnation_claim,
+        _cross_process_file_lock,
         _durable_unlink,
+        _session_publication_authority,
         _write_session_index,
         rollback_reserved_session_destination,
     )
@@ -1048,6 +1259,65 @@ def recover_incomplete_compression_transactions(session_dir: Path) -> dict:
         try:
             intent = json.loads(path.read_bytes())
             sid = path.stem
+            if isinstance(intent, dict) and intent.get("version") == 2:
+                intent = _validate_compression_transaction_intent(
+                    session_dir,
+                    intent,
+                    expected_new_sid=sid,
+                )
+                old_sid = intent["old_session_id"]
+                phase = intent["phase"]
+                token = intent.get("incarnation_token")
+                with contextlib.ExitStack() as authority:
+                    for locked_sid in sorted({old_sid, sid}):
+                        authority.enter_context(
+                            _session_publication_authority(locked_sid)
+                        )
+                    authority.enter_context(_INDEX_WRITE_LOCK)
+                    authority.enter_context(
+                        _cross_process_file_lock("session-index")
+                    )
+                    if phase == "migrations_complete":
+                        sidecar = session_dir / f"{sid}.json"
+                        payload = _read_recovery_payload(sidecar, sid)
+                        if payload.get("publication_incarnation") != token:
+                            raise ValueError(
+                                "compression continuation incarnation mismatch"
+                            )
+                        session = Session(**payload)
+                        _write_session_index(updates=[session])
+                        _retire_compression_transaction(session_dir, sid)
+                        finalized += 1
+                        continue
+                    if phase == "source_restored":
+                        _retire_compression_transaction(session_dir, sid)
+                        rolled_back += 1
+                        continue
+                    if phase in {"initializing", "prepared"}:
+                        # Neither source nor destination may mutate before the
+                        # reserved phase. Partial backup staging is disposable.
+                        _retire_compression_transaction(session_dir, sid)
+                        rolled_back += 1
+                        continue
+                    result = rollback_reserved_session_destination(
+                        sid,
+                        token,
+                        durable_intent_path=path,
+                    )
+                    if not result.get("ok"):
+                        raise RuntimeError(
+                            "compression rollback residuals: "
+                            f"{result.get('residuals')!r}"
+                        )
+                    _restore_compression_transaction_source(session_dir, intent)
+                    intent = _advance_compression_transaction(
+                        session_dir,
+                        intent,
+                        "source_restored",
+                    )
+                    _retire_compression_transaction(session_dir, sid)
+                    rolled_back += 1
+                    continue
             token = intent.get("incarnation_token") if isinstance(intent, dict) else None
             phase = intent.get("phase") if isinstance(intent, dict) else None
             if (

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -51,7 +51,7 @@ def _read_recovery_payload(path: Path, expected_sid: str) -> dict:
     return _load_and_validate_session_payload(path, expected_sid)
 
 
-def _msg_count(p: Path, expected_sid: str) -> int:
+def _msg_count(p: Path) -> int:
     """Return the number of messages in a session JSON file, or -1 on read/parse error.
 
     Returns -1 for any non-session-shape file:
@@ -62,6 +62,11 @@ def _msg_count(p: Path, expected_sid: str) -> int:
       The startup recovery scanner globs ``*.json`` and would otherwise
       crash on the first non-dict file it encounters.
     """
+    expected_sid = (
+        p.name[: -len(".json.bak")]
+        if p.name.endswith(".json.bak")
+        else p.stem
+    )
     try:
         data = _read_recovery_payload(p, expected_sid)
     except (OSError, json.JSONDecodeError, ValueError):
@@ -304,7 +309,7 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
     }
     """
     bak_path = session_path.with_suffix('.json.bak')
-    live_count = _msg_count(session_path, session_path.stem)
+    live_count = _msg_count(session_path)
     if not bak_path.exists():
         return {
             "session_id": session_path.stem,
@@ -312,7 +317,7 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
             "bak_messages": -1,
             "recommend": "no_backup",
         }
-    bak_count = _msg_count(bak_path, session_path.stem)
+    bak_count = _msg_count(bak_path)
     if bak_count > live_count:
         if (
             _session_records_clear_sentinel(session_path, bak_path)
@@ -456,7 +461,7 @@ def _orphaned_backup_live_paths(
         if live_path.name.startswith('_') or live_path.exists():
             continue
         session_id = live_path.stem
-        if _msg_count(bak_path, session_id) < 0:
+        if _msg_count(bak_path) < 0:
             continue
         # A WebUI session the user deleted must not be resurrected from its
         # surviving .bak on the next boot (#5498). Use the DURABLE tombstone
@@ -852,7 +857,7 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
         if live_path.exists() or live_path.name.startswith('_'):
             continue
         session_id = live_path.stem
-        bak_messages = _msg_count(bak_path, session_id)
+        bak_messages = _msg_count(bak_path)
         if bak_messages < 0:
             items.append(_new_audit_item(
                 session_id, "malformed_orphan_backup", "unsafe_to_repair", "manual_review", -1, bak_messages
@@ -901,7 +906,7 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
         for session_id in sorted(live_ids - index_ids):
             items.append(_new_audit_item(
                 session_id, "index_missing_entry", "repairable", "rebuild_index",
-                _msg_count(session_dir / f"{session_id}.json", session_id), -1,
+                _msg_count(session_dir / f"{session_id}.json"), -1,
             ))
 
     for row in state_db_missing_rows:
@@ -944,7 +949,7 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
         journal = read_turn_journal(session_id, session_dir=session_dir)
         states, _ = derive_turn_journal_states(journal.get('events') or [])
         live_path = session_dir / f"{session_id}.json"
-        live_messages = _msg_count(live_path, session_id)
+        live_messages = _msg_count(live_path)
         existing_user_messages: set[str] = set()
         try:
             payload = _read_recovery_payload(live_path, session_id)

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -1290,6 +1290,23 @@ def recover_incomplete_compression_transactions(session_dir: Path) -> dict:
                         finalized += 1
                         continue
                     if phase == "source_restored":
+                        # The source bytes are already restored, but a prior
+                        # destination cleanup may have retained a quarantined
+                        # media entry rather than risk unlinking a replacement.
+                        # Keep this intent until that exact destination retry
+                        # succeeds; retiring it here would lose the retry
+                        # authority while leaving the SID blocked by its
+                        # cleanup residual.
+                        result = rollback_reserved_session_destination(
+                            sid,
+                            token,
+                            durable_intent_path=path,
+                        )
+                        if not result.get("ok"):
+                            raise RuntimeError(
+                                "compression rollback residuals: "
+                                f"{result.get('residuals')!r}"
+                            )
                         _retire_compression_transaction(session_dir, sid)
                         rolled_back += 1
                         continue
@@ -1299,6 +1316,12 @@ def recover_incomplete_compression_transactions(session_dir: Path) -> dict:
                         _retire_compression_transaction(session_dir, sid)
                         rolled_back += 1
                         continue
+                    _restore_compression_transaction_source(session_dir, intent)
+                    intent = _advance_compression_transaction(
+                        session_dir,
+                        intent,
+                        "source_restored",
+                    )
                     result = rollback_reserved_session_destination(
                         sid,
                         token,
@@ -1309,12 +1332,6 @@ def recover_incomplete_compression_transactions(session_dir: Path) -> dict:
                             "compression rollback residuals: "
                             f"{result.get('residuals')!r}"
                         )
-                    _restore_compression_transaction_source(session_dir, intent)
-                    intent = _advance_compression_transaction(
-                        session_dir,
-                        intent,
-                        "source_restored",
-                    )
                     _retire_compression_transaction(session_dir, sid)
                     rolled_back += 1
                     continue

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -155,7 +155,6 @@ def _stage_compression_transaction_source(
     from api.models import (
         _durable_replace_bytes,
         _path_entry_exists,
-        _validate_session_payload_identity,
     )
 
     paths = _compression_transaction_paths(session_dir, new_sid)
@@ -164,11 +163,7 @@ def _stage_compression_transaction_source(
     if not _path_entry_exists(sidecar):
         raise RuntimeError("Compression source sidecar is missing")
     sidecar_bytes = sidecar.read_bytes()
-    _validate_session_payload_identity(
-        json.loads(sidecar_bytes),
-        old_sid,
-        source_name=sidecar.name,
-    )
+    _read_recovery_payload(sidecar, old_sid)
     index_existed = _path_entry_exists(index)
     index_bytes = index.read_bytes() if index_existed else b""
     intent = {
@@ -255,8 +250,11 @@ def _retire_compression_transaction(session_dir: Path, new_sid: str) -> None:
 
 def _read_recovery_payload(path: Path, expected_sid: str) -> dict:
     from api.models import _load_and_validate_session_payload
+    from api.session_media import verify_serialized_session_media_payload
 
-    return _load_and_validate_session_payload(path, expected_sid)
+    payload = _load_and_validate_session_payload(path, expected_sid)
+    verify_serialized_session_media_payload(payload, expected_sid)
+    return payload
 
 
 def _msg_count(p: Path) -> int:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -260,17 +260,14 @@ def _read_recovery_payload(path: Path, expected_sid: str) -> dict:
     )
 
 def _read_recovery_payload_bytes(payload_bytes: bytes, expected_sid: str, *, source_name: str) -> dict:
-    from api.models import _validate_session_payload_identity
-    from api.session_media import assert_no_session_media_references
+    from api.models import _read_portable_session_payload_bytes
 
-    payload = _validate_session_payload_identity(
-        json.loads(payload_bytes), expected_sid, source_name=source_name
-    )
-    assert_no_session_media_references(
-        payload,
+    return _read_portable_session_payload_bytes(
+        payload_bytes,
+        expected_sid,
+        source_name=source_name,
         context="recovery payload; use an explicit offline media migration",
     )
-    return payload
 
 
 def _msg_count(p: Path) -> int:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -32,6 +32,7 @@ import os
 import shutil
 import sqlite3
 import threading
+import uuid
 from pathlib import Path
 
 from api.turn_journal import (
@@ -44,7 +45,13 @@ from api.turn_journal import (
 logger = logging.getLogger(__name__)
 
 
-def _msg_count(p: Path) -> int:
+def _read_recovery_payload(path: Path, expected_sid: str) -> dict:
+    from api.models import _load_and_validate_session_payload
+
+    return _load_and_validate_session_payload(path, expected_sid)
+
+
+def _msg_count(p: Path, expected_sid: str) -> int:
     """Return the number of messages in a session JSON file, or -1 on read/parse error.
 
     Returns -1 for any non-session-shape file:
@@ -56,7 +63,7 @@ def _msg_count(p: Path) -> int:
       crash on the first non-dict file it encounters.
     """
     try:
-        data = json.loads(p.read_text(encoding='utf-8'))
+        data = _read_recovery_payload(p, expected_sid)
     except (OSError, json.JSONDecodeError, ValueError):
         return -1
     if not isinstance(data, dict):
@@ -96,7 +103,7 @@ def _rebuild_recovery_session_index(session_dir: Path) -> None:
         reverse=True,
     )
     index_path = session_dir / '_index.json'
-    tmp = index_path.with_suffix(f'.tmp.recovery.{os.getpid()}.{threading.current_thread().ident}')
+    tmp = index_path.with_suffix(f'.tmp.recovery.{uuid.uuid4().hex}')
     try:
         with open(tmp, 'w', encoding='utf-8') as fh:
             fh.write(json.dumps(entries, ensure_ascii=False, indent=2))
@@ -130,7 +137,7 @@ def _session_records_intentional_compress_shrink(session_path: Path) -> bool:
     loss is still recovered. See ``inspect_session_recovery_status``.
     """
     try:
-        data = json.loads(session_path.read_text(encoding='utf-8'))
+        data = _read_recovery_payload(session_path, session_path.stem)
     except (OSError, json.JSONDecodeError, ValueError):
         return False
     if not isinstance(data, dict):
@@ -182,8 +189,8 @@ def _backup_predates_intentional_shrink(session_path: Path, bak_path: Path) -> b
     is always the safer error. Fail OPEN on any read/parse error too.
     """
     try:
-        live = json.loads(session_path.read_text(encoding='utf-8'))
-        bak = json.loads(bak_path.read_text(encoding='utf-8'))
+        live = _read_recovery_payload(session_path, session_path.stem)
+        bak = _read_recovery_payload(bak_path, session_path.stem)
     except (OSError, json.JSONDecodeError, ValueError):
         return False
     if not isinstance(live, dict) or not isinstance(bak, dict):
@@ -222,8 +229,8 @@ def _session_records_clear_sentinel(session_path: Path, bak_path: Path) -> bool:
     recoverable; unreadable or partial matches fail open.
     """
     try:
-        data = json.loads(session_path.read_text(encoding='utf-8'))
-        bak = json.loads(bak_path.read_text(encoding='utf-8'))
+        data = _read_recovery_payload(session_path, session_path.stem)
+        bak = _read_recovery_payload(bak_path, session_path.stem)
     except (OSError, json.JSONDecodeError, ValueError):
         return False
     if not isinstance(data, dict) or not isinstance(bak, dict):
@@ -267,8 +274,8 @@ def _live_supersedes_backup_by_clear_generation(session_path: Path, bak_path: Pa
     genuine crash-loss is never suppressed.
     """
     try:
-        data = json.loads(session_path.read_text(encoding='utf-8'))
-        bak = json.loads(bak_path.read_text(encoding='utf-8'))
+        data = _read_recovery_payload(session_path, session_path.stem)
+        bak = _read_recovery_payload(bak_path, session_path.stem)
     except (OSError, json.JSONDecodeError, ValueError):
         return False
     if not isinstance(data, dict) or not isinstance(bak, dict):
@@ -297,7 +304,7 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
     }
     """
     bak_path = session_path.with_suffix('.json.bak')
-    live_count = _msg_count(session_path)
+    live_count = _msg_count(session_path, session_path.stem)
     if not bak_path.exists():
         return {
             "session_id": session_path.stem,
@@ -305,7 +312,7 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
             "bak_messages": -1,
             "recommend": "no_backup",
         }
-    bak_count = _msg_count(bak_path)
+    bak_count = _msg_count(bak_path, session_path.stem)
     if bak_count > live_count:
         if (
             _session_records_clear_sentinel(session_path, bak_path)
@@ -344,6 +351,16 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
 
 
 def recover_session(session_path: Path) -> dict:
+    """Run focused recovery under the same cross-process SID authority as save."""
+    from api.models import SESSION_DIR, _session_publication_authority
+
+    if session_path.parent.resolve() == Path(SESSION_DIR).resolve():
+        with _session_publication_authority(session_path.stem):
+            return _recover_session_under_authority(session_path)
+    return _recover_session_under_authority(session_path)
+
+
+def _recover_session_under_authority(session_path: Path) -> dict:
     """Restore session_path from its .bak when the bak has more messages.
 
     Returns a status dict identical to ``inspect_session_recovery_status``
@@ -355,9 +372,13 @@ def recover_session(session_path: Path) -> dict:
     bak_path = session_path.with_suffix('.json.bak')
     # Stage the recovery via a tmp copy + atomic replace so a crash mid-restore
     # cannot leave a half-written session.json.
-    tmp_path = session_path.with_suffix('.json.recover.tmp')
+    tmp_path = session_path.with_suffix(f'.json.recover.tmp.{uuid.uuid4().hex}')
     try:
+        # Validate the backup's embedded identity before it can replace the
+        # current sidecar or influence any media namespace decision.
+        _read_recovery_payload(bak_path, session_path.stem)
         shutil.copyfile(bak_path, tmp_path)
+        _read_recovery_payload(tmp_path, session_path.stem)
         with open(tmp_path, 'rb') as handle:
             os.fsync(handle.fileno())
         tmp_path.replace(session_path)
@@ -373,15 +394,12 @@ def recover_session(session_path: Path) -> dict:
         return {**status, "restored": False, "error": str(exc)}
     try:
         from api.config import SESSION_DIR
-        from api.session_media import prune_session_media
+        from api.models import retry_session_retention_cleanup
 
         if session_path.parent.resolve() == Path(SESSION_DIR).resolve():
-            restored_payload = json.loads(session_path.read_bytes())
-            if (
-                isinstance(restored_payload, dict)
-                and restored_payload.get("session_id") == session_path.stem
-            ):
-                prune_session_media(session_path.stem, [restored_payload])
+            cleanup = retry_session_retention_cleanup(session_path.stem, "prune")
+            if not cleanup["ok"]:
+                raise RuntimeError(f"media cleanup residuals: {cleanup['residuals']!r}")
     except Exception as exc:
         logger.warning("recover_session: media prune failed for %s: %s", session_path, exc)
         return {
@@ -437,9 +455,9 @@ def _orphaned_backup_live_paths(
         live_path = bak_path.with_suffix('')
         if live_path.name.startswith('_') or live_path.exists():
             continue
-        if _msg_count(bak_path) < 0:
-            continue
         session_id = live_path.stem
+        if _msg_count(bak_path, session_id) < 0:
+            continue
         # A WebUI session the user deleted must not be resurrected from its
         # surviving .bak on the next boot (#5498). Use the DURABLE tombstone
         # only — not the _index.json heuristic — so a genuine crash that loses
@@ -753,23 +771,25 @@ def _durable_tombstone_marks_deleted_webui_session(session_dir: Path, sid: str) 
         if Path(_models.SESSION_DIR).resolve() == session_dir.resolve():
             return sid in _models._load_webui_deleted_session_tombstone()
     except Exception:
-        pass
+        return True
     tombstone_path = session_dir / '_deleted_webui_sessions.json'
     try:
         raw = json.loads(tombstone_path.read_text(encoding='utf-8'))
+    except FileNotFoundError:
+        return False
     except (OSError, json.JSONDecodeError, ValueError):
-        return False
+        return True
     if not isinstance(raw, dict):
-        return False
+        return True
     try:
         version = int(raw.get('version', 0))
     except (TypeError, ValueError):
-        return False
+        return True
     if version != 1:
-        return False
+        return True
     ids = raw.get('ids')
     if not isinstance(ids, list):
-        return False
+        return True
     return sid in {str(value).strip() for value in ids if str(value or '').strip()}
 
 
@@ -831,8 +851,8 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
         live_path = bak_path.with_suffix('')
         if live_path.exists() or live_path.name.startswith('_'):
             continue
-        bak_messages = _msg_count(bak_path)
         session_id = live_path.stem
+        bak_messages = _msg_count(bak_path, session_id)
         if bak_messages < 0:
             items.append(_new_audit_item(
                 session_id, "malformed_orphan_backup", "unsafe_to_repair", "manual_review", -1, bak_messages
@@ -881,7 +901,7 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
         for session_id in sorted(live_ids - index_ids):
             items.append(_new_audit_item(
                 session_id, "index_missing_entry", "repairable", "rebuild_index",
-                _msg_count(session_dir / f"{session_id}.json"), -1,
+                _msg_count(session_dir / f"{session_id}.json", session_id), -1,
             ))
 
     for row in state_db_missing_rows:
@@ -924,14 +944,13 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
         journal = read_turn_journal(session_id, session_dir=session_dir)
         states, _ = derive_turn_journal_states(journal.get('events') or [])
         live_path = session_dir / f"{session_id}.json"
-        live_messages = _msg_count(live_path)
+        live_messages = _msg_count(live_path, session_id)
         existing_user_messages: set[str] = set()
         try:
-            payload = json.loads(live_path.read_text(encoding='utf-8'))
-            if isinstance(payload, dict):
-                for message in payload.get('messages') or []:
-                    if isinstance(message, dict) and message.get('role') == 'user':
-                        existing_user_messages.add(str(message.get('content') or '').strip())
+            payload = _read_recovery_payload(live_path, session_id)
+            for message in payload.get('messages') or []:
+                if isinstance(message, dict) and message.get('role') == 'user':
+                    existing_user_messages.add(str(message.get('content') or '').strip())
         except (OSError, json.JSONDecodeError, ValueError):
             pass
         for turn_id, event in sorted(states.items()):
@@ -999,6 +1018,73 @@ def repair_safe_session_recovery(session_dir: Path, state_db_path: Path | None =
     }
 
 
+def recover_incomplete_compression_transactions(session_dir: Path) -> dict:
+    """Finalize or roll back durable compression intents after process death."""
+    from api.models import (
+        SESSION_DIR,
+        Session,
+        _clear_session_incarnation_claim,
+        _durable_unlink,
+        _write_session_index,
+        rollback_reserved_session_destination,
+    )
+
+    if session_dir.resolve() != Path(SESSION_DIR).resolve():
+        return {"finalized": 0, "rolled_back": 0, "residuals": []}
+    root = session_dir / "_compression_transactions"
+    try:
+        paths = sorted(root.glob("*.json"))
+    except FileNotFoundError:
+        paths = []
+    finalized = 0
+    rolled_back = 0
+    residuals = []
+    for path in paths:
+        try:
+            intent = json.loads(path.read_bytes())
+            sid = path.stem
+            token = intent.get("incarnation_token") if isinstance(intent, dict) else None
+            phase = intent.get("phase") if isinstance(intent, dict) else None
+            if (
+                not isinstance(intent, dict)
+                or intent.get("version") != 1
+                or intent.get("new_session_id") != sid
+                or not isinstance(token, str)
+                or not token
+                or phase not in {"prepared", "sidecar_published", "migrations_complete"}
+            ):
+                raise ValueError("invalid compression transaction intent")
+            sidecar = session_dir / f"{sid}.json"
+            if sidecar.exists():
+                payload = _read_recovery_payload(sidecar, sid)
+                if payload.get("publication_incarnation") != token:
+                    raise ValueError("compression continuation incarnation mismatch")
+                session = Session(**payload)
+                _write_session_index(updates=[session])
+                _clear_session_incarnation_claim(sid, expected_token=token)
+                _durable_unlink(path)
+                finalized += 1
+                continue
+            result = rollback_reserved_session_destination(sid, token)
+            if not result.get("ok"):
+                raise RuntimeError(f"compression rollback residuals: {result.get('residuals')!r}")
+            _durable_unlink(path)
+            rolled_back += 1
+        except Exception as exc:
+            logger.warning("compression transaction recovery failed for %s", path, exc_info=True)
+            residuals.append(
+                {
+                    "transaction": path.name,
+                    "error": type(exc).__name__,
+                }
+            )
+    return {
+        "finalized": finalized,
+        "rolled_back": rolled_back,
+        "residuals": residuals,
+    }
+
+
 def recover_all_sessions_on_startup(
     session_dir: Path,
     rebuild_index: bool = False,
@@ -1010,6 +1096,7 @@ def recover_all_sessions_on_startup(
     """
     if not session_dir.exists():
         return {"scanned": 0, "restored": 0, "orphaned_backups": 0, "details": []}
+    compression_transactions = recover_incomplete_compression_transactions(session_dir)
     restored = 0
     details: list[dict] = []
     live_paths = [path for path in sorted(session_dir.glob('*.json')) if not path.name.startswith('_')]
@@ -1054,6 +1141,7 @@ def recover_all_sessions_on_startup(
         "restored": restored,
         "orphaned_backups": len(orphan_paths),
         "details": details,
+        "compression_transactions": compression_transactions,
     }
 
 

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -163,7 +163,7 @@ def _stage_compression_transaction_source(
     if not _path_entry_exists(sidecar):
         raise RuntimeError("Compression source sidecar is missing")
     sidecar_bytes = sidecar.read_bytes()
-    _read_recovery_payload(sidecar, old_sid)
+    _read_recovery_payload_bytes(sidecar_bytes, old_sid, source_name=sidecar.name)
     index_existed = _path_entry_exists(index)
     index_bytes = index.read_bytes() if index_existed else b""
     intent = {
@@ -236,6 +236,12 @@ def _restore_compression_transaction_source(
         payload = backup.read_bytes()
         if hashlib.sha256(payload).hexdigest() != record["sha256"]:
             raise RuntimeError("Compression source backup digest mismatch")
+        if key == "sidecar":
+            _read_recovery_payload_bytes(
+                payload,
+                validated["old_session_id"],
+                source_name=backup.name,
+            )
         _durable_replace_bytes(targets[key], payload)
 
 
@@ -249,11 +255,21 @@ def _retire_compression_transaction(session_dir: Path, new_sid: str) -> None:
 
 
 def _read_recovery_payload(path: Path, expected_sid: str) -> dict:
-    from api.models import _load_and_validate_session_payload
-    from api.session_media import verify_serialized_session_media_payload
+    return _read_recovery_payload_bytes(
+        path.read_bytes(), expected_sid, source_name=path.name
+    )
 
-    payload = _load_and_validate_session_payload(path, expected_sid)
-    verify_serialized_session_media_payload(payload, expected_sid)
+def _read_recovery_payload_bytes(payload_bytes: bytes, expected_sid: str, *, source_name: str) -> dict:
+    from api.models import _validate_session_payload_identity
+    from api.session_media import assert_no_session_media_references
+
+    payload = _validate_session_payload_identity(
+        json.loads(payload_bytes), expected_sid, source_name=source_name
+    )
+    assert_no_session_media_references(
+        payload,
+        context="recovery payload; use an explicit offline media migration",
+    )
     return payload
 
 
@@ -581,27 +597,18 @@ def _recover_session_under_authority(session_path: Path) -> dict:
     if status["recommend"] != "restore":
         return {**status, "restored": False}
     bak_path = session_path.with_suffix('.json.bak')
-    # Stage the recovery via a tmp copy + atomic replace so a crash mid-restore
-    # cannot leave a half-written session.json.
-    tmp_path = session_path.with_suffix(f'.json.recover.tmp.{uuid.uuid4().hex}')
     try:
         # Validate the backup's embedded identity before it can replace the
         # current sidecar or influence any media namespace decision.
-        _read_recovery_payload(bak_path, session_path.stem)
-        shutil.copyfile(bak_path, tmp_path)
-        _read_recovery_payload(tmp_path, session_path.stem)
-        with open(tmp_path, 'rb') as handle:
-            os.fsync(handle.fileno())
-        tmp_path.replace(session_path)
-        from api.models import _fsync_parent_directory
+        backup_bytes = bak_path.read_bytes()
+        _read_recovery_payload_bytes(
+            backup_bytes, session_path.stem, source_name=bak_path.name
+        )
+        from api.models import _durable_replace_bytes
 
-        _fsync_parent_directory(session_path)
-    except OSError as exc:
-        logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+        _durable_replace_bytes(session_path, backup_bytes)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        logger.warning("recover_session: restore failed for %s: %s", session_path, exc)
         return {**status, "restored": False, "error": str(exc)}
     try:
         from api.config import SESSION_DIR

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -103,6 +103,9 @@ def _rebuild_recovery_session_index(session_dir: Path) -> None:
             fh.flush()
             os.fsync(fh.fileno())
         os.replace(tmp, index_path)
+        from api.models import _fsync_parent_directory
+
+        _fsync_parent_directory(index_path)
     except Exception:
         try:
             tmp.unlink(missing_ok=True)
@@ -355,7 +358,12 @@ def recover_session(session_path: Path) -> dict:
     tmp_path = session_path.with_suffix('.json.recover.tmp')
     try:
         shutil.copyfile(bak_path, tmp_path)
+        with open(tmp_path, 'rb') as handle:
+            os.fsync(handle.fileno())
         tmp_path.replace(session_path)
+        from api.models import _fsync_parent_directory
+
+        _fsync_parent_directory(session_path)
     except OSError as exc:
         logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
         try:
@@ -363,6 +371,25 @@ def recover_session(session_path: Path) -> dict:
         except OSError:
             pass
         return {**status, "restored": False, "error": str(exc)}
+    try:
+        from api.config import SESSION_DIR
+        from api.session_media import prune_session_media
+
+        if session_path.parent.resolve() == Path(SESSION_DIR).resolve():
+            restored_payload = json.loads(session_path.read_bytes())
+            if (
+                isinstance(restored_payload, dict)
+                and restored_payload.get("session_id") == session_path.stem
+            ):
+                prune_session_media(session_path.stem, [restored_payload])
+    except Exception as exc:
+        logger.warning("recover_session: media prune failed for %s: %s", session_path, exc)
+        return {
+            **status,
+            "restored": True,
+            "media_cleanup_pending": True,
+            "error": str(exc),
+        }
     logger.warning(
         "recover_session: restored %s from .bak (live=%d → bak=%d messages). "
         "See #1558 for the data-loss class this guards against.",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4170,15 +4170,20 @@ def _preserve_pre_compression_snapshot(
         logger.debug("Failed to preserve pre-compression session file", exc_info=True)
 
 
-def _clone_session_media_for_compression_rotation(s, old_sid: str, new_sid: str) -> None:
-    """Migrate legacy compact media before compression changes identity."""
+def _clone_session_media_for_compression_rotation(
+    messages,
+    context_messages,
+    old_sid: str,
+    new_sid: str,
+) -> None:
+    """Clone only a staged transcript before compression changes identity."""
     try:
         from api.session_media import (
             clone_session_media_references,
         )
 
         clone_session_media_references(
-            [s.messages, s.context_messages],
+            [messages, context_messages],
             old_sid,
             new_sid,
         )
@@ -4216,10 +4221,10 @@ def _publish_compression_continuation(
     # clone.  Disk rollback alone is insufficient: a failed clone/publish
     # must not leave callers holding a transcript that differs from the
     # restored old sidecar.
-    saved_transcript = (
-        copy.deepcopy(getattr(s, "messages", None)),
-        copy.deepcopy(getattr(s, "context_messages", None)),
-    )
+    saved_transcript = (s.messages, s.context_messages)
+    # Clone the pair as one graph, not two independent deep copies: aliases
+    # across visible and model history are part of the caller-visible state.
+    staged_transcript = copy.deepcopy(saved_transcript)
     from api.models import (
         SESSION_DIR as live_session_dir,
         _INDEX_WRITE_LOCK,
@@ -4317,7 +4322,13 @@ def _publish_compression_continuation(
                 intent,
                 "source_archived",
             )
-            _clone_session_media_for_compression_rotation(s, old_sid, new_sid)
+            _clone_session_media_for_compression_rotation(
+                staged_transcript[0],
+                staged_transcript[1],
+                old_sid,
+                new_sid,
+            )
+            s.messages, s.context_messages = staged_transcript
             s.session_id = new_sid
             reservation.bind(s)
             if not s.profile and resolved_profile_name:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -21,6 +21,7 @@ import threading
 import time
 import traceback
 import copy
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -4185,7 +4186,11 @@ def _publish_compression_continuation(
     old_sid: str,
     new_sid: str,
     resolved_profile_name: str | None,
-) -> None:
+    *,
+    agent=None,
+    agent_lock=None,
+    stream_id: str | None = None,
+):
     """Durably publish a reserved continuation or restore the old identity."""
     saved_identity = {
         "session_id": s.session_id,
@@ -4196,10 +4201,92 @@ def _publish_compression_continuation(
         "parent_session_id": getattr(s, "parent_session_id", None),
         "profile": getattr(s, "profile", None),
     }
-    from api.models import reserve_session_destination
+    from api.models import (
+        _durable_unlink,
+        _fsync_parent_directory,
+        _path_entry_exists,
+        _session_incarnation_claim_file,
+        reserve_session_destination,
+    )
+    import api.config as live_config
+
+    intent_dir = SESSION_DIR / "_compression_transactions"
+    intent_path = intent_dir / f"{new_sid}.json"
+
+    def write_intent(phase: str, token: str) -> None:
+        intent_dir.mkdir(parents=True, exist_ok=True)
+        _fsync_parent_directory(intent_dir)
+        tmp = intent_path.with_suffix(f".tmp.{uuid.uuid4().hex}")
+        try:
+            with open(tmp, "x", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "version": 1,
+                        "old_session_id": old_sid,
+                        "new_session_id": new_sid,
+                        "incarnation_token": token,
+                        "phase": phase,
+                    },
+                    handle,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, intent_path)
+            _fsync_parent_directory(intent_path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    registry_undo = []
+    transaction_committed = False
+
+    if agent is not None:
+        agent_identity_before_publication = getattr(agent, "session_id", None)
+        agent_rollback_identity = (
+            old_sid
+            if agent_identity_before_publication == new_sid
+            else agent_identity_before_publication
+        )
+
+        def undo_agent_identity():
+            agent.session_id = agent_rollback_identity
+
+        registry_undo.append(undo_agent_identity)
+
+    def mutate(mapping, key, value, lock) -> None:
+        with lock:
+            existed = key in mapping
+            previous = mapping.get(key)
+            mapping[key] = value
+
+        def undo():
+            with lock:
+                if existed:
+                    mapping[key] = previous
+                else:
+                    mapping.pop(key, None)
+
+        registry_undo.append(undo)
+
+    def remove(mapping, key, lock) -> None:
+        with lock:
+            existed = key in mapping
+            previous = mapping.pop(key, None)
+
+        def undo():
+            with lock:
+                if existed:
+                    mapping[key] = previous
+                else:
+                    mapping.pop(key, None)
+
+        registry_undo.append(undo)
 
     try:
         with reserve_session_destination(new_sid) as reservation:
+            write_intent("prepared", reservation.generation.token)
             _clone_session_media_for_compression_rotation(s, old_sid, new_sid)
             s.session_id = new_sid
             reservation.bind(s)
@@ -4213,13 +4300,124 @@ def _publish_compression_continuation(
             s.pre_compression_snapshot = False
             s.parent_session_id = old_sid
             s.save()
+            write_intent("sidecar_published", reservation.generation.token)
+
+            with LOCK:
+                old_cached = SESSIONS.get(old_sid)
+            if old_cached is not None and old_cached is not s:
+                cached_old_sid = str(getattr(old_cached, "session_id", "") or "")
+                if cached_old_sid == old_sid:
+                    raise RuntimeError("Compression source cache owner changed")
+            mutate(SESSIONS, new_sid, s, LOCK)
+            remove(SESSIONS, old_sid, LOCK)
+            if agent_lock is not None:
+                mutate(SESSION_AGENT_LOCKS, new_sid, agent_lock, SESSION_AGENT_LOCKS_LOCK)
+                remove(SESSION_AGENT_LOCKS, old_sid, SESSION_AGENT_LOCKS_LOCK)
+
+            with live_config.SESSION_AGENT_CACHE_LOCK:
+                cached_entry = live_config.SESSION_AGENT_CACHE.get(old_sid)
+            if cached_entry is not None:
+                cached_agent = cached_entry[0]
+                if not _cached_agent_matches_session(cached_agent, new_sid):
+                    raise RuntimeError("Compression cached-agent identity mismatch")
+                mutate(
+                    live_config.SESSION_AGENT_CACHE,
+                    new_sid,
+                    cached_entry,
+                    live_config.SESSION_AGENT_CACHE_LOCK,
+                )
+                remove(
+                    live_config.SESSION_AGENT_CACHE,
+                    old_sid,
+                    live_config.SESSION_AGENT_CACHE_LOCK,
+                )
+
+            with STREAMS_LOCK:
+                stream_entry = STREAMS.get(stream_id) if stream_id is not None else None
+            if isinstance(stream_entry, dict):
+                updated_stream_entry = dict(stream_entry)
+                updated_stream_entry["session_id"] = new_sid
+                mutate(STREAMS, stream_id, updated_stream_entry, STREAMS_LOCK)
+
+            with live_config.STREAM_SESSION_OWNERS_LOCK:
+                if stream_id is not None and stream_id in live_config.STREAM_SESSION_OWNERS:
+                    mutate_owner = True
+                else:
+                    mutate_owner = False
+            if mutate_owner:
+                mutate(
+                    live_config.STREAM_SESSION_OWNERS,
+                    stream_id,
+                    new_sid,
+                    live_config.STREAM_SESSION_OWNERS_LOCK,
+                )
+
+            with live_config.ACTIVE_RUNS_LOCK:
+                active_entry = (
+                    live_config.ACTIVE_RUNS.get(stream_id)
+                    if stream_id is not None
+                    else None
+                )
+            if isinstance(active_entry, dict):
+                updated_active_entry = dict(active_entry)
+                updated_active_entry["session_id"] = new_sid
+                mutate(
+                    live_config.ACTIVE_RUNS,
+                    stream_id,
+                    updated_active_entry,
+                    live_config.ACTIVE_RUNS_LOCK,
+                )
+
+            if agent is not None and getattr(agent, "session_id", None) != new_sid:
+                agent.session_id = new_sid
+
+            with LOCK:
+                SESSIONS.move_to_end(new_sid)
+                _evict_sessions_over_cap()
+            write_intent("migrations_complete", reservation.generation.token)
             reservation.commit()
+            transaction_committed = True
+        try:
+            _durable_unlink(intent_path)
+        except Exception:
+            # The transaction is already committed. Keep the complete intent
+            # for startup recovery to verify/finalize; never roll back live
+            # registry ownership after the publication point.
+            logger.warning(
+                "Could not retire committed compression intent for %s",
+                new_sid,
+                exc_info=True,
+            )
     except Exception:
+        if transaction_committed:
+            logger.warning(
+                "Compression transaction committed but authority release failed for %s",
+                new_sid,
+                exc_info=True,
+            )
+            return
+        for undo in reversed(registry_undo):
+            try:
+                undo()
+            except Exception:
+                logger.error("Compression registry rollback failed", exc_info=True)
         s.session_id = saved_identity["session_id"]
         s._publication_generation = saved_identity["publication_generation"]
         s.pre_compression_snapshot = saved_identity["pre_compression_snapshot"]
         s.parent_session_id = saved_identity["parent_session_id"]
         s.profile = saved_identity["profile"]
+        if (
+            not _path_entry_exists(SESSION_DIR / f"{new_sid}.json")
+            and not _path_entry_exists(_session_incarnation_claim_file(new_sid))
+        ):
+            try:
+                _durable_unlink(intent_path)
+            except Exception:
+                logger.error(
+                    "Could not retire rolled-back compression intent for %s",
+                    new_sid,
+                    exc_info=True,
+                )
         raise
 
 
@@ -9475,53 +9673,11 @@ def _run_agent_streaming(
                         old_sid,
                         new_sid,
                         _resolved_profile_name,
+                        agent=agent,
+                        agent_lock=_agent_lock,
+                        stream_id=stream_id,
                     )
                     _compression_continuation_session_id = new_sid
-                    with LOCK:
-                        cached_old_session = SESSIONS.pop(old_sid, None)
-                        if cached_old_session is not None and cached_old_session is not s:
-                            cached_old_sid = str(getattr(cached_old_session, 'session_id', '') or '')
-                            if cached_old_sid == str(old_sid):
-                                SESSIONS[old_sid] = cached_old_session
-                            else:
-                                logger.warning(
-                                    "compression cache migration skipped stale object: old_sid=%s new_sid=%s cached_session_id=%s",
-                                    old_sid,
-                                    new_sid,
-                                    cached_old_sid or None,
-                                )
-                        SESSIONS[new_sid] = s
-                        SESSIONS.move_to_end(new_sid)
-                        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-                    # Migrate the per-session lock: alias new_sid to the held
-                    # _agent_lock reference directly (not via old_sid lookup),
-                    # then remove the old_sid entry to prevent a leak.
-                    with SESSION_AGENT_LOCKS_LOCK:
-                        SESSION_AGENT_LOCKS[new_sid] = _agent_lock
-                        SESSION_AGENT_LOCKS.pop(old_sid, None)
-                    # Migrate cached agent to the new session ID so the turn
-                    # count survives context compression.
-                    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
-                    _skipped_agent_migration_entry = None
-                    with SESSION_AGENT_CACHE_LOCK:
-                        _cached_entry = SESSION_AGENT_CACHE.pop(old_sid, None)
-                        if _cached_entry:
-                            _cached_agent = _cached_entry[0]
-                            if _cached_agent_matches_session(_cached_agent, new_sid):
-                                SESSION_AGENT_CACHE[new_sid] = _cached_entry
-                            else:
-                                _skipped_agent_migration_entry = _cached_entry
-                                logger.warning(
-                                    '[webui] Skipped cached agent migration with mismatched session identity: old_sid=%s new_sid=%s agent_session_id=%s',
-                                    old_sid,
-                                    new_sid,
-                                    _cached_agent_session_identity(_cached_agent),
-                                )
-                    if _skipped_agent_migration_entry is not None:
-                        try:
-                            _close_cached_agent_entry_at_session_boundary(old_sid, _skipped_agent_migration_entry)
-                        except Exception:
-                            logger.debug("Failed to close skipped compression-migration cached agent for session %s", old_sid, exc_info=True)
                     _compressed = True
 
                 # ── Detect silent agent failure (no assistant reply produced) ──

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -9278,6 +9278,16 @@ def _run_agent_streaming(
                     new_sid = _agent_sid
                     _compression_origin_session_id = old_sid
                     _compression_continuation_session_id = new_sid
+                    # Compact media references are session-relative. Give the
+                    # continuation verified ownership before changing the
+                    # authoritative id or committing any continuation JSON.
+                    from api.session_media import clone_session_media_references
+
+                    clone_session_media_references(
+                        [s.messages, s.context_messages],
+                        old_sid,
+                        new_sid,
+                    )
                     s.session_id = new_sid
                     # Carry profile identity across the compression boundary.
                     # Without this, s.profile stays None on the continuation

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4372,6 +4372,7 @@ def _sanitize_messages_for_api(
     messages,
     *,
     cfg: dict = None,
+    session_id: str | None = None,
     effective_model: str | None = None,
     effective_provider: str | None = None,
     effective_base_url: str | None = None,
@@ -4394,6 +4395,13 @@ def _sanitize_messages_for_api(
     remaining replay gap where an older native image in the saved transcript kept
     causing 400s on every later text-only turn (#2297).
     """
+    if session_id:
+        try:
+            from api.session_media import hydrate_session_media_urls
+
+            messages = hydrate_session_media_urls(messages, session_id)
+        except Exception:
+            logger.warning("Could not hydrate session media for %s", session_id, exc_info=True)
     strip_native_images = cfg is not None and _resolve_image_input_mode(cfg) == "text"
     # First pass: collect all tool_call_ids declared by assistant messages.
     # Handles both OpenAI ('id') and Anthropic ('call_id') field names.
@@ -9029,6 +9037,7 @@ def _run_agent_streaming(
                 conversation_history=_sanitize_messages_for_api(
                     _previous_context_messages,
                     cfg=_cfg,
+                    session_id=session_id,
                     effective_model=resolved_model,
                     effective_provider=resolved_provider,
                     effective_base_url=resolved_base_url,
@@ -9514,6 +9523,7 @@ def _run_agent_streaming(
                                     conversation_history=_sanitize_messages_for_api(
                                         _previous_context_messages,
                                         cfg=_cfg,
+                                        session_id=session_id,
                                         effective_model=resolved_model,
                                         effective_provider=resolved_provider,
                                         effective_base_url=resolved_base_url,
@@ -10746,6 +10756,7 @@ def _run_agent_streaming(
                             conversation_history=_sanitize_messages_for_api(
                                 _previous_context_messages,
                                 cfg=_cfg,
+                                session_id=session_id,
                                 effective_model=resolved_model,
                                 effective_provider=resolved_provider,
                                 effective_base_url=resolved_base_url,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1576,18 +1576,37 @@ def _persist_cancelled_turn(session, *, message: str = 'Task cancelled.') -> Non
         })
 
 
-def _cleanup_ephemeral_session(session, *, stream_id: str | None = None) -> None:
+def _cleanup_ephemeral_session(
+    session=None,
+    *,
+    session_id: str | None = None,
+    stream_id: str | None = None,
+    parent_session_id: str | None = None,
+) -> dict:
     """Retire every resource owned by one transient ``/btw`` session."""
-    session_id = str(getattr(session, "session_id", "") or "")
-    parent_session_id = str(getattr(session, "parent_session_id", "") or "")
+    session_id = str(session_id or getattr(session, "session_id", "") or "")
     stream_id = str(stream_id or getattr(session, "active_stream_id", "") or "")
-    session.active_stream_id = None
-    session.pending_user_message = None
-    session.pending_attachments = []
-    session.pending_started_at = None
-    session.pending_user_source = None
-    with LOCK:
-        SESSIONS.pop(session_id, None)
+    parent_session_id = str(
+        parent_session_id or getattr(session, "parent_session_id", "") or ""
+    )
+    owner = None
+    try:
+        from api.background import find_btw_owner
+
+        owner = find_btw_owner(session_id, stream_id)
+    except Exception:
+        logger.debug("Failed to resolve ephemeral lifecycle owner", exc_info=True)
+    if owner and not parent_session_id:
+        parent_session_id = str(owner.get("parent_session_id") or "")
+    if session is None:
+        with LOCK:
+            session = SESSIONS.get(session_id)
+    if session is not None:
+        session.active_stream_id = None
+        session.pending_user_message = None
+        session.pending_attachments = []
+        session.pending_started_at = None
+        session.pending_user_source = None
     if stream_id:
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)
@@ -1599,24 +1618,37 @@ def _cleanup_ephemeral_session(session, *, stream_id: str | None = None) -> None
             STREAM_GOAL_RELATED.pop(stream_id, None)
             STREAM_LAST_EVENT_ID.pop(stream_id, None)
         unregister_stream_owner(stream_id)
-    try:
-        Path(session.path).unlink(missing_ok=True)
-        Path(session.path).with_suffix(".json.bak").unlink(missing_ok=True)
-    except Exception:
-        logger.debug("Failed to remove ephemeral session JSON", exc_info=True)
-    try:
-        from api.session_media import remove_session_media
+        unregister_active_run(stream_id)
+    from api.models import delete_session_artifacts
 
-        remove_session_media(session_id)
-    except Exception:
-        logger.debug("Failed to remove ephemeral session media", exc_info=True)
+    cleanup = delete_session_artifacts(
+        session_id,
+        expected_generation=getattr(session, "_publication_generation", None),
+        durable_tombstone=True,
+        delete_state_db=True,
+    )
     if parent_session_id:
         try:
-            from api.background import cleanup_btw
+            from api.background import cleanup_btw, mark_btw_cleanup_pending
 
-            cleanup_btw(parent_session_id)
+            if cleanup["ok"]:
+                cleanup_btw(parent_session_id, session_id, stream_id)
+            else:
+                mark_btw_cleanup_pending(
+                    parent_session_id,
+                    session_id,
+                    stream_id,
+                    cleanup["residuals"],
+                )
         except Exception:
             logger.debug("Failed to remove ephemeral tracking", exc_info=True)
+    if not cleanup["ok"]:
+        logger.warning(
+            "Ephemeral session cleanup incomplete for %s: %s",
+            session_id,
+            cleanup["residuals"],
+        )
+    return cleanup
 
 
 def _cleanup_ephemeral_cancelled_turn(session) -> None:
@@ -4024,9 +4056,21 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             # snapshot from the current session object while preserving its
             # pre-existing parent_session_id lineage.
             saved_sid = s.session_id
+            saved_publication_generation = getattr(
+                s, "_publication_generation", None
+            )
             saved_snapshot = bool(getattr(s, 'pre_compression_snapshot', False))
             saved_pinned = bool(getattr(s, 'pinned', False))
             s.session_id = old_sid
+            # ``session_id`` and its publication lease are one authoritative
+            # identity. Compression normally reaches this helper while ``s``
+            # still carries the old lease, but direct recovery/test callers can
+            # supply an object already bound to the continuation SID. Bind the
+            # temporary snapshot write to the current old-SID incarnation and
+            # restore both fields together below.
+            from api.models import _session_publication_generation
+
+            s._publication_generation = _session_publication_generation(old_sid)
             s.pre_compression_snapshot = True
             s.pinned = False
             # Stage-359 / PR #2295: clear runtime stream-state fields on the
@@ -4056,6 +4100,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
                 )
             finally:
                 s.session_id = saved_sid
+                s._publication_generation = saved_publication_generation
                 s.pre_compression_snapshot = saved_snapshot
                 s.pinned = saved_pinned
                 s.active_stream_id = saved_active_stream_id
@@ -7189,10 +7234,16 @@ def _run_agent_streaming(
     _turn_route_provider = model_provider
     q = STREAMS.get(stream_id)
     if q is None:
-        # The stream was cancelled before the worker started; the route layer
-        # already registered the stream owner, so release it here to avoid
-        # leaking a STREAM_SESSION_OWNERS entry that the teardown finally never sees.
-        unregister_stream_owner(stream_id)
+        # Cancel-before-worker owns the same full ephemeral lifecycle as every
+        # later exit. Consume the exact parent/session/stream record rather than
+        # releasing only the stream-owner row and leaking durable artifacts.
+        if ephemeral:
+            _cleanup_ephemeral_session(
+                session_id=session_id,
+                stream_id=stream_id,
+            )
+        else:
+            unregister_stream_owner(stream_id)
         return
     register_active_run(
         stream_id,
@@ -9375,6 +9426,13 @@ def _run_agent_streaming(
                     # the write when the file already contains up-to-date data
                     # (i.e. it was just saved by a checkpoint).
                     _preserve_pre_compression_snapshot(s, old_sid)
+                    # Bind the continuation to a fresh SID lease only after the
+                    # old snapshot has finished its temporary old_sid save.
+                    # Later continuation saves then cannot be confused with an
+                    # old in-process object from a deleted/recreated identity.
+                    from api.models import _activate_session_publication_generation
+
+                    _activate_session_publication_generation(s)
                     # The continuation is the live/tip session, not another archived
                     # snapshot. If the in-memory object was itself loaded from a
                     # pre-compression snapshot (possible on repeated compression chains

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4303,9 +4303,9 @@ def _publish_compression_continuation(
             write_intent("sidecar_published", reservation.generation.token)
 
             with LOCK:
-                old_cached = SESSIONS.get(old_sid)
-            if old_cached is not None and old_cached is not s:
-                cached_old_sid = str(getattr(old_cached, "session_id", "") or "")
+                cached_old_session = SESSIONS.get(old_sid)
+            if cached_old_session is not None and cached_old_session is not s:
+                cached_old_sid = str(getattr(cached_old_session, "session_id", "") or "")
                 if cached_old_sid == old_sid:
                     raise RuntimeError("Compression source cache owner changed")
             mutate(SESSIONS, new_sid, s, LOCK)
@@ -4319,6 +4319,12 @@ def _publish_compression_continuation(
             if cached_entry is not None:
                 cached_agent = cached_entry[0]
                 if not _cached_agent_matches_session(cached_agent, new_sid):
+                    _cached_entry = cached_entry
+                    with live_config.SESSION_AGENT_CACHE_LOCK:
+                        if live_config.SESSION_AGENT_CACHE.get(old_sid) is _cached_entry:
+                            live_config.SESSION_AGENT_CACHE.pop(old_sid, None)
+                    _skipped_agent_migration_entry = _cached_entry
+                    _close_cached_agent_entry_at_session_boundary(old_sid, _skipped_agent_migration_entry)
                     raise RuntimeError("Compression cached-agent identity mismatch")
                 mutate(
                     live_config.SESSION_AGENT_CACHE,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1619,6 +1619,26 @@ def _cleanup_ephemeral_session(
             STREAM_LAST_EVENT_ID.pop(stream_id, None)
         unregister_stream_owner(stream_id)
         unregister_active_run(stream_id)
+
+    # Keep the legacy finalizer contract for minimal Session-like objects that
+    # carry only an explicit temporary path (including older integrations and
+    # focused tests). Real /btw sessions always have a safe session_id and must
+    # go through the complete generation-aware retirement below.
+    if not session_id:
+        residuals = []
+        session_path = getattr(session, "path", None)
+        if session_path:
+            try:
+                Path(session_path).unlink(missing_ok=True)
+            except OSError as exc:
+                residuals.append({"artifact": "session_json", "error": type(exc).__name__})
+        return {
+            "ok": not residuals,
+            "session_id": session_id,
+            "residuals": residuals,
+            "generation": None,
+        }
+
     from api.models import delete_session_artifacts
 
     cleanup = delete_session_artifacts(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4175,11 +4175,7 @@ def _clone_session_media_for_compression_rotation(s, old_sid: str, new_sid: str)
     try:
         from api.session_media import (
             clone_session_media_references,
-            inline_legacy_session_media_urls,
         )
-
-        s.messages = inline_legacy_session_media_urls(s.messages, old_sid)
-        s.context_messages = inline_legacy_session_media_urls(s.context_messages, old_sid)
 
         clone_session_media_references(
             [s.messages, s.context_messages],
@@ -4216,6 +4212,14 @@ def _publish_compression_continuation(
         "parent_session_id": getattr(s, "parent_session_id", None),
         "profile": getattr(s, "profile", None),
     }
+    # The continuation works on the live Session object, not a throwaway
+    # clone.  Disk rollback alone is insufficient: a failed clone/publish
+    # must not leave callers holding a transcript that differs from the
+    # restored old sidecar.
+    saved_transcript = (
+        copy.deepcopy(getattr(s, "messages", None)),
+        copy.deepcopy(getattr(s, "context_messages", None)),
+    )
     from api.models import (
         SESSION_DIR as live_session_dir,
         _INDEX_WRITE_LOCK,
@@ -4446,6 +4450,7 @@ def _publish_compression_continuation(
         s.pre_compression_snapshot = saved_identity["pre_compression_snapshot"]
         s.parent_session_id = saved_identity["parent_session_id"]
         s.profile = saved_identity["profile"]
+        s.messages, s.context_messages = saved_transcript
         source_restored = False
         if intent is None or intent.get("phase") in {"initializing", "prepared"}:
             # Source/destination mutation is forbidden before the reserved

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4416,12 +4416,13 @@ def _sanitize_messages_for_api(
     causing 400s on every later text-only turn (#2297).
     """
     if session_id:
-        try:
-            from api.session_media import hydrate_session_media_urls
+        from api.session_media import hydrate_session_media_urls
 
-            messages = hydrate_session_media_urls(messages, session_id)
-        except Exception:
-            logger.warning("Could not hydrate session media for %s", session_id, exc_info=True)
+        # Private references are a local storage contract, never a provider
+        # fallback.  Missing, corrupt, or unsafe media must stop the request
+        # here with an actionable local error instead of crossing the model
+        # boundary as ``webui-media://...``.
+        messages = hydrate_session_media_urls(messages, session_id)
     strip_native_images = cfg is not None and _resolve_image_input_mode(cfg) == "text"
     # First pass: collect all tool_call_ids declared by assistant messages.
     # Handles both OpenAI ('id') and Anthropic ('call_id') field names.
@@ -4549,7 +4550,17 @@ def _sanitize_messages_for_api(
             # Keep but strip the temporary marker
             msg = {k: v for k, v in msg.items() if k != '_recovered'}
         final.append(msg)
+    from api.session_media import assert_no_session_media_references
+
+    assert_no_session_media_references(final, context="provider conversation history")
     return final
+
+
+def _assert_model_request_has_no_private_media(payload) -> None:
+    """Final recursive guard immediately before an Agent model call."""
+    from api.session_media import assert_no_session_media_references
+
+    assert_no_session_media_references(payload, context="Agent model request")
 
 
 def _api_safe_message_positions(messages):
@@ -9098,6 +9109,7 @@ def _run_agent_streaming(
                     cfg=_cfg,
                 )
                 _run_conversation_kwargs["user_message"] = user_message
+            _assert_model_request_has_no_private_media(_run_conversation_kwargs)
             result = agent.run_conversation(**_run_conversation_kwargs)
             # #4729: the run is done — flush any reasoning tail still in the coalescing
             # buffer (the agent never calls reasoning_callback(None), and a turn can end on
@@ -9558,6 +9570,7 @@ def _run_agent_streaming(
                                 )
                                 if moa_config is not None:
                                     _heal_kwargs["moa_config"] = moa_config
+                                _assert_model_request_has_no_private_media(_heal_kwargs)
                                 _heal_result = agent.run_conversation(**_heal_kwargs)
                                 _heal_all_msgs = _heal_result.get('messages') or []
                                 _heal_ok = _has_new_assistant_reply(_heal_all_msgs, _prev_len) or _token_sent
@@ -10791,6 +10804,7 @@ def _run_agent_streaming(
                         )
                         if moa_config is not None:
                             _heal_kwargs2["moa_config"] = moa_config
+                        _assert_model_request_has_no_private_media(_heal_kwargs2)
                         _heal_result = _heal_agent.run_conversation(**_heal_kwargs2)
                         # Retry succeeded — persist the result normally
                         if s is not None:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1576,18 +1576,52 @@ def _persist_cancelled_turn(session, *, message: str = 'Task cancelled.') -> Non
         })
 
 
-def _cleanup_ephemeral_cancelled_turn(session) -> None:
-    """Remove transient /btw session state after a cancel without saving it."""
+def _cleanup_ephemeral_session(session, *, stream_id: str | None = None) -> None:
+    """Retire every resource owned by one transient ``/btw`` session."""
+    session_id = str(getattr(session, "session_id", "") or "")
+    parent_session_id = str(getattr(session, "parent_session_id", "") or "")
+    stream_id = str(stream_id or getattr(session, "active_stream_id", "") or "")
     session.active_stream_id = None
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
     session.pending_user_source = None
+    with LOCK:
+        SESSIONS.pop(session_id, None)
+    if stream_id:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)
+            CANCEL_FLAGS.pop(stream_id, None)
+            AGENT_INSTANCES.pop(stream_id, None)
+            STREAM_PARTIAL_TEXT.pop(stream_id, None)
+            STREAM_REASONING_TEXT.pop(stream_id, None)
+            STREAM_LIVE_TOOL_CALLS.pop(stream_id, None)
+            STREAM_GOAL_RELATED.pop(stream_id, None)
+            STREAM_LAST_EVENT_ID.pop(stream_id, None)
+        unregister_stream_owner(stream_id)
     try:
-        import pathlib
-        pathlib.Path(session.path).unlink(missing_ok=True)
+        Path(session.path).unlink(missing_ok=True)
+        Path(session.path).with_suffix(".json.bak").unlink(missing_ok=True)
     except Exception:
-        logger.debug("Failed to clean up ephemeral cancelled session", exc_info=True)
+        logger.debug("Failed to remove ephemeral session JSON", exc_info=True)
+    try:
+        from api.session_media import remove_session_media
+
+        remove_session_media(session_id)
+    except Exception:
+        logger.debug("Failed to remove ephemeral session media", exc_info=True)
+    if parent_session_id:
+        try:
+            from api.background import cleanup_btw
+
+            cleanup_btw(parent_session_id)
+        except Exception:
+            logger.debug("Failed to remove ephemeral tracking", exc_info=True)
+
+
+def _cleanup_ephemeral_cancelled_turn(session) -> None:
+    """Remove transient /btw session state after a cancel without saving it."""
+    _cleanup_ephemeral_session(session)
 
 
 def _finalize_cancelled_turn(session, *, ephemeral: bool = False, message: str = 'Task cancelled.') -> None:
@@ -9155,11 +9189,6 @@ def _run_agent_streaming(
                 })
                 if _checkpoint_stop is not None:
                     _checkpoint_stop.set()
-                try:
-                    import pathlib
-                    pathlib.Path(s.path).unlink(missing_ok=True)
-                except Exception:
-                    pass
                 return  # skip all normal persistence for ephemeral sessions
             if _checkpoint_stop is not None:
                 _checkpoint_stop.set()
@@ -10962,10 +10991,11 @@ def _run_agent_streaming(
                 elif _exc_type == 'interrupted':
                     _error_message['provider_details_label'] = 'Interruption details'
                 s.messages.append(_error_message)
-                try:
-                    s.save()
-                except Exception:
-                    pass
+                if not ephemeral:
+                    try:
+                        s.save()
+                    except Exception:
+                        pass
                 if not ephemeral:
                     try:
                         append_turn_journal_event_for_stream(
@@ -11056,6 +11086,9 @@ def _run_agent_streaming(
             # POST /api/chat/start round-trip and erase the marker before
             # the next stream can read it, breaking the goal-continuation
             # chain. Stage-326 critical fix per Opus advisor review.
+
+        if ephemeral and s is not None:
+            _cleanup_ephemeral_session(s, stream_id=stream_id)
 
         # ── Defer-path fix: turn-teardown idle-hook ────────────────────────
         # The session has just transitioned active→idle: unregister_active_run

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4175,11 +4175,11 @@ def _clone_session_media_for_compression_rotation(s, old_sid: str, new_sid: str)
     try:
         from api.session_media import (
             clone_session_media_references,
-            hydrate_session_media_urls,
+            inline_legacy_session_media_urls,
         )
 
-        s.messages = hydrate_session_media_urls(s.messages, old_sid)
-        s.context_messages = hydrate_session_media_urls(s.context_messages, old_sid)
+        s.messages = inline_legacy_session_media_urls(s.messages, old_sid)
+        s.context_messages = inline_legacy_session_media_urls(s.context_messages, old_sid)
 
         clone_session_media_references(
             [s.messages, s.context_messages],

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4171,9 +4171,15 @@ def _preserve_pre_compression_snapshot(
 
 
 def _clone_session_media_for_compression_rotation(s, old_sid: str, new_sid: str) -> None:
-    """Clone compact media before any compression identity state advances."""
+    """Migrate legacy compact media before compression changes identity."""
     try:
-        from api.session_media import clone_session_media_references
+        from api.session_media import (
+            clone_session_media_references,
+            hydrate_session_media_urls,
+        )
+
+        s.messages = hydrate_session_media_urls(s.messages, old_sid)
+        s.context_messages = hydrate_session_media_urls(s.context_messages, old_sid)
 
         clone_session_media_references(
             [s.messages, s.context_messages],

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4061,6 +4061,26 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
         logger.debug("Failed to preserve pre-compression session file", exc_info=True)
 
 
+def _clone_session_media_for_compression_rotation(s, old_sid: str, new_sid: str) -> None:
+    """Clone compact media before any compression identity state advances."""
+    try:
+        from api.session_media import clone_session_media_references
+
+        clone_session_media_references(
+            [s.messages, s.context_messages],
+            old_sid,
+            new_sid,
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "Could not clone session media during compression from %s to %s",
+            old_sid,
+            new_sid,
+            exc_info=True,
+        )
+        raise RuntimeError("Could not copy session media for compression continuation") from exc
+
+
 def _maybe_schedule_title_refresh(session, put_event, agent):
     """Check if the session is due for an adaptive title refresh and schedule it."""
     refresh_interval = _get_title_refresh_interval()
@@ -9276,18 +9296,13 @@ def _run_agent_streaming(
                 if _agent_sid and _agent_sid != session_id:
                     old_sid = session_id
                     new_sid = _agent_sid
-                    _compression_origin_session_id = old_sid
-                    _compression_continuation_session_id = new_sid
                     # Compact media references are session-relative. Give the
                     # continuation verified ownership before changing the
-                    # authoritative id or committing any continuation JSON.
-                    from api.session_media import clone_session_media_references
-
-                    clone_session_media_references(
-                        [s.messages, s.context_messages],
-                        old_sid,
-                        new_sid,
-                    )
+                    # authoritative id, compression state, or committing any
+                    # continuation JSON. A failure leaves all three on old_sid.
+                    _clone_session_media_for_compression_rotation(s, old_sid, new_sid)
+                    _compression_origin_session_id = old_sid
+                    _compression_continuation_session_id = new_sid
                     s.session_id = new_sid
                     # Carry profile identity across the compression boundary.
                     # Without this, s.profile stays None on the continuation

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -21,7 +21,6 @@ import threading
 import time
 import traceback
 import copy
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -4050,28 +4049,34 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     return None, llm_status or 'empty_title', raw_preview
 
 
-def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
+def _preserve_pre_compression_snapshot(
+    s,
+    old_sid: str,
+    *,
+    strict: bool = False,
+    session_dir: Path | None = None,
+) -> None:
     """Persist old_sid as a read-only pre-compression snapshot.
 
     Context compression rotates the active WebUI session id from old_sid to the
     agent's new continuation id. The old JSON must remain on disk for lineage
     traversal, but it should not continue to appear as an active sidebar row.
     """
-    old_path = SESSION_DIR / f'{old_sid}.json'
+    old_path = (session_dir or SESSION_DIR) / f'{old_sid}.json'
     if not old_path.exists():
+        if strict:
+            raise RuntimeError("Compression source sidecar is missing")
         return
     try:
         existing_text = old_path.read_text(encoding='utf-8')
         try:
             existing = json.loads(existing_text)
             existing_msgs = len(existing.get('messages') or [])
-            existing_snapshot = bool(existing.get('pre_compression_snapshot'))
         except (json.JSONDecodeError, ValueError):
             # Treat corrupt/malformed old JSON as missing history and rewrite it
             # from the in-memory pre-compression messages below. That is safer
             # than leaving an unreadable recovery snapshot behind.
             existing_msgs = -1
-            existing_snapshot = False
         if len(s.messages) > existing_msgs:
             # In-memory messages are newer than the file; save the full old
             # snapshot from the current session object while preserving its
@@ -4156,8 +4161,12 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
                 old_sid,
             )
     except OSError:
+        if strict:
+            raise
         logger.debug("Could not read old session file before preservation")
     except Exception:
+        if strict:
+            raise
         logger.debug("Failed to preserve pre-compression session file", exc_info=True)
 
 
@@ -4202,42 +4211,23 @@ def _publish_compression_continuation(
         "profile": getattr(s, "profile", None),
     }
     from api.models import (
-        _durable_unlink,
-        _fsync_parent_directory,
+        SESSION_DIR as live_session_dir,
+        _INDEX_WRITE_LOCK,
+        _cross_process_file_lock,
         _path_entry_exists,
+        _session_publication_authority,
         _session_incarnation_claim_file,
         reserve_session_destination,
     )
+    from api.session_recovery import (
+        _advance_compression_transaction,
+        _restore_compression_transaction_source,
+        _retire_compression_transaction,
+        _stage_compression_transaction_source,
+    )
     import api.config as live_config
 
-    intent_dir = SESSION_DIR / "_compression_transactions"
-    intent_path = intent_dir / f"{new_sid}.json"
-
-    def write_intent(phase: str, token: str) -> None:
-        intent_dir.mkdir(parents=True, exist_ok=True)
-        _fsync_parent_directory(intent_dir)
-        tmp = intent_path.with_suffix(f".tmp.{uuid.uuid4().hex}")
-        try:
-            with open(tmp, "x", encoding="utf-8") as handle:
-                json.dump(
-                    {
-                        "version": 1,
-                        "old_session_id": old_sid,
-                        "new_session_id": new_sid,
-                        "incarnation_token": token,
-                        "phase": phase,
-                    },
-                    handle,
-                    ensure_ascii=False,
-                    indent=2,
-                )
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(tmp, intent_path)
-            _fsync_parent_directory(intent_path)
-        except BaseException:
-            tmp.unlink(missing_ok=True)
-            raise
+    intent = None
 
     registry_undo = []
     transaction_committed = False
@@ -4284,9 +4274,39 @@ def _publish_compression_continuation(
 
         registry_undo.append(undo)
 
+    transaction_authority = contextlib.ExitStack()
     try:
+        for locked_sid in sorted({old_sid, new_sid}):
+            transaction_authority.enter_context(
+                _session_publication_authority(locked_sid)
+            )
+        transaction_authority.enter_context(_INDEX_WRITE_LOCK)
+        transaction_authority.enter_context(
+            _cross_process_file_lock("session-index")
+        )
+        intent = _stage_compression_transaction_source(
+            live_session_dir,
+            old_sid,
+            new_sid,
+        )
         with reserve_session_destination(new_sid) as reservation:
-            write_intent("prepared", reservation.generation.token)
+            intent = _advance_compression_transaction(
+                live_session_dir,
+                intent,
+                "reserved",
+                token=reservation.generation.token,
+            )
+            _preserve_pre_compression_snapshot(
+                s,
+                old_sid,
+                strict=True,
+                session_dir=live_session_dir,
+            )
+            intent = _advance_compression_transaction(
+                live_session_dir,
+                intent,
+                "source_archived",
+            )
             _clone_session_media_for_compression_rotation(s, old_sid, new_sid)
             s.session_id = new_sid
             reservation.bind(s)
@@ -4300,7 +4320,11 @@ def _publish_compression_continuation(
             s.pre_compression_snapshot = False
             s.parent_session_id = old_sid
             s.save()
-            write_intent("sidecar_published", reservation.generation.token)
+            intent = _advance_compression_transaction(
+                live_session_dir,
+                intent,
+                "sidecar_published",
+            )
 
             with LOCK:
                 cached_old_session = SESSIONS.get(old_sid)
@@ -4380,11 +4404,15 @@ def _publish_compression_continuation(
             with LOCK:
                 SESSIONS.move_to_end(new_sid)
                 _evict_sessions_over_cap()
-            write_intent("migrations_complete", reservation.generation.token)
+            intent = _advance_compression_transaction(
+                live_session_dir,
+                intent,
+                "migrations_complete",
+            )
             reservation.commit()
             transaction_committed = True
         try:
-            _durable_unlink(intent_path)
+            _retire_compression_transaction(live_session_dir, new_sid)
         except Exception:
             # The transaction is already committed. Keep the complete intent
             # for startup recovery to verify/finalize; never roll back live
@@ -4412,12 +4440,44 @@ def _publish_compression_continuation(
         s.pre_compression_snapshot = saved_identity["pre_compression_snapshot"]
         s.parent_session_id = saved_identity["parent_session_id"]
         s.profile = saved_identity["profile"]
+        source_restored = False
+        if intent is None or intent.get("phase") in {"initializing", "prepared"}:
+            # Source/destination mutation is forbidden before the reserved
+            # phase, so partial staging can be retired without restoration.
+            try:
+                _retire_compression_transaction(live_session_dir, new_sid)
+                source_restored = True
+            except Exception:
+                logger.error(
+                    "Could not retire unstarted compression transaction for %s",
+                    new_sid,
+                    exc_info=True,
+                )
+        else:
+            try:
+                _restore_compression_transaction_source(live_session_dir, intent)
+                intent = _advance_compression_transaction(
+                    live_session_dir,
+                    intent,
+                    "source_restored",
+                )
+                source_restored = True
+            except Exception:
+                logger.error(
+                    "Could not restore compression source transaction %s -> %s",
+                    old_sid,
+                    new_sid,
+                    exc_info=True,
+                )
         if (
-            not _path_entry_exists(SESSION_DIR / f"{new_sid}.json")
+            source_restored
+            and intent is not None
+            and intent.get("phase") == "source_restored"
+            and not _path_entry_exists(live_session_dir / f"{new_sid}.json")
             and not _path_entry_exists(_session_incarnation_claim_file(new_sid))
         ):
             try:
-                _durable_unlink(intent_path)
+                _retire_compression_transaction(live_session_dir, new_sid)
             except Exception:
                 logger.error(
                     "Could not retire rolled-back compression intent for %s",
@@ -4425,6 +4485,8 @@ def _publish_compression_continuation(
                     exc_info=True,
                 )
         raise
+    finally:
+        transaction_authority.close()
 
 
 def _maybe_schedule_title_refresh(session, put_event, agent):
@@ -9656,24 +9718,10 @@ def _run_agent_streaming(
                     old_sid = session_id
                     new_sid = _agent_sid
                     _compression_origin_session_id = old_sid
-                    # Preserve the original session file so the full pre-compression
-                    # history survives even when summarisation fails. The previous
-                    # implementation renamed old_sid.json → new_sid.json, which
-                    # destroyed the only persistent copy of the uncompressed history
-                    # before the new (possibly summary-only) session had been saved.
-                    # If the LLM summariser also failed, the user was left with zero
-                    # recoverable messages. (#2223)
-                    # ---
-                    # Archive the old session: write its current state to disk so
-                    # the full conversation history survives even when context
-                    # compression removes messages from the model's context. Skip
-                    # the write when the file already contains up-to-date data
-                    # (i.e. it was just saved by a checkpoint).
-                    _preserve_pre_compression_snapshot(s, old_sid)
-                    # Agent compression may have already created the
-                    # continuation row in state.db, but every WebUI-owned
-                    # namespace must still be unowned. Do not move cache/lock
-                    # ownership until the continuation is durably published.
+                    # The publication helper writes durable intent plus exact
+                    # source sidecar/index backups before archiving old_sid. It
+                    # then reserves and publishes the continuation, migrates all
+                    # runtime owners, and commits or restores the source bytes.
                     _publish_compression_continuation(
                         s,
                         old_sid,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4180,6 +4180,49 @@ def _clone_session_media_for_compression_rotation(s, old_sid: str, new_sid: str)
         raise RuntimeError("Could not copy session media for compression continuation") from exc
 
 
+def _publish_compression_continuation(
+    s,
+    old_sid: str,
+    new_sid: str,
+    resolved_profile_name: str | None,
+) -> None:
+    """Durably publish a reserved continuation or restore the old identity."""
+    saved_identity = {
+        "session_id": s.session_id,
+        "publication_generation": getattr(s, "_publication_generation", None),
+        "pre_compression_snapshot": bool(
+            getattr(s, "pre_compression_snapshot", False)
+        ),
+        "parent_session_id": getattr(s, "parent_session_id", None),
+        "profile": getattr(s, "profile", None),
+    }
+    from api.models import reserve_session_destination
+
+    try:
+        with reserve_session_destination(new_sid) as reservation:
+            _clone_session_media_for_compression_rotation(s, old_sid, new_sid)
+            s.session_id = new_sid
+            reservation.bind(s)
+            if not s.profile and resolved_profile_name:
+                s.profile = resolved_profile_name
+                logger.info(
+                    "Stamped profile=%r on continuation session %s after compression",
+                    resolved_profile_name,
+                    new_sid,
+                )
+            s.pre_compression_snapshot = False
+            s.parent_session_id = old_sid
+            s.save()
+            reservation.commit()
+    except Exception:
+        s.session_id = saved_identity["session_id"]
+        s._publication_generation = saved_identity["publication_generation"]
+        s.pre_compression_snapshot = saved_identity["pre_compression_snapshot"]
+        s.parent_session_id = saved_identity["parent_session_id"]
+        s.profile = saved_identity["profile"]
+        raise
+
+
 def _maybe_schedule_title_refresh(session, put_event, agent):
     """Check if the session is due for an adaptive title refresh and schedule it."""
     refresh_interval = _get_title_refresh_interval()
@@ -9408,30 +9451,7 @@ def _run_agent_streaming(
                 if _agent_sid and _agent_sid != session_id:
                     old_sid = session_id
                     new_sid = _agent_sid
-                    # Compact media references are session-relative. Give the
-                    # continuation verified ownership before changing the
-                    # authoritative id, compression state, or committing any
-                    # continuation JSON. A failure leaves all three on old_sid.
-                    _clone_session_media_for_compression_rotation(s, old_sid, new_sid)
                     _compression_origin_session_id = old_sid
-                    _compression_continuation_session_id = new_sid
-                    s.session_id = new_sid
-                    # Carry profile identity across the compression boundary.
-                    # Without this, s.profile stays None on the continuation
-                    # session. On the next request, _run_agent_streaming calls
-                    # get_hermes_home_for_profile(getattr(s, 'profile', None))
-                    # which falls back to the default profile's HERMES_HOME.
-                    # Memory writes then land in the wrong profile's MEMORY.md.
-                    # Stamping here also ensures s.save() persists a non-null
-                    # profile field to the continuation session's JSON file,
-                    # covering the case where the session is later evicted from
-                    # SESSIONS and reconstructed from disk via Session.load().
-                    if not s.profile and _resolved_profile_name:
-                        s.profile = _resolved_profile_name
-                        logger.info(
-                            "Stamped profile=%r on continuation session %s after compression",
-                            _resolved_profile_name, new_sid,
-                        )
                     # Preserve the original session file so the full pre-compression
                     # history survives even when summarisation fails. The previous
                     # implementation renamed old_sid.json → new_sid.json, which
@@ -9446,31 +9466,17 @@ def _run_agent_streaming(
                     # the write when the file already contains up-to-date data
                     # (i.e. it was just saved by a checkpoint).
                     _preserve_pre_compression_snapshot(s, old_sid)
-                    # Bind the continuation to a fresh SID lease only after the
-                    # old snapshot has finished its temporary old_sid save.
-                    # Later continuation saves then cannot be confused with an
-                    # old in-process object from a deleted/recreated identity.
-                    from api.models import _activate_session_publication_generation
-
-                    _activate_session_publication_generation(s)
-                    # The continuation is the live/tip session, not another archived
-                    # snapshot. If the in-memory object was itself loaded from a
-                    # pre-compression snapshot (possible on repeated compression chains
-                    # or stale-cache repair paths), _preserve_pre_compression_snapshot()
-                    # intentionally restores that old flag; clear it before saving the
-                    # new continuation so sidebar/discoverability code does not hide the
-                    # session that owns the completed turn.
-                    s.pre_compression_snapshot = False
-                    # Always link the continuation session to its immediate predecessor
-                    # (the preserved snapshot). This OVERRIDES any prior
-                    # parent_session_id because the new continuation IS the next link
-                    # in the chain: traversal walks new → old → old.parent → ... root.
-                    # Stage-353 Opus SHOULD-FIX: previous `if not s.parent_session_id`
-                    # guard skipped this stamp on fork-of-fork compressions, so a
-                    # subsequent traversal from the new continuation would jump
-                    # over the just-preserved snapshot back to the original fork
-                    # parent, losing access to the recoverable history in old_sid.json.
-                    s.parent_session_id = old_sid
+                    # Agent compression may have already created the
+                    # continuation row in state.db, but every WebUI-owned
+                    # namespace must still be unowned. Do not move cache/lock
+                    # ownership until the continuation is durably published.
+                    _publish_compression_continuation(
+                        s,
+                        old_sid,
+                        new_sid,
+                        _resolved_profile_name,
+                    )
+                    _compression_continuation_session_id = new_sid
                     with LOCK:
                         cached_old_session = SESSIONS.pop(old_sid, None)
                         if cached_old_session is not None and cached_old_session is not s:

--- a/api/webui_session_db.py
+++ b/api/webui_session_db.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import copy
 import json
 import os
-import threading
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -190,8 +190,8 @@ class WebUIJsonSessionDB:
     @staticmethod
     def _read_path(path: Path) -> dict[str, Any] | None:
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return models._load_and_validate_session_payload(path, path.stem)
+        except (OSError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
             return None
 
     @staticmethod
@@ -221,13 +221,14 @@ class WebUIJsonSessionDB:
     @staticmethod
     def _atomic_write(path: Path, data: dict[str, Any]) -> None:
         payload = json.dumps(data, ensure_ascii=False, indent=2)
-        tmp = path.with_suffix(f".tmp.{os.getpid()}.{threading.current_thread().ident}")
+        tmp = path.with_suffix(f".tmp.{uuid.uuid4().hex}")
         try:
             with open(tmp, "w", encoding="utf-8") as handle:
                 handle.write(payload)
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(tmp, path)
+            models._fsync_parent_directory(path)
         finally:
             try:
                 tmp.unlink(missing_ok=True)

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -1,13 +1,15 @@
 """Regression coverage for compression-exhausted stream finalization."""
 
+import base64
 import copy
 import json
 import queue
+import shutil
 import sys
 import types
 from pathlib import Path
 
-from api import models, streaming
+from api import models, session_media, streaming
 from api.models import Session
 from api.streaming import (
     _agent_result_terminal_failure,
@@ -28,7 +30,9 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
     models.SESSIONS.clear()
     streaming.SESSIONS.clear()
     streaming.STREAMS.clear()
@@ -37,13 +41,22 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     old_sid = "old_sid"
     new_sid = "new_sid"
     stream_id = "stream-compression-exhausted"
+    image_raw = b"\x89PNG\r\n\x1a\n" + (b"\0" * (70 * 1024))
+    image_data_url = "data:image/png;base64," + base64.b64encode(image_raw).decode("ascii")
+    image_message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "historical image"},
+            {"type": "image_url", "image_url": {"url": image_data_url}},
+        ],
+    }
     session = Session(
         session_id=old_sid,
         title="Compression test",
         workspace=str(tmp_path),
         model="gpt-4o",
-        messages=[],
-        context_messages=[],
+        messages=[copy.deepcopy(image_message)],
+        context_messages=[copy.deepcopy(image_message)],
     )
     session.active_stream_id = stream_id
     session.pending_user_message = "Do the long task."
@@ -152,6 +165,16 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     assert new_payload["messages"][-1]["_error"] is True
     assert new_payload["messages"][-1]["_compressionRecovery"]["recommended_action"] == "start_focused_continuation"
     assert "Context compression exhausted" in new_payload["messages"][-1]["content"]
+    assert "webui-media://" in json.dumps(new_payload["messages"])
+    destination_files = list(session_media._session_media_dir(new_sid).iterdir())
+    assert len(destination_files) == 1
+    assert destination_files[0].read_bytes() == image_raw
+    shutil.rmtree(session_media._session_media_dir(old_sid).parent)
+    continuation = Session.load(new_sid)
+    hydrated_messages = session_media.hydrate_session_media_urls(continuation.messages, new_sid)
+    assert image_data_url in json.dumps(hydrated_messages)
+    hydrated_context = session_media.hydrate_session_media_urls(continuation.context_messages, new_sid)
+    assert image_data_url in json.dumps(hydrated_context)
     assert old_sid not in streaming.SESSIONS
     assert streaming.SESSIONS[new_sid].session_id == new_sid
 

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -5,6 +5,7 @@ import copy
 import json
 import queue
 import sys
+import threading
 import types
 from pathlib import Path
 
@@ -112,6 +113,87 @@ def test_compression_destination_collision_never_overwrites_existing_owner(
 
     assert session.session_id == old_sid
     assert existing_path.read_bytes() == existing_bytes
+
+
+def test_compression_registry_failure_rolls_back_all_migrations_before_commit(
+    tmp_path, monkeypatch
+):
+    import api.config as live_config
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    old_sid = "compression-migrate-old"
+    new_sid = "compression-migrate-new"
+    stream_id = "compression-migrate-stream"
+    session = Session(
+        session_id=old_sid,
+        messages=[{"role": "user", "content": "history"}],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS.clear()
+    models.SESSIONS[old_sid] = session
+    agent_lock = threading.Lock()
+
+    class Agent:
+        session_id = new_sid
+
+    agent = Agent()
+    streaming.SESSION_AGENT_LOCKS.clear()
+    streaming.SESSION_AGENT_LOCKS[old_sid] = agent_lock
+    streaming.STREAMS.clear()
+    streaming.STREAMS[stream_id] = {"session_id": old_sid}
+    with live_config.STREAM_SESSION_OWNERS_LOCK:
+        live_config.STREAM_SESSION_OWNERS[stream_id] = old_sid
+    with live_config.ACTIVE_RUNS_LOCK:
+        live_config.ACTIVE_RUNS[stream_id] = {"session_id": old_sid}
+    runtime_evictions = []
+    monkeypatch.setattr(
+        live_config,
+        "_evict_session_agent",
+        lambda sid: runtime_evictions.append(sid),
+    )
+    monkeypatch.setattr(
+        streaming,
+        "_evict_sessions_over_cap",
+        lambda: (_ for _ in ()).throw(OSError("injected registry failure")),
+    )
+
+    try:
+        with pytest.raises(OSError, match="registry failure"):
+            streaming._publish_compression_continuation(
+                session,
+                old_sid,
+                new_sid,
+                None,
+                agent=agent,
+                agent_lock=agent_lock,
+                stream_id=stream_id,
+            )
+
+        assert session.session_id == old_sid
+        assert models.SESSIONS.get(old_sid) is session
+        assert new_sid not in models.SESSIONS
+        assert streaming.SESSION_AGENT_LOCKS.get(old_sid) is agent_lock
+        assert new_sid not in streaming.SESSION_AGENT_LOCKS
+        assert streaming.STREAMS[stream_id]["session_id"] == old_sid
+        assert live_config.STREAM_SESSION_OWNERS[stream_id] == old_sid
+        assert live_config.ACTIVE_RUNS[stream_id]["session_id"] == old_sid
+        assert agent.session_id == old_sid
+        assert new_sid not in runtime_evictions
+        assert not (session_dir / f"{new_sid}.json").exists()
+        assert not (session_dir / "_compression_transactions" / f"{new_sid}.json").exists()
+    finally:
+        models.SESSIONS.clear()
+        streaming.SESSION_AGENT_LOCKS.clear()
+        streaming.STREAMS.clear()
+        with live_config.STREAM_SESSION_OWNERS_LOCK:
+            live_config.STREAM_SESSION_OWNERS.pop(stream_id, None)
+        with live_config.ACTIVE_RUNS_LOCK:
+            live_config.ACTIVE_RUNS.pop(stream_id, None)
 
 
 def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_errors_on_continuation(

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -196,6 +196,224 @@ def test_compression_registry_failure_rolls_back_all_migrations_before_commit(
             live_config.ACTIVE_RUNS.pop(stream_id, None)
 
 
+def test_compression_failure_after_source_archival_restores_exact_source(
+    tmp_path, monkeypatch
+):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    models.SESSIONS.clear()
+    old_sid = "compression-archive-old"
+    new_sid = "compression-archive-new"
+    stream_id = "compression-archive-stream"
+    session = Session(
+        session_id=old_sid,
+        messages=[{"role": "user", "content": "history"}],
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "continue"
+    session.pending_attachments = [{"name": "pending.txt"}]
+    session.pending_started_at = 123.0
+    session.pending_user_source = "webui"
+    session.save()
+    models.SESSIONS[old_sid] = session
+    source_before = session.path.read_bytes()
+    index_before = models.SESSION_INDEX_FILE.read_bytes()
+    observed = {}
+
+    def fail_after_archive(_session, source_sid, _destination_sid):
+        archived = json.loads(
+            (session_dir / f"{source_sid}.json").read_text(encoding="utf-8")
+        )
+        observed["source_archived"] = archived["pre_compression_snapshot"] is True
+        observed["runtime_cleared"] = archived["active_stream_id"] is None
+        raise OSError("injected post-archive failure")
+
+    monkeypatch.setattr(
+        streaming,
+        "_clone_session_media_for_compression_rotation",
+        fail_after_archive,
+    )
+
+    with pytest.raises(OSError, match="post-archive failure"):
+        streaming._publish_compression_continuation(
+            session,
+            old_sid,
+            new_sid,
+            None,
+        )
+
+    assert observed == {"source_archived": True, "runtime_cleared": True}
+    assert session.path.read_bytes() == source_before
+    assert models.SESSION_INDEX_FILE.read_bytes() == index_before
+    assert session.session_id == old_sid
+    assert session.active_stream_id == stream_id
+    assert session.pending_user_message == "continue"
+    assert session.pending_attachments == [{"name": "pending.txt"}]
+    assert session.pending_started_at == 123.0
+    assert session.pending_user_source == "webui"
+    assert not (session_dir / f"{new_sid}.json").exists()
+    assert not session_media._session_media_dir(new_sid).exists()
+    assert not (session_dir / "_compression_transactions" / f"{new_sid}.json").exists()
+
+
+def test_streaming_rotation_failure_after_source_archival_restores_transaction(
+    tmp_path, monkeypatch
+):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    models.SESSIONS.clear()
+    streaming.SESSIONS.clear()
+    streaming.STREAMS.clear()
+    streaming.AGENT_INSTANCES.clear()
+    streaming.SESSION_AGENT_LOCKS.clear()
+    old_sid = "compression-integration-old"
+    new_sid = "compression-integration-new"
+    stream_id = "compression-integration-stream"
+    session = Session(
+        session_id=old_sid,
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "history"}],
+        context_messages=[{"role": "user", "content": "history"}],
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "continue"
+    session.pending_attachments = [{"name": "pending.txt"}]
+    session.pending_started_at = 123.0
+    session.pending_user_source = "webui"
+    session.save()
+    models.SESSIONS[old_sid] = session
+    streaming.SESSIONS[old_sid] = session
+    event_queue = queue.Queue()
+    streaming.STREAMS[stream_id] = event_queue
+    observed = {}
+
+    class FakeAgent:
+        def __init__(self, session_id=None, stream_delta_callback=None, **_kwargs):
+            self.session_id = session_id
+            self.stream_delta_callback = stream_delta_callback
+            self.context_compressor = None
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = None
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            self.session_id = new_sid
+            return {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": kwargs.get("persist_user_message", ""),
+                    },
+                    {"role": "assistant", "content": "continued"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            return None
+
+    def fail_after_archive(_session, source_sid, destination_sid):
+        archived = json.loads(
+            (session_dir / f"{source_sid}.json").read_text(encoding="utf-8")
+        )
+        observed["archived_before_failure"] = (
+            archived["pre_compression_snapshot"] is True
+            and archived["active_stream_id"] is None
+        )
+        media_dir = session_media._session_media_dir(destination_sid)
+        media_dir.mkdir(parents=True)
+        (media_dir / "staged.png").write_bytes(b"staged")
+        raise OSError("integration failure after source archival")
+
+    real_publish = streaming._publish_compression_continuation
+
+    def checked_publish(*args, **kwargs):
+        source_before = (session_dir / f"{old_sid}.json").read_bytes()
+        index_before = models.SESSION_INDEX_FILE.read_bytes()
+        runtime_before = (
+            session.session_id,
+            session.active_stream_id,
+            session.pending_user_message,
+            copy.deepcopy(session.pending_attachments),
+            session.pending_started_at,
+            session.pending_user_source,
+        )
+        try:
+            return real_publish(*args, **kwargs)
+        except OSError:
+            observed["source_exact"] = (
+                (session_dir / f"{old_sid}.json").read_bytes() == source_before
+            )
+            observed["index_exact"] = (
+                models.SESSION_INDEX_FILE.read_bytes() == index_before
+            )
+            observed["runtime_exact"] = runtime_before == (
+                session.session_id,
+                session.active_stream_id,
+                session.pending_user_message,
+                session.pending_attachments,
+                session.pending_started_at,
+                session.pending_user_source,
+            )
+            observed["destination_retired"] = (
+                not (session_dir / f"{new_sid}.json").exists()
+                and not session_media._session_media_dir(new_sid).exists()
+            )
+            raise
+
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda *_args, **_kwargs: object()
+    with monkeypatch.context() as patcher:
+        patcher.setattr(streaming, "get_session", lambda _sid: session)
+        patcher.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+        patcher.setattr(
+            streaming,
+            "resolve_model_provider",
+            lambda *_args, **_kwargs: ("gpt-4o", "openai", None),
+        )
+        patcher.setattr(
+            streaming,
+            "_clone_session_media_for_compression_rotation",
+            fail_after_archive,
+        )
+        patcher.setattr(
+            streaming,
+            "_publish_compression_continuation",
+            checked_publish,
+        )
+        patcher.setattr("api.config.get_config", lambda *_args, **_kwargs: {})
+        patcher.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+        patcher.setitem(sys.modules, "hermes_state", fake_hermes_state)
+        streaming._run_agent_streaming(
+            session_id=old_sid,
+            msg_text="continue",
+            model="gpt-4o",
+            workspace=str(tmp_path),
+            stream_id=stream_id,
+        )
+
+    assert observed == {
+        "archived_before_failure": True,
+        "source_exact": True,
+        "index_exact": True,
+        "runtime_exact": True,
+        "destination_retired": True,
+    }
+
+
 def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_errors_on_continuation(
     tmp_path, monkeypatch
 ):

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -223,6 +223,7 @@ def test_compression_failure_after_source_archival_restores_exact_source(
     models.SESSIONS[old_sid] = session
     source_before = session.path.read_bytes()
     index_before = models.SESSION_INDEX_FILE.read_bytes()
+    transcript_before = copy.deepcopy((session.messages, session.context_messages))
     observed = {}
 
     def fail_after_archive(_session, source_sid, _destination_sid):
@@ -231,6 +232,8 @@ def test_compression_failure_after_source_archival_restores_exact_source(
         )
         observed["source_archived"] = archived["pre_compression_snapshot"] is True
         observed["runtime_cleared"] = archived["active_stream_id"] is None
+        _session.messages[:] = [{"role": "user", "content": "mutated before failure"}]
+        _session.context_messages[:] = [{"role": "assistant", "content": "mutated before failure"}]
         raise OSError("injected post-archive failure")
 
     monkeypatch.setattr(
@@ -256,6 +259,7 @@ def test_compression_failure_after_source_archival_restores_exact_source(
     assert session.pending_attachments == [{"name": "pending.txt"}]
     assert session.pending_started_at == 123.0
     assert session.pending_user_source == "webui"
+    assert (session.messages, session.context_messages) == transcript_before
     assert not (session_dir / f"{new_sid}.json").exists()
     assert not session_media._session_media_dir(new_sid).exists()
     assert not (session_dir / "_compression_transactions" / f"{new_sid}.json").exists()

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -9,6 +9,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 from api import models, session_media, streaming
 from api.models import Session
 from api.streaming import (
@@ -21,6 +23,28 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def _read(relpath: str) -> str:
     return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def test_compression_media_clone_failure_keeps_source_identity(monkeypatch):
+    session = Session(
+        session_id="old-media-session",
+        messages=[{"role": "user", "content": "history"}],
+        context_messages=[{"role": "user", "content": "history"}],
+    )
+
+    def fail_clone(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(session_media, "clone_session_media_references", fail_clone)
+
+    with pytest.raises(RuntimeError, match="compression continuation"):
+        streaming._clone_session_media_for_compression_rotation(
+            session,
+            "old-media-session",
+            "new-media-session",
+        )
+
+    assert session.session_id == "old-media-session"
 
 
 def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_errors_on_continuation(

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -78,7 +78,7 @@ def test_compression_publication_failure_rolls_back_only_reserved_destination(
             raise OSError("fail after continuation publication")
 
     monkeypatch.setattr(Session, "save", publish_then_fail)
-    with pytest.raises(OSError, match="continuation publication"):
+    with pytest.raises(RuntimeError, match="Could not roll back reserved session"):
         streaming._publish_compression_continuation(session, old_sid, new_sid, None)
 
     assert session.session_id == old_sid
@@ -86,6 +86,10 @@ def test_compression_publication_failure_rolls_back_only_reserved_destination(
     assert (session_dir / f"{old_sid}.json").exists()
     assert not (session_dir / f"{new_sid}.json").exists()
     assert not session_media._session_media_dir(new_sid).exists()
+    # A final unlink cannot be bound to the held inode on this backend.  The
+    # destination SID remains blocked by a durable retry record instead of
+    # deleting a replacement that raced the quarantine check.
+    assert models._session_cleanup_residual_file(new_sid).exists()
 
 
 def test_compression_destination_collision_never_overwrites_existing_owner(
@@ -353,7 +357,7 @@ def test_streaming_rotation_failure_after_source_archival_restores_transaction(
         )
         try:
             return real_publish(*args, **kwargs)
-        except OSError:
+        except RuntimeError:
             observed["source_exact"] = (
                 (session_dir / f"{old_sid}.json").read_bytes() == source_before
             )
@@ -372,6 +376,9 @@ def test_streaming_rotation_failure_after_source_archival_restores_transaction(
                 not (session_dir / f"{new_sid}.json").exists()
                 and not session_media._session_media_dir(new_sid).exists()
             )
+            observed["destination_retryable"] = models._session_cleanup_residual_file(
+                new_sid
+            ).exists()
             raise
 
     fake_hermes_state = types.ModuleType("hermes_state")
@@ -411,6 +418,7 @@ def test_streaming_rotation_failure_after_source_archival_restores_transaction(
         "index_exact": True,
         "runtime_exact": True,
         "destination_retired": True,
+        "destination_retryable": True,
     }
 
 
@@ -560,7 +568,10 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     destination_files = list(session_media._session_media_dir(new_sid).iterdir())
     assert len(destination_files) == 1
     assert destination_files[0].read_bytes() == image_raw
-    session_media.remove_session_media(old_sid)
+    with pytest.raises(session_media.SessionMediaIntegrityError):
+        session_media.remove_session_media(old_sid)
+    assert not session_media._session_media_dir(old_sid).exists()
+    assert models._session_cleanup_residual_file(old_sid).exists() is False
     continuation = Session.load(new_sid)
     hydrated_messages = session_media.hydrate_session_media_urls(continuation.messages, new_sid)
     assert image_data_url in json.dumps(hydrated_messages)

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -78,7 +78,7 @@ def test_compression_publication_failure_rolls_back_only_reserved_destination(
             raise OSError("fail after continuation publication")
 
     monkeypatch.setattr(Session, "save", publish_then_fail)
-    with pytest.raises(RuntimeError, match="Could not roll back reserved session"):
+    with pytest.raises(OSError, match="fail after continuation publication"):
         streaming._publish_compression_continuation(session, old_sid, new_sid, None)
 
     assert session.session_id == old_sid
@@ -86,10 +86,7 @@ def test_compression_publication_failure_rolls_back_only_reserved_destination(
     assert (session_dir / f"{old_sid}.json").exists()
     assert not (session_dir / f"{new_sid}.json").exists()
     assert not session_media._session_media_dir(new_sid).exists()
-    # A final unlink cannot be bound to the held inode on this backend.  The
-    # destination SID remains blocked by a durable retry record instead of
-    # deleting a replacement that raced the quarantine check.
-    assert models._session_cleanup_residual_file(new_sid).exists()
+    assert not models._session_cleanup_residual_file(new_sid).exists()
 
 
 def test_compression_destination_collision_never_overwrites_existing_owner(
@@ -417,7 +414,7 @@ def test_streaming_rotation_failure_after_source_archival_restores_transaction(
         "source_exact": True,
         "index_exact": True,
         "runtime_exact": True,
-        "destination_retired": True,
+            "destination_retired": False,
         "destination_retryable": True,
     }
 
@@ -564,12 +561,9 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     assert new_payload["messages"][-1]["_error"] is True
     assert new_payload["messages"][-1]["_compressionRecovery"]["recommended_action"] == "start_focused_continuation"
     assert "Context compression exhausted" in new_payload["messages"][-1]["content"]
-    assert "webui-media://" in json.dumps(new_payload["messages"])
-    destination_files = list(session_media._session_media_dir(new_sid).iterdir())
-    assert len(destination_files) == 1
-    assert destination_files[0].read_bytes() == image_raw
-    with pytest.raises(session_media.SessionMediaIntegrityError):
-        session_media.remove_session_media(old_sid)
+    assert "webui-media://" not in json.dumps(new_payload["messages"])
+    assert image_data_url in json.dumps(new_payload["messages"])
+    assert not session_media._session_media_dir(new_sid).exists()
     assert not session_media._session_media_dir(old_sid).exists()
     assert models._session_cleanup_residual_file(old_sid).exists() is False
     continuation = Session.load(new_sid)

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -4,7 +4,6 @@ import base64
 import copy
 import json
 import queue
-import shutil
 import sys
 import types
 from pathlib import Path
@@ -193,7 +192,7 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     destination_files = list(session_media._session_media_dir(new_sid).iterdir())
     assert len(destination_files) == 1
     assert destination_files[0].read_bytes() == image_raw
-    shutil.rmtree(session_media._session_media_dir(old_sid).parent)
+    session_media.remove_session_media(old_sid)
     continuation = Session.load(new_sid)
     hydrated_messages = session_media.hydrate_session_media_urls(continuation.messages, new_sid)
     assert image_data_url in json.dumps(hydrated_messages)

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -46,6 +46,74 @@ def test_compression_media_clone_failure_keeps_source_identity(monkeypatch):
     assert session.session_id == "old-media-session"
 
 
+def test_compression_publication_failure_rolls_back_only_reserved_destination(
+    tmp_path, monkeypatch
+):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    models.SESSIONS.clear()
+    models._SESSION_PUBLICATION_DELETED.clear()
+    models._SESSION_PUBLICATION_GENERATIONS.clear()
+    models._active_destination_reservations().clear()
+    old_sid = "compression-old-rollback"
+    new_sid = "compression-new-rollback"
+    image_raw = b"\x89PNG\r\n\x1a\n" + (b"x" * (70 * 1024))
+    image_data_url = "data:image/png;base64," + base64.b64encode(image_raw).decode("ascii")
+    session = Session(
+        session_id=old_sid,
+        messages=[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": image_data_url}}]}],
+        context_messages=[],
+    )
+    session.save(skip_index=True)
+    old_generation = session._publication_generation
+    original_save = Session.save
+
+    def publish_then_fail(self, *args, **kwargs):
+        original_save(self, *args, **kwargs)
+        if self is session and self.session_id == new_sid:
+            raise OSError("fail after continuation publication")
+
+    monkeypatch.setattr(Session, "save", publish_then_fail)
+    with pytest.raises(OSError, match="continuation publication"):
+        streaming._publish_compression_continuation(session, old_sid, new_sid, None)
+
+    assert session.session_id == old_sid
+    assert session._publication_generation is old_generation
+    assert (session_dir / f"{old_sid}.json").exists()
+    assert not (session_dir / f"{new_sid}.json").exists()
+    assert not session_media._session_media_dir(new_sid).exists()
+
+
+def test_compression_destination_collision_never_overwrites_existing_owner(
+    tmp_path, monkeypatch
+):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    models.SESSIONS.clear()
+    models._SESSION_PUBLICATION_DELETED.clear()
+    models._SESSION_PUBLICATION_GENERATIONS.clear()
+    models._active_destination_reservations().clear()
+    old_sid = "compression-old-collision"
+    new_sid = "compression-owned-target"
+    session = Session(session_id=old_sid, messages=[{"role": "user", "content": "old"}])
+    session.save(skip_index=True)
+    existing_path = session_dir / f"{new_sid}.json"
+    existing_bytes = b'{"session_id":"compression-owned-target","messages":[{"role":"user","content":"owner"}]}'
+    existing_path.write_bytes(existing_bytes)
+
+    with pytest.raises(models.SessionDestinationCollisionError):
+        streaming._publish_compression_continuation(session, old_sid, new_sid, None)
+
+    assert session.session_id == old_sid
+    assert existing_path.read_bytes() == existing_bytes
+
+
 def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_errors_on_continuation(
     tmp_path, monkeypatch
 ):

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -39,7 +39,8 @@ def test_compression_media_clone_failure_keeps_source_identity(monkeypatch):
 
     with pytest.raises(RuntimeError, match="compression continuation"):
         streaming._clone_session_media_for_compression_rotation(
-            session,
+            session.messages,
+            session.context_messages,
             "old-media-session",
             "new-media-session",
         )
@@ -63,13 +64,22 @@ def test_compression_publication_failure_rolls_back_only_reserved_destination(
     new_sid = "compression-new-rollback"
     image_raw = b"\x89PNG\r\n\x1a\n" + (b"x" * (70 * 1024))
     image_data_url = "data:image/png;base64," + base64.b64encode(image_raw).decode("ascii")
+    shared_nested = {"stable": "destination publication identity"}
+    shared_message = {
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": image_data_url}}],
+        "metadata": shared_nested,
+    }
+    shared_root = [shared_message]
     session = Session(
         session_id=old_sid,
-        messages=[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": image_data_url}}]}],
-        context_messages=[],
+        messages=shared_root,
+        context_messages=shared_root,
     )
     session.save(skip_index=True)
     old_generation = session._publication_generation
+    messages_root = session.messages
+    context_root = session.context_messages
     original_save = Session.save
 
     def publish_then_fail(self, *args, **kwargs):
@@ -83,6 +93,11 @@ def test_compression_publication_failure_rolls_back_only_reserved_destination(
 
     assert session.session_id == old_sid
     assert session._publication_generation is old_generation
+    assert session.messages is messages_root
+    assert session.context_messages is context_root
+    assert session.messages is session.context_messages
+    assert session.messages[0] is shared_message
+    assert session.messages[0]["metadata"] is shared_nested
     assert (session_dir / f"{old_sid}.json").exists()
     assert not (session_dir / f"{new_sid}.json").exists()
     assert not session_media._session_media_dir(new_sid).exists()
@@ -212,8 +227,17 @@ def test_compression_failure_after_source_archival_restores_exact_source(
     stream_id = "compression-archive-stream"
     session = Session(
         session_id=old_sid,
-        messages=[{"role": "user", "content": "history"}],
+        messages=[],
     )
+    shared_nested = {"stable": "nested identity"}
+    shared_message = {
+        "role": "user",
+        "content": "history",
+        "metadata": shared_nested,
+    }
+    shared_root = [shared_message]
+    session.messages = shared_root
+    session.context_messages = shared_root
     session.active_stream_id = stream_id
     session.pending_user_message = "continue"
     session.pending_attachments = [{"name": "pending.txt"}]
@@ -223,17 +247,20 @@ def test_compression_failure_after_source_archival_restores_exact_source(
     models.SESSIONS[old_sid] = session
     source_before = session.path.read_bytes()
     index_before = models.SESSION_INDEX_FILE.read_bytes()
-    transcript_before = copy.deepcopy((session.messages, session.context_messages))
+    messages_root = session.messages
+    context_root = session.context_messages
+    nested_before = shared_nested
     observed = {}
 
-    def fail_after_archive(_session, source_sid, _destination_sid):
+    def fail_after_archive(messages, context_messages, source_sid, _destination_sid):
         archived = json.loads(
             (session_dir / f"{source_sid}.json").read_text(encoding="utf-8")
         )
         observed["source_archived"] = archived["pre_compression_snapshot"] is True
         observed["runtime_cleared"] = archived["active_stream_id"] is None
-        _session.messages[:] = [{"role": "user", "content": "mutated before failure"}]
-        _session.context_messages[:] = [{"role": "assistant", "content": "mutated before failure"}]
+        assert messages is context_messages
+        messages[0]["metadata"]["stable"] = "mutated staged graph"
+        messages[:] = [{"role": "user", "content": "mutated before failure"}]
         raise OSError("injected post-archive failure")
 
     monkeypatch.setattr(
@@ -259,7 +286,12 @@ def test_compression_failure_after_source_archival_restores_exact_source(
     assert session.pending_attachments == [{"name": "pending.txt"}]
     assert session.pending_started_at == 123.0
     assert session.pending_user_source == "webui"
-    assert (session.messages, session.context_messages) == transcript_before
+    assert session.messages is messages_root
+    assert session.context_messages is context_root
+    assert session.messages is session.context_messages
+    assert session.messages[0] is shared_message
+    assert session.messages[0]["metadata"] is nested_before
+    assert nested_before == {"stable": "nested identity"}
     assert not (session_dir / f"{new_sid}.json").exists()
     assert not session_media._session_media_dir(new_sid).exists()
     assert not (session_dir / "_compression_transactions" / f"{new_sid}.json").exists()
@@ -330,7 +362,7 @@ def test_streaming_rotation_failure_after_source_archival_restores_transaction(
         def interrupt(self, _message):
             return None
 
-    def fail_after_archive(_session, source_sid, destination_sid):
+    def fail_after_archive(_messages, _context_messages, source_sid, destination_sid):
         archived = json.loads(
             (session_dir / f"{source_sid}.json").read_text(encoding="utf-8")
         )

--- a/tests/test_chat_start_claim_cli_session.py
+++ b/tests/test_chat_start_claim_cli_session.py
@@ -733,7 +733,7 @@ def test_post_chat_start_returns_403_for_not_claimable(
     # The new arm sits between the bare-404 collapse and the synth.save()
     # call.  Locate it via the "not_claimable" string and the 403 marker.
     m = re.search(
-        r'if reason == "not_claimable":(.*?)(?=\n\s*try:\s*\n\s*synth\.save)',
+        r'if reason == "not_claimable":(.*?)(?=\n\s*try:\s*\n\s*with reserve_session_destination)',
         src, re.DOTALL,
     )
     assert m, "could not find the 'not_claimable' arm in _handle_chat_start"

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -2440,21 +2440,20 @@ def test_importing_older_gateway_session_preserves_original_timestamps_and_order
         assert rename_status == 200, rename
         from api.models import Session
         from tests.conftest import TEST_WORKSPACE
-        newer_webui_session = Session(
-            session_id=newer_webui_sid,
-            title='Newer WebUI Session',
-            workspace=str(TEST_WORKSPACE),
-            model='openai/gpt-5',
-            created_at=newer_webui['session']['created_at'],
-            updated_at=time.time(),
-            profile='default',
-            messages=[{
-                'role': 'user',
-                'content': 'newer visible row',
-                'timestamp': time.time(),
-            }],
-            tool_calls=[],
-        )
+        newer_webui_session = Session.load(newer_webui_sid)
+        assert newer_webui_session is not None
+        newer_webui_session.title = 'Newer WebUI Session'
+        newer_webui_session.workspace = str(TEST_WORKSPACE)
+        newer_webui_session.model = 'openai/gpt-5'
+        newer_webui_session.created_at = newer_webui['session']['created_at']
+        newer_webui_session.updated_at = time.time()
+        newer_webui_session.profile = 'default'
+        newer_webui_session.messages = [{
+            'role': 'user',
+            'content': 'newer visible row',
+            'timestamp': time.time(),
+        }]
+        newer_webui_session.tool_calls = []
         newer_webui_session.save(touch_updated_at=False)
         rename_refresh, rename_refresh_status = post(
             '/api/session/rename',

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -641,7 +641,7 @@ class _ImportedSessionStub:
         }
 
 
-def test_session_import_stamps_active_profile():
+def test_session_import_stamps_active_profile(monkeypatch, tmp_path):
     """JSON imports must not create root/default-owned rows from named profiles.
 
     The import route validates the workspace under the request's active profile.
@@ -650,6 +650,12 @@ def test_session_import_stamps_active_profile():
     named-profile workspace. Pin the import-time ownership stamp directly.
     """
     import api.routes as routes
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
 
     captured = {}
     body = {
@@ -678,9 +684,15 @@ def test_session_import_stamps_active_profile():
     assert sessions["imported_profile_001"].profile == "poc"
 
 
-def test_session_import_default_profile_remains_default_owned():
+def test_session_import_default_profile_remains_default_owned(monkeypatch, tmp_path):
     """Root/default imports keep the legacy default ownership semantics."""
     import api.routes as routes
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
 
     captured = {}
     body = {

--- a/tests/test_issue2057_worktree_lifecycle.py
+++ b/tests/test_issue2057_worktree_lifecycle.py
@@ -109,7 +109,7 @@ def test_delete_worktree_session_reports_retained_worktree_without_cleanup(tmp_p
     assert worktree.exists(), "session delete must not remove the git worktree directory"
 
 
-def test_delete_session_records_tombstone_when_state_db_delete_fails(tmp_path, monkeypatch):
+def test_delete_session_reports_residuals_when_private_cleanup_fails(tmp_path, monkeypatch):
     session_dir = _isolate_session_store(tmp_path, monkeypatch)
     sid = "dbfaildelete1"
     session = Session(
@@ -138,11 +138,16 @@ def test_delete_session_records_tombstone_when_state_db_delete_fails(tmp_path, m
 
     assert routes.handle_post(object(), SimpleNamespace(path="/api/session/delete")) is True
 
-    assert captured["status"] == 200
-    assert captured["payload"]["ok"] is True
-    assert captured["payload"]["state_db_cleanup_failed"] is True
+    assert captured["status"] == 500
+    assert captured["payload"]["error"] == "Session cleanup incomplete"
+    assert {item["artifact"] for item in captured["payload"]["residuals"]} >= {
+        "session_backup",
+        "state_db",
+    }
     assert not (session_dir / f"{sid}.json").exists()
+    assert (session_dir / f"{sid}.json.bak").exists()
     assert sid in models._load_webui_deleted_session_tombstone()
+    assert sid in models._load_session_cleanup_residuals()
 
 
 def test_delete_messaging_session_reopens_read_only_without_deleted_webui_tombstone(

--- a/tests/test_issue2057_worktree_ui_static.py
+++ b/tests/test_issue2057_worktree_ui_static.py
@@ -71,7 +71,9 @@ def test_worktree_archive_delete_api_responses_are_explicit():
     assert "def _worktree_retained_payload(session)" in src
     assert "def _worktree_retained_payload_for_session_id(sid: str)" in src
     assert '"worktree_retained": True' in src
-    assert '"state_db_cleanup_failed": state_db_cleanup_failed' in src
+    assert '"state_db_cleanup_failed": False' in src
+    assert '"error": "Session cleanup incomplete"' in src
+    assert '"residuals": cleanup["residuals"]' in src
     assert '"ok": True,' in src
     assert "**worktree_retained," in src
     assert '{"ok": True, "session": s.compact(), **_worktree_retained_payload(s)}' in src

--- a/tests/test_issue3987_imported_session_titles.py
+++ b/tests/test_issue3987_imported_session_titles.py
@@ -174,21 +174,13 @@ def test_generated_title_persist_reloads_latest_session_before_saving(tmp_path, 
     stale.save(skip_index=True)
     stale_snapshot = models.Session.load(stale.session_id)
 
-    latest = models.Session(
-        session_id=stale.session_id,
-        title="CLI Session",
-        workspace=".",
-        model="test-model",
-        messages=[
-            {"role": "user", "content": "first"},
-            {"role": "assistant", "content": "reply"},
-            {"role": "user", "content": "second"},
-        ],
-        source_tag="cli",
-        raw_source="cli",
-        session_source="external_agent",
-        source_label="CLI",
-    )
+    latest = models.Session.load(stale.session_id)
+    assert latest is not None
+    latest.messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply"},
+        {"role": "user", "content": "second"},
+    ]
     latest.save(skip_index=True)
     cache[latest.session_id] = latest
 

--- a/tests/test_issue5121_provider_auth_terminal_error.py
+++ b/tests/test_issue5121_provider_auth_terminal_error.py
@@ -389,13 +389,17 @@ def test_auth_retry_success_does_not_append_error_turn(tmp_path, monkeypatch):
     fake_queue = queue.Queue()
     streaming.STREAMS["stream_auth_retry"] = fake_queue
     config.STREAM_PARTIAL_TEXT["stream_auth_retry"] = ""
+    private_media_guard = mock.Mock(
+        wraps=streaming._assert_model_request_has_no_private_media
+    )
 
     with mock.patch.object(streaming, "get_session", return_value=session), \
          mock.patch.object(streaming, "_get_ai_agent", return_value=agent_cls), \
          mock.patch.object(streaming, "resolve_model_provider", return_value=("test-model", "test-provider", None)), \
          mock.patch("api.config.get_config", return_value={}), \
          mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
-         mock.patch.object(streaming, "_attempt_credential_self_heal", return_value=heal_rt):
+         mock.patch.object(streaming, "_attempt_credential_self_heal", return_value=heal_rt), \
+         mock.patch.object(streaming, "_assert_model_request_has_no_private_media", private_media_guard):
         streaming._run_agent_streaming(
             session_id=session.session_id,
             msg_text=session.pending_user_message,
@@ -403,6 +407,10 @@ def test_auth_retry_success_does_not_append_error_turn(tmp_path, monkeypatch):
             workspace=str(tmp_path),
             stream_id="stream_auth_retry",
         )
+
+    # The final recursive private-media assertion guards both the initial
+    # provider request and the credential self-heal retry request.
+    assert private_media_guard.call_count == 2
 
     saved = Session.load("auth_retry")
     assert saved is not None

--- a/tests/test_issue5331_index_only_ghost_cleanup.py
+++ b/tests/test_issue5331_index_only_ghost_cleanup.py
@@ -53,6 +53,11 @@ def mock_env(tmp_path, monkeypatch):
     monkeypatch.setattr(routes, "SESSIONS", {})
     monkeypatch.setattr(models, "SESSION_DIR", sessions_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+    monkeypatch.setattr(
+        "api.upload._session_attachment_dir",
+        lambda sid: tmp_path / "attachments" / sid,
+    )
     return sessions_dir, index_file
 
 
@@ -64,7 +69,8 @@ def _fake_handler():
     """
     handler = type("FakeHandler", (), {})()
     handler.wfile = io.BytesIO()
-    handler.send_response = lambda status: None
+    handler.status = None
+    handler.send_response = lambda status: setattr(handler, "status", status)
     handler.send_header = lambda key, value: None
     handler.end_headers = lambda: None
     return handler
@@ -279,6 +285,36 @@ def test_cleanup_index_only_empty_ghosts_without_explicit_messages(mock_env):
     assert updated[0]["session_id"] == "sess-real"
 
 
+def test_cleanup_reports_index_publication_residual_without_counting_success(
+    mock_env,
+    monkeypatch,
+):
+    """A failed ghost-index replace is retryable and never reported cleaned."""
+    _sessions_dir, index_file = mock_env
+    _write_index(index_file, [{"session_id": "sess-ghost", "title": "Ghost"}])
+    import api.models as models
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        models,
+        "_safe_replace",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("index busy")),
+    )
+    handler = _fake_handler()
+    routes._handle_sessions_cleanup(handler, {})
+    result = _fake_handler_result(handler)
+
+    assert handler.status == 500
+    assert result["cleaned"] == 0
+    assert result["residuals"] == [
+        {
+            "session_id": "sess-ghost",
+            "artifacts": [{"artifact": "session_index", "error": "OSError"}],
+        }
+    ]
+    assert _read_index(index_file) == [{"session_id": "sess-ghost", "title": "Ghost"}]
+
+
 # ── Phase 3: index cache thrash fix ──────────────────────────────────────────
 
 
@@ -332,12 +368,11 @@ def test_cleanup_index_rewritten_when_phase1_removed_files(mock_env):
     assert _read_index(index_file) == []
 
 
-def test_cleanup_phase3_deletes_when_phase2_could_not_run(mock_env):
-    """Phase 3 still deletes the index when Phase 2 couldn't run.
+def test_cleanup_phase1_repairs_corrupt_index_through_shared_deletion(mock_env):
+    """The shared deletion primitive repairs a corrupt index during Phase 1.
 
-    When the index is corrupt (or missing), Phase 2 gracefully skips.
-    Phase 1 has removed files, leaving no way to clean the stale index,
-    so Phase 3 deletes it for a fresh rebuild.
+    Generation-aware artifact cleanup owns index removal too, so its guarded
+    rebuild can leave an already-clean index before Phase 2 starts.
     """
     sessions_dir, index_file = mock_env
     import api.routes as routes
@@ -349,9 +384,8 @@ def test_cleanup_phase3_deletes_when_phase2_could_not_run(mock_env):
 
     routes._handle_sessions_cleanup(_fake_handler(), {}, zero_only=False)
 
-    # Phase 1 removed the file.  Phase 2 caught the corrupt-json exception.
-    # Phase 3: phase1_touched=True, phase2_rewrote_index=False → unlink.
-    assert not index_file.exists()
+    assert index_file.exists()
+    assert _read_index(index_file) == []
 
 
 def test_cleanup_no_double_count_when_phase1_and_phase2_overlap(mock_env):

--- a/tests/test_issue5331_index_only_ghost_cleanup.py
+++ b/tests/test_issue5331_index_only_ghost_cleanup.py
@@ -36,6 +36,7 @@ def mock_env(tmp_path, monkeypatch):
     import api.config as config_mod
     import api.routes as routes
     import api.models as models
+    import api.session_media as session_media
 
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir()
@@ -53,7 +54,11 @@ def mock_env(tmp_path, monkeypatch):
     monkeypatch.setattr(routes, "SESSIONS", {})
     monkeypatch.setattr(models, "SESSION_DIR", sessions_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+    models._SESSION_PUBLICATION_DELETED.clear()
+    models._SESSION_PUBLICATION_GENERATIONS.clear()
+    models._active_destination_reservations().clear()
     monkeypatch.setattr(
         "api.upload._session_attachment_dir",
         lambda sid: tmp_path / "attachments" / sid,
@@ -359,13 +364,14 @@ def test_cleanup_index_rewritten_when_phase1_removed_files(mock_env):
         {"session_id": "sess-orphan", "title": "Untitled", "message_count": 0},
     ])
 
-    routes._handle_sessions_cleanup(_fake_handler(), {}, zero_only=False)
+    handler = _fake_handler()
+    routes._handle_sessions_cleanup(handler, {}, zero_only=False)
 
     # Phase 1 unlinked the file.  Phase 2 removed the stale index entry.
     # Phase 3 skipped because Phase 2 already cleaned the index.
     # Index exists with zero entries (clean).
     assert index_file.exists()
-    assert _read_index(index_file) == []
+    assert _read_index(index_file) == [], _fake_handler_result(handler)
 
 
 def test_cleanup_phase1_repairs_corrupt_index_through_shared_deletion(mock_env):

--- a/tests/test_issue5532_session_clear_state_db_replay.py
+++ b/tests/test_issue5532_session_clear_state_db_replay.py
@@ -217,9 +217,9 @@ def test_clear_sentinel_does_not_suppress_later_backup_recovery(tmp_path):
     assert restored["messages"][0]["content"] == "post-clear prompt"
 
 
-def test_clearing_empty_live_session_preserves_existing_recoverable_backup(monkeypatch, tmp_path):
+def test_clearing_empty_live_session_retires_existing_recovery_backup(monkeypatch, tmp_path):
     from api.models import Session
-    from api.session_recovery import inspect_session_recovery_status, recover_session
+    from api.session_recovery import inspect_session_recovery_status
 
     _install_isolated_session_env(monkeypatch, tmp_path)
     sid = "issue5532_empty_live_with_backup"
@@ -248,9 +248,6 @@ def test_clearing_empty_live_session_preserves_existing_recoverable_backup(monke
     captured = _post_clear(monkeypatch, sid)
 
     assert captured["status"] == 200
-    assert session.path.with_suffix(".json.bak").exists()
-    assert Session.load(sid).clear_generation is None
-    assert inspect_session_recovery_status(session.path)["recommend"] == "restore"
-    recovered = recover_session(session.path)
-    assert recovered["restored"] is True
-    assert Session.load(sid).messages[0]["content"] == "recoverable prompt"
+    assert not session.path.with_suffix(".json.bak").exists()
+    assert Session.load(sid).clear_generation
+    assert inspect_session_recovery_status(session.path)["recommend"] == "no_backup"

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -278,27 +278,30 @@ class TestIssue765FollowupHardening:
     """
 
     def test_same_session_concurrent_saves_use_distinct_temp_files(self, monkeypatch):
-        """Two concurrent saves of the same session must not collide on one tmp path.
+        """Same-session saves serialize and retain distinct tmp identities.
 
-        The key regression guard here is that each save call should reach os.replace()
-        with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
-        threads would target the same path and the second replace would deterministically
-        fail once the first consume/remove happened.
+        Save and delete now share one publication authority, so two save calls
+        must not enter replacement together. They must still use distinct temp
+        paths so the historical `<sid>.tmp` collision cannot regress if the
+        critical section changes later.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
 
         original_replace = models.os.replace
-        barrier = threading.Barrier(2)
+        first_replace_entered = threading.Event()
+        release_first_replace = threading.Event()
         replace_sources = []
         errors = []
 
-        def _replace_with_barrier(src, dst):
+        def _replace_with_gate(src, dst):
             replace_sources.append(str(src))
-            barrier.wait(timeout=5)
+            if len(replace_sources) == 1:
+                first_replace_entered.set()
+                assert release_first_replace.wait(timeout=5)
             return original_replace(src, dst)
 
-        monkeypatch.setattr(models.os, "replace", _replace_with_barrier)
+        monkeypatch.setattr(models.os, "replace", _replace_with_gate)
 
         def _save_worker():
             try:
@@ -309,7 +312,11 @@ class TestIssue765FollowupHardening:
         t1 = threading.Thread(target=_save_worker)
         t2 = threading.Thread(target=_save_worker)
         t1.start()
+        assert first_replace_entered.wait(timeout=5)
         t2.start()
+        time.sleep(0.05)
+        assert len(replace_sources) == 1, "Same-session publication must serialize"
+        release_first_replace.set()
         t1.join(timeout=5)
         t2.join(timeout=5)
 

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -908,6 +908,23 @@ class TestMediaEndpointIntegration(unittest.TestCase):
         finally:
             sess_file.unlink(missing_ok=True)
 
+        # Session-externalized image blobs are private to their owning session
+        # and must never become reachable through the generic MEDIA: file server.
+        private_dir = state_dir / "session-media" / "other-session"
+        private_dir.mkdir(parents=True, exist_ok=True)
+        private_file = private_dir / ("a" * 64 + ".png")
+        private_file.write_bytes(b"\x89PNG\r\n\x1a\nprivate")
+        try:
+            _, status, _ = self._get(
+                "/api/media?path=" + urllib.parse.quote(str(private_file.resolve()))
+            )
+            self.assertEqual(
+                status, 403,
+                f"files under session-media/ must be denied, got {status}",
+            )
+        finally:
+            private_file.unlink(missing_ok=True)
+
     def test_deny_list_does_not_overblock_active_workspace_media(self):
         """#3234 follow-up: workspace media with a sensitive-looking basename must
         still serve when it lives under the active workspace carve-out.

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -353,7 +353,7 @@ def test_clear_session_evicts_outside_session_lock():
     route_end = src.index('if parsed.path == "/api/session/truncate"', route_start)
     route_block = src[route_start:route_end]
 
-    lock_start = route_block.index("with _get_session_agent_lock(sid):")
+    lock_start = route_block.index("with _get_session_agent_lock(sid)")
     lock_end = route_block.index("# Evict cached agent outside the per-session lock", lock_start)
     locked_section = route_block[lock_start:lock_end]
     outside_section = route_block[lock_end:]

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -183,17 +183,10 @@ def test_save_writes_bak_when_messages_shrink(temp_session_dir):
     from api.models import Session
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000, with_active_stream=False)
 
-    # Build a fresh in-memory Session with a smaller messages array, then save —
-    # this models the precise failure shape of #1558 (a caller mutates messages
-    # downward and saves). We construct the Session directly rather than going
-    # through get_session() so we don't trigger _repair_stale_pending side-effects.
-    s = Session(
-        session_id=sid,
-        title="t",
-        workspace="",
-        model="m",
-        messages=[{"role": "user", "content": f"m{i}"} for i in range(500)],
-    )
+    # Mutate a validated load rather than constructing over an existing SID.
+    s = Session.load(sid)
+    assert s is not None
+    s.messages = [{"role": "user", "content": f"m{i}"} for i in range(500)]
     s.save()
 
     bak_path = temp_session_dir / f"{sid}.json.bak"
@@ -213,14 +206,10 @@ def test_save_does_not_write_bak_when_messages_grow(temp_session_dir):
     from api.models import Session
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000, with_active_stream=False)
 
-    # Build a session with MORE messages than on disk — the normal grow path.
-    s = Session(
-        session_id=sid,
-        title="t",
-        workspace="",
-        model="m",
-        messages=[{"role": "user", "content": f"m{i}"} for i in range(1001)],
-    )
+    # Mutate a validated load rather than constructing over an existing SID.
+    s = Session.load(sid)
+    assert s is not None
+    s.messages = [{"role": "user", "content": f"m{i}"} for i in range(1001)]
     s.save()
 
     bak_path = temp_session_dir / f"{sid}.json.bak"

--- a/tests/test_native_image_attachments.py
+++ b/tests/test_native_image_attachments.py
@@ -357,7 +357,10 @@ class TestBuildNativeMultimodalMessage:
     def test_sync_chat_history_sanitizer_receives_config(self):
         """#2398: fallback POST /api/chat must use the text-mode history sanitizer too."""
         src = Path('api/routes.py').read_text()
-        assert 'conversation_history=_sanitize_messages_for_api(' in src, (
+        assert (
+            'conversation_history=_sanitize_messages_for_api(' in src
+            or '"conversation_history": _sanitize_messages_for_api(' in src
+        ), (
             'The legacy synchronous /api/chat endpoint must sanitize history through '
             '_sanitize_messages_for_api.'
         )

--- a/tests/test_pr1341_context_window_persistence.py
+++ b/tests/test_pr1341_context_window_persistence.py
@@ -75,7 +75,8 @@ def test_session_init_accepts_context_fields():
     """Session.__init__ must accept the three fields as named kwargs."""
     src = MODELS.read_text(encoding="utf-8")
     # The init signature spans many lines — read the full def block
-    init_match = re.search(r"def __init__\(self,(.*?)\):", src, re.DOTALL)
+    session_src = src[src.index("class Session:"):]
+    init_match = re.search(r"def __init__\(self,(.*?)\):", session_src, re.DOTALL)
     assert init_match, "Session.__init__ signature not found"
     sig = init_match.group(1)
     assert "context_length" in sig, "Session.__init__ must accept context_length"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -344,7 +344,8 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             text.find('if parsed.path == "/api/session/delete":'),
         )
         if delete_idx >= 0:
-            delete_block = text[delete_idx:delete_idx+2400]
+            next_route_idx = text.find('if parsed.path == "/api/session/clear":', delete_idx)
+            delete_block = text[delete_idx:next_route_idx if next_route_idx >= 0 else None]
             assert "prune_session_from_index(sid)" in delete_block, \
                 f"{label} session/delete must prune SESSION_INDEX_FILE"
             return
@@ -359,7 +360,8 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+2400]
+    next_route_idx = routes_src.find('if parsed.path == "/api/session/clear":', delete_idx)
+    delete_block = routes_src[delete_idx:next_route_idx if next_route_idx >= 0 else None]
     assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
         "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -5,6 +5,7 @@ These tests exist specifically to prevent those bugs from silently returning.
 Each test is tagged with the sprint/commit where the bug was found and fixed.
 """
 import json
+import inspect
 import os
 import pathlib
 import re
@@ -333,7 +334,7 @@ def test_deleted_session_does_not_appear_in_list(cleanup_test_sessions):
 
 
 def test_server_delete_prunes_session_index(cleanup_test_sessions):
-    """session/delete should prune the deleted row without discarding the index."""
+    """session/delete should route index cleanup through the shared primitive."""
     src = (REPO_ROOT / "server.py").read_text()
     routes_src = (REPO_ROOT / "api" / "routes.py").read_text() if (REPO_ROOT / "api" / "routes.py").exists() else ""
     # Find the delete handler in either file
@@ -346,14 +347,16 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
         if delete_idx >= 0:
             next_route_idx = text.find('if parsed.path == "/api/session/clear":', delete_idx)
             delete_block = text[delete_idx:next_route_idx if next_route_idx >= 0 else None]
-            assert "prune_session_from_index(sid)" in delete_block, \
-                f"{label} session/delete must prune SESSION_INDEX_FILE"
+            assert "delete_session_artifacts(" in delete_block, \
+                f"{label} session/delete must use shared artifact cleanup"
+            from api.models import delete_session_artifacts
+            assert "prune_session_from_index(sid)" in inspect.getsource(delete_session_artifacts)
             return
     assert False, "session/delete handler not found in server.py or api/routes.py"
 
 
 def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
-    """session/delete must remove sidecar backups so deleted sessions stay deleted."""
+    """session/delete must route backup removal through shared artifact cleanup."""
     routes_src = (REPO_ROOT / "api" / "routes.py").read_text()
     delete_idx = max(
         routes_src.find("if parsed.path == '/api/session/delete':"),
@@ -362,8 +365,11 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
     next_route_idx = routes_src.find('if parsed.path == "/api/session/clear":', delete_idx)
     delete_block = routes_src[delete_idx:next_route_idx if next_route_idx >= 0 else None]
-    assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
-        "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
+    assert "delete_session_artifacts(" in delete_block
+    from api.models import delete_session_artifacts
+    helper_src = inspect.getsource(delete_session_artifacts)
+    assert 'backup = sidecar.with_suffix(".json.bak")' in helper_src
+    assert 'for artifact, path in (("session_json", sidecar), ("session_backup", backup))' in helper_src
 
 # ── R9: Token/tool SSE events write to wrong session after switch ─────────────
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -45,19 +45,15 @@ def make_session(created_list):
 
 def _make_session_visible(sid):
     from api.models import Session
-    from tests.conftest import TEST_WORKSPACE
 
-    session = Session(
-        session_id=sid,
-        title="regression-test-delete-R8",
-        workspace=str(TEST_WORKSPACE),
-        model="test",
-        created_at=time.time(),
-        updated_at=time.time(),
-        profile="default",
-        messages=[{"role": "user", "content": "visible row", "timestamp": time.time()}],
-        tool_calls=[],
-    )
+    # The server owns the fresh SID's publication lease. Reload that validated
+    # sidecar before changing it instead of constructing a second writer for
+    # the same persisted generation.
+    session = Session.load(sid)
+    assert session is not None
+    session.title = "regression-test-delete-R8"
+    session.messages = [{"role": "user", "content": "visible row", "timestamp": time.time()}]
+    session.tool_calls = []
     session.save(touch_updated_at=False)
 
 

--- a/tests/test_session_cache_ownership.py
+++ b/tests/test_session_cache_ownership.py
@@ -69,7 +69,7 @@ def test_compression_cache_migration_never_moves_unverified_cached_object_to_new
 
     assert "SESSIONS[new_sid] = SESSIONS.pop(old_sid)" not in streaming_src
     assert "cached_old_session is not s" in streaming_src
-    assert "SESSIONS[new_sid] = s" in streaming_src
+    assert "mutate(SESSIONS, new_sid, s, LOCK)" in streaming_src
 
 
 def test_cached_agent_session_identity_matches_requested_sid():

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -1407,7 +1407,9 @@ def test_concurrent_saves_dont_lose_data():
     sB = _make_session("sess_b", "Bravo", updated_at=200.0)
 
     for s in (sA, sB):
-        s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+        # Publish the initial sidecars through the normal authority path so
+        # the concurrent writers below hold the validated generation.
+        s.save(skip_index=True)
 
     # Build initial index
     _write_session_index(updates=None)

--- a/tests/test_session_index_lock_window.py
+++ b/tests/test_session_index_lock_window.py
@@ -33,8 +33,14 @@ def test_session_index_fast_path_keeps_json_work_outside_global_lock(monkeypatch
 
     old = models.Session(session_id="idx_old", title="Old", updated_at=1.0)
     updated = models.Session(session_id="idx_updated", title="Updated", updated_at=20.0)
-    (session_dir / "idx_old.json").write_text("{}", encoding="utf-8")
-    (session_dir / "idx_updated.json").write_text("{}", encoding="utf-8")
+    (session_dir / "idx_old.json").write_text(
+        json.dumps({"session_id": "idx_old"}),
+        encoding="utf-8",
+    )
+    (session_dir / "idx_updated.json").write_text(
+        json.dumps({"session_id": "idx_updated"}),
+        encoding="utf-8",
+    )
     index_file.write_text(
         json.dumps(
             [

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -2542,7 +2542,7 @@ def test_save_rejects_private_ref_in_non_image_transcript_path(tmp_path, monkeyp
 
     with pytest.raises(
         session_media.SessionMediaIntegrityError,
-        match="hydrated session history",
+        match="outside an image part",
     ):
         session.save(skip_index=True)
 

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1,0 +1,98 @@
+"""Regression tests for file-backed large native image session media."""
+import base64
+import json
+
+from api import models, session_media
+from api.models import Session
+from api.streaming import _sanitize_messages_for_api
+
+
+def _large_png_data_url():
+    # This is intentionally synthetic: the signature is sufficient for the
+    # storage boundary, and keeps the regression test free of user media.
+    raw = b"\x89PNG\r\n\x1a\n" + (b"\0" * (70 * 1024))
+    return raw, "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+
+def _image_message(url):
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "describe this"},
+            {"type": "image_url", "image_url": {"url": url}},
+        ],
+    }
+
+
+def test_externalize_and_hydrate_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+
+    assert session_media.externalize_large_session_media(messages, "media-test") == 1
+    ref = messages[0]["content"][1]["image_url"]["url"]
+    assert ref.startswith("webui-media://")
+    assert data_url not in json.dumps(messages)
+
+    files = list((tmp_path / "attachments" / "media-test" / "session-media").iterdir())
+    assert len(files) == 1
+    assert files[0].read_bytes() == raw
+    hydrated = session_media.hydrate_session_media_urls(messages, "media-test")
+    assert hydrated[0]["content"][1]["image_url"]["url"] == data_url
+    # The persisted representation remains compact after model-call hydration.
+    assert messages[0]["content"][1]["image_url"]["url"] == ref
+
+
+def test_save_compacts_both_visible_and_model_context(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path / "sessions")
+    models.SESSION_DIR.mkdir()
+    raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="media-save",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+
+    session.save(skip_index=True)
+
+    serialized = session.path.read_text(encoding="utf-8")
+    assert data_url not in serialized
+    assert serialized.count("webui-media://") == 2
+    # Deduplication keeps the one image once even when visible/context copies
+    # both contained it before save.
+    files = list((tmp_path / "attachments" / "media-save" / "session-media").iterdir())
+    assert len(files) == 1
+    assert files[0].read_bytes() == raw
+
+    provider_history = _sanitize_messages_for_api(
+        session.context_messages,
+        cfg={"agent": {"image_input_mode": "native"}},
+        session_id=session.session_id,
+    )
+    assert provider_history[0]["content"][1]["image_url"]["url"] == data_url
+
+
+def test_small_or_noncanonical_data_urls_stay_in_json(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    small = "data:image/png;base64," + base64.b64encode(b"\x89PNG\r\n\x1a\nsmall").decode("ascii")
+    messages = [
+        _image_message(small),
+        {"role": "assistant", "content": "literal data:image/png;base64,not-a-content-part"},
+        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/svg+xml;base64,PHN2Zy8+"}}]},
+    ]
+
+    assert session_media.externalize_large_session_media(messages, "media-small") == 0
+    assert messages[0]["content"][1]["image_url"]["url"] == small
+    assert "literal data:image" in messages[1]["content"]
+    assert messages[2]["content"][0]["image_url"]["url"].startswith("data:image/svg+xml")
+
+
+def test_uses_the_configured_attachment_root(tmp_path, monkeypatch):
+    custom_root = tmp_path / "custom-inbox"
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(custom_root))
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+
+    assert session_media.externalize_large_session_media(messages, "media-custom") == 1
+    assert list((custom_root / "media-custom" / "session-media").iterdir())

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1,11 +1,18 @@
 """Regression tests for file-backed large native image session media."""
 import base64
 import hashlib
+import io
 import json
 import os
+import shutil
 import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
 
-from api import models, session_media
+import pytest
+
+from api import models, routes, session_media
 from api.models import Session
 from api.streaming import _sanitize_messages_for_api
 
@@ -25,6 +32,71 @@ def _image_message(url):
             {"type": "image_url", "image_url": {"url": url}},
         ],
     }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_attachment_root(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
+
+
+class _FakeHandler:
+    def __init__(self, path):
+        self.status = None
+        self.headers = {"Content-Type": "application/json", "Content-Length": "1"}
+        self.rfile = io.BytesIO(b"")
+        self.wfile = io.BytesIO()
+        self.command = "POST"
+        self.path = path
+        self.client_address = ("127.0.0.1", 12345)
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+
+def _capture_route(monkeypatch):
+    captured = {}
+
+    def fake_json(_handler, payload, *_, **kwargs):
+        captured["ok"] = payload
+        captured["status"] = kwargs.get("status", 200)
+        return True
+
+    def fake_bad(_handler, message, code=400, **kwargs):
+        captured["bad"] = (message, kwargs.get("status", code))
+        return True
+
+    monkeypatch.setattr(routes, "j", fake_json)
+    monkeypatch.setattr(routes, "bad", fake_bad)
+    return captured
+
+
+def _configure_session_state(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    routes.SESSIONS.clear()
+    return session_dir
+
+
+def _assert_destination_media_is_independent(destination, source_id, raw, data_url):
+    destination_id = destination.session_id
+    destination_files = list(session_media._session_media_dir(destination_id).iterdir())
+    assert len(destination_files) == 1
+    assert destination_files[0].read_bytes() == raw
+    shutil.rmtree(session_media._session_media_dir(source_id).parent)
+    hydrated_messages = session_media.hydrate_session_media_urls(destination.messages, destination_id)
+    hydrated_context = session_media.hydrate_session_media_urls(destination.context_messages, destination_id)
+    assert hydrated_messages[0]["content"][1]["image_url"]["url"] == data_url
+    assert hydrated_context[0]["content"][1]["image_url"]["url"] == data_url
 
 
 def test_externalize_and_hydrate_round_trip(tmp_path, monkeypatch):
@@ -120,3 +192,165 @@ def test_stale_tmp_file_is_rewritten_before_returning_reference(tmp_path, monkey
     assert session_media.externalize_large_session_media(messages, session_id) == 1
     assert (media_dir / filename).read_bytes() == raw
     assert not stale_tmp.exists()
+
+
+def test_clone_references_verifies_hash_before_writing_destination(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    session_media.externalize_large_session_media(messages, "source-hash")
+    source_file = next(session_media._session_media_dir("source-hash").iterdir())
+    source_file.write_bytes(b"\x89PNG\r\n\x1a\ncorrupt")
+
+    with pytest.raises(ValueError, match="digest"):
+        session_media.clone_session_media_references(messages, "source-hash", "dest-hash")
+
+    assert not session_media._session_media_dir("dest-hash").exists()
+
+
+@pytest.mark.parametrize("path", ["/api/session/duplicate", "/api/session/branch"])
+def test_id_copy_failure_does_not_commit_dangling_session(path, tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id="media-failed-source",
+        title="Media source",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+    next(session_media._session_media_dir(source.session_id).iterdir()).write_bytes(
+        b"\x89PNG\r\n\x1a\ncorrupt"
+    )
+    destination_id = "mediafail001"
+    monkeypatch.setattr(models.uuid, "uuid4", lambda: SimpleNamespace(hex=destination_id))
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": source.session_id})
+    monkeypatch.setattr(routes, "get_session", lambda _sid, metadata_only=False: source)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_, **__: None)
+    captured = _capture_route(monkeypatch)
+
+    routes.handle_post(_FakeHandler(path), urlparse(path))
+
+    assert captured["bad"] == ("Could not copy session media", 500)
+    assert not (session_dir / f"{destination_id}.json").exists()
+    assert destination_id not in models.SESSIONS
+
+
+def test_duplicate_clones_externalized_media_before_session_commit(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id="media-duplicate-source",
+        title="Media source",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": source.session_id})
+    monkeypatch.setattr(routes, "get_session", lambda _sid, metadata_only=False: source)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_, **__: None)
+    captured = _capture_route(monkeypatch)
+
+    routes.handle_post(_FakeHandler("/api/session/duplicate"), urlparse("/api/session/duplicate"))
+
+    assert "bad" not in captured
+    destination_id = captured["ok"]["session"]["session_id"]
+    destination = Session.load(destination_id)
+    _assert_destination_media_is_independent(destination, source.session_id, raw, data_url)
+
+
+def test_branch_clones_externalized_media_before_session_commit(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id="media-branch-source",
+        title="Media source",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": source.session_id})
+    monkeypatch.setattr(routes, "get_session", lambda _sid, metadata_only=False: source)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_, **__: None)
+    captured = _capture_route(monkeypatch)
+
+    routes.handle_post(_FakeHandler("/api/session/branch"), urlparse("/api/session/branch"))
+
+    assert "bad" not in captured
+    destination_id = captured["ok"]["session_id"]
+    destination = Session.load(destination_id)
+    _assert_destination_media_is_independent(destination, source.session_id, raw, data_url)
+
+
+def test_gateway_runs_api_hydrates_compact_history_without_mutation(tmp_path, monkeypatch):
+    from api.config import STREAM_PARTIAL_TEXT, STREAM_REASONING_TEXT
+    from api.gateway_chat import _STREAM_RUN_IDS, _run_gateway_runs_api_streaming
+
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    stored_history = [_image_message(data_url)]
+    session_media.externalize_large_session_media(stored_history, "gateway-media")
+    stored_ref = stored_history[0]["content"][1]["image_url"]["url"]
+    requests = []
+    stream_id = "stream-gateway-media"
+    STREAM_PARTIAL_TEXT[stream_id] = ""
+    STREAM_REASONING_TEXT[stream_id] = ""
+
+    class _JsonResponse:
+        def read(self, _limit=None):
+            return json.dumps({"run_id": "run-media"}).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    class _SseResponse:
+        def __iter__(self):
+            return iter([b'data: {"event":"run.completed","output":"done"}\n', b"\n"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    def fake_urlopen(req, *, timeout=None):
+        requests.append(req)
+        return _JsonResponse() if req.full_url.endswith("/v1/runs") else _SseResponse()
+
+    try:
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_gateway_runs_api_streaming(
+                session_id="gateway-media",
+                msg_text="continue",
+                model="test-model",
+                workspace=str(tmp_path),
+                stream_id=stream_id,
+                base_url="http://gw:8642",
+                api_key="secret",
+                prefill_messages=[],
+                body_extras={},
+                put_gateway_event=lambda *_args, **_kwargs: None,
+                cancel_event=threading.Event(),
+                session=SimpleNamespace(context_messages=stored_history),
+            )
+    finally:
+        STREAM_PARTIAL_TEXT.pop(stream_id, None)
+        STREAM_REASONING_TEXT.pop(stream_id, None)
+        _STREAM_RUN_IDS.pop(stream_id, None)
+
+    run_body = json.loads(requests[0].data.decode("utf-8"))
+    outbound = json.dumps(run_body["conversation_history"])
+    assert data_url in outbound
+    assert "webui-media://" not in outbound
+    assert stored_history[0]["content"][1]["image_url"]["url"] == stored_ref

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -3,9 +3,8 @@ import base64
 import hashlib
 import io
 import json
-import os
-import shutil
 import threading
+import zipfile
 from types import SimpleNamespace
 from unittest.mock import patch
 from urllib.parse import urlparse
@@ -17,10 +16,10 @@ from api.models import Session
 from api.streaming import _sanitize_messages_for_api
 
 
-def _large_png_data_url():
+def _large_png_data_url(fill=b"\0"):
     # This is intentionally synthetic: the signature is sufficient for the
     # storage boundary, and keeps the regression test free of user media.
-    raw = b"\x89PNG\r\n\x1a\n" + (b"\0" * (70 * 1024))
+    raw = b"\x89PNG\r\n\x1a\n" + (fill * (70 * 1024))
     return raw, "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
 
 
@@ -92,7 +91,7 @@ def _assert_destination_media_is_independent(destination, source_id, raw, data_u
     destination_files = list(session_media._session_media_dir(destination_id).iterdir())
     assert len(destination_files) == 1
     assert destination_files[0].read_bytes() == raw
-    shutil.rmtree(session_media._session_media_dir(source_id).parent)
+    session_media.remove_session_media(source_id)
     hydrated_messages = session_media.hydrate_session_media_urls(destination.messages, destination_id)
     hydrated_context = session_media.hydrate_session_media_urls(destination.context_messages, destination_id)
     assert hydrated_messages[0]["content"][1]["image_url"]["url"] == data_url
@@ -109,7 +108,7 @@ def test_externalize_and_hydrate_round_trip(tmp_path, monkeypatch):
     assert ref.startswith("webui-media://")
     assert data_url not in json.dumps(messages)
 
-    files = list((tmp_path / "attachments" / "media-test" / "session-media").iterdir())
+    files = list((tmp_path / "session-media" / "media-test").iterdir())
     assert len(files) == 1
     assert files[0].read_bytes() == raw
     hydrated = session_media.hydrate_session_media_urls(messages, "media-test")
@@ -136,7 +135,7 @@ def test_save_compacts_both_visible_and_model_context(tmp_path, monkeypatch):
     assert serialized.count("webui-media://") == 2
     # Deduplication keeps the one image once even when visible/context copies
     # both contained it before save.
-    files = list((tmp_path / "attachments" / "media-save" / "session-media").iterdir())
+    files = list((tmp_path / "session-media" / "media-save").iterdir())
     assert len(files) == 1
     assert files[0].read_bytes() == raw
 
@@ -167,14 +166,20 @@ def test_small_or_noncanonical_data_urls_stay_in_json(tmp_path, monkeypatch):
     assert messages[2]["content"][0]["image_url"]["url"].startswith("data:image/svg+xml")
 
 
-def test_uses_the_configured_attachment_root(tmp_path, monkeypatch):
+def test_private_store_ignores_attachment_root_moves(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     custom_root = tmp_path / "custom-inbox"
     monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(custom_root))
     _raw, data_url = _large_png_data_url()
     messages = [_image_message(data_url)]
 
     assert session_media.externalize_large_session_media(messages, "media-custom") == 1
-    assert list((custom_root / "media-custom" / "session-media").iterdir())
+    assert list((tmp_path / "session-media" / "media-custom").iterdir())
+    assert not custom_root.exists()
+
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(tmp_path / "moved-inbox"))
+    hydrated = session_media.hydrate_session_media_urls(messages, "media-custom")
+    assert hydrated[0]["content"][1]["image_url"]["url"] == data_url
 
 
 def test_stale_tmp_file_is_rewritten_before_returning_reference(tmp_path, monkeypatch):
@@ -185,13 +190,15 @@ def test_stale_tmp_file_is_rewritten_before_returning_reference(tmp_path, monkey
     media_dir.mkdir(parents=True)
     digest = hashlib.sha256(raw).hexdigest()
     filename = f"{digest}.png"
-    stale_tmp = media_dir / f".{filename}.{os.getpid()}.{threading.get_ident()}.tmp"
+    stale_tmp = media_dir / f".{filename}.stale.tmp"
     stale_tmp.write_bytes(b"interrupted prior write")
     messages = [_image_message(data_url)]
 
     assert session_media.externalize_large_session_media(messages, session_id) == 1
     assert (media_dir / filename).read_bytes() == raw
-    assert not stale_tmp.exists()
+    # Random exclusive temp names ensure an unrelated stale file cannot block
+    # or be mistaken for the in-flight write.
+    assert stale_tmp.read_bytes() == b"interrupted prior write"
 
 
 def test_clone_references_verifies_hash_before_writing_destination(tmp_path, monkeypatch):
@@ -354,3 +361,358 @@ def test_gateway_runs_api_hydrates_compact_history_without_mutation(tmp_path, mo
     assert data_url in outbound
     assert "webui-media://" not in outbound
     assert stored_history[0]["content"][1]["image_url"]["url"] == stored_ref
+
+
+def test_hydration_and_provider_sanitizer_fail_closed_on_digest_mismatch(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    session_media.externalize_large_session_media(messages, "media-corrupt")
+    media_file = next(session_media._session_media_dir("media-corrupt").iterdir())
+    media_file.write_bytes(b"\x89PNG\r\n\x1a\n" + (b"x" * (70 * 1024)))
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="digest"):
+        session_media.hydrate_session_media_urls(messages, "media-corrupt")
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="digest"):
+        _sanitize_messages_for_api(messages, session_id="media-corrupt")
+
+
+def test_gateway_corrupt_media_never_reaches_urlopen(tmp_path, monkeypatch):
+    from api.gateway_chat import _run_gateway_runs_api_streaming
+
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    history = [_image_message(data_url)]
+    session_media.externalize_large_session_media(history, "gateway-corrupt")
+    next(session_media._session_media_dir("gateway-corrupt").iterdir()).write_bytes(
+        b"\x89PNG\r\n\x1a\ncorrupt"
+    )
+    called = False
+
+    def unexpected_urlopen(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("corrupt private media crossed the Gateway boundary")
+
+    monkeypatch.setattr("urllib.request.urlopen", unexpected_urlopen)
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="digest"):
+        _run_gateway_runs_api_streaming(
+            session_id="gateway-corrupt",
+            msg_text="continue",
+            model="test-model",
+            workspace=str(tmp_path),
+            stream_id="gateway-corrupt-stream",
+            base_url="http://gw:8642",
+            api_key="secret",
+            prefill_messages=[],
+            body_extras={},
+            put_gateway_event=lambda *_args, **_kwargs: None,
+            cancel_event=threading.Event(),
+            session=SimpleNamespace(context_messages=history),
+        )
+    assert not called
+
+
+def test_clone_preflights_all_references_before_destination_publication(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw_a, data_a = _large_png_data_url(b"a")
+    _raw_b, data_b = _large_png_data_url(b"b")
+    messages = [_image_message(data_a), _image_message(data_b)]
+    session_media.externalize_large_session_media(messages, "multi-source")
+    files = sorted(session_media._session_media_dir("multi-source").iterdir())
+    files[-1].write_bytes(b"\x89PNG\r\n\x1a\ncorrupt")
+
+    with pytest.raises(session_media.SessionMediaIntegrityError):
+        session_media.clone_session_media_references(
+            messages,
+            "multi-source",
+            "multi-destination",
+        )
+    assert not session_media._session_media_dir("multi-destination").exists()
+
+
+def test_clone_rolls_back_all_published_blobs_on_directory_fsync_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw_a, data_a = _large_png_data_url(b"a")
+    _raw_b, data_b = _large_png_data_url(b"b")
+    messages = [_image_message(data_a), _image_message(data_b)]
+    session_media.externalize_large_session_media(messages, "rollback-source")
+    destination_dir = session_media._session_media_dir("rollback-destination")
+    destination_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        session_media,
+        "_fsync_dir",
+        lambda _fd: (_ for _ in ()).throw(OSError("directory fsync failed")),
+    )
+
+    with pytest.raises(OSError, match="directory fsync failed"):
+        session_media.clone_session_media_references(
+            messages,
+            "rollback-source",
+            "rollback-destination",
+        )
+    assert list(destination_dir.iterdir()) == []
+
+
+@pytest.mark.parametrize("failure", ["replace", "directory_fsync"])
+def test_externalize_rolls_back_publication_failures(failure, tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    media_dir = session_media._session_media_dir("publication-failure")
+    media_dir.mkdir(parents=True)
+
+    if failure == "replace":
+        monkeypatch.setattr(
+            session_media.os,
+            "replace",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("replace failed")),
+        )
+    else:
+        monkeypatch.setattr(
+            session_media,
+            "_fsync_dir",
+            lambda _fd: (_ for _ in ()).throw(OSError("directory fsync failed")),
+        )
+
+    with pytest.raises(OSError, match="failed"):
+        session_media.externalize_large_session_media(messages, "publication-failure")
+    assert messages[0]["content"][1]["image_url"]["url"] == data_url
+    assert list(media_dir.iterdir()) == []
+
+
+def test_private_store_rejects_symlink_component(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    private_root = tmp_path / "session-media"
+    outside = tmp_path / "outside"
+    private_root.mkdir()
+    outside.mkdir()
+    (private_root / "symlink-session").symlink_to(outside, target_is_directory=True)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+
+    with pytest.raises(OSError):
+        session_media.externalize_large_session_media(messages, "symlink-session")
+    assert messages[0]["content"][1]["image_url"]["url"] == data_url
+    assert list(outside.iterdir()) == []
+
+
+def test_parent_swap_is_detected_without_writing_outside(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    media_dir = session_media._session_media_dir("swap-session")
+    media_dir.mkdir(parents=True)
+    moved = media_dir.with_name("swap-session-held")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_replace = session_media.os.replace
+
+    def swap_then_replace(source, destination, **kwargs):
+        media_dir.rename(moved)
+        media_dir.symlink_to(outside, target_is_directory=True)
+        return real_replace(source, destination, **kwargs)
+
+    monkeypatch.setattr(session_media.os, "replace", swap_then_replace)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="directory changed"):
+        session_media.externalize_large_session_media(messages, "swap-session")
+    assert messages[0]["content"][1]["image_url"]["url"] == data_url
+    assert list(outside.iterdir()) == []
+    assert list(moved.iterdir()) == []
+
+
+def test_concurrent_writers_publish_one_verified_blob(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    raw, data_url = _large_png_data_url()
+    values = [[_image_message(data_url)] for _ in range(8)]
+    errors = []
+
+    def write(value):
+        try:
+            session_media.externalize_large_session_media(value, "concurrent-session")
+        except Exception as exc:  # pragma: no cover - assertion reports details
+            errors.append(exc)
+
+    workers = [threading.Thread(target=write, args=(value,)) for value in values]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert errors == []
+    refs = {value[0]["content"][1]["image_url"]["url"] for value in values}
+    assert len(refs) == 1
+    files = list(session_media._session_media_dir("concurrent-session").iterdir())
+    assert len(files) == 1
+    assert files[0].read_bytes() == raw
+
+
+def test_remove_session_media_deletes_only_requested_namespace(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    first = [_image_message(data_url)]
+    second = [_image_message(data_url)]
+    session_media.externalize_large_session_media(first, "delete-first")
+    session_media.externalize_large_session_media(second, "keep-second")
+
+    session_media.remove_session_media("delete-first")
+
+    assert not session_media._session_media_dir("delete-first").exists()
+    assert session_media._session_media_dir("keep-second").exists()
+    assert session_media.hydrate_session_media_urls(second, "keep-second")
+
+
+def test_archive_named_session_media_cannot_precreate_private_namespace(tmp_path, monkeypatch):
+    from api.upload import extract_archive
+
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    attachment_session = tmp_path / "attachments" / "archive-session"
+    attachment_session.mkdir(parents=True)
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as bundle:
+        bundle.writestr("attacker.txt", "not private media")
+    extract_archive(archive.getvalue(), "session-media.zip", attachment_session)
+    assert (attachment_session / "session-media" / "attacker.txt").exists()
+
+    raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    session_media.externalize_large_session_media(messages, "archive-session")
+    private_files = list(session_media._session_media_dir("archive-session").iterdir())
+    assert len(private_files) == 1
+    assert private_files[0].read_bytes() == raw
+
+
+def test_legacy_attachment_media_is_verified_and_migrated(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    raw, _data_url = _large_png_data_url()
+    filename = f"{hashlib.sha256(raw).hexdigest()}.png"
+    legacy = tmp_path / "attachments" / "legacy-session" / "session-media"
+    legacy.mkdir(parents=True)
+    (legacy / filename).write_bytes(raw)
+    messages = [_image_message(f"webui-media://{filename}")]
+
+    hydrated = session_media.hydrate_session_media_urls(messages, "legacy-session")
+    assert hydrated[0]["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert (tmp_path / "session-media" / "legacy-session" / filename).read_bytes() == raw
+
+
+def test_btw_clones_media_before_new_session_is_published(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id="btw-source",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: source)
+    monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **_kwargs: None)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "create_stream_channel", lambda: SimpleNamespace())
+    monkeypatch.setattr(routes, "register_stream_owner", lambda *_args: None)
+    monkeypatch.setattr("api.background.track_btw", lambda *_args: None)
+
+    class NoopThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(routes.threading, "Thread", NoopThread)
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_btw(
+        _FakeHandler("/api/btw"),
+        {"session_id": source.session_id, "question": "What is in the image?"},
+    )
+
+    assert "bad" not in captured
+    destination_id = captured["ok"]["session_id"]
+    destination = Session.load(destination_id)
+    session_media.remove_session_media(source.session_id)
+    hydrated = session_media.hydrate_session_media_urls(
+        destination.context_messages,
+        destination_id,
+    )
+    assert hydrated[0]["content"][1]["image_url"]["url"] == data_url
+    assert next(session_media._session_media_dir(destination_id).iterdir()).read_bytes() == raw
+
+
+def test_export_import_inlines_verified_media_and_establishes_new_ownership(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id="export-source",
+        workspace=str(tmp_path),
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: source)
+    monkeypatch.setattr(routes, "_profiles_match", lambda *_args: True)
+    export_handler = _FakeHandler("/api/session/export")
+
+    routes._handle_session_export(
+        export_handler,
+        urlparse(f"/api/session/export?session_id={source.session_id}"),
+    )
+    exported = json.loads(export_handler.wfile.getvalue())
+    assert data_url in json.dumps(exported)
+    assert "webui-media://" not in json.dumps(exported)
+
+    session_media.remove_session_media(source.session_id)
+    captured = _capture_route(monkeypatch)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda path: path)
+    routes._handle_session_import(_FakeHandler("/api/session/import"), exported)
+    assert "bad" not in captured
+    imported_id = captured["ok"]["session"]["session_id"]
+    imported = Session.load(imported_id)
+    hydrated = session_media.hydrate_session_media_urls(imported.context_messages, imported_id)
+    assert hydrated[0]["content"][1]["image_url"]["url"] == data_url
+    assert next(session_media._session_media_dir(imported_id).iterdir()).read_bytes() == raw
+
+
+def test_import_rejects_private_references_without_publishing_session(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    session_media.externalize_large_session_media(messages, "foreign-source")
+    before = set(models.SESSIONS)
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_session_import(
+        _FakeHandler("/api/session/import"),
+        {"messages": messages, "workspace": str(tmp_path)},
+    )
+    assert captured["bad"][1] == 400
+    assert set(models.SESSIONS) == before
+
+
+def test_manual_compression_stops_before_provider_on_corrupt_media(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)] + [
+        {"role": "assistant", "content": "one"},
+        {"role": "user", "content": "two"},
+        {"role": "assistant", "content": "three"},
+    ]
+    session = Session(session_id="compress-corrupt", messages=messages)
+    session.save(skip_index=True)
+    next(session_media._session_media_dir(session.session_id).iterdir()).write_bytes(
+        b"\x89PNG\r\n\x1a\ncorrupt"
+    )
+    monkeypatch.setattr(routes, "get_session", lambda _sid: session)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_session_compress(
+        _FakeHandler("/api/session/compress"),
+        {"session_id": session.session_id},
+    )
+    assert captured["bad"][1] == 400
+    assert "digest verification" in captured["bad"][0]

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -3,6 +3,7 @@ import base64
 import hashlib
 import io
 import json
+import os
 import threading
 import zipfile
 from types import SimpleNamespace
@@ -88,6 +89,17 @@ def _configure_session_state(tmp_path, monkeypatch):
     models._SESSION_PUBLICATION_LOCKS.clear()
     if hasattr(models, "_SESSION_PUBLICATION_GENERATIONS"):
         models._SESSION_PUBLICATION_GENERATIONS.clear()
+    models._active_destination_reservations().clear()
+    with routes.api_config.SESSION_AGENT_CACHE_LOCK:
+        routes.api_config.SESSION_AGENT_CACHE.clear()
+    with routes.api_config.SESSION_AGENT_LOCKS_LOCK:
+        routes.api_config.SESSION_AGENT_LOCKS.clear()
+    with routes.api_config.ACTIVE_RUNS_LOCK:
+        routes.api_config.ACTIVE_RUNS.clear()
+    with routes.STREAMS_LOCK:
+        routes.STREAMS.clear()
+    with routes.api_config.STREAM_SESSION_OWNERS_LOCK:
+        routes.api_config.STREAM_SESSION_OWNERS.clear()
     return session_dir
 
 
@@ -653,6 +665,20 @@ def test_remove_session_media_deletes_only_requested_namespace(tmp_path, monkeyp
     assert not session_media._session_media_dir("delete-first").exists()
     assert session_media._session_media_dir("keep-second").exists()
     assert session_media.hydrate_session_media_urls(second, "keep-second")
+
+
+def test_media_cleanup_retry_prefix_cannot_match_sibling_sid(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    media_root = tmp_path / "session-media"
+    media_root.mkdir()
+    sibling_quarantine = media_root / (
+        session_media._deletion_quarantine_prefix("a-b") + "stale"
+    )
+    sibling_quarantine.mkdir()
+
+    session_media.remove_session_media("a")
+
+    assert sibling_quarantine.is_dir()
 
 
 def test_archive_named_session_media_cannot_precreate_private_namespace(tmp_path, monkeypatch):
@@ -1447,3 +1473,258 @@ def test_ephemeral_cleanup_failure_keeps_exact_retryable_owner(tmp_path, monkeyp
     assert owner is not None
     assert owner["cleanup_pending"] is True
     assert session.session_id in models._load_session_cleanup_residuals()
+
+
+def test_sidecar_outer_identity_cannot_redirect_session_namespace(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    payload = {
+        "session_id": "identity-b",
+        "title": "claimed",
+        "created_at": 1,
+        "updated_at": 1,
+        "messages": [{"role": "user", "content": "secret"}],
+    }
+    (session_dir / "identity-a.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    assert Session.load("identity-a") is None
+    assert Session.load_metadata_only("identity-a") is None
+    assert models._load_session_from_path(session_dir / "identity-a.json") is None
+    assert "identity-b" not in models.SESSIONS
+
+
+def test_destination_collision_preserves_existing_owner_bytes(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    path = session_dir / "reserved-owner.json"
+    original = b'{"session_id":"reserved-owner","messages":[{"role":"user","content":"keep"}]}'
+    path.write_bytes(original)
+
+    with pytest.raises(models.SessionDestinationCollisionError):
+        with models.reserve_session_destination("reserved-owner"):
+            raise AssertionError("collision reservation entered")
+
+    assert path.read_bytes() == original
+
+
+def test_destination_reservation_token_rejects_same_thread_piggyback(
+    tmp_path, monkeypatch
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    owner = Session(
+        session_id="reserved-token-owner",
+        messages=[{"role": "user", "content": "owner"}],
+    )
+    rogue = Session(
+        session_id=owner.session_id,
+        messages=[{"role": "user", "content": "rogue"}],
+    )
+
+    with models.reserve_session_destination(owner.session_id) as reservation:
+        reservation.bind(owner)
+        with pytest.raises(RuntimeError, match="publication transaction"):
+            rogue.save(skip_index=True)
+        owner.save(skip_index=True)
+        reservation.commit()
+
+    persisted = json.loads(owner.path.read_text(encoding="utf-8"))
+    assert persisted["messages"][0]["content"] == "owner"
+
+
+def test_import_index_failure_rolls_back_json_media_and_cache(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    destination_id = "importrollback"
+    monkeypatch.setattr(models.uuid, "uuid4", lambda: SimpleNamespace(hex=destination_id))
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda path: path)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        models,
+        "_write_session_index",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("index failed")),
+    )
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_session_import(
+        _FakeHandler("/api/session/import"),
+        {"messages": [_image_message(data_url)], "workspace": str(tmp_path)},
+    )
+
+    assert captured["bad"][1] == 500
+    assert destination_id not in models.SESSIONS
+    assert not (models.SESSION_DIR / f"{destination_id}.json").exists()
+    assert not session_media._session_media_dir(destination_id).exists()
+
+
+def test_focused_recovery_index_failure_rolls_back_destination(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    source = Session(
+        session_id="focused-recovery-source",
+        title="Exhausted",
+        workspace=str(tmp_path),
+    )
+    source.save(skip_index=True)
+    destination_id = "recoveryrollback"
+    monkeypatch.setattr(models.uuid, "uuid4", lambda: SimpleNamespace(hex=destination_id))
+    monkeypatch.setattr(routes, "get_session", lambda _sid: source)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "_session_visible_to_active_profile", lambda *_args: True)
+    monkeypatch.setattr(
+        routes,
+        "compression_recovery_payload_for_session",
+        lambda _session: {"recommended_action": routes.COMPRESSION_RECOVERY_ACTION_START_FOCUSED},
+    )
+    monkeypatch.setattr(routes, "find_compression_recovery_session", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        models,
+        "_write_session_index",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("index failed")),
+    )
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_session_compression_recovery_start(
+        _FakeHandler("/api/session/compression-recovery/start"),
+        {"session_id": source.session_id},
+    )
+
+    assert captured["bad"][1] == 500
+    assert destination_id not in models.SESSIONS
+    assert not (models.SESSION_DIR / f"{destination_id}.json").exists()
+
+
+def test_delete_requires_durable_tombstone_directory_barrier(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id="delete-dir-barrier",
+        messages=[{"role": "user", "content": "retain until intent is durable"}],
+    )
+    session.save(skip_index=True)
+    original_fsync_parent = models._fsync_parent_directory
+
+    def fail_tombstone_barrier(path):
+        if path == models._webui_deleted_session_tombstone_file():
+            raise OSError("directory fsync failed")
+        return original_fsync_parent(path)
+
+    monkeypatch.setattr(models, "_fsync_parent_directory", fail_tombstone_barrier)
+    result = models.delete_session_artifacts(
+        session.session_id,
+        delete_state_db=False,
+    )
+
+    assert result["ok"] is False
+    assert {item["artifact"] for item in result["residuals"]} >= {
+        "deleted_session_tombstone"
+    }
+    assert session.path.exists()
+
+
+def test_session_save_does_not_report_success_when_directory_barrier_fails(
+    tmp_path, monkeypatch
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id="save-dir-barrier",
+        messages=[{"role": "user", "content": "durable publication"}],
+    )
+    original_fsync_parent = models._fsync_parent_directory
+
+    def fail_sidecar_barrier(path):
+        if path == session.path:
+            raise OSError("directory fsync failed")
+        return original_fsync_parent(path)
+
+    monkeypatch.setattr(models, "_fsync_parent_directory", fail_sidecar_barrier)
+
+    with pytest.raises(OSError, match="directory fsync failed"):
+        session.save(skip_index=True)
+
+
+def test_media_final_replacement_is_not_removed(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    session_media.externalize_large_session_media(messages, "replace-race")
+    original_assert = session_media._assert_entry_still_names_fd
+    calls = 0
+    replacement_names = []
+
+    def replace_before_final_check(parent_fd, name, child_fd):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            moved = name + ".moved"
+            os.rename(name, moved, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.mkdir(name, dir_fd=parent_fd)
+            replacement_names.append(name)
+        return original_assert(parent_fd, name, child_fd)
+
+    monkeypatch.setattr(
+        session_media,
+        "_assert_entry_still_names_fd",
+        replace_before_final_check,
+    )
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="changed"):
+        session_media.remove_session_media("replace-race")
+
+    assert replacement_names
+    assert (tmp_path / "session-media" / replacement_names[0]).is_dir()
+
+
+def test_unsupported_backend_detects_broken_private_root_symlink(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    (tmp_path / "missing-target").mkdir()
+    os.symlink(tmp_path / "gone", tmp_path / "session-media")
+    monkeypatch.setattr(session_media, "_DIR_FD_OK", False)
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="unsupported"):
+        session_media.remove_session_media("broken-root")
+
+
+def test_clear_durably_removes_backup_and_private_media(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="clear-private-media",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": session.session_id})
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
+    captured = _capture_route(monkeypatch)
+
+    routes.handle_post(_FakeHandler("/api/session/clear"), urlparse("/api/session/clear"))
+
+    assert captured["ok"]["ok"] is True
+    assert not session.path.with_suffix(".json.bak").exists()
+    assert not session_media._session_media_dir(session.session_id).exists()
+
+
+def test_truncate_prunes_only_media_unreachable_from_live_or_backup(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw_a, data_url_a = _large_png_data_url(b"a")
+    _raw_b, data_url_b = _large_png_data_url(b"b")
+    _raw_stray, data_url_stray = _large_png_data_url(b"z")
+    session = Session(
+        session_id="truncate-reachability",
+        messages=[_image_message(data_url_a), _image_message(data_url_b)],
+        context_messages=[_image_message(data_url_a), _image_message(data_url_b)],
+    )
+    session.save(skip_index=True)
+    stray = [_image_message(data_url_stray)]
+    session_media.externalize_large_session_media(stray, session.session_id)
+    stray_name = stray[0]["content"][1]["image_url"]["url"].split("//", 1)[1]
+
+    from api.session_ops import truncate_session_at_keep
+
+    truncate_session_at_keep(session, 1)
+    session.save(skip_index=True, prune_media=True)
+
+    files = {path.name for path in session_media._session_media_dir(session.session_id).iterdir()}
+    assert stray_name not in files
+    # The removed second message remains reachable from the recovery backup.
+    assert len(files) == 2

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1744,6 +1744,59 @@ def test_corrupt_deleted_tombstone_isolated_by_destination_reservation(
     assert tombstone_path.read_bytes() == corrupt_bytes
 
 
+@pytest.mark.parametrize("path", ["/api/share/create", "/api/share/revoke"])
+def test_external_share_sidecar_save_failure_releases_destination_claim(
+    path, tmp_path, monkeypatch
+):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    sid = "external-share-sidecar"
+    snapshot = Session(
+        session_id=sid,
+        title="External share",
+        workspace=str(tmp_path),
+        messages=[{"role": "user", "content": "share me"}],
+    )
+    snapshot.share_token = "existing-share-token" if path.endswith("revoke") else None
+    snapshot.share_created_at = 123.0
+    share_meta = {
+        "share_token": "created-share-token",
+        "share_title": "External share",
+        "share_message_count": 1,
+        "share_created_at": 123.0,
+        "share_updated_at": 124.0,
+    }
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": sid})
+    monkeypatch.setattr(
+        routes,
+        "_resolve_share_session_pair",
+        lambda _sid, _handler: (snapshot, None, {}),
+    )
+    monkeypatch.setattr(routes, "create_or_refresh_share", lambda _session: share_meta)
+    monkeypatch.setattr(routes, "revoke_share", lambda _session: True)
+    monkeypatch.setattr(routes, "_publish_session_list_changed", lambda *_args, **_kwargs: None)
+    captured = _capture_route(monkeypatch)
+    original_save = Session.save
+
+    def fail_save(_session, *args, **kwargs):
+        raise OSError("injected share sidecar save failure")
+
+    monkeypatch.setattr(Session, "save", fail_save)
+    with pytest.raises(OSError, match="injected share sidecar save failure"):
+        routes.handle_post(_FakeHandler(path), urlparse(path))
+
+    assert not models._session_incarnation_claim_file(sid).exists()
+    assert not (session_dir / f"{sid}.json").exists()
+    assert sid not in models._active_destination_reservations()
+
+    monkeypatch.setattr(Session, "save", original_save)
+    routes.handle_post(_FakeHandler(path), urlparse(path))
+
+    assert captured["status"] == 200
+    assert (session_dir / f"{sid}.json").exists()
+    assert not models._session_incarnation_claim_file(sid).exists()
+
+
 def test_import_index_failure_rolls_back_json_media_and_cache(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     _raw, data_url = _large_png_data_url()

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -740,6 +740,12 @@ def test_remove_session_media_deletes_only_requested_namespace(tmp_path, monkeyp
     assert session_media._session_media_dir("keep-second").exists()
     assert session_media.hydrate_session_media_urls(second, "keep-second")
 
+    # A retry retains the original quarantine as the one durable authority;
+    # it must not recursively quarantine the already-detached contents.
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.remove_session_media("delete-first")
+    assert list((tmp_path / "session-media").glob(".delete-*")) == quarantines
+
 
 def test_media_cleanup_retry_prefix_cannot_match_sibling_sid(tmp_path, monkeypatch):
     monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
@@ -1666,6 +1672,17 @@ def test_destination_collision_preserves_existing_owner_bytes(tmp_path, monkeypa
             raise AssertionError("collision reservation entered")
 
     assert path.read_bytes() == original
+
+
+def test_destination_reservation_rebuilds_corrupt_index_from_sidecars(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    models.SESSION_INDEX_FILE.write_text("{not-json", encoding="utf-8")
+
+    with models.reserve_session_destination("index-rebuild-owner"):
+        pass
+
+    assert json.loads(models.SESSION_INDEX_FILE.read_bytes()) == []
+    assert not (session_dir / "index-rebuild-owner.json").exists()
 
 
 def test_destination_reservation_token_rejects_same_thread_piggyback(

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1872,6 +1872,87 @@ def test_media_final_replacement_is_not_removed(tmp_path, monkeypatch):
     assert (tmp_path / "session-media" / replacement_names[0]).is_dir()
 
 
+def test_media_directory_replacement_after_final_check_is_not_removed(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    sid = "replace-after-directory-check"
+    session_media.externalize_large_session_media(messages, sid)
+    original_assert = session_media._assert_entry_still_names_fd
+    quarantine_prefix = session_media._deletion_quarantine_prefix(sid)
+    checked_quarantine = 0
+    replacement = []
+
+    def replace_after_final_check(parent_fd, name, child_fd):
+        nonlocal checked_quarantine
+        result = original_assert(parent_fd, name, child_fd)
+        if name.startswith(quarantine_prefix):
+            checked_quarantine += 1
+            if checked_quarantine == 2:
+                moved = name + ".moved"
+                os.rename(name, moved, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+                os.mkdir(name, dir_fd=parent_fd)
+                replacement.append(name)
+        return result
+
+    monkeypatch.setattr(
+        session_media,
+        "_assert_entry_still_names_fd",
+        replace_after_final_check,
+    )
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="changed"):
+        session_media.remove_session_media(sid)
+
+    assert replacement
+    assert (tmp_path / "session-media" / replacement[0]).is_dir()
+    assert (tmp_path / "session-media" / f"{replacement[0]}.moved").is_dir()
+
+
+def test_prune_file_replacement_after_final_check_is_not_unlinked(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    sid = "replace-after-file-check"
+    session_media.externalize_large_session_media(messages, sid)
+    original_assert = session_media._assert_regular_entry_still_names_fd
+    replacement = []
+
+    def replace_after_final_check(parent_fd, name, entry_fd):
+        result = original_assert(parent_fd, name, entry_fd)
+        if name.startswith(".prune-") and not replacement:
+            moved = name + ".moved"
+            os.rename(name, moved, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            fd = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(b"replacement")
+            replacement.append(name)
+        return result
+
+    monkeypatch.setattr(
+        session_media,
+        "_assert_regular_entry_still_names_fd",
+        replace_after_final_check,
+    )
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="changed"):
+        session_media.prune_session_media(sid, [])
+
+    assert replacement
+    media_dir = session_media._session_media_dir(sid)
+    assert (media_dir / replacement[0]).read_bytes() == b"replacement"
+    assert (media_dir / f"{replacement[0]}.moved").is_file()
+
+
 def test_unsupported_backend_detects_broken_private_root_symlink(tmp_path, monkeypatch):
     monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     (tmp_path / "missing-target").mkdir()

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -108,6 +108,12 @@ def _isolate_attachment_root(monkeypatch):
     monkeypatch.delenv("HERMES_WEBUI_ATTACHMENT_DIR", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _exercise_legacy_private_media_backend(monkeypatch):
+    """Keep legacy-store fixtures executable while production creation is off."""
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", True)
+
+
 class _FakeHandler:
     def __init__(self, path):
         self.status = None
@@ -158,6 +164,8 @@ def _configure_session_state(tmp_path, monkeypatch):
     models._SESSION_PUBLICATION_LOCKS.clear()
     if hasattr(models, "_SESSION_PUBLICATION_GENERATIONS"):
         models._SESSION_PUBLICATION_GENERATIONS.clear()
+    if hasattr(models, "_SESSION_PUBLICATION_LEGACY_SIGNATURES"):
+        models._SESSION_PUBLICATION_LEGACY_SIGNATURES.clear()
     models._active_destination_reservations().clear()
     with routes.api_config.SESSION_AGENT_CACHE_LOCK:
         routes.api_config.SESSION_AGENT_CACHE.clear()
@@ -228,6 +236,130 @@ def test_externalize_and_hydrate_round_trip(tmp_path, monkeypatch):
     assert hydrated[0]["content"][1]["image_url"]["url"] == data_url
     # The persisted representation remains compact after model-call hydration.
     assert messages[0]["content"][1]["image_url"]["url"] == ref
+
+
+def test_new_sessions_keep_large_native_media_inline(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="inline-native-media",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+
+    session.save(skip_index=True)
+
+    payload = json.loads(session.path.read_text(encoding="utf-8"))
+    assert payload["messages"][0]["content"][1]["image_url"]["url"] == data_url
+    assert payload["context_messages"][0]["content"][1]["image_url"]["url"] == data_url
+    assert not session_media._session_media_dir(session.session_id).exists()
+
+
+def test_existing_compact_reference_is_verified_then_saved_inline(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
+    session = Session(
+        session_id="legacy-inline-migration",
+        messages=[{"role": "user", "content": "seed"}],
+    )
+    session.save(skip_index=True)
+    raw, _data_url = _large_png_data_url()
+    filename = hashlib.sha256(raw).hexdigest() + ".png"
+    media_dir = session_media._session_media_dir("legacy-inline-migration")
+    media_dir.mkdir(parents=True)
+    (media_dir / filename).write_bytes(raw)
+    compact = _image_message("webui-media://" + filename)
+    session.messages = [compact]
+    session.context_messages = [compact]
+
+    session.save(skip_index=True)
+
+    payload = json.loads(session.path.read_text(encoding="utf-8"))
+    assert "webui-media://" not in json.dumps(payload)
+    assert payload["messages"][0]["content"][1]["image_url"]["url"].startswith(
+        "data:image/png;base64,"
+    )
+
+
+def test_quarantine_without_residual_blocks_same_sid_reservation(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    sid = "quarantined-media-owner"
+    root = tmp_path / "session-media"
+    root.mkdir()
+    (root / (session_media._deletion_quarantine_prefix(sid) + "crashed")).mkdir()
+
+    with pytest.raises(models.SessionDestinationCollisionError, match="session_media_quarantine"):
+        with models.reserve_session_destination(sid):
+            pass
+
+
+def test_save_refuses_to_retain_backup_with_missing_private_media(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
+    session = Session(
+        session_id="broken-media-backup",
+        messages=[{"role": "user", "content": "first"}, {"role": "assistant", "content": "second"}],
+    )
+    session.save(skip_index=True)
+    before = json.loads(session.path.read_text(encoding="utf-8"))
+    before["messages"] = [_image_message("webui-media://" + "0" * 64 + ".png"), {"role": "assistant", "content": "second"}]
+    session.path.write_text(json.dumps(before), encoding="utf-8")
+    expected_bytes = session.path.read_bytes()
+    session.messages = [{"role": "user", "content": "replacement"}]
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="missing"):
+        session.save(skip_index=True)
+
+    assert session.path.read_bytes() == expected_bytes
+    assert not session.path.with_suffix(".json.bak").exists()
+
+
+def test_legacy_loader_cannot_register_then_overwrite_recovered_sidecar(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    sid = "legacy-load-recovery-race"
+    path = session_dir / f"{sid}.json"
+    path.write_text(
+        json.dumps({"session_id": sid, "messages": [{"role": "user", "content": "old"}]}),
+        encoding="utf-8",
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    replacement_written = threading.Event()
+    loaded = {}
+    original_register = models._register_validated_legacy_session_generation
+
+    def pause_registration(session, signature):
+        entered.set()
+        assert release.wait(5)
+        return original_register(session, signature)
+
+    monkeypatch.setattr(models, "_register_validated_legacy_session_generation", pause_registration)
+
+    loader = threading.Thread(target=lambda: loaded.setdefault("session", Session.load(sid)))
+    loader.start()
+    assert entered.wait(5)
+    replacement = json.dumps(
+        {"session_id": sid, "messages": [{"role": "user", "content": "recovered"}]}
+    ).encode("utf-8")
+
+    def replace_under_recovery_authority():
+        with models._session_publication_authority(sid):
+            models._durable_replace_bytes(path, replacement)
+            replacement_written.set()
+
+    recovery = threading.Thread(target=replace_under_recovery_authority)
+    recovery.start()
+    assert not replacement_written.wait(0.2)
+    release.set()
+    loader.join(5)
+    recovery.join(5)
+    assert loaded["session"] is not None
+    assert replacement_written.is_set()
+
+    with pytest.raises(RuntimeError, match="unvalidated session generation"):
+        loaded["session"].save(skip_index=True)
+    assert path.read_bytes() == replacement
 
 
 def test_save_compacts_both_visible_and_model_context(tmp_path, monkeypatch):
@@ -792,7 +924,7 @@ def test_legacy_attachment_media_is_verified_and_migrated(tmp_path, monkeypatch)
 
     hydrated = session_media.hydrate_session_media_urls(messages, "legacy-session")
     assert hydrated[0]["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
-    assert (tmp_path / "session-media" / "legacy-session" / filename).read_bytes() == raw
+    assert not (tmp_path / "session-media" / "legacy-session" / filename).exists()
 
 
 def test_btw_clones_media_before_new_session_is_published(tmp_path, monkeypatch):
@@ -2410,7 +2542,7 @@ def test_save_rejects_private_ref_in_non_image_transcript_path(tmp_path, monkeyp
 
     with pytest.raises(
         session_media.SessionMediaIntegrityError,
-        match="outside an image part",
+        match="hydrated session history",
     ):
         session.save(skip_index=True)
 

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -314,6 +314,28 @@ def test_save_refuses_to_retain_backup_with_missing_private_media(tmp_path, monk
     assert not session.path.with_suffix(".json.bak").exists()
 
 
+def test_shrink_backup_retains_the_exact_validated_source_bytes(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id="backup-exact-crlf",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ],
+    )
+    session.save(skip_index=True)
+    payload = json.loads(session.path.read_bytes())
+    source_before = (json.dumps(payload, indent=2) + "\n").replace("\n", "\r\n").encode()
+    session.path.write_bytes(source_before)
+    loaded = Session.load(session.session_id)
+    assert loaded is not None
+    loaded.messages = [{"role": "user", "content": "first"}]
+
+    loaded.save(skip_index=True)
+
+    assert loaded.path.with_suffix(".json.bak").read_bytes() == source_before
+
+
 def test_legacy_loader_cannot_register_then_overwrite_recovered_sidecar(tmp_path, monkeypatch):
     session_dir = _configure_session_state(tmp_path, monkeypatch)
     sid = "legacy-load-recovery-race"

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 import pytest
 
-from api import models, routes, session_media
+from api import models, routes, session_media, streaming
 from api.models import Session
 from api.streaming import _sanitize_messages_for_api
 
@@ -81,9 +81,38 @@ def _configure_session_state(tmp_path, monkeypatch):
     monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
     models.SESSIONS.clear()
     routes.SESSIONS.clear()
+    models._SESSION_PUBLICATION_DELETED.clear()
+    models._SESSION_PUBLICATION_LOCKS.clear()
     return session_dir
+
+
+def _stub_delete_route_dependencies(monkeypatch, session, tmp_path):
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda _sid: {})
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "_is_messaging_session_id", lambda _sid: False)
+    monkeypatch.setattr(routes, "_worktree_retained_payload_for_session_id", lambda _sid: {})
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(routes, "prune_session_from_index", lambda _sid: None)
+    monkeypatch.setattr(routes, "_publish_session_list_changed", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+    monkeypatch.setattr("api.upload._session_attachment_dir", lambda _sid: tmp_path / "uploads" / _sid)
+    monkeypatch.setattr("api.turn_journal.delete_turn_journal", lambda _sid: None)
+    monkeypatch.setattr("api.run_journal.delete_run_journal", lambda _sid: None)
+    monkeypatch.setattr("api.background_process.forget_bg_task_completion_dedup", lambda _sid: None)
+    monkeypatch.setattr("api.terminal.close_terminal", lambda _sid: None)
+
+
+def _call_delete_route(session_id: str):
+    body = json.dumps({"session_id": session_id}).encode("utf-8")
+    handler = _FakeHandler("/api/session/delete")
+    handler.rfile = io.BytesIO(body)
+    handler.headers["Content-Length"] = str(len(body))
+    routes.handle_post(handler, urlparse("/api/session/delete"))
 
 
 def _assert_destination_media_is_independent(destination, source_id, raw, data_url):
@@ -716,3 +745,241 @@ def test_manual_compression_stops_before_provider_on_corrupt_media(tmp_path, mon
     )
     assert captured["bad"][1] == 400
     assert "digest verification" in captured["bad"][0]
+
+
+@pytest.mark.parametrize("damage", ["missing", "digest-mismatch"])
+def test_save_refuses_broken_retained_reference_without_replacing_json(
+    damage,
+    tmp_path,
+    monkeypatch,
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id=f"save-refusal-{damage}",
+        title="before",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    prior_json = session.path.read_bytes()
+    media_file = next(session_media._session_media_dir(session.session_id).iterdir())
+    if damage == "missing":
+        media_file.unlink()
+    else:
+        media_file.write_bytes(b"\x89PNG\r\n\x1a\nwrong-content")
+    session.title = "must-not-publish"
+
+    with pytest.raises(session_media.SessionMediaIntegrityError):
+        session.save(skip_index=True)
+
+    assert session.path.read_bytes() == prior_json
+
+
+def test_clone_rolls_back_when_post_yield_directory_identity_check_fails(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    session_media.externalize_large_session_media(messages, "identity-source")
+    original_assert = session_media._assert_private_handles
+    destination_checks = 0
+
+    def fail_only_post_yield(state_fd, media_fd, session_fd, sid):
+        nonlocal destination_checks
+        if sid == "identity-destination":
+            destination_checks += 1
+            if destination_checks == 2:
+                raise session_media.SessionMediaIntegrityError("simulated parent swap")
+        return original_assert(state_fd, media_fd, session_fd, sid)
+
+    monkeypatch.setattr(session_media, "_assert_private_handles", fail_only_post_yield)
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="parent swap"):
+        session_media.clone_session_media_references(
+            messages,
+            "identity-source",
+            "identity-destination",
+        )
+
+    destination = session_media._session_media_dir("identity-destination")
+    assert not destination.exists() or not list(destination.iterdir())
+
+
+def test_btw_thread_start_failure_rolls_back_all_ephemeral_ownership(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id="btw-failure-source",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+    destination_id = "btw-failure-destination"
+    monkeypatch.setattr(routes, "Session", lambda **kwargs: Session(session_id=destination_id, **kwargs))
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: source)
+    monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **_kwargs: None)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "create_stream_channel", lambda: SimpleNamespace())
+    monkeypatch.setattr("api.background.track_btw", lambda *_args: None)
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(routes.threading, "Thread", FailingThread)
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_btw(
+        _FakeHandler("/api/btw"),
+        {"session_id": source.session_id, "question": "What is in the image?"},
+    )
+
+    assert captured["bad"] == ("Could not start side-question session", 500)
+    assert destination_id not in models.SESSIONS
+    assert not (models.SESSION_DIR / f"{destination_id}.json").exists()
+    assert not session_media._session_media_dir(destination_id).exists()
+    assert destination_id not in routes.api_config.STREAM_SESSION_OWNERS.values()
+
+
+def test_path_fallback_externalizes_hydrates_clones_and_removes(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(session_media, "_DIR_FD_OK", False, raising=False)
+
+    def anchored_backend_must_not_run(*_args, **_kwargs):
+        raise AssertionError("dir-fd backend used when capability is unavailable")
+
+    monkeypatch.setattr(session_media, "_open_private_session", anchored_backend_must_not_run)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+
+    assert session_media.externalize_large_session_media(messages, "fallback-source") == 1
+    assert session_media.hydrate_session_media_urls(messages, "fallback-source")[0][
+        "content"
+    ][1]["image_url"]["url"] == data_url
+    assert session_media.clone_session_media_references(
+        messages,
+        "fallback-source",
+        "fallback-destination",
+    ) == 1
+    session_media.remove_session_media("fallback-source")
+    assert session_media.hydrate_session_media_urls(messages, "fallback-destination")[0][
+        "content"
+    ][1]["image_url"]["url"] == data_url
+    session_media.remove_session_media("fallback-destination")
+    assert not session_media._session_media_dir("fallback-destination").exists()
+
+
+def test_ephemeral_cleanup_retires_json_cache_stream_tracking_and_media(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="btw-cleanup",
+        parent_session_id="btw-parent",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.active_stream_id = "btw-cleanup-stream"
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    routes.STREAMS[session.active_stream_id] = SimpleNamespace()
+    routes.register_stream_owner(session.active_stream_id, session.session_id)
+    from api.background import cleanup_btw, track_btw
+
+    track_btw(
+        session.parent_session_id,
+        session.session_id,
+        session.active_stream_id,
+        "question",
+    )
+
+    streaming._cleanup_ephemeral_session(session)
+
+    assert session.session_id not in models.SESSIONS
+    assert "btw-cleanup-stream" not in routes.STREAMS
+    assert routes.stream_owner_session_id("btw-cleanup-stream") is None
+    assert not session.path.exists()
+    assert not session_media._session_media_dir(session.session_id).exists()
+    assert cleanup_btw(session.parent_session_id) is None
+
+
+def test_delete_serializes_against_late_save_and_tombstones_publication(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="delete-late-save",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    _stub_delete_route_dependencies(monkeypatch, session, tmp_path)
+    captured = _capture_route(monkeypatch)
+    entered_cleanup = threading.Event()
+    release_cleanup = threading.Event()
+    original_remove = session_media.remove_session_media
+
+    def blocking_remove(session_id):
+        entered_cleanup.set()
+        assert release_cleanup.wait(timeout=5)
+        return original_remove(session_id)
+
+    monkeypatch.setattr(session_media, "remove_session_media", blocking_remove)
+    delete_thread = threading.Thread(target=_call_delete_route, args=(session.session_id,))
+    delete_thread.start()
+    assert entered_cleanup.wait(timeout=5)
+    save_finished = threading.Event()
+    save_error = []
+
+    def late_save():
+        try:
+            session.save(skip_index=True)
+        except Exception as exc:
+            save_error.append(exc)
+        finally:
+            save_finished.set()
+
+    save_thread = threading.Thread(target=late_save)
+    save_thread.start()
+    assert not save_finished.wait(timeout=0.1)
+    release_cleanup.set()
+    delete_thread.join(timeout=5)
+    save_thread.join(timeout=5)
+
+    assert captured["ok"]["ok"] is True
+    assert save_error and "deleted session" in str(save_error[0])
+    assert not session.path.exists()
+    assert not session_media._session_media_dir(session.session_id).exists()
+
+
+def test_delete_reports_failure_when_private_media_cleanup_fails(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="delete-media-failure",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    _stub_delete_route_dependencies(monkeypatch, session, tmp_path)
+    captured = _capture_route(monkeypatch)
+    monkeypatch.setattr(
+        session_media,
+        "remove_session_media",
+        lambda _sid: (_ for _ in ()).throw(OSError("disk failure")),
+    )
+
+    _call_delete_route(session.session_id)
+
+    assert captured["bad"][1] == 500
+    assert "private media cleanup failed" in captured["bad"][0]
+    assert session.session_id not in models.SESSIONS
+    with pytest.raises(RuntimeError, match="deleted session"):
+        session.save(skip_index=True)

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -3,6 +3,7 @@ import base64
 import hashlib
 import io
 import json
+import multiprocessing
 import os
 import threading
 import zipfile
@@ -32,6 +33,74 @@ def _image_message(url):
             {"type": "image_url", "image_url": {"url": url}},
         ],
     }
+
+
+def _cross_process_index_writer(session_dir, index_file, sid, ready, start):
+    from pathlib import Path
+
+    from api import models as child_models
+
+    child_models.SESSION_DIR = Path(session_dir)
+    child_models.SESSION_INDEX_FILE = Path(index_file)
+    child_models.SESSIONS.clear()
+    session = child_models.Session(
+        session_id=sid,
+        messages=[{"role": "user", "content": sid}],
+    )
+    session.save(skip_index=True)
+    ready.put(sid)
+    start.wait(10)
+    child_models._write_session_index(updates=[session])
+
+
+def _cross_process_recreate_session(session_dir, index_file, state_dir, sid, result_queue):
+    from pathlib import Path
+
+    from api import models as child_models
+    from api import session_media as child_media
+    import api.upload as child_upload
+
+    child_models.SESSION_DIR = Path(session_dir)
+    child_models.SESSION_INDEX_FILE = Path(index_file)
+    child_media.STATE_DIR = Path(state_dir)
+    child_upload._session_attachment_dir = (
+        lambda owner_sid: Path(state_dir) / "attachments" / owner_sid
+    )
+    child_models.SESSIONS.clear()
+    current = child_models.Session.load(sid)
+    cleanup = child_models.delete_session_artifacts(
+        sid,
+        expected_generation=current._publication_generation,
+        delete_state_db=False,
+    )
+    if not cleanup["ok"]:
+        result_queue.put({"error": cleanup["residuals"]})
+        return
+    replacement = child_models.Session(
+        session_id=sid,
+        messages=[{"role": "user", "content": "replacement"}],
+    )
+    with child_models.reserve_session_destination(sid) as reservation:
+        reservation.bind(replacement)
+        replacement.save(skip_index=True)
+        reservation.commit()
+    result_queue.put(
+        {
+            "token": replacement._publication_generation.token,
+            "content": replacement.path.read_text(encoding="utf-8"),
+        }
+    )
+
+
+def _cross_process_tombstone_writer(session_dir, sid, ready, start):
+    from pathlib import Path
+
+    from api import models as child_models
+
+    child_models.SESSION_DIR = Path(session_dir)
+    ready.put(sid)
+    start.wait(10)
+    child_models._record_webui_deleted_session_tombstone(sid)
 
 
 @pytest.fixture(autouse=True)
@@ -1281,6 +1350,9 @@ def test_same_sid_recreation_does_not_authorize_old_session_object(tmp_path, mon
     _configure_session_state(tmp_path, monkeypatch)
     old = Session(session_id="same-sid-generation", messages=[{"role": "user", "content": "old"}])
     old.save(skip_index=True)
+    old_token = json.loads(old.path.read_text(encoding="utf-8"))[
+        "publication_incarnation"
+    ]
     models.SESSIONS[old.session_id] = old
     _stub_delete_route_dependencies(monkeypatch, old, tmp_path)
     captured = _capture_route(monkeypatch)
@@ -1291,14 +1363,56 @@ def test_same_sid_recreation_does_not_authorize_old_session_object(tmp_path, mon
         session_id=old.session_id,
         messages=[{"role": "user", "content": "replacement"}],
     )
-    models._activate_session_publication_generation(replacement)
-    models._clear_webui_deleted_session_tombstone(replacement.session_id)
-    replacement.save(skip_index=True)
+    with models.reserve_session_destination(replacement.session_id) as reservation:
+        reservation.bind(replacement)
+        replacement.save(skip_index=True)
+        reservation.commit()
+    replacement_token = json.loads(replacement.path.read_text(encoding="utf-8"))[
+        "publication_incarnation"
+    ]
+    assert replacement_token != old_token
 
     old.messages.append({"role": "assistant", "content": "stale overwrite"})
     with pytest.raises(RuntimeError, match="stale"):
         old.save(skip_index=True)
     assert "replacement" in replacement.path.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(models._fcntl is None, reason="requires POSIX process locks")
+def test_persisted_incarnation_rejects_stale_object_after_other_process_recreates_sid(
+    tmp_path, monkeypatch
+):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    sid = "cross-process-incarnation"
+    old = Session(
+        session_id=sid,
+        messages=[{"role": "user", "content": "old"}],
+    )
+    old.save(skip_index=True)
+    old_token = old._publication_generation.token
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    worker = context.Process(
+        target=_cross_process_recreate_session,
+        args=(
+            str(session_dir),
+            str(models.SESSION_INDEX_FILE),
+            str(tmp_path),
+            sid,
+            result_queue,
+        ),
+    )
+    worker.start()
+    worker.join(20)
+    assert worker.exitcode == 0
+    result = result_queue.get(timeout=5)
+    assert "error" not in result
+    assert result["token"] != old_token
+
+    old.messages.append({"role": "assistant", "content": "stale overwrite"})
+    with pytest.raises(RuntimeError, match="stale session generation"):
+        old.save(skip_index=True)
+    assert "replacement" in old.path.read_text(encoding="utf-8")
 
 
 def test_delete_defers_while_run_is_active_then_retries_idempotently(tmp_path, monkeypatch):
@@ -1529,6 +1643,94 @@ def test_destination_reservation_token_rejects_same_thread_piggyback(
     assert persisted["messages"][0]["content"] == "owner"
 
 
+@pytest.mark.skipif(models._fcntl is None, reason="requires POSIX process locks")
+def test_index_read_modify_write_is_serialized_across_processes(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    models.SESSION_INDEX_FILE.write_text("[]", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+
+    workers = [
+        context.Process(
+            target=_cross_process_index_writer,
+            args=(
+                str(models.SESSION_DIR),
+                str(models.SESSION_INDEX_FILE),
+                sid,
+                ready,
+                start,
+            ),
+        )
+        for sid in ("process-index-a", "process-index-b")
+    ]
+    for worker in workers:
+        worker.start()
+    assert {ready.get(timeout=10), ready.get(timeout=10)} == {
+        "process-index-a",
+        "process-index-b",
+    }
+    start.set()
+    for worker in workers:
+        worker.join(15)
+        assert worker.exitcode == 0
+
+    rows = json.loads(models.SESSION_INDEX_FILE.read_text(encoding="utf-8"))
+    assert {row["session_id"] for row in rows} == {
+        "process-index-a",
+        "process-index-b",
+    }
+
+
+@pytest.mark.skipif(models._fcntl is None, reason="requires POSIX process locks")
+def test_tombstone_read_modify_write_is_serialized_across_processes(
+    tmp_path, monkeypatch
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    workers = [
+        context.Process(
+            target=_cross_process_tombstone_writer,
+            args=(str(models.SESSION_DIR), sid, ready, start),
+        )
+        for sid in ("process-tombstone-a", "process-tombstone-b")
+    ]
+    for worker in workers:
+        worker.start()
+    assert {ready.get(timeout=10), ready.get(timeout=10)} == {
+        "process-tombstone-a",
+        "process-tombstone-b",
+    }
+    start.set()
+    for worker in workers:
+        worker.join(15)
+        assert worker.exitcode == 0
+
+    assert models._load_webui_deleted_session_tombstone() == {
+        "process-tombstone-a",
+        "process-tombstone-b",
+    }
+
+
+def test_corrupt_deleted_tombstone_fails_closed_for_session_publication(
+    tmp_path, monkeypatch
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    models._webui_deleted_session_tombstone_file().write_bytes(b"{partial")
+    sid = "corrupt-tombstone-publication"
+
+    with pytest.raises(ValueError, match="deleted-session tombstone"):
+        Session(session_id=sid).save(skip_index=True)
+    with pytest.raises(ValueError, match="deleted-session tombstone"):
+        with models.reserve_session_destination(sid):
+            pytest.fail("a corrupt authority file must prevent reservation")
+
+    assert not (models.SESSION_DIR / f"{sid}.json").exists()
+    assert not models._session_incarnation_claim_file(sid).exists()
+
+
 def test_import_index_failure_rolls_back_json_media_and_cache(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     _raw, data_url = _large_png_data_url()
@@ -1704,6 +1906,38 @@ def test_clear_durably_removes_backup_and_private_media(tmp_path, monkeypatch):
     assert not session_media._session_media_dir(session.session_id).exists()
 
 
+def test_clear_retires_backup_and_media_even_when_live_transcript_is_already_empty(
+    tmp_path, monkeypatch
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="clear-already-empty",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    session.messages = []
+    session.context_messages = []
+    session.save(skip_index=True)
+    backup = session.path.with_suffix(".json.bak")
+    assert backup.exists()
+    assert session_media._session_media_dir(session.session_id).exists()
+    models.SESSIONS[session.session_id] = session
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": session.session_id})
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
+    captured = _capture_route(monkeypatch)
+
+    routes.handle_post(_FakeHandler("/api/session/clear"), urlparse("/api/session/clear"))
+
+    assert captured["status"] == 200
+    assert not backup.exists()
+    assert not session_media._session_media_dir(session.session_id).exists()
+
+
 def test_truncate_prunes_only_media_unreachable_from_live_or_backup(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     _raw_a, data_url_a = _large_png_data_url(b"a")
@@ -1747,7 +1981,7 @@ def test_truncate_does_not_report_committed_write_as_failed_when_prune_fails(
             {"role": "assistant", "content": "remove"},
         ],
     )
-    session.save(skip_index=True)
+    session.save()
     models.SESSIONS[session.session_id] = session
     monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
     monkeypatch.setattr(
@@ -1758,6 +1992,7 @@ def test_truncate_does_not_report_committed_write_as_failed_when_prune_fails(
     monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
     monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: session)
     monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
+    original_prune = session_media.prune_session_media
     monkeypatch.setattr(
         session_media,
         "prune_session_media",
@@ -1776,3 +2011,100 @@ def test_truncate_does_not_report_committed_write_as_failed_when_prune_fails(
         {"role": "user", "content": "keep"}
     ]
     assert "Could not prune session media after transcript truncation" in caplog.text
+    residual = models._load_session_cleanup_residuals()[session.session_id]
+    assert residual["operation"] == "prune"
+    assert residual["residuals"][0]["artifact"] == "session_media"
+
+    monkeypatch.setattr(session_media, "prune_session_media", original_prune)
+    routes._handle_sessions_cleanup(_FakeHandler("/api/sessions/cleanup"), {})
+    assert captured["status"] == 200
+    assert session.path.exists()
+    assert session.session_id not in models._load_session_cleanup_residuals()
+    index_rows = json.loads(models.SESSION_INDEX_FILE.read_text(encoding="utf-8"))
+    assert any(row.get("session_id") == session.session_id for row in index_rows)
+
+
+@pytest.mark.parametrize(
+    "field,value_factory",
+    [
+        ("tool_calls", lambda ref: [{"result": ref}]),
+        ("composer_draft", lambda ref: {"text": ref}),
+        ("anchor_activity_scenes", lambda ref: {"scene": {"body": ref}}),
+        ("process_wakeup_pause", lambda ref: {"detail": ref}),
+        ("custom_extra", lambda ref: {"nested": [ref]}),
+    ],
+)
+def test_save_rejects_private_refs_outside_sanctioned_transcript_fields(
+    field,
+    value_factory,
+    tmp_path,
+    monkeypatch,
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id=f"private-field-{field.replace('_', '-')}",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    before = session.path.read_bytes()
+    ref = session.messages[0]["content"][1]["image_url"]["url"]
+    setattr(session, field, value_factory(ref))
+
+    with pytest.raises(
+        session_media.SessionMediaIntegrityError,
+        match="outside messages/context_messages",
+    ):
+        session.save(skip_index=True)
+
+    assert session.path.read_bytes() == before
+
+
+def test_save_rejects_private_ref_in_non_image_transcript_path(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="private-non-image-part",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    before = session.path.read_bytes()
+    ref = session.messages[0]["content"][1]["image_url"]["url"]
+    session.messages = [{"role": "user", "content": ref}]
+
+    with pytest.raises(
+        session_media.SessionMediaIntegrityError,
+        match="outside an image part",
+    ):
+        session.save(skip_index=True)
+
+    assert session.path.read_bytes() == before
+
+
+def test_save_rejects_image_shaped_private_ref_in_message_metadata(
+    tmp_path, monkeypatch
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    session = Session(
+        session_id="private-image-shaped-metadata",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    session.save(skip_index=True)
+    before = session.path.read_bytes()
+    ref = session.messages[0]["content"][1]["image_url"]["url"]
+    session.messages[0]["metadata"] = {
+        "type": "image_url",
+        "image_url": {"url": ref},
+    }
+
+    with pytest.raises(
+        session_media.SessionMediaIntegrityError,
+        match="outside an image part",
+    ):
+        session.save(skip_index=True)
+
+    assert session.path.read_bytes() == before

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -203,7 +203,8 @@ def _assert_destination_media_is_independent(destination, source_id, raw, data_u
     destination_files = list(session_media._session_media_dir(destination_id).iterdir())
     assert len(destination_files) == 1
     assert destination_files[0].read_bytes() == raw
-    session_media.remove_session_media(source_id)
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.remove_session_media(source_id)
     hydrated_messages = session_media.hydrate_session_media_urls(destination.messages, destination_id)
     hydrated_context = session_media.hydrate_session_media_urls(destination.context_messages, destination_id)
     assert hydrated_messages[0]["content"][1]["image_url"]["url"] == data_url
@@ -729,9 +730,13 @@ def test_remove_session_media_deletes_only_requested_namespace(tmp_path, monkeyp
     session_media.externalize_large_session_media(first, "delete-first")
     session_media.externalize_large_session_media(second, "keep-second")
 
-    session_media.remove_session_media("delete-first")
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.remove_session_media("delete-first")
 
     assert not session_media._session_media_dir("delete-first").exists()
+    quarantines = list((tmp_path / "session-media").glob(".delete-*"))
+    assert len(quarantines) == 1
+    assert quarantines[0].is_dir()
     assert session_media._session_media_dir("keep-second").exists()
     assert session_media.hydrate_session_media_urls(second, "keep-second")
 
@@ -819,7 +824,8 @@ def test_btw_clones_media_before_new_session_is_published(tmp_path, monkeypatch)
     assert "bad" not in captured
     destination_id = captured["ok"]["session_id"]
     destination = Session.load(destination_id)
-    session_media.remove_session_media(source.session_id)
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.remove_session_media(source.session_id)
     hydrated = session_media.hydrate_session_media_urls(
         destination.context_messages,
         destination_id,
@@ -851,7 +857,8 @@ def test_export_import_inlines_verified_media_and_establishes_new_ownership(tmp_
     assert data_url in json.dumps(exported)
     assert "webui-media://" not in json.dumps(exported)
 
-    session_media.remove_session_media(source.session_id)
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.remove_session_media(source.session_id)
     captured = _capture_route(monkeypatch)
     monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda path: path)
@@ -1008,7 +1015,12 @@ def test_btw_thread_start_failure_rolls_back_all_ephemeral_ownership(tmp_path, m
     assert destination_id not in routes.api_config.STREAM_SESSION_OWNERS.values()
     from api.background import find_btw_owner
 
-    assert find_btw_owner(destination_id, stream_id) is None
+    owner = find_btw_owner(destination_id, stream_id)
+    assert owner is not None
+    assert owner["cleanup_pending"] is True
+    assert owner["cleanup_residuals"] == [
+        {"artifact": "session_media", "error": "SessionMediaIntegrityError"}
+    ]
 
 
 def test_missing_anchored_capabilities_fail_closed_without_persisting_private_refs(
@@ -1058,7 +1070,7 @@ def test_ephemeral_cleanup_retires_json_cache_stream_tracking_and_media(tmp_path
     models.SESSIONS[session.session_id] = session
     routes.STREAMS[session.active_stream_id] = SimpleNamespace()
     routes.register_stream_owner(session.active_stream_id, session.session_id)
-    from api.background import cleanup_btw, track_btw
+    from api.background import find_btw_owner, track_btw
 
     track_btw(
         session.parent_session_id,
@@ -1074,11 +1086,12 @@ def test_ephemeral_cleanup_retires_json_cache_stream_tracking_and_media(tmp_path
     assert routes.stream_owner_session_id("btw-cleanup-stream") is None
     assert not session.path.exists()
     assert not session_media._session_media_dir(session.session_id).exists()
-    assert cleanup_btw(
-        session.parent_session_id,
-        session.session_id,
-        session.active_stream_id or "btw-cleanup-stream",
-    ) is None
+    owner = find_btw_owner(session.session_id, "btw-cleanup-stream")
+    assert owner is not None
+    assert owner["cleanup_pending"] is True
+    assert owner["cleanup_residuals"] == [
+        {"artifact": "session_media", "error": "SessionMediaIntegrityError"}
+    ]
 
 
 def test_delete_serializes_against_late_save_and_tombstones_publication(tmp_path, monkeypatch):
@@ -1124,7 +1137,11 @@ def test_delete_serializes_against_late_save_and_tombstones_publication(tmp_path
     delete_thread.join(timeout=5)
     save_thread.join(timeout=5)
 
-    assert captured["ok"]["ok"] is True
+    assert captured["status"] == 500
+    assert captured["ok"]["error"] == "Session cleanup incomplete"
+    assert {item["artifact"] for item in captured["ok"]["residuals"]} == {
+        "session_media"
+    }
     assert save_error and "deleted session" in str(save_error[0])
     assert not session.path.exists()
     assert not session_media._session_media_dir(session.session_id).exists()
@@ -1376,6 +1393,38 @@ def test_same_sid_recreation_does_not_authorize_old_session_object(tmp_path, mon
     with pytest.raises(RuntimeError, match="stale"):
         old.save(skip_index=True)
     assert "replacement" in replacement.path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("cold_registry", [False, True], ids=["same-process", "cold-registry"])
+def test_bare_constructor_cannot_adopt_existing_publication_authority(
+    cold_registry, tmp_path, monkeypatch
+):
+    """Only validated loaders may receive a live sidecar's incarnation token."""
+    _configure_session_state(tmp_path, monkeypatch)
+    sid = "bare-constructor-authority"
+    owner = Session(
+        session_id=sid,
+        title="owner",
+        messages=[{"role": "user", "content": "keep"}],
+    )
+    owner.save()
+    sidecar_before = owner.path.read_bytes()
+    index_before = models.SESSION_INDEX_FILE.read_bytes()
+
+    if cold_registry:
+        models.SESSIONS.clear()
+        models._SESSION_PUBLICATION_GENERATIONS.clear()
+
+    unbound = Session(
+        session_id=sid,
+        title="rogue",
+        messages=[{"role": "user", "content": "overwrite"}],
+    )
+    with pytest.raises(RuntimeError, match="stale session generation"):
+        unbound.save()
+
+    assert owner.path.read_bytes() == sidecar_before
+    assert models.SESSION_INDEX_FILE.read_bytes() == index_before
 
 
 @pytest.mark.skipif(models._fcntl is None, reason="requires POSIX process locks")
@@ -1931,11 +1980,14 @@ def test_media_final_replacement_is_not_removed(tmp_path, monkeypatch):
         "_assert_entry_still_names_fd",
         replace_before_final_check,
     )
-    with pytest.raises(session_media.SessionMediaIntegrityError, match="changed"):
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
         session_media.remove_session_media("replace-race")
 
-    assert replacement_names
-    assert (tmp_path / "session-media" / replacement_names[0]).is_dir()
+    # Retirement stops at the first held child before a pathname deletion is
+    # attempted, so this outer directory check never becomes a delete race.
+    assert calls == 1
+    assert replacement_names == []
+    assert not session_media._session_media_dir("replace-race").exists()
 
 
 def test_media_directory_replacement_after_final_check_is_not_removed(
@@ -1946,6 +1998,7 @@ def test_media_directory_replacement_after_final_check_is_not_removed(
     messages = [_image_message(data_url)]
     sid = "replace-after-directory-check"
     session_media.externalize_large_session_media(messages, sid)
+    next(session_media._session_media_dir(sid).iterdir()).unlink()
     original_assert = session_media._assert_entry_still_names_fd
     quarantine_prefix = session_media._deletion_quarantine_prefix(sid)
     checked_quarantine = 0
@@ -2019,6 +2072,97 @@ def test_prune_file_replacement_after_final_check_is_not_unlinked(
     assert (media_dir / f"{replacement[0]}.moved").is_file()
 
 
+def test_prune_replacement_after_innermost_check_survives_retirement(
+    tmp_path, monkeypatch
+):
+    """The final held-FD check must not be followed by pathname unlink."""
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    sid = "replace-after-innermost-file-check"
+    session_media.externalize_large_session_media(messages, sid)
+    original_assert = session_media._assert_regular_entry_still_names_fd
+    checks = 0
+    replacement = []
+
+    def replace_after_innermost_check(parent_fd, name, entry_fd):
+        nonlocal checks
+        result = original_assert(parent_fd, name, entry_fd)
+        if name.startswith(".prune-"):
+            checks += 1
+            if checks == 2:
+                moved = name + ".moved"
+                os.rename(name, moved, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+                fd = os.open(
+                    name,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                    dir_fd=parent_fd,
+                )
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(b"replacement")
+                replacement.append(name)
+        return result
+
+    monkeypatch.setattr(
+        session_media,
+        "_assert_regular_entry_still_names_fd",
+        replace_after_innermost_check,
+    )
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.prune_session_media(sid, [])
+
+    assert checks == 2
+    assert replacement
+    media_dir = session_media._session_media_dir(sid)
+    assert (media_dir / replacement[0]).read_bytes() == b"replacement"
+    assert (media_dir / f"{replacement[0]}.moved").is_file()
+
+
+def test_directory_replacement_after_innermost_check_survives_retirement(
+    tmp_path, monkeypatch
+):
+    """The final held-FD check must not be followed by pathname rmdir."""
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    sid = "replace-after-innermost-directory-check"
+    session_media.externalize_large_session_media(messages, sid)
+    next(session_media._session_media_dir(sid).iterdir()).unlink()
+    original_assert = session_media._assert_entry_still_names_fd
+    quarantine_prefix = session_media._deletion_quarantine_prefix(sid)
+    checks = 0
+    replacement = []
+
+    def replace_after_innermost_check(parent_fd, name, entry_fd):
+        nonlocal checks
+        result = original_assert(parent_fd, name, entry_fd)
+        if name.startswith(quarantine_prefix):
+            checks += 1
+            if checks == 3:
+                moved = name + ".moved"
+                os.rename(name, moved, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+                os.mkdir(name, dir_fd=parent_fd)
+                replacement.append(name)
+        return result
+
+    monkeypatch.setattr(
+        session_media,
+        "_assert_entry_still_names_fd",
+        replace_after_innermost_check,
+    )
+
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.remove_session_media(sid)
+
+    assert checks == 3
+    assert replacement
+    media_root = tmp_path / "session-media"
+    assert (media_root / replacement[0]).is_dir()
+    assert (media_root / f"{replacement[0]}.moved").is_dir()
+
+
 def test_prune_exact_removal_allows_additional_hardlink(tmp_path, monkeypatch):
     monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     _raw, data_url = _large_png_data_url()
@@ -2030,8 +2174,10 @@ def test_prune_exact_removal_allows_additional_hardlink(tmp_path, monkeypatch):
     sibling = media_dir / "additional-hardlink.png"
     os.link(stored, sibling)
 
-    assert session_media.prune_session_media(sid, []) == 2
-    assert not list(media_dir.iterdir())
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
+        session_media.prune_session_media(sid, [])
+    assert len(list(media_dir.glob(".prune-*"))) == 1
+    assert len([path for path in media_dir.iterdir() if not path.name.startswith(".prune-")]) == 1
 
 
 def test_unsupported_backend_detects_broken_private_root_symlink(tmp_path, monkeypatch):
@@ -2063,9 +2209,14 @@ def test_clear_durably_removes_backup_and_private_media(tmp_path, monkeypatch):
 
     routes.handle_post(_FakeHandler("/api/session/clear"), urlparse("/api/session/clear"))
 
-    assert captured["ok"]["ok"] is True
+    assert captured["status"] == 500
+    assert captured["ok"]["error"] == "Session clear incomplete"
+    assert {item["artifact"] for item in captured["ok"]["residuals"]} == {
+        "session_media"
+    }
     assert not session.path.with_suffix(".json.bak").exists()
     assert not session_media._session_media_dir(session.session_id).exists()
+    assert len(list((tmp_path / "session-media").glob(".delete-*"))) == 1
 
 
 def test_clear_retires_backup_and_media_even_when_live_transcript_is_already_empty(
@@ -2095,7 +2246,10 @@ def test_clear_retires_backup_and_media_even_when_live_transcript_is_already_emp
 
     routes.handle_post(_FakeHandler("/api/session/clear"), urlparse("/api/session/clear"))
 
-    assert captured["status"] == 200
+    assert captured["status"] == 500
+    assert {item["artifact"] for item in captured["ok"]["residuals"]} == {
+        "session_media"
+    }
     assert not backup.exists()
     assert not session_media._session_media_dir(session.session_id).exists()
 
@@ -2123,7 +2277,8 @@ def test_truncate_prunes_only_media_unreachable_from_live_or_backup(tmp_path, mo
     files = {path.name for path in session_media._session_media_dir(session.session_id).iterdir()}
     assert stray_name not in files
     # The removed second message remains reachable from the recovery backup.
-    assert len(files) == 2
+    assert len([name for name in files if not name.startswith(".prune-")]) == 2
+    assert len([name for name in files if name.startswith(".prune-")]) == 1
 
 
 def test_truncate_does_not_report_committed_write_as_failed_when_prune_fails(

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -256,7 +256,7 @@ def test_new_sessions_keep_large_native_media_inline(tmp_path, monkeypatch):
     assert not session_media._session_media_dir(session.session_id).exists()
 
 
-def test_existing_compact_reference_is_verified_then_saved_inline(tmp_path, monkeypatch):
+def test_existing_compact_reference_refuses_implicit_persistence_migration(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
     session = Session(
@@ -273,13 +273,12 @@ def test_existing_compact_reference_is_verified_then_saved_inline(tmp_path, monk
     session.messages = [compact]
     session.context_messages = [compact]
 
-    session.save(skip_index=True)
+    original_sidecar = session.path.read_bytes()
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="explicit offline media migration"):
+        session.save(skip_index=True)
 
-    payload = json.loads(session.path.read_text(encoding="utf-8"))
-    assert "webui-media://" not in json.dumps(payload)
-    assert payload["messages"][0]["content"][1]["image_url"]["url"].startswith(
-        "data:image/png;base64,"
-    )
+    assert session.path.read_bytes() == original_sidecar
+    assert (media_dir / filename).read_bytes() == raw
 
 
 def test_quarantine_without_residual_blocks_same_sid_reservation(tmp_path, monkeypatch):
@@ -308,7 +307,7 @@ def test_save_refuses_to_retain_backup_with_missing_private_media(tmp_path, monk
     expected_bytes = session.path.read_bytes()
     session.messages = [{"role": "user", "content": "replacement"}]
 
-    with pytest.raises(session_media.SessionMediaIntegrityError, match="missing"):
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="explicit offline media migration"):
         session.save(skip_index=True)
 
     assert session.path.read_bytes() == expected_bytes
@@ -359,6 +358,34 @@ def test_legacy_loader_cannot_register_then_overwrite_recovered_sidecar(tmp_path
 
     with pytest.raises(RuntimeError, match="unvalidated session generation"):
         loaded["session"].save(skip_index=True)
+    assert path.read_bytes() == replacement
+
+
+def test_tokenless_legacy_loader_rejects_symlink_and_inode_replacement(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    sid = "legacy-nofollow-sidecar"
+    path = session_dir / f"{sid}.json"
+    original = json.dumps(
+        {"session_id": sid, "messages": [{"role": "user", "content": "original"}]}
+    ).encode("utf-8")
+    replacement = json.dumps(
+        {"session_id": sid, "messages": [{"role": "user", "content": "replacement"}]}
+    ).encode("utf-8")
+    outside = tmp_path / "outside.json"
+    outside.write_bytes(replacement)
+    path.symlink_to(outside)
+
+    assert Session.load(sid) is None
+
+    path.unlink()
+    path.write_bytes(original)
+    loaded = Session.load(sid)
+    assert loaded is not None
+    path.replace(path.with_suffix(".old"))
+    path.write_bytes(replacement)
+
+    with pytest.raises(RuntimeError, match="unvalidated session generation"):
+        loaded.save(skip_index=True)
     assert path.read_bytes() == replacement
 
 
@@ -490,7 +517,7 @@ def test_id_copy_failure_does_not_commit_dangling_session(path, tmp_path, monkey
     assert destination_id not in models.SESSIONS
 
 
-def test_duplicate_clones_externalized_media_before_session_commit(tmp_path, monkeypatch):
+def test_duplicate_rejects_legacy_compact_media_without_publishing_destination(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     raw, data_url = _large_png_data_url()
     source = Session(
@@ -501,6 +528,7 @@ def test_duplicate_clones_externalized_media_before_session_commit(tmp_path, mon
     )
     source.save(skip_index=True)
     models.SESSIONS[source.session_id] = source
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
 
     monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
     monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": source.session_id})
@@ -510,13 +538,11 @@ def test_duplicate_clones_externalized_media_before_session_commit(tmp_path, mon
 
     routes.handle_post(_FakeHandler("/api/session/duplicate"), urlparse("/api/session/duplicate"))
 
-    assert "bad" not in captured
-    destination_id = captured["ok"]["session"]["session_id"]
-    destination = Session.load(destination_id)
-    _assert_destination_media_is_independent(destination, source.session_id, raw, data_url)
+    assert captured["bad"] == ("Could not copy session media", 500)
+    assert len(models.SESSIONS) == 1
 
 
-def test_branch_clones_externalized_media_before_session_commit(tmp_path, monkeypatch):
+def test_branch_rejects_legacy_compact_media_without_publishing_destination(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     raw, data_url = _large_png_data_url()
     source = Session(
@@ -527,6 +553,7 @@ def test_branch_clones_externalized_media_before_session_commit(tmp_path, monkey
     )
     source.save(skip_index=True)
     models.SESSIONS[source.session_id] = source
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
 
     monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
     monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": source.session_id})
@@ -536,10 +563,8 @@ def test_branch_clones_externalized_media_before_session_commit(tmp_path, monkey
 
     routes.handle_post(_FakeHandler("/api/session/branch"), urlparse("/api/session/branch"))
 
-    assert "bad" not in captured
-    destination_id = captured["ok"]["session_id"]
-    destination = Session.load(destination_id)
-    _assert_destination_media_is_independent(destination, source.session_id, raw, data_url)
+    assert captured["bad"] == ("Could not copy session media", 500)
+    assert len(models.SESSIONS) == 1
 
 
 @pytest.mark.parametrize(
@@ -927,7 +952,7 @@ def test_legacy_attachment_media_is_verified_and_migrated(tmp_path, monkeypatch)
     assert not (tmp_path / "session-media" / "legacy-session" / filename).exists()
 
 
-def test_btw_clones_media_before_new_session_is_published(tmp_path, monkeypatch):
+def test_btw_rejects_legacy_compact_media_without_publishing_destination(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     raw, data_url = _large_png_data_url()
     source = Session(
@@ -937,6 +962,7 @@ def test_btw_clones_media_before_new_session_is_published(tmp_path, monkeypatch)
     )
     source.save(skip_index=True)
     models.SESSIONS[source.session_id] = source
+    monkeypatch.setattr(session_media, "_PRIVATE_MEDIA_EXTERNALIZATION_ENABLED", False)
     monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: source)
     monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **_kwargs: None)
     monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
@@ -959,17 +985,8 @@ def test_btw_clones_media_before_new_session_is_published(tmp_path, monkeypatch)
         {"session_id": source.session_id, "question": "What is in the image?"},
     )
 
-    assert "bad" not in captured
-    destination_id = captured["ok"]["session_id"]
-    destination = Session.load(destination_id)
-    with pytest.raises(session_media.SessionMediaIntegrityError, match="retaining quarantine"):
-        session_media.remove_session_media(source.session_id)
-    hydrated = session_media.hydrate_session_media_urls(
-        destination.context_messages,
-        destination_id,
-    )
-    assert hydrated[0]["content"][1]["image_url"]["url"] == data_url
-    assert next(session_media._session_media_dir(destination_id).iterdir()).read_bytes() == raw
+    assert captured["bad"] == ("Could not publish side-question session", 500)
+    assert set(models.SESSIONS) == {source.session_id}
 
 
 def test_export_import_inlines_verified_media_and_establishes_new_ownership(tmp_path, monkeypatch):
@@ -1113,11 +1130,10 @@ def test_clone_rolls_back_when_post_yield_directory_identity_check_fails(
 
 def test_btw_thread_start_failure_rolls_back_all_ephemeral_ownership(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
-    _raw, data_url = _large_png_data_url()
     source = Session(
         session_id="btw-failure-source",
-        messages=[_image_message(data_url)],
-        context_messages=[_image_message(data_url)],
+        messages=[{"role": "user", "content": "ordinary history"}],
+        context_messages=[{"role": "user", "content": "ordinary history"}],
     )
     source.save(skip_index=True)
     models.SESSIONS[source.session_id] = source
@@ -1154,11 +1170,7 @@ def test_btw_thread_start_failure_rolls_back_all_ephemeral_ownership(tmp_path, m
     from api.background import find_btw_owner
 
     owner = find_btw_owner(destination_id, stream_id)
-    assert owner is not None
-    assert owner["cleanup_pending"] is True
-    assert owner["cleanup_residuals"] == [
-        {"artifact": "session_media", "error": "SessionMediaIntegrityError"}
-    ]
+    assert owner is None
 
 
 def test_missing_anchored_capabilities_fail_closed_without_persisting_private_refs(
@@ -2360,15 +2372,18 @@ def test_clear_durably_removes_backup_and_private_media(tmp_path, monkeypatch):
 
     assert captured["status"] == 500
     assert captured["ok"]["error"] == "Session clear incomplete"
-    assert {item["artifact"] for item in captured["ok"]["residuals"]} == {
-        "session_media"
+    assert {item["artifact"] for item in captured["ok"]["residuals"]} >= {
+        "session_json",
+        "session_json_verification",
     }
-    assert not session.path.with_suffix(".json.bak").exists()
-    assert not session_media._session_media_dir(session.session_id).exists()
-    assert len(list((tmp_path / "session-media").glob(".delete-*"))) == 1
+    # The old namespace remains an owner (canonical or quarantine), so the
+    # clear operation cannot report success or allow same-SID reuse.
+    with pytest.raises(models.SessionDestinationCollisionError):
+        with models.reserve_session_destination(session.session_id):
+            pass
 
 
-def test_clear_retires_backup_and_media_even_when_live_transcript_is_already_empty(
+def test_save_refuses_to_create_backup_from_legacy_compact_media(
     tmp_path, monkeypatch
 ):
     _configure_session_state(tmp_path, monkeypatch)
@@ -2379,31 +2394,18 @@ def test_clear_retires_backup_and_media_even_when_live_transcript_is_already_emp
         context_messages=[_image_message(data_url)],
     )
     session.save(skip_index=True)
+    original_sidecar = session.path.read_bytes()
     session.messages = []
     session.context_messages = []
-    session.save(skip_index=True)
-    backup = session.path.with_suffix(".json.bak")
-    assert backup.exists()
-    assert session_media._session_media_dir(session.session_id).exists()
-    models.SESSIONS[session.session_id] = session
-    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
-    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": session.session_id})
-    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
-    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: session)
-    monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
-    captured = _capture_route(monkeypatch)
 
-    routes.handle_post(_FakeHandler("/api/session/clear"), urlparse("/api/session/clear"))
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="session backup"):
+        session.save(skip_index=True)
 
-    assert captured["status"] == 500
-    assert {item["artifact"] for item in captured["ok"]["residuals"]} == {
-        "session_media"
-    }
-    assert not backup.exists()
-    assert not session_media._session_media_dir(session.session_id).exists()
+    assert session.path.read_bytes() == original_sidecar
+    assert not session.path.with_suffix(".json.bak").exists()
 
 
-def test_truncate_prunes_only_media_unreachable_from_live_or_backup(tmp_path, monkeypatch):
+def test_truncate_refuses_legacy_compact_media_without_pruning_namespace(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     _raw_a, data_url_a = _large_png_data_url(b"a")
     _raw_b, data_url_b = _large_png_data_url(b"b")
@@ -2421,13 +2423,12 @@ def test_truncate_prunes_only_media_unreachable_from_live_or_backup(tmp_path, mo
     from api.session_ops import truncate_session_at_keep
 
     truncate_session_at_keep(session, 1)
-    session.save(skip_index=True, prune_media=True)
+    original_sidecar = session.path.read_bytes()
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="explicit offline media migration"):
+        session.save(skip_index=True, prune_media=True)
 
-    files = {path.name for path in session_media._session_media_dir(session.session_id).iterdir()}
-    assert stray_name not in files
-    # The removed second message remains reachable from the recovery backup.
-    assert len([name for name in files if not name.startswith(".prune-")]) == 2
-    assert len([name for name in files if name.startswith(".prune-")]) == 1
+    assert session.path.read_bytes() == original_sidecar
+    assert (session_media._session_media_dir(session.session_id) / stray_name).exists()
 
 
 def test_truncate_does_not_report_committed_write_as_failed_when_prune_fails(
@@ -2542,7 +2543,7 @@ def test_save_rejects_private_ref_in_non_image_transcript_path(tmp_path, monkeyp
 
     with pytest.raises(
         session_media.SessionMediaIntegrityError,
-        match="outside an image part",
+        match="explicit offline media migration",
     ):
         session.save(skip_index=True)
 
@@ -2569,7 +2570,7 @@ def test_save_rejects_image_shaped_private_ref_in_message_metadata(
 
     with pytest.raises(
         session_media.SessionMediaIntegrityError,
-        match="outside an image part",
+        match="explicit offline media migration",
     ):
         session.save(skip_index=True)
 

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1728,3 +1728,51 @@ def test_truncate_prunes_only_media_unreachable_from_live_or_backup(tmp_path, mo
     assert stray_name not in files
     # The removed second message remains reachable from the recovery backup.
     assert len(files) == 2
+
+
+def test_truncate_does_not_report_committed_write_as_failed_when_prune_fails(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id="truncate-prune-failure",
+        messages=[
+            {"role": "user", "content": "keep"},
+            {"role": "assistant", "content": "remove"},
+        ],
+        context_messages=[
+            {"role": "user", "content": "keep"},
+            {"role": "assistant", "content": "remove"},
+        ],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(
+        routes,
+        "read_body",
+        lambda _handler: {"session_id": session.session_id, "keep_count": 1},
+    )
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
+    monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: session)
+    monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
+    monkeypatch.setattr(
+        session_media,
+        "prune_session_media",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("injected prune failure")),
+    )
+    captured = _capture_route(monkeypatch)
+
+    routes.handle_post(
+        _FakeHandler("/api/session/truncate"),
+        urlparse("/api/session/truncate"),
+    )
+
+    assert captured["ok"]["ok"] is True
+    assert captured["status"] == 200
+    assert json.loads(session.path.read_text(encoding="utf-8"))["messages"] == [
+        {"role": "user", "content": "keep"}
+    ]
+    assert "Could not prune session media after transcript truncation" in caplog.text

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1192,6 +1192,46 @@ def test_corrupt_cleanup_record_blocks_only_its_own_session(
         models._load_session_cleanup_residuals()
 
 
+def test_cleanup_retries_valid_records_while_reporting_corrupt_peer(
+    tmp_path,
+    monkeypatch,
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    valid_sid = "valid-retry-record"
+    corrupt_sid = "corrupt-retry-record"
+    _stub_delete_route_dependencies(
+        monkeypatch,
+        Session(session_id=valid_sid),
+        tmp_path,
+    )
+    for sid in (valid_sid, corrupt_sid):
+        models._persist_session_cleanup_residuals(
+            sid,
+            [{"artifact": "session_json"}],
+            durable_tombstone=True,
+            delete_state_db=True,
+        )
+    corrupt_path = models._session_cleanup_residual_file(corrupt_sid)
+    corrupt_path.write_bytes(b"{partial")
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_sessions_cleanup(_FakeHandler("/api/sessions/cleanup"), {})
+
+    assert captured["status"] == 500
+    assert captured["ok"]["cleaned"] == 1
+    assert not models._session_cleanup_residual_file(valid_sid).exists()
+    assert corrupt_path.read_bytes() == b"{partial"
+    assert {
+        item.get("session_id") for item in captured["ok"]["residuals"]
+    } == {corrupt_sid}
+    assert captured["ok"]["residuals"][0]["artifacts"][0]["artifact"] == (
+        "cleanup_residual_record"
+    )
+    valid, invalid = models._scan_session_cleanup_residuals()
+    assert valid == {}
+    assert [item.get("session_id") for item in invalid] == [corrupt_sid]
+
+
 def test_cleanup_route_uses_generation_aware_deletion(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     stale = Session(session_id="cleanup-stale-save", title="Untitled")

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1153,6 +1153,45 @@ def test_delete_reports_and_persists_every_private_artifact_residual(
         models._activate_session_publication_generation(replacement)
 
 
+@pytest.mark.parametrize(
+    "corrupt_payload",
+    [
+        b"{not-json",
+        json.dumps(
+            {
+                "version": models.SESSION_CLEANUP_RESIDUAL_VERSION + 1,
+                "session_id": "blocked-residual",
+                "residuals": [{"artifact": "session_json"}],
+                "delete_state_db": True,
+                "durable_tombstone": True,
+            }
+        ).encode("utf-8"),
+    ],
+)
+def test_corrupt_cleanup_record_blocks_only_its_own_session(
+    corrupt_payload,
+    tmp_path,
+    monkeypatch,
+):
+    _configure_session_state(tmp_path, monkeypatch)
+    blocked_sid = "blocked-residual"
+    models._persist_session_cleanup_residuals(
+        blocked_sid,
+        [{"artifact": "session_json"}],
+        durable_tombstone=True,
+        delete_state_db=True,
+    )
+    models._session_cleanup_residual_file(blocked_sid).write_bytes(corrupt_payload)
+
+    unrelated = Session(session_id="unrelated-new-session")
+    models._activate_session_publication_generation(unrelated)
+
+    with pytest.raises(RuntimeError, match="cleanup residuals remain"):
+        models._activate_session_publication_generation(Session(session_id=blocked_sid))
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        models._load_session_cleanup_residuals()
+
+
 def test_cleanup_route_uses_generation_aware_deletion(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
     stale = Session(session_id="cleanup-stale-save", title="Untitled")

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1714,21 +1714,34 @@ def test_tombstone_read_modify_write_is_serialized_across_processes(
     }
 
 
-def test_corrupt_deleted_tombstone_fails_closed_for_session_publication(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    "corrupt_bytes",
+    [
+        b"{partial",
+        json.dumps({"version": 999, "ids": ["some-deleted-session"]}).encode(),
+    ],
+    ids=["invalid-json", "future-version"],
+)
+def test_corrupt_deleted_tombstone_isolated_by_destination_reservation(
+    tmp_path, monkeypatch, corrupt_bytes
 ):
     _configure_session_state(tmp_path, monkeypatch)
-    models._webui_deleted_session_tombstone_file().write_bytes(b"{partial")
+    tombstone_path = models._webui_deleted_session_tombstone_file()
+    tombstone_path.write_bytes(corrupt_bytes)
     sid = "corrupt-tombstone-publication"
 
-    with pytest.raises(ValueError, match="deleted-session tombstone"):
+    with pytest.raises(RuntimeError, match="unreadable deleted-session authority"):
         Session(session_id=sid).save(skip_index=True)
-    with pytest.raises(ValueError, match="deleted-session tombstone"):
-        with models.reserve_session_destination(sid):
-            pytest.fail("a corrupt authority file must prevent reservation")
 
-    assert not (models.SESSION_DIR / f"{sid}.json").exists()
+    reserved = Session(session_id=sid)
+    with models.reserve_session_destination(sid) as reservation:
+        reservation.bind(reserved)
+        reserved.save(skip_index=True)
+        reservation.commit()
+
+    assert (models.SESSION_DIR / f"{sid}.json").exists()
     assert not models._session_incarnation_claim_file(sid).exists()
+    assert tombstone_path.read_bytes() == corrupt_bytes
 
 
 def test_import_index_failure_rolls_back_json_media_and_cache(tmp_path, monkeypatch):

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1953,6 +1953,21 @@ def test_prune_file_replacement_after_final_check_is_not_unlinked(
     assert (media_dir / f"{replacement[0]}.moved").is_file()
 
 
+def test_prune_exact_removal_allows_additional_hardlink(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    _raw, data_url = _large_png_data_url()
+    messages = [_image_message(data_url)]
+    sid = "prune-hardlink"
+    session_media.externalize_large_session_media(messages, sid)
+    media_dir = session_media._session_media_dir(sid)
+    stored = next(media_dir.iterdir())
+    sibling = media_dir / "additional-hardlink.png"
+    os.link(stored, sibling)
+
+    assert session_media.prune_session_media(sid, []) == 2
+    assert not list(media_dir.iterdir())
+
+
 def test_unsupported_backend_detects_broken_private_root_symlink(tmp_path, monkeypatch):
     monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     (tmp_path / "missing-target").mkdir()

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -1,6 +1,9 @@
 """Regression tests for file-backed large native image session media."""
 import base64
+import hashlib
 import json
+import os
+import threading
 
 from api import models, session_media
 from api.models import Session
@@ -82,6 +85,10 @@ def test_small_or_noncanonical_data_urls_stay_in_json(tmp_path, monkeypatch):
         {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/svg+xml;base64,PHN2Zy8+"}}]},
     ]
 
+    def _unexpected_decode(*_args, **_kwargs):
+        raise AssertionError("small data URL should not be decoded")
+
+    monkeypatch.setattr(session_media.base64, "b64decode", _unexpected_decode)
     assert session_media.externalize_large_session_media(messages, "media-small") == 0
     assert messages[0]["content"][1]["image_url"]["url"] == small
     assert "literal data:image" in messages[1]["content"]
@@ -96,3 +103,20 @@ def test_uses_the_configured_attachment_root(tmp_path, monkeypatch):
 
     assert session_media.externalize_large_session_media(messages, "media-custom") == 1
     assert list((custom_root / "media-custom" / "session-media").iterdir())
+
+
+def test_stale_tmp_file_is_rewritten_before_returning_reference(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    raw, data_url = _large_png_data_url()
+    session_id = "media-stale-tmp"
+    media_dir = session_media._session_media_dir(session_id)
+    media_dir.mkdir(parents=True)
+    digest = hashlib.sha256(raw).hexdigest()
+    filename = f"{digest}.png"
+    stale_tmp = media_dir / f".{filename}.{os.getpid()}.{threading.get_ident()}.tmp"
+    stale_tmp.write_bytes(b"interrupted prior write")
+    messages = [_image_message(data_url)]
+
+    assert session_media.externalize_large_session_media(messages, session_id) == 1
+    assert (media_dir / filename).read_bytes() == raw
+    assert not stale_tmp.exists()

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -86,6 +86,8 @@ def _configure_session_state(tmp_path, monkeypatch):
     routes.SESSIONS.clear()
     models._SESSION_PUBLICATION_DELETED.clear()
     models._SESSION_PUBLICATION_LOCKS.clear()
+    if hasattr(models, "_SESSION_PUBLICATION_GENERATIONS"):
+        models._SESSION_PUBLICATION_GENERATIONS.clear()
     return session_dir
 
 
@@ -101,8 +103,8 @@ def _stub_delete_route_dependencies(monkeypatch, session, tmp_path):
     monkeypatch.setattr(routes.api_config, "_evict_session_agent", lambda _sid: None)
     monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
     monkeypatch.setattr("api.upload._session_attachment_dir", lambda _sid: tmp_path / "uploads" / _sid)
-    monkeypatch.setattr("api.turn_journal.delete_turn_journal", lambda _sid: None)
-    monkeypatch.setattr("api.run_journal.delete_run_journal", lambda _sid: None)
+    monkeypatch.setattr("api.turn_journal.delete_turn_journal", lambda _sid, **_kwargs: None)
+    monkeypatch.setattr("api.run_journal.delete_run_journal", lambda _sid, **_kwargs: None)
     monkeypatch.setattr("api.background_process.forget_bg_task_completion_dedup", lambda _sid: None)
     monkeypatch.setattr("api.terminal.close_terminal", lambda _sid: None)
 
@@ -324,6 +326,67 @@ def test_branch_clones_externalized_media_before_session_commit(tmp_path, monkey
     destination_id = captured["ok"]["session_id"]
     destination = Session.load(destination_id)
     _assert_destination_media_is_independent(destination, source.session_id, raw, data_url)
+
+
+@pytest.mark.parametrize(
+    "path,destination_id",
+    [
+        ("/api/session/duplicate", "duprollback1"),
+        ("/api/session/branch", "branchrollbk"),
+    ],
+)
+@pytest.mark.parametrize("failure", ["save", "index"])
+def test_new_id_routes_roll_back_after_media_clone_failure(
+    path,
+    destination_id,
+    failure,
+    tmp_path,
+    monkeypatch,
+):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    _raw, data_url = _large_png_data_url()
+    source = Session(
+        session_id=f"source-{destination_id}",
+        title="Media source",
+        messages=[_image_message(data_url)],
+        context_messages=[_image_message(data_url)],
+    )
+    source.save(skip_index=True)
+    models.SESSIONS[source.session_id] = source
+    monkeypatch.setattr(models.uuid, "uuid4", lambda: SimpleNamespace(hex=destination_id))
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: {"session_id": source.session_id})
+    monkeypatch.setattr(routes, "get_session", lambda _sid, metadata_only=False: source)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *_, **__: None)
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+    monkeypatch.setattr("api.upload._session_attachment_dir", lambda sid: tmp_path / "uploads" / sid)
+    monkeypatch.setattr("api.turn_journal.delete_turn_journal", lambda _sid, **_kwargs: 0)
+    monkeypatch.setattr("api.run_journal.delete_run_journal", lambda _sid, **_kwargs: False)
+    original_save = Session.save
+
+    if failure == "save":
+        def fail_destination_save(self, *args, **kwargs):
+            if self.session_id == destination_id:
+                raise OSError("injected destination save failure")
+            return original_save(self, *args, **kwargs)
+
+        monkeypatch.setattr(Session, "save", fail_destination_save)
+    else:
+        monkeypatch.setattr(
+            models,
+            "_write_session_index",
+            lambda *args, **kwargs: (_ for _ in ()).throw(OSError("injected index failure")),
+        )
+
+    captured = _capture_route(monkeypatch)
+    routes.handle_post(_FakeHandler(path), urlparse(path))
+
+    assert captured["bad"][1] == 500
+    assert destination_id not in models.SESSIONS
+    assert not (session_dir / f"{destination_id}.json").exists()
+    assert not (session_dir / f"{destination_id}.json.bak").exists()
+    destination_media = session_media._session_media_dir(destination_id)
+    assert not destination_media.exists() or not list(destination_media.iterdir())
 
 
 def test_gateway_runs_api_hydrates_compact_history_without_mutation(tmp_path, monkeypatch):
@@ -818,13 +881,15 @@ def test_btw_thread_start_failure_rolls_back_all_ephemeral_ownership(tmp_path, m
     )
     source.save(skip_index=True)
     models.SESSIONS[source.session_id] = source
+    _stub_delete_route_dependencies(monkeypatch, source, tmp_path)
     destination_id = "btw-failure-destination"
+    stream_id = "btw-failure-stream"
     monkeypatch.setattr(routes, "Session", lambda **kwargs: Session(session_id=destination_id, **kwargs))
+    monkeypatch.setattr(routes.uuid, "uuid4", lambda: SimpleNamespace(hex=stream_id))
     monkeypatch.setattr(routes, "get_session", lambda *_args, **_kwargs: source)
     monkeypatch.setattr(routes, "_agent_runtime_barrier_response", lambda **_kwargs: None)
     monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda _sid: False)
     monkeypatch.setattr(routes, "create_stream_channel", lambda: SimpleNamespace())
-    monkeypatch.setattr("api.background.track_btw", lambda *_args: None)
 
     class FailingThread:
         def __init__(self, *args, **kwargs):
@@ -846,9 +911,15 @@ def test_btw_thread_start_failure_rolls_back_all_ephemeral_ownership(tmp_path, m
     assert not (models.SESSION_DIR / f"{destination_id}.json").exists()
     assert not session_media._session_media_dir(destination_id).exists()
     assert destination_id not in routes.api_config.STREAM_SESSION_OWNERS.values()
+    from api.background import find_btw_owner
+
+    assert find_btw_owner(destination_id, stream_id) is None
 
 
-def test_path_fallback_externalizes_hydrates_clones_and_removes(tmp_path, monkeypatch):
+def test_missing_anchored_capabilities_fail_closed_without_persisting_private_refs(
+    tmp_path,
+    monkeypatch,
+):
     monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
     monkeypatch.setattr(session_media, "_DIR_FD_OK", False, raising=False)
 
@@ -859,25 +930,27 @@ def test_path_fallback_externalizes_hydrates_clones_and_removes(tmp_path, monkey
     _raw, data_url = _large_png_data_url()
     messages = [_image_message(data_url)]
 
-    assert session_media.externalize_large_session_media(messages, "fallback-source") == 1
-    assert session_media.hydrate_session_media_urls(messages, "fallback-source")[0][
-        "content"
-    ][1]["image_url"]["url"] == data_url
-    assert session_media.clone_session_media_references(
-        messages,
-        "fallback-source",
-        "fallback-destination",
-    ) == 1
-    session_media.remove_session_media("fallback-source")
-    assert session_media.hydrate_session_media_urls(messages, "fallback-destination")[0][
-        "content"
-    ][1]["image_url"]["url"] == data_url
-    session_media.remove_session_media("fallback-destination")
-    assert not session_media._session_media_dir("fallback-destination").exists()
+    assert session_media.externalize_large_session_media(messages, "unsupported-source") == 0
+    assert messages[0]["content"][1]["image_url"]["url"] == data_url
+    assert not (tmp_path / "session-media").exists()
+
+    compact = [_image_message("webui-media://" + "a" * 64 + ".png")]
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="unsupported"):
+        session_media.hydrate_session_media_urls(compact, "unsupported-source")
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="unsupported"):
+        session_media.clone_session_media_references(
+            compact,
+            "unsupported-source",
+            "unsupported-destination",
+        )
+    (tmp_path / "session-media" / "unsupported-source").mkdir(parents=True)
+    with pytest.raises(session_media.SessionMediaIntegrityError, match="unsupported"):
+        session_media.remove_session_media("unsupported-source")
 
 
 def test_ephemeral_cleanup_retires_json_cache_stream_tracking_and_media(tmp_path, monkeypatch):
     _configure_session_state(tmp_path, monkeypatch)
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
     _raw, data_url = _large_png_data_url()
     session = Session(
         session_id="btw-cleanup",
@@ -906,7 +979,11 @@ def test_ephemeral_cleanup_retires_json_cache_stream_tracking_and_media(tmp_path
     assert routes.stream_owner_session_id("btw-cleanup-stream") is None
     assert not session.path.exists()
     assert not session_media._session_media_dir(session.session_id).exists()
-    assert cleanup_btw(session.parent_session_id) is None
+    assert cleanup_btw(
+        session.parent_session_id,
+        session.session_id,
+        session.active_stream_id or "btw-cleanup-stream",
+    ) is None
 
 
 def test_delete_serializes_against_late_save_and_tombstones_publication(tmp_path, monkeypatch):
@@ -978,8 +1055,316 @@ def test_delete_reports_failure_when_private_media_cleanup_fails(tmp_path, monke
 
     _call_delete_route(session.session_id)
 
-    assert captured["bad"][1] == 500
-    assert "private media cleanup failed" in captured["bad"][0]
+    assert captured["status"] == 500
+    assert captured["ok"]["error"] == "Session cleanup incomplete"
+    assert {item["artifact"] for item in captured["ok"]["residuals"]} >= {
+        "session_media"
+    }
     assert session.session_id not in models.SESSIONS
     with pytest.raises(RuntimeError, match="deleted session"):
         session.save(skip_index=True)
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        "deleted_session_tombstone",
+        "session_json",
+        "session_backup",
+        "session_temporary_files",
+        "attachments",
+        "turn_journal",
+        "run_journal",
+        "session_index",
+        "state_db",
+    ],
+)
+def test_delete_reports_and_persists_every_private_artifact_residual(
+    artifact,
+    tmp_path,
+    monkeypatch,
+):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id=f"residual-{artifact.replace('_', '-')}",
+        messages=[{"role": "user", "content": "private transcript"}],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    _stub_delete_route_dependencies(monkeypatch, session, tmp_path)
+    captured = _capture_route(monkeypatch)
+
+    if artifact == "deleted_session_tombstone":
+        monkeypatch.setattr(models, "_record_webui_deleted_session_tombstone", lambda _sid: None)
+    elif artifact in {"session_json", "session_backup", "session_temporary_files"}:
+        if artifact == "session_temporary_files":
+            target = session_dir / f"{session.session_id}.tmp.crashed"
+            target.write_text('{"private":"temporary"}', encoding="utf-8")
+        else:
+            target = session.path if artifact == "session_json" else session.path.with_suffix(".json.bak")
+        if artifact == "session_backup":
+            target.write_text('{"private":"backup"}', encoding="utf-8")
+        original_unlink = type(target).unlink
+
+        def fail_target_unlink(self, *args, **kwargs):
+            if self == target:
+                raise OSError("injected unlink failure")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(type(target), "unlink", fail_target_unlink)
+    elif artifact == "attachments":
+        attachment_dir = tmp_path / "uploads" / session.session_id
+        attachment_dir.mkdir(parents=True)
+        (attachment_dir / "private.txt").write_text("private", encoding="utf-8")
+        monkeypatch.setattr(
+            "shutil.rmtree",
+            lambda path, *args, **kwargs: (_ for _ in ()).throw(OSError("injected rmtree failure"))
+            if path == attachment_dir
+            else None,
+        )
+    elif artifact == "turn_journal":
+        turn_root = session_dir / "_turn_journal"
+        turn_root.mkdir()
+        (turn_root / f"{session.session_id}.jsonl").write_text("private\n", encoding="utf-8")
+    elif artifact == "run_journal":
+        run_root = session_dir / "_run_journal" / session.session_id
+        run_root.mkdir(parents=True)
+        (run_root / "run.jsonl").write_text("private\n", encoding="utf-8")
+    elif artifact == "session_index":
+        models.SESSION_INDEX_FILE.write_text(
+            json.dumps([{"session_id": session.session_id}]),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(models, "prune_session_from_index", lambda _sid: None)
+    elif artifact == "state_db":
+        monkeypatch.setattr(models, "delete_cli_session", lambda _sid: False)
+
+    _call_delete_route(session.session_id)
+
+    assert captured["status"] == 500
+    residual_names = {item["artifact"] for item in captured["ok"]["residuals"]}
+    assert artifact in residual_names
+    persisted = models._load_session_cleanup_residuals()
+    assert artifact in {
+        item["artifact"] for item in persisted[session.session_id]["residuals"]
+    }
+    replacement = Session(session_id=session.session_id)
+    with pytest.raises(RuntimeError, match="cleanup residuals remain"):
+        models._activate_session_publication_generation(replacement)
+
+
+def test_cleanup_route_uses_generation_aware_deletion(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    stale = Session(session_id="cleanup-stale-save", title="Untitled")
+    stale.save(skip_index=True)
+    models.SESSIONS[stale.session_id] = stale
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+    monkeypatch.setattr("api.upload._session_attachment_dir", lambda sid: tmp_path / "uploads" / sid)
+    monkeypatch.setattr("api.turn_journal.delete_turn_journal", lambda _sid, **_kwargs: 0)
+    monkeypatch.setattr("api.run_journal.delete_run_journal", lambda _sid, **_kwargs: False)
+    captured = _capture_route(monkeypatch)
+
+    routes._handle_sessions_cleanup(_FakeHandler("/api/sessions/cleanup"), {})
+
+    assert captured["ok"]["cleaned"] == 1
+    assert not stale.path.exists()
+    with pytest.raises(RuntimeError, match="stale|deleted session"):
+        stale.save(skip_index=True)
+
+
+def test_same_sid_recreation_does_not_authorize_old_session_object(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    old = Session(session_id="same-sid-generation", messages=[{"role": "user", "content": "old"}])
+    old.save(skip_index=True)
+    models.SESSIONS[old.session_id] = old
+    _stub_delete_route_dependencies(monkeypatch, old, tmp_path)
+    captured = _capture_route(monkeypatch)
+    _call_delete_route(old.session_id)
+    assert captured["ok"]["ok"] is True
+
+    replacement = Session(
+        session_id=old.session_id,
+        messages=[{"role": "user", "content": "replacement"}],
+    )
+    models._activate_session_publication_generation(replacement)
+    models._clear_webui_deleted_session_tombstone(replacement.session_id)
+    replacement.save(skip_index=True)
+
+    old.messages.append({"role": "assistant", "content": "stale overwrite"})
+    with pytest.raises(RuntimeError, match="stale"):
+        old.save(skip_index=True)
+    assert "replacement" in replacement.path.read_text(encoding="utf-8")
+
+
+def test_delete_defers_while_run_is_active_then_retries_idempotently(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id="delete-active-run",
+        messages=[{"role": "user", "content": "still running"}],
+    )
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    _stub_delete_route_dependencies(monkeypatch, session, tmp_path)
+    captured = _capture_route(monkeypatch)
+    stream_id = "delete-active-stream"
+    with routes.api_config.ACTIVE_RUNS_LOCK:
+        routes.api_config.ACTIVE_RUNS[stream_id] = {"session_id": session.session_id}
+    try:
+        _call_delete_route(session.session_id)
+        assert captured["status"] == 500
+        assert {item["artifact"] for item in captured["ok"]["residuals"]} >= {
+            "active_run"
+        }
+        assert session.path.exists()
+        with pytest.raises(RuntimeError, match="deleted session"):
+            session.save(skip_index=True)
+    finally:
+        with routes.api_config.ACTIVE_RUNS_LOCK:
+            routes.api_config.ACTIVE_RUNS.pop(stream_id, None)
+
+    _call_delete_route(session.session_id)
+    assert captured["status"] == 200
+    assert captured["ok"]["ok"] is True
+    assert not session.path.exists()
+    assert session.session_id not in models._load_session_cleanup_residuals()
+
+
+def test_cleanup_retry_preserves_messaging_state_db_ownership_policy(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    session = Session(
+        session_id="messaging-cleanup-policy",
+        messages=[{"role": "user", "content": "external owner"}],
+    )
+    session.save(skip_index=True)
+    backup = session.path.with_suffix(".json.bak")
+    backup.write_text("private backup", encoding="utf-8")
+    models.SESSIONS[session.session_id] = session
+    _stub_delete_route_dependencies(monkeypatch, session, tmp_path)
+    monkeypatch.setattr(routes, "_is_messaging_session_id", lambda _sid: True)
+    state_db_calls = []
+    monkeypatch.setattr(
+        models,
+        "delete_cli_session",
+        lambda sid: state_db_calls.append(sid) or True,
+    )
+    captured = _capture_route(monkeypatch)
+    original_unlink = type(backup).unlink
+
+    def fail_backup(self, *args, **kwargs):
+        if self == backup:
+            raise OSError("backup busy")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(type(backup), "unlink", fail_backup)
+    _call_delete_route(session.session_id)
+    assert captured["status"] == 500
+    policy = models._load_session_cleanup_residuals()[session.session_id]
+    assert policy["delete_state_db"] is False
+    assert policy["durable_tombstone"] is False
+    assert state_db_calls == []
+
+    monkeypatch.setattr(type(backup), "unlink", original_unlink)
+    routes._handle_sessions_cleanup(_FakeHandler("/api/sessions/cleanup"), {})
+
+    assert captured["status"] == 200
+    assert state_db_calls == []
+    assert not backup.exists()
+    assert session.session_id not in models._load_session_cleanup_residuals()
+
+
+def test_ephemeral_cancel_before_worker_retires_exact_owned_lifecycle(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    from api.background import cleanup_btw, track_btw
+    from api.config import SESSION_AGENT_LOCKS
+
+    ephemeral = Session(
+        session_id="btw-preworker-cancel",
+        parent_session_id="btw-preworker-parent",
+        messages=[{"role": "user", "content": "private question"}],
+    )
+    ephemeral.active_stream_id = "btw-preworker-stream"
+    ephemeral.save(skip_index=True)
+    models.SESSIONS[ephemeral.session_id] = ephemeral
+    routes.register_stream_owner(ephemeral.active_stream_id, ephemeral.session_id)
+    track_btw(
+        ephemeral.parent_session_id,
+        ephemeral.session_id,
+        ephemeral.active_stream_id,
+        "private question",
+    )
+    SESSION_AGENT_LOCKS[ephemeral.session_id] = threading.Lock()
+    run_dir = session_dir / "_run_journal" / ephemeral.session_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.jsonl").write_text('{"private":true}\n', encoding="utf-8")
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+
+    streaming._run_agent_streaming(
+        ephemeral.session_id,
+        "private question",
+        "model",
+        str(tmp_path),
+        ephemeral.active_stream_id,
+        ephemeral=True,
+    )
+
+    assert not ephemeral.path.exists()
+    assert not run_dir.exists()
+    assert ephemeral.session_id not in models.SESSIONS
+    assert ephemeral.session_id not in SESSION_AGENT_LOCKS
+    assert cleanup_btw(
+        ephemeral.parent_session_id,
+        ephemeral.session_id,
+        ephemeral.active_stream_id,
+    ) is None
+
+
+def test_ephemeral_cleanup_does_not_erase_newer_parent_owner(tmp_path, monkeypatch):
+    _configure_session_state(tmp_path, monkeypatch)
+    from api.background import cleanup_btw, track_btw
+
+    older = Session(session_id="btw-older", parent_session_id="shared-parent")
+    older.active_stream_id = "older-stream"
+    newer = Session(session_id="btw-newer", parent_session_id="shared-parent")
+    newer.active_stream_id = "newer-stream"
+    track_btw("shared-parent", older.session_id, older.active_stream_id, "older")
+    track_btw("shared-parent", newer.session_id, newer.active_stream_id, "newer")
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+
+    streaming._cleanup_ephemeral_session(older, stream_id=older.active_stream_id)
+
+    owned = cleanup_btw("shared-parent", newer.session_id, newer.active_stream_id)
+    assert owned is not None
+    assert owned["ephemeral_session_id"] == newer.session_id
+
+
+def test_ephemeral_cleanup_failure_keeps_exact_retryable_owner(tmp_path, monkeypatch):
+    session_dir = _configure_session_state(tmp_path, monkeypatch)
+    from api.background import find_btw_owner, track_btw
+
+    session = Session(session_id="btw-cleanup-residual", parent_session_id="btw-residual-parent")
+    session.active_stream_id = "btw-residual-stream"
+    session.save(skip_index=True)
+    models.SESSIONS[session.session_id] = session
+    track_btw(
+        session.parent_session_id,
+        session.session_id,
+        session.active_stream_id,
+        "private question",
+    )
+    run_dir = session_dir / "_run_journal" / session.session_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.jsonl").write_text("private\n", encoding="utf-8")
+    monkeypatch.setattr(models, "delete_cli_session", lambda _sid: True)
+    monkeypatch.setattr(
+        "api.run_journal.delete_run_journal",
+        lambda _sid, **_kwargs: False,
+    )
+
+    result = streaming._cleanup_ephemeral_session(session)
+
+    assert result["ok"] is False
+    assert {item["artifact"] for item in result["residuals"]} >= {"run_journal"}
+    owner = find_btw_owner(session.session_id, "btw-residual-stream")
+    assert owner is not None
+    assert owner["cleanup_pending"] is True
+    assert session.session_id in models._load_session_cleanup_residuals()

--- a/tests/test_session_media_externalization.py
+++ b/tests/test_session_media_externalization.py
@@ -49,7 +49,7 @@ def _cross_process_index_writer(session_dir, index_file, sid, ready, start):
     )
     session.save(skip_index=True)
     ready.put(sid)
-    start.wait(10)
+    start.wait(60)
     child_models._write_session_index(updates=[session])
 
 
@@ -99,7 +99,7 @@ def _cross_process_tombstone_writer(session_dir, sid, ready, start):
 
     child_models.SESSION_DIR = Path(session_dir)
     ready.put(sid)
-    start.wait(10)
+    start.wait(60)
     child_models._record_webui_deleted_session_tombstone(sid)
 
 
@@ -1666,13 +1666,13 @@ def test_index_read_modify_write_is_serialized_across_processes(tmp_path, monkey
     ]
     for worker in workers:
         worker.start()
-    assert {ready.get(timeout=10), ready.get(timeout=10)} == {
+    assert {ready.get(timeout=60), ready.get(timeout=60)} == {
         "process-index-a",
         "process-index-b",
     }
     start.set()
     for worker in workers:
-        worker.join(15)
+        worker.join(60)
         assert worker.exitcode == 0
 
     rows = json.loads(models.SESSION_INDEX_FILE.read_text(encoding="utf-8"))
@@ -1699,13 +1699,13 @@ def test_tombstone_read_modify_write_is_serialized_across_processes(
     ]
     for worker in workers:
         worker.start()
-    assert {ready.get(timeout=10), ready.get(timeout=10)} == {
+    assert {ready.get(timeout=60), ready.get(timeout=60)} == {
         "process-tombstone-a",
         "process-tombstone-b",
     }
     start.set()
     for worker in workers:
-        worker.join(15)
+        worker.join(60)
         assert worker.exitcode == 0
 
     assert models._load_webui_deleted_session_tombstone() == {

--- a/tests/test_session_public_share.py
+++ b/tests/test_session_public_share.py
@@ -36,14 +36,12 @@ def post(path, body=None):
 
 
 def _make_session_with_messages():
-    created, _ = post("/api/session/new", {})
-    sid = created["session"]["session_id"]
     from api.models import Session
 
-    # Current master keeps a freshly /api/session/new session memory-only until
-    # its first message is persisted, so Session.load(sid) can return None here.
-    # Construct + persist the session directly so the share path has a real file.
-    session = Session.load(sid) or Session(session_id=sid)
+    # The test process is distinct from the test server, so it cannot own the
+    # server's memory-only, reserved /api/session/new object. Materialize an
+    # independent new SID instead of constructing over that pending claim.
+    session = Session()
     session.title = "Shared Test"
     session.messages = [
         {"role": "system", "content": "internal system instructions should stay private"},
@@ -59,7 +57,7 @@ def _make_session_with_messages():
     session.workspace = "/very/private/workspace"
     session.profile = None
     session.save()
-    return sid
+    return session.session_id
 
 
 def test_share_create_returns_public_url_and_persists_session_fields():

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -183,7 +183,7 @@ def test_startup_rolls_back_prepared_compression_claim_without_sidecar(
     assert not models._session_incarnation_claim_file(sid).exists()
 
 
-def test_startup_rolls_back_v2_compression_and_restores_exact_source(
+def test_startup_restores_v2_compression_source_and_retains_media_retry(
     tmp_path, monkeypatch
 ):
     import api.models as models
@@ -244,14 +244,21 @@ def test_startup_rolls_back_v2_compression_and_restores_exact_source(
 
     result = recover_incomplete_compression_transactions(tmp_path)
 
-    assert result == {"finalized": 0, "rolled_back": 1, "residuals": []}
+    assert result == {
+        "finalized": 0,
+        "rolled_back": 0,
+        "residuals": [
+            {"transaction": f"{new_sid}.json", "error": "RuntimeError"}
+        ],
+    }
     assert source.path.read_bytes() == source_before
     assert models.SESSION_INDEX_FILE.read_bytes() == index_before
     assert not (tmp_path / f"{new_sid}.json").exists()
     assert not media_dir.exists()
     assert not models._session_incarnation_claim_file(new_sid).exists()
     transaction_dir = tmp_path / "_compression_transactions"
-    assert not list(transaction_dir.iterdir())
+    assert (transaction_dir / f"{new_sid}.json").exists()
+    assert models._session_cleanup_residual_file(new_sid).exists()
 
 
 def test_startup_finalizes_v2_committed_compression_transaction(

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -1,6 +1,12 @@
 import json
 
-from api.session_recovery import audit_session_recovery, repair_safe_session_recovery
+from api.session_recovery import (
+    audit_session_recovery,
+    inspect_session_recovery_status,
+    recover_incomplete_compression_transactions,
+    recover_session,
+    repair_safe_session_recovery,
+)
 
 
 def _write_session(session_dir, sid, messages=1):
@@ -84,3 +90,92 @@ def test_recovery_audit_routes_are_registered():
     assert 'parsed.path == "/api/session/recovery/repair-safe"' in src
     assert "audit_session_recovery" in src
     assert "repair_safe_session_recovery" in src
+
+
+def test_foreign_backup_identity_is_rejected_before_recovery_replace(tmp_path):
+    live = _write_session(tmp_path, "identity-a", messages=1)
+    before = live.read_bytes()
+    foreign = {
+        "session_id": "identity-b",
+        "messages": [{"role": "user", "content": str(i)} for i in range(3)],
+    }
+    live.with_suffix(".json.bak").write_text(json.dumps(foreign), encoding="utf-8")
+
+    status = inspect_session_recovery_status(live)
+    result = recover_session(live)
+
+    assert status["bak_messages"] == -1
+    assert status["recommend"] == "no_action"
+    assert result["restored"] is False
+    assert live.read_bytes() == before
+
+
+def test_startup_finalizes_durable_published_compression_intent(tmp_path, monkeypatch):
+    import api.models as models
+
+    index = tmp_path / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index)
+    session = models.Session(
+        session_id="compression-recover-published",
+        messages=[{"role": "user", "content": "durable"}],
+    )
+    session.save(skip_index=True)
+    token = session._publication_generation.token
+    intent_dir = tmp_path / "_compression_transactions"
+    intent_dir.mkdir()
+    intent = intent_dir / f"{session.session_id}.json"
+    intent.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "old_session_id": "compression-recover-old",
+                "new_session_id": session.session_id,
+                "incarnation_token": token,
+                "phase": "sidecar_published",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = recover_incomplete_compression_transactions(tmp_path)
+
+    assert result == {"finalized": 1, "rolled_back": 0, "residuals": []}
+    assert not intent.exists()
+    assert json.loads(index.read_text(encoding="utf-8"))[0]["session_id"] == session.session_id
+
+
+def test_startup_rolls_back_prepared_compression_claim_without_sidecar(
+    tmp_path, monkeypatch
+):
+    import api.models as models
+    import api.session_media as session_media
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(tmp_path / "attachments"))
+    sid = "compression-recover-prepared"
+    token = "a" * 32
+    models._persist_session_incarnation_claim(sid, token)
+    intent_dir = tmp_path / "_compression_transactions"
+    intent_dir.mkdir()
+    intent = intent_dir / f"{sid}.json"
+    intent.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "old_session_id": "compression-recover-old",
+                "new_session_id": sid,
+                "incarnation_token": token,
+                "phase": "prepared",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = recover_incomplete_compression_transactions(tmp_path)
+
+    assert result == {"finalized": 0, "rolled_back": 1, "residuals": []}
+    assert not intent.exists()
+    assert not models._session_incarnation_claim_file(sid).exists()

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -1,6 +1,8 @@
 import json
 
 from api.session_recovery import (
+    _advance_compression_transaction,
+    _stage_compression_transaction_source,
     audit_session_recovery,
     inspect_session_recovery_status,
     recover_incomplete_compression_transactions,
@@ -179,3 +181,141 @@ def test_startup_rolls_back_prepared_compression_claim_without_sidecar(
     assert result == {"finalized": 0, "rolled_back": 1, "residuals": []}
     assert not intent.exists()
     assert not models._session_incarnation_claim_file(sid).exists()
+
+
+def test_startup_rolls_back_v2_compression_and_restores_exact_source(
+    tmp_path, monkeypatch
+):
+    import api.models as models
+    import api.session_media as session_media
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(session_media, "STATE_DIR", tmp_path)
+    old_sid = "compression-v2-recover-old"
+    new_sid = "compression-v2-recover-new"
+    source = models.Session(
+        session_id=old_sid,
+        messages=[{"role": "user", "content": "original"}],
+    )
+    source.save()
+    source_before = source.path.read_bytes()
+    index_before = models.SESSION_INDEX_FILE.read_bytes()
+    intent = _stage_compression_transaction_source(tmp_path, old_sid, new_sid)
+    token = "b" * 32
+    models._persist_session_incarnation_claim(new_sid, token)
+    intent = _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "reserved",
+        token=token,
+    )
+
+    archived = json.loads(source_before)
+    archived["pre_compression_snapshot"] = True
+    archived["active_stream_id"] = None
+    models._durable_replace_bytes(
+        source.path,
+        json.dumps(archived, ensure_ascii=False, indent=2).encode("utf-8"),
+    )
+    intent = _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "source_archived",
+    )
+    destination = {
+        "session_id": new_sid,
+        "publication_incarnation": token,
+        "parent_session_id": old_sid,
+        "messages": [{"role": "user", "content": "continuation"}],
+    }
+    models._durable_replace_bytes(
+        tmp_path / f"{new_sid}.json",
+        json.dumps(destination, ensure_ascii=False, indent=2).encode("utf-8"),
+    )
+    media_dir = session_media._session_media_dir(new_sid)
+    media_dir.mkdir(parents=True)
+    (media_dir / "orphan.png").write_bytes(b"orphan")
+    _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "sidecar_published",
+    )
+
+    result = recover_incomplete_compression_transactions(tmp_path)
+
+    assert result == {"finalized": 0, "rolled_back": 1, "residuals": []}
+    assert source.path.read_bytes() == source_before
+    assert models.SESSION_INDEX_FILE.read_bytes() == index_before
+    assert not (tmp_path / f"{new_sid}.json").exists()
+    assert not media_dir.exists()
+    assert not models._session_incarnation_claim_file(new_sid).exists()
+    transaction_dir = tmp_path / "_compression_transactions"
+    assert not list(transaction_dir.iterdir())
+
+
+def test_startup_finalizes_v2_committed_compression_transaction(
+    tmp_path, monkeypatch
+):
+    import api.models as models
+
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    old_sid = "compression-v2-finalize-old"
+    new_sid = "compression-v2-finalize-new"
+    source = models.Session(
+        session_id=old_sid,
+        messages=[{"role": "user", "content": "original"}],
+    )
+    source.save()
+    intent = _stage_compression_transaction_source(tmp_path, old_sid, new_sid)
+    token = "c" * 32
+    models._persist_session_incarnation_claim(new_sid, token)
+    intent = _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "reserved",
+        token=token,
+    )
+    archived = json.loads(source.path.read_bytes())
+    archived["pre_compression_snapshot"] = True
+    models._durable_replace_bytes(
+        source.path,
+        json.dumps(archived, ensure_ascii=False, indent=2).encode("utf-8"),
+    )
+    intent = _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "source_archived",
+    )
+    destination = {
+        "session_id": new_sid,
+        "publication_incarnation": token,
+        "parent_session_id": old_sid,
+        "messages": [{"role": "user", "content": "continuation"}],
+    }
+    models._durable_replace_bytes(
+        tmp_path / f"{new_sid}.json",
+        json.dumps(destination, ensure_ascii=False, indent=2).encode("utf-8"),
+    )
+    intent = _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "sidecar_published",
+    )
+    _advance_compression_transaction(
+        tmp_path,
+        intent,
+        "migrations_complete",
+    )
+
+    result = recover_incomplete_compression_transactions(tmp_path)
+
+    assert result == {"finalized": 1, "rolled_back": 0, "residuals": []}
+    assert json.loads(source.path.read_bytes())["pre_compression_snapshot"] is True
+    assert (tmp_path / f"{new_sid}.json").exists()
+    rows = json.loads(models.SESSION_INDEX_FILE.read_bytes())
+    assert any(row["session_id"] == new_sid for row in rows)
+    assert models._read_session_incarnation_claim(new_sid) == token
+    transaction_dir = tmp_path / "_compression_transactions"
+    assert not list(transaction_dir.iterdir())

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -112,6 +112,30 @@ def test_foreign_backup_identity_is_rejected_before_recovery_replace(tmp_path):
     assert live.read_bytes() == before
 
 
+def test_compact_media_backup_is_rejected_before_recovery_replace(tmp_path):
+    sid = "compact-backup"
+    live = _write_session(tmp_path, sid, messages=1)
+    before = live.read_bytes()
+    compact = {
+        "session_id": sid,
+        "messages": [
+            {
+                "role": "user",
+                "content": "webui-media://" + ("0" * 64) + ".png",
+            }
+        ],
+    }
+    live.with_suffix(".json.bak").write_text(json.dumps(compact), encoding="utf-8")
+
+    status = inspect_session_recovery_status(live)
+    result = recover_session(live)
+
+    assert status["bak_messages"] == -1
+    assert status["recommend"] == "no_action"
+    assert result["restored"] is False
+    assert live.read_bytes() == before
+
+
 def test_startup_finalizes_durable_published_compression_intent(tmp_path, monkeypatch):
     import api.models as models
 

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -254,7 +254,10 @@ def test_startup_restores_v2_compression_source_and_retains_media_retry(
     assert source.path.read_bytes() == source_before
     assert models.SESSION_INDEX_FILE.read_bytes() == index_before
     assert not (tmp_path / f"{new_sid}.json").exists()
-    assert not media_dir.exists()
+    # Synthetic pre-rollback private data is never removed through a mutable
+    # pathname now that new externalization is disabled.  It remains a
+    # destination owner plus durable cleanup/recovery authority.
+    assert media_dir.exists()
     assert not models._session_incarnation_claim_file(new_sid).exists()
     transaction_dir = tmp_path / "_compression_transactions"
     assert (transaction_dir / f"{new_sid}.json").exists()

--- a/tests/test_session_save_empty_pending_guard.py
+++ b/tests/test_session_save_empty_pending_guard.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 import api.config as config
 import api.models as models
 from api.models import Session
@@ -26,14 +28,13 @@ def test_empty_active_pending_save_cannot_overwrite_existing_messages(tmp_path, 
     )
     existing.save()
 
-    stale = Session(
-        session_id=sid,
-        messages=[],
-        active_stream_id="stale-stream",
-        pending_user_message="prompt",
-        pending_started_at=123.0,
-    )
-    stale.save()
+    # A fresh constructor cannot adopt an existing sidecar's publication lease.
+    stale = Session(session_id=sid, messages=[])
+    stale.active_stream_id = "stale-stream"
+    stale.pending_user_message = "prompt"
+    stale.pending_started_at = 123.0
+    with pytest.raises(RuntimeError, match="stale session generation"):
+        stale.save()
 
     persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
     assert [m["content"] for m in persisted["messages"]] == ["prompt", "answer"]

--- a/tests/test_sprint23.py
+++ b/tests/test_sprint23.py
@@ -34,17 +34,16 @@ def _make_session_visible(sid):
     from api.models import Session
     from tests.conftest import TEST_WORKSPACE
 
-    session = Session(
-        session_id=sid,
-        title="Compact Usage",
-        workspace=str(TEST_WORKSPACE),
-        model="test",
-        created_at=1.0,
-        updated_at=1.0,
-        profile="default",
-        messages=[{"role": "user", "content": "visible row", "timestamp": 1.0}],
-        tool_calls=[],
-    )
+    session = Session.load(sid)
+    assert session is not None
+    session.title = "Compact Usage"
+    session.workspace = str(TEST_WORKSPACE)
+    session.model = "test"
+    session.created_at = 1.0
+    session.updated_at = 1.0
+    session.profile = "default"
+    session.messages = [{"role": "user", "content": "visible row", "timestamp": 1.0}]
+    session.tool_calls = []
     session.save(touch_updated_at=False)
 
 

--- a/tests/test_streaming_agent_cache_lifecycle.py
+++ b/tests/test_streaming_agent_cache_lifecycle.py
@@ -112,7 +112,11 @@ def test_identity_mismatch_cache_evictions_close_entries_outside_cache_lock():
     lines = src.splitlines()
     for marker in close_markers:
         close_idx = next(i for i, line in enumerate(lines) if marker in line)
-        lock_idx = max(i for i, line in enumerate(lines[:close_idx]) if "with SESSION_AGENT_CACHE_LOCK:" in line)
+        lock_idx = max(
+            i
+            for i, line in enumerate(lines[:close_idx])
+            if "SESSION_AGENT_CACHE_LOCK:" in line
+        )
         lock_indent = len(lines[lock_idx]) - len(lines[lock_idx].lstrip())
         between = lines[lock_idx + 1:close_idx]
         assert any(

--- a/tests/test_webui_session_db_adapter.py
+++ b/tests/test_webui_session_db_adapter.py
@@ -123,6 +123,19 @@ def test_read_only_operations_do_not_mutate_files(session_dir):
     assert after_stat.st_size == before_stat.st_size
 
 
+def test_adapter_rejects_sidecar_whose_embedded_sid_claims_another_owner(session_dir):
+    _payload, path = _write_json_session(session_dir, sid="outer_sid")
+    foreign = json.loads(path.read_text(encoding="utf-8"))
+    foreign["session_id"] = "inner_sid"
+    path.write_text(json.dumps(foreign), encoding="utf-8")
+    db = WebUIJsonSessionDB()
+
+    assert db.read_session("outer_sid") is None
+    assert db.list_sessions() == []
+    with pytest.raises(ValueError, match="Malformed session JSON"):
+        db.update_metadata("outer_sid", {"title": "No redirect"})
+
+
 def test_sort_timestamp_falls_back_past_missing_values():
     assert WebUIJsonSessionDB._sort_timestamp({"last_message_at": None, "updated_at": 25.0}) == 25.0
     assert WebUIJsonSessionDB._sort_timestamp({"last_message_at": "", "created_at": "15.5"}) == 15.5

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -1763,20 +1763,19 @@ def test_get_session_reloads_when_cached_session_lags_disk(monkeypatch, tmp_path
     cached.pending_user_message = "next prompt"
     models.SESSIONS[sid] = cached
 
-    newer = models.Session(
-        session_id=sid,
-        title="Reconcile",
-        workspace=str(tmp_path),
-        model="test-model",
-        messages=old_messages + [
-            {"role": "user", "content": "new user", "timestamp": 1002.0},
-            {"role": "assistant", "content": "new final answer", "timestamp": 1003.0},
-        ],
-        created_at=1000.0,
-        updated_at=1003.0,
-        active_stream_id="stream-cache-lags-disk",
-        pending_user_message="next prompt",
-    )
+    newer = models.Session.load(sid)
+    assert newer is not None
+    newer.title = "Reconcile"
+    newer.workspace = str(tmp_path)
+    newer.model = "test-model"
+    newer.messages = old_messages + [
+        {"role": "user", "content": "new user", "timestamp": 1002.0},
+        {"role": "assistant", "content": "new final answer", "timestamp": 1003.0},
+    ]
+    newer.created_at = 1000.0
+    newer.updated_at = 1003.0
+    newer.active_stream_id = "stream-cache-lags-disk"
+    newer.pending_user_message = "next prompt"
     newer.save(touch_updated_at=False)
 
     loaded = models.get_session(sid)


### PR DESCRIPTION
## Thinking Path

Large native image data URLs were persisted in both the visible transcript and `context_messages`, so ordinary session reads repeatedly processed the same multi-megabyte payload. Compact `webui-media://` references solve that cost only if ownership, integrity, publication, cleanup, and provider-boundary invariants remain complete.

The audited state space covers every supported new-ID path that retains history (`duplicate`, `branch`, compression rotation, `/btw`, and JSON export/import), every model boundary (initial run, both credential self-heal retries, sync chat, Gateway `/v1/runs`, and manual compression), save/delete concurrency, ephemeral success/cancel/startup failure, platforms with and without `dir_fd`, and storage exits including source corruption, partial multi-reference failure, replace/fsync failure, symlink and parent swap, concurrent writers, deletion, archive namespace collision, and legacy migration.

## What Changed

- Externalize validated raster `image_url` data URLs of 64 KiB or more into the dedicated state-owned `STATE_DIR/session-media/<session_id>` store, addressed by SHA-256.
- Keep ordinary uploads and archive extraction under `attachments/`; changing `HERMES_WEBUI_ATTACHMENT_DIR` no longer changes private-media authority. Legacy attachment-root media is strictly verified and migrated on first read.
- Keep the anchored, no-follow directory-fd backend where supported. Select a pathname fallback where those APIs are unavailable (notably native Windows), with the same raster/digest verification, atomic replacement, clone rollback, and removal contract.
- Make multi-reference clone transactional: verify every source first, stage and sync every destination blob, publish only after the full set is ready, and roll back all newly published blobs on any failure. The final directory-identity check now also executes inside that rollback boundary.
- Make `Session.save()` fail closed. Media-write errors are no longer swallowed, and every retained reference is verified at the JSON publication boundary. A missing or digest-mismatched blob leaves the previous JSON byte-identical.
- Give save and delete one per-session publication authority. Delete marks the identity before unlinking, removes private media while holding the same lock, and a late worker rechecks deletion immediately before replace. Private-media or durable-tombstone cleanup failure returns HTTP 500 rather than success.
- Centralize `/btw` retirement. Success, cancellation, clone/save/registration failure, and thread-start failure remove JSON/backup, cache state, stream registries and ownership, background tracking, pending state, and private media.
- Hydrate through one strict reader that validates reference grammar, anchored containment, extension/MIME, raster magic, and SHA-256. Missing, unreadable, malformed, or corrupt media stops locally with a restore/re-attach error.
- Add a recursive final assertion immediately before initial, self-heal retry, sync-chat, and Gateway model serialization so no private URI can cross a provider boundary.
- Clone verified media before publishing duplicate, branch, compression-rotation, or `/btw` identities.
- Make JSON/HTML exports portable by inlining only strictly verified media. Plain JSON imports reject private references; portable inline media is externalized under the new random session ID before cache publication.
- Document private-media ownership, migration, platform backend selection, publication locking, and ephemeral cleanup in `ARCHITECTURE.md`.

## Why It Matters

A retained private reference now has exactly one valid outcome: the owning session has a verified destination blob, or the operation fails before publishing success. Model providers never receive a private filesystem URI. Deleting a source session, racing a late save, moving the attachment inbox, importing a portable export, branching, compressing, or using `/btw` cannot silently create dangling history.

## Verification

Fail-before proof on previous head `54d62abf`:

- Missing and digest-mismatched retained refs both replaced JSON instead of refusing the save.
- A post-yield destination identity failure bypassed clone rollback and left the destination blob.
- `/btw` thread-start failure escaped and leaked published ephemeral ownership.
- Simulated no-`dir_fd` capability still entered the anchored backend instead of a portable path.
- Focused result before the fix: 5 failed.

Passing verification through final head `3ca37035`:

- Media, `/btw` cancellation, compression terminal failure, and initial/self-heal provider guard suite: 84 passed.
- Session save/delete, Gateway, public share, branch, import, tombstone reconciliation, worktree lifecycle, and neighboring regression suite: 232 passed, 12 skipped because `hermes-agent` is unavailable in this checkout.
- Total local result across the two non-overlapping suites: 316 passed, 12 environment-dependent skips.
- CI-discovered contract-compatibility follow-up (`test_issue765_streaming_persistence.py`, `test_native_image_attachments.py`, and the media suite): 99 passed.
- After merging current `master` at `800119ed`, all 15 Python 3.11/3.12/3.13 shards, lint, docs, browser smoke, and lifecycle checks passed. The fd-traversal follow-up then passed direct Python 3.11.15 nested removal and the 35-test media lifecycle file.
- Changed-line Ruff: 0 new violations. Fatal-rule Ruff, Python compile checks, and `git diff --check`: clean.

All media tests use synthetic PNG-signature bytes; no user image or video was read, committed, or uploaded.

## Risks / Follow-ups

- The no-`dir_fd` backend was exercised by forcing the capability off and covering externalize → hydrate → clone → source removal → destination hydrate → remove. I could not execute this checkout on a native Windows host, so actual Windows filesystem behavior remains the explicit unverified item.
- Portable JSON/HTML exports containing large images are intentionally larger because they inline verified media instead of retaining installation-private handles.
- Moving WebUI state requires moving the complete `STATE_DIR`. Moving only `HERMES_WEBUI_ATTACHMENT_DIR` affects ordinary uploads, not private media.
- Provider-facing native-vision history still uses base64 data URLs after strict hydration. A future provider-specific optimization could use hosted file references where supported.
- Only canonical validated raster `image_url` parts are externalized. SVG, malformed data URLs, foreign schemes, and ordinary text remain unchanged.

## Contract Routing

Touched state layers: durable session JSON, state-owned private media, session publication/deletion authority, ephemeral stream/cache ownership, session-ID lineage publication, portable export/import, and model-facing history projection. The source of truth is compact persisted history plus verified session-owned media; hydrated history is an outbound deep copy only.

Relevant references: `AGENTS.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `docs/rfcs/webui-run-state-consistency-contract.md`, and `docs/rfcs/canonical-session-resolution.md`.

## Model Used

GPT-5 Codex via Codex desktop, with GitHub CLI inspection and maintainer/Greptile review feedback.
