### PR TITLE
Add #6247: conversation lifecycle regression gate

### DIFF
--- a/tests/browser_conversation_lifecycle.py
+++ b/tests/browser_conversation_lifecycle.py
@@ -5,6 +5,8 @@ This test boots the real WebUI server with isolated state, drives the real chat
 composer in Chromium, and supplies deterministic runtime events through the
 existing Hermes Gateway Runs API. It proves that one assistant turn keeps the
 same semantic activity across live streaming, settlement, and a hard reload.
+
+Proposed in #6247; first implementation slice merged as #6251.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

This PR adds the public conversation lifecycle regression gate as proposed in #6247.

The core implementation was already merged as #6251 by @franksong2702. This PR closes the loop from the webtecnica fork by documenting the proposal→implementation link in the test file header.

### What was already delivered in #6251

- `tests/browser_conversation_lifecycle.py` — Public credential-free browser test that boots the real WebUI server with isolated temporary state, drives the real chat composer in Chromium, and supplies deterministic Gateway Runs events. Validates:
  - Live anchor activity with reasoning + completed tool
  - Settled final answer coexistence with semantic activity
  - `activity_scene_v1` persistence via `/api/session/anchor-scene`
  - Hard-reload parity preserving settled semantics
  - Zero unexpected browser console/page errors
  - `LIFECYCLE_TEST_BITE=drop-anchor-persistence` mutation proves the gate bites

- `.github/workflows/conversation-lifecycle.yml` — Informational (non-blocking, `continue-on-error: true`) CI workflow

### Scope boundary

Per #6247: normal Live-to-Final row only. Session switch/reattach, terminal errors, cancel, compression, recovery, and pending-intent controls remain separate follow-ups.

### Verification

```bash
python tests/browser_conversation_lifecycle.py
LIFECYCLE_TEST_BITE=drop-anchor-persistence python tests/browser_conversation_lifecycle.py
```

Refs #6247. Refs #6251."