### PR TITLE
fix(#6333): repair Gemini fallback replay at request boundary

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -172,6 +172,47 @@ class _GeminiRequestBoundaryMessage(dict):
         return copied
 
 
+def _strip_materialized_gemini_request_boundary_marker(message):
+    if not isinstance(message, dict):
+        return message
+    cleaned = dict(message)
+    cleaned.pop(_GEMINI_REQUEST_BOUNDARY_MARKER, None)
+    return cleaned
+
+
+def _normalize_canonical_gemini_request_boundary_message(message):
+    if not isinstance(message, dict):
+        return message
+    if type(message) is dict and _GEMINI_REQUEST_BOUNDARY_MARKER not in message:
+        return message
+    return _strip_materialized_gemini_request_boundary_marker(message)
+
+
+def _clear_materialized_gemini_request_boundary_markers(messages):
+    if not isinstance(messages, list):
+        return
+    for idx, message in enumerate(messages):
+        normalized = _normalize_canonical_gemini_request_boundary_message(message)
+        if normalized is not message:
+            messages[idx] = normalized
+
+
+def _sanitize_materialized_gemini_request_boundary_history(messages):
+    _clear_materialized_gemini_request_boundary_markers(messages)
+    return messages
+
+
+def _replace_message_with_boundary_marker(messages, idx):
+    if not isinstance(messages, list) or not (0 <= idx < len(messages)):
+        return
+    message = messages[idx]
+    if not isinstance(message, dict) or message.get('role') != 'user':
+        return
+    messages[idx] = _GeminiRequestBoundaryMessage(
+        _strip_materialized_gemini_request_boundary_marker(message)
+    )
+
+
 def _stream_writeback_diag_threshold_seconds(environ=None):
     if environ is None:
         environ = os.environ
@@ -471,10 +512,9 @@ def _install_gemini_request_boundary_wrapper() -> None:
                     ctx = original_build_turn_context(*args, **kwargs)
                     idx = getattr(ctx, "current_turn_user_idx", -1)
                     messages = getattr(ctx, "messages", None)
-                    if isinstance(messages, list) and 0 <= idx < len(messages):
-                        message = messages[idx]
-                        if isinstance(message, dict) and message.get('role') == 'user':
-                            messages[idx] = _GeminiRequestBoundaryMessage(message)
+                    if isinstance(messages, list):
+                        _clear_materialized_gemini_request_boundary_markers(messages)
+                        _replace_message_with_boundary_marker(messages, idx)
                     return ctx
 
                 _wrapped_build_turn_context.__dict__["_webui_gemini_request_boundary_wrapper"] = True
@@ -487,10 +527,9 @@ def _install_gemini_request_boundary_wrapper() -> None:
 
                 def _wrapped_reanchor(messages, user_message):
                     idx = original_reanchor(messages, user_message)
-                    if 0 <= idx < len(messages):
-                        message = messages[idx]
-                        if isinstance(message, dict) and message.get('role') == 'user':
-                            messages[idx] = _GeminiRequestBoundaryMessage(message)
+                    if isinstance(messages, list):
+                        _clear_materialized_gemini_request_boundary_markers(messages)
+                        _replace_message_with_boundary_marker(messages, idx)
                     return idx
 
                 _wrapped_reanchor.__dict__["_webui_gemini_request_boundary_wrapper"] = True
@@ -9450,6 +9489,9 @@ def _run_agent_streaming(
                 with _stream_writeback_stage(_writeback_timings, "merge_result"):
                     _tool_limit_reached = _agent_result_tool_limit_reached(result)
                     _result_messages = result.get('messages') or _previous_context_messages
+                    _result_messages = _sanitize_materialized_gemini_request_boundary_history(
+                        _result_messages
+                    )
                     _result_messages = _drop_synthetic_max_iteration_summary_requests(
                         _result_messages,
                         enabled=_tool_limit_reached,
@@ -9507,7 +9549,12 @@ def _run_agent_streaming(
                         _next_context_messages,
                         msg_text,
                     )
-                    s.context_messages = _deduplicate_context_messages(_next_context_messages)
+                    _next_context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                        _next_context_messages
+                    )
+                    s.context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                        _deduplicate_context_messages(_next_context_messages)
+                    )
                     s.messages = _merge_display_messages_after_agent_result(
                         _previous_messages,
                         _previous_context_messages,
@@ -9515,6 +9562,7 @@ def _run_agent_streaming(
                         msg_text,
                         source=getattr(s, 'pending_user_source', None) or 'webui',
                     )
+                    s.messages = _sanitize_materialized_gemini_request_boundary_history(s.messages)
                     _compact_session_image_parts_for_persistence(s)
                     _advance_truncation_watermark_after_commit(s)  # #3831
                 # Strip XML tool-call blocks from assistant message content.
@@ -9833,6 +9881,9 @@ def _run_agent_streaming(
                                 # Since we're in a flat block, directly run the
                                 # post-result merge logic here.
                                 _result_messages = result.get('messages') or _previous_context_messages
+                                _result_messages = _sanitize_materialized_gemini_request_boundary_history(
+                                    _result_messages
+                                )
                                 _result_messages = _drop_synthetic_max_iteration_summary_requests(
                                     _result_messages,
                                     enabled=_agent_result_tool_limit_reached(result),
@@ -9852,7 +9903,12 @@ def _run_agent_streaming(
                                     _next_context_messages,
                                     msg_text,
                                 )
-                                s.context_messages = _deduplicate_context_messages(_next_context_messages)
+                                _next_context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                                    _next_context_messages
+                                )
+                                s.context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                                    _deduplicate_context_messages(_next_context_messages)
+                                )
                                 s.messages = _merge_display_messages_after_agent_result(
                                     _previous_messages,
                                     _previous_context_messages,
@@ -9860,6 +9916,7 @@ def _run_agent_streaming(
                                     msg_text,
                                     source=getattr(s, 'pending_user_source', None) or 'webui',
                                 )
+                                s.messages = _sanitize_materialized_gemini_request_boundary_history(s.messages)
                                 _compact_session_image_parts_for_persistence(s)
                                 _advance_truncation_watermark_after_commit(s)  # #3831
                                 # normal post-result persistence path by
@@ -10002,6 +10059,9 @@ def _run_agent_streaming(
                     s.context_messages = _prune_context_tool_results_after_compression(
                         agent,
                         s.context_messages,
+                    )
+                    s.context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                        s.context_messages
                     )
                     s.post_compression_context_tokens_estimate = _estimate_post_compression_context_tokens(
                         agent,
@@ -11061,6 +11121,9 @@ def _run_agent_streaming(
                                     )
                                     return
                                 _result_messages = _heal_result.get('messages') or _previous_context_messages
+                                _result_messages = _sanitize_materialized_gemini_request_boundary_history(
+                                    _result_messages
+                                )
                                 _next_context_messages = _restore_reasoning_metadata(
                                     _previous_context_messages, _result_messages,
                                 )
@@ -11075,7 +11138,12 @@ def _run_agent_streaming(
                                     _next_context_messages,
                                     msg_text,
                                 )
-                                s.context_messages = _deduplicate_context_messages(_next_context_messages)
+                                _next_context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                                    _next_context_messages
+                                )
+                                s.context_messages = _sanitize_materialized_gemini_request_boundary_history(
+                                    _deduplicate_context_messages(_next_context_messages)
+                                )
                                 s.messages = _merge_display_messages_after_agent_result(
                                     _previous_messages,
                                     _previous_context_messages,
@@ -11083,6 +11151,7 @@ def _run_agent_streaming(
                                     msg_text,
                                     source=getattr(s, 'pending_user_source', None) or 'webui',
                                 )
+                                s.messages = _sanitize_materialized_gemini_request_boundary_history(s.messages)
                                 _compact_session_image_parts_for_persistence(s)
                                 _advance_truncation_watermark_after_commit(s)  # #3831
                                 s.save()

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -162,6 +162,14 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 _STREAMING_CRONJOB_WRAPPER_INSTALLED = False
 _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
 _GEMINI_REQUEST_BOUNDARY_WRAPPER_LOCK = threading.Lock()
+_GEMINI_REQUEST_BOUNDARY_MARKER = "_webui_gemini_request_boundary"
+
+
+class _GeminiRequestBoundaryMessage(dict):
+    def copy(self):
+        copied = dict(self)
+        copied[_GEMINI_REQUEST_BOUNDARY_MARKER] = True
+        return copied
 
 
 def _stream_writeback_diag_threshold_seconds(environ=None):
@@ -372,30 +380,42 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
     """
     if not isinstance(messages, list):
         return messages
+
+    boundary_indexes = []
+    marker_found = False
+    marker_free_messages = []
+    for idx, message in enumerate(messages):
+        if not isinstance(message, dict) or _GEMINI_REQUEST_BOUNDARY_MARKER not in message:
+            marker_free_messages.append(message)
+            continue
+        marker_found = True
+        marker_free = dict(message)
+        marker = marker_free.pop(_GEMINI_REQUEST_BOUNDARY_MARKER)
+        marker_free_messages.append(marker_free)
+        if marker is True and marker_free.get('role') == 'user':
+            boundary_indexes.append(idx)
+
+    if not boundary_indexes:
+        return marker_free_messages if marker_found else messages
+
     if not _request_targets_google_gemini_three(
         model,
         base_url=base_url,
         provider_profile=provider_profile,
     ):
-        return messages
+        return marker_free_messages
 
-    last_user_index = None
-    for idx in range(len(messages) - 1, -1, -1):
-        msg = messages[idx]
-        if isinstance(msg, dict) and msg.get('role') == 'user':
-            last_user_index = idx
-            break
-    if last_user_index is None:
-        return messages
+    if len(boundary_indexes) != 1:
+        return marker_free_messages
 
-    replay_turn_user_index = last_user_index
-    if last_user_index == len(messages) - 1:
-        return messages
+    replay_turn_user_index = boundary_indexes[0]
+    if replay_turn_user_index == len(marker_free_messages) - 1:
+        return marker_free_messages
 
     drop_assistant_indexes = set()
     dropped_tool_call_ids: set[str] = set()
     for idx in range(replay_turn_user_index + 1, len(messages)):
-        msg = messages[idx]
+        msg = marker_free_messages[idx]
         if not isinstance(msg, dict) or msg.get('role') != 'assistant':
             continue
         tool_calls = msg.get('tool_calls')
@@ -412,10 +432,10 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
                 dropped_tool_call_ids.add(str(tool_id))
 
     if not drop_assistant_indexes and not dropped_tool_call_ids:
-        return messages
+        return marker_free_messages
 
     repaired = []
-    for idx, msg in enumerate(messages):
+    for idx, msg in enumerate(marker_free_messages):
         if idx <= replay_turn_user_index or not isinstance(msg, dict):
             repaired.append(msg)
             continue
@@ -437,32 +457,68 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
 
 
 def _install_gemini_request_boundary_wrapper() -> None:
-    """Patch the agent chat-completions transport with a request-boundary repair."""
+    """Patch the Agent request boundary and chat-completions transport."""
     global _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
-    try:
-        from agent.transports.chat_completions import ChatCompletionsTransport
-    except Exception:
-        logger.debug("gemini request-boundary wrapper: transport unavailable", exc_info=True)
-        return
-
     with _GEMINI_REQUEST_BOUNDARY_WRAPPER_LOCK:
-        current_build_kwargs = ChatCompletionsTransport.build_kwargs
-        if getattr(current_build_kwargs, "_webui_gemini_request_boundary_wrapper", False):
-            _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
-            return
+        try:
+            from agent import conversation_loop
 
-        def _wrapped_build_kwargs(self, model, messages, tools=None, **params):
-            repaired_messages = _repair_google_gemini_current_turn_tool_state_for_request(
-                messages,
-                model=model,
-                base_url=params.get('base_url'),
-                provider_profile=params.get('provider_profile'),
-            )
-            return current_build_kwargs(self, model, repaired_messages, tools, **params)
+            current_build_turn_context = conversation_loop.build_turn_context
+            if not getattr(current_build_turn_context, "_webui_gemini_request_boundary_wrapper", False):
+                original_build_turn_context = current_build_turn_context
 
-        _wrapped_build_kwargs.__dict__["_webui_gemini_request_boundary_wrapper"] = True
-        _wrapped_build_kwargs.__dict__["_webui_original_build_kwargs"] = current_build_kwargs
-        ChatCompletionsTransport.build_kwargs = _wrapped_build_kwargs
+                def _wrapped_build_turn_context(*args, **kwargs):
+                    ctx = original_build_turn_context(*args, **kwargs)
+                    idx = getattr(ctx, "current_turn_user_idx", -1)
+                    messages = getattr(ctx, "messages", None)
+                    if isinstance(messages, list) and 0 <= idx < len(messages):
+                        message = messages[idx]
+                        if isinstance(message, dict) and message.get('role') == 'user':
+                            messages[idx] = _GeminiRequestBoundaryMessage(message)
+                    return ctx
+
+                _wrapped_build_turn_context.__dict__["_webui_gemini_request_boundary_wrapper"] = True
+                _wrapped_build_turn_context.__dict__["_webui_original_build_turn_context"] = original_build_turn_context
+                conversation_loop.build_turn_context = _wrapped_build_turn_context
+
+            current_reanchor = conversation_loop.reanchor_current_turn_user_idx
+            if not getattr(current_reanchor, "_webui_gemini_request_boundary_wrapper", False):
+                original_reanchor = current_reanchor
+
+                def _wrapped_reanchor(messages, user_message):
+                    idx = original_reanchor(messages, user_message)
+                    if 0 <= idx < len(messages):
+                        message = messages[idx]
+                        if isinstance(message, dict) and message.get('role') == 'user':
+                            messages[idx] = _GeminiRequestBoundaryMessage(message)
+                    return idx
+
+                _wrapped_reanchor.__dict__["_webui_gemini_request_boundary_wrapper"] = True
+                _wrapped_reanchor.__dict__["_webui_original_reanchor"] = original_reanchor
+                conversation_loop.reanchor_current_turn_user_idx = _wrapped_reanchor
+        except Exception:
+            logger.debug("gemini request-boundary wrapper: Agent hooks unavailable", exc_info=True)
+
+        try:
+            from agent.transports.chat_completions import ChatCompletionsTransport
+
+            current_build_kwargs = ChatCompletionsTransport.build_kwargs
+            if not getattr(current_build_kwargs, "_webui_gemini_request_boundary_wrapper", False):
+
+                def _wrapped_build_kwargs(self, model, messages, tools=None, **params):
+                    repaired_messages = _repair_google_gemini_current_turn_tool_state_for_request(
+                        messages,
+                        model=model,
+                        base_url=params.get('base_url'),
+                        provider_profile=params.get('provider_profile'),
+                    )
+                    return current_build_kwargs(self, model, repaired_messages, tools, **params)
+
+                _wrapped_build_kwargs.__dict__["_webui_gemini_request_boundary_wrapper"] = True
+                _wrapped_build_kwargs.__dict__["_webui_original_build_kwargs"] = current_build_kwargs
+                ChatCompletionsTransport.build_kwargs = _wrapped_build_kwargs
+        except Exception:
+            logger.debug("gemini request-boundary wrapper: transport unavailable", exc_info=True)
         _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -21,6 +21,7 @@ import threading
 import time
 import traceback
 import copy
+from urllib.parse import urlsplit
 from pathlib import Path
 from typing import Optional
 
@@ -337,19 +338,21 @@ def _request_targets_google_gemini_three(
     model_lower = str(model or '').strip().lower()
     if 'gemini-3' not in model_lower:
         return False
-    base_lower = str(base_url or '').strip().lower()
-    if 'generativelanguage.googleapis.com' in base_lower:
+    try:
+        hostname = (urlsplit(str(base_url or '').strip()).hostname or '').lower()
+    except ValueError:
+        hostname = ''
+    if hostname == 'generativelanguage.googleapis.com':
         return True
     if provider_profile is None:
         return False
-    module_name = str(getattr(type(provider_profile), '__module__', '') or '').lower()
     provider_id = str(
         getattr(provider_profile, 'provider_id', None)
         or getattr(provider_profile, 'id', None)
         or getattr(provider_profile, 'name', None)
         or ''
     ).strip().lower()
-    return 'google' in module_name or provider_id in {'google', 'gemini'}
+    return provider_id in {'google', 'gemini'}
 
 
 def _repair_google_gemini_current_turn_tool_state_for_request(
@@ -387,29 +390,6 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
 
     replay_turn_user_index = last_user_index
     if last_user_index == len(messages) - 1:
-        prior_msg = messages[last_user_index - 1] if last_user_index > 0 else None
-        prior_turn_incomplete = (
-            isinstance(prior_msg, dict)
-            and (
-                prior_msg.get('role') == 'tool'
-                or (
-                    prior_msg.get('role') == 'assistant'
-                    and isinstance(prior_msg.get('tool_calls'), list)
-                    and bool(prior_msg.get('tool_calls'))
-                )
-            )
-        )
-        if not prior_turn_incomplete:
-            return messages
-        replay_turn_user_index = None
-        for idx in range(last_user_index - 1, -1, -1):
-            msg = messages[idx]
-            if isinstance(msg, dict) and msg.get('role') == 'user':
-                replay_turn_user_index = idx
-                break
-        if replay_turn_user_index is None:
-            return messages
-    elif last_user_index >= len(messages) - 1:
         return messages
 
     drop_assistant_indexes = set()

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4368,6 +4368,63 @@ def _compact_session_image_parts_for_persistence(session) -> int:
     return changed
 
 
+def _tool_call_has_thought_signature(tool_call) -> bool:
+    """Return True when a replayed tool call already carries Gemini signature metadata."""
+    if not isinstance(tool_call, dict):
+        return False
+    for candidate in (
+        tool_call,
+        tool_call.get('function'),
+        tool_call.get('extra_content'),
+        (tool_call.get('extra_content') or {}).get('google'),
+    ):
+        if not isinstance(candidate, dict):
+            continue
+        for key in ('thought_signature', 'thoughtSignature'):
+            if str(candidate.get(key) or '').strip():
+                return True
+    return False
+
+
+def _replay_may_target_google(cfg, effective_provider) -> bool:
+    """Return True when the current replay may be consumed by Google/Gemini."""
+    try:
+        from api.routes import _normalize_provider_id
+    except Exception:
+        _normalize_provider_id = None
+
+    def _is_google(provider):
+        if not provider:
+            return False
+        raw = str(provider).strip()
+        if not raw:
+            return False
+        if _normalize_provider_id is not None:
+            try:
+                return _normalize_provider_id(raw) == 'google'
+            except Exception:
+                pass
+        lowered = raw.lower()
+        return lowered == 'google' or lowered == 'gemini' or lowered.startswith('google:')
+
+    if _is_google(effective_provider):
+        return True
+    if not isinstance(cfg, dict):
+        return False
+    for key in ('fallback_providers', 'fallback_model'):
+        raw_entries = cfg.get(key)
+        if isinstance(raw_entries, dict):
+            entries = [raw_entries]
+        elif isinstance(raw_entries, list):
+            entries = raw_entries
+        else:
+            entries = []
+        for entry in entries:
+            if isinstance(entry, dict) and _is_google(entry.get('provider')):
+                return True
+    return False
+
+
 def _sanitize_messages_for_api(
     messages,
     *,
@@ -4395,6 +4452,7 @@ def _sanitize_messages_for_api(
     causing 400s on every later text-only turn (#2297).
     """
     strip_native_images = cfg is not None and _resolve_image_input_mode(cfg) == "text"
+    replay_google_tool_state = _replay_may_target_google(cfg, effective_provider)
     # First pass: collect all tool_call_ids declared by assistant messages.
     # Handles both OpenAI ('id') and Anthropic ('call_id') field names.
     valid_tool_call_ids: set = set()
@@ -4403,10 +4461,14 @@ def _sanitize_messages_for_api(
             continue
         if msg.get('role') == 'assistant':
             for tc in msg.get('tool_calls') or []:
-                if isinstance(tc, dict):
-                    tid = tc.get('id') or tc.get('call_id') or ''
-                    if tid:
-                        valid_tool_call_ids.add(tid)
+                if not isinstance(tc, dict):
+                    continue
+                tid = tc.get('id') or tc.get('call_id') or ''
+                if not tid:
+                    continue
+                if replay_google_tool_state and not _tool_call_has_thought_signature(tc):
+                    continue
+                valid_tool_call_ids.add(tid)
 
     # Second pass: build the sanitized list, dropping orphaned tool messages.
     clean = []

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -160,6 +160,7 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
 )
 _STREAMING_CRONJOB_WRAPPER_INSTALLED = False
 _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+_GEMINI_REQUEST_BOUNDARY_WRAPPER_LOCK = threading.Lock()
 
 
 def _stream_writeback_diag_threshold_seconds(environ=None):
@@ -381,12 +382,39 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
         if isinstance(msg, dict) and msg.get('role') == 'user':
             last_user_index = idx
             break
-    if last_user_index is None or last_user_index >= len(messages) - 1:
+    if last_user_index is None:
+        return messages
+
+    replay_turn_user_index = last_user_index
+    if last_user_index == len(messages) - 1:
+        prior_msg = messages[last_user_index - 1] if last_user_index > 0 else None
+        prior_turn_incomplete = (
+            isinstance(prior_msg, dict)
+            and (
+                prior_msg.get('role') == 'tool'
+                or (
+                    prior_msg.get('role') == 'assistant'
+                    and isinstance(prior_msg.get('tool_calls'), list)
+                    and bool(prior_msg.get('tool_calls'))
+                )
+            )
+        )
+        if not prior_turn_incomplete:
+            return messages
+        replay_turn_user_index = None
+        for idx in range(last_user_index - 1, -1, -1):
+            msg = messages[idx]
+            if isinstance(msg, dict) and msg.get('role') == 'user':
+                replay_turn_user_index = idx
+                break
+        if replay_turn_user_index is None:
+            return messages
+    elif last_user_index >= len(messages) - 1:
         return messages
 
     drop_assistant_indexes = set()
     dropped_tool_call_ids: set[str] = set()
-    for idx in range(last_user_index + 1, len(messages)):
+    for idx in range(replay_turn_user_index + 1, len(messages)):
         msg = messages[idx]
         if not isinstance(msg, dict) or msg.get('role') != 'assistant':
             continue
@@ -408,7 +436,7 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
 
     repaired = []
     for idx, msg in enumerate(messages):
-        if idx <= last_user_index or not isinstance(msg, dict):
+        if idx <= replay_turn_user_index or not isinstance(msg, dict):
             repaired.append(msg)
             continue
         if msg.get('role') == 'tool':
@@ -431,32 +459,31 @@ def _repair_google_gemini_current_turn_tool_state_for_request(
 def _install_gemini_request_boundary_wrapper() -> None:
     """Patch the agent chat-completions transport with a request-boundary repair."""
     global _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
-    if _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED:
-        return
     try:
         from agent.transports.chat_completions import ChatCompletionsTransport
     except Exception:
         logger.debug("gemini request-boundary wrapper: transport unavailable", exc_info=True)
         return
 
-    original_build_kwargs = ChatCompletionsTransport.build_kwargs
-    if getattr(original_build_kwargs, "_webui_gemini_request_boundary_wrapper", False):
+    with _GEMINI_REQUEST_BOUNDARY_WRAPPER_LOCK:
+        current_build_kwargs = ChatCompletionsTransport.build_kwargs
+        if getattr(current_build_kwargs, "_webui_gemini_request_boundary_wrapper", False):
+            _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
+            return
+
+        def _wrapped_build_kwargs(self, model, messages, tools=None, **params):
+            repaired_messages = _repair_google_gemini_current_turn_tool_state_for_request(
+                messages,
+                model=model,
+                base_url=params.get('base_url'),
+                provider_profile=params.get('provider_profile'),
+            )
+            return current_build_kwargs(self, model, repaired_messages, tools, **params)
+
+        _wrapped_build_kwargs.__dict__["_webui_gemini_request_boundary_wrapper"] = True
+        _wrapped_build_kwargs.__dict__["_webui_original_build_kwargs"] = current_build_kwargs
+        ChatCompletionsTransport.build_kwargs = _wrapped_build_kwargs
         _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
-        return
-
-    def _wrapped_build_kwargs(self, model, messages, tools=None, **params):
-        repaired_messages = _repair_google_gemini_current_turn_tool_state_for_request(
-            messages,
-            model=model,
-            base_url=params.get('base_url'),
-            provider_profile=params.get('provider_profile'),
-        )
-        return original_build_kwargs(self, model, repaired_messages, tools, **params)
-
-    _wrapped_build_kwargs.__dict__["_webui_gemini_request_boundary_wrapper"] = True
-    _wrapped_build_kwargs.__dict__["_webui_original_build_kwargs"] = original_build_kwargs
-    ChatCompletionsTransport.build_kwargs = _wrapped_build_kwargs
-    _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
 
 
 _PERSISTENT_MEMORY_FILES = (

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -159,6 +159,7 @@ _STREAMING_CRON_PROFILE_HOME: contextvars.ContextVar[str | None] = contextvars.C
     default=None,
 )
 _STREAMING_CRONJOB_WRAPPER_INSTALLED = False
+_GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
 
 
 def _stream_writeback_diag_threshold_seconds(environ=None):
@@ -289,6 +290,173 @@ def _install_streaming_cronjob_profile_wrapper() -> None:
         dynamic_schema_overrides=entry.dynamic_schema_overrides,
     )
     _STREAMING_CRONJOB_WRAPPER_INSTALLED = True
+
+
+def _tool_call_has_google_thought_signature(tool_call) -> bool:
+    """Return True when a tool call already carries Gemini thought-signature metadata."""
+    if not isinstance(tool_call, dict):
+        return False
+    for candidate in (
+        tool_call,
+        tool_call.get('function'),
+        tool_call.get('extra_content'),
+        (tool_call.get('extra_content') or {}).get('google'),
+    ):
+        if not isinstance(candidate, dict):
+            continue
+        for key in ('thought_signature', 'thoughtSignature'):
+            if str(candidate.get(key) or '').strip():
+                return True
+    return False
+
+
+def _assistant_message_has_visible_content(message) -> bool:
+    content = message.get('content') if isinstance(message, dict) else None
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, str) and part.strip():
+                return True
+            if isinstance(part, dict):
+                for key in ('text', 'content'):
+                    value = part.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return True
+        return False
+    return bool(content)
+
+
+def _request_targets_google_gemini_three(
+    model,
+    *,
+    base_url=None,
+    provider_profile=None,
+) -> bool:
+    model_lower = str(model or '').strip().lower()
+    if 'gemini-3' not in model_lower:
+        return False
+    base_lower = str(base_url or '').strip().lower()
+    if 'generativelanguage.googleapis.com' in base_lower:
+        return True
+    if provider_profile is None:
+        return False
+    module_name = str(getattr(type(provider_profile), '__module__', '') or '').lower()
+    provider_id = str(
+        getattr(provider_profile, 'provider_id', None)
+        or getattr(provider_profile, 'id', None)
+        or getattr(provider_profile, 'name', None)
+        or ''
+    ).strip().lower()
+    return 'google' in module_name or provider_id in {'google', 'gemini'}
+
+
+def _repair_google_gemini_current_turn_tool_state_for_request(
+    messages,
+    *,
+    model,
+    base_url=None,
+    provider_profile=None,
+):
+    """Return a request-only copy with Gemini-unsafe current-turn tool state removed.
+
+    This repair runs at the outbound request boundary, not on canonical session
+    history. Gemini 3 only requires current-turn tool-call replay to carry
+    thought signatures, and Hermes-native parallel groups sign only the first
+    call in the assistant message. So keep whole groups whose first call is
+    signed, and drop whole current-turn groups whose first call is unsigned.
+    """
+    if not isinstance(messages, list):
+        return messages
+    if not _request_targets_google_gemini_three(
+        model,
+        base_url=base_url,
+        provider_profile=provider_profile,
+    ):
+        return messages
+
+    last_user_index = None
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if isinstance(msg, dict) and msg.get('role') == 'user':
+            last_user_index = idx
+            break
+    if last_user_index is None or last_user_index >= len(messages) - 1:
+        return messages
+
+    drop_assistant_indexes = set()
+    dropped_tool_call_ids: set[str] = set()
+    for idx in range(last_user_index + 1, len(messages)):
+        msg = messages[idx]
+        if not isinstance(msg, dict) or msg.get('role') != 'assistant':
+            continue
+        tool_calls = msg.get('tool_calls')
+        if not isinstance(tool_calls, list) or not tool_calls:
+            continue
+        if _tool_call_has_google_thought_signature(tool_calls[0]):
+            continue
+        drop_assistant_indexes.add(idx)
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            tool_id = tool_call.get('id') or tool_call.get('call_id') or ''
+            if tool_id:
+                dropped_tool_call_ids.add(str(tool_id))
+
+    if not drop_assistant_indexes and not dropped_tool_call_ids:
+        return messages
+
+    repaired = []
+    for idx, msg in enumerate(messages):
+        if idx <= last_user_index or not isinstance(msg, dict):
+            repaired.append(msg)
+            continue
+        if msg.get('role') == 'tool':
+            tool_call_id = str(msg.get('tool_call_id') or '').strip()
+            if tool_call_id and tool_call_id in dropped_tool_call_ids:
+                continue
+            repaired.append(msg)
+            continue
+        if idx in drop_assistant_indexes:
+            patched = dict(msg)
+            patched.pop('tool_calls', None)
+            if not _assistant_message_has_visible_content(patched):
+                continue
+            repaired.append(patched)
+            continue
+        repaired.append(msg)
+    return repaired
+
+
+def _install_gemini_request_boundary_wrapper() -> None:
+    """Patch the agent chat-completions transport with a request-boundary repair."""
+    global _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
+    if _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED:
+        return
+    try:
+        from agent.transports.chat_completions import ChatCompletionsTransport
+    except Exception:
+        logger.debug("gemini request-boundary wrapper: transport unavailable", exc_info=True)
+        return
+
+    original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    if getattr(original_build_kwargs, "_webui_gemini_request_boundary_wrapper", False):
+        _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
+        return
+
+    def _wrapped_build_kwargs(self, model, messages, tools=None, **params):
+        repaired_messages = _repair_google_gemini_current_turn_tool_state_for_request(
+            messages,
+            model=model,
+            base_url=params.get('base_url'),
+            provider_profile=params.get('provider_profile'),
+        )
+        return original_build_kwargs(self, model, repaired_messages, tools, **params)
+
+    _wrapped_build_kwargs.__dict__["_webui_gemini_request_boundary_wrapper"] = True
+    _wrapped_build_kwargs.__dict__["_webui_original_build_kwargs"] = original_build_kwargs
+    ChatCompletionsTransport.build_kwargs = _wrapped_build_kwargs
+    _GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
 
 
 _PERSISTENT_MEMORY_FILES = (
@@ -4423,8 +4591,6 @@ def _replay_may_target_google(cfg, effective_provider) -> bool:
             if isinstance(entry, dict) and _is_google(entry.get('provider')):
                 return True
     return False
-
-
 def _sanitize_messages_for_api(
     messages,
     *,
@@ -4452,7 +4618,6 @@ def _sanitize_messages_for_api(
     causing 400s on every later text-only turn (#2297).
     """
     strip_native_images = cfg is not None and _resolve_image_input_mode(cfg) == "text"
-    replay_google_tool_state = _replay_may_target_google(cfg, effective_provider)
     # First pass: collect all tool_call_ids declared by assistant messages.
     # Handles both OpenAI ('id') and Anthropic ('call_id') field names.
     valid_tool_call_ids: set = set()
@@ -4465,8 +4630,6 @@ def _sanitize_messages_for_api(
                     continue
                 tid = tc.get('id') or tc.get('call_id') or ''
                 if not tid:
-                    continue
-                if replay_google_tool_state and not _tool_call_has_thought_signature(tc):
                     continue
                 valid_tool_call_ids.add(tid)
 
@@ -7771,7 +7934,6 @@ def _run_agent_streaming(
         ensure_agent_runtime_current()
         _prewarm_skill_tool_modules()
         _install_streaming_cronjob_profile_wrapper()
-
         # Full-turn serialization is only needed for static/legacy skill-module
         # resolution, where process-global skill-module globals are still used.
         # Dynamic-capable modules continue concurrent execution.
@@ -7796,6 +7958,7 @@ def _run_agent_streaming(
                 _SKILL_HOME_MODULE_PATCH_LOCK.acquire()
                 _acquired_streaming_skill_home_patch_lock = True
 
+        _install_gemini_request_boundary_wrapper()
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -6,6 +6,8 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+import pytest
+
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
@@ -199,8 +201,14 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     import api.session_lifecycle as lifecycle
     import api.streaming as streaming
     from api.models import Session
-    from agent.transports.chat_completions import ChatCompletionsTransport
-    import run_agent
+    ChatCompletionsTransport = pytest.importorskip(
+        "agent.transports.chat_completions",
+        reason="hermes-agent transport modules not importable",
+    ).ChatCompletionsTransport
+    run_agent = pytest.importorskip(
+        "run_agent",
+        reason="hermes-agent runner not importable",
+    )
 
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
@@ -531,8 +539,14 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_history():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
-    from agent.transports import get_transport
-    from agent.transports.chat_completions import ChatCompletionsTransport
+    get_transport = pytest.importorskip(
+        "agent.transports",
+        reason="hermes-agent transport modules not importable",
+    ).get_transport
+    ChatCompletionsTransport = pytest.importorskip(
+        "agent.transports.chat_completions",
+        reason="hermes-agent transport modules not importable",
+    ).ChatCompletionsTransport
 
     original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
     original_build_kwargs = ChatCompletionsTransport.build_kwargs
@@ -591,7 +605,10 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
 def test_transport_wrapper_rewraps_replaced_real_chat_transport():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
-    from agent.transports.chat_completions import ChatCompletionsTransport
+    ChatCompletionsTransport = pytest.importorskip(
+        "agent.transports.chat_completions",
+        reason="hermes-agent transport modules not importable",
+    ).ChatCompletionsTransport
 
     original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
     original_build_kwargs = ChatCompletionsTransport.build_kwargs

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -2,6 +2,7 @@
 import copy
 import pathlib
 import sys
+import types
 
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -167,3 +168,55 @@ def test_non_google_route_does_not_prune_gemini_named_model_history():
     )
 
     assert result == messages, "only Google Gemini requests should receive the request-boundary repair"
+
+
+def test_transport_wrapper_repairs_google_request_copy_without_mutating_input(monkeypatch):
+    from api.streaming import _install_gemini_request_boundary_wrapper
+    import api.streaming as streaming
+
+    agent_pkg = types.ModuleType("agent")
+    agent_pkg.__path__ = []
+    transports_pkg = types.ModuleType("agent.transports")
+    transports_pkg.__path__ = []
+    chat_module = types.ModuleType("agent.transports.chat_completions")
+
+    class ChatCompletionsTransport:
+        def build_kwargs(self, model, messages, tools=None, **params):
+            return {
+                "model": model,
+                "messages": messages,
+                "tools": tools,
+                **params,
+            }
+
+    chat_module.ChatCompletionsTransport = ChatCompletionsTransport
+    transports_pkg.chat_completions = chat_module
+    agent_pkg.transports = transports_pkg
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.transports", transports_pkg)
+    monkeypatch.setitem(sys.modules, "agent.transports.chat_completions", chat_module)
+
+    streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+
+    messages = _prior_and_current_turn_history()
+    original = copy.deepcopy(messages)
+
+    _install_gemini_request_boundary_wrapper()
+    transport = ChatCompletionsTransport()
+    kwargs = transport.build_kwargs(
+        model="gemini-3-flash",
+        messages=messages,
+        tools=None,
+        base_url=GOOGLE_OPENAI_BASE,
+    )
+
+    result = kwargs["messages"]
+    assert messages == original, "the transport wrapper must repair only the outbound request copy"
+    assert any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_prior"
+        for m in result
+    ), "prior completed turns must stay intact through the wrapped build path"
+    assert not any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+        for m in result
+    ), "the wrapped build path must strip the current-turn unsigned group before Gemini sees it"

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -31,6 +31,35 @@ def _boundary_marker_key():
     return _GEMINI_REQUEST_BOUNDARY_MARKER
 
 
+def _boundary_wrapper_type():
+    from api.streaming import _GeminiRequestBoundaryMessage
+
+    return _GeminiRequestBoundaryMessage
+
+
+def _assert_no_materialized_boundary_marker(messages):
+    marker = _boundary_marker_key()
+    assert not any(
+        marker in message
+        for message in messages
+        if isinstance(message, dict)
+    )
+
+
+def _assert_no_boundary_wrapper_instances(messages):
+    wrapper_type = _boundary_wrapper_type()
+    assert not any(
+        isinstance(message, wrapper_type)
+        for message in messages
+        if isinstance(message, dict)
+    )
+
+
+def _assert_no_boundary_artifacts(messages):
+    _assert_no_materialized_boundary_marker(messages)
+    _assert_no_boundary_wrapper_instances(messages)
+
+
 def _import_real_conversation_loop():
     original_agent_modules = {
         name: module
@@ -331,6 +360,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 
     primary_success_calls = []
     fallback_primary_calls = []
+    writeback_primary_calls = []
     fallback_calls = []
     fallback_resolution_calls = []
     captured_results = {}
@@ -363,6 +393,12 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
         fallback_calls.append(copy.deepcopy(kwargs))
         return _assistant_response("fallback recovered")
 
+    def _writeback_primary_create(*_args, **kwargs):
+        writeback_primary_calls.append(copy.deepcopy(kwargs))
+        if len(writeback_primary_calls) == 1:
+            return _assistant_response("Checking the next order.", [active_tool_call])
+        return _assistant_response("primary stayed primary")
+
     scenarios = {
         "issue6333-primary": {
             "primary_client": _make_client(
@@ -374,6 +410,12 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             "primary_client": _make_client(
                 "https://integrate.api.nvidia.com/v1",
                 _fallback_primary_create,
+            ),
+        },
+        "issue6333-writeback": {
+            "primary_client": _make_client(
+                "https://integrate.api.nvidia.com/v1",
+                _writeback_primary_create,
             ),
         },
     }
@@ -407,6 +449,17 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 
         def run_conversation(self, **kwargs):
             result = super().run_conversation(**kwargs)
+            if self.session_id == "issue6333-writeback":
+                dirty_result = copy.deepcopy(result)
+                for message in dirty_result.get("messages") or []:
+                    if (
+                        isinstance(message, dict)
+                        and message.get("role") == "user"
+                        and str(message.get("content") or "").endswith("continue after dirty copied result")
+                    ):
+                        message[streaming._GEMINI_REQUEST_BOUNDARY_MARKER] = True
+                        break
+                result = dirty_result
             captured_results[self.session_id] = copy.deepcopy(result)
             return result
 
@@ -583,6 +636,11 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             stream_id="stream-6333-fallback",
             msg_text="continue with fallback",
         )
+        writeback_saved = _run_stream(
+            session_id="issue6333-writeback",
+            stream_id="stream-6333-writeback",
+            msg_text="continue after dirty copied result",
+        )
     finally:
         restore_agent_modules()
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
@@ -630,14 +688,17 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
         "name": "lookup",
         "content": "order 2: pending",
     }
-    assert tool_executions == [expected_tool_row, expected_tool_row]
+    assert tool_executions == [expected_tool_row, expected_tool_row, expected_tool_row]
     primary_messages = primary_success_calls[1]["messages"]
     _assert_canonical_current_turn(primary_messages)
     primary_result = captured_results["issue6333-primary"]
     _assert_canonical_current_turn(primary_result["messages"])
+    _assert_no_materialized_boundary_marker(primary_result["messages"])
     assert primary_saved is not None
     _assert_canonical_current_turn(primary_saved.context_messages)
     _assert_canonical_current_turn(primary_saved.messages)
+    _assert_no_materialized_boundary_marker(primary_saved.context_messages)
+    _assert_no_materialized_boundary_marker(primary_saved.messages)
     assert primary_result["messages"][-1]["content"] == "primary stayed primary"
     assert primary_saved.messages[-1]["content"] == "primary stayed primary"
 
@@ -659,6 +720,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 
     fallback_result = captured_results["issue6333-fallback"]
     _assert_canonical_current_turn(fallback_result["messages"])
+    _assert_no_materialized_boundary_marker(fallback_result["messages"])
     fallback_messages = fallback_calls[0]["messages"]
     current_assistant = next(
         m
@@ -675,8 +737,21 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     assert fallback_saved is not None
     _assert_canonical_current_turn(fallback_saved.context_messages)
     _assert_canonical_current_turn(fallback_saved.messages)
+    _assert_no_materialized_boundary_marker(fallback_saved.context_messages)
+    _assert_no_materialized_boundary_marker(fallback_saved.messages)
     assert fallback_result["messages"][-1]["content"] == "fallback recovered"
     assert fallback_saved.messages[-1]["content"] == "fallback recovered"
+    writeback_result = captured_results["issue6333-writeback"]
+    assert any(
+        _boundary_marker_key() in message
+        for message in writeback_result["messages"]
+        if isinstance(message, dict)
+    ), "the integration must inject a dirty copied marker or the writeback assertion is vacuous"
+    assert writeback_saved is not None
+    _assert_canonical_current_turn(writeback_saved.context_messages)
+    _assert_canonical_current_turn(writeback_saved.messages)
+    _assert_no_materialized_boundary_marker(writeback_saved.context_messages)
+    _assert_no_materialized_boundary_marker(writeback_saved.messages)
 
     from api.streaming import _GEMINI_REQUEST_BOUNDARY_MARKER
     for call in primary_success_calls + fallback_primary_calls + fallback_calls:
@@ -764,7 +839,10 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
 
 def test_boundary_wrapper_reanchors_rebuilt_message_list_and_strips_marker():
     import api.streaming as streaming
-    from api.streaming import _install_gemini_request_boundary_wrapper
+    from api.streaming import (
+        _GeminiRequestBoundaryMessage,
+        _install_gemini_request_boundary_wrapper,
+    )
     conversation_loop, restore_agent_modules = _import_real_conversation_loop()
 
     original_reanchor = conversation_loop.reanchor_current_turn_user_idx
@@ -782,9 +860,11 @@ def test_boundary_wrapper_reanchors_rebuilt_message_list_and_strips_marker():
         rebuilt = [
             {"role": "user", "content": "old"},
             {"role": "assistant", "content": "summary"},
-            {"role": "user", "content": "current"},
+            _GeminiRequestBoundaryMessage({"role": "user", "content": "current"}).copy(),
         ]
+        assert rebuilt[2].get(streaming._GEMINI_REQUEST_BOUNDARY_MARKER) is True
         assert conversation_loop.reanchor_current_turn_user_idx(rebuilt, "current") == 2
+        _assert_no_materialized_boundary_marker(rebuilt)
         outbound = rebuilt[2].copy()
         assert outbound.pop(streaming._GEMINI_REQUEST_BOUNDARY_MARKER) is True
         assert rebuilt[2] == {"role": "user", "content": "current"}
@@ -907,3 +987,211 @@ def test_transport_wrapper_rewraps_replaced_real_chat_transport():
         conversation_loop.build_turn_context = original_build_turn_context
         conversation_loop.reanchor_current_turn_user_idx = original_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
+
+
+def test_build_turn_wrapper_cleans_stale_marker_before_second_turn_and_keeps_single_boundary(
+    tmp_path,
+    monkeypatch,
+):
+    from api.streaming import (
+        _GeminiRequestBoundaryMessage,
+        _install_gemini_request_boundary_wrapper,
+    )
+    import api.models as models
+    import api.streaming as streaming
+    from api.models import Session
+    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+    ChatCompletionsTransport = pytest.importorskip(
+        "agent.transports.chat_completions",
+        reason="hermes-agent transport modules not importable",
+    ).ChatCompletionsTransport
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+
+    original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
+    original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    original_build_turn_context = conversation_loop.build_turn_context
+    original_reanchor = conversation_loop.reanchor_current_turn_user_idx
+    baseline_build_kwargs = getattr(
+        original_build_kwargs,
+        "_webui_original_build_kwargs",
+        original_build_kwargs,
+    )
+    baseline_build_turn_context = getattr(
+        original_build_turn_context,
+        "_webui_original_build_turn_context",
+        original_build_turn_context,
+    )
+    baseline_reanchor = getattr(
+        original_reanchor,
+        "_webui_original_reanchor",
+        original_reanchor,
+    )
+    try:
+        ChatCompletionsTransport.build_kwargs = baseline_build_kwargs
+        conversation_loop.build_turn_context = baseline_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = baseline_reanchor
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+
+        _install_gemini_request_boundary_wrapper()
+        rebuilt_history = [
+            {"role": "user", "content": "look up the first order"},
+            {
+                "role": "assistant",
+                "content": "Found it.",
+                "tool_calls": [{
+                    "id": "call_prior",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"id":"1"}'},
+                }],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_prior",
+                "name": "lookup",
+                "content": "order 1: shipped",
+            },
+            _GeminiRequestBoundaryMessage({"role": "user", "content": "now check the next one"}).copy(),
+        ]
+        assert rebuilt_history[3].get(streaming._GEMINI_REQUEST_BOUNDARY_MARKER) is True
+        assert conversation_loop.reanchor_current_turn_user_idx(rebuilt_history, "now check the next one") == 3
+        assert isinstance(rebuilt_history[3], _GeminiRequestBoundaryMessage)
+
+        def replacement_build_turn_context(*args, **kwargs):
+            return types.SimpleNamespace(
+                messages=list(rebuilt_history) + [
+                    {"role": "user", "content": "and then check the last one"},
+                    {
+                        "role": "assistant",
+                        "content": "Checking the last order.",
+                        "tool_calls": [{
+                            "id": "call_current",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": '{"id":"3"}'},
+                        }],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_current",
+                        "name": "lookup",
+                        "content": "order 3: pending",
+                    },
+                ],
+                current_turn_user_idx=4,
+            )
+
+        conversation_loop.build_turn_context = replacement_build_turn_context
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+        _install_gemini_request_boundary_wrapper()
+
+        ctx = conversation_loop.build_turn_context()
+        _assert_no_materialized_boundary_marker(ctx.messages)
+        assert sum(
+            1
+            for message in ctx.messages
+            if isinstance(message, _GeminiRequestBoundaryMessage)
+        ) == 1
+        assert isinstance(ctx.messages[4], _GeminiRequestBoundaryMessage)
+
+        request_copies = [
+            message.copy()
+            for message in ctx.messages
+            if isinstance(message, dict)
+        ]
+        boundary_count = sum(
+            1
+            for message in request_copies
+            if message.get(streaming._GEMINI_REQUEST_BOUNDARY_MARKER) is True
+        )
+        assert boundary_count == 1
+
+        fallback_kwargs = ChatCompletionsTransport().build_kwargs(
+            model="gemini-3-flash",
+            messages=request_copies,
+            tools=None,
+            base_url=GOOGLE_OPENAI_BASE,
+        )
+        result = fallback_kwargs["messages"]
+        _assert_no_materialized_boundary_marker(ctx.messages)
+        assert any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_prior"
+            for m in result
+        )
+        assert not any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+            for m in result
+        ), "the rebuilt-history second turn must still repair the current-turn unsigned group"
+
+        canonical_ctx_messages = copy.deepcopy(ctx.messages)
+        streaming._sanitize_materialized_gemini_request_boundary_history(canonical_ctx_messages)
+        _assert_no_boundary_artifacts(canonical_ctx_messages)
+        _assert_no_boundary_artifacts(result)
+
+        session = Session(session_id="issue6333-second-turn-history", title="Gemini fallback")
+        session.messages = copy.deepcopy(result)
+        session.context_messages = copy.deepcopy(canonical_ctx_messages)
+        session.save()
+
+        saved = Session.load("issue6333-second-turn-history")
+        assert saved is not None
+        _assert_no_boundary_artifacts(saved.messages)
+        _assert_no_boundary_artifacts(saved.context_messages)
+    finally:
+        restore_agent_modules()
+        ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        conversation_loop.build_turn_context = original_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = original_reanchor
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
+
+
+def test_compression_copied_boundary_marker_is_stripped_before_session_save(
+    tmp_path,
+    monkeypatch,
+):
+    import api.models as models
+    import api.streaming as streaming
+    from api.models import Session
+    from api.streaming import _GeminiRequestBoundaryMessage
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+
+    canonical_messages = [
+        {"role": "user", "content": "look up the first order"},
+        _GeminiRequestBoundaryMessage({"role": "user", "content": "now check the next one"}),
+        {
+            "role": "assistant",
+            "content": "Checking the next order.",
+            "tool_calls": [{
+                "id": "call_current",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": '{"id":"2"}'},
+            }],
+        },
+    ]
+    compression_copied_history = [
+        message.copy()
+        for message in canonical_messages
+        if isinstance(message, dict)
+    ]
+    assert compression_copied_history[1].get(_boundary_marker_key()) is True
+
+    streaming._sanitize_materialized_gemini_request_boundary_history(
+        compression_copied_history
+    )
+    _assert_no_boundary_artifacts(compression_copied_history)
+
+    session = Session(session_id="issue6333-compression-copy", title="Gemini fallback")
+    session.messages = copy.deepcopy(compression_copied_history)
+    session.context_messages = copy.deepcopy(compression_copied_history)
+    session.save()
+
+    saved = Session.load("issue6333-compression-copy")
+    assert saved is not None
+    _assert_no_boundary_artifacts(saved.messages)
+    _assert_no_boundary_artifacts(saved.context_messages)

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -1,8 +1,10 @@
 """Regression coverage for #6333 Gemini fallback request-boundary replay repair."""
 import copy
 import pathlib
+import queue
 import sys
 import types
+from unittest.mock import MagicMock
 
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -170,18 +172,443 @@ def test_non_google_route_does_not_prune_gemini_named_model_history():
     assert result == messages, "only Google Gemini requests should receive the request-boundary repair"
 
 
-def test_transport_wrapper_repairs_google_request_copy_without_mutating_input(monkeypatch):
+def test_gemini3_request_preserves_completed_tool_turn_before_next_user_message():
+    messages = _prior_and_current_turn_history() + [
+        {"role": "assistant", "content": "Order 2 is pending."},
+        {"role": "user", "content": "Thanks, now check order 3."},
+    ]
+    original = copy.deepcopy(messages)
+
+    result = _repair(
+        messages,
+        model="gemini-3-flash",
+        base_url=GOOGLE_OPENAI_BASE,
+    )
+
+    assert messages == original, "request-boundary repair must not mutate canonical history"
+    assert result == original, "a completed prior tool turn must survive a later user message intact"
+
+
+def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outbound_copy(
+    tmp_path,
+    monkeypatch,
+):
+    import api.config as config
+    import api.models as models
+    import api.oauth as oauth
+    import api.session_lifecycle as lifecycle
+    import api.streaming as streaming
+    from api.models import Session
+    from agent.transports.chat_completions import ChatCompletionsTransport
+    import run_agent
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+
+    def _assistant_response(content):
+        message = types.SimpleNamespace(content=content, tool_calls=None)
+        choice = types.SimpleNamespace(message=message, finish_reason="stop")
+        return types.SimpleNamespace(choices=[choice], model="stub/model", usage=None)
+
+    class _RateLimitError(Exception):
+        status_code = 429
+
+        def __init__(self):
+            super().__init__("Error code: 429 - rate limit exceeded")
+            self.response = types.SimpleNamespace(headers={})
+            self.body = {"error": {"message": "rate limit exceeded"}}
+
+    def _make_client(base_url, create_side_effect):
+        create = MagicMock(side_effect=create_side_effect)
+        return types.SimpleNamespace(
+            api_key="synthetic-key",
+            base_url=base_url,
+            _custom_headers=None,
+            default_headers=None,
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            ),
+        )
+
+    primary_success_calls = []
+    fallback_primary_calls = []
+    fallback_calls = []
+    fallback_resolution_calls = []
+    captured_results = {}
+
+    def _primary_success_create(*_args, **kwargs):
+        primary_success_calls.append(copy.deepcopy(kwargs))
+        return _assistant_response("primary stayed primary")
+
+    def _fallback_primary_create(*_args, **kwargs):
+        fallback_primary_calls.append(copy.deepcopy(kwargs))
+        if len(fallback_primary_calls) > 1:
+            raise AssertionError("primary request should switch to fallback after the first 429")
+        raise _RateLimitError()
+
+    def _fallback_create(*_args, **kwargs):
+        fallback_calls.append(copy.deepcopy(kwargs))
+        return _assistant_response("fallback recovered")
+
+    scenarios = {
+        "issue6333-primary": {
+            "primary_client": _make_client(
+                "https://integrate.api.nvidia.com/v1",
+                _primary_success_create,
+            ),
+        },
+        "issue6333-fallback": {
+            "primary_client": _make_client(
+                "https://integrate.api.nvidia.com/v1",
+                _fallback_primary_create,
+            ),
+        },
+    }
+    fallback_client = _make_client(GOOGLE_OPENAI_BASE, _fallback_create)
+
+    class HarnessAgent(run_agent.AIAgent):
+        def __init__(self, **kwargs):
+            kwargs.setdefault("skip_context_files", True)
+            kwargs.setdefault("skip_memory", True)
+            super().__init__(**kwargs)
+            scenario = scenarios[kwargs["session_id"]]
+            self.client = scenario["primary_client"]
+            self._client_kwargs = {
+                "api_key": scenario["primary_client"].api_key,
+                "base_url": scenario["primary_client"].base_url,
+            }
+            self._cached_system_prompt = "You are helpful."
+            self._use_prompt_caching = False
+            self.tool_delay = 0
+            self.compression_enabled = False
+            self.save_trajectories = False
+            self.valid_tool_names = set()
+            self._persist_session = lambda *args, **kwargs: None
+            self._save_trajectory = lambda *args, **kwargs: None
+            self._cleanup_task_resources = lambda *args, **kwargs: None
+
+        def _create_request_openai_client(self, *, reason, api_kwargs=None):
+            if self._fallback_activated or self.provider == "google":
+                return fallback_client
+            return scenarios[self.session_id]["primary_client"]
+
+        def run_conversation(self, **kwargs):
+            result = super().run_conversation(**kwargs)
+            captured_results[self.session_id] = copy.deepcopy(result)
+            return result
+
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
+        "provider": requested or "nvidia",
+        "api_key": "synthetic-key",
+        "base_url": "https://integrate.api.nvidia.com/v1",
+    }
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.runtime_provider = fake_runtime_module
+    fake_model_normalize = types.ModuleType("hermes_cli.model_normalize")
+    fake_model_normalize.normalize_model_for_provider = lambda model, provider: model
+    fake_hermes_cli.model_normalize = fake_model_normalize
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda *args, **kwargs: None
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
+    monkeypatch.setitem(sys.modules, "hermes_cli.model_normalize", fake_model_normalize)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda *args, **kwargs: [])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        run_agent,
+        "OpenAI",
+        lambda *args, **kwargs: _make_client(
+            kwargs.get("base_url") or "https://stub.invalid/v1",
+            lambda *_a, **_kw: _assistant_response("unused"),
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 262144,
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda provider, model=None, **kwargs: (
+            fallback_resolution_calls.append(
+                {
+                    "provider": provider,
+                    "model": model,
+                    "base_url": kwargs.get("explicit_base_url"),
+                }
+            )
+            or (fallback_client, model)
+        ),
+    )
+    monkeypatch.setattr(
+        streaming,
+        "resolve_model_provider",
+        lambda *_args, **_kwargs: (
+            "glm-5.2",
+            "nvidia",
+            "https://integrate.api.nvidia.com/v1",
+        ),
+    )
+    monkeypatch.setattr(streaming, "_maybe_schedule_title_refresh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(streaming, "ensure_agent_runtime_current", lambda: None)
+    monkeypatch.setattr(streaming, "_prewarm_skill_tool_modules", lambda: None)
+    monkeypatch.setattr(
+        oauth,
+        "resolve_runtime_provider_with_anthropic_env_lock",
+        lambda resolver, **kwargs: resolver(**kwargs),
+    )
+    monkeypatch.setattr(streaming, "_get_ai_agent", lambda: HarnessAgent)
+    monkeypatch.setattr(streaming, "get_config", lambda: {
+        "fallback_providers": [
+            {"provider": "google", "model": "gemini-3-flash"},
+        ]
+    })
+    monkeypatch.setattr("api.config.get_config", lambda: {
+        "fallback_providers": [
+            {"provider": "google", "model": "gemini-3-flash"},
+        ]
+    })
+    monkeypatch.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("api.config.load_settings", lambda: {})
+
+    sessions = {}
+    original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
+    sessions_snapshot = dict(models.SESSIONS)
+    streams_snapshot = dict(config.STREAMS)
+    cancel_flags_snapshot = dict(config.CANCEL_FLAGS)
+    agent_instances_snapshot = dict(config.AGENT_INSTANCES)
+    partial_text_snapshot = dict(config.STREAM_PARTIAL_TEXT)
+    reasoning_text_snapshot = dict(config.STREAM_REASONING_TEXT)
+    live_tool_calls_snapshot = dict(config.STREAM_LIVE_TOOL_CALLS)
+    session_agent_locks_snapshot = dict(config.SESSION_AGENT_LOCKS)
+    with config.SESSION_AGENT_CACHE_LOCK:
+        session_agent_cache_snapshot = list(config.SESSION_AGENT_CACHE.items())
+    with lifecycle._condition:
+        lifecycle_sessions_snapshot = dict(lifecycle._sessions)
+
+    def _new_session(session_id, stream_id, pending_user_message):
+        session = Session(session_id=session_id, title="Gemini fallback")
+        session.messages = _prior_and_current_turn_history()
+        session.context_messages = _prior_and_current_turn_history()
+        session.pending_user_message = pending_user_message
+        session.pending_attachments = []
+        session.pending_started_at = 1234567890.0
+        session.pending_user_source = "webui"
+        session.active_stream_id = stream_id
+        session.workspace = str(tmp_path)
+        session.save()
+        sessions[session_id] = session
+        return session
+
+    def _run_stream(session_id, stream_id, msg_text):
+        session = _new_session(session_id, stream_id, msg_text)
+        models.SESSIONS[session_id] = session
+        config.STREAMS[stream_id] = queue.Queue()
+        streaming._run_agent_streaming(
+            session_id=session_id,
+            msg_text=msg_text,
+            model="glm-5.2",
+            workspace=str(tmp_path),
+            stream_id=stream_id,
+            attachments=[],
+        )
+        return Session.load(session_id)
+
+    def _assert_canonical_current_turn(messages):
+        assert any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+            for m in messages
+        ), "canonical history must keep the current-turn tool row"
+        assert any(
+            tc.get("id") == "call_current"
+            for m in messages
+            if m.get("role") == "assistant"
+            for tc in (m.get("tool_calls") or [])
+        ), "canonical history must keep the unsigned current-turn tool call metadata"
+
+    monkeypatch.setattr(streaming, "get_session", lambda session_id: sessions[session_id])
+
+    models.SESSIONS.clear()
+    config.STREAMS.clear()
+    config.CANCEL_FLAGS.clear()
+    config.AGENT_INSTANCES.clear()
+    config.STREAM_PARTIAL_TEXT.clear()
+    config.STREAM_REASONING_TEXT.clear()
+    config.STREAM_LIVE_TOOL_CALLS.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+    with config.SESSION_AGENT_CACHE_LOCK:
+        config.SESSION_AGENT_CACHE.clear()
+    with lifecycle._condition:
+        lifecycle._sessions.clear()
+        lifecycle._condition.notify_all()
+
+    try:
+        primary_saved = _run_stream(
+            session_id="issue6333-primary",
+            stream_id="stream-6333-primary",
+            msg_text="continue without fallback",
+        )
+        fallback_saved = _run_stream(
+            session_id="issue6333-fallback",
+            stream_id="stream-6333-fallback",
+            msg_text="continue with fallback",
+        )
+    finally:
+        ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
+        models.SESSIONS.clear()
+        models.SESSIONS.update(sessions_snapshot)
+        config.STREAMS.clear()
+        config.STREAMS.update(streams_snapshot)
+        config.CANCEL_FLAGS.clear()
+        config.CANCEL_FLAGS.update(cancel_flags_snapshot)
+        config.AGENT_INSTANCES.clear()
+        config.AGENT_INSTANCES.update(agent_instances_snapshot)
+        config.STREAM_PARTIAL_TEXT.clear()
+        config.STREAM_PARTIAL_TEXT.update(partial_text_snapshot)
+        config.STREAM_REASONING_TEXT.clear()
+        config.STREAM_REASONING_TEXT.update(reasoning_text_snapshot)
+        config.STREAM_LIVE_TOOL_CALLS.clear()
+        config.STREAM_LIVE_TOOL_CALLS.update(live_tool_calls_snapshot)
+        config.SESSION_AGENT_LOCKS.clear()
+        config.SESSION_AGENT_LOCKS.update(session_agent_locks_snapshot)
+        with config.SESSION_AGENT_CACHE_LOCK:
+            config.SESSION_AGENT_CACHE.clear()
+            config.SESSION_AGENT_CACHE.update(session_agent_cache_snapshot)
+        with lifecycle._condition:
+            lifecycle._sessions.clear()
+            lifecycle._sessions.update(lifecycle_sessions_snapshot)
+            lifecycle._condition.notify_all()
+
+    assert len(primary_success_calls) == 1
+    primary_messages = primary_success_calls[0]["messages"]
+    _assert_canonical_current_turn(primary_messages)
+    primary_result = captured_results["issue6333-primary"]
+    _assert_canonical_current_turn(primary_result["messages"])
+    assert primary_saved is not None
+    _assert_canonical_current_turn(primary_saved.context_messages)
+    _assert_canonical_current_turn(primary_saved.messages)
+    assert primary_result["messages"][-1]["content"] == "primary stayed primary"
+    assert primary_saved.messages[-1]["content"] == "primary stayed primary"
+
+    assert len(fallback_primary_calls) == 1
+    assert len(fallback_calls) == 1
+    assert len(fallback_resolution_calls) == 1
+    assert fallback_resolution_calls[0]["provider"] == "google"
+    assert fallback_resolution_calls[0]["model"] == "gemini-3-flash"
+
+    fallback_primary_messages = fallback_primary_calls[0]["messages"]
+    _assert_canonical_current_turn(fallback_primary_messages)
+
+    fallback_result = captured_results["issue6333-fallback"]
+    _assert_canonical_current_turn(fallback_result["messages"])
+    fallback_messages = fallback_calls[0]["messages"]
+    current_assistant = next(
+        m
+        for m in fallback_messages
+        if m.get("role") == "assistant"
+        and m.get("content") == "Checking the next order."
+    )
+    assert "tool_calls" not in current_assistant
+    assert not any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+        for m in fallback_messages
+    ), "activated Gemini fallback must repair only its outbound request copy"
+
+    assert fallback_saved is not None
+    _assert_canonical_current_turn(fallback_saved.context_messages)
+    _assert_canonical_current_turn(fallback_saved.messages)
+    assert fallback_result["messages"][-1]["content"] == "fallback recovered"
+    assert fallback_saved.messages[-1]["content"] == "fallback recovered"
+
+
+def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_history():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
+    from agent.transports import get_transport
+    from agent.transports.chat_completions import ChatCompletionsTransport
 
-    agent_pkg = types.ModuleType("agent")
-    agent_pkg.__path__ = []
-    transports_pkg = types.ModuleType("agent.transports")
-    transports_pkg.__path__ = []
-    chat_module = types.ModuleType("agent.transports.chat_completions")
+    original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
+    original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    baseline_build_kwargs = getattr(
+        original_build_kwargs,
+        "_webui_original_build_kwargs",
+        original_build_kwargs,
+    )
+    try:
+        ChatCompletionsTransport.build_kwargs = baseline_build_kwargs
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
 
-    class ChatCompletionsTransport:
-        def build_kwargs(self, model, messages, tools=None, **params):
+        _install_gemini_request_boundary_wrapper()
+        transport = get_transport("chat_completions")
+        assert transport is not None
+
+        messages = _prior_and_current_turn_history()
+        original = copy.deepcopy(messages)
+
+        primary_kwargs = transport.build_kwargs(
+            model="glm-5.2",
+            messages=messages,
+            tools=None,
+            base_url="https://integrate.api.nvidia.com/v1",
+            provider_preferences={
+                "fallback_providers": [
+                    {"provider": "google", "model": "gemini-3-flash"},
+                ]
+            },
+        )
+        assert primary_kwargs["messages"] == original
+        assert messages == original, "the wrapper must not mutate canonical history for a successful non-Google primary turn"
+
+        fallback_kwargs = transport.build_kwargs(
+            model="gemini-3-flash",
+            messages=messages,
+            tools=None,
+            base_url=GOOGLE_OPENAI_BASE,
+        )
+
+        result = fallback_kwargs["messages"]
+        assert messages == original, "the transport wrapper must repair only the outbound request copy"
+        assert any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_prior"
+            for m in result
+        ), "prior completed turns must stay intact through the wrapped build path"
+        assert not any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+            for m in result
+        ), "the wrapped build path must strip the current-turn unsigned group before Gemini sees it"
+    finally:
+        ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
+
+
+def test_transport_wrapper_rewraps_replaced_real_chat_transport():
+    from api.streaming import _install_gemini_request_boundary_wrapper
+    import api.streaming as streaming
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
+    original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    baseline_build_kwargs = getattr(
+        original_build_kwargs,
+        "_webui_original_build_kwargs",
+        original_build_kwargs,
+    )
+    try:
+        ChatCompletionsTransport.build_kwargs = baseline_build_kwargs
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+
+        _install_gemini_request_boundary_wrapper()
+        first_wrapper = ChatCompletionsTransport.build_kwargs
+        assert getattr(first_wrapper, "_webui_gemini_request_boundary_wrapper", False)
+
+        def replacement_build_kwargs(self, model, messages, tools=None, **params):
             return {
                 "model": model,
                 "messages": messages,
@@ -189,34 +616,30 @@ def test_transport_wrapper_repairs_google_request_copy_without_mutating_input(mo
                 **params,
             }
 
-    chat_module.ChatCompletionsTransport = ChatCompletionsTransport
-    transports_pkg.chat_completions = chat_module
-    agent_pkg.transports = transports_pkg
-    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
-    monkeypatch.setitem(sys.modules, "agent.transports", transports_pkg)
-    monkeypatch.setitem(sys.modules, "agent.transports.chat_completions", chat_module)
+        ChatCompletionsTransport.build_kwargs = replacement_build_kwargs
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
 
-    streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+        _install_gemini_request_boundary_wrapper()
+        rewrapped = ChatCompletionsTransport.build_kwargs
+        assert getattr(rewrapped, "_webui_gemini_request_boundary_wrapper", False)
+        assert getattr(rewrapped, "_webui_original_build_kwargs", None) is replacement_build_kwargs
+        assert rewrapped is not replacement_build_kwargs
 
-    messages = _prior_and_current_turn_history()
-    original = copy.deepcopy(messages)
+        _install_gemini_request_boundary_wrapper()
+        assert ChatCompletionsTransport.build_kwargs is rewrapped
 
-    _install_gemini_request_boundary_wrapper()
-    transport = ChatCompletionsTransport()
-    kwargs = transport.build_kwargs(
-        model="gemini-3-flash",
-        messages=messages,
-        tools=None,
-        base_url=GOOGLE_OPENAI_BASE,
-    )
-
-    result = kwargs["messages"]
-    assert messages == original, "the transport wrapper must repair only the outbound request copy"
-    assert any(
-        m.get("role") == "tool" and m.get("tool_call_id") == "call_prior"
-        for m in result
-    ), "prior completed turns must stay intact through the wrapped build path"
-    assert not any(
-        m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
-        for m in result
-    ), "the wrapped build path must strip the current-turn unsigned group before Gemini sees it"
+        messages = _prior_and_current_turn_history()
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="gemini-3-flash",
+            messages=messages,
+            tools=None,
+            base_url=GOOGLE_OPENAI_BASE,
+        )
+        result = kwargs["messages"]
+        assert not any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+            for m in result
+        ), "reinstall must re-wrap a replaced transport before Gemini sees the request"
+    finally:
+        ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -16,11 +16,61 @@ sys.path.insert(0, str(REPO_ROOT))
 GOOGLE_OPENAI_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
 
 
-def _repair(messages, *, model, base_url):
+def _mark_boundary(messages, index):
+    from api.streaming import _GEMINI_REQUEST_BOUNDARY_MARKER
+
+    marked = copy.deepcopy(messages)
+    marked[index] = dict(marked[index])
+    marked[index][_GEMINI_REQUEST_BOUNDARY_MARKER] = True
+    return marked
+
+
+def _boundary_marker_key():
+    from api.streaming import _GEMINI_REQUEST_BOUNDARY_MARKER
+
+    return _GEMINI_REQUEST_BOUNDARY_MARKER
+
+
+def _import_real_conversation_loop():
+    original_agent_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "agent" or name.startswith("agent.")
+    }
+
+    for name, module in list(original_agent_modules.items()):
+        if name != "agent" and not name.startswith("agent."):
+            continue
+        if isinstance(module, types.ModuleType) and getattr(module, "__file__", None) is None:
+            sys.modules.pop(name, None)
+
+    def _restore_agent_modules():
+        for name in list(sys.modules):
+            if (name == "agent" or name.startswith("agent.")) and name not in original_agent_modules:
+                sys.modules.pop(name, None)
+        for name, module in original_agent_modules.items():
+            sys.modules[name] = module
+
+    try:
+        conversation_loop = pytest.importorskip(
+            "agent.conversation_loop",
+            reason="hermes-agent conversation loop not importable",
+        )
+    except BaseException:
+        _restore_agent_modules()
+        raise
+
+    agent_pkg = sys.modules.get("agent")
+    if isinstance(agent_pkg, types.ModuleType):
+        agent_pkg.conversation_loop = conversation_loop  # type: ignore[attr-defined]
+    return conversation_loop, _restore_agent_modules
+
+
+def _repair(messages, *, model, base_url, boundary_index):
     from api.streaming import _repair_google_gemini_current_turn_tool_state_for_request
 
     return _repair_google_gemini_current_turn_tool_state_for_request(
-        messages,
+        _mark_boundary(messages, boundary_index),
         model=model,
         base_url=base_url,
     )
@@ -75,6 +125,7 @@ def test_gemini3_request_repairs_only_current_turn_and_leaves_input_untouched():
         messages,
         model="gemini-3-flash",
         base_url=GOOGLE_OPENAI_BASE,
+        boundary_index=3,
     )
 
     assert messages == original, "request-boundary repair must not mutate canonical history"
@@ -135,6 +186,7 @@ def test_gemini3_parallel_group_keeps_unsigned_siblings_when_first_call_is_signe
         messages,
         model="gemini-3-flash",
         base_url=GOOGLE_OPENAI_BASE,
+        boundary_index=0,
     )
 
     assistant = next(m for m in result if m.get("role") == "assistant")
@@ -157,6 +209,7 @@ def test_gemini25_request_does_not_prune_unsigned_current_turn_history():
         messages,
         model="gemini-2.5-flash",
         base_url=GOOGLE_OPENAI_BASE,
+        boundary_index=3,
     )
 
     assert result == messages, "Gemini 2.5 is out of scope for the strict current-turn repair"
@@ -169,6 +222,7 @@ def test_non_google_route_does_not_prune_gemini_named_model_history():
         messages,
         model="gemini-3-flash",
         base_url="https://openrouter.ai/api/v1",
+        boundary_index=3,
     )
 
     assert result == messages, "only Google Gemini requests should receive the request-boundary repair"
@@ -195,6 +249,7 @@ def test_gemini3_request_preserves_completed_tool_turn_before_next_user_message(
         messages,
         model="gemini-3-flash",
         base_url=GOOGLE_OPENAI_BASE,
+        boundary_index=3,
     )
 
     assert messages == original, "request-boundary repair must not mutate canonical history"
@@ -234,6 +289,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     import api.session_lifecycle as lifecycle
     import api.streaming as streaming
     from api.models import Session
+    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
     ChatCompletionsTransport = pytest.importorskip(
         "agent.transports.chat_completions",
         reason="hermes-agent transport modules not importable",
@@ -248,9 +304,9 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
 
-    def _assistant_response(content, tool_calls=None):
+    def _assistant_response(content, tool_calls=None, finish_reason="stop"):
         message = types.SimpleNamespace(content=content, tool_calls=tool_calls)
-        choice = types.SimpleNamespace(message=message, finish_reason="stop")
+        choice = types.SimpleNamespace(message=message, finish_reason=finish_reason)
         return types.SimpleNamespace(choices=[choice], model="stub/model", usage=None)
 
     class _RateLimitError(Exception):
@@ -278,6 +334,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     fallback_calls = []
     fallback_resolution_calls = []
     captured_results = {}
+    tool_executions = []
 
     active_tool_call = types.SimpleNamespace(
         id="call_active",
@@ -298,6 +355,8 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
         fallback_primary_calls.append(copy.deepcopy(kwargs))
         if len(fallback_primary_calls) == 1:
             return _assistant_response("Checking the next order.", [active_tool_call])
+        if len(fallback_primary_calls) == 2:
+            return _assistant_response("The order status is", finish_reason="length")
         raise _RateLimitError()
 
     def _fallback_create(*_args, **kwargs):
@@ -336,7 +395,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             self.tool_delay = 0
             self.compression_enabled = False
             self.save_trajectories = False
-            self.valid_tool_names = set()
+            self.valid_tool_names = {"lookup"}
             self._persist_session = lambda *args, **kwargs: None
             self._save_trajectory = lambda *args, **kwargs: None
             self._cleanup_task_resources = lambda *args, **kwargs: None
@@ -352,12 +411,14 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             return result
 
         def _execute_tool_calls(self, assistant_message, messages, effective_task_id, api_call_count=0):
-            messages.append({
+            tool_row = {
                 "role": "tool",
                 "tool_call_id": assistant_message.tool_calls[0].id,
                 "name": assistant_message.tool_calls[0].function.name,
                 "content": "order 2: pending",
-            })
+            }
+            tool_executions.append(copy.deepcopy(tool_row))
+            messages.append(tool_row)
 
     fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
     fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
@@ -438,6 +499,8 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 
     sessions = {}
     original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    original_build_turn_context = conversation_loop.build_turn_context
+    original_reanchor = conversation_loop.reanchor_current_turn_user_idx
     original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
     sessions_snapshot = dict(models.SESSIONS)
     streams_snapshot = dict(config.STREAMS)
@@ -454,7 +517,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 
     def _new_session(session_id, stream_id, pending_user_message):
         session = Session(session_id=session_id, title="Gemini fallback")
-        history = _prior_and_current_turn_history()[:4]
+        history = _prior_and_current_turn_history()[:3]
         session.messages = history
         session.context_messages = copy.deepcopy(history)
         session.pending_user_message = pending_user_message
@@ -521,7 +584,10 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             msg_text="continue with fallback",
         )
     finally:
+        restore_agent_modules()
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        conversation_loop.build_turn_context = original_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = original_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
         models.SESSIONS.clear()
         models.SESSIONS.update(sessions_snapshot)
@@ -548,6 +614,23 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             lifecycle._condition.notify_all()
 
     assert len(primary_success_calls) == 2
+    primary_first_messages = primary_success_calls[0]["messages"]
+    fallback_first_messages = fallback_primary_calls[0]["messages"]
+    for first_messages, user_text in (
+        (primary_first_messages, "continue without fallback"),
+        (fallback_first_messages, "continue with fallback"),
+    ):
+        assert first_messages[0]["role"] == "system"
+        assert first_messages[1:-1] == _prior_and_current_turn_history()[:3]
+        assert first_messages[-1]["role"] == "user"
+        assert first_messages[-1]["content"].endswith(user_text)
+    expected_tool_row = {
+        "role": "tool",
+        "tool_call_id": "call_active",
+        "name": "lookup",
+        "content": "order 2: pending",
+    }
+    assert tool_executions == [expected_tool_row, expected_tool_row]
     primary_messages = primary_success_calls[1]["messages"]
     _assert_canonical_current_turn(primary_messages)
     primary_result = captured_results["issue6333-primary"]
@@ -558,14 +641,21 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     assert primary_result["messages"][-1]["content"] == "primary stayed primary"
     assert primary_saved.messages[-1]["content"] == "primary stayed primary"
 
-    assert len(fallback_primary_calls) == 2
+    assert len(fallback_primary_calls) == 3
+    assert fallback_first_messages[-1]["role"] == "user"
+    assert fallback_first_messages[-1]["content"].endswith("continue with fallback")
     assert len(fallback_calls) == 1
     assert len(fallback_resolution_calls) == 1
     assert fallback_resolution_calls[0]["provider"] == "google"
     assert fallback_resolution_calls[0]["model"] == "gemini-3-flash"
 
-    fallback_primary_messages = fallback_primary_calls[1]["messages"]
+    fallback_primary_messages = fallback_primary_calls[2]["messages"]
     _assert_canonical_current_turn(fallback_primary_messages)
+    assert any(
+        message.get("role") == "user"
+        and "truncated by the output length limit" in message.get("content", "")
+        for message in fallback_primary_messages
+    ), "the fallback request must follow the real synthetic continuation user row"
 
     fallback_result = captured_results["issue6333-fallback"]
     _assert_canonical_current_turn(fallback_result["messages"])
@@ -588,10 +678,19 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     assert fallback_result["messages"][-1]["content"] == "fallback recovered"
     assert fallback_saved.messages[-1]["content"] == "fallback recovered"
 
+    from api.streaming import _GEMINI_REQUEST_BOUNDARY_MARKER
+    for call in primary_success_calls + fallback_primary_calls + fallback_calls:
+        assert not any(
+            _GEMINI_REQUEST_BOUNDARY_MARKER in message
+            for message in call["messages"]
+            if isinstance(message, dict)
+        )
+
 
 def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_history():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
+    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
     get_transport = pytest.importorskip(
         "agent.transports",
         reason="hermes-agent transport modules not importable",
@@ -603,6 +702,8 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
 
     original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
     original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    original_build_turn_context = conversation_loop.build_turn_context
+    original_reanchor = conversation_loop.reanchor_current_turn_user_idx
     baseline_build_kwargs = getattr(
         original_build_kwargs,
         "_webui_original_build_kwargs",
@@ -616,8 +717,10 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
         transport = get_transport("chat_completions")
         assert transport is not None
 
-        messages = _prior_and_current_turn_history()
-        original = copy.deepcopy(messages)
+        messages = _mark_boundary(_prior_and_current_turn_history(), 3)
+        marked_original = copy.deepcopy(messages)
+        original = [dict(message) for message in messages]
+        original[3].pop(_boundary_marker_key(), None)
 
         primary_kwargs = transport.build_kwargs(
             model="glm-5.2",
@@ -631,7 +734,8 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
             },
         )
         assert primary_kwargs["messages"] == original
-        assert messages == original, "the wrapper must not mutate canonical history for a successful non-Google primary turn"
+        assert messages[3].get(_boundary_marker_key()) is True
+        assert messages == marked_original
 
         fallback_kwargs = transport.build_kwargs(
             model="gemini-3-flash",
@@ -641,7 +745,7 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
         )
 
         result = fallback_kwargs["messages"]
-        assert messages == original, "the transport wrapper must repair only the outbound request copy"
+        assert messages == marked_original, "the transport wrapper must repair only the outbound request copy"
         assert any(
             m.get("role") == "tool" and m.get("tool_call_id") == "call_prior"
             for m in result
@@ -651,13 +755,49 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
             for m in result
         ), "the wrapped build path must strip the current-turn unsigned group before Gemini sees it"
     finally:
+        restore_agent_modules()
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        conversation_loop.build_turn_context = original_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = original_reanchor
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
+
+
+def test_boundary_wrapper_reanchors_rebuilt_message_list_and_strips_marker():
+    import api.streaming as streaming
+    from api.streaming import _install_gemini_request_boundary_wrapper
+    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+
+    original_reanchor = conversation_loop.reanchor_current_turn_user_idx
+    original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
+    baseline_reanchor = getattr(
+        original_reanchor,
+        "_webui_original_reanchor",
+        original_reanchor,
+    )
+    try:
+        conversation_loop.reanchor_current_turn_user_idx = baseline_reanchor
+        streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
+        _install_gemini_request_boundary_wrapper()
+
+        rebuilt = [
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "content": "summary"},
+            {"role": "user", "content": "current"},
+        ]
+        assert conversation_loop.reanchor_current_turn_user_idx(rebuilt, "current") == 2
+        outbound = rebuilt[2].copy()
+        assert outbound.pop(streaming._GEMINI_REQUEST_BOUNDARY_MARKER) is True
+        assert rebuilt[2] == {"role": "user", "content": "current"}
+    finally:
+        restore_agent_modules()
+        conversation_loop.reanchor_current_turn_user_idx = original_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
 
 
 def test_transport_wrapper_rewraps_replaced_real_chat_transport():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
+    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
     ChatCompletionsTransport = pytest.importorskip(
         "agent.transports.chat_completions",
         reason="hermes-agent transport modules not importable",
@@ -665,18 +805,36 @@ def test_transport_wrapper_rewraps_replaced_real_chat_transport():
 
     original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
     original_build_kwargs = ChatCompletionsTransport.build_kwargs
+    original_build_turn_context = conversation_loop.build_turn_context
+    original_reanchor = conversation_loop.reanchor_current_turn_user_idx
     baseline_build_kwargs = getattr(
         original_build_kwargs,
         "_webui_original_build_kwargs",
         original_build_kwargs,
     )
+    baseline_build_turn_context = getattr(
+        original_build_turn_context,
+        "_webui_original_build_turn_context",
+        original_build_turn_context,
+    )
+    baseline_reanchor = getattr(
+        original_reanchor,
+        "_webui_original_reanchor",
+        original_reanchor,
+    )
     try:
         ChatCompletionsTransport.build_kwargs = baseline_build_kwargs
+        conversation_loop.build_turn_context = baseline_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = baseline_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = False
 
         _install_gemini_request_boundary_wrapper()
         first_wrapper = ChatCompletionsTransport.build_kwargs
+        first_build_turn_context = conversation_loop.build_turn_context
+        first_reanchor = conversation_loop.reanchor_current_turn_user_idx
         assert getattr(first_wrapper, "_webui_gemini_request_boundary_wrapper", False)
+        assert getattr(first_build_turn_context, "_webui_gemini_request_boundary_wrapper", False)
+        assert getattr(first_reanchor, "_webui_gemini_request_boundary_wrapper", False)
 
         def replacement_build_kwargs(self, model, messages, tools=None, **params):
             return {
@@ -687,6 +845,15 @@ def test_transport_wrapper_rewraps_replaced_real_chat_transport():
             }
 
         ChatCompletionsTransport.build_kwargs = replacement_build_kwargs
+
+        def replacement_build_turn_context(*args, **kwargs):
+            return args, kwargs
+
+        def replacement_reanchor(messages, user_message):
+            return 0
+
+        conversation_loop.build_turn_context = replacement_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = replacement_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = True
 
         _install_gemini_request_boundary_wrapper()
@@ -694,11 +861,23 @@ def test_transport_wrapper_rewraps_replaced_real_chat_transport():
         assert getattr(rewrapped, "_webui_gemini_request_boundary_wrapper", False)
         assert getattr(rewrapped, "_webui_original_build_kwargs", None) is replacement_build_kwargs
         assert rewrapped is not replacement_build_kwargs
+        rewrapped_build_turn_context = conversation_loop.build_turn_context
+        rewrapped_reanchor = conversation_loop.reanchor_current_turn_user_idx
+        assert getattr(
+            rewrapped_build_turn_context,
+            "_webui_original_build_turn_context",
+            None,
+        ) is replacement_build_turn_context
+        assert getattr(rewrapped_reanchor, "_webui_original_reanchor", None) is replacement_reanchor
+        assert rewrapped_build_turn_context is not replacement_build_turn_context
+        assert rewrapped_reanchor is not replacement_reanchor
 
         _install_gemini_request_boundary_wrapper()
         assert ChatCompletionsTransport.build_kwargs is rewrapped
+        assert conversation_loop.build_turn_context is rewrapped_build_turn_context
+        assert conversation_loop.reanchor_current_turn_user_idx is rewrapped_reanchor
 
-        messages = _prior_and_current_turn_history()
+        messages = _mark_boundary(_prior_and_current_turn_history(), 3)
         kwargs = ChatCompletionsTransport().build_kwargs(
             model="gemini-3-flash",
             messages=messages,
@@ -710,6 +889,21 @@ def test_transport_wrapper_rewraps_replaced_real_chat_transport():
             m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
             for m in result
         ), "reinstall must re-wrap a replaced transport before Gemini sees the request"
+        malformed = [{
+            "role": "user",
+            "content": "malformed boundary",
+            streaming._GEMINI_REQUEST_BOUNDARY_MARKER: "invalid",
+        }]
+        delegated = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.2",
+            messages=malformed,
+            tools=None,
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+        assert streaming._GEMINI_REQUEST_BOUNDARY_MARKER not in delegated["messages"][0]
     finally:
+        restore_agent_modules()
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
+        conversation_loop.build_turn_context = original_build_turn_context
+        conversation_loop.reanchor_current_turn_user_idx = original_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -473,24 +473,25 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             tool_executions.append(copy.deepcopy(tool_row))
             messages.append(tool_row)
 
-    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
-    fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
-        "provider": requested or "nvidia",
-        "api_key": "synthetic-key",
-        "base_url": "https://integrate.api.nvidia.com/v1",
-    }
-    fake_hermes_cli = types.ModuleType("hermes_cli")
-    fake_hermes_cli.runtime_provider = fake_runtime_module
-    fake_model_normalize = types.ModuleType("hermes_cli.model_normalize")
-    fake_model_normalize.normalize_model_for_provider = lambda model, provider: model
-    fake_hermes_cli.model_normalize = fake_model_normalize
-    fake_hermes_state = types.ModuleType("hermes_state")
-    fake_hermes_state.SessionDB = lambda *args, **kwargs: None
+    import hermes_cli.model_normalize as model_normalize
+    import hermes_cli.runtime_provider as runtime_provider
+    import hermes_state
 
-    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
-    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
-    monkeypatch.setitem(sys.modules, "hermes_cli.model_normalize", fake_model_normalize)
-    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda requested=None, **_kw: {
+            "provider": requested or "nvidia",
+            "api_key": "synthetic-key",
+            "base_url": "https://integrate.api.nvidia.com/v1",
+        },
+    )
+    monkeypatch.setattr(
+        model_normalize,
+        "normalize_model_for_provider",
+        lambda model, provider: model,
+    )
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda *args, **kwargs: None)
     monkeypatch.setattr(run_agent, "get_tool_definitions", lambda *args, **kwargs: [])
     monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda *args, **kwargs: {})
     monkeypatch.setattr(

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -175,9 +175,19 @@ def test_non_google_route_does_not_prune_gemini_named_model_history():
 
 
 def test_gemini3_request_preserves_completed_tool_turn_before_next_user_message():
-    messages = _prior_and_current_turn_history() + [
-        {"role": "assistant", "content": "Order 2 is pending."},
-        {"role": "user", "content": "Thanks, now check order 3."},
+    messages = [
+        {"role": "user", "content": "look up the first order"},
+        {
+            "role": "assistant",
+            "content": "Found it.",
+            "tool_calls": [{
+                "id": "call_prior",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": '{"id":"1"}'},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_prior", "content": "order 1: shipped"},
+        {"role": "user", "content": "Thanks, now check order 2."},
     ]
     original = copy.deepcopy(messages)
 
@@ -189,6 +199,29 @@ def test_gemini3_request_preserves_completed_tool_turn_before_next_user_message(
 
     assert messages == original, "request-boundary repair must not mutate canonical history"
     assert result == original, "a completed prior tool turn must survive a later user message intact"
+
+
+@pytest.mark.parametrize(
+    "base_url, provider_profile, expected",
+    [
+        ("HTTPS://GENERATIVELANGUAGE.GOOGLEAPIS.COM/v1beta/openai", None, True),
+        ("https://custom.example/v1", types.SimpleNamespace(name="gemini"), True),
+        ("https://generativelanguage.googleapis.com.example/v1", None, False),
+        ("https://custom.example/generativelanguage.googleapis.com/v1", None, False),
+        ("https://custom.example/v1?provider=google", None, False),
+        ("https://custom.example/v1", types.SimpleNamespace(provider_id="google-compatible"), False),
+    ],
+)
+def test_gemini3_route_identity_requires_exact_host_or_provider_id(
+    base_url, provider_profile, expected
+):
+    from api.streaming import _request_targets_google_gemini_three
+
+    assert _request_targets_google_gemini_three(
+        "gemini-3-flash",
+        base_url=base_url,
+        provider_profile=provider_profile,
+    ) is expected
 
 
 def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outbound_copy(
@@ -215,8 +248,8 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
 
-    def _assistant_response(content):
-        message = types.SimpleNamespace(content=content, tool_calls=None)
+    def _assistant_response(content, tool_calls=None):
+        message = types.SimpleNamespace(content=content, tool_calls=tool_calls)
         choice = types.SimpleNamespace(message=message, finish_reason="stop")
         return types.SimpleNamespace(choices=[choice], model="stub/model", usage=None)
 
@@ -246,14 +279,25 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     fallback_resolution_calls = []
     captured_results = {}
 
+    active_tool_call = types.SimpleNamespace(
+        id="call_active",
+        type="function",
+        function=types.SimpleNamespace(
+            name="lookup",
+            arguments='{"id":"2"}',
+        ),
+    )
+
     def _primary_success_create(*_args, **kwargs):
         primary_success_calls.append(copy.deepcopy(kwargs))
+        if len(primary_success_calls) == 1:
+            return _assistant_response("Checking the next order.", [active_tool_call])
         return _assistant_response("primary stayed primary")
 
     def _fallback_primary_create(*_args, **kwargs):
         fallback_primary_calls.append(copy.deepcopy(kwargs))
-        if len(fallback_primary_calls) > 1:
-            raise AssertionError("primary request should switch to fallback after the first 429")
+        if len(fallback_primary_calls) == 1:
+            return _assistant_response("Checking the next order.", [active_tool_call])
         raise _RateLimitError()
 
     def _fallback_create(*_args, **kwargs):
@@ -306,6 +350,14 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             result = super().run_conversation(**kwargs)
             captured_results[self.session_id] = copy.deepcopy(result)
             return result
+
+        def _execute_tool_calls(self, assistant_message, messages, effective_task_id, api_call_count=0):
+            messages.append({
+                "role": "tool",
+                "tool_call_id": assistant_message.tool_calls[0].id,
+                "name": assistant_message.tool_calls[0].function.name,
+                "content": "order 2: pending",
+            })
 
     fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
     fake_runtime_module.resolve_runtime_provider = lambda requested=None, **_kw: {
@@ -402,8 +454,9 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 
     def _new_session(session_id, stream_id, pending_user_message):
         session = Session(session_id=session_id, title="Gemini fallback")
-        session.messages = _prior_and_current_turn_history()
-        session.context_messages = _prior_and_current_turn_history()
+        history = _prior_and_current_turn_history()[:4]
+        session.messages = history
+        session.context_messages = copy.deepcopy(history)
         session.pending_user_message = pending_user_message
         session.pending_attachments = []
         session.pending_started_at = 1234567890.0
@@ -428,13 +481,13 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
         )
         return Session.load(session_id)
 
-    def _assert_canonical_current_turn(messages):
+    def _assert_canonical_current_turn(messages, call_id="call_active"):
         assert any(
-            m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+            m.get("role") == "tool" and m.get("tool_call_id") == call_id
             for m in messages
         ), "canonical history must keep the current-turn tool row"
         assert any(
-            tc.get("id") == "call_current"
+            tc.get("id") == call_id
             for m in messages
             if m.get("role") == "assistant"
             for tc in (m.get("tool_calls") or [])
@@ -494,8 +547,8 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             lifecycle._sessions.update(lifecycle_sessions_snapshot)
             lifecycle._condition.notify_all()
 
-    assert len(primary_success_calls) == 1
-    primary_messages = primary_success_calls[0]["messages"]
+    assert len(primary_success_calls) == 2
+    primary_messages = primary_success_calls[1]["messages"]
     _assert_canonical_current_turn(primary_messages)
     primary_result = captured_results["issue6333-primary"]
     _assert_canonical_current_turn(primary_result["messages"])
@@ -505,13 +558,13 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     assert primary_result["messages"][-1]["content"] == "primary stayed primary"
     assert primary_saved.messages[-1]["content"] == "primary stayed primary"
 
-    assert len(fallback_primary_calls) == 1
+    assert len(fallback_primary_calls) == 2
     assert len(fallback_calls) == 1
     assert len(fallback_resolution_calls) == 1
     assert fallback_resolution_calls[0]["provider"] == "google"
     assert fallback_resolution_calls[0]["model"] == "gemini-3-flash"
 
-    fallback_primary_messages = fallback_primary_calls[0]["messages"]
+    fallback_primary_messages = fallback_primary_calls[1]["messages"]
     _assert_canonical_current_turn(fallback_primary_messages)
 
     fallback_result = captured_results["issue6333-fallback"]
@@ -525,7 +578,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     )
     assert "tool_calls" not in current_assistant
     assert not any(
-        m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_active"
         for m in fallback_messages
     ), "activated Gemini fallback must repair only its outbound request copy"
 

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -1,4 +1,5 @@
-"""Regression coverage for #6333 Gemini fallback replay sanitization."""
+"""Regression coverage for #6333 Gemini fallback request-boundary replay repair."""
+import copy
 import pathlib
 import sys
 
@@ -7,167 +8,162 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
 
 
-def _unsigned_tool_history():
+GOOGLE_OPENAI_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
+
+
+def _repair(messages, *, model, base_url):
+    from api.streaming import _repair_google_gemini_current_turn_tool_state_for_request
+
+    return _repair_google_gemini_current_turn_tool_state_for_request(
+        messages,
+        model=model,
+        base_url=base_url,
+    )
+
+
+def _prior_and_current_turn_history():
     return [
-        {"role": "user", "content": "look up the order"},
+        {"role": "user", "content": "look up the first order"},
         {
             "role": "assistant",
-            "content": "Looking that up.",
+            "content": "Found it.",
             "tool_calls": [
                 {
-                    "id": "call_glm_1",
+                    "id": "call_prior",
                     "type": "function",
-                    "function": {"name": "lookup", "arguments": '{"id":"7"}'},
+                    "function": {"name": "lookup", "arguments": '{"id":"1"}'},
                 },
             ],
         },
         {
             "role": "tool",
-            "tool_call_id": "call_glm_1",
+            "tool_call_id": "call_prior",
             "name": "lookup",
-            "content": "order 7: shipped",
+            "content": "order 1: shipped",
         },
-        {"role": "user", "content": "thanks, and the next one?"},
+        {"role": "user", "content": "now check the next one"},
+        {
+            "role": "assistant",
+            "content": "Checking the next order.",
+            "tool_calls": [
+                {
+                    "id": "call_current",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"id":"2"}'},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_current",
+            "name": "lookup",
+            "content": "order 2: pending",
+        },
     ]
 
 
-def test_google_fallback_prunes_unsigned_tool_call_and_linked_tool_row():
-    from api.streaming import _sanitize_messages_for_api
+def test_gemini3_request_repairs_only_current_turn_and_leaves_input_untouched():
+    messages = _prior_and_current_turn_history()
+    original = copy.deepcopy(messages)
 
-    result = _sanitize_messages_for_api(
-        _unsigned_tool_history(),
-        effective_provider="google",
+    result = _repair(
+        messages,
+        model="gemini-3-flash",
+        base_url=GOOGLE_OPENAI_BASE,
     )
+
+    assert messages == original, "request-boundary repair must not mutate canonical history"
+
+    prior_assistant = result[1]
+    assert prior_assistant.get("tool_calls"), "prior completed turns must stay intact"
+    assert any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_prior"
+        for m in result
+    ), "prior completed tool rows must stay intact"
+
+    current_assistant = next(
+        m for m in result
+        if m.get("role") == "assistant" and m.get("content") == "Checking the next order."
+    )
+    assert "tool_calls" not in current_assistant, "current-turn unsigned Gemini 3 tool state must be stripped from the request copy"
     assert not any(
-        m.get("role") == "tool" and m.get("tool_call_id") == "call_glm_1"
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_current"
         for m in result
-    ), "linked tool row must be pruned with an unsigned Gemini-unsafe tool call"
-    for message in result:
-        if message.get("role") != "assistant":
-            continue
-        assert not message.get("tool_calls"), (
-            "Google-targeted replay must prune unsigned historical tool calls. "
-            f"Got: {message}"
-        )
+    ), "linked current-turn tool rows must be removed with the stripped group"
 
 
-def test_configured_google_fallback_prunes_unsigned_history_before_switch():
-    from api.streaming import _sanitize_messages_for_api
-
-    result = _sanitize_messages_for_api(
-        _unsigned_tool_history(),
-        cfg={
-            "fallback_providers": [
-                {"provider": "google", "model": "gemini-2.5-flash"},
-            ],
-        },
-        effective_provider="z-ai",
-    )
-    assert not any(m.get("role") == "tool" for m in result)
-    assert all(
-        not m.get("tool_calls")
-        for m in result
-        if m.get("role") == "assistant"
-    )
-
-
-def test_gemini_alias_provider_also_prunes_unsigned_history():
-    from api.streaming import _sanitize_messages_for_api
-
-    result = _sanitize_messages_for_api(
-        _unsigned_tool_history(),
-        effective_provider="gemini",
-    )
-    assert not any(m.get("role") == "tool" for m in result)
-    assert all(
-        not m.get("tool_calls")
-        for m in result
-        if m.get("role") == "assistant"
-    )
-
-
-def test_google_fallback_keeps_signed_call_and_prunes_unsigned_sibling():
-    from api.streaming import _sanitize_messages_for_api
-
+def test_gemini3_parallel_group_keeps_unsigned_siblings_when_first_call_is_signed():
     messages = [
-        {"role": "user", "content": "first"},
+        {"role": "user", "content": "check both orders"},
         {
             "role": "assistant",
-            "content": "signed turn",
+            "content": "Checking both.",
             "tool_calls": [
                 {
                     "id": "call_signed",
                     "type": "function",
-                    "function": {"name": "safe", "arguments": "{}"},
-                    "extra_content": {"google": {"thought_signature": "sig-function"}},
+                    "function": {"name": "lookup", "arguments": '{"id":"1"}'},
+                    "extra_content": {"google": {"thought_signature": "sig-1"}},
+                },
+                {
+                    "id": "call_unsigned",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"id":"2"}'},
                 },
             ],
         },
         {
             "role": "tool",
             "tool_call_id": "call_signed",
-            "name": "safe",
-            "content": "ok",
-        },
-        {"role": "user", "content": "second"},
-        {
-            "role": "assistant",
-            "content": "unsigned turn",
-            "tool_calls": [
-                {
-                    "id": "call_unsigned",
-                    "type": "function",
-                    "function": {"name": "risky", "arguments": "{}"},
-                },
-            ],
+            "name": "lookup",
+            "content": "order 1: shipped",
         },
         {
             "role": "tool",
             "tool_call_id": "call_unsigned",
-            "name": "risky",
-            "content": "ok",
+            "name": "lookup",
+            "content": "order 2: pending",
         },
     ]
-    result = _sanitize_messages_for_api(messages, effective_provider="google")
-    kept_call_ids = {
-        tc.get("id")
-        for message in result
-        if message.get("role") == "assistant"
-        for tc in (message.get("tool_calls") or [])
-    }
-    kept_tool_ids = {
-        message.get("tool_call_id")
-        for message in result
-        if message.get("role") == "tool"
-    }
-    assert "call_signed" in kept_call_ids
-    assert "call_signed" in kept_tool_ids
-    assert "call_unsigned" not in kept_call_ids
-    assert "call_unsigned" not in kept_tool_ids
+
+    result = _repair(
+        messages,
+        model="gemini-3-flash",
+        base_url=GOOGLE_OPENAI_BASE,
+    )
+
+    assistant = next(m for m in result if m.get("role") == "assistant")
+    kept_ids = [tc.get("id") for tc in assistant.get("tool_calls") or []]
+    assert kept_ids == ["call_signed", "call_unsigned"], (
+        "a signed first Gemini call must keep the whole parallel group"
+    )
+    kept_tool_ids = [
+        m.get("tool_call_id")
+        for m in result
+        if m.get("role") == "tool"
+    ]
+    assert kept_tool_ids == ["call_signed", "call_unsigned"]
 
 
-def test_non_google_provider_preserves_unsigned_history():
-    from api.streaming import _sanitize_messages_for_api
+def test_gemini25_request_does_not_prune_unsigned_current_turn_history():
+    messages = _prior_and_current_turn_history()
 
-    for provider in (None, "openai", "anthropic", "z-ai"):
-        result = _sanitize_messages_for_api(
-            _unsigned_tool_history(),
-            effective_provider=provider,
-        )
-        kept_call_ids = {
-            tc.get("id")
-            for message in result
-            if message.get("role") == "assistant"
-            for tc in (message.get("tool_calls") or [])
-        }
-        kept_tool_ids = {
-            message.get("tool_call_id")
-            for message in result
-            if message.get("role") == "tool"
-        }
-        assert "call_glm_1" in kept_call_ids, (
-            f"provider {provider!r} must preserve current replay behavior"
-        )
-        assert "call_glm_1" in kept_tool_ids, (
-            f"provider {provider!r} must keep the linked tool row"
-        )
+    result = _repair(
+        messages,
+        model="gemini-2.5-flash",
+        base_url=GOOGLE_OPENAI_BASE,
+    )
+
+    assert result == messages, "Gemini 2.5 is out of scope for the strict current-turn repair"
+
+
+def test_non_google_route_does_not_prune_gemini_named_model_history():
+    messages = _prior_and_current_turn_history()
+
+    result = _repair(
+        messages,
+        model="gemini-3-flash",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert result == messages, "only Google Gemini requests should receive the request-boundary repair"

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -1,0 +1,173 @@
+"""Regression coverage for #6333 Gemini fallback replay sanitization."""
+import pathlib
+import sys
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _unsigned_tool_history():
+    return [
+        {"role": "user", "content": "look up the order"},
+        {
+            "role": "assistant",
+            "content": "Looking that up.",
+            "tool_calls": [
+                {
+                    "id": "call_glm_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"id":"7"}'},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_glm_1",
+            "name": "lookup",
+            "content": "order 7: shipped",
+        },
+        {"role": "user", "content": "thanks, and the next one?"},
+    ]
+
+
+def test_google_fallback_prunes_unsigned_tool_call_and_linked_tool_row():
+    from api.streaming import _sanitize_messages_for_api
+
+    result = _sanitize_messages_for_api(
+        _unsigned_tool_history(),
+        effective_provider="google",
+    )
+    assert not any(
+        m.get("role") == "tool" and m.get("tool_call_id") == "call_glm_1"
+        for m in result
+    ), "linked tool row must be pruned with an unsigned Gemini-unsafe tool call"
+    for message in result:
+        if message.get("role") != "assistant":
+            continue
+        assert not message.get("tool_calls"), (
+            "Google-targeted replay must prune unsigned historical tool calls. "
+            f"Got: {message}"
+        )
+
+
+def test_configured_google_fallback_prunes_unsigned_history_before_switch():
+    from api.streaming import _sanitize_messages_for_api
+
+    result = _sanitize_messages_for_api(
+        _unsigned_tool_history(),
+        cfg={
+            "fallback_providers": [
+                {"provider": "google", "model": "gemini-2.5-flash"},
+            ],
+        },
+        effective_provider="z-ai",
+    )
+    assert not any(m.get("role") == "tool" for m in result)
+    assert all(
+        not m.get("tool_calls")
+        for m in result
+        if m.get("role") == "assistant"
+    )
+
+
+def test_gemini_alias_provider_also_prunes_unsigned_history():
+    from api.streaming import _sanitize_messages_for_api
+
+    result = _sanitize_messages_for_api(
+        _unsigned_tool_history(),
+        effective_provider="gemini",
+    )
+    assert not any(m.get("role") == "tool" for m in result)
+    assert all(
+        not m.get("tool_calls")
+        for m in result
+        if m.get("role") == "assistant"
+    )
+
+
+def test_google_fallback_keeps_signed_call_and_prunes_unsigned_sibling():
+    from api.streaming import _sanitize_messages_for_api
+
+    messages = [
+        {"role": "user", "content": "first"},
+        {
+            "role": "assistant",
+            "content": "signed turn",
+            "tool_calls": [
+                {
+                    "id": "call_signed",
+                    "type": "function",
+                    "function": {"name": "safe", "arguments": "{}"},
+                    "extra_content": {"google": {"thought_signature": "sig-function"}},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_signed",
+            "name": "safe",
+            "content": "ok",
+        },
+        {"role": "user", "content": "second"},
+        {
+            "role": "assistant",
+            "content": "unsigned turn",
+            "tool_calls": [
+                {
+                    "id": "call_unsigned",
+                    "type": "function",
+                    "function": {"name": "risky", "arguments": "{}"},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_unsigned",
+            "name": "risky",
+            "content": "ok",
+        },
+    ]
+    result = _sanitize_messages_for_api(messages, effective_provider="google")
+    kept_call_ids = {
+        tc.get("id")
+        for message in result
+        if message.get("role") == "assistant"
+        for tc in (message.get("tool_calls") or [])
+    }
+    kept_tool_ids = {
+        message.get("tool_call_id")
+        for message in result
+        if message.get("role") == "tool"
+    }
+    assert "call_signed" in kept_call_ids
+    assert "call_signed" in kept_tool_ids
+    assert "call_unsigned" not in kept_call_ids
+    assert "call_unsigned" not in kept_tool_ids
+
+
+def test_non_google_provider_preserves_unsigned_history():
+    from api.streaming import _sanitize_messages_for_api
+
+    for provider in (None, "openai", "anthropic", "z-ai"):
+        result = _sanitize_messages_for_api(
+            _unsigned_tool_history(),
+            effective_provider=provider,
+        )
+        kept_call_ids = {
+            tc.get("id")
+            for message in result
+            if message.get("role") == "assistant"
+            for tc in (message.get("tool_calls") or [])
+        }
+        kept_tool_ids = {
+            message.get("tool_call_id")
+            for message in result
+            if message.get("role") == "tool"
+        }
+        assert "call_glm_1" in kept_call_ids, (
+            f"provider {provider!r} must preserve current replay behavior"
+        )
+        assert "call_glm_1" in kept_tool_ids, (
+            f"provider {provider!r} must keep the linked tool row"
+        )

--- a/tests/test_issue6333_gemini_fallback_tool_state.py
+++ b/tests/test_issue6333_gemini_fallback_tool_state.py
@@ -4,6 +4,7 @@ import pathlib
 import queue
 import sys
 import types
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
@@ -60,39 +61,61 @@ def _assert_no_boundary_artifacts(messages):
     _assert_no_boundary_wrapper_instances(messages)
 
 
-def _import_real_conversation_loop():
-    original_agent_modules = {
+def _snapshot_agent_modules():
+    return {
         name: module
         for name, module in sys.modules.items()
         if name == "agent" or name.startswith("agent.")
     }
 
-    for name, module in list(original_agent_modules.items()):
-        if name != "agent" and not name.startswith("agent."):
-            continue
-        if isinstance(module, types.ModuleType) and getattr(module, "__file__", None) is None:
+
+def _clear_agent_modules():
+    for name in list(sys.modules):
+        if name == "agent" or name.startswith("agent."):
             sys.modules.pop(name, None)
 
-    def _restore_agent_modules():
-        for name in list(sys.modules):
-            if (name == "agent" or name.startswith("agent.")) and name not in original_agent_modules:
-                sys.modules.pop(name, None)
-        for name, module in original_agent_modules.items():
-            sys.modules[name] = module
 
+def _restore_agent_modules(snapshot):
+    _clear_agent_modules()
+    for name, module in snapshot.items():
+        sys.modules[name] = module
+
+    agent_pkg = sys.modules.get("agent")
+    if not isinstance(agent_pkg, types.ModuleType):
+        return
+
+    for name, module in snapshot.items():
+        if not name.startswith("agent."):
+            continue
+        child_name = name.split(".", 1)[1]
+        if "." not in child_name:
+            setattr(agent_pkg, child_name, module)
+
+
+def _fallback_reanchor_current_turn_user_idx(messages, user_message):
+    for idx in range(len(messages) - 1, -1, -1):
+        message = messages[idx]
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "user" and message.get("content") == user_message:
+            return idx
+    raise ValueError(f"user message not found for reanchor: {user_message!r}")
+
+
+@contextmanager
+def _import_real_conversation_loop():
+    original_agent_modules = _snapshot_agent_modules()
+    _clear_agent_modules()
     try:
         conversation_loop = pytest.importorskip(
             "agent.conversation_loop",
             reason="hermes-agent conversation loop not importable",
         )
-    except BaseException:
-        _restore_agent_modules()
-        raise
-
-    agent_pkg = sys.modules.get("agent")
-    if isinstance(agent_pkg, types.ModuleType):
-        agent_pkg.conversation_loop = conversation_loop  # type: ignore[attr-defined]
-    return conversation_loop, _restore_agent_modules
+        if not hasattr(conversation_loop, "reanchor_current_turn_user_idx"):
+            conversation_loop.reanchor_current_turn_user_idx = _fallback_reanchor_current_turn_user_idx  # type: ignore[attr-defined]
+        yield conversation_loop
+    finally:
+        _restore_agent_modules(original_agent_modules)
 
 
 def _repair(messages, *, model, base_url, boundary_index):
@@ -318,7 +341,8 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
     import api.session_lifecycle as lifecycle
     import api.streaming as streaming
     from api.models import Session
-    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+    conversation_loop_ctx = _import_real_conversation_loop()
+    conversation_loop = conversation_loop_ctx.__enter__()
     ChatCompletionsTransport = pytest.importorskip(
         "agent.transports.chat_completions",
         reason="hermes-agent transport modules not importable",
@@ -643,7 +667,7 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
             msg_text="continue after dirty copied result",
         )
     finally:
-        restore_agent_modules()
+        conversation_loop_ctx.__exit__(None, None, None)
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
         conversation_loop.build_turn_context = original_build_turn_context
         conversation_loop.reanchor_current_turn_user_idx = original_reanchor
@@ -766,7 +790,8 @@ def test_streaming_fallback_preserves_persisted_history_and_repairs_only_outboun
 def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_history():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
-    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+    conversation_loop_ctx = _import_real_conversation_loop()
+    conversation_loop = conversation_loop_ctx.__enter__()
     get_transport = pytest.importorskip(
         "agent.transports",
         reason="hermes-agent transport modules not importable",
@@ -831,7 +856,7 @@ def test_transport_wrapper_repairs_real_chat_transport_and_preserves_primary_his
             for m in result
         ), "the wrapped build path must strip the current-turn unsigned group before Gemini sees it"
     finally:
-        restore_agent_modules()
+        conversation_loop_ctx.__exit__(None, None, None)
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
         conversation_loop.build_turn_context = original_build_turn_context
         conversation_loop.reanchor_current_turn_user_idx = original_reanchor
@@ -844,7 +869,8 @@ def test_boundary_wrapper_reanchors_rebuilt_message_list_and_strips_marker():
         _GeminiRequestBoundaryMessage,
         _install_gemini_request_boundary_wrapper,
     )
-    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+    conversation_loop_ctx = _import_real_conversation_loop()
+    conversation_loop = conversation_loop_ctx.__enter__()
 
     original_reanchor = conversation_loop.reanchor_current_turn_user_idx
     original_flag = streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED
@@ -870,7 +896,7 @@ def test_boundary_wrapper_reanchors_rebuilt_message_list_and_strips_marker():
         assert outbound.pop(streaming._GEMINI_REQUEST_BOUNDARY_MARKER) is True
         assert rebuilt[2] == {"role": "user", "content": "current"}
     finally:
-        restore_agent_modules()
+        conversation_loop_ctx.__exit__(None, None, None)
         conversation_loop.reanchor_current_turn_user_idx = original_reanchor
         streaming._GEMINI_REQUEST_BOUNDARY_WRAPPER_INSTALLED = original_flag
 
@@ -878,7 +904,8 @@ def test_boundary_wrapper_reanchors_rebuilt_message_list_and_strips_marker():
 def test_transport_wrapper_rewraps_replaced_real_chat_transport():
     from api.streaming import _install_gemini_request_boundary_wrapper
     import api.streaming as streaming
-    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+    conversation_loop_ctx = _import_real_conversation_loop()
+    conversation_loop = conversation_loop_ctx.__enter__()
     ChatCompletionsTransport = pytest.importorskip(
         "agent.transports.chat_completions",
         reason="hermes-agent transport modules not importable",
@@ -983,7 +1010,7 @@ def test_transport_wrapper_rewraps_replaced_real_chat_transport():
         )
         assert streaming._GEMINI_REQUEST_BOUNDARY_MARKER not in delegated["messages"][0]
     finally:
-        restore_agent_modules()
+        conversation_loop_ctx.__exit__(None, None, None)
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
         conversation_loop.build_turn_context = original_build_turn_context
         conversation_loop.reanchor_current_turn_user_idx = original_reanchor
@@ -1001,7 +1028,8 @@ def test_build_turn_wrapper_cleans_stale_marker_before_second_turn_and_keeps_sin
     import api.models as models
     import api.streaming as streaming
     from api.models import Session
-    conversation_loop, restore_agent_modules = _import_real_conversation_loop()
+    conversation_loop_ctx = _import_real_conversation_loop()
+    conversation_loop = conversation_loop_ctx.__enter__()
     ChatCompletionsTransport = pytest.importorskip(
         "agent.transports.chat_completions",
         reason="hermes-agent transport modules not importable",
@@ -1141,7 +1169,7 @@ def test_build_turn_wrapper_cleans_stale_marker_before_second_turn_and_keeps_sin
         _assert_no_boundary_artifacts(saved.messages)
         _assert_no_boundary_artifacts(saved.context_messages)
     finally:
-        restore_agent_modules()
+        conversation_loop_ctx.__exit__(None, None, None)
         ChatCompletionsTransport.build_kwargs = original_build_kwargs
         conversation_loop.build_turn_context = original_build_turn_context
         conversation_loop.reanchor_current_turn_user_idx = original_reanchor

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -22,8 +22,15 @@ sys.modules.setdefault('agent.auxiliary_client', _aux_stub)
 _agent_stub.auxiliary_client = _aux_stub
 
 
+def _ensure_agent_aux_stub():
+    sys.modules['agent'] = _agent_stub
+    sys.modules['agent.auxiliary_client'] = _aux_stub
+    _agent_stub.auxiliary_client = _aux_stub
+
+
 def _patch_tg_config(config_dict):
     """Return a patch context manager that makes _get_auxiliary_task_config return config_dict."""
+    _ensure_agent_aux_stub()
     return patch('agent.auxiliary_client._get_auxiliary_task_config', return_value=config_dict, create=True)
 
 
@@ -64,6 +71,7 @@ class TestAuxTitleConfigured(unittest.TestCase):
 
     def test_import_error_returns_false(self):
         from api.streaming import _aux_title_configured
+        _ensure_agent_aux_stub()
         with patch('agent.auxiliary_client._get_auxiliary_task_config', side_effect=ImportError("no module"), create=True):
             self.assertFalse(_aux_title_configured())
 

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -6,32 +6,76 @@ Covers:
   - aux→agent fallback triggers on 'llm_invalid_aux' status
   - _aux_title_timeout rejects zero, negative, and non-numeric values
 """
+import importlib
 import os
+from contextlib import contextmanager
 from pathlib import Path
 import sys
 import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Stub agent.auxiliary_client so it is importable in the test environment
-# (the real package lives in hermes-agent, which is not installed here).
-_agent_stub = types.ModuleType('agent')
-_aux_stub = types.ModuleType('agent.auxiliary_client')
-sys.modules.setdefault('agent', _agent_stub)
-sys.modules.setdefault('agent.auxiliary_client', _aux_stub)
-_agent_stub.auxiliary_client = _aux_stub
+def _snapshot_agent_modules():
+    return {
+        name: module
+        for name, module in sys.modules.items()
+        if name == 'agent' or name.startswith('agent.')
+    }
 
 
+def _clear_agent_modules():
+    for name in list(sys.modules):
+        if name == 'agent' or name.startswith('agent.'):
+            sys.modules.pop(name, None)
+
+
+def _restore_agent_modules(snapshot):
+    _clear_agent_modules()
+    for name, module in snapshot.items():
+        sys.modules[name] = module
+
+    agent_pkg = sys.modules.get('agent')
+    if not isinstance(agent_pkg, types.ModuleType):
+        return
+
+    for name, module in snapshot.items():
+        if not name.startswith('agent.'):
+            continue
+        child_name = name.split('.', 1)[1]
+        if '.' not in child_name:
+            setattr(agent_pkg, child_name, module)
+
+
+@contextmanager
 def _ensure_agent_aux_stub():
-    sys.modules['agent'] = _agent_stub
-    sys.modules['agent.auxiliary_client'] = _aux_stub
-    _agent_stub.auxiliary_client = _aux_stub
+    snapshot = _snapshot_agent_modules()
+    _clear_agent_modules()
+
+    try:
+        try:
+            aux_module = importlib.import_module('agent.auxiliary_client')
+        except ModuleNotFoundError:
+            agent_stub = types.ModuleType('agent')
+            agent_stub.__path__ = []
+            aux_module = types.ModuleType('agent.auxiliary_client')
+            sys.modules['agent'] = agent_stub
+            sys.modules['agent.auxiliary_client'] = aux_module
+            agent_stub.auxiliary_client = aux_module
+        else:
+            agent_pkg = sys.modules.get('agent')
+            if isinstance(agent_pkg, types.ModuleType):
+                agent_pkg.auxiliary_client = aux_module
+        yield aux_module
+    finally:
+        _restore_agent_modules(snapshot)
 
 
+@contextmanager
 def _patch_tg_config(config_dict):
     """Return a patch context manager that makes _get_auxiliary_task_config return config_dict."""
-    _ensure_agent_aux_stub()
-    return patch('agent.auxiliary_client._get_auxiliary_task_config', return_value=config_dict, create=True)
+    with _ensure_agent_aux_stub() as aux_module:
+        with patch.object(aux_module, '_get_auxiliary_task_config', return_value=config_dict, create=True):
+            yield
 
 
 class TestAuxTitleConfigured(unittest.TestCase):
@@ -71,9 +115,9 @@ class TestAuxTitleConfigured(unittest.TestCase):
 
     def test_import_error_returns_false(self):
         from api.streaming import _aux_title_configured
-        _ensure_agent_aux_stub()
-        with patch('agent.auxiliary_client._get_auxiliary_task_config', side_effect=ImportError("no module"), create=True):
-            self.assertFalse(_aux_title_configured())
+        with _ensure_agent_aux_stub() as aux_module:
+            with patch.object(aux_module, '_get_auxiliary_task_config', side_effect=ImportError("no module"), create=True):
+                self.assertFalse(_aux_title_configured())
 
 
 class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):


### PR DESCRIPTION
## Thinking Path

- The provider fallback itself was already routing correctly.
- The production fix still belongs at the request boundary on the outbound Google Gemini copy, keyed by the active-turn boundary Hermes Agent already owns.
- The remaining blocker was not another product bug. The supporting real-Agent regressions could still leave the shared `agent` module graph in a mixed state across files, which let a real preloaded `agent.model_metadata` child survive under a replaced parent.
- The final branch therefore needs both pieces together: the accepted request-boundary repair in `api/streaming.py`, and test harnesses that restore the full `agent` graph so the real fallback proof stays hermetic under the installed-Agent preload and file-order the maintainer reproduced.

## What Changed

- `api/streaming.py`: no production change in this follow-up. The accepted request-boundary Gemini repair remains the branch's production behavior.
- `tests/test_title_aux_routing.py`: snapshots, clears, and restores the full `agent` and `agent.*` graph around the temporary aux stub, and prefers the real importable package when it exists.
- `tests/test_issue6333_gemini_fallback_tool_state.py`: snapshots and restores the full `agent` graph before importing the real conversation loop, attaches the reanchor seam explicitly when a clean import path does not export it, and keeps the real `_run_agent_streaming` fallback lifecycle coverage.

## Why It Matters

Gemini fallback still fixes the reported 400 without broadening product scope. The branch now also has hermetic local proof under the reachable installed-Agent preload and file-order that previously produced a false red harness failure.

## Verification

With real `agent.model_metadata` preloaded, the unfixed head still fails when the title-aux regression runs before the issue6333 real-Agent fallback regression, and this head passes that same order and the reverse order. The touched-file pack also passes locally, covering the title-aux harness and the full issue6333 real fallback, boundary re-anchor, replacement rewrap, and persisted-history paths.

## Risks / Follow-ups

This stays intentionally narrow. The production request-boundary mechanism is unchanged in this follow-up, and the smaller Hermes Agent-owned design from the re-decision remains a possible future simplification if maintainers want to collapse the remaining WebUI-owned boundary carrier later.

## Upstream

Closes #6333.

The external contract reference is Google's current Generate Content thought-signatures docs: https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures .

## Model Used

GPT-5 via Codex CLI
