### PR TITLE
feat(notifications): harden profile-local cron inbox

### DIFF
--- a/api/cron_notifications.py
+++ b/api/cron_notifications.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
+import secrets
+import stat
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
@@ -22,6 +23,10 @@ except ImportError:  # pragma: no cover
 
 _MAX_LIMIT = 200
 _MAX_SCAN_RECORDS = 2000
+_NOTIFICATION_FILE = "notifications.jsonl"
+_LOCK_FILE = "notifications.jsonl.lock"
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
 
 
 def utc_now_iso() -> str:
@@ -45,23 +50,135 @@ def _lock_path(path: Path) -> Path:
     return path.with_suffix(path.suffix + ".lock")
 
 
-def _read_records(home: Path) -> list[dict[str, Any]]:
-    path = notification_path(home)
-    if not path.exists():
-        return []
-    lock = _lock_path(path)
-    lock.parent.mkdir(parents=True, exist_ok=True)
-    records: list[dict[str, Any]] = []
-    with open(lock, "a+", encoding="utf-8") as lock_fh:
+def _notification_key(profile: str, notification_id: Any) -> str:
+    return json.dumps(
+        [str(profile), str(notification_id or "")],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _authoritative_record(row: dict[str, Any], profile: str) -> dict[str, Any]:
+    decorated = dict(row)
+    decorated["profile"] = profile
+    decorated["notification_key"] = _notification_key(profile, decorated.get("id"))
+    return decorated
+
+
+def _require_owned_regular(fd: int, label: str) -> None:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OSError(f"{label}: expected regular file")
+    if metadata.st_uid != os.geteuid():
+        raise PermissionError(f"{label}: owner mismatch")
+    if metadata.st_nlink != 1:
+        raise OSError(f"{label}: hard-linked file rejected")
+
+
+def _open_directory_path(path: Path) -> int:
+    """Open every absolute path component without following symlinks."""
+    expanded = path.expanduser().absolute()
+    parts = expanded.parts
+    if not parts or parts[0] != os.path.sep:
+        raise OSError(f"{expanded}: expected absolute directory path")
+    fd = os.open(os.path.sep, os.O_RDONLY | _O_DIRECTORY)
+    try:
+        for component in parts[1:]:
+            next_fd = os.open(
+                component,
+                os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW,
+                dir_fd=fd,
+            )
+            os.close(fd)
+            fd = next_fd
+        metadata = os.fstat(fd)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise OSError(f"{expanded}: expected profile directory")
+        if metadata.st_uid != os.geteuid():
+            raise PermissionError(f"{expanded}: owner mismatch")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _open_cron_dir(home: Path, *, create: bool) -> int | None:
+    expanded = home.expanduser().absolute()
+    home_fd = _open_directory_path(expanded)
+    try:
         try:
-            os.chmod(lock, 0o600)
-        except OSError:
-            pass
+            cron_fd = os.open(
+                "cron",
+                os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW,
+                dir_fd=home_fd,
+            )
+        except FileNotFoundError:
+            if not create:
+                return None
+            os.mkdir("cron", 0o700, dir_fd=home_fd)
+            cron_fd = os.open(
+                "cron",
+                os.O_RDONLY | _O_DIRECTORY | _O_NOFOLLOW,
+                dir_fd=home_fd,
+            )
+        metadata = os.fstat(cron_fd)
+        if not stat.S_ISDIR(metadata.st_mode):
+            os.close(cron_fd)
+            raise OSError(f"{expanded / 'cron'}: expected directory")
+        if metadata.st_uid != os.geteuid():
+            os.close(cron_fd)
+            raise PermissionError(f"{expanded / 'cron'}: owner mismatch")
+        return cron_fd
+    finally:
+        os.close(home_fd)
+
+
+def _open_owned_regular_at(
+    directory_fd: int,
+    name: str,
+    flags: int,
+    *,
+    mode: int = 0o600,
+) -> int:
+    fd = os.open(name, flags | _O_NOFOLLOW, mode, dir_fd=directory_fd)
+    try:
+        _require_owned_regular(fd, name)
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _read_records(home: Path, profile: str) -> list[dict[str, Any]]:
+    cron_fd = _open_cron_dir(home, create=False)
+    if cron_fd is None:
+        return []
+    records: list[dict[str, Any]] = []
+    lock_fd = -1
+    data_fd = -1
+    try:
+        try:
+            existing = os.stat(
+                _NOTIFICATION_FILE,
+                dir_fd=cron_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return []
+        if not stat.S_ISREG(existing.st_mode):
+            raise OSError(f"{notification_path(home)}: expected regular file")
+        lock_fd = _open_owned_regular_at(
+            cron_fd,
+            _LOCK_FILE,
+            os.O_RDWR | os.O_CREAT,
+        )
+        os.fchmod(lock_fd, 0o600)
         if fcntl is not None:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_SH)
+            fcntl.flock(lock_fd, fcntl.LOCK_SH)
+        data_fd = _open_owned_regular_at(cron_fd, _NOTIFICATION_FILE, os.O_RDONLY)
         try:
             raw_records: deque[str] = deque(maxlen=_MAX_SCAN_RECORDS)
-            with open(path, "r", encoding="utf-8") as fh:
+            with os.fdopen(os.dup(data_fd), "r", encoding="utf-8") as fh:
                 raw_records.extend(fh)
             for raw in raw_records:
                 try:
@@ -70,39 +187,54 @@ def _read_records(home: Path) -> list[dict[str, Any]]:
                     continue
                 if not isinstance(row, dict):
                     continue
-                row = dict(row)
-                row.setdefault("profile", profile_name_for_home(home))
-                records.append(row)
+                records.append(_authoritative_record(row, profile))
         finally:
             if fcntl is not None:
-                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    finally:
+        if data_fd >= 0:
+            os.close(data_fd)
+        if lock_fd >= 0:
+            os.close(lock_fd)
+        os.close(cron_fd)
     return records
 
 
-def _rewrite_mark_read(home: Path, notification_id: str | None, *, read_all: bool = False) -> tuple[list[dict[str, Any]], int]:
-    path = notification_path(home)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock = _lock_path(path)
-    lock.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a", encoding="utf-8"):
-        pass
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
+def _rewrite_mark_read(
+    home: Path,
+    notification_id: str | None,
+    *,
+    profile: str,
+    read_all: bool = False,
+) -> tuple[list[dict[str, Any]], int]:
+    cron_fd = _open_cron_dir(home, create=True)
+    if cron_fd is None:  # pragma: no cover - create=True guarantees a descriptor.
+        raise OSError(f"{home}: cron directory unavailable")
     now = utc_now_iso()
     updated: list[dict[str, Any]] = []
     changed = 0
-    with open(lock, "a+", encoding="utf-8") as lock_fh:
-        try:
-            os.chmod(lock, 0o600)
-        except OSError:
-            pass
+    lock_fd = -1
+    data_fd = -1
+    temp_fd = -1
+    temp_name = ""
+    try:
+        lock_fd = _open_owned_regular_at(
+            cron_fd,
+            _LOCK_FILE,
+            os.O_RDWR | os.O_CREAT,
+        )
+        os.fchmod(lock_fd, 0o600)
         if fcntl is not None:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        data_fd = _open_owned_regular_at(
+            cron_fd,
+            _NOTIFICATION_FILE,
+            os.O_RDWR | os.O_CREAT,
+        )
+        os.fchmod(data_fd, 0o600)
         try:
             rows: list[tuple[str | None, dict[str, Any] | None]] = []
-            with open(path, "r", encoding="utf-8") as fh:
+            with os.fdopen(os.dup(data_fd), "r", encoding="utf-8") as fh:
                 for raw in fh:
                     try:
                         row = json.loads(raw)
@@ -119,13 +251,19 @@ def _rewrite_mark_read(home: Path, notification_id: str | None, *, read_all: boo
                         row["read_at"] = now
                         changed += 1
                     if should_mark:
-                        row.setdefault("profile", profile_name_for_home(home))
-                        updated.append(dict(row))
+                        row["profile"] = profile
+                        updated.append(_authoritative_record(row, profile))
                     rows.append((None, row))
 
-            fd, tmp_name = tempfile.mkstemp(prefix="notifications.", suffix=".tmp", dir=str(path.parent))
+            temp_name = f".notifications.{os.getpid()}.{secrets.token_hex(12)}.tmp"
+            temp_fd = _open_owned_regular_at(
+                cron_fd,
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            )
+            os.fchmod(temp_fd, 0o600)
             try:
-                with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+                with os.fdopen(os.dup(temp_fd), "w", encoding="utf-8") as tmp:
                     for raw, row in rows:
                         if row is not None:
                             tmp.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
@@ -136,19 +274,33 @@ def _rewrite_mark_read(home: Path, notification_id: str | None, *, read_all: boo
                         os.fsync(tmp.fileno())
                     except OSError:
                         pass
-                os.replace(tmp_name, path)
-                try:
-                    os.chmod(path, 0o600)
-                except OSError:
-                    pass
+                os.replace(
+                    temp_name,
+                    _NOTIFICATION_FILE,
+                    src_dir_fd=cron_fd,
+                    dst_dir_fd=cron_fd,
+                )
+                temp_name = ""
             finally:
-                try:
-                    os.unlink(tmp_name)
-                except FileNotFoundError:
-                    pass
+                if temp_fd >= 0:
+                    os.close(temp_fd)
+                    temp_fd = -1
+                if temp_name:
+                    try:
+                        os.unlink(temp_name, dir_fd=cron_fd)
+                    except FileNotFoundError:
+                        pass
         finally:
             if fcntl is not None:
-                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    finally:
+        if temp_fd >= 0:
+            os.close(temp_fd)
+        if data_fd >= 0:
+            os.close(data_fd)
+        if lock_fd >= 0:
+            os.close(lock_fd)
+        os.close(cron_fd)
     return updated, changed
 
 
@@ -173,9 +325,11 @@ def visible_profile_homes(*, all_profiles: bool = False) -> list[tuple[str, Path
     )
 
     active_name = get_active_profile_name() or "default"
-    active_home = Path(get_active_hermes_home()).expanduser()
+    active_home = Path(get_active_hermes_home()).expanduser().absolute()
+    if active_home.is_symlink() or not active_home.is_dir():
+        raise OSError(f"{active_home}: unsafe active profile home")
     homes: list[tuple[str, Path]] = [(active_name, active_home)]
-    seen = {str(active_home.resolve()) if active_home.exists() else str(active_home)}
+    seen = {str(active_home)}
     if not all_profiles or _is_isolated_profile_mode():
         return homes
 
@@ -185,18 +339,26 @@ def visible_profile_homes(*, all_profiles: bool = False) -> list[tuple[str, Path
             name = str(row.get("name") or "").strip()
             if name:
                 names.add(name)
-    profiles_dir = _active_base_home(active_home) / "profiles"
+    base_home = _active_base_home(active_home).absolute()
+    profiles_dir = base_home / "profiles"
+    if profiles_dir.is_symlink():
+        raise OSError(f"{profiles_dir}: symlinked profiles directory rejected")
     if profiles_dir.is_dir():
         for child in profiles_dir.iterdir():
+            if child.is_symlink():
+                continue
             if child.is_dir() and child.name:
                 names.add(child.name)
 
     for name in sorted(names):
         try:
-            home = Path(get_hermes_home_for_profile(name)).expanduser()
+            home = Path(get_hermes_home_for_profile(name)).expanduser().absolute()
         except Exception:
             continue
-        key = str(home.resolve()) if home.exists() else str(home)
+        expected = base_home if name == "default" else profiles_dir / name
+        if home != expected or home.is_symlink() or not home.is_dir():
+            continue
+        key = str(home)
         if key in seen:
             continue
         seen.add(key)
@@ -213,12 +375,11 @@ def notification_summary(*, limit: int = 50, unread_only: bool = False, all_prof
     records: list[dict[str, Any]] = []
     unread_by_profile: dict[str, int] = {}
     for profile, home in visible_profile_homes(all_profiles=all_profiles):
-        profile_records = _read_records(home)
+        profile_records = _read_records(home, profile)
         # Newer appended rows win ties from legacy second-resolution timestamps.
         for row in reversed(profile_records):
-            row.setdefault("profile", profile)
             if not row.get("read_at"):
-                unread_by_profile[row["profile"]] = unread_by_profile.get(row["profile"], 0) + 1
+                unread_by_profile[profile] = unread_by_profile.get(profile, 0) + 1
             if unread_only and row.get("read_at"):
                 continue
             records.append(row)
@@ -239,12 +400,17 @@ def mark_read(notification_id: str, *, profile: str | None = None) -> dict[str, 
         match = next((home for name, home in visible if name == requested), None)
         if match is None:
             return None
+        selected_profile = requested
         home = match
     else:
         if not visible:
             return None
-        home = visible[0][1]
-    updated, _changed = _rewrite_mark_read(home, notification_id)
+        selected_profile, home = visible[0]
+    updated, _changed = _rewrite_mark_read(
+        home,
+        notification_id,
+        profile=selected_profile,
+    )
     for row in updated:
         if str(row.get("id") or "") == str(notification_id):
             return row
@@ -253,8 +419,13 @@ def mark_read(notification_id: str, *, profile: str | None = None) -> dict[str, 
 
 def mark_all_read(*, all_profiles: bool = False) -> dict[str, Any]:
     changed = 0
-    for _profile, home in visible_profile_homes(all_profiles=all_profiles):
-        _updated, count = _rewrite_mark_read(home, None, read_all=True)
+    for profile, home in visible_profile_homes(all_profiles=all_profiles):
+        _updated, count = _rewrite_mark_read(
+            home,
+            None,
+            profile=profile,
+            read_all=True,
+        )
         changed += count
     return {"ok": True, "changed": changed}
 

--- a/api/cron_notifications.py
+++ b/api/cron_notifications.py
@@ -1,0 +1,264 @@
+"""WebUI/Hermex cron notification API helpers.
+
+Reads the profile-local cron notification JSONL files written by Hermes Agent's
+``cron.webui_notifications`` module.  This file deliberately contains only
+filesystem-level helpers and leaves HTTP concerns in ``api.routes``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - platform fallback.
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+_MAX_LIMIT = 200
+_MAX_SCAN_RECORDS = 2000
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def notification_path(home: str | Path) -> Path:
+    return Path(home).expanduser() / "cron" / "notifications.jsonl"
+
+
+def profile_name_for_home(home: str | Path) -> str:
+    p = Path(home).expanduser()
+    if p.parent.name == "profiles" and p.name:
+        return p.name
+    return "default"
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".lock")
+
+
+def _read_records(home: Path) -> list[dict[str, Any]]:
+    path = notification_path(home)
+    if not path.exists():
+        return []
+    lock = _lock_path(path)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict[str, Any]] = []
+    with open(lock, "a+", encoding="utf-8") as lock_fh:
+        try:
+            os.chmod(lock, 0o600)
+        except OSError:
+            pass
+        if fcntl is not None:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_SH)
+        try:
+            raw_records: deque[str] = deque(maxlen=_MAX_SCAN_RECORDS)
+            with open(path, "r", encoding="utf-8") as fh:
+                raw_records.extend(fh)
+            for raw in raw_records:
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                row = dict(row)
+                row.setdefault("profile", profile_name_for_home(home))
+                records.append(row)
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+    return records
+
+
+def _rewrite_mark_read(home: Path, notification_id: str | None, *, read_all: bool = False) -> tuple[list[dict[str, Any]], int]:
+    path = notification_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = _lock_path(path)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8"):
+        pass
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    now = utc_now_iso()
+    updated: list[dict[str, Any]] = []
+    changed = 0
+    with open(lock, "a+", encoding="utf-8") as lock_fh:
+        try:
+            os.chmod(lock, 0o600)
+        except OSError:
+            pass
+        if fcntl is not None:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            rows: list[tuple[str | None, dict[str, Any] | None]] = []
+            with open(path, "r", encoding="utf-8") as fh:
+                for raw in fh:
+                    try:
+                        row = json.loads(raw)
+                    except json.JSONDecodeError:
+                        rows.append((raw, None))
+                        continue
+                    if not isinstance(row, dict):
+                        rows.append((raw, None))
+                        continue
+                    row = dict(row)
+                    row_id = str(row.get("id") or "")
+                    should_mark = read_all or (notification_id is not None and row_id == str(notification_id))
+                    if should_mark and not row.get("read_at"):
+                        row["read_at"] = now
+                        changed += 1
+                    if should_mark:
+                        row.setdefault("profile", profile_name_for_home(home))
+                        updated.append(dict(row))
+                    rows.append((None, row))
+
+            fd, tmp_name = tempfile.mkstemp(prefix="notifications.", suffix=".tmp", dir=str(path.parent))
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+                    for raw, row in rows:
+                        if row is not None:
+                            tmp.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+                        elif raw:
+                            tmp.write(raw if raw.endswith("\n") else raw + "\n")
+                    tmp.flush()
+                    try:
+                        os.fsync(tmp.fileno())
+                    except OSError:
+                        pass
+                os.replace(tmp_name, path)
+                try:
+                    os.chmod(path, 0o600)
+                except OSError:
+                    pass
+            finally:
+                try:
+                    os.unlink(tmp_name)
+                except FileNotFoundError:
+                    pass
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+    return updated, changed
+
+
+def _active_base_home(active_home: Path) -> Path:
+    if active_home.parent.name == "profiles":
+        return active_home.parent.parent
+    return active_home
+
+
+def visible_profile_homes(*, all_profiles: bool = False) -> list[tuple[str, Path]]:
+    """Return visible profile homes for notification reads.
+
+    Default is the active request profile only.  ``all_profiles`` mirrors the
+    existing WebUI cross-profile opt-in and is ignored in isolated profile mode.
+    """
+    from api.profiles import (
+        _is_isolated_profile_mode,
+        get_active_hermes_home,
+        get_active_profile_name,
+        get_hermes_home_for_profile,
+        list_profiles_api,
+    )
+
+    active_name = get_active_profile_name() or "default"
+    active_home = Path(get_active_hermes_home()).expanduser()
+    homes: list[tuple[str, Path]] = [(active_name, active_home)]
+    seen = {str(active_home.resolve()) if active_home.exists() else str(active_home)}
+    if not all_profiles or _is_isolated_profile_mode():
+        return homes
+
+    names = {"default"}
+    for row in list_profiles_api():
+        if isinstance(row, dict):
+            name = str(row.get("name") or "").strip()
+            if name:
+                names.add(name)
+    profiles_dir = _active_base_home(active_home) / "profiles"
+    if profiles_dir.is_dir():
+        for child in profiles_dir.iterdir():
+            if child.is_dir() and child.name:
+                names.add(child.name)
+
+    for name in sorted(names):
+        try:
+            home = Path(get_hermes_home_for_profile(name)).expanduser()
+        except Exception:
+            continue
+        key = str(home.resolve()) if home.exists() else str(home)
+        if key in seen:
+            continue
+        seen.add(key)
+        homes.append((name, home))
+    return homes
+
+
+def notification_summary(*, limit: int = 50, unread_only: bool = False, all_profiles: bool = False) -> dict[str, Any]:
+    try:
+        cap = int(limit)
+    except (TypeError, ValueError):
+        cap = 50
+    cap = max(1, min(cap, _MAX_LIMIT))
+    records: list[dict[str, Any]] = []
+    unread_by_profile: dict[str, int] = {}
+    for profile, home in visible_profile_homes(all_profiles=all_profiles):
+        profile_records = _read_records(home)
+        # Newer appended rows win ties from legacy second-resolution timestamps.
+        for row in reversed(profile_records):
+            row.setdefault("profile", profile)
+            if not row.get("read_at"):
+                unread_by_profile[row["profile"]] = unread_by_profile.get(row["profile"], 0) + 1
+            if unread_only and row.get("read_at"):
+                continue
+            records.append(row)
+    records.sort(key=lambda r: str(r.get("created_at") or ""), reverse=True)
+    return {
+        "notifications": records[:cap],
+        "unread_count": sum(unread_by_profile.values()),
+        "unread_by_profile": unread_by_profile,
+    }
+
+
+def mark_read(notification_id: str, *, profile: str | None = None) -> dict[str, Any] | None:
+    if not notification_id:
+        return None
+    visible = visible_profile_homes(all_profiles=bool(profile))
+    if profile:
+        requested = str(profile).strip()
+        match = next((home for name, home in visible if name == requested), None)
+        if match is None:
+            return None
+        home = match
+    else:
+        if not visible:
+            return None
+        home = visible[0][1]
+    updated, _changed = _rewrite_mark_read(home, notification_id)
+    for row in updated:
+        if str(row.get("id") or "") == str(notification_id):
+            return row
+    return None
+
+
+def mark_all_read(*, all_profiles: bool = False) -> dict[str, Any]:
+    changed = 0
+    for _profile, home in visible_profile_homes(all_profiles=all_profiles):
+        _updated, count = _rewrite_mark_read(home, None, read_all=True)
+        changed += count
+    return {"ok": True, "changed": changed}
+
+
+def sse_event(event: str, data: dict[str, Any]) -> bytes:
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return f"event: {event}\ndata: {payload}\n\n".encode("utf-8")

--- a/api/routes.py
+++ b/api/routes.py
@@ -13362,6 +13362,12 @@ def handle_get(handler, parsed) -> bool:
     if session_events_session_id is not None:
         return _handle_session_sse_stream_for_session(handler, parsed, session_events_session_id)
 
+    if parsed.path == "/api/notifications":
+        return _handle_notifications(handler, parsed)
+
+    if parsed.path == "/api/notifications/events":
+        return _handle_notifications_events(handler, parsed)
+
     if parsed.path == "/api/media":
         return _handle_media(handler, parsed)
 
@@ -15274,6 +15280,12 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/terminal/close":
         return _handle_terminal_close(handler, body)
+
+    if parsed.path == "/api/notifications/read":
+        return _handle_notifications_read(handler, body)
+
+    if parsed.path == "/api/notifications/read-all":
+        return _handle_notifications_read_all(handler, parsed)
 
     # ── Cron API (POST) ──
     # See GET-side comment above: wrap in cron_profile_context so writes go
@@ -22517,6 +22529,93 @@ def _selected_profile_snapshot_updates(
     return updates
 
 
+def _handle_notifications(handler, parsed):
+    """Return profile-scoped WebUI/Hermex cron notifications."""
+    from api.cron_notifications import notification_summary
+
+    limit = _query_positive_int(parsed, "limit", default=50, maximum=200) or 50
+    unread_only = _query_flag(parsed, "unread_only")
+    return j(
+        handler,
+        notification_summary(
+            limit=limit,
+            unread_only=unread_only,
+            all_profiles=_all_profiles_enabled(parsed),
+        ),
+    )
+
+
+def _handle_notifications_events(handler, parsed):
+    """Polling SSE stream for new cron notifications."""
+    from api.cron_notifications import notification_summary, sse_event
+
+    all_profiles = _all_profiles_enabled(parsed)
+    once = _query_flag(parsed, "once")
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
+    handler.send_header("Cache-Control", "no-cache")
+    handler.send_header("X-Accel-Buffering", "no")
+    handler.send_header("Connection", "close")
+    end_sse_headers(handler)
+    try:
+        _sse_set_write_deadline(handler)
+    except Exception:
+        pass
+
+    try:
+        initial = notification_summary(limit=200, all_profiles=all_profiles)
+        seen = {str(row.get("id") or "") for row in initial.get("notifications", []) if row.get("id")}
+        if once:
+            handler.wfile.write(sse_event("snapshot", initial))
+            handler.wfile.flush()
+            return True
+
+        last_heartbeat = time.time()
+        while True:
+            # Cron completion is not latency-critical. Five seconds keeps the
+            # inbox responsive while bounding repeated JSONL scans per browser.
+            time.sleep(5)
+            current = notification_summary(limit=200, all_profiles=all_profiles)
+            new_rows = [
+                row for row in reversed(current.get("notifications", []))
+                if row.get("id") and str(row.get("id")) not in seen
+            ]
+            for row in new_rows:
+                seen.add(str(row.get("id")))
+                handler.wfile.write(sse_event("notification", row))
+                handler.wfile.flush()
+            now = time.time()
+            if now - last_heartbeat >= 25:
+                handler.wfile.write(b": notifications heartbeat\n\n")
+                handler.wfile.flush()
+                last_heartbeat = now
+    except _CLIENT_DISCONNECT_ERRORS:
+        pass
+    return True
+
+
+def _handle_notifications_read(handler, body):
+    notification_id = str(body.get("id") or "").strip()
+    if not notification_id:
+        return bad(handler, "id required")
+    profile = body.get("profile") or None
+    from api.cron_notifications import mark_read, notification_summary
+
+    row = mark_read(notification_id, profile=profile)
+    if not row:
+        return bad(handler, "Notification not found", 404)
+    return j(handler, {"ok": True, "notification": row, "summary": notification_summary(limit=1)})
+
+
+def _handle_notifications_read_all(handler, parsed):
+    from api.cron_notifications import mark_all_read, notification_summary
+
+    all_profiles = _all_profiles_enabled(parsed)
+    result = mark_all_read(all_profiles=all_profiles)
+    result["summary"] = notification_summary(limit=1, all_profiles=all_profiles)
+    return j(handler, result)
+
+
 def _handle_cron_create(handler, body):
     try:
         require(body, "prompt", "schedule")
@@ -22565,6 +22664,7 @@ def _handle_cron_delivery_options(handler):
         _KNOWN_DELIVERY_PLATFORMS = frozenset()
     platforms = [
         {"value": "local", "label": "Local (save output only)"},
+        {"value": "webui", "label": "Hermex/WebUI Inbox"},
         {"value": "origin", "label": "Origin (reply to creator)"}
     ]
     for name in sorted(_KNOWN_DELIVERY_PLATFORMS):

--- a/api/routes.py
+++ b/api/routes.py
@@ -22564,10 +22564,14 @@ def _handle_notifications_events(handler, parsed):
 
     try:
         initial = notification_summary(limit=200, all_profiles=all_profiles)
-        seen = {str(row.get("id") or "") for row in initial.get("notifications", []) if row.get("id")}
+        seen = {
+            str(row.get("notification_key") or "")
+            for row in initial.get("notifications", [])
+            if row.get("notification_key")
+        }
+        handler.wfile.write(sse_event("snapshot", initial))
+        handler.wfile.flush()
         if once:
-            handler.wfile.write(sse_event("snapshot", initial))
-            handler.wfile.flush()
             return True
 
         last_heartbeat = time.time()
@@ -22578,10 +22582,11 @@ def _handle_notifications_events(handler, parsed):
             current = notification_summary(limit=200, all_profiles=all_profiles)
             new_rows = [
                 row for row in reversed(current.get("notifications", []))
-                if row.get("id") and str(row.get("id")) not in seen
+                if row.get("notification_key")
+                and str(row.get("notification_key")) not in seen
             ]
             for row in new_rows:
-                seen.add(str(row.get("id")))
+                seen.add(str(row.get("notification_key")))
                 handler.wfile.write(sse_event("notification", row))
                 handler.wfile.flush()
             now = time.time()

--- a/scripts/plan_cron_webui_migration.py
+++ b/scripts/plan_cron_webui_migration.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Plan/apply additive Hermex/WebUI cron delivery migration.
+
+Adds the profile-local WebUI inbox target (`webui`) in front of existing push
+cron delivery targets while preserving existing Telegram/origin fallback. Local
+jobs stay local by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+WEBUI_ALIASES = {"webui", "hermex"}
+LOCAL_TOKENS = {"", "local"}
+
+
+@dataclass
+class ProfileCronFile:
+    profile: str
+    home: Path
+    path: Path
+
+
+@dataclass
+class DeliveryChange:
+    profile: str
+    job_id: str
+    name: str
+    old_deliver: Any
+    new_deliver: Any
+    reason: str
+
+
+@dataclass
+class ProfileReport:
+    profile: str
+    path: str
+    status: str
+    total_jobs: int = 0
+    changed_jobs: int = 0
+    unchanged_jobs: int = 0
+    local_jobs: int = 0
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_profile_files(home: Path) -> list[ProfileCronFile]:
+    home = home.expanduser().resolve()
+    rows = [ProfileCronFile("default", home, home / "cron" / "jobs.json")]
+    profiles_dir = home / "profiles"
+    if profiles_dir.is_dir():
+        for child in sorted(profiles_dir.iterdir(), key=lambda p: p.name):
+            if child.is_dir() and child.name:
+                rows.append(ProfileCronFile(child.name, child, child / "cron" / "jobs.json"))
+    return rows
+
+
+def load_jobs_file(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected top-level object")
+    jobs = data.get("jobs")
+    if jobs is None:
+        jobs = []
+        data["jobs"] = jobs
+    if not isinstance(jobs, list):
+        raise ValueError(f"{path}: expected jobs list")
+    for idx, job in enumerate(jobs):
+        if not isinstance(job, dict):
+            raise ValueError(f"{path}: jobs[{idx}] is not an object")
+    return data, jobs
+
+
+def split_deliver(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        raw = value
+    else:
+        raw = str(value).split(",")
+    tokens: list[str] = []
+    for item in raw:
+        text = str(item).strip()
+        if text and text not in tokens:
+            tokens.append(text)
+    return tokens
+
+
+def deliver_has_webui(tokens: Iterable[str]) -> bool:
+    return any(str(token).strip().lower() in WEBUI_ALIASES for token in tokens)
+
+
+def deliver_is_local_only(tokens: list[str]) -> bool:
+    if not tokens:
+        return True
+    return len(tokens) == 1 and tokens[0].strip().lower() in LOCAL_TOKENS
+
+
+def add_webui_delivery(value: Any, *, include_local: bool = False) -> tuple[Any, str | None]:
+    tokens = split_deliver(value)
+    if deliver_has_webui(tokens):
+        return value, None
+    if deliver_is_local_only(tokens) and not include_local:
+        return value, "local"
+    if not tokens:
+        tokens = ["local"]
+    new_tokens = ["webui"] + tokens
+    if isinstance(value, list):
+        return new_tokens, "additive"
+    return ",".join(new_tokens), "additive"
+
+
+def job_label(job: dict[str, Any]) -> str:
+    return str(job.get("name") or job.get("id") or "unnamed")
+
+
+def plan_profile(profile_file: ProfileCronFile, *, include_local: bool = False) -> tuple[ProfileReport, list[DeliveryChange], dict[str, Any] | None]:
+    path = profile_file.path
+    if not path.exists():
+        return ProfileReport(profile_file.profile, str(path), "missing"), [], None
+    data, jobs = load_jobs_file(path)
+    planned = copy.deepcopy(data)
+    planned_jobs = planned.get("jobs") or []
+    changes: list[DeliveryChange] = []
+    local_jobs = 0
+    unchanged = 0
+    for job in planned_jobs:
+        old = job.get("deliver", "local")
+        new, reason = add_webui_delivery(old, include_local=include_local)
+        if reason == "local":
+            local_jobs += 1
+            unchanged += 1
+            continue
+        if reason is None:
+            unchanged += 1
+            continue
+        if new != old:
+            job["deliver"] = new
+            changes.append(
+                DeliveryChange(
+                    profile=profile_file.profile,
+                    job_id=str(job.get("id") or ""),
+                    name=job_label(job),
+                    old_deliver=old,
+                    new_deliver=new,
+                    reason=reason,
+                )
+            )
+        else:
+            unchanged += 1
+    report = ProfileReport(
+        profile=profile_file.profile,
+        path=str(path),
+        status="ok",
+        total_jobs=len(jobs),
+        changed_jobs=len(changes),
+        unchanged_jobs=unchanged,
+        local_jobs=local_jobs,
+    )
+    return report, changes, planned if changes else data
+
+
+def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def backup_file(source: Path, backup_dir: Path, profile: str) -> Path:
+    target = backup_dir / profile / "cron" / "jobs.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    return target
+
+
+def build_plan(home: Path, *, include_local: bool = False) -> tuple[list[ProfileReport], list[DeliveryChange], dict[str, dict[str, Any]]]:
+    reports: list[ProfileReport] = []
+    changes: list[DeliveryChange] = []
+    planned_by_profile: dict[str, dict[str, Any]] = {}
+    for profile_file in discover_profile_files(home):
+        report, profile_changes, planned = plan_profile(profile_file, include_local=include_local)
+        reports.append(report)
+        changes.extend(profile_changes)
+        if profile_changes and planned is not None:
+            planned_by_profile[profile_file.profile] = planned
+    return reports, changes, planned_by_profile
+
+
+def print_report(reports: list[ProfileReport], changes: list[DeliveryChange], *, as_json: bool) -> None:
+    payload = {
+        "summary": {
+            "profiles": len(reports),
+            "changed_jobs": len(changes),
+            "local_jobs_unchanged": sum(r.local_jobs for r in reports),
+        },
+        "profiles": [asdict(r) for r in reports],
+        "changes": [asdict(c) for c in changes],
+    }
+    if as_json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    print(f"Hermex/WebUI cron migration plan: {len(changes)} job(s) would gain webui")
+    for report in reports:
+        if report.status == "missing":
+            print(f"- {report.profile}: no cron/jobs.json ({report.path})")
+        else:
+            print(
+                f"- {report.profile}: {report.changed_jobs}/{report.total_jobs} change(s), "
+                f"{report.local_jobs} local-only unchanged"
+            )
+    if changes:
+        print("\nProposed delivery changes:")
+        for change in changes:
+            print(
+                f"- {change.profile}:{change.job_id} — {change.name}: "
+                f"{change.old_deliver!r} -> {change.new_deliver!r}"
+            )
+
+
+def apply_plan(home: Path, backup_dir: Path, reports: list[ProfileReport], changes: list[DeliveryChange], planned_by_profile: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    backup_dir = backup_dir.expanduser().resolve()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    profile_files = {row.profile: row for row in discover_profile_files(home)}
+    backups: list[dict[str, str]] = []
+    for profile in planned_by_profile:
+        source = profile_files[profile].path
+        backup_path = backup_file(source, backup_dir, profile)
+        backups.append({"profile": profile, "source": str(source), "backup": str(backup_path)})
+    manifest = {
+        "created_at": utc_now(),
+        "home": str(home.expanduser().resolve()),
+        "changes": [asdict(c) for c in changes],
+        "reports": [asdict(r) for r in reports],
+        "backups": backups,
+    }
+    (backup_dir / "manifest.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    for profile, planned in planned_by_profile.items():
+        atomic_write_json(profile_files[profile].path, planned)
+    return manifest
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plan/apply additive webui delivery migration for Hermes cron jobs.")
+    parser.add_argument("--home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")), help="Base Hermes home containing cron/jobs.json and profiles/. Default: $HERMES_HOME or ~/.hermes")
+    parser.add_argument("--apply", action="store_true", help="Write proposed delivery changes. Dry-run is the default.")
+    parser.add_argument("--backup-dir", help="Required with --apply. A copy of every affected jobs.json is written here before mutation.")
+    parser.add_argument("--include-local", action="store_true", help="Also add webui to local-only jobs. Default leaves local jobs unchanged.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON plan/report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(argv or sys.argv[1:]))
+    home = Path(args.home).expanduser().resolve()
+    reports, changes, planned_by_profile = build_plan(home, include_local=args.include_local)
+    if args.apply and not args.backup_dir:
+        print("ERROR: --apply requires --backup-dir", file=sys.stderr)
+        return 2
+    print_report(reports, changes, as_json=args.json)
+    if args.apply:
+        manifest = apply_plan(home, Path(args.backup_dir), reports, changes, planned_by_profile)
+        if args.json:
+            # Keep stdout JSON parseable for dry-run plans; apply receipt goes to stderr.
+            print(json.dumps({"applied": True, "manifest": str(Path(args.backup_dir).expanduser().resolve() / "manifest.json")}), file=sys.stderr)
+        else:
+            print(f"\nApplied {len(changes)} change(s). Backup manifest: {Path(args.backup_dir).expanduser().resolve() / 'manifest.json'}")
+            for item in manifest["backups"]:
+                print(f"- backup {item['profile']}: {item['backup']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_cron_webui_migration.py
+++ b/scripts/plan_cron_webui_migration.py
@@ -10,18 +10,29 @@ from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
 import json
 import os
-import shutil
+import secrets
+import stat
 import sys
-import tempfile
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - apply is intentionally POSIX-only.
+    fcntl = None  # type: ignore[assignment]
+
 WEBUI_ALIASES = {"webui", "hermex"}
 LOCAL_TOKENS = {"", "local"}
+O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+O_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+JOBS_LOCK_FILE = ".jobs.lock"
+JOBS_LOCK_TIMEOUT_SECONDS = 5.0
 
 
 @dataclass
@@ -52,35 +63,301 @@ class ProfileReport:
     local_jobs: int = 0
 
 
+class PlannedJobs(dict[str, Any]):
+    """Transformed jobs plus the exact source digest the plan was based on."""
+
+    def __init__(self, data: dict[str, Any], source_sha256: str):
+        super().__init__(data)
+        self.source_sha256 = source_sha256
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def assert_no_symlink_components(path: Path, *, allow_missing: bool = False) -> None:
+    expanded = path.expanduser().absolute()
+    parts = expanded.parts
+    if not parts or parts[0] != os.path.sep:
+        raise ValueError(f"{expanded}: expected absolute path")
+    cursor = Path(parts[0])
+    for component in parts[1:]:
+        cursor /= component
+        try:
+            metadata = os.lstat(cursor)
+        except FileNotFoundError:
+            if allow_missing:
+                return
+            raise ValueError(f"{cursor}: path component missing") from None
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError(f"{cursor}: symlinked path component rejected")
+
+
+def _open_directory_path(path: Path) -> int:
+    """Open every absolute directory component with openat + O_NOFOLLOW."""
+    expanded = path.expanduser().absolute()
+    parts = expanded.parts
+    if not parts or parts[0] != os.path.sep:
+        raise ValueError(f"{expanded}: expected absolute path")
+    fd = os.open(os.path.sep, os.O_RDONLY | O_DIRECTORY)
+    try:
+        for component in parts[1:]:
+            next_fd = os.open(
+                component,
+                os.O_RDONLY | O_DIRECTORY | O_NOFOLLOW,
+                dir_fd=fd,
+            )
+            os.close(fd)
+            fd = next_fd
+        metadata = os.fstat(fd)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"{expanded}: expected directory")
+        if metadata.st_uid != os.geteuid():
+            raise PermissionError(f"{expanded}: owner mismatch")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _require_owned_regular(fd: int, label: str) -> os.stat_result:
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"{label}: expected regular file")
+    if metadata.st_uid != os.geteuid():
+        raise PermissionError(f"{label}: owner mismatch")
+    if metadata.st_nlink != 1:
+        raise ValueError(f"{label}: hard-linked file rejected")
+    return metadata
+
+
+def _open_profile_file(
+    profile_file: ProfileCronFile,
+) -> tuple[int, int, int] | None:
+    """Return stable home/cron/jobs descriptors, or None for a missing file."""
+    home_fd = _open_directory_path(profile_file.home)
+    cron_fd = -1
+    jobs_fd = -1
+    try:
+        try:
+            cron_fd = os.open(
+                "cron",
+                os.O_RDONLY | O_DIRECTORY | O_NOFOLLOW,
+                dir_fd=home_fd,
+            )
+        except FileNotFoundError:
+            os.close(home_fd)
+            return None
+        try:
+            jobs_fd = os.open(
+                profile_file.path.name,
+                os.O_RDONLY | O_NOFOLLOW,
+                dir_fd=cron_fd,
+            )
+        except FileNotFoundError:
+            os.close(cron_fd)
+            os.close(home_fd)
+            return None
+        _require_owned_regular(jobs_fd, str(profile_file.path))
+        return home_fd, cron_fd, jobs_fd
+    except BaseException:
+        if jobs_fd >= 0:
+            os.close(jobs_fd)
+        if cron_fd >= 0:
+            os.close(cron_fd)
+        if home_fd >= 0:
+            os.close(home_fd)
+        raise
+
+
+def _close_profile_file(handles: tuple[int, int, int]) -> None:
+    for fd in reversed(handles):
+        os.close(fd)
+
+
+def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def _assert_profile_file_current(
+    profile_file: ProfileCronFile,
+    handles: tuple[int, int, int],
+) -> None:
+    """Fail closed if any validated home/cron/jobs anchor was swapped."""
+    home_fd, cron_fd, jobs_fd = handles
+    reopened_home = _open_directory_path(profile_file.home)
+    try:
+        if not _same_inode(os.fstat(home_fd), os.fstat(reopened_home)):
+            raise ValueError(f"{profile_file.home}: profile home changed during apply")
+    finally:
+        os.close(reopened_home)
+
+    cron_path_stat = os.stat("cron", dir_fd=home_fd, follow_symlinks=False)
+    if not stat.S_ISDIR(cron_path_stat.st_mode) or not _same_inode(
+        cron_path_stat, os.fstat(cron_fd)
+    ):
+        raise ValueError(f"{profile_file.home / 'cron'}: cron directory changed during apply")
+
+    jobs_path_stat = os.stat(
+        profile_file.path.name,
+        dir_fd=cron_fd,
+        follow_symlinks=False,
+    )
+    jobs_fd_stat = _require_owned_regular(jobs_fd, str(profile_file.path))
+    if not stat.S_ISREG(jobs_path_stat.st_mode) or not _same_inode(
+        jobs_path_stat, jobs_fd_stat
+    ):
+        raise ValueError(f"{profile_file.path}: jobs file changed during apply")
+
+
+def _acquire_jobs_lock(profile_file: ProfileCronFile, cron_fd: int) -> int:
+    """Acquire Hermes Agent's canonical per-profile cron writer lock."""
+    if fcntl is None:
+        raise RuntimeError("cron migration apply requires POSIX fcntl locking")
+    lock_fd = os.open(
+        JOBS_LOCK_FILE,
+        os.O_RDWR | os.O_CREAT | O_NOFOLLOW,
+        0o600,
+        dir_fd=cron_fd,
+    )
+    try:
+        metadata = _require_owned_regular(
+            lock_fd, str(profile_file.home / "cron" / JOBS_LOCK_FILE)
+        )
+        os.fchmod(lock_fd, 0o600)
+        path_metadata = os.stat(
+            JOBS_LOCK_FILE,
+            dir_fd=cron_fd,
+            follow_symlinks=False,
+        )
+        if not _same_inode(metadata, path_metadata):
+            raise ValueError(
+                f"{profile_file.home / 'cron' / JOBS_LOCK_FILE}: lock changed"
+            )
+        deadline = time.monotonic() + JOBS_LOCK_TIMEOUT_SECONDS
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return lock_fd
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"{profile_file.home / 'cron' / JOBS_LOCK_FILE}: "
+                        "timed out waiting for cron writer lock"
+                    ) from None
+                time.sleep(0.05)
+    except BaseException:
+        os.close(lock_fd)
+        raise
+
+
+def _assert_jobs_lock_current(
+    profile_file: ProfileCronFile, cron_fd: int, lock_fd: int
+) -> None:
+    lock_fd_stat = _require_owned_regular(
+        lock_fd, str(profile_file.home / "cron" / JOBS_LOCK_FILE)
+    )
+    lock_path_stat = os.stat(
+        JOBS_LOCK_FILE,
+        dir_fd=cron_fd,
+        follow_symlinks=False,
+    )
+    if not stat.S_ISREG(lock_path_stat.st_mode) or not _same_inode(
+        lock_fd_stat, lock_path_stat
+    ):
+        raise ValueError(
+            f"{profile_file.home / 'cron' / JOBS_LOCK_FILE}: lock changed"
+        )
+
+
+def _release_jobs_lock(lock_fd: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    os.close(lock_fd)
+
+
 def discover_profile_files(home: Path) -> list[ProfileCronFile]:
-    home = home.expanduser().resolve()
+    requested_home = home.expanduser().absolute()
+    assert_no_symlink_components(requested_home)
+    home = requested_home.resolve(strict=True)
+    if not home.is_dir():
+        raise ValueError(f"{home}: expected Hermes home directory")
     rows = [ProfileCronFile("default", home, home / "cron" / "jobs.json")]
     profiles_dir = home / "profiles"
+    if profiles_dir.is_symlink():
+        raise ValueError(f"{profiles_dir}: symlinked profiles directory rejected")
     if profiles_dir.is_dir():
         for child in sorted(profiles_dir.iterdir(), key=lambda p: p.name):
+            if child.is_symlink():
+                raise ValueError(f"{child}: symlinked profile directory rejected")
             if child.is_dir() and child.name:
                 rows.append(ProfileCronFile(child.name, child, child / "cron" / "jobs.json"))
     return rows
 
 
-def load_jobs_file(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    data = json.loads(path.read_text(encoding="utf-8"))
+def assert_profile_file_safe(profile_file: ProfileCronFile) -> None:
+    home = profile_file.home
+    path = profile_file.path
+    cron_dir = home / "cron"
+    assert_no_symlink_components(home)
+    assert_no_symlink_components(cron_dir, allow_missing=True)
+    assert_no_symlink_components(path, allow_missing=True)
+    if not path.exists():
+        return
+    metadata = path.stat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"{path}: expected regular jobs file")
+    try:
+        path.resolve(strict=True).relative_to(home.resolve(strict=True))
+    except ValueError:
+        raise ValueError(f"{path}: jobs file escapes profile home") from None
+
+
+def _validate_jobs_data(
+    data: Any, label: str
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     if not isinstance(data, dict):
-        raise ValueError(f"{path}: expected top-level object")
+        raise ValueError(f"{label}: expected top-level object")
     jobs = data.get("jobs")
     if jobs is None:
         jobs = []
         data["jobs"] = jobs
     if not isinstance(jobs, list):
-        raise ValueError(f"{path}: expected jobs list")
+        raise ValueError(f"{label}: expected jobs list")
     for idx, job in enumerate(jobs):
         if not isinstance(job, dict):
-            raise ValueError(f"{path}: jobs[{idx}] is not an object")
+            raise ValueError(f"{label}: jobs[{idx}] is not an object")
     return data, jobs
+
+
+def load_jobs_file(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    return _validate_jobs_data(
+        json.loads(path.read_text(encoding="utf-8")), str(path)
+    )
+
+
+def _read_fd_bytes(fd: int) -> bytes:
+    os.lseek(fd, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(fd, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _sha256_fd(fd: int) -> str:
+    return hashlib.sha256(_read_fd_bytes(fd)).hexdigest()
+
+
+def _load_jobs_fd(
+    fd: int, label: str
+) -> tuple[dict[str, Any], list[dict[str, Any]], str]:
+    raw = _read_fd_bytes(fd)
+    data = json.loads(raw.decode("utf-8"))
+    validated, jobs = _validate_jobs_data(data, label)
+    return validated, jobs, hashlib.sha256(raw).hexdigest()
 
 
 def split_deliver(value: Any) -> list[str]:
@@ -128,10 +405,16 @@ def job_label(job: dict[str, Any]) -> str:
 
 def plan_profile(profile_file: ProfileCronFile, *, include_local: bool = False) -> tuple[ProfileReport, list[DeliveryChange], dict[str, Any] | None]:
     path = profile_file.path
-    if not path.exists():
+    assert_profile_file_safe(profile_file)
+    handles = _open_profile_file(profile_file)
+    if handles is None:
         return ProfileReport(profile_file.profile, str(path), "missing"), [], None
-    data, jobs = load_jobs_file(path)
-    planned = copy.deepcopy(data)
+    try:
+        _assert_profile_file_current(profile_file, handles)
+        data, jobs, source_sha256 = _load_jobs_fd(handles[2], str(path))
+    finally:
+        _close_profile_file(handles)
+    planned = PlannedJobs(copy.deepcopy(data), source_sha256)
     planned_jobs = planned.get("jobs") or []
     changes: list[DeliveryChange] = []
     local_jobs = 0
@@ -172,27 +455,65 @@ def plan_profile(profile_file: ProfileCronFile, *, include_local: bool = False) 
     return report, changes, planned if changes else data
 
 
-def atomic_write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+def atomic_write_json_at(
+    profile_file: ProfileCronFile,
+    handles: tuple[int, int, int],
+    data: dict[str, Any],
+    expected_source_sha256: str,
+) -> None:
+    _home_fd, cron_fd, jobs_fd = handles
+    metadata = _require_owned_regular(jobs_fd, str(profile_file.path))
+    temp_name = (
+        f".{profile_file.path.name}.{os.getpid()}.{secrets.token_hex(12)}.tmp"
+    )
+    temp_fd = os.open(
+        temp_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | O_NOFOLLOW,
+        metadata.st_mode & 0o777,
+        dir_fd=cron_fd,
+    )
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False, indent=2)
             fh.write("\n")
             fh.flush()
             os.fsync(fh.fileno())
-        os.replace(tmp_name, path)
+        _assert_profile_file_current(profile_file, handles)
+        if _sha256_fd(jobs_fd) != expected_source_sha256:
+            raise ValueError(
+                f"{profile_file.path}: jobs contents changed after planning"
+            )
+        os.replace(
+            temp_name,
+            profile_file.path.name,
+            src_dir_fd=cron_fd,
+            dst_dir_fd=cron_fd,
+        )
+        os.fsync(cron_fd)
     finally:
         try:
-            os.unlink(tmp_name)
+            os.unlink(temp_name, dir_fd=cron_fd)
         except FileNotFoundError:
             pass
 
 
-def backup_file(source: Path, backup_dir: Path, profile: str) -> Path:
+def backup_file_from_fd(
+    source_fd: int, backup_dir: Path, profile: str
+) -> Path:
     target = backup_dir / profile / "cron" / "jobs.json"
     target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(source, target)
+    assert_no_symlink_components(target.parent)
+    os.lseek(source_fd, 0, os.SEEK_SET)
+    source_mode = os.fstat(source_fd).st_mode & 0o777
+    with os.fdopen(os.dup(source_fd), "rb") as source, target.open("xb") as output:
+        while True:
+            chunk = source.read(1024 * 1024)
+            if not chunk:
+                break
+            output.write(chunk)
+        output.flush()
+        os.fsync(output.fileno())
+    target.chmod(source_mode)
     return target
 
 
@@ -241,25 +562,102 @@ def print_report(reports: list[ProfileReport], changes: list[DeliveryChange], *,
 
 
 def apply_plan(home: Path, backup_dir: Path, reports: list[ProfileReport], changes: list[DeliveryChange], planned_by_profile: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    backup_dir = backup_dir.expanduser().resolve()
+    backup_dir = backup_dir.expanduser().absolute()
     backup_dir.mkdir(parents=True, exist_ok=True)
+    assert_no_symlink_components(backup_dir)
     profile_files = {row.profile: row for row in discover_profile_files(home)}
     backups: list[dict[str, str]] = []
-    for profile in planned_by_profile:
-        source = profile_files[profile].path
-        backup_path = backup_file(source, backup_dir, profile)
-        backups.append({"profile": profile, "source": str(source), "backup": str(backup_path)})
-    manifest = {
-        "created_at": utc_now(),
-        "home": str(home.expanduser().resolve()),
-        "changes": [asdict(c) for c in changes],
-        "reports": [asdict(r) for r in reports],
-        "backups": backups,
-    }
-    (backup_dir / "manifest.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    for profile, planned in planned_by_profile.items():
-        atomic_write_json(profile_files[profile].path, planned)
-    return manifest
+    opened: dict[str, tuple[int, int, int]] = {}
+    lock_fds: dict[str, int] = {}
+    try:
+        for profile in planned_by_profile:
+            profile_file = profile_files[profile]
+            planned = planned_by_profile[profile]
+            expected_source_sha256 = getattr(planned, "source_sha256", "")
+            if not expected_source_sha256:
+                raise ValueError(
+                    f"{profile_file.path}: plan is missing its source digest"
+                )
+            assert_profile_file_safe(profile_file)
+            handles = _open_profile_file(profile_file)
+            if handles is None:
+                raise ValueError(f"{profile_file.path}: jobs file disappeared before apply")
+            opened[profile] = handles
+
+        for profile in planned_by_profile:
+            profile_file = profile_files[profile]
+            lock_fds[profile] = _acquire_jobs_lock(
+                profile_file, opened[profile][1]
+            )
+
+        for profile in planned_by_profile:
+            profile_file = profile_files[profile]
+            handles = opened[profile]
+            _assert_jobs_lock_current(
+                profile_file, handles[1], lock_fds[profile]
+            )
+            _assert_profile_file_current(profile_file, handles)
+            if _sha256_fd(handles[2]) != planned_by_profile[profile].source_sha256:
+                raise ValueError(
+                    f"{profile_file.path}: jobs contents changed after planning"
+                )
+
+        for profile in planned_by_profile:
+            profile_file = profile_files[profile]
+            handles = opened[profile]
+            _assert_jobs_lock_current(
+                profile_file, handles[1], lock_fds[profile]
+            )
+            _assert_profile_file_current(profile_file, handles)
+            expected_source_sha256 = planned_by_profile[profile].source_sha256
+            if _sha256_fd(handles[2]) != expected_source_sha256:
+                raise ValueError(
+                    f"{profile_file.path}: jobs contents changed after planning"
+                )
+            backup_path = backup_file_from_fd(
+                handles[2], backup_dir, profile
+            )
+            backups.append(
+                {
+                    "profile": profile,
+                    "source": str(profile_file.path),
+                    "backup": str(backup_path),
+                }
+            )
+
+        manifest = {
+            "created_at": utc_now(),
+            "home": str(home.expanduser().absolute()),
+            "changes": [asdict(c) for c in changes],
+            "reports": [asdict(r) for r in reports],
+            "backups": backups,
+        }
+        manifest_path = backup_dir / "manifest.json"
+        with manifest_path.open("x", encoding="utf-8") as manifest_file:
+            json.dump(manifest, manifest_file, ensure_ascii=False, indent=2)
+            manifest_file.write("\n")
+            manifest_file.flush()
+            os.fsync(manifest_file.fileno())
+
+        for profile, planned in planned_by_profile.items():
+            profile_file = profile_files[profile]
+            handles = opened[profile]
+            _assert_jobs_lock_current(
+                profile_file, handles[1], lock_fds[profile]
+            )
+            _assert_profile_file_current(profile_file, handles)
+            atomic_write_json_at(
+                profile_file,
+                handles,
+                planned,
+                planned.source_sha256,
+            )
+        return manifest
+    finally:
+        for lock_fd in reversed(list(lock_fds.values())):
+            _release_jobs_lock(lock_fd)
+        for handles in opened.values():
+            _close_profile_file(handles)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -274,7 +672,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(list(argv or sys.argv[1:]))
-    home = Path(args.home).expanduser().resolve()
+    home = Path(args.home).expanduser().absolute()
     reports, changes, planned_by_profile = build_plan(home, include_local=args.include_local)
     if args.apply and not args.backup_dir:
         print("ERROR: --apply requires --backup-dir", file=sys.stderr)

--- a/static/index.html
+++ b/static/index.html
@@ -154,6 +154,7 @@
   <nav class="rail" aria-label="Primary navigation">
     <button class="rail-btn nav-tab active has-tooltip" data-panel="chat" onclick="switchPanel('chat',{fromRailClick:true})" data-tooltip="Chat" data-i18n-title="tab_chat" aria-label="Chat"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="tasks" onclick="switchPanel('tasks',{fromRailClick:true})" data-tooltip="Tasks" data-i18n-title="tab_tasks" aria-label="Tasks"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></button>
+    <button class="rail-btn nav-tab notification-nav-btn has-tooltip" data-panel="notifications" onclick="switchPanel('notifications',{fromRailClick:true})" data-tooltip="Hermex Inbox" aria-label="Hermex Inbox"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span class="notification-badge" id="notificationsBadge" hidden></span></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="kanban" onclick="switchPanel('kanban',{fromRailClick:true})" data-tooltip="Kanban" data-i18n-title="tab_kanban" aria-label="Kanban"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M8 4v16"/><path d="M16 4v16"/><path d="M3 10h18"/></svg></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="skills" onclick="switchPanel('skills',{fromRailClick:true})" data-tooltip="Skills" data-i18n-title="tab_skills" aria-label="Skills"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="memory" onclick="switchPanel('memory',{fromRailClick:true})" data-tooltip="Memory" data-i18n-title="tab_memory" aria-label="Memory"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2z"/><path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2z"/></svg></button>
@@ -173,6 +174,7 @@
     <div class="sidebar-nav">
       <button class="nav-tab active has-tooltip has-tooltip--bottom" data-panel="chat" data-label="Chat" onclick="switchPanel('chat',{fromRailClick:true})" data-tooltip="Chat" data-i18n-title="tab_chat"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks',{fromRailClick:true})" data-tooltip="Tasks" data-i18n-title="tab_tasks"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></button>
+      <button class="nav-tab notification-nav-btn has-tooltip has-tooltip--bottom" data-panel="notifications" data-label="Inbox" onclick="switchPanel('notifications',{fromRailClick:true})" data-tooltip="Hermex Inbox"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span class="notification-badge" id="notificationsBadgeMobile" hidden></span></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="kanban" data-label="Kanban" onclick="switchPanel('kanban',{fromRailClick:true})" data-tooltip="Kanban" data-i18n-title="tab_kanban"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M8 4v16"/><path d="M16 4v16"/><path d="M3 10h18"/></svg></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="skills" data-label="Skills" onclick="switchPanel('skills',{fromRailClick:true})" data-tooltip="Skills" data-i18n-title="tab_skills"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="memory" data-label="Memory" onclick="switchPanel('memory',{fromRailClick:true})" data-tooltip="Memory" data-i18n-title="tab_memory"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2z"/><path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2z"/></svg></button>
@@ -214,6 +216,18 @@
       </div>
       <div id="cronGatewayNotice" class="detail-alert cron-gateway-notice" style="display:none"></div>
       <div class="cron-list" id="cronList"><div style="padding:12px;color:var(--muted);font-size:12px" data-i18n="loading">Loading...</div></div>
+    </div>
+    <!-- Notifications (Hermex/WebUI cron inbox) panel -->
+    <div class="panel-view" id="panelNotifications">
+      <div class="panel-head">
+        <span>Hermex Inbox <span class="notification-title-badge" id="notificationsTitleBadge" hidden></span></span>
+        <div class="panel-head-actions">
+          <button class="panel-head-btn has-tooltip has-tooltip--bottom" id="notificationsRefreshBtn" onclick="loadNotifications(true)" data-tooltip="Refresh inbox" aria-label="Refresh inbox"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg></button>
+          <button class="panel-head-btn has-tooltip has-tooltip--bottom" onclick="markAllNotificationsRead()" data-tooltip="Mark all read" aria-label="Mark all read"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg></button>
+        </div>
+      </div>
+      <div class="panel-head-sub notifications-panel-sub">Cron outputs delivered to Hermex/WebUI across visible profiles.</div>
+      <div class="notifications-list" id="notificationsList"><div class="notifications-empty">Loading...</div></div>
     </div>
     <!-- Kanban panel -->
     <div class="panel-view" id="panelKanban">
@@ -832,6 +846,20 @@
         <svg class="main-view-empty-icon" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
         <div class="main-view-empty-title" data-i18n="tasks_empty_title">Select a scheduled job</div>
         <div class="main-view-empty-sub" data-i18n="tasks_empty_sub">Pick a job from the sidebar to view its details and runs, or create a new one.</div>
+      </div>
+    </div>
+    <div id="mainNotifications" class="main-view">
+      <div class="main-view-header">
+        <div class="main-view-title" id="notificationDetailTitle"></div>
+        <div class="main-view-actions">
+          <button id="btnNotificationRead" class="panel-head-btn has-tooltip has-tooltip--bottom" onclick="markSelectedNotificationRead()" data-tooltip="Mark read" aria-label="Mark selected notification read" style="display:none"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg></button>
+        </div>
+      </div>
+      <div class="main-view-body" id="notificationDetailBody" style="display:none"></div>
+      <div class="main-view-empty" id="notificationDetailEmpty">
+        <svg class="main-view-empty-icon" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
+        <div class="main-view-empty-title">Hermex Inbox</div>
+        <div class="main-view-empty-sub">Cron outputs delivered to WebUI appear here. Choose a notification from the sidebar.</div>
       </div>
     </div>
     <div id="mainKanban" class="main-view">
@@ -1760,6 +1788,7 @@
 <script src="static/assistant_turn_anchors.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/ui.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/workspace.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/notifications.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/terminal.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/sessions.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/commands.js?v=__WEBUI_VERSION__" defer></script>

--- a/static/notifications.js
+++ b/static/notifications.js
@@ -8,10 +8,10 @@
 // server's isolated-profile guard.
 
 let _notificationsCache = [];
-let _notificationsSelectedId = '';
+let _notificationsSelectedKey = '';
 let _notificationsEventSource = null;
 let _notificationsReconnectTimer = null;
-let _notificationsSeenIds = new Set();
+let _notificationsSeenKeys = new Set();
 let _notificationsUnreadCount = 0;
 
 function _notificationsUrl(path, params) {
@@ -30,6 +30,12 @@ function _notificationsApiParams(extra) {
 
 function _notificationId(row) {
   return row && row.id != null ? String(row.id) : '';
+}
+
+function _notificationKey(row) {
+  const id = _notificationId(row);
+  if (!id) return '';
+  return JSON.stringify([String(row && row.profile || ''), id]);
 }
 
 function _notificationCreated(row) {
@@ -59,13 +65,13 @@ function _sortNotifications(rows) {
 }
 
 function _mergeNotification(row) {
-  const id = _notificationId(row);
-  if (!id) return false;
-  const idx = _notificationsCache.findIndex(n => _notificationId(n) === id);
+  const key = _notificationKey(row);
+  if (!key) return false;
+  const idx = _notificationsCache.findIndex(n => _notificationKey(n) === key);
   if (idx >= 0) _notificationsCache[idx] = Object.assign({}, _notificationsCache[idx], row);
   else _notificationsCache.unshift(row);
   _notificationsCache = _sortNotifications(_notificationsCache).slice(0, 200);
-  _notificationsSeenIds.add(id);
+  _notificationsSeenKeys.add(key);
   return idx < 0;
 }
 
@@ -99,10 +105,10 @@ function _renderNotificationList() {
     return;
   }
   box.innerHTML = _notificationsCache.map(row => {
-    const id = _notificationId(row);
+    const key = _notificationKey(row);
     const unread = row && !row.read_at;
-    const selected = id && id === _notificationsSelectedId;
-    return `<button type="button" class="notification-row ${unread ? 'unread' : ''} ${selected ? 'active' : ''}" data-notification-id="${esc(id)}" onclick="openNotificationDetail(this.dataset.notificationId)">
+    const selected = key && key === _notificationsSelectedKey;
+    return `<button type="button" class="notification-row ${unread ? 'unread' : ''} ${selected ? 'active' : ''}" data-notification-key="${esc(key)}" onclick="openNotificationDetail(this.dataset.notificationKey)">
       <span class="notification-row-dot" aria-hidden="true"></span>
       <span class="notification-row-main">
         <span class="notification-row-title">${esc(_notificationTitle(row))}</span>
@@ -111,10 +117,10 @@ function _renderNotificationList() {
       </span>
     </button>`;
   }).join('');
-  if (!_notificationsSelectedId || !_notificationsCache.some(row => _notificationId(row) === _notificationsSelectedId)) {
-    _notificationsSelectedId = _notificationId(_notificationsCache[0]) || '';
+  if (!_notificationsSelectedKey || !_notificationsCache.some(row => _notificationKey(row) === _notificationsSelectedKey)) {
+    _notificationsSelectedKey = _notificationKey(_notificationsCache[0]) || '';
   }
-  _renderNotificationDetail(_notificationsCache.find(row => _notificationId(row) === _notificationsSelectedId) || null);
+  _renderNotificationDetail(_notificationsCache.find(row => _notificationKey(row) === _notificationsSelectedKey) || null);
 }
 
 function _renderNotificationDetail(row) {
@@ -150,7 +156,7 @@ function _renderNotificationDetail(row) {
 function _renderNotifications(summary) {
   const rows = summary && Array.isArray(summary.notifications) ? summary.notifications : _notificationsCache;
   _notificationsCache = _sortNotifications(rows);
-  _notificationsSeenIds = new Set(_notificationsCache.map(_notificationId).filter(Boolean));
+  _notificationsSeenKeys = new Set(_notificationsCache.map(_notificationKey).filter(Boolean));
   _setNotificationBadge(summary && Number.isFinite(Number(summary.unread_count)) ? Number(summary.unread_count) : _notificationsCache.filter(n => !n.read_at).length);
   _renderNotificationList();
 }
@@ -172,16 +178,18 @@ async function loadNotifications(force) {
   }
 }
 
-function openNotificationDetail(id) {
-  _notificationsSelectedId = String(id || '');
+function openNotificationDetail(key) {
+  _notificationsSelectedKey = String(key || '');
   _renderNotificationList();
 }
 
 async function markSelectedNotificationRead() {
-  if (!_notificationsSelectedId) return;
-  const row = _notificationsCache.find(n => _notificationId(n) === _notificationsSelectedId);
+  if (!_notificationsSelectedKey) return;
+  const row = _notificationsCache.find(n => _notificationKey(n) === _notificationsSelectedKey);
+  const notificationId = _notificationId(row);
+  if (!notificationId) return;
   try {
-    const payload = { id: _notificationsSelectedId };
+    const payload = { id: notificationId };
     if (row && row.profile) payload.profile = row.profile;
     const data = await api('/api/notifications/read', { method: 'POST', body: JSON.stringify(payload) });
     if (data && data.notification) _mergeNotification(data.notification);
@@ -222,8 +230,10 @@ function _handleNotificationEvent(row) {
 
 function startNotificationInboxStream() {
   if (typeof window === 'undefined') return;
-  loadNotifications(false).catch(() => {});
-  if (typeof EventSource === 'undefined') return;
+  if (typeof EventSource === 'undefined') {
+    loadNotifications(false).catch(() => {});
+    return;
+  }
   if (_notificationsEventSource) return;
   const url = _notificationsUrl('api/notifications/events', _notificationsApiParams());
   try {
@@ -237,6 +247,7 @@ function startNotificationInboxStream() {
     _notificationsEventSource.onerror = function() {
       try { _notificationsEventSource.close(); } catch (_) {}
       _notificationsEventSource = null;
+      loadNotifications(false).catch(() => {});
       if (_notificationsReconnectTimer) return;
       _notificationsReconnectTimer = setTimeout(() => {
         _notificationsReconnectTimer = null;

--- a/static/notifications.js
+++ b/static/notifications.js
@@ -1,0 +1,271 @@
+// ── Hermex/WebUI cron notification inbox ───────────────────────────────────
+// Cron jobs can deliver to the profile-local WebUI inbox via deliver="webui".
+// This client shows an unread badge and sidebar inbox for new SSE events.
+// Completion toasts remain owned by the existing per-cron preference path so
+// the inbox cannot emit a second alert for the same run. Reads aggregate
+// visible profiles by default so Hermex can surface
+// cron deliveries from role profiles like newsletteros while respecting the
+// server's isolated-profile guard.
+
+let _notificationsCache = [];
+let _notificationsSelectedId = '';
+let _notificationsEventSource = null;
+let _notificationsReconnectTimer = null;
+let _notificationsSeenIds = new Set();
+let _notificationsUnreadCount = 0;
+
+function _notificationsUrl(path, params) {
+  const rel = String(path || '').replace(/^\//, '');
+  const url = new URL(rel, document.baseURI || location.href);
+  const p = params || {};
+  Object.keys(p).forEach(k => {
+    if (p[k] !== undefined && p[k] !== null && p[k] !== '') url.searchParams.set(k, String(p[k]));
+  });
+  return url;
+}
+
+function _notificationsApiParams(extra) {
+  return Object.assign({ all_profiles: '1' }, extra || {});
+}
+
+function _notificationId(row) {
+  return row && row.id != null ? String(row.id) : '';
+}
+
+function _notificationCreated(row) {
+  return row && row.created_at ? String(row.created_at) : '';
+}
+
+function _notificationTitle(row) {
+  const title = row && (row.title || row.name || row.job_id);
+  return String(title || 'Cron notification');
+}
+
+function _notificationBody(row) {
+  return String((row && (row.body || row.content || row.text)) || '');
+}
+
+function _formatNotificationTime(value) {
+  if (!value) return '';
+  try {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date.toLocaleString();
+  } catch (_) {}
+  return String(value);
+}
+
+function _sortNotifications(rows) {
+  return (Array.isArray(rows) ? rows.slice() : []).sort((a, b) => _notificationCreated(b).localeCompare(_notificationCreated(a)));
+}
+
+function _mergeNotification(row) {
+  const id = _notificationId(row);
+  if (!id) return false;
+  const idx = _notificationsCache.findIndex(n => _notificationId(n) === id);
+  if (idx >= 0) _notificationsCache[idx] = Object.assign({}, _notificationsCache[idx], row);
+  else _notificationsCache.unshift(row);
+  _notificationsCache = _sortNotifications(_notificationsCache).slice(0, 200);
+  _notificationsSeenIds.add(id);
+  return idx < 0;
+}
+
+function _setNotificationBadge(count) {
+  const safe = Math.max(0, Number(count) || 0);
+  _notificationsUnreadCount = safe;
+  ['notificationsBadge', 'notificationsBadgeMobile', 'notificationsTitleBadge'].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.textContent = safe > 99 ? '99+' : String(safe);
+    el.hidden = safe <= 0;
+    el.style.display = safe > 0 ? '' : 'none';
+  });
+}
+
+function _notificationMetaText(row) {
+  const bits = [];
+  if (row && row.profile) bits.push(String(row.profile));
+  if (row && row.job_id) bits.push('job ' + String(row.job_id));
+  const when = _formatNotificationTime(row && row.created_at);
+  if (when) bits.push(when);
+  return bits.join(' · ');
+}
+
+function _renderNotificationList() {
+  const box = document.getElementById('notificationsList');
+  if (!box) return;
+  if (!_notificationsCache.length) {
+    box.innerHTML = '<div class="notifications-empty">No cron notifications yet.</div>';
+    _renderNotificationDetail(null);
+    return;
+  }
+  box.innerHTML = _notificationsCache.map(row => {
+    const id = _notificationId(row);
+    const unread = row && !row.read_at;
+    const selected = id && id === _notificationsSelectedId;
+    return `<button type="button" class="notification-row ${unread ? 'unread' : ''} ${selected ? 'active' : ''}" data-notification-id="${esc(id)}" onclick="openNotificationDetail(this.dataset.notificationId)">
+      <span class="notification-row-dot" aria-hidden="true"></span>
+      <span class="notification-row-main">
+        <span class="notification-row-title">${esc(_notificationTitle(row))}</span>
+        <span class="notification-row-meta">${esc(_notificationMetaText(row))}</span>
+        <span class="notification-row-preview">${esc(_notificationBody(row)).slice(0, 180)}</span>
+      </span>
+    </button>`;
+  }).join('');
+  if (!_notificationsSelectedId || !_notificationsCache.some(row => _notificationId(row) === _notificationsSelectedId)) {
+    _notificationsSelectedId = _notificationId(_notificationsCache[0]) || '';
+  }
+  _renderNotificationDetail(_notificationsCache.find(row => _notificationId(row) === _notificationsSelectedId) || null);
+}
+
+function _renderNotificationDetail(row) {
+  const title = document.getElementById('notificationDetailTitle');
+  const body = document.getElementById('notificationDetailBody');
+  const empty = document.getElementById('notificationDetailEmpty');
+  const readBtn = document.getElementById('btnNotificationRead');
+  if (!body || !empty) return;
+  if (!row) {
+    if (title) title.textContent = '';
+    if (readBtn) readBtn.style.display = 'none';
+    body.style.display = 'none';
+    body.innerHTML = '';
+    empty.style.display = '';
+    return;
+  }
+  if (title) title.textContent = _notificationTitle(row);
+  if (readBtn) readBtn.style.display = row.read_at ? 'none' : '';
+  empty.style.display = 'none';
+  body.style.display = '';
+  const media = Array.isArray(row.media) ? row.media : [];
+  const outputPath = row.output_file || row.output_path || '';
+  body.innerHTML = `<div class="main-view-content notification-detail-card">
+    <div class="notification-detail-meta">${esc(_notificationMetaText(row))}</div>
+    <pre class="notification-detail-body">${esc(_notificationBody(row))}</pre>
+    ${outputPath ? `<div class="notification-detail-kv"><span>Output</span><code>${esc(outputPath)}</code></div>` : ''}
+    ${row.job_id ? `<div class="notification-detail-actions"><button type="button" class="btn secondary" data-job-id="${esc(String(row.job_id))}" onclick="openNotificationCronJob(this.dataset.jobId)">Open scheduled job</button></div>` : ''}
+    ${media.length ? `<div class="notification-detail-kv"><span>Media</span><code>${esc(String(media.length))} attachment${media.length === 1 ? '' : 's'}</code></div>` : ''}
+    ${row.read_at ? `<div class="notification-detail-kv"><span>Read</span><code>${esc(_formatNotificationTime(row.read_at))}</code></div>` : ''}
+  </div>`;
+}
+
+function _renderNotifications(summary) {
+  const rows = summary && Array.isArray(summary.notifications) ? summary.notifications : _notificationsCache;
+  _notificationsCache = _sortNotifications(rows);
+  _notificationsSeenIds = new Set(_notificationsCache.map(_notificationId).filter(Boolean));
+  _setNotificationBadge(summary && Number.isFinite(Number(summary.unread_count)) ? Number(summary.unread_count) : _notificationsCache.filter(n => !n.read_at).length);
+  _renderNotificationList();
+}
+
+async function loadNotifications(force) {
+  const refreshBtn = document.getElementById('notificationsRefreshBtn');
+  if (refreshBtn && force) refreshBtn.classList.add('spinning');
+  try {
+    const data = await api('/api/notifications?' + new URLSearchParams(_notificationsApiParams({ limit: 100 })).toString(), { timeoutMs: 10000, retries: 1 });
+    _renderNotifications(data || {});
+    return data;
+  } catch (e) {
+    const box = document.getElementById('notificationsList');
+    if (box && !_notificationsCache.length) box.innerHTML = '<div class="notifications-empty error">Could not load notifications.</div>';
+    if (force && typeof showToast === 'function') showToast('Could not load notifications: ' + (e && e.message || e), 4000, 'error');
+    return null;
+  } finally {
+    if (refreshBtn) refreshBtn.classList.remove('spinning');
+  }
+}
+
+function openNotificationDetail(id) {
+  _notificationsSelectedId = String(id || '');
+  _renderNotificationList();
+}
+
+async function markSelectedNotificationRead() {
+  if (!_notificationsSelectedId) return;
+  const row = _notificationsCache.find(n => _notificationId(n) === _notificationsSelectedId);
+  try {
+    const payload = { id: _notificationsSelectedId };
+    if (row && row.profile) payload.profile = row.profile;
+    const data = await api('/api/notifications/read', { method: 'POST', body: JSON.stringify(payload) });
+    if (data && data.notification) _mergeNotification(data.notification);
+    await loadNotifications(false);
+  } catch (e) {
+    if (typeof showToast === 'function') showToast('Mark read failed: ' + (e && e.message || e), 4000, 'error');
+  }
+}
+
+async function markAllNotificationsRead() {
+  try {
+    const url = '/api/notifications/read-all?' + new URLSearchParams(_notificationsApiParams()).toString();
+    const data = await api(url, { method: 'POST', body: JSON.stringify({}) });
+    if (data && data.summary) _renderNotifications(data.summary);
+    else await loadNotifications(false);
+  } catch (e) {
+    if (typeof showToast === 'function') showToast('Mark all read failed: ' + (e && e.message || e), 4000, 'error');
+  }
+}
+
+async function openNotificationCronJob(jobId) {
+  const target = String(jobId || '');
+  if (!target) return;
+  try {
+    if (typeof switchPanel === 'function') await switchPanel('tasks');
+    if (typeof loadCrons === 'function') await loadCrons(false);
+    if (typeof openCronDetail === 'function') openCronDetail(target);
+  } catch (e) {
+    if (typeof showToast === 'function') showToast('Could not open scheduled job: ' + (e && e.message || e), 4000, 'error');
+  }
+}
+
+function _handleNotificationEvent(row) {
+  const isNew = _mergeNotification(row);
+  if (isNew && !(row && row.read_at)) _setNotificationBadge(_notificationsUnreadCount + 1);
+  _renderNotificationList();
+}
+
+function startNotificationInboxStream() {
+  if (typeof window === 'undefined') return;
+  loadNotifications(false).catch(() => {});
+  if (typeof EventSource === 'undefined') return;
+  if (_notificationsEventSource) return;
+  const url = _notificationsUrl('api/notifications/events', _notificationsApiParams());
+  try {
+    _notificationsEventSource = new EventSource(url.href, { withCredentials: true });
+    _notificationsEventSource.addEventListener('notification', ev => {
+      try { _handleNotificationEvent(JSON.parse(ev.data)); } catch (_) {}
+    });
+    _notificationsEventSource.addEventListener('snapshot', ev => {
+      try { _renderNotifications(JSON.parse(ev.data)); } catch (_) {}
+    });
+    _notificationsEventSource.onerror = function() {
+      try { _notificationsEventSource.close(); } catch (_) {}
+      _notificationsEventSource = null;
+      if (_notificationsReconnectTimer) return;
+      _notificationsReconnectTimer = setTimeout(() => {
+        _notificationsReconnectTimer = null;
+        if (!document.hidden) startNotificationInboxStream();
+      }, 15000);
+    };
+  } catch (_) {
+    _notificationsEventSource = null;
+  }
+}
+
+function stopNotificationInboxStream() {
+  if (_notificationsReconnectTimer) {
+    clearTimeout(_notificationsReconnectTimer);
+    _notificationsReconnectTimer = null;
+  }
+  if (_notificationsEventSource) {
+    try { _notificationsEventSource.close(); } catch (_) {}
+    _notificationsEventSource = null;
+  }
+}
+
+function _syncNotificationInboxVisibility() {
+  if (document.hidden) stopNotificationInboxStream();
+  else startNotificationInboxStream();
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', startNotificationInboxStream, { once: true });
+  else startNotificationInboxStream();
+  document.addEventListener('visibilitychange', _syncNotificationInboxVisibility);
+}

--- a/static/panels.js
+++ b/static/panels.js
@@ -40,11 +40,11 @@ let _logsSeverityFilter = 'all';
 
 // Map of panel names → i18n keys for the app titlebar label.
 const APP_TITLEBAR_KEYS = {
-  chat: 'tab_chat', tasks: 'tab_tasks', skills: 'tab_skills',
+  chat: 'tab_chat', tasks: 'tab_tasks', notifications: 'Hermex Inbox', skills: 'tab_skills',
   memory: 'tab_memory', workspaces: 'tab_workspaces',
   profiles: 'tab_profiles', todos: 'tab_todos', insights: 'tab_insights', logs: 'tab_logs', settings: 'tab_settings',
 };
-const MAIN_VIEW_PANELS = ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs','plugin'];
+const MAIN_VIEW_PANELS = ['settings','skills','memory','tasks','notifications','kanban','workspaces','profiles','insights','logs','plugin'];
 const MAIN_VIEW_SIDEBAR_PANEL_FALLBACKS = { plugin: 'settings' };
 
 /**
@@ -413,6 +413,7 @@ async function switchPanel(name, opts = {}) {
   }
   // Lazy-load panel data
   if (nextPanel === 'tasks') await loadCrons();
+  if (nextPanel === 'notifications' && typeof loadNotifications === 'function') await loadNotifications(false);
   if (nextPanel === 'kanban') await loadKanban();
   if (nextPanel === 'skills') await loadSkills();
   if (nextPanel === 'memory') await loadMemory();

--- a/static/style.css
+++ b/static/style.css
@@ -4878,16 +4878,18 @@ main.main > #mainSettings,
 main.main > #mainSkills,
 main.main > #mainMemory,
 main.main > #mainTasks,
+main.main > #mainNotifications,
 main.main > #mainKanban,
 main.main > #mainWorkspaces,
 main.main > #mainProfiles,
 main.main > #mainInsights,
 main.main > #mainLogs{display:none;}
-main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs):not(.showing-plugin) > #mainChat{display:flex;}
+main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-notifications):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs):not(.showing-plugin) > #mainChat{display:flex;}
 main.main.showing-settings > #mainSettings{display:flex;overflow-y:auto;}
 main.main.showing-skills > #mainSkills{display:flex;}
 main.main.showing-memory > #mainMemory{display:flex;}
 main.main.showing-tasks > #mainTasks{display:flex;}
+main.main.showing-notifications > #mainNotifications{display:flex;}
 main.main.showing-kanban > #mainKanban{display:flex;overflow-y:auto;}
 main.main.showing-workspaces > #mainWorkspaces{display:flex;}
 main.main.showing-profiles > #mainProfiles{display:flex;}
@@ -4911,6 +4913,32 @@ main.main > #mainPlugin{display:none;}
 .app-titlebar-new-chat:disabled:hover,.app-titlebar-new-chat[aria-busy="true"]:hover{background:transparent;color:var(--muted);}
 .panel-head-btn svg{width:14px;height:14px;display:block;}
 .panel-head-sub{padding:6px 12px 8px;font-size:11px;color:var(--muted);flex-shrink:0;}
+.notification-nav-btn{position:relative;}
+.notification-badge,.notification-title-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;border-radius:999px;background:var(--accent);color:var(--accent-contrast,#fff);font-size:10px;font-weight:700;line-height:1;box-shadow:0 0 0 2px var(--sidebar);}
+.notification-badge{position:absolute;top:3px;right:3px;}
+.sidebar-nav .notification-badge{top:4px;right:6px;}
+.notification-title-badge{position:relative;top:-1px;margin-left:4px;box-shadow:none;}
+.notifications-panel-sub{line-height:1.4;text-transform:none;letter-spacing:normal;}
+.notifications-list{display:flex;flex-direction:column;gap:4px;padding:8px;overflow-y:auto;}
+.notification-row{display:flex;align-items:flex-start;gap:8px;width:100%;padding:9px 10px;border:1px solid transparent;border-radius:10px;background:transparent;color:var(--text);text-align:left;cursor:pointer;}
+.notification-row:hover{background:var(--surface);}
+.notification-row.active{border-color:var(--accent);background:var(--accent-bg);}
+.notification-row-dot{width:7px;height:7px;border-radius:50%;margin-top:5px;background:transparent;flex-shrink:0;}
+.notification-row.unread .notification-row-dot{background:var(--accent);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 18%,transparent);}
+.notification-row-main{display:flex;flex-direction:column;gap:3px;min-width:0;}
+.notification-row-title{font-size:13px;font-weight:650;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.notification-row.unread .notification-row-title{color:var(--accent-text);}
+.notification-row-meta,.notification-row-preview{font-size:11px;color:var(--muted);line-height:1.35;overflow:hidden;text-overflow:ellipsis;}
+.notification-row-preview{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;white-space:normal;}
+.notifications-empty{padding:14px 10px;color:var(--muted);font-size:12px;line-height:1.45;}
+.notifications-empty.error{color:var(--error,#ff6b6b);}
+.notification-detail-card{display:flex;flex-direction:column;gap:14px;}
+.notification-detail-meta{font-size:12px;color:var(--muted);}
+.notification-detail-body{margin:0;padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--code-bg);color:var(--pre-text);white-space:pre-wrap;word-break:break-word;font:13px/1.55 'SF Mono',ui-monospace,monospace;}
+.notification-detail-kv{display:flex;gap:10px;align-items:flex-start;font-size:12px;color:var(--muted);}
+.notification-detail-kv span{min-width:64px;color:var(--text);font-weight:600;}
+.notification-detail-kv code{white-space:pre-wrap;word-break:break-word;color:var(--pre-text);}
+.notification-detail-actions{display:flex;gap:8px;flex-wrap:wrap;}
 .side-menu{display:flex;flex-direction:column;gap:2px;padding:8px;overflow-y:auto;}
 .side-menu-item{display:flex;align-items:center;gap:8px;padding:8px 10px;border-radius:8px;border:none;background:transparent;color:var(--text);cursor:pointer;text-align:left;font-size:13px;font-weight:500;transition:background .15s,color .15s;width:100%;}
 .side-menu-item:hover{background:var(--surface);}

--- a/tests/test_cron_delivery_options.py
+++ b/tests/test_cron_delivery_options.py
@@ -30,9 +30,10 @@ def test_delivery_options_has_platforms():
     assert isinstance(platforms, list)
     assert len(platforms) > 0
 
-    # 'local' must always be present (it's the built-in default)
+    # 'local' and Hermex/WebUI inbox must always be present (built-in defaults)
     values = [p["value"] for p in platforms]
     assert "local" in values, f"'local' missing from delivery options: {values}"
+    assert "webui" in values, f"'webui' missing from delivery options: {values}"
 
 
 def test_delivery_options_structure():
@@ -65,3 +66,11 @@ def test_delivery_options_local_label():
     local_entry = next(p for p in result["platforms"] if p["value"] == "local")
     # Label should contain "Local" or be an i18n key — just verify it's non-empty
     assert local_entry["label"], "Local platform label is empty"
+
+
+def test_delivery_options_webui_label():
+    """Hermex/WebUI inbox has an explicit human label."""
+    result, status = get("/api/crons/delivery-options")
+    assert status == 200
+    entry = next(p for p in result["platforms"] if p["value"] == "webui")
+    assert entry["label"] == "Hermex/WebUI Inbox"

--- a/tests/test_cron_notifications.py
+++ b/tests/test_cron_notifications.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import urllib.request
 import urllib.error
 
+import pytest
+
 from tests._pytest_port import BASE
 
 
@@ -282,3 +284,123 @@ def test_mark_read_allows_visible_profile_in_multi_profile_mode(tmp_path, monkey
     assert result is not None
     assert result["id"] == "visible-notification"
     assert result["read_at"]
+
+
+def test_cross_profile_identity_is_authoritative_and_composite(tmp_path, monkeypatch):
+    from api import cron_notifications, profiles
+
+    default_home = tmp_path / "hermes"
+    wolf_home = default_home / "profiles" / "wolf-of-hermes"
+    _reset(default_home)
+    _reset(wolf_home)
+    _write_record(
+        {
+            "id": "shared-id",
+            "profile": "wolf-of-hermes",
+            "created_at": "2026-01-01T00:00:00Z",
+            "read_at": None,
+        },
+        home=default_home,
+    )
+    _write_record(
+        {
+            "id": "shared-id",
+            "profile": "default",
+            "created_at": "2026-01-02T00:00:00Z",
+            "read_at": None,
+        },
+        home=wolf_home,
+    )
+
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: default_home)
+    monkeypatch.setattr(
+        profiles,
+        "get_hermes_home_for_profile",
+        lambda name: wolf_home if name == "wolf-of-hermes" else default_home,
+    )
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles_api",
+        lambda: [{"name": "wolf-of-hermes"}],
+    )
+
+    summary = cron_notifications.notification_summary(all_profiles=True, limit=10)
+
+    assert len(summary["notifications"]) == 2
+    assert {row["profile"] for row in summary["notifications"]} == {
+        "default",
+        "wolf-of-hermes",
+    }
+    assert {row["notification_key"] for row in summary["notifications"]} == {
+        '["default","shared-id"]',
+        '["wolf-of-hermes","shared-id"]',
+    }
+
+    marked = cron_notifications.mark_read("shared-id", profile="wolf-of-hermes")
+
+    assert marked is not None
+    assert marked["profile"] == "wolf-of-hermes"
+    assert marked["notification_key"] == '["wolf-of-hermes","shared-id"]'
+    default_row = json.loads(_notification_file(default_home).read_text(encoding="utf-8"))
+    wolf_row = json.loads(_notification_file(wolf_home).read_text(encoding="utf-8"))
+    assert default_row["read_at"] is None
+    assert wolf_row["read_at"]
+
+
+def test_notification_reader_rejects_symlinked_data_file(tmp_path):
+    from api import cron_notifications
+
+    home = tmp_path / "hermes"
+    cron_dir = home / "cron"
+    cron_dir.mkdir(parents=True)
+    external = tmp_path / "external-notifications.jsonl"
+    external.write_text('{"id":"external"}\n', encoding="utf-8")
+    before_mode = external.stat().st_mode
+    _notification_file(home).symlink_to(external)
+
+    with pytest.raises(OSError):
+        cron_notifications._read_records(home, "default")
+
+    assert external.read_text(encoding="utf-8") == '{"id":"external"}\n'
+    assert external.stat().st_mode == before_mode
+
+
+def test_notification_reader_rejects_symlinked_lock_file(tmp_path):
+    from api import cron_notifications
+
+    home = tmp_path / "hermes"
+    _write_record(
+        {"id": "local", "created_at": "2026-01-01T00:00:00Z"},
+        home=home,
+    )
+    external = tmp_path / "external-lock"
+    external.write_text("outside", encoding="utf-8")
+    before_mode = external.stat().st_mode
+    _notification_file(home).with_suffix(".jsonl.lock").symlink_to(external)
+
+    with pytest.raises(OSError):
+        cron_notifications._read_records(home, "default")
+
+    assert external.read_text(encoding="utf-8") == "outside"
+    assert external.stat().st_mode == before_mode
+
+
+def test_notification_reader_rejects_symlinked_parent_component(tmp_path):
+    from api import cron_notifications
+
+    external_home = tmp_path / "external-home"
+    _write_record(
+        {"id": "outside", "created_at": "2026-01-01T00:00:00Z"},
+        home=external_home,
+    )
+    external_path = _notification_file(external_home)
+    before = external_path.read_bytes()
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(external_home, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        cron_notifications._read_records(linked_parent, "default")
+
+    assert external_path.read_bytes() == before

--- a/tests/test_cron_notifications.py
+++ b/tests/test_cron_notifications.py
@@ -1,0 +1,284 @@
+"""Tests for WebUI/Hermex cron notification inbox endpoints."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import urllib.request
+import urllib.error
+
+from tests._pytest_port import BASE
+
+
+TEST_HOME = Path(os.environ["HERMES_WEBUI_TEST_STATE_DIR"])
+
+
+def _notification_file(home: Path = TEST_HOME) -> Path:
+    return home / "cron" / "notifications.jsonl"
+
+
+def _reset(home: Path = TEST_HOME) -> Path:
+    path = _notification_file(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    return path
+
+
+def _write_record(record: dict, home: Path = TEST_HOME) -> None:
+    path = _notification_file(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def get(path):
+    req = urllib.request.Request(BASE + path)
+    with urllib.request.urlopen(req, timeout=10) as r:
+        raw = r.read()
+        ctype = r.headers.get("Content-Type", "")
+        if ctype.startswith("text/event-stream"):
+            return raw.decode("utf-8"), r.status, ctype
+        return json.loads(raw), r.status, ctype
+
+
+def post(path, body=None):
+    data = json.dumps(body or {}).encode("utf-8")
+    req = urllib.request.Request(
+        BASE + path,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read()), r.status
+    except urllib.error.HTTPError as e:
+        return json.loads(e.read()), e.code
+
+
+def test_notifications_endpoint_returns_unread_profile_scoped_records():
+    _reset()
+    _write_record({
+        "id": "notif_old",
+        "profile": "default",
+        "job_id": "old-job",
+        "title": "Old",
+        "body": "old body",
+        "created_at": "2026-01-01T00:00:00Z",
+        "read_at": "2026-01-01T00:01:00Z",
+    })
+    _write_record({
+        "id": "notif_new",
+        "profile": "default",
+        "job_id": "new-job",
+        "title": "New",
+        "body": "new body",
+        "created_at": "2026-01-02T00:00:00Z",
+        "read_at": None,
+    })
+    path = _notification_file()
+    path.write_text(path.read_text(encoding="utf-8") + "malformed-json\n", encoding="utf-8")
+
+    result, status, _ctype = get("/api/notifications?limit=10")
+
+    assert status == 200
+    assert [row["id"] for row in result["notifications"]] == ["notif_new", "notif_old"]
+    assert result["unread_count"] == 1
+    assert result["unread_by_profile"] == {"default": 1}
+
+
+def test_notifications_equal_legacy_timestamps_use_append_order():
+    _reset()
+    for notification_id in ("older", "newer"):
+        _write_record({
+            "id": notification_id,
+            "profile": "default",
+            "created_at": "2026-01-01T00:00:00Z",
+            "read_at": None,
+        })
+
+    result, status, _ctype = get("/api/notifications?limit=10")
+
+    assert status == 200
+    assert [row["id"] for row in result["notifications"]] == ["newer", "older"]
+
+
+def test_notifications_unread_only_and_mark_read():
+    _reset()
+    _write_record({
+        "id": "notif_mark",
+        "profile": "default",
+        "job_id": "mark-job",
+        "title": "Mark me",
+        "body": "body",
+        "created_at": "2026-01-03T00:00:00Z",
+        "read_at": None,
+    })
+
+    unread, status, _ctype = get("/api/notifications?unread_only=1")
+    assert status == 200
+    assert [row["id"] for row in unread["notifications"]] == ["notif_mark"]
+
+    marked, status = post("/api/notifications/read", {"id": "notif_mark", "profile": "default"})
+    assert status == 200
+    assert marked["ok"] is True
+    assert marked["notification"]["read_at"]
+
+    unread_after, status, _ctype = get("/api/notifications?unread_only=1")
+    assert status == 200
+    assert unread_after["notifications"] == []
+    assert unread_after["unread_count"] == 0
+    path = _notification_file()
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.with_suffix(path.suffix + ".lock").stat().st_mode & 0o777 == 0o600
+
+
+def test_notifications_all_profiles_aggregates_visible_profile_dirs():
+    _reset()
+    other_home = TEST_HOME / "profiles" / "newsletteros"
+    _reset(other_home)
+    _write_record({
+        "id": "notif_default",
+        "profile": "default",
+        "job_id": "default-job",
+        "title": "Default",
+        "body": "default body",
+        "created_at": "2026-01-04T00:00:00Z",
+        "read_at": None,
+    })
+    _write_record({
+        "id": "notif_newsletter",
+        "profile": "newsletteros",
+        "job_id": "newsletter-job",
+        "title": "Newsletter",
+        "body": "newsletter body",
+        "created_at": "2026-01-05T00:00:00Z",
+        "read_at": None,
+    }, home=other_home)
+
+    scoped, status, _ctype = get("/api/notifications?limit=10")
+    assert status == 200
+    assert [row["id"] for row in scoped["notifications"]] == ["notif_default"]
+
+    aggregate, status, _ctype = get("/api/notifications?limit=10&all_profiles=1")
+    assert status == 200
+    assert [row["id"] for row in aggregate["notifications"]] == ["notif_newsletter", "notif_default"]
+    assert aggregate["unread_by_profile"]["newsletteros"] == 1
+
+
+def test_notifications_events_once_returns_sse_snapshot():
+    _reset()
+    _write_record({
+        "id": "notif_sse",
+        "profile": "default",
+        "job_id": "sse-job",
+        "title": "SSE",
+        "body": "sse body",
+        "created_at": "2026-01-06T00:00:00Z",
+        "read_at": None,
+    })
+
+    raw, status, ctype = get("/api/notifications/events?once=1")
+
+    assert status == 200
+    assert ctype.startswith("text/event-stream")
+    assert "event: snapshot" in raw
+    assert "notif_sse" in raw
+
+
+def test_notifications_reader_bounds_legacy_unbounded_store():
+    path = _reset()
+    with open(path, "a", encoding="utf-8") as fh:
+        for idx in range(2005):
+            fh.write(json.dumps({
+                "id": f"legacy_{idx}",
+                "created_at": f"2026-01-01T00:00:{idx:04d}Z",
+                "read_at": None,
+            }) + "\n")
+
+    result, status, _ctype = get("/api/notifications?limit=200")
+
+    assert status == 200
+    assert result["unread_count"] == 2000
+    assert all(row["id"] != "legacy_0" for row in result["notifications"])
+
+
+def test_mark_read_rejects_foreign_profile_in_isolated_mode(tmp_path, monkeypatch):
+    from api import cron_notifications, profiles
+
+    isolated_home = tmp_path / "profiles" / "newsletteros"
+    foreign_home = tmp_path / "profiles" / "wolf-of-hermes"
+    _reset(isolated_home)
+    foreign_path = _reset(foreign_home)
+    _write_record(
+        {
+            "id": "foreign-notification",
+            "profile": "wolf-of-hermes",
+            "created_at": "2026-01-01T00:00:00Z",
+            "read_at": None,
+        },
+        home=foreign_home,
+    )
+    before = foreign_path.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: True)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "newsletteros")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: isolated_home)
+    monkeypatch.setattr(
+        profiles,
+        "get_hermes_home_for_profile",
+        lambda _name: foreign_home,
+    )
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles_api",
+        lambda: [{"name": "newsletteros"}, {"name": "wolf-of-hermes"}],
+    )
+
+    result = cron_notifications.mark_read(
+        "foreign-notification", profile="wolf-of-hermes"
+    )
+
+    assert result is None
+    assert foreign_path.read_text(encoding="utf-8") == before
+
+
+def test_mark_read_allows_visible_profile_in_multi_profile_mode(tmp_path, monkeypatch):
+    from api import cron_notifications, profiles
+
+    default_home = tmp_path
+    foreign_home = tmp_path / "profiles" / "wolf-of-hermes"
+    _reset(default_home)
+    _reset(foreign_home)
+    _write_record(
+        {
+            "id": "visible-notification",
+            "profile": "wolf-of-hermes",
+            "created_at": "2026-01-01T00:00:00Z",
+            "read_at": None,
+        },
+        home=foreign_home,
+    )
+
+    monkeypatch.setattr(profiles, "_is_isolated_profile_mode", lambda: False)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: default_home)
+    monkeypatch.setattr(
+        profiles,
+        "get_hermes_home_for_profile",
+        lambda name: foreign_home if name == "wolf-of-hermes" else default_home,
+    )
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles_api",
+        lambda: [{"name": "wolf-of-hermes"}],
+    )
+
+    result = cron_notifications.mark_read(
+        "visible-notification", profile="wolf-of-hermes"
+    )
+
+    assert result is not None
+    assert result["id"] == "visible-notification"
+    assert result["read_at"]

--- a/tests/test_notifications_ui_static.py
+++ b/tests/test_notifications_ui_static.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 INDEX = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
 PANELS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 NOTIFICATIONS = (ROOT / "static" / "notifications.js").read_text(encoding="utf-8")
+ROUTES = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 STYLE = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
 
@@ -40,7 +41,22 @@ def test_notifications_js_uses_aggregate_api_sse_and_badge_without_duplicate_toa
 
 
 def test_notification_ids_never_enter_inline_javascript_string_literals():
-    assert "openNotificationDetail(this.dataset.notificationId)" in NOTIFICATIONS
+    assert "openNotificationDetail(this.dataset.notificationKey)" in NOTIFICATIONS
     assert "openNotificationCronJob(this.dataset.jobId)" in NOTIFICATIONS
+    assert "data-notification-key" in NOTIFICATIONS
+    assert "data-notification-id" not in NOTIFICATIONS
     assert "openNotificationDetail('${esc(id)}')" not in NOTIFICATIONS
     assert "openNotificationCronJob('${esc(String(row.job_id))}')" not in NOTIFICATIONS
+
+
+def test_notification_identity_is_profile_scoped_end_to_end():
+    assert "JSON.stringify([String(row && row.profile || ''), id])" in NOTIFICATIONS
+    assert "_notificationsSelectedKey" in NOTIFICATIONS
+    assert "_notificationsSeenKeys" in NOTIFICATIONS
+    assert "payload.profile = row.profile" in NOTIFICATIONS
+
+
+def test_sse_connection_snapshot_precedes_once_exit():
+    snapshot = 'handler.wfile.write(sse_event("snapshot", initial))'
+    assert snapshot in ROUTES
+    assert ROUTES.index(snapshot) < ROUTES.index("if once:", ROUTES.index(snapshot))

--- a/tests/test_notifications_ui_static.py
+++ b/tests/test_notifications_ui_static.py
@@ -1,0 +1,46 @@
+"""Static coverage for the Hermex/WebUI cron notification inbox UI."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+PANELS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+NOTIFICATIONS = (ROOT / "static" / "notifications.js").read_text(encoding="utf-8")
+STYLE = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_notifications_script_and_nav_are_wired():
+    assert 'static/notifications.js?v=__WEBUI_VERSION__' in INDEX
+    assert 'data-panel="notifications"' in INDEX
+    assert 'id="notificationsBadge"' in INDEX
+    assert 'id="notificationsBadgeMobile"' in INDEX
+    assert 'id="panelNotifications"' in INDEX
+    assert 'id="mainNotifications"' in INDEX
+
+
+def test_notifications_panel_is_part_of_main_view_switching():
+    assert "notifications: 'Hermex Inbox'" in PANELS
+    assert "'notifications'" in PANELS
+    assert "nextPanel === 'notifications'" in PANELS
+    assert "loadNotifications" in PANELS
+    assert "showing-notifications" in STYLE
+    assert "#mainNotifications" in STYLE
+
+
+def test_notifications_js_uses_aggregate_api_sse_and_badge_without_duplicate_toast():
+    assert "all_profiles: '1'" in NOTIFICATIONS
+    assert "/api/notifications" in NOTIFICATIONS
+    assert "api/notifications/events" in NOTIFICATIONS
+    assert "new EventSource" in NOTIFICATIONS
+    assert "_setNotificationBadge" in NOTIFICATIONS
+    assert "showToast('Cron finished:" not in NOTIFICATIONS
+    assert "markSelectedNotificationRead" in NOTIFICATIONS
+    assert "markAllNotificationsRead" in NOTIFICATIONS
+    assert "openNotificationCronJob" in NOTIFICATIONS
+
+
+def test_notification_ids_never_enter_inline_javascript_string_literals():
+    assert "openNotificationDetail(this.dataset.notificationId)" in NOTIFICATIONS
+    assert "openNotificationCronJob(this.dataset.jobId)" in NOTIFICATIONS
+    assert "openNotificationDetail('${esc(id)}')" not in NOTIFICATIONS
+    assert "openNotificationCronJob('${esc(String(row.job_id))}')" not in NOTIFICATIONS

--- a/tests/test_plan_cron_webui_migration.py
+++ b/tests/test_plan_cron_webui_migration.py
@@ -1,0 +1,90 @@
+"""Tests for scripts/plan_cron_webui_migration.py."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "plan_cron_webui_migration.py"
+spec = importlib.util.spec_from_file_location("plan_cron_webui_migration", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+def _write_jobs(path: Path, jobs: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"jobs": jobs, "updated_at": "2026-01-01T00:00:00Z"}, indent=2) + "\n", encoding="utf-8")
+
+
+def _sample_home(tmp_path: Path) -> Path:
+    home = tmp_path / "hermes"
+    _write_jobs(home / "cron" / "jobs.json", [
+        {"id": "default-origin", "name": "Default origin", "deliver": "origin", "prompt": "keep"},
+        {"id": "default-local", "name": "Default local", "deliver": "local", "prompt": "keep"},
+        {"id": "already", "name": "Already migrated", "deliver": "webui,origin", "prompt": "keep"},
+    ])
+    _write_jobs(home / "profiles" / "newsletteros" / "cron" / "jobs.json", [
+        {"id": "telegram", "name": "Telegram", "deliver": "telegram:123", "prompt": "keep"},
+        {"id": "list", "name": "List", "deliver": ["origin"], "prompt": "keep"},
+    ])
+    (home / "profiles" / "emptyprofile").mkdir(parents=True)
+    return home
+
+
+def test_dry_run_adds_webui_without_writing_or_touching_local(tmp_path):
+    home = _sample_home(tmp_path)
+    before = (home / "cron" / "jobs.json").read_text(encoding="utf-8")
+
+    reports, changes, planned = mod.build_plan(home)
+
+    assert len(changes) == 3
+    observed = {
+        (c.profile, c.job_id, json.dumps(c.old_deliver, sort_keys=True), json.dumps(c.new_deliver, sort_keys=True))
+        for c in changes
+    }
+    assert observed == {
+        ("default", "default-origin", '"origin"', '"webui,origin"'),
+        ("newsletteros", "telegram", '"telegram:123"', '"webui,telegram:123"'),
+        ("newsletteros", "list", '["origin"]', '["webui", "origin"]'),
+    }
+    assert any(r.profile == "emptyprofile" and r.status == "missing" for r in reports)
+    assert planned["default"]["jobs"][0]["prompt"] == "keep"
+    assert (home / "cron" / "jobs.json").read_text(encoding="utf-8") == before
+
+
+def test_apply_requires_backup_dir(tmp_path):
+    home = _sample_home(tmp_path)
+    assert mod.main(["--home", str(home), "--apply"]) == 2
+    data = json.loads((home / "cron" / "jobs.json").read_text(encoding="utf-8"))
+    assert data["jobs"][0]["deliver"] == "origin"
+
+
+def test_apply_writes_only_delivery_changes_and_backups(tmp_path):
+    home = _sample_home(tmp_path)
+    backup_dir = tmp_path / "backup"
+    default_path = home / "cron" / "jobs.json"
+    before = json.loads(default_path.read_text(encoding="utf-8"))
+    before_copy = copy.deepcopy(before)
+
+    assert mod.main(["--home", str(home), "--apply", "--backup-dir", str(backup_dir)]) == 0
+
+    after = json.loads(default_path.read_text(encoding="utf-8"))
+    assert after["jobs"][0]["deliver"] == "webui,origin"
+    assert after["jobs"][1]["deliver"] == "local"
+    assert after["jobs"][2]["deliver"] == "webui,origin"
+    # Non-delivery fields and top-level metadata remain logically unchanged.
+    comparable_before = copy.deepcopy(before_copy)
+    comparable_before["jobs"][0]["deliver"] = "webui,origin"
+    assert after == comparable_before
+
+    backed_up = json.loads((backup_dir / "default" / "cron" / "jobs.json").read_text(encoding="utf-8"))
+    assert backed_up == before_copy
+    manifest = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert len(manifest["changes"]) == 3
+    assert {item["profile"] for item in manifest["backups"]} == {"default", "newsletteros"}

--- a/tests/test_plan_cron_webui_migration.py
+++ b/tests/test_plan_cron_webui_migration.py
@@ -6,7 +6,10 @@ import copy
 import importlib.util
 import json
 import sys
+import threading
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "plan_cron_webui_migration.py"
@@ -88,3 +91,156 @@ def test_apply_writes_only_delivery_changes_and_backups(tmp_path):
     manifest = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
     assert len(manifest["changes"]) == 3
     assert {item["profile"] for item in manifest["backups"]} == {"default", "newsletteros"}
+
+
+def test_profile_symlink_is_rejected_before_plan_or_apply(tmp_path):
+    home = tmp_path / "hermes"
+    profiles_dir = home / "profiles"
+    profiles_dir.mkdir(parents=True)
+    outside = tmp_path / "outside-profile"
+    outside_jobs = outside / "cron" / "jobs.json"
+    _write_jobs(
+        outside_jobs,
+        [{"id": "outside", "deliver": "origin", "prompt": "preserve"}],
+    )
+    before = outside_jobs.read_bytes()
+    (profiles_dir / "escaped").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlinked profile directory rejected"):
+        mod.build_plan(home)
+
+    assert outside_jobs.read_bytes() == before
+
+
+def test_home_symlink_is_rejected_before_resolution(tmp_path):
+    real_home = _sample_home(tmp_path)
+    linked_home = tmp_path / "linked-hermes"
+    linked_home.symlink_to(real_home, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlinked path component rejected"):
+        mod.build_plan(linked_home)
+
+
+def test_cron_symlink_is_rejected_before_plan_or_apply(tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    outside_cron = tmp_path / "outside-cron"
+    outside_jobs = outside_cron / "jobs.json"
+    _write_jobs(
+        outside_jobs,
+        [{"id": "outside", "deliver": "origin", "prompt": "preserve"}],
+    )
+    before = outside_jobs.read_bytes()
+    (home / "cron").symlink_to(outside_cron, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlinked path component rejected"):
+        mod.build_plan(home)
+
+    assert outside_jobs.read_bytes() == before
+
+
+def test_apply_rejects_cron_swap_after_descriptor_open(tmp_path, monkeypatch):
+    home = _sample_home(tmp_path)
+    reports, changes, planned = mod.build_plan(home)
+    original_path = home / "cron" / "jobs.json"
+    original_before = original_path.read_bytes()
+    outside_cron = tmp_path / "outside-cron"
+    outside_jobs = outside_cron / "jobs.json"
+    _write_jobs(
+        outside_jobs,
+        [{"id": "outside", "deliver": "origin", "prompt": "preserve"}],
+    )
+    outside_before = outside_jobs.read_bytes()
+    real_backup = mod.backup_file_from_fd
+    swapped = False
+
+    def swap_then_backup(source_fd, backup_dir, profile):
+        nonlocal swapped
+        if profile == "default" and not swapped:
+            swapped = True
+            (home / "cron").rename(home / "cron-before-swap")
+            (home / "cron").symlink_to(outside_cron, target_is_directory=True)
+        return real_backup(source_fd, backup_dir, profile)
+
+    monkeypatch.setattr(mod, "backup_file_from_fd", swap_then_backup)
+
+    with pytest.raises((OSError, ValueError)):
+        mod.apply_plan(home, tmp_path / "backup", reports, changes, planned)
+
+    assert swapped is True
+    assert outside_jobs.read_bytes() == outside_before
+    assert (home / "cron-before-swap" / "jobs.json").read_bytes() == original_before
+
+
+def test_apply_rejects_jobs_changed_after_plan(tmp_path):
+    home = _sample_home(tmp_path)
+    reports, changes, planned = mod.build_plan(home)
+    jobs_path = home / "cron" / "jobs.json"
+    current = json.loads(jobs_path.read_text(encoding="utf-8"))
+    current["jobs"].append(
+        {
+            "id": "concurrent-job",
+            "name": "Concurrent job",
+            "deliver": "local",
+            "prompt": "must survive",
+        }
+    )
+    jobs_path.write_text(json.dumps(current, indent=2) + "\n", encoding="utf-8")
+    changed_bytes = jobs_path.read_bytes()
+
+    with pytest.raises(ValueError, match="jobs contents changed after planning"):
+        mod.apply_plan(home, tmp_path / "backup", reports, changes, planned)
+
+    assert jobs_path.read_bytes() == changed_bytes
+
+
+def test_canonical_writer_waits_and_preserves_both_changes(
+    tmp_path, monkeypatch
+):
+    if mod.fcntl is None:
+        pytest.skip("POSIX flock required")
+    home = _sample_home(tmp_path)
+    reports, changes, planned = mod.build_plan(home)
+    jobs_path = home / "cron" / "jobs.json"
+    migration_has_lock = threading.Event()
+    writer_done = threading.Event()
+    real_backup = mod.backup_file_from_fd
+
+    def signal_after_lock(source_fd, backup_dir, profile):
+        if profile == "default":
+            migration_has_lock.set()
+        return real_backup(source_fd, backup_dir, profile)
+
+    def canonical_writer():
+        assert migration_has_lock.wait(timeout=5)
+        lock_path = home / "cron" / mod.JOBS_LOCK_FILE
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            mod.fcntl.flock(lock_file.fileno(), mod.fcntl.LOCK_EX)
+            current = json.loads(jobs_path.read_text(encoding="utf-8"))
+            current["jobs"].append(
+                {
+                    "id": "concurrent-job",
+                    "name": "Concurrent job",
+                    "deliver": "local",
+                    "prompt": "must survive",
+                }
+            )
+            temp_path = home / "cron" / ".writer-jobs.tmp"
+            temp_path.write_text(json.dumps(current, indent=2) + "\n", encoding="utf-8")
+            temp_path.replace(jobs_path)
+            mod.fcntl.flock(lock_file.fileno(), mod.fcntl.LOCK_UN)
+        writer_done.set()
+
+    monkeypatch.setattr(mod, "backup_file_from_fd", signal_after_lock)
+    writer = threading.Thread(target=canonical_writer)
+    writer.start()
+    try:
+        mod.apply_plan(home, tmp_path / "backup", reports, changes, planned)
+        assert writer_done.wait(timeout=5)
+    finally:
+        writer.join(timeout=5)
+
+    final = json.loads(jobs_path.read_text(encoding="utf-8"))
+    by_id = {job["id"]: job for job in final["jobs"]}
+    assert by_id["default-origin"]["deliver"] == "webui,origin"
+    assert by_id["concurrent-job"]["prompt"] == "must survive"


### PR DESCRIPTION
<h2>Summary</h2><p>Adds a profile-aware cron notification inbox to Hermes WebUI and hardens its migration, identity, locking, and live-update behavior for multiplexed VPS runtimes.</p><h2>What changed</h2><ul><li>Uses profile plus notification id as the authoritative identity.</li><li>Sends a fresh snapshot on every SSE connection to close the startup race.</li><li>Uses descriptor-anchored access, path containment, content digests, and canonical cron locking for migration writes.</li><li>Coordinates migration with normal writers so concurrent updates are preserved.</li></ul><h2>Tests</h2><ul><li>Pytest: 28 passed and 5 agent-dependent tests skipped because hermes-agent is absent from the WebUI test environment.</li><li>Node syntax checks passed for static/notifications.js and static/panels.js.</li><li>Ruff: no findings on added or modified hunks; current routes.py has 20 baseline findings versus 59 on origin/master.</li><li>git diff --check passed.</li><li>Independent adversarial review: APPROVE at a1926f9550d572e5b940145d013b7a18fe6ec8e9.</li></ul><h2>Risks</h2><p>Touches cron inbox migration and SSE notification behavior. Agent-dependent delivery tests require the integrated Hermes deployment gate.</p><h2>Rollback</h2><p>Revert the PR merge commit or redeploy the previous versioned WebUI artifact; migration planning is digest-bound and creates descriptor-anchored backups before replacement.</p>