### PR TITLE
feat(#6351): expose WebUI runtime memory diagnostics

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8582,6 +8582,10 @@ def get_sessions_cache_max(config_data: dict | None = None) -> int:
     ``HERMES_WEBUI_SESSIONS_MAX`` env override, then to
     ``DEFAULT_SESSIONS_CACHE_MAX`` — a typo can never disable the bound and
     reintroduce unbounded memory growth.
+
+    This is the sole resolution authority and it is side-effect free. The cap
+    diagnostics report is published by the code that enforces it; see
+    ``_LAST_APPLIED_SESSIONS_CACHE_MAX`` below.
     """
     active_cfg = config_data if isinstance(config_data, dict) else get_config()
     webui_cfg = active_cfg.get("webui", {}) if isinstance(active_cfg, dict) else {}
@@ -8590,7 +8594,10 @@ def get_sessions_cache_max(config_data: dict | None = None) -> int:
         if raw is not None:
             try:
                 value = int(raw)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError covers YAML's float infinities (`.inf`, `1e400`),
+                # which safe_load resolves to a real float. Without it a typo
+                # would escape the fallback and raise out of every caller.
                 value = None
             if value is not None and value >= 1:
                 return value
@@ -8599,6 +8606,16 @@ def get_sessions_cache_max(config_data: dict | None = None) -> int:
     if isinstance(SESSIONS_MAX, int) and SESSIONS_MAX >= 1:
         return SESSIONS_MAX
     return DEFAULT_SESSIONS_CACHE_MAX
+
+
+# The cap api/models.py::_evict_sessions_over_cap() last enforced. That function
+# publishes it after its own fallback and range normalization, so a nonblocking
+# diagnostics read reports what eviction applied without re-entering config or
+# profile I/O, and nothing else writes this field. Seeded from the config
+# reload_config() already loaded at import (see `cfg` above) through the getter's
+# dict mode, which reads no file and takes no lock, so the value is right before
+# the first eviction pass instead of after it.
+_LAST_APPLIED_SESSIONS_CACHE_MAX: int = get_sessions_cache_max(cfg)
 CHAT_LOCK = threading.Lock()
 
 
@@ -8814,19 +8831,39 @@ class StreamChannel:
                 self._SUBSCRIBER_QUEUE_MAXSIZE,
             )
 
+    def _diagnostic_counters_locked(self) -> dict[str, object]:
+        """Return the counter dict. CALLER CONTRACT: ``self._lock`` is held."""
+        return {
+            "subscriber_count": len(self._subscribers),
+            "offline_buffered_events": len(self._offline_buffer),
+            # Cumulative over the channel lifetime (ops visibility), vs. the
+            # per-cycle count subscribe_with_snapshot() reports for truncation.
+            "offline_dropped_events": self._offline_dropped_total,
+            # Cumulative per-subscriber queue drops (replay + broadcast) over
+            # the channel lifetime — surfaces slow/backpressured tabs.
+            "subscriber_dropped_events": self._subscriber_dropped_total,
+        }
+
     def diagnostic_snapshot(self) -> dict[str, object]:
         """Return non-sensitive stream observation counters for health checks."""
         with self._lock:
-            return {
-                "subscriber_count": len(self._subscribers),
-                "offline_buffered_events": len(self._offline_buffer),
-                # Cumulative over the channel lifetime (ops visibility), vs. the
-                # per-cycle count subscribe_with_snapshot() reports for truncation.
-                "offline_dropped_events": self._offline_dropped_total,
-                # Cumulative per-subscriber queue drops (replay + broadcast) over
-                # the channel lifetime — surfaces slow/backpressured tabs.
-                "subscriber_dropped_events": self._subscriber_dropped_total,
-            }
+            return self._diagnostic_counters_locked()
+
+    def try_diagnostic_snapshot(self) -> dict[str, object] | None:
+        """Return the same counters without waiting, or ``None`` when busy.
+
+        An aggregate health poll must never stall behind one channel's producer
+        or subscriber work, so a contended channel is reported as unavailable
+        instead of waited on. ``diagnostic_snapshot()`` keeps its blocking
+        contract for the per-stream ``/health?deep=1`` view, which needs the
+        counters of every stream rather than a best-effort aggregate.
+        """
+        if not self._lock.acquire(blocking=False):
+            return None
+        try:
+            return self._diagnostic_counters_locked()
+        finally:
+            self._lock.release()
 
 
 def create_stream_channel() -> StreamChannel:
@@ -9900,6 +9937,70 @@ if _settings_file_exists:
 
 # ── SESSIONS in-memory cache (LRU OrderedDict) ───────────────────────────────
 SESSIONS: collections.OrderedDict = collections.OrderedDict()
+
+
+def get_runtime_diagnostics_snapshot() -> dict[str, dict[str, object]]:
+    """Return nonblocking scalar observations owned by the config module."""
+    result = {
+        "sessions": {"available": False, "resident": 0, "cap": 0},
+        "models_cache": {
+            "available": False,
+            "groups": 0,
+            "models": 0,
+            "age_seconds": None,
+        },
+    }
+    try:
+        if LOCK.acquire(blocking=False):
+            try:
+                # Held-section discipline: len(), arithmetic, and owner-held
+                # scalars only. Never call anything here that can resolve config
+                # or a profile, touch the filesystem, import a module, or wait on
+                # another lock — the cap is the scalar _evict_sessions_over_cap()
+                # published, precisely so this section stays leaf-nonblocking.
+                result["sessions"] = {
+                    "available": True,
+                    "resident": max(0, int(len(SESSIONS))),
+                    "cap": max(0, int(_LAST_APPLIED_SESSIONS_CACHE_MAX)),
+                }
+            finally:
+                LOCK.release()
+    except Exception:
+        pass
+    try:
+        if _available_models_cache_lock.acquire(blocking=False):
+            try:
+                # Same held-section discipline: len(), isinstance, float(), and
+                # time.monotonic() only. _available_models_cache_lock is an RLock
+                # (see its definition), so a nonblocking acquire from a thread
+                # that already holds it would report available mid-build; safe
+                # here because health collection is never nested inside a
+                # catalog build, and nothing may be added that changes that.
+                snapshot = _available_models_cache
+                groups = snapshot.get("groups") if isinstance(snapshot, dict) else None
+                group_count = len(groups) if isinstance(groups, list) else 0
+                model_count = 0
+                if isinstance(groups, list):
+                    for group in groups:
+                        if isinstance(group, dict):
+                            for bucket in ("models", "extra_models"):
+                                models = group.get(bucket)
+                                if isinstance(models, list):
+                                    model_count += len(models)
+                age = None
+                if snapshot is not None and _available_models_cache_ts:
+                    age = max(0.0, time.monotonic() - float(_available_models_cache_ts))
+                result["models_cache"] = {
+                    "available": True,
+                    "groups": max(0, int(group_count)),
+                    "models": max(0, int(model_count)),
+                    "age_seconds": age,
+                }
+            finally:
+                _available_models_cache_lock.release()
+    except Exception:
+        pass
+    return result
 
 # ── Profile state initialisation ────────────────────────────────────────────
 # Must run after all imports are resolved to correctly patch module-level caches

--- a/api/models.py
+++ b/api/models.py
@@ -4620,6 +4620,10 @@ def _evict_sessions_over_cap(cap: int | None = None) -> int:
     CALLER CONTRACT: the global ``LOCK`` MUST already be held (every call site
     mutates ``SESSIONS`` under ``LOCK``). This function never acquires ``LOCK``
     or any stream lock itself, so it cannot introduce a lock-ordering deadlock.
+    Under that same held ``LOCK`` it publishes the cap it enforced into
+    ``api.config._LAST_APPLIED_SESSIONS_CACHE_MAX`` for nonblocking diagnostics
+    (#6351); any future edit that can change ``cap`` after that point must move
+    the publish down with it.
 
     Returns the number of sessions evicted. If every over-cap candidate is
     active/unsaved, the cache may temporarily exceed ``cap`` — that is the
@@ -4632,6 +4636,11 @@ def _evict_sessions_over_cap(cap: int | None = None) -> int:
             cap = SESSIONS_MAX
     if not isinstance(cap, int) or cap < 1:
         cap = SESSIONS_MAX if isinstance(SESSIONS_MAX, int) and SESSIONS_MAX >= 1 else 1
+    # Diagnostics owns the field; this function owns the decision. Publishing the
+    # normalized cap here, rather than from the resolver, is what makes the health
+    # payload report a cap eviction actually applied — including the getter-failure
+    # fallback and explicit/normalized calls, which never reach the resolver (#6351).
+    _cfg._LAST_APPLIED_SESSIONS_CACHE_MAX = cap
     evicted = 0
     # Iterate over a snapshot of ids in LRU order (oldest first). We stop as
     # soon as we are at/below the cap. Skipping a non-evictable oldest entry and

--- a/api/route_session_list_cache.py
+++ b/api/route_session_list_cache.py
@@ -35,6 +35,41 @@ _SESSIONS_CACHE_ALL_PROFILES_INVALIDATION_VERSION = 0
 _SESSIONS_CACHE_PROFILE_INVALIDATION_VERSION: dict[str, int] = {}
 
 
+def get_session_list_cache_snapshot() -> dict[str, object]:
+    """Return scalar cache occupancy without waiting or changing LRU state.
+
+    Held-section discipline: between the nonblocking acquire and the release,
+    only ``len()`` and module-constant reads are permitted. Nothing that can
+    resolve config, resolve a profile, touch the filesystem, import a module, or
+    wait on another lock may be added here. ``_SESSIONS_CACHE_LOCK`` is an
+    ``RLock``, so a nonblocking acquire from a thread already holding it would
+    report available mid-mutation; the health collector is this helper's only
+    caller and never runs nested inside a cache rebuild.
+    """
+    result = {
+        "available": False,
+        "entries": 0,
+        "inflight_rebuilds": 0,
+        "cap": 0,
+    }
+    acquired = False
+    try:
+        acquired = _SESSIONS_CACHE_LOCK.acquire(blocking=False)
+        if not acquired:
+            return result
+        return {
+            "available": True,
+            "entries": max(0, int(len(_SESSIONS_CACHE))),
+            "inflight_rebuilds": max(0, int(len(_SESSIONS_CACHE_INFLIGHT))),
+            "cap": max(0, int(_SESSIONS_CACHE_MAX_ENTRIES)),
+        }
+    except Exception:
+        return result
+    finally:
+        if acquired:
+            _SESSIONS_CACHE_LOCK.release()
+
+
 def _session_list_cache_session_dir() -> Path:
     try:
         import api.routes as _routes

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -77,6 +77,61 @@ from api.process_event_utils import (
 )
 
 
+def get_stream_runtime_snapshot() -> dict[str, object]:
+    """Return aggregate stream observations without waiting on the registry.
+
+    The registry is copied under a nonblocking ``STREAMS_LOCK`` acquire and the
+    lock is released before any channel lock is touched, so registry and channel
+    locks are never nested. Each channel is then read through its nonblocking
+    owner method: a channel busy with its own producer or subscriber work counts
+    as one unavailable channel and the loop keeps summing its siblings.
+    """
+    result = {
+        "available": False,
+        "active": 0,
+        "agent_instances": 0,
+        "subscribers": 0,
+        "offline_buffered_events": 0,
+        "offline_dropped_events": 0,
+        "subscriber_dropped_events": 0,
+        "unavailable_channels": 0,
+    }
+    try:
+        if not STREAMS_LOCK.acquire(blocking=False):
+            return result
+        try:
+            channels = list(STREAMS.values())
+            agent_count = len(AGENT_INSTANCES)
+        finally:
+            STREAMS_LOCK.release()
+        result["available"] = True
+        result["active"] = len(channels)
+        result["agent_instances"] = agent_count
+        for channel in channels:
+            try:
+                snapshot = channel.try_diagnostic_snapshot()
+                if snapshot is None:
+                    result["unavailable_channels"] += 1
+                    continue
+                result["subscribers"] += max(0, int(snapshot.get("subscriber_count", 0)))
+                result["offline_buffered_events"] += max(
+                    0, int(snapshot.get("offline_buffered_events", 0))
+                )
+                result["offline_dropped_events"] += max(
+                    0, int(snapshot.get("offline_dropped_events", 0))
+                )
+                result["subscriber_dropped_events"] += max(
+                    0, int(snapshot.get("subscriber_dropped_events", 0))
+                )
+            except Exception:
+                result["unavailable_channels"] += 1
+    except Exception:
+        # Keep the aggregates already summed from channels that read cleanly; a
+        # late unexpected failure must not discard successful sibling counts.
+        return result
+    return result
+
+
 def _session_payload_with_full_messages(session, *, tool_calls=None):
     """Return compact session metadata plus the embedded full transcript.
 

--- a/api/system_health.py
+++ b/api/system_health.py
@@ -261,8 +261,6 @@ def _webui_runtime_payload(errors: list[dict[str, str]]) -> dict[str, Any]:
                     target[key] = None if age is None else max(0.0, float(age))
                 else:
                     target[key] = _safe_runtime_int(source.get(key, 0))
-            if not target["available"]:
-                errors.append(_safe_error(f"webui_runtime.{name}", RuntimeError("unavailable")))
         except Exception as exc:
             errors.append(_safe_error(f"webui_runtime.{name}", exc))
     return runtime

--- a/api/system_health.py
+++ b/api/system_health.py
@@ -159,6 +159,115 @@ def _safe_error(metric: str, exc: Exception) -> dict[str, str]:
     return {"metric": metric, "code": type(exc).__name__}
 
 
+def _zero_webui_runtime_payload() -> dict[str, Any]:
+    return {
+        "sessions": {"available": False, "resident": 0, "cap": 0},
+        "streams": {
+            "available": False, "active": 0, "agent_instances": 0,
+            "subscribers": 0, "offline_buffered_events": 0,
+            "offline_dropped_events": 0, "subscriber_dropped_events": 0,
+            "unavailable_channels": 0,
+        },
+        "session_list_cache": {
+            "available": False, "entries": 0, "inflight_rebuilds": 0, "cap": 0,
+        },
+        "models_cache": {
+            "available": False, "groups": 0, "models": 0, "age_seconds": None,
+        },
+    }
+
+
+def _safe_runtime_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _webui_runtime_payload(errors: list[dict[str, str]]) -> dict[str, Any]:
+    runtime = _zero_webui_runtime_payload()
+    # The three owner modules stay lazily imported so this small diagnostics
+    # module cannot create an eager import cycle. The import-lock wait that
+    # implies is only reachable while a first import is in flight, and
+    # api/routes.py imports all three at load, before any request can dispatch.
+    try:
+        from api import config
+    except Exception as exc:
+        config = None
+        config_import_error = exc
+    else:
+        config_import_error = None
+    try:
+        from api import route_session_list_cache
+    except Exception as exc:
+        route_session_list_cache = None
+        cache_import_error = exc
+    else:
+        cache_import_error = None
+    try:
+        from api import streaming
+    except Exception as exc:
+        streaming = None
+        streaming_import_error = exc
+    else:
+        streaming_import_error = None
+
+    # Collect the config owner exactly once per payload: two calls would double
+    # the blocking edge and let `sessions` and `models_cache` come from two
+    # different snapshots of the same process.
+    config_snapshot: Any = None
+    config_error = config_import_error
+    if config is not None and config_error is None:
+        try:
+            config_snapshot = config.get_runtime_diagnostics_snapshot()
+        except Exception as exc:
+            config_error = exc
+
+    def _config_section(section: str):
+        def project():
+            if not isinstance(config_snapshot, dict):
+                raise TypeError("runtime_snapshot_invalid")
+            return config_snapshot[section]
+
+        return project
+
+    sources = {
+        "sessions": (_config_section("sessions"), config_error),
+        "models_cache": (_config_section("models_cache"), config_error),
+        "streams": (
+            (lambda: streaming.get_stream_runtime_snapshot())
+            if streaming is not None else None,
+            streaming_import_error,
+        ),
+        "session_list_cache": (
+            (lambda: route_session_list_cache.get_session_list_cache_snapshot())
+            if route_session_list_cache is not None else None,
+            cache_import_error,
+        ),
+    }
+    for name, (collect, import_error) in sources.items():
+        try:
+            if import_error is not None:
+                raise import_error
+            source = collect()
+            if not isinstance(source, dict):
+                raise TypeError("runtime_snapshot_invalid")
+            target = runtime[name]
+            for key in target:
+                if key == "available":
+                    target[key] = bool(source.get(key, False))
+                elif key == "age_seconds":
+                    age = source.get(key)
+                    target[key] = None if age is None else max(0.0, float(age))
+                else:
+                    target[key] = _safe_runtime_int(source.get(key, 0))
+            if not target["available"]:
+                errors.append(_safe_error(f"webui_runtime.{name}", RuntimeError("unavailable")))
+        except Exception as exc:
+            errors.append(_safe_error(f"webui_runtime.{name}", exc))
+    return runtime
+
+
 def build_system_health_payload() -> dict[str, Any]:
     metrics: dict[str, Any] = {"cpu": None, "memory": None, "disk": None}
     errors: list[dict[str, str]] = []
@@ -182,6 +291,15 @@ def build_system_health_payload() -> dict[str, Any]:
         except Exception as exc:
             errors.append(_safe_error(name, exc))
 
+    try:
+        runtime = _webui_runtime_payload(errors)
+    except Exception as exc:
+        # Terminal fail-open: an unexpected failure in the runtime compositor
+        # itself must not fail the whole authenticated response, which returned
+        # host metrics before this subtree existed.
+        runtime = _zero_webui_runtime_payload()
+        errors.append(_safe_error("webui_runtime", exc))
+
     available = any(metrics[name] is not None for name in metrics)
     status = "ok" if available and not errors else "partial" if available else "unavailable"
     return {
@@ -191,5 +309,6 @@ def build_system_health_payload() -> dict[str, Any]:
         "cpu": metrics["cpu"],
         "memory": metrics["memory"],
         "disk": metrics["disk"],
+        "webui_runtime": runtime,
         "errors": errors,
     }

--- a/tests/test_issue693_system_health_panel.py
+++ b/tests/test_issue693_system_health_panel.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import pathlib
+import queue
+import subprocess
 import sys
+import threading
+import time
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
 
@@ -302,3 +309,790 @@ def test_system_health_backend_uses_no_shell_or_private_process_sources():
     assert "/proc/self/environ" not in src
     for private_field in ("argv", "cmdline", "username", "mountpoint"):
         assert private_field not in src
+
+
+# #6351 runtime-diagnostics hygiene rule for every test below: a test that
+# touches a process-owned shared mapping copies it by value, performs the
+# clear/seed and the restore inside the mapping's owning lock, and restores the
+# original key order and value identities. Contested locks are always held from
+# a worker thread, which is the only schedule production can produce.
+_LOCK_HOLD_SECONDS = 3.0
+# A nonblocking collector does no I/O, so a second is generous even on a loaded
+# CI box, while staying far enough below the hold that a blocking regression
+# (which waits the full _LOCK_HOLD_SECONDS) cannot slip past.
+_NONBLOCKING_BUDGET_SECONDS = 1.0
+
+
+@contextlib.contextmanager
+def _held_from_worker(lock, hold_seconds=_LOCK_HOLD_SECONDS):
+    """Hold ``lock`` from a worker thread for the body of the with-block."""
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold():
+        with lock:
+            entered.set()
+            release.wait(hold_seconds)
+
+    worker = threading.Thread(target=hold, daemon=True)
+    worker.start()
+    try:
+        # Inside the try so a worker that never acquires still gets released and
+        # joined; otherwise it takes the lock after this test fails and starves
+        # the next contention test for the full hold.
+        assert entered.wait(5), "worker thread never acquired the contested lock"
+        yield
+    finally:
+        release.set()
+        worker.join(hold_seconds + 5)
+
+
+@contextlib.contextmanager
+def _seeded_mapping(lock, mapping, entries):
+    """Seed a process-owned mapping under its owning lock and restore it exactly."""
+    with lock:
+        original = dict(mapping)
+        mapping.clear()
+        mapping.update(entries)
+    try:
+        yield original
+    finally:
+        with lock:
+            mapping.clear()
+            mapping.update(original)
+
+
+def _seed_channel_counters(
+    channel,
+    *,
+    subscribers=0,
+    offline_buffered=0,
+    offline_dropped=0,
+    subscriber_dropped=0,
+):
+    """Seed a real StreamChannel's diagnostic counters under its own lock."""
+    with channel._lock:
+        channel._subscribers.extend(queue.Queue() for _ in range(subscribers))
+        channel._offline_buffer.extend(
+            ("token", {"seq": index}, str(index)) for index in range(offline_buffered)
+        )
+        channel._offline_dropped_total = offline_dropped
+        channel._subscriber_dropped_total = subscriber_dropped
+
+
+def _pin_config_module_cache(monkeypatch):
+    """Let pytest restore the config globals a forced reload or eviction rebinds."""
+    from api import config
+
+    # _LAST_APPLIED_SESSIONS_CACHE_MAX belongs here because a real
+    # _evict_sessions_over_cap() pass rewrites it outside monkeypatch's view;
+    # pinning first records the true pre-test value.
+    for name in (
+        "cfg",
+        "_cfg_cache",
+        "_cfg_mtime",
+        "_cfg_path",
+        "_cfg_fingerprint",
+        "_LAST_APPLIED_SESSIONS_CACHE_MAX",
+    ):
+        monkeypatch.setattr(config, name, getattr(config, name), raising=False)
+
+
+def _fixed_host_metrics(monkeypatch):
+    from api import system_health
+
+    monkeypatch.setattr(system_health, "_cpu_percent", lambda: 12.0)
+    monkeypatch.setattr(
+        system_health,
+        "_memory_usage",
+        lambda: {"used_bytes": 1, "total_bytes": 4, "percent": 25.0},
+    )
+    monkeypatch.setattr(
+        system_health,
+        "_disk_usage",
+        lambda: {"used_bytes": 4, "total_bytes": 8, "percent": 50.0},
+    )
+
+
+def _assert_host_metrics_intact(payload):
+    assert payload["cpu"] == {"percent": 12.0}
+    assert payload["memory"] == {"used_bytes": 1, "total_bytes": 4, "percent": 25.0}
+    assert payload["disk"] == {"used_bytes": 4, "total_bytes": 8, "percent": 50.0}
+
+
+def test_runtime_diagnostics_absence_presence_and_privacy(monkeypatch):
+    from api import system_health
+
+    monkeypatch.setattr(system_health, "_cpu_percent", lambda: 1.0)
+    monkeypatch.setattr(system_health, "_memory_usage", lambda: {"used_bytes": 1, "total_bytes": 2, "percent": 50})
+    monkeypatch.setattr(system_health, "_disk_usage", lambda: {"used_bytes": 1, "total_bytes": 2, "percent": 50})
+    payload = system_health.build_system_health_payload()
+    assert set(payload["webui_runtime"]) == {"sessions", "streams", "session_list_cache", "models_cache"}
+    assert "stream_id" not in repr(payload)
+    assert "provider" not in repr(payload)
+    assert "secret-model" not in repr(payload)
+    assert "private-provider" not in repr(payload)
+
+
+def test_health_route_completes_while_config_cache_lock_is_held(monkeypatch, tmp_path):
+    from api import config, routes
+
+    _fixed_host_metrics(monkeypatch)
+    _pin_config_module_cache(monkeypatch)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("webui:\n  sessions_cache_max: 41\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_CONFIG_PATH", str(config_path))
+    # Cold cache: get_config() takes the reload branch, which waits on _cfg_lock.
+    monkeypatch.setattr(config, "_cfg_cache", {})
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0)
+    monkeypatch.setattr(config, "_cfg_path", None)
+    monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", 41, raising=False)
+
+    seeded = {"health-route-a": object(), "health-route-b": object()}
+    with _seeded_mapping(config.LOCK, config.SESSIONS, seeded):
+        with _held_from_worker(config._cfg_lock):
+            handler = _FakeHandler()
+            started = time.monotonic()
+            assert routes.handle_get(handler, urlparse("http://example.test/api/system/health")) is True
+            elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS, (
+        f"health response waited {elapsed:.3f}s on the config cache lock"
+    )
+    payload = handler.json_body()
+    _assert_host_metrics_intact(payload)
+    runtime = payload["webui_runtime"]
+    assert runtime["sessions"] == {"available": True, "resident": 2, "cap": 41}
+    assert runtime["streams"]["available"] is True
+    assert runtime["session_list_cache"]["available"] is True
+    assert runtime["session_list_cache"]["cap"] == 64
+    assert set(runtime["models_cache"]) == {"available", "groups", "models", "age_seconds"}
+    assert "health-route-a" not in repr(payload)
+
+
+def test_sessions_snapshot_never_resolves_config_or_profile(monkeypatch):
+    from api import config, profiles, system_health
+
+    _fixed_host_metrics(monkeypatch)
+    fired = []
+
+    def trap(*args, **kwargs):
+        fired.append(True)
+        raise AssertionError("health collection must not resolve config or profile state")
+
+    monkeypatch.setattr(config, "get_config", trap)
+    monkeypatch.setattr(config, "_get_config_path", trap)
+    monkeypatch.setattr(profiles, "get_active_hermes_home", trap)
+    monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", 57, raising=False)
+
+    with _seeded_mapping(config.LOCK, config.SESSIONS, {"trap-probe": object()}):
+        payload = system_health.build_system_health_payload()
+
+    assert fired == []
+    assert payload["webui_runtime"]["sessions"] == {"available": True, "resident": 1, "cap": 57}
+    assert {"metric": "webui_runtime.sessions", "code": "AssertionError"} not in payload["errors"]
+
+
+def test_health_route_completes_while_one_real_stream_channel_lock_is_held(monkeypatch):
+    from api import config, routes
+
+    _fixed_host_metrics(monkeypatch)
+    healthy = config.StreamChannel()
+    _seed_channel_counters(
+        healthy,
+        subscribers=2,
+        offline_buffered=3,
+        offline_dropped=4,
+        subscriber_dropped=5,
+    )
+    busy = config.StreamChannel()
+
+    streams = {"health-open-stream": healthy, "health-busy-stream": busy}
+    with _seeded_mapping(config.STREAMS_LOCK, config.STREAMS, streams):
+        with _seeded_mapping(config.STREAMS_LOCK, config.AGENT_INSTANCES, {"health-open-stream": object()}):
+            with _held_from_worker(busy._lock):
+                handler = _FakeHandler()
+                started = time.monotonic()
+                assert routes.handle_get(handler, urlparse("http://example.test/api/system/health")) is True
+                elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS, (
+        f"health response waited {elapsed:.3f}s on one busy stream channel"
+    )
+    payload = handler.json_body()
+    _assert_host_metrics_intact(payload)
+    runtime = payload["webui_runtime"]
+    assert runtime["streams"] == {
+        "available": True,
+        "active": 2,
+        "agent_instances": 1,
+        "subscribers": 2,
+        "offline_buffered_events": 3,
+        "offline_dropped_events": 4,
+        "subscriber_dropped_events": 5,
+        "unavailable_channels": 1,
+    }
+    assert runtime["sessions"]["available"] is True
+    assert runtime["session_list_cache"]["available"] is True
+    assert set(runtime["models_cache"]) == {"available", "groups", "models", "age_seconds"}
+    assert "health-open-stream" not in repr(payload)
+    assert "health-busy-stream" not in repr(payload)
+
+
+def test_stream_channel_try_snapshot_matches_blocking_snapshot():
+    from api import config
+
+    channel = config.StreamChannel()
+    _seed_channel_counters(
+        channel,
+        subscribers=1,
+        offline_buffered=2,
+        offline_dropped=3,
+        subscriber_dropped=4,
+    )
+    blocking = channel.diagnostic_snapshot()
+    nonblocking = channel.try_diagnostic_snapshot()
+    assert nonblocking == blocking
+    assert set(nonblocking) == {
+        "subscriber_count",
+        "offline_buffered_events",
+        "offline_dropped_events",
+        "subscriber_dropped_events",
+    }
+    assert blocking == {
+        "subscriber_count": 1,
+        "offline_buffered_events": 2,
+        "offline_dropped_events": 3,
+        "subscriber_dropped_events": 4,
+    }
+
+    # diagnostic_snapshot() is deliberately not called here: it keeps its
+    # blocking contract for /health?deep=1 and would wait out the whole hold.
+    with _held_from_worker(channel._lock):
+        started = time.monotonic()
+        assert channel.try_diagnostic_snapshot() is None
+        assert time.monotonic() - started < _NONBLOCKING_BUDGET_SECONDS
+
+
+def test_sessions_owner_snapshot_preserves_existing_cache_identities(monkeypatch):
+    from api import config
+
+    monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", 37, raising=False)
+    probe_key = "pre-existing-identity-probe"
+    probe = object()
+    with config.LOCK:
+        config.SESSIONS[probe_key] = probe
+    try:
+        seeded = {"first": object(), "second": object()}
+        with _seeded_mapping(config.LOCK, config.SESSIONS, seeded) as original:
+            assert probe_key not in config.SESSIONS
+            assert config.get_runtime_diagnostics_snapshot()["sessions"] == {
+                "available": True, "resident": 2, "cap": 37
+            }
+            assert list(config.SESSIONS) == ["first", "second"]
+
+        assert list(config.SESSIONS) == list(original)
+        for key, value in original.items():
+            assert config.SESSIONS[key] is value
+        assert config.SESSIONS[probe_key] is probe
+    finally:
+        with config.LOCK:
+            config.SESSIONS.pop(probe_key, None)
+
+
+def test_diagnostics_cap_tracks_the_eviction_owner(monkeypatch, tmp_path):
+    from api import config, models
+
+    _pin_config_module_cache(monkeypatch)
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setenv("HERMES_CONFIG_PATH", str(config_path))
+    fallback = (
+        config.SESSIONS_MAX
+        if isinstance(config.SESSIONS_MAX, int) and config.SESSIONS_MAX >= 1
+        else config.DEFAULT_SESSIONS_CACHE_MAX
+    )
+
+    for body, expected in (
+        ("webui:\n  sessions_cache_max: 23\n", 23),
+        ("webui:\n  sessions_cache_max: 0\n", fallback),
+        ("webui: {}\n", fallback),
+    ):
+        config_path.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(config, "_cfg_cache", {})
+        monkeypatch.setattr(config, "_cfg_path", None)
+        assert config.get_sessions_cache_max() == expected
+        # Poison the memo so only a real eviction pass can restore it.
+        monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", -1)
+        with _seeded_mapping(config.LOCK, config.SESSIONS, {}):
+            with config.LOCK:
+                models._evict_sessions_over_cap()
+            assert config.get_runtime_diagnostics_snapshot()["sessions"]["cap"] == expected
+
+
+def test_diagnostics_cap_reports_the_owner_fallback_when_the_getter_raises(monkeypatch):
+    from api import config, models, system_health
+
+    _fixed_host_metrics(monkeypatch)
+    _pin_config_module_cache(monkeypatch)
+
+    def raiser(*args, **kwargs):
+        raise RuntimeError("cap resolution failed")
+
+    # A distinct prior memo, so no assertion below can pass on the incumbent value.
+    monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", 4321, raising=False)
+    # api/models.py resolves the getter through _cfg at call time, so failing the
+    # real attribute is what the production lookup hits, not a shadowed copy.
+    monkeypatch.setattr(config, "get_sessions_cache_max", raiser)
+    # Pinning models' own binding is what proves the published cap came from the
+    # enforcer's fallback rather than from anything the resolver returned.
+    monkeypatch.setattr(models, "SESSIONS_MAX", 29)
+
+    with _seeded_mapping(config.LOCK, config.SESSIONS, {}):
+        with config.LOCK:
+            models._evict_sessions_over_cap()
+        snapshot = config.get_runtime_diagnostics_snapshot()
+        payload = system_health.build_system_health_payload()
+
+    assert snapshot["sessions"]["cap"] != 4321
+    assert snapshot["sessions"]["cap"] == 29
+    assert payload["webui_runtime"]["sessions"]["cap"] == 29
+
+
+def test_diagnostics_cap_reports_the_normalized_explicit_cap(monkeypatch):
+    from api import config, models, system_health
+
+    _fixed_host_metrics(monkeypatch)
+    _pin_config_module_cache(monkeypatch)
+    # An explicit cap never reaches the resolver, so only the enforcer can publish.
+    monkeypatch.setattr(models, "SESSIONS_MAX", 17)
+
+    for explicit, expected in ((0, 17), ("nope", 17), (5, 5)):
+        monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", 4321, raising=False)
+        with _seeded_mapping(config.LOCK, config.SESSIONS, {}):
+            with config.LOCK:
+                models._evict_sessions_over_cap(cap=explicit)
+            snapshot = config.get_runtime_diagnostics_snapshot()
+            payload = system_health.build_system_health_payload()
+
+        assert snapshot["sessions"]["cap"] != 4321, explicit
+        assert snapshot["sessions"]["cap"] == expected, explicit
+        assert payload["webui_runtime"]["sessions"]["cap"] == expected, explicit
+
+
+def test_the_cap_getter_does_not_publish_diagnostics_state(monkeypatch, tmp_path):
+    from api import config
+
+    _pin_config_module_cache(monkeypatch)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("webui:\n  sessions_cache_max: 88\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(config, "_cfg_cache", {})
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0)
+    monkeypatch.setattr(config, "_cfg_path", None)
+    monkeypatch.setattr(config, "_LAST_APPLIED_SESSIONS_CACHE_MAX", 4321, raising=False)
+
+    assert config.get_sessions_cache_max({"webui": {"sessions_cache_max": 42}}) == 42
+    assert config._LAST_APPLIED_SESSIONS_CACHE_MAX == 4321
+    assert config.get_sessions_cache_max() == 88
+    assert config._LAST_APPLIED_SESSIONS_CACHE_MAX == 4321
+
+    # Process start: a fresh import must already carry the getter's dict-mode
+    # answer for the config it loaded, not the SESSIONS_MAX/default tier. Read in
+    # a child process because this one's memo has been rewritten by earlier tests.
+    seeded = subprocess.run(
+        [sys.executable, "-c", "import api.config as c; print(c._LAST_APPLIED_SESSIONS_CACHE_MAX)"],
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "HERMES_CONFIG_PATH": str(config_path)},
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert seeded.returncode == 0, seeded.stderr
+    printed = seeded.stdout.strip().splitlines()
+    assert printed, f"child printed nothing; stderr={seeded.stderr!r}"
+    assert int(printed[-1]) == 88
+
+
+def test_infinite_cap_falls_back_instead_of_raising(tmp_path):
+    """A YAML float infinity must degrade to the bound, not abort the import.
+
+    ``yaml.safe_load`` resolves ``.inf`` to a real float and ``int(float('inf'))``
+    raises OverflowError, which is neither TypeError nor ValueError. The cap is
+    resolved at module scope, so an uncaught raise here takes down startup.
+    """
+    from api import config
+
+    fallback = (
+        config.SESSIONS_MAX
+        if isinstance(config.SESSIONS_MAX, int) and config.SESSIONS_MAX >= 1
+        else config.DEFAULT_SESSIONS_CACHE_MAX
+    )
+    for raw in (float("inf"), float("-inf"), float("nan")):
+        assert config.get_sessions_cache_max({"webui": {"sessions_cache_max": raw}}) == fallback
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("webui:\n  sessions_cache_max: .inf\n", encoding="utf-8")
+    booted = subprocess.run(
+        [sys.executable, "-c", "import api.config as c; print(c._LAST_APPLIED_SESSIONS_CACHE_MAX)"],
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "HERMES_CONFIG_PATH": str(config_path)},
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert booted.returncode == 0, booted.stderr
+    printed = booted.stdout.strip().splitlines()
+    assert printed, f"child printed nothing; stderr={booted.stderr!r}"
+    assert int(printed[-1]) == fallback
+
+
+def test_sessions_lock_busy_does_not_block_sibling_owner():
+    from api import config
+
+    with _held_from_worker(config.LOCK):
+        started = time.monotonic()
+        snapshot = config.get_runtime_diagnostics_snapshot()
+        elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS
+    assert snapshot["sessions"] == {"available": False, "resident": 0, "cap": 0}
+    assert "models_cache" in snapshot
+
+
+def test_models_cache_snapshot_counts_published_groups_without_names():
+    from api import config
+
+    groups = [
+        {
+            "name": "private-provider",
+            "models": [{"id": "secret-model"}],
+            "extra_models": [{"id": "overflow-secret"}, {"id": "other"}],
+        },
+        {"models": [], "extra_models": [{"id": "overflow-two"}]},
+    ]
+    baseline = time.monotonic()
+    with config._available_models_cache_lock:
+        original_cache = config._available_models_cache
+        original_ts = config._available_models_cache_ts
+        config._available_models_cache = {"groups": groups}
+        config._available_models_cache_ts = baseline - 30.0
+    try:
+        result = config.get_runtime_diagnostics_snapshot()["models_cache"]
+    finally:
+        with config._available_models_cache_lock:
+            config._available_models_cache = original_cache
+            config._available_models_cache_ts = original_ts
+
+    assert result["available"] is True
+    assert result["groups"] == 2
+    assert result["models"] == 4
+    # Real clock, bounded range: patching time.monotonic would freeze the stdlib
+    # clock for every other thread in the process.
+    assert 30.0 <= result["age_seconds"] < 30.0 + _NONBLOCKING_BUDGET_SECONDS
+    assert "private-provider" not in repr(result)
+    assert "secret-model" not in repr(result)
+
+
+def test_stream_owner_snapshot_aggregates_channels():
+    from api import config, streaming
+
+    first = config.StreamChannel()
+    _seed_channel_counters(
+        first,
+        subscribers=2,
+        offline_buffered=3,
+        offline_dropped=4,
+        subscriber_dropped=5,
+    )
+    second = config.StreamChannel()
+    _seed_channel_counters(second, subscribers=1, subscriber_dropped=7)
+
+    streams = {"secret-id": first, "other-secret-id": second}
+    with _seeded_mapping(config.STREAMS_LOCK, config.STREAMS, streams):
+        with _seeded_mapping(config.STREAMS_LOCK, config.AGENT_INSTANCES, {"secret-id": object()}):
+            result = streaming.get_stream_runtime_snapshot()
+
+    assert result == {
+        "available": True, "active": 2, "agent_instances": 1,
+        "subscribers": 3, "offline_buffered_events": 3,
+        "offline_dropped_events": 4, "subscriber_dropped_events": 12,
+        "unavailable_channels": 0,
+    }
+    assert "secret-id" not in repr(result)
+
+
+def test_stream_registry_lock_busy_isolated():
+    from api import config, streaming
+
+    with _held_from_worker(config.STREAMS_LOCK):
+        started = time.monotonic()
+        result = streaming.get_stream_runtime_snapshot()
+        elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS
+    assert result["available"] is False
+    assert result["active"] == 0
+
+
+def test_session_list_cache_snapshot_reads_scalars_without_lru_mutation():
+    from api import route_session_list_cache as cache
+
+    probe_key = ("pre-existing-identity-probe",)
+    probe = (0.0, (), {})
+    with cache._SESSIONS_CACHE_LOCK:
+        cache._SESSIONS_CACHE[probe_key] = probe
+    try:
+        with _seeded_mapping(
+            cache._SESSIONS_CACHE_LOCK, cache._SESSIONS_CACHE, {("one",): (0.0, (), {})}
+        ) as original:
+            result = cache.get_session_list_cache_snapshot()
+            assert result == {"available": True, "entries": 1, "inflight_rebuilds": 0, "cap": 64}
+            assert list(cache._SESSIONS_CACHE) == [("one",)]
+
+        assert list(cache._SESSIONS_CACHE) == list(original)
+        assert cache._SESSIONS_CACHE[probe_key] is probe
+    finally:
+        with cache._SESSIONS_CACHE_LOCK:
+            cache._SESSIONS_CACHE.pop(probe_key, None)
+
+
+def test_runtime_unexpected_exception_fail_open(monkeypatch):
+    from api import config, system_health
+
+    monkeypatch.setattr(system_health, "_cpu_percent", lambda: 1.0)
+    monkeypatch.setattr(config, "get_runtime_diagnostics_snapshot", lambda: (_ for _ in ()).throw(RecursionError("secret")))
+    payload = system_health.build_system_health_payload()
+    assert payload["status"] == "partial"
+    assert payload["webui_runtime"]["sessions"]["available"] is False
+    assert {"metric": "webui_runtime.sessions", "code": "RecursionError"} in payload["errors"]
+    assert "secret" not in repr(payload)
+
+
+def test_runtime_owner_failure_preserves_sibling_metrics(monkeypatch):
+    from api import config, route_session_list_cache, streaming, system_health
+
+    monkeypatch.setattr(config, "get_runtime_diagnostics_snapshot", lambda: (_ for _ in ()).throw(RecursionError("secret config")))
+    monkeypatch.setattr(streaming, "get_stream_runtime_snapshot", lambda: {"available": True, "active": 4, "agent_instances": 3, "subscribers": 0, "offline_buffered_events": 0, "offline_dropped_events": 0, "subscriber_dropped_events": 0, "unavailable_channels": 0})
+    monkeypatch.setattr(route_session_list_cache, "get_session_list_cache_snapshot", lambda: {"available": True, "entries": 2, "inflight_rebuilds": 0, "cap": 64})
+    payload = system_health.build_system_health_payload()
+    runtime = payload["webui_runtime"]
+    assert runtime["sessions"]["available"] is False
+    assert runtime["models_cache"]["available"] is False
+    assert runtime["streams"]["active"] == 4
+    assert runtime["session_list_cache"]["entries"] == 2
+    assert "secret config" not in repr(payload)
+
+
+def test_config_owner_collected_once_per_health_payload(monkeypatch):
+    from api import config, system_health
+
+    _fixed_host_metrics(monkeypatch)
+    real = config.get_runtime_diagnostics_snapshot
+    calls = []
+
+    def counting_wrapper():
+        calls.append(True)
+        snapshot = real()
+        # Successive calls disagree, so a second collection would show up as a
+        # sessions/models_cache skew in the response.
+        snapshot["sessions"]["resident"] = 10 * len(calls)
+        snapshot["models_cache"]["groups"] = 10 * len(calls)
+        return snapshot
+
+    monkeypatch.setattr(config, "get_runtime_diagnostics_snapshot", counting_wrapper)
+    payload = system_health.build_system_health_payload()
+
+    assert len(calls) == 1
+    runtime = payload["webui_runtime"]
+    assert runtime["sessions"]["resident"] == 10
+    assert runtime["models_cache"]["groups"] == 10
+
+
+def test_webui_runtime_compositor_failure_preserves_host_metrics(monkeypatch):
+    from api import system_health
+
+    _fixed_host_metrics(monkeypatch)
+
+    def boom(errors):
+        raise RecursionError("secret compositor path")
+
+    monkeypatch.setattr(system_health, "_webui_runtime_payload", boom)
+    payload = system_health.build_system_health_payload()
+
+    _assert_host_metrics_intact(payload)
+    assert payload["status"] == "partial"
+    assert payload["webui_runtime"] == system_health._zero_webui_runtime_payload()
+    assert {"metric": "webui_runtime", "code": "RecursionError"} in payload["errors"]
+    assert "secret compositor path" not in repr(payload)
+
+
+def test_cancel_cleanup_updates_runtime_diagnostics():
+    from api import config, streaming
+
+    stream_id = "production-cleanup-stream"
+    session_id = "production-cleanup-session"
+    agent = Mock()
+    agent.session_id = session_id
+    session = SimpleNamespace(
+        session_id=session_id,
+        active_stream_id=stream_id,
+        pending_user_message=None,
+        pending_user_source=None,
+        pending_attachments=[],
+        pending_started_at=None,
+        messages=[],
+        save=Mock(),
+    )
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            _seeded_mapping(config.STREAMS_LOCK, config.STREAMS, {stream_id: config.StreamChannel()})
+        )
+        stack.enter_context(
+            _seeded_mapping(config.STREAMS_LOCK, config.AGENT_INSTANCES, {stream_id: agent})
+        )
+        stack.enter_context(
+            _seeded_mapping(config.STREAMS_LOCK, config.CANCEL_FLAGS, {stream_id: threading.Event()})
+        )
+        stack.enter_context(_seeded_mapping(config.ACTIVE_RUNS_LOCK, config.ACTIVE_RUNS, {}))
+        before = streaming.get_stream_runtime_snapshot()
+        with patch("api.streaming.get_session", return_value=session):
+            assert streaming.cancel_stream(stream_id) is True
+        after = streaming.get_stream_runtime_snapshot()
+
+    assert before["active"] == 1
+    assert before["agent_instances"] == 1
+    assert after["active"] == 0
+    assert after["agent_instances"] == 0
+    agent.interrupt.assert_called_once_with("Cancelled by user")
+
+
+def test_models_cache_lock_busy():
+    from api import config
+
+    with _held_from_worker(config._available_models_cache_lock):
+        started = time.monotonic()
+        snapshot = config.get_runtime_diagnostics_snapshot()
+        elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS
+    assert snapshot["models_cache"]["available"] is False
+
+
+def test_session_list_cache_lock_busy():
+    from api import route_session_list_cache as cache
+
+    with _held_from_worker(cache._SESSIONS_CACHE_LOCK):
+        started = time.monotonic()
+        result = cache.get_session_list_cache_snapshot()
+        elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS
+    assert result["available"] is False
+
+
+def test_stream_snapshot_failure():
+    from api import config, streaming
+
+    class _FailingChannel(config.StreamChannel):
+        def try_diagnostic_snapshot(self):
+            raise RecursionError("secret path")
+
+    healthy = config.StreamChannel()
+    _seed_channel_counters(
+        healthy,
+        subscribers=2,
+        offline_buffered=3,
+        offline_dropped=4,
+        subscriber_dropped=5,
+    )
+    streams = {"healthy-secret-id": healthy, "failing-secret-id": _FailingChannel()}
+    with _seeded_mapping(config.STREAMS_LOCK, config.STREAMS, streams):
+        with _seeded_mapping(config.STREAMS_LOCK, config.AGENT_INSTANCES, {"healthy-secret-id": object()}):
+            result = streaming.get_stream_runtime_snapshot()
+
+    assert result == {
+        "available": True, "active": 2, "agent_instances": 1,
+        "subscribers": 2, "offline_buffered_events": 3,
+        "offline_dropped_events": 4, "subscriber_dropped_events": 5,
+        "unavailable_channels": 1,
+    }
+    rendered = repr(result)
+    assert "secret path" not in rendered
+    assert "RecursionError" not in rendered
+    assert "secret-id" not in rendered
+
+
+def test_runtime_route_auth_and_privacy(monkeypatch):
+    from api import auth as _auth
+    from api.auth import check_auth
+    from api import system_health
+
+    monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "test-password")
+    _auth._invalidate_password_hash_cache()
+    handler = _FakeHandler()
+    try:
+        assert check_auth(handler, SimpleNamespace(path="/api/system/health", query="")) is False
+        assert handler.status in (302, 401)
+    finally:
+        monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
+        _auth._invalidate_password_hash_cache()
+
+    monkeypatch.setattr(system_health, "_cpu_percent", lambda: 1.0)
+    payload = system_health.build_system_health_payload()
+    assert payload["webui_runtime"]["streams"].keys() >= {
+        "available", "active", "agent_instances", "subscribers"
+    }
+    assert all(key not in repr(payload) for key in ("stream-id", "session-id", "secret-model"))
+
+
+def test_runtime_owner_adapter_routing(monkeypatch):
+    from api import config, route_session_list_cache, streaming, system_health
+
+    monkeypatch.setattr(config, "get_runtime_diagnostics_snapshot", lambda: {
+        "sessions": {"available": True, "resident": 9, "cap": 11},
+        "models_cache": {"available": True, "groups": 3, "models": 4, "age_seconds": 5},
+    })
+    monkeypatch.setattr(streaming, "get_stream_runtime_snapshot", lambda: {
+        "available": True, "active": 7, "agent_instances": 6, "subscribers": 5,
+        "offline_buffered_events": 4, "offline_dropped_events": 3,
+        "subscriber_dropped_events": 2, "unavailable_channels": 1,
+    })
+    monkeypatch.setattr(route_session_list_cache, "get_session_list_cache_snapshot", lambda: {
+        "available": True, "entries": 8, "inflight_rebuilds": 1, "cap": 64,
+    })
+    runtime = system_health._webui_runtime_payload([])
+    assert runtime["sessions"]["resident"] == 9
+    assert runtime["streams"]["active"] == 7
+    assert runtime["session_list_cache"]["entries"] == 8
+
+
+def test_runtime_diagnostics_ignore_profile_storage(monkeypatch, tmp_path):
+    from api import config, profiles, system_health
+
+    _fixed_host_metrics(monkeypatch)
+    hermes_home = tmp_path / ".hermes"
+    leftover_profile = hermes_home / "profiles" / "work"
+    (leftover_profile / "sessions").mkdir(parents=True)
+    (leftover_profile / "config.yaml").write_text(
+        "webui:\n  sessions_cache_max: 7\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    fired = []
+
+    def trap(*args, **kwargs):
+        fired.append(True)
+        raise AssertionError("health collection must not resolve profile storage")
+
+    monkeypatch.setattr(profiles, "get_active_hermes_home", trap)
+    monkeypatch.setattr(config, "_get_config_path", trap)
+
+    payload = system_health.build_system_health_payload()
+
+    assert fired == []
+    assert payload["status"] in {"ok", "partial"}
+    rendered = repr(payload)
+    assert "profiles" not in rendered
+    assert str(hermes_home) not in rendered
+    assert "work" not in rendered

--- a/tests/test_issue693_system_health_panel.py
+++ b/tests/test_issue693_system_health_panel.py
@@ -462,6 +462,7 @@ def test_health_route_completes_while_config_cache_lock_is_held(monkeypatch, tmp
     )
     payload = handler.json_body()
     _assert_host_metrics_intact(payload)
+    assert payload["status"] == "ok"
     runtime = payload["webui_runtime"]
     assert runtime["sessions"] == {"available": True, "resident": 2, "cap": 41}
     assert runtime["streams"]["available"] is True
@@ -522,6 +523,7 @@ def test_health_route_completes_while_one_real_stream_channel_lock_is_held(monke
     )
     payload = handler.json_body()
     _assert_host_metrics_intact(payload)
+    assert payload["status"] == "ok"
     runtime = payload["webui_runtime"]
     assert runtime["streams"] == {
         "available": True,
@@ -758,6 +760,21 @@ def test_sessions_lock_busy_does_not_block_sibling_owner():
     assert elapsed < _NONBLOCKING_BUDGET_SECONDS
     assert snapshot["sessions"] == {"available": False, "resident": 0, "cap": 0}
     assert "models_cache" in snapshot
+
+
+def test_health_status_stays_ok_when_sessions_owner_lock_is_busy(monkeypatch):
+    from api import config, system_health
+
+    _fixed_host_metrics(monkeypatch)
+    with _held_from_worker(config.LOCK):
+        started = time.monotonic()
+        payload = system_health.build_system_health_payload()
+        elapsed = time.monotonic() - started
+
+    assert elapsed < _NONBLOCKING_BUDGET_SECONDS
+    assert payload["status"] == "ok"
+    assert payload["webui_runtime"]["sessions"]["available"] is False
+    assert payload["webui_runtime"]["models_cache"]["available"] is True
 
 
 def test_models_cache_snapshot_counts_published_groups_without_names():


### PR DESCRIPTION
## Thinking Path

- #6351 names several process-owned caches and stream structures, but the existing system-health response only exposes host CPU, RAM, and disk usage.
- Current master already owns the relevant bounds and cleanup paths. The diagnostics change should observe those owners instead of creating profile identity or config-publication state.
- Observing them has to be nonblocking end to end, not just at the outer acquire. A collector that takes an owner lock without waiting and then calls something that waits still lets one busy structure stall the whole health response, so every call reachable from a held section is restricted to counting, arithmetic, module constants, owner-held scalars, and the monotonic clock. That applies at all four owner adapters and the response compositor. `_stream_runtime_diagnostics()` in `api/routes.py` is deliberately left alone: its per-stream deep-health contract and the byte gauge in #6500 both depend on the existing blocking channel snapshot.

## What Changed

- `api/config.py`: add nonblocking aggregate snapshots for the resident session cache, its effective cap, and the published in-memory models cache. The cap is read from a scalar the eviction owner publishes, so collection performs no config, profile, or filesystem work. `get_sessions_cache_max()` stays the sole resolution authority, is side-effect free, and now degrades a YAML float infinity to the documented bound instead of raising. `StreamChannel` also gains a nonblocking snapshot method that shares its counter body with the existing blocking one.
- `api/models.py`: `_evict_sessions_over_cap()` publishes the cap it is about to enforce, as one assignment after its own fallback and type/range normalization, under the `LOCK` its caller contract already requires. Eviction decisions, signature, return value, gate, and log line are unchanged.
- `api/streaming.py`: add an aggregate stream and agent snapshot that uses each channel's nonblocking snapshot, counts a busy channel into `unavailable_channels`, and continues with the remaining channels, without returning stream IDs.
- `api/route_session_list_cache.py`: expose entry and in-flight rebuild counts through the cache owner's lock.
- `api/system_health.py`: add a fixed `webui_runtime` subtree to the existing authenticated health response, with independent degradation when an owner is busy or unavailable. The config owner is collected once per response so its two sections always come from one snapshot, and the runtime block carries its own terminal fail-open so a failure there cannot take the host metrics down with it.
- `tests/test_issue693_system_health_panel.py`: cover owner snapshots, two real contention schedules composed through the route, an exact-identity cleanup oracle, real failing-channel containment, cancellation cleanup, fail-open behavior, authentication, and aggregate-only output.

## Why It Matters

Operators can see whether resident sessions, active streams, offline event buffers, agent instances, sidebar cache entries, or the in-memory model catalog are occupied during a long-running process. The payload provides evidence without changing the lifetime or authority of those objects, and without the diagnostics call becoming a source of contention on the very caches it reports.

## Verification

The two contention regressions hold a real lock from a worker thread and fail on the unmodified collectors for the right reason, blocking for the full hold, then pass here. One holds the config cache lock with the config forced onto the cold path; the other holds one real `StreamChannel`'s lock while a sibling channel carries seeded counters. Both prove the response returns promptly, that the busy owner degrades alone, and that host metrics and every sibling runtime subtree stay populated. The reported cap is proven equal to what a real eviction pass applied on every path that sets it: resolved from config, substituted when the resolver raises, and an explicit argument that is valid, non-integer, or below one. A separate regression proves the resolver itself publishes nothing, and another boots a fresh interpreter against a config carrying a float infinity to prove it starts and reports the bound. The cleanup oracle proves pre-existing cache entries survive by identity, not merely by equality. Focused suites cover the owner snapshots, cancellation cleanup, unexpected collector failure, route authentication, and the absence of identifiers, paths, environment values, model names, or event payloads. CI runs the full matrix.

## Risks / Follow-ups

The reported `cap` is the value `_evict_sessions_over_cap()` last enforced, published by that function after its own fallback and normalization, so it follows the owner rather than a resolution the owner may never have applied. A `config.yaml` change is reflected on the next eviction rather than at read time. That freshness tradeoff is deliberate, because health collection must never perform config or profile I/O. The field's starting value is resolved at import against the config already loaded, so a configured cap is reported correctly before the first eviction runs. `_evict_sessions_over_cap()` reads `SESSIONS_MAX` through `api/models.py`'s import-time copy rather than `api.config`'s live binding; no production path rebinds it, and reporting the copy is faithful to what eviction enforced, but unifying the two bindings would be its own change.

This does not claim to reproduce or fix the reporter's exact three-hour macOS RSS growth. It adds the measurements needed to identify which owner is occupied on real installs. StreamChannel byte-bounding remains in #6500, and lazy transcript loading or periodic eviction remain separate follow-ups if measurements justify them.

The response change is additive. Existing clients can ignore `webui_runtime`. The endpoint remains authenticated and returns aggregate counts only.

## Contract Routing

Task type: additive diagnostics contract

Touched areas: system-health response, process-owned cache snapshots, nonblocking channel snapshot method, stream runtime aggregation, focused backend tests

Relevant public docs:

- None; the existing authenticated route is unchanged and the response addition is self-describing.

Scope boundaries: one scalar publish inside `_evict_sessions_over_cap()` and nothing else in `api/models.py`, no profile lifecycle or identity changes, no stream buffer-policy changes, no new endpoint, no frontend changes, no CHANGELOG edit

Evidence needed before claiming done: base/head response regression, owner-level snapshot tests, two real lock-contention schedules, cleanup coverage, authenticated aggregate-only route proof, and CI

## Contract Change

- Previous contract: `/api/system/health` returned host CPU, RAM, disk, status, timestamp, and errors.
- New contract: the same response also returns an additive `webui_runtime` subtree with aggregate session, stream, sidebar-cache, and models-cache occupancy.
- `StreamChannel` gains an additive nonblocking snapshot method. The existing `diagnostic_snapshot()` keeps its signature, semantics, and counters, so `/health?deep=1` and #6500 are unaffected.
- Affected tests: `tests/test_issue693_system_health_panel.py` covers the response shape, availability behavior, authentication, and privacy boundary.
- Compatibility: no existing key changes type or meaning; clients that do not use the new subtree continue unchanged.

## Upstream

Refs #6351.

## Model Used

Claude Opus 5 via Claude Code CLI
