### PR TITLE
fix: clean up gpt 5.6 labels

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6299,8 +6299,11 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
     # preserving vendor hierarchy for multi-slash IDs (#3360).
     # Skip for URI-scheme IDs whose slashes are path separators (#3429).
     bare = lookup_id.split("/", 1)[1] if ("/" in lookup_id and not _has_scheme(lookup_id)) else lookup_id
+    is_gpt_56 = bare.lower().startswith("gpt-5.6-")
     return " ".join(
-        w.upper() if (len(w) <= 3 and w.replace(".", "").isalnum() and not w.isdigit()) else w.capitalize()
+        w.capitalize() if is_gpt_56 and w.lower() in {"sol", "terra", "luna", "pro"}
+        else w.upper() if (len(w) <= 3 and w.replace(".", "").isalnum() and not w.isdigit())
+        else w.capitalize()
         for w in bare.replace("_", "-").split("-")
     )
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -6921,10 +6921,12 @@ function scrollToBottom(){
 function _fmtOllamaLabel(mid){
   const [namePart, ...variantParts] = mid.split(':');
   const variant = variantParts.join(':');
+  const isGpt56 = /^gpt-5\.6-/i.test(namePart);
   const _fmt = (s) => {
     const tokens = s.replace(/[-_]/g, ' ').split(' ');
     return tokens.map(t => {
       const alphaOnly = t.replace(/\./g, '');
+      if (isGpt56 && /^(sol|terra|luna|pro)$/i.test(t)) return t.charAt(0).toUpperCase() + t.slice(1).toLowerCase();
       if (t.length <= 3 && /^[a-zA-Z.]+$/.test(t)) return t.toUpperCase();
       if (/^\d/.test(alphaOnly)) return t.toUpperCase();
       return t.charAt(0).toUpperCase() + t.slice(1);

--- a/tests/test_ollama_model_chip_label_regression.py
+++ b/tests/test_ollama_model_chip_label_regression.py
@@ -1,4 +1,9 @@
+import json
 import pathlib
+import shutil
+import subprocess
+
+import pytest
 
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -54,3 +59,45 @@ def test_fmt_ollama_label_preserves_dotted_acronyms():
     assert "if (t.length <= 3 && /^[a-zA-Z.]+$/.test(t)) return t.toUpperCase();" in src, (
         "JS Ollama formatter should preserve dotted acronyms like 'a.b' -> 'A.B'."
     )
+
+
+def test_fmt_ollama_label_uses_title_case_for_gpt_5_6_variant_names():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the JavaScript formatter regression test")
+
+    src = _read_ui()
+    start = src.index("function _fmtOllamaLabel")
+    end = src.index("\nfunction getModelLabel", start)
+    formatter = src[start:end]
+    model_ids = [
+        "gpt-5.6-sol-pro",
+        "gpt-5.6-terra-pro",
+        "gpt-5.6-luna-pro",
+        "api-xl:7b",
+    ]
+    script = formatter + "\nconsole.log(JSON.stringify(modelIds.map(_fmtOllamaLabel)));"
+
+    completed = subprocess.run(
+        [node, "-e", "const modelIds = " + json.dumps(model_ids) + ";\n" + script],
+        check=True,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )
+
+    assert json.loads(completed.stdout) == [
+        "GPT 5.6 Sol Pro",
+        "GPT 5.6 Terra Pro",
+        "GPT 5.6 Luna Pro",
+        "API XL (7B)",
+    ]
+
+
+def test_server_catalog_uses_title_case_for_gpt_5_6_variant_names():
+    from api.config import _get_label_for_model
+
+    assert _get_label_for_model("gpt-5.6-sol-pro", []) == "GPT 5.6 Sol Pro"
+    assert _get_label_for_model("gpt-5.6-terra-pro", []) == "GPT 5.6 Terra Pro"
+    assert _get_label_for_model("gpt-5.6-luna-pro", []) == "GPT 5.6 Luna Pro"
+    assert _get_label_for_model("api-xl", []) == "API XL"


### PR DESCRIPTION
## Thinking Path

- The 5.6 family is already in the live model catalog.
- The generic label formatter treats every short token as an acronym.
- That turns `sol` and `pro` into `SOL` and `PRO`, even though these are product-name words here.
- The smallest safe fix is to title-case those tokens only inside GPT-5.6 family labels while leaving existing acronym behavior alone everywhere else.

## What Changed

- Render the 5.6 family as `GPT 5.6 Sol`, `GPT 5.6 Terra`, and `GPT 5.6 Luna`.
- Render the tier suffix as `Pro`, not `PRO`.
- Keep the server catalog and browser fallback formatter aligned.
- Add executable regression coverage for Sol, Terra, Luna, and an unrelated acronym control case.

## Why It Matters

The picker should show the model names as names, not shout half of them in accidental acronym casing. This cleans up the visible labels without changing model IDs, routing, or selection behavior.

## Contract Routing

Task type: small model-picker label fix.

Touched areas:
- Server model-catalog labels
- Browser fallback model labels

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`

Scope boundaries:
- No model IDs or provider routing changed.
- Existing short-token acronym behavior remains unchanged outside GPT-5.6 family labels.

## Verification

- `./scripts/test.sh tests/test_ollama_model_chip_label_regression.py tests/test_issue1538_nous_live_catalog.py -q` → `17 passed`
- `npm run lint:runtime` → passed
- `node --check static/ui.js` → passed
- `python -m py_compile api/config.py` → passed
- `python scripts/ruff_lint.py --diff origin/master` → no new violations
- `git diff --check` → passed
- Reproduced the old live catalog payload before the fix: `GPT 5.6 SOL PRO` / `GPT 5.6 Terra PRO` / `GPT 5.6 Luna PRO`.

## Risks / Follow-ups

- Risk is limited to display text for GPT-5.6 family labels; wire IDs are untouched.
- Before/after picker screenshots still need to be attached before this leaves draft.

Release note: GPT-5.6 Sol, Terra, Luna, and Pro model-picker labels now use normal title casing.

## Model Used

- OpenAI Codex `gpt-5.6-sol` with subagent implementation and direct maintainer verification.
