### PR TITLE
fix(tests): isolate model-selection env vars so the suite passes on any runner

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,20 @@ os.environ['HERMES_BASE_HOME'] = str(TEST_STATE_DIR)
 # tests that read/write config.yaml stay inside the isolated test home.
 os.environ['HERMES_CONFIG_PATH'] = str(TEST_STATE_DIR / 'config.yaml')
 
+# Model-selection env overrides must NOT leak from the runner into tests.
+# get_effective_default_model() (api/config.py) treats HERMES_MODEL / OPENAI_MODEL
+# / LLM_MODEL as the highest-priority default-model source — above the isolated
+# test config. When the pytest process runs inside a live Hermes agent session,
+# HERMES_MODEL is exported to the agent's runtime model (e.g. "opus-4.8"), which
+# then overrides the sandbox config and pollutes the model picker/catalog. That
+# broke test_sprint12 (default-model readback), test_issue1538 (Nous @nous:
+# prefix invariant) and test_issue1567 (picker capacity/symmetry) whenever the
+# suite ran on a box with HERMES_MODEL set. Strip them at module level so the
+# isolated config is authoritative for the pytest process; the out-of-process
+# test server env is scrubbed identically in the test_server fixture below.
+for _model_env in ('HERMES_MODEL', 'OPENAI_MODEL', 'LLM_MODEL'):
+    os.environ.pop(_model_env, None)
+
 
 @pytest.fixture(autouse=True)
 def _isolate_hermes_config_path():
@@ -987,6 +1001,13 @@ def test_server():
     for _k in list(env):
         if any(_k.startswith(p) for p in _CRED_ENV_PREFIXES):
             del env[_k]
+    # Model-selection overrides must not reach the test server either. They are
+    # already popped from the pytest process env at module level, but strip them
+    # explicitly here so the subprocess default model comes only from the isolated
+    # config / HERMES_WEBUI_DEFAULT_MODEL below — never a runner-exported
+    # HERMES_MODEL (get_effective_default_model gives these env vars top priority).
+    for _model_env in ('HERMES_MODEL', 'OPENAI_MODEL', 'LLM_MODEL'):
+        env.pop(_model_env, None)
     # Belt-and-suspenders: keep IMDS disabled in the spawn env too (we set it
     # at module level above for the pytest process, but make it explicit here
     # so it's never accidentally cleared by an env.update later).

--- a/tests/test_issue1538_nous_live_catalog.py
+++ b/tests/test_issue1538_nous_live_catalog.py
@@ -129,6 +129,12 @@ def _scrub_provider_env(monkeypatch):
         "XIAOMI_API_KEY",
         "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
         "NOUS_API_KEY", "NVIDIA_API_KEY", "LM_API_KEY", "LMSTUDIO_API_KEY",
+        # Model-selection overrides: get_effective_default_model() treats these
+        # as the highest-priority default-model source, above config. A runner
+        # that exports HERMES_MODEL (e.g. a live agent session set to "opus-4.8")
+        # injects that id into the picker/catalog and breaks the @nous: prefix
+        # invariant below. Scrub so detection sees only the installed stubs.
+        "HERMES_MODEL", "OPENAI_MODEL", "LLM_MODEL",
     ):
         monkeypatch.delenv(var, raising=False)
 

--- a/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
+++ b/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
@@ -130,6 +130,11 @@ def _scrub_provider_env(monkeypatch):
         "XIAOMI_API_KEY",
         "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
         "NOUS_API_KEY", "NVIDIA_API_KEY", "LM_API_KEY", "LMSTUDIO_API_KEY",
+        # Model-selection overrides: get_effective_default_model() treats these
+        # as the highest-priority default-model source, above config. A runner
+        # exporting HERMES_MODEL (e.g. a live agent session on "opus-4.8") injects
+        # that id into the picker/catalog and breaks capacity/symmetry assertions.
+        "HERMES_MODEL", "OPENAI_MODEL", "LLM_MODEL",
     ):
         monkeypatch.delenv(var, raising=False)
 


### PR DESCRIPTION
## Problem

The test suite fails 6 tests whenever it runs on a machine that exports `HERMES_MODEL` (or `OPENAI_MODEL` / `LLM_MODEL`) — e.g. inside a live Hermes agent session, where `HERMES_MODEL` is set to the agent's own runtime model:

- `tests/test_sprint12.py::test_default_model_updates_hermes_config`
- `tests/test_issue1538_nous_live_catalog.py` (2 tests — `@nous:` prefix invariant)
- `tests/test_issue1567_nous_picker_capacity_and_symmetry.py` (3 tests — picker capacity/symmetry)

## Root cause

`get_effective_default_model()` (`api/config.py`) resolves the default model as **config → then env override**, treating `HERMES_MODEL` / `OPENAI_MODEL` / `LLM_MODEL` as the *highest-priority* source — above the isolated test config. When the runner exports one of these (e.g. `HERMES_MODEL=opus-4.8`), it overrides the sandbox config and pollutes the model picker/catalog: the default-model readback returns the runner's model, and the leaked id is injected into the Nous catalog, breaking the `@nous:` prefix invariant and the picker capacity/symmetry assertions.

This is purely an environmental isolation gap in the test harness — the product behavior (env override wins) is correct for production.

## Fix

- Scrub `HERMES_MODEL` / `OPENAI_MODEL` / `LLM_MODEL` at **conftest module level** (before any product module imports — covers all in-process tests), so the isolated config is authoritative for the pytest process.
- Scrub them again in the **out-of-process `test_server` subprocess env**, alongside the existing credential strip, so the server's default model comes only from the isolated config / `HERMES_WEBUI_DEFAULT_MODEL`.
- Add them to the per-test `_scrub_provider_env` helpers in both Nous test modules (self-documenting + robust if copied).

## Verification

With `HERMES_MODEL=opus-4.8` exported (reproducing the failing condition):
- **Before:** 6 failed
- **After:** 0 failed — `13550 passed, 10 skipped, 1 xfailed, 2 xpassed` (full serial suite)
- **Non-vacuity:** disabling the scrub reproduces the 6 failures; re-enabling makes them pass.

No product code changed — test isolation only.