### PR TITLE
fix: publish Docker experimental builds to ghcr (#6298)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+      - 'exp-v*'
 
 jobs:
   release:
@@ -15,11 +16,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Check whether this is a stable or experimental release
+      - name: Detect release channel
+        id: channel
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "is_stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Create GitHub Release from tag with auto-generated notes
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.channel.outputs.is_stable == 'false' }}
 
       # Set up multi-arch build (QEMU + Buildx)
       - uses: docker/setup-qemu-action@v3
@@ -41,7 +53,9 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=match,pattern=v(\d+\.\d+(?:\.\d+)?),group=1
-            type=raw,value=latest
+            type=match,pattern=exp-v(\d+\.\d+(?:\.\d+)?),group=1
+            type=raw,value=latest,enable=${{ steps.channel.outputs.is_stable == 'true' }}
+            type=raw,value=experimental,enable=${{ steps.channel.outputs.is_stable == 'false' }}
 
       # Build and push multi-arch image (amd64 + arm64)
       - name: Build and push Docker image

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,6 +11,27 @@ This is the comprehensive Docker reference. For a 5-minute quickstart, see the [
 | **Three-container** | Two-container PLUS the dashboard for monitoring. | `docker-compose.three-container.yml` |
 | **All-in-one image** (community fork — third-party, not maintained by us) | Podman 3.4 / multi-arch / supervisord-style preference. | [sunnysktsang/hermes-suite](https://github.com/sunnysktsang/hermes-suite) — see [#1399](https://github.com/nesquena/hermes-webui/issues/1399) for the original discussion |
 
+### Available Docker tags
+
+The WebUI Docker image is published to `ghcr.io/nesquena/hermes-webui` with these tags:
+
+| Tag | Channel | Description |
+|---|---|---|
+| `:latest` | stable | The most recent stable release (from `v*` tags). Suitable for production. |
+| `:experimental` | experimental | The most recent experimental release (from `exp-v*` tags). For early testing; may include breaking changes or unfinished features. Do not run in production. |
+| `:X.Y` / `:X.Y.Z` | stable | Pinned stable releases (e.g., `:1.5`, `:1.5.0`). |
+| `:X.Y` / `:X.Y.Z` | experimental | Pinned experimental releases — same version numbers but pushed from `exp-v*` tags. The `:experimental` floating tag always points at the latest of these. |
+
+To track experimental builds in Docker Compose, use the `:experimental` tag:
+
+```yaml
+services:
+  hermes-webui:
+    image: ghcr.io/nesquena/hermes-webui:experimental
+```
+
+> **Note:** updating between `:experimental` builds requires `docker compose pull` followed by `docker compose up -d` — the floating tag is updated only when a new `exp-v*` release is pushed. Experimental builds are not pushed on every commit to the default branch.
+
 > **Note (v0.14+):** If you use `docker-compose.three-container.yml`, both
 > `hermes-agent` and `hermes-dashboard` initialise from the same image and write
 > to the same `hermes-home` volume simultaneously. This can cause overlapping lock


### PR DESCRIPTION
## Summary

Fixes #6298 — Docker experimental builds for the WebUI image were never published to ghcr because the release workflow only triggered on stable `v*` tags.

## Changes

### `.github/workflows/release.yml`
- **Trigger**: Added `exp-v*` tag pattern so experimental releases now build & push Docker images
- **Channel detection**: Added a step that detects whether the triggering tag is stable (`v*`) or experimental (`exp-v*`)
- **GitHub Releases**: Experimental tags now create pre-releases
- **Docker tags**: 
  - Added `exp-v*` version match pattern (e.g. `exp-v1.5.0` → tag `:1.5.0`)
  - `:latest` tag is now conditional — only applied to stable `v*` builds
  - New `:experimental` floating tag applied to experimental builds

### `docs/docker.md`
- Added "Available Docker tags" section documenting all image tags (`:latest`, `:experimental`, version pins) with channel descriptions
- Included example compose snippet for tracking experimental builds

## Verification

Not directly verifiable from a fork — the workflow requires a tag push to trigger. The logic is:
- `v1.5.0` → triggers workflow, matches `v*`, produces tags `:1.5.0`, `:latest`, creates full GitHub Release
- `exp-v1.5.0` → triggers workflow, matches `exp-v*`, produces tags `:1.5.0`, `:experimental`, creates pre-release

## Release-note

```
Published experimental WebUI Docker builds now push to ghcr with a dedicated
:experimental tag. Containerized testers can track experimental releases by
pointing their compose file at ghcr.io/nesquena/hermes-webui:experimental.
```