### PR TITLE
feat: render Background wakeup messages as collapsed summary cards (#6345)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2333,6 +2333,29 @@
   .process-wakeup-row .msg-body pre.process-wakeup-text{margin:0;padding:0;border:0;border-radius:0;background:transparent;color:var(--muted);font-family:var(--font-mono);font-size:12px;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;word-break:break-word;}
   .process-wakeup-row .msg-foot{padding-left:0;margin-top:5px;}
   @media(max-width:700px){.process-wakeup-notice{margin-left:0;}}
+  /* ── Wakeup collapsed card ── */
+  .wakeup-card{padding:0;overflow:hidden;border-left:2px solid var(--accent-bg-strong);border-radius:9px;background:var(--surface-subtle,var(--hover-bg));color:var(--muted);}
+  .wakeup-card.wakeup-card-error{border-left-color:var(--error);}
+  .wakeup-card-header{display:flex;align-items:center;gap:6px;padding:8px 10px;cursor:pointer;user-select:none;font-size:12px;line-height:1.3;color:var(--muted);min-width:0;}
+  .wakeup-card-header:hover{background:var(--hover-bg);color:var(--text);}
+  .wakeup-card-header .tool-card-toggle{font-size:10px;color:var(--muted);opacity:.4;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
+  .wakeup-card.open .tool-card-toggle{transform:rotate(90deg);}
+  .wakeup-card-header .msg-time{margin-left:auto;flex-shrink:0;font-size:10px;opacity:.7;}
+  .wakeup-command{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:var(--font-mono);font-size:12px;color:var(--text);opacity:.6;flex:1 1 auto;}
+  .wakeup-exit-chip{display:inline-flex;align-items:center;gap:3px;padding:1px 6px;border-radius:4px;font-family:var(--font-mono);font-size:10px;font-weight:600;flex-shrink:0;white-space:nowrap;}
+  .wakeup-exit-chip-ok{background:color-mix(in srgb,var(--success) 15%,transparent);color:var(--success);}
+  .wakeup-exit-chip-error{background:color-mix(in srgb,var(--error) 15%,transparent);color:var(--error);}
+  .wakeup-exit-chip-watch{background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent-text);max-width:200px;overflow:hidden;text-overflow:ellipsis;}
+  .wakeup-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;transition:max-height .26s ease,opacity .2s ease;background:var(--code-bg);border-radius:0 0 8px 8px;}
+  .wakeup-card.open .wakeup-card-detail{max-height:320px;opacity:1;overflow:auto;}
+  .wakeup-card-detail-inner{padding:9px 12px 11px;}
+  .wakeup-card-command-row{display:flex;align-items:baseline;gap:8px;margin-bottom:4px;font-size:12px;line-height:1.5;}
+  .wakeup-card-command-row code{font-family:var(--font-mono);font-size:12px;color:var(--text);white-space:pre-wrap;word-break:break-word;}
+  .wakeup-detail-label{color:var(--muted);font-size:11px;opacity:.65;flex-shrink:0;font-weight:500;}
+  .wakeup-card-output{font-size:12px;color:var(--muted);font-family:var(--font-mono);white-space:pre-wrap;word-break:break-word;max-height:220px;overflow-y:auto;margin:6px 0 0;padding:0;border:0;background:transparent;line-height:1.5;}
+  .wakeup-card .msg-foot{padding:4px 10px 6px;}
+  .wakeup-card .msg-foot .msg-copy-btn{opacity:.5;}
+  .wakeup-card .msg-foot .msg-copy-btn:hover{opacity:1;}
   /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
   .msg-body pre[class*="language-"],.msg-body pre code[class*="language-"]{background:var(--code-bg) !important;}
   /* Fix #1463: Prism YAML grammar collapses newlines inside token spans — force pre */

--- a/static/ui.js
+++ b/static/ui.js
@@ -15840,9 +15840,65 @@ function renderMessages(options){
       let row=_msgNodeRecycleEnabled?_recycleStash.get(rawIdx):null;
       if(row&&(!row.classList.contains('msg-row')||row.classList.contains('assistant-turn'))) row=null;
       const processText=String(rowDisplayContent||'').trim();
-      const processFootHtml=`<div class="msg-foot">${timeHtml}<span class="msg-actions">${copyBtn}</span></div>`;
-      const processTextHtml=processText?`<pre class="process-wakeup-text">${esc(processText)}</pre>`:'';
-      const nextRowHtml=`<div class="process-wakeup-notice"><div class="process-wakeup-label">${li('terminal',13)}<span>${esc(t('process_wakeup_label'))}</span></div>${filesHtml}<div class="msg-body process-wakeup-body">${processTextHtml}</div>${processFootHtml}</div>`;
+      const copyBtnHtml=`<button class="msg-copy-btn msg-action-btn" onclick="copyMsg(this)" title="${t('copy')}">${li('copy',13)}</button>`;
+      // Try to parse structured wakeup data for collapsed card rendering
+      const cmdMatch=processText.match(/^\[IMPORTANT: Background process \S+ completed \(exit_code=([^)]+)\)\.\nCommand: (.+)\nOutput:\n([\s\S]*)\]$/);
+      const watchMatch=processText.match(/^\[IMPORTANT: Background process \S+ matched watch pattern "([^"]+)".\nCommand: (.+)\nMatched output:\n([\s\S]*?)(?:\n\(\d+ earlier matches were suppressed by rate limit\))?\]$/);
+      let nextRowHtml;
+      if(cmdMatch){
+        const exitCode=cmdMatch[1];
+        const command=cmdMatch[2];
+        const output=cmdMatch[3].trim();
+        const isError=String(exitCode)!=='0';
+        nextRowHtml=`<div class="process-wakeup-notice wakeup-card${isError?' wakeup-card-error':''}">
+          <div class="tool-card-header wakeup-card-header" onclick="this.closest('.wakeup-card').classList.toggle('open')" role="button" tabindex="0">
+            <span class="tool-card-toggle">${li('chevron-right',11)}</span>
+            ${li('terminal',14)}
+            <span>${esc(t('process_wakeup_label'))}</span>
+            <code class="wakeup-command">${esc(command)}</code>
+            <span class="wakeup-exit-chip${isError?' wakeup-exit-chip-error':' wakeup-exit-chip-ok'}">exit ${esc(exitCode)}</span>
+            ${tsTime?`<span class="msg-time" title="${esc(tsTitle)}">${tsTime}</span>`:''}
+          </div>
+          <div class="tool-card-detail wakeup-card-detail">
+            <div class="wakeup-card-detail-inner">
+              ${filesHtml}
+              <div class="wakeup-card-command-row"><span class="wakeup-detail-label">${esc(t('command_label'))}</span><code>${esc(command)}</code></div>
+              <pre class="wakeup-card-output">${esc(output)}</pre>
+            </div>
+          </div>
+          <div class="msg-foot">${copyBtnHtml}</div>
+        </div>`;
+      }else if(watchMatch){
+        const pattern=watchMatch[1];
+        const command=watchMatch[2];
+        const output=watchMatch[3].trim();
+        const suppressed=watchMatch[4]!==undefined;
+        const shortPat=pattern.length>50?pattern.slice(0,50)+'…':pattern;
+        nextRowHtml=`<div class="process-wakeup-notice wakeup-card">
+          <div class="tool-card-header wakeup-card-header" onclick="this.closest('.wakeup-card').classList.toggle('open')" role="button" tabindex="0">
+            <span class="tool-card-toggle">${li('chevron-right',11)}</span>
+            ${li('terminal',14)}
+            <span>${esc(t('process_wakeup_label'))}</span>
+            <code class="wakeup-command">${esc(command)}</code>
+            <span class="wakeup-exit-chip wakeup-exit-chip-watch" title="${esc(pattern)}">${li('eye',11)} ${esc(shortPat)}</span>
+            ${tsTime?`<span class="msg-time" title="${esc(tsTitle)}">${tsTime}</span>`:''}
+          </div>
+          <div class="tool-card-detail wakeup-card-detail">
+            <div class="wakeup-card-detail-inner">
+              ${filesHtml}
+              <div class="wakeup-card-command-row"><span class="wakeup-detail-label">${esc(t('command_label'))}</span><code>${esc(command)}</code></div>
+              <div class="wakeup-card-command-row"><span class="wakeup-detail-label">Pattern</span><code>${esc(pattern)}</code>${suppressed?`<span class="wakeup-exit-chip wakeup-exit-chip-watch">suppressed</span>`:''}</div>
+              <pre class="wakeup-card-output">${esc(output)}</pre>
+            </div>
+          </div>
+          <div class="msg-foot">${copyBtnHtml}</div>
+        </div>`;
+      }else{
+        // Fallback to raw rendering for unparseable formats (async_delegation, watch overflow free-text)
+        const processFootHtml=`<div class="msg-foot">${timeHtml}<span class="msg-actions">${copyBtnHtml}</span></div>`;
+        const processTextHtml=processText?`<pre class="process-wakeup-text">${esc(processText)}</pre>`:'';
+        nextRowHtml=`<div class="process-wakeup-notice"><div class="process-wakeup-label">${li('terminal',13)}<span>${esc(t('process_wakeup_label'))}</span></div>${filesHtml}<div class="msg-body process-wakeup-body">${processTextHtml}</div>${processFootHtml}</div>`;
+      }
       if(row){
         row.className='msg-row process-wakeup-row';
         row.id=_userMessageDomId(rawIdx);


### PR DESCRIPTION
Closes #6345.

## What

Background-process wakeup messages (`_source: 'process_wakeup'`) currently render as a single always-expanded `<pre>` dump of the entire agent-facing `[IMPORTANT: …]` prompt — up to ~4 KB of raw output per wakeup. This PR renders the two structured shapes (completion, watch_match) as a collapsed summary card instead:

```
▸ ⌨ BACKGROUND WAKEUP   npm run build   ✓ exit 0        14:32
```

- Collapsed by default with chevron affordance; expanding shows the full command and a scroll-capped output `<pre>`, plus the copy button (copies original raw text).
- Exit-code chip: green `exit 0`, red for nonzero (also gets the error accent border).
- Watch matches show the pattern with an eye icon (full pattern on hover) and suppressed count in the detail.
- The `[IMPORTANT: …]` scaffolding is stripped for display only — stored content is byte-identical to before.
- Unparseable bodies (async_delegation, watch overflow free-text) keep the existing raw-notice rendering, so the fallback is never worse than today.

## How

Frontend-only: client-side regex parsing of the pinned `format_wakeup_prompt` shapes in `renderMessages` (`static/ui.js`), replacing the flat render branch with the card layout. Server-side unchanged.

## Files changed

- `static/ui.js` — regex parsing + collapsed card HTML for completion and watch_match formats; fallback preserved.
- `static/style.css` — `.wakeup-card*` rules for header, toggle, exit chip, and lazy detail.

## Notes

An alternative implementation exists in PR #6350 (b3nw) with server-side `_wakeup_meta` stamping. This version takes a simpler frontend-only approach with no server-side changes.

## Deferred (per issue)

Grouping consecutive wakeups and the live `bg_task_complete` toast are explicitly out of scope.