### PR TITLE
fix: allow max reasoning for gpt 5.6

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3173,6 +3173,15 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
 # Keep this WebUI-visible set aligned with hermes-agent#29248.
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
+_OPENAI_MAX_REASONING_MODELS = frozenset({
+    "gpt-5.6-sol",
+    "gpt-5.6-sol-pro",
+    "gpt-5.6-terra",
+    "gpt-5.6-terra-pro",
+    "gpt-5.6-luna",
+    "gpt-5.6-luna-pro",
+})
+
 
 def parse_reasoning_effort(effort):
     """Parse an effort level into the dict the agent expects.
@@ -3484,12 +3493,14 @@ def _filter_reasoning_efforts_for_provider(
     normalized = list(dict.fromkeys(normalized))
     provider = _resolve_provider_alias(str(provider_id or "").strip().lower())
     bare = _strip_provider_hint_for_reasoning(model_id).lower().rsplit("/", 1)[-1]
-    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap GPT-5 at xhigh
-    # and o-series at high — 'max' is a WebUI-only level none of them accept.
+    # OpenAI-family lanes (Codex, direct OpenAI, Azure Foundry) cap older GPT-5
+    # at xhigh and o-series at high. Only the six explicitly known GPT-5.6
+    # Sol/Terra/Luna ids accept max; keep this exact-match allowlist fail-closed
+    # so an unknown future gpt-5.6-* id does not inherit the capability.
     if provider in {"openai-codex", "openai", "openai-api", "azure-foundry", "azure-openai", "azure"}:
         if bare.startswith(("o1", "o3", "o4")):
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]
-        if bare.startswith("gpt-5"):
+        if bare.startswith("gpt-5") and bare not in _OPENAI_MAX_REASONING_MODELS:
             return [eff for eff in normalized if eff != "max"]
     # 'max' is a WebUI-level ceiling; providers whose native ladder tops out lower
     # must NOT advertise it, otherwise a stored/CLI 'max' degrades WORSE than the
@@ -3839,8 +3850,9 @@ def resolve_model_reasoning_efforts(
     """Return supported reasoning-effort levels for *model_id*, or [] if none.
 
     Always passes the sourced list through _filter_reasoning_efforts_for_provider
-    so the hard provider ceilings (openai-codex/openai/azure GPT-5 cap at xhigh,
-    Gemini + pre-adaptive/cloud-hosted Claude cap at xhigh) are applied uniformly
+    so the hard provider ceilings (OpenAI-family GPT-5 except the six known
+    GPT-5.6 Sol/Terra/Luna ids, Gemini, and pre-adaptive/cloud-hosted Claude)
+    are applied uniformly
     — the UI dropdown (which gates options on this list) and coercion therefore
     agree: 'max' is offered ONLY for models whose native ladder genuinely includes
     it, and is stripped everywhere it would be rejected/mishandled.

--- a/tests/test_gpt_5_6_max_reasoning.py
+++ b/tests/test_gpt_5_6_max_reasoning.py
@@ -1,0 +1,120 @@
+"""Regression coverage for GPT-5.6 max-reasoning capability policy."""
+
+import pytest
+
+from api import config as cfg
+from api.gateway_chat import _gateway_reasoning_effort_for_request
+
+
+KNOWN_GPT_5_6_MODELS = (
+    "gpt-5.6-sol",
+    "gpt-5.6-sol-pro",
+    "gpt-5.6-terra",
+    "gpt-5.6-terra-pro",
+    "gpt-5.6-luna",
+    "gpt-5.6-luna-pro",
+)
+OPENAI_FAMILY_PROVIDERS = (
+    "openai-codex",
+    "openai",
+    "openai-api",
+    "azure-foundry",
+    "azure-openai",
+    "azure",
+)
+
+
+@pytest.mark.parametrize("model_id", KNOWN_GPT_5_6_MODELS)
+@pytest.mark.parametrize("provider_id", OPENAI_FAMILY_PROVIDERS)
+def test_known_gpt_5_6_models_advertise_max_on_openai_family(model_id, provider_id):
+    assert "max" in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("@openai-codex:gpt-5.6-sol", "openai-codex"),
+        ("@openai:gpt-5.6-terra-pro", "openai"),
+        ("openai/gpt-5.6-luna", "openai-api"),
+        ("azure/gpt-5.6-luna-pro", "azure-foundry"),
+    ],
+)
+def test_known_gpt_5_6_prefixed_and_provider_hinted_ids_advertise_max(model_id, provider_id):
+    assert "max" in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+
+
+@pytest.mark.parametrize("model_id", ["gpt-5", "gpt-5.1", "gpt-5.5", "gpt-5-pro"])
+def test_older_gpt_5_models_keep_xhigh_ceiling(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai")
+    assert "xhigh" in efforts
+    assert "max" not in efforts
+    assert cfg.coerce_reasoning_effort_for_model("max", model_id, provider_id="openai") == "xhigh"
+
+
+@pytest.mark.parametrize("model_id", ["o1", "o3-mini", "o4-mini"])
+def test_o_series_models_keep_high_ceiling(model_id):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai-codex")
+    assert efforts == ["low", "medium", "high"]
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id="openai-codex"
+    ) == "high"
+
+
+def test_unknown_gpt_5_6_variant_does_not_gain_max():
+    model_id = "gpt-5.6-nebula"
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id="openai")
+    assert "max" not in efforts
+    assert cfg.coerce_reasoning_effort_for_model("max", model_id, provider_id="openai") == "xhigh"
+
+
+def test_configured_provider_effort_list_still_passes_through_model_ceiling(monkeypatch):
+    monkeypatch.setitem(
+        cfg.cfg,
+        "providers",
+        {"openai": {"reasoning_efforts": ["none", "high", "xhigh", "max"]}},
+    )
+    assert cfg.resolve_model_reasoning_efforts(
+        "gpt-5.6-sol", provider_id="openai"
+    ) == ["none", "high", "xhigh", "max"]
+    assert cfg.resolve_model_reasoning_efforts(
+        "gpt-5.6-nebula", provider_id="openai"
+    ) == ["none", "high", "xhigh"]
+
+
+def test_status_metadata_advertises_and_preserves_max_for_known_gpt_5_6(monkeypatch):
+    monkeypatch.setattr(
+        cfg,
+        "_load_yaml_config_file",
+        lambda *_args, **_kwargs: {"agent": {"reasoning_effort": "max"}},
+    )
+    status = cfg.get_reasoning_status(
+        model_id="gpt-5.6-terra-pro", provider_id="openai-codex"
+    )
+    assert "max" in status["supported_efforts"]
+    assert status["supports_reasoning_effort"] is True
+    assert status["reasoning_effort"] == "max"
+
+
+@pytest.mark.parametrize("model_id", KNOWN_GPT_5_6_MODELS)
+def test_max_is_preserved_by_coercion_and_gateway_streaming(model_id):
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id="openai-codex"
+    ) == "max"
+    gateway_cfg = {"agent": {"reasoning_effort": "max"}}
+    assert _gateway_reasoning_effort_for_request(
+        gateway_cfg, model=model_id, model_provider="openai-codex"
+    ) == "max"
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("gemini-3-pro", "gemini"),
+        ("claude-sonnet-4-5", "anthropic"),
+    ],
+)
+def test_other_existing_model_ceilings_remain_unchanged(model_id, provider_id):
+    assert "max" not in cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+    assert cfg.coerce_reasoning_effort_for_model(
+        "max", model_id, provider_id=provider_id
+    ) == "xhigh"


### PR DESCRIPTION
## Thinking Path

Hermes already accepts `max`, and GPT-5.6 supports it natively. The WebUI’s OpenAI-family ceiling currently strips `max` from every GPT-5 model, so Sol, Terra, and Luna stop at `xhigh` even though the models can go higher.

There are broader PRs open for GPT-5.6 and `ultra`, but this one is intentionally boring: no new vocabulary, no catalog changes, no transport changes, and no guessing based on a loose `gpt-5.6-*` prefix. It only lifts the existing ceiling for the six model IDs Hermes currently knows support `max`.

## What Changed

- Added an exact allowlist for GPT-5.6 Sol, Terra, and Luna, including each `-pro` variant.
- Preserved `max` for those six IDs on OpenAI-family lanes.
- Kept the existing ceilings for:
  - older GPT-5 models
  - o-series models
  - unknown GPT-5.6 variants
  - Gemini
  - pre-adaptive Claude
- Added focused coverage for model/provider hints, configured effort lists, status metadata, coercion, and gateway streaming.

## Why It Matters

The WebUI should not quietly cap a model below a reasoning level the runtime supports. At the same time, capability policy should fail closed instead of handing `max` to every future slug that happens to begin with `gpt-5.6-`.

## Contract Routing

Task type: reasoning capability-policy correction.

Touched areas:
- Server-side model capability filtering
- Reasoning status metadata
- Runtime effort coercion, covered through existing call paths

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/GUIDELINES.md`
- `docs/CONTRACTS.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`

Scope boundaries:
- No `ultra` level added.
- No model catalog changed.
- No frontend layout changed.
- No provider outside the existing OpenAI-family policy changed.

## Verification

- Focused GPT-5.6 policy suite: `58 passed`
- Reasoning and gateway slice: `424 passed`
- Python compilation: passed
- Diff-scoped Ruff: no findings on added or modified lines
- `git diff --check`: passed
- Fresh independent review of exact commit/diff: no actionable findings
- Fresh `/thermo-nuclear-code-quality-review`: **APPROVE**, no CORE, SILENT, or NIT findings
- Full repository suite: `13,324 passed`, `104 skipped`, `1 xfailed`, `2 xpassed`; `115 failed` in unrelated auth/workspace/TLS clusters
- Representative auth, workspace, upload, and TLS failures were rerun at pristine base `dd554c17`; auth and TLS failures reproduced unchanged, while the sampled workspace/upload tests passed independently (the larger full-suite cluster is state/order-sensitive)

Exact reviewed revision:
- Commit: `f8f35b0ab4208f6a3b4c15582e497f4b342737c9`
- Base: `dd554c1788948ca5892f549575daf741aa6a8850`
- Binary diff SHA-256: `6541d2866d513bef47ff449384d7ec2da2c5d824666df8a72f26a26b5550205d`

## Risks / Follow-ups

- The exact allowlist is deliberately fail-closed. New GPT-5.6 variants will need an explicit capability update rather than inheriting `max` by name.
- This overlaps conceptually with #5879 and #6018 but avoids their broader catalog/`ultra` scope.

Release note: GPT-5.6 Sol, Terra, Luna, and Pro variants can now use Max reasoning in the WebUI.

## Model Used

- OpenAI Codex `gpt-5.6-sol` for implementation orchestration, with separate fresh independent and thermo-nuclear review agents.
