### PR TITLE
fix: preserve timing and seal tool rows on terminal error (#6309)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -567,6 +567,14 @@ def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, mode
             error_classification["type"],
             error_classification.get("hint", ""),
         )
+        # Freeze turn duration before terminal cleanup clears pending_started_at (#6309)
+        _turn_duration_seconds = 0.0
+        try:
+            _pending_ts = getattr(session, 'pending_started_at', None)
+            if _pending_ts:
+                _turn_duration_seconds = max(0.0, time.time() - float(_pending_ts))
+        except Exception:
+            pass
         _materialize_pending_user_turn_before_error(session)
         session.active_stream_id = None
         session.pending_user_message = None
@@ -585,6 +593,7 @@ def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, mode
             ) + (f"\n\n*{error_payload['hint']}*" if error_payload.get("hint") else ""),
             "timestamp": int(time.time()),
             "_error": True,
+            "_turnDuration": round(_turn_duration_seconds, 3),
         }
         if error_payload.get("details"):
             error_message["provider_details"] = error_payload["details"]

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -6445,6 +6445,15 @@ def _snapshot_and_append_partial_on_error(session, stream_id) -> dict | None:
             if _live_tools is not live_tool_calls:
                 _snap_tool_calls = list(_live_tools.get(stream_id, []) or [])
 
+    # Seal projected live tool rows so the durable scene cannot disagree with
+    # the settled terminal state (#6309). Any tool call that was still running
+    # at error time is marked as completed with the terminal-error metadata.
+    if _snap_tool_calls:
+        for _tc in _snap_tool_calls:
+            if isinstance(_tc, dict) and not _tc.get('done'):
+                _tc['done'] = True
+                _tc['_sealed_by_terminal_error'] = True
+
     _partial_msg = _build_partial_message(_snap_partial_text, _snap_reasoning, _snap_tool_calls)
     if _partial_msg is None:
         return None
@@ -9449,6 +9458,14 @@ def _run_agent_streaming(
                                     + 'send a message, switch the model/provider, or fix the credentials.'
                                 )
                                 _error_payload['hint'] = _err_hint
+                        # Freeze turn duration before terminal cleanup clears pending_started_at (#6309)
+                        _turn_duration_seconds = 0.0
+                        try:
+                            _pending_ts = getattr(s, 'pending_started_at', None)
+                            if _pending_ts:
+                                _turn_duration_seconds = max(0.0, time.time() - float(_pending_ts))
+                        except Exception:
+                            pass
                         _materialize_pending_user_turn_before_error(s)
                         s.active_stream_id = None
                         s.pending_user_message = None
@@ -9468,6 +9485,7 @@ def _run_agent_streaming(
                             'content': _error_content,
                             'timestamp': int(time.time()),
                             '_error': True,
+                            '_turnDuration': round(_turn_duration_seconds, 3),
                         }
                         if _err_type == 'compression_exhausted':
                             _recovery = stamp_compression_exhausted_recovery(
@@ -10672,6 +10690,14 @@ def _run_agent_streaming(
                             + 'send a message, switch the model/provider, or fix the credentials.'
                         )
                         _error_payload['hint'] = _exc_hint
+                # Freeze turn duration before terminal cleanup clears pending_started_at (#6309)
+                _turn_duration_seconds = 0.0
+                try:
+                    _pending_ts = getattr(s, 'pending_started_at', None)
+                    if _pending_ts:
+                        _turn_duration_seconds = max(0.0, time.time() - float(_pending_ts))
+                except Exception:
+                    pass
                 _materialize_pending_user_turn_before_error(s)
                 s.active_stream_id = None
                 s.pending_user_message = None
@@ -10687,6 +10713,7 @@ def _run_agent_streaming(
                     'content': f'**{_exc_label}:** {_error_payload.get("message") or err_str}' + (f'\n\n*{_exc_hint}*' if _exc_hint else ''),
                     'timestamp': int(time.time()),
                     '_error': True,
+                    '_turnDuration': round(_turn_duration_seconds, 3),
                 }
                 if _exc_type == 'compression_exhausted':
                     _recovery = stamp_compression_exhausted_recovery(

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -618,8 +618,9 @@ def test_gateway_chat_worker_persists_reasoning_and_tool_state_on_terminal_error
     assert partial_message["_partial_tool_calls"] == [{
         "name": "terminal",
         "args": {},
-        "done": False,
+        "done": True,
         "tid": "call-1",
+        "_sealed_by_terminal_error": True,
     }]
     apperrors = [item[1] for item in events if item[0] == "apperror"]
     assert apperrors[-1]["session"]["messages"][-2]["reasoning"] == "Preview reasoning"


### PR DESCRIPTION
Fixes #6309

## Changes
- **In-stream error path**: freeze `_turn_duration_seconds` before clearing `pending_started_at` in `api/streaming.py`
- **Outer error path**: same pattern in the outer `except Exception` handler
- **`_snapshot_and_append_partial_on_error`**: seal tool calls as `done: True` with `_sealed_by_terminal_error: True` metadata
- **`_settle_gateway_terminal_error`**: freeze turn duration before terminal cleanup
- **Test update**: change `done: False` to `done: True` and add `_sealed_by_terminal_error: True` assertion in `test_webui_gateway_chat_backend.py`

## Problem
When a terminal error occurs during streaming, the system would clear `pending_started_at` before capturing the turn duration, resulting in lost timing information. Additionally, tool calls in partial messages were left as `done: False`, creating disagreement between the durable scene and the settled terminal state.

## Verification
- Turn duration is now frozen before cleanup occurs
- Tool call rows are sealed as completed on terminal errors
- Updated test reflects the new expected behavior