### PR TITLE
fix: render Codex reasoning Markdown

### DIFF
--- a/static/assistant_turn_anchors.js
+++ b/static/assistant_turn_anchors.js
@@ -1396,7 +1396,7 @@
     return _firstTextValue(
       _rendererSnapshotQueryText(row,'.transparent-event-preview'),
       _rendererSnapshotQueryText(row,'.transparent-event-thinking-preview'),
-      _rendererSnapshotQueryText(row,'.thinking-card-body pre'),
+      _rendererSnapshotQueryText(row,'.thinking-card-body'),
       _rendererSnapshotQueryText(row,'.tool-card-preview'),
       _rendererSnapshotQueryText(row,'.tool-card-result pre'),
       typeof row.textContent==='string'?row.textContent:''

--- a/static/messages.js
+++ b/static/messages.js
@@ -3776,7 +3776,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const markdown=document.createElement('div');
         markdown.className='thinking-card-markdown';
         body.appendChild(markdown);
-        const renderer=_smdRendererWithoutUnderscoreEmphasis(_safeSmdRenderer(markdown));
+        const renderer=_smdThinkingRenderer(_safeSmdRenderer(markdown));
         st={node,parser:window.smd.parser(renderer),writtenText:''};
         _smdBindParserIdentity(renderer,st.parser,markdown);
         _anchorThinkingSmdCache.set(key,st);
@@ -4217,6 +4217,34 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         return;
       }
       baseEndToken(data);
+    };
+    return renderer;
+  }
+  function _smdThinkingRenderer(renderer){
+    renderer=_smdRendererWithoutUnderscoreEmphasis(renderer);
+    if(!renderer||!window.smd) return renderer;
+    const baseAddToken=renderer.add_token;
+    const baseEndToken=renderer.end_token;
+    const baseAddText=renderer.add_text;
+    const tokenStack=[];
+    let previousStrongClosed=false;
+    renderer.add_token=(data,token)=>{
+      if(token===window.smd.STRONG_AST&&previousStrongClosed){
+        baseAddToken(data,window.smd.LINE_BREAK);
+        baseEndToken(data);
+      }
+      previousStrongClosed=false;
+      tokenStack.push(token);
+      baseAddToken(data,token);
+    };
+    renderer.end_token=(data)=>{
+      const token=tokenStack.pop();
+      baseEndToken(data);
+      previousStrongClosed=token===window.smd.STRONG_AST;
+    };
+    renderer.add_text=(data,text)=>{
+      if(String(text||'')) previousStrongClosed=false;
+      baseAddText(data,text);
     };
     return renderer;
   }

--- a/static/messages.js
+++ b/static/messages.js
@@ -3760,6 +3760,47 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // falls back to the full renderMd path — identical structure, just not
   // incremental. (#5455 WS2.1)
   const _anchorProseSmdCache = new Map();
+  const _anchorThinkingSmdCache = new Map();
+  function _anchorThinkingIncrementalNode(key, text){
+    if(!window.smd || !key || typeof _safeSmdRenderer!=='function') return null;
+    const value=String(text||'');
+    try{
+      let st=_anchorThinkingSmdCache.get(key);
+      // Reasoning normally grows by append-only deltas. If sanitization or replay
+      // changes the prefix, rebuild this one parser rather than corrupting its DOM.
+      if(st && st.writtenText && !value.startsWith(st.writtenText)) st=null;
+      if(!st){
+        const node=_thinkingActivityNode('',false,key);
+        const body=node&&node.querySelector&&node.querySelector('.thinking-card-body');
+        if(!body) return null;
+        const markdown=document.createElement('div');
+        markdown.className='thinking-card-markdown';
+        body.appendChild(markdown);
+        const renderer=_smdRendererWithoutUnderscoreEmphasis(_safeSmdRenderer(markdown));
+        st={node,parser:window.smd.parser(renderer),writtenText:''};
+        _smdBindParserIdentity(renderer,st.parser,markdown);
+        _anchorThinkingSmdCache.set(key,st);
+        if(_anchorThinkingSmdCache.size>32){
+          const oldest=_anchorThinkingSmdCache.keys().next().value;
+          if(oldest!==key) _anchorThinkingSmdCache.delete(oldest);
+        }
+      }
+      const delta=value.slice(st.writtenText.length);
+      if(delta){
+        window.smd.parser_write(st.parser,delta);
+        st.writtenText=value;
+      }
+      const card=st.node&&st.node.querySelector&&st.node.querySelector('.thinking-card');
+      if(card) card._thinkingSource=value;
+      st.node._thinkingPendingText=value;
+      st.node._thinkingRenderedText=value;
+      return st.node;
+    }catch(_){
+      _anchorThinkingSmdCache.delete(key);
+      return null;
+    }
+  }
+  window.__anchorThinkingIncrementalNode=_anchorThinkingIncrementalNode;
   function _anchorProseIncrementalNode(key, text){
     if(!window.smd || !key || typeof _safeSmdRenderer!=='function') return null;
     const value=String(text||'');
@@ -3807,6 +3848,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   window.__anchorProseIncrementalNode=_anchorProseIncrementalNode;
   function _clearAnchorProseIncrementalNode(){
     if(typeof window!=='undefined'&&window.__anchorProseIncrementalNode===_anchorProseIncrementalNode) window.__anchorProseIncrementalNode=null;
+    if(typeof window!=='undefined'&&window.__anchorThinkingIncrementalNode===_anchorThinkingIncrementalNode) window.__anchorThinkingIncrementalNode=null;
     // Clear the per-parser MEDIA tail for each cached smd parser.
     // _anchorProseSmdCache is a Map<key, {parser, ...}>; we can't
     // iterate a WeakMap to clean up, but WeakMap keys become eligible
@@ -3825,6 +3867,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       });
     }
     _anchorProseSmdCache.clear();
+    if(typeof _anchorThinkingSmdCache!=='undefined'&&_anchorThinkingSmdCache.size){
+      _anchorThinkingSmdCache.forEach(function(st){
+        if(st&&st.parser&&typeof _smdMediaTailFlush==='function') _smdMediaTailFlush(st.parser);
+        if(st&&st.parser&&typeof _smdMediaTailClear==='function') _smdMediaTailClear(st.parser);
+      });
+    }
+    _anchorThinkingSmdCache.clear();
   }
   function _anchorHasReasoningEvents(){
     const events=_anchorActivityEvents();

--- a/static/style.css
+++ b/static/style.css
@@ -6240,7 +6240,6 @@ main.main > #mainPlugin{display:none;}
 .thinking-card-markdown { font-family: 'SF Mono', ui-monospace, monospace; font-size: 11px; line-height: 1.6; color: var(--muted); overflow-wrap: anywhere; }
 .thinking-card-markdown p { margin: 0 0 6px; }
 .thinking-card-markdown p:last-child { margin-bottom: 0; }
-.thinking-card-markdown strong + strong { margin-left: .5em; }
 .thinking-card-markdown ul,
 .thinking-card-markdown ol { margin: 6px 0; padding-left: 1.35em; }
 .thinking-card-markdown li { margin: 2px 0; }

--- a/static/style.css
+++ b/static/style.css
@@ -3864,7 +3864,7 @@ body.resizing .sidebar{transition:none!important;}
   border-radius:8px;
   background:var(--code-bg);
 }
-.tool-worklog-list > .agent-activity-thinking .thinking-card-body pre{
+.tool-worklog-list > .agent-activity-thinking .thinking-card-markdown{
   font-family:var(--font-mono);
   font-size:var(--message-body-font-size);
   line-height:var(--message-body-line-height);
@@ -4351,7 +4351,7 @@ body.resizing .sidebar{transition:none!important;}
   color:var(--muted);
   line-height:1.5;
 }
-.transparent-event-row .thinking-card-body pre{
+.transparent-event-row .thinking-card-markdown{
   background:transparent;
   border:0;
   border-radius:0;
@@ -6237,7 +6237,13 @@ main.main > #mainPlugin{display:none;}
   transition: max-height .22s ease, opacity .18s ease, padding .22s ease, border-top-color .22s ease;
 }
 .thinking-card.open .thinking-card-body { max-height: 260px; overflow-y: auto; opacity: 1; padding: 8px 12px; border-top-color: var(--accent-bg-strong); }
-.thinking-card-body pre { font-family: 'SF Mono', ui-monospace, monospace; font-size: 11px; line-height: 1.6; color: var(--muted); white-space: pre-wrap; word-break: break-word; margin: 0; }
+.thinking-card-markdown { font-family: 'SF Mono', ui-monospace, monospace; font-size: 11px; line-height: 1.6; color: var(--muted); overflow-wrap: anywhere; }
+.thinking-card-markdown p { margin: 0 0 6px; }
+.thinking-card-markdown p:last-child { margin-bottom: 0; }
+.thinking-card-markdown strong + strong { margin-left: .5em; }
+.thinking-card-markdown ul,
+.thinking-card-markdown ol { margin: 6px 0; padding-left: 1.35em; }
+.thinking-card-markdown li { margin: 2px 0; }
 
 /* ── Tool cards: quiet disclosure rows ── */
 .tool-card { background:transparent;border:0;border-left:0;border-radius:0;margin-top:0;margin-bottom:0; }

--- a/static/ui.js
+++ b/static/ui.js
@@ -10992,7 +10992,13 @@ function _restoreWorklogDetailDisclosureState(root, state){
 }
 function _thinkingBodyHtml(text=''){
   const clean=_sanitizeThinkingDisplayText(text);
-  return clean?`<div class="thinking-card-markdown">${renderMd(clean)}</div>`:'';
+  if(!clean) return '';
+  // Codex emits distinct reasoning summaries as source-adjacent bold spans:
+  // **first****second**. renderMd correctly produces adjacent <strong> nodes;
+  // only Thinking-card presentation turns that exact adjacency into line breaks.
+  // Ordinary inline bold retains its surrounding text/whitespace and is untouched.
+  const rendered=renderMd(clean).replace(/<\/strong><strong>/g,'</strong><br><strong>');
+  return `<div class="thinking-card-markdown">${rendered}</div>`;
 }
 function _thinkingCardHtml(text, open){
   const clean=_sanitizeThinkingDisplayText(text);

--- a/static/ui.js
+++ b/static/ui.js
@@ -7093,6 +7093,16 @@ function _stripVisibleAssistantEchoFromThinking(thinkingText, ...visibleTexts){
   return clean;
 }
 
+function _renderExactAsteriskEmphasis(text,multiline=false){
+  const five=multiline
+    ? /(^|[^*])\*{5}(?!\*)([^*](?:[\s\S]*?[^*])?)\*{5}(?!\*)/g
+    : /(^|[^*])\*{5}(?!\*)([^*\n](?:.*?[^*\n])?)\*{5}(?!\*)/g;
+  const triple=multiline
+    ? /(^|[^*])\*\*\*(?!\*)([^*](?:[\s\S]*?[^*])?)\*\*\*(?!\*)/g
+    : /(^|[^*])\*\*\*(?!\*)([^*\n](?:.*?[^*\n])?)\*\*\*(?!\*)/g;
+  const wrap=(_,lead,value)=>`${lead}<strong><em>${esc(value)}</em></strong>`;
+  return text.replace(five,wrap).replace(triple,wrap);
+}
 function renderMd(raw){
   let s=(raw||'').replace(/\r\n/g,'\n').replace(/\r/g,'\n');
   // ── Entity decode: must run FIRST so &gt; lines become > for the blockquote
@@ -7312,13 +7322,6 @@ function renderMd(raw){
   // Inline backtick spans: restore <code> tags produced in the stash callback above.
   // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
-  // Adjacent bold spans use four stars at the shared close/open boundary:
-  // **first****second**. Protect that boundary from the bold-italic (`***`)
-  // pass, which would otherwise consume stars from both spans and emit escaped,
-  // malformed nested tags. This shape is emitted by Codex reasoning summaries.
-  const _adjacentBoldBoundary='\x00BOLD_BOUNDARY\x00';
-  const _protectAdjacentBold=value=>String(value||'').replace(/(\S)\*\*\*\*(?=\S)/g,(_,lead)=>lead+'**'+_adjacentBoldBoundary+'**');
-  const _restoreAdjacentBold=value=>String(value||'').split(_adjacentBoldBoundary).join('');
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -7326,8 +7329,7 @@ function renderMd(raw){
     // Stash backtick code spans first so bold/italic never esc() their content
     const _code_stash=[];
     t=t.replace(/`([^`\n]+)`/g,(_,x)=>{_code_stash.push(`<code>${esc(x)}</code>`);return `\x00C${_code_stash.length-1}\x00`;});
-    t=_protectAdjacentBold(t);
-    t=t.replace(/\*\*\*(.+?)\*\*\*/g,(_,x)=>`<strong><em>${esc(x)}</em></strong>`);
+    t=_renderExactAsteriskEmphasis(t);
     t=t.replace(/\*\*(.+?)\*\*/g,(_,x)=>`<strong>${esc(x)}</strong>`);
     t=t.replace(/\*([^*\n]+)\*/g,(_,x)=>`<em>${esc(x)}</em>`);
     // Strikethrough: ~~text~~ → <del>text</del>
@@ -7351,19 +7353,17 @@ function renderMd(raw){
     // by escaping bare < > that are not part of our own tags
     const SAFE_INLINE=/^<\/?(strong|em|del|code|a|img)([\s>]|$)/i;
     t=t.replace(/<\/?[a-z][^>]*>/gi,tag=>SAFE_INLINE.test(tag)?tag:esc(tag));
-    return _restoreAdjacentBold(t);
+    return t;
   }
   // Stash <code> tags from the backtick pass above so the outer bold/italic
   // regexes don't esc() their content (e.g. **`code`** → <strong><code>code</code></strong>)
   const _ob_stash=[];
   s=s.replace(/(<code\b[^>]*>[\s\S]*?<\/code>)/g,m=>{_ob_stash.push(m);return `\x00O${_ob_stash.length-1}\x00`;});
-  s=_protectAdjacentBold(s);
-  s=s.replace(/\*\*\*(.+?)\*\*\*/g,(_,t)=>`<strong><em>${esc(t)}</em></strong>`);
+  s=_renderExactAsteriskEmphasis(s,true);
   s=s.replace(/\*\*(.+?)\*\*/g,(_,t)=>`<strong>${esc(t)}</strong>`);
   s=s.replace(/\*([^*\n]+)\*/g,(_,t)=>`<em>${esc(t)}</em>`);
   s=s.replace(/~~(.+?)~~/g,(_,t)=>`<del>${esc(t)}</del>`);
   s=s.replace(/\x00O(\d+)\x00/g,(_,i)=>_ob_stash[+i]);
-  s=_restoreAdjacentBold(s);
   s=s.replace(/^###### (.+)$/gm,(_,t)=>`<h6>${inlineMd(t)}</h6>`).replace(/^##### (.+)$/gm,(_,t)=>`<h5>${inlineMd(t)}</h5>`).replace(/^#### (.+)$/gm,(_,t)=>`<h4>${inlineMd(t)}</h4>`).replace(/^### (.+)$/gm,(_,t)=>`<h3>${inlineMd(t)}</h3>`).replace(/^## (.+)$/gm,(_,t)=>`<h2>${inlineMd(t)}</h2>`).replace(/^# (.+)$/gm,(_,t)=>`<h1>${inlineMd(t)}</h1>`);
   s=s.replace(/^---+$/gm,'<hr>');
   // (Blockquotes are handled by the pre-pass at the top of renderMd, before
@@ -8500,7 +8500,10 @@ function _copyThinkingText(btn){
   const card=btn&&btn.closest?btn.closest('.thinking-card'):null;
   if(!card)return;
   const body=card.querySelector('.thinking-card-body');
-  const text=body?body.textContent:'';
+  const source=typeof card._thinkingSource==='string'
+    ? card._thinkingSource
+    : card.getAttribute&&card.getAttribute('data-thinking-source');
+  const text=source!==null&&source!==undefined?source:(body?body.textContent:'');
   if(!text)return;
   _copyText(text).then(()=>{
     const orig=btn.innerHTML;
@@ -10992,22 +10995,26 @@ function _thinkingBodyHtml(text=''){
   return clean?`<div class="thinking-card-markdown">${renderMd(clean)}</div>`:'';
 }
 function _thinkingCardHtml(text, open){
-  const bodyHtml=_thinkingBodyHtml(text);
+  const clean=_sanitizeThinkingDisplayText(text);
+  const bodyHtml=_thinkingBodyHtml(clean);
+  const sourceAttr=clean?` data-thinking-source="${esc(clean)}"`:'';
   const copyBtn=`<button class="thinking-copy-btn" onclick="event.stopPropagation();_copyThinkingText(this)" title="${t('copy')}" aria-label="${t('copy')}">${li('copy',12)}</button>`;
   const shouldOpen=!!open||_worklogDetailsExpandedDefault();
   const classes=`thinking-card${shouldOpen?' open':''}`;
-  return `<div class="${classes}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body">${bodyHtml}</div></div>`;
+  return `<div class="${classes}"${sourceAttr}><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body">${bodyHtml}</div></div>`;
 }
 function isSimplifiedToolCalling(){
   return window._simplifiedToolCalling!==false;
 }
 function _thinkingActivityNode(text, open, disclosureKey){
   const row=document.createElement('div');
+  const clean=_sanitizeThinkingDisplayText(text);
   row.className='agent-activity-thinking';
   row.setAttribute('data-worklog-thinking-card','1');
   if(disclosureKey) row.setAttribute('data-thinking-key', String(disclosureKey));
-  row.innerHTML=_thinkingCardHtml(text, open);
-  _renderThinkingInto(row,text);
+  row.innerHTML=_thinkingCardHtml(clean, open);
+  row._thinkingPendingText=clean;
+  row._thinkingRenderedText=clean;
   return row;
 }
 function chatActivityMode(){
@@ -11116,8 +11123,12 @@ function _copyEventToClipboard(row){
     }
     text=parts.join('\n');
   }else if(type==='thinking'){
+    const card=row.querySelector('.thinking-card');
     const body=row.querySelector('.thinking-card-body');
-    text=body?body.textContent:(row.textContent||'').replace(/^\s*Thinking\s*/i,'');
+    const source=card&&typeof card._thinkingSource==='string'
+      ? card._thinkingSource
+      : card&&card.getAttribute&&card.getAttribute('data-thinking-source');
+    text=source!==null&&source!==undefined?source:(body?body.textContent:(row.textContent||'').replace(/^\s*Thinking\s*/i,''));
     label='thinking';
   }else{
     text=row.textContent||'';
@@ -12383,7 +12394,11 @@ function _anchorSceneNodeForRow(row, opts){
     if(window._showThinking===false) return null;
     const text=String(row.text||row.thinking&&row.thinking.text||'').trim();
     if(!text) return null;
-    node=_thinkingActivityNode(text, false, row.row_id||row.local_id||'anchor-thinking');
+    const thinkingKey=row.row_id||row.local_id||'anchor-thinking';
+    if(!settled&&typeof window.__anchorThinkingIncrementalNode==='function'){
+      node=window.__anchorThinkingIncrementalNode(thinkingKey,text);
+    }
+    if(!node) node=_thinkingActivityNode(text,false,thinkingKey);
   }else if(row.role==='tool'){
     node=buildToolCard(_anchorSceneToolCallFromRow(row,opts));
   }else if(row.role==='lifecycle'){
@@ -12458,14 +12473,21 @@ function _anchorSceneTransparentNodeForRow(row, opts){
     if(window._showThinking===false) return null;
     const text=String(row.text||row.thinking&&row.thinking.text||'').trim();
     if(!text) return null;
-    node=_decorateTransparentEventRow(_thinkingActivityNode(text,false,row.row_id||row.local_id||'anchor-thinking'),{
+    const thinkingKey=row.row_id||row.local_id||'anchor-thinking';
+    if(!settled&&typeof window.__anchorThinkingIncrementalNode==='function'){
+      node=window.__anchorThinkingIncrementalNode(thinkingKey,text);
+    }
+    const thinkingMeta={
       type:'thinking',
       text,
       preview:text,
       ts:eventTs,
       ...meta,
       live,
-    });
+    };
+    node=node
+      ? _decorateTransparentEventRow(node,thinkingMeta)
+      : _decorateTransparentEventRow(_thinkingActivityNode(text,false,thinkingKey),thinkingMeta);
   }else if(row.role==='tool'){
     const toolCall=_anchorSceneToolCallFromRow(row,{settled});
     node=_decorateTransparentEventRow(buildToolCard(toolCall),{
@@ -12735,7 +12757,7 @@ function _updateLiveAnchorReasoningRowForFallback(turn, text, opts){
     const group=row.closest&&row.closest('.tool-worklog-group,.tool-call-group,.live-worklog');
     if(group&&typeof _syncToolCallGroupSummary==='function') _syncToolCallGroupSummary(group);
   }else if(row.classList&&row.classList.contains('transparent-event-row')){
-    _renderThinkingInto(row, clean);
+    _renderThinkingInto(row, clean, {force:true});
     const eventAt=row.getAttribute&&row.getAttribute('data-event-at');
     const nextTs=typeof _firstValidTimestampSeconds==='function'
       ? _firstValidTimestampSeconds(opts&&opts.ts, opts&&opts.timestamp, opts&&opts.created_at, eventAt)
@@ -12752,7 +12774,7 @@ function _updateLiveAnchorReasoningRowForFallback(turn, text, opts){
       });
     }
   }else{
-    _renderThinkingInto(row, clean);
+    _renderThinkingInto(row, clean, {force:true});
   }
   if(turn&&typeof _syncTransparentEventControls==='function') _syncTransparentEventControls(turn);
   if(typeof scrollIfPinned==='function') scrollIfPinned();
@@ -13038,8 +13060,19 @@ function _refreshTransparentThinkingLiveRow(existing, node){
   const existingBody = existing.querySelector('.thinking-card-body');
   const nodeBody = node.querySelector('.thinking-card-body');
   if(!existingBody || !nodeBody) return false;
-  const nextText = String(nodeBody.textContent || '');
-  if(existingBody.innerHTML !== nodeBody.innerHTML) existingBody.innerHTML = nodeBody.innerHTML;
+  const nextText = typeof node._thinkingPendingText==='string'
+    ? node._thinkingPendingText
+    : String(nodeBody.textContent || '');
+  const currentText = typeof existing._thinkingPendingText==='string'
+    ? existing._thinkingPendingText
+    : String(existingBody.textContent || '');
+  if(currentText!==nextText && existingBody.innerHTML!==nodeBody.innerHTML){
+    existingBody.innerHTML=nodeBody.innerHTML;
+  }
+  existing._thinkingPendingText=nextText;
+  existing._thinkingRenderedText=nextText;
+  const existingCard=existing.querySelector('.thinking-card');
+  if(existingCard) existingCard._thinkingSource=nextText;
   const nodePreview = node.querySelector('.transparent-event-thinking-preview');
   const previewText = nodePreview ? String(nodePreview.textContent || '') : nextText;
   if(typeof _decorateTransparentEventRow === 'function'){
@@ -18798,25 +18831,58 @@ function renderKatexBlocks(container,options){
 }
 
 function _thinkingMarkup(text=''){
-  const bodyHtml=_thinkingBodyHtml(text);
+  const clean=_sanitizeThinkingDisplayText(text);
+  const bodyHtml=_thinkingBodyHtml(clean);
+  const sourceAttr=clean?` data-thinking-source="${esc(clean)}"`:'';
   const openClass=_worklogDetailsExpandedDefault()?' open':'';
   return bodyHtml
-    ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body">${bodyHtml}</div></div>`
+    ? `<div class="thinking-card${openClass}"${sourceAttr}><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body">${bodyHtml}</div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;
+}
+function _flushThinkingMarkdown(row){
+  if(!row) return;
+  if(row._thinkingMarkdownTimer){
+    clearTimeout(row._thinkingMarkdownTimer);
+    row._thinkingMarkdownTimer=null;
+  }
+  const clean=_sanitizeThinkingDisplayText(row._thinkingPendingText||'');
+  const body=row.querySelector&&row.querySelector('.thinking-card-body');
+  if(body&&row._thinkingRenderedText===clean) return;
+  if(!clean){
+    row.innerHTML=_thinkingMarkup('');
+    row._thinkingRenderedText='';
+    return;
+  }
+  const html=_thinkingBodyHtml(clean);
+  if(body){
+    if(body.innerHTML!==html) body.innerHTML=html;
+  }else{
+    row.innerHTML=_thinkingMarkup(clean);
+  }
+  row._thinkingRenderedText=clean;
+}
+function _scheduleThinkingMarkdownRender(row){
+  if(!row) return;
+  if(row._thinkingMarkdownTimer) clearTimeout(row._thinkingMarkdownTimer);
+  row._thinkingMarkdownTimer=setTimeout(()=>{
+    row._thinkingMarkdownTimer=null;
+    _flushThinkingMarkdown(row);
+  },120);
 }
 function _renderThinkingInto(row,text=''){
   if(!row) return;
-  const html=_thinkingBodyHtml(text);
-  if(!html){
-    row.innerHTML=_thinkingMarkup(text);
+  const clean=_sanitizeThinkingDisplayText(text);
+  const options=(arguments.length>2&&arguments[2])||{};
+  row._thinkingPendingText=clean;
+  const card=row.querySelector&&row.querySelector('.thinking-card');
+  if(card) card._thinkingSource=clean;
+  const body=row.querySelector&&row.querySelector('.thinking-card-body');
+  if(!body||!clean||options.force===true){
+    _flushThinkingMarkdown(row);
     return;
   }
-  const body=row.querySelector('.thinking-card-body');
-  if(body){
-    body.innerHTML=html;
-    return;
-  }
-  row.innerHTML=_thinkingMarkup(text);
+  if(row._thinkingRenderedText===clean) return;
+  _scheduleThinkingMarkdownRender(row);
 }
 function finalizeThinkingCard(){
   // Guard: only finalize thinking card if we're looking at the session that started it.
@@ -18825,6 +18891,18 @@ function finalizeThinkingCard(){
   // stream that started it, not the session currently displayed.
   const _guardTurn = $('liveAssistantTurn');
   if(_guardTurn && S.session && _guardTurn.dataset.sessionId !== S.session.session_id) return;
+  // A trailing debounce keeps cumulative reasoning from re-running renderMd on
+  // every SSE chunk. Flush the latest source before the row loses its live
+  // identity so the settled card can never retain stale Markdown.
+  const pendingRows=[];
+  const standaloneRow=$('thinkingRow');
+  if(standaloneRow) pendingRows.push(standaloneRow);
+  if(_guardTurn&&_guardTurn.querySelectorAll){
+    _guardTurn.querySelectorAll('.agent-activity-thinking[data-thinking-active="1"]').forEach(row=>{
+      if(!pendingRows.includes(row)) pendingRows.push(row);
+    });
+  }
+  pendingRows.forEach(row=>_flushThinkingMarkdown(row));
   if(isTransparentStream()){
     const row=$('thinkingRow');
     if(row){

--- a/static/ui.js
+++ b/static/ui.js
@@ -7312,6 +7312,13 @@ function renderMd(raw){
   // Inline backtick spans: restore <code> tags produced in the stash callback above.
   // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
+  // Adjacent bold spans use four stars at the shared close/open boundary:
+  // **first****second**. Protect that boundary from the bold-italic (`***`)
+  // pass, which would otherwise consume stars from both spans and emit escaped,
+  // malformed nested tags. This shape is emitted by Codex reasoning summaries.
+  const _adjacentBoldBoundary='\x00BOLD_BOUNDARY\x00';
+  const _protectAdjacentBold=value=>String(value||'').replace(/(\S)\*\*\*\*(?=\S)/g,(_,lead)=>lead+'**'+_adjacentBoldBoundary+'**');
+  const _restoreAdjacentBold=value=>String(value||'').split(_adjacentBoldBoundary).join('');
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -7319,6 +7326,7 @@ function renderMd(raw){
     // Stash backtick code spans first so bold/italic never esc() their content
     const _code_stash=[];
     t=t.replace(/`([^`\n]+)`/g,(_,x)=>{_code_stash.push(`<code>${esc(x)}</code>`);return `\x00C${_code_stash.length-1}\x00`;});
+    t=_protectAdjacentBold(t);
     t=t.replace(/\*\*\*(.+?)\*\*\*/g,(_,x)=>`<strong><em>${esc(x)}</em></strong>`);
     t=t.replace(/\*\*(.+?)\*\*/g,(_,x)=>`<strong>${esc(x)}</strong>`);
     t=t.replace(/\*([^*\n]+)\*/g,(_,x)=>`<em>${esc(x)}</em>`);
@@ -7343,17 +7351,19 @@ function renderMd(raw){
     // by escaping bare < > that are not part of our own tags
     const SAFE_INLINE=/^<\/?(strong|em|del|code|a|img)([\s>]|$)/i;
     t=t.replace(/<\/?[a-z][^>]*>/gi,tag=>SAFE_INLINE.test(tag)?tag:esc(tag));
-    return t;
+    return _restoreAdjacentBold(t);
   }
   // Stash <code> tags from the backtick pass above so the outer bold/italic
   // regexes don't esc() their content (e.g. **`code`** → <strong><code>code</code></strong>)
   const _ob_stash=[];
   s=s.replace(/(<code\b[^>]*>[\s\S]*?<\/code>)/g,m=>{_ob_stash.push(m);return `\x00O${_ob_stash.length-1}\x00`;});
+  s=_protectAdjacentBold(s);
   s=s.replace(/\*\*\*(.+?)\*\*\*/g,(_,t)=>`<strong><em>${esc(t)}</em></strong>`);
   s=s.replace(/\*\*(.+?)\*\*/g,(_,t)=>`<strong>${esc(t)}</strong>`);
   s=s.replace(/\*([^*\n]+)\*/g,(_,t)=>`<em>${esc(t)}</em>`);
   s=s.replace(/~~(.+?)~~/g,(_,t)=>`<del>${esc(t)}</del>`);
   s=s.replace(/\x00O(\d+)\x00/g,(_,i)=>_ob_stash[+i]);
+  s=_restoreAdjacentBold(s);
   s=s.replace(/^###### (.+)$/gm,(_,t)=>`<h6>${inlineMd(t)}</h6>`).replace(/^##### (.+)$/gm,(_,t)=>`<h5>${inlineMd(t)}</h5>`).replace(/^#### (.+)$/gm,(_,t)=>`<h4>${inlineMd(t)}</h4>`).replace(/^### (.+)$/gm,(_,t)=>`<h3>${inlineMd(t)}</h3>`).replace(/^## (.+)$/gm,(_,t)=>`<h2>${inlineMd(t)}</h2>`).replace(/^# (.+)$/gm,(_,t)=>`<h1>${inlineMd(t)}</h1>`);
   s=s.replace(/^---+$/gm,'<hr>');
   // (Blockquotes are handled by the pre-pass at the top of renderMd, before
@@ -8489,8 +8499,8 @@ function copyMsg(btn){
 function _copyThinkingText(btn){
   const card=btn&&btn.closest?btn.closest('.thinking-card'):null;
   if(!card)return;
-  const pre=card.querySelector('.thinking-card-body pre');
-  const text=pre?pre.textContent:'';
+  const body=card.querySelector('.thinking-card-body');
+  const text=body?body.textContent:'';
   if(!text)return;
   _copyText(text).then(()=>{
     const orig=btn.innerHTML;
@@ -10977,12 +10987,16 @@ function _restoreWorklogDetailDisclosureState(root, state){
     }
   });
 }
-function _thinkingCardHtml(text, open){
+function _thinkingBodyHtml(text=''){
   const clean=_sanitizeThinkingDisplayText(text);
+  return clean?`<div class="thinking-card-markdown">${renderMd(clean)}</div>`:'';
+}
+function _thinkingCardHtml(text, open){
+  const bodyHtml=_thinkingBodyHtml(text);
   const copyBtn=`<button class="thinking-copy-btn" onclick="event.stopPropagation();_copyThinkingText(this)" title="${t('copy')}" aria-label="${t('copy')}">${li('copy',12)}</button>`;
   const shouldOpen=!!open||_worklogDetailsExpandedDefault();
   const classes=`thinking-card${shouldOpen?' open':''}`;
-  return `<div class="${classes}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
+  return `<div class="${classes}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body">${bodyHtml}</div></div>`;
 }
 function isSimplifiedToolCalling(){
   return window._simplifiedToolCalling!==false;
@@ -11102,8 +11116,8 @@ function _copyEventToClipboard(row){
     }
     text=parts.join('\n');
   }else if(type==='thinking'){
-    const pre=row.querySelector('.thinking-card-body pre');
-    text=pre?pre.textContent:(row.textContent||'').replace(/^\s*Thinking\s*/i,'');
+    const body=row.querySelector('.thinking-card-body');
+    text=body?body.textContent:(row.textContent||'').replace(/^\s*Thinking\s*/i,'');
     label='thinking';
   }else{
     text=row.textContent||'';
@@ -13021,11 +13035,11 @@ function _refreshTransparentThinkingLiveRow(existing, node){
   const existingIsThinking = existingType === 'thinking' || (existing.classList&&existing.classList.contains('transparent-thinking-event'));
   const nodeIsThinking = nodeType === 'thinking' || (node.classList&&node.classList.contains('transparent-thinking-event'));
   if(!existingIsThinking || !nodeIsThinking) return false;
-  const existingPre = existing.querySelector('.thinking-card-body pre');
-  const nodePre = node.querySelector('.thinking-card-body pre');
-  if(!existingPre || !nodePre) return false;
-  const nextText = String(nodePre.textContent || '');
-  if(existingPre.textContent !== nextText) existingPre.textContent = nextText;
+  const existingBody = existing.querySelector('.thinking-card-body');
+  const nodeBody = node.querySelector('.thinking-card-body');
+  if(!existingBody || !nodeBody) return false;
+  const nextText = String(nodeBody.textContent || '');
+  if(existingBody.innerHTML !== nodeBody.innerHTML) existingBody.innerHTML = nodeBody.innerHTML;
   const nodePreview = node.querySelector('.transparent-event-thinking-preview');
   const previewText = nodePreview ? String(nodePreview.textContent || '') : nextText;
   if(typeof _decorateTransparentEventRow === 'function'){
@@ -18784,22 +18798,22 @@ function renderKatexBlocks(container,options){
 }
 
 function _thinkingMarkup(text=''){
-  const clean=_sanitizeThinkingDisplayText(text);
+  const bodyHtml=_thinkingBodyHtml(text);
   const openClass=_worklogDetailsExpandedDefault()?' open':'';
-  return (clean&&String(clean).trim())
-    ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
+  return bodyHtml
+    ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body">${bodyHtml}</div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;
 }
 function _renderThinkingInto(row,text=''){
   if(!row) return;
-  const clean=_sanitizeThinkingDisplayText(text);
-  if(!clean){
+  const html=_thinkingBodyHtml(text);
+  if(!html){
     row.innerHTML=_thinkingMarkup(text);
     return;
   }
-  const pre=row.querySelector('.thinking-card-body pre');
-  if(pre){
-    pre.textContent=clean;
+  const body=row.querySelector('.thinking-card-body');
+  if(body){
+    body.innerHTML=html;
     return;
   }
   row.innerHTML=_thinkingMarkup(text);

--- a/tests/test_data_uri_images.py
+++ b/tests/test_data_uri_images.py
@@ -84,6 +84,7 @@ eval(extractFunc('_mdImageHtml'));
 eval(extractFunc('_inlineMediaHtmlForRef'));
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue1154_fenced_code_leak.py
+++ b/tests/test_issue1154_fenced_code_leak.py
@@ -45,6 +45,7 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue1446_glued_heading_lift.py
+++ b/tests/test_issue1446_glued_heading_lift.py
@@ -210,6 +210,7 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue1618_yaml_json_diff_newline_preserve.py
+++ b/tests/test_issue1618_yaml_json_diff_newline_preserve.py
@@ -147,6 +147,7 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue2428_table_pipe_protection.py
+++ b/tests/test_issue2428_table_pipe_protection.py
@@ -60,6 +60,7 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue2768_workspace_links.py
+++ b/tests/test_issue2768_workspace_links.py
@@ -44,6 +44,7 @@ def _render(markdown: str) -> str:
     )
     js += "\n" + _extract_function(UI_JS, "_matchBacktickFenceLine")
     js += "\n" + _extract_function(UI_JS, "_isBacktickFenceClose")
+    js += "\n" + _extract_function(UI_JS, "_renderExactAsteriskEmphasis")
     js += "\n" + _extract_function(UI_JS, "renderMd")
     js += textwrap.dedent(
         r'''

--- a/tests/test_issue2881_workspace_chat_links.py
+++ b/tests/test_issue2881_workspace_chat_links.py
@@ -42,6 +42,7 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -56,6 +56,7 @@ def _run_renderers(markdown: str) -> dict:
     js += "\n" + _extract_function(UI_JS, "_matchBacktickFenceLine")
     js += "\n" + _extract_function(UI_JS, "_isBacktickFenceClose")
     js += "\n" + _extract_function(UI_JS, "_renderUserFencedBlocks")
+    js += "\n" + _extract_function(UI_JS, "_renderExactAsteriskEmphasis")
     js += "\n" + _extract_function(UI_JS, "renderMd")
     js += textwrap.dedent(
         r'''

--- a/tests/test_issue3820_chat_activity_display_mode.py
+++ b/tests/test_issue3820_chat_activity_display_mode.py
@@ -664,7 +664,7 @@ def test_transparent_event_row_quiet_metadata_visual_rhythm():
     assert "background:transparent;" in _pre_block
     assert "border-left:2px solid var(--border-subtle);" in _pre_block
     assert "max-height:none;" in _pre_block
-    assert ".transparent-event-row .thinking-card-body pre{" in STYLE_CSS
+    assert ".transparent-event-row .thinking-card-markdown{" in STYLE_CSS
     assert "border:0;" in STYLE_CSS
     assert "border-radius:0;" in STYLE_CSS
     assert "margin-top:0;" in STYLE_CSS

--- a/tests/test_issue5367_transparent_live_row_reconcile.py
+++ b/tests/test_issue5367_transparent_live_row_reconcile.py
@@ -1711,7 +1711,12 @@ class FakeElement {
   get textContent(){ return this.children.length ? this.children.map(child=>child.textContent).join('') : this._textContent; }
   set textContent(value){ this._textContent = String(value ?? ''); this.children = []; }
   get innerHTML(){ return this._innerHTML || this.children.map(child=>child.textContent).join(''); }
-  set innerHTML(value){ this.innerHTMLSetCount += 1; this._innerHTML = String(value ?? ''); this._textContent = this._innerHTML; this.children = []; }
+  set innerHTML(value){
+    this.innerHTMLSetCount += 1;
+    this._innerHTML = String(value ?? '');
+    this._textContent = this._innerHTML.replace(/<[^>]+>/g, '');
+    this.children = [];
+  }
   setAttribute(name, value){ this.attributes[String(name)] = String(value); if(name === 'class') this.className = value; }
   getAttribute(name){ return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null; }
   getAttributeNames(){ return Object.keys(this.attributes); }
@@ -1771,11 +1776,10 @@ function thinkingRow(text, preview){
   const body = new FakeElement('div');
   body.className = 'thinking-card-body';
   body.scrollTop = 37;
-  const pre = new FakeElement('pre');
-  pre.textContent = text;
+  body.innerHTML = `<div class="thinking-card-markdown"><strong>${text}</strong></div>`;
+  body.innerHTMLSetCount = 0;
   header.appendChild(label);
   header.appendChild(previewEl);
-  body.appendChild(pre);
   card.appendChild(header);
   card.appendChild(body);
   row.appendChild(card);
@@ -1795,29 +1799,30 @@ eval(extractFunc('_refreshTransparentLiveRow'));
 
 const existing = thinkingRow('short thought', 'short thought');
 const originalBody = existing.querySelector('.thinking-card-body');
-const originalPre = existing.querySelector('.thinking-card-body pre');
 const candidate = thinkingRow('long thought\\n'.repeat(80), 'long thought');
+const candidateBody = candidate.querySelector('.thinking-card-body');
 const refreshed = _refreshTransparentLiveRow(existing, candidate);
 const refreshedBody = refreshed.querySelector('.thinking-card-body');
-const refreshedPre = refreshed.querySelector('.thinking-card-body pre');
 const refreshedPreview = refreshed.querySelector('.transparent-event-thinking-preview');
 process.stdout.write(JSON.stringify({
   sameRow: refreshed === existing,
   sameBody: refreshedBody === originalBody,
-  samePre: refreshedPre === originalPre,
-  textUpdated: refreshedPre.textContent === 'long thought\\n'.repeat(80),
+  renderedHtmlUpdated: refreshedBody.innerHTML === candidateBody.innerHTML,
+  textUpdated: refreshedBody.textContent === 'long thought\\n'.repeat(80),
   previewUpdated: refreshedPreview.textContent === 'long thought',
   scrollTopPreserved: refreshedBody.scrollTop === 37,
   innerHTMLSetCount: refreshed.innerHTMLSetCount,
+  bodyInnerHTMLSetCount: refreshedBody.innerHTMLSetCount,
   cardOpen: !!refreshed.querySelector('.thinking-card').classList.contains('open'),
 }));
 """
     data = _run_node_script(script, str(ROOT / "static" / "ui.js"))
     assert data["sameRow"] is True
     assert data["sameBody"] is True
-    assert data["samePre"] is True
+    assert data["renderedHtmlUpdated"] is True
     assert data["textUpdated"] is True
     assert data["previewUpdated"] is True
     assert data["scrollTopPreserved"] is True
     assert data["innerHTMLSetCount"] == 0
+    assert data["bodyInnerHTMLSetCount"] == 1
     assert data["cardOpen"] is True

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -461,6 +461,7 @@ global._decorateTransparentEventRow=(row,opts)=>{
 };
 global._rehydrateTransparentLiveRow=()=>{};
 global._sanitizeThinkingDisplayText=value=>String(value||'').trim();
+global._thinkingBodyHtml=value=>String(value||'').trim();
 global._firstValidTimestampSeconds=()=>null;
 
 eval(anchorsSrc);
@@ -548,8 +549,8 @@ function fallbackReasoningRows(){
 }
 function reasoningText(row){
   if(!row) return null;
-  const pre=row.querySelector&&row.querySelector('pre');
-  return pre?pre.textContent:row.textContent;
+  const body=row.querySelector&&row.querySelector('.thinking-card-body');
+  return body?body.textContent:row.textContent;
 }
 function applyProductionAnchorEvent(sourceEventType, data){
   const registry=window._liveAnchorRegistries&&window._liveAnchorRegistries.get('stream-1');

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -472,7 +472,7 @@ for(const name of [
   '_transparentLiveRowKey','_transparentLiveRowsCompatible',
   '_transparentLiveRowAttributePairs','_transparentLiveRowInteractiveState',
   '_refreshTransparentThinkingLiveRow','_refreshTransparentLiveRow',
-  '_thinkingMarkup','_renderThinkingInto',
+  '_thinkingMarkup','_flushThinkingMarkdown','_scheduleThinkingMarkdownRender','_renderThinkingInto',
   '_resetMismatchedLiveAssistantTurnForSession',
   '_liveAnchorReasoningRowForFallback','_updateLiveAnchorReasoningRowForFallback',
   '_anchorSceneNodeForRow','_anchorSceneWorklogGroup','_renderAnchorSceneRowsIntoWorklog',

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -73,10 +73,15 @@ eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
 eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
+eval(extractFunc('_stripXmlToolCallsDisplay'));
+eval(extractFunc('_sanitizeThinkingDisplayText'));
+eval(extractFunc('_thinkingBodyHtml'));
 
 let buf = '';
 process.stdin.on('data', c => { buf += c; });
-process.stdin.on('end', () => { process.stdout.write(renderMd(buf)); });
+process.stdin.on('end', () => {
+  process.stdout.write(process.argv[3] === 'thinking' ? _thinkingBodyHtml(buf) : renderMd(buf));
+});
 """
 
 
@@ -102,6 +107,21 @@ def _render(driver_path, markdown: str) -> str:
     return result.stdout
 
 
+def _render_thinking(driver_path, markdown: str) -> str:
+    """Run the exact Thinking-card Markdown wrapper from static/ui.js."""
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), "thinking"],
+        input=markdown,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node Thinking driver failed: {result.stderr}")
+    return result.stdout
+
+
 def test_codex_reasoning_adjacent_bold_summaries_render_as_markdown(driver_path):
     raw = (
         "**Evaluating doc sync strategies****Deciding repo docs ingestion model****"
@@ -115,6 +135,32 @@ def test_codex_reasoning_adjacent_bold_summaries_render_as_markdown(driver_path)
     assert "****" not in out
     assert "**Evaluating" not in out
     assert "&lt;strong" not in out
+
+
+def test_codex_reasoning_adjacent_bold_summaries_get_one_line_each(driver_path):
+    raw = (
+        "**Evaluating doc sync strategies****Deciding repo docs ingestion model****"
+        "Planning dirtypages daemon for docs****Designing distributed repo syncing****"
+        "Designing metadata tagging policy**"
+    )
+
+    out = _render_thinking(driver_path, raw)
+
+    assert out.count("<strong>") == 5
+    assert out.count("<br>") == 4
+    assert "</strong><br><strong>" in out
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "This is **important** text.",
+        "**First** and **second** stay inline.",
+        "`**code****stays**`",
+    ],
+)
+def test_thinking_summary_lines_do_not_blockify_ordinary_bold(driver_path, raw):
+    assert "<br>" not in _render_thinking(driver_path, raw)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -71,6 +71,7 @@ function extractFunc(name) {
 }
 eval(extractFunc('_matchBacktickFenceLine'));
 eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('_renderExactAsteriskEmphasis'));
 eval(extractFunc('renderMd'));
 
 let buf = '';
@@ -114,7 +115,28 @@ def test_codex_reasoning_adjacent_bold_summaries_render_as_markdown(driver_path)
     assert "****" not in out
     assert "**Evaluating" not in out
     assert "&lt;strong" not in out
-    assert "BOLD_BOUNDARY" not in out
+
+
+@pytest.mark.parametrize(
+    "markdown, expected",
+    [
+        ("***bold italic***", "<strong><em>bold italic</em></strong>"),
+        ("*****five star bold italic*****", "<strong><em>five star bold italic</em></strong>"),
+        ("- **one****two**", "<li><strong>one</strong><strong>two</strong></li>"),
+        ("# **one****two**", "<h1><strong>one</strong><strong>two</strong></h1>"),
+        ("> **one****two**", "<blockquote><p><strong>one</strong><strong>two</strong></p></blockquote>"),
+        ("`**one****two**`", "<code>**one****two**</code>"),
+    ],
+)
+def test_adjacent_bold_fix_preserves_other_emphasis_contexts(driver_path, markdown, expected):
+    assert expected in _render(driver_path, markdown)
+
+
+def test_literal_four_star_run_is_not_turned_into_empty_bold(driver_path):
+    out = _render(driver_path, "a****b")
+
+    assert "a****b" in out
+    assert "<strong></strong>" not in out
 
 
 

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -101,6 +101,22 @@ def _render(driver_path, markdown: str) -> str:
     return result.stdout
 
 
+def test_codex_reasoning_adjacent_bold_summaries_render_as_markdown(driver_path):
+    raw = (
+        "**Evaluating doc sync strategies****Deciding repo docs ingestion model****"
+        "Planning dirtypages daemon for docs****Designing distributed repo syncing****"
+        "Designing metadata tagging policy**"
+    )
+
+    out = _render(driver_path, raw)
+
+    assert out.count("<strong>") == 5
+    assert "****" not in out
+    assert "**Evaluating" not in out
+    assert "&lt;strong" not in out
+    assert "BOLD_BOUNDARY" not in out
+
+
 
 class TestSessionInternalLinks:
     """Drive renderMd() so session:// hardening covers the real sanitizer path."""

--- a/tests/test_stable_assistant_turn_anchor_registry.py
+++ b/tests/test_stable_assistant_turn_anchor_registry.py
@@ -394,7 +394,7 @@ const transparentRows = [
     'data-event-type':'thinking',
     'data-event-id':'run-renderer:1',
   }}, '', {{
-    '.thinking-card-body pre': {{textContent:'thinking'}},
+    '.thinking-card-body': {{textContent:'thinking'}},
     '.transparent-event-preview': {{textContent:'thinking'}},
   }}, ['transparent-event-row']),
   node({{
@@ -446,7 +446,7 @@ const matchingReconciliation = api.reconcileAssistantTurnAnchorRendererSnapshot(
 
 const compactRows = [
   node({{'data-worklog-reason-source':'reasoning'}}, '', {{
-    '.thinking-card-body pre': {{textContent:'compact thinking'}},
+    '.thinking-card-body': {{textContent:'compact thinking'}},
   }}, ['wl-reason']),
   node({{'data-tool-name':'terminal','data-tool-done':'false','data-tool-error':'false','data-live-tid':'tool-live'}}, '', {{
     '.tool-card-name': {{textContent:'terminal'}},

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -377,6 +377,68 @@ console.log(JSON.stringify(cases));
         assert "_label_" in cases["nestedLinkShape"]
 
 
+class TestSmdThinkingSummaryLines:
+    """Live Thinking turns only source-adjacent bold spans into separate lines."""
+
+    def test_live_thinking_separates_adjacent_bold_without_blockifying_inline_bold(self):
+        underscore = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        thinking = extract_fn(MESSAGES_JS, "_smdThinkingRenderer")
+        assert underscore and thinking
+        script = f"""
+import * as smd from './static/vendor/smd.min.js';
+globalThis.window = {{ smd }};
+{underscore}
+{thinking}
+function render(input){{
+  const out=[];
+  const stack=[];
+  const renderer=_smdThinkingRenderer({{
+    data: {{}},
+    add_token(_data, token){{
+      let tag='';
+      if(token===smd.PARAGRAPH) tag='p';
+      if(token===smd.STRONG_AST||token===smd.STRONG_UND) tag='strong';
+      if(token===smd.LINE_BREAK) tag='br';
+      stack.push(tag);
+      if(tag==='br') out.push('<br>');
+      else if(tag) out.push('<'+tag+'>');
+    }},
+    end_token() {{
+      const tag=stack.pop();
+      if(tag&&tag!=='br') out.push('</'+tag+'>');
+    }},
+    add_text(_data, text) {{ out.push(text); }},
+    set_attr() {{}},
+  }});
+  const parser=smd.parser(renderer);
+  for(const char of input) smd.parser_write(parser,char);
+  smd.parser_end(parser);
+  return out.join('');
+}}
+console.log(JSON.stringify({{
+  adjacent:render('**one****two****three**'),
+  inline:render('This is **important** text.'),
+  separated:render('**First** and **second** stay inline.'),
+  code:render('`**one****two**`'),
+}}));
+"""
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        cases = json.loads(completed.stdout)
+        assert cases["adjacent"].count("<strong>") == 3
+        assert cases["adjacent"].count("<br>") == 2
+        assert "</strong><br><strong>" in cases["adjacent"]
+        assert "<br>" not in cases["inline"]
+        assert "<br>" not in cases["separated"]
+        assert "<br>" not in cases["code"]
+        assert "**one****two**" in cases["code"]
+
+
 # ── 4. _scheduleRender: smd path vs fallback ──────────────────────────────────
 
 class TestScheduleRenderSmdPath:

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -49,7 +49,7 @@ def test_thinking_card_header_includes_copy_button_that_does_not_toggle_card():
     assert "function _copyThinkingText(btn){" in UI_JS
     assert "const copyBtn=`<button class=\"thinking-copy-btn\"" in UI_JS
     assert "event.stopPropagation();_copyThinkingText(this)" in UI_JS
-    assert "card.querySelector('.thinking-card-body pre')" in UI_JS
+    assert "card.querySelector('.thinking-card-body')" in UI_JS
     assert "_copyText(text).then(()=>{" in UI_JS
     assert "btn.innerHTML=li('check',12);" in UI_JS
     assert ".thinking-copy-btn{" in COMPACT_CSS
@@ -58,9 +58,24 @@ def test_thinking_card_header_includes_copy_button_that_does_not_toggle_card():
 
 def test_live_thinking_updates_existing_card_body_in_place():
     assert "function _renderThinkingInto(row,text='')" in UI_JS
-    assert "row.querySelector('.thinking-card-body pre')" in UI_JS
-    assert "pre.textContent=clean" in UI_JS
+    assert "row.querySelector('.thinking-card-body')" in UI_JS
+    assert "body.innerHTML=html" in UI_JS
     assert "_renderThinkingInto(row,text);" in UI_JS
+
+
+def test_thinking_cards_use_the_markdown_renderer_for_codex_reasoning():
+    assert "function _thinkingBodyHtml(text='')" in UI_JS
+    helper = UI_JS.split("function _thinkingBodyHtml(text='')", 1)[1].split("function ", 1)[0]
+    assert "renderMd(clean)" in helper
+
+    for function_name in ("_thinkingCardHtml", "_thinkingMarkup", "_renderThinkingInto"):
+        body = UI_JS.split(f"function {function_name}", 1)[1].split("function ", 1)[0]
+        assert "_thinkingBodyHtml(" in body, (
+            f"{function_name} must share the reasoning Markdown renderer"
+        )
+
+    assert '<div class="thinking-card-body">${bodyHtml}</div>' in UI_JS
+    assert '<pre>${esc(clean)}</pre>' not in UI_JS
 
 
 def test_thinking_card_uses_panel_chrome_with_gold_palette():

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -190,6 +190,7 @@ global.window={smd:{
 }};
 function _safeSmdRenderer(root){ return {root}; }
 function _smdRendererWithoutUnderscoreEmphasis(renderer){ return renderer; }
+function _smdThinkingRenderer(renderer){ return renderer; }
 function _smdBindParserIdentity(){}
 function _thinkingActivityNode(){
   nodeCreates++;

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -1,9 +1,15 @@
 import pathlib
 import re
+import json
+import shutil
+import subprocess
+
+import pytest
 
 
 STYLE_CSS = (pathlib.Path(__file__).parent.parent / "static" / "style.css").read_text(encoding="utf-8")
 UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (pathlib.Path(__file__).parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
 COMPACT_CSS = re.sub(r"\s+", "", STYLE_CSS)
 
 
@@ -42,7 +48,7 @@ def test_thinking_card_toggle_and_body_use_animation_friendly_state():
 def test_tool_card_toggle_uses_same_chevron_icon_markup_as_thinking_card():
     assert "<span class=\"thinking-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
     assert "<span class=\"tool-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
-    assert "<div class=\"${classes}\"><div class=\"thinking-card-header\" onclick=\"this.parentElement.classList.toggle('open')\"><span class=\"thinking-card-icon\">" in UI_JS
+    assert "<div class=\"${classes}\"${sourceAttr}><div class=\"thinking-card-header\" onclick=\"this.parentElement.classList.toggle('open')\"><span class=\"thinking-card-icon\">" in UI_JS
 
 
 def test_thinking_card_header_includes_copy_button_that_does_not_toggle_card():
@@ -50,16 +56,22 @@ def test_thinking_card_header_includes_copy_button_that_does_not_toggle_card():
     assert "const copyBtn=`<button class=\"thinking-copy-btn\"" in UI_JS
     assert "event.stopPropagation();_copyThinkingText(this)" in UI_JS
     assert "card.querySelector('.thinking-card-body')" in UI_JS
+    assert "typeof card._thinkingSource==='string'" in UI_JS
+    assert "card.getAttribute('data-thinking-source')" in UI_JS
+    assert 'data-thinking-source="${esc(clean)}"' in UI_JS
     assert "_copyText(text).then(()=>{" in UI_JS
     assert "btn.innerHTML=li('check',12);" in UI_JS
     assert ".thinking-copy-btn{" in COMPACT_CSS
     assert ".thinking-copy-btn:hover,.thinking-copy-btn:focus-visible{" in COMPACT_CSS
 
 
-def test_live_thinking_updates_existing_card_body_in_place():
+def test_live_thinking_debounces_markdown_while_preserving_card_body():
     assert "function _renderThinkingInto(row,text='')" in UI_JS
     assert "row.querySelector('.thinking-card-body')" in UI_JS
-    assert "body.innerHTML=html" in UI_JS
+    assert "function _flushThinkingMarkdown(row)" in UI_JS
+    assert "function _scheduleThinkingMarkdownRender(row)" in UI_JS
+    assert "clearTimeout(row._thinkingMarkdownTimer)" in UI_JS
+    assert "_flushThinkingMarkdown(row);" in UI_JS
     assert "_renderThinkingInto(row,text);" in UI_JS
 
 
@@ -68,7 +80,7 @@ def test_thinking_cards_use_the_markdown_renderer_for_codex_reasoning():
     helper = UI_JS.split("function _thinkingBodyHtml(text='')", 1)[1].split("function ", 1)[0]
     assert "renderMd(clean)" in helper
 
-    for function_name in ("_thinkingCardHtml", "_thinkingMarkup", "_renderThinkingInto"):
+    for function_name in ("_thinkingCardHtml", "_thinkingMarkup", "_flushThinkingMarkdown"):
         body = UI_JS.split(f"function {function_name}", 1)[1].split("function ", 1)[0]
         assert "_thinkingBodyHtml(" in body, (
             f"{function_name} must share the reasoning Markdown renderer"
@@ -76,6 +88,153 @@ def test_thinking_cards_use_the_markdown_renderer_for_codex_reasoning():
 
     assert '<div class="thinking-card-body">${bodyHtml}</div>' in UI_JS
     assert '<pre>${esc(clean)}</pre>' not in UI_JS
+
+
+NODE = shutil.which("node")
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_hundred_live_reasoning_updates_trigger_one_markdown_render_after_quiet_period(tmp_path):
+    assert NODE is not None
+    driver = tmp_path / "thinking-debounce.js"
+    driver.write_text(
+        r"""
+const fs=require('fs');
+const src=fs.readFileSync(process.argv[2],'utf8');
+function extractFunc(name){
+  const start=src.search(new RegExp('function\\s+'+name+'\\s*\\('));
+  if(start<0) throw new Error(name+' not found');
+  let i=src.indexOf('{',start)+1, depth=1;
+  while(depth>0&&i<src.length){ if(src[i]==='{')depth++; else if(src[i]==='}')depth--; i++; }
+  return src.slice(start,i);
+}
+let renderCount=0, timerId=0;
+const timers=new Map();
+global.setTimeout=(fn)=>{ const id=++timerId; timers.set(id,fn); return id; };
+global.clearTimeout=(id)=>timers.delete(id);
+function _sanitizeThinkingDisplayText(text){ return String(text||'').trim(); }
+function _thinkingBodyHtml(text){ renderCount++; return `<div class="thinking-card-markdown"><p>${text}</p></div>`; }
+function _thinkingMarkup(text){ return `<div class="thinking-card-body">${_thinkingBodyHtml(text)}</div>`; }
+eval(extractFunc('_flushThinkingMarkdown'));
+eval(extractFunc('_scheduleThinkingMarkdownRender'));
+eval(extractFunc('_renderThinkingInto'));
+const body={innerHTML:'<div class="thinking-card-markdown"><p>seed</p></div>'};
+const row={
+  _thinkingRenderedText:'seed',
+  querySelector:(selector)=>selector==='.thinking-card-body'?body:null,
+  innerHTML:'',
+};
+for(let i=1;i<=100;i++) _renderThinkingInto(row,'seed '+i);
+const before=renderCount;
+const pending=Array.from(timers.values());
+timers.clear();
+pending.forEach(fn=>fn());
+process.stdout.write(JSON.stringify({
+  before,
+  after:renderCount,
+  pendingCount:pending.length,
+  rendered:row._thinkingRenderedText,
+  sameBody:row.querySelector('.thinking-card-body')===body,
+}));
+""",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [NODE, str(driver), str(pathlib.Path(__file__).parent.parent / "static" / "ui.js")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data == {
+        "before": 0,
+        "after": 1,
+        "pendingCount": 1,
+        "rendered": "seed 100",
+        "sameBody": True,
+    }
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_anchor_reasoning_streams_only_deltas_into_one_markdown_node(tmp_path):
+    assert NODE is not None
+    driver = tmp_path / "anchor-reasoning-incremental.js"
+    driver.write_text(
+        r"""
+const fs=require('fs');
+const src=fs.readFileSync(process.argv[2],'utf8');
+function extractFunc(name){
+  const start=src.search(new RegExp('function\\s+'+name+'\\s*\\('));
+  if(start<0) throw new Error(name+' not found');
+  let i=src.indexOf('{',start)+1, depth=1;
+  while(depth>0&&i<src.length){ if(src[i]==='{')depth++; else if(src[i]==='}')depth--; i++; }
+  return src.slice(start,i);
+}
+class FakeElement{
+  constructor(){ this.children=[]; this.className=''; }
+  appendChild(child){ this.children.push(child); return child; }
+  querySelector(selector){
+    if(selector==='.thinking-card-body') return this.body||null;
+    if(selector==='.thinking-card') return this.card||null;
+    return null;
+  }
+}
+let nodeCreates=0;
+const writes=[];
+const _anchorThinkingSmdCache=new Map();
+global.document={createElement:()=>new FakeElement()};
+global.window={smd:{
+  parser:(renderer)=>({renderer}),
+  parser_write:(_parser,delta)=>writes.push(delta),
+}};
+function _safeSmdRenderer(root){ return {root}; }
+function _smdRendererWithoutUnderscoreEmphasis(renderer){ return renderer; }
+function _smdBindParserIdentity(){}
+function _thinkingActivityNode(){
+  nodeCreates++;
+  const node=new FakeElement();
+  node.body=new FakeElement();
+  node.card=new FakeElement();
+  return node;
+}
+eval(extractFunc('_anchorThinkingIncrementalNode'));
+let first=null, last=null;
+for(let i=1;i<=100;i++){
+  last=_anchorThinkingIncrementalNode('reason-1','x'.repeat(i));
+  if(i===1) first=last;
+}
+process.stdout.write(JSON.stringify({
+  sameNode:first===last,
+  nodeCreates,
+  writeCalls:writes.length,
+  writtenChars:writes.join('').length,
+  source:first.card._thinkingSource,
+  cacheSize:_anchorThinkingSmdCache.size,
+}));
+""",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [NODE, str(driver), str(pathlib.Path(__file__).parent.parent / "static" / "messages.js")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "sameNode": True,
+        "nodeCreates": 1,
+        "writeCalls": 100,
+        "writtenChars": 100,
+        "source": "x" * 100,
+        "cacheSize": 1,
+    }
+
+
+def test_anchor_reasoning_uses_persistent_streaming_markdown_node():
+    assert "window.__anchorThinkingIncrementalNode=_anchorThinkingIncrementalNode" in MESSAGES_JS
+    assert "window.__anchorThinkingIncrementalNode(thinkingKey,text)" in UI_JS
 
 
 def test_thinking_card_uses_panel_chrome_with_gold_palette():

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -889,10 +889,10 @@ class TestToolCardDesignTokens:
             "",
             CSS.split(".tool-worklog-list > .agent-activity-thinking .thinking-card.open .thinking-card-body{", 1)[1].split("}", 1)[0],
         )
-        pre_rule = re.sub(
+        markdown_rule = re.sub(
             r"\s+",
             "",
-            CSS.split(".tool-worklog-list > .agent-activity-thinking .thinking-card-body pre{", 1)[1].split("}", 1)[0],
+            CSS.split(".tool-worklog-list > .agent-activity-thinking .thinking-card-markdown{", 1)[1].split("}", 1)[0],
         )
 
         assert "background:transparent" in card_rule
@@ -906,8 +906,8 @@ class TestToolCardDesignTokens:
         assert "letter-spacing:0" in label_rule
         assert "color:var(--muted)" in icon_rule
         assert "padding:6px8px7px8px" in body_rule
-        assert "font-size:var(--message-body-font-size)" in pre_rule
-        assert "line-height:var(--message-body-line-height)" in pre_rule
+        assert "font-size:var(--message-body-font-size)" in markdown_rule
+        assert "line-height:var(--message-body-line-height)" in markdown_rule
 
     def test_worklog_tool_steps_align_with_thinking_rows(self):
         rule = re.sub(


### PR DESCRIPTION
1|## Thinking Path
2|
3|- Hermes WebUI treats Thinking/reasoning as supporting activity inside the assistant-turn lifecycle; that activity still needs to be readable and reconcilable while a long turn streams.
4|- The reporter's capture pins the bug shape: newer Codex reasoning emitted adjacent bold spans such as `**first****second**`, but Thinking cards escaped the payload into a plain `<pre>`, exposing the Markdown delimiters as one dense chunk.
5|- Routing Thinking text through the existing sanitized `renderMd()` pipeline fixed settled formatting, but exposed a parser sibling: the triple-emphasis pass could steal stars from the shared `****` close/open boundary.
6|- Re-rendering the entire cumulative reasoning string on every SSE update would then be functionally correct but quadratic and selection-hostile, so live Anchor reasoning must use the existing incremental `streaming-markdown` mechanism instead.
7|- The fix therefore handles the class across settled cards, live Anchor rendering, non-Anchor fallback rendering, Transparent Stream reconciliation, copy behavior, snapshots, and styling while preserving one assistant-turn owner.
8|
9|## What Changed
10|
11|- Render settled/fallback Thinking-card content through the existing sanitized Markdown renderer in `.thinking-card-markdown` instead of escaping it into a plain `<pre>`.
12|- Parse exact three-star and five-star emphasis delimiter runs without consuming the four-star boundary between adjacent bold spans.
13|- Present each source-adjacent Codex bold summary on its own line inside Thinking cards; ordinary inline/separated bold and code spans remain unchanged.
14|- Give primary live Anchor reasoning one persistent `smd` parser and DOM node, feed only append deltas, and rebuild only that reasoning segment if its cumulative prefix diverges.
15|- Debounce the non-Anchor full-render fallback and force the latest source during finalization; keep the rare Anchor-paint-failure fallback synchronous so ownership semantics do not change.
16|- Preserve the card/body nodes used by live reconciliation, scroll retention, snapshots, and display-mode projection.
17|- Copy from the canonical safely escaped reasoning source rather than reconstructing source text from rendered HTML.
18|- Update affected CSS hooks and regression fixtures from the removed nested `<pre>` contract to `.thinking-card-markdown` / `.thinking-card-body`.
19|
20|## Why It Matters
21|
22|Codex reasoning summaries now read as structured Markdown instead of a wall of literal asterisks, and each appended summary starts on its own line rather than collapsing into a dense inline paragraph. The live path also remains proportional to the final reasoning length rather than repeatedly reparsing and replacing cumulative content on every token.
23|
24|The reporter separately reproduced literal `**...**` delimiters in Hermes Agent CLI Reasoning panels. That cross-surface reproduction supports the narrower diagnosis here: newer Codex output contains Markdown-formatted reasoning summaries, and WebUI was presenting that provider-originated structure as plain text rather than inventing malformed delimiters itself.
25|
26|The change preserves Hermes WebUI's accepted live-to-final model: Thinking remains quiet supporting activity, all display modes project the same assistant-turn state, and the final answer owner is unchanged.
27|
28|## UI Evidence
29|
30|### Before
31|
32|Adjacent bold delimiters are displayed literally as one dense chunk:
33|
34|![Before: Codex reasoning shows literal adjacent Markdown delimiters](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/pr-assets/pr-6398/before-codex-reasoning-markdown.png)
35|
36|### After
37|
38|The updated checkout renders a real heading and paragraph inside the same Thinking-card visual family:
39|
40|![After: Thinking card renders readable Markdown](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/pr-assets/pr-6398/after-codex-reasoning-markdown.png)
41|
42|The after image is a focused crop of the user-provided live WebUI screenshot; local machine paths and unrelated session chrome were intentionally excluded from the public evidence.
43|
44|### Narrow viewport
45|
46|The reporter's exact payload streamed through the vendored `smd` renderer in a 390px message column against the real app stylesheet. Five adjacent summaries produce five readable lines:
47|
48|![390px after: each adjacent Codex reasoning summary starts on its own line](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/pr-assets/pr-6398/after-codex-reasoning-summary-lines.png)
49|
50|## Existing Work Checked
51|
52|I searched open and closed issues/PRs, remote branches, and Git history for Codex reasoning Markdown, Thinking Markdown, literal asterisks, raw Markdown, adjacent bold, and `thinking-card-body`. No existing issue or PR implements this fix.
53|
54|Nearby but distinct work:
55|
56|- #1446 / #1449 handle LLM text shaped like `sentence.**Heading**\n\n` by lifting a glued bold heading into its own paragraph. They do not render Thinking-card Markdown or handle adjacent `**a****b**` spans.
57|- #5773 consolidates live reasoning ownership and fallback behavior. This PR preserves those ownership contracts while adding Markdown rendering and incremental reasoning DOM updates.
58|- [NousResearch/hermes-agent#6736](https://github.com/NousResearch/hermes-agent/pull/6736) independently identifies the corresponding Hermes Agent CLI gap: live reasoning remains raw terminal text while final responses use a Rich Markdown path. Its review recommends a targeted current-main port because that older Agent patch also carries broad historical rendering and skin work. It targets a separate Python/ANSI renderer and does not implement or supersede this WebUI DOM/streaming fix.
59|
60|## Contract Routing
61|
62|- **Task type:** focused UI rendering and live-stream reconciliation bug fix.
63|- **Touched areas:** Thinking-card Markdown, Assistant Turn Anchor reasoning projection, Transparent Stream reconciliation, copy/snapshot extraction, and Thinking-card CSS.
64|- **Relevant public docs:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/GUIDELINES.md`, `docs/CONTRACTS.md`, `docs/UIUX-GUIDE.md`, `DESIGN.md`, `docs/rfcs/live-to-final-assistant-replies.md`, and `docs/rfcs/stable-assistant-turn-anchors.md`.
65|- **State owner/invariant:** one Assistant Turn Anchor owns live reasoning; the persistent live parser/node receives append-only deltas, fallback rendering converges to the same canonical source, and finalization releases pending parser/cache state without changing final-answer ownership.
66|- **Scope boundaries:** no provider API/schema change, no new display mode, no runtime adapter change, no dependency/build step, and no product-contract redefinition.
67|- **Contract outcome:** this restores the documented readable-supporting-activity and single-owner behavior; it does not intentionally change an existing contract, so no `Contract Change` section is needed.
68|
69|## Verification
70|
71|### Reproduction and observable behavior
72|
73|- The exact screenshot payload regression failed against the pre-fix renderer for the expected reason, then passed on this branch.
74|- The final renderer produces five `<strong>` elements with no literal `****`, raw `**Evaluating`, escaped generated `<strong>` tags, or leaked placeholder text.
75|- Settled and live Thinking renderers produce four line breaks between the five source-adjacent summaries; ordinary inline bold, bold separated by prose, and backticked adjacent delimiters produce no inserted break.
76|- The emphasis grammar matrix covers paragraphs, headings, lists, blockquotes, inline code, triple/five-star emphasis, and literal four-star text.
77|- A 100-update Anchor regression proves one persistent Markdown node and total parser input proportional to final source length.
78|- A 100-update fallback regression proves full Markdown conversion is coalesced after a burst and force-flushed at settlement.
79|- Copy-source, ownership, reconciliation, timestamp, transparent-row, finalization, cache-cleanup, and DOM-identity regressions pass.
80|
81|### Automated checks
82|
83|- Expanded canonical change-adjacent wrapper: **350 passed, 1 skipped** (the skip requires a local `hermes-agent` checkout).
84|- Final post-review renderer/Thinking/ownership/reconciliation slice: **288 passed**.
85|- Broader reasoning/Thinking/Markdown family: **268 passed**.
86|- Final post-amend renderer/streaming/ownership/reconciliation plus standalone-renderer harness gate: **425 passed**.
87|- Supplemental reasoning and streaming-Markdown slice: **192 passed, 1 environment-dependent skip, 18 subtests passed**.
88|- `npm run lint:runtime` — passed.
89|- `node --check static/ui.js` and `node --check static/messages.js` — passed.
90|- Repository diff-aware Ruff gate — **0 findings on added or modified lines**. A direct whole-file invocation reports two pre-existing unused imports (`os`, `sys`) in `tests/test_renderer_js_behaviour.py`; neither is introduced by this diff.
91|- `git diff --check upstream/master` — passed.
92|
93|### Visual and responsive checks
94|
95|- The supplied after screenshot was captured from the updated checkout running under the real Hermes WebUI service.
96|- The exact adjacent-bold payload was streamed in small chunks through the vendored `smd` default renderer: five `<strong>` elements, four `<br>` boundaries, no raw Markdown, and no clipping/overflow.
97|- A real-stylesheet fixture constrained to a **390px message column** reported no card or viewport overflow and visually confirmed five separate summary lines.
98|
99|### Broad-suite attribution
100|
101|The canonical full suite was exercised on this snapshot: **13,334 passed, 132 skipped, 1 xfailed, 2 xpassed** before eight stale standalone `renderMd()` extraction harnesses were repaired. The repaired renderer-driver family is now **107/107 passing**; a `--last-failed` replay leaves **114 failures** exclusively in unrelated auth cookie/CSRF configuration, TLS, stale static-shell expectations, symlink/workspace, and downstream `401` cascades, with no renderer, Thinking, timestamp, ownership, Markdown, or Anchor failures. A detached clean `upstream/master` independently reproduces the root trusted-auth cluster.
102|
103|### Independent review
104|
105|The first thermo-nuclear review found one P1 blocker: cumulative live reasoning was fully reparsed and its descendants replaced on every update. That finding drove the incremental `smd` / debounced-fallback design.
106|
107|A second review confirmed the performance blocker was resolved and found no runtime performance, security/XSS, ownership, reconciliation, convergence, cache, copy, CSS, or maintainability blocker. Its one stale structural test assertion was corrected.
108|
109|The definitive independent thermo-nuclear review of final candidate `bbb5dab93621825c503e4a8d842fdfe268c406b8` returned **NO BLOCKER**. It independently verified settled/live line separation, nested emphasis/link/code/list boundaries, balanced `smd.LINE_BREAK` injection, O(n) incremental behavior, stable ownership, final flush/cache cleanup, XSS boundaries, and all eight standalone-renderer harness repairs. Its focused runs reported **250 passed**, **127 passed**, **107 passed**, and **75 passed / 57 deselected**; ESLint, four Node syntax checks, diff-aware Ruff, and diff hygiene also passed. The reviewer modified no files and performed no GitHub actions.
110|
111|## Risks / Follow-ups
112|
113|- A broader Thinking/activity interface redesign is intentionally out of scope; this PR only restores Markdown readability, streaming behavior, and one-line-per-adjacent-summary presentation.
114|- This PR does not fix the separate Hermes Agent CLI renderer and does not normalize or strip Markdown in the provider adapter. Keeping the source structure intact lets each capable presentation surface render it appropriately.
115|- The exact provider payload is grounded in the reporter's screenshot; this PR does not claim or depend on an undocumented Codex API contract.
116|- The Markdown renderer remains the existing WebUI sanitizer boundary. Independent review found no new direct XSS path, and hostile/literal delimiter cases are covered.
117|- Physical touch-device QA was not performed. The relevant narrow-width message-column layout was checked at 390px with the real stylesheet, and no new control or interaction surface was added.
118|- Hosted GitHub checks are not currently reported for this branch. Local project-native, syntax, lint, browser, and independent-review evidence is listed above.
119|- No tracked documentation update is needed because this restores existing documented behavior rather than changing setup, architecture, or product semantics. `CHANGELOG.md` is intentionally untouched per contributor policy.
120|
121|## Release Note
122|
123|Thinking cards now render newer Codex reasoning summaries as readable Markdown, putting each adjacent bold summary on its own line without reparsing the full cumulative reasoning subtree on every live update.
124|
125|## Model Used
126|
127|AI-assisted contribution:
128|
129|- **Provider:** OpenAI Codex
130|- **Exact model:** `gpt-5.6-sol`
131|- **Reasoning mode:** High
132|- **Notable mode/tool use:** Hermes Agent WebUI orchestration; terminal and file tools for implementation and project-native verification; browser and vision tools for live visual QA and public-image review; `delegate_task` with the repository's thermo-nuclear review workflow for independent review.
133|