### PR TITLE
feat: steer selected queued messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1710,6 +1710,7 @@
 ### Added
 
 - **Vietnamese (Tiếng Việt) is now a selectable UI language.** Adds a full `vi` locale to the language picker, including the login page. Thanks @thanhtantran. (#4241)
+
 ## [v0.51.620] — 2026-06-24 — Release WA (fix /api/sessions CPU spike + slowness during streaming)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1710,7 +1710,6 @@
 ### Added
 
 - **Vietnamese (Tiếng Việt) is now a selectable UI language.** Adds a full `vi` locale to the language picker, including the login page. Thanks @thanhtantran. (#4241)
-
 ## [v0.51.620] — 2026-06-24 — Release WA (fix /api/sessions CPU spike + slowness during streaming)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -13469,6 +13469,16 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/clarify/stream":
         return _handle_clarify_sse_stream(handler, parsed)
 
+    if parsed.path == "/api/session/queue":
+        query = parse_qs(parsed.query)
+        sid = query.get("session_id", [""])[0]
+        try:
+            get_session(sid)
+        except KeyError:
+            return bad(handler, "Session not found", 404)
+        from api.session_queue import list_queue
+        return j(handler, {"ok": True, "session_id": sid, "items": list_queue(sid)})
+
     if parsed.path == "/api/session/stream":
         return _handle_session_sse_stream(handler, parsed)
 
@@ -15322,6 +15332,15 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/bg-task-complete-ack":
         return _handle_bg_task_complete_ack(handler, body)
+
+    if parsed.path == "/api/session/queue":
+        return _handle_session_queue_enqueue(handler, body)
+
+    if parsed.path == "/api/session/queue/update":
+        return _handle_session_queue_update(handler, body)
+
+    if parsed.path == "/api/session/queue/delete":
+        return _handle_session_queue_delete(handler, body)
 
     if parsed.path == "/api/chat/start":
         return _handle_chat_start(handler, body, diag=diag)
@@ -21502,6 +21521,10 @@ def start_session_turn(
     message: str,
     *,
     source: str = "process_wakeup",
+    attachments=None,
+    requested_model=None,
+    requested_provider=None,
+    queue_item_id: str | None = None,
 ):
     """Start a server-side agent turn for ``session_id`` with ``message``.
 
@@ -21551,8 +21574,13 @@ def start_session_turn(
     except ValueError as e:
         return {"error": str(e), "_status": 400}
 
-    requested_model = s.model
-    requested_provider = getattr(s, "model_provider", None)
+    requested_model = requested_model if requested_model not in (None, "") else s.model
+    requested_provider = (
+        requested_provider
+        if requested_provider not in (None, "")
+        else getattr(s, "model_provider", None)
+    )
+    turn_attachments = attachments or []
     # Server-initiated wakeup (Option Z): resolve persisted model via the
     # standard helper in cache-only mode so wakeups never trigger a cold
     # catalog rebuild. Thread the session's PROFILE model defaults through too
@@ -21684,7 +21712,7 @@ def start_session_turn(
     resp = _start_run(
         s,
         msg=msg,
-        attachments=[],
+        attachments=turn_attachments,
         workspace=workspace,
         model=model,
         model_provider=model_provider,
@@ -21723,6 +21751,7 @@ def start_session_turn(
                         "stream_id": str(stream_id),
                         "pending_started_at": (resp or {}).get("pending_started_at"),
                         "source": source,
+                        **({"queue_item_id": str(queue_item_id)} if queue_item_id else {}),
                     },
                 )
     except Exception:
@@ -21730,6 +21759,65 @@ def start_session_turn(
             "server_turn_started fan-out failed for session %s", session_id, exc_info=True
         )
     return resp
+
+
+def _handle_session_queue_enqueue(handler, body):
+    """Acknowledge a backend-owned queued follow-up turn for a session."""
+    try:
+        require(body, "session_id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import enqueue, list_queue
+
+    try:
+        item = enqueue(sid, body)
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
+
+
+def _handle_session_queue_update(handler, body):
+    try:
+        require(body, "session_id")
+        require(body, "id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import list_queue, update_item
+
+    item = update_item(sid, str(body.get("id") or ""), body)
+    if item is None:
+        return bad(handler, "Queued item not found", 404)
+    return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
+
+
+def _handle_session_queue_delete(handler, body):
+    try:
+        require(body, "session_id")
+        require(body, "id")
+    except ValueError as e:
+        return bad(handler, str(e))
+    sid = str(body.get("session_id") or "").strip()
+    try:
+        get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+    from api.session_queue import delete_item, list_queue
+
+    deleted = delete_item(sid, str(body.get("id") or ""))
+    if not deleted:
+        return bad(handler, "Queued item not found", 404)
+    return j(handler, {"ok": True, "session_id": sid, "deleted": True, "items": list_queue(sid)})
+
 
 
 def _handle_bg_task_complete_ack(handler, body):

--- a/api/routes.py
+++ b/api/routes.py
@@ -13469,6 +13469,13 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/clarify/stream":
         return _handle_clarify_sse_stream(handler, parsed)
 
+    if parsed.path == "/api/session/queue/steer-capability":
+        return j(
+            handler,
+            {"ok": True, "queue_item_steer": True, "protocol": 1},
+            extra_headers={"Cache-Control": "no-store"},
+        )
+
     if parsed.path == "/api/session/queue":
         query = parse_qs(parsed.query)
         sid = query.get("session_id", [""])[0]

--- a/api/routes.py
+++ b/api/routes.py
@@ -21772,12 +21772,13 @@ def _handle_session_queue_enqueue(handler, body):
         get_session(sid)
     except KeyError:
         return bad(handler, "Session not found", 404)
-    from api.session_queue import enqueue, list_queue
+    from api.session_queue import drain_for_session, enqueue, list_queue
 
     try:
         item = enqueue(sid, body)
     except ValueError as e:
         return bad(handler, str(e), 400)
+    drain_for_session(sid)
     return j(handler, {"ok": True, "session_id": sid, "item": item, "items": list_queue(sid)})
 
 

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 _LOCK = threading.RLock()
 _SAFE_SESSION_ID_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_QUEUE_ITEMS = 50
+_MAX_START_RETRIES = 3
 
 
 def _queue_dir() -> Path:
@@ -109,17 +111,29 @@ def _normalize_attachments(raw: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _normalize_model_provider(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _public_item(item: dict[str, Any]) -> dict[str, Any]:
-    return {
+    out = {
         "id": str(item.get("id") or ""),
         "session_id": str(item.get("session_id") or ""),
         "text": str(item.get("text") or ""),
         "attachments": list(item.get("attachments") or []),
         "model": str(item.get("model") or ""),
-        "model_provider": item.get("model_provider"),
+        "model_provider": _normalize_model_provider(item.get("model_provider")),
         "profile": str(item.get("profile") or ""),
         "created_at": float(item.get("created_at") or 0.0),
     }
+    if item.get("blocked"):
+        out["blocked"] = True
+    if item.get("error"):
+        out["error"] = str(item.get("error") or "")
+    return out
 
 
 def list_queue(session_id: str) -> list[dict[str, Any]]:
@@ -131,7 +145,7 @@ def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
     text = str(payload.get("text") or payload.get("message") or "").strip()
     if not session_id:
         raise ValueError("session_id is required")
-    if not text and not payload.get("attachments") and not payload.get("files"):
+    if not text:
         raise ValueError("text is required")
     item = {
         "id": uuid.uuid4().hex,
@@ -139,12 +153,14 @@ def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         "text": text,
         "attachments": _normalize_attachments(payload.get("attachments") or payload.get("files") or []),
         "model": str(payload.get("model") or ""),
-        "model_provider": payload.get("model_provider"),
+        "model_provider": _normalize_model_provider(payload.get("model_provider")),
         "profile": str(payload.get("profile") or ""),
         "created_at": time.time(),
     }
     with _LOCK:
         items = _read_items_unlocked(session_id)
+        if len(items) >= _MAX_QUEUE_ITEMS:
+            items = items[-(_MAX_QUEUE_ITEMS - 1) :]
         items.append(item)
         _write_items_unlocked(session_id, items)
     return _public_item(item)
@@ -165,7 +181,11 @@ def update_item(session_id: str, item_id: str, patch: dict[str, Any]) -> dict[st
             if "model" in patch:
                 item["model"] = str(patch.get("model") or "")
             if "model_provider" in patch:
-                item["model_provider"] = patch.get("model_provider")
+                item["model_provider"] = _normalize_model_provider(patch.get("model_provider"))
+            if any(key in patch for key in ("text", "model", "model_provider")):
+                item.pop("blocked", None)
+                item.pop("error", None)
+                item.pop("retry_count", None)
             _write_items_unlocked(session_id, items)
             return _public_item(item)
     return None
@@ -190,7 +210,10 @@ def claim_next(session_id: str) -> dict[str, Any] | None:
         items = _read_items_unlocked(session_id)
         if not items:
             return None
-        item = items.pop(0)
+        idx = next((i for i, existing in enumerate(items) if not existing.get("blocked")), -1)
+        if idx < 0:
+            return None
+        item = items.pop(idx)
         _write_items_unlocked(session_id, items)
         return dict(item)
 
@@ -254,14 +277,21 @@ def drain_for_session(session_id: str) -> int:
             if status == 409:
                 requeue_front(session_id, item)
             elif status >= 400:
+                retry_count = int(item.get("retry_count") or 0) + 1
+                item["retry_count"] = retry_count
+                item["error"] = str((resp or {}).get("error") or f"start_failed_{status}")
+                if status < 500 and retry_count >= _MAX_START_RETRIES:
+                    item["blocked"] = True
                 # Keep user intent instead of dropping it on transient or
-                # configuration errors; the browser can still show/edit/delete
-                # it after reconnect.
+                # configuration errors; blocked items remain editable/deletable
+                # but claim_next will not churn on them every teardown.
                 requeue_front(session_id, item)
                 logger.warning(
-                    "queued follow-up failed for session %s: status=%s err=%r",
+                    "queued follow-up failed for session %s: status=%s retries=%s blocked=%s err=%r",
                     session_id,
                     status,
+                    retry_count,
+                    bool(item.get("blocked")),
                     (resp or {}).get("error"),
                 )
             else:

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -1,0 +1,283 @@
+"""Backend-owned queued follow-up turns for WebUI sessions.
+
+The browser may optimistically render queue chips, but once this module
+acknowledges an item the backend owns dispatch.  The invariant is:
+
+    acknowledged queued follow-ups drain into their original session after the
+    active run settles, even if no browser tab is connected.
+
+Storage is deliberately small and local: one JSON file per session under the
+WebUI session directory.  This keeps the first implementation profile/state-dir
+local without introducing a database migration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.RLock()
+_SAFE_SESSION_ID_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _queue_dir() -> Path:
+    from api.config import SESSION_DIR
+
+    path = Path(SESSION_DIR) / "_session_queue"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _queue_path(session_id: str) -> Path:
+    safe = _SAFE_SESSION_ID_RE.sub("_", str(session_id or "").strip())
+    if not safe:
+        safe = "unknown"
+    return _queue_dir() / f"{safe}.json"
+
+
+def _read_items_unlocked(session_id: str) -> list[dict[str, Any]]:
+    path = _queue_path(session_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        parsed = json.loads(raw)
+    except FileNotFoundError:
+        return []
+    except Exception:
+        logger.warning("Failed to read session queue for %s", session_id, exc_info=True)
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [dict(item) for item in parsed if isinstance(item, dict)]
+
+
+def _write_items_unlocked(session_id: str, items: list[dict[str, Any]]) -> None:
+    path = _queue_path(session_id)
+    if not items:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return
+    payload = json.dumps(items, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def _normalize_attachments(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in raw[:20]:
+        if isinstance(item, dict):
+            att: dict[str, Any] = {}
+            for key in ("name", "filename", "path", "mime"):
+                value = item.get(key)
+                if value not in (None, ""):
+                    att[key] = str(value)
+            size = item.get("size")
+            if isinstance(size, int):
+                att["size"] = size
+            is_image = item.get("is_image")
+            if isinstance(is_image, bool):
+                att["is_image"] = is_image
+            if att:
+                out.append(att)
+        else:
+            value = str(item or "").strip()
+            if value:
+                out.append({"name": value})
+    return out
+
+
+def _public_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(item.get("id") or ""),
+        "session_id": str(item.get("session_id") or ""),
+        "text": str(item.get("text") or ""),
+        "attachments": list(item.get("attachments") or []),
+        "model": str(item.get("model") or ""),
+        "model_provider": item.get("model_provider"),
+        "profile": str(item.get("profile") or ""),
+        "created_at": float(item.get("created_at") or 0.0),
+    }
+
+
+def list_queue(session_id: str) -> list[dict[str, Any]]:
+    with _LOCK:
+        return [_public_item(item) for item in _read_items_unlocked(session_id)]
+
+
+def enqueue(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    text = str(payload.get("text") or payload.get("message") or "").strip()
+    if not session_id:
+        raise ValueError("session_id is required")
+    if not text and not payload.get("attachments") and not payload.get("files"):
+        raise ValueError("text is required")
+    item = {
+        "id": uuid.uuid4().hex,
+        "session_id": str(session_id),
+        "text": text,
+        "attachments": _normalize_attachments(payload.get("attachments") or payload.get("files") or []),
+        "model": str(payload.get("model") or ""),
+        "model_provider": payload.get("model_provider"),
+        "profile": str(payload.get("profile") or ""),
+        "created_at": time.time(),
+    }
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        items.append(item)
+        _write_items_unlocked(session_id, items)
+    return _public_item(item)
+
+
+def update_item(session_id: str, item_id: str, patch: dict[str, Any]) -> dict[str, Any] | None:
+    if not session_id or not item_id:
+        return None
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        for item in items:
+            if str(item.get("id") or "") != str(item_id):
+                continue
+            if "text" in patch:
+                text = str(patch.get("text") or "").strip()
+                if text:
+                    item["text"] = text
+            if "model" in patch:
+                item["model"] = str(patch.get("model") or "")
+            if "model_provider" in patch:
+                item["model_provider"] = patch.get("model_provider")
+            _write_items_unlocked(session_id, items)
+            return _public_item(item)
+    return None
+
+
+def delete_item(session_id: str, item_id: str) -> bool:
+    if not session_id or not item_id:
+        return False
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        kept = [item for item in items if str(item.get("id") or "") != str(item_id)]
+        if len(kept) == len(items):
+            return False
+        _write_items_unlocked(session_id, kept)
+        return True
+
+
+def claim_next(session_id: str) -> dict[str, Any] | None:
+    if not session_id:
+        return None
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        if not items:
+            return None
+        item = items.pop(0)
+        _write_items_unlocked(session_id, items)
+        return dict(item)
+
+
+def requeue_front(session_id: str, item: dict[str, Any]) -> None:
+    if not session_id or not item:
+        return
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        # Preserve exact-once-ish behavior: do not duplicate an item id already
+        # requeued by a racing 409 handler.
+        item_id = str(item.get("id") or "")
+        if item_id and any(str(existing.get("id") or "") == item_id for existing in items):
+            return
+        items.insert(0, dict(item))
+        _write_items_unlocked(session_id, items)
+
+
+def _session_has_active_turn(session_id: str) -> bool:
+    try:
+        from api import config as _cfg
+
+        with _cfg.ACTIVE_RUNS_LOCK:
+            for _stream_id, meta in (_cfg.ACTIVE_RUNS or {}).items():
+                if isinstance(meta, dict) and meta.get("session_id") == session_id:
+                    return True
+    except Exception:
+        logger.debug("ACTIVE_RUNS queue active-turn check failed", exc_info=True)
+    return False
+
+
+def drain_for_session(session_id: str) -> int:
+    """Start at most one queued follow-up turn for an idle session.
+
+    Called from the streaming teardown hook after ``unregister_active_run``.
+    It claims one item atomically, starts it on a daemon thread, and requeues the
+    item if the existing chat-start guard reports a 409 race.
+    """
+    if not session_id:
+        return 0
+    if _session_has_active_turn(session_id):
+        return 0
+    item = claim_next(session_id)
+    if not item:
+        return 0
+
+    def _runner() -> None:
+        try:
+            from api.routes import start_session_turn
+
+            resp = start_session_turn(
+                session_id,
+                str(item.get("text") or ""),
+                source="queued_followup",
+                attachments=list(item.get("attachments") or []),
+                requested_model=str(item.get("model") or "") or None,
+                requested_provider=item.get("model_provider"),
+                queue_item_id=str(item.get("id") or "") or None,
+            )
+            status = int((resp or {}).get("_status", 200) or 200)
+            if status == 409:
+                requeue_front(session_id, item)
+            elif status >= 400:
+                # Keep user intent instead of dropping it on transient or
+                # configuration errors; the browser can still show/edit/delete
+                # it after reconnect.
+                requeue_front(session_id, item)
+                logger.warning(
+                    "queued follow-up failed for session %s: status=%s err=%r",
+                    session_id,
+                    status,
+                    (resp or {}).get("error"),
+                )
+            else:
+                logger.info(
+                    "queued follow-up turn started for session %s item=%s stream_id=%s",
+                    session_id,
+                    item.get("id"),
+                    (resp or {}).get("stream_id"),
+                )
+        except Exception:
+            requeue_front(session_id, item)
+            logger.warning("queued follow-up turn raised for session %s", session_id, exc_info=True)
+
+    threading.Thread(
+        target=_runner,
+        name=f"hermes-webui-queued-followup-{str(session_id)[:8]}",
+        daemon=True,
+    ).start()
+    return 1

--- a/api/session_queue.py
+++ b/api/session_queue.py
@@ -203,6 +203,60 @@ def delete_item(session_id: str, item_id: str) -> bool:
         return True
 
 
+def claim_item(session_id: str, item_id: str) -> dict[str, Any] | None:
+    """Remove one exact queued item and return a reversible claim receipt."""
+    if not session_id or not item_id:
+        return None
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        for index, item in enumerate(items):
+            if str(item.get("id") or "") != str(item_id):
+                continue
+            claimed = items.pop(index)
+            _write_items_unlocked(session_id, items)
+            return {"item": dict(claimed), "index": index}
+    return None
+
+
+def restore_claim(session_id: str, claim: dict[str, Any] | None) -> None:
+    """Restore a failed queue claim at its original position without duplication."""
+    if not session_id or not isinstance(claim, dict):
+        return
+    item = claim.get("item")
+    if not isinstance(item, dict):
+        return
+    item_id = str(item.get("id") or "")
+    with _LOCK:
+        items = _read_items_unlocked(session_id)
+        if item_id and any(str(existing.get("id") or "") == item_id for existing in items):
+            return
+        try:
+            index = int(claim.get("index", len(items)))
+        except (TypeError, ValueError):
+            index = len(items)
+        items.insert(max(0, min(index, len(items))), dict(item))
+        _write_items_unlocked(session_id, items)
+
+
+def steer_text_for_item(item: dict[str, Any]) -> str:
+    """Build active-run guidance from the backend-authoritative queued payload."""
+    text = str((item or {}).get("text") or "").strip()
+    paths = []
+    for attachment in (item or {}).get("attachments") or []:
+        if not isinstance(attachment, dict):
+            continue
+        path = str(attachment.get("path") or "").strip()
+        if path:
+            paths.append(path)
+    if not paths:
+        return text
+    note = (
+        f"[Attached files for this steer: {', '.join(paths)}]\n"
+        "Use the file tools/read_file to inspect these documents if needed."
+    )
+    return f"{text}\n\n{note}" if text else note
+
+
 def claim_next(session_id: str) -> dict[str, Any] | None:
     if not session_id:
         return None

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11118,12 +11118,14 @@ def _handle_chat_steer(handler, body: dict) -> bool:
     """
     from api.helpers import j, bad
     from api import config as _cfg
+    from api import session_queue as _session_queue
 
     sid = str((body or {}).get("session_id", "") or "").strip()
     text = str((body or {}).get("text", "") or "").strip()
+    queue_item_id = str((body or {}).get("queue_item_id", "") or "").strip()
     if not sid:
         return bad(handler, "session_id required")
-    if not text:
+    if not text and not queue_item_id:
         return bad(handler, "text required")
 
     evicted_cached_entry = None
@@ -11196,12 +11198,25 @@ def _handle_chat_steer(handler, body: dict) -> bool:
         return j(handler, {"accepted": False, "fallback": "stream_dead",
                            "stream_id": None})
 
+    queue_claim = None
+    if queue_item_id:
+        queue_claim = _session_queue.claim_item(sid, queue_item_id)
+        if queue_claim is None:
+            return j(handler, {"accepted": False, "fallback": "queue_item_not_found",
+                               "stream_id": active_stream_id})
+        text = _session_queue.steer_text_for_item(queue_claim["item"])
+
     try:
         accepted = bool(agent.steer(text))
     except Exception as exc:
+        if queue_claim is not None:
+            _session_queue.restore_claim(sid, queue_claim)
         logger.debug("agent.steer() raised for session=%s: %s", sid, exc)
         return j(handler, {"accepted": False, "fallback": "steer_error",
                            "stream_id": active_stream_id})
+
+    if not accepted and queue_claim is not None:
+        _session_queue.restore_claim(sid, queue_claim)
 
     return j(handler, {"accepted": accepted, "fallback": None,
                        "stream_id": active_stream_id})

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11067,6 +11067,22 @@ def _run_agent_streaming(
                 exc_info=True,
             )
 
+        # Backend-owned queued follow-ups are session intent, not browser UI
+        # state. Once /api/session/queue acknowledges an item, this teardown
+        # hook starts the next queued turn after the active run settles even if
+        # every WebUI tab is disconnected. The queue drain has the same active
+        # run guard and 409 requeue behavior as process wakeups.
+        try:
+            from api.session_queue import drain_for_session
+
+            drain_for_session(session_id)
+        except Exception:
+            logger.debug(
+                "turn-teardown queued-followup drain failed for session %s",
+                session_id,
+                exc_info=True,
+            )
+
 # ============================================================
 # SECTION: HTTP Request Handler
 # do_GET: read-only API endpoints + SSE stream + static HTML

--- a/static/icons.js
+++ b/static/icons.js
@@ -66,6 +66,7 @@ const LI_PATHS = {
   // Suggestion buttons
   'clipboard-list':  '<path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/><line x1="9" y1="12" x2="15" y2="12"/><line x1="9" y1="16" x2="12" y2="16"/>',
   'map':             '<polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/>',
+  'compass':         '<circle cx="12" cy="12" r="10"/><polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"/>',
   'git-branch':      '<line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>',
   // Audio / TTS
   'volume-2':        '<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>',

--- a/static/messages.js
+++ b/static/messages.js
@@ -7702,6 +7702,9 @@ function startSessionStream(sid) {
         const evSid = d.session_id || sid;
         const streamId = String(d.stream_id || '');
         if (!streamId || evSid !== sid) return;
+        if (d.queue_item_id && typeof _removeServerQueuedEntry === 'function') {
+          _removeServerQueuedEntry(sid, String(d.queue_item_id));
+        }
         // `recovered` marks an on-subscribe replay from the server: the tab
         // (re)connected to /api/session/stream AFTER the original
         // fire-and-forget server_turn_started had already been broadcast, so

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2032,6 +2032,7 @@ async function loadSession(sid){
   try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
   _setActiveSessionUrl(S.session.session_id);
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
+  if(typeof syncBackendSessionQueue==='function') syncBackendSessionQueue(S.session.session_id);
 
 
   function _mergePendingSessionMessage(session,messages){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1545,6 +1545,7 @@ async function newSession(flash, options={}){
       });
     }
     updateQueueBadge(S.session.session_id);
+    if(typeof syncBackendSessionQueue==='function') syncBackendSessionQueue(S.session.session_id);
     syncTopbar();renderMessages();
     if(typeof _announceNewSessionWorkspace==='function') _announceNewSessionWorkspace(S.session);
     // Keep new-chat first paint instant. The workspace tree / git badge can

--- a/static/style.css
+++ b/static/style.css
@@ -2027,6 +2027,10 @@
   .queue-card-header-actions{display:flex;align-items:center;gap:4px;margin-left:auto;}
   .queue-card-btn{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:6px;border:1px solid var(--border);background:none;color:var(--muted);font-size:11px;font-weight:500;cursor:pointer;transition:background .12s,color .12s;white-space:nowrap;}
   .queue-card-btn:hover{background:var(--hover-bg);color:var(--text);}
+  .queue-card-btn:disabled{opacity:.45;cursor:wait;}
+  .queue-card-steer-btn{flex-shrink:0;}
+  @media (max-width:600px){.queue-card-steer-btn{min-height:40px;padding:8px 9px;}}
+  @media (max-width:340px){.queue-card-steer-btn{width:40px;padding:8px;justify-content:center;}.queue-card-steer-btn span{display:none;}}
   .queue-card-icon-btn{display:inline-flex;align-items:center;padding:3px;border-radius:5px;border:none;background:none;color:var(--muted);cursor:pointer;opacity:.5;transition:opacity .12s,background .12s;}
   .queue-card-icon-btn:hover{opacity:1;background:var(--hover-bg);}
   .queue-card-row{display:flex;align-items:center;gap:8px;padding:8px 14px;border-bottom:1px solid var(--border);cursor:grab;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -353,9 +353,10 @@ function syncBackendSessionQueue(sid){
         const id=String(item&&item.id||'');
         if(!id||q.some(e=>e&&e._server_queue_id===id))return;
         const itemText=String(item.text||'');
-        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'')===itemText);
+        const itemMatchText=itemText.trim();
+        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'').trim()===itemMatchText);
         if(pendingIdx>=0){
-          q[pendingIdx]={...q[pendingIdx],_server_pending:false,_server_owned:true,_server_queue_id:id};
+          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id};
           changed=true;
           return;
         }
@@ -373,6 +374,12 @@ function syncBackendSessionQueue(sid){
         });
         changed=true;
       });
+      for(let i=0;i<q.length;i++){
+        if(q[i]&&q[i]._server_pending&&!q[i]._server_queue_id){
+          q[i]={...q[i],_server_pending:false,_server_error:'queue_ack_recovered'};
+          changed=true;
+        }
+      }
       if(changed){_persistSessionQueueStorage(sid,q);delete _queueRenderKeys[sid];updateQueueBadge(sid);}
     }).catch(()=>{});
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -266,6 +266,13 @@ function _findQueuedEntryByClientId(sid, clientId){
   const idx=q.findIndex(e=>e&&e._client_queue_id===clientId);
   return {q,idx,entry:idx>=0?q[idx]:null};
 }
+function _deleteBackendQueuedItem(sid, serverId){
+  if(!sid||!serverId||typeof fetch!=='function')return;
+  fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+    method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({session_id:sid,id:serverId}),
+  }).catch(()=>{});
+}
 function _backendAcknowledgeQueuedMessage(sid, entry){
   if(!sid||!entry||entry._server_owned||entry._server_pending)return;
   if(_queuedEntryHasBrowserOnlyFiles(entry))return;
@@ -287,7 +294,10 @@ function _backendAcknowledgeQueuedMessage(sid, entry){
   }).then(r=>r.json().then(data=>({ok:r.ok,data})).catch(()=>({ok:r.ok,data:{}})))
     .then(({ok,data})=>{
       const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
-      if(found.idx<0)return;
+      if(found.idx<0){
+        if(ok&&data&&data.item&&data.item.id)_deleteBackendQueuedItem(sid,data.item.id);
+        return;
+      }
       if(ok&&data&&data.item&&data.item.id){
         found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,_server_queue_id:data.item.id};
       }else{
@@ -341,7 +351,12 @@ function syncBackendSessionQueue(sid){
     .then(r=>r.ok?r.json():null)
     .then(data=>{
       if(!data||!Array.isArray(data.items))return;
-      const q=_getSessionQueue(sid,true);
+      let q=_getSessionQueue(sid,false);
+      if(!q.length){
+        const persisted=_readPersistedSessionQueue(sid);
+        if(persisted.length){SESSION_QUEUES[sid]=persisted;q=persisted;}
+      }
+      if(!q.length)q=_getSessionQueue(sid,true);
       const serverIds=new Set(data.items.map(item=>String(item&&item.id||'')).filter(Boolean));
       let changed=false;
       for(let i=q.length-1;i>=0;i--){
@@ -356,7 +371,7 @@ function syncBackendSessionQueue(sid){
         const itemMatchText=itemText.trim();
         const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'').trim()===itemMatchText);
         if(pendingIdx>=0){
-          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id};
+          q[pendingIdx]={...q[pendingIdx],text:itemText,_server_pending:false,_server_owned:true,_server_queue_id:id,_server_error:item.error||'',_server_blocked:!!item.blocked};
           changed=true;
           return;
         }
@@ -371,6 +386,8 @@ function syncBackendSessionQueue(sid){
           _server_owned:true,
           _server_pending:false,
           _server_queue_id:id,
+          _server_error:item.error||'',
+          _server_blocked:!!item.blocked,
         });
         changed=true;
       });

--- a/static/ui.js
+++ b/static/ui.js
@@ -342,6 +342,85 @@ function shiftQueuedSessionMessage(sid){
   return next;
 }
 function _serverEntryOwnedOrPending(entry){return !!(entry&&(entry._server_owned||entry._server_pending));}
+function _queuedEntryKey(entry){
+  if(!entry)return'';
+  if(entry._server_queue_id)return'server:'+entry._server_queue_id;
+  if(entry._client_queue_id)return'client:'+entry._client_queue_id;
+  return'time:'+String(entry._queued_at||'')+':'+String(entry.text||entry.message||entry.content||'');
+}
+let _queueSteerCapability=null;
+let _queueSteerCapabilityPromise=null;
+async function _ensureQueueSteerCapability(){
+  if(_queueSteerCapability===true||_queueSteerCapability===false)return _queueSteerCapability;
+  if(_queueSteerCapabilityPromise)return _queueSteerCapabilityPromise;
+  _queueSteerCapabilityPromise=fetch(new URL('api/session/queue/steer-capability',document.baseURI||location.href).href,{credentials:'include',cache:'no-store'})
+    .then(async response=>{
+      if(!response.ok)return false;
+      const data=await response.json().catch(()=>({}));
+      return !!(data&&data.queue_item_steer===true&&Number(data.protocol)>=1);
+    })
+    .catch(()=>false)
+    .then(supported=>{
+      _queueSteerCapability=supported;
+      const sid=S.session&&S.session.session_id;
+      if(sid){delete _queueRenderKeys[sid];updateQueueBadge(sid);}
+      return supported;
+    })
+    .finally(()=>{_queueSteerCapabilityPromise=null;});
+  return _queueSteerCapabilityPromise;
+}
+async function _steerQueuedEntry(sid, entryKey){
+  const q=_getSessionQueue(sid,false);
+  const findIndex=()=>q.findIndex(entry=>_queuedEntryKey(entry)===String(entryKey)||entry&&entry._queued_at===entryKey);
+  let idx=findIndex();
+  if(idx<0)return false;
+  const entry=q[idx];
+  if(entry._server_pending||entry._steer_pending)return false;
+  const currentSid=S.session&&S.session.session_id;
+  const activeStreamId=S.activeStreamId||(S.session&&S.session.active_stream_id);
+  if(!S.busy||!activeStreamId||currentSid!==sid){
+    if(typeof showToast==='function')showToast('Steer is only available while this conversation is running',3200,'warning');
+    return false;
+  }
+  const text=String(entry.text||entry.message||entry.content||'').trim();
+  const files=Array.isArray(entry.files)?entry.files.filter(Boolean):[];
+  if(!text&&!files.length)return false;
+  entry._steer_pending=true;
+  delete _queueRenderKeys[sid];
+  updateQueueBadge(sid);
+  let steerText=text;
+  try{
+    if(files.length&&typeof _steerTextWithPendingFiles==='function'){
+      steerText=await _steerTextWithPendingFiles(text,sid,files);
+    }
+    const response=await fetch(new URL('api/chat/steer',document.baseURI||location.href).href,{
+      method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({session_id:sid,text:steerText,queue_item_id:entry._server_queue_id||null}),
+    });
+    const result=await response.json().catch(()=>({accepted:false,fallback:'network_error'}));
+    if(!response.ok||!result||!result.accepted){
+      if(typeof showToast==='function')showToast('Could not steer this queued message; it remains queued',3500,'warning');
+      return false;
+    }
+    idx=findIndex();
+    if(idx>=0)q.splice(idx,1);
+    if(!q.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
+    else _persistSessionQueueStorage(sid,q);
+    delete _queueRenderKeys[sid];
+    updateQueueBadge(sid);
+    if(typeof _showSteerIndicator==='function')_showSteerIndicator(typeof _steerIndicatorText==='function'?_steerIndicatorText(text,files):text);
+    if(typeof showToast==='function')showToast('Queued message delivered as steer',2500,'success');
+    return true;
+  }catch(_){
+    if(typeof showToast==='function')showToast('Could not steer this queued message; it remains queued',3500,'warning');
+    return false;
+  }finally{
+    idx=findIndex();
+    if(idx>=0&&q[idx])delete q[idx]._steer_pending;
+    delete _queueRenderKeys[sid];
+    updateQueueBadge(sid);
+  }
+}
 function getQueuedSessionCount(sid){
   return _getSessionQueue(sid,false).length;
 }
@@ -8124,6 +8203,7 @@ function _clearQueueCardDisplay(sid){
 }
 
 function _renderQueueChips(sid){
+  if(_queueSteerCapability===null)_ensureQueueSteerCapability();
   const card=document.getElementById('queueCard');
   const inner=document.getElementById('queueChips');
   if(!card||!inner) return;
@@ -8322,6 +8402,21 @@ function _renderQueueChips(sid){
       badges.appendChild(mb);
     }
     // Profile badge removed — drain cannot server-switch profiles so badge was misleading
+    let steerBtn=null;
+    if(_queueSteerCapability===true){
+      steerBtn=document.createElement('button');
+      steerBtn.className='queue-card-btn queue-card-steer-btn';
+      steerBtn.setAttribute('aria-label','Steer current run with this queued message');
+      steerBtn.setAttribute('draggable','false');
+      steerBtn.title=entry&&entry._server_pending?'Waiting for queue sync':'Steer current run now';
+      steerBtn.disabled=!!(entry&&(entry._server_pending||entry._steer_pending));
+      steerBtn.innerHTML=li('compass',12)+'<span>Steer</span>';
+      steerBtn.onclick=async()=>{
+        steerBtn.disabled=true;
+        await _steerQueuedEntry(sid,_queuedEntryKey(entry));
+        if(document.contains(steerBtn))steerBtn.disabled=!!(entry&&(entry._server_pending||entry._steer_pending));
+      };
+    }
     // Delete button
     const delBtn=document.createElement('button');
     delBtn.className='queue-card-icon-btn';
@@ -8350,6 +8445,7 @@ function _renderQueueChips(sid){
     row.appendChild(drag);
     row.appendChild(msgSpan);
     if(badges.childNodes.length) row.appendChild(badges);
+    if(steerBtn) row.appendChild(steerBtn);
     row.appendChild(delBtn);
     inner.appendChild(row);
   });

--- a/static/ui.js
+++ b/static/ui.js
@@ -251,15 +251,78 @@ function queueSessionMessage(sid, payload){
   if(!sid||!payload) return 0;
   const q=_getSessionQueue(sid,true);
   // Stamp created_at so the restore path can detect stale entries (agent already responded)
-  const entry={...payload, _queued_at: Date.now()};
+  const entry={...payload, _queued_at: Date.now(), _client_queue_id: (Date.now().toString(36)+'-'+Math.random().toString(36).slice(2))};
   q.push(entry);
   _persistSessionQueueStorage(sid,q);
+  _backendAcknowledgeQueuedMessage(sid, entry);
   return q.length;
+}
+function _queuedEntryHasBrowserOnlyFiles(entry){
+  const files=entry&&Array.isArray(entry.files)?entry.files:[];
+  return files.some(f=>f&&typeof File!=='undefined'&&f instanceof File);
+}
+function _findQueuedEntryByClientId(sid, clientId){
+  const q=_getSessionQueue(sid,false);
+  const idx=q.findIndex(e=>e&&e._client_queue_id===clientId);
+  return {q,idx,entry:idx>=0?q[idx]:null};
+}
+function _backendAcknowledgeQueuedMessage(sid, entry){
+  if(!sid||!entry||entry._server_owned||entry._server_pending)return;
+  if(_queuedEntryHasBrowserOnlyFiles(entry))return;
+  const text=String(entry.text||entry.message||entry.content||'').trim();
+  if(!text)return;
+  entry._server_pending=true;
+  _persistSessionQueueStorage(sid,_getSessionQueue(sid,false));
+  const body={
+    session_id:sid,
+    text,
+    attachments:Array.isArray(entry.attachments)?entry.attachments:[],
+    model:entry.model||'',
+    model_provider:entry.model_provider||null,
+    profile:entry.profile||S.activeProfile||'default',
+  };
+  fetch(new URL('api/session/queue',document.baseURI||location.href).href,{
+    method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify(body),
+  }).then(r=>r.json().then(data=>({ok:r.ok,data})).catch(()=>({ok:r.ok,data:{}})))
+    .then(({ok,data})=>{
+      const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
+      if(found.idx<0)return;
+      if(ok&&data&&data.item&&data.item.id){
+        found.q[found.idx]={...found.entry,_server_pending:false,_server_owned:true,_server_queue_id:data.item.id};
+      }else{
+        found.q[found.idx]={...found.entry,_server_pending:false,_server_error:(data&&data.error)||'queue_ack_failed'};
+      }
+      _persistSessionQueueStorage(sid,found.q);
+      delete _queueRenderKeys[sid];
+      updateQueueBadge(sid);
+    }).catch(()=>{
+      const found=_findQueuedEntryByClientId(sid,entry._client_queue_id);
+      if(found.idx<0)return;
+      found.q[found.idx]={...found.entry,_server_pending:false,_server_error:'queue_ack_failed'};
+      _persistSessionQueueStorage(sid,found.q);
+      delete _queueRenderKeys[sid];
+      updateQueueBadge(sid);
+    });
+}
+function _removeServerQueuedEntry(sid, serverId){
+  if(!sid||!serverId)return false;
+  const q=_getSessionQueue(sid,false);
+  const idx=q.findIndex(e=>e&&e._server_queue_id===serverId);
+  if(idx<0)return false;
+  q.splice(idx,1);
+  if(!q.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
+  else _persistSessionQueueStorage(sid,q);
+  delete _queueRenderKeys[sid];
+  updateQueueBadge(sid);
+  return true;
 }
 function shiftQueuedSessionMessage(sid){
   const q=_getSessionQueue(sid,false);
   if(!q.length) return null;
-  const next=q.shift();
+  const idx=q.findIndex(e=>!(e&&(_serverEntryOwnedOrPending(e))));
+  if(idx<0)return null;
+  const next=q.splice(idx,1)[0];
   if(!q.length){
     delete SESSION_QUEUES[sid];
     _clearPersistedSessionQueue(sid);
@@ -268,8 +331,50 @@ function shiftQueuedSessionMessage(sid){
   }
   return next;
 }
+function _serverEntryOwnedOrPending(entry){return !!(entry&&(entry._server_owned||entry._server_pending));}
 function getQueuedSessionCount(sid){
   return _getSessionQueue(sid,false).length;
+}
+function syncBackendSessionQueue(sid){
+  if(!sid||typeof fetch!=='function')return;
+  fetch(new URL('api/session/queue?session_id='+encodeURIComponent(sid),document.baseURI||location.href).href,{credentials:'include'})
+    .then(r=>r.ok?r.json():null)
+    .then(data=>{
+      if(!data||!Array.isArray(data.items))return;
+      const q=_getSessionQueue(sid,true);
+      const serverIds=new Set(data.items.map(item=>String(item&&item.id||'')).filter(Boolean));
+      let changed=false;
+      for(let i=q.length-1;i>=0;i--){
+        if(q[i]&&q[i]._server_owned&&q[i]._server_queue_id&&!serverIds.has(String(q[i]._server_queue_id))){
+          q.splice(i,1);changed=true;
+        }
+      }
+      data.items.forEach(item=>{
+        const id=String(item&&item.id||'');
+        if(!id||q.some(e=>e&&e._server_queue_id===id))return;
+        const itemText=String(item.text||'');
+        const pendingIdx=q.findIndex(e=>e&&e._server_pending&&!e._server_queue_id&&String(e.text||e.message||e.content||'')===itemText);
+        if(pendingIdx>=0){
+          q[pendingIdx]={...q[pendingIdx],_server_pending:false,_server_owned:true,_server_queue_id:id};
+          changed=true;
+          return;
+        }
+        q.push({
+          text:itemText,
+          files:[],
+          attachments:Array.isArray(item.attachments)?item.attachments:[],
+          model:item.model||'',
+          model_provider:item.model_provider||null,
+          profile:item.profile||S.activeProfile||'default',
+          _queued_at:Math.round((Number(item.created_at)||Date.now()/1000)*1000),
+          _server_owned:true,
+          _server_pending:false,
+          _server_queue_id:id,
+        });
+        changed=true;
+      });
+      if(changed){_persistSessionQueueStorage(sid,q);delete _queueRenderKeys[sid];updateQueueBadge(sid);}
+    }).catch(()=>{});
 }
 function _compressionSessionLock(){
   return window._compressionLockSid||null;
@@ -8071,15 +8176,30 @@ function _renderQueueChips(sid){
       if(hasFiles){
         if(typeof showToast==='function') showToast('Attachments on queued items will be removed',2600,'warning');
       }
+      const snapshot=[..._getSessionQueue(sid,false)];
+      if(snapshot.some(e=>e&&e._server_owned)){
+        if(typeof showToast==='function') showToast('Already-synced queued messages cannot be merged yet',2600,'warning');
+        return;
+      }
       // Merge from current live queue (no delay — snapshot + defer caused data-loss races)
-      _doMerge([..._getSessionQueue(sid,false)]);
+      _doMerge(snapshot);
     };
     const clearBtn=document.createElement('button');
     clearBtn.className='queue-card-icon-btn';
     clearBtn.title='Clear all queued messages';
     clearBtn.setAttribute('aria-label','Clear all queued messages');
     clearBtn.innerHTML=li('x',13);
-    clearBtn.onclick=()=>{q.length=0;_saveAndRefresh();};
+    clearBtn.onclick=()=>{
+      q.forEach(entry=>{
+        if(entry&&entry._server_owned&&entry._server_queue_id){
+          fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+            method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({session_id:sid,id:entry._server_queue_id}),
+          }).catch(()=>{});
+        }
+      });
+      q.length=0;_saveAndRefresh();
+    };
     actions.appendChild(mergeBtn);
     actions.appendChild(clearBtn);
     // Hide button — collapses flyout entirely; queue pill re-shows it
@@ -8145,6 +8265,12 @@ function _renderQueueChips(sid){
         if(idx!==-1){
           liveQ[idx]={...liveQ[idx],text:newText};
           _persistSessionQueueStorage(sid,liveQ);
+          if(liveQ[idx]._server_owned&&liveQ[idx]._server_queue_id){
+            fetch(new URL('api/session/queue/update',document.baseURI||location.href).href,{
+              method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+              body:JSON.stringify({session_id:sid,id:liveQ[idx]._server_queue_id,text:newText}),
+            }).catch(()=>{});
+          }
           delete _queueRenderKeys[sid];
           updateQueueBadge(sid);
         }
@@ -8182,7 +8308,16 @@ function _renderQueueChips(sid){
     delBtn.onclick=()=>{
       const liveQ=_getSessionQueue(sid,false);
       const idx=_entryTs!=null?liveQ.findIndex(e=>e&&e._queued_at===_entryTs):i;
-      if(idx!==-1) liveQ.splice(idx,1);
+      if(idx!==-1){
+        const removed=liveQ[idx];
+        liveQ.splice(idx,1);
+        if(removed&&removed._server_owned&&removed._server_queue_id){
+          fetch(new URL('api/session/queue/delete',document.baseURI||location.href).href,{
+            method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({session_id:sid,id:removed._server_queue_id}),
+          }).catch(()=>{});
+        }
+      }
       if(!liveQ.length){delete SESSION_QUEUES[sid];_clearPersistedSessionQueue(sid);}
       else{SESSION_QUEUES[sid]=[...liveQ];_persistSessionQueueStorage(sid,liveQ);}
       delete _queueRenderKeys[sid];

--- a/tests/test_issue4749_steer_reason_and_recovery.py
+++ b/tests/test_issue4749_steer_reason_and_recovery.py
@@ -41,6 +41,7 @@ BACKEND_CODES = {
 
 HANDLED_NON_RECOVERY_CODES = {
     "gateway_steer_queued",
+    "queue_item_not_found",
 }
 
 FRONTEND_NETWORK_CODE = "network_error"

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -123,6 +123,86 @@ class TestHandleChatSteerHappyPath:
         body = _captured_response(handler)
         assert body == {"accepted": True, "fallback": None, "stream_id": stream_id}
 
+    def test_accepted_queued_steer_claims_only_selected_backend_item(
+        self, _clear_caches, monkeypatch, tmp_path
+    ):
+        import queue as _q
+
+        from api import config as api_config
+        from api import session_queue
+        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK, STREAMS, STREAMS_LOCK
+        from api.streaming import _handle_chat_steer
+
+        monkeypatch.setattr(api_config, "SESSION_DIR", tmp_path)
+        sid, stream_id = "sid_queue_steer", "stream_queue_steer"
+        first = session_queue.enqueue(sid, {"text": "keep queued"})
+        selected = session_queue.enqueue(sid, {"text": "steer selected"})
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        with SESSION_AGENT_CACHE_LOCK:
+            SESSION_AGENT_CACHE[sid] = (agent, "sig")
+        with STREAMS_LOCK:
+            STREAMS[stream_id] = _q.Queue()
+        sess = MagicMock()
+        sess.active_stream_id = stream_id
+
+        with patch("api.streaming.get_session", return_value=sess):
+            handler = _make_handler()
+            _handle_chat_steer(
+                handler,
+                {
+                    "session_id": sid,
+                    "text": "stale browser copy",
+                    "queue_item_id": selected["id"],
+                },
+            )
+
+        agent.steer.assert_called_once_with("steer selected")
+        assert _captured_response(handler)["accepted"] is True
+        assert [item["id"] for item in session_queue.list_queue(sid)] == [first["id"]]
+
+    @pytest.mark.parametrize("steer_result", [False, RuntimeError("boom")], ids=["refused", "exception"])
+    def test_failed_queued_steer_restores_selected_backend_item_in_order(
+        self, _clear_caches, monkeypatch, tmp_path, steer_result
+    ):
+        import queue as _q
+
+        from api import config as api_config
+        from api import session_queue
+        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK, STREAMS, STREAMS_LOCK
+        from api.streaming import _handle_chat_steer
+
+        monkeypatch.setattr(api_config, "SESSION_DIR", tmp_path)
+        sid, stream_id = "sid_queue_restore", "stream_queue_restore"
+        first = session_queue.enqueue(sid, {"text": "first"})
+        selected = session_queue.enqueue(sid, {"text": "selected"})
+        third = session_queue.enqueue(sid, {"text": "third"})
+        agent = MagicMock()
+        if isinstance(steer_result, Exception):
+            agent.steer = MagicMock(side_effect=steer_result)
+        else:
+            agent.steer = MagicMock(return_value=steer_result)
+        with SESSION_AGENT_CACHE_LOCK:
+            SESSION_AGENT_CACHE[sid] = (agent, "sig")
+        with STREAMS_LOCK:
+            STREAMS[stream_id] = _q.Queue()
+        sess = MagicMock()
+        sess.active_stream_id = stream_id
+
+        with patch("api.streaming.get_session", return_value=sess):
+            handler = _make_handler()
+            _handle_chat_steer(
+                handler,
+                {"session_id": sid, "text": "selected", "queue_item_id": selected["id"]},
+            )
+
+        assert _captured_response(handler)["accepted"] is False
+        assert [item["id"] for item in session_queue.list_queue(sid)] == [
+            first["id"],
+            selected["id"],
+            third["id"],
+        ]
+
 
 class TestHandleChatSteerFallbacks:
     """Each gate that fails returns a structured fallback the frontend can branch on."""

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -230,6 +230,19 @@ if(calls[1].body.id !== 'srv-ghost' || calls[1].body.session_id !== sid){
     )
 
 
+def test_existing_session_load_syncs_backend_queue():
+    src = (pathlib.Path(__file__).parent.parent / "static" / "sessions.js").read_text(
+        encoding="utf-8"
+    )
+    load_start = src.index("async function loadSession(")
+    load_body = src[load_start : src.index("// ── Handoff hint logic", load_start)]
+    assign_pos = load_body.index("S.session=data.session")
+    stream_pos = load_body.index("startSessionStream(S.session.session_id)")
+    sync_pos = load_body.index("syncBackendSessionQueue(S.session.session_id)")
+    active_stream_pos = load_body.index("let activeStreamId=S.session.active_stream_id")
+    assert assign_pos < active_stream_pos < stream_pos < sync_pos
+
+
 def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(config, "ACTIVE_RUNS", {})

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -1,0 +1,106 @@
+import sys
+import time
+import types
+
+from api import config
+from api import session_queue
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return bool(predicate())
+
+
+def _install_fake_routes(monkeypatch, start_session_turn):
+    fake_routes = types.SimpleNamespace(start_session_turn=start_session_turn)
+    monkeypatch.setitem(sys.modules, "api.routes", fake_routes)
+
+
+def _is_empty_queue_dir(path):
+    qdir = path / "_session_queue"
+    return not qdir.exists() or not any(qdir.iterdir())
+
+
+def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+
+    item = session_queue.enqueue(
+        "sid-1",
+        {"text": "next please", "model": "m1", "model_provider": "p1", "profile": "default"},
+    )
+
+    assert item["id"]
+    assert item["text"] == "next please"
+    assert session_queue.list_queue("sid-1") == [item]
+
+
+def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+
+    item = session_queue.enqueue(
+        "sid-drain",
+        {"text": "queued followup", "model": "m-drain", "model_provider": "p-drain"},
+    )
+    calls = []
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        calls.append((session_id, message, kwargs))
+        return {"stream_id": "stream-1", "_status": 200}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-drain") == 1
+    assert _wait_until(lambda: calls)
+    assert calls == [
+        (
+            "sid-drain",
+            "queued followup",
+            {
+                "source": "queued_followup",
+                "attachments": [],
+                "requested_model": "m-drain",
+                "requested_provider": "p-drain",
+                "queue_item_id": item["id"],
+            },
+        )
+    ]
+    assert session_queue.list_queue("sid-drain") == []
+    assert _is_empty_queue_dir(tmp_path)
+
+
+def test_drain_requeues_item_when_start_races_active_turn(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+
+    item = session_queue.enqueue("sid-race", {"text": "still needed"})
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        return {"error": "session already has an active stream", "_status": 409}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-race") == 1
+    assert _wait_until(lambda: session_queue.list_queue("sid-race"))
+    queued = session_queue.list_queue("sid-race")
+    assert len(queued) == 1
+    assert queued[0]["id"] == item["id"]
+    assert queued[0]["text"] == "still needed"
+
+
+def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(
+        config,
+        "ACTIVE_RUNS",
+        {"stream-active": {"session_id": "sid-active"}},
+    )
+
+    item = session_queue.enqueue("sid-active", {"text": "later"})
+
+    assert session_queue.drain_for_session("sid-active") == 0
+    assert session_queue.list_queue("sid-active")[0]["id"] == item["id"]

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -107,6 +107,32 @@ def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
     assert session_queue.list_queue("sid-1") == [item]
 
 
+def test_enqueue_requires_text_even_with_attachments(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+
+    try:
+        session_queue.enqueue("sid-empty", {"attachments": [{"name": "file.txt"}]})
+    except ValueError as exc:
+        assert str(exc) == "text is required"
+    else:  # pragma: no cover - defensive clarity for the regression
+        raise AssertionError("attachments-only backend queue item should be rejected")
+
+
+def test_enqueue_coerces_provider_and_caps_queue(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(session_queue, "_MAX_QUEUE_ITEMS", 3)
+
+    for idx in range(5):
+        session_queue.enqueue(
+            "sid-cap",
+            {"text": f"item {idx}", "model_provider": {"provider": idx}},
+        )
+
+    queued = session_queue.list_queue("sid-cap")
+    assert [item["text"] for item in queued] == ["item 2", "item 3", "item 4"]
+    assert queued[-1]["model_provider"] == "{'provider': 4}"
+
+
 def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
     monkeypatch.setattr(routes, "get_session", lambda sid: {"id": sid})
@@ -155,6 +181,50 @@ if(q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
 const shifted = shiftQueuedSessionMessage(sid);
 if(!shifted || shifted.text !== 'orphan after tab close'){
   throw new Error('reset orphan should be browser-drainable: '+JSON.stringify(shifted));
+}
+"""
+    )
+
+
+def test_frontend_sync_hydrates_persisted_queue_before_reconcile():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-hydrate';
+sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify([
+  {text: ' persisted pending ', _server_pending: true, _client_queue_id: 'persisted-1'},
+]));
+fetch = async () => ({ok: true, json: async () => ({items: [
+  {id: 'srv-hydrated', text: 'persisted pending', attachments: [], created_at: 1700000000},
+]})});
+syncBackendSessionQueue(sid);
+await new Promise(resolve => setTimeout(resolve, 0));
+const q = SESSION_QUEUES[sid];
+if(!q || q.length !== 1 || q[0]._server_queue_id !== 'srv-hydrated' || q[0]._server_pending){
+  throw new Error('persisted pending entry was not hydrated and reconciled: '+JSON.stringify(q));
+}
+"""
+    )
+
+
+def test_frontend_ack_deletes_backend_item_when_local_chip_was_removed():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-ghost';
+const entry = {text: 'ghost followup', _client_queue_id: 'local-ghost'};
+const calls = [];
+fetch = async (url, opts) => {
+  calls.push({url: String(url), body: opts && opts.body ? JSON.parse(opts.body) : null});
+  if(String(url).includes('/delete')) return {ok: true, json: async () => ({ok: true})};
+  return {ok: true, json: async () => ({item: {id: 'srv-ghost'}})};
+};
+_backendAcknowledgeQueuedMessage(sid, entry);
+await new Promise(resolve => setTimeout(resolve, 0));
+await new Promise(resolve => setTimeout(resolve, 0));
+if(calls.length !== 2 || !String(calls[1].url).includes('api/session/queue/delete')){
+  throw new Error('expected cleanup delete after missing local chip: '+JSON.stringify(calls));
+}
+if(calls[1].body.id !== 'srv-ghost' || calls[1].body.session_id !== sid){
+  throw new Error('delete payload mismatch: '+JSON.stringify(calls[1]));
 }
 """
     )
@@ -212,6 +282,32 @@ def test_drain_requeues_item_when_start_races_active_turn(monkeypatch, tmp_path)
     assert len(queued) == 1
     assert queued[0]["id"] == item["id"]
     assert queued[0]["text"] == "still needed"
+
+
+def test_permanent_start_errors_stop_churning_after_retry_limit(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(config, "ACTIVE_RUNS", {})
+    monkeypatch.setattr(session_queue, "_MAX_START_RETRIES", 2)
+
+    item = session_queue.enqueue("sid-bad", {"text": "bad model"})
+    calls = []
+
+    def fake_start_session_turn(session_id, message, **kwargs):
+        calls.append((session_id, message, kwargs))
+        return {"error": "invalid model", "_status": 400}
+
+    _install_fake_routes(monkeypatch, fake_start_session_turn)
+
+    assert session_queue.drain_for_session("sid-bad") == 1
+    assert _wait_until(lambda: session_queue.list_queue("sid-bad") and len(calls) == 1)
+    assert session_queue.drain_for_session("sid-bad") == 1
+    assert _wait_until(lambda: session_queue.list_queue("sid-bad")[0].get("blocked") is True)
+    queued = session_queue.list_queue("sid-bad")
+    assert queued[0]["id"] == item["id"]
+    assert queued[0]["blocked"] is True
+    assert queued[0]["error"] == "invalid model"
+    assert session_queue.drain_for_session("sid-bad") == 0
+    assert len(calls) == 2
 
 
 def test_drain_does_not_claim_while_session_has_active_run(monkeypatch, tmp_path):

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 import types
+from urllib.parse import urlparse
 
 from api import config
 from api import routes
@@ -92,6 +93,39 @@ vm.runInContext({json.dumps(queue_src)}, ctx, {{filename: 'ui-queue.js'}});
 }});
 """
     subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
+def test_queue_steer_capability_route_is_read_only_and_cache_safe():
+    handler = _FakeHandler()
+
+    handled = routes.handle_get(
+        handler, urlparse("http://example.test/api/session/queue/steer-capability")
+    )
+
+    assert handled is None
+    assert handler.status == 200
+    assert handler.headers["Cache-Control"] == "no-store"
+    assert handler.json_body() == {
+        "ok": True,
+        "queue_item_steer": True,
+        "protocol": 1,
+    }
+
+
+def test_queue_steer_capability_fails_closed_against_old_backend():
+    _run_queue_sync_node_script(
+        r"""
+fetch = async () => ({ok: false, status: 404, json: async () => ({error: 'not found'})});
+if(await _ensureQueueSteerCapability() !== false || _queueSteerCapability !== false){
+  throw new Error('old backend must leave queued steer disabled');
+}
+_queueSteerCapability = null;
+fetch = async () => ({ok: true, status: 200, json: async () => ({queue_item_steer: true, protocol: 1})});
+if(await _ensureQueueSteerCapability() !== true || _queueSteerCapability !== true){
+  throw new Error('new backend capability handshake was not accepted');
+}
+"""
+    )
 
 
 def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
@@ -228,6 +262,101 @@ if(calls[1].body.id !== 'srv-ghost' || calls[1].body.session_id !== sid){
 }
 """
     )
+
+
+def test_frontend_queue_upgrade_to_steer_removes_only_accepted_entry():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-steer';
+SESSION_QUEUES[sid] = [
+  {text: 'keep queued', _queued_at: 1, _server_owned: true, _server_queue_id: 'srv-keep'},
+  {text: 'steer this', _queued_at: 2, _server_owned: true, _server_queue_id: 'srv-steer'},
+];
+S.session = {session_id: sid, active_stream_id: 'stream-1'};
+S.activeStreamId = 'stream-1';
+S.busy = true;
+const calls = [];
+fetch = async (url, opts) => {
+  calls.push({url: String(url), body: JSON.parse(opts.body)});
+  return {ok: true, json: async () => ({accepted: true, fallback: null, stream_id: 'stream-1'})};
+};
+const accepted = await _steerQueuedEntry(sid, 2);
+if(!accepted) throw new Error('expected queued steer to be accepted');
+if(calls.length !== 1 || !calls[0].url.includes('api/chat/steer')){
+  throw new Error('wrong steer request: '+JSON.stringify(calls));
+}
+if(calls[0].body.queue_item_id !== 'srv-steer' || calls[0].body.text !== 'steer this'){
+  throw new Error('steer payload did not identify the selected queue item: '+JSON.stringify(calls[0].body));
+}
+const q = SESSION_QUEUES[sid];
+if(q.length !== 1 || q[0]._server_queue_id !== 'srv-keep'){
+  throw new Error('accepted steer removed the wrong queue entry: '+JSON.stringify(q));
+}
+"""
+    )
+
+
+def test_frontend_queue_upgrade_to_steer_keeps_entry_on_rejection():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-steer-reject';
+SESSION_QUEUES[sid] = [
+  {text: 'still queued', _queued_at: 7, _server_owned: true, _server_queue_id: 'srv-reject'},
+];
+S.session = {session_id: sid, active_stream_id: 'stream-2'};
+S.activeStreamId = 'stream-2';
+S.busy = true;
+fetch = async () => ({ok: true, json: async () => ({accepted: false, fallback: 'stream_dead'})});
+const accepted = await _steerQueuedEntry(sid, 7);
+if(accepted) throw new Error('rejected steer must return false');
+const q = SESSION_QUEUES[sid];
+if(q.length !== 1 || q[0]._server_queue_id !== 'srv-reject'){
+  throw new Error('rejected steer lost the queued entry: '+JSON.stringify(q));
+}
+"""
+    )
+
+
+def test_queue_claim_by_id_preserves_other_items_and_can_be_restored(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    first = session_queue.enqueue("sid-claim", {"text": "first"})
+    second = session_queue.enqueue("sid-claim", {"text": "second"})
+
+    claimed = session_queue.claim_item("sid-claim", second["id"])
+
+    assert claimed is not None
+    assert claimed["item"]["id"] == second["id"]
+    assert claimed["index"] == 1
+    assert [item["id"] for item in session_queue.list_queue("sid-claim")] == [first["id"]]
+
+    session_queue.restore_claim("sid-claim", claimed)
+    assert [item["id"] for item in session_queue.list_queue("sid-claim")] == [
+        first["id"],
+        second["id"],
+    ]
+
+
+def test_queue_claim_by_id_is_atomic_under_concurrency(monkeypatch, tmp_path):
+    import threading
+
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    item = session_queue.enqueue("sid-concurrent-claim", {"text": "claim once"})
+    barrier = threading.Barrier(3)
+    claims = []
+
+    def claim_selected():
+        barrier.wait()
+        claims.append(session_queue.claim_item("sid-concurrent-claim", item["id"]))
+
+    workers = [threading.Thread(target=claim_selected) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    barrier.wait()
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert sum(claim is not None for claim in claims) == 1
+    assert session_queue.list_queue("sid-concurrent-claim") == []
 
 
 def test_existing_session_load_syncs_backend_queue():

--- a/tests/test_session_queue.py
+++ b/tests/test_session_queue.py
@@ -1,8 +1,13 @@
+import io
+import json
+import pathlib
+import subprocess
 import sys
 import time
 import types
 
 from api import config
+from api import routes
 from api import session_queue
 
 
@@ -25,6 +30,70 @@ def _is_empty_queue_dir(path):
     return not qdir.exists() or not any(qdir.iterdir())
 
 
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def json_body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _run_queue_sync_node_script(script_body):
+    ui_src = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(
+        encoding="utf-8"
+    )
+    start = ui_src.index("function _getSessionQueue")
+    end = ui_src.index("function _compressionSessionLock", start)
+    queue_src = ui_src[start:end]
+    script = f"""
+const vm = require('vm');
+const storage = {{}};
+const store = {{
+  getItem: (key) => Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null,
+  setItem: (key, value) => {{ storage[key] = String(value); }},
+  removeItem: (key) => {{ delete storage[key]; }},
+}};
+const ctx = {{
+  SESSION_QUEUES: {{}},
+  S: {{activeProfile: 'default'}},
+  _queueRenderKeys: {{}},
+  sessionStorage: store,
+  localStorage: store,
+  document: {{baseURI: 'http://example.test/session/sid/'}},
+  location: {{href: 'http://example.test/session/sid/', pathname: '/session/sid/', search: ''}},
+  fetch: null,
+  updateQueueBadge: () => {{}},
+  File: function File(){{}},
+  URL,
+  setTimeout,
+  clearTimeout,
+}};
+ctx.window = ctx;
+vm.createContext(ctx);
+vm.runInContext({json.dumps(queue_src)}, ctx, {{filename: 'ui-queue.js'}});
+(async () => {{
+  await vm.runInContext(`(async () => {{
+{script_body}
+  }})()`, ctx, {{filename: 'ui-queue-test.js'}});
+}})().catch(err => {{
+  console.error(err && err.stack || err);
+  process.exit(1);
+}});
+"""
+    subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+
+
 def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
 
@@ -36,6 +105,59 @@ def test_enqueue_persists_and_lists_session_queue(monkeypatch, tmp_path):
     assert item["id"]
     assert item["text"] == "next please"
     assert session_queue.list_queue("sid-1") == [item]
+
+
+def test_enqueue_handler_attempts_idle_drain(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(routes, "get_session", lambda sid: {"id": sid})
+    drained = []
+
+    def fake_drain_for_session(sid):
+        drained.append(sid)
+        return 1
+
+    monkeypatch.setattr(session_queue, "drain_for_session", fake_drain_for_session)
+
+    handler = _FakeHandler()
+    routes._handle_session_queue_enqueue(
+        handler,
+        {"session_id": "sid-idle", "text": "queued while idle", "profile": "default"},
+    )
+
+    assert handler.status == 200
+    assert drained == ["sid-idle"]
+    body = handler.json_body()
+    assert body["ok"] is True
+    assert body["item"]["text"] == "queued while idle"
+
+
+def test_frontend_sync_recovers_stale_pending_and_matches_trimmed_text():
+    _run_queue_sync_node_script(
+        r"""
+const sid = 'sid-sync';
+SESSION_QUEUES[sid] = [
+  {text: '  hello from pending  ', _server_pending: true, _client_queue_id: 'local-1'},
+  {text: 'orphan after tab close', _server_pending: true, _client_queue_id: 'local-2'},
+];
+fetch = async () => ({ok: true, json: async () => ({items: [
+  {id: 'srv-1', text: 'hello from pending', attachments: [], model: 'm1', model_provider: 'p1', profile: 'default', created_at: 1700000000},
+]})});
+syncBackendSessionQueue(sid);
+await new Promise(resolve => setTimeout(resolve, 0));
+const q = SESSION_QUEUES[sid];
+if(q.length !== 2) throw new Error('expected no duplicate server chip, got '+q.length);
+if(q[0]._server_queue_id !== 'srv-1' || !q[0]._server_owned || q[0]._server_pending){
+  throw new Error('trimmed pending entry was not promoted: '+JSON.stringify(q[0]));
+}
+if(q[1]._server_pending || q[1]._server_owned || q[1]._server_queue_id){
+  throw new Error('orphan pending entry was not reset: '+JSON.stringify(q[1]));
+}
+const shifted = shiftQueuedSessionMessage(sid);
+if(!shifted || shifted.text !== 'orphan after tab close'){
+  throw new Error('reset orphan should be browser-drainable: '+JSON.stringify(shifted));
+}
+"""
+    )
 
 
 def test_drain_for_session_starts_one_backend_owned_turn(monkeypatch, tmp_path):


### PR DESCRIPTION
## Dependency

- Stacked on #4415. **Do not merge this PR until #4415 lands.**
- The single feature commit is `feat: steer selected queued messages`; the preceding four commits belong to #4415 and will disappear from this diff after that PR merges.

## Summary

- adds a compact per-item **Steer** action to the queued-message card, including 390px mobile sizing
- capability-gates the control so a new frontend fails closed against an older backend
- claims exactly the selected backend queue item under the queue lock and derives steer text from the backend-owned payload
- removes that one item only after `agent.steer(...)` accepts; rejection or exception restores the exact item at its original queue position
- preserves attachment paths in the generated steer guidance

## State ownership / invariants

- Session queue remains backend-owned and persisted by `api/session_queue.py`.
- A selected item moves `queued -> claimed -> delivered` only on accepted Steer.
- Refused and exceptional paths move `claimed -> queued` without changing sibling order.
- Concurrent claims for one item admit exactly one owner.
- Frontend removal is keyed by the selected queue identity, never by queue head.

## TDD proof

- RED: 7 expected failures / 46 passes before implementation (missing capability, selective claim, frontend action, and backend-authoritative payload behavior).
- GREEN: focused + neighboring suite: `60 passed`.

## Verification

- `./scripts/test.sh tests/test_session_queue.py tests/test_real_steer.py tests/test_issue1413_li_path_coverage.py tests/test_issue4749_steer_reason_and_recovery.py -q` — **60 passed**
- `node --check static/ui.js && node --check static/icons.js` — **PASS**
- `python3 -m py_compile api/routes.py api/session_queue.py api/streaming.py` — **PASS**
- `python3 scripts/ruff_lint.py --diff upstream/master` — **PASS**, no new violations
- ESLint runtime guard over `static/**/*.js` — **PASS**
- `git diff --check` — **PASS**
- Full suite: `13425 passed, 143 skipped, 1 xfailed, 2 xpassed`; after fixing the two feature-adjacent failures it exposed, one unrelated environment-dependent compression-metering test remains non-green because the repo test venv cannot import the external Hermes Agent's `requests` dependency.
- Desktop visual QA at 1454×1000 — both Steer actions visible and queue card attached above Composer.
- Mobile visual QA at 390×844 — both compass + Steer controls visible, ~40px high, with no clipping or overlap.

## Residual risk

- This is intentionally stacked and must be rebased onto `master` after #4415 merges if GitHub does not collapse the parent commits automatically.
