### PR TITLE
fix(#6303): preserve Worklog identity on reattach via INFLIGHT anchor fallback

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2623,7 +2623,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const _anchorRegistryMap=(typeof window!=='undefined')
     ? (window._liveAnchorRegistries=window._liveAnchorRegistries||new Map())
     : null;
-  const _existingAnchorRegistry=_anchorRegistryMap?_anchorRegistryMap.get(streamId):null;
+  // #6303: Preserve Worklog identity across reattach. When _liveAnchorRegistries
+  // is cleared (e.g. by sidebar cancelSessionStream() or an explicit cleanup
+  // during session switch), INFLIGHT[activeSid]._liveAnchorRegistry survives as
+  // a durable fallback so the same Anchor registry instance and its local
+  // identities are reused rather than recreated.
+  const _inflightCachedAnchor=INFLIGHT[activeSid]&&INFLIGHT[activeSid]._liveAnchorRegistry||null;
+  const _existingAnchorRegistry=(_anchorRegistryMap?_anchorRegistryMap.get(streamId):null)
+    || (_inflightCachedAnchor&&_inflightCachedAnchor._stream_id===streamId?_inflightCachedAnchor:null);
   const _anchorRegistry=_existingAnchorRegistry||(_anchorApi&&typeof _anchorApi.createAssistantTurnAnchorRegistry==='function'
     ? _anchorApi.createAssistantTurnAnchorRegistry({
       session_id:activeSid,
@@ -2634,11 +2641,20 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _anchorShadowWarned=false;
   let _anchorReasoningFlushed=false;
   let _anchorLocalSeq=0;
-  if(_anchorRegistryMap&&_anchorRegistry) _anchorRegistryMap.set(streamId,_anchorRegistry);
+  if(_anchorRegistryMap&&_anchorRegistry){
+    _anchorRegistryMap.set(streamId,_anchorRegistry);
+    if(!_anchorRegistry._stream_id) _anchorRegistry._stream_id=streamId;
+  }
+  // #6303: Persist the live Anchor registry reference in INFLIGHT so it survives
+  // cleanup of window._liveAnchorRegistries during session switch/reattach.
+  if(_anchorRegistry&&INFLIGHT[activeSid]) INFLIGHT[activeSid]._liveAnchorRegistry=_anchorRegistry;
   function _scheduleAnchorRegistryCleanup(delayMs=600000){
     if(!_anchorRegistryMap||!_anchorRegistry) return;
     setTimeout(()=>{
       if(_anchorRegistryMap.get(streamId)===_anchorRegistry) _anchorRegistryMap.delete(streamId);
+      // #6303: Also remove from INFLIGHT when the Anchor registry is expired
+      // from the window-level Map so we don't hold a stale reference.
+      if(INFLIGHT[activeSid]&&INFLIGHT[activeSid]._liveAnchorRegistry===_anchorRegistry) delete INFLIGHT[activeSid]._liveAnchorRegistry;
     },delayMs);
   }
   // Backstop: schedule an identity-guarded cleanup at creation so this shadow


### PR DESCRIPTION
Closes #6303

## Problem

When switching away from an actively streaming session and returning, the Compact Worklog can rebuild with different row identities or ordering. This happens because `window._liveAnchorRegistries` — the browser-only Map that caches anchor registry instances — can be cleaned up during session switch, sidebar operations like `cancelSessionStream()`, or explicit cache clearing. When the lookup on reattach fails, a brand-new anchor registry is created with fresh local identities.

## Root Cause

In `attachLiveStream()`, the anchor registry lookup is:

```js
const _existingAnchorRegistry = _anchorRegistryMap
  ? _anchorRegistryMap.get(streamId)
  : null;
```

This only checks `window._liveAnchorRegistries`. If that Map entry was deleted (scheduled cleanup, sidebar cancel, cache clearing for reproduction), a new registry is created even though the same stream is being reattached.

## Fix

Three-part change in `static/messages.js` (`attachLiveStream` closure):

1. **Fallback lookup**: Before Map lookup, check `INFLIGHT[activeSid]._liveAnchorRegistry` as a durable fallback. The INFLIGHT object survives session switches (in-memory), so the anchor registry reference persists even when `_liveAnchorRegistries` is cleared.

2. **Persist reference**: After the anchor registry is created/found, store it in `INFLIGHT[activeSid]._liveAnchorRegistry`. Also tag the registry with `_stream_id` for identity verification on reattach.

3. **Mirror cleanup**: When `_scheduleAnchorRegistryCleanup` removes from the Map, also remove the INFLIGHT reference so we don't hold a stale registry.

The `_liveAnchorRegistry` reference is NOT serialized to sessionStorage (`_compactInflightState` explicitly enumerates allowed properties), so it only survives during the same page lifecycle — matching the existing contract where hard reloads rebuild from server-side data.

## Verification

- `./scripts/test.sh tests/test_stable_assistant_turn_anchor_registry.py` — 22 passed
- `./scripts/test.sh tests/test_live_to_final_anchor_visible_order.py tests/test_issue5720_reasoning_owner.py tests/test_issue3040_reattach_invariant.py tests/test_inflight_stream_reuse.py` — 123 passed
- `./scripts/test.sh tests/test_inflight_purge_missing_sessions.py tests/test_session_runtime_ownership_invariants.py tests/test_run_journal_frontend_static.py` — 20 passed

## Files Changed

- `static/messages.js`: 18 insertions, 2 deletions

## Release Note

Anchor registry identity now survives session switch via an INFLIGHT fallback, preventing duplicated Thinking text and misordered Worklog rows when returning to an active session.