### PR TITLE
Honor memory feature flags in the WebUI

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -20598,6 +20598,7 @@ def _read_active_project_context(workspace: Path | None) -> dict:
 
 
 def _handle_memory_read(handler, parsed=None):
+    memory_enabled, user_profile_enabled = _memory_feature_flags()
     try:
         from api.profiles import get_active_hermes_home
 
@@ -20611,12 +20612,12 @@ def _handle_memory_read(handler, parsed=None):
     soul_file = home / "SOUL.md"
     memory = (
         mem_file.read_text(encoding="utf-8", errors="replace")
-        if mem_file.exists()
+        if memory_enabled and mem_file.exists()
         else ""
     )
     user = (
         user_file.read_text(encoding="utf-8", errors="replace")
-        if user_file.exists()
+        if user_profile_enabled and user_file.exists()
         else ""
     )
     soul = (
@@ -20638,12 +20639,14 @@ def _handle_memory_read(handler, parsed=None):
             "project_context_path": project_context["path"],
             "project_context_name": project_context.get("name", ""),
             "project_context_workspace": project_context["workspace"],
-            "memory_mtime": mem_file.stat().st_mtime if mem_file.exists() else None,
-            "user_mtime": user_file.stat().st_mtime if user_file.exists() else None,
+            "memory_mtime": mem_file.stat().st_mtime if memory_enabled and mem_file.exists() else None,
+            "user_mtime": user_file.stat().st_mtime if user_profile_enabled and user_file.exists() else None,
             "soul_mtime": soul_file.stat().st_mtime if soul_file.exists() else None,
             "project_context_mtime": project_context["mtime"],
             "project_context_shadowed": project_context["shadowed"],
             "external_notes_enabled": _external_notes_sources_enabled(),
+            "memory_enabled": memory_enabled,
+            "user_profile_enabled": user_profile_enabled,
         },
     )
 
@@ -25709,8 +25712,13 @@ def _handle_memory_write(handler, body):
     except ImportError:
         home = Path.home() / ".hermes"
         mem_dir = home / "memories"
-    mem_dir.mkdir(parents=True, exist_ok=True)
     section = body["section"]
+    memory_enabled, user_profile_enabled = _memory_feature_flags()
+    if section == "memory" and not memory_enabled:
+        return bad(handler, "Memory is disabled", 403)
+    if section == "user" and not user_profile_enabled:
+        return bad(handler, "User profile is disabled", 403)
+    mem_dir.mkdir(parents=True, exist_ok=True)
     if section == "memory":
         target = mem_dir / "MEMORY.md"
     elif section == "user":
@@ -26405,6 +26413,20 @@ def _external_notes_sources_enabled(config_data: dict | None = None) -> bool:
         cfg.get("webui_external_notes_sources")
         or cfg.get("external_notes_sources")
         or cfg.get("notes_sources_drawer")
+    )
+
+
+def _memory_feature_flags() -> tuple[bool, bool]:
+    config_data = get_config()
+    memory_config = config_data.get("memory") if isinstance(config_data, dict) else None
+    if not isinstance(memory_config, dict):
+        memory_config = {}
+    return tuple(
+        value if isinstance(value, bool) else _webui_truthy(value)
+        for value in (
+            memory_config.get("memory_enabled", True),
+            memory_config.get("user_profile_enabled", True),
+        )
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -20598,7 +20598,8 @@ def _read_active_project_context(workspace: Path | None) -> dict:
 
 
 def _handle_memory_read(handler, parsed=None):
-    memory_enabled, user_profile_enabled = _memory_feature_flags()
+    config_snapshot = get_config_snapshot()
+    memory_enabled, user_profile_enabled = _memory_feature_flags(config_snapshot)
     try:
         from api.profiles import get_active_hermes_home
 
@@ -20633,8 +20634,8 @@ def _handle_memory_read(handler, parsed=None):
             "user": _redact_text(user),
             "soul": _redact_text(soul),
             "project_context": _redact_text(project_context["content"]),
-            "memory_path": str(mem_file),
-            "user_path": str(user_file),
+            "memory_path": str(mem_file) if memory_enabled else None,
+            "user_path": str(user_file) if user_profile_enabled else None,
             "soul_path": str(soul_file),
             "project_context_path": project_context["path"],
             "project_context_name": project_context.get("name", ""),
@@ -20644,7 +20645,7 @@ def _handle_memory_read(handler, parsed=None):
             "soul_mtime": soul_file.stat().st_mtime if soul_file.exists() else None,
             "project_context_mtime": project_context["mtime"],
             "project_context_shadowed": project_context["shadowed"],
-            "external_notes_enabled": _external_notes_sources_enabled(),
+            "external_notes_enabled": _external_notes_sources_enabled(config_snapshot),
             "memory_enabled": memory_enabled,
             "user_profile_enabled": user_profile_enabled,
         },
@@ -25713,7 +25714,8 @@ def _handle_memory_write(handler, body):
         home = Path.home() / ".hermes"
         mem_dir = home / "memories"
     section = body["section"]
-    memory_enabled, user_profile_enabled = _memory_feature_flags()
+    config_snapshot = get_config_snapshot()
+    memory_enabled, user_profile_enabled = _memory_feature_flags(config_snapshot)
     if section == "memory" and not memory_enabled:
         return bad(handler, "Memory is disabled", 403)
     if section == "user" and not user_profile_enabled:
@@ -26416,18 +26418,18 @@ def _external_notes_sources_enabled(config_data: dict | None = None) -> bool:
     )
 
 
-def _memory_feature_flags() -> tuple[bool, bool]:
-    config_data = get_config()
+def _memory_feature_flags(config_data: dict | None = None) -> tuple[bool, bool]:
+    config_data = config_data if isinstance(config_data, dict) else get_config_snapshot()
     memory_config = config_data.get("memory") if isinstance(config_data, dict) else None
-    if not isinstance(memory_config, dict):
+    has_memory_block = isinstance(memory_config, dict)
+    if not has_memory_block:
         memory_config = {}
-    return tuple(
-        value if isinstance(value, bool) else _webui_truthy(value)
-        for value in (
-            memory_config.get("memory_enabled", True),
-            memory_config.get("user_profile_enabled", True),
-        )
-    )
+    missing_default = False if has_memory_block else True
+    flags = []
+    for key in ("memory_enabled", "user_profile_enabled"):
+        value = memory_config.get(key, missing_default)
+        flags.append(value if isinstance(value, bool) else _webui_truthy(value))
+    return tuple(flags)
 
 
 _NOTES_SOURCE_SERVER_HINTS = {

--- a/api/routes.py
+++ b/api/routes.py
@@ -26421,13 +26421,11 @@ def _external_notes_sources_enabled(config_data: dict | None = None) -> bool:
 def _memory_feature_flags(config_data: dict | None = None) -> tuple[bool, bool]:
     config_data = config_data if isinstance(config_data, dict) else get_config_snapshot()
     memory_config = config_data.get("memory") if isinstance(config_data, dict) else None
-    has_memory_block = isinstance(memory_config, dict)
-    if not has_memory_block:
+    if not isinstance(memory_config, dict):
         memory_config = {}
-    missing_default = False if has_memory_block else True
     flags = []
     for key in ("memory_enabled", "user_profile_enabled"):
-        value = memory_config.get(key, missing_default)
+        value = memory_config.get(key, True)
         flags.append(value if isinstance(value, bool) else _webui_truthy(value))
     return tuple(flags)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -26421,13 +26421,11 @@ def _external_notes_sources_enabled(config_data: dict | None = None) -> bool:
 def _memory_feature_flags(config_data: dict | None = None) -> tuple[bool, bool]:
     config_data = config_data if isinstance(config_data, dict) else get_config_snapshot()
     memory_config = config_data.get("memory") if isinstance(config_data, dict) else None
-    if not isinstance(memory_config, dict):
+    if memory_config is None:
         memory_config = {}
-    flags = []
-    for key in ("memory_enabled", "user_profile_enabled"):
-        value = memory_config.get(key, True)
-        flags.append(value if isinstance(value, bool) else _webui_truthy(value))
-    return tuple(flags)
+    elif not isinstance(memory_config, dict):
+        return False, False
+    return tuple(bool(memory_config.get(key, True)) for key in ("memory_enabled", "user_profile_enabled"))
 
 
 _NOTES_SOURCE_SERVER_HINTS = {

--- a/static/panels.js
+++ b/static/panels.js
@@ -5535,6 +5535,7 @@ function closeMemoryEdit() { cancelMemoryEdit(); }
 
 async function submitMemorySave() {
   if (!_currentMemorySection) return;
+  const section = _currentMemorySection;
   const meta = _memorySectionMeta(_currentMemorySection);
   if (!_memorySectionEnabled(meta) || meta.readOnly) return;
   const ta = $('memEditContent');
@@ -5545,7 +5546,9 @@ async function submitMemorySave() {
     await api('/api/memory/write', {method:'POST', body: JSON.stringify({section: _currentMemorySection, content: ta.value})});
     showToast(t('memory_saved'));
     await loadMemory(true);
-    _renderMemoryDetail(_currentMemorySection);
+    if (_currentMemorySection === section && _currentMemorySection) {
+      _renderMemoryDetail(_currentMemorySection);
+    }
   } catch(e) {
     if (errEl) { errEl.textContent = t('error_prefix') + e.message; errEl.style.display = ''; }
   }

--- a/static/panels.js
+++ b/static/panels.js
@@ -5231,8 +5231,8 @@ let _currentMemorySection = null; // 'memory' | 'user' | 'soul' | 'project_conte
 let _memoryMode = 'empty'; // 'empty' | 'read' | 'edit'
 
 const MEMORY_SECTIONS = [
-  { key: 'memory', labelKey: 'my_notes', emptyKey: 'no_notes_yet', iconKey: 'brain' },
-  { key: 'user',   labelKey: 'user_profile', emptyKey: 'no_profile_yet', iconKey: 'user' },
+  { key: 'memory', labelKey: 'my_notes', emptyKey: 'no_notes_yet', iconKey: 'brain', enabledField: 'memory_enabled' },
+  { key: 'user',   labelKey: 'user_profile', emptyKey: 'no_profile_yet', iconKey: 'user', enabledField: 'user_profile_enabled' },
   { key: 'soul',   labelKey: 'agent_soul', emptyKey: 'no_soul_yet', iconKey: 'sparkles' },
   { key: 'project_context', label: 'Project Context', empty: 'No project context file found for this workspace.', iconKey: 'file-text', readOnly: true },
   { key: 'external_notes', labelKey: 'external_notes_sources', emptyKey: 'external_notes_empty', iconKey: 'book-open' },
@@ -5240,6 +5240,12 @@ const MEMORY_SECTIONS = [
 
 function _memorySectionMeta(key) {
   return MEMORY_SECTIONS.find(s => s.key === key) || MEMORY_SECTIONS[0];
+}
+
+function _memorySectionEnabled(meta, data = _memoryData) {
+  if (meta.key === 'external_notes') return !data || data.external_notes_enabled === true;
+  if (!meta.enabledField) return true;
+  return !data || typeof data[meta.enabledField] !== 'boolean' || data[meta.enabledField];
 }
 
 function _memorySectionLabel(meta) {
@@ -5295,6 +5301,20 @@ function _setMemoryHeaderButtons(mode) {
   }
   else if (mode === 'edit') { if (header) header.style.display = 'flex'; hide(editBtn); show(cancelBtn); show(saveBtn); }
   else { if (header) header.style.display = 'none'; hide(editBtn); hide(cancelBtn); hide(saveBtn); }
+}
+
+function _renderMemoryEmpty() {
+  const title = $('memoryDetailTitle');
+  const body = $('memoryDetailBody');
+  const empty = $('memoryDetailEmpty');
+  if (title) title.textContent = '';
+  if (body) {
+    body.innerHTML = '';
+    body.style.display = 'none';
+  }
+  if (empty) empty.style.display = '';
+  _memoryMode = 'empty';
+  _setMemoryHeaderButtons('empty');
 }
 
 function _renderExternalNotesSources() {
@@ -5487,7 +5507,7 @@ async function previewExternalNote(source, id) {
 }
 
 async function openMemorySection(section, el) {
-  if (section === 'external_notes' && _memoryData && !_memoryData.external_notes_enabled) return;
+  if (!_memorySectionEnabled(_memorySectionMeta(section))) return;
   _currentMemorySection = section;
   document.querySelectorAll('#memoryPanel .side-menu-item').forEach(e => e.classList.remove('active'));
   if (el) el.classList.add('active');
@@ -5500,7 +5520,7 @@ async function openMemorySection(section, el) {
 
 function editCurrentMemory() {
   const meta = _memorySectionMeta(_currentMemorySection);
-  if (!_currentMemorySection || _currentMemorySection === 'external_notes' || meta.readOnly) return;
+  if (!_currentMemorySection || !_memorySectionEnabled(meta) || _currentMemorySection === 'external_notes' || meta.readOnly) return;
   _renderMemoryEdit(_currentMemorySection);
 }
 
@@ -5515,7 +5535,8 @@ function closeMemoryEdit() { cancelMemoryEdit(); }
 
 async function submitMemorySave() {
   if (!_currentMemorySection) return;
-  if (_memorySectionMeta(_currentMemorySection).readOnly) return;
+  const meta = _memorySectionMeta(_currentMemorySection);
+  if (!_memorySectionEnabled(meta) || meta.readOnly) return;
   const ta = $('memEditContent');
   const errEl = $('memEditError');
   if (!ta) return;
@@ -7390,7 +7411,8 @@ async function loadMemory(force) {
       : '/api/memory';
     const data = await api(memoryUrl);
     _memoryData = data;
-    if (_currentMemorySection === 'external_notes' && !data.external_notes_enabled) {
+    const resetDisabledSection = _currentMemorySection && !_memorySectionEnabled(_memorySectionMeta(_currentMemorySection), data);
+    if (resetDisabledSection) {
       _currentMemorySection = null;
     }
     if (_currentMemorySection === 'external_notes') {
@@ -7400,6 +7422,8 @@ async function loadMemory(force) {
       panel.innerHTML = '';
       for (const s of MEMORY_SECTIONS) {
         if (s.key === 'external_notes' && !_memoryData.external_notes_enabled) continue;
+        if (s.key === 'memory' && _memoryData.memory_enabled === false) continue;
+        if (s.key === 'user' && _memoryData.user_profile_enabled === false) continue;
         const el = document.createElement('button');
         el.type = 'button';
         el.className = 'side-menu-item';
@@ -7413,6 +7437,8 @@ async function loadMemory(force) {
     }
     if (_currentMemorySection && _memoryMode !== 'edit') {
       _renderMemoryDetail(_currentMemorySection);
+    } else if (resetDisabledSection || !_currentMemorySection) {
+      _renderMemoryEmpty();
     }
   } catch(e) {
     if (panel) panel.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">${esc(t('error_prefix'))}${esc(e.message)}</div>`;

--- a/static/panels.js
+++ b/static/panels.js
@@ -7424,9 +7424,7 @@ async function loadMemory(force) {
     if (panel) {
       panel.innerHTML = '';
       for (const s of MEMORY_SECTIONS) {
-        if (s.key === 'external_notes' && !_memoryData.external_notes_enabled) continue;
-        if (s.key === 'memory' && _memoryData.memory_enabled === false) continue;
-        if (s.key === 'user' && _memoryData.user_profile_enabled === false) continue;
+        if (!_memorySectionEnabled(s, _memoryData)) continue;
         const el = document.createElement('button');
         el.type = 'button';
         el.className = 'side-menu-item';

--- a/tests/test_3866_project_context_memory_section.py
+++ b/tests/test_3866_project_context_memory_section.py
@@ -114,7 +114,7 @@ def test_project_context_content_is_redacted_in_memory_response(tmp_path, monkey
 
     monkeypatch.setattr(api.profiles, "get_active_hermes_home", lambda: home)
     monkeypatch.setattr(routes, "_memory_project_context_workspace", lambda _parsed: workspace)
-    monkeypatch.setattr(routes, "_external_notes_sources_enabled", lambda: False)
+    monkeypatch.setattr(routes, "_external_notes_sources_enabled", lambda _config_data=None: False)
     monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload)
 
     payload = routes._handle_memory_read(object(), SimpleNamespace(query=""))
@@ -228,13 +228,15 @@ def _memory_button_render_blocks():
     panels = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
     sections_start = panels.index("const MEMORY_SECTIONS = [")
     sections_end = panels.index("];", sections_start) + 2
-    helper_start = panels.index("function _memorySectionPath(key)")
-    helper_end = panels.index("function _setMemoryHeaderButtons", helper_start)
+    enabled_start = panels.index("function _memorySectionEnabled(meta, data = _memoryData)")
+    enabled_end = panels.index("function _memorySectionLabel", enabled_start)
+    path_start = panels.index("function _memorySectionPath(key)")
+    path_end = panels.index("function _setMemoryHeaderButtons", path_start)
     loop_start = panels.index("for (const s of MEMORY_SECTIONS) {")
     loop_end = panels.index("    if (_currentMemorySection && _memoryMode !== 'edit') {", loop_start)
     return (
         panels[sections_start:sections_end],
-        panels[helper_start:helper_end],
+        panels[enabled_start:enabled_end] + panels[path_start:path_end],
         panels[loop_start:loop_end].rsplit("    }", 1)[0],
     )
 

--- a/tests/test_issue6406_memory_feature_gates.py
+++ b/tests/test_issue6406_memory_feature_gates.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import api.profiles
 import api.routes as routes
 import pytest
+from tests.js_source_extract import extract_function
 
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -46,103 +47,57 @@ def _write(section, captured):
     return captured.get("error")
 
 
-def _panel_rows(data):
-    panels = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-    sections_start = panels.index("const MEMORY_SECTIONS = [")
-    sections_end = panels.index("];", sections_start) + 2
-    helper_start = panels.index("function _memorySectionMeta(key)")
-    helper_end = panels.index("function _memorySectionLabel", helper_start)
-    loop_start = panels.index("for (const s of MEMORY_SECTIONS) {")
-    loop_end = panels.index("    if (_currentMemorySection && _memoryMode !== 'edit')", loop_start)
-    script = (
-        "const sections = " + json.dumps(panels[sections_start:sections_end]) + ";\n"
-        "const helper = " + json.dumps(panels[helper_start:helper_end]) + ";\n"
-        "const loop = " + json.dumps(panels[loop_start:loop_end].rsplit("    }", 1)[0]) + ";\n"
-        "let _memoryData = " + json.dumps(data) + ";\n"
-        + r"""
-const nodes = {memoryPanel: {appended: [], innerHTML: '', appendChild(node) { this.appended.push(node); }}};
-const panel = nodes.memoryPanel;
-let _currentMemorySection = 'memory';
-const document = {createElement() { return {innerHTML: '', title: '', classList: {add() {}}}; }};
-function _memorySectionLabel(meta) { return meta.key; }
-function _memorySectionPath() { return ''; }
-function li() { return ''; }
-function esc(value) { return String(value); }
-function openMemorySection() {}
-eval(sections + "\n" + helper + "\nfunction renderRows() {" + loop + "}\nrenderRows();");
-console.log(JSON.stringify(nodes.memoryPanel.appended.map(button => button.innerHTML.replace(/<[^>]+>/g, ''))));
-"""
+def _panels_source():
+    return (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def _extract_js_const_array(source, name):
+    start = source.index(f"const {name} = [")
+    end = source.index("];", start) + 2
+    return source[start:end]
+
+
+def _extract_panel_function(source, name):
+    try:
+        return extract_function(source, name, prefix="async function")
+    except AssertionError:
+        return extract_function(source, name)
+
+
+def _panel_driver_source():
+    panels = _panels_source()
+    sections = _extract_js_const_array(panels, "MEMORY_SECTIONS")
+    functions = "\n".join(
+        _extract_panel_function(panels, name)
+        for name in [
+            "_memorySectionMeta",
+            "_memorySectionEnabled",
+            "_renderMemoryEmpty",
+            "loadMemory",
+            "openMemorySection",
+            "editCurrentMemory",
+            "submitMemorySave",
+        ]
     )
-    completed = subprocess.run([NODE, "-e", script], capture_output=True, text=True)
-    assert completed.returncode == 0, completed.stderr
-    return json.loads(completed.stdout)
+    return (
+        sections
+        + "\n"
+        + functions
+        + "\n"
+        + _PANEL_DRIVER_BODY
+    )
 
 
-_PANEL_DRIVER = r"""
-const fs = require('fs');
-const src = fs.readFileSync(process.argv[1], 'utf8');
+@pytest.fixture(scope="session")
+def panel_driver_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("memory-panel-driver") / "panel_driver.js"
+    path.write_text(_panel_driver_source(), encoding="utf-8")
+    return path
+
+
+_PANEL_DRIVER_BODY = r"""
 const scenario = process.argv[2];
-
-function extractFunc(name) {
-  const re = new RegExp('(?:async\\s+)?function\\s+' + name + '\\s*\\(');
-  const start = src.search(re);
-  if (start < 0) throw new Error(name + ' not found');
-  const braceStart = src.indexOf('{', start);
-  let depth = 0;
-  let inString = null;
-  let escaped = false;
-  let inLineComment = false;
-  let inBlockComment = false;
-  for (let i = braceStart; i < src.length; i++) {
-    const ch = src[i];
-    const next = i + 1 < src.length ? src[i + 1] : '';
-    if (inLineComment) {
-      if (ch === '\n') inLineComment = false;
-      continue;
-    }
-    if (inBlockComment) {
-      if (ch === '*' && next === '/') {
-        inBlockComment = false;
-        i++;
-      }
-      continue;
-    }
-    if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === '\\') escaped = true;
-      else if (ch === inString) inString = null;
-      continue;
-    }
-    if (ch === '/' && next === '/') {
-      inLineComment = true;
-      i++;
-      continue;
-    }
-    if (ch === '/' && next === '*') {
-      inBlockComment = true;
-      i++;
-      continue;
-    }
-    if (ch === "'" || ch === '"' || ch === '`') {
-      inString = ch;
-      continue;
-    }
-    if (ch === '{') depth++;
-    else if (ch === '}') {
-      depth--;
-      if (depth === 0) return src.slice(start, i + 1);
-    }
-  }
-  throw new Error(name + ' brace scan failed');
-}
-
-function extractConst(name) {
-  const start = src.indexOf('const ' + name + ' = [');
-  if (start < 0) throw new Error(name + ' not found');
-  const end = src.indexOf('];', start);
-  if (end < 0) throw new Error(name + ' terminator not found');
-  return src.slice(start, end + 2);
-}
+let payload = JSON.parse(process.argv[3] || '{}');
 
 function makeClassList(owner) {
   return {
@@ -251,32 +206,34 @@ global._setMemoryHeaderButtons = (mode) => {
   nodes.mainMemory._header.style.display = mode === 'empty' ? 'none' : 'flex';
 };
 
-let payload = null;
 const writes = [];
 global.api = async (url, opts) => {
   if (url === '/api/memory' || url.startsWith('/api/memory?')) return payload;
   if (url === '/api/memory/write') {
     writes.push(JSON.parse(opts.body));
+    if (scenario === 'save_refresh_disabled') {
+      payload = {
+        memory_enabled: true,
+        user_profile_enabled: false,
+        external_notes_enabled: true,
+        memory: 'memory body',
+        user: '',
+        soul: '',
+        project_context: '',
+      };
+    }
     return {};
   }
   throw new Error('unexpected url: ' + url);
 };
 
-eval(extractConst('MEMORY_SECTIONS').replace('const MEMORY_SECTIONS', 'var MEMORY_SECTIONS'));
-for (const name of [
-  '_memorySectionMeta',
-  '_memorySectionEnabled',
-  '_renderMemoryEmpty',
-  'loadMemory',
-  'openMemorySection',
-  'editCurrentMemory',
-  'submitMemorySave',
-]) {
-  eval(extractFunc(name));
-}
-
 function rowLabels() {
   return nodes.memoryPanel.children.map((node) => node.innerHTML.replace(/<[^>]+>/g, ''));
+}
+
+async function runRows() {
+  await loadMemory(false);
+  return rowLabels();
 }
 
 async function runStaleReset() {
@@ -362,8 +319,40 @@ async function runGuards() {
   };
 }
 
+async function runSaveRefreshDisabled() {
+  payload = {
+    memory_enabled: true,
+    user_profile_enabled: true,
+    external_notes_enabled: true,
+    memory: 'memory body',
+    user: 'user body',
+    soul: '',
+    project_context: '',
+  };
+  _memoryData = payload;
+  const allowed = makeEl();
+  await openMemorySection('user', allowed);
+  nodes.memEditContent.value = 'changed';
+  await submitMemorySave();
+  return {
+    section: _currentMemorySection,
+    mode: _memoryMode,
+    title: nodes.memoryDetailTitle.textContent,
+    body: nodes.memoryDetailBody.innerHTML,
+    bodyDisplay: nodes.memoryDetailBody.style.display,
+    emptyDisplay: nodes.memoryDetailEmpty.style.display,
+    headerDisplay: nodes.mainMemory._header.style.display,
+    renderDetailCalls: global.__renderDetailCalls.slice(),
+    writes,
+  };
+}
+
 (async () => {
-  const out = scenario === 'stale_reset' ? await runStaleReset() : await runGuards();
+  let out;
+  if (scenario === 'rows') out = await runRows();
+  else if (scenario === 'stale_reset') out = await runStaleReset();
+  else if (scenario === 'save_refresh_disabled') out = await runSaveRefreshDisabled();
+  else out = await runGuards();
   process.stdout.write(JSON.stringify(out));
 })().catch((err) => {
   console.error(err && err.stack ? err.stack : String(err));
@@ -372,11 +361,23 @@ async function runGuards() {
 """
 
 
-def _panel_behavior(scenario: str) -> dict:
+def _panel_rows(panel_driver_path, data):
     completed = subprocess.run(
-        [NODE, "-e", _PANEL_DRIVER, str(REPO_ROOT / "static" / "panels.js"), scenario],
+        [NODE, str(panel_driver_path), "rows", json.dumps(data)],
         capture_output=True,
         text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def _panel_behavior(panel_driver_path, scenario: str) -> dict:
+    completed = subprocess.run(
+        [NODE, str(panel_driver_path), scenario, "{}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
     assert completed.returncode == 0, completed.stderr
     return json.loads(completed.stdout)
@@ -450,23 +451,23 @@ def test_soul_project_context_and_external_notes_remain_available(tmp_path, monk
 
 
 @pytest.mark.skipif(NODE is None, reason="node is required for panel row coverage")
-def test_panel_rows_follow_memory_feature_flags():
-    assert _panel_rows({
+def test_panel_rows_follow_memory_feature_flags(panel_driver_path):
+    assert _panel_rows(panel_driver_path, {
         "memory_enabled": False,
         "user_profile_enabled": False,
         "external_notes_enabled": True,
     }) == ["soul", "project_context", "external_notes"]
-    assert _panel_rows({
+    assert _panel_rows(panel_driver_path, {
         "memory_enabled": False,
         "user_profile_enabled": True,
         "external_notes_enabled": True,
     }) == ["user", "soul", "project_context", "external_notes"]
-    assert _panel_rows({
+    assert _panel_rows(panel_driver_path, {
         "memory_enabled": True,
         "user_profile_enabled": False,
         "external_notes_enabled": True,
     }) == ["memory", "soul", "project_context", "external_notes"]
-    assert _panel_rows({
+    assert _panel_rows(panel_driver_path, {
         "memory_enabled": True,
         "user_profile_enabled": True,
         "external_notes_enabled": True,
@@ -474,13 +475,13 @@ def test_panel_rows_follow_memory_feature_flags():
 
 
 @pytest.mark.skipif(NODE is None, reason="node is required for panel row coverage")
-def test_missing_payload_flags_leave_sections_visible():
-    assert _panel_rows({"external_notes_enabled": False}) == ["memory", "user", "soul", "project_context"]
+def test_missing_payload_flags_leave_sections_visible(panel_driver_path):
+    assert _panel_rows(panel_driver_path, {"external_notes_enabled": False}) == ["memory", "user", "soul", "project_context"]
 
 
 @pytest.mark.skipif(NODE is None, reason="node is required for panel behavior coverage")
-def test_disabled_section_refresh_clears_stale_detail_state():
-    out = _panel_behavior("stale_reset")
+def test_disabled_section_refresh_clears_stale_detail_state(panel_driver_path):
+    out = _panel_behavior(panel_driver_path, "stale_reset")
     assert out["section"] is None
     assert out["mode"] == "empty"
     assert out["title"] == ""
@@ -493,8 +494,8 @@ def test_disabled_section_refresh_clears_stale_detail_state():
 
 
 @pytest.mark.skipif(NODE is None, reason="node is required for panel behavior coverage")
-def test_open_edit_and_save_guards_respect_disabled_sections():
-    out = _panel_behavior("guards")
+def test_open_edit_and_save_guards_respect_disabled_sections(panel_driver_path):
+    out = _panel_behavior(panel_driver_path, "guards")
     assert out["blockedState"] == {
         "current": None,
         "renderDetailCalls": [],
@@ -513,3 +514,17 @@ def test_open_edit_and_save_guards_respect_disabled_sections():
     assert out["writes"] == [{"section": "user", "content": "changed"}]
     assert out["toastCalls"] == 1
     assert out["finalRenderDetailCalls"] == ["user", "user"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for panel behavior coverage")
+def test_save_refresh_does_not_restore_disabled_detail_state(panel_driver_path):
+    out = _panel_behavior(panel_driver_path, "save_refresh_disabled")
+    assert out["section"] is None
+    assert out["mode"] == "empty"
+    assert out["title"] == ""
+    assert out["body"] == ""
+    assert out["bodyDisplay"] == "none"
+    assert out["emptyDisplay"] == ""
+    assert out["headerDisplay"] == "none"
+    assert out["renderDetailCalls"] == ["user"]
+    assert out["writes"] == [{"section": "user", "content": "changed"}]

--- a/tests/test_issue6406_memory_feature_gates.py
+++ b/tests/test_issue6406_memory_feature_gates.py
@@ -404,6 +404,8 @@ def test_memory_flag_only_gates_memory_surface(tmp_path, monkeypatch):
     payload = _read(home, captured)
     assert payload["memory"] == ""
     assert payload["user"] == "user body"
+    assert payload["memory_path"] is None
+    assert payload["user_path"] == str(home / "memories" / "USER.md")
     assert payload["memory_enabled"] is False
     assert payload["user_profile_enabled"] is True
     assert _write("memory", captured) == ("Memory is disabled", 403)
@@ -416,10 +418,13 @@ def test_user_flag_only_gates_user_surface(tmp_path, monkeypatch):
     payload = _read(home, captured)
     assert payload["memory"] == "memory body"
     assert payload["user"] == ""
+    assert payload["memory_path"] == str(home / "memories" / "MEMORY.md")
+    assert payload["user_path"] is None
     assert payload["memory_enabled"] is True
     assert payload["user_profile_enabled"] is False
     assert _write("memory", captured) is None
     assert _write("user", captured) == ("User profile is disabled", 403)
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "changed"
 
 
 def test_absent_flags_default_to_enabled(tmp_path, monkeypatch):
@@ -450,15 +455,44 @@ def test_string_flags_follow_existing_truthy_config_semantics(tmp_path, monkeypa
     home, captured = _setup_home(
         tmp_path,
         monkeypatch,
-        {"memory": {"memory_enabled": "false", "user_profile_enabled": "yes"}},
+        {"memory": {"memory_enabled": "false", "user_profile_enabled": "no"}},
     )
     payload = _read(home, captured)
-    assert payload["memory"] == ""
+    assert payload["memory"] == "memory body"
     assert payload["user"] == "user body"
-    assert payload["memory_enabled"] is False
+    assert payload["memory_enabled"] is True
     assert payload["user_profile_enabled"] is True
-    assert _write("memory", captured) == ("Memory is disabled", 403)
+    assert _write("memory", captured) is None
     assert _write("user", captured) is None
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "changed"
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "changed"
+
+
+@pytest.mark.parametrize("memory_value", ["disabled", []])
+def test_non_mapping_memory_section_fails_closed(tmp_path, monkeypatch, memory_value):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": memory_value})
+    payload = _read(home, captured)
+    assert payload["memory"] == payload["user"] == ""
+    assert payload["memory_path"] is payload["user_path"] is None
+    assert payload["memory_mtime"] is payload["user_mtime"] is None
+    assert payload["memory_enabled"] is payload["user_profile_enabled"] is False
+    assert _write("memory", captured) == ("Memory is disabled", 403)
+    assert _write("user", captured) == ("User profile is disabled", 403)
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "memory body"
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "user body"
+
+
+def test_null_memory_section_keeps_defaults_enabled(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": None})
+    payload = _read(home, captured)
+    assert payload["memory"] == "memory body"
+    assert payload["user"] == "user body"
+    assert payload["memory_path"] == str(home / "memories" / "MEMORY.md")
+    assert payload["user_path"] == str(home / "memories" / "USER.md")
+    assert payload["memory_enabled"] is payload["user_profile_enabled"] is True
+    assert _write("memory", captured) is None
+    assert _write("user", captured) is None
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "changed"
     assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "changed"
 
 

--- a/tests/test_issue6406_memory_feature_gates.py
+++ b/tests/test_issue6406_memory_feature_gates.py
@@ -2,6 +2,8 @@ import json
 import pathlib
 import shutil
 import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import api.profiles
@@ -23,8 +25,9 @@ def _setup_home(tmp_path, monkeypatch, config):
     (home / "SOUL.md").write_text("soul body", encoding="utf-8")
     monkeypatch.setattr(api.profiles, "get_active_hermes_home", lambda: home)
     monkeypatch.setattr(routes, "get_config", lambda: config)
+    monkeypatch.setattr(routes, "get_config_snapshot", lambda: config)
     monkeypatch.setattr(routes, "_memory_project_context_workspace", lambda _parsed: tmp_path)
-    monkeypatch.setattr(routes, "_external_notes_sources_enabled", lambda: True)
+    monkeypatch.setattr(routes, "_external_notes_sources_enabled", lambda _config_data=None: True)
     captured = {}
     monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.setdefault("payload", payload))
     monkeypatch.setattr(
@@ -388,6 +391,7 @@ def test_reporter_repro_both_flags_disabled_blank_payload_hide_rows_and_block_wr
     payload = _read(home, captured)
     assert payload["memory"] == payload["user"] == ""
     assert payload["memory_mtime"] is payload["user_mtime"] is None
+    assert payload["memory_path"] is payload["user_path"] is None
     assert payload["memory_enabled"] is payload["user_profile_enabled"] is False
     assert _write("memory", captured) == ("Memory is disabled", 403)
     assert _write("user", captured) == ("User profile is disabled", 403)
@@ -424,6 +428,18 @@ def test_absent_flags_default_to_enabled(tmp_path, monkeypatch):
     assert _write("user", captured) is None
 
 
+def test_present_memory_block_missing_flags_disable_current_server_surfaces(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {}})
+    payload = _read(home, captured)
+    assert payload["memory"] == payload["user"] == ""
+    assert payload["memory_enabled"] is payload["user_profile_enabled"] is False
+    assert payload["memory_path"] is payload["user_path"] is None
+    assert _write("memory", captured) == ("Memory is disabled", 403)
+    assert _write("user", captured) == ("User profile is disabled", 403)
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "memory body"
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "user body"
+
+
 def test_string_flags_follow_existing_truthy_config_semantics(tmp_path, monkeypatch):
     home, captured = _setup_home(
         tmp_path,
@@ -448,6 +464,86 @@ def test_soul_project_context_and_external_notes_remain_available(tmp_path, monk
     assert payload["external_notes_enabled"] is True
     assert _write("soul", captured) is None
     assert (home / "SOUL.md").read_text(encoding="utf-8") == "changed"
+
+
+def test_concurrent_profiles_keep_request_owned_memory_flags(tmp_path, monkeypatch):
+    profiles = {
+        "alpha": {
+            "config": {"memory": {"memory_enabled": False, "user_profile_enabled": True}},
+            "other": "beta",
+            "memory_result": ("Memory is disabled", 403),
+            "user_result": None,
+            "memory_content": "memory body",
+            "user_content": "alpha user",
+        },
+        "beta": {
+            "config": {"memory": {"memory_enabled": True, "user_profile_enabled": False}},
+            "other": "alpha",
+            "memory_result": None,
+            "user_result": ("User profile is disabled", 403),
+            "memory_content": "beta memory",
+            "user_content": "user body",
+        },
+    }
+    tls = threading.local()
+    start = threading.Barrier(len(profiles))
+
+    for name in profiles:
+        home = tmp_path / name
+        memories = home / "memories"
+        memories.mkdir(parents=True)
+        (memories / "MEMORY.md").write_text("memory body", encoding="utf-8")
+        (memories / "USER.md").write_text("user body", encoding="utf-8")
+        profiles[name]["home"] = home
+
+    monkeypatch.setattr(api.profiles, "get_active_hermes_home", lambda: tls.home)
+    monkeypatch.setattr(routes, "get_config_snapshot", lambda: tls.config)
+    monkeypatch.setattr(routes, "get_config", lambda: profiles[tls.name]["config"])
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: payload)
+    monkeypatch.setattr(routes, "bad", lambda _handler, message, status=400: {"error": (message, status)})
+
+    def run(profile_name):
+        profile = profiles[profile_name]
+        tls.name = profile["other"]
+        tls.home = profile["home"]
+        tls.config = profile["config"]
+        start.wait(timeout=5)
+        memory = routes._handle_memory_write(
+            object(),
+            {"section": "memory", "content": f"{profile_name} memory"},
+        )
+        user = routes._handle_memory_write(
+            object(),
+            {"section": "user", "content": f"{profile_name} user"},
+        )
+        return {
+            "memory": memory.get("error") if isinstance(memory, dict) and "error" in memory else None,
+            "user": user.get("error") if isinstance(user, dict) and "error" in user else None,
+            "memory_content": (profile["home"] / "memories" / "MEMORY.md").read_text(encoding="utf-8"),
+            "user_content": (profile["home"] / "memories" / "USER.md").read_text(encoding="utf-8"),
+        }
+
+    with ThreadPoolExecutor(max_workers=len(profiles)) as executor:
+        results = {
+            name: future.result()
+            for name, future in {
+                name: executor.submit(run, name)
+                for name in profiles
+            }.items()
+        }
+
+    assert results["alpha"] == {
+        "memory": profiles["alpha"]["memory_result"],
+        "user": profiles["alpha"]["user_result"],
+        "memory_content": profiles["alpha"]["memory_content"],
+        "user_content": profiles["alpha"]["user_content"],
+    }
+    assert results["beta"] == {
+        "memory": profiles["beta"]["memory_result"],
+        "user": profiles["beta"]["user_result"],
+        "memory_content": profiles["beta"]["memory_content"],
+        "user_content": profiles["beta"]["user_content"],
+    }
 
 
 @pytest.mark.skipif(NODE is None, reason="node is required for panel row coverage")

--- a/tests/test_issue6406_memory_feature_gates.py
+++ b/tests/test_issue6406_memory_feature_gates.py
@@ -400,20 +400,24 @@ def test_reporter_repro_both_flags_disabled_blank_payload_hide_rows_and_block_wr
 
 
 def test_memory_flag_only_gates_memory_surface(tmp_path, monkeypatch):
-    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": False, "user_profile_enabled": True}})
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": False}})
     payload = _read(home, captured)
     assert payload["memory"] == ""
     assert payload["user"] == "user body"
+    assert payload["memory_enabled"] is False
+    assert payload["user_profile_enabled"] is True
     assert _write("memory", captured) == ("Memory is disabled", 403)
     assert _write("user", captured) is None
     assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "changed"
 
 
 def test_user_flag_only_gates_user_surface(tmp_path, monkeypatch):
-    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": True, "user_profile_enabled": False}})
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"user_profile_enabled": False}})
     payload = _read(home, captured)
     assert payload["memory"] == "memory body"
     assert payload["user"] == ""
+    assert payload["memory_enabled"] is True
+    assert payload["user_profile_enabled"] is False
     assert _write("memory", captured) is None
     assert _write("user", captured) == ("User profile is disabled", 403)
 
@@ -428,16 +432,18 @@ def test_absent_flags_default_to_enabled(tmp_path, monkeypatch):
     assert _write("user", captured) is None
 
 
-def test_present_memory_block_missing_flags_disable_current_server_surfaces(tmp_path, monkeypatch):
-    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {}})
+def test_present_memory_block_with_unrelated_setting_keeps_missing_flags_enabled(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"write_approval": True}})
     payload = _read(home, captured)
-    assert payload["memory"] == payload["user"] == ""
-    assert payload["memory_enabled"] is payload["user_profile_enabled"] is False
-    assert payload["memory_path"] is payload["user_path"] is None
-    assert _write("memory", captured) == ("Memory is disabled", 403)
-    assert _write("user", captured) == ("User profile is disabled", 403)
-    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "memory body"
-    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "user body"
+    assert payload["memory"] == "memory body"
+    assert payload["user"] == "user body"
+    assert payload["memory_enabled"] is payload["user_profile_enabled"] is True
+    assert payload["memory_path"] == str(home / "memories" / "MEMORY.md")
+    assert payload["user_path"] == str(home / "memories" / "USER.md")
+    assert _write("memory", captured) is None
+    assert _write("user", captured) is None
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "changed"
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "changed"
 
 
 def test_string_flags_follow_existing_truthy_config_semantics(tmp_path, monkeypatch):

--- a/tests/test_issue6406_memory_feature_gates.py
+++ b/tests/test_issue6406_memory_feature_gates.py
@@ -1,0 +1,515 @@
+import json
+import pathlib
+import shutil
+import subprocess
+from types import SimpleNamespace
+
+import api.profiles
+import api.routes as routes
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+NODE = shutil.which("node")
+
+
+def _setup_home(tmp_path, monkeypatch, config):
+    home = tmp_path / "home"
+    memories = home / "memories"
+    memories.mkdir(parents=True)
+    (memories / "MEMORY.md").write_text("memory body", encoding="utf-8")
+    (memories / "USER.md").write_text("user body", encoding="utf-8")
+    (home / "SOUL.md").write_text("soul body", encoding="utf-8")
+    monkeypatch.setattr(api.profiles, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(routes, "get_config", lambda: config)
+    monkeypatch.setattr(routes, "_memory_project_context_workspace", lambda _parsed: tmp_path)
+    monkeypatch.setattr(routes, "_external_notes_sources_enabled", lambda: True)
+    captured = {}
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, **_kwargs: captured.setdefault("payload", payload))
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, message, status=400: captured.setdefault("error", (message, status)),
+    )
+    return home, captured
+
+
+def _read(home, captured):
+    routes._handle_memory_read(object(), SimpleNamespace(query=""))
+    return captured["payload"]
+
+
+def _write(section, captured):
+    captured.pop("error", None)
+    captured.pop("payload", None)
+    routes._handle_memory_write(object(), {"section": section, "content": "changed"})
+    return captured.get("error")
+
+
+def _panel_rows(data):
+    panels = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    sections_start = panels.index("const MEMORY_SECTIONS = [")
+    sections_end = panels.index("];", sections_start) + 2
+    helper_start = panels.index("function _memorySectionMeta(key)")
+    helper_end = panels.index("function _memorySectionLabel", helper_start)
+    loop_start = panels.index("for (const s of MEMORY_SECTIONS) {")
+    loop_end = panels.index("    if (_currentMemorySection && _memoryMode !== 'edit')", loop_start)
+    script = (
+        "const sections = " + json.dumps(panels[sections_start:sections_end]) + ";\n"
+        "const helper = " + json.dumps(panels[helper_start:helper_end]) + ";\n"
+        "const loop = " + json.dumps(panels[loop_start:loop_end].rsplit("    }", 1)[0]) + ";\n"
+        "let _memoryData = " + json.dumps(data) + ";\n"
+        + r"""
+const nodes = {memoryPanel: {appended: [], innerHTML: '', appendChild(node) { this.appended.push(node); }}};
+const panel = nodes.memoryPanel;
+let _currentMemorySection = 'memory';
+const document = {createElement() { return {innerHTML: '', title: '', classList: {add() {}}}; }};
+function _memorySectionLabel(meta) { return meta.key; }
+function _memorySectionPath() { return ''; }
+function li() { return ''; }
+function esc(value) { return String(value); }
+function openMemorySection() {}
+eval(sections + "\n" + helper + "\nfunction renderRows() {" + loop + "}\nrenderRows();");
+console.log(JSON.stringify(nodes.memoryPanel.appended.map(button => button.innerHTML.replace(/<[^>]+>/g, ''))));
+"""
+    )
+    completed = subprocess.run([NODE, "-e", script], capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+_PANEL_DRIVER = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[1], 'utf8');
+const scenario = process.argv[2];
+
+function extractFunc(name) {
+  const re = new RegExp('(?:async\\s+)?function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  const braceStart = src.indexOf('{', start);
+  let depth = 0;
+  let inString = null;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = braceStart; i < src.length; i++) {
+    const ch = src[i];
+    const next = i + 1 < src.length ? src[i + 1] : '';
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      inString = ch;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(name + ' brace scan failed');
+}
+
+function extractConst(name) {
+  const start = src.indexOf('const ' + name + ' = [');
+  if (start < 0) throw new Error(name + ' not found');
+  const end = src.indexOf('];', start);
+  if (end < 0) throw new Error(name + ' terminator not found');
+  return src.slice(start, end + 2);
+}
+
+function makeClassList(owner) {
+  return {
+    add(name) { owner._classes.add(name); },
+    remove(name) { owner._classes.delete(name); },
+    contains(name) { return owner._classes.has(name); },
+  };
+}
+
+function makeEl(id = '') {
+  const el = {
+    id,
+    children: [],
+    _classes: new Set(),
+    classList: null,
+    style: {},
+    innerHTML: '',
+    textContent: '',
+    title: '',
+    value: '',
+    onclick: null,
+    appendChild(child) {
+      this.children.push(child);
+      return child;
+    },
+    querySelector(selector) {
+      if (selector === '.main-view-header') return this._header || null;
+      return null;
+    },
+    focus() {
+      this.focused = true;
+    },
+  };
+  el.classList = makeClassList(el);
+  return el;
+}
+
+let _memoryData = null;
+let _currentMemorySection = null;
+let _memoryMode = 'empty';
+let _notesSourcesData = null;
+let _notesSearchResults = [];
+let _notesPreviewNote = null;
+let _notesSearchError = '';
+let _notesSearchLoading = false;
+let _notesSelectedSource = 'joplin';
+let S = {session: null};
+
+const nodes = {
+  memoryPanel: makeEl('memoryPanel'),
+  memoryDetailTitle: makeEl('memoryDetailTitle'),
+  memoryDetailBody: makeEl('memoryDetailBody'),
+  memoryDetailEmpty: makeEl('memoryDetailEmpty'),
+  mainMemory: makeEl('mainMemory'),
+  btnEditMemoryDetail: makeEl('btnEditMemoryDetail'),
+  btnCancelMemoryDetail: makeEl('btnCancelMemoryDetail'),
+  btnSaveMemoryDetail: makeEl('btnSaveMemoryDetail'),
+  memEditContent: makeEl('memEditContent'),
+  memEditError: makeEl('memEditError'),
+};
+nodes.memoryDetailBody.style.display = 'none';
+nodes.memoryDetailEmpty.style.display = '';
+nodes.memEditError.style.display = 'none';
+nodes.mainMemory._header = makeEl('memoryHeader');
+nodes.mainMemory._header.style.display = 'none';
+
+global.document = {
+  createElement() {
+    return makeEl();
+  },
+  querySelectorAll(selector) {
+    if (selector === '#memoryPanel .side-menu-item') return nodes.memoryPanel.children;
+    return [];
+  },
+};
+global.$ = (id) => nodes[id] || null;
+global.t = (key) => key;
+global.esc = (value) => String(value == null ? '' : value);
+global.li = () => '';
+global.showToast = () => {
+  global.__toastCalls = (global.__toastCalls || 0) + 1;
+};
+global._memorySectionLabel = (meta) => meta.key;
+global._memorySectionPath = () => '';
+global._closeMobileSidebarAfterPanelSelection = () => {
+  global.__closeCalls = (global.__closeCalls || 0) + 1;
+};
+global.__renderDetailCalls = [];
+global.__renderEditCalls = [];
+global._renderMemoryDetail = (section) => {
+  global.__renderDetailCalls.push(section);
+  _memoryMode = 'read';
+  nodes.memoryDetailBody.innerHTML = 'detail:' + section;
+  nodes.memoryDetailBody.style.display = '';
+  nodes.memoryDetailEmpty.style.display = 'none';
+};
+global._renderMemoryEdit = (section) => {
+  global.__renderEditCalls.push(section);
+  _memoryMode = 'edit';
+};
+global.loadNotesSources = async () => {
+  global.__notesCalls = (global.__notesCalls || 0) + 1;
+  return {};
+};
+global._setMemoryHeaderButtons = (mode) => {
+  nodes.mainMemory._header.style.display = mode === 'empty' ? 'none' : 'flex';
+};
+
+let payload = null;
+const writes = [];
+global.api = async (url, opts) => {
+  if (url === '/api/memory' || url.startsWith('/api/memory?')) return payload;
+  if (url === '/api/memory/write') {
+    writes.push(JSON.parse(opts.body));
+    return {};
+  }
+  throw new Error('unexpected url: ' + url);
+};
+
+eval(extractConst('MEMORY_SECTIONS').replace('const MEMORY_SECTIONS', 'var MEMORY_SECTIONS'));
+for (const name of [
+  '_memorySectionMeta',
+  '_memorySectionEnabled',
+  '_renderMemoryEmpty',
+  'loadMemory',
+  'openMemorySection',
+  'editCurrentMemory',
+  'submitMemorySave',
+]) {
+  eval(extractFunc(name));
+}
+
+function rowLabels() {
+  return nodes.memoryPanel.children.map((node) => node.innerHTML.replace(/<[^>]+>/g, ''));
+}
+
+async function runStaleReset() {
+  payload = {
+    memory_enabled: false,
+    user_profile_enabled: true,
+    external_notes_enabled: true,
+    user: 'user body',
+    soul: '',
+    project_context: '',
+  };
+  _currentMemorySection = 'memory';
+  _memoryMode = 'edit';
+  nodes.memoryDetailTitle.textContent = 'Memory';
+  nodes.memoryDetailBody.innerHTML = 'stale body';
+  nodes.memoryDetailBody.style.display = '';
+  nodes.memoryDetailEmpty.style.display = 'none';
+  nodes.mainMemory._header.style.display = 'flex';
+  await loadMemory(false);
+  return {
+    section: _currentMemorySection,
+    mode: _memoryMode,
+    title: nodes.memoryDetailTitle.textContent,
+    body: nodes.memoryDetailBody.innerHTML,
+    bodyDisplay: nodes.memoryDetailBody.style.display,
+    emptyDisplay: nodes.memoryDetailEmpty.style.display,
+    headerDisplay: nodes.mainMemory._header.style.display,
+    renderDetailCalls: global.__renderDetailCalls.slice(),
+    rows: rowLabels(),
+  };
+}
+
+async function runGuards() {
+  payload = {
+    memory_enabled: false,
+    user_profile_enabled: true,
+    external_notes_enabled: true,
+    memory: '',
+    user: 'user body',
+    soul: '',
+    project_context: '',
+  };
+  _memoryData = payload;
+  const blocked = makeEl();
+  const allowed = makeEl();
+  await openMemorySection('memory', blocked);
+  const blockedState = {
+    current: _currentMemorySection,
+    renderDetailCalls: global.__renderDetailCalls.slice(),
+    closeCalls: global.__closeCalls || 0,
+    blockedActive: blocked.classList.contains('active'),
+  };
+  await openMemorySection('user', allowed);
+  const openState = {
+    current: _currentMemorySection,
+    renderDetailCalls: global.__renderDetailCalls.slice(),
+    closeCalls: global.__closeCalls || 0,
+    allowedActive: allowed.classList.contains('active'),
+  };
+  _currentMemorySection = 'memory';
+  editCurrentMemory();
+  const blockedEditCalls = global.__renderEditCalls.slice();
+  _currentMemorySection = 'user';
+  editCurrentMemory();
+  const editState = {
+    renderEditCalls: global.__renderEditCalls.slice(),
+  };
+  nodes.memEditContent.value = 'changed';
+  _currentMemorySection = 'memory';
+  await submitMemorySave();
+  const blockedSaveWrites = writes.slice();
+  _currentMemorySection = 'user';
+  await submitMemorySave();
+  return {
+    blockedState,
+    openState,
+    blockedEditCalls,
+    editState,
+    blockedSaveWrites,
+    writes,
+    toastCalls: global.__toastCalls || 0,
+    finalRenderDetailCalls: global.__renderDetailCalls.slice(),
+  };
+}
+
+(async () => {
+  const out = scenario === 'stale_reset' ? await runStaleReset() : await runGuards();
+  process.stdout.write(JSON.stringify(out));
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+});
+"""
+
+
+def _panel_behavior(scenario: str) -> dict:
+    completed = subprocess.run(
+        [NODE, "-e", _PANEL_DRIVER, str(REPO_ROOT / "static" / "panels.js"), scenario],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def test_reporter_repro_both_flags_disabled_blank_payload_hide_rows_and_block_writes(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": False, "user_profile_enabled": False}})
+    payload = _read(home, captured)
+    assert payload["memory"] == payload["user"] == ""
+    assert payload["memory_mtime"] is payload["user_mtime"] is None
+    assert payload["memory_enabled"] is payload["user_profile_enabled"] is False
+    assert _write("memory", captured) == ("Memory is disabled", 403)
+    assert _write("user", captured) == ("User profile is disabled", 403)
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "memory body"
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "user body"
+
+
+def test_memory_flag_only_gates_memory_surface(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": False, "user_profile_enabled": True}})
+    payload = _read(home, captured)
+    assert payload["memory"] == ""
+    assert payload["user"] == "user body"
+    assert _write("memory", captured) == ("Memory is disabled", 403)
+    assert _write("user", captured) is None
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "changed"
+
+
+def test_user_flag_only_gates_user_surface(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": True, "user_profile_enabled": False}})
+    payload = _read(home, captured)
+    assert payload["memory"] == "memory body"
+    assert payload["user"] == ""
+    assert _write("memory", captured) is None
+    assert _write("user", captured) == ("User profile is disabled", 403)
+
+
+def test_absent_flags_default_to_enabled(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {})
+    payload = _read(home, captured)
+    assert payload["memory"] == "memory body"
+    assert payload["user"] == "user body"
+    assert payload["memory_enabled"] is payload["user_profile_enabled"] is True
+    assert _write("memory", captured) is None
+    assert _write("user", captured) is None
+
+
+def test_string_flags_follow_existing_truthy_config_semantics(tmp_path, monkeypatch):
+    home, captured = _setup_home(
+        tmp_path,
+        monkeypatch,
+        {"memory": {"memory_enabled": "false", "user_profile_enabled": "yes"}},
+    )
+    payload = _read(home, captured)
+    assert payload["memory"] == ""
+    assert payload["user"] == "user body"
+    assert payload["memory_enabled"] is False
+    assert payload["user_profile_enabled"] is True
+    assert _write("memory", captured) == ("Memory is disabled", 403)
+    assert _write("user", captured) is None
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8") == "changed"
+
+
+def test_soul_project_context_and_external_notes_remain_available(tmp_path, monkeypatch):
+    home, captured = _setup_home(tmp_path, monkeypatch, {"memory": {"memory_enabled": False, "user_profile_enabled": False}})
+    payload = _read(home, captured)
+    assert payload["soul"] == "soul body"
+    assert payload["project_context"] == ""
+    assert payload["external_notes_enabled"] is True
+    assert _write("soul", captured) is None
+    assert (home / "SOUL.md").read_text(encoding="utf-8") == "changed"
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for panel row coverage")
+def test_panel_rows_follow_memory_feature_flags():
+    assert _panel_rows({
+        "memory_enabled": False,
+        "user_profile_enabled": False,
+        "external_notes_enabled": True,
+    }) == ["soul", "project_context", "external_notes"]
+    assert _panel_rows({
+        "memory_enabled": False,
+        "user_profile_enabled": True,
+        "external_notes_enabled": True,
+    }) == ["user", "soul", "project_context", "external_notes"]
+    assert _panel_rows({
+        "memory_enabled": True,
+        "user_profile_enabled": False,
+        "external_notes_enabled": True,
+    }) == ["memory", "soul", "project_context", "external_notes"]
+    assert _panel_rows({
+        "memory_enabled": True,
+        "user_profile_enabled": True,
+        "external_notes_enabled": True,
+    }) == ["memory", "user", "soul", "project_context", "external_notes"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for panel row coverage")
+def test_missing_payload_flags_leave_sections_visible():
+    assert _panel_rows({"external_notes_enabled": False}) == ["memory", "user", "soul", "project_context"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for panel behavior coverage")
+def test_disabled_section_refresh_clears_stale_detail_state():
+    out = _panel_behavior("stale_reset")
+    assert out["section"] is None
+    assert out["mode"] == "empty"
+    assert out["title"] == ""
+    assert out["body"] == ""
+    assert out["bodyDisplay"] == "none"
+    assert out["emptyDisplay"] == ""
+    assert out["headerDisplay"] == "none"
+    assert out["renderDetailCalls"] == []
+    assert out["rows"] == ["user", "soul", "project_context", "external_notes"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node is required for panel behavior coverage")
+def test_open_edit_and_save_guards_respect_disabled_sections():
+    out = _panel_behavior("guards")
+    assert out["blockedState"] == {
+        "current": None,
+        "renderDetailCalls": [],
+        "closeCalls": 0,
+        "blockedActive": False,
+    }
+    assert out["openState"] == {
+        "current": "user",
+        "renderDetailCalls": ["user"],
+        "closeCalls": 1,
+        "allowedActive": True,
+    }
+    assert out["blockedEditCalls"] == []
+    assert out["editState"]["renderEditCalls"] == ["user"]
+    assert out["blockedSaveWrites"] == []
+    assert out["writes"] == [{"section": "user", "content": "changed"}]
+    assert out["toastCalls"] == 1
+    assert out["finalRenderDetailCalls"] == ["user", "user"]

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -345,7 +345,8 @@ def test_external_notes_menu_item_is_default_off_from_memory_payload():
 
     panels = Path("static/panels.js").read_text(encoding="utf-8")
     assert "external_notes_enabled" in panels
-    assert "if (s.key === 'external_notes' && !_memoryData.external_notes_enabled) continue;" in panels
+    assert "if (meta.key === 'external_notes') return !data || data.external_notes_enabled === true;" in panels
+    assert "if (!_memorySectionEnabled(s, _memoryData)) continue;" in panels
 
 
 def test_external_notes_drawer_copy_is_localized_outside_english():


### PR DESCRIPTION
## Thinking Path

- The Memory panel is a first-party surface over Hermes Agent's `MEMORY.md` and `USER.md`. Hermes Agent gates those two surfaces with `memory.memory_enabled` and `memory.user_profile_enabled`, deep-merged from `DEFAULT_CONFIG` where both default to `true`. The WebUI's `/api/memory` never read those flags, so a disabled surface still returned its file contents and stayed editable (#6406).
- The fix reads one request-owned config snapshot per handler and resolves the two flags through a single shared helper, `_memory_feature_flags`, that both `_handle_memory_read` and `_handle_memory_write` consume. Disabled surfaces come back blank with null path and null mtime, disabled writes return 403 before any directory creation or target selection, and the panel drops the row.
- The remaining subtlety was not the route shape, it was the config contract. The WebUI now mirrors Hermes Agent's effective rules for loadable `memory` config values: omitted leaves and `memory: null` keep both surfaces enabled, a scalar or list `memory` section fails closed, and mapping leaves follow normal Python truthiness. `soul`, project context, and the default-off external-notes drawer keep their separate rules.

## What Changed

- `api/routes.py`: `_memory_feature_flags` now keeps `memory: null` on the merged default-on path, fails closed for non-mapping `memory` section shapes, and resolves `memory_enabled` / `user_profile_enabled` with Python truthiness instead of `_webui_truthy`. The read and write handlers keep their single request-owned snapshot, additive `memory_enabled` / `user_profile_enabled` payload fields, blanked disabled content, null disabled paths and mtimes, and 403-before-mutation writes.
- `tests/test_issue6406_memory_feature_gates.py`: the focused matrix now covers unrelated-setting only, one-key disable for each leaf, quoted `"false"` / `"no"` leaves, scalar and list section shapes, and the null-section success case, while preserving the concurrent-profile isolation and panel-behavior coverage.

## Why It Matters

The WebUI now follows the same effective memory-flag contract the Agent already applies. Valid configs no longer get silently disabled by the WebUI, and wrong-shape configs now fail closed before exposing or writing private memory data.

## Verification

The focused gate now fails on the unfixed helper for the new parity classes, quoted-string leaves and non-mapping `memory` sections, and passes once `_memory_feature_flags()` mirrors Agent semantics. The rerun kept the one-flag omission cases, the unrelated-setting case, the both-disabled reporter case, concurrent request-owned snapshot isolation, adjacent-surface availability, and the scanner-safe Node panel harness green. The two neighboring counterparts, `test_3866_project_context_memory_section.py` and `test_webui_notes_sources.py`, also reran green. CI runs the full suite on Python 3.11/3.12/3.13.

## Risks / Follow-ups

This touches path handling and file read/write gating, so the security posture is explicit: disabled surfaces still return an empty body with null path and null mtime, and writes still return 403 before any `mkdir` or target selection, so nothing on disk is touched. `memory: null` now keeps the merged defaults enabled, while scalar and list section shapes fail closed, matching Hermes Agent's effective behavior. The Memory panel markup and CSS are unchanged from the current visible behavior, so the before/after pair below remains the both-disabled row-removal steady state; the broader responsive render matrix stays CI-owned. No other known risks; nothing else deferred.

## Contract Routing

- **Task type:** bugfix, config-contract parity for memory feature flags.
- **Touched areas:** `api/routes.py` `_memory_feature_flags`; `tests/test_issue6406_memory_feature_gates.py`.
- **Relevant public docs:** issue #6406; Hermes Agent memory defaults and runtime config semantics; `docs/UIUX-GUIDE.md` for the Memory panel's primary-surface role.
- **Scope boundaries:** helper semantics and the focused expectation matrix only; request-owned snapshot capture, route structure, payload shape, the `_memorySectionEnabled` frontend seam, and adjacent surfaces stay unchanged.
- **Evidence needed before claiming done:** focused gate base-fail and head-pass for the new parity cases, plus green reruns for the neighboring project-context and external-notes counterparts.

## Upstream

Closes #6406.

Thanks to @Lilirissa for the clear config-level repro and route pointers in the original report.

## Screenshots

Memory panel with both surfaces disabled in config, before both rows still render with populated, editable content; after My Notes and User Profile are removed and the remaining rows stay unclipped and touch-usable.

![Before](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui-PR-TARGET-6406-before.png)

![After](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui-PR-TARGET-6406-after.png)

## Model Used

GPT-5 via Codex CLI.
