### PR TITLE
feat: expose recent project messages over MCP

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,7 @@ actions. The topbar remains focused on conversation context and the workspace/fi
     bootstrap.py           One-shot launcher: optional agent install, deps, health wait, browser open.
     start.sh               Thin wrapper around bootstrap.py for shell-based startup.
     ctl.sh                 Daemon lifecycle wrapper (start/stop/restart/status/logs) for homelab installs.
+    mcp_server.py          Profile-scoped MCP project/session tools, including bounded read-only project context.
     pyproject.toml         Standard build metadata plus the Ruff lint gate; source-checkout launch surface still centers on bootstrap.py / start.sh / ctl.sh.
     Dockerfile             python:3.12-slim container image
     docker-compose.yml     Compose config with named volume and optional auth
@@ -63,6 +64,7 @@ actions. The topbar remains focused on conversation context and the workspace/fi
       models.py            Session model + CRUD, per-session profile tracking, CLI/state.db bridge
       profiles.py          Profile state management, hermes_cli wrapper
       onboarding.py        First-run onboarding status, real provider config writes, OAuth linking, readiness detection
+      project_context.py   Read-only global recent-message projection for one profile/project.
       routes.py            All GET + POST route handlers (if/elif dispatch, no decorators)
       startup.py           Startup helpers: auto_install_agent_deps()
       state_sync.py        /insights sync — message_count to the agent's state.db

--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ The WebUI is still coupled to Hermes Agent internals for runtime execution, prov
 **Using & customizing**
 - [`THEMES.md`](THEMES.md) — theme + skin system, custom theme guide
 - [`docs/workspace-git.md`](docs/workspace-git.md) — the workspace Git controls
+- [`docs/project-context.md`](docs/project-context.md) — read-only MCP project context across WebUI sessions
 - [`docs/EXTENSIONS.md`](docs/EXTENSIONS.md) — administrator-controlled WebUI extension injection
 
 **Deploying & operating**

--- a/api/project_context.py
+++ b/api/project_context.py
@@ -1,0 +1,431 @@
+"""Read-only, profile-scoped project context projections.
+
+Project membership is confirmed by both the compact WebUI index and each
+session's bounded metadata prefix. Message content is then read from the active
+profile's ``state.db`` through bounded per-session tail queries. No Session
+objects are loaded and no transcript sidecars are parsed.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import math
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+from api.helpers import _redact_text
+from api.models import _read_metadata_json_prefix, is_safe_session_id
+from api.profiles import _profiles_match
+
+
+_DEFAULT_LIMIT = 5
+_MAX_LIMIT = 20
+_MIN_SCAN_ROWS = 20
+_SCAN_MULTIPLIER = 5
+_ALLOWED_ROLES = frozenset({"user", "assistant"})
+_SYNTHETIC_SESSION_SOURCES = frozenset({"cron", "subagent", "delegation"})
+_SYNTHETIC_CONTENT_PREFIXES = (
+    "[important:",
+    "[async delegation",
+    "[context compaction",
+    "[your active task list was preserved across context compression]",
+    "[session arc summary",
+    "[system:",
+)
+_MAX_ITERATION_SUMMARY_REQUEST = (
+    "You've reached the maximum number of tool-calling iterations allowed. "
+    "Please provide a final response summarizing what you've found and accomplished "
+    "so far, without calling any more tools."
+)
+_CURSOR_VERSION = 2
+_CLASSIFIER_VERSION = "project_context_v1"
+
+
+def _load_json_list(path: Path) -> list[dict[str, Any]]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return []
+    if not isinstance(value, list):
+        return []
+    return [row for row in value if isinstance(row, dict)]
+
+
+def _load_json_list_with_status(path: Path) -> tuple[list[dict[str, Any]], bool]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return [], False
+    if not isinstance(value, list):
+        return [], False
+    return [row for row in value if isinstance(row, dict)], True
+
+
+def _normalize_roles(roles: Any) -> tuple[str, ...]:
+    if roles is None:
+        return ("user",)
+    if isinstance(roles, str):
+        roles = [roles]
+    if not isinstance(roles, (list, tuple, set, frozenset)):
+        raise ValueError("roles must be a list containing user and/or assistant")
+    normalized = tuple(dict.fromkeys(str(role).strip().lower() for role in roles if str(role).strip()))
+    if not normalized or any(role not in _ALLOWED_ROLES for role in normalized):
+        raise ValueError("roles may contain only user and assistant")
+    return normalized
+
+
+def _normalize_limit(limit: Any) -> int:
+    if limit is None:
+        return _DEFAULT_LIMIT
+    try:
+        value = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer between 1 and 20") from exc
+    if value < 1:
+        raise ValueError("limit must be an integer between 1 and 20")
+    return min(value, _MAX_LIMIT)
+
+
+def _cursor_scope(project_id: str, profile: str, roles: tuple[str, ...], include_archived: bool) -> str:
+    payload = json.dumps(
+        [project_id, profile, sorted(roles), bool(include_archived)],
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:24]
+
+
+def _encode_cursor(timestamp: float, session_id: str, message_rowid: int, scope: str) -> str:
+    payload = json.dumps(
+        [_CURSOR_VERSION, scope, timestamp, session_id, message_rowid],
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def _decode_cursor(value: Any, scope: str) -> tuple[float, str, int] | None:
+    if value in (None, ""):
+        return None
+    if not isinstance(value, str):
+        raise ValueError("before must be an opaque cursor returned by this contract")
+    try:
+        padded = value + "=" * (-len(value) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded.encode("ascii")))
+        if (
+            not isinstance(decoded, list)
+            or len(decoded) != 5
+            or decoded[0] != _CURSOR_VERSION
+            or decoded[1] != scope
+        ):
+            raise ValueError
+        timestamp = float(decoded[2])
+        session_id = str(decoded[3])
+        rowid = int(decoded[4])
+        if not math.isfinite(timestamp) or not is_safe_session_id(session_id) or rowid < 1:
+            raise ValueError
+        return timestamp, session_id, rowid
+    except (ValueError, TypeError, UnicodeDecodeError, json.JSONDecodeError, binascii.Error) as exc:
+        raise ValueError("before must be an opaque cursor returned by this contract") from exc
+
+
+def _sidecar_metadata(path: Path) -> dict[str, Any] | None:
+    try:
+        prefix = _read_metadata_json_prefix(path)
+        if not prefix:
+            return None
+        value = json.loads(prefix)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _project_for_profile(projects_file: Path, project_id: str, profile: str) -> dict[str, Any]:
+    project = next(
+        (
+            row
+            for row in _load_json_list(projects_file)
+            if str(row.get("project_id") or "") == project_id
+            and _profiles_match(row.get("profile"), profile)
+        ),
+        None,
+    )
+    if project is None:
+        # Deliberately identical for absent and foreign-profile projects.
+        raise LookupError("Project not found")
+    return project
+
+
+def _eligible_session_metadata(
+    *,
+    session_index_file: Path,
+    session_dir: Path,
+    project_id: str,
+    profile: str,
+    include_archived: bool,
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    diagnostics: dict[str, Any] = {
+        "index_rows_considered": 0,
+        "invalid_index_rows": 0,
+        "missing_sidecars": 0,
+        "unreadable_sidecars": 0,
+        "membership_mismatches": 0,
+        "archived_sessions_excluded": 0,
+    }
+    eligible: dict[str, dict[str, Any]] = {}
+    index_rows, index_available = _load_json_list_with_status(session_index_file)
+    diagnostics["session_index_unavailable"] = 0 if index_available else 1
+    for row in index_rows:
+        if row.get("project_id") != project_id or not _profiles_match(row.get("profile"), profile):
+            continue
+        diagnostics["index_rows_considered"] += 1
+        sid = str(row.get("session_id") or "")
+        if not is_safe_session_id(sid):
+            diagnostics["invalid_index_rows"] += 1
+            continue
+        sidecar_path = session_dir / f"{sid}.json"
+        if not sidecar_path.is_file():
+            diagnostics["missing_sidecars"] += 1
+            continue
+        sidecar = _sidecar_metadata(sidecar_path)
+        if sidecar is None:
+            diagnostics["unreadable_sidecars"] += 1
+            continue
+        if (
+            str(sidecar.get("session_id") or "") != sid
+            or sidecar.get("project_id") != project_id
+            or not _profiles_match(sidecar.get("profile"), profile)
+        ):
+            diagnostics["membership_mismatches"] += 1
+            continue
+        archived = bool(sidecar.get("archived", row.get("archived", False)))
+        if archived and not include_archived:
+            diagnostics["archived_sessions_excluded"] += 1
+            continue
+        eligible[sid] = {
+            "session_id": sid,
+            "title": str(sidecar.get("title") or row.get("title") or "Untitled"),
+            "workspace": sidecar.get("workspace") if sidecar.get("workspace") is not None else row.get("workspace"),
+            "profile": profile,
+            "project_id": project_id,
+        }
+    return eligible, diagnostics
+
+
+def _state_db_sources(
+    conn: sqlite3.Connection,
+    session_ids: list[str],
+) -> tuple[dict[str, str], int]:
+    sources: dict[str, str] = {}
+    for offset in range(0, len(session_ids), 500):
+        chunk = session_ids[offset : offset + 500]
+        placeholders = ",".join("?" for _ in chunk)
+        cursor = conn.execute(
+            f"SELECT id, source FROM sessions WHERE id IN ({placeholders})",
+            chunk,
+        )
+        for row in cursor.fetchall():
+            sources[str(row["id"])] = str(row["source"] or "").strip().lower()
+    return sources, len(session_ids) - len(sources)
+
+
+def _is_synthetic_content(content: Any) -> bool:
+    text = str(content or "").strip()
+    if not text or text == _MAX_ITERATION_SUMMARY_REQUEST:
+        return True
+    lowered = text.lower()
+    return any(lowered.startswith(prefix) for prefix in _SYNTHETIC_CONTENT_PREFIXES)
+
+
+def _message_tail_sql(roles: tuple[str, ...], before: tuple[float, str, int] | None) -> tuple[str, list[Any]]:
+    role_placeholders = ",".join("?" for _ in roles)
+    clauses = [
+        f"LOWER(role) IN ({role_placeholders})",
+        "timestamp IS NOT NULL",
+    ]
+    params: list[Any] = list(roles)
+    if before is not None:
+        timestamp, cursor_sid, cursor_rowid = before
+        clauses.append(
+            "(timestamp < ? OR "
+            "(timestamp = ? AND session_id < ?) OR "
+            "(timestamp = ? AND session_id = ? AND rowid < ?))"
+        )
+        params.extend([timestamp, timestamp, cursor_sid, timestamp, cursor_sid, cursor_rowid])
+    sql = (
+        "SELECT rowid AS message_rowid, session_id, role, content, timestamp "
+        "FROM messages WHERE session_id = ? AND "
+        + " AND ".join(clauses)
+        + " ORDER BY timestamp DESC, session_id DESC, rowid DESC LIMIT ?"
+    )
+    return sql, params
+
+
+def recent_project_messages(
+    *,
+    project_id: str,
+    profile: str,
+    projects_file: Path | str,
+    session_index_file: Path | str,
+    session_dir: Path | str,
+    state_db_path: Path | str,
+    roles: Any = None,
+    limit: Any = _DEFAULT_LIMIT,
+    before: Any = None,
+    include_archived: bool = False,
+) -> dict[str, Any]:
+    """Return the latest genuine messages across every eligible project session.
+
+    Results are newest-first by ``timestamp``, then ``session_id``, then SQLite
+    message ``rowid`` (all descending). The row id is used only inside the opaque
+    cursor and is never exposed as message content or metadata.
+    """
+    project_id = str(project_id or "").strip()
+    profile = str(profile or "").strip() or "default"
+    if not project_id:
+        raise ValueError("project_id is required")
+    normalized_roles = _normalize_roles(roles)
+    normalized_limit = _normalize_limit(limit)
+    include_archived = bool(include_archived)
+    cursor_scope = _cursor_scope(project_id, profile, normalized_roles, include_archived)
+    decoded_before = _decode_cursor(before, cursor_scope)
+    projects_path = Path(projects_file)
+    index_path = Path(session_index_file)
+    sessions_path = Path(session_dir)
+    db_path = Path(state_db_path)
+
+    project = _project_for_profile(projects_path, project_id, profile)
+    eligible, diagnostics = _eligible_session_metadata(
+        session_index_file=index_path,
+        session_dir=sessions_path,
+        project_id=project_id,
+        profile=profile,
+        include_archived=include_archived,
+    )
+    diagnostics.update(
+        {
+            "eligible_sessions": 0,
+            "missing_state_db_sessions": 0,
+            "candidate_rows_read": 0,
+            "classifier_scan_saturated_sessions": 0,
+            "invalid_timestamp_rows": 0,
+        }
+    )
+
+    rows: list[dict[str, Any]] = []
+    if eligible and db_path.is_file():
+        uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        try:
+            with closing(sqlite3.connect(uri, uri=True)) as conn:
+                conn.row_factory = sqlite3.Row
+                session_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)")}
+                message_columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(messages)")}
+                if not {"id", "source"}.issubset(session_columns) or not {
+                    "session_id",
+                    "role",
+                    "content",
+                    "timestamp",
+                }.issubset(message_columns):
+                    diagnostics["state_db_schema_unavailable"] = 1
+                else:
+                    sources, missing_count = _state_db_sources(conn, list(eligible))
+                    diagnostics["missing_state_db_sessions"] = missing_count
+                    for sid, metadata in eligible.items():
+                        source = sources.get(sid)
+                        if source is None or source in _SYNTHETIC_SESSION_SOURCES:
+                            continue
+                        sql, tail_params = _message_tail_sql(normalized_roles, decoded_before)
+                        scan_limit = max(_MIN_SCAN_ROWS, normalized_limit * _SCAN_MULTIPLIER)
+                        fetched = conn.execute(
+                            sql,
+                            [sid, *tail_params, scan_limit + 1],
+                        ).fetchall()
+                        diagnostics["candidate_rows_read"] += len(fetched)
+                        genuine_count = 0
+                        for row in fetched[:scan_limit]:
+                            if _is_synthetic_content(row["content"]):
+                                continue
+                            try:
+                                timestamp = float(row["timestamp"])
+                            except (TypeError, ValueError):
+                                diagnostics["invalid_timestamp_rows"] += 1
+                                continue
+                            if not math.isfinite(timestamp):
+                                diagnostics["invalid_timestamp_rows"] += 1
+                                continue
+                            rows.append(
+                                {
+                                    "timestamp": timestamp,
+                                    "role": str(row["role"]).lower(),
+                                    "content": _redact_text(str(row["content"]), _enabled=True),
+                                    "session_id": sid,
+                                    "session_title": _redact_text(metadata["title"], _enabled=True),
+                                    "workspace": metadata["workspace"],
+                                    "profile": profile,
+                                    "project_id": project_id,
+                                    "_message_rowid": int(row["message_rowid"]),
+                                }
+                            )
+                            genuine_count += 1
+                            if genuine_count >= normalized_limit:
+                                break
+                        if len(fetched) > scan_limit and genuine_count < normalized_limit:
+                            diagnostics["classifier_scan_saturated_sessions"] += 1
+                    diagnostics["eligible_sessions"] = sum(
+                        1
+                        for sid, source in sources.items()
+                        if sid in eligible and source not in _SYNTHETIC_SESSION_SOURCES
+                    )
+        except sqlite3.Error:
+            diagnostics["state_db_read_error"] = 1
+    elif eligible:
+        diagnostics["state_db_unavailable"] = 1
+        diagnostics["missing_state_db_sessions"] = len(eligible)
+
+    rows.sort(
+        key=lambda row: (row["timestamp"], row["session_id"], row["_message_rowid"]),
+        reverse=True,
+    )
+    selected = rows[:normalized_limit]
+    next_before = None
+    if selected:
+        last = selected[-1]
+        next_before = _encode_cursor(
+            last["timestamp"],
+            last["session_id"],
+            last["_message_rowid"],
+            cursor_scope,
+        )
+    for row in selected:
+        row.pop("_message_rowid", None)
+
+    partial_keys = (
+        "invalid_index_rows",
+        "session_index_unavailable",
+        "missing_sidecars",
+        "unreadable_sidecars",
+        "membership_mismatches",
+        "missing_state_db_sessions",
+        "state_db_schema_unavailable",
+        "state_db_read_error",
+        "state_db_unavailable",
+        "classifier_scan_saturated_sessions",
+        "invalid_timestamp_rows",
+    )
+    partial = any(int(diagnostics.get(key, 0) or 0) > 0 for key in partial_keys)
+    return {
+        "project_id": project_id,
+        "project_name": project.get("name"),
+        "profile": profile,
+        "roles": list(normalized_roles),
+        "include_archived": include_archived,
+        "classifier": _CLASSIFIER_VERSION,
+        "order": "timestamp_desc_session_id_desc_message_id_desc",
+        "messages": selected,
+        "next_before": next_before,
+        "partial": partial,
+        "diagnostics": diagnostics,
+    }

--- a/api/project_context.py
+++ b/api/project_context.py
@@ -56,14 +56,15 @@ def _load_json_list(path: Path) -> list[dict[str, Any]]:
     return [row for row in value if isinstance(row, dict)]
 
 
-def _load_json_list_with_status(path: Path) -> tuple[list[dict[str, Any]], bool]:
+def _load_json_list_with_status(path: Path) -> tuple[list[dict[str, Any]], bool, int]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return [], False
+        return [], False, 0
     if not isinstance(value, list):
-        return [], False
-    return [row for row in value if isinstance(row, dict)], True
+        return [], False, 0
+    rows = [row for row in value if isinstance(row, dict)]
+    return rows, True, len(value) - len(rows)
 
 
 def _normalize_roles(roles: Any) -> tuple[str, ...]:
@@ -176,16 +177,21 @@ def _eligible_session_metadata(
         "archived_sessions_excluded": 0,
     }
     eligible: dict[str, dict[str, Any]] = {}
-    index_rows, index_available = _load_json_list_with_status(session_index_file)
+    index_rows, index_available, malformed_rows = _load_json_list_with_status(session_index_file)
     diagnostics["session_index_unavailable"] = 0 if index_available else 1
+    diagnostics["invalid_index_rows"] += malformed_rows
     for row in index_rows:
-        if row.get("project_id") != project_id or not _profiles_match(row.get("profile"), profile):
+        if "project_id" in row and row.get("project_id") != project_id:
             continue
-        diagnostics["index_rows_considered"] += 1
+        if "profile" in row and not _profiles_match(row.get("profile"), profile):
+            continue
         sid = str(row.get("session_id") or "")
         if not is_safe_session_id(sid):
             diagnostics["invalid_index_rows"] += 1
             continue
+        if row.get("project_id") != project_id or not _profiles_match(row.get("profile"), profile):
+            continue
+        diagnostics["index_rows_considered"] += 1
         sidecar_path = session_dir / f"{sid}.json"
         if not sidecar_path.is_file():
             diagnostics["missing_sidecars"] += 1

--- a/api/project_context.py
+++ b/api/project_context.py
@@ -94,7 +94,7 @@ def _normalize_limit(limit: Any) -> int:
 
 def _cursor_scope(project_id: str, profile: str, roles: tuple[str, ...], include_archived: bool) -> str:
     payload = json.dumps(
-        [project_id, profile, sorted(roles), bool(include_archived)],
+        [_CLASSIFIER_VERSION, project_id, profile, sorted(roles), bool(include_archived)],
         separators=(",", ":"),
     ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()[:24]
@@ -240,18 +240,25 @@ def _state_db_sources(
 
 def _is_synthetic_content(content: Any) -> bool:
     text = str(content or "").strip()
-    if not text or text == _MAX_ITERATION_SUMMARY_REQUEST:
+    if not text or text.casefold() == _MAX_ITERATION_SUMMARY_REQUEST.casefold():
         return True
     lowered = text.lower()
     return any(lowered.startswith(prefix) for prefix in _SYNTHETIC_CONTENT_PREFIXES)
 
 
-def _message_tail_sql(roles: tuple[str, ...], before: tuple[float, str, int] | None) -> tuple[str, list[Any]]:
+def _message_tail_sql(
+    roles: tuple[str, ...],
+    before: tuple[float, str, int] | None,
+    *,
+    has_active: bool,
+) -> tuple[str, list[Any]]:
     role_placeholders = ",".join("?" for _ in roles)
     clauses = [
         f"LOWER(role) IN ({role_placeholders})",
         "timestamp IS NOT NULL",
     ]
+    if has_active:
+        clauses.append("(active IS NULL OR active != 0)")
     params: list[Any] = list(roles)
     if before is not None:
         timestamp, cursor_sid, cursor_rowid = before
@@ -343,7 +350,11 @@ def recent_project_messages(
                         source = sources.get(sid)
                         if source is None or source in _SYNTHETIC_SESSION_SOURCES:
                             continue
-                        sql, tail_params = _message_tail_sql(normalized_roles, decoded_before)
+                        sql, tail_params = _message_tail_sql(
+                            normalized_roles,
+                            decoded_before,
+                            has_active="active" in message_columns,
+                        )
                         scan_limit = max(_MIN_SCAN_ROWS, normalized_limit * _SCAN_MULTIPLIER)
                         fetched = conn.execute(
                             sql,

--- a/api/project_context.py
+++ b/api/project_context.py
@@ -92,6 +92,16 @@ def _normalize_limit(limit: Any) -> int:
     return min(value, _MAX_LIMIT)
 
 
+def _normalize_include_archived(include_archived: Any) -> bool:
+    if type(include_archived) is not bool:
+        raise ValueError("include_archived must be a boolean")
+    return include_archived
+
+
+def _persisted_profile_matches(value: Any, profile: str) -> bool:
+    return (value is None or isinstance(value, str)) and _profiles_match(value, profile)
+
+
 def _cursor_scope(project_id: str, profile: str, roles: tuple[str, ...], include_archived: bool) -> str:
     payload = json.dumps(
         [_CLASSIFIER_VERSION, project_id, profile, sorted(roles), bool(include_archived)],
@@ -150,7 +160,7 @@ def _project_for_profile(projects_file: Path, project_id: str, profile: str) -> 
             row
             for row in _load_json_list(projects_file)
             if str(row.get("project_id") or "") == project_id
-            and _profiles_match(row.get("profile"), profile)
+            and _persisted_profile_matches(row.get("profile"), profile)
         ),
         None,
     )
@@ -174,6 +184,8 @@ def _eligible_session_metadata(
         "missing_sidecars": 0,
         "unreadable_sidecars": 0,
         "membership_mismatches": 0,
+        "invalid_sidecar_rows": 0,
+        "invalid_archive_rows": 0,
         "archived_sessions_excluded": 0,
     }
     eligible: dict[str, dict[str, Any]] = {}
@@ -183,13 +195,20 @@ def _eligible_session_metadata(
     for row in index_rows:
         if "project_id" in row and row.get("project_id") != project_id:
             continue
-        if "profile" in row and not _profiles_match(row.get("profile"), profile):
+        row_profile = row.get("profile")
+        if "profile" in row and not (row_profile is None or isinstance(row_profile, str)):
+            diagnostics["invalid_index_rows"] += 1
+            continue
+        if "profile" in row and not _persisted_profile_matches(row_profile, profile):
+            continue
+        if "archived" in row and type(row["archived"]) is not bool:
+            diagnostics["invalid_archive_rows"] += 1
             continue
         sid = str(row.get("session_id") or "")
         if not is_safe_session_id(sid):
             diagnostics["invalid_index_rows"] += 1
             continue
-        if row.get("project_id") != project_id or not _profiles_match(row.get("profile"), profile):
+        if row.get("project_id") != project_id or not _persisted_profile_matches(row_profile, profile):
             continue
         diagnostics["index_rows_considered"] += 1
         sidecar_path = session_dir / f"{sid}.json"
@@ -200,14 +219,21 @@ def _eligible_session_metadata(
         if sidecar is None:
             diagnostics["unreadable_sidecars"] += 1
             continue
+        sidecar_profile = sidecar.get("profile")
+        if not (sidecar_profile is None or isinstance(sidecar_profile, str)):
+            diagnostics["invalid_sidecar_rows"] += 1
+            continue
+        if "archived" in sidecar and type(sidecar["archived"]) is not bool:
+            diagnostics["invalid_archive_rows"] += 1
+            continue
         if (
             str(sidecar.get("session_id") or "") != sid
             or sidecar.get("project_id") != project_id
-            or not _profiles_match(sidecar.get("profile"), profile)
+            or not _persisted_profile_matches(sidecar_profile, profile)
         ):
             diagnostics["membership_mismatches"] += 1
             continue
-        archived = bool(sidecar.get("archived", row.get("archived", False)))
+        archived = sidecar.get("archived", row.get("archived", False))
         if archived and not include_archived:
             diagnostics["archived_sessions_excluded"] += 1
             continue
@@ -277,6 +303,23 @@ def _message_tail_sql(
     return sql, params
 
 
+def _invalid_timestamp_probe_sql(roles: tuple[str, ...], *, has_active: bool) -> tuple[str, list[Any]]:
+    role_placeholders = ",".join("?" for _ in roles)
+    clauses = [
+        f"LOWER(role) IN ({role_placeholders})",
+        "(timestamp IS NULL OR typeof(timestamp) NOT IN ('integer', 'real') "
+        "OR timestamp > 1.7976931348623157e308 OR timestamp < -1.7976931348623157e308)",
+    ]
+    if has_active:
+        clauses.append("(active IS NULL OR active != 0)")
+    sql = (
+        "SELECT timestamp FROM messages WHERE session_id = ? AND "
+        + " AND ".join(clauses)
+        + " LIMIT ?"
+    )
+    return sql, list(roles)
+
+
 def recent_project_messages(
     *,
     project_id: str,
@@ -302,7 +345,7 @@ def recent_project_messages(
         raise ValueError("project_id is required")
     normalized_roles = _normalize_roles(roles)
     normalized_limit = _normalize_limit(limit)
-    include_archived = bool(include_archived)
+    include_archived = _normalize_include_archived(include_archived)
     cursor_scope = _cursor_scope(project_id, profile, normalized_roles, include_archived)
     decoded_before = _decode_cursor(before, cursor_scope)
     projects_path = Path(projects_file)
@@ -325,6 +368,7 @@ def recent_project_messages(
             "candidate_rows_read": 0,
             "classifier_scan_saturated_sessions": 0,
             "invalid_timestamp_rows": 0,
+            "invalid_timestamp_probe_saturated_sessions": 0,
         }
     )
 
@@ -350,12 +394,31 @@ def recent_project_messages(
                         source = sources.get(sid)
                         if source is None or source in _SYNTHETIC_SESSION_SOURCES:
                             continue
+                        has_active = "active" in message_columns
+                        scan_limit = max(_MIN_SCAN_ROWS, normalized_limit * _SCAN_MULTIPLIER)
+                        probe_sql, probe_params = _invalid_timestamp_probe_sql(
+                            normalized_roles,
+                            has_active=has_active,
+                        )
+                        invalid_timestamp_rows = conn.execute(
+                            probe_sql,
+                            [sid, *probe_params, scan_limit + 1],
+                        ).fetchall()
+                        for invalid_row in invalid_timestamp_rows[:scan_limit]:
+                            try:
+                                probe_timestamp = float(invalid_row["timestamp"])
+                            except (TypeError, ValueError):
+                                diagnostics["invalid_timestamp_rows"] += 1
+                                continue
+                            if not math.isfinite(probe_timestamp):
+                                diagnostics["invalid_timestamp_rows"] += 1
+                        if len(invalid_timestamp_rows) > scan_limit:
+                            diagnostics["invalid_timestamp_probe_saturated_sessions"] += 1
                         sql, tail_params = _message_tail_sql(
                             normalized_roles,
                             decoded_before,
-                            has_active="active" in message_columns,
+                            has_active=has_active,
                         )
-                        scan_limit = max(_MIN_SCAN_ROWS, normalized_limit * _SCAN_MULTIPLIER)
                         fetched = conn.execute(
                             sql,
                             [sid, *tail_params, scan_limit + 1],
@@ -368,10 +431,8 @@ def recent_project_messages(
                             try:
                                 timestamp = float(row["timestamp"])
                             except (TypeError, ValueError):
-                                diagnostics["invalid_timestamp_rows"] += 1
                                 continue
                             if not math.isfinite(timestamp):
-                                diagnostics["invalid_timestamp_rows"] += 1
                                 continue
                             rows.append(
                                 {
@@ -425,12 +486,15 @@ def recent_project_messages(
         "missing_sidecars",
         "unreadable_sidecars",
         "membership_mismatches",
+        "invalid_sidecar_rows",
+        "invalid_archive_rows",
         "missing_state_db_sessions",
         "state_db_schema_unavailable",
         "state_db_read_error",
         "state_db_unavailable",
         "classifier_scan_saturated_sessions",
         "invalid_timestamp_rows",
+        "invalid_timestamp_probe_saturated_sessions",
     )
     partial = any(int(diagnostics.get(key, 0) or 0) > 0 for key in partial_keys)
     return {

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -23,6 +23,10 @@ contributor guidance; it does not change runtime behavior or CI gates.
 
 ## Runtime, durability, and state contracts
 
+- [`docs/project-context.md`](project-context.md): implemented read-only MCP
+  contract for bounded, profile-scoped recent messages across all sessions in a
+  WebUI project. Start here for project-context membership, genuine-message
+  classification, cursor ordering, archive policy, and partial diagnostics.
 - [`docs/rfcs/webui-run-state-consistency-contract.md`](rfcs/webui-run-state-consistency-contract.md):
   proposed consistency rules for current WebUI streaming, recovery, replay,
   model-context reconstruction, compression, UI scene/cache, and sidebar metadata

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -1,0 +1,99 @@
+# Project Context MCP Contract
+
+Hermes WebUI exposes a read-only MCP tool named `recent_project_messages` for
+external agents that need bounded context from an existing WebUI project. The
+tool is generic: it reads projects and sessions already managed by WebUI and has
+no product-specific UI or mutation path.
+
+## Scope and setup
+
+Run `mcp_server.py` as documented in its module header. The MCP process is
+scoped to one active Hermes profile. Use `--profile <name>` to choose a profile
+when starting the process; callers cannot use a tool invocation to switch to or
+read another profile.
+
+The tool accepts:
+
+- `project_id` (required): an ID returned by `list_projects` in the active
+  profile.
+- `profile` (optional): an assertion that must match the MCP process's active
+  profile. A mismatch returns the same `Project not found` error as an absent
+  project.
+- `roles` (optional): `user` and/or `assistant`; defaults to `user`. `tool` and
+  `system` are rejected so raw tool payloads and system prompts are never part
+  of this contract.
+- `limit` (optional): defaults to 5 and is capped at 20.
+- `before` (optional): the opaque `next_before` value from a prior response.
+- `include_archived` (optional): defaults to `false`. Set it to `true` to include
+  sessions whose authoritative sidecar metadata is archived.
+
+## Response and ordering
+
+The response includes project/profile scope, selected roles, archive policy,
+`partial`, classifier version, count-only diagnostics, `next_before`, and a
+`messages` array. Every message contains only:
+
+- `timestamp`
+- `role`
+- `content`
+- `session_id`
+- `session_title`
+- `workspace`
+- `profile`
+- `project_id`
+
+Messages are selected globally across every eligible project session, not by
+choosing one recent session first. Results are newest-first using the stable
+order `timestamp DESC, session_id DESC, message row ID DESC`. The database row
+ID is used only inside the opaque cursor and is not exposed. Pass `next_before`
+back as `before` to continue strictly after the last returned row in that order.
+
+## Genuine-message classifier
+
+Classifier `project_context_v1` excludes:
+
+- sessions whose `state.db.sessions.source` is `cron`, `subagent`, or
+  `delegation`;
+- blank content;
+- the Hermes max-tool-iteration summary request;
+- user-visible synthetic prefixes for background-process wakeups, asynchronous
+  delegation delivery, context compaction/compression, session-arc summaries,
+  and `[System: ...]` scaffolding.
+
+Only `user` and `assistant` content columns are selected; tool-call columns are
+never read or returned. For each session, the classifier examines a hard-bounded
+tail of `max(20, limit × 5)` rows plus one saturation sentinel. Synthetic rows
+do not consume the requested result limit within that window. If the window is
+all or mostly synthetic and older rows may remain, the response fails bounded:
+it returns the genuine rows it can prove, sets `partial=true`, and increments
+the count-only `classifier_scan_saturated_sessions` diagnostic rather than
+scanning the full transcript.
+The selected message content and session title then pass through the standard
+credential redactor with redaction forced on for this external-agent surface.
+
+## Membership, isolation, and partial reads
+
+Project ownership must match the active profile. A session is eligible only
+when all of these agree:
+
+1. `projects.json` assigns the project to the active profile.
+2. `sessions/_index.json` assigns the session to that project/profile.
+3. The session sidecar exists and its bounded metadata prefix confirms the same
+   session ID, project, and profile.
+4. The active profile's `state.db.sessions` contains that session.
+
+Missing, malformed, deleted, foreign-profile, unassigned, or conflicting rows
+fail closed and contribute only count diagnostics. Diagnostics never contain
+excluded session IDs or content. `partial` is true when a candidate cannot be
+confirmed because a sidecar, database row/schema, read, bounded classifier
+window, or timestamp is unavailable.
+Missing or malformed session indexes are likewise partial, never a silently
+complete empty result. Opaque cursors are bound to the project, profile, roles,
+and archive policy that created them; cross-scope reuse is rejected.
+
+The read path never mutates WebUI state, repairs indexes, loads `Session`
+objects, or parses sidecar transcript arrays. It opens `state.db` in SQLite
+read-only mode. After metadata confirmation, it issues one indexed, hard-capped
+tail query per eligible session, then merges up to the requested number of
+genuine candidates per session into the global result. This avoids N-session full
+transcript scans while preserving correct global ordering.

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -61,8 +61,10 @@ Classifier `project_context_v1` excludes:
   and `[System: ...]` scaffolding.
 
 Only `user` and `assistant` content columns are selected; tool-call columns are
-never read or returned. For each session, the classifier examines a hard-bounded
-tail of `max(20, limit × 5)` rows plus one saturation sentinel. Synthetic rows
+never read or returned. When the messages schema exposes the canonical `active`
+column, compacted inactive rows are excluded; legacy schemas without that column
+remain supported. For each session, the classifier examines a hard-bounded tail
+of `max(20, limit × 5)` rows plus one saturation sentinel. Synthetic rows
 do not consume the requested result limit within that window. If the window is
 all or mostly synthetic and older rows may remain, the response fails bounded:
 it returns the genuine rows it can prove, sets `partial=true`, and increments
@@ -89,7 +91,8 @@ confirmed because a sidecar, database row/schema, read, bounded classifier
 window, or timestamp is unavailable.
 Missing or malformed session indexes are likewise partial, never a silently
 complete empty result. Opaque cursors are bound to the project, profile, roles,
-and archive policy that created them; cross-scope reuse is rejected.
+archive policy, and classifier version that created them; cross-scope or
+stale-classifier reuse is rejected.
 
 The read path never mutates WebUI state, repairs indexes, loads `Session`
 objects, or parses sidecar transcript arrays. It opens `state.db` in SQLite

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -25,7 +25,8 @@ The tool accepts:
 - `limit` (optional): defaults to 5 and is capped at 20.
 - `before` (optional): the opaque `next_before` value from a prior response.
 - `include_archived` (optional): defaults to `false`. Set it to `true` to include
-  sessions whose authoritative sidecar metadata is archived.
+  sessions whose authoritative sidecar metadata is archived. Only JSON booleans
+  are accepted; strings and numbers are rejected.
 
 ## Response and ordering
 
@@ -88,7 +89,11 @@ Missing, malformed, deleted, foreign-profile, unassigned, or conflicting rows
 fail closed and contribute only count diagnostics. Diagnostics never contain
 excluded session IDs or content. `partial` is true when a candidate cannot be
 confirmed because a sidecar, database row/schema, read, bounded classifier
-window, or timestamp is unavailable.
+window, archive flag, or timestamp is unavailable. Persisted profile values must
+be strings or null, and persisted archive values must be booleans. A bounded,
+cursor-independent probe counts NULL timestamps (including NaN values normalized
+to NULL by SQLite); saturation is reported as partial rather than scanning an
+unbounded transcript.
 Missing or malformed session indexes are likewise partial, never a silently
 complete empty result. Opaque cursors are bound to the project, profile, roles,
 archive policy, and classifier version that created them; cross-scope or

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -56,7 +56,9 @@ from api.config import (
     STATE_DIR, SESSION_DIR, SESSION_INDEX_FILE, PROJECTS_FILE, HOME,
 )
 from api.models import load_projects, save_projects
+from api.models import _active_state_db_path
 from api.profiles import get_active_profile_name, _is_root_profile, _profiles_match
+from api.project_context import recent_project_messages
 
 # ── Apply --profile override before any module uses get_active_profile_name
 if _profile_arg is not None:
@@ -243,6 +245,32 @@ async def handle_list_sessions(arguments: dict) -> list[TextContent]:
 
     sessions = sessions[:limit]
     return [TextContent(type="text", text=json.dumps(sessions, ensure_ascii=False, indent=2))]
+
+
+async def handle_recent_project_messages(arguments: dict) -> list[TextContent]:
+    """Return a bounded global message tail for one active-profile project."""
+    active = _active_profile()
+    requested_profile = str(arguments.get("profile") or active).strip() or active
+    if not _profiles_match(requested_profile, active):
+        return [TextContent(type="text", text=json.dumps(
+            {"error": "Project not found"}, ensure_ascii=False))]
+    try:
+        result = recent_project_messages(
+            project_id=str(arguments.get("project_id") or ""),
+            profile=active,
+            projects_file=PROJECTS_FILE,
+            session_index_file=SESSION_INDEX_FILE,
+            session_dir=SESSION_DIR,
+            state_db_path=_active_state_db_path(),
+            roles=arguments.get("roles"),
+            limit=arguments.get("limit", 5),
+            before=arguments.get("before"),
+            include_archived=arguments.get("include_archived", False),
+        )
+    except (LookupError, ValueError) as exc:
+        return [TextContent(type="text", text=json.dumps(
+            {"error": str(exc)}, ensure_ascii=False))]
+    return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False, indent=2))]
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -547,6 +575,30 @@ TOOLS = [
             "required": [],
         },
     ),
+    Tool(
+        name="recent_project_messages",
+        description=(
+            "Read the latest genuine user/assistant messages globally across all sessions "
+            "assigned to one project in the active profile. Results are newest-first; "
+            "tool/system payloads and synthetic cron/delegation/compaction notices are excluded."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "project_id": {"type": "string", "description": "Project ID in the active profile"},
+                "profile": {"type": "string", "description": "Optional active-profile assertion"},
+                "roles": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": ["user", "assistant"]},
+                    "description": "Roles to include (default: user)",
+                },
+                "limit": {"type": "integer", "minimum": 1, "maximum": 20, "description": "Max results (default: 5, max: 20)"},
+                "before": {"type": "string", "description": "Opaque next_before cursor from a prior response"},
+                "include_archived": {"type": "boolean", "description": "Include archived project sessions (default: false)"},
+            },
+            "required": ["project_id"],
+        },
+    ),
 ]
 
 HANDLERS = {
@@ -557,6 +609,7 @@ HANDLERS = {
     "rename_session": handle_rename_session,
     "move_session": handle_move_session,
     "list_sessions": handle_list_sessions,
+    "recent_project_messages": handle_recent_project_messages,
 }
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -6296,6 +6296,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             }
           }
           _attachProjectedAnchorSceneToLastAssistant(S.messages);
+          // The settled transcript can be rebuilt by a concurrent session refresh
+          // immediately after the done event. Retry the idempotent anchor-scene
+          // handoff on the refreshed message object so a transient miss cannot
+          // leave the durable scene with zero persistence requests.
+          if(lastAsst){
+            const _retryIndex=S.messages.indexOf(lastAsst);
+            const _retryOwnerKey=_settledAnchorRetryOwnerKey(S.messages,_retryIndex,_settledStreamId);
+            setTimeout(()=>{
+              _retrySettledAnchorScene(lastAsst,_retryIndex,_settledStreamId,_anchorRegistry,_retryOwnerKey);
+            },0);
+          }
           const hasMessageToolMetadata=S.messages.some(m=>{
             if(!m||m.role!=='assistant') return false;
             const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;

--- a/tests/browser_conversation_lifecycle.py
+++ b/tests/browser_conversation_lifecycle.py
@@ -1079,6 +1079,10 @@ def main() -> int:
                 anchor_scene_requests=anchor_scene_requests,
             )
             assert scene.get("version") == "activity_scene_v1", scene
+            assert any(item.get("type") == "request" for item in anchor_scene_requests), {
+                "message": "anchor scene was hydrated without a persistence request",
+                "anchor_scene_requests": anchor_scene_requests,
+            }
             if scenario == "terminal-error":
                 scene_rows = scene.get("activity_rows") or []
                 assert any(

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -1050,6 +1050,16 @@ def test_done_sets_turn_duration_before_persisting_anchor_scene():
     assert duration_idx < attach_idx
 
 
+def test_done_retries_anchor_scene_persistence_after_settlement():
+    done = _event_listener_body(MESSAGES_JS, "done")
+
+    attach_idx = done.index("_attachProjectedAnchorSceneToLastAssistant(S.messages);")
+    retry_idx = done.index("_retrySettledAnchorScene(", attach_idx)
+    schedule_idx = done.index("setTimeout(()=>{", attach_idx)
+
+    assert attach_idx < schedule_idx < retry_idx
+
+
 def test_settled_anchor_scene_is_persisted_as_ui_metadata():
     attach = _function_body(MESSAGES_JS, "_attachProjectedAnchorSceneToLastAssistant")
     persist = _function_body(MESSAGES_JS, "_persistSettledAnchorScene")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -568,6 +568,72 @@ class TestListSessions:
         assert isinstance(result, list)
 
 
+class TestRecentProjectMessages:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.state_dir = _fresh_state_dir()
+        self.mod, self.profiles = _reimport_mcp()
+        yield
+        _cleanup_state_dir(self.state_dir)
+
+    async def test_tool_schema_pins_bounds_and_profile_scope(self):
+        tool = next(tool for tool in self.mod.TOOLS if tool.name == "recent_project_messages")
+        schema = tool.inputSchema
+        assert schema["required"] == ["project_id"]
+        assert schema["properties"]["limit"]["maximum"] == 20
+        assert schema["properties"]["roles"]["items"]["enum"] == ["user", "assistant"]
+        assert "include_archived" in schema["properties"]
+        assert "before" in schema["properties"]
+
+    async def test_handler_delegates_to_read_contract_without_api_mutation(self, monkeypatch):
+        seen = {}
+
+        def fake_recent_project_messages(**kwargs):
+            seen.update(kwargs)
+            return {"messages": [{"content": "safe"}], "profile": kwargs["profile"]}
+
+        monkeypatch.setattr(self.mod, "recent_project_messages", fake_recent_project_messages)
+        monkeypatch.setattr(self.mod, "_active_state_db_path", lambda: Path("/tmp/read-only-state.db"))
+
+        result = await _call(
+            self.mod,
+            "recent_project_messages",
+            project_id="project00001",
+            profile="default",
+            roles=["user", "assistant"],
+            limit=7,
+            before="opaque",
+            include_archived=True,
+        )
+
+        assert result["messages"] == [{"content": "safe"}]
+        assert seen["project_id"] == "project00001"
+        assert seen["profile"] == "default"
+        assert seen["roles"] == ["user", "assistant"]
+        assert seen["limit"] == 7
+        assert seen["before"] == "opaque"
+        assert seen["include_archived"] is True
+
+    async def test_explicit_foreign_profile_fails_closed(self, monkeypatch):
+        called = False
+
+        def fake_recent_project_messages(**_kwargs):
+            nonlocal called
+            called = True
+            return {}
+
+        monkeypatch.setattr(self.mod, "recent_project_messages", fake_recent_project_messages)
+        result = await _call(
+            self.mod,
+            "recent_project_messages",
+            project_id="foreign-project",
+            profile="other",
+        )
+
+        assert result == {"error": "Project not found"}
+        assert called is False
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 #  Session mutations (HTTP API — basic validation only)
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -289,6 +289,23 @@ async def _call(mod, tool_name, **kwargs):
     return json.loads(result[0].text)
 
 
+async def test_recent_project_messages_rejects_non_boolean_include_archived():
+    state_dir = _fresh_state_dir()
+    try:
+        mod, _profiles = _reimport_mcp()
+
+        result = await _call(
+            mod,
+            "recent_project_messages",
+            project_id="project00001",
+            include_archived="false",
+        )
+
+        assert result == {"error": "include_archived must be a boolean"}
+    finally:
+        _cleanup_state_dir(state_dir)
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 #  Project CRUD
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_recent_project_messages.py
+++ b/tests/test_recent_project_messages.py
@@ -1,0 +1,434 @@
+"""Contract tests for bounded, profile-scoped project message reads."""
+
+import json
+import sqlite3
+
+import pytest
+
+from api.project_context import recent_project_messages
+
+
+PROJECT_ID = "project00001"
+PROFILE = "research"
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _sidecar(path, sid, *, project_id=PROJECT_ID, profile=PROFILE, archived=False, title=None, workspace=None):
+    # Keep the transcript deliberately after the metadata fields. The read path
+    # must stop before it rather than scanning full session transcripts.
+    _write_json(
+        path / f"{sid}.json",
+        {
+            "session_id": sid,
+            "title": title or f"Title {sid}",
+            "workspace": workspace or f"/work/{sid}",
+            "created_at": 1.0,
+            "updated_at": 2.0,
+            "archived": archived,
+            "project_id": project_id,
+            "profile": profile,
+            "messages": [{"role": "user", "content": "must not be read"}] * 100,
+        },
+    )
+
+
+@pytest.fixture
+def project_store(tmp_path):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    projects_file = tmp_path / "projects.json"
+    index_file = session_dir / "_index.json"
+    state_db = tmp_path / "state.db"
+    _write_json(
+        projects_file,
+        [{"project_id": PROJECT_ID, "name": "Example", "profile": PROFILE}],
+    )
+    _write_json(index_file, [])
+    with sqlite3.connect(state_db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                title TEXT,
+                started_at REAL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL
+            );
+            CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+            """
+        )
+    return {
+        "projects_file": projects_file,
+        "session_index_file": index_file,
+        "session_dir": session_dir,
+        "state_db_path": state_db,
+    }
+
+
+def _seed(store, sessions, messages):
+    index = []
+    with sqlite3.connect(store["state_db_path"]) as conn:
+        for session in sessions:
+            sid = session["session_id"]
+            index.append(
+                {
+                    "session_id": sid,
+                    "title": session.get("title", f"Title {sid}"),
+                    "workspace": session.get("workspace", f"/work/{sid}"),
+                    "project_id": session.get("project_id", PROJECT_ID),
+                    "profile": session.get("profile", PROFILE),
+                    "archived": session.get("archived", False),
+                }
+            )
+            _sidecar(
+                store["session_dir"],
+                sid,
+                project_id=session.get("sidecar_project_id", session.get("project_id", PROJECT_ID)),
+                profile=session.get("sidecar_profile", session.get("profile", PROFILE)),
+                archived=session.get("archived", False),
+                title=session.get("title"),
+                workspace=session.get("workspace"),
+            )
+            conn.execute(
+                "INSERT INTO sessions (id, source, title, started_at) VALUES (?, ?, ?, ?)",
+                (sid, session.get("source", "webui"), session.get("title", f"Title {sid}"), 1.0),
+            )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            messages,
+        )
+    _write_json(store["session_index_file"], index)
+
+
+def _read(store, **kwargs):
+    return recent_project_messages(
+        project_id=PROJECT_ID,
+        profile=PROFILE,
+        **store,
+        **kwargs,
+    )
+
+
+def test_latest_messages_are_global_across_three_sessions_with_stable_ties(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}, {"session_id": "session_b"}, {"session_id": "session_c"}],
+        [
+            ("session_a", "user", "a-old", 10.0),
+            ("session_b", "user", "b-new", 30.0),
+            ("session_a", "user", "a-new", 20.0),
+            ("session_c", "user", "c-tie", 30.0),
+            ("session_c", "user", "c-old", 15.0),
+        ],
+    )
+
+    result = _read(project_store, limit=5)
+
+    assert [row["content"] for row in result["messages"]] == [
+        "c-tie",
+        "b-new",
+        "a-new",
+        "c-old",
+        "a-old",
+    ]
+    assert all(
+        set(row) == {
+            "timestamp",
+            "role",
+            "content",
+            "session_id",
+            "session_title",
+            "workspace",
+            "profile",
+            "project_id",
+        }
+        for row in result["messages"]
+    )
+    assert result["order"] == "timestamp_desc_session_id_desc_message_id_desc"
+
+
+def test_roles_default_to_user_and_reject_privileged_roles(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [
+            ("session_a", "user", "question", 1.0),
+            ("session_a", "assistant", "answer", 2.0),
+            ("session_a", "tool", "raw tool payload", 3.0),
+            ("session_a", "system", "system prompt", 4.0),
+        ],
+    )
+
+    assert [m["content"] for m in _read(project_store)["messages"]] == ["question"]
+    assert [m["content"] for m in _read(project_store, roles=["user", "assistant"])["messages"]] == [
+        "answer",
+        "question",
+    ]
+    with pytest.raises(ValueError, match="roles"):
+        _read(project_store, roles=["tool"])
+
+
+def test_message_content_and_title_are_always_credential_redacted(project_store, monkeypatch):
+    _seed(
+        project_store,
+        [{"session_id": "session_a", "title": "secret title"}],
+        [("session_a", "user", "secret content", 1.0)],
+    )
+    calls = []
+
+    def fake_redact(value, *, _enabled=None):
+        calls.append((value, _enabled))
+        return value.replace("secret", "[REDACTED]")
+
+    monkeypatch.setattr("api.project_context._redact_text", fake_redact)
+
+    result = _read(project_store)
+
+    assert result["messages"][0]["content"] == "[REDACTED] content"
+    assert result["messages"][0]["session_title"] == "[REDACTED] title"
+    assert calls == [("secret content", True), ("secret title", True)]
+
+
+def test_profile_and_project_ownership_fail_closed(project_store):
+    _seed(
+        project_store,
+        [
+            {"session_id": "owned"},
+            {"session_id": "foreign", "profile": "other", "sidecar_profile": "other"},
+            {"session_id": "unassigned", "project_id": None, "sidecar_project_id": None},
+        ],
+        [
+            ("owned", "user", "owned text", 1.0),
+            ("foreign", "user", "foreign text", 3.0),
+            ("unassigned", "user", "unassigned text", 2.0),
+        ],
+    )
+
+    result = _read(project_store)
+    assert [m["content"] for m in result["messages"]] == ["owned text"]
+
+    with pytest.raises(LookupError, match="Project not found"):
+        recent_project_messages(
+            project_id=PROJECT_ID,
+            profile="other",
+            **project_store,
+        )
+
+
+def test_missing_or_disagreeing_sidecars_are_excluded_with_count_only_diagnostics(project_store):
+    _seed(
+        project_store,
+        [
+            {"session_id": "valid"},
+            {"session_id": "missing"},
+            {"session_id": "mismatch", "sidecar_project_id": "different0001"},
+        ],
+        [
+            ("valid", "user", "safe", 1.0),
+            ("missing", "user", "must not leak missing", 3.0),
+            ("mismatch", "user", "must not leak mismatch", 2.0),
+        ],
+    )
+    (project_store["session_dir"] / "missing.json").unlink()
+
+    result = _read(project_store)
+
+    assert [m["content"] for m in result["messages"]] == ["safe"]
+    assert result["partial"] is True
+    assert result["diagnostics"]["missing_sidecars"] == 1
+    assert result["diagnostics"]["membership_mismatches"] == 1
+    assert "missing" not in result["diagnostics"].values()
+    assert "mismatch" not in result["diagnostics"].values()
+
+
+def test_state_db_disagreement_is_excluded_without_exposing_session_identity(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "valid"}, {"session_id": "db_missing"}],
+        [("valid", "user", "safe", 1.0)],
+    )
+    with sqlite3.connect(project_store["state_db_path"]) as conn:
+        conn.execute("DELETE FROM sessions WHERE id = 'db_missing'")
+
+    result = _read(project_store)
+
+    assert [m["content"] for m in result["messages"]] == ["safe"]
+    assert result["partial"] is True
+    assert result["diagnostics"]["missing_state_db_sessions"] == 1
+    assert "db_missing" not in json.dumps(result["diagnostics"])
+
+
+def test_explicit_classifier_excludes_cron_delegation_compaction_and_system_notices(project_store):
+    _seed(
+        project_store,
+        [
+            {"session_id": "regular"},
+            {"session_id": "cron_session", "source": "cron"},
+            {"session_id": "delegated", "source": "subagent"},
+        ],
+        [
+            ("regular", "user", "genuine", 1.0),
+            ("regular", "user", "[IMPORTANT: Background process done]", 9.0),
+            ("regular", "user", "[ASYNC DELEGATION BATCH COMPLETE — x]", 8.0),
+            ("regular", "user", "[context compaction: summary]", 7.0),
+            ("regular", "user", "[Your active task list was preserved across context compression]", 6.0),
+            ("regular", "user", "[Session arc summary: prior work]", 5.0),
+            ("regular", "user", "[System: verify before finishing]", 4.0),
+            ("regular", "user", "You've reached the maximum number of tool-calling iterations allowed. Please provide a final response summarizing what you've found and accomplished so far, without calling any more tools.", 3.5),
+            ("cron_session", "user", "cron prompt", 3.0),
+            ("delegated", "user", "delegation goal", 2.0),
+        ],
+    )
+
+    result = _read(project_store, limit=20)
+
+    assert [m["content"] for m in result["messages"]] == ["genuine"]
+    assert result["classifier"] == "project_context_v1"
+
+
+def test_classifier_does_not_drop_plain_user_discussion_of_context_compaction(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "regular"}],
+        [("regular", "user", "context compaction strategies are worth discussing", 1.0)],
+    )
+
+    assert [m["content"] for m in _read(project_store)["messages"]] == [
+        "context compaction strategies are worth discussing"
+    ]
+
+
+def test_limit_and_opaque_before_cursor_page_without_overlap(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}, {"session_id": "session_b"}],
+        [
+            ("session_a", "user", "a3", 3.0),
+            ("session_a", "user", "a2", 2.0),
+            ("session_a", "user", "a1", 1.0),
+            ("session_b", "user", "b3", 3.0),
+            ("session_b", "user", "b2", 2.0),
+            ("session_b", "user", "b1", 1.0),
+        ],
+    )
+
+    first = _read(project_store, limit=3)
+    second = _read(project_store, limit=3, before=first["next_before"])
+
+    assert [m["content"] for m in first["messages"]] == ["b3", "a3", "b2"]
+    assert [m["content"] for m in second["messages"]] == ["a2", "b1", "a1"]
+    assert set(m["content"] for m in first["messages"]).isdisjoint(
+        m["content"] for m in second["messages"]
+    )
+    with pytest.raises(ValueError, match="before"):
+        _read(project_store, before="not-a-valid-cursor")
+    with pytest.raises(ValueError, match="before"):
+        _read(project_store, roles=["assistant"], before=first["next_before"])
+
+
+def test_archived_sessions_are_opt_in(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "active"}, {"session_id": "archived", "archived": True}],
+        [
+            ("active", "user", "active text", 1.0),
+            ("archived", "user", "archived text", 2.0),
+        ],
+    )
+
+    assert [m["content"] for m in _read(project_store)["messages"]] == ["active text"]
+    assert [m["content"] for m in _read(project_store, include_archived=True)["messages"]] == [
+        "archived text",
+        "active text",
+    ]
+
+
+def test_large_corpus_reads_only_a_bounded_tail_per_eligible_session(project_store):
+    sessions = [{"session_id": f"session_{i}"} for i in range(3)]
+    messages = []
+    for i in range(3):
+        sid = f"session_{i}"
+        messages.extend((sid, "user", f"{sid}-{n}", float(n)) for n in range(1000))
+    _seed(project_store, sessions, messages)
+
+    result = _read(project_store, limit=5)
+
+    assert len(result["messages"]) == 5
+    assert result["diagnostics"]["candidate_rows_read"] <= 26 * len(sessions)
+    assert result["diagnostics"]["eligible_sessions"] == len(sessions)
+
+
+def test_synthetic_tail_saturation_fails_bounded_and_reports_partial(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [
+            ("session_a", "user", "genuine but beyond the bounded window", 1.0),
+            *[
+                ("session_a", "user", f"[System: synthetic {i}]", float(i + 2))
+                for i in range(25)
+            ],
+        ],
+    )
+
+    result = _read(project_store)
+
+    assert result["messages"] == []
+    assert result["partial"] is True
+    assert result["diagnostics"]["classifier_scan_saturated_sessions"] == 1
+    assert result["diagnostics"]["candidate_rows_read"] == 26
+
+
+@pytest.mark.parametrize("index_value", [None, {"not": "a list"}])
+def test_missing_or_malformed_index_reports_partial(project_store, index_value):
+    if index_value is None:
+        project_store["session_index_file"].unlink()
+    else:
+        _write_json(project_store["session_index_file"], index_value)
+
+    result = _read(project_store)
+
+    assert result["messages"] == []
+    assert result["partial"] is True
+    assert result["diagnostics"]["session_index_unavailable"] == 1
+
+
+def test_malformed_and_non_finite_timestamps_fail_closed_per_row(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [
+            ("session_a", "user", "valid", 1.0),
+            ("session_a", "user", "malformed", "not-a-timestamp"),
+            ("session_a", "user", "non-finite", "NaN"),
+        ],
+    )
+
+    result = _read(project_store)
+
+    assert [m["content"] for m in result["messages"]] == ["valid"]
+    assert result["partial"] is True
+    assert result["diagnostics"]["invalid_timestamp_rows"] == 2
+
+
+def test_limit_contract_is_default_five_and_max_twenty(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [("session_a", "user", str(i), float(i)) for i in range(30)],
+    )
+
+    assert len(_read(project_store)["messages"]) == 5
+    assert len(_read(project_store, limit=999)["messages"]) == 20
+    with pytest.raises(ValueError, match="limit"):
+        _read(project_store, limit=0)

--- a/tests/test_recent_project_messages.py
+++ b/tests/test_recent_project_messages.py
@@ -1,7 +1,9 @@
 """Contract tests for bounded, profile-scoped project message reads."""
 
+import base64
 import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -300,11 +302,11 @@ def test_classifier_does_not_drop_plain_user_discussion_of_context_compaction(pr
     _seed(
         project_store,
         [{"session_id": "regular"}],
-        [("regular", "user", "context compaction strategies are worth discussing", 1.0)],
+        [("regular", "user", "context compaction: strategies are worth discussing", 1.0)],
     )
 
     assert [m["content"] for m in _read(project_store)["messages"]] == [
-        "context compaction strategies are worth discussing"
+        "context compaction: strategies are worth discussing"
     ]
 
 
@@ -334,6 +336,43 @@ def test_limit_and_opaque_before_cursor_page_without_overlap(project_store):
         _read(project_store, before="not-a-valid-cursor")
     with pytest.raises(ValueError, match="before"):
         _read(project_store, roles=["assistant"], before=first["next_before"])
+
+
+def test_cursor_reuse_is_rejected_across_every_query_scope_dimension(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [("session_a", "user", "message", 1.0)],
+    )
+    first = _read(project_store)
+    cursor = first["next_before"]
+    _write_json(
+        project_store["projects_file"],
+        [
+            {"project_id": PROJECT_ID, "name": "Example", "profile": PROFILE},
+            {"project_id": "project00002", "name": "Other project", "profile": PROFILE},
+            {"project_id": PROJECT_ID, "name": "Other profile", "profile": "other"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="before"):
+        _read(project_store, roles=["assistant"], before=cursor)
+    with pytest.raises(ValueError, match="before"):
+        _read(project_store, include_archived=True, before=cursor)
+    with pytest.raises(ValueError, match="before"):
+        recent_project_messages(
+            project_id="project00002",
+            profile=PROFILE,
+            before=cursor,
+            **project_store,
+        )
+    with pytest.raises(ValueError, match="before"):
+        recent_project_messages(
+            project_id=PROJECT_ID,
+            profile="other",
+            before=cursor,
+            **project_store,
+        )
 
 
 def test_archived_sessions_are_opt_in(project_store):
@@ -389,7 +428,10 @@ def test_synthetic_tail_saturation_fails_bounded_and_reports_partial(project_sto
     assert result["diagnostics"]["candidate_rows_read"] == 26
 
 
-@pytest.mark.parametrize("index_value", [None, {"not": "a list"}])
+@pytest.mark.parametrize(
+    "index_value",
+    [None, {"not": "a list"}, ["not-a-row"], [{"not": "a session row"}]],
+)
 def test_missing_or_malformed_index_reports_partial(project_store, index_value):
     if index_value is None:
         project_store["session_index_file"].unlink()
@@ -400,7 +442,66 @@ def test_missing_or_malformed_index_reports_partial(project_store, index_value):
 
     assert result["messages"] == []
     assert result["partial"] is True
+    assert (
+        result["diagnostics"]["session_index_unavailable"]
+        + result["diagnostics"]["invalid_index_rows"]
+        == 1
+    )
+
+
+def test_unreadable_index_reports_partial(project_store, monkeypatch):
+    original_read_text = Path.read_text
+
+    def fail_index_read(path, *args, **kwargs):
+        if path == project_store["session_index_file"]:
+            raise OSError("fixture-owned unreadable index")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_index_read)
+
+    result = _read(project_store)
+
+    assert result["messages"] == []
+    assert result["partial"] is True
     assert result["diagnostics"]["session_index_unavailable"] == 1
+
+
+def test_malformed_foreign_index_row_does_not_degrade_owned_scope(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "valid"}],
+        [("valid", "user", "safe", 1.0)],
+    )
+    index = json.loads(project_store["session_index_file"].read_text(encoding="utf-8"))
+    index.append(
+        {
+            "session_id": "unsafe/session",
+            "project_id": "foreign00001",
+            "profile": "other",
+        }
+    )
+    _write_json(project_store["session_index_file"], index)
+
+    result = _read(project_store)
+
+    assert [message["content"] for message in result["messages"]] == ["safe"]
+    assert result["partial"] is False
+    assert result["diagnostics"]["invalid_index_rows"] == 0
+
+
+def test_diagnostics_are_counts_only(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "valid"}, {"session_id": "missing"}],
+        [("valid", "user", "safe", 1.0)],
+    )
+    (project_store["session_dir"] / "missing.json").unlink()
+
+    result = _read(project_store)
+
+    assert result["classifier"] == "project_context_v1"
+    assert result["diagnostics"]
+    assert all(type(value) is int for value in result["diagnostics"].values())
 
 
 def test_malformed_and_non_finite_timestamps_fail_closed_per_row(project_store):
@@ -410,7 +511,9 @@ def test_malformed_and_non_finite_timestamps_fail_closed_per_row(project_store):
         [
             ("session_a", "user", "valid", 1.0),
             ("session_a", "user", "malformed", "not-a-timestamp"),
-            ("session_a", "user", "non-finite", "NaN"),
+            ("session_a", "user", "nan", "NaN"),
+            ("session_a", "user", "positive-infinity", "Infinity"),
+            ("session_a", "user", "negative-infinity", "-Infinity"),
         ],
     )
 
@@ -418,7 +521,16 @@ def test_malformed_and_non_finite_timestamps_fail_closed_per_row(project_store):
 
     assert [m["content"] for m in result["messages"]] == ["valid"]
     assert result["partial"] is True
-    assert result["diagnostics"]["invalid_timestamp_rows"] == 2
+    assert result["diagnostics"]["invalid_timestamp_rows"] == 4
+    padded = result["next_before"] + "=" * (-len(result["next_before"]) % 4)
+    cursor_json = base64.urlsafe_b64decode(padded).decode("utf-8")
+
+    def reject_non_standard_constant(value):
+        raise AssertionError(f"non-standard JSON constant in cursor: {value}")
+
+    decoded = json.loads(cursor_json, parse_constant=reject_non_standard_constant)
+    assert decoded[0] == 2
+    assert decoded[2] == 1.0
 
 
 def test_limit_contract_is_default_five_and_max_twenty(project_store):

--- a/tests/test_recent_project_messages.py
+++ b/tests/test_recent_project_messages.py
@@ -228,6 +228,47 @@ def test_profile_and_project_ownership_fail_closed(project_store):
         )
 
 
+@pytest.mark.parametrize("malformed_profile", [["research"], {"name": "research"}])
+def test_malformed_project_profile_is_generic_not_found(project_store, malformed_profile):
+    _write_json(
+        project_store["projects_file"],
+        [{"project_id": PROJECT_ID, "name": "Example", "profile": malformed_profile}],
+    )
+
+    with pytest.raises(LookupError, match="^Project not found$"):
+        _read(project_store)
+
+
+@pytest.mark.parametrize("metadata_source", ["index", "sidecar"])
+def test_malformed_matching_scope_session_profile_is_excluded_and_counted(
+    project_store, metadata_source
+):
+    _seed(
+        project_store,
+        [{"session_id": "valid"}, {"session_id": "malformed"}],
+        [
+            ("valid", "user", "safe", 1.0),
+            ("malformed", "user", "must not leak", 2.0),
+        ],
+    )
+    if metadata_source == "index":
+        index = json.loads(project_store["session_index_file"].read_text(encoding="utf-8"))
+        index[1]["profile"] = [PROFILE]
+        _write_json(project_store["session_index_file"], index)
+    else:
+        sidecar_path = project_store["session_dir"] / "malformed.json"
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        sidecar["profile"] = {"name": PROFILE}
+        _write_json(sidecar_path, sidecar)
+
+    result = _read(project_store)
+
+    assert [message["content"] for message in result["messages"]] == ["safe"]
+    assert result["partial"] is True
+    diagnostic = "invalid_index_rows" if metadata_source == "index" else "invalid_sidecar_rows"
+    assert result["diagnostics"][diagnostic] == 1
+
+
 def test_missing_or_disagreeing_sidecars_are_excluded_with_count_only_diagnostics(project_store):
     _seed(
         project_store,
@@ -425,6 +466,40 @@ def test_archived_sessions_are_opt_in(project_store):
     ]
 
 
+@pytest.mark.parametrize("include_archived", ["false", 0, 1, None, [], {}])
+def test_include_archived_accepts_only_real_booleans(project_store, include_archived):
+    with pytest.raises(ValueError, match="include_archived must be a boolean"):
+        _read(project_store, include_archived=include_archived)
+
+
+@pytest.mark.parametrize("metadata_source", ["index", "sidecar"])
+def test_malformed_persisted_archive_value_is_excluded_and_counted(project_store, metadata_source):
+    _seed(
+        project_store,
+        [{"session_id": "valid"}, {"session_id": "malformed"}],
+        [
+            ("valid", "user", "safe", 1.0),
+            ("malformed", "user", "must not leak", 2.0),
+        ],
+    )
+    index = json.loads(project_store["session_index_file"].read_text(encoding="utf-8"))
+    sidecar_path = project_store["session_dir"] / "malformed.json"
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    if metadata_source == "index":
+        index[1]["archived"] = "false"
+        sidecar.pop("archived")
+        _write_json(project_store["session_index_file"], index)
+    else:
+        sidecar["archived"] = "false"
+    _write_json(sidecar_path, sidecar)
+
+    result = _read(project_store)
+
+    assert [message["content"] for message in result["messages"]] == ["safe"]
+    assert result["partial"] is True
+    assert result["diagnostics"]["invalid_archive_rows"] == 1
+
+
 def test_large_corpus_reads_only_a_bounded_tail_per_eligible_session(project_store):
     sessions = [{"session_id": f"session_{i}"} for i in range(3)]
     messages = []
@@ -461,6 +536,20 @@ def test_compacted_inactive_messages_are_not_returned(project_store):
     result = _read(project_store, limit=5)
 
     assert [m["content"] for m in result["messages"]] == ["active"]
+
+
+def test_legacy_null_active_messages_remain_visible(project_store):
+    with sqlite3.connect(project_store["state_db_path"]) as conn:
+        conn.execute("ALTER TABLE messages ADD COLUMN active INTEGER")
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [("session_a", "user", "legacy-null-active", 1.0)],
+    )
+
+    result = _read(project_store)
+
+    assert [message["content"] for message in result["messages"]] == ["legacy-null-active"]
 
 
 def test_synthetic_tail_saturation_fails_bounded_and_reports_partial(project_store):
@@ -587,6 +676,67 @@ def test_malformed_and_non_finite_timestamps_fail_closed_per_row(project_store):
     decoded = json.loads(cursor_json, parse_constant=reject_non_standard_constant)
     assert decoded[0] == 2
     assert decoded[2] == 1.0
+
+
+@pytest.mark.parametrize("stored_timestamp", [None, float("nan")])
+def test_null_and_sqlite_nan_timestamps_are_counted_on_initial_and_cursor_pages(
+    project_store, stored_timestamp
+):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [
+            ("session_a", "user", "new", 2.0),
+            ("session_a", "user", "old", 1.0),
+            ("session_a", "user", "invalid", stored_timestamp),
+        ],
+    )
+
+    first = _read(project_store, limit=1)
+    second = _read(project_store, limit=1, before=first["next_before"])
+
+    assert [message["content"] for message in first["messages"]] == ["new"]
+    assert [message["content"] for message in second["messages"]] == ["old"]
+    for page in (first, second):
+        assert page["partial"] is True
+        assert page["diagnostics"]["invalid_timestamp_rows"] == 1
+
+
+def test_malformed_timestamp_diagnostics_are_cursor_independent(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [
+            ("session_a", "user", "new", 2.0),
+            ("session_a", "user", "old", 1.0),
+            ("session_a", "user", "invalid", "not-a-timestamp"),
+        ],
+    )
+
+    first = _read(project_store, limit=1)
+    second = _read(project_store, limit=1, before=first["next_before"])
+
+    for page in (first, second):
+        assert page["partial"] is True
+        assert page["diagnostics"]["invalid_timestamp_rows"] == 1
+
+
+def test_invalid_timestamp_probe_is_bounded_and_saturation_is_partial(project_store):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [
+            ("session_a", "user", "valid", 1.0),
+            *[("session_a", "user", f"invalid-{index}", None) for index in range(21)],
+        ],
+    )
+
+    result = _read(project_store, limit=1)
+
+    assert [message["content"] for message in result["messages"]] == ["valid"]
+    assert result["partial"] is True
+    assert result["diagnostics"]["invalid_timestamp_rows"] == 20
+    assert result["diagnostics"]["invalid_timestamp_probe_saturated_sessions"] == 1
 
 
 def test_limit_contract_is_default_five_and_max_twenty(project_store):

--- a/tests/test_recent_project_messages.py
+++ b/tests/test_recent_project_messages.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import api.project_context as project_context
 from api.project_context import recent_project_messages
 
 
@@ -298,6 +299,24 @@ def test_explicit_classifier_excludes_cron_delegation_compaction_and_system_noti
     assert result["classifier"] == "project_context_v1"
 
 
+def test_max_iteration_summary_classifier_is_case_insensitive(project_store):
+    mixed_case_summary = (
+        "You've reached the maximum number of tool-calling iterations allowed. "
+        "Please provide a final response summarizing what you've found and accomplished "
+        "so far, without calling any more tools."
+    ).swapcase()
+    _seed(
+        project_store,
+        [{"session_id": "regular"}],
+        [
+            ("regular", "user", "genuine", 1.0),
+            ("regular", "user", mixed_case_summary, 2.0),
+        ],
+    )
+
+    assert [m["content"] for m in _read(project_store, limit=20)["messages"]] == ["genuine"]
+
+
 def test_classifier_does_not_drop_plain_user_discussion_of_context_compaction(project_store):
     _seed(
         project_store,
@@ -375,6 +394,20 @@ def test_cursor_reuse_is_rejected_across_every_query_scope_dimension(project_sto
         )
 
 
+def test_cursor_reuse_is_rejected_after_classifier_version_changes(project_store, monkeypatch):
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [("session_a", "user", "message", 1.0)],
+    )
+    cursor = _read(project_store)["next_before"]
+
+    monkeypatch.setattr(project_context, "_CLASSIFIER_VERSION", "project_context_v2")
+
+    with pytest.raises(ValueError, match="before"):
+        _read(project_store, before=cursor)
+
+
 def test_archived_sessions_are_opt_in(project_store):
     _seed(
         project_store,
@@ -405,6 +438,29 @@ def test_large_corpus_reads_only_a_bounded_tail_per_eligible_session(project_sto
     assert len(result["messages"]) == 5
     assert result["diagnostics"]["candidate_rows_read"] <= 26 * len(sessions)
     assert result["diagnostics"]["eligible_sessions"] == len(sessions)
+
+
+def test_compacted_inactive_messages_are_not_returned(project_store):
+    with sqlite3.connect(project_store["state_db_path"]) as conn:
+        conn.execute("ALTER TABLE messages ADD COLUMN active INTEGER")
+    _seed(
+        project_store,
+        [{"session_id": "session_a"}],
+        [("session_a", "user", "active", 2.0)],
+    )
+    with sqlite3.connect(project_store["state_db_path"]) as conn:
+        conn.execute("UPDATE messages SET active = 1 WHERE content = 'active'")
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp, active) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("session_a", "user", "inactive-newer", 3.0, 0),
+                ("session_a", "user", "inactive-older", 1.0, 0),
+            ],
+        )
+
+    result = _read(project_store, limit=5)
+
+    assert [m["content"] for m in result["messages"]] == ["active"]
 
 
 def test_synthetic_tail_saturation_fails_bounded_and_reports_partial(project_store):


### PR DESCRIPTION
## Thinking Path

- External agents need bounded project context without loading one arbitrary session or exposing raw tool/system rows.
- The first implementation established a read-only, profile-scoped projection, but staged review found fail-open diagnostics and edge cases around classifiers, timestamps, and cursor reuse.
- This PR keeps the generic `recent_project_messages` scope and hardens the shared read boundary so unverifiable state is partial, malformed rows are isolated, and cursors cannot cross query scopes.

## What Changed

- Added the profile-scoped `recent_project_messages` MCP tool and bounded global merge across eligible project sessions.
- Confirms project/session membership through `projects.json`, `_index.json`, bounded sidecar metadata, and read-only `state.db` membership.
- Returns only user/assistant text with forced credential redaction and count-only diagnostics.
- Treats missing, unreadable, malformed, and wrong-shaped indexes as partial; malformed foreign-scope rows do not degrade an owned query.
- Preserves plain unbracketed `context compaction` discussion while filtering canonical synthetic notices.
- Rejects malformed and non-finite timestamps per row and emits only finite, standard-JSON cursor data.
- Versions and binds cursors to project, profile, roles, archive policy, and classifier version.
- Excludes compacted inactive message rows when the canonical `active` column is present while retaining legacy-schema compatibility.
- Classifies the canonical max-iteration summary case-insensitively without broadening ordinary user-content prefix filtering.
- Documents the MCP contract and architecture surface.

## Why It Matters

External agents can retrieve recent project context deterministically without scanning full transcripts, crossing profile boundaries, leaking tool/system payloads, or mistaking an unverifiable empty read for complete success.

## Verification

- RED proof: wrong-shaped `_index.json` rows previously returned `partial=false`; the new regression failed before the fix.
- RED proof from independent staged review: a malformed foreign-project row incorrectly degraded the owned scope; a dedicated regression failed before the correction.
- RED proof from independent review: compacted `active=0` rows, a mixed-case canonical max-iteration prompt, and a stale classifier-version cursor each reproduced at accepted head `9e423f11`; all three new regressions failed before the fix and passed after it.
- `./scripts/test.sh tests/test_recent_project_messages.py tests/test_mcp_server.py -q` — 78 passed.
- `./scripts/test.sh tests/test_recent_project_messages.py tests/test_mcp_server.py tests/test_webui_session_db_adapter.py tests/test_session_index.py tests/test_state_db_readonly_reads_models.py tests/test_issue5455_listing_readonly_connection.py tests/test_issue1611_session_profile_filtering.py tests/test_security_redaction.py -q` — 248 passed, 1 existing agent-dependent skip.
- `./.venv/bin/python scripts/ruff_lint.py --diff upstream/master` — 0 findings on added/modified lines after the review fixes.
- `python -m py_compile api/project_context.py tests/test_recent_project_messages.py` and `git diff --check` — passed.
- `git diff --cached --check` — passed before commit.
- Isolated temporary-state readback returned the genuine unbracketed compaction discussion, count-only diagnostics, `partial=true` for malformed owned state, and a finite cursor.
- Independent final staged review via `codex exec review --uncommitted --ephemeral` — PASS, no blocking findings; its targeted run reported 22 passed.
- Full `./scripts/test.sh -q` sweep: 13,432 passed, 141 skipped, 1 xfailed, 2 xpassed; one unrelated environment failure in `test_issue4685_post_compression_context_metering.py` because the local external `agent.context_compressor` could not import `call_llm` from its installed `agent.auxiliary_client`.

## Contract Routing

Task type: new bounded read-only MCP runtime contract plus review hardening.

Touched areas:
- project/session metadata reads
- profile isolation
- `state.db` message projection
- MCP schema/handler
- cursor and partial-read semantics

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/project-context.md`
- `ARCHITECTURE.md`

Scope boundaries:
- no WebUI mutation or index repair
- no transcript-sidecar parsing
- no tool/system payloads
- no product-specific UI

Evidence needed before claiming done:
- multi-session global ordering
- profile/project isolation
- bounded large-corpus reads
- fail-closed diagnostics
- timestamp and cursor edge cases
- MCP handler/schema coverage

- Maintainer re-gate RED proof at reviewed head `44b2886f`: the new behavior suite produced 16 expected failures across malformed project/index/sidecar profiles, strict archive booleans, and cursor-independent NULL/SQLite-NaN timestamp diagnostics.
- Follow-up head `b543ecbc6444044ad53a6e0c7e8489b8ecc880c3`: `./scripts/test.sh tests/test_recent_project_messages.py tests/test_mcp_server.py -q` — 96 passed.
- Neighboring project-context/MCP/state/index/profile/redaction suite — 266 passed, 1 existing agent-dependent skip.
- Ruff diff gate, `py_compile`, `git diff --check`, static security scan, and independent read-only diff review — PASS.

## Risks / Follow-ups

- The classifier intentionally uses the canonical bracketed synthetic notices available on this read surface; unbracketed text remains genuine because structured `_compressed_summary` evidence is not selected from `state.db`.
- Per-session scans remain hard bounded and may return `partial=true` when a synthetic-heavy tail saturates.
- No UI behavior changed, so screenshots are not applicable.

## Release Note

Added a bounded, profile-scoped `recent_project_messages` MCP tool for retrieving genuine recent user/assistant messages across all sessions in a WebUI project, with redaction, opaque pagination, archive controls, and fail-closed partial diagnostics.

## Model Used

OpenAI `gpt-5.6-sol` via Hermes Agent, with repository tools for TDD, isolated execution, and an independent Codex staged-diff review.

