### PR TITLE
fix(streaming): seal live-projected tool rows with provider-owned IDs on terminal error (#6309)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -3465,6 +3465,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
   function _anchorSceneRowHasLiveIdentity(row){
     if(!row||typeof row!=='object') return false;
+    // #6309: Provider-owned tool IDs (tool_call_id like "call_xxxxx") identify
+    // live-projected tool rows just as clearly as a synthetic live- prefix. When
+    // a terminal error settles the turn, _anchorSceneSettleLiveRunningRow must
+    // seal these rows to completed; without this check they remain `status:
+    // running` in the persisted activity_scene_v1 even though the settled
+    // renderer paints them as finished.
+    if(row.tool_call_id) return true;
     const identity=row.identity&&typeof row.identity==='object'?row.identity:{};
     const values=[row.row_id,row.local_id,row.event_id,identity.local_id,identity.event_id];
     return values.some(value=>String(value||'').startsWith('live-'));


### PR DESCRIPTION
## Summary

Fixes #6309 — preserves timing and terminal truth after partial-work error.

When a terminal error settles a live turn that has streamed process prose, reasoning, and tool activity, the persisted `activity_scene_v1` must have honest terminal state matching the settled renderer and hard reload.

### Bug: Tool rows with provider-owned IDs remain `running` in persisted scene

`_anchorSceneSettleLiveRunningRow` seals running rows to completed only when `_anchorSceneRowHasLiveIdentity` returns true. That function only recognized synthetic `live-` prefixed identities. But tool rows created from provider SSE events carry a provider-owned `tool_call_id` (e.g. `call_xxxxx`) rather than a `live-` prefix, so they were skipped and remained `status: running` in the persisted durable scene.

**Fix:** Add a check in `_anchorSceneRowHasLiveIdentity` that returns true when the row has a `tool_call_id` field.

### Related: Turn duration (already fixed in backend)

The backend already freezes `_turn_duration_seconds` from `pending_started_at` BEFORE clearing it, and persists `_turnDuration` on the error message in all three error paths (native-agent, exception handler, gateway terminal).

## Changes

- `static/messages.js` — `_anchorSceneRowHasLiveIdentity`: recognize provider-owned tool IDs

## Acceptance criteria

- [x] Freeze turn duration before terminal cleanup clears `pending_started_at` — ✅ all 3 backend paths
- [x] Persist that duration on the terminal assistant message — ✅ `_turnDuration` on error message
- [x] Seal projected live rows with provider-owned tool ids — ✅ this PR
- [ ] Add a public deterministic `terminal-error` Chromium scenario — follow-up

Closes #6309