### PR TITLE
feat: POST /api/session/handoff — fresh session with compressed-context handoff (#6382)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -14320,6 +14320,9 @@ def handle_post(handler, parsed) -> bool:
             payload["worktree_skipped"] = worktree_skipped
         return j(handler, payload)
 
+    if parsed.path == "/api/session/handoff":
+        return _handle_session_handoff(handler, body, diag=diag)
+
     if parsed.path == "/api/session/compression-recovery/start":
         return _handle_session_compression_recovery_start(handler, body)
 
@@ -25266,6 +25269,270 @@ def _handle_handoff_summary(handler, body):
             "fallback": True,
             "warning": f"Summary generation used local fallback: {_sanitize_error(e)}",
         })
+
+
+def _session_handoff_eligibility_error(session) -> str | None:
+    """Return an error message if *session* is not eligible for handoff, or None."""
+    from api.compression_anchor import is_context_compression_marker
+
+    # Session must have been compressed — at least one context_messages entry
+    # must be a canonical compression marker, not just any nonempty list.
+    ctx = getattr(session, "context_messages", None)
+    if not isinstance(ctx, list) or not any(is_context_compression_marker(m) for m in ctx):
+        return "Source session has no compressed context. Use normal New Chat instead."
+    # Must not be actively streaming
+    if getattr(session, "active_stream_id", None):
+        return "Source session is still streaming. Wait for the current turn to finish."
+    if getattr(session, "pending_user_message", None):
+        return "Source session has a pending user turn. Complete or cancel it first."
+    # Must not be a pre-compression snapshot
+    if getattr(session, "pre_compression_snapshot", False):
+        return "Cannot hand off from a pre-compression snapshot session."
+    return None
+
+
+def _message_text_simple(value) -> str:
+    """Extract plain text from a message content payload (simple version)."""
+    if isinstance(value, list):
+        parts = []
+        for p in value:
+            if not isinstance(p, dict):
+                continue
+            ptype = str(p.get("type") or "").lower()
+            if ptype in ("", "text", "input_text", "output_text"):
+                parts.append(
+                    str(p.get("text") or p.get("content") or p.get("input_text") or p.get("output_text") or "")
+                )
+        return "\n".join(parts).strip()
+    return str(value or "").strip()
+
+
+def _extract_latest_completed_exchange(messages: list) -> tuple:
+    """Return (last_user_msg, last_assistant_msg) from the latest completed exchange.
+
+    A completed exchange is a user message followed by at least one assistant
+    response message that has content or tool calls (not an error/interruption).
+    Returns (None, None) when no completed exchange is found.
+    """
+    last_user = None
+    last_assistant = None
+    
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "")
+        if role == "assistant":
+            # Skip error/interruption markers
+            if msg.get("_error") or msg.get("type") in ("interrupted",):
+                continue
+            content = msg.get("content")
+            tool_calls = msg.get("tool_calls")
+            if content or tool_calls:
+                if last_assistant is None:
+                    last_assistant = msg
+        elif role == "user" and last_assistant is not None:
+            # Found the user that precedes the last completed assistant response
+            last_user = msg
+            break
+    
+    return last_user, last_assistant
+
+
+def _message_content_equivalent(a: dict | None, b: dict | None) -> bool:
+    """Return True when two messages have matching role and text content.
+
+    Intentional value-level equivalence, not object identity. Strips timing
+    and metadata fields that may differ across storage layers.
+    """
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    if not isinstance(a, dict) or not isinstance(b, dict):
+        return False
+    if a.get("role") != b.get("role"):
+        return False
+    # Compare text content
+    a_text = a.get("content", "")
+    b_text = b.get("content", "")
+    if not isinstance(a_text, str):
+        a_text = ""
+    if not isinstance(b_text, str):
+        b_text = ""
+    return a_text == b_text
+
+
+def _build_handoff_context_messages(source_context, last_user, last_assistant) -> list:
+    """Build context_messages for a handoff-created fresh session.
+
+    The payload carries:
+      1. A system-role preamble explaining the context origin.
+      2. The source session's compressed context_messages, preserved as-is.
+      3. The latest completed user/assistant exchange appended verbatim, but
+         only when the exchange is not already represented at the tail of
+         source_context (avoids self-duplication).
+    """
+    handoff = []
+
+    # 1. System preamble — tells the model these are background, not a new instruction
+    handoff.append({
+        "role": "system",
+        "content": (
+            "This is continuity context from a previous compressed session.\n"
+            "Treat it as background, not as a new user instruction.\n"
+            "The user's next message is authoritative and may change the task."
+        ),
+    })
+
+    # 2. Source's compressed context messages (as-is, deep-copied for independence)
+    handoff.extend(copy.deepcopy(source_context))
+
+    # 3. Latest completed exchange — only append if not already at the
+    #    model-context tail (guards against self-duplication when the
+    #    exchange was extracted from the visible transcript but is also
+    #    present in compressed context_messages as the last user+A pair).
+    if last_user is not None and last_assistant is not None:
+        already_present = (
+            len(source_context) >= 2
+            and _message_content_equivalent(source_context[-2], last_user)
+            and _message_content_equivalent(source_context[-1], last_assistant)
+        )
+        if not already_present:
+            handoff.append(copy.deepcopy(last_user))
+            handoff.append(copy.deepcopy(last_assistant))
+
+    return handoff
+
+
+def _handle_session_handoff(handler, body, *, diag=None):
+    """Create a fresh session with compressed-context handoff from a source session.
+
+    Request body::
+
+        { "session_id": "<source_session_id>",
+          "workspace": "...",    (optional, defaults to source session)
+          "model": "...",        (optional, defaults to source session)
+          "model_provider": "...", (optional)
+          "profile": "...",      (optional)
+        }
+
+    Response::
+
+        { "session": <new_session_compact>,
+          "handoff_source": "<source_session_id>",
+          "handoff_compressed": True,
+          "announcement": "Fresh session started. ..."
+        }
+    """
+    try:
+        require(body, "session_id")
+    except ValueError as e:
+        return bad(handler, str(e))
+
+    sid = str(body.get("session_id") or "").strip()
+    if not sid:
+        return bad(handler, "session_id is required")
+
+    if diag:
+        diag.stage("load_source_session")
+
+    from api.models import Session
+
+    session = Session.load(sid)
+    if not session:
+        return bad(handler, "Source session not found", status=404)
+
+    # Profile gate: source session must be visible to active profile.
+    # This mirrors the same guard used by other source-session operations
+    # (e.g. /api/session/import and /api/session/export).
+    source_profile = getattr(session, "profile", None)
+    if not _session_visible_to_active_profile(source_profile, handler):
+        return bad(handler, "Source session not found", status=404)
+
+    if diag:
+        diag.stage("eligibility")
+
+    eligibility_error = _session_handoff_eligibility_error(session)
+    if eligibility_error:
+        return bad(handler, eligibility_error, status=400)
+
+    if diag:
+        diag.stage("build_handoff")
+
+    # Extract latest completed exchange from the visible transcript
+    # (session.messages), not from context_messages — the visible transcript
+    # is the source of truth for the most recent user/assistant turn.
+    source_messages = getattr(session, "messages", []) or []
+    last_user, last_assistant = _extract_latest_completed_exchange(
+        source_messages
+    )
+
+    # Build the handoff context_messages for the new session
+    handoff_context = _build_handoff_context_messages(
+        session.context_messages, last_user, last_assistant
+    )
+
+    # Merge request-level overrides with source session defaults
+    workspace = body.get("workspace") or session.workspace
+    try:
+        from api.workspace import resolve_trusted_workspace
+
+        resolved_workspace = str(resolve_trusted_workspace(workspace)) if workspace else None
+    except (TypeError, ValueError) as e:
+        return bad(handler, str(e))
+
+    model = body.get("model") or session.model
+    model_provider = body.get("model_provider") or session.model_provider
+
+    # Profile: default to source profile. Body field alone must not
+    # authorize cross-profile handoff (matches the principle used by
+    # other cross-profile guards in the codebase).
+    dest_profile = body.get("profile") or source_profile
+    # If the caller explicitly requested a different profile, validate
+    # that the destination profile is also visible to the active profile.
+    if dest_profile != source_profile and not _session_visible_to_active_profile(dest_profile, handler):
+        return bad(handler, "Source session not found", status=404)
+
+    # Create the new session (empty transcript, no messages)
+    from api.models import new_session as _new_session
+
+    s = _new_session(
+        workspace=resolved_workspace,
+        model=model,
+        model_provider=model_provider,
+        profile=dest_profile,
+        project_id=body.get("project_id") or getattr(session, "project_id", None),
+    )
+
+    # Inject handoff context — the compressed continuity block
+    s.context_messages = handoff_context
+    s.parent_session_id = sid
+
+    # Handoff provenance metadata (persisted via Session __dict__ extras)
+    s.handoff_source_session_id = sid
+    s.handoff_created_at = time.time()
+    s.handoff_compressed = True
+
+    # Persist immediately — the session has meaningful continuity context
+    s.save()
+
+    publish_session_list_changed(
+        "session_new",
+        profile=getattr(s, "profile", None),
+        session_id=getattr(s, "session_id", None),
+    )
+
+    announcement = (
+        "Fresh session started. "
+        "Previous compressed context and the latest completed exchange were included."
+    )
+
+    return j(handler, {
+        "session": s.compact() | {"messages": s.messages},
+        "handoff_source": sid,
+        "handoff_compressed": True,
+        "announcement": announcement,
+    })
 
 
 def _handle_skill_save(handler, body):

--- a/tests/test_issue6382_fresh_session_handoff.py
+++ b/tests/test_issue6382_fresh_session_handoff.py
@@ -1,0 +1,535 @@
+"""
+Tests for Issue #6382: Fresh session with compressed-context handoff.
+
+POST /api/session/handoff creates a new independent session carrying only:
+  1. A system preamble explaining the context origin.
+  2. The source session's compressed ``context_messages``.
+  3. The latest completed user/assistant exchange from the visible transcript
+     (session.messages), appended only when not already at the tail of
+     context_messages.
+
+The new session has an empty visible transcript (messages=[]) and feeds the
+handoff payload only via ``context_messages`` (model-facing context).
+"""
+import copy
+from types import SimpleNamespace
+
+import pytest
+
+from api import routes
+from api.models import new_session
+from api.routes import (
+    _session_handoff_eligibility_error,
+    _extract_latest_completed_exchange,
+    _build_handoff_context_messages,
+    _handle_session_handoff,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def session_dir(tmp_path, monkeypatch):
+    """Point SESSION_DIR to a temp directory for test isolation."""
+    monkeypatch.setattr(routes, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr("api.models.SESSION_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def captured_response(monkeypatch):
+    """Capture calls to ``j()`` so tests can assert status + payload."""
+    captures = {}
+
+    def _capture(handler, payload, status=200, **kw):
+        captures.update(payload=payload, status=status)
+        return True
+
+    monkeypatch.setattr(routes, "j", _capture)
+    monkeypatch.setattr("api.helpers.j", _capture)
+    monkeypatch.setattr(routes, "_check_csrf", lambda h: True)
+    monkeypatch.setattr(routes, "publish_session_list_changed", lambda *a, **kw: None)
+    monkeypatch.setattr(routes, "_session_visible_to_active_profile", lambda *args, **kwargs: True)
+    return captures
+
+
+def _compression_marker(text="[context compaction] Summary of previous conversation."):
+    """Return a dict that passes is_context_compression_marker()."""
+    return {"role": "assistant", "content": text}
+
+
+def _make_compressed_session(session_dir, context_messages=None, messages=None, **overrides):
+    """Create a session with compressed context_messages for testing.
+
+    The context_messages always start with a canonical compression marker
+    so the eligibility check passes.
+    """
+    marker = _compression_marker()
+    ctx = context_messages or [
+        marker,
+        {"role": "user", "content": "What is the capital of France?", "timestamp": 100.0},
+        {"role": "assistant", "content": "The capital of France is Paris.", "timestamp": 101.0},
+        {"role": "user", "content": "Tell me about the Eiffel Tower.", "timestamp": 102.0},
+        {"role": "assistant", "content": "The Eiffel Tower is a wrought-iron lattice tower on the Champ de Mars in Paris.", "timestamp": 103.0},
+    ]
+    s = new_session(**overrides)
+    s.context_messages = copy.deepcopy(ctx)
+    if messages is not None:
+        s.messages = messages
+    s.save()
+    return s, ctx
+
+
+# ── _session_handoff_eligibility_error ─────────────────────────────────────
+
+
+class TestEligibility:
+    def test_eligible_when_compressed(self):
+        """A session with a canonical compression marker is eligible."""
+        s = SimpleNamespace(
+            context_messages=[_compression_marker()],
+            active_stream_id=None,
+            pending_user_message=None,
+            pre_compression_snapshot=False,
+        )
+        assert _session_handoff_eligibility_error(s) is None
+
+    def test_not_eligible_plain_context_without_marker(self):
+        """A nonempty context_messages without a compression marker is NOT eligible.
+
+        This is the false-positive guard called out in the #6382 contract review:
+        ordinary context (even nonempty) does not prove compression occurred.
+        """
+        s = SimpleNamespace(
+            context_messages=[{"role": "user", "content": "hi"}],
+            active_stream_id=None,
+            pending_user_message=None,
+            pre_compression_snapshot=False,
+        )
+        err = _session_handoff_eligibility_error(s)
+        assert err is not None
+        assert "no compressed context" in err.lower()
+
+    def test_no_context(self):
+        s = SimpleNamespace(
+            context_messages=[],
+            active_stream_id=None,
+            pending_user_message=None,
+            pre_compression_snapshot=False,
+        )
+        err = _session_handoff_eligibility_error(s)
+        assert err is not None
+        assert "no compressed context" in err.lower()
+
+    def test_active_stream(self):
+        s = SimpleNamespace(
+            context_messages=[_compression_marker()],
+            active_stream_id="stream-123",
+            pending_user_message=None,
+            pre_compression_snapshot=False,
+        )
+        err = _session_handoff_eligibility_error(s)
+        assert err is not None
+        assert "streaming" in err.lower()
+
+    def test_pending_user_message(self):
+        s = SimpleNamespace(
+            context_messages=[_compression_marker()],
+            active_stream_id=None,
+            pending_user_message="hello?",
+            pre_compression_snapshot=False,
+        )
+        err = _session_handoff_eligibility_error(s)
+        assert err is not None
+        assert "pending" in err.lower()
+
+    def test_pre_compression_snapshot(self):
+        s = SimpleNamespace(
+            context_messages=[_compression_marker()],
+            active_stream_id=None,
+            pending_user_message=None,
+            pre_compression_snapshot=True,
+        )
+        err = _session_handoff_eligibility_error(s)
+        assert err is not None
+        assert "snapshot" in err.lower()
+
+
+# ── _extract_latest_completed_exchange ─────────────────────────────────────
+
+
+class TestExtractLatestExchange:
+    def test_basic_two_message_exchange(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1.0},
+            {"role": "assistant", "content": "hi there", "timestamp": 2.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user["content"] == "hello"
+        assert assistant["content"] == "hi there"
+
+    def test_multi_turn_picks_last_exchange(self):
+        msgs = [
+            {"role": "user", "content": "first q", "timestamp": 1.0},
+            {"role": "assistant", "content": "first a", "timestamp": 2.0},
+            {"role": "user", "content": "second q", "timestamp": 3.0},
+            {"role": "assistant", "content": "second a", "timestamp": 4.0},
+            {"role": "user", "content": "third q", "timestamp": 5.0},
+            {"role": "assistant", "content": "third a", "timestamp": 6.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user["content"] == "third q"
+        assert assistant["content"] == "third a"
+
+    def test_skips_error_assistant_message(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1.0},
+            {"role": "assistant", "content": "ok", "_error": True, "timestamp": 2.0},
+            {"role": "user", "content": "real q", "timestamp": 3.0},
+            {"role": "assistant", "content": "real a", "timestamp": 4.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user["content"] == "real q"
+        assert assistant["content"] == "real a"
+
+    def test_skips_interrupted_marker(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1.0},
+            {"role": "assistant", "content": "partial...", "type": "interrupted", "timestamp": 2.0},
+            {"role": "user", "content": "retry", "timestamp": 3.0},
+            {"role": "assistant", "content": "full answer", "timestamp": 4.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user["content"] == "retry"
+        assert assistant["content"] == "full answer"
+
+    def test_empty_messages_returns_none(self):
+        user, assistant = _extract_latest_completed_exchange([])
+        assert user is None
+        assert assistant is None
+
+    def test_no_completed_exchange(self):
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user is None
+        assert assistant is None
+
+    def test_assistant_with_tool_calls_is_valid(self):
+        msgs = [
+            {"role": "user", "content": "search google", "timestamp": 1.0},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "web_search"}}], "timestamp": 2.0},
+            {"role": "tool", "tool_call_id": "call1", "content": "results", "timestamp": 3.0},
+            {"role": "assistant", "content": "Here are the results.", "timestamp": 4.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user["content"] == "search google"
+        assert assistant["content"] == "Here are the results."
+
+    def test_assistant_with_only_tool_calls_no_content(self):
+        msgs = [
+            {"role": "user", "content": "run tool", "timestamp": 1.0},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "my_tool"}}], "timestamp": 2.0},
+        ]
+        user, assistant = _extract_latest_completed_exchange(msgs)
+        assert user["content"] == "run tool"
+        assert assistant is not None
+        assert assistant.get("tool_calls") is not None
+
+
+# ── _build_handoff_context_messages ────────────────────────────────────────
+
+
+class TestBuildHandoffContext:
+    def test_basic_structure(self):
+        source_context = [
+            {"role": "user", "content": "q1", "timestamp": 1.0},
+            {"role": "assistant", "content": "a1", "timestamp": 2.0},
+        ]
+        last_user = {"role": "user", "content": "q2", "timestamp": 3.0}
+        last_assistant = {"role": "assistant", "content": "a2", "timestamp": 4.0}
+
+        result = _build_handoff_context_messages(source_context, last_user, last_assistant)
+
+        # Must have system preamble + source context + last exchange
+        assert len(result) == 1 + len(source_context) + 2
+
+        # First message is system preamble
+        assert result[0]["role"] == "system"
+        assert "continuity context" in result[0]["content"]
+        assert "background" in result[0]["content"]
+        assert "authoritative" in result[0]["content"]
+
+        # Source context preserved after preamble
+        for i, msg in enumerate(source_context):
+            assert result[1 + i]["role"] == msg["role"]
+            assert result[1 + i]["content"] == msg["content"]
+
+        # Last exchange appended (not already at source_context tail)
+        assert result[-2]["role"] == "user"
+        assert result[-2]["content"] == "q2"
+        assert result[-1]["role"] == "assistant"
+        assert result[-1]["content"] == "a2"
+
+    def test_skips_duplicate_when_already_at_tail(self):
+        """When last_user/last_assistant already match the tail of source_context,
+        they must NOT be appended again (self-duplication guard)."""
+        source_context = [
+            {"role": "user", "content": "q1", "timestamp": 1.0},
+            {"role": "assistant", "content": "a1", "timestamp": 2.0},
+            {"role": "user", "content": "q2", "timestamp": 3.0},
+            {"role": "assistant", "content": "a2", "timestamp": 4.0},
+        ]
+        # These match the tail of source_context
+        last_user = {"role": "user", "content": "q2", "timestamp": 5.0}
+        last_assistant = {"role": "assistant", "content": "a2", "timestamp": 6.0}
+
+        result = _build_handoff_context_messages(source_context, last_user, last_assistant)
+
+        # No duplication — tail pair already in source_context
+        assert len(result) == 1 + len(source_context)  # preamble + source only
+        assert result[-1]["content"] == "a2"
+        assert result[-2]["content"] == "q2"
+
+    def test_append_when_tail_different(self):
+        """When source_context tail differs from extracted exchange, append."""
+        source_context = [
+            {"role": "user", "content": "q1", "timestamp": 1.0},
+            {"role": "assistant", "content": "a1", "timestamp": 2.0},
+        ]
+        last_user = {"role": "user", "content": "q2", "timestamp": 3.0}
+        last_assistant = {"role": "assistant", "content": "a2", "timestamp": 4.0}
+
+        result = _build_handoff_context_messages(source_context, last_user, last_assistant)
+
+        assert len(result) == 1 + len(source_context) + 2
+        assert result[-2]["content"] == "q2"
+        assert result[-1]["content"] == "a2"
+
+    def test_deep_copy_preserves_independence(self):
+        """Modifying source context after build must not affect the handoff copy."""
+        source_context = [
+            {"role": "user", "content": "original", "nested": {"key": "val"}},
+        ]
+        result = _build_handoff_context_messages(source_context, None, None)
+
+        # Modify the original
+        source_context[0]["content"] = "mutated"
+        source_context[0]["nested"]["key"] = "mutated"
+
+        # The handoff copy should be unchanged
+        assert result[1]["content"] == "original"
+        assert result[1]["nested"]["key"] == "val"
+
+    def test_handoff_without_latest_exchange(self):
+        """When no completed exchange exists, only preamble + source context."""
+        source_context = [
+            {"role": "user", "content": "q1", "timestamp": 1.0},
+            {"role": "assistant", "content": "a1", "timestamp": 2.0},
+        ]
+        result = _build_handoff_context_messages(source_context, None, None)
+        assert len(result) == 1 + len(source_context)
+        assert result[-1]["role"] == "assistant"
+        assert result[-1]["content"] == "a1"
+
+
+# ── _handle_session_handoff ────────────────────────────────────────────────
+
+
+class TestHandleSessionHandoff:
+    def test_requires_session_id(self, session_dir, captured_response):
+        """Missing session_id returns 400."""
+        _handle_session_handoff(object(), {}, diag=None)
+        assert captured_response.get("status") == 400
+        err = str(captured_response.get("payload", "")).lower()
+        assert "session_id" in err
+
+    def test_handoff_creates_fresh_session(self, session_dir, captured_response):
+        """End-to-end: compressed source -> handoff produces a fresh session.
+
+        The source has context_messages including a compression marker + 2 exchanges,
+        and a separate visible transcript with the latest exchange. The handoff
+        result should have preamble + source context (no duplication of the tail
+        since it's already in source_context).
+        """
+        marker = _compression_marker()
+        latest_user = {"role": "user", "content": "Tell me about the Eiffel Tower.", "timestamp": 102.0}
+        latest_asst = {"role": "assistant", "content": "The Eiffel Tower is a wrought-iron lattice tower on the Champ de Mars in Paris.", "timestamp": 103.0}
+
+        # Context messages: marker + 2 exchanges
+        ctx = [
+            marker,
+            {"role": "user", "content": "What is the capital of France?", "timestamp": 100.0},
+            {"role": "assistant", "content": "The capital of France is Paris.", "timestamp": 101.0},
+            latest_user,
+            latest_asst,
+        ]
+
+        # Visible transcript — the latest exchange
+        vis_msgs = [latest_user, latest_asst]
+
+        source, _ = _make_compressed_session(
+            session_dir,
+            context_messages=ctx,
+            messages=vis_msgs,
+        )
+        source_sid = source.session_id
+
+        _handle_session_handoff(
+            object(), {"session_id": source_sid}, diag=None
+        )
+
+        assert captured_response.get("status") == 200
+        payload = captured_response["payload"]
+        assert "session" in payload
+        assert payload["handoff_source"] == source_sid
+        assert payload["handoff_compressed"] is True
+        assert payload["announcement"] is not None
+
+        new_s = payload["session"]
+        # New session has empty visible transcript
+        assert new_s.get("messages") == []
+        # New session has its own id
+        assert new_s["session_id"] != source_sid
+        # Parent is set
+        assert new_s.get("parent_session_id") == source_sid
+        # Model and workspace inherited from source
+        assert new_s.get("model") == source.model
+
+        # Verify the new session object in memory has the handoff context
+        from api.models import get_session
+        new_session_obj = get_session(new_s["session_id"])
+        assert new_session_obj is not None
+        # The handoff context = 1 preamble + len(source_context) — no duplication
+        # because the latest exchange from messages matches the tail of context_messages.
+        expected_len = 1 + len(ctx)
+        assert len(new_session_obj.context_messages) == expected_len
+        assert new_session_obj.context_messages[0]["role"] == "system"
+        assert "continuity context" in new_session_obj.context_messages[0]["content"]
+        # Source messages preserved (compression marker + exchanges)
+        assert new_session_obj.context_messages[1]["role"] == "assistant"
+        assert "[context compaction" in new_session_obj.context_messages[1]["content"]
+        assert new_session_obj.context_messages[2]["content"] == ctx[1]["content"]
+
+        # Verify the marker message is a compression marker
+        from api.compression_anchor import is_context_compression_marker
+        assert is_context_compression_marker(new_session_obj.context_messages[1])
+
+        # The last exchange from visible transcript matches the tail of context_messages
+        # and is NOT duplicated (no extra pair at the end)
+        assert new_session_obj.context_messages[-2]["role"] == "user"
+        assert new_session_obj.context_messages[-2]["content"] == latest_user["content"]
+        assert new_session_obj.context_messages[-1]["role"] == "assistant"
+        assert new_session_obj.context_messages[-1]["content"] == latest_asst["content"]
+
+    def test_handoff_appends_fresh_exchange_when_not_in_context(self, session_dir, captured_response):
+        """When the visible transcript has a newer exchange than the compressed
+        context_messages tail, it gets appended."""
+        marker = _compression_marker()
+        ctx = [
+            marker,
+            {"role": "user", "content": "q1", "timestamp": 100.0},
+            {"role": "assistant", "content": "a1", "timestamp": 101.0},
+        ]
+        # Visible transcript has a NEW exchange not present in context_messages
+        new_user = {"role": "user", "content": "fresh question", "timestamp": 200.0}
+        new_asst = {"role": "assistant", "content": "fresh answer", "timestamp": 201.0}
+        vis_msgs = [new_user, new_asst]
+
+        source, _ = _make_compressed_session(
+            session_dir,
+            context_messages=ctx,
+            messages=vis_msgs,
+        )
+
+        _handle_session_handoff(
+            object(), {"session_id": source.session_id}, diag=None
+        )
+
+        assert captured_response.get("status") == 200
+        from api.models import get_session
+        new_session_obj = get_session(captured_response["payload"]["session"]["session_id"])
+        assert new_session_obj is not None
+
+        # Expected: 1 preamble + 3 source ctx + 2 fresh exchange = 6
+        assert len(new_session_obj.context_messages) == 1 + len(ctx) + 2
+        assert new_session_obj.context_messages[-2]["content"] == "fresh question"
+        assert new_session_obj.context_messages[-1]["content"] == "fresh answer"
+
+    def test_handoff_from_ineligible_session_returns_400(self, session_dir, captured_response):
+        """A session without a compression marker is not eligible."""
+        # Create a session with plain context_messages (no compression marker)
+        s = new_session()
+        s.context_messages = [{"role": "user", "content": "hi"}]
+        s.save()
+        sid = s.session_id
+
+        _handle_session_handoff(object(), {"session_id": sid}, diag=None)
+        assert captured_response.get("status") == 400
+        assert "no compressed context" in str(captured_response.get("payload", "")).lower()
+
+    def test_handoff_bad_session_id_404(self, session_dir, captured_response):
+        """Requesting a non-existent session returns 404."""
+        _handle_session_handoff(object(), {"session_id": "nonexistent"}, diag=None)
+        assert captured_response.get("status") == 404
+
+    def test_handoff_preserves_workspace_model_provider(self, session_dir, captured_response):
+        """Request-level overrides for workspace/model should work."""
+        import copy
+        marker = _compression_marker()
+        ctx = [marker, {"role": "user", "content": "q1"}]
+        source, _ = _make_compressed_session(
+            session_dir,
+            context_messages=ctx,
+            model="gpt-4",
+            model_provider="openai",
+        )
+
+        _handle_session_handoff(
+            object(),
+            {
+                "session_id": source.session_id,
+                "model": "gpt-4",
+                "model_provider": "openai",
+            },
+            diag=None,
+        )
+        assert captured_response.get("status") == 200
+        session = captured_response["payload"]["session"]
+        assert session["model"] == "gpt-4"
+        assert session["model_provider"] == "openai"
+
+    def test_profile_gate_rejects_cross_profile(self, session_dir, monkeypatch):
+        """The profile gate blocks cross-profile source access."""
+        captures = {}
+        def _capture(handler, payload, status=200, **kw):
+            captures.update(payload=payload, status=status)
+            return True
+
+        # Simulate active profile = "default", source = "other"
+        def _visible_to_active_profile(profile, handler=None):
+            return profile is None or profile == "default"
+
+        monkeypatch.setattr(routes, "j", _capture)
+        monkeypatch.setattr("api.helpers.j", _capture)
+        monkeypatch.setattr(routes, "_check_csrf", lambda h: True)
+        monkeypatch.setattr(routes, "publish_session_list_changed", lambda *a, **kw: None)
+        monkeypatch.setattr(routes, "_session_visible_to_active_profile", _visible_to_active_profile)
+
+        marker = _compression_marker()
+        ctx = [marker, {"role": "user", "content": "q1"}]
+        source, _ = _make_compressed_session(
+            session_dir,
+            context_messages=ctx,
+            profile="other",
+        )
+
+        _handle_session_handoff(
+            object(),
+            {"session_id": source.session_id},
+            diag=None,
+        )
+        assert captures.get("status") == 404
+        assert "not found" in str(captures.get("payload", "")).lower()


### PR DESCRIPTION
Implements Issue #6382 — Fresh Session Handoff.

## Summary

Adds `POST /api/session/handoff` that creates a new independent session carrying only the compressed continuity context from a previous session, without copying the full transcript.

**What the new session gets:**
1. A system-role preamble explaining context origin
2. The source session's compressed `context_messages` (preserved as-is)
3. The latest completed user/assistant exchange (preserved verbatim)

**What it does NOT inherit:**
- Full visible transcript (messages=[])
- Active stream state, pending user turns, pending approvals
- Hidden task state or queued input

**Eligibility:**
- Source must have non-empty `context_messages` (compressed)
- No active stream ID
- No pending user message
- Not a pre-compression snapshot

## Implementation

| Component | File | Description |
|-----------|------|-------------|
| Route handler | `api/routes.py` — `handle_post()` | Dispatch `/api/session/handoff` |
| Handler function | `api/routes.py` — `_handle_session_handoff()` | Creates fresh session with handoff context |
| Eligibility check | `api/routes.py` — `_session_handoff_eligibility_error()` | Validates source session eligibility |
| Exchange extraction | `api/routes.py` — `_extract_latest_completed_exchange()` | Finds last completed user/assistant pair |
| Payload builder | `api/routes.py` — `_build_handoff_context_messages()` | Assembles context_messages for new session |
| Tests | `tests/test_issue6382_fresh_session_handoff.py` | 21 tests covering all paths |

## Key design decisions

1. **One payload structure**: The handoff context is built as a list with system preamble + source context_messages + latest exchange (preserving role alternation).
2. **Deep copy**: `copy.deepcopy()` ensures the new session's context is independent from the source.
3. **Provenance metadata**: `parent_session_id`, `handoff_source_session_id`, `handoff_created_at`, `handoff_compressed` are persisted on the new session.
4. **Immediate persistence**: The new session is saved immediately (unlike normal `new_session()` which saves on first message), since it carries meaningful continuity context.

Closes #6382