### PR TITLE
test: skip missing environment prerequisites cleanly

### DIFF
--- a/tests/_playwright_utils.py
+++ b/tests/_playwright_utils.py
@@ -1,0 +1,56 @@
+"""Shared Playwright helpers for browser regression tests.
+
+These tests need a real Chromium binary. In constrained environments — CI images
+or sandboxes where ``playwright install chromium`` was never run — the Python
+package imports fine but ``chromium.launch()`` fails because the browser
+*executable* is absent (``Executable doesn't exist at .../chrome-headless-shell``).
+
+That is a missing optional dependency, not a product regression, so such tests
+should ``pytest.skip`` rather than FAIL. Any OTHER launch/assertion error is
+re-raised unchanged so real bugs still surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+# Substrings (matched case-insensitively) that identify a "browser executable is
+# missing / not installed" launch failure, as opposed to a real assertion/logic
+# error we must not hide. These are emitted by Playwright only when the browser
+# binary itself is absent.
+_BROWSER_MISSING_MARKERS = (
+    "executable doesn't exist",
+    "please run the following command to download new browsers",
+    "playwright install",
+    "looks like playwright was just installed",
+)
+
+
+def _is_browser_missing_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in _BROWSER_MISSING_MARKERS)
+
+
+def skip_if_browser_unavailable(exc: BaseException) -> None:
+    """``pytest.skip`` when *exc* is a missing-browser-binary launch failure.
+
+    Returns normally (does nothing) for any other exception so the caller can
+    re-raise it — real assertion errors and unexpected failures must still fail
+    the test.
+    """
+    if _is_browser_missing_error(exc):
+        pytest.skip(
+            "playwright browser not installed; run `playwright install chromium`"
+        )
+
+
+def launch_chromium_or_skip(playwright, **launch_kwargs):
+    """Launch Chromium, or ``pytest.skip`` if the browser binary is missing.
+
+    All keyword arguments are forwarded verbatim to
+    ``playwright.chromium.launch`` so each caller keeps its exact launch flags.
+    """
+    try:
+        return playwright.chromium.launch(**launch_kwargs)
+    except Exception as exc:  # noqa: BLE001 - narrowed by skip_if_browser_unavailable
+        skip_if_browser_unavailable(exc)
+        raise

--- a/tests/test_docs_gitignore_policy.py
+++ b/tests/test_docs_gitignore_policy.py
@@ -3,6 +3,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -15,24 +17,52 @@ def _git_check_ignore(path: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _require_git_work_tree() -> None:
+    """Skip when ROOT is not a usable git work tree.
+
+    Under a detached worktree whose ``.git`` file points at a gitdir that isn't
+    reachable (e.g. a bubblewrap sandbox that only bind-mounts the worktree, or a
+    checkout without the parent repo's ``.git`` metadata), ``git`` exits 128 with
+    ``fatal: not a git repository``.  ``git check-ignore`` then returns 128
+    instead of the 0/1 these tests assert on, so the ignore policy simply cannot
+    be evaluated here.  That is a missing-prerequisite condition, not a policy
+    regression — skip rather than fail.
+    """
+    probe = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0 or probe.stdout.strip() != "true":
+        pytest.skip(
+            "not inside a usable git work tree; git check-ignore is unavailable "
+            f"(git rev-parse rc={probe.returncode}, stderr={probe.stderr.strip()!r})"
+        )
+
+
 def test_new_top_level_markdown_docs_are_trackable():
     """New docs/*.md files should be visible to Git, not silently ignored."""
+    _require_git_work_tree()
     assert _git_check_ignore("docs/example-new-guide.md").returncode == 1
 
 
 def test_root_agents_entrypoint_is_trackable():
     """AGENTS.md is the shared repo entrypoint; local overrides stay ignored."""
+    _require_git_work_tree()
     assert _git_check_ignore("AGENTS.md").returncode == 1
     assert _git_check_ignore("AGENTS.local.md").returncode == 0
 
 
 def test_docs_scratch_files_remain_ignored():
     """The broad docs/* ignore rule should still keep arbitrary scratch files out."""
+    _require_git_work_tree()
     assert _git_check_ignore("docs/local-scratch.tmp").returncode == 0
 
 
 def test_local_only_ai_context_files_remain_ignored_under_docs():
     """Local AI assistant context files must stay out of commits under docs/."""
+    _require_git_work_tree()
     assert _git_check_ignore("docs/AGENTS.md").returncode == 0
     assert _git_check_ignore("docs/CLAUDE.md").returncode == 0
     assert _git_check_ignore("docs/.cursorrules").returncode == 0

--- a/tests/test_issue1499_keyless_onboarding.py
+++ b/tests/test_issue1499_keyless_onboarding.py
@@ -70,6 +70,16 @@ def _isolate_onboarding_writes(monkeypatch, tmp_path):
     cfg_path = tmp_path / "config.yaml"
     monkeypatch.setattr(ob, "_get_config_path", lambda: cfg_path)
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    # ``config.get_config()`` (called from ``get_onboarding_status``) resolves its
+    # own path through ``api.config._get_config_path`` — which honours the
+    # ``HERMES_CONFIG_PATH`` env override BEFORE the active-profile home. If an
+    # earlier test in the suite leaked that env var into ``os.environ`` (set
+    # outside monkeypatch's scope), ``get_config()`` reloads a foreign config
+    # over this test's in-memory setup and the keyless status flips. Clear the
+    # override and pin config's path resolver to this test's tmp home so the
+    # full-status path is hermetic regardless of suite ordering.
+    monkeypatch.delenv("HERMES_CONFIG_PATH", raising=False)
+    monkeypatch.setattr(config, "_get_config_path", lambda: cfg_path)
     monkeypatch.delenv("HERMES_WEBUI_SKIP_ONBOARDING", raising=False)
     for var in (
         "LM_API_KEY", "LMSTUDIO_API_KEY", "OLLAMA_API_KEY", "OPENAI_API_KEY",
@@ -350,12 +360,20 @@ class TestKeylessChatReady:
         # _swap_in_test_config-style — replicate just enough of that pattern.
         old_cfg = dict(config.cfg)
         old_mtime = config._cfg_mtime
+        old_cfg_path = config._cfg_path
+        old_fingerprint = config._cfg_fingerprint
         config.cfg.clear()
         try:
             import yaml
             config.cfg.update(yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {})
         except Exception:
             pass
+        # Stamp the path-tracking globals to THIS test's config so a spurious
+        # ``path_changed`` staleness check inside get_config()/get_available_models()
+        # cannot reload a foreign config over the in-memory setup above (the
+        # cross-file _cfg_path leak class). config._get_config_path is already
+        # pinned to cfg_path by _isolate_onboarding_writes.
+        config._cfg_path = cfg_path
         try:
             config._cfg_mtime = cfg_path.stat().st_mtime
         except Exception:
@@ -379,3 +397,5 @@ class TestKeylessChatReady:
             config.cfg.clear()
             config.cfg.update(old_cfg)
             config._cfg_mtime = old_mtime
+            config._cfg_path = old_cfg_path
+            config._cfg_fingerprint = old_fingerprint

--- a/tests/test_issue5250_settings_search_dropdown_escape.py
+++ b/tests/test_issue5250_settings_search_dropdown_escape.py
@@ -72,8 +72,11 @@ def test_issue5250_settings_search_dropdown_escape():
             "playwright is unavailable; run manual local browser hit-test for issue #5250"
         )
 
+    from tests._playwright_utils import launch_chromium_or_skip
+
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(
+        browser = launch_chromium_or_skip(
+            playwright,
             headless=True,
             args=["--no-sandbox", "--disable-dev-shm-usage"],
         )

--- a/tests/test_issue609.py
+++ b/tests/test_issue609.py
@@ -68,6 +68,16 @@ def test_path_outside_boot_default_and_home_is_rejected(monkeypatch, tmp_path):
 
     monkeypatch.setattr(ws_mod, "_BOOT_DEFAULT_WORKSPACE", str(boot_default))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    # api.workspace resolves the user home through ``$HOME`` (via
+    # ``_expanduser_path("~")``), NOT ``Path.home()``.  In a sandbox/CI where
+    # ``$HOME`` points at the tmp root (e.g. ``HOME=/tmp`` and ``tmp_path`` is
+    # ``/tmp/pytest-of-...``), ``outside`` would be seen as *under home* and
+    # wrongly trusted.  Pin every home source to the test's ``home`` dir so the
+    # rejection is exercised regardless of where ``tmp_path`` physically lives.
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
 
     with pytest.raises(ValueError, match="outside the user home"):
         resolve_trusted_workspace(str(outside))
@@ -105,6 +115,13 @@ def test_path_traversal_via_dotdot_does_not_escape_boot_default(monkeypatch, tmp
 
     monkeypatch.setattr(ws_mod, "_BOOT_DEFAULT_WORKSPACE", str(boot_default))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    # Pin every home source (see the sibling test): api.workspace derives home
+    # from ``$HOME``, not ``Path.home()``.  Without this a sandbox ``HOME=/tmp``
+    # makes the resolved escape path look like it is under home.
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
 
     # `boot_default/../private` resolves to `tmp_path/data/private`, which is
     # NOT a child of boot_default and not under home — must reject.

--- a/tests/test_layout_helpers.py
+++ b/tests/test_layout_helpers.py
@@ -13,6 +13,7 @@ from tests._layout_helpers import (
     assert_no_raw_i18n_keys,
     collect_layout_violations,
 )
+from tests._playwright_utils import launch_chromium_or_skip
 
 
 def _require_playwright():
@@ -22,6 +23,11 @@ def _require_playwright():
 
 
 _BROWSER_ARGS = ["--no-sandbox", "--disable-dev-shm-usage"]
+
+
+def _launch(pw):
+    """Launch headless Chromium, or skip if the browser binary is missing."""
+    return launch_chromium_or_skip(pw, headless=True, args=_BROWSER_ARGS)
 
 
 _SCOPE_FIXTURE_HTML = """\
@@ -82,7 +88,7 @@ def test_layout_sane_on_master_pages():
     _LIVE_CHECKS = ["overlap", "clip", "container-escape", "raw-string"]
 
     with sp() as pw:
-        browser = pw.chromium.launch(headless=True, args=_BROWSER_ARGS)
+        browser = _launch(pw)
         try:
             for path in ["/", "/#settings", "/#sessions"]:
                 ctx = browser.new_context(viewport={"width": 1280, "height": 720})
@@ -99,7 +105,7 @@ def test_default_scope_vs_full_body():
     """Scoping to main.main excludes collapsed rightpanel noise; body scope catches it."""
     sp = _require_playwright()
     with sp() as pw:
-        browser = pw.chromium.launch(headless=True, args=_BROWSER_ARGS)
+        browser = _launch(pw)
         try:
             page = browser.new_page(viewport={"width": 1280, "height": 720})
             page.set_content(_SCOPE_FIXTURE_HTML)
@@ -114,7 +120,7 @@ def test_injected_overlap_detected():
     """A flex row where a nowrap label's negative margin pulls it over its sibling's box."""
     sp = _require_playwright()
     with sp() as pw:
-        browser = pw.chromium.launch(headless=True, args=_BROWSER_ARGS)
+        browser = _launch(pw)
         try:
             page = browser.new_page(viewport={"width": 320, "height": 200})
             page.set_content(_OVERLAP_FIXTURE_HTML)
@@ -129,7 +135,7 @@ def test_raw_i18n_key_detected():
     """A raw snake_case i18n key rendered as text should fail the raw-string check."""
     sp = _require_playwright()
     with sp() as pw:
-        browser = pw.chromium.launch(headless=True, args=_BROWSER_ARGS)
+        browser = _launch(pw)
         try:
             page = browser.new_page(viewport={"width": 320, "height": 200})
             page.set_content(_RAW_STRING_FIXTURE_HTML)

--- a/tests/test_session_action_menu_focus.py
+++ b/tests/test_session_action_menu_focus.py
@@ -129,8 +129,11 @@ def test_session_action_menu_focus_lifecycle_in_browser():
     except Exception:  # pragma: no cover - dependency missing path
         pytest.skip("playwright is unavailable; run the session action menu browser test")
 
+    from tests._playwright_utils import launch_chromium_or_skip
+
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(
+        browser = launch_chromium_or_skip(
+            playwright,
             headless=True,
             args=["--no-sandbox", "--disable-dev-shm-usage"],
         )
@@ -161,8 +164,11 @@ def test_session_action_menu_returns_to_prior_focus_for_nonfocusable_opener_in_b
     except Exception:  # pragma: no cover - dependency missing path
         pytest.skip("playwright is unavailable; run the session action menu browser test")
 
+    from tests._playwright_utils import launch_chromium_or_skip
+
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(
+        browser = launch_chromium_or_skip(
+            playwright,
             headless=True,
             args=["--no-sandbox", "--disable-dev-shm-usage"],
         )


### PR DESCRIPTION
## Summary

Makes environment-sensitive tests distinguish a missing hard prerequisite from a product failure, while preserving every real assertion when the prerequisite is available.

### Playwright browser availability

- Adds a shared `launch_chromium_or_skip()` helper.
- Skips only when Chromium launch reports the browser executable is not installed.
- Re-raises every other launch error unchanged, so assertion, runtime, and browser regressions still fail.
- Applies the helper to the seven affected browser tests.

### Git worktree availability

- Probes `git rev-parse --is-inside-work-tree` before the four `.gitignore` policy tests.
- Skips only when the checkout does not expose usable Git metadata, such as a bubblewrap bind mount whose worktree `.git` pointer cannot reach the parent repository.
- Keeps all `git check-ignore` assertions unchanged when Git is available.

### Hermetic logic/isolation tests

- Pins every home-source environment variable in the issue #609 traversal tests, so their outside paths are genuinely outside both the boot workspace and home even when a sandbox sets `HOME=/tmp`.
- Makes the LM Studio keyless full-status test independent of leaked `HERMES_CONFIG_PATH` / `api.config` path-tracking state and restores the shared config globals afterward.

No application code or production behavior changes.

## Verification

### Constrained sandbox

```text
5 passed, 11 skipped, 0 failed
```

The eleven skips are exactly the seven missing-Chromium tests and four unavailable-Git-metadata tests. The issue #609 assertions execute and pass.

### Normal targeted runs

```text
21 passed  # tests/test_issue609.py + tests/test_issue1499_keyless_onboarding.py
11 passed  # browser/git test files with normal local prerequisites
```

### Real five-shard suite split

```text
shard 0: 2714 passed, 4 skipped, 2 unrelated no-network failures
shard 1: 2650 passed, 4 skipped
shard 2: 2692 passed, 2 skipped, 2 unrelated no-network failures
shard 3: 2598 passed, 2 skipped
shard 4: 2783 passed, 3 skipped
```

The four remaining failures are the established no-network Nous catalog/picker/config cases and reproduce independently of this patch. The keyless full-status test passes in its real shard ordering.

Additional checks:
- Static threat scan: CLEAN
- Ruff forward-diff gate: CLEAN, zero findings on changed lines
- `py_compile`: CLEAN
- `git diff --check`: CLEAN
- No assertions or `pytest.raises` checks removed
