### PR TITLE
feat(tts): add VoiceBox TTS engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ graphify-out/
 node_modules/
 package-lock.json
 docs/ui-ux/review-shots/
+webui.log

--- a/api/routes.py
+++ b/api/routes.py
@@ -18317,6 +18317,112 @@ def _handle_tts(handler, parsed):
             pass
         return True
 
+    # ── VoiceBox (local) TTS ────────────────────────────────────────────
+    if engine == "voicebox":
+        # Read VoiceBox config from Hermes config.yaml
+        endpoint = "http://localhost:17494"
+        profile_id = "fa296c25-e979-46e8-aff6-dc930cfad3d0"
+        try:
+            from api.config import get_config
+            cfg = get_config() or {}
+            tts_cfg = cfg.get("tts") or {}
+            if isinstance(tts_cfg, dict):
+                vb_cfg = tts_cfg.get("voicebox") or {}
+                if isinstance(vb_cfg, dict):
+                    endpoint = vb_cfg.get("endpoint", endpoint)
+                    profile_id = vb_cfg.get("default_profile", profile_id)
+                # Also check under tts.providers.voicebox
+                provs = tts_cfg.get("providers") or {}
+                if isinstance(provs, dict):
+                    pvb = provs.get("voicebox") or {}
+                    if isinstance(pvb, dict):
+                        endpoint = pvb.get("endpoint", endpoint)
+                        profile_id = pvb.get("default_profile", profile_id)
+        except Exception:
+            pass  # fall back to defaults
+
+        voicebox_engine = "luxtts"
+
+        # Step 1: Submit generation request
+        gen_url = f"{endpoint}/generate"
+        gen_body = json.dumps({
+            "text": text,
+            "profile_id": profile_id,
+            "engine": voicebox_engine,
+        }).encode("utf-8")
+        gen_req = Request(gen_url, data=gen_body, headers={
+            "Content-Type": "application/json",
+        })
+        try:
+            with _tts_open(gen_req, timeout=30) as resp:
+                gen_data = json.loads(resp.read().decode())
+        except Exception:
+            logger.exception("VoiceBox TTS generation request failed")
+            from api.helpers import bad as _bad
+            return _bad(handler, "VoiceBox TTS generation request failed", 502)
+
+        gen_id = gen_data.get("id")
+        if not gen_id:
+            logger.error("VoiceBox TTS: no generation id in response: %s", gen_data)
+            from api.helpers import bad as _bad
+            return _bad(handler, "VoiceBox TTS generation failed: no id returned", 502)
+
+        # Step 2: Poll until completed
+        status_url = f"{endpoint}/generate/{gen_id}/status"
+        completed = False
+        for _ in range(120):
+            try:
+                with _tts_open(Request(status_url), timeout=10) as resp:
+                    for line in resp.read().decode().split("\n"):
+                        line = line.strip()
+                        if line.startswith("data: "):
+                            try:
+                                d = json.loads(line[6:])
+                                if d.get("status") == "completed":
+                                    completed = True
+                                    break
+                                if d.get("status") == "failed":
+                                    err_msg = d.get("error", "unknown error")
+                                    logger.error("VoiceBox TTS generation failed: %s", err_msg)
+                                    from api.helpers import bad as _bad
+                                    return _bad(handler, f"VoiceBox TTS failed: {err_msg}", 502)
+                            except json.JSONDecodeError:
+                                continue
+                if completed:
+                    break
+            except Exception:
+                logger.debug("VoiceBox TTS poll error", exc_info=True)
+            import time
+            time.sleep(1)
+        else:
+            from api.helpers import bad as _bad
+            return _bad(handler, "VoiceBox TTS generation timed out", 502)
+
+        # Step 3: Download audio
+        audio_url = f"{endpoint}/audio/{gen_id}"
+        try:
+            with _tts_open(Request(audio_url), timeout=30) as resp:
+                audio_data = _buffer_tts_audio_response(resp)
+        except Exception:
+            logger.exception("VoiceBox TTS audio download failed")
+            from api.helpers import bad as _bad
+            return _bad(handler, "VoiceBox TTS audio download failed", 502)
+
+        if not audio_data:
+            from api.helpers import bad as _bad
+            return _bad(handler, "VoiceBox TTS produced no audio", 502)
+
+        handler.send_response(200)
+        handler.send_header("Content-Type", "audio/mpeg")
+        handler.send_header("Cache-Control", "no-store")
+        handler.send_header("Content-Length", str(len(audio_data)))
+        handler.end_headers()
+        try:
+            handler.wfile.write(audio_data)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        return True
+
     # ── Edge TTS ────────────────────────────────────────────────────────
     allowed = {
         "zh-CN-XiaoxiaoNeural", "zh-CN-XiaoyiNeural", "zh-CN-YunxiNeural",

--- a/api/routes.py
+++ b/api/routes.py
@@ -18321,7 +18321,7 @@ def _handle_tts(handler, parsed):
     if engine == "voicebox":
         # Read VoiceBox config from Hermes config.yaml
         endpoint = "http://localhost:17494"
-        profile_id = "fa296c25-e979-46e8-aff6-dc930cfad3d0"
+        profile_id = ""
         try:
             from api.config import get_config
             cfg = get_config() or {}
@@ -18341,6 +18341,11 @@ def _handle_tts(handler, parsed):
         except Exception:
             pass  # fall back to defaults
 
+        if not profile_id:
+            logger.error("VoiceBox TTS: no default_profile configured — set tts.voicebox.default_profile in config.yaml")
+            from api.helpers import bad as _bad
+            return _bad(handler, "VoiceBox TTS not configured: default_profile is required", 502)
+
         voicebox_engine = "luxtts"
 
         # Step 1: Submit generation request
@@ -18354,7 +18359,7 @@ def _handle_tts(handler, parsed):
             "Content-Type": "application/json",
         })
         try:
-            with _tts_open(gen_req, timeout=30) as resp:
+            with _tts_open(gen_req, timeout=30, opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectTtsHandler())) as resp:
                 gen_data = json.loads(resp.read().decode())
         except Exception:
             logger.exception("VoiceBox TTS generation request failed")
@@ -18367,41 +18372,53 @@ def _handle_tts(handler, parsed):
             from api.helpers import bad as _bad
             return _bad(handler, "VoiceBox TTS generation failed: no id returned", 502)
 
-        # Step 2: Poll until completed
+        # Step 2: Poll until completed via SSE (single connection, line-by-line)
         status_url = f"{endpoint}/generate/{gen_id}/status"
         completed = False
-        for _ in range(120):
+        deadline = time.time() + 120
+        while time.time() < deadline:
             try:
-                with _tts_open(Request(status_url), timeout=10) as resp:
-                    for line in resp.read().decode().split("\n"):
-                        line = line.strip()
-                        if line.startswith("data: "):
-                            try:
-                                d = json.loads(line[6:])
-                                if d.get("status") == "completed":
-                                    completed = True
-                                    break
-                                if d.get("status") == "failed":
-                                    err_msg = d.get("error", "unknown error")
-                                    logger.error("VoiceBox TTS generation failed: %s", err_msg)
-                                    from api.helpers import bad as _bad
-                                    return _bad(handler, f"VoiceBox TTS failed: {err_msg}", 502)
-                            except json.JSONDecodeError:
-                                continue
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                with _tts_open(
+                    Request(status_url),
+                    timeout=min(30, remaining),
+                    opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectTtsHandler()),
+                ) as resp:
+                    while time.time() < deadline:
+                        raw = resp.readline()
+                        if not raw:
+                            break  # stream ended, reconnect
+                        line = raw.decode("utf-8", errors="replace").strip()
+                        if not line.startswith("data: "):
+                            continue
+                        try:
+                            d = json.loads(line[6:])
+                            if d.get("status") == "completed":
+                                completed = True
+                                break
+                            if d.get("status") == "failed":
+                                err_msg = d.get("error", "unknown error")
+                                logger.error("VoiceBox TTS generation failed: %s", err_msg)
+                                from api.helpers import bad as _bad
+                                return _bad(handler, f"VoiceBox TTS failed: {err_msg}", 502)
+                        except json.JSONDecodeError:
+                            continue
                 if completed:
                     break
             except Exception:
                 logger.debug("VoiceBox TTS poll error", exc_info=True)
-            import time
             time.sleep(1)
-        else:
+
+        if not completed:
             from api.helpers import bad as _bad
             return _bad(handler, "VoiceBox TTS generation timed out", 502)
 
         # Step 3: Download audio
         audio_url = f"{endpoint}/audio/{gen_id}"
         try:
-            with _tts_open(Request(audio_url), timeout=30) as resp:
+            with _tts_open(Request(audio_url), timeout=30, opener_factory=lambda: build_opener(ProxyHandler({}), _NoRedirectTtsHandler())) as resp:
                 audio_data = _buffer_tts_audio_response(resp)
         except Exception:
             logger.exception("VoiceBox TTS audio download failed")

--- a/static/ui.js
+++ b/static/ui.js
@@ -8360,6 +8360,10 @@ function speakMessage(btn){
     _playEdgeTtsChunked(clean, btn);
     return;
   }
+  if(engine==='voicebox'){
+    _playVoiceboxTts(clean, btn);
+    return;
+  }
   // Extension-registered TTS engine (window.registerHermesTtsEngine). Synthesize
   // via the extension, then play through the shared audio-buffer path.
   if(typeof window._hermesTtsIsRegistered==='function' && window._hermesTtsIsRegistered(engine)){
@@ -8422,6 +8426,33 @@ function _playElevenLabsTts(text, btn){
     return _playAudioBuf(buf, btn, 'ElevenLabs TTS');
   })
   .catch(function(e){ _fail((e&&e.message)||'ElevenLabs TTS failed'); });
+}
+
+function _playVoiceboxTts(text, btn){
+  if(btn) btn.dataset.speaking='1';
+  _ttsSpeaking=true;
+  const _fail=function(msg){
+    _ttsSpeaking=false;_playingEdgeAudio=null;
+    if(btn)btn.dataset.speaking='0';
+    if(msg&&typeof showToast==='function') showToast(msg,4000,'error');
+  };
+  fetch(new URL('api/tts', document.baseURI || location.href).href, {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({text:text, engine:'voicebox'})
+  })
+  .then(function(r){
+    if(!r.ok){
+      return r.json().catch(function(){return {};}).then(function(j){
+        throw new Error((j&&j.error)||('TTS request failed: '+r.status));
+      });
+    }
+    return r.arrayBuffer();
+  })
+  .then(function(buf){
+    return _playAudioBuf(buf, btn, 'VoiceBox TTS');
+  })
+  .catch(function(e){ _fail((e&&e.message)||'VoiceBox TTS failed'); });
 }
 
 function _playOpenaiTts(text, btn){
@@ -8540,6 +8571,10 @@ function autoReadLastAssistant(){
   }
   if(engine==='edge'){
     _playEdgeTtsChunked(clean, null);
+    return;
+  }
+  if(engine==='voicebox'){
+    _playVoiceboxTts(clean, null);
     return;
   }
   // Extension-registered TTS engine (window.registerHermesTtsEngine): synth via


### PR DESCRIPTION
## Summary

Adds full VoiceBox TTS engine support to the Hermes WebUI — both server-side API proxy and client-side speak/auto-read buttons.

VoiceBox is a local GPU-accelerated voice cloning TTS service that runs on port 17494. This PR enables the WebUI to use it as a first-class TTS engine alongside Edge, OpenAI, and ElevenLabs.

## Changes

### `api/routes.py` — Server-side VoiceBox handler (+106 lines)
- New `engine == "voicebox"` branch in `_handle_tts()` that:
  1. Reads endpoint and profile_id from Hermes config (`tts.voicebox` or `tts.providers.voicebox`)
  2. POSTs the text to `{endpoint}/generate` for VoiceBox generation
  3. Polls `{endpoint}/generate/{id}/status` (SSE) until completion or failure
  4. Downloads the generated audio from `{endpoint}/audio/{id}`
  5. Returns it with proper Content-Type and headers
- Falls back to sensible defaults (`http://localhost:17494` + LuxTTS engine) if no config found
- Uses the same `_tts_open()`, `_buffer_tts_audio_response()`, and error-handling patterns as existing engines

### `static/ui.js` — Client-side VoiceBox support (+35 lines)
- **`_playVoiceboxTts()`** — New function that POSTs to `/api/tts` with `engine: 'voicebox'` and plays the returned audio buffer. Mirrors the pattern of `_playOpenaiTts()` / `_playElevenLabsTts()`.
- **`speakMessage()`** — Added `voicebox` engine branch so the manual speak button dispatches to `_playVoiceboxTts()`.
- **`autoReadLastAssistant()`** — Added `voicebox` engine branch so auto-read (when enabled) also uses VoiceBox instead of falling back to browser speech synthesis.

## How to test

1. Have VoiceBox running locally (`http://localhost:17494`)
2. Configure in `~/.hermes/config.yaml`:
```yaml
tts:
  provider: voicebox
  voicebox:
    endpoint: http://localhost:17494
    default_profile: "<your-profile-id>"
```
3. In WebUI Settings, select "voicebox" as the TTS Engine
4. Click the speaker icon on any message or enable auto-read

## Notes

- LuxTTS is the default generation engine (configurable server-side via VoiceBox API)
- Config resolution checks both `tts.voicebox.*` and `tts.providers.voicebox.*` for compatibility with existing configs