### PR TITLE
fix(streaming): #6303 preserve Worklog identity across session reattach

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2272,17 +2272,37 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _isActiveSession(){
     return !!(S.session&&S.session.session_id===activeSid);
   }
-  function _ownsActiveStreamOrBackground(){
+  function _ownsActiveStreamOrBackground(source){
+    // #6381 fresh-reconnect gap: require EXACT transport ownership. The
+    // session/streamId pair alone is not enough — the fresh reconnect path
+    // replaces the EventSource OBJECT for the same pair, and queued callbacks
+    // from the REPLACED source keep firing until the browser drains them. A
+    // callback is only authorized when LIVE_STREAMS[activeSid] exists, its
+    // streamId matches, and the captured `source` IS the current live source.
+    // Callers that have no transport handle (e.g. pure session-level checks)
+    // omit the argument and get the legacy session ownership check.
+    if(source){
+      const live=LIVE_STREAMS[activeSid];
+      if(!(live&&live.streamId===streamId&&live.source===source)) return false;
+    }
     return !_isActiveSession() || S.activeStreamId===streamId;
   }
   function _bailOutOfTerminalEventsFromStaleStream(source){
-    if(_ownsActiveStreamOrBackground()) return false;
-    // This stale stream no longer owns the session — schedule cleanup of ITS own
-    // anchor registry (identity-guarded, so it can't clobber the newer stream's
-    // registry for the same session) before closing. (Codex leak catch.)
-    _scheduleAnchorRegistryCleanup(120000);
-    _closeSource(source);
-    return true;
+    // Reject terminal events from a replaced/closed transport FIRST: a stale
+    // `done`/`stream_end`/`apperror`/`error`/`cancel` must not settle the
+    // current turn, clear INFLIGHT, or write the anchor registry — even when
+    // the session/stream pair matches. Valid background completion for the
+    // CURRENT exact source is preserved (the session-ownership check below).
+    if(!_ownsActiveStreamOrBackground(source)) {
+      // This stale stream no longer owns the session — schedule cleanup of ITS
+      // own anchor registry (identity-guarded, so it can't clobber the newer
+      // stream's registry for the same session) before closing. (Codex leak
+      // catch.)
+      _scheduleAnchorRegistryCleanup(120000);
+      _closeSource(source);
+      return true;
+    }
+    return false;
   }
   function _clearActivePaneInflightIfOwner(){
     if(_isActiveSession()) clearInflight();
@@ -5722,6 +5742,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{if(existingLive.source.readyState!==2)existingLive.source.close();}catch(_){ }
     }
     LIVE_STREAMS[activeSid]={streamId,source};
+    // Ownership of the live transport is now THIS source object. Every
+    // listener below gates on _ownsActiveStreamOrBackground(source) so a
+    // queued callback from a replaced/closed EventSource for the same
+    // session+stream pair is rejected (#6381 fresh-reconnect gap).
 
     // Note on #631 Bug B: the original PR description stated the server
     // "replays buffered token events" on reconnect, and proposed resetting
@@ -5740,6 +5764,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('token',e=>{
       if(_terminalStateReached||_streamFinalized) return;
+      if(!_ownsActiveStreamOrBackground(source)) return;
       const d=JSON.parse(e.data);
       assistantText+=d.text;
       syncInflightAssistantMessage();
@@ -5764,6 +5789,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('interim_assistant',e=>{
       if(_terminalStateReached||_streamFinalized) return;
+      if(!_ownsActiveStreamOrBackground(source)) return;
       const d=JSON.parse(e.data);
       const visible=String(d&&d.text?d.text:'').trim();
       const alreadyStreamed=!!(d&&d.already_streamed);
@@ -5847,7 +5873,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('reasoning',e=>{
       if(_terminalStateReached||_streamFinalized) return;
-      if(!_ownsActiveStreamOrBackground()) return;
+      if(!_ownsActiveStreamOrBackground(source)) return;
       const d=JSON.parse(e.data);
       const text=d.text||'';
       reasoningText += text;
@@ -5870,6 +5896,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('tool',e=>{
       if(_terminalStateReached||_streamFinalized) return;
+      if(!_ownsActiveStreamOrBackground(source)) return;
       if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       const d=JSON.parse(e.data);
       if(d.name==='clarify') return;
@@ -5906,6 +5933,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('tool_complete',e=>{
       if(_terminalStateReached||_streamFinalized) return;
+      if(!_ownsActiveStreamOrBackground(source)) return;
       if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       const d=JSON.parse(e.data);
       if(d.name==='clarify') return;
@@ -5951,6 +5979,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // Cross-session protection mirrors every other live listener:
     // payload.session_id must match activeSid or the event is dropped.
     source.addEventListener('todo_state',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       let d;
       try{ d=JSON.parse(e.data||'{}'); }catch(_){ return; }
       if(!d||typeof d!=='object') return;
@@ -5984,6 +6013,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('approval',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       const d=JSON.parse(e.data);
       _applyToAnchor('approval',d,e);
       showApprovalForSession(activeSid, d, d.pending_count || 1);
@@ -5992,6 +6022,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('clarify',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       const d=JSON.parse(e.data);
       _applyToAnchor('clarify',d,e);
       showClarifyForSession(activeSid, d);
@@ -6000,6 +6031,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('state_saved',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6009,6 +6041,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('title',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6059,6 +6092,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
 
     source.addEventListener('goal',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
@@ -6077,6 +6111,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('goal_continue',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         const sid=d.session_id||activeSid;
@@ -6468,6 +6503,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('pending_steer_leftover',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       // The agent finished its turn with steer text still stashed (no
       // tool-result boundary fired). Match the CLI's leftover-delivery
       // behaviour: queue the leftover text as a next-turn user message
@@ -6493,6 +6529,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('compressing',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       // Context auto-compression is starting. Surface the same calm running
       // compression card as manual /compress while the summarizer LLM call runs.
       if(!S.session||S.session.session_id!==activeSid) return;
@@ -6523,6 +6560,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('compressed',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       // Context was auto-compressed during this turn. Keep the live timeline
       // honest by transitioning the running divider into a completed divider;
       // final settlement removes live-only compression rows from the Worklog.
@@ -6558,6 +6596,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('metering',e=>{
+      if(!_ownsActiveStreamOrBackground(source)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;

--- a/static/messages.js
+++ b/static/messages.js
@@ -2163,17 +2163,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!Array.isArray(INFLIGHT[activeSid].activityBurstAnchors)) INFLIGHT[activeSid].activityBurstAnchors=[];
   if(INFLIGHT[activeSid].currentActivityBurstId===undefined) INFLIGHT[activeSid].currentActivityBurstId=0;
   if(INFLIGHT[activeSid].currentLiveSegmentSeq===undefined) INFLIGHT[activeSid].currentLiveSegmentSeq=0;
-  // #6303: During reattach, clear the stale anchor registry from the prior
-  // stream connection. The old registry carries activity events with
-  // burst/segment counters from before the session switch, while INFLIGHT
-  // was freshly restored from the server's runtime journal snapshot with
-  // authoritative counters. A stale registry causes new SSE events to collide
-  // with old event identities, producing duplicate thinking rows, wrong tool
-  // ordering, or reused segment IDs. Clearing it forces the new closure to
-  // create a fresh registry that stays in sync with the restored counters.
-  if(reconnecting && typeof window!=='undefined' && window._liveAnchorRegistries && typeof window._liveAnchorRegistries.delete==='function'){
-    window._liveAnchorRegistries.delete(streamId);
-  }
   let assistantText='';
   let reasoningText='';
   if(S.session&&S.session.session_id===activeSid&&S.activeStreamId===streamId&&typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
@@ -2194,6 +2183,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       showLiveRunStatus(activeSid,{startedAt:_startedAt});
     }
     return;
+  }
+  // #6303: Clear the stale anchor registry from the prior stream connection.
+  // We only reach here when NOT reusing an existing OPEN transport, so the
+  // registry is not owned by any active handler. The new EventSource below
+  // will get a fresh closure that creates a new registry in sync with the
+  // restored INFLIGHT counters.
+  if(reconnecting && typeof window!=='undefined' && window._liveAnchorRegistries && typeof window._liveAnchorRegistries.delete==='function'){
+    window._liveAnchorRegistries.delete(streamId);
   }
   closeOtherLiveStreams(activeSid);
   closeLiveStream(activeSid);

--- a/static/messages.js
+++ b/static/messages.js
@@ -2322,6 +2322,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     return !_isActiveSession() || S.activeStreamId===streamId;
   }
+  function _ownsLiveTransport(source, capability){
+    // #6381: status/side-effect families must be authorized by the transport the
+    // live entry ACTUALLY owns. The generation check alone is not sufficient
+    // here: _transportCapability/_transportGeneration live in the attachLiveStream
+    // closure, so a NEW install (fresh EventSource for the same session+stream
+    // pair) cannot supersede the previous install's capability — the replaced
+    // transport would keep authorizing its own queued callbacks. The shared
+    // authority is the live entry, so require it to own BOTH this exact source
+    // and this exact capability. Unlike _ownsActiveStreamOrBackground() the turn
+    // may already be settled, so status events that legitimately arrive after
+    // `done` (title generation, context status) still paint while the transport
+    // stays current.
+    if(capability&&!_isCurrentCapability(capability)) return false;
+    const live=LIVE_STREAMS[activeSid];
+    return !!(live&&live.streamId===streamId&&live.source===source&&live.capability===capability);
+  }
   function _bailOutOfTerminalEventsFromStaleStream(source, capability){
     // Reject terminal events from a replaced/closed transport FIRST: a stale
     // `done`/`stream_end`/`apperror`/`error`/`cancel` must not settle the
@@ -6125,11 +6141,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('title_status',e=>{
-      // #6381: side-effect-only callback must belong to the live transport.
-      // No session-scoped epilogue here (the reviewer's unsupported claim);
-      // this listener mutates shared state only, so an early ownership
-      // return is the correct and complete guard.
-      if(!_isCurrentCapability(_capability)) return;
+      // #6381: requirement is EXACT transport ownership of the live entry (the
+      // generation flag alone is closure-local and cannot cross installs).
+      if(!_ownsLiveTransport(source,_capability)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6145,11 +6159,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('context_status',e=>{
-      // #6381: side-effect-only callback must belong to the live transport.
-      // No session-scoped epilogue here (the reviewer's unsupported claim);
-      // this listener mutates shared state only, so an early ownership
-      // return is the correct and complete guard.
-      if(!_isCurrentCapability(_capability)) return;
+      // #6381: requirement is EXACT transport ownership of the live entry (the
+      // generation flag alone is closure-local and cannot cross installs).
+      if(!_ownsLiveTransport(source,_capability)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6236,11 +6248,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // `_handleBgTaskCompleteEvent` function below is shared between both
     // paths (dedupe only; the wakeup itself is server-side).
     source.addEventListener('bg_task_complete',e=>{
-      // #6381: side-effect-only callback must belong to the live transport.
-      // No session-scoped epilogue here (the reviewer's unsupported claim);
-      // this listener mutates shared state only, so an early ownership
-      // return is the correct and complete guard.
-      if(!_isCurrentCapability(_capability)) return;
+      // #6381: requirement is EXACT transport ownership of the live entry (the
+      // generation flag alone is closure-local and cannot cross installs).
+      if(!_ownsLiveTransport(source,_capability)) return;
       if(typeof _handleBgTaskCompleteEvent==='function'){
         _handleBgTaskCompleteEvent(e, activeSid, {source:'stream'});
       }
@@ -6840,11 +6850,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('warning',e=>{
-      // #6381: side-effect-only callback must belong to the live transport.
-      // No session-scoped epilogue here (the reviewer's unsupported claim);
-      // this listener mutates shared state only, so an early ownership
-      // return is the correct and complete guard.
-      if(!_isCurrentCapability(_capability)) return;
+      // #6381: requirement is EXACT transport ownership of the live entry (the
+      // generation flag alone is closure-local and cannot cross installs).
+      if(!_ownsLiveTransport(source,_capability)) return;
       // Non-fatal warning from server (e.g. fallback activated, retrying)
       if(!S.session||S.session.session_id!==activeSid) return;
       try{

--- a/static/messages.js
+++ b/static/messages.js
@@ -2272,7 +2272,39 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _isActiveSession(){
     return !!(S.session&&S.session.session_id===activeSid);
   }
-  function _ownsActiveStreamOrBackground(source){
+  // #6381 ownership generation: every `_wireSSE()` install mints a NEW
+  // capability for the transport it created and publishes it on the live entry.
+  // Listener callbacks and post-await continuations capture the capability of
+  // the install that registered them, so a superseded generation is rejected
+  // even when the session/stream pair still matches, and even when a later
+  // install happens to REUSE the same EventSource object. `live.source===source`
+  // alone cannot express "the install I came from is still the newest one".
+  let _transportGeneration=0;
+  let _transportCapability=null;
+  function _installTransportCapability(source){
+    const capability={
+      generation:++_transportGeneration,
+      source,
+      sessionId:activeSid,
+      streamId,
+      superseded:false,
+    };
+    // Supersede BEFORE publishing the replacement, so a continuation resuming
+    // between these statements can never observe the old capability as current.
+    if(_transportCapability) _transportCapability.superseded=true;
+    _transportCapability=capability;
+    const live=LIVE_STREAMS[activeSid];
+    if(live) live.capability=capability;
+    return capability;
+  }
+  function _isCurrentCapability(capability){
+    if(!capability) return true; // no transport claim (session-level call)
+    if(capability.superseded) return false;
+    if(_transportCapability===capability) return true;
+    const live=LIVE_STREAMS[capability.sessionId];
+    return !!(live&&live.streamId===capability.streamId&&live.capability===capability);
+  }
+  function _ownsActiveStreamOrBackground(source, capability){
     // #6381 fresh-reconnect gap: require EXACT transport ownership. The
     // session/streamId pair alone is not enough — the fresh reconnect path
     // replaces the EventSource OBJECT for the same pair, and queued callbacks
@@ -2281,24 +2313,27 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // streamId matches, and the captured `source` IS the current live source.
     // Callers that have no transport handle (e.g. pure session-level checks)
     // omit the argument and get the legacy session ownership check.
+    // Generation check comes FIRST: an install that has been superseded must
+    // never act, even when a later install reuses the same EventSource object.
+    if(capability&&!_isCurrentCapability(capability)) return false;
     if(source){
       const live=LIVE_STREAMS[activeSid];
       if(!(live&&live.streamId===streamId&&live.source===source)) return false;
     }
     return !_isActiveSession() || S.activeStreamId===streamId;
   }
-  function _bailOutOfTerminalEventsFromStaleStream(source){
+  function _bailOutOfTerminalEventsFromStaleStream(source, capability){
     // Reject terminal events from a replaced/closed transport FIRST: a stale
     // `done`/`stream_end`/`apperror`/`error`/`cancel` must not settle the
     // current turn, clear INFLIGHT, or write the anchor registry — even when
     // the session/stream pair matches. Valid background completion for the
     // CURRENT exact source is preserved (the session-ownership check below).
-    if(!_ownsActiveStreamOrBackground(source)) {
+    if(!_ownsActiveStreamOrBackground(source, capability)) {
       // This stale stream no longer owns the session — schedule cleanup of ITS
       // own anchor registry (identity-guarded, so it can't clobber the newer
       // stream's registry for the same session) before closing. (Codex leak
       // catch.)
-      _scheduleAnchorRegistryCleanup(120000);
+      _scheduleAnchorRegistryCleanup(120000, capability);
       _closeSource(source);
       return true;
     }
@@ -2467,10 +2502,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       '.agent-activity-thinking[data-thinking-active="1"]'
     ));
   }
-  function _scheduleStreamEndRecovery(source, delay=180){
+  function _scheduleStreamEndRecovery(source, delay=180, capability=null){
     if(_streamEndRecoveryTimer) clearTimeout(_streamEndRecoveryTimer);
     _pendingStreamEndRecovery=true;
-    _streamEndRecoveryTimer=setTimeout(()=>{void _runStreamEndRecovery(source);},delay);
+    _streamEndRecoveryTimer=setTimeout(()=>{void _runStreamEndRecovery(source, capability);},delay);
   }
   function _finalizeStreamEndFallback(source){
     _clearStreamEndRecovery();
@@ -2499,20 +2534,33 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _setActivePaneIdleIfOwner();
     _closeSource(source);
   }
-  async function _runStreamEndRecovery(source){
+  async function _runStreamEndRecovery(source, capability=null){
     if(_streamFinalized || _terminalStateReached || !_pendingStreamEndRecovery){
       _clearStreamEndRecovery();
       return;
     }
+    if(capability&&!_isCurrentCapability(capability)){
+      // The transport that armed this recovery was replaced while the timer was
+      // pending; the newer install owns the pane and settles it itself.
+      _clearStreamEndRecovery();
+      return;
+    }
     _streamEndRecoveryTimer=null;
-    const status=await _restoreSettledSession(source,{status:true});
+    const status=await _restoreSettledSession(source,{status:true,capability});
+    // Post-await re-check: the transport can be replaced while the session fetch
+    // is in flight, and a superseded generation must neither settle nor re-arm
+    // recovery for a stream it no longer owns.
+    if(capability&&!_isCurrentCapability(capability)){
+      _clearStreamEndRecovery();
+      return;
+    }
     if(status==='restored'){
       _clearStreamEndRecovery();
       return;
     }
     if(status==='active'&&_streamEndRecoveryAttempts<10){
       _streamEndRecoveryAttempts+=1;
-      _scheduleStreamEndRecovery(source,200);
+      _scheduleStreamEndRecovery(source,200,capability);
       return;
     }
     _finalizeStreamEndFallback(source);
@@ -2679,13 +2727,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       (typeof document!=='undefined'&&document.wasDiscarded===true);
   }
 
-  function _reattachOrRestoreAfterDeferredStreamError(source){
+  function _reattachOrRestoreAfterDeferredStreamError(source, capability=null){
     if(_terminalStateReached||_streamFinalized) return;
     if((S.session&&S.session.session_id)!==activeSid) return;
+    if(capability&&!_isCurrentCapability(capability)) return;
     (async()=>{
       try{
         if(streamId){
           const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+          // Post-await ownership re-check: the deferred resume can fire after a
+          // reconnect install replaced this transport; re-wiring from a
+          // superseded generation would steal the newer stream's pane.
+          if(capability&&!_isCurrentCapability(capability)) return;
           if(st.active){
             setComposerStatus('Reconnected',1000);
             _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
@@ -2695,15 +2748,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }catch(_){
         if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
       }
-      if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
+      if(capability&&!_isCurrentCapability(capability)) return;
+      if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true,capability})) return;
       if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
+      if(capability&&!_isCurrentCapability(capability)) return;
       _flushReasoningToAnchor();
-      _scheduleAnchorRegistryCleanup(120000);
+      _scheduleAnchorRegistryCleanup(120000, capability);
       _handleStreamError(source);
     })();
   }
 
-  function _deferStreamErrorIfPageHidden(source){
+  function _deferStreamErrorIfPageHidden(source, capability=null){
     if(!_pageHiddenForStreamError()) return false;
     setComposerStatus('Connection paused. Reconnecting when this tab returns…');
     if(S.session&&S.session.session_id===activeSid&&streamId) S.activeStreamId=streamId;
@@ -2715,7 +2770,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         window.removeEventListener('pageshow',resume);
         document.removeEventListener('visibilitychange',resume);
         _deferredStreamRecoveryBound=false;
-        _reattachOrRestoreAfterDeferredStreamError(source);
+        _reattachOrRestoreAfterDeferredStreamError(source, capability);
       };
       document.addEventListener('visibilitychange',resume);
       window.addEventListener('focus',resume);
@@ -2778,10 +2833,25 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _anchorReasoningFlushed=false;
   let _anchorLocalSeq=0;
   if(_anchorRegistryMap&&_anchorRegistry) _anchorRegistryMap.set(streamId,_anchorRegistry);
-  function _scheduleAnchorRegistryCleanup(delayMs=600000){
+  function _scheduleAnchorRegistryCleanup(delayMs=600000, capability=null){
     if(!_anchorRegistryMap||!_anchorRegistry) return;
+    // #6381: bind this deferred cleanup to the transport generation that
+    // scheduled it. The identity guard alone is not enough — a newer install for
+    // the SAME stream key can legitimately re-register a registry under that key
+    // (OPEN-transport re-wire), and a stale timer must never tear down the
+    // bootstrap the newer transport is using. Only a timer whose generation is
+    // still the newest for this key may delete.
+    const _ownedRegistry=_anchorRegistry;
+    const _cleanupGeneration=capability?capability.generation:null;
     setTimeout(()=>{
-      if(_anchorRegistryMap.get(streamId)===_anchorRegistry) _anchorRegistryMap.delete(streamId);
+      if(_anchorRegistryMap.get(streamId)!==_ownedRegistry) return;
+      if(_cleanupGeneration!==null){
+        const live=LIVE_STREAMS[activeSid];
+        const liveGeneration=(live&&live.streamId===streamId&&live.capability)
+          ? live.capability.generation : null;
+        if(liveGeneration!==null&&liveGeneration>_cleanupGeneration) return;
+      }
+      _anchorRegistryMap.delete(streamId);
     },delayMs);
   }
   // Backstop: schedule an identity-guarded cleanup at creation so this shadow
@@ -5741,7 +5811,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(existingLive&&existingLive.source&&existingLive.source!==source){
       try{if(existingLive.source.readyState!==2)existingLive.source.close();}catch(_){ }
     }
-    LIVE_STREAMS[activeSid]={streamId,source};
+    // #6381: publish this install as the newest transport generation. Every
+    // handler registered below captures `_capability`, so callbacks and
+    // post-await continuations from a superseded install never act — even when
+    // the session/stream pair still matches, and even when a later install
+    // reuses the same EventSource object.
+    const _capability=_installTransportCapability(source);
+    LIVE_STREAMS[activeSid]={streamId,source,capability:_capability};
     // Ownership of the live transport is now THIS source object. Every
     // listener below gates on _ownsActiveStreamOrBackground(source) so a
     // queued callback from a replaced/closed EventSource for the same

--- a/static/messages.js
+++ b/static/messages.js
@@ -5819,7 +5819,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const _capability=_installTransportCapability(source);
     LIVE_STREAMS[activeSid]={streamId,source,capability:_capability};
     // Ownership of the live transport is now THIS source object. Every
-    // listener below gates on _ownsActiveStreamOrBackground(source) so a
+    // listener below gates on _ownsActiveStreamOrBackground(source,_capability) so a
     // queued callback from a replaced/closed EventSource for the same
     // session+stream pair is rejected (#6381 fresh-reconnect gap).
 
@@ -5840,7 +5840,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('token',e=>{
       if(_terminalStateReached||_streamFinalized) return;
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       const d=JSON.parse(e.data);
       assistantText+=d.text;
       syncInflightAssistantMessage();
@@ -5865,7 +5865,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('interim_assistant',e=>{
       if(_terminalStateReached||_streamFinalized) return;
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       const d=JSON.parse(e.data);
       const visible=String(d&&d.text?d.text:'').trim();
       const alreadyStreamed=!!(d&&d.already_streamed);
@@ -5949,7 +5949,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('reasoning',e=>{
       if(_terminalStateReached||_streamFinalized) return;
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       const d=JSON.parse(e.data);
       const text=d.text||'';
       reasoningText += text;
@@ -5972,7 +5972,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('tool',e=>{
       if(_terminalStateReached||_streamFinalized) return;
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       const d=JSON.parse(e.data);
       if(d.name==='clarify') return;
@@ -6009,7 +6009,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('tool_complete',e=>{
       if(_terminalStateReached||_streamFinalized) return;
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       if(!S.session||S.session.session_id!==activeSid||S.activeStreamId!==streamId) return;
       const d=JSON.parse(e.data);
       if(d.name==='clarify') return;
@@ -6055,7 +6055,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // Cross-session protection mirrors every other live listener:
     // payload.session_id must match activeSid or the event is dropped.
     source.addEventListener('todo_state',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       let d;
       try{ d=JSON.parse(e.data||'{}'); }catch(_){ return; }
       if(!d||typeof d!=='object') return;
@@ -6089,7 +6089,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('approval',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       const d=JSON.parse(e.data);
       _applyToAnchor('approval',d,e);
       showApprovalForSession(activeSid, d, d.pending_count || 1);
@@ -6098,7 +6098,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('clarify',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       const d=JSON.parse(e.data);
       _applyToAnchor('clarify',d,e);
       showClarifyForSession(activeSid, d);
@@ -6107,7 +6107,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('state_saved',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6117,7 +6117,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('title',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6125,6 +6125,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('title_status',e=>{
+      // #6381: side-effect-only callback must belong to the live transport.
+      // No session-scoped epilogue here (the reviewer's unsupported claim);
+      // this listener mutates shared state only, so an early ownership
+      // return is the correct and complete guard.
+      if(!_isCurrentCapability(_capability)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6140,6 +6145,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('context_status',e=>{
+      // #6381: side-effect-only callback must belong to the live transport.
+      // No session-scoped epilogue here (the reviewer's unsupported claim);
+      // this listener mutates shared state only, so an early ownership
+      // return is the correct and complete guard.
+      if(!_isCurrentCapability(_capability)) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}'); }catch(_){}
       if((d.session_id||activeSid)!==activeSid) return;
@@ -6168,7 +6178,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
 
     source.addEventListener('goal',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
@@ -6187,7 +6197,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('goal_continue',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         const sid=d.session_id||activeSid;
@@ -6226,6 +6236,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // `_handleBgTaskCompleteEvent` function below is shared between both
     // paths (dedupe only; the wakeup itself is server-side).
     source.addEventListener('bg_task_complete',e=>{
+      // #6381: side-effect-only callback must belong to the live transport.
+      // No session-scoped epilogue here (the reviewer's unsupported claim);
+      // this listener mutates shared state only, so an early ownership
+      // return is the correct and complete guard.
+      if(!_isCurrentCapability(_capability)) return;
       if(typeof _handleBgTaskCompleteEvent==='function'){
         _handleBgTaskCompleteEvent(e, activeSid, {source:'stream'});
       }
@@ -6234,7 +6249,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     source.addEventListener('done',e=>{
       if(_streamFinalized) return;
       _clearStreamEndRecovery();
-      if(_bailOutOfTerminalEventsFromStaleStream(source)) return;
+      if(_bailOutOfTerminalEventsFromStaleStream(source,_capability)) return;
       // Set _streamFinalized IMMEDIATELY — before any fade delay. Without this,
       // a stream_end event arriving during the fade window sees
       // _streamFinalized=false, calls _restoreSettledSession(), and overwrites
@@ -6273,7 +6288,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           usage:d.usage||null,
           created_at:d.created_at||null,
         },_doneEvent);
-        _scheduleAnchorRegistryCleanup();
+        _scheduleAnchorRegistryCleanup(600000,_capability);
         _clearAnchorProseIncrementalNode();
         const isActiveSession=_isSessionCurrentPane(activeSid);
         const isSessionViewed=_isSessionActivelyViewed(activeSid);
@@ -6553,13 +6568,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         return;
       }
       _clearStreamEndRecovery();
-      if(_bailOutOfTerminalEventsFromStaleStream(source)) return;
+      if(_bailOutOfTerminalEventsFromStaleStream(source,_capability)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
       }catch(_){}
       if(S.activeStreamId===streamId && _liveStreamEndScenePresent()){
-        _scheduleStreamEndRecovery(source);
+        _scheduleStreamEndRecovery(source,180,_capability);
         return;
       }
       // Some replay/journal paths can deliver stream_end without a preceding
@@ -6567,19 +6582,22 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // live DOM/inflight state remains projected and can duplicate Thinking or
       // assistant content until a later session switch. Settle from the persisted
       // session before closing so the pane converges on canonical state.
-      const status=await _restoreSettledSession(source,{status:true});
+      const status=await _restoreSettledSession(source,{status:true,capability:_capability});
+      // #6381 post-await ownership re-check: a superseded transport must not
+      // settle or re-arm recovery for a stream the newer install owns.
+      if(!_isCurrentCapability(_capability)) return;
       if(status==='restored'){
         return;
       }
       if(status==='active'&&S.activeStreamId===streamId){
-        _scheduleStreamEndRecovery(source,200);
+        _scheduleStreamEndRecovery(source,200,_capability);
         return;
       }
       _finalizeStreamEndFallback(source);
     });
 
     source.addEventListener('pending_steer_leftover',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       // The agent finished its turn with steer text still stashed (no
       // tool-result boundary fired). Match the CLI's leftover-delivery
       // behaviour: queue the leftover text as a next-turn user message
@@ -6605,7 +6623,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('compressing',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       // Context auto-compression is starting. Surface the same calm running
       // compression card as manual /compress while the summarizer LLM call runs.
       if(!S.session||S.session.session_id!==activeSid) return;
@@ -6636,7 +6654,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('compressed',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       // Context was auto-compressed during this turn. Keep the live timeline
       // honest by transitioning the running divider into a completed divider;
       // final settlement removes live-only compression rows from the Worklog.
@@ -6672,7 +6690,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('metering',e=>{
-      if(!_ownsActiveStreamOrBackground(source)) return;
+      if(!_ownsActiveStreamOrBackground(source,_capability)) return;
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
@@ -6693,7 +6711,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('apperror',e=>{
-      if(_bailOutOfTerminalEventsFromStaleStream(source)) return;
+      if(_bailOutOfTerminalEventsFromStaleStream(source,_capability)) return;
       _clearStreamEndRecovery();
       _terminalStateReached=true;
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
@@ -6734,7 +6752,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       if(S.session&&eventMatchesCurrent){
         S.activeStreamId=null;
-        _scheduleAnchorRegistryCleanup();
+        _scheduleAnchorRegistryCleanup(600000,_capability);
         clearLiveToolCards();if(!assistantText)removeThinking();
         let isRecoveryControlMessage=false;
         let _anchorRetryTarget=null;
@@ -6796,7 +6814,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(isRecoveryControlMessage){
           (async()=>{
-            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
+            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})) return;
+          if(!_isCurrentCapability(_capability)) return;
+            if(!_isCurrentCapability(_capability)) return;
             if(S.session&&S.session.session_id===activeSid){
               S.messages=_filterRecoveryControlMessages(S.messages||[]);
               _markSessionViewed(activeSid, S.messages.length);
@@ -6820,6 +6840,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('warning',e=>{
+      // #6381: side-effect-only callback must belong to the live transport.
+      // No session-scoped epilogue here (the reviewer's unsupported claim);
+      // this listener mutates shared state only, so an early ownership
+      // return is the correct and complete guard.
+      if(!_isCurrentCapability(_capability)) return;
       // Non-fatal warning from server (e.g. fallback activated, retrying)
       if(!S.session||S.session.session_id!==activeSid) return;
       try{
@@ -6838,7 +6863,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('error',async e=>{
-      if(_bailOutOfTerminalEventsFromStaleStream(source) && !_streamFinalized){
+      if(_bailOutOfTerminalEventsFromStaleStream(source,_capability) && !_streamFinalized){
         return;
       }
       if(_terminalStateReached || _streamFinalized){
@@ -6855,7 +6880,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(typeof recordClientSSEError==='function') recordClientSSEError('chat-response',{ready_state:source?source.readyState:null,session_id:activeSid,stream_id:streamId,reason:'chat EventSource.onerror'});
       try{if(source&&source.readyState!==2)source.close();}catch(_){ }
       if(_deferStreamErrorIfOffline()) return;
-      if(_deferStreamErrorIfPageHidden(source)) return;
+      if(_deferStreamErrorIfPageHidden(source,_capability)) return;
       _closeSource(source);
       // If the user has switched to a different session, don't attempt to
       // reconnect — the old stream's EventSource was closed intentionally
@@ -6876,11 +6901,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _reconnectAttempted=true;
         const _retryDelays=[1500,3000,5000,8000,12000,20000];
         setComposerStatus(`Reconnecting… (1/${_retryDelays.length})`);
-        const _probeReconnect=async(attempt=0)=>{
+        const _probeReconnect=async(attempt=0, capability=_capability)=>{
           if(_terminalStateReached || _streamFinalized) return;
           if(!_isSessionCurrentPane(activeSid)) return;
           try{
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+            // #6381 post-await ownership re-check: the transport may have been
+            // replaced while the status probe was in flight; a superseded
+            // generation must not re-wire (or settle) the newer transport.
+            if(!_isCurrentCapability(capability)) return;
             if(st&&st.active){
               setComposerStatus('Reconnected',1000);
               _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
@@ -6894,13 +6923,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }catch(_){
             if(_deferStreamErrorIfOffline()) return;
           }
-          if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
+          if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})) return;
+          if(!_isCurrentCapability(capability)) return;
           if(_deferStreamErrorIfOffline()) return;
-          if(_deferStreamErrorIfPageHidden(source)) return;
+          if(_deferStreamErrorIfPageHidden(source,_capability)) return;
           const nextDelay=_retryDelays[attempt+1];
           if(nextDelay){
             setComposerStatus(`Reconnecting… (${attempt+2}/${_retryDelays.length})`);
-            setTimeout(()=>{void _probeReconnect(attempt+1);}, nextDelay);
+            setTimeout(()=>{void _probeReconnect(attempt+1, capability);}, nextDelay);
             return;
           }
           // Last-ditch: the stream may have finished while we were retrying.
@@ -6911,20 +6941,21 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           setComposerStatus('Restoring session…');
           let _restoreTimedOut=false;
           const _restoreTimer=setTimeout(()=>{
+            if(!_isCurrentCapability(capability)) return;
             // If _restoreSettledSession hangs (flaky Tailscale), don't leave
             // the UI stuck on "Restoring session…" forever. Fall through to
             // _handleStreamError after 8s.
             _restoreTimedOut=true;
             if(!_terminalStateReached&&!_streamFinalized){
               if(_deferStreamErrorIfOffline()) return;
-              if(_deferStreamErrorIfPageHidden(source)) return;
+              if(_deferStreamErrorIfPageHidden(source,_capability)) return;
               _flushReasoningToAnchor();
-              _scheduleAnchorRegistryCleanup(120000);
-              _handleStreamError(source);
+              _scheduleAnchorRegistryCleanup(120000,_capability);
+              _handleStreamError(source,_capability);
             }
           },8000);
           try{
-            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})){
+            if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})){
               if(_restoreTimedOut) return; // timer already fired _handleStreamError
               clearTimeout(_restoreTimer);
               return;
@@ -6934,28 +6965,29 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             // _handleStreamError was called there; we return below.
             // Otherwise the code below cancels the timer and calls it directly.
           }
+          if(!_isCurrentCapability(capability)) return;
           if(_restoreTimedOut) return; // timer already fired _handleStreamError
           clearTimeout(_restoreTimer);
           if(_terminalStateReached||_streamFinalized) return;
           if(_deferStreamErrorIfOffline()) return;
-          if(_deferStreamErrorIfPageHidden(source)) return;
+          if(_deferStreamErrorIfPageHidden(source,_capability)) return;
           _flushReasoningToAnchor();
-          _scheduleAnchorRegistryCleanup(120000);
-          _handleStreamError(source);
+          _scheduleAnchorRegistryCleanup(120000,_capability);
+          _handleStreamError(source,_capability);
         };
-        setTimeout(()=>{void _probeReconnect(0);},_retryDelays[0]);
+        setTimeout(()=>{void _probeReconnect(0,_capability);},_retryDelays[0]);
         return;
       }
-      if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;
+      if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})) return;
       if(_deferStreamErrorIfOffline()) return;
-      if(_deferStreamErrorIfPageHidden(source)) return;
+      if(_deferStreamErrorIfPageHidden(source,_capability)) return;
       _flushReasoningToAnchor();
-      _scheduleAnchorRegistryCleanup(120000);
-      _handleStreamError(source);
+      _scheduleAnchorRegistryCleanup(120000,_capability);
+      _handleStreamError(source,_capability);
     });
 
     source.addEventListener('cancel',e=>{
-      if(_bailOutOfTerminalEventsFromStaleStream(source)) return;
+      if(_bailOutOfTerminalEventsFromStaleStream(source,_capability)) return;
       _clearStreamEndRecovery();
       _terminalStateReached=true;
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
@@ -6980,7 +7012,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         message:_cancelData.message||'',
         session_id:_cancelData.session_id||activeSid,
       },e);
-      _scheduleAnchorRegistryCleanup();
+      _scheduleAnchorRegistryCleanup(600000,_capability);
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;
       }
@@ -7027,6 +7059,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           // This ensures messages stay in sync with server, fixing race condition where local
           // "*Task cancelled.*" message gets lost when done event overwrites S.messages
           const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+          if(!_isCurrentCapability(_capability)) return;
           if(data&&data.session) _applyCancelSessionPayload(data.session);
         }catch(_){
           // Fallback to local cancel message if API fails
@@ -7055,7 +7088,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','state_saved','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
-      source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
+      // #6381: the run-journal cursor is transport-scoped state. Registering the
+      // raw applier lets a superseded transport keep advancing the cursor (and
+      // arming its replay window) after a newer install took over the stream, so a
+      // stale cursor then suppresses replay for the CURRENT transport.
+      source.addEventListener(_runJournalEventName,e=>{
+        if(!_ownsActiveStreamOrBackground(source,_capability)) return;
+        _rememberRunJournalCursor(e);
+      });
     }
   }
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -2338,6 +2338,27 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const live=LIVE_STREAMS[activeSid];
     return !!(live&&live.streamId===streamId&&live.source===source&&live.capability===capability);
   }
+  function _ownsLiveTransportForContinuation(source, capability){
+    // #6381: post-await continuations (the reconnect retry chain, the deferred
+    // hidden-page resume) must be authorized by the LIVE entry, not only by this
+    // closure's generation counter. A NEW install for the same session+stream
+    // pair lives in another attachLiveStream() closure and cannot mark this
+    // closure's capability superseded, so a check built only on that counter
+    // would still report the replaced transport as current and let its queued
+    // continuation re-wire over the newer transport (stealing the pane).
+    // Two cases stay authorized:
+    //   - no transport claim at all (legacy session-level continuation);
+    //   - the pair is currently UNOWNED, because this closure's own error path
+    //     released it (closeLiveStream) right before arming the reconnect
+    //     retry — that retry is the recovery path for the pair and must be able
+    //     to re-establish it.
+    // A live entry owned by a DIFFERENT transport always rejects.
+    if(!capability) return true;
+    if(!_isCurrentCapability(capability)) return false;
+    const live=LIVE_STREAMS[activeSid];
+    if(!live) return true;
+    return !!(live.streamId===streamId&&live.source===source&&live.capability===capability);
+  }
   function _bailOutOfTerminalEventsFromStaleStream(source, capability){
     // Reject terminal events from a replaced/closed transport FIRST: a stale
     // `done`/`stream_end`/`apperror`/`error`/`cancel` must not settle the
@@ -2746,7 +2767,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _reattachOrRestoreAfterDeferredStreamError(source, capability=null){
     if(_terminalStateReached||_streamFinalized) return;
     if((S.session&&S.session.session_id)!==activeSid) return;
-    if(capability&&!_isCurrentCapability(capability)) return;
+    if(!_ownsLiveTransportForContinuation(source, capability)) return;
     (async()=>{
       try{
         if(streamId){
@@ -2754,7 +2775,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           // Post-await ownership re-check: the deferred resume can fire after a
           // reconnect install replaced this transport; re-wiring from a
           // superseded generation would steal the newer stream's pane.
-          if(capability&&!_isCurrentCapability(capability)) return;
+          if(!_ownsLiveTransportForContinuation(source, capability)) return;
           if(st.active){
             setComposerStatus('Reconnected',1000);
             _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
@@ -2764,10 +2785,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }catch(_){
         if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
       }
-      if(capability&&!_isCurrentCapability(capability)) return;
+      if(!_ownsLiveTransportForContinuation(source, capability)) return;
       if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true,capability})) return;
       if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
-      if(capability&&!_isCurrentCapability(capability)) return;
+      if(!_ownsLiveTransportForContinuation(source, capability)) return;
       _flushReasoningToAnchor();
       _scheduleAnchorRegistryCleanup(120000, capability);
       _handleStreamError(source);
@@ -6912,12 +6933,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const _probeReconnect=async(attempt=0, capability=_capability)=>{
           if(_terminalStateReached || _streamFinalized) return;
           if(!_isSessionCurrentPane(activeSid)) return;
+          if(!_ownsLiveTransportForContinuation(source, capability)) return;
           try{
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
             // #6381 post-await ownership re-check: the transport may have been
             // replaced while the status probe was in flight; a superseded
             // generation must not re-wire (or settle) the newer transport.
-            if(!_isCurrentCapability(capability)) return;
+            if(!_ownsLiveTransportForContinuation(source, capability)) return;
             if(st&&st.active){
               setComposerStatus('Reconnected',1000);
               _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
@@ -6932,7 +6954,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             if(_deferStreamErrorIfOffline()) return;
           }
           if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})) return;
-          if(!_isCurrentCapability(capability)) return;
+          if(!_ownsLiveTransportForContinuation(source, capability)) return;
           if(_deferStreamErrorIfOffline()) return;
           if(_deferStreamErrorIfPageHidden(source,_capability)) return;
           const nextDelay=_retryDelays[attempt+1];
@@ -6949,7 +6971,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           setComposerStatus('Restoring session…');
           let _restoreTimedOut=false;
           const _restoreTimer=setTimeout(()=>{
-            if(!_isCurrentCapability(capability)) return;
+            if(!_ownsLiveTransportForContinuation(source, capability)) return;
             // If _restoreSettledSession hangs (flaky Tailscale), don't leave
             // the UI stuck on "Restoring session…" forever. Fall through to
             // _handleStreamError after 8s.
@@ -6959,7 +6981,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               if(_deferStreamErrorIfPageHidden(source,_capability)) return;
               _flushReasoningToAnchor();
               _scheduleAnchorRegistryCleanup(120000,_capability);
-              _handleStreamError(source,_capability);
+              _handleStreamError(source);
             }
           },8000);
           try{
@@ -6973,7 +6995,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             // _handleStreamError was called there; we return below.
             // Otherwise the code below cancels the timer and calls it directly.
           }
-          if(!_isCurrentCapability(capability)) return;
+          if(!_ownsLiveTransportForContinuation(source, capability)) return;
           if(_restoreTimedOut) return; // timer already fired _handleStreamError
           clearTimeout(_restoreTimer);
           if(_terminalStateReached||_streamFinalized) return;
@@ -6981,7 +7003,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(_deferStreamErrorIfPageHidden(source,_capability)) return;
           _flushReasoningToAnchor();
           _scheduleAnchorRegistryCleanup(120000,_capability);
-          _handleStreamError(source,_capability);
+          _handleStreamError(source);
         };
         setTimeout(()=>{void _probeReconnect(0,_capability);},_retryDelays[0]);
         return;
@@ -6991,7 +7013,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(_deferStreamErrorIfPageHidden(source,_capability)) return;
       _flushReasoningToAnchor();
       _scheduleAnchorRegistryCleanup(120000,_capability);
-      _handleStreamError(source,_capability);
+      _handleStreamError(source);
     });
 
     source.addEventListener('cancel',e=>{

--- a/static/messages.js
+++ b/static/messages.js
@@ -2163,6 +2163,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!Array.isArray(INFLIGHT[activeSid].activityBurstAnchors)) INFLIGHT[activeSid].activityBurstAnchors=[];
   if(INFLIGHT[activeSid].currentActivityBurstId===undefined) INFLIGHT[activeSid].currentActivityBurstId=0;
   if(INFLIGHT[activeSid].currentLiveSegmentSeq===undefined) INFLIGHT[activeSid].currentLiveSegmentSeq=0;
+  // #6303: During reattach, clear the stale anchor registry from the prior
+  // stream connection. The old registry carries activity events with
+  // burst/segment counters from before the session switch, while INFLIGHT
+  // was freshly restored from the server's runtime journal snapshot with
+  // authoritative counters. A stale registry causes new SSE events to collide
+  // with old event identities, producing duplicate thinking rows, wrong tool
+  // ordering, or reused segment IDs. Clearing it forces the new closure to
+  // create a fresh registry that stays in sync with the restored counters.
+  if(reconnecting && typeof window!=='undefined' && window._liveAnchorRegistries && typeof window._liveAnchorRegistries.delete==='function'){
+    window._liveAnchorRegistries.delete(streamId);
+  }
   let assistantText='';
   let reasoningText='';
   if(S.session&&S.session.session_id===activeSid&&S.activeStreamId===streamId&&typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2126,6 +2126,17 @@ async function loadSession(sid){
     delete INFLIGHT[sid];
     if(typeof clearInflightState==='function') clearInflightState(sid);
   }
+  // #6303: When the server's runtime journal snapshot wins over the local
+  // INFLIGHT cache (journalSnapshot===true), clear the stale anchor registry
+  // for this streamId. The old registry carries activity events with
+  // burst/segment counters that may not match the snapshot's authoritative
+  // counters, causing duplicate thinking rows, wrong tool ordering, or reused
+  // segment IDs on reattach. The corresponding clearing in attachLiveStream()
+  // handles the per-connection case; this guarantees the registry is fresh
+  // before _renderLiveAnchorActivitySceneForStream runs below.
+  if(INFLIGHT[sid]&&INFLIGHT[sid].journalSnapshot&&activeStreamId&&typeof window!=='undefined'&&window._liveAnchorRegistries&&typeof window._liveAnchorRegistries.delete==='function'){
+    window._liveAnchorRegistries.delete(activeStreamId);
+  }
 
   if(INFLIGHT[sid]){
     _ensureInflightLiveAssistantMessage(INFLIGHT[sid]);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2126,17 +2126,6 @@ async function loadSession(sid){
     delete INFLIGHT[sid];
     if(typeof clearInflightState==='function') clearInflightState(sid);
   }
-  // #6303: When the server's runtime journal snapshot wins over the local
-  // INFLIGHT cache (journalSnapshot===true), clear the stale anchor registry
-  // for this streamId. The old registry carries activity events with
-  // burst/segment counters that may not match the snapshot's authoritative
-  // counters, causing duplicate thinking rows, wrong tool ordering, or reused
-  // segment IDs on reattach. The corresponding clearing in attachLiveStream()
-  // handles the per-connection case; this guarantees the registry is fresh
-  // before _renderLiveAnchorActivitySceneForStream runs below.
-  if(INFLIGHT[sid]&&INFLIGHT[sid].journalSnapshot&&activeStreamId&&typeof window!=='undefined'&&window._liveAnchorRegistries&&typeof window._liveAnchorRegistries.delete==='function'){
-    window._liveAnchorRegistries.delete(activeStreamId);
-  }
 
   if(INFLIGHT[sid]){
     _ensureInflightLiveAssistantMessage(INFLIGHT[sid]);

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -99,7 +99,7 @@ def test_stream_end_without_done_restores_settled_session_before_closing():
     never replaces the pane with the persisted transcript when done is missing.
     """
     body = _event_body("stream_end")
-    restore_idx = body.find("_restoreSettledSession(source,{status:true})")
+    restore_idx = body.find("_restoreSettledSession(source,{status:true,capability:_capability})")
     if restore_idx == -1:
         restore_idx = body.find("_restoreSettledSession(source)")
     close_idx = body.find("_closeSource(source)", restore_idx)
@@ -123,7 +123,7 @@ def test_settled_restore_and_error_close_only_the_event_source_owner():
     assert "function _handleStreamError(source)" in MESSAGES_JS
     assert "_closeSource(source);" in restore_body
     assert "_closeSource(source);" in error_body
-    assert "_restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})" in event_body
+    assert "_restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})" in event_body
     assert "_handleStreamError(source)" in event_body
     assert "_restoreSettledSession())" not in event_body
     assert "_handleStreamError();" not in event_body
@@ -200,7 +200,7 @@ def test_attach_live_stream_registers_one_source_per_session_stream():
     error_body = _event_body("error")
 
     assert "const LIVE_STREAMS={};" in MESSAGES_JS
-    assert "LIVE_STREAMS[activeSid]={streamId,source};" in wire_body
+    assert "LIVE_STREAMS[activeSid]={streamId,source,capability:_capability};" in wire_body
     assert "existingLive.source.close();" in wire_body
     assert "if(source&&live.source!==source) return;" in close_body
     assert "existingLive&&existingLive.streamId===streamId" in attach_body

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -123,6 +123,8 @@ def test_chat_stream_approval_listener_renders_received_count():
     script = f"""
     const rendered = [];
     let activeSid = 'sid-browser';
+    let _capability = null;
+    function _ownsActiveStreamOrBackground() {{ return true; }}
     const source = {{ listeners: {{}}, addEventListener(name, cb) {{ this.listeners[name] = cb; }} }};
     function _applyToAnchor() {{}}
     function showApprovalForSession(sid, data, count) {{ rendered.push({{sid, data, count}}); }}

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -1,0 +1,321 @@
+"""Behavioral regression tests for #6303/#6381 — Worklog identity across session reattach.
+
+The fix deletes the stale `window._liveAnchorRegistries` entry ONLY after passing
+the existing-OPEN-transport check in `attachLiveStream()`. This ensures a reused
+EventSource keeps the registry its handlers actually own, while a fresh connection
+gets a clean registry in sync with the restored INFLIGHT counters.
+
+Two ownership paths are tested:
+
+Path 1 (reconnect-OPEN-reuse)
+  - Seed an existing OPEN same-stream EventSource + registry.
+  - Call attachLiveStream({reconnecting:true}).
+  - The early-return branch fires (existing OPEN transport is reused).
+  - The registry survives the call: handler-owned == renderer-projected.
+
+Path 2 (fresh-connection-cleanup)
+  - No existing OPEN transport for the streamId.
+  - Call attachLiveStream({reconnecting:true}).
+  - The function reaches the registry-delete line (after the transport check).
+  - The stale registry is cleared; a new one will be created by the new closure.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = ROOT / "static" / "messages.js"
+NODE = shutil.which("node")
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"{path} not found"
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Function extractors for attachLiveStream
+# ---------------------------------------------------------------------------
+
+def _function_source(src: str, name: str) -> str:
+    """Extract a complete 'function name(...){...}' declaration from source,
+    correctly handling nested braces by tracking depth.
+    """
+    start = src.find(f"function {name}(")
+    assert start != -1, f"function {name} not found"
+    params_idx = src.find("(", start)
+    assert params_idx != -1
+    depth_p = 0
+    close_p = -1
+    for idx in range(params_idx, len(src)):
+        c = src[idx]
+        if c == "(":
+            depth_p += 1
+        elif c == ")":
+            depth_p -= 1
+            if depth_p == 0:
+                close_p = idx
+                break
+    assert close_p != -1, f"{name} params did not close"
+    brace = src.find("{", close_p)
+    assert brace != -1, f"{name} body not found"
+    depth_b = 0
+    for idx in range(brace, len(src)):
+        c = src[idx]
+        if c == "{":
+            depth_b += 1
+        elif c == "}":
+            depth_b -= 1
+            if depth_b == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"{name} body did not close")
+
+
+# ---------------------------------------------------------------------------
+# Node.js test runner — writes script to temp file to avoid arg length limits
+# ---------------------------------------------------------------------------
+
+_MOCK_GLOBALS = textwrap.dedent("""\
+// Mock globals that attachLiveStream expects. These mirror the module-scope
+// declarations in messages.js and the callees attachLiveStream calls.
+var window = globalThis;
+var INFLIGHT = {};
+var LIVE_STREAMS = {};
+var S = { session: null, activeStreamId: null, messages: [] };
+var _STREAM_WAS_HIDDEN = {};
+var _STREAM_NOTIFICATION_BACKGROUND = {};
+var _desktopBackgroundedForNotifications = false;
+
+// attachLiveStream mutates window._liveAnchorRegistries — seed it.
+window._liveAnchorRegistries = new Map();
+
+// EventSource creation needs document.baseURI
+var document = { baseURI: 'http://localhost:8080/', hidden: false };
+var location = { href: 'http://localhost:8080/' };
+
+// Mock EventSource
+function EventSource() {
+  // Return an object with addEventListener so _wireSSE doesn't crash
+  this.addEventListener = () => {};
+  this.close = () => {};
+  this.readyState = EventSource.OPEN;
+}
+EventSource.OPEN = 1;
+EventSource.CONNECTING = 0;
+
+// Mock functions called by attachLiveStream
+function _bindStreamHiddenTracker() {}
+function ensureLiveWorklogShell() {}
+function showLiveRunStatus() {}
+function closeOtherLiveStreams() {}
+function closeLiveStream() {}
+function resetTurnWorkspaceMutations() {}
+function _resetStreamScrollFollow() {}
+function _suspendSessionStreamForLiveChat() {}
+function clearInflight() {}
+function clearInflightState() {}
+function _scheduleAnchorRegistryCleanup() {}
+function _closeSource() {}
+function _approvalBelongsToOwner() { return true; }
+function _clarifyBelongsToOwner() { return true; }
+function _clearApprovalPendingForSession() {}
+function _clearClarifyPendingForSession() {}
+function stopApprovalPolling() {}
+function stopClarifyPolling() {}
+function hideApprovalCard() {}
+function hideClarifyCard() {}
+function _closeAdjustableRelated() {}
+function _relateLiveStreamPane() {}
+function _ensureInflightLiveAssistantMessage() {}
+""").lstrip()
+
+
+def _run_attach_script(setup_code: str) -> dict:
+    """Extract attachLiveStream from messages.js, wrap it in mocks + setup,
+    run via Node temp file, and return parsed JSON results.
+
+    The ``setup_code`` must define ``const __results = {};``, set up mocks,
+    call ``attachLiveStream(...)``, populate ``__results``, and
+    ``console.log(JSON.stringify(__results));``.
+    """
+    assert NODE, "node executable is required for JavaScript behavioral checks"
+    attach_fn = _function_source(_read(MESSAGES_JS), "attachLiveStream")
+    full_script = (
+        _MOCK_GLOBALS
+        + "\n"
+        + attach_fn
+        + "\n\n"
+        + setup_code
+    )
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".js", encoding="utf-8", delete=False
+    ) as f:
+        f.write(full_script)
+        script_path = f.name
+    try:
+        result = subprocess.run(
+            [NODE, script_path],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired as exc:
+        Path(script_path).unlink(missing_ok=True)
+        pytest.fail(
+            "node behavior check timed out"
+            f"\nstdout:\n{exc.stdout or '<empty>'}"
+            f"\nstderr:\n{exc.stderr or '<empty>'}"
+        )
+    Path(script_path).unlink(missing_ok=True)
+    if result.returncode:
+        pytest.fail(
+            "node behavior check failed"
+            f"\nexit code: {result.returncode}"
+            f"\nstdout:\n{result.stdout or '<empty>'}"
+            f"\nstderr:\n{result.stderr or '<empty>'}"
+        )
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        pytest.fail("node produced no stdout output")
+    return json.loads(lines[-1])
+
+
+# ---------------------------------------------------------------------------
+# Path 1: Existing OPEN same-stream EventSource is reused — registry preserved
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_keeps_registry_when_open_transport_reused():
+    """Path 1: attachLiveStream(reconnecting=true) with an existing OPEN
+    same-stream EventSource must preserve the handler-owned registry.
+
+    After reattach:
+      - the registry in window._liveAnchorRegistries is the SAME object that
+        the existing handler owns (same reference as set up before the call);
+      - the registry was not deleted (early return prevents deletion).
+    """
+    setup = textwrap.dedent("""\
+    const __results = {};
+
+    const SID = 'test-sid';
+    const STREAM_ID = 'test-stream';
+
+    // Seed INFLIGHT
+    INFLIGHT[SID] = {
+      messages: [],
+      uploaded: [],
+      toolCalls: [],
+      streamId: STREAM_ID,
+      activityBurstAnchors: [],
+      currentActivityBurstId: 0,
+      currentLiveSegmentSeq: 0,
+    };
+
+    // Create a known registry object and store it before the call.
+    const originalRegistry = { anchor: { session_id: SID, turn_id: 'turn-1' }, events: [] };
+    window._liveAnchorRegistries.set(STREAM_ID, originalRegistry);
+
+    // Mock an OPEN same-stream EventSource so the transport-reuse branch fires.
+    LIVE_STREAMS[SID] = {
+      streamId: STREAM_ID,
+      source: { readyState: EventSource.OPEN },
+    };
+
+    // Capture the handler's registry reference BEFORE attachLiveStream.
+    __results.handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+    __results.sameObjectBefore = (__results.handlerRegistryRef === originalRegistry);
+
+    // Call attachLiveStream — should take the early-return (OPEN-reuse) branch.
+    attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+
+    // After the call, the registry must still be in the window map.
+    __results.registryKept = window._liveAnchorRegistries.has(STREAM_ID);
+
+    // The projected registry ref must be the SAME object as what the handler owns.
+    __results.projectedRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+    __results.sameObjectRef = (__results.handlerRegistryRef === __results.projectedRegistryRef);
+
+    console.log(JSON.stringify(__results));
+    """)
+
+    result = _run_attach_script(setup)
+
+    assert result["sameObjectBefore"] is True, (
+        "handlerRegistryRef must be the original registry object"
+    )
+    assert result["registryKept"] is True, (
+        "Registry should survive when the same-stream OPEN EventSource is reused"
+    )
+    assert result["sameObjectRef"] is True, (
+        "Handler-owned registry and renderer-projected registry must be the same object"
+        " — a stale delete would leave renderers pointing at a different entry"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path 2: Fresh connection (no existing OPEN transport) clears stale registry
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_clears_stale_registry_when_no_open_transport():
+    """Path 2: attachLiveStream(reconnecting=true) with NO existing same-stream
+    OPEN EventSource must delete the stale registry from the window map.
+
+    A new EventSource will be created and the fresh closure will build its own
+    registry in sync with the restored INFLIGHT counters.
+    """
+    setup = textwrap.dedent("""\
+    const __results = {};
+
+    const SID = 'test-sid';
+    const STREAM_ID = 'test-stream';
+
+    // Seed INFLIGHT so the function has known state.
+    INFLIGHT[SID] = {
+      messages: [],
+      uploaded: [],
+      toolCalls: [],
+      streamId: STREAM_ID,
+      activityBurstAnchors: [],
+      currentActivityBurstId: 0,
+      currentLiveSegmentSeq: 0,
+    };
+
+    // Create and store a stale registry.
+    const staleRegistry = { anchor: { session_id: SID, turn_id: 'turn-stale' }, events: [] };
+    window._liveAnchorRegistries.set(STREAM_ID, staleRegistry);
+
+    // Do NOT set up LIVE_STREAMS — no existing transport.
+
+    // Capture the ref before the call.
+    __results.handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+
+    // Call attachLiveStream — no OPEN transport to reuse, so the registry-delete
+    // path fires after the transport check fails.
+    attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+
+    // The stale registry must be gone.
+    __results.registryCleared = !window._liveAnchorRegistries.has(STREAM_ID);
+    __results.projectedRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+
+    console.log(JSON.stringify(__results));
+    """)
+
+    result = _run_attach_script(setup)
+
+    assert result["registryCleared"] is True, (
+        "Stale registry should be deleted when no existing OPEN transport is reused"
+    )
+    # After deletion, get() returns undefined → JSON.stringify omits the key.
+    # We verify the key is absent rather than asserting null.
+    assert "projectedRegistryRef" not in result, (
+        "After deletion, window._liveAnchorRegistries.get(streamId) must return undefined"
+    )

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -125,6 +125,16 @@ var S = { session: null, activeStreamId: null, messages: [], toolCalls: [], busy
 var _STREAM_WAS_HIDDEN = {};
 var _STREAM_NOTIFICATION_BACKGROUND = {};
 var _desktopBackgroundedForNotifications = false;
+// Module-level approval/clarify session trackers the attachLiveStream closure
+// reads via _approvalBelongsToOwner()/_clarifyBelongsToOwner().
+var _approvalSessionId = null;
+var _clarifySessionId = null;
+// Module-level thinking-delimiter pairs used by the real
+// _extractInlineThinkingFromContent().
+const _thinkPairs=[
+  {open:'<think>',close:'</think>'},
+  {open:'<|channel>thought\\n',close:'<channel|>'},
+];
 
 // Module-scope state loadSession() touches.
 var _loadingSessionId = null;
@@ -195,11 +205,94 @@ async function api(url) { return __apiResponse; }
 function _bindStreamHiddenTracker() {}
 function ensureLiveWorklogShell() {}
 function showLiveRunStatus() {}
-function closeOtherLiveStreams() {}
-function closeLiveStream() {}
+// REAL transport teardown — the fresh-reconnect regression test must exercise
+// the production attach/wire/teardown path, so closeLiveStream and
+// closeOtherLiveStreams mirror static/messages.js exactly (identity-guarded
+// close + LIVE_STREAMS entry deletion + INFLIGHT reattach marking).
+function closeLiveStream(sessionId, streamId, source){
+  const live=LIVE_STREAMS[sessionId];
+  if(!live) return;
+  if(streamId&&live.streamId!==streamId) return;
+  if(source&&live.source!==source) return;
+  if(typeof snapshotLiveTurnHtmlForSession==='function') snapshotLiveTurnHtmlForSession(sessionId);
+  if(typeof _clearLiveRunStatusTimer==='function') _clearLiveRunStatusTimer(sessionId);
+  if(typeof hideLiveRunStatus==='function') hideLiveRunStatus(sessionId);
+  try{if(live.source&&live.source.readyState!==2)live.source.close();}catch(_){ }
+  delete LIVE_STREAMS[sessionId];
+  _resumeSessionStreamAfterLiveChat(sessionId);
+  if(INFLIGHT[sessionId]){
+    INFLIGHT[sessionId].reattach=true;
+    INFLIGHT[sessionId].journalReplayFromStart=true;
+    if(typeof saveInflightState==='function'){
+      saveInflightState(sessionId,{
+        streamId:live.streamId||streamId||null,
+        messages:INFLIGHT[sessionId].messages||[],
+        uploaded:INFLIGHT[sessionId].uploaded||[],
+        toolCalls:INFLIGHT[sessionId].toolCalls||[],
+        lastAssistantText:INFLIGHT[sessionId].lastAssistantText||'',
+        lastReasoningText:INFLIGHT[sessionId].lastReasoningText||'',
+        lastRunJournalSeq:INFLIGHT[sessionId].lastRunJournalSeq||0,
+        lastRunJournalEventId:INFLIGHT[sessionId].lastRunJournalEventId||'',
+        journalReplayFromStart:true,
+        currentActivityBurstId:INFLIGHT[sessionId].currentActivityBurstId||0,
+        currentLiveSegmentSeq:INFLIGHT[sessionId].currentLiveSegmentSeq||0,
+        activityBurstAnchors:Array.isArray(INFLIGHT[sessionId].activityBurstAnchors)?INFLIGHT[sessionId].activityBurstAnchors:[],
+      });
+    }
+  }
+}
+function closeOtherLiveStreams(activeSid){
+  for(const sid of Object.keys(LIVE_STREAMS)){
+    if(sid!==activeSid) closeLiveStream(sid);
+  }
+}
+// Real module-scope helpers used by the terminal (done) path.
+function _clearStreamHidden(sid, streamId){
+  if(!sid) return;
+  const e=_STREAM_WAS_HIDDEN[sid];
+  if(!e) return;
+  if(streamId&&e.streamId&&e.streamId!==streamId) return;
+  delete _STREAM_WAS_HIDDEN[sid];
+}
+function _clearStreamNotificationBackground(sid, streamId){
+  if(!sid) return;
+  const e=_STREAM_NOTIFICATION_BACKGROUND[sid];
+  if(!e) return;
+  if(streamId&&e.streamId&&e.streamId!==streamId) return;
+  delete _STREAM_NOTIFICATION_BACKGROUND[sid];
+}
+function _shouldForceCompletionNotification(sid, streamId){
+  const hiddenEntry=_STREAM_WAS_HIDDEN[sid];
+  const backgroundEntry=_STREAM_NOTIFICATION_BACKGROUND[sid];
+  const wasHidden=!!(hiddenEntry&&hiddenEntry.wasHidden);
+  const wasBackgrounded=!!(backgroundEntry&&backgroundEntry.wasBackgrounded);
+  _clearStreamHidden(sid, streamId);
+  _clearStreamNotificationBackground(sid, streamId);
+  return wasHidden||wasBackgrounded;
+}
+function _isSessionCurrentPane(sid) {
+  if(!sid || !S.session || S.session.session_id!==sid) return false;
+  if(typeof _loadingSessionId!=='undefined' && _loadingSessionId && _loadingSessionId!==sid) return false;
+  return true;
+}
+function _isSessionActivelyViewed(sid) {
+  if(!_isSessionCurrentPane(sid)) return false;
+  if(!_isDocumentVisibleAndFocused()) return false;
+  return true;
+}
+function _isDocumentVisibleAndFocused() { return true; }
+function _markSessionViewed() {}
 function resetTurnWorkspaceMutations() {}
 function _resetStreamScrollFollow() {}
 function _suspendSessionStreamForLiveChat() {}
+function _resumeSessionStreamAfterLiveChat() {}
+function clearLiveToolCards() {}
+function loadDir() {}
+function renderSessionList() {}
+function playNotificationSound() {}
+function sendBrowserNotification() {}
+function _completionNotificationPreviewText() { return ''; }
+function removeThinking() {}
 function clearInflight() {}
 function clearInflightState() {}
 function _closeSource() {}
@@ -653,4 +746,175 @@ def test_fresh_connection_replaces_stale_registry_when_no_open_transport():
     )
     assert result["freshRegistryIdentity"] is True, (
         "the fresh registry must be seeded for the active stream"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Required path 4 (maintainer fix-spec): fresh reconnect replaces the source
+# for the SAME session+stream pair, and queued callbacks from the REPLACED
+# EventSource must be rejected by EXACT transport ownership.
+# ---------------------------------------------------------------------------
+
+_FRESH_RECONNECT_STALE_SOURCE_DRIVER = textwrap.dedent("""\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+(async () => {
+  // Phase 1 — install the OLD same-stream transport through the production
+  // listener path (real attachLiveStream -> _wireSSE -> LIVE_STREAMS entry).
+  attachLiveStream(SID, STREAM_ID, [], {});
+  const oldSource = __esCreated[0];
+  const oldRegistry = window._liveAnchorRegistries.get(STREAM_ID);
+  __results.oldTransportInstalled = !!oldRegistry && LIVE_STREAMS[SID].source === oldSource;
+
+  // Phase 2 — force the FRESH-source reconnect path: the old source is
+  // closed (absent/closed/CONNECTING), so attachLiveStream({reconnecting:true})
+  // must NOT reuse it. The production path deletes the stale registry, runs the
+  // REAL closeOtherLiveStreams()/closeLiveStream() teardown, and wires a NEW
+  // EventSource whose fresh closure creates a NEW registry. The server preflight
+  // reports the stream still active so the reconnect actually opens.
+  oldSource.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await new Promise((resolve) => setTimeout(resolve, 0)); // let the preflight + _wireSSE complete
+  const newSource = __esCreated[1];
+  const newRegistry = window._liveAnchorRegistries.get(STREAM_ID);
+  __results.freshSourceCreated = __esCreated.length === 2;
+  __results.freshRegistryReplaced = !!newRegistry && newRegistry !== oldRegistry;
+  __results.currentTransportIsNew = !!LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === newSource;
+  __results.realTeardownDeletedOldEntry = !(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === oldSource);
+
+  // Phase 3 — DELAYED events from the REPLACED old source (same session/stream
+  // pair, different object). Every one must be inert: no registry writes, no
+  // INFLIGHT/transcript mutation, no terminal settle.
+  const inflightBefore = JSON.stringify(INFLIGHT[SID]);
+  const oldRegEventsBefore = oldRegistry.anchor.activity_events.length;
+  oldSource.dispatch('token', { text: 'OLD-STALE-TOKEN' });
+  oldSource.dispatch('interim_assistant', { text: 'OLD-STALE-INTERIM' });
+  oldSource.dispatch('reasoning', { text: 'OLD-STALE-REASONING' });
+  oldSource.dispatch('tool', { name: 'stale_tool', tool_call_id: 'stale-1', args: '{}', session_id: SID });
+  oldSource.dispatch('done', { status: 'completed', session: { session_id: SID, messages: [] } });
+  __results.registryStillPointsToNew = window._liveAnchorRegistries.get(STREAM_ID) === newRegistry;
+  __results.newRegistryUntouchedByOldEvents = newRegistry.anchor.activity_events.length === 0;
+  __results.oldRegistryUntouchedByOldEvents = oldRegistry.anchor.activity_events.length === oldRegEventsBefore;
+  __results.inflightUntouchedByOldEvents = JSON.stringify(INFLIGHT[SID]) === inflightBefore;
+  __results.transcriptUntouchedByOldEvents = Array.isArray(S.messages) && S.messages.length === 0;
+  __results.oldDoneDidNotSettle = S.activeStreamId === STREAM_ID && !!INFLIGHT[SID];
+
+  // Phase 4 — an event from the CURRENT new source applies exactly once, and
+  // its terminal event settles the turn exactly once.
+  newSource.dispatch('reasoning', { text: 'fresh reasoning' });
+  __results.newReasoningAppliedOnce = newRegistry.anchor.activity_events.length === 1;
+  const scene = window._projectLiveAnchorActivitySceneForStream(STREAM_ID, 'compact_worklog');
+  __results.sceneRows = scene && Array.isArray(scene.activity_rows) ? scene.activity_rows.length : -1;
+  newSource.dispatch('done', {
+    status: 'completed',
+    session: { session_id: SID, messages: [{ role: 'assistant', content: 'fresh answer' }] },
+  });
+  __results.newDoneSettledOnce = (
+    S.activeStreamId === null &&
+    !INFLIGHT[SID] &&
+    Array.isArray(S.messages) &&
+    S.messages.length === 1 &&
+    S.messages[0].content === 'fresh answer'
+  );
+  __results.newDoneAppliedToRegistry = newRegistry.anchor.activity_events.some(
+    (ev) => ev && ev.source_event_type === 'done'
+  );
+
+  process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+""")
+
+
+def test_fresh_reconnect_rejects_delayed_events_from_replaced_source():
+    """Maintainer fix-spec: the fresh reconnect path replaces the EventSource
+    for the SAME session+stream pair, and queued callbacks from the REPLACED
+    source must be rejected by EXACT transport ownership.
+
+    Composes the production attach/wire/teardown path end-to-end (REAL
+    closeOtherLiveStreams()/closeLiveStream() — not stubs):
+
+      - Phase 1: install an old same-stream source through the production path.
+      - Phase 2: force the fresh-source reconnect path (old source closed) and
+        let the real teardown + fresh _wireSSE install the replacement.
+      - Phase 3: retain the old source's callback handles and deliver delayed
+        old-source token/interim/reasoning/tool/done events. Assert the registry
+        map still points to the NEW registry, neither registry gained events,
+        INFLIGHT and the transcript are untouched, and the stale done did NOT
+        settle the turn.
+      - Phase 4: a reasoning event from the new source applies exactly once and
+        a done event from the new source settles the turn exactly once.
+    """
+    result = _run_harness(_FRESH_RECONNECT_STALE_SOURCE_DRIVER)
+
+    assert result["oldTransportInstalled"] is True, (
+        "phase 1 must install the old transport through the production path"
+    )
+    assert result["freshSourceCreated"] is True, (
+        "the fresh reconnect must create exactly one replacement EventSource "
+        "(old closed -> not reusable -> fresh _wireSSE)"
+    )
+    assert result["freshRegistryReplaced"] is True, (
+        "the fresh closure must create a NEW registry object (the stale one was "
+        "deleted by the production delete-before-wire path)"
+    )
+    assert result["currentTransportIsNew"] is True, (
+        "LIVE_STREAMS[activeSid] must now own the NEW source object"
+    )
+    assert result["realTeardownDeletedOldEntry"] is True, (
+        "the real closeLiveStream() teardown must remove the old transport entry"
+    )
+    assert result["registryStillPointsToNew"] is True, (
+        "after the delayed old-source events, window._liveAnchorRegistries must "
+        "still point to the NEW registry"
+    )
+    assert result["newRegistryUntouchedByOldEvents"] is True, (
+        "delayed old-source events must not write the new registry"
+    )
+    assert result["oldRegistryUntouchedByOldEvents"] is True, (
+        "delayed old-source events must not write even the old (orphaned) registry"
+    )
+    assert result["inflightUntouchedByOldEvents"] is True, (
+        "delayed old-source token/reasoning/tool events must not mutate INFLIGHT"
+    )
+    assert result["transcriptUntouchedByOldEvents"] is True, (
+        "delayed old-source events must not mutate S.messages"
+    )
+    assert result["oldDoneDidNotSettle"] is True, (
+        "the delayed done from the REPLACED source must NOT settle the turn "
+        "(S.activeStreamId must stay set, INFLIGHT must survive) — this is the "
+        "fresh-reconnect gap the maintainer flagged"
+    )
+    assert result["newReasoningAppliedOnce"] is True, (
+        "a reasoning event from the CURRENT new source must apply exactly once"
+    )
+    assert result["sceneRows"] == 1, (
+        "the renderer projection must contain exactly one Worklog row from the "
+        "new source's event"
+    )
+    assert result["newDoneSettledOnce"] is True, (
+        "the done from the CURRENT new source must settle the turn exactly once "
+        "(S.activeStreamId null, INFLIGHT cleared, transcript replaced)"
+    )
+    assert result["newDoneAppliedToRegistry"] is True, (
+        "the new source's done must be recorded in the new registry"
     )

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -1,23 +1,41 @@
 """Behavioral regression tests for #6303/#6381 — Worklog identity across session reattach.
 
-The fix deletes the stale `window._liveAnchorRegistries` entry ONLY after passing
-the existing-OPEN-transport check in `attachLiveStream()`. This ensures a reused
-EventSource keeps the registry its handlers actually own, while a fresh connection
-gets a clean registry in sync with the restored INFLIGHT counters.
+The production fix (static/messages.js) makes registry reset and transport/closure
+ownership one atomic decision: `attachLiveStream()` checks and reuses an existing
+OPEN same-stream EventSource BEFORE deleting `window._liveAnchorRegistries[streamId]`,
+and the independent pre-attach deletion was removed from `loadSession()` in
+static/sessions.js. A reused transport keeps the registry its handlers own; only a
+fresh connection replaces it.
 
-Two ownership paths are tested:
+These tests exercise the two ownership paths the maintainer re-gate required, using
+the REAL production code (not re-implementations):
 
-Path 1 (reconnect-OPEN-reuse)
-  - Seed an existing OPEN same-stream EventSource + registry.
-  - Call attachLiveStream({reconnecting:true}).
-  - The early-return branch fires (existing OPEN transport is reused).
-  - The registry survives the call: handler-owned == renderer-projected.
+Path 1 — OPEN-transport reuse (test_open_transport_reuse_dispatches_post_reattach_event_into_same_registry)
+  - Install an existing OPEN EventSource through the production listener-registration
+    path (a real `attachLiveStream()` call wires real SSE handlers via `_wireSSE`).
+  - Call the real `attachLiveStream(..., {reconnecting:true})`; it must reuse the OPEN
+    transport (early-return branch) and keep the handler-owned registry.
+  - Dispatch a post-reattach reasoning event THROUGH that production listener and
+    assert the registry the handler applied to is object-identical to the registry
+    the renderer projects from (`window._liveAnchorRegistries.get(streamId)`), with
+    exactly one matching Worklog row.
 
-Path 2 (fresh-connection-cleanup)
-  - No existing OPEN transport for the streamId.
-  - Call attachLiveStream({reconnecting:true}).
-  - The function reaches the registry-delete line (after the transport check).
-  - The stale registry is cleared; a new one will be created by the new closure.
+Path 2 — loadSession() with a winning server journal snapshot
+  (test_loadsession_journal_snapshot_reattach_reuses_open_source_exactly_once)
+  - Run the REAL `loadSession()` with a winning `runtime_journal_snapshot`
+    (no local INFLIGHT tail, so `_selectLiveRecoveryInflight()` picks the server
+    snapshot, which carries `reattach:true`).
+  - The existing OPEN source is reused through loadSession's real reattach call
+    (`attachLiveStream(..., {reconnecting:true})` at the INFLIGHT reattach branch).
+  - Assert the journal-snapshot branch and the reattach branch actually ran
+    (`journalSnapshot===true`, `reattach` flipped to false), that the production
+    listener still owns the SAME registry object, that a post-reattach reasoning
+    event projects exactly one Worklog row, and that NO replacement EventSource was
+    created during the whole loadSession reattach.
+
+A third sentinel keeps the other side of the ownership decision locked: a fresh
+connection (no existing OPEN transport) must delete the stale registry and let the
+new closure create its own registry via the real anchor API.
 """
 from __future__ import annotations
 
@@ -32,6 +50,9 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = ROOT / "static" / "messages.js"
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+UI_JS = ROOT / "static" / "ui.js"
+ANCHORS_JS = ROOT / "static" / "assistant_turn_anchors.js"
 NODE = shutil.which("node")
 
 
@@ -41,15 +62,24 @@ def _read(path: Path) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Function extractors for attachLiveStream
+# Function extractor — pulls a complete 'function name(...){...}' declaration
+# (or 'async function name(...){...}') out of a source file, correctly
+# handling nested braces by tracking depth.
 # ---------------------------------------------------------------------------
 
 def _function_source(src: str, name: str) -> str:
-    """Extract a complete 'function name(...){...}' declaration from source,
-    correctly handling nested braces by tracking depth.
+    """Extract a complete function declaration ('function name(...){...}' or
+    'async function name(...){...}') from source, correctly handling nested
+    braces by tracking depth.
     """
     start = src.find(f"function {name}(")
     assert start != -1, f"function {name} not found"
+    # Preserve an 'async' modifier when present: 'async function name(...)'
+    # must keep its modifier so 'await' stays inside an async context.
+    head = src[max(0, start - 60):start]
+    marker = head.rfind("async")
+    if marker != -1 and head[marker:].strip() == "async":
+        start = start - (len(head) - marker)
     params_idx = src.find("(", start)
     assert params_idx != -1
     depth_p = 0
@@ -79,38 +109,89 @@ def _function_source(src: str, name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Node.js test runner — writes script to temp file to avoid arg length limits
+# Node.js harness — mirrors the module-scope environment the production
+# functions expect, then concatenates the REAL production functions and runs
+# the driver code. Results are printed as one JSON object on the last stdout
+# line (same contract as the previous version of this file).
 # ---------------------------------------------------------------------------
 
 _MOCK_GLOBALS = textwrap.dedent("""\
-// Mock globals that attachLiveStream expects. These mirror the module-scope
-// declarations in messages.js and the callees attachLiveStream calls.
+// Mock globals expected by the production module scopes. `window` is the
+// global object so window.* assignments mirror the browser.
 var window = globalThis;
 var INFLIGHT = {};
 var LIVE_STREAMS = {};
-var S = { session: null, activeStreamId: null, messages: [] };
+var S = { session: null, activeStreamId: null, messages: [], toolCalls: [], busy: false };
 var _STREAM_WAS_HIDDEN = {};
 var _STREAM_NOTIFICATION_BACKGROUND = {};
 var _desktopBackgroundedForNotifications = false;
 
-// attachLiveStream mutates window._liveAnchorRegistries — seed it.
+// Module-scope state loadSession() touches.
+var _loadingSessionId = null;
+var _loadSessionGeneration = 0;
+var _pendingCarryForwardSnapshot = null;
+var _messagesTruncated = false;
+var _oldestIdx = 0;
+var _loadingOlder = false;
+var _messageUserUnpinned = false;
+var _scrollPinned = true;
+var _yoloEnabled = false;
+
 window._liveAnchorRegistries = new Map();
 
-// EventSource creation needs document.baseURI
-var document = { baseURI: 'http://localhost:8080/', hidden: false };
+var document = {
+  baseURI: 'http://localhost:8080/',
+  hidden: false,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  querySelector: () => null,
+  getElementById: () => null,
+  createElement: () => ({ className: '', dataset: {}, style: {}, setAttribute: () => {}, appendChild: () => {}, querySelector: () => null, querySelectorAll: () => [], classList: { add: () => {}, remove: () => {} } }),
+};
 var location = { href: 'http://localhost:8080/' };
+var localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+function $(id) { return null; }
 
-// Mock EventSource
-function EventSource() {
-  // Return an object with addEventListener so _wireSSE doesn't crash
-  this.addEventListener = () => {};
-  this.close = () => {};
+// Recording EventSource: mirrors browser semantics — addEventListener APPENDS
+// (production registers both the typed handler and the run-journal cursor
+// listener for the same event name), dispatch fires every listener in order.
+// Every construction is counted so tests can prove no replacement transport
+// was created.
+var __esCreated = [];
+function EventSource(url) {
+  this.url = url;
   this.readyState = EventSource.OPEN;
+  this._handlers = {};
+  this.addEventListener = (type, fn) => {
+    if (!this._handlers[type]) this._handlers[type] = [];
+    this._handlers[type].push(fn);
+  };
+  this.removeEventListener = (type, fn) => {
+    const list = this._handlers[type];
+    if (!list) return;
+    if (!fn) { delete this._handlers[type]; return; }
+    const idx = list.indexOf(fn);
+    if (idx >= 0) list.splice(idx, 1);
+  };
+  this.close = () => { this.readyState = EventSource.CLOSED; };
+  this.dispatch = (type, data) => {
+    const list = this._handlers[type] || [];
+    const event = { data: JSON.stringify(data), lastEventId: (data && data.event_id) || '' };
+    for (const fn of list.slice()) fn(event);
+  };
+  __esCreated.push(this);
 }
 EventSource.OPEN = 1;
 EventSource.CONNECTING = 0;
+EventSource.CLOSED = 2;
 
-// Mock functions called by attachLiveStream
+// The mocked API fetch used by loadSession(); the driver sets __apiResponse.
+var __apiResponse = null;
+async function api(url) { return __apiResponse; }
+
+// Stubbed module-scope helpers the production functions call. The code paths
+// under test (registry ownership, reattach, journal-snapshot projection) are
+// real; these are presentation/side-effect hooks outside the tested invariant.
 function _bindStreamHiddenTracker() {}
 function ensureLiveWorklogShell() {}
 function showLiveRunStatus() {}
@@ -121,7 +202,6 @@ function _resetStreamScrollFollow() {}
 function _suspendSessionStreamForLiveChat() {}
 function clearInflight() {}
 function clearInflightState() {}
-function _scheduleAnchorRegistryCleanup() {}
 function _closeSource() {}
 function _approvalBelongsToOwner() { return true; }
 function _clarifyBelongsToOwner() { return true; }
@@ -133,27 +213,98 @@ function hideApprovalCard() {}
 function hideClarifyCard() {}
 function _closeAdjustableRelated() {}
 function _relateLiveStreamPane() {}
-function _ensureInflightLiveAssistantMessage() {}
+function _ensureInflightLiveAssistantMessageStub() {}
+function startSessionStream() {}
+function stopSessionStream() {}
+function _updateYoloPill() {}
+function syncTopbar() {}
+function renderMessages() {}
+function setBusy() {}
+function setComposerStatus() {}
+function startApprovalPolling() {}
+function ensureRunActivityForCurrentTurn() {}
+function _resolveSessionModelForDisplaySoon() {}
+function _deferWorkspaceRefreshForSession() {}
+function _setActiveSessionUrl() {}
+function _acknowledgeSessionVisit() {}
+function _clearDeferredActiveSessionExternalRefresh() {}
+function _clearSameSessionForceReloadHint() {}
+function _captureSameSessionForceReloadHint() {}
+function _clearEmptyComposerModelOverride() {}
+function _renderRuntimeJournalAnchorActivityScene() { return false; }
+async function _ensureMessagesLoaded() { return undefined; }
+function updateThinking() {}
+function appendThinking() {}
+function _hideHandoffHint() {}
+function _checkAndShowHandoffHint() {}
+
+// ui.js renderer hooks: chatActivityMode() is the production mode source;
+// renderLiveAnchorActivityScene() is the DOM paint step — recorded here so
+// tests can inspect the scene the real renderer would have painted.
+function chatActivityMode() { return 'compact_worklog'; }
+var __renderCalls = [];
+function renderLiveAnchorActivityScene(streamId, scene, opts) {
+  __renderCalls.push({ streamId: streamId, scene: scene, opts: opts || {} });
+  return true;
+}
 """).lstrip()
 
+# Real sessions.js helpers pulled in for the loadSession() test. Order does not
+# matter — function declarations hoist within the script scope.
+_SESSIONS_HELPERS = [
+    "loadSession",
+    "_rearmActiveSessionStream",
+    "_serverLiveSnapshotInflight",
+    "_selectLiveRecoveryInflight",
+    "_inflightHasVisibleLiveState",
+    "_ensureInflightLiveAssistantMessage",
+    "_projectInflightMessagesForActivityBursts",
+    "_messageComparableText",
+    "_compactTranscriptText",
+    "_currentTurnAssistantText",
+    "_sameTranscriptMessage",
+    "_hasCurrentTailUserDuplicate",
+    "_dropCurrentTurnAssistantMessages",
+    "_prepareRunningLiveTail",
+    "_mergeInflightTailMessages",
+    "_isMessagingSession",
+]
 
-def _run_attach_script(setup_code: str) -> dict:
-    """Extract attachLiveStream from messages.js, wrap it in mocks + setup,
-    run via Node temp file, and return parsed JSON results.
 
-    The ``setup_code`` must define ``const __results = {};``, set up mocks,
-    call ``attachLiveStream(...)``, populate ``__results``, and
-    ``console.log(JSON.stringify(__results));``.
+def _run_harness(setup_code: str, include_loadsession: bool = False) -> dict:
+    """Assemble the REAL production functions + mocks + driver and run via Node.
+
+    The script always includes:
+      - the real HermesAssistantTurnAnchors API (static/assistant_turn_anchors.js);
+      - the real attachLiveStream() (static/messages.js, incl. its _wireSSE
+        listener-registration path and all closure helpers);
+      - the real renderer projection (static/ui.js
+        _projectLiveAnchorActivitySceneForStream /
+        _renderLiveAnchorActivitySceneForStream).
+
+    When include_loadsession is true it also includes the real loadSession() and
+    the sessions.js helpers it calls.
     """
     assert NODE, "node executable is required for JavaScript behavioral checks"
-    attach_fn = _function_source(_read(MESSAGES_JS), "attachLiveStream")
-    full_script = (
-        _MOCK_GLOBALS
-        + "\n"
-        + attach_fn
-        + "\n\n"
-        + setup_code
-    )
+    parts = [
+        _MOCK_GLOBALS,
+        _read(ANCHORS_JS),
+        _function_source(_read(MESSAGES_JS), "_extractInlineThinkingFromContent"),
+        _function_source(_read(MESSAGES_JS), "attachLiveStream"),
+        _function_source(_read(UI_JS), "_projectLiveAnchorActivitySceneForStream"),
+        _function_source(_read(UI_JS), "_renderLiveAnchorActivitySceneForStream"),
+    ]
+    if include_loadsession:
+        sessions = _read(SESSIONS_JS)
+        parts.append(
+            "const _MESSAGING_RAW_SOURCES = new Set("
+            "['weixin','telegram','discord','slack','email','wecom','wecom_callback']);"
+        )
+        for name in _SESSIONS_HELPERS:
+            parts.append(_function_source(sessions, name))
+    parts.append(setup_code)
+    full_script = "\n".join(parts)
+
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".js", encoding="utf-8", delete=False
     ) as f:
@@ -165,7 +316,7 @@ def _run_attach_script(setup_code: str) -> dict:
             cwd=ROOT,
             text=True,
             capture_output=True,
-            timeout=15,
+            timeout=20,
         )
     except subprocess.TimeoutExpired as exc:
         Path(script_path).unlink(missing_ok=True)
@@ -189,133 +340,317 @@ def _run_attach_script(setup_code: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Path 1: Existing OPEN same-stream EventSource is reused — registry preserved
+# Required path 1: existing OPEN same-stream transport reused through the
+# production listener-registration path.
 # ---------------------------------------------------------------------------
 
+_OPEN_REUSE_DRIVER = textwrap.dedent("""\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
 
-def test_reconnect_keeps_registry_when_open_transport_reused():
-    """Path 1: attachLiveStream(reconnecting=true) with an existing OPEN
-    same-stream EventSource must preserve the handler-owned registry.
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
 
-    After reattach:
-      - the registry in window._liveAnchorRegistries is the SAME object that
-        the existing handler owns (same reference as set up before the call);
-      - the registry was not deleted (early return prevents deletion).
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+
+// Phase 1 — install the OPEN source through the PRODUCTION listener path:
+// a real attachLiveStream() call creates the EventSource and _wireSSE() binds
+// the real reasoning/tool handlers that close over the anchor registry.
+attachLiveStream(SID, STREAM_ID, [], {});
+const handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+const source = __esCreated[0];
+__results.registryCreatedThroughProduction = !!handlerRegistryRef;
+__results.esCreatedAfterInstall = __esCreated.length;
+
+// Phase 2 — reattach: the OPEN same-stream transport must be reused (early
+// return) and the registry it owns must NOT be deleted.
+attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+__results.esCreatedAfterReattach = __esCreated.length;
+__results.registryKeptThroughReattach = window._liveAnchorRegistries.get(STREAM_ID) === handlerRegistryRef;
+
+// Phase 3 — dispatch a post-reattach reasoning event THROUGH the production
+// listener installed in phase 1.
+source.dispatch('reasoning', { text: 'deep reasoning step' });
+
+// Phase 4 — the handler applied the event to its closure registry; the
+// renderer resolves the same object from the window map.
+__results.projectedRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+__results.sameObjectRef = __results.projectedRegistryRef === handlerRegistryRef;
+__results.appliedEvents = handlerRegistryRef.anchor.activity_events.length;
+const scene = window._projectLiveAnchorActivitySceneForStream(STREAM_ID, 'compact_worklog');
+__results.sceneRows = scene && Array.isArray(scene.activity_rows) ? scene.activity_rows.length : -1;
+__results.sceneRowKind = scene && scene.activity_rows[0] ? scene.activity_rows[0].kind : null;
+__results.sceneRowRole = scene && scene.activity_rows[0] ? scene.activity_rows[0].role : null;
+__results.sceneRowSourceType = scene && scene.activity_rows[0] ? scene.activity_rows[0].source_event_type : null;
+__results.renderCalls = __renderCalls.length;
+
+process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+""")
+
+
+def test_open_transport_reuse_dispatches_post_reattach_event_into_same_registry():
+    """Required path 1: OPEN transport reuse keeps handler/renderer registry
+    identity and projects exactly one Worklog row after a post-reattach event.
+
+    Installs the OPEN source through the production listener-registration path
+    (real attachLiveStream -> _wireSSE), calls the real
+    attachLiveStream({reconnecting:true}), dispatches a reasoning event through
+    that listener, and proves:
+      - no replacement EventSource was created on reattach;
+      - the registry the handler applied the event to is object-identical to the
+        registry the renderer projects from;
+      - exactly one matching Worklog row is projected.
     """
-    setup = textwrap.dedent("""\
-    const __results = {};
+    result = _run_harness(_OPEN_REUSE_DRIVER)
 
-    const SID = 'test-sid';
-    const STREAM_ID = 'test-stream';
-
-    // Seed INFLIGHT
-    INFLIGHT[SID] = {
-      messages: [],
-      uploaded: [],
-      toolCalls: [],
-      streamId: STREAM_ID,
-      activityBurstAnchors: [],
-      currentActivityBurstId: 0,
-      currentLiveSegmentSeq: 0,
-    };
-
-    // Create a known registry object and store it before the call.
-    const originalRegistry = { anchor: { session_id: SID, turn_id: 'turn-1' }, events: [] };
-    window._liveAnchorRegistries.set(STREAM_ID, originalRegistry);
-
-    // Mock an OPEN same-stream EventSource so the transport-reuse branch fires.
-    LIVE_STREAMS[SID] = {
-      streamId: STREAM_ID,
-      source: { readyState: EventSource.OPEN },
-    };
-
-    // Capture the handler's registry reference BEFORE attachLiveStream.
-    __results.handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
-    __results.sameObjectBefore = (__results.handlerRegistryRef === originalRegistry);
-
-    // Call attachLiveStream — should take the early-return (OPEN-reuse) branch.
-    attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
-
-    // After the call, the registry must still be in the window map.
-    __results.registryKept = window._liveAnchorRegistries.has(STREAM_ID);
-
-    // The projected registry ref must be the SAME object as what the handler owns.
-    __results.projectedRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
-    __results.sameObjectRef = (__results.handlerRegistryRef === __results.projectedRegistryRef);
-
-    console.log(JSON.stringify(__results));
-    """)
-
-    result = _run_attach_script(setup)
-
-    assert result["sameObjectBefore"] is True, (
-        "handlerRegistryRef must be the original registry object"
+    assert result["registryCreatedThroughProduction"] is True, (
+        "the first attachLiveStream call must create a registry through the real "
+        "anchor API and register it in window._liveAnchorRegistries"
     )
-    assert result["registryKept"] is True, (
-        "Registry should survive when the same-stream OPEN EventSource is reused"
+    assert result["esCreatedAfterInstall"] == 1, (
+        "exactly one EventSource should exist after the initial install"
+    )
+    assert result["esCreatedAfterReattach"] == 1, (
+        "reattach must reuse the existing OPEN transport — no replacement "
+        "EventSource may be created"
+    )
+    assert result["registryKeptThroughReattach"] is True, (
+        "the registry owned by the reused OPEN transport must survive the "
+        "reconnecting:true call (delete order bug #6381)"
     )
     assert result["sameObjectRef"] is True, (
-        "Handler-owned registry and renderer-projected registry must be the same object"
-        " — a stale delete would leave renderers pointing at a different entry"
+        "the registry the production listener applied the post-reattach event to "
+        "must be object-identical to the registry the renderer projects from"
+    )
+    assert result["appliedEvents"] == 1, (
+        "the post-reattach reasoning event must be applied exactly once"
+    )
+    assert result["sceneRows"] == 1, (
+        "the renderer projection must contain exactly one Worklog row — not zero "
+        "(orphaned registry) and not duplicates"
+    )
+    assert result["sceneRowKind"] == "reasoning" and result["sceneRowRole"] == "thinking", (
+        "the single Worklog row must be the reasoning event that was dispatched"
+    )
+    assert result["sceneRowSourceType"] == "reasoning", (
+        "the Worklog row must carry the dispatched event's source type"
     )
 
 
 # ---------------------------------------------------------------------------
-# Path 2: Fresh connection (no existing OPEN transport) clears stale registry
+# Required path 2: real loadSession() with a winning server journal snapshot.
+# ---------------------------------------------------------------------------
+
+_LOADSESSION_DRIVER = textwrap.dedent("""\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+// Session the mocked metadata API will return to loadSession(): an active
+// stream plus a WINNING server runtime_journal_snapshot.
+const __session = {
+  session_id: SID,
+  active_stream_id: STREAM_ID,
+  pending_attachments: [],
+  message_count: 0,
+  last_usage: {},
+  runtime_journal_snapshot: {
+    stream_id: STREAM_ID,
+    last_seq: 5,
+    last_event_id: 'evt-5',
+    last_assistant_text: 'partial answer',
+    last_reasoning_text: '',
+    current_activity_burst_id: 0,
+    current_live_segment_seq: 0,
+    activity_burst_anchors: [],
+    messages: [{ role: 'assistant', content: 'partial answer', _live: true, _journal_snapshot: true }],
+    tool_calls: [],
+  },
+};
+__apiResponse = { session: __session };
+
+// Phase 1 — boot state: no current session, no local INFLIGHT tail (so the
+// server journal snapshot must win), and an existing OPEN same-stream source
+// whose listeners were installed through the production path before the load.
+S.session = null;
+S.activeStreamId = null;
+S.messages = [];
+S.toolCalls = [];
+S.busy = false;
+delete INFLIGHT[SID];
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+attachLiveStream(SID, STREAM_ID, [], {});
+const handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+const source = __esCreated[0];
+delete INFLIGHT[SID];   // drop the local tail: server snapshot must win
+S.session = null;       // fresh boot for the real loadSession()
+S.activeStreamId = null;
+
+(async () => {
+  // Phase 2 — run the REAL loadSession() with the winning journal snapshot.
+  await loadSession(SID, { skipLineageResolve: true, skipExtHooks: true, skipContinuationResolve: true });
+
+  // The journal-snapshot branch and the reattach branch must have run:
+  __results.journalSnapshotWon = !!(INFLIGHT[SID] && INFLIGHT[SID].journalSnapshot === true);
+  __results.reattachBranchRan = !!(INFLIGHT[SID] && INFLIGHT[SID].reattach === false);
+  // No replacement EventSource may have been created by the reattach call.
+  __results.esCreatedDuringLoad = __esCreated.length;
+  // The registry the OPEN source's handlers own must have survived loadSession.
+  __results.registryKeptThroughLoad = window._liveAnchorRegistries.get(STREAM_ID) === handlerRegistryRef;
+
+  // Phase 3 — dispatch a post-reattach reasoning event through the production
+  // listener (the one installed before loadSession).
+  source.dispatch('reasoning', { text: 'post-reattach reasoning' });
+
+  // Phase 4 — identity + exactly-once Worklog projection.
+  __results.projectedRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+  __results.sameObjectRef = __results.projectedRegistryRef === handlerRegistryRef;
+  __results.appliedEvents = handlerRegistryRef.anchor.activity_events.length;
+  const scene = window._projectLiveAnchorActivitySceneForStream(STREAM_ID, 'compact_worklog');
+  __results.sceneRows = scene && Array.isArray(scene.activity_rows) ? scene.activity_rows.length : -1;
+  __results.sceneRowKind = scene && scene.activity_rows[0] ? scene.activity_rows[0].kind : null;
+  __results.sceneRowRole = scene && scene.activity_rows[0] ? scene.activity_rows[0].role : null;
+  __results.loadSessionRenderedScene = __renderCalls.some(c => c.streamId === STREAM_ID);
+
+  process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+""")
+
+
+def test_loadsession_journal_snapshot_reattach_reuses_open_source_exactly_once():
+    """Required path 2: real loadSession() with a winning server journal
+    snapshot reuses the OPEN source through its real reattach call and keeps
+    registry identity with an exactly-once Worklog projection.
+
+    Asserts:
+      - the server runtime_journal_snapshot won (journalSnapshot===true);
+      - loadSession's reattach branch actually ran (reattach flipped to false);
+      - the production listener from the pre-load OPEN source still owns the
+        SAME registry object as the renderer;
+      - a post-reattach reasoning event projects exactly one Worklog row;
+      - no replacement EventSource was created during loadSession.
+    """
+    result = _run_harness(_LOADSESSION_DRIVER, include_loadsession=True)
+
+    assert result["journalSnapshotWon"] is True, (
+        "the server runtime_journal_snapshot must win inside loadSession() "
+        "(_serverLiveSnapshotInflight/_selectLiveRecoveryInflight) and mark "
+        "INFLIGHT with journalSnapshot:true"
+    )
+    assert result["reattachBranchRan"] is True, (
+        "loadSession() must have executed its reattach branch (it flips "
+        "INFLIGHT.reattach to false before calling attachLiveStream)"
+    )
+    assert result["esCreatedDuringLoad"] == 1, (
+        "loadSession()'s real reattach call must reuse the existing OPEN "
+        "transport — no replacement EventSource may be created"
+    )
+    assert result["registryKeptThroughLoad"] is True, (
+        "the registry owned by the reused OPEN transport must survive the full "
+        "loadSession() reattach path"
+    )
+    assert result["sameObjectRef"] is True, (
+        "after loadSession(), the registry the production listener applied the "
+        "post-reattach event to must be object-identical to the registry the "
+        "renderer projects from"
+    )
+    assert result["appliedEvents"] == 1, (
+        "the post-reattach reasoning event must be applied exactly once"
+    )
+    assert result["sceneRows"] == 1, (
+        "the renderer projection must contain exactly one Worklog row — not zero "
+        "and not duplicates"
+    )
+    assert result["sceneRowKind"] == "reasoning" and result["sceneRowRole"] == "thinking", (
+        "the single Worklog row must be the dispatched reasoning event"
+    )
+    assert result["loadSessionRenderedScene"] is True, (
+        "loadSession() must have invoked the real renderer for the stream"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sentinel: fresh connection (no existing OPEN transport) replaces the stale
+# registry through the real anchor API.
 # ---------------------------------------------------------------------------
 
 
-def test_reconnect_clears_stale_registry_when_no_open_transport():
-    """Path 2: attachLiveStream(reconnecting=true) with NO existing same-stream
-    OPEN EventSource must delete the stale registry from the window map.
-
-    A new EventSource will be created and the fresh closure will build its own
-    registry in sync with the restored INFLIGHT counters.
+def test_fresh_connection_replaces_stale_registry_when_no_open_transport():
+    """The other side of the ownership decision: when attachLiveStream() does
+    NOT find an existing OPEN same-stream transport, it must delete the stale
+    registry and the fresh closure must create its own registry via the real
+    anchor API (never reuse the stale object).
     """
     setup = textwrap.dedent("""\
     const __results = {};
-
     const SID = 'test-sid';
     const STREAM_ID = 'test-stream';
 
-    // Seed INFLIGHT so the function has known state.
+    window._liveAnchorRegistries = new Map();
+    window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+    window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
     INFLIGHT[SID] = {
-      messages: [],
-      uploaded: [],
-      toolCalls: [],
+      messages: [], uploaded: [], toolCalls: [],
       streamId: STREAM_ID,
-      activityBurstAnchors: [],
-      currentActivityBurstId: 0,
-      currentLiveSegmentSeq: 0,
+      activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
     };
 
-    // Create and store a stale registry.
+    // A stale registry left behind by a prior stream connection.
     const staleRegistry = { anchor: { session_id: SID, turn_id: 'turn-stale' }, events: [] };
     window._liveAnchorRegistries.set(STREAM_ID, staleRegistry);
 
-    // Do NOT set up LIVE_STREAMS — no existing transport.
-
-    // Capture the ref before the call.
-    __results.handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
-
-    // Call attachLiveStream — no OPEN transport to reuse, so the registry-delete
-    // path fires after the transport check fails.
+    // NO existing OPEN transport for the stream.
     attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
 
-    // The stale registry must be gone.
-    __results.registryCleared = !window._liveAnchorRegistries.has(STREAM_ID);
-    __results.projectedRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
+    // The stale object must be gone from the map (delete-order fix) and a
+    // brand-new registry created by the fresh closure via the real API.
+    __results.staleRegistryReplaced = window._liveAnchorRegistries.get(STREAM_ID) !== staleRegistry;
+    __results.freshRegistryCreated = !!window._liveAnchorRegistries.get(STREAM_ID);
+    __results.freshRegistrySession = window._liveAnchorRegistries.get(STREAM_ID)
+      ? window._liveAnchorRegistries.get(STREAM_ID).anchor.identity.session_id
+      : null;
+    __results.freshRegistryIdentity = window._liveAnchorRegistries.get(STREAM_ID)
+      ? (window._liveAnchorRegistries.get(STREAM_ID).anchor.identity.stream_id === STREAM_ID)
+      : false;
 
-    console.log(JSON.stringify(__results));
+    process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
     """)
 
-    result = _run_attach_script(setup)
+    result = _run_harness(setup)
 
-    assert result["registryCleared"] is True, (
-        "Stale registry should be deleted when no existing OPEN transport is reused"
+    assert result["staleRegistryReplaced"] is True, (
+        "with no existing OPEN transport, the stale registry must be deleted "
+        "from window._liveAnchorRegistries"
     )
-    # After deletion, get() returns undefined → JSON.stringify omits the key.
-    # We verify the key is absent rather than asserting null.
-    assert "projectedRegistryRef" not in result, (
-        "After deletion, window._liveAnchorRegistries.get(streamId) must return undefined"
+    assert result["freshRegistryCreated"] is True, (
+        "the fresh connection closure must create its own registry through the "
+        "real anchor API"
+    )
+    assert result["freshRegistrySession"] == "test-sid", (
+        "the fresh registry must be seeded for the active session"
+    )
+    assert result["freshRegistryIdentity"] is True, (
+        "the fresh registry must be seeded for the active stream"
     )

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -918,3 +918,350 @@ def test_fresh_reconnect_rejects_delayed_events_from_replaced_source():
     assert result["newDoneAppliedToRegistry"] is True, (
         "the new source's done must be recorded in the new registry"
     )
+# ---------------------------------------------------------------------------
+# Ownership-generation regression matrix (maintainer re-gate item 6, #6381).
+#
+# The tests above prove the required reattach paths and the replaced-source
+# terminal path. The matrix below pins the *discriminator* those fixes rely on:
+# every transport callback must be authorized by TRANSPORT-GENERATION ownership,
+# never by the (session_id, stream_id) pair. Every test here:
+#
+#   1. installs generation A for a pair through the production path;
+#   2. forces the fresh-reconnect path (old transport closed -> not reusable), so
+#      production SUPERSEDES A and wires generation B for the SAME pair;
+#   3. delivers that family's event through the SUPERSEDED transport and proves
+#      the newer transport's state is untouched;
+#   4. proves the family is actually wired on BOTH transports, and that the
+#      CURRENT generation still reaches the same sink — so a silent no-op can
+#      never pass vacuously.
+#
+# Mutation evidence (each row must fail when ownership is weakened): replacing
+# `_isCurrentCapability()` with a pair-only comparison
+#
+#     function _isCurrentCapability(capability){
+#       if(!capability) return true;
+#       const live=LIVE_STREAMS[capability.sessionId];
+#       return !!(live&&live.streamId===capability.streamId);
+#     }
+#
+# makes the superseded-generation rows below fail (the stale callback reaches
+# its sink / clears the current transport's trackers). Same when the capability
+# check is dropped from `_ownsActiveStreamOrBackground()`.
+# ---------------------------------------------------------------------------
+
+_SIDE_EFFECT_GENERATION_DRIVER = textwrap.dedent("""\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+// Recorders that replace the harness stubs: the three side-effect sinks the
+// families under test write to.
+var __statusCalls = [];
+var __infoCalls = [];
+var __bgTaskCalls = [];
+setComposerStatus = function(msg){ __statusCalls.push(String(msg)); };
+console.info = function(){
+  __infoCalls.push(Array.prototype.slice.call(arguments).map(function(x){ return String(x); }).join(' '));
+};
+_handleBgTaskCompleteEvent = function(){ __bgTaskCalls.push('bg_task_complete'); };
+
+(async () => {
+  // Phase 1 — generation A installs through the production listener path.
+  attachLiveStream(SID, STREAM_ID, [], {});
+  const sourceA = __esCreated[0];
+
+  // Phase 2 — the SAME (session_id, stream_id) pair gets a new transport: the
+  // closed transport cannot be reused, so production supersedes generation A and
+  // wires generation B for the identical pair.
+  sourceA.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await new Promise((resolve) => setTimeout(resolve, 0)); // preflight + _wireSSE
+  const sourceB = __esCreated[1];
+
+  __results.generationAInstalled = !!sourceA;
+  __results.generationBInstalled = __esCreated.length === 2 && !!sourceB && sourceB !== sourceA;
+  __results.currentTransportIsB = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  __results.pairUnchanged = !!(
+    LIVE_STREAMS[SID] && LIVE_STREAMS[SID].streamId === STREAM_ID &&
+    LIVE_STREAMS[SID].capability && LIVE_STREAMS[SID].capability.sessionId === SID
+  );
+
+  const EVENTS = {
+    title_status:     {status:'generated', title:'Renamed', session_id: SID},
+    context_status:   {prefill:{status:'loaded', label:'session recall'}, session_id: SID},
+    bg_task_complete: {task_id:'bg-1', session_id: SID},
+    warning:          {type:'generic', message:'degraded but running', session_id: SID},
+  };
+  const SINKS = {
+    title_status:'info',
+    context_status:'status',
+    bg_task_complete:'bg',
+    warning:'status',
+  };
+
+  __results.registeredOnA = {};
+  __results.registeredOnB = {};
+  for (const type of Object.keys(EVENTS)) {
+    __results.registeredOnA[type] = (sourceA._handlers[type] || []).length;
+    __results.registeredOnB[type] = (sourceB._handlers[type] || []).length;
+  }
+
+  function _delta(fn){
+    const before = { status: __statusCalls.length, info: __infoCalls.length, bg: __bgTaskCalls.length };
+    let threw = null;
+    try { fn(); } catch (err) { threw = String((err && err.message) || err); }
+    return {
+      status: __statusCalls.length - before.status,
+      info: __infoCalls.length - before.info,
+      bg: __bgTaskCalls.length - before.bg,
+      threw: threw,
+    };
+  }
+
+  // Phase 3 — every family delivered by the SUPERSEDED generation is a no-op.
+  __results.superseded = {};
+  for (const type of Object.keys(EVENTS)) {
+    const row = _delta(function(){ sourceA.dispatch(type, EVENTS[type]); });
+    row.sink = SINKS[type];
+    row.sinkCalls = row[SINKS[type]];
+    __results.superseded[type] = row;
+  }
+
+  // Phase 4 — the CURRENT generation delivers the same events (wiring control).
+  __results.current = {};
+  for (const type of Object.keys(EVENTS)) {
+    const row = _delta(function(){ sourceB.dispatch(type, EVENTS[type]); });
+    row.sink = SINKS[type];
+    row.sinkCalls = row[SINKS[type]];
+    __results.current[type] = row;
+  }
+
+  process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+""")
+
+
+def _assert_side_effect_row(result: dict, family: str, sink: str) -> None:
+    """Superseded generation must not reach the family's sink; the current
+    generation must (wiring control, so a no-op cannot pass vacuously)."""
+    assert result["generationAInstalled"] is True, "generation A must install"
+    assert result["generationBInstalled"] is True, (
+        "the fresh-reconnect path must supersede generation A with a NEW "
+        "EventSource for the same session+stream pair"
+    )
+    assert result["currentTransportIsB"] is True, (
+        "LIVE_STREAMS[activeSid] must own generation B"
+    )
+    assert result["pairUnchanged"] is True, (
+        "the discriminator must be the transport generation: session_id and "
+        "stream_id are identical in both generations"
+    )
+    assert result["registeredOnA"][family] >= 1, (
+        f"the superseded transport must have the '{family}' listener registered "
+        "(otherwise the no-op assertion would be vacuous)"
+    )
+    assert result["registeredOnB"][family] >= 1, (
+        f"the current transport must have the '{family}' listener registered"
+    )
+    assert result["superseded"][family]["threw"] is None, (
+        f"the superseded '{family}' callback must be rejected by the ownership "
+        f"guard, not crash: {result['superseded'][family]['threw']}"
+    )
+    assert result["superseded"][family][sink] == 0, (
+        f"a '{family}' event from the SUPERSEDED transport (identical "
+        f"session_id+stream_id) must not reach its side-effect sink "
+        f"({sink}); generation ownership must reject it"
+    )
+    assert result["current"][family][sink] >= 1, (
+        f"the CURRENT transport's '{family}' event must still reach the same "
+        f"sink ({sink})"
+    )
+
+
+def test_title_status_from_superseded_transport_never_reaches_its_sink():
+    """title_status (generation-fenced, side-effect only) must be ignored when
+    the delivering transport has been superseded for the same pair."""
+    result = _run_harness(_SIDE_EFFECT_GENERATION_DRIVER)
+    _assert_side_effect_row(result, "title_status", "info")
+
+
+def test_context_status_from_superseded_transport_never_reaches_its_sink():
+    """context_status must be ignored when the delivering transport has been
+    superseded for the same pair."""
+    result = _run_harness(_SIDE_EFFECT_GENERATION_DRIVER)
+    _assert_side_effect_row(result, "context_status", "status")
+
+
+def test_bg_task_complete_from_superseded_transport_never_reaches_its_sink():
+    """bg_task_complete must be ignored when the delivering transport has been
+    superseded for the same pair."""
+    result = _run_harness(_SIDE_EFFECT_GENERATION_DRIVER)
+    _assert_side_effect_row(result, "bg_task_complete", "bg")
+
+
+def test_warning_from_superseded_transport_never_reaches_its_sink():
+    """warning must be ignored when the delivering transport has been superseded
+    for the same pair."""
+    result = _run_harness(_SIDE_EFFECT_GENERATION_DRIVER)
+    _assert_side_effect_row(result, "warning", "status")
+
+
+_TERMINAL_GENERATION_DRIVER = textwrap.dedent("""\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+(async () => {
+  attachLiveStream(SID, STREAM_ID, [], {});
+  const sourceA = __esCreated[0];
+  sourceA.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await new Promise((resolve) => setTimeout(resolve, 0)); // preflight + _wireSSE
+  const sourceB = __esCreated[1];
+  const registryB = window._liveAnchorRegistries.get(STREAM_ID);
+
+  __results.generationBInstalled = __esCreated.length === 2 && !!sourceB && sourceB !== sourceA;
+  __results.currentTransportIsB = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  __results.registered = {
+    apperror: (sourceA._handlers['apperror'] || []).length,
+    cancel: (sourceA._handlers['cancel'] || []).length,
+  };
+
+  function _snapshot(){
+    const reg = window._liveAnchorRegistries.get(STREAM_ID);
+    return {
+      hiddenEntry: !!_STREAM_WAS_HIDDEN[SID],
+      backgroundEntry: !!_STREAM_NOTIFICATION_BACKGROUND[SID],
+      activeStreamId: String(S.activeStreamId || ''),
+      registryIsB: reg === registryB,
+      registryEvents: (reg && reg.anchor && Array.isArray(reg.anchor.activity_events))
+        ? reg.anchor.activity_events.length : -1,
+      sourceBOpen: sourceB.readyState === EventSource.OPEN,
+      currentTransportIsB: !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB),
+    };
+  }
+
+  // Precondition for the whole matrix: the trackers the terminal paths drop must
+  // exist BEFORE the stale dispatch, or the assertions below prove nothing.
+  _STREAM_WAS_HIDDEN[SID] = {streamId: STREAM_ID, wasHidden: true};
+  _STREAM_NOTIFICATION_BACKGROUND[SID] = {streamId: STREAM_ID, wasBackgrounded: true};
+  S.activeStreamId = STREAM_ID;
+  __results.before = _snapshot();
+
+  __results.superseded = {};
+  const TERMINAL = [
+    ['apperror', {type:'error', message:'boom', session_id: SID}],
+    ['cancel', {status:'cancelled', session_id: SID}],
+  ];
+  for (const pair of TERMINAL) {
+    const type = pair[0];
+    let threw = null;
+    try { sourceA.dispatch(type, pair[1]); } catch (err) { threw = String((err && err.message) || err); }
+    const snap = _snapshot();
+    snap.threw = threw;
+    __results.superseded[type] = snap;
+    // Reset the shared trackers so each family starts from the same state.
+    _STREAM_WAS_HIDDEN[SID] = {streamId: STREAM_ID, wasHidden: true};
+    _STREAM_NOTIFICATION_BACKGROUND[SID] = {streamId: STREAM_ID, wasBackgrounded: true};
+    S.activeStreamId = STREAM_ID;
+  }
+
+  process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+""")
+
+
+def _assert_terminal_row(result: dict, family: str) -> None:
+    """A terminal event from the superseded generation must not settle, clear,
+    or replace anything the newer transport owns."""
+    before = result["before"]
+    after = result["superseded"][family]
+    assert result["generationBInstalled"] is True, (
+        "the fresh-reconnect path must supersede generation A"
+    )
+    assert result["currentTransportIsB"] is True, (
+        "LIVE_STREAMS[activeSid] must own generation B"
+    )
+    assert result["registered"][family] >= 1, (
+        f"the superseded transport must have the '{family}' listener registered "
+        "(otherwise the no-op assertion would be vacuous)"
+    )
+    assert before["hiddenEntry"] is True and before["backgroundEntry"] is True, (
+        "precondition: the hidden/notification trackers must exist before the "
+        "stale terminal event, so their survival is meaningful"
+    )
+    assert after["threw"] is None, (
+        f"the superseded '{family}' callback must be rejected by the ownership "
+        f"guard, not crash: {after['threw']}"
+    )
+    assert after["hiddenEntry"] is True, (
+        f"the superseded '{family}' must not drop the current transport's hidden "
+        "tracker (#4416 state belongs to the live transport)"
+    )
+    assert after["backgroundEntry"] is True, (
+        f"the superseded '{family}' must not drop the current transport's "
+        "notification-background tracker"
+    )
+    assert after["activeStreamId"] == before["activeStreamId"] == "test-stream", (
+        f"the superseded '{family}' must not settle the CURRENT turn "
+        "(S.activeStreamId must stay set)"
+    )
+    assert after["registryIsB"] is True, (
+        f"the superseded '{family}' must not replace the current registry"
+    )
+    assert after["registryEvents"] == before["registryEvents"], (
+        f"the superseded '{family}' must not write the current registry"
+    )
+    assert after["sourceBOpen"] is True and after["currentTransportIsB"] is True, (
+        f"the superseded '{family}' must leave the CURRENT transport open and owned"
+    )
+
+
+def test_apperror_from_superseded_transport_does_not_settle_current_transport():
+    """A stale apperror must not clear INFLIGHT/trackers or settle the newer
+    transport that owns the same session+stream pair."""
+    result = _run_harness(_TERMINAL_GENERATION_DRIVER)
+    _assert_terminal_row(result, "apperror")
+
+
+def test_cancel_from_superseded_transport_does_not_settle_current_transport():
+    """A stale cancel must not clear trackers or settle the newer transport that
+    owns the same session+stream pair."""
+    result = _run_harness(_TERMINAL_GENERATION_DRIVER)
+    _assert_terminal_row(result, "cancel")

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -297,6 +297,29 @@ function removeThinking() {}
 function clearInflight() {}
 function clearInflightState() {}
 function _closeSource() {}
+// Real module-scope helpers of the stream-error / reconnect path (messages.js):
+// the offline defer is copied from production (it is the gate that decides
+// whether an error reconnects now or waits), the rest are side-effect hooks the
+// tested ownership invariants do not depend on.
+function isOfflineBannerVisible() { return false; }
+function showOfflineBanner() {}
+function t(key) { return String(key); }
+function _deferStreamErrorIfOffline(){
+  if(typeof isOfflineBannerVisible==='function' && isOfflineBannerVisible()){
+    setComposerStatus(t('offline_stream_waiting'));
+    return true;
+  }
+  if(typeof showOfflineBanner==='function' && navigator.onLine===false){
+    showOfflineBanner('browser');
+    setComposerStatus(t('offline_stream_waiting'));
+    return true;
+  }
+  return false;
+}
+function recordClientSSEError() {}
+function _handleStreamError() {}
+function _flushReasoningToAnchor() {}
+async function _restoreSettledSession() { return false; }
 function _approvalBelongsToOwner() { return true; }
 function _clarifyBelongsToOwner() { return true; }
 function _clearApprovalPendingForSession() {}
@@ -1401,4 +1424,545 @@ def test_stale_transport_cannot_advance_the_run_journal_cursor():
     )
     assert result["cursorAfterSecondStale"] == "42", (
         "no later stale event may advance the cursor beyond the current transport's seq"
+    )
+
+# ---------------------------------------------------------------------------
+# Matrix rows: post-await continuations and the deferred cleanup (review item 6,
+# remaining families).
+#
+# The stale-callback families above are fenced INSIDE the listener body. These
+# rows cover continuations that resume AFTER an await (or after a timer) — the
+# reconnect retry chain and the deferred hidden-page resume — plus the deferred
+# anchor-registry cleanup. Same rule as the rest of the matrix: a continuation
+# captured from a replaced transport must not act, and the assertions below fail
+# when the ownership check is weakened to the (session_id, stream_id) pair.
+#
+# The timers are captured instead of fired: production arms the reconnect probe
+# at 1500ms, the terminal restore at 8000ms and the registry cleanup at 120000ms.
+# All three are dropped by the recording setTimeout() and invoked explicitly, so
+# each row asserts on the real continuation body rather than on a sleep.
+# ---------------------------------------------------------------------------
+
+_TIMER_CAPTURE_PRELUDE = '''
+var __timers = [];
+var __realSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = function(fn, delay){
+  var ms = Number(delay) || 0;
+  if (ms >= 500) { __timers.push({ delay: ms, fn: fn }); return 0; }
+  return __realSetTimeout.apply(globalThis, arguments);
+};
+function __timersAt(delay){ return __timers.filter(function(t){ return t.delay === delay; }); }
+function __fireTimersAt(delay){
+  var fired = 0;
+  for (var t of __timersAt(delay)) { fired += 1; try { t.fn(); } catch (_) { } }
+  return fired;
+}
+var __apiCalls = [];
+var __realApi = api;
+api = async function(url){ __apiCalls.push(String(url)); return __apiResponse; };
+var __statusCalls = [];
+setComposerStatus = function(msg){ __statusCalls.push(String(msg)); };
+function __reconnectedStatuses(){ return __statusCalls.filter(function(m){ return m.indexOf('Reconnected') >= 0; }).length; }
+'''
+
+_RETRY_TIMER_GENERATION_DRIVER = textwrap.dedent('''\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+''' + _TIMER_CAPTURE_PRELUDE + '''
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+const tick = () => new Promise((resolve) => __realSetTimeout(resolve, 0));
+
+(async () => {
+  // Phase 1 — generation A installs through the production listener path.
+  attachLiveStream(SID, STREAM_ID, [], {});
+  await tick();
+  const sourceA = __esCreated[0];
+  __results.errorListenerOnA = (sourceA._handlers['error'] || []).length;
+  const registryA = window._liveAnchorRegistries.get(STREAM_ID);
+
+  // Phase 2 — the transport errors out: production arms the first reconnect
+  // probe on a 1500ms timer while generation A is still the live transport.
+  __apiResponse = { active: false, replay_available: false };
+  sourceA.dispatch('error', { message: 'boom' });
+  await tick();
+  __results.retryTimerArmed = __timersAt(1500).length;
+  __results.statusAfterError = __statusCalls.slice();
+  __results.registryIsA = window._liveAnchorRegistries.get(STREAM_ID) === registryA;
+
+  // Phase 3 — the SAME (session_id, stream_id) pair gets a NEW transport. The
+  // retry timer armed by generation A is still pending at this point: it is the
+  // stale continuation this row is about.
+  sourceA.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await tick();
+  const sourceB = __esCreated[1];
+  const registryB = window._liveAnchorRegistries.get(STREAM_ID);
+  __results.generationBInstalled = __esCreated.length === 2 && !!sourceB && sourceB !== sourceA;
+  __results.currentTransportIsB = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  __results.registryIsB = window._liveAnchorRegistries.get(STREAM_ID) === registryB;
+
+  const creationsBefore = __esCreated.length;
+  const probesBefore = __apiCalls.length;
+  const statusesBefore = __statusCalls.length;
+
+  // Phase 4 — the STALE retry timer fires and its probe resolves active:true,
+  // i.e. the exact input that makes the stale chain re-wire a transport.
+  __results.staleRetryTimersFired = __fireTimersAt(1500);
+  await tick();
+  await tick();
+  await tick();
+
+  __results.sourcesCreatedByStaleRetry = __esCreated.length - creationsBefore;
+  __results.probeCallsFromStaleRetry = __apiCalls.length - probesBefore;
+  __results.reconnectedStatusesFromStaleRetry = __reconnectedStatuses() - __statusCalls.length + statusesBefore;
+  __results.reconnectedStatusesTotal = __reconnectedStatuses();
+  __results.currentTransportIsBAfter = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  __results.registryIsBAfter = window._liveAnchorRegistries.get(STREAM_ID) === registryB;
+  __results.sourceBOpen = sourceB.readyState === EventSource.OPEN;
+
+  process.stdout.write(JSON.stringify(__results) + String.fromCharCode(10), () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+''')
+
+
+def test_reconnect_retry_timer_from_replaced_transport_cannot_rewire():
+    """A reconnect probe armed by a transport that was replaced meanwhile must
+    not re-wire a new EventSource for the pair the newer transport owns."""
+    result = _run_harness(_RETRY_TIMER_GENERATION_DRIVER)
+
+    assert result["errorListenerOnA"] >= 1, (
+        "the superseded transport must have the error listener registered, "
+        "otherwise the stale-retry assertion would be vacuous"
+    )
+    assert result["retryTimerArmed"] == 1, (
+        "precondition: the error path must arm exactly one 1500ms reconnect "
+        "probe while generation A is the live transport"
+    )
+    assert result["generationBInstalled"] is True, (
+        "the fresh-reconnect path must supersede generation A with a NEW "
+        "EventSource for the same session+stream pair"
+    )
+    assert result["currentTransportIsB"] is True, (
+        "LIVE_STREAMS[activeSid] must own generation B before the stale timer fires"
+    )
+    assert result["registryIsB"] is True, (
+        "the current transport's registry must own the stream key"
+    )
+    assert result["staleRetryTimersFired"] == 1, (
+        "the captured stale retry timer must actually run"
+    )
+    assert result["sourcesCreatedByStaleRetry"] == 0, (
+        "the stale retry probe resolved {active:true} and must NOT re-wire: a "
+        "replaced transport's continuation may not create a second EventSource "
+        "for the pair the live entry already owns"
+    )
+    assert result["probeCallsFromStaleRetry"] == 0, (
+        "a stale retry must be rejected before it even probes the stream status"
+    )
+    assert result["reconnectedStatusesTotal"] == 0, (
+        "no 'Reconnected' status may be issued by a stale retry continuation"
+    )
+    assert result["currentTransportIsBAfter"] is True, (
+        "the stale retry must not steal LIVE_STREAMS ownership from generation B"
+    )
+    assert result["registryIsBAfter"] is True, (
+        "the stale retry must not replace the current transport's registry"
+    )
+    assert result["sourceBOpen"] is True, (
+        "the current transport must stay open"
+    )
+
+
+_HIDDEN_RESUME_GENERATION_DRIVER = textwrap.dedent('''\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+''' + _TIMER_CAPTURE_PRELUDE + '''
+var __docListeners = {};
+var __winListeners = {};
+document.addEventListener = function(type, fn){ (__docListeners[type] = __docListeners[type] || []).push(fn); };
+document.removeEventListener = function(type, fn){
+  const list = __docListeners[type] || [];
+  const idx = list.indexOf(fn);
+  if (idx >= 0) list.splice(idx, 1);
+};
+window.addEventListener = function(type, fn){ (__winListeners[type] = __winListeners[type] || []).push(fn); };
+window.removeEventListener = function(type, fn){
+  const list = __winListeners[type] || [];
+  const idx = list.indexOf(fn);
+  if (idx >= 0) list.splice(idx, 1);
+};
+document.visibilityState = 'hidden';
+
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+const tick = () => new Promise((resolve) => __realSetTimeout(resolve, 0));
+
+(async () => {
+  attachLiveStream(SID, STREAM_ID, [], {});
+  await tick();
+  const sourceA = __esCreated[0];
+  __results.errorListenerOnA = (sourceA._handlers['error'] || []).length;
+
+  // Phase 1 — the transport errors while the page is HIDDEN: production defers
+  // the recovery and binds a resume listener instead of reconnecting now.
+  sourceA.dispatch('error', { message: 'boom' });
+  await tick();
+  __results.pausedStatusIssued = __statusCalls.filter(function(m){ return m.indexOf('Connection paused') >= 0; }).length;
+  __results.visibilityListenersBound = (__docListeners['visibilitychange'] || []).length;
+  __results.focusListenersBound = (__winListeners['focus'] || []).length;
+  __results.sourcesBeforeResume = __esCreated.length;
+
+  // Phase 2 — the page comes back and a NEW transport takes over the same
+  // (session_id, stream_id) pair before the deferred resume is delivered.
+  sourceA.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await tick();
+  const sourceB = __esCreated[1];
+  const registryB = window._liveAnchorRegistries.get(STREAM_ID);
+  __results.generationBInstalled = __esCreated.length === 2 && !!sourceB && sourceB !== sourceA;
+  __results.currentTransportIsB = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+
+  const creationsBefore = __esCreated.length;
+  const probesBefore = __apiCalls.length;
+
+  // Phase 3 — the deferred resume fires with the tab visible again.
+  document.visibilityState = 'visible';
+  for (const fn of (__docListeners['visibilitychange'] || []).slice()) fn();
+  await tick();
+  await tick();
+  await tick();
+
+  __results.resumeListenersRemaining = (__docListeners['visibilitychange'] || []).length;
+  __results.sourcesCreatedByResume = __esCreated.length - creationsBefore;
+  __results.probeCallsFromResume = __apiCalls.length - probesBefore;
+  __results.reconnectedStatusesTotal = __reconnectedStatuses();
+  __results.currentTransportIsBAfter = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  __results.registryIsBAfter = window._liveAnchorRegistries.get(STREAM_ID) === registryB;
+  __results.sourceBOpen = sourceB.readyState === EventSource.OPEN;
+
+  process.stdout.write(JSON.stringify(__results) + String.fromCharCode(10), () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+''')
+
+
+def test_deferred_hidden_page_resume_from_replaced_transport_cannot_rewire():
+    """The deferred hidden-page resume belongs to the transport that armed it:
+    once a newer transport owns the pair, the resume must not re-wire or probe."""
+    result = _run_harness(_HIDDEN_RESUME_GENERATION_DRIVER)
+
+    assert result["errorListenerOnA"] >= 1, (
+        "the deferred transport must have the error listener registered"
+    )
+    assert result["pausedStatusIssued"] >= 1, (
+        "precondition: a hidden-page stream error must defer (status mentions "
+        "the paused connection) instead of reconnecting immediately"
+    )
+    assert result["visibilityListenersBound"] >= 1 and result["focusListenersBound"] >= 1, (
+        "precondition: the deferred resume must bind visibilitychange + focus"
+    )
+    assert result["sourcesBeforeResume"] == 1, (
+        "precondition: the deferred error path must not create a transport"
+    )
+    assert result["generationBInstalled"] is True, (
+        "the fresh-reconnect path must supersede generation A with a NEW "
+        "EventSource for the same session+stream pair"
+    )
+    assert result["currentTransportIsB"] is True, (
+        "LIVE_STREAMS[activeSid] must own generation B before the resume fires"
+    )
+    assert result["resumeListenersRemaining"] == 0, (
+        "the resume callback must actually run (it unbinds itself first)"
+    )
+    assert result["sourcesCreatedByResume"] == 0, (
+        "the deferred resume must NOT re-wire a transport: its generation no "
+        "longer owns the live entry, and re-wiring steals the newer stream"
+    )
+    assert result["probeCallsFromResume"] == 0, (
+        "the deferred resume must not even probe the stream status once the "
+        "transport that armed it was replaced"
+    )
+    assert result["reconnectedStatusesTotal"] == 0, (
+        "no 'Reconnected' status may be issued by a stale deferred resume"
+    )
+    assert result["currentTransportIsBAfter"] is True, (
+        "the stale resume must not steal LIVE_STREAMS ownership from generation B"
+    )
+    assert result["registryIsBAfter"] is True, (
+        "the stale resume must not replace the current transport's registry"
+    )
+    assert result["sourceBOpen"] is True, (
+        "the current transport must stay open"
+    )
+
+
+_IN_PLACE_REWIRE_GENERATION_DRIVER = textwrap.dedent('''\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+''' + _TIMER_CAPTURE_PRELUDE + '''
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+const tick = () => new Promise((resolve) => __realSetTimeout(resolve, 0));
+
+(async () => {
+  attachLiveStream(SID, STREAM_ID, [], {});
+  await tick();
+  const sourceA = __esCreated[0];
+  const capabilityA = LIVE_STREAMS[SID].capability;
+  const registryA = window._liveAnchorRegistries.get(STREAM_ID);
+
+  // Phase 1 — arm the retry chain, then let it find the stream alive: the SAME
+  // closure re-wires a replacement EventSource for the identical pair.
+  __apiResponse = { active: false, replay_available: false };
+  sourceA.dispatch('error', { message: 'boom' });
+  await tick();
+  __results.retryTimerArmed = __timersAt(1500).length;
+  __apiResponse = { active: true };
+  __results.retryTimersFired = __fireTimersAt(1500);
+  await tick();
+  await tick();
+
+  const sourceC = __esCreated[1];
+  __results.inPlaceRewireCreatedNewSource = __esCreated.length === 2 && !!sourceC && sourceC !== sourceA;
+  __results.liveEntryOwnsNewSource = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceC);
+  __results.newGenerationPublished = !!(
+    LIVE_STREAMS[SID] && LIVE_STREAMS[SID].capability && LIVE_STREAMS[SID].capability !== capabilityA
+  );
+  __results.previousCapabilitySuperseded = !!(capabilityA && capabilityA.superseded === true);
+  __results.reconnectedStatusesTotal = __reconnectedStatuses();
+  __results.registryStillEntry = window._liveAnchorRegistries.get(STREAM_ID) === registryA;
+
+  // Phase 2 — a terminal event from the REPLACED source must not settle the
+  // turn the newer generation owns.
+  sourceA.dispatch('apperror', { type: 'error', message: 'boom', session_id: SID });
+  await tick();
+  __results.registeredAppErrorOnA = (sourceA._handlers['apperror'] || []).length;
+  __results.activeStreamIdAfterStaleTerminal = String(S.activeStreamId || '');
+  __results.registryIdentityAfterStaleTerminal = window._liveAnchorRegistries.get(STREAM_ID) === registryA;
+
+  // Phase 3 — the 120s cleanup the STALE generation scheduled must not tear
+  // down the registry the newer generation is still using (same stream key, so
+  // the map identity matches; only the generation guard can reject it).
+  __results.staleCleanupTimersArmed = __timersAt(120000).length;
+  __results.staleCleanupTimersFired = __fireTimersAt(120000);
+  __results.registrySurvivesStaleCleanup = window._liveAnchorRegistries.get(STREAM_ID) === registryA;
+  __results.registryStillUsable = !!(window._liveAnchorRegistries.get(STREAM_ID)
+    && window._liveAnchorRegistries.get(STREAM_ID).anchor);
+  __results.liveEntryOwnsNewSourceAfterCleanup = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceC);
+
+  process.stdout.write(JSON.stringify(__results) + String.fromCharCode(10), () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+''')
+
+
+def test_in_place_rewire_publishes_new_generation_and_survives_stale_cleanup():
+    """When the same closure re-wires its transport, the replacement generation
+    must become the shared authority: the previous one is superseded and the
+    deferred cleanup it scheduled cannot tear down the newer registry."""
+    result = _run_harness(_IN_PLACE_REWIRE_GENERATION_DRIVER)
+
+    assert result["retryTimerArmed"] == 1, (
+        "precondition: the error path must arm the 1500ms probe"
+    )
+    assert result["retryTimersFired"] == 1, (
+        "the live retry chain must be allowed to run (the ownership guard must "
+        "not block a transport that still owns the live entry)"
+    )
+    assert result["inPlaceRewireCreatedNewSource"] is True, (
+        "the retry must re-wire exactly one replacement EventSource for the pair"
+    )
+    assert result["liveEntryOwnsNewSource"] is True, (
+        "LIVE_STREAMS[activeSid] must own the replacement source"
+    )
+    assert result["newGenerationPublished"] is True, (
+        "the in-place re-wire must publish a NEW capability generation into the "
+        "shared live entry (the authority every listener re-checks)"
+    )
+    assert result["previousCapabilitySuperseded"] is True, (
+        "the replaced capability must be marked superseded BEFORE the new one is "
+        "published, so a continuation resuming in between cannot see it as current"
+    )
+    assert result["reconnectedStatusesTotal"] >= 1, (
+        "wiring control: the live retry chain must actually reconnect"
+    )
+    assert result["registeredAppErrorOnA"] >= 1, (
+        "the replaced source must still have its terminal listener registered"
+    )
+    assert result["activeStreamIdAfterStaleTerminal"] == "test-stream", (
+        "a terminal event from the replaced source must not settle the turn the "
+        "newer generation owns"
+    )
+    assert result["staleCleanupTimersArmed"] >= 1, (
+        "the stale terminal path must schedule its 120s registry cleanup"
+    )
+    assert result["staleCleanupTimersFired"] >= 1, (
+        "the captured 120s cleanups must actually run"
+    )
+    assert result["registrySurvivesStaleCleanup"] is True, (
+        "the 120s cleanup scheduled by a SUPERSEDED generation must not delete "
+        "the registry under the same stream key: the newer installation "
+        "re-registers that key and its consumers still read it"
+    )
+    assert result["registryStillUsable"] is True, (
+        "the surviving registry must still be the usable bootstrap entry"
+    )
+    assert result["liveEntryOwnsNewSourceAfterCleanup"] is True, (
+        "the stale cleanup must not touch LIVE_STREAMS ownership"
+    )
+
+
+_CROSS_INSTALL_CLEANUP_DRIVER = textwrap.dedent('''\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+''' + _TIMER_CAPTURE_PRELUDE + '''
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+const tick = () => new Promise((resolve) => __realSetTimeout(resolve, 0));
+
+(async () => {
+  // Phase 1 — generation A installs its registry under the stream key.
+  attachLiveStream(SID, STREAM_ID, [], {});
+  await tick();
+  const sourceA = __esCreated[0];
+  const registryA = window._liveAnchorRegistries.get(STREAM_ID);
+
+  // Phase 2 — a NEW install re-registers the SAME stream key with its own
+  // registry (this is the legitimate OPEN-transport re-registration the
+  // production comment warns about).
+  sourceA.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await tick();
+  const sourceB = __esCreated[1];
+  const registryB = window._liveAnchorRegistries.get(STREAM_ID);
+  __results.freshInstallReplaced = __esCreated.length === 2 && !!sourceB && sourceB !== sourceA;
+  __results.registryReRegistered = !!registryB && registryB !== registryA;
+  __results.currentTransportIsB = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  __results.registeredAppErrorOnA = (sourceA._handlers['apperror'] || []).length;
+
+  // Phase 3 — the stale transport's terminal event schedules ITS 120s cleanup.
+  sourceA.dispatch('apperror', { type: 'error', message: 'boom', session_id: SID });
+  await tick();
+  __results.staleCleanupTimersArmed = __timersAt(120000).length;
+  __results.registryIsBBeforeCleanup = window._liveAnchorRegistries.get(STREAM_ID) === registryB;
+  __results.staleCleanupTimersFired = __fireTimersAt(120000);
+  __results.registrySurvivesStaleCleanup = window._liveAnchorRegistries.get(STREAM_ID) === registryB;
+
+  // Phase 4 — control: the CURRENT install's own self-expiry timer DOES delete
+  // the key, so the cleanup under test is a real deletion, not a no-op.
+  __results.selfExpiryTimersArmed = __timersAt(600000).length;
+  __results.selfExpiryTimersFired = __fireTimersAt(600000);
+  __results.keyDeletedBySelfExpiry = window._liveAnchorRegistries.get(STREAM_ID) === undefined;
+
+  process.stdout.write(JSON.stringify(__results) + String.fromCharCode(10), () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+''')
+
+
+def test_stale_transport_cleanup_cannot_delete_the_newer_registry():
+    """The deferred 120s cleanup belongs to the registry it was created for: a
+    stale transport's timer must not delete the newer install's registry."""
+    result = _run_harness(_CROSS_INSTALL_CLEANUP_DRIVER)
+
+    assert result["freshInstallReplaced"] is True, (
+        "the fresh install must replace generation A for the same pair"
+    )
+    assert result["registryReRegistered"] is True, (
+        "precondition: the newer install must re-register the stream key with "
+        "its own registry object (else the identity guard would be untested)"
+    )
+    assert result["currentTransportIsB"] is True, (
+        "LIVE_STREAMS[activeSid] must own generation B"
+    )
+    assert result["registeredAppErrorOnA"] >= 1, (
+        "the superseded transport must have the terminal listener registered"
+    )
+    assert result["staleCleanupTimersArmed"] >= 1, (
+        "the stale terminal path must schedule the 120s registry cleanup"
+    )
+    assert result["registryIsBBeforeCleanup"] is True, (
+        "precondition: the current transport's registry owns the stream key"
+    )
+    assert result["staleCleanupTimersFired"] >= 1, (
+        "the captured stale cleanup must actually run"
+    )
+    assert result["registrySurvivesStaleCleanup"] is True, (
+        "a stale transport's 120s cleanup must not delete the registry the "
+        "current transport installed under the same stream key (identity guard)"
+    )
+    assert result["selfExpiryTimersArmed"] >= 1, (
+        "precondition: each install arms its own self-expiry cleanup"
+    )
+    assert result["selfExpiryTimersFired"] >= 1, (
+        "the captured self-expiry cleanups must actually run"
+    )
+    assert result["keyDeletedBySelfExpiry"] is True, (
+        "control: the current registry's own self-expiry must still delete the "
+        "key, so the stale-cleanup assertion above proves a real guard"
     )

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -1284,3 +1284,121 @@ def test_cancel_from_superseded_transport_does_not_settle_current_transport():
     owns the same session+stream pair."""
     result = _run_harness(_TERMINAL_GENERATION_DRIVER)
     _assert_terminal_row(result, "cancel")
+
+# ---------------------------------------------------------------------------
+# Matrix row: stale run-journal cursor mutation (review item 6, first bullet).
+#
+# The run journal cursor (INFLIGHT[activeSid].lastRunJournalSeq/EventId) is
+# transport-scoped replay authority: if a superseded transport keeps advancing
+# it, a later replay starts after content that was never rendered and silently
+# skips it. The cursor listeners are registered for every journal event name
+# through the production _wireSSE() path, so this row drives the real listener.
+# ---------------------------------------------------------------------------
+
+_CURSOR_GENERATION_DRIVER = textwrap.dedent("""\
+const __results = {};
+const SID = 'test-sid';
+const STREAM_ID = 'test-stream';
+
+window._liveAnchorRegistries = new Map();
+window._renderLiveAnchorActivitySceneForStream = _renderLiveAnchorActivitySceneForStream;
+window._projectLiveAnchorActivitySceneForStream = _projectLiveAnchorActivitySceneForStream;
+
+INFLIGHT[SID] = {
+  messages: [], uploaded: [], toolCalls: [],
+  streamId: STREAM_ID,
+  activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
+  lastRunJournalSeq: 5,
+  lastRunJournalEventId: 'evt-5',
+};
+S.session = { session_id: SID };
+S.activeStreamId = STREAM_ID;
+S.messages = [];
+S.toolCalls = [];
+
+(async () => {
+  attachLiveStream(SID, STREAM_ID, [], {});
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const sourceA = __esCreated[0];
+
+  // The same (session_id, stream_id) pair gets a NEW transport: the superseded
+  // generation A must lose replay authority over the cursor.
+  sourceA.close();
+  __apiResponse = { active: true };
+  attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const sourceB = __esCreated[1];
+
+  __results.generationBInstalled = __esCreated.length === 2 && !!sourceB && sourceB !== sourceA;
+  __results.currentTransportIsB = !!(LIVE_STREAMS[SID] && LIVE_STREAMS[SID].source === sourceB);
+  // The cursor listeners are registered for every journal event name: prove the
+  // stale transport has one, else the no-op assertion would be vacuous.
+  __results.cursorListenerOnA = (sourceA._handlers['reasoning'] || []).length;
+  __results.cursorListenerOnB = (sourceB._handlers['reasoning'] || []).length;
+
+  __results.cursorBefore = String(INFLIGHT[SID].lastRunJournalSeq);
+
+  // A stale higher event id must not advance closure cursor state or the
+  // persisted INFLIGHT cursor.
+  sourceA.dispatch('reasoning', { text: 'STALE-A', event_id: 'stream:41' });
+  __results.cursorAfterStale = String(INFLIGHT[SID].lastRunJournalSeq);
+  __results.cursorEventIdAfterStale = String(INFLIGHT[SID].lastRunJournalEventId || '');
+  __results.staleAppliedToRegistry = window._liveAnchorRegistries.get(STREAM_ID).anchor.activity_events.length;
+
+  // The current transport's matching event advances the cursor exactly once.
+  sourceB.dispatch('reasoning', { text: 'CURRENT-B', event_id: 'stream:42' });
+  __results.cursorAfterCurrent = String(INFLIGHT[SID].lastRunJournalSeq);
+  __results.cursorEventIdAfterCurrent = String(INFLIGHT[SID].lastRunJournalEventId || '');
+  __results.currentAppliedToRegistry = window._liveAnchorRegistries.get(STREAM_ID).anchor.activity_events.length;
+
+  // A second stale event with an even higher id must still be inert.
+  sourceA.dispatch('reasoning', { text: 'STALE-A-2', event_id: 'stream:99' });
+  __results.cursorAfterSecondStale = String(INFLIGHT[SID].lastRunJournalSeq);
+
+  process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+})().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(2);
+});
+""")
+
+
+def test_stale_transport_cannot_advance_the_run_journal_cursor():
+    """A superseded transport must not advance the persisted run-journal cursor
+    (replay authority), while the current transport advances it exactly once."""
+    result = _run_harness(_CURSOR_GENERATION_DRIVER)
+
+    assert result["generationBInstalled"] is True, (
+        "the fresh-reconnect path must supersede generation A"
+    )
+    assert result["currentTransportIsB"] is True, (
+        "LIVE_STREAMS[activeSid] must own generation B"
+    )
+    assert result["cursorListenerOnA"] >= 1 and result["cursorListenerOnB"] >= 1, (
+        "both transports must have the journal-event listeners registered, "
+        "otherwise the inert-event assertions would be vacuous"
+    )
+    assert result["cursorBefore"] == "5", "precondition: the cursor starts at seq 5"
+    assert result["cursorAfterStale"] == "5", (
+        "a stale higher event_id (stream:41) from the SUPERSEDED transport must "
+        "not advance closure cursor state or the persisted INFLIGHT cursor — a "
+        "stale advance makes a later replay skip unrendered content"
+    )
+    assert result["cursorEventIdAfterStale"] == "evt-5", (
+        "the stale event must not overwrite the persisted cursor event id"
+    )
+    assert result["staleAppliedToRegistry"] == 0, (
+        "the stale event must not be applied to the registry either"
+    )
+    assert result["cursorAfterCurrent"] == "42", (
+        "the CURRENT transport's event must advance the cursor exactly once"
+    )
+    assert result["cursorEventIdAfterCurrent"].endswith("42"), (
+        "the persisted cursor event id must come from the current transport"
+    )
+    assert result["currentAppliedToRegistry"] == 1, (
+        "the current transport's event must be applied to the registry exactly once"
+    )
+    assert result["cursorAfterSecondStale"] == "42", (
+        "no later stale event may advance the cursor beyond the current transport's seq"
+    )

--- a/tests/test_issue6303_worklog_reattach_registry.py
+++ b/tests/test_issue6303_worklog_reattach_registry.py
@@ -203,6 +203,7 @@ async function api(url) { return __apiResponse; }
 // under test (registry ownership, reattach, journal-snapshot projection) are
 // real; these are presentation/side-effect hooks outside the tested invariant.
 function _bindStreamHiddenTracker() {}
+function _dispatchExtensionTurnLifecycle() {}
 function ensureLiveWorklogShell() {}
 function showLiveRunStatus() {}
 // REAL transport teardown — the fresh-reconnect regression test must exercise
@@ -351,6 +352,7 @@ _SESSIONS_HELPERS = [
     "_selectLiveRecoveryInflight",
     "_inflightHasVisibleLiveState",
     "_ensureInflightLiveAssistantMessage",
+    "_mergePendingSessionMessage",
     "_projectInflightMessagesForActivityBursts",
     "_messageComparableText",
     "_compactTranscriptText",
@@ -458,7 +460,9 @@ S.messages = [];
 // Phase 1 — install the OPEN source through the PRODUCTION listener path:
 // a real attachLiveStream() call creates the EventSource and _wireSSE() binds
 // the real reasoning/tool handlers that close over the anchor registry.
+  (async () => {
 attachLiveStream(SID, STREAM_ID, [], {});
+await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
 const handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
 const source = __esCreated[0];
 __results.registryCreatedThroughProduction = !!handlerRegistryRef;
@@ -467,6 +471,7 @@ __results.esCreatedAfterInstall = __esCreated.length;
 // Phase 2 — reattach: the OPEN same-stream transport must be reused (early
 // return) and the registry it owns must NOT be deleted.
 attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
 __results.esCreatedAfterReattach = __esCreated.length;
 __results.registryKeptThroughReattach = window._liveAnchorRegistries.get(STREAM_ID) === handlerRegistryRef;
 
@@ -487,6 +492,10 @@ __results.sceneRowSourceType = scene && scene.activity_rows[0] ? scene.activity_
 __results.renderCalls = __renderCalls.length;
 
 process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+  })().catch(err => {
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exit(2);
+  });
 """)
 
 
@@ -591,6 +600,7 @@ INFLIGHT[SID] = {
   activityBurstAnchors: [], currentActivityBurstId: 0, currentLiveSegmentSeq: 0,
 };
 attachLiveStream(SID, STREAM_ID, [], {});
+await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
 const handlerRegistryRef = window._liveAnchorRegistries.get(STREAM_ID);
 const source = __esCreated[0];
 delete INFLIGHT[SID];   // drop the local tail: server snapshot must win
@@ -715,7 +725,9 @@ def test_fresh_connection_replaces_stale_registry_when_no_open_transport():
     window._liveAnchorRegistries.set(STREAM_ID, staleRegistry);
 
     // NO existing OPEN transport for the stream.
+  (async () => {
     attachLiveStream(SID, STREAM_ID, [], { reconnecting: true });
+    await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
 
     // The stale object must be gone from the map (delete-order fix) and a
     // brand-new registry created by the fresh closure via the real API.
@@ -729,6 +741,10 @@ def test_fresh_connection_replaces_stale_registry_when_no_open_transport():
       : false;
 
     process.stdout.write(JSON.stringify(__results) + '\\n', () => { process.exit(0); });
+  })().catch(err => {
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exit(2);
+  });
     """)
 
     result = _run_harness(setup)
@@ -778,6 +794,7 @@ S.toolCalls = [];
   // Phase 1 — install the OLD same-stream transport through the production
   // listener path (real attachLiveStream -> _wireSSE -> LIVE_STREAMS entry).
   attachLiveStream(SID, STREAM_ID, [], {});
+  await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
   const oldSource = __esCreated[0];
   const oldRegistry = window._liveAnchorRegistries.get(STREAM_ID);
   __results.oldTransportInstalled = !!oldRegistry && LIVE_STREAMS[SID].source === oldSource;
@@ -982,6 +999,7 @@ _handleBgTaskCompleteEvent = function(){ __bgTaskCalls.push('bg_task_complete');
 (async () => {
   // Phase 1 — generation A installs through the production listener path.
   attachLiveStream(SID, STREAM_ID, [], {});
+  await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
   const sourceA = __esCreated[0];
 
   // Phase 2 — the SAME (session_id, stream_id) pair gets a new transport: the
@@ -1145,6 +1163,7 @@ S.toolCalls = [];
 
 (async () => {
   attachLiveStream(SID, STREAM_ID, [], {});
+  await new Promise((resolve) => setTimeout(resolve, 0)); // master defers EventSource creation to a microtask
   const sourceA = __esCreated[0];
   sourceA.close();
   __apiResponse = { active: true };

--- a/tests/test_live_stream_ux.py
+++ b/tests/test_live_stream_ux.py
@@ -20,7 +20,7 @@ def test_done_and_restore_filters_recovery_messages_from_frontend_state():
 def test_apererror_recovers_on_recovery_control_event():
     assert "isRecoveryControlMessage=isInterrupted && (d.recovery_control===true || _streamRecoveryControlMessageText(d.message));" in MESSAGES_JS
     assert "Stream recovery signal received. Restoring transcript..." in MESSAGES_JS
-    assert "if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;" in MESSAGES_JS
+    assert "if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true, capability:_capability})) return;" in MESSAGES_JS
 
 
 def test_ui_rejects_recovery_control_as_visible_assistant_content():

--- a/tests/test_messages_stale_stream_source_scope.py
+++ b/tests/test_messages_stale_stream_source_scope.py
@@ -48,7 +48,7 @@ def test_no_bare_bailout_call_sites_remain():
 
 def test_bailout_call_sites_pass_source():
     """Positive check: the call sites pass `source`."""
-    calls = re.findall(r"_bailOutOfTerminalEventsFromStaleStream\(\s*source\s*\)", MESSAGES_JS)
+    calls = re.findall(r"_bailOutOfTerminalEventsFromStaleStream\(\s*source\s*[,)]", MESSAGES_JS)
     assert len(calls) >= 5, (
         f"expected >=5 call sites passing `source`, found {len(calls)} — if the SSE "
         "terminal-event wiring changed, update this count, but every call must still "

--- a/tests/test_offline_banner.py
+++ b/tests/test_offline_banner.py
@@ -75,21 +75,21 @@ def test_sse_network_error_defers_to_offline_banner_instead_of_inline_error():
 
 
 def test_sse_error_defers_while_page_hidden_until_tab_returns():
-    assert "function _deferStreamErrorIfPageHidden(source)" in MESSAGES_JS
+    assert "function _deferStreamErrorIfPageHidden(source, capability=null)" in MESSAGES_JS
     assert "document.visibilityState==='hidden'" in MESSAGES_JS
     assert "document.wasDiscarded===true" in MESSAGES_JS
     assert "Connection paused. Reconnecting when this tab returns…" in MESSAGES_JS
     assert "document.addEventListener('visibilitychange',resume)" in MESSAGES_JS
     assert "window.addEventListener('pageshow',resume)" in MESSAGES_JS
     error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
-    assert "if(_deferStreamErrorIfPageHidden(source)) return;" in error_handler
-    assert error_handler.find("_deferStreamErrorIfPageHidden(source)") < error_handler.rfind("_handleStreamError(source)")
+    assert "if(_deferStreamErrorIfPageHidden(source,_capability)) return;" in error_handler
+    assert error_handler.find("_deferStreamErrorIfPageHidden(source,_capability)") < error_handler.rfind("_handleStreamError(source)")
 
 
 def test_deferred_hidden_stream_error_reattaches_or_restores_before_inline_error():
-    recovery_block = MESSAGES_JS.split("function _reattachOrRestoreAfterDeferredStreamError(source){", 1)[1].split("function _deferStreamErrorIfPageHidden(source)", 1)[0]
+    recovery_block = MESSAGES_JS.split("function _reattachOrRestoreAfterDeferredStreamError(source, capability=null){", 1)[1].split("function _deferStreamErrorIfPageHidden(source, capability=null)", 1)[0]
     assert "api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`)" in recovery_block
     assert "if(st.active)" in recovery_block
     assert "_wireSSE(new EventSource" in recovery_block
-    assert "if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;" in recovery_block
-    assert recovery_block.find("if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true})) return;") < recovery_block.rfind("_handleStreamError(source)")
+    assert "if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true,capability})) return;" in recovery_block
+    assert recovery_block.find("if(await _restoreSettledSession(source, {preserveVisibleOnShorterTerminalSnapshot:true,capability})) return;") < recovery_block.rfind("_handleStreamError(source)")

--- a/tests/test_pwa_notification_controls.py
+++ b/tests/test_pwa_notification_controls.py
@@ -93,7 +93,7 @@ def test_desktop_background_notification_signal_stays_out_of_stream_visibility()
         "function closeLiveStream(sessionId, streamId, source){",
     )
     deferred_recovery = _source_between(
-        "function _reattachOrRestoreAfterDeferredStreamError(source){",
+        "function _reattachOrRestoreAfterDeferredStreamError(source, capability=null){",
         "  // Bug A fix (#631):",
     )
 

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -951,7 +951,9 @@ class TestFrontendWiring:
         """Frontend must listen for pending_steer_leftover SSE events and queue them."""
         idx = self.msgs.find("addEventListener('pending_steer_leftover'")
         assert idx >= 0, "messages.js must add a listener for pending_steer_leftover"
-        block = self.msgs[idx:idx + 600]
+        # Window widened to 900: the #6381 ownership guard line now opens the
+        # pending_steer_leftover listener, pushing queueSessionMessage further in.
+        block = self.msgs[idx:idx + 900]
         assert "queueSessionMessage" in block, (
             "pending_steer_leftover handler must queue the leftover text for the next turn"
         )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -387,7 +387,7 @@ def test_token_handler_guards_session_id(cleanup_test_sessions):
     if token_idx < 0:
         token_idx = src.find("es.addEventListener('token'")
     assert token_idx >= 0, "token event handler not found"
-    token_block = src[token_idx:token_idx+300]
+    token_block = src[token_idx:token_idx+800]
     assert "activeSid" in token_block, \
         "token handler must check activeSid before writing to DOM"
     assert "S.session.session_id!==activeSid" in token_block or \

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -405,7 +405,10 @@ def test_error_reconnect_path_can_restore_from_journal():
     # `Reconnecting… (1/${_retryDelays.length})` (staged-probe counter), so the
     # old single-quoted "setComposerStatus('Reconnecting" anchor no longer exists.
     reconnect_pos = MESSAGES_SRC.index("_reconnectAttempted=true;")
-    block = MESSAGES_SRC[reconnect_pos : reconnect_pos + 1100]
+    # Window widened to 1500: the #6381 ownership guard added to the error path
+    # (deferral + staged-probe authorization) grew the reconnect block, pushing
+    # the replay assertions below past the old 1100-character slice.
+    block = MESSAGES_SRC[reconnect_pos : reconnect_pos + 1500]
 
     assert "st.active" in block
     assert "st.replay_available" in block
@@ -420,7 +423,10 @@ def test_frontend_replay_cursor_uses_eventsource_last_event_id():
     assert "e.lastEventId" in block
     assert "lastIndexOf(':')" in block
     assert "_lastRunJournalSeq=seq" in block
-    assert "source.addEventListener(_runJournalEventName,_rememberRunJournalCursor)" in MESSAGES_SRC
+    # #6381: the cursor listener is now registered as an ownership-guarded arrow
+    # that delegates to _rememberRunJournalCursor(e).
+    assert "source.addEventListener(_runJournalEventName,e=>{" in MESSAGES_SRC
+    assert "_rememberRunJournalCursor(e);" in MESSAGES_SRC
     assert "after_seq=${encodeURIComponent(String(_runJournalReplayAfterSeq()))}" in MESSAGES_SRC
     assert "after_seq=0" not in MESSAGES_SRC
 

--- a/tests/test_sse_error_multi_probe_reconnect.py
+++ b/tests/test_sse_error_multi_probe_reconnect.py
@@ -65,7 +65,7 @@ def test_staged_retry_delays_present():
 def test_probe_reconnect_helper_defined():
     # The staged retry is driven by a recursive _probeReconnect(attempt) closure.
     compact = _compact(MESSAGES_JS)
-    assert "const_probeReconnect=async(attempt=0)=>{" in compact
+    assert "const_probeReconnect=async(attempt=0,capability=_capability)=>{" in compact
 
 
 def test_first_probe_scheduled_from_retry_delays_head():
@@ -73,7 +73,7 @@ def test_first_probe_scheduled_from_retry_delays_head():
     # hard-coded 1500 — i.e. the old `setTimeout(async()=>{...},1500)` single
     # probe is gone.
     compact = _compact(MESSAGES_JS)
-    assert "setTimeout(()=>{void_probeReconnect(0);},_retryDelays[0]);" in compact
+    assert "setTimeout(()=>{void_probeReconnect(0,_capability);},_retryDelays[0]);" in compact
 
 
 def test_stage_counter_starts_at_one():
@@ -104,7 +104,7 @@ def test_next_stage_is_scheduled_before_giving_up():
     compact = _compact(MESSAGES_JS)
     assert "constnextDelay=_retryDelays[attempt+1];" in compact
     assert "if(nextDelay){" in compact
-    assert "setTimeout(()=>{void_probeReconnect(attempt+1);},nextDelay);" in compact
+    assert "setTimeout(()=>{void_probeReconnect(attempt+1,capability);},nextDelay);" in compact
 
 
 def test_handle_stream_error_only_after_retry_window_exhausted():

--- a/tests/test_stable_assistant_turn_anchor_registry.py
+++ b/tests/test_stable_assistant_turn_anchor_registry.py
@@ -1485,7 +1485,7 @@ def test_slice6_live_shadow_feed_wires_anchor_scene_for_visible_order_handoff():
     error_body = _event_listener_body(src, "error")
     assert "_applyToAnchor('error'" not in error_body
     assert "_flushReasoningToAnchor();" in error_body
-    assert "_scheduleAnchorRegistryCleanup(120000);" in error_body
+    assert "_scheduleAnchorRegistryCleanup(120000,_capability);" in error_body
     assert "_handleStreamError(source)" in error_body
     assert "projectAssistantTurnAnchorActivityScene" in src
 
@@ -1502,7 +1502,7 @@ def test_slice6_live_shadow_feed_wires_anchor_scene_for_visible_order_handoff():
     assert "created_at:d.created_at||null" in done_body
     assert "_applyToAnchor('done',{...d" not in done_body
     assert "_flushReasoningToAnchor();" in done_body
-    assert "_scheduleAnchorRegistryCleanup();" in done_body
+    assert "_scheduleAnchorRegistryCleanup(600000,_capability);" in done_body
     assert "_attachProjectedAnchorSceneToLastAssistant(S.messages);" in done_body
     attach_body = _function_body(src, "_attachProjectedAnchorSceneToLastAssistant")
     assert "lastAsst._anchor_stream_id=streamId" in attach_body

--- a/tests/test_stream_end_recovery_gating.py
+++ b/tests/test_stream_end_recovery_gating.py
@@ -59,28 +59,28 @@ def test_stream_end_defers_settlement_when_live_assistant_still_present():
     assert "if(S.activeStreamId===streamId && _liveStreamEndScenePresent())" in body, (
         "stream_end should defer terminal cleanup while active live scene content is still present"
     )
-    assert "_scheduleStreamEndRecovery(source);" in body, (
+    assert "_scheduleStreamEndRecovery(source,180,_capability);" in body, (
         "stream_end should schedule the deferred recovery timer before returning"
     )
-    assert "_scheduleStreamEndRecovery(source)" in body, (
+    assert "_scheduleStreamEndRecovery(source," in body, (
         "stream_end must delegate deferred cleanup to helper"
     )
 
 
 def test_stream_end_fallback_does_not_finalize_when_session_is_still_active():
     body = _event_block("stream_end")
-    assert "const status=await _restoreSettledSession(source,{status:true});" in body
+    assert "const status=await _restoreSettledSession(source,{status:true,capability:_capability});" in body
     assert "if(status==='active'&&S.activeStreamId===streamId)" in body
-    assert "_scheduleStreamEndRecovery(source,200);" in body
+    assert "_scheduleStreamEndRecovery(source,200,_capability);" in body
     assert "_finalizeStreamEndFallback(source);" in body
 
 
 def test_stream_end_recovery_helper_retries_while_session_is_still_active():
     fn = _function_body("_runStreamEndRecovery")
     assert "if(_streamFinalized || _terminalStateReached || !_pendingStreamEndRecovery)" in fn
-    assert "_restoreSettledSession(source,{status:true})" in fn
+    assert "_restoreSettledSession(source,{status:true,capability})" in fn
     assert "if(status==='active'&&_streamEndRecoveryAttempts<10)" in fn
-    assert "_scheduleStreamEndRecovery(source,200);" in fn
+    assert "_scheduleStreamEndRecovery(source,200,capability);" in fn
     assert "_finalizeStreamEndFallback(source);" in fn
 
 

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -221,8 +221,8 @@ class TestReconnectAccumulatorPreservation:
         """Deferred hidden-tab recovery must not reattach an old stream after
         the user has switched to a different session in the same tab."""
         src = read('static/messages.js')
-        m = re.search(r'function _reattachOrRestoreAfterDeferredStreamError\(source\)\{.*?\n  \}', src, re.DOTALL)
-        assert m, "_reattachOrRestoreAfterDeferredStreamError(source) not found"
+        m = re.search(r'function _reattachOrRestoreAfterDeferredStreamError\(source, capability=null\)\{.*?\n  \}', src, re.DOTALL)
+        assert m, "_reattachOrRestoreAfterDeferredStreamError(source, capability=null) not found"
         fn = m.group(0)
         assert 'S.session&&S.session.session_id' in fn
         assert '!==activeSid' in fn

--- a/tests/test_todo_live_frontend_static.py
+++ b/tests/test_todo_live_frontend_static.py
@@ -179,8 +179,8 @@ let persistCalls = 0;
 function persistInflightState(){ persistCalls++; }
 let refreshCalls = 0;
 function scheduleTodosRefresh(){ refreshCalls++; }
-const handler = new Function('e','S','INFLIGHT','activeSid','persistInflightState','scheduleTodosRefresh', body);
-function fire(payload){ handler({data: JSON.stringify(payload)}, S, INFLIGHT, activeSid, persistInflightState, scheduleTodosRefresh); }
+const handler = new Function('e','S','INFLIGHT','activeSid','persistInflightState','scheduleTodosRefresh','source','_capability','_ownsActiveStreamOrBackground', body);
+function fire(payload){ handler({data: JSON.stringify(payload)}, S, INFLIGHT, activeSid, persistInflightState, scheduleTodosRefresh, {listeners:{}}, null, () => true); }
 function assert(cond, msg){ if(!cond) throw new Error(msg); }
 
 fire({session_id:'other', todos:[{id:'x', content:'wrong', status:'pending'}], ts:20});
@@ -198,7 +198,7 @@ fire({session_id:'s1', todos:[{id:'old', content:'old', status:'pending'}], ts:5
 assert(S.todos[0].id === 'a', 'older event must not roll back S.todos');
 assert(persistCalls === 1 && refreshCalls === 1, 'older event must not persist or refresh');
 
-handler({data:'not json'}, S, INFLIGHT, activeSid, persistInflightState, scheduleTodosRefresh);
+handler({data:'not json'}, S, INFLIGHT, activeSid, persistInflightState, scheduleTodosRefresh, {listeners:{}}, null, () => true);
 assert(S.todos[0].id === 'a', 'malformed event must be swallowed');
 '''
     script_path = tmp_path / "todo_listener_test.js"


### PR DESCRIPTION
## Summary

Issue #6303: When switching away from an actively streaming session and returning, the Compact Worklog could be rebuilt with different row identities or ordering from the pre-switch scene. This caused duplicate Thinking text, tool rows moving relative to process prose, and reasoning updating the wrong Thinking card.

## Root Cause

During session reattach, the anchor registry (`_liveAnchorRegistries`) from the prior stream connection survived in browser memory while `INFLIGHT` was freshly restored from the server's runtime journal snapshot. This created two divergent sources of truth:

1. The stale registry carried activity events with burst/segment counters from *before* the session switch
2. INFLIGHT carried authoritative counters reconstructed from the run journal by `_run_journal_live_snapshot()`

New SSE events arriving after reattach used the INFLIGHT counters, but the registry's existing events had different counter positions, causing duplicate thinking rows, wrong tool ordering, and reused segment IDs.

## Fix

Clear the stale anchor registry for the streamId in two places:

1. **`attachLiveStream()`** (`static/messages.js`) — On reconnect, before the closure's registry lookup (`_existingAnchorRegistry = _liveAnchorRegistries.get(streamId)`), delete the stale entry. This forces the new closure to create a fresh registry in sync with the restored INFLIGHT counters.

2. **`loadSession()`** (`static/sessions.js`) — After `_selectLiveRecoveryInflight` selects the server's runtime journal snapshot (marked `journalSnapshot: true`), clear the stale registry before `_renderLiveAnchorActivitySceneForStream` runs.

Both guards are idempotent: deleting a non-existent Map key is a no-op, and the initial (non-reconnect) path skips the guard.