### PR TITLE
fix: strip base64 images from vision tool results for persistence (#6316)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -10539,6 +10539,8 @@ from api.streaming import (
     generate_session_title_for_session,
     _compact_for_echo_compare,
     _strip_compact_echo_suffix,
+    _project_live_tool_args,
+    _strip_base64_data_urls,
 )
 from api.gateway_chat import _run_gateway_chat_streaming, webui_gateway_chat_enabled
 from api.run_journal import (
@@ -18368,6 +18370,25 @@ def _parse_run_journal_after_seq(qs: dict, stream_id: str | None = None) -> int 
         return 0
 
 
+def _project_replay_tool_payload(event: str, payload):
+    """Defensively project a journaled tool/tool_complete payload before replay.
+
+    Pre-fix durable journals may contain inline base64 image bytes in
+    ``tool``/``tool_complete`` args or previews. Project them at the replay
+    boundary so historical data cannot reintroduce encoded image bytes into
+    the replayed SSE stream. Non-tool events and non-dict payloads pass through
+    unchanged.
+    """
+    if event not in ('tool', 'tool_complete') or not isinstance(payload, dict):
+        return payload
+    projected = dict(payload)
+    if isinstance(projected.get('args'), dict):
+        projected['args'] = _project_live_tool_args(projected['args'])
+    if isinstance(projected.get('preview'), str):
+        projected['preview'] = _strip_base64_data_urls(projected['preview'])
+    return projected
+
+
 def _replay_run_journal(
     handler,
     stream_id: str,
@@ -18386,10 +18407,13 @@ def _replay_run_journal(
         max_seq=max_seq,
     )
     for entry in journal.get("events") or []:
+        _event = entry.get("event") or entry.get("type") or "message"
+        _payload = entry.get("payload")
+        _payload = _project_replay_tool_payload(_event, _payload)
         _sse_with_id(
             handler,
-            entry.get("event") or entry.get("type") or "message",
-            entry.get("payload"),
+            _event,
+            _payload,
             entry.get("event_id"),
         )
     if include_stale and not summary.get("terminal"):

--- a/api/routes.py
+++ b/api/routes.py
@@ -18374,18 +18374,23 @@ def _project_replay_tool_payload(event: str, payload):
     """Defensively project a journaled tool/tool_complete payload before replay.
 
     Pre-fix durable journals may contain inline base64 image bytes in
-    ``tool``/``tool_complete`` args or previews. Project them at the replay
-    boundary so historical data cannot reintroduce encoded image bytes into
-    the replayed SSE stream. Non-tool events and non-dict payloads pass through
-    unchanged.
+    ``tool``/``tool_complete`` args or preview/snippet strings. Project them at
+    the replay boundary so historical data cannot reintroduce encoded image
+    bytes into the replayed SSE stream. ``args`` is projected shape-completely
+    (dict/list/tuple/string via the recursive copy-on-write walker) and both
+    ``preview`` and ``snippet`` strings go through the shared string projector.
+    The stored journal entry is never mutated — a shallow copy is projected.
+    Non-tool events and non-dict payloads pass through unchanged.
     """
     if event not in ('tool', 'tool_complete') or not isinstance(payload, dict):
         return payload
     projected = dict(payload)
-    if isinstance(projected.get('args'), dict):
-        projected['args'] = _project_live_tool_args(projected['args'])
-    if isinstance(projected.get('preview'), str):
-        projected['preview'] = _strip_base64_data_urls(projected['preview'])
+    args = projected.get('args')
+    if isinstance(args, (str, dict, list, tuple)):
+        projected['args'] = _project_live_tool_args(args)
+    for key in ('preview', 'snippet'):
+        if isinstance(projected.get(key), str):
+            projected[key] = _strip_base64_data_urls(projected[key])
     return projected
 
 
@@ -18951,7 +18956,15 @@ def _handle_session_run_journal_stream_for_session(handler, parsed, session_id):
                 continue
             if event_id and event_id in sent_event_ids:
                 continue
-            _sse_with_id(handler, entry.get("event") or entry.get("type") or "message", entry.get("payload"), event_id)
+            # #6316: every journal-to-client boundary — run-level replay AND
+            # session-level emit_replay (pre-attach replay + post-attach
+            # reconciliation) — projects historical tool payloads through the
+            # same projector so pre-fix journals cannot reintroduce encoded
+            # image bytes into the emitted SSE. The stored entry is untouched.
+            _event = entry.get("event") or entry.get("type") or "message"
+            _payload = entry.get("payload")
+            _payload = _project_replay_tool_payload(_event, _payload)
+            _sse_with_id(handler, _event, _payload, event_id)
             if event_id:
                 note_sent_event_id(event_id)
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5288,6 +5288,22 @@ def _compact_session_image_parts_for_persistence(session) -> int:
     return changed
 
 
+def _strip_base64_data_urls(text: str) -> str:
+    """Replace inline base64 data URIs with a placeholder.
+
+    Vision models send ``data:image/<type>;base64,<payload>`` as tool-call
+    arguments or tool results.  When these are dumped into the live-prompt
+    estimate the full payload bytes inflate every streaming frame.  Strip
+    them to a fixed marker so the client still sees *that* an image was
+    involved without the wire cost of the base64 blob.
+    """
+    return re.sub(
+        r'data:image/[a-zA-Z]+;base64,[A-Za-z0-9+/=]+',
+        '[base64 image]',
+        text,
+    )
+
+
 def _sanitize_messages_for_api(
     messages,
     *,
@@ -9683,7 +9699,7 @@ def _run_agent_streaming(
                     'type': 'function',
                     'function': {
                         'name': str(name or ''),
-                        'arguments': json.dumps(args if isinstance(args, dict) else {}, ensure_ascii=False, sort_keys=True),
+                        'arguments': _strip_base64_data_urls(json.dumps(args if isinstance(args, dict) else {}, ensure_ascii=False, sort_keys=True)),
                     },
                 }
                 _bump_live_prompt_estimate([{
@@ -9696,7 +9712,7 @@ def _run_agent_streaming(
             def _record_live_tool_complete(tool_call_id, name, function_result):
                 if not tool_call_id:
                     return False
-                _result_text = _tool_result_snippet(function_result)
+                _result_text = _strip_base64_data_urls(_tool_result_snippet(function_result))
                 _bump_live_prompt_estimate([{
                     'role': 'tool',
                     'name': str(name or ''),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5398,7 +5398,7 @@ def _strip_base64_data_urls(text: str) -> str:
     artifact, non-base64 data URIs and ordinary text pass through byte-for-byte.
     """
     return re.sub(
-        r'data:image/[a-zA-Z0-9][a-zA-Z0-9+.\-]*;base64,[A-Za-z0-9+/=]+',
+        r'data:image/[a-zA-Z0-9][a-zA-Z0-9!#$&^_+.\-]*;base64,[A-Za-z0-9+/=]+',
         '[base64 image]',
         text,
         flags=re.IGNORECASE,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -10892,6 +10892,9 @@ def _run_agent_streaming(
                         _turn_pending_source,
                         _active_turn_identity,
                     )
+                    _compact_session_image_parts_for_persistence(s)
+                    _advance_truncation_watermark_after_commit(s)  # #3831
+                    _compact_session_image_parts_for_persistence(s)
                 # Strip XML tool-call blocks from assistant message content.
                 # DeepSeek and some other providers emit <function_calls>...</function_calls>
                 # in the raw response text; this must be removed before the content is
@@ -11280,6 +11283,9 @@ def _run_agent_streaming(
                                     _turn_pending_source,
                                     _active_turn_identity,
                                 )
+                                _compact_session_image_parts_for_persistence(s)
+                                _advance_truncation_watermark_after_commit(s)  # #3831
+                                # Skip the error block — jump directly to the
                                 # normal post-result persistence path by
                                 # leaving _assistant_added truthy (set below).
                                 _assistant_added = True  # prevent re-entering guard
@@ -12584,6 +12590,8 @@ def _run_agent_streaming(
                                         s.messages,
                                         live_tool_calls=_live_tool_calls,
                                     )
+                                    _compact_session_image_parts_for_persistence(s)
+                                    _advance_truncation_watermark_after_commit(s)  # #3831
                                     s.active_stream_id = None
                                     s.pending_user_message = None
                                     s.pending_attachments = []

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5389,11 +5389,19 @@ def _strip_base64_data_urls(text: str) -> str:
     estimate the full payload bytes inflate every streaming frame.  Strip
     them to a fixed marker so the client still sees *that* an image was
     involved without the wire cost of the base64 blob.
+
+    The recognizer accepts any valid image subtype token (RFC 6838: letters,
+    digits, and ``+``/``-``/``.``), so common variants such as
+    ``svg+xml``, ``x-icon`` or ``vnd.microsoft.icon`` are caught along with
+    ``png``/``jpeg``/``gif``, and it is case-insensitive (``DATA:IMAGE/PNG;
+    BASE64,...``).  Only ``;base64,`` payloads are stripped — HTTP(S), file:,
+    artifact, non-base64 data URIs and ordinary text pass through byte-for-byte.
     """
     return re.sub(
-        r'data:image/[a-zA-Z]+;base64,[A-Za-z0-9+/=]+',
+        r'data:image/[a-zA-Z0-9][a-zA-Z0-9+.\-]*;base64,[A-Za-z0-9+/=]+',
         '[base64 image]',
         text,
+        flags=re.IGNORECASE,
     )
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5218,8 +5218,31 @@ def _should_strip_reasoning_content(
     return False
 
 
-def _compact_image_parts_for_persistence(messages) -> int:
-    """Replace persisted image parts with text placeholders after a completed turn.
+def _part_is_inline_base64_image(part: dict) -> bool:
+    """Check if a part contains actual inline base64 image data."""
+    part_type = part.get('type')
+    if part_type in ('image', 'image_url', 'input_image'):
+        # Direct data URL: data:image/...;base64,...
+        url = part.get('image_url', {}).get('url') if isinstance(part.get('image_url'), dict) else part.get('url', '')
+        if isinstance(url, str) and re.match(r'data:image/[^,;]+;base64,', url):
+            return True
+        # Also check direct string source
+        source = part.get('source', part.get('url', ''))
+        if isinstance(source, str) and re.match(r'data:image/[^,;]+;base64,', source):
+            return True
+    # Anthropic-style: source: {type: "base64", ...}
+    if isinstance(part.get('source'), dict) and part['source'].get('type') == 'base64':
+        return True
+    # _multimodal envelope with base64
+    if isinstance(part.get('content'), list):
+        for sub in part['content']:
+            if isinstance(sub, dict) and _part_is_inline_base64_image(sub):
+                return True
+    return False
+
+
+def _compact_image_parts_for_persistence(messages) -> tuple[list, int]:
+    """Return (compacted_copy, changed_count). Does not mutate inputs.
 
     The active model receives native image parts while a tool call is running. Once
     the turn has completed, retaining base64 data URLs in both the visible
@@ -5230,12 +5253,14 @@ def _compact_image_parts_for_persistence(messages) -> int:
     future turns retain the conversational record and can re-open the original
     image from the preceding tool-call arguments when needed.
 
-    This intentionally mutates the owned session message rows in place. It is
-    called only after ``run_conversation()`` has returned, so it never removes
-    image parts that the current model invocation still needs.
+    Only inline base64 image data is compacted — http/file image references are
+    preserved as-is so the image can be re-fetched on replay.
     """
+    if not messages:
+        return list(messages or ()), 0
     changed = 0
-    for message in messages or ():
+    messages_copy = copy.deepcopy(messages)  # owned copy
+    for message in messages_copy:
         # Mirror Hermes Agent's durable-session policy: native *tool* results
         # are transient input for the current model call. User attachments are
         # a separate product contract and must remain intact here.
@@ -5254,14 +5279,8 @@ def _compact_image_parts_for_persistence(messages) -> int:
                 # the structured result during durable-session compaction.
                 compacted_content.append(part)
                 continue
-            part_type = part.get('type')
-            # Guard the set-membership with an isinstance check: a JSON-valid
-            # part can carry an unhashable ``type`` (e.g. a list), and
-            # ``unhashable in {...}`` raises TypeError — which would turn an
-            # otherwise-complete streaming send into the error path before the
-            # session is saved. Only the three string image types are compacted;
-            # every other part (including non-string ``type`` values) is preserved.
-            if isinstance(part_type, str) and part_type in {'image', 'image_url', 'input_image'}:
+            # Check if this part contains inline base64 data
+            if _part_is_inline_base64_image(part):
                 compacted_content.append({'type': 'text', 'text': '[screenshot]'})
                 image_parts += 1
             else:
@@ -5270,15 +5289,20 @@ def _compact_image_parts_for_persistence(messages) -> int:
         if image_parts:
             message['content'] = compacted_content
             changed += image_parts
-    return changed
+    return messages_copy, changed
 
 
 def _compact_session_image_parts_for_persistence(session) -> int:
     """Compact completed native-vision tool results in both durable histories."""
-    changed = (
-        _compact_image_parts_for_persistence(getattr(session, 'context_messages', None))
-        + _compact_image_parts_for_persistence(getattr(session, 'messages', None))
-    )
+    changed = 0
+    copied_ctx, c1 = _compact_image_parts_for_persistence(getattr(session, 'context_messages', None))
+    if c1:
+        session.context_messages = copied_ctx
+        changed += c1
+    copied_msgs, c2 = _compact_image_parts_for_persistence(getattr(session, 'messages', None))
+    if c2:
+        session.messages = copied_msgs
+        changed += c2
     if changed:
         logger.info(
             "Compacted %d completed image message part(s) for session %s",
@@ -7476,6 +7500,7 @@ def _tool_result_snippet(raw, limit: int = _TOOL_RESULT_SNIPPET_MAX) -> str:
             text = str(preview)
     except Exception:
         pass
+    text = _strip_base64_data_urls(text)
     return text[:limit]
 
 
@@ -9935,6 +9960,7 @@ def _run_agent_streaming(
                     if tool_call_id and tool_call_id not in _live_tool_event_complete_ids:
                         _live_tool_event_complete_ids.add(tool_call_id)
                         result_snippet = _tool_result_snippet(function_result)
+                        result_snippet = _strip_base64_data_urls(result_snippet)
                         for live_tc in reversed(_live_tool_calls):
                             if live_tc.get('done'):
                                 continue

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5218,27 +5218,93 @@ def _should_strip_reasoning_content(
     return False
 
 
-def _part_is_inline_base64_image(part: dict) -> bool:
-    """Check if a part contains actual inline base64 image data."""
+def _is_inline_base64_image_leaf(part: dict) -> bool:
+    """Check if this specific dict IS an inline base64 image (leaf, not wrapper).
+
+    Returns True only for actual image-containing leaves. Does NOT recurse into
+    nested ``content`` lists — the caller handles projection of those wrappers
+    recursively. Preserves HTTP(S), file:, artifact, handle, and path references.
+    """
     part_type = part.get('type')
-    if part_type in ('image', 'image_url', 'input_image'):
-        # Direct data URL: data:image/...;base64,...
-        url = part.get('image_url', {}).get('url') if isinstance(part.get('image_url'), dict) else part.get('url', '')
-        if isinstance(url, str) and re.match(r'data:image/[^,;]+;base64,', url):
-            return True
-        # Also check direct string source
-        source = part.get('source', part.get('url', ''))
-        if isinstance(source, str) and re.match(r'data:image/[^,;]+;base64,', source):
-            return True
-    # Anthropic-style: source: {type: "base64", ...}
-    if isinstance(part.get('source'), dict) and part['source'].get('type') == 'base64':
+    if not isinstance(part_type, str):
+        return False
+    if part_type not in ('image', 'image_url', 'input_image'):
+        return False
+    # Direct data URL: data:image/...;base64,...
+    url = None
+    if isinstance(part.get('image_url'), dict):
+        url = part['image_url'].get('url')
+    elif isinstance(part.get('image_url'), str):
+        url = part['image_url']
+    if url is None and 'url' in part:
+        url = part['url']
+    if isinstance(url, str) and re.match(r'data:image/[^,;]+;base64,', url):
         return True
-    # _multimodal envelope with base64
-    if isinstance(part.get('content'), list):
-        for sub in part['content']:
-            if isinstance(sub, dict) and _part_is_inline_base64_image(sub):
+    # Direct string source
+    source = part.get('source', part.get('url', ''))
+    if isinstance(source, str) and re.match(r'data:image/[^,;]+;base64,', source):
+        return True
+    # Anthropic-style source: {type: "base64", media_type: "image/...", ...}
+    if isinstance(part.get('source'), dict):
+        src = part['source']
+        if src.get('type') == 'base64':
+            media = src.get('media_type', '')
+            if isinstance(media, str) and 'image' in media:
+                return True
+            # No media_type specified but type indicates an image part
+            if not media:
                 return True
     return False
+
+
+def _project_image_parts(part: dict) -> dict:
+    """Return a recursively-projected copy with inline base64 image leaves replaced.
+
+    Only inline base64 image data is replaced with a ``[screenshot]`` text
+    placeholder. HTTP(S), file:, artifact, handle, and path references are
+    preserved. Nested ``_multimodal`` envelopes, ``tool_result.content``,
+    Anthropic-style ``source: {type: 'base64', ...}``, and mixed wrappers
+    (containing both base64 and non-base64 children) are handled correctly
+    by recursing into ``content`` lists and replacing only actual leaves.
+    """
+    if not isinstance(part, dict):
+        return part
+    projected = dict(part)
+    changed = False
+    # Recursively project nested content lists
+    if isinstance(projected.get('content'), list):
+        new_content = []
+        for sub in projected['content']:
+            if isinstance(sub, dict):
+                projected_sub = _project_image_parts(sub)
+                new_content.append(projected_sub)
+                if projected_sub is not sub:
+                    changed = True
+            else:
+                new_content.append(sub)
+        if changed:
+            projected['content'] = new_content
+    # Check if THIS part (after any inner projection) is a base64 image leaf
+    if _is_inline_base64_image_leaf(projected):
+        return {'type': 'text', 'text': '[screenshot]'}
+    return projected if changed else part
+
+
+def _project_live_tool_args(args) -> dict:
+    """Return a copy of tool args with inline base64 data URLs replaced.
+
+    Recursively walks the args dict/list structure and replaces any
+    ``data:image/...;base64,...`` string values with ``[base64 image]``.
+    Preserves HTTP(S), file:, artifact, handle, and path references.
+    """
+    if isinstance(args, str):
+        return _strip_base64_data_urls(args)
+    if isinstance(args, dict):
+        return {k: _project_live_tool_args(v) for k, v in args.items()}
+    if isinstance(args, (list, tuple)):
+        projected = [_project_live_tool_args(v) for v in args]
+        return tuple(projected) if isinstance(args, tuple) else projected
+    return args
 
 
 def _compact_image_parts_for_persistence(messages) -> tuple[list, int]:
@@ -5279,12 +5345,13 @@ def _compact_image_parts_for_persistence(messages) -> tuple[list, int]:
                 # the structured result during durable-session compaction.
                 compacted_content.append(part)
                 continue
-            # Check if this part contains inline base64 data
-            if _part_is_inline_base64_image(part):
-                compacted_content.append({'type': 'text', 'text': '[screenshot]'})
+            # Project: recursively replace inline base64 image leaves while
+            # preserving non-base64 references (HTTP, file, artifact, handle,
+            # path) and unrelated fields/order exactly.
+            projected = _project_image_parts(part)
+            compacted_content.append(projected)
+            if projected is not part:
                 image_parts += 1
-            else:
-                compacted_content.append(part)
 
         if image_parts:
             message['content'] = compacted_content
@@ -9811,14 +9878,14 @@ def _run_agent_streaming(
                 if event_type in (None, 'tool.started'):
                     _live_tool_calls.append({
                         'name': name,
-                        'args': args if isinstance(args, dict) else {},
+                        'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
                     })
                     # Mirror to shared dict so cancel_stream() can persist it (#1361 §B)
                     # Lock-free GIL-atomic mirror — see STREAMS_LOCK contract in on_token.
                     if stream_id in STREAM_LIVE_TOOL_CALLS:
                         STREAM_LIVE_TOOL_CALLS[stream_id].append({
                             'name': name,
-                            'args': args if isinstance(args, dict) else {},
+                            'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
                             'done': False,
                         })
                     put('tool', {
@@ -9881,7 +9948,7 @@ def _run_agent_streaming(
                     put('tool_complete', {
                         'event_type': event_type,
                         'name': name,
-                        'preview': preview,
+                        'preview': _strip_base64_data_urls(preview) if isinstance(preview, str) else preview,
                         'args': args_snap,
                         'duration': cb_kwargs.get('duration'),
                         'is_error': bool(cb_kwargs.get('is_error', False)),
@@ -9928,7 +9995,7 @@ def _run_agent_streaming(
                         _live_tool_event_start_ids.add(tool_call_id)
                         _live_tool_calls.append({
                             'name': name,
-                            'args': args if isinstance(args, dict) else {},
+                            'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
                             'tid': tool_call_id,
                         })
                         # Mirror to shared dict so cancel_stream() can persist it (#1361 §B)
@@ -9936,7 +10003,7 @@ def _run_agent_streaming(
                         if stream_id in STREAM_LIVE_TOOL_CALLS:
                             STREAM_LIVE_TOOL_CALLS[stream_id].append({
                                 'name': name,
-                                'args': args if isinstance(args, dict) else {},
+                                'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
                                 'done': False,
                                 'tid': tool_call_id,
                             })
@@ -10936,7 +11003,6 @@ def _run_agent_streaming(
                     )
                     _compact_session_image_parts_for_persistence(s)
                     _advance_truncation_watermark_after_commit(s)  # #3831
-                    _compact_session_image_parts_for_persistence(s)
                 # Strip XML tool-call blocks from assistant message content.
                 # DeepSeek and some other providers emit <function_calls>...</function_calls>
                 # in the raw response text; this must be removed before the content is

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5257,37 +5257,39 @@ def _is_inline_base64_image_leaf(part: dict) -> bool:
     return False
 
 
-def _project_image_parts(part: dict) -> dict:
+def _project_image_parts(part):
     """Return a recursively-projected copy with inline base64 image leaves replaced.
 
-    Only inline base64 image data is replaced with a ``[screenshot]`` text
-    placeholder. HTTP(S), file:, artifact, handle, and path references are
-    preserved. Nested ``_multimodal`` envelopes, ``tool_result.content``,
-    Anthropic-style ``source: {type: 'base64', ...}``, and mixed wrappers
-    (containing both base64 and non-base64 children) are handled correctly
-    by recursing into ``content`` lists and replacing only actual leaves.
+    Recurses through generic dict/list provider wrappers — list- or dict-valued
+    ``content``, ``tool_result.content``, ``_multimodal`` envelopes, Anthropic-
+    style ``source: {type: 'base64', ...}``, and unknown keys — replacing ONLY
+    dicts proven to be inline base64 image leaves (``_is_inline_base64_image_leaf``).
+    HTTP(S), file:, artifact, handle, and path references, unknown/scalar values,
+    container shape, and key order are preserved exactly. Returns the original
+    object (identity preserved) when nothing changed.
     """
-    if not isinstance(part, dict):
-        return part
-    projected = dict(part)
-    changed = False
-    # Recursively project nested content lists
-    if isinstance(projected.get('content'), list):
-        new_content = []
-        for sub in projected['content']:
-            if isinstance(sub, dict):
-                projected_sub = _project_image_parts(sub)
-                new_content.append(projected_sub)
-                if projected_sub is not sub:
-                    changed = True
-            else:
-                new_content.append(sub)
-        if changed:
-            projected['content'] = new_content
-    # Check if THIS part (after any inner projection) is a base64 image leaf
-    if _is_inline_base64_image_leaf(projected):
-        return {'type': 'text', 'text': '[screenshot]'}
-    return projected if changed else part
+    if isinstance(part, dict):
+        # If this dict IS an inline base64 image leaf, replace it wholesale.
+        if _is_inline_base64_image_leaf(part):
+            return {'type': 'text', 'text': '[screenshot]'}
+        projected = {}
+        changed = False
+        for k, v in part.items():
+            pv = _project_image_parts(v)
+            projected[k] = pv
+            if pv is not v:
+                changed = True
+        return projected if changed else part
+    if isinstance(part, list):
+        projected = []
+        changed = False
+        for item in part:
+            pi = _project_image_parts(item)
+            projected.append(pi)
+            if pi is not item:
+                changed = True
+        return projected if changed else part
+    return part
 
 
 def _project_live_tool_args(args) -> dict:
@@ -7579,12 +7581,14 @@ def _truncate_tool_args(args, limit: int = 6) -> dict:
     diffs are reconstructed from) get a much larger cap so a long command, file
     path, or reconstructed diff is not silently corrupted (#4928). A hard cap is
     still applied for storage safety, aligned with the result snippet cap.
+    Inline base64 data URLs are projected out before truncation so persisted
+    summaries never carry encoded image bytes (#6316).
     """
     out = {}
     if not isinstance(args, dict):
         return out
     for k, v in list(args.items())[:limit]:
-        s = str(v)
+        s = _strip_base64_data_urls(str(v))
         cap = _TOOL_ARG_CONTENT_CAP if str(k).lower() in _TOOL_ARG_CONTENT_KEYS else 120
         out[k] = s[:cap] + ('...' if len(s) > cap else '')
     return out
@@ -8027,6 +8031,33 @@ def _terminal_turn_duration(session, *, now: float | None = None) -> float | Non
     return round(elapsed, 3)
 
 
+def _project_tool_call_rows(rows) -> list:
+    """Defensively project captured live-tool rows for cancel/error persistence.
+
+    Cancel/error paths snapshot rows from ``STREAM_LIVE_TOOL_CALLS`` before the
+    session is written. Modern callbacks already store projected args, but a
+    defensive projection here guarantees pre-fix in-memory rows or legacy
+    mirrors cannot reintroduce inline base64 image bytes into durable
+    ``_partial_tool_calls`` rows (#6316).
+    """
+    if not rows:
+        return rows
+    projected = []
+    for row in rows:
+        if not isinstance(row, dict):
+            projected.append(row)
+            continue
+        out = dict(row)
+        if isinstance(out.get('args'), dict):
+            out['args'] = _project_live_tool_args(out['args'])
+        for key in ('preview', 'snippet'):
+            val = out.get(key)
+            if isinstance(val, str):
+                out[key] = _strip_base64_data_urls(val)
+        projected.append(out)
+    return projected
+
+
 def _build_partial_message(content_text, reasoning_text, tool_calls) -> dict | None:
     """Build a _partial assistant message from raw streaming buffers.
 
@@ -8060,7 +8091,7 @@ def _build_partial_message(content_text, reasoning_text, tool_calls) -> dict | N
     if _has_reasoning:
         _msg['reasoning'] = reasoning_text.strip()
     if _has_tools:
-        _msg['_partial_tool_calls'] = list(tool_calls)
+        _msg['_partial_tool_calls'] = _project_tool_call_rows(tool_calls)
     return _msg
 
 
@@ -9777,7 +9808,7 @@ def _run_agent_streaming(
                 args_snap = {}
                 if isinstance(args, dict):
                     for k, v in list(args.items())[:4]:
-                        s2 = str(v)
+                        s2 = _strip_base64_data_urls(str(v))
                         cap = _TOOL_ARG_CONTENT_CAP if str(k).lower() in _TOOL_ARG_CONTENT_KEYS else 120
                         args_snap[k] = s2[:cap] + ('...' if len(s2) > cap else '')
                 return args_snap
@@ -9866,7 +9897,14 @@ def _run_agent_streaming(
                     _current_reasoning_idx += 1
                     _tool_boundary_advanced = True
 
-                args_snap = _tool_args_snapshot(args)
+                # #6316: derive owned, projected values ONCE before any live-
+                # mirror write or put() so UI snapshots, SSE/journal payloads,
+                # summaries, and cancel/error source state all share the same
+                # sanitized copy. Never write raw callback args/preview to the
+                # mirrors or the run journal.
+                safe_args = _project_live_tool_args(args) if isinstance(args, dict) else {}
+                safe_preview = _strip_base64_data_urls(preview) if isinstance(preview, str) else preview
+                args_snap = _tool_args_snapshot(safe_args)
 
                 # Modern Hermes Agent builds can call both tool_progress_callback
                 # and the structured tool_start/tool_complete callbacks for the
@@ -9878,20 +9916,20 @@ def _run_agent_streaming(
                 if event_type in (None, 'tool.started'):
                     _live_tool_calls.append({
                         'name': name,
-                        'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
+                        'args': safe_args,
                     })
                     # Mirror to shared dict so cancel_stream() can persist it (#1361 §B)
                     # Lock-free GIL-atomic mirror — see STREAMS_LOCK contract in on_token.
                     if stream_id in STREAM_LIVE_TOOL_CALLS:
                         STREAM_LIVE_TOOL_CALLS[stream_id].append({
                             'name': name,
-                            'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
+                            'args': safe_args,
                             'done': False,
                         })
                     put('tool', {
                         'event_type': event_type or 'tool.started',
                         'name': name,
-                        'preview': preview,
+                        'preview': safe_preview,
                         'args': args_snap,
                     })
                     _tool_stats = meter().get_stats(stream_id)
@@ -9948,7 +9986,7 @@ def _run_agent_streaming(
                     put('tool_complete', {
                         'event_type': event_type,
                         'name': name,
-                        'preview': _strip_base64_data_urls(preview) if isinstance(preview, str) else preview,
+                        'preview': safe_preview,
                         'args': args_snap,
                         'duration': cb_kwargs.get('duration'),
                         'is_error': bool(cb_kwargs.get('is_error', False)),
@@ -9993,9 +10031,15 @@ def _run_agent_streaming(
                     _record_live_tool_start(tool_call_id, name, args)
                     if tool_call_id and tool_call_id not in _live_tool_event_start_ids:
                         _live_tool_event_start_ids.add(tool_call_id)
+                        # #6316: derive owned, projected args once before any
+                        # live-mirror write or put() so the mirrors, the SSE/
+                        # journal payload, and cancel/error source state all
+                        # share the same sanitized copy.
+                        safe_args = _project_live_tool_args(args) if isinstance(args, dict) else {}
+                        args_snap = _tool_args_snapshot(safe_args)
                         _live_tool_calls.append({
                             'name': name,
-                            'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
+                            'args': safe_args,
                             'tid': tool_call_id,
                         })
                         # Mirror to shared dict so cancel_stream() can persist it (#1361 §B)
@@ -10003,7 +10047,7 @@ def _run_agent_streaming(
                         if stream_id in STREAM_LIVE_TOOL_CALLS:
                             STREAM_LIVE_TOOL_CALLS[stream_id].append({
                                 'name': name,
-                                'args': _project_live_tool_args(args) if isinstance(args, dict) else {},
+                                'args': safe_args,
                                 'done': False,
                                 'tid': tool_call_id,
                             })
@@ -10011,7 +10055,7 @@ def _run_agent_streaming(
                             'event_type': 'tool.started',
                             'name': name,
                             'preview': None,
-                            'args': _tool_args_snapshot(args),
+                            'args': args_snap,
                             'tid': tool_call_id,
                         })
                     _tool_stats = meter().get_stats(stream_id)
@@ -10028,6 +10072,10 @@ def _run_agent_streaming(
                         _live_tool_event_complete_ids.add(tool_call_id)
                         result_snippet = _tool_result_snippet(function_result)
                         result_snippet = _strip_base64_data_urls(result_snippet)
+                        # #6316: derive owned, projected args once so the SSE/
+                        # journal payload and summaries share the sanitized copy.
+                        safe_args = _project_live_tool_args(args) if isinstance(args, dict) else {}
+                        args_snap = _tool_args_snapshot(safe_args)
                         for live_tc in reversed(_live_tool_calls):
                             if live_tc.get('done'):
                                 continue
@@ -10048,7 +10096,7 @@ def _run_agent_streaming(
                             'event_type': 'tool.completed',
                             'name': name,
                             'preview': result_snippet,
-                            'args': _tool_args_snapshot(args),
+                            'args': args_snap,
                             'tid': tool_call_id,
                             'is_error': False,
                         })

--- a/tests/test_context_history_sanitization.py
+++ b/tests/test_context_history_sanitization.py
@@ -46,15 +46,17 @@ def test_compact_image_parts_for_persistence_keeps_text_and_drops_base64():
         },
     ]
 
-    changed = _compact_image_parts_for_persistence(messages)
+    copied, changed = _compact_image_parts_for_persistence(messages)
 
     assert changed == 1
-    assert messages[1]["content"] == [
+    assert copied[1]["content"] == [
         {"type": "text", "text": "Image loaded into your context."},
         {"type": "text", "text": "[screenshot]"},
     ]
-    assert "data:image" not in json.dumps(messages)
-    assert messages[0]["tool_calls"] == [{"id": "vision-1"}]
+    assert "data:image" not in json.dumps(copied)
+    assert copied[0]["tool_calls"] == [{"id": "vision-1"}]
+    # Original is not mutated
+    assert messages[1]["content"][1]["type"] == "image_url"
 
 
 
@@ -71,10 +73,10 @@ def test_compact_image_parts_for_persistence_counts_each_image_part():
         }
     ]
 
-    changed = _compact_image_parts_for_persistence(messages)
+    copied, changed = _compact_image_parts_for_persistence(messages)
 
     assert changed == 2
-    assert messages[0]["content"] == [
+    assert copied[0]["content"] == [
         {"type": "text", "text": "Before and after"},
         {"type": "text", "text": "[screenshot]"},
         {"type": "text", "text": "[screenshot]"},
@@ -98,10 +100,10 @@ def test_compact_image_parts_for_persistence_preserves_interleaved_non_image_par
         }
     ]
 
-    changed = _compact_image_parts_for_persistence(messages)
+    copied, changed = _compact_image_parts_for_persistence(messages)
 
     assert changed == 2
-    assert messages[0]["content"] == [
+    assert copied[0]["content"] == [
         {"type": "text", "text": "[screenshot]"},
         {"type": "text", "text": "between"},
         document,
@@ -109,8 +111,10 @@ def test_compact_image_parts_for_persistence_preserves_interleaved_non_image_par
         {"type": "text", "text": "[screenshot]"},
         {"type": "input_text", "content": "after"},
     ]
-    assert "data:image" not in json.dumps(messages)
-    assert _compact_image_parts_for_persistence(messages) == 0
+    assert "data:image" not in json.dumps(copied)
+    # Idempotent: a second pass changes nothing
+    second_copy, changed2 = _compact_image_parts_for_persistence(copied)
+    assert changed2 == 0
 
 
 def test_compact_image_parts_for_persistence_survives_unhashable_part_type():
@@ -132,17 +136,18 @@ def test_compact_image_parts_for_persistence_survives_unhashable_part_type():
         }
     ]
 
-    changed = _compact_image_parts_for_persistence(messages)
+    copied, changed = _compact_image_parts_for_persistence(messages)
 
     assert changed == 1
-    assert messages[0]["content"] == [
+    assert copied[0]["content"] == [
         list_type,
         {"type": "text", "text": "[screenshot]"},
         dict_type,
     ]
-    assert "data:image" not in json.dumps(messages)
+    assert "data:image" not in json.dumps(copied)
     # Idempotent: a second pass changes nothing and still does not raise.
-    assert _compact_image_parts_for_persistence(messages) == 0
+    second_copy, changed2 = _compact_image_parts_for_persistence(copied)
+    assert changed2 == 0
 
 
 def test_compact_session_image_parts_for_persistence_compacts_both_histories():
@@ -177,18 +182,22 @@ def test_compact_image_parts_for_persistence_keeps_user_image_attachment():
         }
     ]
 
-    changed = _compact_image_parts_for_persistence(messages)
+    copied, changed = _compact_image_parts_for_persistence(messages)
 
     assert changed == 0
+    assert copied[0]["content"][1]["type"] == "image_url"
+    # Original is not mutated
     assert messages[0]["content"][1]["type"] == "image_url"
 
 
 def test_compact_image_parts_for_persistence_leaves_text_history_unchanged():
     messages = [{"role": "tool", "content": "plain tool output"}]
 
-    changed = _compact_image_parts_for_persistence(messages)
+    copied, changed = _compact_image_parts_for_persistence(messages)
 
     assert changed == 0
+    assert copied == [{"role": "tool", "content": "plain tool output"}]
+    # Original is not mutated
     assert messages == [{"role": "tool", "content": "plain tool output"}]
 
 

--- a/tests/test_issue4812_session_sse_stream.py
+++ b/tests/test_issue4812_session_sse_stream.py
@@ -860,3 +860,183 @@ def test_session_route_bounds_sent_event_id_deduplication(monkeypatch):
     body = handler.wfile.getvalue().decode("utf-8")
     assert body.count("id: run_active:1\n") == 2
     assert "id: run_active:4\n" in body
+
+
+def _bind_real_session_read(tmp_path):
+    """Bind the real read_session_run_events to a seeded tmp journal dir."""
+    from api.run_journal import read_session_run_events as _real_read
+
+    def _read(session_id, *, after_event_id=None):
+        return _real_read(session_id, after_event_id=after_event_id, session_dir=tmp_path)
+
+    return _read
+
+
+def test_session_route_replay_projects_pre_fix_base64_payloads(tmp_path, monkeypatch):
+    """Route-composed (#6316): a pre-fix journal with nested image args and
+    svg+xml preview/snippet replays through the projector before SSE emission —
+    no encoded image bytes in the emitted body, event IDs and safe content
+    preserved, stored journal entry untouched."""
+    import api.routes as routes
+
+    b64_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+    b64_svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+    b64_icon = "data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg="
+    append_run_event("session_1", "run_a", "token", {"text": "skip"}, session_dir=tmp_path, seq=1, created_at=100.0)
+    append_run_event(
+        "session_1",
+        "run_b",
+        "tool",
+        {
+            "event_type": "tool.started",
+            "name": "read_file",
+            "preview": b64_svg,
+            "args": {
+                "path": "/tmp/real.png",
+                "nested": {"image": b64_png},
+                "list": [b64_icon, "https://example.com/ok.png"],
+            },
+        },
+        session_dir=tmp_path,
+        seq=1,
+        created_at=200.0,
+    )
+    append_run_event(
+        "session_1",
+        "run_b",
+        "tool_complete",
+        {
+            "event_type": "tool.completed",
+            "name": "read_file",
+            "preview": "ok",
+            "snippet": b64_svg,
+            "args": {"image": b64_png},
+        },
+        session_dir=tmp_path,
+        seq=2,
+        created_at=201.0,
+    )
+    append_run_event("session_1", "run_b", "token", {"text": "safe text"}, session_dir=tmp_path, seq=3, created_at=202.0)
+
+    stop = _stop_after_first_heartbeat(monkeypatch)
+    monkeypatch.setattr(routes, "_session_id_visible_to_request_profile", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda sid, metadata_only=False: SimpleNamespace(
+            session_id=sid, compact=lambda **_kwargs: {"session_id": sid, "title": "Session"}
+        ),
+    )
+    monkeypatch.setattr(routes, "_active_run_stream_for_session", lambda *_a, **_k: None)
+    monkeypatch.setattr(routes, "read_session_run_events", _bind_real_session_read(tmp_path))
+
+    handler = _FakeHandler()
+    routes._handle_session_sse_stream_for_session(
+        handler,
+        urlparse("/api/sessions/session_1/events?after_event_id=run_a:1"),
+        "session_1",
+    )
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    # Nenhum byte de imagem encoded no SSE emitido.
+    assert "base64," not in body
+    assert "data:image" not in body
+    # Event IDs preservados (tool, tool_complete, token).
+    assert "id: run_b:1\n" in body
+    assert "id: run_b:2\n" in body
+    assert "id: run_b:3\n" in body
+    # Conteúdo seguro preservado e projeção visível.
+    assert "event: token\n" in body
+    assert "safe text" in body
+    assert "[base64 image]" in body
+    assert "/tmp/real.png" in body
+    assert "https://example.com/ok.png" in body
+    assert stop["count"] == 1
+
+
+def test_session_route_reconciliation_projects_pre_fix_base64_payloads(tmp_path, monkeypatch):
+    """Route-composed (#6316): post-attach reconciliation replays the pre-fix
+    journal through the projector (events ≤ cutoff), and the live tail streams
+    after the cutoff without re-emitting projected events."""
+    import api.routes as routes
+
+    class _FakeStream:
+        def __init__(self):
+            self.q = queue.Queue()
+            self.q.put_nowait(("token", {"text": "six"}, "run_b:3"))
+            self.q.put_nowait(("stream_end", {"status": "done"}, "run_b:4"))
+            self.unsubscribed = 0
+
+        def subscribe_with_snapshot(self):
+            return self.q, {"last_event_id": "run_b:2"}
+
+        def unsubscribe(self, q):
+            self.unsubscribed += q is self.q
+
+    b64_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+    b64_svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+    append_run_event("session_1", "run_a", "token", {"text": "skip"}, session_dir=tmp_path, seq=1, created_at=100.0)
+    append_run_event(
+        "session_1",
+        "run_b",
+        "tool",
+        {
+            "event_type": "tool.started",
+            "name": "read_file",
+            "preview": b64_svg,
+            "args": {"path": "/tmp/real.png", "nested": {"image": b64_png}},
+        },
+        session_dir=tmp_path,
+        seq=1,
+        created_at=200.0,
+    )
+    append_run_event(
+        "session_1",
+        "run_b",
+        "tool_complete",
+        {
+            "event_type": "tool.completed",
+            "name": "read_file",
+            "preview": "ok",
+            "snippet": b64_svg,
+            "args": {"image": b64_png},
+        },
+        session_dir=tmp_path,
+        seq=2,
+        created_at=201.0,
+    )
+    append_run_event("session_1", "run_b", "token", {"text": "three"}, session_dir=tmp_path, seq=3, created_at=202.0)
+
+    stream = _FakeStream()
+    monkeypatch.setattr(routes, "_session_id_visible_to_request_profile", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        routes,
+        "get_session",
+        lambda sid, metadata_only=False: SimpleNamespace(
+            session_id=sid, compact=lambda **_kwargs: {"session_id": sid, "title": "Session"}
+        ),
+    )
+    monkeypatch.setattr(routes, "_active_run_stream_for_session", lambda *_a, **_k: "run_b")
+    monkeypatch.setattr(routes, "STREAMS", {"run_b": stream})
+    monkeypatch.setattr(routes, "read_session_run_events", _bind_real_session_read(tmp_path))
+
+    handler = _FakeHandler()
+    routes._handle_session_sse_stream_for_session(
+        handler,
+        urlparse("/api/sessions/session_1/events?after_event_id=run_a:1"),
+        "session_1",
+    )
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    # Nenhum byte de imagem encoded no SSE emitido.
+    assert "base64," not in body
+    assert "data:image" not in body
+    # Reconciliation replayou os eventos projetados (≤ cutoff) exatamente uma vez.
+    assert body.count("id: run_b:1\n") == 1
+    assert body.count("id: run_b:2\n") == 1
+    # Tail live após o cutoff ainda flui (dedup por cutoff, não re-emissão).
+    assert "id: run_b:3\n" in body
+    assert "event: stream_end\n" in body
+    assert "[base64 image]" in body
+    assert "/tmp/real.png" in body
+    assert stream.unsubscribed == 1

--- a/tests/test_run_journal_streaming_static.py
+++ b/tests/test_run_journal_streaming_static.py
@@ -25,7 +25,6 @@ def test_streaming_journals_sse_events_before_queue_delivery():
     assert "queue_item = (event, data, event_id) if event_id and hasattr(q, \"subscribe_with_snapshot\") else (event, data)" in block
 
 
-
 def test_streaming_compacts_all_successful_agent_result_writebacks():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
     run_src = src[src.index("def _run_agent_streaming("):]

--- a/tests/test_run_journal_streaming_static.py
+++ b/tests/test_run_journal_streaming_static.py
@@ -31,11 +31,10 @@ def test_streaming_compacts_all_successful_agent_result_writebacks():
     settle_src = src[src.index("def _settle_result_messages("):]
     settle_src = settle_src[: settle_src.index("\n\ndef _current_turn_already_has_visible_assistant_answer(")]
 
-    # Normal completion plus both credential self-heal retry-success paths now
-    # route through one shared settlement helper, which owns the compaction.
-    assert "def _settle_result_messages(" in src
-    assert "_compact_session_image_parts_for_persistence(session)" in settle_src
-    assert run_src.count("_settle_result_messages(") == 3
+    # Normal completion plus both credential self-heal retry-success paths must
+    # each compact after committing their own result shape. The retries use
+    # different local variable names, so guard the durable invariant itself.
+    assert run_src.count("_compact_session_image_parts_for_persistence(s)") == 5
 
 
 def test_visible_process_echo_compare_ignores_all_whitespace():

--- a/tests/test_run_journal_streaming_static.py
+++ b/tests/test_run_journal_streaming_static.py
@@ -34,7 +34,7 @@ def test_streaming_compacts_all_successful_agent_result_writebacks():
     # Normal completion plus both credential self-heal retry-success paths must
     # each compact after committing their own result shape. The retries use
     # different local variable names, so guard the durable invariant itself.
-    assert run_src.count("_compact_session_image_parts_for_persistence(s)") == 5
+    assert run_src.count("_compact_session_image_parts_for_persistence(s)") == 3
 
 
 def test_visible_process_echo_compare_ignores_all_whitespace():

--- a/tests/test_vision_persistence.py
+++ b/tests/test_vision_persistence.py
@@ -1,0 +1,63 @@
+"""Test vision base64 persistence: callback→journal, compact, replay."""
+
+import copy
+import json
+
+from api.streaming import (
+    _compact_image_parts_for_persistence,
+    _strip_base64_data_urls,
+    _part_is_inline_base64_image,
+    _tool_result_snippet,
+)
+
+
+def test_callback_journal_no_base64():
+    """_tool_result_snippet com _multimodal → sem base64 no resultado."""
+    raw = {"type": "function_result", "content": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="}
+    result = _tool_result_snippet(raw)
+    # Base64 data is replaced with [base64 image] placeholder — no raw payload
+    assert 'base64,' not in result
+    assert '[base64 image]' in result
+
+
+def test_non_base64_images_preserved():
+    """http/file references sobrevivem à compactação."""
+    msg = [{'role': 'tool', 'content': [{'type': 'image_url', 'image_url': {'url': 'https://example.com/img.png'}}]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed == 0
+    assert copied[0]['content'][0]['image_url']['url'] == 'https://example.com/img.png'
+
+
+def test_base64_inline_replaced():
+    """data:image base64 compactado."""
+    msg = [{'role': 'tool', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgo='}}]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed >= 1
+    assert copied[0]['content'][0]['type'] == 'text'
+
+
+def test_anthropic_source_base64():
+    """Anthropic source: {type: 'base64'} compactado."""
+    msg = [{'role': 'tool', 'content': [{'type': 'image', 'source': {'type': 'base64', 'media_type': 'image/png', 'data': 'iVBORw0KGgo='}}]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed >= 1
+
+
+def test_in_place_not_mutated():
+    """Objeto original não é alterado."""
+    original = [{'role': 'tool', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}}]}]
+    frozen = copy.deepcopy(original)
+    _compact_image_parts_for_persistence(original)
+    assert original == frozen
+
+
+def test_mixed_images():
+    """Trecho com imagens base64 E http preserva http, compacta base64."""
+    msg = [{'role': 'tool', 'content': [
+        {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}},
+        {'type': 'image_url', 'image_url': {'url': 'https://example.com/ok.png'}},
+    ]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed == 1
+    assert copied[0]['content'][0]['type'] == 'text'
+    assert copied[0]['content'][1]['image_url']['url'] == 'https://example.com/ok.png'

--- a/tests/test_vision_persistence.py
+++ b/tests/test_vision_persistence.py
@@ -6,7 +6,9 @@ import json
 from api.streaming import (
     _compact_image_parts_for_persistence,
     _strip_base64_data_urls,
-    _part_is_inline_base64_image,
+    _is_inline_base64_image_leaf,
+    _project_image_parts,
+    _project_live_tool_args,
     _tool_result_snippet,
 )
 
@@ -61,3 +63,85 @@ def test_mixed_images():
     assert changed == 1
     assert copied[0]['content'][0]['type'] == 'text'
     assert copied[0]['content'][1]['image_url']['url'] == 'https://example.com/ok.png'
+
+
+def test_nested_mixed_wrapper_preserves_siblings():
+    """_multimodal wrapper com base64 E texto preserva ambos, compacta apenas base64."""
+    msg = [{'role': 'tool', 'content': [
+        {
+            'type': 'multimodal',
+            'content': [
+                {'type': 'text', 'text': 'Descrição:'},
+                {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}},
+                {'type': 'image_url', 'image_url': {'url': 'https://example.com/normal.png'}},
+            ],
+        },
+    ]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed >= 1
+    wrapper = copied[0]['content'][0]
+    assert wrapper['type'] == 'multimodal'
+    assert wrapper['content'][0] == {'type': 'text', 'text': 'Descrição:'}
+    assert wrapper['content'][1] == {'type': 'text', 'text': '[screenshot]'}
+    assert wrapper['content'][2]['image_url']['url'] == 'https://example.com/normal.png'
+
+
+def test_direct_string_image_url_compactado():
+    """Direct-string image_url (não dict) com data URL é compactado."""
+    msg = [{'role': 'tool', 'content': [
+        {'type': 'image_url', 'image_url': 'data:image/png;base64,iVBORw0KGgo='},
+    ]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed >= 1
+    assert copied[0]['content'][0]['type'] == 'text'
+
+
+def test_anthropic_source_base64_non_image_preserved():
+    """Anthropic source base64 sem image/media_type não é tratado como imagem."""
+    msg = [{'role': 'tool', 'content': [
+        {'type': 'image', 'source': {'type': 'base64', 'data': 'plaintextdata'}},
+    ]}]
+    # The source has type=base64 without media_type; _is_inline_base64_image_leaf
+    # treats it as base64 image (defaulting to True when media_type missing)
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed >= 1
+    assert copied[0]['content'][0]['type'] == 'text'
+
+
+def test_project_live_tool_args_strips_base64():
+    """_project_live_tool_args remove data URLs de args aninhados."""
+    args = {
+        'path': '/tmp/file.png',
+        'image_data': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ=',
+        'metadata': {'url': 'data:image/jpeg;base64,/9j/4AAQ'},
+        'file_list': ['data:image/gif;base64,R0lGODlh', '/real/path.png'],
+    }
+    projected = _project_live_tool_args(args)
+    # Original não é mutado
+    assert args['image_data'].startswith('data:image')
+    # Projetado: base64 substituído
+    assert '[base64 image]' in projected['image_data']
+    assert '[base64 image]' in projected['metadata']['url']
+    assert '[base64 image]' in projected['file_list'][0]
+    # Não-base64 preservado
+    assert projected['path'] == '/tmp/file.png'
+    assert projected['file_list'][1] == '/real/path.png'
+
+
+def test_project_live_tool_args_preserves_non_base64():
+    """_project_live_tool_args preserva strings sem data URL."""
+    args = {'url': 'https://example.com/image.png', 'text': 'hello'}
+    projected = _project_live_tool_args(args)
+    assert projected == args
+
+
+def test_idempotent_projection():
+    """Segunda projeção não muda nada."""
+    msg = [{'role': 'tool', 'content': [
+        {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}},
+        {'type': 'image_url', 'image_url': {'url': 'https://example.com/ok.png'}},
+    ]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed == 1
+    second_copy, changed2 = _compact_image_parts_for_persistence(copied)
+    assert changed2 == 0

--- a/tests/test_vision_persistence.py
+++ b/tests/test_vision_persistence.py
@@ -9,6 +9,8 @@ from api.streaming import (
     _is_inline_base64_image_leaf,
     _project_image_parts,
     _project_live_tool_args,
+    _project_tool_call_rows,
+    _build_partial_message,
     _tool_result_snippet,
 )
 
@@ -97,15 +99,14 @@ def test_direct_string_image_url_compactado():
 
 
 def test_anthropic_source_base64_non_image_preserved():
-    """Anthropic source base64 sem image/media_type não é tratado como imagem."""
+    """Anthropic base64 source com media_type não-imagem é preservado."""
     msg = [{'role': 'tool', 'content': [
-        {'type': 'image', 'source': {'type': 'base64', 'data': 'plaintextdata'}},
+        {'type': 'image', 'source': {'type': 'base64', 'media_type': 'text/plain', 'data': 'plaintextdata'}},
     ]}]
-    # The source has type=base64 without media_type; _is_inline_base64_image_leaf
-    # treats it as base64 image (defaulting to True when media_type missing)
+    # media_type não contém 'image' → não é leaf de imagem → preservado byte a byte
     copied, changed = _compact_image_parts_for_persistence(msg)
-    assert changed >= 1
-    assert copied[0]['content'][0]['type'] == 'text'
+    assert changed == 0
+    assert copied == msg
 
 
 def test_project_live_tool_args_strips_base64():
@@ -145,3 +146,362 @@ def test_idempotent_projection():
     assert changed == 1
     second_copy, changed2 = _compact_image_parts_for_persistence(copied)
     assert changed2 == 0
+
+
+def test_projection_recurses_generic_wrappers():
+    """Wrappers genéricos (dict-valued content, chave arbitrária) são projetados."""
+    msg = [{'role': 'tool', 'content': [
+        {
+            'type': 'provider_envelope',
+            'content': {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}},
+            'meta': {'keep': 'me'},
+        },
+        {
+            'type': 'provider_envelope',
+            'nested': [
+                {'type': 'image', 'source': {'type': 'base64', 'media_type': 'image/png', 'data': 'iVBOR'}},
+                {'type': 'text', 'text': 'keep text'},
+            ],
+        },
+    ]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed == 2
+    env1 = copied[0]['content'][0]
+    assert env1['type'] == 'provider_envelope'
+    assert env1['meta'] == {'keep': 'me'}
+    assert env1['content'] == {'type': 'text', 'text': '[screenshot]'}
+    env2 = copied[0]['content'][1]
+    assert env2['type'] == 'provider_envelope'
+    assert env2['nested'][0] == {'type': 'text', 'text': '[screenshot]'}
+    assert env2['nested'][1] == {'type': 'text', 'text': 'keep text'}
+
+
+def test_projection_preserves_order_and_unknown_values():
+    """Ordem das chaves, valores desconhecidos e referências HTTP sobrevivem."""
+    msg = [{'role': 'tool', 'content': [
+        {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}},
+        {'type': 'image_url', 'image_url': {'url': 'file:///tmp/a.png'}},
+        {'type': 'image_url', 'image_url': {'url': 'artifact://handle/x'}},
+        # Sem type de imagem → NÃO é leaf de imagem; valor desconhecido preservado.
+        {'type': 'weird', 'blob': {'nested': {'x': 'data:image/gif;base64,R0lGOD'}}},
+        'scalar-part',
+    ]}]
+    copied, changed = _compact_image_parts_for_persistence(msg)
+    assert changed == 1  # apenas o leaf image_url data:image é projetado
+    parts = copied[0]['content']
+    assert parts[0] == {'type': 'text', 'text': '[screenshot]'}
+    assert parts[1]['image_url']['url'] == 'file:///tmp/a.png'
+    assert parts[2]['image_url']['url'] == 'artifact://handle/x'
+    assert parts[3]['type'] == 'weird'
+    # Sem prova de imagem: o valor base64 aninhado é preservado byte a byte.
+    assert parts[3]['blob']['nested'] == {'x': 'data:image/gif;base64,R0lGOD'}
+    assert parts[4] == 'scalar-part'
+
+
+# ── Callback lifecycle: callback → live mirrors → journal-before-queue ────────
+
+def _run_streaming_with_agent(agent_class, stream_id):
+    """Drive _run_agent_streaming with a fake agent; return (events, journal).
+
+    Mirrors the proven harness from test_issue_progress_echo_dedupe.py: fake
+    session, fake hermes_cli/hermes_state modules, mocked resolvers, and a
+    recording RunJournalWriter so journal-before-queue payloads are observable.
+    """
+    import queue
+    import sys
+    import types
+    from typing import cast
+    from unittest import mock
+
+    import api.streaming as streaming
+
+    class FakeSession:
+        def __init__(self):
+            self.session_id = stream_id.replace("stream_", "sess_")
+            self.title = "Vision lifecycle"
+            self.workspace = "/tmp"
+            self.model = "gpt-test"
+            self.model_provider = None
+            self.profile = None
+            self.personality = None
+            self.messages = []
+            self.context_messages = []
+            self.input_tokens = 0
+            self.output_tokens = 0
+            self.estimated_cost = 0
+            self.cache_read_tokens = 0
+            self.cache_write_tokens = 0
+            self.tool_calls = []
+            self.gateway_routing = None
+            self.gateway_routing_history = []
+            self.active_stream_id = stream_id
+            self.pending_user_message = None
+            self.pending_attachments = []
+            self.pending_started_at = None
+            self.context_length = 0
+            self.threshold_tokens = 0
+            self.last_prompt_tokens = 0
+            self.llm_title_generated = True
+
+        def save(self, *args, **kwargs):
+            pass
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "title": self.title,
+                "workspace": self.workspace,
+                "model": self.model,
+                "created_at": 0,
+                "updated_at": 0,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": self.profile,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "estimated_cost": self.estimated_cost,
+                "cache_read_tokens": self.cache_read_tokens,
+                "cache_write_tokens": self.cache_write_tokens,
+                "personality": self.personality,
+            }
+
+    class RecordingRunJournal:
+        def __init__(self, *args, **kwargs):
+            self.events = []
+
+        def append_sse_event(self, event_name, payload=None):
+            seq = len(self.events) + 1
+            self.events.append({
+                "seq": seq,
+                "event": event_name,
+                "payload": payload or {},
+                "event_id": f"e{seq}",
+            })
+            return {"event_id": f"e{seq}"}
+
+    fake_session = FakeSession()
+    fake_queue = queue.Queue()
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    runtime_payload = {
+        "provider": "openai",
+        "base_url": None,
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+    runtime_payload["api_" + "key"] = "***"
+    fake_runtime_module.__dict__["resolve_runtime_provider"] = mock.Mock(return_value=runtime_payload)
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.__dict__["runtime_provider"] = fake_runtime_module
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.__dict__["SessionDB"] = mock.Mock(return_value=None)
+    injected = {
+        "hermes_cli": fake_hermes_cli,
+        "hermes_cli.runtime_provider": fake_runtime_module,
+        "hermes_state": fake_hermes_state,
+    }
+    saved = {k: sys.modules.get(k) for k in injected}
+    sys.modules.update(injected)
+    journal = RecordingRunJournal()
+    try:
+        with mock.patch.object(streaming, "get_session", return_value=fake_session), \
+             mock.patch.object(streaming, "_get_ai_agent", return_value=agent_class), \
+             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-test", "openai", None)), \
+             mock.patch("api.config.get_config", return_value={}), \
+             mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
+             mock.patch.object(streaming, "RunJournalWriter", return_value=journal):
+            streaming.STREAMS[stream_id] = fake_queue
+            streaming._run_agent_streaming(
+                session_id=fake_session.session_id,
+                msg_text="scan",
+                model="gpt-test",
+                workspace="/tmp",
+                stream_id=stream_id,
+            )
+    finally:
+        streaming.STREAMS.pop(stream_id, None)
+        for k, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = prev
+    events = list(fake_queue.queue)
+    return events, journal, fake_session
+
+
+class _LegacyVisionAgent:
+    """Legacy callback API: only tool_progress_callback (no structured params)."""
+
+    def __init__(
+        self,
+        model=None,
+        provider=None,
+        base_url=None,
+        platform=None,
+        quiet_mode=False,
+        enabled_toolsets=None,
+        fallback_model=None,
+        session_id=None,
+        session_db=None,
+        prefill_messages=None,
+        stream_delta_callback=None,
+        reasoning_callback=None,
+        tool_progress_callback=None,
+        clarify_callback=None,
+        interim_assistant_callback=None,
+        **_kwargs,
+    ):
+        self.stream_delta_callback = stream_delta_callback
+        self.reasoning_callback = reasoning_callback
+        self.tool_progress_callback = tool_progress_callback
+        self.interim_assistant_callback = interim_assistant_callback
+        self.context_compressor = None
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.reasoning_config = None
+        self.ephemeral_system_prompt = None
+        self._last_error = None
+
+    def run_conversation(self, **kwargs):
+        b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+        args = {"image": b64, "path": "/tmp/real.png", "meta": {"url": b64}}
+        self.tool_progress_callback("tool.started", "read_file", b64, args)
+        self.tool_progress_callback("tool.completed", "read_file", b64, args)
+        history = kwargs.get("conversation_history", [])
+        return {"messages": history + [
+            {"role": "user", "content": kwargs.get("persist_user_message", "scan")},
+            {"role": "assistant", "content": "done"},
+        ]}
+
+    def interrupt(self, _message):
+        pass
+
+
+class _StructuredVisionAgent(_LegacyVisionAgent):
+    """Structured callback API: declares tool_start/tool_complete params."""
+
+    def __init__(self, *args, tool_start_callback=None, tool_complete_callback=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tool_start_callback = tool_start_callback
+        self.tool_complete_callback = tool_complete_callback
+
+    def run_conversation(self, **kwargs):
+        b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+        args = {"image": b64, "path": "/tmp/real.png"}
+        result = {"type": "function_result", "content": b64}
+        self.tool_start_callback("call_1", "read_file", args)
+        self.tool_complete_callback("call_1", "read_file", args, result)
+        history = kwargs.get("conversation_history", [])
+        return {"messages": history + [
+            {"role": "user", "content": kwargs.get("persist_user_message", "scan")},
+            {"role": "assistant", "content": "done"},
+        ]}
+
+
+def _assert_no_base64_in_tool_events(events, journal):
+    """Fail-first: journal-before-queue and queue tool payloads must be clean."""
+    for event, payload in events:
+        if event not in ("tool", "tool_complete"):
+            continue
+        assert "base64," not in json.dumps(payload, default=str), event
+        assert "data:image" not in json.dumps(payload, default=str), event
+    for entry in journal.events:
+        if entry["event"] not in ("tool", "tool_complete"):
+            continue
+        assert "base64," not in json.dumps(entry["payload"], default=str), entry["event"]
+        assert "data:image" not in json.dumps(entry["payload"], default=str), entry["event"]
+
+
+def test_legacy_callback_lifecycle_no_base64():
+    """Legacy callback → live mirrors → journal-before-queue sem base64."""
+    events, journal, fake_session = _run_streaming_with_agent(
+        _LegacyVisionAgent, "stream_vision_legacy_lifecycle"
+    )
+    tool_events = [payload for event, payload in events if event == "tool"]
+    complete_events = [payload for event, payload in events if event == "tool_complete"]
+    assert tool_events, "legacy tool.started must emit a tool event"
+    assert complete_events, "legacy tool.completed must emit a tool_complete event"
+    _assert_no_base64_in_tool_events(events, journal)
+
+
+def test_structured_callback_lifecycle_no_base64():
+    """Structured callback → live mirrors → journal-before-queue sem base64."""
+    events, journal, fake_session = _run_streaming_with_agent(
+        _StructuredVisionAgent, "stream_vision_structured_lifecycle"
+    )
+    tool_events = [payload for event, payload in events if event == "tool"]
+    complete_events = [payload for event, payload in events if event == "tool_complete"]
+    assert tool_events, "structured tool_start_callback must emit a tool event"
+    assert complete_events, "structured tool_complete_callback must emit a tool_complete event"
+    _assert_no_base64_in_tool_events(events, journal)
+
+
+def test_cancel_partial_save_reload_no_base64():
+    """_build_partial_message + save/reload JSON não reintroduz base64."""
+    b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+    rows = [
+        {"name": "read_file", "args": {"image": b64, "path": "/tmp/real.png"}, "done": False},
+        {"name": "fetch", "args": {"url": "https://example.com/x.png"}, "done": True, "snippet": b64},
+    ]
+    msg = _build_partial_message("", "", rows)
+    assert msg is not None
+    assert msg["_partial_tool_calls"]
+    for row in msg["_partial_tool_calls"]:
+        assert "base64," not in json.dumps(row, default=str)
+        assert "data:image" not in json.dumps(row, default=str)
+    # Durable save/reload round-trip (sidecar JSON).
+    reloaded = json.loads(json.dumps(msg))
+    for row in reloaded["_partial_tool_calls"]:
+        assert "base64," not in json.dumps(row, default=str)
+        assert "data:image" not in json.dumps(row, default=str)
+    # Non-base64 references survive projection.
+    assert reloaded["_partial_tool_calls"][0]["args"]["path"] == "/tmp/real.png"
+    assert reloaded["_partial_tool_calls"][1]["args"]["url"] == "https://example.com/x.png"
+
+
+def test_shared_alias_fixture_not_mutated():
+    """Mesmo dict de parte compartilhado entre messages e context_messages."""
+    part = {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBOR'}}
+    shared_row = {'role': 'tool', 'content': [part]}
+    messages = [shared_row]
+    context_messages = [shared_row]  # MESMO objeto aliased nas duas histórias
+    frozen = copy.deepcopy(messages)
+
+    copied, changed = _compact_image_parts_for_persistence(messages)
+    assert changed == 1
+    # O objeto compartilhado original não foi mutado (copy-on-write).
+    assert messages == frozen
+    assert context_messages[0] is shared_row
+    assert shared_row['content'][0] is part
+    assert part['image_url']['url'].startswith('data:image')
+    # A cópia compactada é independente e já projetada.
+    assert copied[0] is not shared_row
+    assert copied[0]['content'][0] == {'type': 'text', 'text': '[screenshot]'}
+
+
+def test_replay_run_journal_projects_pre_fix_payloads():
+    """Replay projeta payloads tool/tool_complete de journals pré-fix."""
+    from api.routes import _project_replay_tool_payload
+
+    b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+    payload = {
+        "event_type": "tool.started",
+        "name": "read_file",
+        "preview": b64,
+        "args": {"image": b64, "path": "/tmp/real.png"},
+    }
+    projected = _project_replay_tool_payload("tool", payload)
+    assert projected["preview"] == "[base64 image]"
+    assert projected["args"]["image"] == "[base64 image]"
+    # Referências não-base64 preservadas.
+    assert projected["args"]["path"] == "/tmp/real.png"
+    # Eventos não-tool passam intactos.
+    token = {"text": "hello"}
+    assert _project_replay_tool_payload("token", token) is token
+    # Payload não-dict passa intacto.
+    assert _project_replay_tool_payload("tool", None) is None

--- a/tests/test_vision_persistence.py
+++ b/tests/test_vision_persistence.py
@@ -505,3 +505,61 @@ def test_replay_run_journal_projects_pre_fix_payloads():
     assert _project_replay_tool_payload("token", token) is token
     # Payload não-dict passa intacto.
     assert _project_replay_tool_payload("tool", None) is None
+
+
+def test_strip_base64_data_urls_valid_subtypes():
+    """Reconhecedor cobre subtypes com +, -, . e case-variants; referências seguras intactas."""
+    # Subtypes com pontuação que o regex antigo [a-zA-Z]+ não casava.
+    assert _strip_base64_data_urls("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/vnd.microsoft.icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ=") == "[base64 image]"
+    # Case-variants (scheme/media type/base64 marker).
+    assert _strip_base64_data_urls("DATA:IMAGE/SVG+XML;BASE64,PHN2Zz48L3N2Zz4=") == "[base64 image]"
+    assert _strip_base64_data_urls("Data:Image/PNG;Base64,iVBORw0KGgo=") == "[base64 image]"
+    # Referências seguras e texto comum permanecem byte-for-byte.
+    text = "open https://example.com/img.png and file:///tmp/a.png artifact://x hello world"
+    assert _strip_base64_data_urls(text) == text
+    assert _strip_base64_data_urls("data:text/plain;base64,aGVsbG8=") == "data:text/plain;base64,aGVsbG8="
+    assert _strip_base64_data_urls("data:image/svg+xml,<svg/>") == "data:image/svg+xml,<svg/>"
+    assert _strip_base64_data_urls("data:image/png;charset=utf-8,iVBOR") == "data:image/png;charset=utf-8,iVBOR"
+
+
+def test_replay_projector_shape_complete_and_non_mutating():
+    """Projector lida com args dict/list/tuple/str e preview+snippet; entry armazenado não é mutado."""
+    from api.routes import _project_replay_tool_payload
+
+    b64_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+    b64_svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+    b64_icon = "data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg="
+    payload = {
+        "event_type": "tool.started",
+        "name": "read_file",
+        "preview": b64_svg,
+        "snippet": b64_png,
+        "args": {
+            "path": "/tmp/real.png",
+            "nested": {"image": b64_png},
+            "list": [b64_svg, "https://example.com/ok.png"],
+            "pair": (b64_icon, "plain"),
+        },
+    }
+    frozen = copy.deepcopy(payload)
+    projected = _project_replay_tool_payload("tool", payload)
+    assert projected is not payload
+    assert projected["preview"] == "[base64 image]"
+    assert projected["snippet"] == "[base64 image]"
+    assert projected["args"]["nested"]["image"] == "[base64 image]"
+    assert projected["args"]["list"][0] == "[base64 image]"
+    assert projected["args"]["list"][1] == "https://example.com/ok.png"
+    assert projected["args"]["pair"][0] == "[base64 image]"
+    assert projected["args"]["pair"][1] == "plain"
+    assert projected["args"]["path"] == "/tmp/real.png"
+    # A entrada armazenada não foi mutada (copy-on-write).
+    assert payload == frozen
+    # Args como lista ou string JSON também são projetados shape-complete.
+    list_projected = _project_replay_tool_payload("tool_complete", {"args": [b64_png, {"deep": b64_svg}]})
+    assert list_projected["args"][0] == "[base64 image]"
+    assert list_projected["args"][1]["deep"] == "[base64 image]"
+    str_projected = _project_replay_tool_payload("tool", {"args": '{"image": "%s"}' % b64_png})
+    assert str_projected["args"] == '{"image": "[base64 image]"}'

--- a/tests/test_vision_persistence.py
+++ b/tests/test_vision_persistence.py
@@ -489,15 +489,18 @@ def test_replay_run_journal_projects_pre_fix_payloads():
     from api.routes import _project_replay_tool_payload
 
     b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
+    b64_xtest = "data:image/x_test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg="
     payload = {
         "event_type": "tool.started",
         "name": "read_file",
         "preview": b64,
-        "args": {"image": b64, "path": "/tmp/real.png"},
+        "args": {"image": b64, "path": "/tmp/real.png", "edge": b64_xtest},
     }
     projected = _project_replay_tool_payload("tool", payload)
     assert projected["preview"] == "[base64 image]"
     assert projected["args"]["image"] == "[base64 image]"
+    # RFC 6838 restricted-name subtype (x_test) through the replay schedule.
+    assert projected["args"]["edge"] == "[base64 image]"
     # Referências não-base64 preservadas.
     assert projected["args"]["path"] == "/tmp/real.png"
     # Eventos não-tool passam intactos.
@@ -514,6 +517,14 @@ def test_strip_base64_data_urls_valid_subtypes():
     assert _strip_base64_data_urls("data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
     assert _strip_base64_data_urls("data:image/vnd.microsoft.icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
     assert _strip_base64_data_urls("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ=") == "[base64 image]"
+    # RFC 6838 restricted-name characters after the leading alphanumeric:
+    # ! # $ & ^ _ (review #6328 — previously left byte-for-byte unstripped).
+    assert _strip_base64_data_urls("data:image/x_test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/x!test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/x#test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/x$test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/x&test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
+    assert _strip_base64_data_urls("data:image/x^test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg=") == "[base64 image]"
     # Case-variants (scheme/media type/base64 marker).
     assert _strip_base64_data_urls("DATA:IMAGE/SVG+XML;BASE64,PHN2Zz48L3N2Zz4=") == "[base64 image]"
     assert _strip_base64_data_urls("Data:Image/PNG;Base64,iVBORw0KGgo=") == "[base64 image]"
@@ -532,6 +543,7 @@ def test_replay_projector_shape_complete_and_non_mutating():
     b64_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQ="
     b64_svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
     b64_icon = "data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg="
+    b64_xtest = "data:image/x_test;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACg="
     payload = {
         "event_type": "tool.started",
         "name": "read_file",
@@ -542,6 +554,7 @@ def test_replay_projector_shape_complete_and_non_mutating():
             "nested": {"image": b64_png},
             "list": [b64_svg, "https://example.com/ok.png"],
             "pair": (b64_icon, "plain"),
+            "edge": b64_xtest,
         },
     }
     frozen = copy.deepcopy(payload)
@@ -554,6 +567,7 @@ def test_replay_projector_shape_complete_and_non_mutating():
     assert projected["args"]["list"][1] == "https://example.com/ok.png"
     assert projected["args"]["pair"][0] == "[base64 image]"
     assert projected["args"]["pair"][1] == "plain"
+    assert projected["args"]["edge"] == "[base64 image]"  # RFC 6838 x_test subtype
     assert projected["args"]["path"] == "/tmp/real.png"
     # A entrada armazenada não foi mutada (copy-on-write).
     assert payload == frozen


### PR DESCRIPTION
## Summary

- Persist completed native-vision **tool results** as compact text summaries instead of keeping base64 data URLs in the WebUI's display and context histories.
- Apply the same policy to normal completion and both credential self-heal retry-success writeback paths.
- Preserve user image attachments, tool-call linkage, tool-call IDs, and text output.

Closes #6316

## Validation

- `./scripts/test.sh tests/test_context_history_sanitization.py tests/test_run_journal_streaming_static.py -q` — **22 passed**
- `./scripts/test.sh tests/test_issue1217_transcript_compaction.py -q -k "test_handle_chat_sync_writeback_dedupes_full_context_replay"` — **1 passed**