### PR TITLE
a11y: avoid no-op composer height resets

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -6733,12 +6733,23 @@ function transcript(){
 }
 
 let _composerAutoResizeRaf=0;
+let _composerLastResizeValueLength=0;
 function autoResize(){
   if(_composerAutoResizeRaf && typeof cancelAnimationFrame==='function'){
     cancelAnimationFrame(_composerAutoResizeRaf);
     _composerAutoResizeRaf=0;
   }
   const el=$('msg');
+  const _nextValueLength=String(el.value||'').length;
+  const _isGrowing=_nextValueLength>_composerLastResizeValueLength;
+  const _fitsCurrentHeight=el.scrollHeight<=el.offsetHeight;
+  // A one-line append does not need a height round trip. Avoiding the
+  // `auto` → measured-height mutation keeps textarea caret geometry stable for
+  // assistive technology while deletes and genuine multi-line growth still resize.
+  if(_isGrowing&&_fitsCurrentHeight){
+    _composerLastResizeValueLength=_nextValueLength;
+    return;
+  }
   const _prevComposerH=el.offsetHeight;
   // #5514: autoResize() momentarily sets the textarea to height:'auto' (collapses
   // a multi-row composer toward its 1-row min) before reading scrollHeight and
@@ -6763,6 +6774,7 @@ function autoResize(){
   const _prevScrollTop=_msgs?_msgs.scrollTop:0;
   el.style.height='auto';
   el.style.height=Math.min(el.scrollHeight,200)+'px';
+  _composerLastResizeValueLength=_nextValueLength;
   if(_msgs&&_msgs.scrollTop!==_prevScrollTop) _msgs.scrollTop=_prevScrollTop;
   updateSendBtn();
   // Genuine NET growth (a new row that keeps the composer taller than before)

--- a/static/messages.js
+++ b/static/messages.js
@@ -6748,6 +6748,7 @@ function autoResize(){
   // assistive technology while deletes and genuine multi-line growth still resize.
   if(_isGrowing&&_fitsCurrentHeight){
     _composerLastResizeValueLength=_nextValueLength;
+    updateSendBtn();
     return;
   }
   const _prevComposerH=el.offsetHeight;

--- a/static/messages.js
+++ b/static/messages.js
@@ -6743,10 +6743,12 @@ function autoResize(){
   const _nextValue=String(el.value||'');
   const _isAppendOnly=_nextValue.length>_composerLastResizeValue.length&&_nextValue.startsWith(_composerLastResizeValue);
   const _fitsCurrentHeight=el.scrollHeight<=el.offsetHeight;
-  // Only a direct append that already fits can skip the height round trip.
-  // Replacements (including session and draft restoration) must remeasure so a
-  // previously tall composer can shrink back to its natural height.
-  if(_isAppendOnly&&_fitsCurrentHeight){
+  // Only a direct append at the natural one-row height can skip the height
+  // round trip. Replacements and an already-tall composer must remeasure so the
+  // textarea can shrink back to its natural height.
+  const _minHeight=_isAppendOnly&&_fitsCurrentHeight?parseFloat(getComputedStyle(el).minHeight):NaN;
+  const _isAtMinimumHeight=Number.isFinite(_minHeight)&&el.offsetHeight<=Math.ceil(_minHeight)+1;
+  if(_isAppendOnly&&_fitsCurrentHeight&&_isAtMinimumHeight){
     _composerLastResizeValue=_nextValue;
     updateSendBtn();
     return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -6733,21 +6733,21 @@ function transcript(){
 }
 
 let _composerAutoResizeRaf=0;
-let _composerLastResizeValueLength=0;
+let _composerLastResizeValue='';
 function autoResize(){
   if(_composerAutoResizeRaf && typeof cancelAnimationFrame==='function'){
     cancelAnimationFrame(_composerAutoResizeRaf);
     _composerAutoResizeRaf=0;
   }
   const el=$('msg');
-  const _nextValueLength=String(el.value||'').length;
-  const _isGrowing=_nextValueLength>_composerLastResizeValueLength;
+  const _nextValue=String(el.value||'');
+  const _isAppendOnly=_nextValue.length>_composerLastResizeValue.length&&_nextValue.startsWith(_composerLastResizeValue);
   const _fitsCurrentHeight=el.scrollHeight<=el.offsetHeight;
-  // A one-line append does not need a height round trip. Avoiding the
-  // `auto` → measured-height mutation keeps textarea caret geometry stable for
-  // assistive technology while deletes and genuine multi-line growth still resize.
-  if(_isGrowing&&_fitsCurrentHeight){
-    _composerLastResizeValueLength=_nextValueLength;
+  // Only a direct append that already fits can skip the height round trip.
+  // Replacements (including session and draft restoration) must remeasure so a
+  // previously tall composer can shrink back to its natural height.
+  if(_isAppendOnly&&_fitsCurrentHeight){
+    _composerLastResizeValue=_nextValue;
     updateSendBtn();
     return;
   }
@@ -6775,7 +6775,7 @@ function autoResize(){
   const _prevScrollTop=_msgs?_msgs.scrollTop:0;
   el.style.height='auto';
   el.style.height=Math.min(el.scrollHeight,200)+'px';
-  _composerLastResizeValueLength=_nextValueLength;
+  _composerLastResizeValue=_nextValue;
   if(_msgs&&_msgs.scrollTop!==_prevScrollTop) _msgs.scrollTop=_prevScrollTop;
   updateSendBtn();
   // Genuine NET growth (a new row that keeps the composer taller than before)

--- a/tests/test_issue5514_composer_grow_scroll_pin.py
+++ b/tests/test_issue5514_composer_grow_scroll_pin.py
@@ -41,9 +41,73 @@ MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
 
 
-# ---------------------------------------------------------------------------
-# Static wiring
-# ---------------------------------------------------------------------------
+
+def test_single_line_growth_does_not_write_height_in_node_fixture():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    body = _autoresize_body()
+    harness = textwrap.dedent(
+        """
+        let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValueLength = 0;
+        let writes = 0;
+        const msg = {
+          value: 'a',
+          offsetHeight: 44,
+          scrollHeight: 44,
+          style: {
+            set height(_value) { writes += 1; },
+            get height() { return '44px'; },
+          },
+        };
+        const messages = { scrollTop: 0 };
+        const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
+        function updateSendBtn() { throw new Error('one-line append must not refresh again from autoResize'); }
+        function _repinMessagesAfterComposerResize() { throw new Error('one-line append must not repin transcript'); }
+        %(autoresize)s
+        autoResize();
+        console.log(JSON.stringify({ writes, lastLength: _composerLastResizeValueLength }));
+        """
+    ) % {"autoresize": body}
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {"writes": 0, "lastLength": 1}
+
+
+def test_single_line_delete_still_runs_the_height_round_trip_in_node_fixture():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    body = _autoresize_body()
+    harness = textwrap.dedent(
+        """
+        let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValueLength = 5;
+        let writes = 0, height = 100;
+        const msg = {
+          value: 'a',
+          get offsetHeight() { return height; },
+          scrollHeight: 44,
+          style: {
+            set height(value) { writes += 1; height = value === 'auto' ? 44 : parseInt(value, 10); },
+            get height() { return height + 'px'; },
+          },
+        };
+        const messages = { scrollTop: 0 };
+        const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
+        let sendUpdates = 0;
+        function updateSendBtn() { sendUpdates += 1; }
+        function _repinMessagesAfterComposerResize() {}
+        %(autoresize)s
+        autoResize();
+        console.log(JSON.stringify({ writes, height, lastLength: _composerLastResizeValueLength, sendUpdates }));
+        """
+    ) % {"autoresize": body}
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {"writes": 2, "height": 44, "lastLength": 1, "sendUpdates": 1}
+
 
 def _helper_body() -> str:
     start = UI_JS.find("function _repinMessagesAfterComposerResize(")
@@ -118,8 +182,13 @@ def test_resize_observer_installed_on_composer():
     assert "can't strand" in BOOT_JS
 
 
-# ---------------------------------------------------------------------------
-# Behavioral (node vm) — the pin guard under a viewport shrink
+def test_single_line_growth_skips_the_height_round_trip():
+    body = _autoresize_body()
+    assert "let _composerLastResizeValueLength=0;" in MESSAGES_JS
+    assert "const _isGrowing=_nextValueLength>_composerLastResizeValueLength;" in body
+    assert "const _fitsCurrentHeight=el.scrollHeight<=el.offsetHeight;" in body
+    assert "if(_isGrowing&&_fitsCurrentHeight){" in body
+    assert "el.style.height='auto'" in body
 # ---------------------------------------------------------------------------
 
 def _run(scenario):
@@ -232,6 +301,7 @@ def _run_autoresize(scenario):
         const $ = (id) => (id === 'msg' ? msgEl : id === 'messages' ? msgsEl : null);
         let _messageUserUnpinned = %(unpinned)s, _scrollPinned = %(pinned)s;
         let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValueLength = 0;
         let _repinCalls = 0;
         function updateSendBtn(){}
         function _messageBottomDistance(){ return msgsEl.scrollHeight - msgsEl.scrollTop - msgsEl.clientHeight; }

--- a/tests/test_issue5514_composer_grow_scroll_pin.py
+++ b/tests/test_issue5514_composer_grow_scroll_pin.py
@@ -109,6 +109,65 @@ def test_single_line_delete_still_runs_the_height_round_trip_in_node_fixture():
     assert json.loads(proc.stdout) == {"writes": 2, "height": 44, "lastLength": 1, "sendUpdates": 1}
 
 
+def _run_resize_boundary_fixture(*, value: str, last_length: int, offset_height: int, scroll_height: int):
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    body = _autoresize_body()
+    harness = textwrap.dedent(
+        """
+        let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValueLength = %(last_length)s;
+        let writes = 0, height = %(offset_height)s, repins = 0;
+        const msg = {
+          value: %(value)r,
+          get offsetHeight() { return height; },
+          scrollHeight: %(scroll_height)s,
+          style: {
+            set height(value) { writes += 1; height = value === 'auto' ? 44 : parseInt(value, 10); },
+            get height() { return height + 'px'; },
+          },
+        };
+        const messages = { scrollTop: 0 };
+        const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
+        function updateSendBtn() {}
+        function _repinMessagesAfterComposerResize() { repins += 1; }
+        %(autoresize)s
+        autoResize();
+        console.log(JSON.stringify({ writes, height, lastLength: _composerLastResizeValueLength, repins }));
+        """
+    ) % {
+        "last_length": last_length,
+        "offset_height": offset_height,
+        "scroll_height": scroll_height,
+        "value": value,
+        "autoresize": body,
+    }
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_newline_growth_keeps_full_resize_and_repin_path():
+    out = _run_resize_boundary_fixture(
+        value="a\nb",
+        last_length=1,
+        offset_height=44,
+        scroll_height=68,
+    )
+    assert out == {"writes": 2, "height": 68, "lastLength": 3, "repins": 1}
+
+
+def test_equal_length_replacement_keeps_full_resize_path():
+    out = _run_resize_boundary_fixture(
+        value="ab",
+        last_length=2,
+        offset_height=44,
+        scroll_height=44,
+    )
+    assert out == {"writes": 2, "height": 44, "lastLength": 2, "repins": 0}
+
+
 def _helper_body() -> str:
     start = UI_JS.find("function _repinMessagesAfterComposerResize(")
     assert start != -1, "the _repinMessagesAfterComposerResize helper must exist in ui.js"

--- a/tests/test_issue5514_composer_grow_scroll_pin.py
+++ b/tests/test_issue5514_composer_grow_scroll_pin.py
@@ -41,6 +41,20 @@ MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
 
 
+def _function_source(source: str, name: str) -> str:
+    start = source.find(f"function {name}(")
+    assert start != -1, f"{name} not found"
+    open_brace = source.find("{", start)
+    depth = 0
+    for index in range(open_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"{name} is not balanced")
+
 
 def test_single_line_growth_does_not_write_height_in_node_fixture():
     node = shutil.which("node")
@@ -63,16 +77,88 @@ def test_single_line_growth_does_not_write_height_in_node_fixture():
         };
         const messages = { scrollTop: 0 };
         const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
-        function updateSendBtn() { throw new Error('one-line append must not refresh again from autoResize'); }
+        let sendUpdates = 0;
+        function updateSendBtn() { sendUpdates += 1; }
         function _repinMessagesAfterComposerResize() { throw new Error('one-line append must not repin transcript'); }
         %(autoresize)s
         autoResize();
-        console.log(JSON.stringify({ writes, lastLength: _composerLastResizeValueLength }));
+        console.log(JSON.stringify({ writes, lastLength: _composerLastResizeValueLength, sendUpdates }));
         """
     ) % {"autoresize": body}
     proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
-    assert json.loads(proc.stdout) == {"writes": 0, "lastLength": 1}
+    assert json.loads(proc.stdout) == {"writes": 0, "lastLength": 1, "sendUpdates": 1}
+
+
+def test_programmatic_one_line_fill_refreshes_primary_button_without_height_writes():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    auto_resize = _autoresize_body()
+    composer_has_content = _function_source(UI_JS, "_composerHasContent")
+    primary_action = _function_source(UI_JS, "getComposerPrimaryAction")
+    button_icon = _function_source(UI_JS, "_setComposerPrimaryButtonIcon")
+    update_send = _function_source(UI_JS, "updateSendBtn")
+    harness = textwrap.dedent(
+        """
+        let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValueLength = 0;
+        let heightWrites = 0;
+        const classes = new Set();
+        const btn = {
+          dataset: {}, style: {}, disabled: true, title: 'Type a message to send', innerHTML: '',
+          classList: {
+            toggle(name, enabled) { if (enabled) classes.add(name); else classes.delete(name); },
+            contains(name) { return classes.has(name); },
+            add(name) { classes.add(name); },
+            remove(name) { classes.delete(name); },
+          },
+          setAttribute(name, value) { this[name] = value; },
+        };
+        const msg = {
+          value: 'prefilled', disabled: false, offsetHeight: 44, scrollHeight: 44,
+          style: { set height(_value) { heightWrites += 1; }, get height() { return '44px'; } },
+        };
+        const messages = { scrollTop: 0 };
+        const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : id === 'btnSend' ? btn : null;
+        const S = { busy: false, pendingFiles: [] };
+        const window = { _hasPendingSelections() { return false; } };
+        function t(_key) { return _key; }
+        function requestAnimationFrame(callback) { callback(); return 1; }
+        function _applyBusyComposerPlaceholder() {}
+        function _repinMessagesAfterComposerResize() { throw new Error('one-line programmatic fill must not repin transcript'); }
+        %(composer_has_content)s
+        %(primary_action)s
+        %(button_icon)s
+        %(update_send)s
+        %(auto_resize)s
+        // This models URL prefill and other programmatic fills: no DOM input event
+        // is dispatched before autoResize() runs.
+        autoResize();
+        console.log(JSON.stringify({
+          heightWrites,
+          disabled: btn.disabled,
+          action: btn.dataset.action,
+          title: btn.title,
+          ariaLabel: btn['aria-label'],
+        }));
+        """
+    ) % {
+        "composer_has_content": composer_has_content,
+        "primary_action": primary_action,
+        "button_icon": button_icon,
+        "update_send": update_send,
+        "auto_resize": auto_resize,
+    }
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {
+        "heightWrites": 0,
+        "disabled": False,
+        "action": "send",
+        "title": "Send message",
+        "ariaLabel": "Send message",
+    }
 
 
 def test_single_line_delete_still_runs_the_height_round_trip_in_node_fixture():

--- a/tests/test_issue5514_composer_grow_scroll_pin.py
+++ b/tests/test_issue5514_composer_grow_scroll_pin.py
@@ -64,7 +64,7 @@ def test_single_line_growth_does_not_write_height_in_node_fixture():
     harness = textwrap.dedent(
         """
         let _composerAutoResizeRaf = 0;
-        let _composerLastResizeValueLength = 0;
+        let _composerLastResizeValue = '';
         let writes = 0;
         const msg = {
           value: 'a',
@@ -82,12 +82,51 @@ def test_single_line_growth_does_not_write_height_in_node_fixture():
         function _repinMessagesAfterComposerResize() { throw new Error('one-line append must not repin transcript'); }
         %(autoresize)s
         autoResize();
-        console.log(JSON.stringify({ writes, lastLength: _composerLastResizeValueLength, sendUpdates }));
+        console.log(JSON.stringify({ writes, lastValue: _composerLastResizeValue, sendUpdates }));
         """
     ) % {"autoresize": body}
     proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
-    assert json.loads(proc.stdout) == {"writes": 0, "lastLength": 1, "sendUpdates": 1}
+    assert json.loads(proc.stdout) == {"writes": 0, "lastValue": "a", "sendUpdates": 1}
+
+
+def test_session_restore_replaces_tall_composer_with_natural_one_line_height():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    body = _autoresize_body()
+    harness = textwrap.dedent(
+        """
+        let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValue = 'a\\nb';
+        let height = 150, writes = 0;
+        const msg = {
+          // Mirrors sessions.js draft restore: a prior multi-line value is
+          // replaced directly, then autoResize() runs without an input event.
+          value: 'a longer one-line restored draft',
+          get offsetHeight() { return height; },
+          get scrollHeight() { return height > 44 ? height : 44; },
+          style: {
+            set height(value) { writes += 1; height = value === 'auto' ? 44 : parseInt(value, 10); },
+            get height() { return height + 'px'; },
+          },
+        };
+        const messages = { scrollTop: 0 };
+        const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
+        function updateSendBtn() {}
+        function _repinMessagesAfterComposerResize() {}
+        %(autoresize)s
+        autoResize();
+        console.log(JSON.stringify({ writes, height, lastValue: _composerLastResizeValue }));
+        """
+    ) % {"autoresize": body}
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {
+        "writes": 2,
+        "height": 44,
+        "lastValue": "a longer one-line restored draft",
+    }
 
 
 def test_programmatic_one_line_fill_refreshes_primary_button_without_height_writes():
@@ -102,7 +141,7 @@ def test_programmatic_one_line_fill_refreshes_primary_button_without_height_writ
     harness = textwrap.dedent(
         """
         let _composerAutoResizeRaf = 0;
-        let _composerLastResizeValueLength = 0;
+        let _composerLastResizeValue = '';
         let heightWrites = 0;
         const classes = new Set();
         const btn = {
@@ -169,7 +208,7 @@ def test_single_line_delete_still_runs_the_height_round_trip_in_node_fixture():
     harness = textwrap.dedent(
         """
         let _composerAutoResizeRaf = 0;
-        let _composerLastResizeValueLength = 5;
+        let _composerLastResizeValue = 'hello';
         let writes = 0, height = 100;
         const msg = {
           value: 'a',
@@ -187,15 +226,15 @@ def test_single_line_delete_still_runs_the_height_round_trip_in_node_fixture():
         function _repinMessagesAfterComposerResize() {}
         %(autoresize)s
         autoResize();
-        console.log(JSON.stringify({ writes, height, lastLength: _composerLastResizeValueLength, sendUpdates }));
+        console.log(JSON.stringify({ writes, height, lastValue: _composerLastResizeValue, sendUpdates }));
         """
     ) % {"autoresize": body}
     proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, proc.stderr
-    assert json.loads(proc.stdout) == {"writes": 2, "height": 44, "lastLength": 1, "sendUpdates": 1}
+    assert json.loads(proc.stdout) == {"writes": 2, "height": 44, "lastValue": "a", "sendUpdates": 1}
 
 
-def _run_resize_boundary_fixture(*, value: str, last_length: int, offset_height: int, scroll_height: int):
+def _run_resize_boundary_fixture(*, value: str, previous_value: str, offset_height: int, scroll_height: int):
     node = shutil.which("node")
     if not node:  # pragma: no cover
         pytest.skip("node not available")
@@ -203,7 +242,7 @@ def _run_resize_boundary_fixture(*, value: str, last_length: int, offset_height:
     harness = textwrap.dedent(
         """
         let _composerAutoResizeRaf = 0;
-        let _composerLastResizeValueLength = %(last_length)s;
+        let _composerLastResizeValue = %(previous_value)r;
         let writes = 0, height = %(offset_height)s, repins = 0;
         const msg = {
           value: %(value)r,
@@ -220,10 +259,10 @@ def _run_resize_boundary_fixture(*, value: str, last_length: int, offset_height:
         function _repinMessagesAfterComposerResize() { repins += 1; }
         %(autoresize)s
         autoResize();
-        console.log(JSON.stringify({ writes, height, lastLength: _composerLastResizeValueLength, repins }));
+        console.log(JSON.stringify({ writes, height, lastValue: _composerLastResizeValue, repins }));
         """
     ) % {
-        "last_length": last_length,
+        "previous_value": previous_value,
         "offset_height": offset_height,
         "scroll_height": scroll_height,
         "value": value,
@@ -237,21 +276,21 @@ def _run_resize_boundary_fixture(*, value: str, last_length: int, offset_height:
 def test_newline_growth_keeps_full_resize_and_repin_path():
     out = _run_resize_boundary_fixture(
         value="a\nb",
-        last_length=1,
+        previous_value="a",
         offset_height=44,
         scroll_height=68,
     )
-    assert out == {"writes": 2, "height": 68, "lastLength": 3, "repins": 1}
+    assert out == {"writes": 2, "height": 68, "lastValue": "a\nb", "repins": 1}
 
 
 def test_equal_length_replacement_keeps_full_resize_path():
     out = _run_resize_boundary_fixture(
         value="ab",
-        last_length=2,
+        previous_value="cd",
         offset_height=44,
         scroll_height=44,
     )
-    assert out == {"writes": 2, "height": 44, "lastLength": 2, "repins": 0}
+    assert out == {"writes": 2, "height": 44, "lastValue": "ab", "repins": 0}
 
 
 def _helper_body() -> str:
@@ -329,10 +368,10 @@ def test_resize_observer_installed_on_composer():
 
 def test_single_line_growth_skips_the_height_round_trip():
     body = _autoresize_body()
-    assert "let _composerLastResizeValueLength=0;" in MESSAGES_JS
-    assert "const _isGrowing=_nextValueLength>_composerLastResizeValueLength;" in body
+    assert "let _composerLastResizeValue='';" in MESSAGES_JS
+    assert "const _isAppendOnly=_nextValue.length>_composerLastResizeValue.length&&_nextValue.startsWith(_composerLastResizeValue);" in body
     assert "const _fitsCurrentHeight=el.scrollHeight<=el.offsetHeight;" in body
-    assert "if(_isGrowing&&_fitsCurrentHeight){" in body
+    assert "if(_isAppendOnly&&_fitsCurrentHeight){" in body
     assert "el.style.height='auto'" in body
 # ---------------------------------------------------------------------------
 
@@ -446,7 +485,7 @@ def _run_autoresize(scenario):
         const $ = (id) => (id === 'msg' ? msgEl : id === 'messages' ? msgsEl : null);
         let _messageUserUnpinned = %(unpinned)s, _scrollPinned = %(pinned)s;
         let _composerAutoResizeRaf = 0;
-        let _composerLastResizeValueLength = 0;
+        let _composerLastResizeValue = '';
         let _repinCalls = 0;
         function updateSendBtn(){}
         function _messageBottomDistance(){ return msgsEl.scrollHeight - msgsEl.scrollTop - msgsEl.clientHeight; }

--- a/tests/test_issue5514_composer_grow_scroll_pin.py
+++ b/tests/test_issue5514_composer_grow_scroll_pin.py
@@ -77,6 +77,7 @@ def test_single_line_growth_does_not_write_height_in_node_fixture():
         };
         const messages = { scrollTop: 0 };
         const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
+        const getComputedStyle = () => ({ minHeight: '44px' });
         let sendUpdates = 0;
         function updateSendBtn() { sendUpdates += 1; }
         function _repinMessagesAfterComposerResize() { throw new Error('one-line append must not repin transcript'); }
@@ -129,6 +130,46 @@ def test_session_restore_replaces_tall_composer_with_natural_one_line_height():
     }
 
 
+def test_append_to_an_oversized_composer_remeasures_natural_height():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    body = _autoresize_body()
+    harness = textwrap.dedent(
+        """
+        let _composerAutoResizeRaf = 0;
+        let _composerLastResizeValue = 'short prefi';
+        let height = 176, writes = 0;
+        const msg = {
+          // The content is an append-only update, but the textarea is still
+          // taller than the content needs. The fast path must not preserve it.
+          value: 'short prefix',
+          get offsetHeight() { return height; },
+          get scrollHeight() { return height > 44 ? height : 44; },
+          style: {
+            set height(value) { writes += 1; height = value === 'auto' ? 44 : parseInt(value, 10); },
+            get height() { return height + 'px'; },
+          },
+        };
+        const messages = { scrollTop: 0 };
+        const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : null;
+        const getComputedStyle = () => ({ minHeight: '44px' });
+        function updateSendBtn() {}
+        function _repinMessagesAfterComposerResize() {}
+        %(autoresize)s
+        autoResize();
+        console.log(JSON.stringify({ writes, height, lastValue: _composerLastResizeValue }));
+        """
+    ) % {"autoresize": body}
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {
+        "writes": 2,
+        "height": 44,
+        "lastValue": "short prefix",
+    }
+
+
 def test_programmatic_one_line_fill_refreshes_primary_button_without_height_writes():
     node = shutil.which("node")
     if not node:  # pragma: no cover
@@ -161,6 +202,7 @@ def test_programmatic_one_line_fill_refreshes_primary_button_without_height_writ
         const messages = { scrollTop: 0 };
         const $ = (id) => id === 'msg' ? msg : id === 'messages' ? messages : id === 'btnSend' ? btn : null;
         const S = { busy: false, pendingFiles: [] };
+        const getComputedStyle = () => ({ minHeight: '44px' });
         const window = { _hasPendingSelections() { return false; } };
         function t(_key) { return _key; }
         function requestAnimationFrame(callback) { callback(); return 1; }
@@ -371,7 +413,9 @@ def test_single_line_growth_skips_the_height_round_trip():
     assert "let _composerLastResizeValue='';" in MESSAGES_JS
     assert "const _isAppendOnly=_nextValue.length>_composerLastResizeValue.length&&_nextValue.startsWith(_composerLastResizeValue);" in body
     assert "const _fitsCurrentHeight=el.scrollHeight<=el.offsetHeight;" in body
-    assert "if(_isAppendOnly&&_fitsCurrentHeight){" in body
+    assert "const _minHeight=_isAppendOnly&&_fitsCurrentHeight?parseFloat(getComputedStyle(el).minHeight):NaN;" in body
+    assert "const _isAtMinimumHeight=Number.isFinite(_minHeight)&&el.offsetHeight<=Math.ceil(_minHeight)+1;" in body
+    assert "if(_isAppendOnly&&_fitsCurrentHeight&&_isAtMinimumHeight){" in body
     assert "el.style.height='auto'" in body
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Typing in the composer could trigger an unnecessary textarea height reset even when the text still fit on one line:

```text
44px → auto → 44px
```

This change skips that round trip only for a direct one-line append that already fits at the current height. Replacements keep the existing resize path, so a previously tall composer can shrink back to its natural height after a session or draft restore.

The goal is to reduce unnecessary editable-layout churn during typing. In manual NVDA testing on the live WebUI, one-line typing was noticeably more responsive.

## Scope

- Updated the shared `autoResize()` path in `static/messages.js`.
- Skips the no-op height reset only when the new value is an append-only extension of the exact previous value and `scrollHeight` already fits within the current `offsetHeight`.
- Preserves `updateSendBtn()` on the fast path, including programmatic composer fills that call `autoResize()` without dispatching a DOM `input` event.
- Keeps the existing resize, scroll-position preservation, and bottom re-pin behavior for:
  - genuine multi-line growth;
  - shrinkage after deletion;
  - equal-length and other replacements;
  - session or draft restoration.
- Does not change draft persistence or transcript rendering.

## Measurement

A Playwright/Chromium run typed one-line English and Korean sentences at 80 ms per character and recorded composer-adjacent work.

Before → after:

| Scenario | Textarea height style mutations | `autoResize()` total |
| --- | ---: | ---: |
| English, 51 characters | 102 → 0 | 46.4 ms → 6.3 ms |
| Korean, 42 characters | 66 → 0 | 24.4 ms → 5.1 ms |

The fast path still refreshes the primary action button. It deliberately removes only the textarea height writes, not the button's disabled state, title, or `aria-label` synchronization.

Neither run produced a browser long task or console error.

## Validation

- `./scripts/test.sh tests/test_issue5514_composer_grow_scroll_pin.py tests/test_issue4042_typing_lag_autoresize.py`
  - 18 passed
- `node --check static/messages.js`
- `npm run lint:runtime`
- `git diff --check`
- Diff-scoped Ruff check
- Node regression fixtures verify:
  - a direct growing one-line append performs no textarea height writes, refreshes the primary action once, and does not re-pin the transcript;
  - a programmatic one-line fill that invokes only `autoResize()` enables the primary button and refreshes its action, title, and `aria-label` without height writes;
  - a shrinking value, newline growth, equal-length replacement, and longer one-line session/draft restoration over a previously tall composer continue through the existing full resize path.
- Playwright/Chromium measurement above.
- Manual NVDA check on the live WebUI: one-line typing was noticeably more responsive.

## Not verified

- Playwright measures browser events, DOM mutations, and JavaScript timing. It does not measure NVDA speech or IME composition behavior directly.
- The manual check covered one-line typing. Multi-line and IME-composition behavior should receive follow-up manual coverage if this approach is accepted.