### PR TITLE
perf: paint active sessions before restoring live scenes

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2015,8 +2015,114 @@ function closeOtherLiveStreams(activeSid){
   }
 }
 
+// A reconnecting loadSession() call does not own a transport until its async
+// status preflight completes. Track that gap explicitly so a newer pane/load
+// owner can supersede it before EventSource construction.
+const _PENDING_LIVE_ATTACHES=Object.create(null);
+
+function _pendingLiveAttachIdentity(activeSid, streamId, options={}){
+  if(typeof options.isCurrentOwner!=='function') return null;
+  return {
+    sid:String(activeSid||''),
+    streamId:String(streamId||''),
+    ownerToken:String(options.ownerToken||''),
+    loadGeneration:Number.isFinite(Number(options.loadGeneration))?Number(options.loadGeneration):null,
+    isCurrentOwner:options.isCurrentOwner,
+    onAttached:typeof options.onAttached==='function'?options.onAttached:null,
+  };
+}
+
+function _claimPendingLiveAttach(activeSid, streamId, options={}){
+  const claim=_pendingLiveAttachIdentity(activeSid,streamId,options);
+  if(!claim||!claim.sid||!claim.streamId) return null;
+  const existing=_PENDING_LIVE_ATTACHES[claim.sid];
+  if(existing&&existing.streamId===claim.streamId&&
+    existing.ownerToken===claim.ownerToken&&
+    existing.loadGeneration===claim.loadGeneration){
+    return {claim:existing,shouldStart:false};
+  }
+  _PENDING_LIVE_ATTACHES[claim.sid]=claim;
+  return {claim,shouldStart:true};
+}
+
+function _ownsPendingLiveAttach(claim){
+  if(!claim||_PENDING_LIVE_ATTACHES[claim.sid]!==claim) return false;
+  try{return !!claim.isCurrentOwner();}catch(_){return false;}
+}
+
+function _finishPendingLiveAttach(claim, attached){
+  if(!claim) return attached;
+  if(_PENDING_LIVE_ATTACHES[claim.sid]===claim) delete _PENDING_LIVE_ATTACHES[claim.sid];
+  if(attached&&claim.onAttached){try{claim.onAttached();}catch(_){}}
+  return attached;
+}
+
+function _invalidatePendingLiveAttachClaims(){
+  for(const sid of Object.keys(_PENDING_LIVE_ATTACHES)) delete _PENDING_LIVE_ATTACHES[sid];
+}
+
+function _attachLiveStreamWithOwnership({
+  activeSid,
+  streamId,
+  reconnecting=false,
+  ownsAttach,
+  finishAttach,
+  statusDecision,
+  replayParamsForAttach,
+  connectSource,
+  wireSource,
+}){
+  const _ownsAttach=typeof ownsAttach==='function'?ownsAttach:()=>true;
+  const _finishAttach=typeof finishAttach==='function'?finishAttach:(attached)=>attached;
+  const _decide=typeof statusDecision==='function'?statusDecision:()=>({shouldConnect:true,replayOnly:false});
+  const _replayParams=typeof replayParamsForAttach==='function'?replayParamsForAttach:()=>'';
+  const _makeSource=typeof connectSource==='function'?connectSource:()=>null;
+  const _wireSource=typeof wireSource==='function'?wireSource:()=>{};
+
+  return (async()=>{
+    if(!_ownsAttach()) return _finishAttach(false);
+    let replayOnly=false;
+    if(reconnecting){
+      try{
+        const status=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+        if(!_ownsAttach()) return _finishAttach(false);
+        const decision=_decide(status);
+        if(!decision||decision.shouldConnect===false) return _finishAttach(false);
+        replayOnly=!!decision.replayOnly;
+      }catch(_){
+        if(!_ownsAttach()) return _finishAttach(false);
+      }
+    }
+
+    let source;
+    try{
+      const replayParams=_replayParams(reconnecting||replayOnly);
+      if(!_ownsAttach()) return _finishAttach(false);
+      source=_makeSource(replayParams);
+      if(!_ownsAttach()){
+        try{source.close();}catch(_){}
+        return _finishAttach(false);
+      }
+      _wireSource(source);
+      return _finishAttach(true);
+    }catch(_){
+      if(source&&typeof source.close==='function'){
+        try{source.close();}catch(_){}
+      }
+      return _finishAttach(false);
+    }
+  })();
+}
+
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
-  if(!activeSid||!streamId) return;
+  if(!activeSid||!streamId) return false;
+  const _pendingAttach=_claimPendingLiveAttach(activeSid,streamId,options);
+  if(_pendingAttach&&!_pendingAttach.shouldStart) return true;
+  const _attachClaim=_pendingAttach&&_pendingAttach.claim;
+  const _ownsAttach=()=>!_attachClaim||_ownsPendingLiveAttach(_attachClaim);
+  const _finishAttach=(attached)=>_finishPendingLiveAttach(_attachClaim,attached);
+  if(!_ownsAttach()) return _finishAttach(false);
+  try{
   const reconnecting=!!options.reconnecting;
   // #4416: start (or, on reconnect for the SAME stream, keep) tracking whether
   // the tab was hidden during this stream so the done-notification fires for a
@@ -2062,13 +2168,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       existingLive.source.readyState===EventSource.OPEN||
       (!reconnecting&&existingLive.source.readyState===EventSource.CONNECTING))
   ){
+    if(!_ownsAttach()) return _finishAttach(false);
     // Phase D: restore bottom run status on reattach after the Worklog shell
     // exists. There is no stale transport teardown in this branch.
     if(reconnecting && S.activeStreamId && typeof showLiveRunStatus==='function'){
       const _startedAt=(S.session&&S.session.pending_started_at)||Date.now()/1000;
       showLiveRunStatus(activeSid,{startedAt:_startedAt});
     }
-    return;
+    return _finishAttach(true);
   }
   closeOtherLiveStreams(activeSid);
   closeLiveStream(activeSid);
@@ -6707,48 +6814,53 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _setActivePaneIdleIfOwner();
   }
 
-  (async()=>{
-    // Reattach path can carry stale stream ids after server restart; preflight
-    // status avoids opening a dead SSE URL that will 404 in the console.
-    let replayOnly=false;
-    if(reconnecting){
-      try{
-        const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
-        if(!st.active&&st.replay_available){
-          replayOnly=true;
-        }else if(!st.active){
-          _clearOwnerInflightState();
-          _clearApprovalForOwner();
-          _clearClarifyForOwner('terminal');
-          if(S.session&&S.session.session_id===activeSid){
-            // Follow-intent BEFORE removing live placeholders: a reader following
-            // the (now-dead) stream should stay pinned to the bottom as the
-            // thinking/tool placeholders are cleared, not be stranded mid-transcript
-            // by preserveScroll restoring a stale scrollTop after the height shrinks.
-            const _wasFollowingAtReconnectDead=((typeof _isMessagePaneNearBottom==='function')
-                ? _isMessagePaneNearBottom(1200)
-                : true)
-              && !((typeof _isMessageReaderUnpinned==='function')
-                ? _isMessageReaderUnpinned()
-                : (typeof _messageUserUnpinned!=='undefined' && _messageUserUnpinned));
-            S.activeStreamId=null;
-            clearLiveToolCards();
-            removeThinking();
-            if(_isActiveSession()) _queueDrainSid=activeSid;
-            _setActivePaneIdleIfOwner();
-            renderMessages({preserveScroll:true});
-            if(_wasFollowingAtReconnectDead && typeof scrollToBottom==='function') scrollToBottom();
-            renderSessionList();
-          }
-          _scheduleAnchorRegistryCleanup(120000);
-          return;
-        }
-      }catch(_){}
-    }
-    const replayParams=(reconnecting||replayOnly)?_runJournalReplayParams():'';
-    _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${replayParams}`,document.baseURI||location.href).href,{withCredentials:true}));
-  })();
+  _attachLiveStreamWithOwnership({
+    activeSid,
+    streamId,
+    reconnecting,
+    ownsAttach: _ownsAttach,
+    finishAttach:_finishAttach,
+    statusDecision:(status)=>{
+      if(status&&status.active){
+        setComposerStatus('Reconnected');
+        return {shouldConnect:true,replayOnly:false};
+      }
+      if(status&&status.replay_available) return {shouldConnect:true,replayOnly:true};
+      _clearOwnerInflightState();
+      _clearApprovalForOwner();
+      _clearClarifyForOwner('terminal');
+      if(S.session&&S.session.session_id===activeSid){
+        const _wasFollowingAtReconnectDead=((typeof _isMessagePaneNearBottom==='function')
+            ? _isMessagePaneNearBottom(1200)
+            : true)
+          && !((typeof _isMessageReaderUnpinned==='function')
+            ? _isMessageReaderUnpinned()
+            : (typeof _messageUserUnpinned!=='undefined' && _messageUserUnpinned));
+        S.activeStreamId=null;
+        clearLiveToolCards();
+        removeThinking();
+        if(_isActiveSession()) _queueDrainSid=activeSid;
+        _setActivePaneIdleIfOwner();
+        renderMessages({preserveScroll:true});
+        if(_wasFollowingAtReconnectDead&&typeof scrollToBottom==='function') scrollToBottom();
+        renderSessionList();
+      }
+      _scheduleAnchorRegistryCleanup(120000);
+      return {shouldConnect:false,replayOnly:false};
+    },
+    replayParamsForAttach:(shouldReplay)=>shouldReplay?_runJournalReplayParams():'',
+    connectSource:(replayParams)=>new EventSource(
+      new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${replayParams}`,document.baseURI||location.href).href,
+      {withCredentials:true},
+    ),
+    wireSource:_wireSSE,
+  });
 
+    return _attachClaim?true:undefined;
+  }catch(error){
+    _finishAttach(false);
+    throw error;
+  }
 }
 
 function transcript(){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -922,6 +922,19 @@ function _purgeStaleInflightEntries() {
     && typeof _allSessionsScope.sidebarSource === 'string'
     ? _allSessionsScope.sidebarSource
     : null;
+  const isActiveSessionInflightOwnerCoherent = (sid, inflightValue) => {
+    if (!sid || !inflightValue || !S || !S.session) return false;
+    if (S.session.session_id !== sid) return false;
+    const streamId = String(inflightValue.streamId || '').trim();
+    if (!streamId) return false;
+  const ownerStreamIds = [];
+  if (S.activeStreamId) ownerStreamIds.push(String(S.activeStreamId).trim());
+  if (S.session.active_stream_id) ownerStreamIds.push(String(S.session.active_stream_id).trim());
+  if (!ownerStreamIds.length) return false;
+  if (ownerStreamIds.some((ownerStreamId) => ownerStreamId !== streamId)) return false;
+  if (S.busy !== true) return false;
+  return true;
+};
   for (const sid of Object.keys(INFLIGHT)) {
     // #4354: purge stale INFLIGHT even for a hung/idle session, BUT skip the one
     // session actively mid-send (#2689 start-race) — during /api/chat/start the
@@ -933,6 +946,9 @@ function _purgeStaleInflightEntries() {
     if (!sessionsById.has(sid)) {
       const knownSource = sourceById ? sourceById.get(sid) : null;
       if (currentSidebarSource && (!knownSource || knownSource !== currentSidebarSource)) {
+        continue;
+      }
+      if (isActiveSessionInflightOwnerCoherent(sid, INFLIGHT[sid])) {
         continue;
       }
       // Session is absent from _allSessions — it was deleted / archived /
@@ -2138,6 +2154,7 @@ async function loadSession(sid){
     // replaying persisted live tools so the compact Activity count survives
     // switching away from and back to an active chat (#1715).
     S.activeStreamId=activeStreamId;
+
     const liveToolReplayId=(tc)=>String(tc&&(tc.tid||tc.id||tc.tool_call_id||tc.tool_use_id||tc.call_id||'')||'').trim();
     const replayPersistedLiveToolCards=(opts)=>{
       const liveToolCalls=Array.isArray(S.toolCalls)
@@ -2145,69 +2162,88 @@ async function loadSession(sid){
         : (Array.isArray(INFLIGHT[sid]&&INFLIGHT[sid].toolCalls)?INFLIGHT[sid].toolCalls:[]);
       const skipUnkeyedRestoredDuplicates=!!(opts&&opts.skipUnkeyedRestoredDuplicates);
       const restoredLiveTurn=skipUnkeyedRestoredDuplicates?document.getElementById('liveAssistantTurn'):null;
-      const hasRestoredLiveToolRows=!!(restoredLiveTurn&&restoredLiveTurn.querySelector('.tool-card-row'));
+      const hasCurrentWorklogContent=!!(restoredLiveTurn&&restoredLiveTurn.querySelector('.tool-card-row'));
       for(const tc of (liveToolCalls||[])){
-        if(skipUnkeyedRestoredDuplicates&&hasRestoredLiveToolRows&&!liveToolReplayId(tc)) continue;
+        if(skipUnkeyedRestoredDuplicates&&hasCurrentWorklogContent&&!liveToolReplayId(tc)) continue;
         if(tc&&tc.name) appendLiveToolCard(tc,{sessionId:sid,streamId:activeStreamId});
       }
     };
-    let didReconnect=false;
-    if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
-      INFLIGHT[sid].reattach=false;
-      if (!_isCurrentLoad()) return;
-      didReconnect=true;
-      attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
-    }
-    syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
-    const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
-      ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid))||
-        _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
-      : false;
-    if(typeof ensureRunActivityForCurrentTurn==='function') ensureRunActivityForCurrentTurn();
-    const hasStructuredLiveState=!!(INFLIGHT[sid]&&(
-      String(INFLIGHT[sid].lastAssistantText||'').trim()||
-      String(INFLIGHT[sid].lastReasoningText||'').trim()||
-      !!(INFLIGHT[sid].anchorActivityScene&&Array.isArray(INFLIGHT[sid].anchorActivityScene.activity_rows)&&INFLIGHT[sid].anchorActivityScene.activity_rows.length)||
-      (Array.isArray(INFLIGHT[sid].activityBurstAnchors)&&INFLIGHT[sid].activityBurstAnchors.length)||
-      (Array.isArray(INFLIGHT[sid].toolCalls)&&INFLIGHT[sid].toolCalls.length)
-    ));
-    let restoredLiveTurn=!!restoredAnchorScene;
-    if(!restoredLiveTurn&&typeof restoreLiveTurnHtmlForSession==='function'){
-      if(!hasStructuredLiveState){
-        restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
-      }else{
-        const liveTurn=document.getElementById('liveAssistantTurn');
-        const hasCurrentWorklogContent=!!(liveTurn&&liveTurn.querySelector(
-          '.live-worklog[data-live-worklog-shell="1"] .tool-card-row,'+
-          '.live-worklog[data-live-worklog-shell="1"] .wl-reason,'+
-          '.tool-call-group[data-live-tool-worklog-group="1"] .tool-card-row,'+
-          '.tool-call-group[data-live-tool-worklog-group="1"] .wl-reason,'+
-          '.tool-call-group[data-live-tool-call-group="1"] .tool-card-row,'+
-          '.tool-call-group[data-live-tool-call-group="1"] .wl-reason'
-        ));
-        if(hasCurrentWorklogContent) restoredLiveTurn=true;
-        else restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
-      }
-    }
-    if(restoredLiveTurn&&didReconnect){
-      replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});
-    }
-    if(!restoredLiveTurn){
-      clearLiveToolCards();
-      if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
+
+    const restoreLiveSurfaceForActiveInflight=()=>{
       if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
-      else appendThinking();
-      replayPersistedLiveToolCards();
-    }
-    if(!restoredAnchorScene&&typeof ensureLiveWorklogShell==='function'){
-      const liveTurn=document.getElementById('liveAssistantTurn');
-      if(!liveTurn||!liveTurn.querySelector('.tool-call-group[data-tool-worklog-group="1"]')) ensureLiveWorklogShell();
-    }
+      const anchorSceneRenderResult=activeStreamId&&typeof window!=='undefined'
+        ? (
+          (typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid)) ||
+          _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid)
+        )
+        : false;
+      if(typeof ensureRunActivityForCurrentTurn==='function') ensureRunActivityForCurrentTurn();
+      const restoredAnchorScene=!!anchorSceneRenderResult||_hasRenderedLiveAnchorActivityScene();
+      const hasStructuredLiveState=!!(INFLIGHT[sid]&&(
+        String(INFLIGHT[sid].lastAssistantText||'').trim()||
+        String(INFLIGHT[sid].lastReasoningText||'').trim()||
+        !!(INFLIGHT[sid].anchorActivityScene&&Array.isArray(INFLIGHT[sid].anchorActivityScene.activity_rows)&&INFLIGHT[sid].anchorActivityScene.activity_rows.length)||
+        (Array.isArray(INFLIGHT[sid].activityBurstAnchors)&&INFLIGHT[sid].activityBurstAnchors.length)||
+        (Array.isArray(INFLIGHT[sid].toolCalls)&&INFLIGHT[sid].toolCalls.length)
+      ));
+      let restoredLiveTurn=!!restoredAnchorScene;
+      if(!restoredLiveTurn&&typeof restoreLiveTurnHtmlForSession==='function'){
+        if(!hasStructuredLiveState){
+          restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
+        }else{
+          const liveTurn=document.getElementById('liveAssistantTurn');
+          const hasCurrentWorklogContent=!!(liveTurn&&liveTurn.querySelector(
+            '.live-worklog[data-live-worklog-shell="1"] .tool-card-row,'+
+            '.live-worklog[data-live-worklog-shell="1"] .wl-reason,'+
+            '.tool-call-group[data-live-tool-worklog-group="1"] .tool-card-row,'+
+            '.tool-call-group[data-live-tool-worklog-group="1"] .wl-reason,'+
+            '.tool-call-group[data-live-tool-call-group="1"] .tool-card-row,'+
+            '.tool-call-group[data-live-tool-call-group="1"] .wl-reason'
+          ));
+          if(hasCurrentWorklogContent) restoredLiveTurn=true;
+          else restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
+        }
+      }
+      if(!restoredLiveTurn){
+        clearLiveToolCards();
+        if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
+        if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+        else appendThinking();
+        replayPersistedLiveToolCards();
+      }
+      if(!restoredAnchorScene&&typeof ensureLiveWorklogShell==='function'){
+        const liveTurn=document.getElementById('liveAssistantTurn');
+        if(!liveTurn||!liveTurn.querySelector('.tool-call-group[data-tool-worklog-group="1"]')) ensureLiveWorklogShell();
+      }
+      return {
+        restoredLiveTurn: !!restoredLiveTurn,
+        restoredAnchorScene: !!restoredAnchorScene,
+      };
+    };
+
+    const attachLiveSceneForActiveSession=()=>{
+      const currentInflight=INFLIGHT[sid];
+      if(!currentInflight||!currentInflight.reattach||!activeStreamId||typeof attachLiveStream!=='function') return false;
+      currentInflight.reattach=false;
+      attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
+      return true;
+    };
+
+    syncTopbar();
+    renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
     _deferWorkspaceRefreshForSession(sid);
-    setBusy(true);setComposerStatus('');
+    setBusy(true);
+    setComposerStatus('');
     startApprovalPolling(sid);
     if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
     if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
+    _deferActiveSessionSceneRestore(sid, activeStreamId, _loadGeneration, ()=>{
+      const restoreResult=restoreLiveSurfaceForActiveInflight();
+      const didReconnect=attachLiveSceneForActiveSession();
+      if(didReconnect&&restoreResult&&restoreResult.restoredLiveTurn&&!restoreResult.restoredAnchorScene){
+        replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});
+      }
+    }).catch(()=>{});
   }else{
     // Phase 2b: Idle session — load full messages lazily for rendering.
     // _ensureMessagesLoaded is idempotent; it skips if S.messages already populated.
@@ -2284,29 +2320,51 @@ async function loadSession(sid){
     if(activeStreamId){
       S.busy=true;
       S.activeStreamId=activeStreamId;
-      if(typeof attachLiveStream==='function') attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
-      else if(typeof watchInflightSession==='function') watchInflightSession(sid, activeStreamId);
+
+      const restoreLiveSurfaceForIdleInflight=()=>{
+        if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+        const anchorSceneRenderResult=activeStreamId&&typeof window!=='undefined'
+          ? (
+            (typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid)) ||
+            _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid)
+          )
+          : false;
+        const restoredAnchorScene=!!anchorSceneRenderResult||_hasRenderedLiveAnchorActivityScene();
+        let restoredLiveTurn=!!restoredAnchorScene;
+        if(!restoredLiveTurn&&typeof restoreLiveTurnHtmlForSession==='function'){
+          restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
+        }
+        if(!restoredLiveTurn){
+          if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+          else appendThinking();
+        }
+      };
+
+      const attachLiveSceneForIdleSession=()=>{
+        if(typeof attachLiveStream==='function'){
+          attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
+          return true;
+        }
+        if(typeof watchInflightSession==='function'){
+          watchInflightSession(sid, activeStreamId);
+          return true;
+        }
+        return false;
+      };
+
       updateSendBtn();
       setStatus('');
       setComposerStatus('');
       syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
-      const restoredAnchorScene=activeStreamId&&typeof window!=='undefined'
-        ? ((typeof window._renderLiveAnchorActivitySceneForStream==='function'&&window._renderLiveAnchorActivitySceneForStream(activeStreamId, sid))||
-          _renderRuntimeJournalAnchorActivityScene(activeStreamId, sid))
-        : false;
-      let restoredLiveTurn=!!restoredAnchorScene;
-      if(!restoredLiveTurn&&typeof restoreLiveTurnHtmlForSession==='function'){
-        restoredLiveTurn=restoreLiveTurnHtmlForSession(sid);
-      }
-      if(!restoredLiveTurn){
-        if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
-        else appendThinking();
-      }
       _deferWorkspaceRefreshForSession(sid);
       updateQueueBadge(sid);
       startApprovalPolling(sid);
       if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
       if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
+      _deferActiveSessionSceneRestore(sid, activeStreamId, _loadGeneration, ()=>{
+        restoreLiveSurfaceForIdleInflight();
+        attachLiveSceneForIdleSession();
+      }).catch(()=>{});
     }else{
       S.busy=false;
       S.activeStreamId=null;
@@ -2929,6 +2987,125 @@ function _afterSessionFirstPaint(fn, delayMs=0){
     }else{
       setTimeout(run, delayMs);
     }
+  });
+}
+
+const _ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS = 1200;
+
+function _hasRenderedLiveAnchorActivityScene(){
+  const liveTurn=document.getElementById('liveAssistantTurn');
+  return !!(liveTurn&&liveTurn.querySelector('[data-anchor-scene-row="1"]'));
+}
+
+function _isActiveSessionSceneRestoreOwner(sid, activeStreamId, loadGeneration){
+  if(!sid||!activeStreamId) return false;
+  if(_loadSessionGeneration !== loadGeneration) return false;
+  if(!S || !S.session || String(S.session.session_id)!==String(sid)) return false;
+  if(String(S.activeStreamId||'') !== String(activeStreamId)) return false;
+  const sidStream = String(S.session && S.session.active_stream_id || '');
+  if(sidStream && sidStream !== String(activeStreamId)) return false;
+  return true;
+}
+
+function _deferActiveSessionSceneRestore(sid, activeStreamId, loadGeneration, restoreFn){
+  if(!sid||!activeStreamId||typeof restoreFn!=='function') return Promise.resolve(undefined);
+  return new Promise((resolve)=>{
+    let invoked = false;
+    let done = false;
+    let raf1Id = null;
+    let raf2Id = null;
+    let fallbackTimerId = null;
+    let visibilityHandler = null;
+
+    const complete = (value) => {
+      if (done) return;
+      done = true;
+      if (raf1Id !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(raf1Id);
+      if (raf2Id !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(raf2Id);
+      if (fallbackTimerId !== null && typeof clearTimeout === 'function') {
+        clearTimeout(fallbackTimerId);
+      }
+      if (visibilityHandler && typeof document !== 'undefined' && document && typeof document.removeEventListener === 'function') {
+        try { document.removeEventListener('visibilitychange', visibilityHandler); } catch (_) {}
+      }
+      resolve(value);
+    };
+
+    const invoke = () => {
+      if (invoked) return;
+      invoked = true;
+      if (!_isActiveSessionSceneRestoreOwner(sid, activeStreamId, loadGeneration)) {
+        complete(undefined);
+        return;
+      }
+      try {
+        const result = restoreFn();
+        if (result && typeof result.then === 'function') {
+          result.then((value)=>complete(value), ()=>complete(undefined));
+          return;
+        }
+        complete(result);
+      }catch(_){
+        complete(undefined);
+      }
+    };
+
+    const scheduleFallback = () => {
+      if (done || invoked || fallbackTimerId !== null) return;
+      if (typeof setTimeout === 'function') {
+        fallbackTimerId = setTimeout(() => {
+          fallbackTimerId = null;
+          invoke();
+        }, _ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS);
+      } else {
+        invoke();
+      }
+    };
+
+    const frame2 = () => {
+      if(done || invoked) return;
+      invoke();
+    };
+
+    const frame1 = () => {
+      if(done || invoked) return;
+      if (!_isActiveSessionSceneRestoreOwner(sid, activeStreamId, loadGeneration)) {
+        complete(undefined);
+        return;
+      }
+      if (typeof requestAnimationFrame === 'function') {
+        raf2Id = requestAnimationFrame(frame2);
+        if (raf2Id === null) {
+          scheduleFallback();
+        }
+      } else {
+        invoke();
+      }
+    };
+
+    if (typeof document !== 'undefined' && document && typeof document.addEventListener === 'function') {
+      visibilityHandler = () => {
+        if (done || invoked) return;
+        if (document.visibilityState === 'hidden' || document.hidden) {
+          scheduleFallback();
+        }
+      };
+      document.addEventListener('visibilitychange', visibilityHandler);
+    }
+
+    if (
+      typeof requestAnimationFrame === 'function' &&
+      typeof document !== 'undefined' &&
+      document.visibilityState !== 'hidden' &&
+      document.hidden !== true
+    ) {
+      raf1Id = requestAnimationFrame(frame1);
+      if (raf1Id === null) {
+        scheduleFallback();
+      }
+      return;
+    }
+    scheduleFallback();
   });
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1729,6 +1729,7 @@ async function loadSession(sid){
   // Mark this session as the in-flight load. Subsequent loadSession() calls
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   const _loadGeneration = ++_loadSessionGeneration;
+  if(typeof _invalidatePendingLiveAttachClaims==='function') _invalidatePendingLiveAttachClaims();
   const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration;
   _loadingSessionId = sid;
   if(currentSid!==sid&&typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
@@ -2061,6 +2062,22 @@ async function loadSession(sid){
     return true;
   }
 
+  const attachOwnedSessionStream=(requireReattach=false)=>{
+    const inflight=INFLIGHT[sid];
+    if(!activeStreamId||typeof attachLiveStream!=='function') return false;
+    if(requireReattach&&(!inflight||!inflight.reattach)) return false;
+    return attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {
+      reconnecting:true,
+      ownerToken:`load-session:${sid}:${_loadGeneration}`,
+      loadGeneration:_loadGeneration,
+      isCurrentOwner:()=>_isActiveSessionSceneRestoreOwner(sid, activeStreamId, _loadGeneration),
+      onAttached:()=>{
+        const latest=INFLIGHT[sid];
+        if(latest&&String(latest.streamId||'')===String(activeStreamId)) latest.reattach=false;
+      },
+    });
+  };
+
   // Phase 2a: If session is streaming, restore the persisted transcript first,
   // then merge the local INFLIGHT live tail. INFLIGHT is a recovery tail, not a
   // complete transcript; treating it as the full source makes long sessions look
@@ -2222,33 +2239,38 @@ async function loadSession(sid){
     };
 
     const attachLiveSceneForActiveSession=()=>{
-      const currentInflight=INFLIGHT[sid];
-      if(!currentInflight||!currentInflight.reattach||!activeStreamId||typeof attachLiveStream!=='function') return false;
-      currentInflight.reattach=false;
-      attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
-      return true;
+      return attachOwnedSessionStream(true);
     };
 
-    syncTopbar();
-    renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
-    _deferWorkspaceRefreshForSession(sid);
-    setBusy(true);
-    setComposerStatus('');
-    startApprovalPolling(sid);
-    if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
-    if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
-    _deferActiveSessionSceneRestore(sid, activeStreamId, _loadGeneration, ()=>{
-      const restoreResult=restoreLiveSurfaceForActiveInflight();
-      const didReconnect=attachLiveSceneForActiveSession();
-      if(didReconnect&&restoreResult&&restoreResult.restoredLiveTurn&&!restoreResult.restoredAnchorScene){
-        replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});
-      }
-    }).catch(()=>{});
-  }else{
+    try{
+      syncTopbar();
+      renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+      _deferWorkspaceRefreshForSession(sid);
+      setBusy(true);
+      setComposerStatus('');
+      startApprovalPolling(sid);
+      if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
+      if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
+    }finally{
+      _deferActiveSessionSceneRestoreAndAttach(
+        sid,
+        activeStreamId,
+        _loadGeneration,
+        restoreLiveSurfaceForActiveInflight,
+        attachLiveSceneForActiveSession,
+      ).then((result)=>{
+        const restoreResult = result && typeof result === 'object' ? result.restoreResult : undefined;
+        const didReconnect = result && typeof result === 'object' ? result.attached : false;
+        if(didReconnect&&restoreResult&&restoreResult.restoredLiveTurn&&!restoreResult.restoredAnchorScene){
+          replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});
+        }
+      }).catch(()=>{});
+    }
+  } else {
     // Phase 2b: Idle session — load full messages lazily for rendering.
-    // _ensureMessagesLoaded is idempotent; it skips if S.messages already populated.
-    // #5177: when the caller asked us to keep stale messages until the new ones
-    // arrive (visibility/focus recovery), force the fetch so the
+    // _ensureMessagesLoaded is idempotent; it skips if S.messages already
+    // populated. #5177: when the caller asked us to keep stale messages until
+    // the new ones arrive (visibility/focus recovery), force the fetch so the
     // "messages already populated" early-return inside _ensureMessagesLoaded
     // does NOT skip the swap to the new transcript.
     try {
@@ -2342,8 +2364,7 @@ async function loadSession(sid){
 
       const attachLiveSceneForIdleSession=()=>{
         if(typeof attachLiveStream==='function'){
-          attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
-          return true;
+          return attachOwnedSessionStream();
         }
         if(typeof watchInflightSession==='function'){
           watchInflightSession(sid, activeStreamId);
@@ -2352,19 +2373,25 @@ async function loadSession(sid){
         return false;
       };
 
-      updateSendBtn();
-      setStatus('');
-      setComposerStatus('');
-      syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
-      _deferWorkspaceRefreshForSession(sid);
-      updateQueueBadge(sid);
-      startApprovalPolling(sid);
-      if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
-      if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
-      _deferActiveSessionSceneRestore(sid, activeStreamId, _loadGeneration, ()=>{
-        restoreLiveSurfaceForIdleInflight();
-        attachLiveSceneForIdleSession();
-      }).catch(()=>{});
+      try{
+        updateSendBtn();
+        setStatus('');
+        setComposerStatus('');
+        syncTopbar();renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined);
+        _deferWorkspaceRefreshForSession(sid);
+        updateQueueBadge(sid);
+        startApprovalPolling(sid);
+        if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
+        if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
+      }finally{
+        _deferActiveSessionSceneRestoreAndAttach(
+          sid,
+          activeStreamId,
+          _loadGeneration,
+          restoreLiveSurfaceForIdleInflight,
+          attachLiveSceneForIdleSession,
+        ).catch(()=>{});
+      }
     }else{
       S.busy=false;
       S.activeStreamId=null;
@@ -3106,6 +3133,24 @@ function _deferActiveSessionSceneRestore(sid, activeStreamId, loadGeneration, re
       return;
     }
     scheduleFallback();
+  });
+}
+
+function _deferActiveSessionSceneRestoreAndAttach(sid, activeStreamId, loadGeneration, restoreFn, attachFn){
+  if(!sid||!activeStreamId||typeof restoreFn!=='function'||typeof attachFn!=='function'){
+    return Promise.resolve({restoreResult:undefined,attached:false});
+  }
+  return _deferActiveSessionSceneRestore(sid,activeStreamId,loadGeneration,()=>{
+    let restoreResult;
+    let attached=false;
+    try{
+      restoreResult=restoreFn();
+    }catch(_){
+      restoreResult=undefined;
+    }finally{
+      try{attached=!!attachFn();}catch(_){attached=false;}
+    }
+    return {restoreResult,attached};
   });
 }
 

--- a/tests/browser_session_switch_active_render.py
+++ b/tests/browser_session_switch_active_render.py
@@ -1,0 +1,1685 @@
+#!/usr/bin/env python3
+"""Deterministic browser harness for active-session switch-back paint ordering."""
+
+import json
+import os
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+PORT = int(os.getenv("BENCH_PORT", "8789"))
+BASE = f"http://127.0.0.1:{PORT}"
+
+ACTIVE_SESSION_ID = "bench-session-active-switch"
+IDLE_SESSION_ID = "bench-session-active-switch-idle"
+ACTIVE_STREAM_ID = "bench-stream-active-switch"
+VISIBLE_MESSAGES = 30
+TOTAL_MESSAGES = 4410
+TOTAL_TOOL_CALLS = 2882
+RUNTIME_ACTIVITY_ROWS = 424
+EXPECTED_FINAL_SCENE_ROWS = 129
+TARGET_INFLIGHT_LAST_SEQ = RUNTIME_ACTIVITY_ROWS + 25
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORK_ROOT = Path(os.getenv("BENCH_WORK_ROOT", str(REPO_ROOT / ".benchmarks" / "session-switch-active-render")))
+REPORT_ROOT = Path(os.getenv("BENCH_REPORT_ROOT", str(WORK_ROOT / "final")))
+
+
+def _fixture_timestamp(i: int) -> int:
+    return 1_760_000_000_000 + (i * 60_000)
+
+
+def _build_messages() -> list[dict]:
+    return [
+        {
+            "role": "user" if (i % 2 == 0) else "assistant",
+            "content": f"Synthetic message row {i + 1:04d}",
+            "timestamp": _fixture_timestamp(i),
+            "msg_idx": i,
+            "msg_id": f"bench-msg-{i:05d}",
+        }
+        for i in range(TOTAL_MESSAGES)
+    ]
+
+
+_MESSAGES = _build_messages()
+
+
+def _build_tool_calls() -> list[dict]:
+    out: list[dict] = []
+    for i in range(TOTAL_TOOL_CALLS):
+        out.append(
+            {
+                "tool_call_id": f"bench-tool-call-{i:05d}",
+                "id": f"bench-tool-call-{i:05d}",
+                "name": "synth_tool",
+                "type": "tool_call",
+                "args": {"value": i},
+                "status": "running" if i < 75 else "ok",
+                "order": i,
+            }
+        )
+    return out
+
+
+_TOOL_CALLS = _build_tool_calls()
+
+
+def _build_runtime_activity_rows() -> list[dict]:
+    out: list[dict] = []
+    for i in range(RUNTIME_ACTIVITY_ROWS):
+        if i < 75:
+            source_event_type = "tool_started"
+            role = "tool"
+            status = "running"
+            text = f"tool-start {i:04d}"
+        elif i < 149:
+            source_event_type = "tool_completed"
+            role = "tool"
+            status = "ok"
+            text = f"tool-complete {i:04d}"
+        elif i < 203:
+            source_event_type = "reasoning"
+            role = "assistant"
+            status = ""
+            text = f"reasoning text {i:04d}"
+        elif i < 214:
+            source_event_type = "prose"
+            role = "assistant"
+            status = ""
+            text = f"interim prose {i:04d}"
+        elif i < 218:
+            source_event_type = "compressing"
+            role = "lifecycle"
+            status = "running"
+            text = "compressing"
+        else:
+            source_event_type = "lifecycle"
+            role = "lifecycle"
+            status = "done"
+            text = f"activity {i:04d}"
+        row = {
+            "row_id": f"bench-runtime-row-{i:04d}",
+            "local_id": f"bench-runtime-row-{i:04d}",
+            "source_event_type": source_event_type,
+            "role": role,
+            "text": text,
+            "status": status,
+            "ts": _fixture_timestamp(TOTAL_MESSAGES + i),
+            "anchor_event_id": f"bench-runtime-event-{i:04d}",
+        }
+        if role == "tool":
+            row["tool"] = {
+                "id": f"tool-{i:04d}",
+                "name": "synth_tool",
+                "tool_call_id": f"bench-tool-call-{i % TOTAL_TOOL_CALLS:05d}",
+            }
+        out.append(row)
+    return out
+
+
+_RUNTIME_ACTIVITY_ROWS = _build_runtime_activity_rows()
+
+
+def _build_anchor_activity_rows() -> list[dict]:
+    out: list[dict] = []
+    for i in range(EXPECTED_FINAL_SCENE_ROWS):
+        tool_call_id = f"bench-tool-call-{i:05d}"
+        row = {
+            "role": "tool",
+            "source_event_type": "tool_started",
+            "row_id": f"bench-anchor-row-{i:04d}",
+            "local_id": f"bench-anchor-row-{i:04d}",
+            "text": f"tool call {i}",
+            "status": "running" if i < 75 else "ok",
+            "tool": {
+                "id": f"bench-anchor-tool-{i:04d}",
+                "name": "synth_tool",
+                "tool_call_id": tool_call_id,
+                "status": "running" if i < 75 else "ok",
+            },
+        }
+        out.append(row)
+    return out
+
+
+_ANCHOR_ACTIVITY_ROWS = _build_anchor_activity_rows()
+
+
+def _runtime_snapshot() -> dict:
+    return {
+        "stream_id": ACTIVE_STREAM_ID,
+        "session_id": ACTIVE_SESSION_ID,
+        "active": True,
+        "identity": {
+            "stream_id": ACTIVE_STREAM_ID,
+            "session_id": ACTIVE_SESSION_ID,
+        },
+        "activity_rows": _RUNTIME_ACTIVITY_ROWS,
+        "last_seq": RUNTIME_ACTIVITY_ROWS,
+        "last_event_id": f"bench-runtime-event-{RUNTIME_ACTIVITY_ROWS-1:04d}",
+        "tool_count": TOTAL_TOOL_CALLS,
+        "tool_calls": _TOOL_CALLS,
+        "activity_burst_anchors": [
+            {"id": i, "textEnd": (i + 1) * 120}
+            for i in range(1, 11)
+        ],
+        "anchor_activity_scene": {
+            "version": "activity_scene_v1",
+            "stream_id": ACTIVE_STREAM_ID,
+            "session_id": ACTIVE_SESSION_ID,
+            "activity_rows": _ANCHOR_ACTIVITY_ROWS,
+            "tool_calls": [],
+            "activity_burst_id": 0,
+            "last_seq": EXPECTED_FINAL_SCENE_ROWS,
+            "identity": {
+                "stream_id": ACTIVE_STREAM_ID,
+                "session_id": ACTIVE_SESSION_ID,
+            },
+        },
+    }
+
+
+def _clamp_int(value, fallback: int = 0) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _session_payload(
+    active: bool = True,
+    messages_requested: int = 0,
+    messages_limit: int = 0,
+    messages_before: int = 0,
+) -> dict:
+    if active:
+        limit = max(0, int(messages_requested or 0))
+        limit = max(0, int(messages_limit or 0)) or limit
+
+        messages = []
+        truncated = False
+        offset = 0
+
+        if limit <= 0:
+            messages = []
+        elif messages_before > 0:
+            end = min(messages_before, len(_MESSAGES))
+            start = max(0, end - limit)
+            messages = _MESSAGES[start:end]
+            offset = start
+            truncated = start > 0
+        else:
+            limit = min(limit, len(_MESSAGES))
+            messages = _MESSAGES[-limit:]
+            offset = len(_MESSAGES) - limit
+            truncated = offset > 0
+
+        payload = {
+            "session_id": ACTIVE_SESSION_ID,
+            "title": "Benchmark active session",
+            "message_count": TOTAL_MESSAGES,
+            "tool_call_count": TOTAL_TOOL_CALLS,
+            "active_stream_id": ACTIVE_STREAM_ID,
+            "stream_id": ACTIVE_STREAM_ID,
+            "last_message_at": _fixture_timestamp(TOTAL_MESSAGES),
+            "updated_at": _fixture_timestamp(TOTAL_MESSAGES + 1),
+            "model": "benchmark-model",
+            "model_provider": "benchmark-provider",
+            "context_length": 180000,
+            "threshold_tokens": 120000,
+            "runtime_journal_snapshot": _runtime_snapshot(),
+            "tool_calls": _TOOL_CALLS,
+            "pending_attachments": [],
+            "messages": messages,
+        }
+        if limit and limit < TOTAL_MESSAGES:
+            payload["_messages_truncated"] = truncated
+            payload["_messages_offset"] = offset
+        return payload
+
+    return {
+        "session_id": IDLE_SESSION_ID,
+        "title": "Benchmark idle session",
+        "message_count": 2,
+        "tool_call_count": 0,
+        "active_stream_id": None,
+        "stream_id": None,
+        "last_message_at": _fixture_timestamp(3),
+        "updated_at": _fixture_timestamp(4),
+        "model": "benchmark-model",
+        "model_provider": "benchmark-provider",
+        "context_length": 4096,
+        "threshold_tokens": 12288,
+        "pending_attachments": [],
+        "tool_calls": [
+            {
+                "tool_call_id": "idle-tool-001",
+                "id": "idle-tool-001",
+                "name": "idle_tool",
+                "status": "ok",
+            }
+        ],
+        "messages": [
+            {
+                "role": "user",
+                "content": "Idle benchmark start",
+                "timestamp": _fixture_timestamp(1),
+                "msg_idx": 0,
+                "msg_id": "idle-msg-1",
+            },
+            {
+                "role": "assistant",
+                "content": "Idle benchmark assistant",
+                "timestamp": _fixture_timestamp(2),
+                "msg_idx": 1,
+                "msg_id": "idle-msg-2",
+            },
+        ],
+    }
+
+
+def _fixture_description() -> dict:
+    return {
+        "active_session_id": ACTIVE_SESSION_ID,
+        "active_stream_id": ACTIVE_STREAM_ID,
+        "message_count": TOTAL_MESSAGES,
+        "visible_messages": VISIBLE_MESSAGES,
+        "tool_call_count": TOTAL_TOOL_CALLS,
+        "runtime_activity_rows": RUNTIME_ACTIVITY_ROWS,
+        "expected_final_scene_rows": EXPECTED_FINAL_SCENE_ROWS,
+        "mobile_emulation": "Pixel 5",
+    }
+
+
+def _snapshot_session_seed(page, sid: str) -> dict:
+    return page.evaluate(
+        """
+        (sid) => {
+          const targetSid = String(sid || '');
+          const session = (typeof S !== 'undefined' && S && S.session && String(S.session.session_id || '') === targetSid)
+            ? S.session
+            : null;
+          const runtimeJournalSnapshot = session && session.runtime_journal_snapshot ? session.runtime_journal_snapshot : null;
+          const toolCalls = Array.isArray(session && session.tool_calls)
+            ? session.tool_calls
+            : (Array.isArray(runtimeJournalSnapshot && runtimeJournalSnapshot.tool_calls)
+                ? runtimeJournalSnapshot.tool_calls
+                : []);
+          const messages = Array.isArray(S && S.messages) ? S.messages : [];
+          if (!session) {
+            return {
+              sid: targetSid,
+              session: null,
+              runtime_journal_snapshot: null,
+              tool_calls: [],
+              messages: [],
+            };
+          }
+          return {
+            sid: targetSid,
+            session: JSON.parse(JSON.stringify(session)),
+            runtime_journal_snapshot: runtimeJournalSnapshot ? JSON.parse(JSON.stringify(runtimeJournalSnapshot)) : null,
+            tool_calls: JSON.parse(JSON.stringify(toolCalls)),
+            messages: JSON.parse(JSON.stringify(messages)),
+          };
+        }
+        """,
+        sid,
+    )
+
+
+def _query_inflight_state(page, sid: str) -> dict:
+    return page.evaluate(
+        """
+        (sid) => {
+          const inflight = (typeof INFLIGHT !== 'undefined' && INFLIGHT && INFLIGHT[sid]) ? INFLIGHT[sid] : null;
+          const scene = inflight && inflight.anchorActivityScene ? inflight.anchorActivityScene : null;
+          const liveTurn = typeof document !== 'undefined' ? document.getElementById('liveAssistantTurn') : null;
+          const liveRowCount = liveTurn
+            ? liveTurn.querySelectorAll('[data-anchor-scene-row=\"1\"]').length
+            : 0;
+          return {
+            exists: !!inflight,
+            hasMessageState: !!(inflight && Array.isArray(inflight.messages) && inflight.messages.length),
+            reattach: !!(inflight && inflight.reattach),
+            journalReplayFromStart: !!(inflight && inflight.journalReplayFromStart),
+            streamId: inflight ? String(inflight.streamId || '') : '',
+            lastRunJournalSeq: inflight ? Number(inflight.lastRunJournalSeq || 0) : 0,
+            hasAnchorActivityScene:
+              !!(inflight && inflight.anchorActivityScene && inflight.anchorActivityScene.version === 'activity_scene_v1'),
+            anchorRows: !!scene && Array.isArray(scene.activity_rows)
+              ? scene.activity_rows.length
+              : 0,
+            liveSceneRows: liveRowCount,
+            toolCallCount: inflight && Array.isArray(inflight.toolCalls) ? inflight.toolCalls.length : 0,
+            activeStreamId: (() => {
+              try { return String(S && S.activeStreamId || ''); } catch (_) { return ''; }
+            })(),
+            sessionStreamId: (() => {
+              try { return String(S && S.session && S.session.active_stream_id || ''); } catch (_) { return ''; }
+            })(),
+            sessionId: (() => {
+              try { return String(S && S.session && S.session.session_id || ''); } catch (_) { return ''; }
+            })(),
+            liveStreams: (typeof LIVE_STREAMS !== 'undefined' && LIVE_STREAMS) ? Object.keys(LIVE_STREAMS) : [],
+            hasActiveStream: !!(typeof S !== 'undefined' && S && S.activeStreamId),
+          };
+        }
+        """,
+        sid,
+    )
+
+
+def _inject_synthetic_inflight(page, sid: str, stream_id: str, base_seq: int, seed_state: dict | None = None) -> dict:
+    return page.evaluate(
+        """
+        (args) => {
+          const sid = String((args && args.sid) || '');
+          const streamId = String((args && args.streamId) || '');
+          const baseSeq = Number(args && args.baseSeq);
+          const seedState = args && args.seedState ? args.seedState : null;
+          const targetSid = sid;
+          const normalizedSeed = (seedState && typeof seedState === 'object') ? seedState : {};
+          const sessionFromSeed = normalizedSeed.session && typeof normalizedSeed.session === 'object'
+            ? normalizedSeed.session
+            : null;
+          const messagesFromSeed = Array.isArray(normalizedSeed.messages) ? normalizedSeed.messages : [];
+          const toolCallsFromSeed = Array.isArray(normalizedSeed.tool_calls) ? normalizedSeed.tool_calls : [];
+          const session = (typeof S !== 'undefined' && S && S.session && String(S.session.session_id || '') === targetSid)
+            ? S.session
+            : sessionFromSeed;
+          if (!session) {
+            return {ok: false, reason: 'session missing for sid'};
+          }
+          const snapshot = session.runtime_journal_snapshot
+            || (typeof normalizedSeed.runtime_journal_snapshot === 'object' ? normalizedSeed.runtime_journal_snapshot : null);
+          const scene = snapshot && snapshot.anchor_activity_scene && snapshot.anchor_activity_scene.version === 'activity_scene_v1'
+            ? snapshot.anchor_activity_scene
+            : null;
+          const anchorScene = scene
+            ? JSON.parse(JSON.stringify(scene))
+            : null;
+          const activityAnchors = Array.isArray(snapshot && snapshot.activity_burst_anchors)
+            ? JSON.parse(JSON.stringify(snapshot.activity_burst_anchors))
+            : [];
+          const toolCalls = Array.isArray(toolCallsFromSeed)
+            ? JSON.parse(JSON.stringify(toolCallsFromSeed))
+            : (Array.isArray(snapshot && snapshot.tool_calls)
+              ? JSON.parse(JSON.stringify(snapshot.tool_calls))
+              : []);
+          const msgs = Array.isArray(messagesFromSeed)
+            ? JSON.parse(JSON.stringify(messagesFromSeed))
+            : (Array.isArray(S && S.messages) ? JSON.parse(JSON.stringify(S.messages)) : []);
+          const sessionAttachments = Array.isArray(session && session.pending_attachments)
+            ? session.pending_attachments
+            : [];
+          const attachments = Array.isArray(sessionAttachments)
+            ? JSON.parse(JSON.stringify(session.pending_attachments))
+            : [];
+          if (typeof INFLIGHT !== 'object' || !INFLIGHT) {
+            window.INFLIGHT = {};
+          }
+          const seq = Number.isFinite(Number(baseSeq)) ? Number(baseSeq) : 0;
+          INFLIGHT[sid] = {
+            streamId,
+            messages: msgs,
+            uploaded: attachments,
+            toolCalls,
+            reattach: true,
+            lastAssistantText: String(snapshot && (snapshot.last_assistant_text || snapshot.lastAssistantText || '') || ''),
+            lastReasoningText: String(snapshot && (snapshot.last_reasoning_text || snapshot.lastReasoningText || '') || ''),
+            lastRunJournalSeq: Math.max(0, seq),
+            lastRunJournalEventId: String(snapshot && (snapshot.last_event_id || snapshot.lastEventId || '') || ''),
+            journalReplayFromStart: false,
+            anchorActivityScene: anchorScene,
+            currentActivityBurstId: Number(snapshot && (snapshot.current_activity_burst_id || snapshot.currentActivityBurstId || 0)) || 0,
+            currentLiveSegmentSeq: Number(snapshot && (snapshot.current_live_segment_seq || snapshot.currentLiveSegmentSeq || 0)) || 0,
+            activityBurstAnchors: activityAnchors,
+          };
+          if (typeof window.__benchSetCaptureMetric === 'function') {
+            window.__benchSetCaptureMetric('synth-inflight=' + sid);
+          }
+          return {
+            ok: true,
+            reattach: true,
+            streamId,
+            lastRunJournalSeq: INFLIGHT[sid].lastRunJournalSeq,
+            hasAnchorActivityScene: !!anchorScene,
+            toolCallCount: toolCalls.length,
+          };
+        }
+        """,
+        {"sid": sid, "streamId": stream_id, "baseSeq": base_seq, "seedState": seed_state},
+    )
+
+
+def _build_report() -> dict:
+    return {
+        "fixture": _fixture_description(),
+        "command": {
+            "script": str(Path(__file__).name),
+            "bench_port": PORT,
+            "bench_server_root": str(REPO_ROOT),
+            "samples": 0,
+            "capability": {
+                "is_mobile": True,
+                "touch": True,
+                "capture_enabled": False,
+                "cpu_throttle": 1,
+            },
+        },
+        "samples": [],
+        "median": {},
+        "p95": {},
+        "errors": [],
+        "invalidSamples": 0,
+    }
+
+
+def _build_routes_payload(path: str, qs: dict[str, list[str]], *, include_session_list: bool = True) -> str:
+    if path == "/api/sessions":
+        if not include_session_list:
+            return json.dumps([])
+        return json.dumps(
+            [
+                {
+                    "session_id": ACTIVE_SESSION_ID,
+                    "message_count": TOTAL_MESSAGES,
+                    "active_stream_id": ACTIVE_STREAM_ID,
+                    "is_streaming": True,
+                },
+                {
+                    "session_id": IDLE_SESSION_ID,
+                    "message_count": 2,
+                    "active_stream_id": None,
+                    "is_streaming": False,
+                },
+            ]
+        )
+
+    if path == "/api/session":
+        sid = (qs.get("session_id") or [""])[0]
+        if sid == ACTIVE_SESSION_ID:
+            if qs.get("resolve_model", ["0"])[0] == "1":
+                return json.dumps({"session": _session_payload(active=True, messages_requested=0)})
+            msg_limit = _clamp_int((qs.get("msg_limit") or [0])[0], 0)
+            msg_before = _clamp_int((qs.get("msg_before") or qs.get("messages_before") or [0])[0], 0)
+            try:
+                msg_requested = int(qs.get("messages", ["0"])[0] or 0)
+            except ValueError:
+                msg_requested = 0
+            return json.dumps(
+                {
+                    "session": _session_payload(
+                        active=True,
+                        messages_requested=msg_requested,
+                        messages_limit=msg_limit,
+                        messages_before=msg_before,
+                    )
+                }
+            )
+
+        if sid == IDLE_SESSION_ID:
+            if qs.get("resolve_model", ["0"])[0] == "1":
+                return json.dumps({"session": _session_payload(active=False, messages_requested=0)})
+            msg_limit = _clamp_int((qs.get("msg_limit") or [0])[0], 0)
+            msg_before = _clamp_int((qs.get("msg_before") or qs.get("messages_before") or [0])[0], 0)
+            try:
+                msg_requested = int(qs.get("messages", ["0"])[0] or 0)
+            except ValueError:
+                msg_requested = 0
+            return json.dumps(
+                {
+                    "session": _session_payload(
+                        active=False,
+                        messages_requested=msg_requested,
+                        messages_limit=msg_limit,
+                        messages_before=msg_before,
+                    )
+                }
+            )
+
+        return json.dumps({"session": {"session_id": sid, "message_count": 0, "messages": []}})
+
+    if path == "/api/chat/stream/status":
+        stream_id = (qs.get("stream_id") or [""])[0]
+        return json.dumps(
+            {
+                "active": stream_id == ACTIVE_STREAM_ID,
+                "stream_id": stream_id or ACTIVE_STREAM_ID,
+                "session_id": ACTIVE_SESSION_ID,
+                "state": "running" if stream_id == ACTIVE_STREAM_ID else "idle",
+            }
+        )
+
+    if path == "/api/chat/stream" or path == "/api/session/stream":
+        return "retry: 1000\n\n"
+
+    if path == "/health":
+        return "{}"
+
+    if path.startswith("/api/"):
+        return "{}"
+
+    return None
+
+
+def _start_server() -> tuple[subprocess.Popen | None, str | None]:
+    repo_root = Path(os.getenv("BENCH_SERVER_ROOT", str(REPO_ROOT))).resolve()
+    server_py = repo_root / "server.py"
+    if not server_py.exists():
+        print(f"SETUP FAIL: server.py not found at {server_py}", file=sys.stderr)
+        return None, None
+
+    state_dir = tempfile.mkdtemp(prefix="hermes-bench-session-switch-active-render-")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HERMES_WEBUI_PORT": str(PORT),
+            "HERMES_WEBUI_HOST": "127.0.0.1",
+            "HERMES_WEBUI_STATE_DIR": state_dir,
+            "HERMES_HOME": state_dir,
+            "HERMES_BASE_HOME": state_dir,
+            "HERMES_WEBUI_SKIP_ONBOARDING": "1",
+            "HERMES_WEBUI_AGENT_DIR": os.path.join(state_dir, "agent"),
+        }
+    )
+    for key in list(env.keys()):
+        if key.endswith("_API_KEY"):
+            env.pop(key, None)
+
+    logfile = Path(state_dir) / "server.log"
+    proc = subprocess.Popen(
+        [sys.executable, str(server_py)],
+        cwd=str(repo_root),
+        env=env,
+        stdout=open(logfile, "w", encoding="utf-8"),
+        stderr=subprocess.STDOUT,
+        **({"creationflags": subprocess.CREATE_NO_WINDOW} if sys.platform == "win32" else {}),
+    )
+
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        try:
+            import urllib.request
+
+            with urllib.request.urlopen(f"{BASE}/health", timeout=1) as r:
+                if getattr(r, "status", 200) == 200:
+                    return proc, state_dir
+        except Exception:
+            time.sleep(0.25)
+
+    print("SETUP FAIL: server did not become healthy", file=sys.stderr)
+    proc.terminate()
+    proc.wait(timeout=5)
+    return None, None
+
+
+def _stop_server(proc: subprocess.Popen | None) -> None:
+    if not proc:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def _install_runtime_stubs(page):
+    page.add_init_script(
+        """
+        (() => {
+          if (typeof window.t !== 'function') {
+            window.t = (key) => (key == null ? '' : String(key));
+          }
+          const noop = () => {};
+          window._uploadPendingFilesProgressBySession =
+            window._uploadPendingFilesProgressBySession || new Map();
+          window._uploadPendingFilesShowProgressBar = window._uploadPendingFilesShowProgressBar || noop;
+          window._uploadPendingFilesHideProgressBar = window._uploadPendingFilesHideProgressBar || noop;
+          window._uploadPendingFilesSyncProgressForSession = window._uploadPendingFilesSyncProgressForSession || noop;
+          window._uploadPendingFilesUpdateProgress = window._uploadPendingFilesUpdateProgress || noop;
+        })();
+        """
+    )
+
+
+def _install_fake_event_source(page):
+    page.add_init_script(
+        """
+        (() => {
+          const state = {
+            constructorCalls: 0,
+            openCount: 0,
+            closeCount: 0,
+            openByInstance: {},
+            closeByInstance: {},
+            events: [],
+          };
+
+          function FakeEventSource(url) {
+            const id = ++FakeEventSource._nextId;
+            this.__id = id;
+            this.url = url || '';
+            this.readyState = FakeEventSource.OPEN;
+            this.listeners = new Map();
+            this.onerror = null;
+            this.onopen = null;
+            this.onclose = null;
+
+            state.constructorCalls += 1;
+            state.openCount += 1;
+            state.openByInstance[id] = (state.openByInstance[id] || 0) + 1;
+            state.events.push({
+              type: 'open',
+              id,
+              url: String(this.url || ''),
+              token: Number(window.__benchCurrentSampleToken || 0),
+              t: performance.now(),
+            });
+            setTimeout(() => {
+              if (typeof this.onopen === 'function') {
+                try { this.onopen({type: 'open', target: this}); } catch (_) {}
+              }
+            }, 0);
+          }
+          FakeEventSource._nextId = FakeEventSource._nextId || 0;
+          FakeEventSource.OPEN = 1;
+          FakeEventSource.CONNECTING = 0;
+          FakeEventSource.CLOSED = 2;
+          FakeEventSource.prototype.OPEN = 1;
+          FakeEventSource.prototype.CONNECTING = 0;
+          FakeEventSource.prototype.CLOSED = 2;
+
+          FakeEventSource.prototype.addEventListener = function(type, fn) {
+            if (!type || typeof fn !== 'function') return;
+            const list = this.listeners.get(type) || [];
+            list.push(fn);
+            this.listeners.set(type, list);
+          };
+          FakeEventSource.prototype.removeEventListener = function(type, fn) {
+            const list = this.listeners.get(type) || [];
+            this.listeners.set(
+              type,
+              list.filter((entry) => entry !== fn),
+            );
+          };
+          FakeEventSource.prototype.close = function() {
+            if (this.readyState === FakeEventSource.CLOSED) return;
+            this.readyState = FakeEventSource.CLOSED;
+            state.closeCount += 1;
+            state.closeByInstance[this.__id] = (state.closeByInstance[this.__id] || 0) + 1;
+            state.events.push({
+              type: 'close',
+              id: this.__id,
+              url: String(this.url || ''),
+              token: Number(window.__benchCurrentSampleToken || 0),
+              t: performance.now(),
+            });
+            const listeners = this.listeners.get('close') || [];
+            for (const fn of listeners) {
+              try { fn({ type: 'close', target: this }); } catch (_) {}
+            }
+          };
+          FakeEventSource.prototype.dispatchEvent = function(event) {
+            const type = String(event && event.type || '');
+            const listeners = this.listeners.get(type) || [];
+            for (const fn of listeners) {
+              try { fn.call(this, event); } catch (_) {}
+            }
+            const onType = this['on' + type];
+            if (typeof onType === 'function') {
+              try { onType(event); } catch (_) {}
+            }
+          };
+
+          window.EventSource = FakeEventSource;
+          window.__benchEventSourceState = state;
+        })();
+        """
+    )
+
+
+def _install_capture_overlay(page):
+    page.add_init_script(
+        """
+        (() => {
+          const ensure = () => {
+            if (document.getElementById('__benchCaptureHud')) return;
+            const host = document.createElement('div');
+            host.id = '__benchCaptureHud';
+            host.style.position = 'fixed';
+            host.style.top = '8px';
+            host.style.left = '8px';
+            host.style.padding = '8px 10px';
+            host.style.font = '12px/1.2 ui-monospace, monospace';
+            host.style.color = '#dfe3f0';
+            host.style.background = 'rgba(9, 15, 31, 0.86)';
+            host.style.border = '1px solid rgba(255,255,255,.25)';
+            host.style.borderRadius = '8px';
+            host.style.zIndex = '2147483647';
+            host.style.pointerEvents = 'none';
+            host.style.maxWidth = '32rem';
+
+            const stage = document.createElement('div');
+            const timer = document.createElement('div');
+            const metric = document.createElement('div');
+
+            host.appendChild(stage);
+            host.appendChild(timer);
+            host.appendChild(metric);
+            document.body.appendChild(host);
+
+            window.__benchHud = {
+              start: performance.now(),
+              stage: 'init',
+              timer,
+              stageEl: stage,
+              metricEl: metric,
+            };
+          };
+
+          window.__benchSetCaptureStage = (value) => {
+            ensure();
+            if (!window.__benchHud) return;
+            window.__benchHud.stage = String(value || 'init');
+            window.__benchHud.stageEl.textContent = `stage: ${window.__benchHud.stage}`;
+          };
+
+          window.__benchSetCaptureMetric = (value) => {
+            ensure();
+            if (!window.__benchHud || !window.__benchHud.metricEl) return;
+            const text = String(value == null ? '' : value);
+            window.__benchHud.metricEl.textContent = text;
+          };
+
+          window.__benchCreateCaptureHud = () => {
+            ensure();
+            if (window.__benchHud._timer) return;
+            const update = () => {
+              const elapsed = Math.max(0, performance.now() - (window.__benchHud.start || 0));
+              if (window.__benchHud.timer) {
+                window.__benchHud.timer.textContent = `t=${elapsed.toFixed(1)}ms`;
+              }
+            };
+            window.__benchHud._timer = setInterval(update, 120);
+            update();
+          };
+        })();
+        """
+    )
+
+
+def _install_benchmark_hooks(page):
+    page.evaluate(
+        """
+        () => {
+          if (typeof window.__benchHookState === 'undefined') {
+            const state = {
+              token: 0,
+              events: [],
+              selectRecoveryCalls: [],
+              deferCallbacks: [],
+              attachCalls: [],
+              watchCalls: [],
+              sceneRenderCalls: [],
+              appendLiveToolCardCount: 0,
+              firstAppendLiveToolCardStack: '',
+            };
+
+            const push = (type, payload) => {
+              state.events.push({
+                type,
+                token: state.token,
+                t: typeof performance !== 'undefined' && performance.now ? performance.now() : 0,
+                ...(payload || {}),
+              });
+            };
+
+            const wrap = (name, makeWrapper) => {
+              const original = window[name];
+              if (typeof original !== 'function' || original.__benchWrapped) return;
+              const wrapped = makeWrapper(original);
+              wrapped.__benchWrapped = true;
+              window[name] = wrapped;
+            };
+
+            wrap('_selectLiveRecoveryInflight', (orig) => function(localInflight, serverSnapshot, activeStreamId) {
+              const token = state.token;
+              const selected = orig.call(this, localInflight, serverSnapshot, activeStreamId);
+              state.selectRecoveryCalls.push({
+                token,
+                hasLocal: !!localInflight,
+                hasServer: !!serverSnapshot,
+                activeStreamId: String(activeStreamId || ''),
+                selected: selected === localInflight ? 'inflight' : (selected === serverSnapshot ? 'discover' : 'other'),
+              });
+              push('selectLiveRecovery', {
+                hasLocal: !!localInflight,
+                hasServer: !!serverSnapshot,
+                localStreamId: localInflight && localInflight.streamId ? String(localInflight.streamId) : '',
+                hasActive: !!(typeof INFLIGHT === 'object' && INFLIGHT),
+                inflightKeys: (typeof INFLIGHT === 'object' && INFLIGHT) ? Object.keys(INFLIGHT) : [],
+                selected: state.selectRecoveryCalls[state.selectRecoveryCalls.length - 1].selected,
+                activeStreamId: String(activeStreamId || '')
+              });
+              return selected;
+            });
+
+            wrap('_deferActiveSessionSceneRestore', (orig) => function(sid, activeStreamId, loadGeneration, restoreFn) {
+              const token = state.token;
+              const sidValue = String(sid || '');
+              const streamValue = String(activeStreamId || '');
+              push('deferScheduled', {sid: sidValue, activeStreamId: streamValue, loadGeneration});
+
+              const wrappedRestore = function() {
+                const beforeInflight = (typeof INFLIGHT === 'object' && INFLIGHT) ? INFLIGHT[sidValue] : null;
+                push('deferCallbackStart', {
+                  sid: sidValue,
+                  activeStreamId: streamValue,
+                  inflightExists: !!beforeInflight,
+                  inflightReattach: !!(beforeInflight && beforeInflight.reattach),
+                  inflightStreamId: String(beforeInflight && beforeInflight.streamId || ''),
+                  ownerSessionId: String(typeof S !== 'undefined' && S && S.session && S.session.session_id || ''),
+                  ownerActiveStreamId: String(typeof S !== 'undefined' && S && S.activeStreamId || ''),
+                });
+                state.deferCallbacks.push({
+                  token,
+                  sid: sidValue,
+                  activeStreamId: streamValue,
+                  loadGeneration,
+                  started: true,
+                });
+                try {
+                  const result = restoreFn && restoreFn();
+                  if (result && typeof result.then === 'function') {
+                    return result.then(
+                      (value) => {
+                        push('deferCallbackDone', {sid: sidValue, activeStreamId: streamValue, ok: true});
+                        return value;
+                      },
+                      () => {
+                        push('deferCallbackDone', {sid: sidValue, activeStreamId: streamValue, ok: false});
+                        return undefined;
+                      }
+                    );
+                  }
+                  const afterInflight = (typeof INFLIGHT === 'object' && INFLIGHT) ? INFLIGHT[sidValue] : null;
+                  push('deferCallbackDone', {
+                    sid: sidValue,
+                    activeStreamId: streamValue,
+                    ok: true,
+                    inflightExists: !!afterInflight,
+                    inflightReattach: !!(afterInflight && afterInflight.reattach),
+                    inflightStreamId: String(afterInflight && afterInflight.streamId || ''),
+                  });
+                  return result;
+                } catch (_) {
+                  push('deferCallbackDone', {sid: sidValue, activeStreamId: streamValue, ok: false});
+                  return undefined;
+                }
+              };
+
+              return orig.call(this, sid, activeStreamId, loadGeneration, wrappedRestore);
+            });
+
+            wrap('_renderLiveAnchorActivitySceneForStream', (orig) => function(streamId, sid) {
+              const token = state.token;
+              push('sceneRenderLive', {streamId: String(streamId || ''), sid: String(sid || ''), token});
+              state.sceneRenderCalls.push({
+                token,
+                type: 'live',
+                sid: String(sid || ''),
+                streamId: String(streamId || ''),
+              });
+              const result = orig.call(this, streamId, sid);
+              if (!state.sceneRenderCalls.some((entry) => entry.type === 'live-result' && entry.token === token)) {
+                state.sceneRenderCalls.push({
+                  token,
+                  type: 'live-result',
+                  sid: String(sid || ''),
+                  streamId: String(streamId || ''),
+                  returned: !!result,
+                  liveTurnExists: !!document.getElementById('liveAssistantTurn'),
+                  totalSceneRows: document.querySelectorAll('[data-anchor-scene-row="1"]').length,
+                });
+              }
+              return result;
+            });
+
+            wrap('_renderRuntimeJournalAnchorActivityScene', (orig) => function(streamId, sid) {
+              const token = state.token;
+              push('sceneRenderRuntime', {streamId: String(streamId || ''), sid: String(sid || ''), token});
+              state.sceneRenderCalls.push({
+                token,
+                type: 'runtime',
+                sid: String(sid || ''),
+                streamId: String(streamId || ''),
+              });
+              const result = orig.call(this, streamId, sid);
+              if (!state.sceneRenderCalls.some((entry) => entry.type === 'runtime-result' && entry.token === token)) {
+                state.sceneRenderCalls.push({
+                  token,
+                  type: 'runtime-result',
+                  sid: String(sid || ''),
+                  streamId: String(streamId || ''),
+                  returned: !!result,
+                  liveTurnExists: !!document.getElementById('liveAssistantTurn'),
+                  totalSceneRows: document.querySelectorAll('[data-anchor-scene-row="1"]').length,
+                });
+              }
+              return result;
+            });
+
+            wrap('attachLiveStream', (orig) => function(sid, streamId, pendingAttachments, opts) {
+              const reconnecting = !!(opts && opts.reconnecting);
+              push('attachLiveStream', {sid: String(sid || ''), streamId: String(streamId || ''), reconnecting});
+              state.attachCalls.push({
+                token: state.token,
+                sid: String(sid || ''),
+                streamId: String(streamId || ''),
+                reconnecting,
+              });
+              return orig.call(this, sid, streamId, pendingAttachments, opts);
+            });
+
+            wrap('appendLiveToolCard', (orig) => function() {
+              state.appendLiveToolCardCount += 1;
+              if (!state.firstAppendLiveToolCardStack) {
+                state.firstAppendLiveToolCardStack = String(new Error('bench appendLiveToolCard').stack || '');
+              }
+              return orig.apply(this, arguments);
+            });
+
+            if (typeof window.watchInflightSession === 'function') {
+              wrap('watchInflightSession', (orig) => function(sid, streamId) {
+                push('watchInflightSession', {sid: String(sid || ''), streamId: String(streamId || '')});
+                state.watchCalls.push({
+                  token: state.token,
+                  sid: String(sid || ''),
+                  streamId: String(streamId || ''),
+                });
+                return orig.call(this, sid, streamId);
+              });
+            }
+
+            window.__benchBeginSample = () => {
+              state.token += 1;
+              return state.token;
+            };
+            window.__benchResetHookState = () => {
+              state.events.length = 0;
+              state.selectRecoveryCalls.length = 0;
+              state.deferCallbacks.length = 0;
+              state.attachCalls.length = 0;
+              state.watchCalls.length = 0;
+              state.sceneRenderCalls.length = 0;
+              state.appendLiveToolCardCount = 0;
+              state.firstAppendLiveToolCardStack = '';
+            };
+            window.__benchGetHookState = () => ({
+              token: state.token,
+              events: [...state.events],
+              selectRecoveryCalls: [...state.selectRecoveryCalls],
+              deferCallbacks: [...state.deferCallbacks],
+              attachCalls: [...state.attachCalls],
+              watchCalls: [...state.watchCalls],
+              sceneRenderCalls: [...state.sceneRenderCalls],
+              appendLiveToolCardCount: state.appendLiveToolCardCount,
+              firstAppendLiveToolCardStack: state.firstAppendLiveToolCardStack,
+            });
+            window.__benchHookState = state;
+          }
+        }
+        """
+    )
+
+
+def _install_routes(page):
+    route_state = {"session_list_seen": False, "first_session_list_omitted": False}
+
+    def handler(route):
+        parsed = urlsplit(route.request.url)
+        path = parsed.path
+        qs = parse_qs((parsed.query or ""))
+        include_session_list = True
+        if path == "/api/sessions":
+            include_session_list = route_state.get("session_list_seen", False)
+            if not route_state.get("session_list_seen", False):
+                route_state["first_session_list_omitted"] = not include_session_list
+            route_state["session_list_seen"] = True
+        payload = _build_routes_payload(path, qs, include_session_list=include_session_list)
+        if payload is None:
+            route.continue_()
+            return
+
+        headers = {"content-type": "application/json"}
+        if path in ("/api/chat/stream", "/api/session/stream"):
+            headers = {"content-type": "text/event-stream"}
+
+        route.fulfill(status=200, headers=headers, body=payload)
+
+    page.route("**/*", handler)
+    return route_state
+
+
+def _median(values):
+    return statistics.median(values) if values else None
+
+
+def _p95(values):
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = int(round(0.95 * (len(ordered) - 1)))
+    return ordered[max(0, min(len(ordered) - 1, idx))]
+
+
+def _run_one_sample(browser, device, sample_index: int, config: dict, capture: bool = False, capture_dir: Path | None = None):
+    capture_dir = capture_dir or Path(REPORT_ROOT / "captures")
+    sample_capture = None
+    context_opts = dict(device)
+    if capture:
+        sample_capture = capture_dir / f"sample_{sample_index:02d}"
+        sample_capture.mkdir(parents=True, exist_ok=True)
+        context_opts["record_video_dir"] = str(sample_capture)
+        if "viewport" in context_opts:
+            context_opts["record_video_size"] = context_opts["viewport"]
+
+    context_opts.setdefault("base_url", BASE)
+
+    sample: dict = {
+        "sample": sample_index,
+        "errors": [],
+        "pageErrorCount": 0,
+        "pageErrors": [],
+        "firstSessionListOmitted": False,
+    }
+
+    with browser.new_context(**context_opts) as ctx:
+        page = ctx.new_page()
+        page.set_default_timeout(30_000)
+
+        page_errors: list[str] = []
+        page.on("pageerror", lambda e: page_errors.append(str(e)))
+        page.on("requestfailed", lambda req: page_errors.append(f"requestfailed: {req.url}"))
+
+        _install_runtime_stubs(page)
+        _install_fake_event_source(page)
+        _install_capture_overlay(page)
+        route_state = _install_routes(page)
+
+        throttle = float(config.get("cpuThrottle", 1))
+        if throttle != 1:
+            try:
+                cdp = ctx.new_cdp_session(page)
+                cdp.send("Emulation.setCPUThrottlingRate", {"rate": throttle})
+            except Exception:
+                pass
+
+        page.goto(f"{BASE}/", wait_until="domcontentloaded")
+        if capture:
+            page.evaluate(
+                "if (typeof window.__benchCreateCaptureHud === 'function') { window.__benchCreateCaptureHud(); }"
+            )
+
+        if isinstance(page, object):
+            page.evaluate("window.localStorage.removeItem('hermes-webui-session')")
+        page.wait_for_function("typeof window.loadSession === 'function'", timeout=15_000)
+
+        _install_benchmark_hooks(page)
+
+        # Start from a tiny idle conversation. The measured action is a real
+        # switch to an already-running background conversation represented by
+        # its persisted local INFLIGHT snapshot.
+        idle_state = page.evaluate(
+            f"""
+            async () => {{
+              const out = {{ ok: true }};
+              try {{
+                await window.loadSession({json.dumps(IDLE_SESSION_ID)});
+                return out;
+              }} catch (err) {{
+                out.ok = false;
+                out.error = String(err && (err.message || err));
+                return out;
+              }}
+            }}
+            """
+        )
+        if not idle_state.get("ok"):
+            sample["errors"].append(f"idle setup failed: {idle_state.get('error')}")
+            sample["pageErrorCount"] = len(page_errors)
+            sample["pageErrors"] = page_errors[:20]
+            return sample
+
+        seeded_session = _session_payload(
+            active=True,
+            messages_requested=1,
+            messages_limit=VISIBLE_MESSAGES,
+            messages_before=0,
+        )
+        prime_seed = {
+            "sid": ACTIVE_SESSION_ID,
+            "session": seeded_session,
+            "runtime_journal_snapshot": seeded_session.get("runtime_journal_snapshot"),
+            "tool_calls": seeded_session.get("tool_calls") or [],
+            "messages": seeded_session.get("messages") or [],
+        }
+
+        sample["primeInflightSynthetic"] = False
+        sample["primeInflightState"] = {}
+        # This is the deterministic equivalent of the browser's persisted
+        # switch-away snapshot. No product method is stubbed: loadSession still
+        # selects, renders, and reattaches this state through its real path.
+        synthetic = _inject_synthetic_inflight(
+            page,
+            ACTIVE_SESSION_ID,
+            ACTIVE_STREAM_ID,
+            TARGET_INFLIGHT_LAST_SEQ,
+            prime_seed,
+        )
+        sample["primeInflightSynthetic"] = bool(synthetic.get("ok"))
+        if not synthetic.get("ok"):
+            sample["errors"].append(f"prime INFLIGHT unavailable: {synthetic.get('reason', 'unknown')}")
+
+        pre_return_state = _query_inflight_state(page, ACTIVE_SESSION_ID)
+        sample["primeInflightState"] = pre_return_state
+        sample["primeInflightPostSwitch"] = pre_return_state
+        sample["primeRetainedInflightSnapshot"] = bool(pre_return_state.get("exists"))
+        sample["retainedInflightSnapshot"] = bool(pre_return_state.get("exists"))
+        sample["replayedInflightRestored"] = bool(
+            pre_return_state.get("exists")
+            and pre_return_state.get("streamId") == ACTIVE_STREAM_ID
+            and pre_return_state.get("reattach")
+            and not pre_return_state.get("journalReplayFromStart")
+            and pre_return_state.get("toolCallCount") == TOTAL_TOOL_CALLS
+            and pre_return_state.get("hasAnchorActivityScene")
+        )
+        sample["preReturnState"] = pre_return_state
+
+        if capture:
+            page.evaluate(
+                """
+                () => {
+                  if (typeof window.__benchSetCaptureStage === 'function') window.__benchSetCaptureStage('ready');
+                  if (typeof window.__benchSetCaptureMetric === 'function') window.__benchSetCaptureMetric('next: switch to active fixture');
+                }
+                """
+            )
+            page.wait_for_timeout(1000)
+
+        measurement = page.evaluate(
+            f"""
+            async () => {{
+              const out = {{
+                branchObserved: 'non_inflight',
+                tLoadSessionCallMs: null,
+                tTranscriptReadyMs: null,
+                tTranscriptPaintOpportunityMs: null,
+                tAfterTranscriptPaintMs: null,
+                tFullSceneReadyMs: null,
+                sceneRowFirstSeenMs: null,
+                transcriptRowCount: 0,
+                transcriptRowCountAtTranscriptPaintOpportunity: null,
+                sceneRowCountAtTranscriptPaintOpportunity: null,
+                sceneRowCount: 0,
+                sceneRowIds: [],
+                sceneRowIdSetSize: 0,
+                eventSourceOpenCount: 0,
+                eventSourceCloseCount: 0,
+                longTaskTotalMs: 0,
+                longTaskMaxMs: 0,
+                longTaskCount: 0,
+                errors: [],
+                t0: performance.now(),
+                captureSwitchElapsedMs: null,
+                attachAfterSceneRestore: false,
+              }};
+
+              const targetStream = {json.dumps(ACTIVE_STREAM_ID)};
+              const targetSid = {json.dumps(ACTIVE_SESSION_ID)};
+              const expectPatched = {json.dumps(bool(config.get('expectPatch', True)))};
+              if (typeof window.__benchBeginSample === 'function') {{
+                window.__benchCurrentSampleToken = window.__benchBeginSample();
+              }} else {{
+                out.errors.push('benchmark hooks not installed');
+                return out;
+              }}
+
+              const token = window.__benchCurrentSampleToken;
+              const sampleToken = (typeof window.__benchCurrentSampleToken === 'number')
+                ? window.__benchCurrentSampleToken
+                : 0;
+              if (window.__benchHud) {{
+                out.captureSwitchElapsedMs = performance.now() - Number(window.__benchHud.start || 0);
+              }}
+              if (typeof window.__benchSetCaptureStage === 'function') {{
+                window.__benchSetCaptureStage('switch-start');
+              }}
+
+              const countRows = () => {{
+                const inner = document.getElementById('msgInner');
+                const liveTurn = document.getElementById('liveAssistantTurn');
+                const transcriptRows = inner ? inner.querySelectorAll('[data-msg-idx], .message').length : 0;
+                const loading = inner ? String(inner.textContent || '').includes('Loading conversation...') : false;
+                const sceneRows = liveTurn ? liveTurn.querySelectorAll('[data-anchor-scene-row="1"]').length : 0;
+                if (out.sceneRowFirstSeenMs === null && sceneRows > 0) {{
+                  out.sceneRowFirstSeenMs = performance.now() - out.t0;
+                }}
+                return {{ transcriptRows, loading, sceneRows }};
+              }};
+
+              let longTaskTotal = 0;
+              let longTaskMax = 0;
+              let longTaskCount = 0;
+              let observer = null;
+              try {{
+                observer = new PerformanceObserver((list) => {{
+                  for (const entry of list.getEntries()) {{
+                    const duration = Number(entry.duration || 0);
+                    if (duration > 0) {{
+                      longTaskCount += 1;
+                      longTaskTotal += duration;
+                      if (duration > longTaskMax) longTaskMax = duration;
+                    }}
+                  }}
+                }});
+                observer.observe({{ type: 'longtask', buffered: true }});
+              }} catch (_) {{}}
+
+              const makeProbe = (predicate) => new Promise((resolve) => {{
+                const timeoutMs = 30000;
+                const started = performance.now();
+                const finish = (result) => {{
+                  if (result && result.timeout) return resolve({{timeout: true}});
+                  resolve({{timeout: false, ...result}});
+                }};
+                const state = {{ done: false }};
+                const timer = setTimeout(() => {{
+                  if (state.done) return;
+                  state.done = true;
+                  finish({{ timeout: true }});
+                }}, timeoutMs);
+                const evaluate = () => {{
+                  if (state.done) return;
+                  const current = countRows();
+                  if (predicate(current)) {{
+                    state.done = true;
+                    clearTimeout(timer);
+                    finish({{
+                      timeout: false,
+                      tMs: performance.now() - out.t0,
+                      current,
+                    }});
+                  }}
+                }};
+                const mo = new MutationObserver(evaluate);
+                mo.observe(document.body || document.documentElement, {{ childList: true, subtree: true, characterData: true }});
+                evaluate();
+              }});
+
+              const transcriptPromise = makeProbe((current) => !current.loading && current.transcriptRows >= {VISIBLE_MESSAGES});
+              const scenePromise = makeProbe((current) => current.sceneRows >= {EXPECTED_FINAL_SCENE_ROWS});
+
+              const tLoadStart = performance.now();
+              const loadPromise = window.loadSession(targetSid)
+                .then(() => {{
+                  out.tLoadSessionCallMs = performance.now() - tLoadStart;
+                  return true;
+                }})
+                .catch((err) => {{
+                  out.errors.push('loadSession failed: ' + String(err && (err.message || err)));
+                  return false;
+                }});
+
+              const transcriptResult = await transcriptPromise;
+              if (transcriptResult && transcriptResult.timeout) {{
+                out.errors.push('transcript-ready timeout');
+              }} else if (transcriptResult) {{
+                out.tTranscriptReadyMs = Number(transcriptResult.tMs || 0);
+                if (typeof window.__benchSetCaptureStage === 'function') {{ window.__benchSetCaptureStage('frame-1'); }}
+                await new Promise((resolve) => requestAnimationFrame(resolve));
+                const frame1 = countRows();
+                out.transcriptRowCountAtTranscriptPaintOpportunity = Number(frame1.transcriptRows || 0);
+                out.sceneRowCountAtTranscriptPaintOpportunity = Number(frame1.sceneRows || 0);
+                out.tTranscriptPaintOpportunityMs = performance.now() - out.t0;
+                if (typeof window.__benchSetCaptureMetric === 'function') {{
+                  window.__benchSetCaptureMetric('paint-op=' + Math.round(out.tTranscriptPaintOpportunityMs) + 'ms scene=' + out.sceneRowCountAtTranscriptPaintOpportunity);
+                }}
+                await new Promise((resolve) => requestAnimationFrame(resolve));
+                out.tAfterTranscriptPaintMs = performance.now() - out.t0;
+                if (typeof window.__benchSetCaptureStage === 'function') {{ window.__benchSetCaptureStage('frame-2'); }}
+              }}
+
+              if (expectPatched) {{
+                const fullSceneResult = await scenePromise;
+                if (fullSceneResult && fullSceneResult.timeout) {{
+                  out.errors.push('full scene timeout');
+                }} else if (fullSceneResult) {{
+                  out.tFullSceneReadyMs = Number(fullSceneResult.tMs || 0);
+                }}
+              }}
+
+              await loadPromise;
+
+              // attachLiveStream performs an async status preflight before it
+              // constructs the real EventSource. Wait briefly so transport
+              // ownership is part of the verified outcome rather than a race
+              // against report collection.
+              await Promise.race([
+                new Promise((resolve) => {{
+                  const check = () => {{
+                    const es = window.__benchEventSourceState || {{}};
+                    const targetOpen = (es.events || []).some(
+                      (entry) =>
+                        entry &&
+                        entry.type === 'open' &&
+                        entry.token === sampleToken &&
+                        String(entry.url || '').includes('stream_id=' + encodeURIComponent(targetStream))
+                    );
+                    if (targetOpen) return resolve();
+                    setTimeout(check, 10);
+                  }};
+                  check();
+                }}),
+                new Promise((resolve) => setTimeout(resolve, 2000)),
+              ]);
+
+              const final = countRows();
+              out.transcriptRowCount = final.transcriptRows;
+              out.sceneRowCount = final.sceneRows;
+
+              const liveTurn = document.getElementById('liveAssistantTurn');
+              if (liveTurn) {{
+                const ids = [];
+                liveTurn.querySelectorAll('[data-anchor-scene-row="1"]').forEach((row) => {{
+                  const rid =
+                    row.getAttribute('data-anchor-row-id') ||
+                    row.getAttribute('data-anchor-local-id') ||
+                    '';
+                  if (rid) {{
+                    ids.push(String(rid));
+                  }}
+                }});
+                const setSize = (new Set(ids)).size;
+                out.sceneRowIds = ids;
+                out.sceneRowIdSetSize = setSize;
+              }}
+
+              const esState = window.__benchEventSourceState || {{}};
+              out.eventSourceOpenCount = Number(esState.openCount || 0);
+              out.eventSourceCloseCount = Number(esState.closeCount || 0);
+              const targetEventSourceOpen = (esState.events || []).find(
+                (entry) =>
+                  entry &&
+                  entry.type === 'open' &&
+                  entry.token === sampleToken &&
+                  String(entry.url || '').includes('stream_id=' + encodeURIComponent(targetStream))
+              );
+              out.targetEventSourceOpenMs = targetEventSourceOpen
+                ? Number(targetEventSourceOpen.t || 0) - out.t0
+                : null;
+
+              if (observer) {{
+                observer.disconnect();
+              }}
+              out.longTaskTotalMs = Number(longTaskTotal || 0);
+              out.longTaskMaxMs = Number(longTaskMax || 0);
+              out.longTaskCount = Number(longTaskCount || 0);
+              const hook = (typeof window.__benchGetHookState === 'function')
+                ? window.__benchGetHookState()
+                : null;
+              out.hookToken = sampleToken;
+              if (!hook) {{
+                out.errors.push('benchmark hook state missing');
+                return out;
+              }}
+
+              const matchingSelection = (hook.selectRecoveryCalls || []).filter(
+                (entry) => entry && entry.token === sampleToken && String(entry.activeStreamId || '') === targetStream
+              );
+              const matchingDefers = (hook.deferCallbacks || []).filter(
+                (entry) => entry && entry.token === sampleToken && String(entry.activeStreamId || '') === targetStream
+              );
+              if (matchingSelection.length) {{
+                const last = matchingSelection[matchingSelection.length - 1];
+                if (last.selected === 'inflight') {{
+                  out.branchObserved = 'local_inflight';
+                }} else if (last.selected === 'discover' && matchingDefers.length) {{
+                  out.branchObserved = 'server_snapshot_inflight';
+                }} else {{
+                  out.branchObserved = last.selected || 'non_inflight';
+                }}
+              }} else if (matchingDefers.length) {{
+                out.branchObserved = 'active_recovery';
+              }} else {{
+                out.errors.push('branch-selection hook never recorded');
+              }}
+              out.deferCallbackCount = matchingDefers.length;
+
+              const matchingEvents = (hook.events || []).filter(
+                (entry) =>
+                  entry &&
+                  entry.token === sampleToken &&
+                  (
+                    String(entry.sid || '') === targetSid ||
+                    String(entry.streamId || '') === targetStream ||
+                    (!entry.sid && !entry.streamId)
+                  ),
+              );
+              const firstSceneIdx = matchingEvents.findIndex((entry) => String(entry.type || '').startsWith('sceneRender'));
+              const firstAttachIdx = matchingEvents.findIndex((entry) =>
+                String(entry.type || '') === 'attachLiveStream' || String(entry.type || '') === 'watchInflightSession'
+              );
+              const firstSceneEvent = firstSceneIdx >= 0 ? matchingEvents[firstSceneIdx] : null;
+              if (matchingDefers.length > 0 && firstSceneEvent && targetEventSourceOpen) {{
+                out.attachAfterSceneRestore = Number(targetEventSourceOpen.t || 0) >= Number(firstSceneEvent.t || 0);
+                if (!out.attachAfterSceneRestore) out.errors.push('target EventSource opened before scene restore event');
+              }} else if (matchingDefers.length > 0) {{
+                out.attachAfterSceneRestore = false;
+                out.errors.push('missing scene or target EventSource ordering evidence');
+              }} else if (firstAttachIdx !== -1 && firstSceneIdx !== -1 && firstAttachIdx < firstSceneIdx) {{
+                out.attachAfterSceneRestore = false;
+              }} else {{
+                out.attachAfterSceneRestore = true;
+              }}
+
+              return out;
+            }}
+            """
+        )
+
+        sample.update(measurement)
+        sample["firstSessionListOmitted"] = bool(route_state.get("first_session_list_omitted"))
+        sample.pop("t0", None)
+        sample["hookState"] = page.evaluate(
+            "() => (typeof window.__benchGetHookState === 'function' ? window.__benchGetHookState() : null);"
+        )
+        hook_state = sample.get("hookState") or {}
+        sample["hookSummary"] = {
+            "sceneRenderCalls": len(hook_state.get("sceneRenderCalls") or []),
+            "deferCallbacks": len(hook_state.get("deferCallbacks") or []),
+            "attachCalls": len(hook_state.get("attachCalls") or []),
+            "watchCalls": len(hook_state.get("watchCalls") or []),
+            "events": len(hook_state.get("events") or []),
+        }
+
+        if sample.get("sceneRowIdSetSize") and sample.get("sceneRowIdSetSize") != sample.get("sceneRowCount"):
+            sample.setdefault("errors", []).append("duplicate final scene ids")
+
+        if capture and sample_capture:
+            page.screenshot(path=str(sample_capture / "final.png"), full_page=True)
+
+    sample["pageErrors"] = page_errors[:20]
+    sample["pageErrorCount"] = len(page_errors)
+    if sample.get("pageErrorCount"):
+        sample.setdefault("errors", []).append(f"page errors: {sample['pageErrorCount']}")
+    return sample
+
+
+def main() -> int:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("SKIP: playwright not installed", file=sys.stderr)
+        return 2
+
+    samples = max(1, int(os.getenv("BENCH_SAMPLES", "5")))
+    cpu_throttle = float(os.getenv("BENCH_CDP_THROTTLE", "1"))
+    expect_patch = os.getenv("BENCH_EXPECT_PATCH", "1") != "0"
+    capture = os.getenv("BENCH_CAPTURE") == "1"
+    capture_dir = Path(os.getenv("BENCH_CAPTURE_DIR", str(REPORT_ROOT / "captures")))
+
+    report_root = REPORT_ROOT
+    report_root.mkdir(parents=True, exist_ok=True)
+    report = _build_report()
+    report["command"]["samples"] = samples
+    report["command"]["capability"]["capture_enabled"] = capture
+    report["command"]["capability"]["cpu_throttle"] = cpu_throttle
+    report["command"]["capability"]["expect_patch"] = expect_patch
+
+    fixture_path = Path(os.getenv("BENCH_FIXTURE_OUT", str(report_root / "session-switch-active-render-fixture.json")))
+    report_path = Path(os.getenv("BENCH_OUT", str(report_root / "session-switch-active-render-report.json")))
+
+    fixture_path.parent.mkdir(parents=True, exist_ok=True)
+    fixture_path.write_text(json.dumps({"fixture": _fixture_description()}, indent=2), encoding="utf-8")
+
+    proc, state_dir = _start_server()
+    if not proc:
+        return 2
+
+    results: list[dict] = []
+    errors: list[str] = []
+    expected_scene_ids: list[str] | None = None
+
+    try:
+        with sync_playwright() as pw:
+            device = pw.devices["Pixel 5"]
+            browser = pw.chromium.launch(
+                headless=True,
+                args=["--no-sandbox", "--disable-dev-shm-usage"],
+            )
+            for i in range(samples):
+                sample = _run_one_sample(
+                    browser,
+                    device,
+                    i + 1,
+                    {"cpuThrottle": cpu_throttle, "expectPatch": expect_patch},
+                    capture=capture,
+                    capture_dir=capture_dir,
+                )
+                results.append(sample)
+
+                if sample.get("branchObserved") != "local_inflight":
+                    errors.append(f"sample {i + 1}: expected local INFLIGHT recovery branch, observed {sample.get('branchObserved')}")
+                if not sample.get("retainedInflightSnapshot", False):
+                    errors.append(f"sample {i + 1}: no retained INFLIGHT snapshot from prime before idle switch")
+                if not sample.get("replayedInflightRestored", False):
+                    errors.append(f"sample {i + 1}: seeded INFLIGHT state was not reattach-ready before measured switch")
+                pre_return_state = sample.get("preReturnState") or {}
+                if not pre_return_state.get("exists"):
+                    errors.append(f"sample {i + 1}: no INFLIGHT entry retained before measured return")
+                if not pre_return_state.get("reattach"):
+                    errors.append(f"sample {i + 1}: INFLIGHT entry not marked for reattach before measured return")
+                if pre_return_state.get("journalReplayFromStart"):
+                    errors.append(f"sample {i + 1}: seeded INFLIGHT unexpectedly requested replay-from-start")
+                if sample.get("transcriptRowCount", 0) != VISIBLE_MESSAGES:
+                    errors.append(f"sample {i + 1}: transcriptRowCount {sample.get('transcriptRowCount')} != {VISIBLE_MESSAGES}")
+                if expect_patch:
+                    if sample.get("sceneRowCount", 0) != EXPECTED_FINAL_SCENE_ROWS:
+                        errors.append(f"sample {i + 1}: final scene count {sample.get('sceneRowCount')} != {EXPECTED_FINAL_SCENE_ROWS}")
+                    if not sample.get("firstSessionListOmitted", False):
+                        errors.append(f"sample {i + 1}: first /api/sessions response was not omitted")
+                    if sample.get("sceneRowCountAtTranscriptPaintOpportunity") != 0:
+                        errors.append(f"sample {i + 1}: scene rows at transcript paint opportunity = {sample.get('sceneRowCountAtTranscriptPaintOpportunity')}")
+                    if sample.get("sceneRowIdSetSize", 0) != sample.get("sceneRowCount", 0):
+                        errors.append(f"sample {i + 1}: duplicate final scene row ids")
+                    if sample.get("deferCallbackCount") != 1:
+                        errors.append(f"sample {i + 1}: expected one deferred restore callback")
+                    if not sample.get("attachAfterSceneRestore"):
+                        errors.append(f"sample {i + 1}: target EventSource did not open after scene restore")
+                else:
+                    hook_summary = sample.get("hookSummary") or {}
+                    if sample.get("deferCallbackCount") != 0:
+                        errors.append(f"sample {i + 1}: pre-fix baseline unexpectedly used deferred restore")
+                    if int(hook_summary.get("sceneRenderCalls") or 0) < TOTAL_TOOL_CALLS:
+                        errors.append(f"sample {i + 1}: pre-fix baseline did not reproduce persisted-tool scene-render cascade")
+                if sample.get("eventSourceOpenCount", 0) < 1:
+                    errors.append(f"sample {i + 1}: no EventSource opens")
+                if sample.get("eventSourceCloseCount", 0) > sample.get("eventSourceOpenCount", 0):
+                    errors.append(f"sample {i + 1}: EventSource close count exceeded opens")
+                if sample.get("pageErrorCount", 0):
+                    errors.append(f"sample {i + 1}: page errors {sample.get('pageErrorCount')}")
+                for err in sample.get("errors") or []:
+                    errors.append(f"sample {i + 1}: {err}")
+
+                ids = sample.get("sceneRowIds") or []
+                if ids:
+                    if expected_scene_ids is None:
+                        expected_scene_ids = ids
+                    elif sorted(ids) != sorted(expected_scene_ids):
+                        errors.append(f"sample {i + 1}: final scene identities changed from baseline")
+
+            browser.close()
+    finally:
+        _stop_server(proc)
+
+    report["samples"] = results
+    valid = [s for s in results if not s.get("errors")]
+    report["invalidSamples"] = len(results) - len(valid)
+    report["median"] = {
+        "tTranscriptReadyMs": _median([s.get("tTranscriptReadyMs") for s in valid if s.get("tTranscriptReadyMs") is not None]),
+        "tTranscriptPaintOpportunityMs": _median([
+            s.get("tTranscriptPaintOpportunityMs") for s in valid if s.get("tTranscriptPaintOpportunityMs") is not None
+        ]),
+        "tAfterTranscriptPaintMs": _median([
+            s.get("tAfterTranscriptPaintMs") for s in valid if s.get("tAfterTranscriptPaintMs") is not None
+        ]),
+        "tFullSceneReadyMs": _median([s.get("tFullSceneReadyMs") for s in valid if s.get("tFullSceneReadyMs") is not None]),
+        "tLoadSessionCallMs": _median([s.get("tLoadSessionCallMs") for s in valid if s.get("tLoadSessionCallMs") is not None]),
+        "longTaskTotalMs": _median([s.get("longTaskTotalMs") for s in valid if s.get("longTaskTotalMs") is not None]),
+        "longTaskMaxMs": _median([s.get("longTaskMaxMs") for s in valid if s.get("longTaskMaxMs") is not None]),
+        "longTaskCount": _median([s.get("longTaskCount") for s in valid if s.get("longTaskCount") is not None]),
+    }
+    report["p95"] = {
+        "tTranscriptReadyMs": _p95([s.get("tTranscriptReadyMs") for s in valid if s.get("tTranscriptReadyMs") is not None]),
+        "tTranscriptPaintOpportunityMs": _p95([s.get("tTranscriptPaintOpportunityMs") for s in valid if s.get("tTranscriptPaintOpportunityMs") is not None]),
+        "tAfterTranscriptPaintMs": _p95([s.get("tAfterTranscriptPaintMs") for s in valid if s.get("tAfterTranscriptPaintMs") is not None]),
+        "tFullSceneReadyMs": _p95([s.get("tFullSceneReadyMs") for s in valid if s.get("tFullSceneReadyMs") is not None]),
+        "tLoadSessionCallMs": _p95([s.get("tLoadSessionCallMs") for s in valid if s.get("tLoadSessionCallMs") is not None]),
+        "longTaskTotalMs": _p95([s.get("longTaskTotalMs") for s in valid if s.get("longTaskTotalMs") is not None]),
+        "longTaskMaxMs": _p95([s.get("longTaskMaxMs") for s in valid if s.get("longTaskMaxMs") is not None]),
+        "longTaskCount": _p95([s.get("longTaskCount") for s in valid if s.get("longTaskCount") is not None]),
+    }
+    report["errors"] = errors
+
+    report["command"]["bench_server_root"] = os.getenv("BENCH_SERVER_ROOT", str(REPO_ROOT))
+    report["command"]["base_dir"] = str(Path(state_dir).parent)
+
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    fixture_path.write_text(json.dumps({"fixture": _fixture_description()}, indent=2), encoding="utf-8")
+
+    if errors:
+        print("FAILURE: one or more samples failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    if valid:
+        print(
+            "PASS: "
+            f"{len(valid)} sample(s), "
+            f"scene-opportunity-max={max((s.get('sceneRowCountAtTranscriptPaintOpportunity') or 0) for s in valid)} "
+            f"final-scene={max((s.get('sceneRowCount') or 0) for s in valid)}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -280,52 +280,111 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
     # the wrong one. rfind = the substantive restore branch.
     inflight_idx = body.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = body[inflight_idx : inflight_idx + 4200]
-    assert "INFLIGHT[sid].reattach" in inflight_block, (
-        "loadSession()'s INFLIGHT branch must gate the SSE reattach on the "
-        "reattach flag so closeLiveStream()'s marking flows through"
+    inflight_block = body[inflight_idx : inflight_idx + 9000]
+    assert "attachLiveSceneForActiveSession" in inflight_block or "const attachLiveSceneForActiveSession" in inflight_block, (
+        "loadSession()'s INFLIGHT branch must route reattach through the owned "
+        "active session restore callback"
+    )
+    assert "currentInflight.reattach" in inflight_block, (
+        "loadSession()'s INFLIGHT branch should still require reattach=true from "
+        "the current inflight entry"
     )
     reattach_gate = re.search(
-        r"if\(INFLIGHT\[sid\]\.reattach\s*&&\s*activeStreamId.*?attachLiveStream\(sid, activeStreamId",
+        r"const\s+currentInflight=INFLIGHT\[sid\];[\s\S]*?if\s*\(!currentInflight\|\|!currentInflight\.reattach\|\|!activeStreamId",
         inflight_block,
         re.DOTALL,
     )
     assert reattach_gate, (
-        "loadSession() must reattach via attachLiveStream() when "
-        "INFLIGHT[sid].reattach && activeStreamId"
+        "loadSession() must gate active-session attach on currentInflight.reattach and "
+        "activeStreamId before calling attachLiveStream()"
     )
 
 
-def test_load_session_attaches_sse_before_auxiliary_work():
-    """Live SSE reattach is the primary recovery path.
+def test_load_session_replays_live_scene_after_transcript_with_deferred_attach():
+    """Session restore should render bounded transcript first, then defer
+    live-scene ownership and attach/watch through the scheduler.
 
-    Rendering, workspace refresh, badges, and side-channel pollers must not run
-    before attachLiveStream(), because any synchronous failure in those paths
-    would otherwise leave the backend stream active with no browser subscriber.
+    This preserves backend-observable side effects on the main path (badge,
+    status, pollers) while ensuring the expensive scene restore/attach work is
+    deferred and executed only after transcript paint.
     """
     body = _function_body(SESSIONS_JS, "loadSession")
-    active_branch = body[body.find("if(activeStreamId){") : body.find("}else{", body.find("if(activeStreamId){"))]
-    active_attach = active_branch.find("attachLiveStream(sid, activeStreamId")
-    assert active_attach != -1
-    # #3899 inserted restoreLiveTurnHtmlForSession between renderMessages and
-    # appendThinking, and renderMessages now takes a preserveScroll arg — so the
-    # old contiguous "syncTopbar();renderMessages();appendThinking();loadDir('.');"
-    # literal no longer exists. Assert each auxiliary call individually; all must
-    # still run AFTER attachLiveStream (the invariant this test protects). The
-    # workspace refresh is now scheduled through a first-paint deferral helper
-    # rather than calling loadDir('.') inline.
-    for marker in (
-        "updateSendBtn();",
-        "syncTopbar();",
-        "renderMessages(",
-        "appendThinking();",
-        "_deferWorkspaceRefreshForSession(sid);",
-        "updateQueueBadge(sid);",
-        "startApprovalPolling(sid)",
-    ):
-        pos = active_branch.find(marker)
-        assert pos != -1, f"{marker} not found in active-stream branch"
-        assert active_attach < pos, f"attachLiveStream() must run before {marker}"
+    inflight_idx = body.rfind("if(INFLIGHT[sid]){")
+    assert inflight_idx != -1, "INFLIGHT branch not found"
+    inflight_branch = body[inflight_idx : inflight_idx + 9000]
+    inflight_defer = inflight_branch.find("_deferActiveSessionSceneRestore(")
+    assert inflight_defer != -1, "active INFLIGHT branch should defer live restore path"
+    inflight_sync_topbar_pos = inflight_branch.find("syncTopbar();")
+    inflight_render_messages_pos = inflight_branch.find("renderMessages(")
+    inflight_busy_pos = inflight_branch.find("setBusy(true)")
+    inflight_composer_status_pos = inflight_branch.find("setComposerStatus('')")
+    inflight_start_approval_pos = inflight_branch.find("startApprovalPolling(sid)")
+    inflight_start_clarify_pos = inflight_branch.find("startClarifyPolling")
+    inflight_defer_workspace_pos = inflight_branch.find("_deferWorkspaceRefreshForSession(sid)")
+    assert inflight_sync_topbar_pos != -1, "inflight branch should call syncTopbar() before deferring restore"
+    assert inflight_sync_topbar_pos < inflight_defer
+    assert inflight_render_messages_pos != -1, "inflight branch should render messages before deferring restore"
+    assert inflight_render_messages_pos < inflight_defer
+    assert inflight_busy_pos != -1, "inflight branch should set busy before deferring restore"
+    assert inflight_busy_pos < inflight_defer
+    assert inflight_composer_status_pos != -1, "inflight branch should clear composer status before deferring restore"
+    assert inflight_composer_status_pos < inflight_defer
+    assert inflight_start_approval_pos != -1, "inflight branch should restart approval polling before deferring restore"
+    assert inflight_start_approval_pos < inflight_defer
+    assert inflight_start_clarify_pos != -1, "inflight branch should restart clarify polling before deferring restore"
+    assert inflight_start_clarify_pos < inflight_defer
+    assert inflight_defer_workspace_pos != -1, "inflight branch should defer workspace refresh before deferring restore"
+    assert inflight_defer_workspace_pos < inflight_defer
+
+    active_inflight_order_re = re.search(
+        r"_deferActiveSessionSceneRestore\([\s\S]*?restoreLiveSurfaceForActiveInflight\(\)[\s\S]*?attachLiveSceneForActiveSession\(\)",
+        inflight_branch,
+    )
+    assert active_inflight_order_re is not None, "INFLIGHT path should restore live scene ownership before attach/watch"
+
+    idle_anchor = body.find("if(activeStreamId){")
+    assert idle_anchor != -1, "discovered active stream branch not found"
+    active_idle = body[idle_anchor : idle_anchor + 2400]
+    idle_defer = active_idle.find("_deferActiveSessionSceneRestore(")
+    assert idle_defer != -1, "discovered active stream branch should defer live restore path"
+    active_idle_sync_topbar_pos = active_idle.find("syncTopbar();")
+    active_idle_render_messages_pos = active_idle.find("renderMessages(")
+    active_idle_busy_pos = active_idle.find("S.busy=true")
+    active_idle_set_status_pos = active_idle.find("setStatus('')")
+    active_idle_composer_status_pos = active_idle.find("setComposerStatus('')")
+    active_idle_update_queue_pos = active_idle.find("updateQueueBadge(sid)")
+    active_idle_start_approval_pos = active_idle.find("startApprovalPolling(sid)")
+    active_idle_start_clarify_pos = active_idle.find("startClarifyPolling")
+    active_idle_defer_workspace_pos = active_idle.find("_deferWorkspaceRefreshForSession(sid)")
+    assert active_idle_sync_topbar_pos != -1, "active discovered branch should call syncTopbar() before deferring restore"
+    assert active_idle_sync_topbar_pos < idle_defer
+    assert active_idle_render_messages_pos != -1, "active discovered branch should render messages before deferring restore"
+    assert active_idle_render_messages_pos < idle_defer
+    assert active_idle_busy_pos != -1, "active discovered branch should set S.busy=true before deferring restore"
+    assert active_idle_busy_pos < idle_defer
+    assert active_idle_set_status_pos != -1, "active discovered branch should clear status before deferring restore"
+    assert active_idle_set_status_pos < idle_defer
+    assert active_idle_composer_status_pos != -1, "active discovered branch should clear composer status before deferring restore"
+    assert active_idle_composer_status_pos < idle_defer
+    assert active_idle_update_queue_pos != -1, "active discovered branch should update queue badge before deferring restore"
+    assert active_idle_update_queue_pos < idle_defer
+    assert active_idle_start_approval_pos != -1, "active discovered branch should restart approval polling before deferring restore"
+    assert active_idle_start_approval_pos < idle_defer
+    assert active_idle_start_clarify_pos != -1, "active discovered branch should restart clarify polling before deferring restore"
+    assert active_idle_start_clarify_pos < idle_defer
+    assert active_idle_defer_workspace_pos != -1, "active discovered branch should defer workspace refresh before deferring restore"
+    assert active_idle_defer_workspace_pos < idle_defer
+
+    active_idle_order_re = re.search(
+        r"_deferActiveSessionSceneRestore\([\s\S]*?restoreLiveSurfaceForIdleInflight\(\)[\s\S]*?attachLiveSceneForIdleSession\(\)",
+        active_idle,
+    )
+    assert active_idle_order_re is not None, "idle active-stream reattach path should establish live ownership before attach/watch"
+
+
+def test_load_session_active_scene_restore_is_deferred_after_transcript_render():
+    # Backward compatibility shim for existing dashboards/coverage references.
+    test_load_session_replays_live_scene_after_transcript_with_deferred_attach()
 
 
 def test_running_reattach_refreshes_single_live_assistant_from_server_progress():
@@ -917,43 +976,63 @@ def test_load_session_restores_worklog_shell_before_reattach_replay():
 
 
 def test_restore_succeeded_reconnect_replays_tool_cards():
-    """When reconnect replay succeeds in restoring the live turn HTML, tool cards
-    are still repainted from the persisted live-call list instead of waiting for a
-    future SSE event to reintroduce them."""
-    body = _function_body(SESSIONS_JS, "loadSession")
-    replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
-    reattach_pos = body.find("if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function')")
-    restore_pos = body.find("restoreLiveTurnHtmlForSession", reattach_pos if reattach_pos != -1 else 0)
-    fallback_pos = body.find("if(!restoredLiveTurn){", restore_pos)
-    restore_replay_pos = body.find("if(restoredLiveTurn&&didReconnect){", restore_pos)
-    restore_replay_block = body[restore_replay_pos:fallback_pos]
-    helper_replay_call = restore_replay_block.find("replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});")
-    assert reattach_pos != -1, "loadSession must keep the reconnect reattach branch"
-    assert replay_fn != -1, "loadSession should extract live tool replay into a helper"
-    assert restore_pos != -1, "loadSession must still execute restoreLiveTurnHtmlForSession"
-    assert reattach_pos > replay_fn, "live-tool replay helper must be defined before reattach branch"
-    assert restore_pos > reattach_pos, "restore/fallback branch should be after reattach handling in INFLIGHT flow"
-    assert restore_replay_pos != -1, "restored live turns must explicitly replay tools on reconnect"
-    assert helper_replay_call != -1, "replay helper must be executed so reconnect can repopulate tool cards"
-    assert replay_fn < restore_replay_pos < fallback_pos, "restore+reconnect replay should run before fallback"
-    assert restore_replay_block.strip().startswith("if(restoredLiveTurn&&didReconnect){")
-    assert (
-        "if(restoredLiveTurn&&didReconnect){"
-        "replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});"
-        "}"
-    ) in re.sub(r"\s+", "", restore_replay_block)
+    """Legacy HTML-only restore still repaints persisted live tool cards.
 
-
-def test_restore_succeeded_reconnect_skips_unkeyed_restored_tool_duplicates():
-    """Restored snapshots can already contain legacy tool rows without live tids.
-
-    Replaying an unkeyed persisted tool over that restored DOM would append a
-    duplicate, so the restore-success reconnect path should only replay unkeyed
-    tools when the restored turn has no visible tool rows to preserve.
+    An authoritative Anchor scene already contains the current-turn worklog and
+    must skip this session-wide replay; the browser regression covers that path.
     """
     body = _function_body(SESSIONS_JS, "loadSession")
     replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
-    restore_replay_pos = body.find("if(restoredLiveTurn&&didReconnect){")
+    reattach_pos = body.find("const attachLiveSceneForActiveSession=()=>{")
+    restore_pos = body.find("restoreLiveTurnHtmlForSession", reattach_pos if reattach_pos != -1 else 0)
+    fallback_pos = body.find("if(!restoredLiveTurn){", restore_pos)
+    restore_replay_block = ""
+    restore_replay_match = re.search(
+        r"replayPersistedLiveToolCards\(\s*\{skipUnkeyedRestoredDuplicates:\s*true\}\s*\)",
+        body,
+        re.DOTALL,
+    )
+    restore_replay_pos = restore_replay_match.start() if restore_replay_match else -1
+    guard_match = re.search(
+        r"if\s*\(\s*didReconnect\s*&&\s*restoreResult\s*&&\s*restoreResult\.restoredLiveTurn\s*&&\s*!restoreResult\.restoredAnchorScene\s*\)\s*\{",
+        body,
+        re.DOTALL,
+    )
+    guard_pos = guard_match.start() if guard_match else -1
+    restore_replay_block = body[guard_pos:fallback_pos] if guard_pos != -1 else ""
+    helper_replay_call = restore_replay_block.find("replayPersistedLiveToolCards")
+    assert reattach_pos != -1, "loadSession must keep the reconnect reattach helper"
+    assert replay_fn != -1, "loadSession should extract live tool replay into a helper"
+    assert restore_pos != -1, "loadSession must still execute restoreLiveTurnHtmlForSession"
+    assert reattach_pos > replay_fn, "live-tool replay helper must be defined before reattach branch"
+    assert restore_pos > reattach_pos, "restore/fallback branch should be after reattach helper in INFLIGHT flow"
+    assert guard_pos != -1, "HTML-only restored live turns must gate tool replay on reconnect"
+    assert restore_replay_pos != -1, "HTML-only restored live turns must explicitly replay tools"
+    assert helper_replay_call != -1, "HTML-only reconnect must repopulate persisted tool cards"
+    assert replay_fn < guard_pos < fallback_pos, "restore+reconnect replay should run before fallback"
+    assert guard_match is not None
+    assert restore_replay_match is not None
+    assert (
+        re.search(
+            r"if\s*\(\s*didReconnect\s*&&\s*restoreResult\s*&&\s*restoreResult\.restoredLiveTurn\s*&&\s*!restoreResult\.restoredAnchorScene\s*\)\s*\{",
+            restore_replay_block,
+        )
+        is not None
+    )
+
+
+def test_restore_succeeded_reconnect_skips_anchor_scene_and_unkeyed_tool_duplicates():
+    """Restored snapshots can already contain authoritative or legacy tool rows.
+
+    Anchor scenes skip the session-wide replay entirely. HTML-only restores keep
+    replay, but skip unkeyed rows when restored DOM already has visible tool rows.
+    """
+    body = _function_body(SESSIONS_JS, "loadSession")
+    replay_fn = body.find("const replayPersistedLiveToolCards=(opts)=>{")
+    restore_replay_pos = body.find(
+        "if(didReconnect&&restoreResult&&restoreResult.restoredLiveTurn&&!restoreResult.restoredAnchorScene){"
+    )
+    assert restore_replay_pos != -1, "loadSession must keep reconnect replay guard"
     fallback_pos = body.find("if(!restoredLiveTurn){", restore_replay_pos)
     assert replay_fn != -1, "loadSession should keep replay options on the helper"
     assert "const liveToolReplayId=(tc)=>" in body
@@ -961,12 +1040,18 @@ def test_restore_succeeded_reconnect_skips_unkeyed_restored_tool_duplicates():
     helper_block = body[replay_fn:restore_replay_pos]
     assert "skipUnkeyedRestoredDuplicates" in helper_block
     assert "restoredLiveTurn.querySelector('.tool-card-row')" in helper_block
-    assert "hasRestoredLiveToolRows&&!liveToolReplayId(tc)" in helper_block
-    restore_block = body[restore_replay_pos:fallback_pos]
-    assert "replayPersistedLiveToolCards({skipUnkeyedRestoredDuplicates:true});" in restore_block
-    refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid);", fallback_pos)
-    assert refresh_pos != -1, "fallback path should still schedule workspace refresh after first paint"
-    assert "replayPersistedLiveToolCards();" in body[fallback_pos:refresh_pos]
+    assert "hasCurrentWorklogContent&&!liveToolReplayId(tc)" in helper_block
+    assert "restoredAnchorScene: !!restoredAnchorScene" in body
+    active_fallback_pos = body.find("if(!restoredLiveTurn){", replay_fn)
+    assert active_fallback_pos != -1, "active branch should include a restored-live fallback"
+    active_refresh_pos = body.find("_deferWorkspaceRefreshForSession(sid);", active_fallback_pos)
+    assert active_refresh_pos != -1, "active branch should schedule workspace refresh after first paint"
+    restore_guard_tail = body[restore_replay_pos:restore_replay_pos + 400]
+    assert re.search(
+        r"replayPersistedLiveToolCards\s*\(\s*\{skipUnkeyedRestoredDuplicates:\s*true\}\s*\)",
+        restore_guard_tail,
+    ) is not None
+    assert "replayPersistedLiveToolCards();" in body[active_fallback_pos:active_refresh_pos]
 
 
 def test_merge_inflight_tail_preserves_all_segmented_live_progress():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -148,7 +148,10 @@ def test_load_session_reattach_path_uses_attach_live_stream_for_running_sessions
     assert active_pos != -1
     assert reattach_pos != -1
     assert active_pos < reattach_pos
-    assert "{reconnecting:true}" in body[reattach_pos : reattach_pos + 200]
+    attach_opts = body[reattach_pos : reattach_pos + 700]
+    assert "reconnecting:true" in attach_opts
+    assert "isCurrentOwner:()=>_isActiveSessionSceneRestoreOwner" in attach_opts
+    assert "onAttached:" in attach_opts
 
 
 def test_load_session_same_sid_noop_does_not_mask_pending_switch_back():
@@ -285,16 +288,13 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
         "loadSession()'s INFLIGHT branch must route reattach through the owned "
         "active session restore callback"
     )
-    assert "currentInflight.reattach" in inflight_block, (
+    assert "attachOwnedSessionStream(true)" in inflight_block, (
         "loadSession()'s INFLIGHT branch should still require reattach=true from "
         "the current inflight entry"
     )
-    reattach_gate = re.search(
-        r"const\s+currentInflight=INFLIGHT\[sid\];[\s\S]*?if\s*\(!currentInflight\|\|!currentInflight\.reattach\|\|!activeStreamId",
-        inflight_block,
-        re.DOTALL,
-    )
-    assert reattach_gate, (
+    helper_pos = body.find("const attachOwnedSessionStream=")
+    helper_tail = body[helper_pos : helper_pos + 1000]
+    assert helper_pos != -1 and "requireReattach&&(!inflight||!inflight.reattach)" in helper_tail, (
         "loadSession() must gate active-session attach on currentInflight.reattach and "
         "activeStreamId before calling attachLiveStream()"
     )
@@ -312,7 +312,7 @@ def test_load_session_replays_live_scene_after_transcript_with_deferred_attach()
     inflight_idx = body.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx != -1, "INFLIGHT branch not found"
     inflight_branch = body[inflight_idx : inflight_idx + 9000]
-    inflight_defer = inflight_branch.find("_deferActiveSessionSceneRestore(")
+    inflight_defer = inflight_branch.find("_deferActiveSessionSceneRestoreAndAttach(")
     assert inflight_defer != -1, "active INFLIGHT branch should defer live restore path"
     inflight_sync_topbar_pos = inflight_branch.find("syncTopbar();")
     inflight_render_messages_pos = inflight_branch.find("renderMessages(")
@@ -336,16 +336,15 @@ def test_load_session_replays_live_scene_after_transcript_with_deferred_attach()
     assert inflight_defer_workspace_pos != -1, "inflight branch should defer workspace refresh before deferring restore"
     assert inflight_defer_workspace_pos < inflight_defer
 
-    active_inflight_order_re = re.search(
-        r"_deferActiveSessionSceneRestore\([\s\S]*?restoreLiveSurfaceForActiveInflight\(\)[\s\S]*?attachLiveSceneForActiveSession\(\)",
-        inflight_branch,
-    )
-    assert active_inflight_order_re is not None, "INFLIGHT path should restore live scene ownership before attach/watch"
+    inflight_restore_ref = inflight_branch.find("restoreLiveSurfaceForActiveInflight,", inflight_defer)
+    inflight_attach_ref = inflight_branch.find("attachLiveSceneForActiveSession,", inflight_defer)
+    assert inflight_defer < inflight_restore_ref < inflight_attach_ref
+    assert inflight_branch.find(".then((result)=>{", inflight_attach_ref) > inflight_attach_ref
 
     idle_anchor = body.find("if(activeStreamId){")
     assert idle_anchor != -1, "discovered active stream branch not found"
-    active_idle = body[idle_anchor : idle_anchor + 2400]
-    idle_defer = active_idle.find("_deferActiveSessionSceneRestore(")
+    active_idle = body[idle_anchor : idle_anchor + 4200]
+    idle_defer = active_idle.find("_deferActiveSessionSceneRestoreAndAttach(")
     assert idle_defer != -1, "discovered active stream branch should defer live restore path"
     active_idle_sync_topbar_pos = active_idle.find("syncTopbar();")
     active_idle_render_messages_pos = active_idle.find("renderMessages(")
@@ -375,11 +374,9 @@ def test_load_session_replays_live_scene_after_transcript_with_deferred_attach()
     assert active_idle_defer_workspace_pos != -1, "active discovered branch should defer workspace refresh before deferring restore"
     assert active_idle_defer_workspace_pos < idle_defer
 
-    active_idle_order_re = re.search(
-        r"_deferActiveSessionSceneRestore\([\s\S]*?restoreLiveSurfaceForIdleInflight\(\)[\s\S]*?attachLiveSceneForIdleSession\(\)",
-        active_idle,
-    )
-    assert active_idle_order_re is not None, "idle active-stream reattach path should establish live ownership before attach/watch"
+    idle_restore_ref = active_idle.find("restoreLiveSurfaceForIdleInflight,", idle_defer)
+    idle_attach_ref = active_idle.find("attachLiveSceneForIdleSession,", idle_defer)
+    assert idle_defer < idle_restore_ref < idle_attach_ref
 
 
 def test_load_session_active_scene_restore_is_deferred_after_transcript_render():

--- a/tests/test_issue2066_stale_sidebar_spinner.py
+++ b/tests/test_issue2066_stale_sidebar_spinner.py
@@ -47,6 +47,15 @@ def test_cache_render_purges_stale_non_streaming_inflight_entries():
 def test_stale_inflight_purge_executes_without_undeclared_session_map():
     purge_block = _function_block("_purgeStaleInflightEntries", "_rememberRenderedStreamingState")
     script = f"""
+let S = {{
+  session: null,
+  activeStreamId: null,
+  busy: false,
+}};
+let _sessionListSourceById = new Map();
+let _allSessionsScope = null;
+let _sendInProgress = false;
+let _sendInProgressSid = null;
 let _allSessions = [
   {{session_id: 'done-session', is_streaming: false}},
   {{session_id: 'running-session', is_streaming: true}}

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -8,10 +8,12 @@ UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 def _load_session_inflight_branch() -> str:
     start_marker = "\n  if(INFLIGHT[sid]){"
-    end_marker = "\n  }else{\n    // Phase 2b:"
+    end_marker = "\n    // Phase 2b:"
     start = SESSIONS_JS.rfind(start_marker)
     assert start != -1, "loadSession INFLIGHT branch not found"
     end = SESSIONS_JS.find(end_marker, start)
+    if end != -1:
+        end = SESSIONS_JS.rfind("\n  }", start, end)
     assert end != -1, "loadSession INFLIGHT branch end not found"
     return SESSIONS_JS[start:end]
 

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -7,9 +7,11 @@ UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def _load_session_inflight_branch() -> str:
-    start = SESSIONS_JS.find("if(INFLIGHT[sid]){")
+    start_marker = "\n  if(INFLIGHT[sid]){"
+    end_marker = "\n  }else{\n    // Phase 2b:"
+    start = SESSIONS_JS.rfind(start_marker)
     assert start != -1, "loadSession INFLIGHT branch not found"
-    end = SESSIONS_JS.find("}else{", start)
+    end = SESSIONS_JS.find(end_marker, start)
     assert end != -1, "loadSession INFLIGHT branch end not found"
     return SESSIONS_JS[start:end]
 

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -555,6 +555,11 @@ global._sessionListSnapshotById = new Map([['webui-live', {{ message_count: 1, l
 global._sendInProgress = false;
 global._sendInProgressSid = null;
 global.INFLIGHT = {{ 'webui-live': {{ lastAssistantText: 'working' }} }};
+global.S = {{
+  session: null,
+  activeStreamId: null,
+  busy: false,
+}};
 const cleared = [];
 global.clearInflightState = sid => cleared.push(sid);
 global._isSessionEffectivelyStreaming = s => Boolean(s.is_streaming);
@@ -603,6 +608,167 @@ console.log(JSON.stringify({{
     assert "cli-stale" not in body["snapshotKeys"]
     assert "webui-live" in body["sourceKeys"]
     assert "cli-stale" not in body["sourceKeys"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_purge_stale_inflight_preserves_active_session_with_coherent_ownership():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    purge_fn = _extract_function(src, "_purgeStaleInflightEntries")
+    script = f"""
+global._allSessions = [{{ session_id: 'webui-other', source_tag: 'webui', raw_source: 'webui', session_source: 'webui', is_streaming: true }}];
+global._allSessionsScope = {{}};
+global._sessionListSourceById = new Map();
+global._sendInProgress = false;
+global._sendInProgressSid = null;
+global.INFLIGHT = {{
+  'active-1': {{ streamId: 'stream-1', lastAssistantText: 'working' }},
+}};
+global.S = {{
+  session: {{ session_id: 'active-1', active_stream_id: 'stream-1' }},
+  activeStreamId: 'stream-1',
+  busy: true,
+}};
+const cleared = [];
+global.clearInflightState = sid => cleared.push(sid);
+{purge_fn}
+_purgeStaleInflightEntries();
+console.log(JSON.stringify({{
+  inflightKeys: Object.keys(INFLIGHT),
+  cleared,
+}}));
+"""
+    body = _run_node(script)
+    assert body["inflightKeys"] == ["active-1"]
+    assert body["cleared"] == []
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_purge_stale_inflight_removes_absent_active_session_when_not_busy():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    purge_fn = _extract_function(src, "_purgeStaleInflightEntries")
+    script = f"""
+global._allSessions = [{{ session_id: 'webui-other', source_tag: 'webui', raw_source: 'webui', session_source: 'webui', is_streaming: true }}];
+global._allSessionsScope = {{}};
+global._sessionListSourceById = new Map();
+global._sendInProgress = false;
+global._sendInProgressSid = null;
+global.INFLIGHT = {{
+  'active-1': {{ streamId: 'stream-1', lastAssistantText: 'working' }},
+}};
+global.S = {{
+  session: {{ session_id: 'active-1', active_stream_id: 'stream-1' }},
+  activeStreamId: 'stream-1',
+  busy: false,
+}};
+const cleared = [];
+global.clearInflightState = sid => cleared.push(sid);
+{purge_fn}
+_purgeStaleInflightEntries();
+console.log(JSON.stringify({{
+  inflightKeys: Object.keys(INFLIGHT),
+  cleared,
+}}));
+"""
+    body = _run_node(script)
+    assert body["inflightKeys"] == []
+    assert body["cleared"] == ["active-1"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_purge_stale_inflight_prunes_background_entry_when_row_absent():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    purge_fn = _extract_function(src, "_purgeStaleInflightEntries")
+    script = f"""
+global._allSessions = [{{ session_id: 'webui-active', source_tag: 'webui', raw_source: 'webui', session_source: 'webui', is_streaming: true }}];
+global._allSessionsScope = {{}};
+global._sessionListSourceById = new Map();
+global._sendInProgress = false;
+global._sendInProgressSid = null;
+global.INFLIGHT = {{
+  'webui-active': {{ streamId: 'stream-active', lastAssistantText: 'active' }},
+  'webui-bg': {{ streamId: 'stream-bg', lastAssistantText: 'bg' }},
+}};
+global.S = {{
+  session: {{ session_id: 'webui-active', active_stream_id: 'stream-active' }},
+  activeStreamId: 'stream-active',
+  busy: true,
+}};
+const cleared = [];
+global.clearInflightState = sid => cleared.push(sid);
+{purge_fn}
+_purgeStaleInflightEntries();
+console.log(JSON.stringify({{
+  inflightKeys: Object.keys(INFLIGHT).sort(),
+  cleared: cleared.sort(),
+}}));
+"""
+    body = _run_node(script)
+    assert body["inflightKeys"] == ["webui-active"]
+    assert body["cleared"] == ["webui-bg"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_purge_stale_inflight_prunes_absent_active_session_when_stream_ownership_conflicts():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    purge_fn = _extract_function(src, "_purgeStaleInflightEntries")
+    script = f"""
+global._allSessions = [{{ session_id: 'webui-other', source_tag: 'webui', raw_source: 'webui', session_source: 'webui', is_streaming: true }}];
+global._allSessionsScope = {{}};
+global._sessionListSourceById = new Map();
+global._sendInProgress = false;
+global._sendInProgressSid = null;
+global.INFLIGHT = {{
+  'active-1': {{ streamId: 'stream-1', lastAssistantText: 'working' }},
+}};
+global.S = {{
+  session: {{ session_id: 'active-1', active_stream_id: 'stream-2' }},
+  activeStreamId: 'stream-3',
+  busy: true,
+}};
+const cleared = [];
+global.clearInflightState = sid => cleared.push(sid);
+{purge_fn}
+_purgeStaleInflightEntries();
+console.log(JSON.stringify({{
+  inflightKeys: Object.keys(INFLIGHT),
+  cleared,
+}}));
+"""
+    body = _run_node(script)
+    assert body["inflightKeys"] == []
+    assert body["cleared"] == ["active-1"]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_purge_stale_inflight_purges_present_idle_row_even_if_client_fields_stale():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    purge_fn = _extract_function(src, "_purgeStaleInflightEntries")
+    script = f"""
+global._allSessions = [{{ session_id: 'active-1', source_tag: 'webui', raw_source: 'webui', session_source: 'webui', is_streaming: false }}];
+global._allSessionsScope = {{}};
+global._sessionListSourceById = new Map();
+global._sendInProgress = false;
+global._sendInProgressSid = null;
+global.INFLIGHT = {{
+  'active-1': {{ streamId: 'stream-1', lastAssistantText: 'working' }},
+}};
+global.S = {{
+  session: {{ session_id: 'active-1', active_stream_id: 'stream-1' }},
+  activeStreamId: 'stream-1',
+  busy: true,
+}};
+const cleared = [];
+global.clearInflightState = sid => cleared.push(sid);
+{purge_fn}
+_purgeStaleInflightEntries();
+console.log(JSON.stringify({{
+  inflightKeys: Object.keys(INFLIGHT),
+  cleared: cleared,
+}}));
+"""
+    body = _run_node(script)
+    assert body["inflightKeys"] == []
+    assert body["cleared"] == ["active-1"]
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")

--- a/tests/test_issue5720_reasoning_owner.py
+++ b/tests/test_issue5720_reasoning_owner.py
@@ -527,9 +527,9 @@ class FakeEventSource {
 }
 global.EventSource=FakeEventSource;
 
-const attachStart=messagesSrc.indexOf('function attachLiveStream(');
+const attachStart=messagesSrc.indexOf('const _PENDING_LIVE_ATTACHES=');
 const attachEnd=messagesSrc.indexOf('\nfunction transcript(){',attachStart);
-if(attachStart<0||attachEnd<0) throw new Error('attachLiveStream source boundary not found');
+if(attachStart<0||attachEnd<0) throw new Error('live-attach source boundary not found');
 eval(messagesSrc.slice(attachStart,attachEnd));
 attachLiveStream('sid-1','stream-1');
 const source=FakeEventSource.instances[0];

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -658,11 +658,20 @@ def test_reload_path_restores_pending_message_and_reattaches_live_stream(cleanup
     active_branch_end = sessions_src.index("}else{\n      S.busy=false;", active_branch_start)
     active_branch = sessions_src[active_branch_start:active_branch_end]
     render_pos = active_branch.index("renderMessages(")
-    shell_pos = active_branch.index("ensureLiveWorklogShell")
-    assert render_pos < shell_pos, (
-        "Reloading an active stream must recreate the live worklog shell after "
-        "renderMessages() rebuilds msgInner; otherwise the stream stays invisible "
-        "until a session switch triggers another restore path."
+    defer_pos = active_branch.index("_deferActiveSessionSceneRestore(")
+    callback_pos = active_branch.find("restoreLiveSurfaceForIdleInflight()", defer_pos)
+    restore_helper_start = active_branch.index("const restoreLiveSurfaceForIdleInflight=()=>{")
+    restore_helper_end = active_branch.index("const attachLiveSceneForIdleSession=()=>{", restore_helper_start)
+    restore_helper = active_branch[restore_helper_start:restore_helper_end]
+    assert render_pos < defer_pos, (
+        "The active in-flight branch must paint messages before "
+        "deferring scene restore for the live session."
+    )
+    assert callback_pos > defer_pos, (
+        "Deferred active-session scene restore must invoke restoreLiveSurfaceForIdleInflight()."
+    )
+    assert "ensureLiveWorklogShell" in restore_helper, (
+        "Active reload restoration helper should include ensureLiveWorklogShell fallback."
     )
     assert "else appendThinking();" in active_branch, (
         "Non-simplified tool-calling must keep the legacy fallback."
@@ -732,11 +741,15 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
     # Anchor on the Phase-2 INFLIGHT restore branch (the later occurrence); #3899
-    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so .find() would
-    # grab the wrong one. (rfind = the substantive restore branch.)
-    inflight_idx = src.rfind("if(INFLIGHT[sid]){")
-    assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+4200]
+    # added an earlier if(INFLIGHT[sid]){ idle-reset block, so a fixed
+    # character-window slice could grab the wrong fragment.
+    start_marker = "\n  if(INFLIGHT[sid]){"
+    phase2b_marker = "\n  }else{\n    // Phase 2b:"
+    inflight_idx = src.rfind(start_marker)
+    phase2b_idx = src.find(phase2b_marker, inflight_idx)
+    assert inflight_idx >= 0, "loadSession INFLIGHT branch not found"
+    assert phase2b_idx >= 0, "loadSession Phase 2b boundary not found"
+    inflight_block = src[inflight_idx:phase2b_idx]
     busy_pos = inflight_block.find("S.busy=")
     # #3326 added an optional {preserveScroll} arg to the INFLIGHT-branch render
     # call, so match the call form rather than the bare `renderMessages();`.

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -658,8 +658,8 @@ def test_reload_path_restores_pending_message_and_reattaches_live_stream(cleanup
     active_branch_end = sessions_src.index("}else{\n      S.busy=false;", active_branch_start)
     active_branch = sessions_src[active_branch_start:active_branch_end]
     render_pos = active_branch.index("renderMessages(")
-    defer_pos = active_branch.index("_deferActiveSessionSceneRestore(")
-    callback_pos = active_branch.find("restoreLiveSurfaceForIdleInflight()", defer_pos)
+    defer_pos = active_branch.index("_deferActiveSessionSceneRestoreAndAttach(")
+    callback_pos = active_branch.find("restoreLiveSurfaceForIdleInflight,", defer_pos)
     restore_helper_start = active_branch.index("const restoreLiveSurfaceForIdleInflight=()=>{")
     restore_helper_end = active_branch.index("const attachLiveSceneForIdleSession=()=>{", restore_helper_start)
     restore_helper = active_branch[restore_helper_start:restore_helper_end]
@@ -744,7 +744,7 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     # added an earlier if(INFLIGHT[sid]){ idle-reset block, so a fixed
     # character-window slice could grab the wrong fragment.
     start_marker = "\n  if(INFLIGHT[sid]){"
-    phase2b_marker = "\n  }else{\n    // Phase 2b:"
+    phase2b_marker = "\n  } else {\n    // Phase 2b:"
     inflight_idx = src.rfind(start_marker)
     phase2b_idx = src.find(phase2b_marker, inflight_idx)
     assert inflight_idx >= 0, "loadSession INFLIGHT branch not found"

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -291,16 +291,12 @@ process.stdout.write(JSON.stringify({{
 
 
 def test_reattach_path_uses_replay_when_status_reports_journal():
-    reattach_pos = MESSAGES_SRC.index("let replayOnly=false;")
-    # Window widened to 2200: the SSE-recovery follow-restore fix (the
-    # _wasFollowingAtReconnectDead guard + its sticky-unpin check) inserted lines
-    # into the reconnect-dead cleanup block between this anchor and the
-    # replay-params assertion below, pushing the target string past the old slice.
-    block = MESSAGES_SRC[reattach_pos : reattach_pos + 2200]
+    reattach_pos = MESSAGES_SRC.index("statusDecision:(status)=>{")
+    block = MESSAGES_SRC[reattach_pos : reattach_pos + 1800]
 
-    assert "st.replay_available" in block
-    assert "replayOnly=true" in block
-    assert "(reconnecting||replayOnly)?_runJournalReplayParams():''" in block
+    assert "status&&status.replay_available" in block
+    assert "replayOnly:true" in block
+    assert "replayParamsForAttach:(shouldReplay)=>shouldReplay?_runJournalReplayParams():''" in block
     assert "_clearOwnerInflightState()" in block
 
 

--- a/tests/test_session_stream_attach_ownership.py
+++ b/tests/test_session_stream_attach_ownership.py
@@ -1,0 +1,307 @@
+"""Ownership helper regression tests for loadSession attach orchestration."""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+MESSAGES_JS = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _extract_function(source: str, name: str) -> str:
+    marker = f"function {name}("
+    start = source.find(marker)
+    assert start != -1, f"{name}() not found in source"
+    open_paren = source.find("(", start)
+    close_paren = source.find(")", open_paren)
+    open_brace = source.find("{", close_paren)
+    depth = 1
+    i = open_brace + 1
+    while i < len(source) and depth:
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name}() did not close"
+    return source[start:i]
+
+
+def _extract_const(source: str, name: str) -> str:
+    marker = f"const {name}"
+    start = source.find(marker)
+    assert start != -1, f"{name} declaration not found"
+    end = source.find(";", start)
+    assert end != -1, f"{name} declaration did not terminate"
+    return source[start : end + 1]
+
+
+def _run_node(script: str) -> dict:
+    result = subprocess.run(
+        [NODE],
+        input=script,
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr.strip() or result.stdout.strip())
+    output = result.stdout.strip()
+    if not output:
+        raise AssertionError("node script emitted no JSON output")
+    return json.loads(output)
+
+
+def _messages_owner_script() -> str:
+    return "\n".join(
+        [
+            _extract_const(MESSAGES_JS, "_PENDING_LIVE_ATTACHES"),
+            _extract_function(MESSAGES_JS, "_pendingLiveAttachIdentity"),
+            _extract_function(MESSAGES_JS, "_claimPendingLiveAttach"),
+            _extract_function(MESSAGES_JS, "_ownsPendingLiveAttach"),
+            _extract_function(MESSAGES_JS, "_finishPendingLiveAttach"),
+            _extract_function(MESSAGES_JS, "_invalidatePendingLiveAttachClaims"),
+            _extract_function(MESSAGES_JS, "_attachLiveStreamWithOwnership"),
+            _extract_function(MESSAGES_JS, "attachLiveStream"),
+        ]
+    )
+
+
+def _sessions_restore_script() -> str:
+    return "\n".join(
+        [
+            _extract_const(SESSIONS_JS, "_ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS"),
+            _extract_function(SESSIONS_JS, "_isActiveSessionSceneRestoreOwner"),
+            _extract_function(SESSIONS_JS, "_deferActiveSessionSceneRestore"),
+            _extract_function(SESSIONS_JS, "_deferActiveSessionSceneRestoreAndAttach"),
+        ]
+    )
+
+
+def _run_ownership_script() -> dict:
+    js = (
+        "const __EMPTY = () => {};\n"
+        + _messages_owner_script()
+        + "\n"
+        + _sessions_restore_script()
+        + """
+global.__openSources = [];
+global.__apiQueue = Object.create(null);
+global.document = {
+  visibilityState: 'visible',
+  hidden: false,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+global.location = { href: 'http://localhost/' };
+global.setTimeout = (fn) => { fn(); return 1; };
+global.clearTimeout = () => {};
+
+class FakeEventSource {
+  constructor(url, options) {
+    this.url = String(url || '');
+    this.options = options || {};
+    this.readyState = 1;
+    this.OPEN = 1;
+    this.CONNECTING = 0;
+    this.CLOSED = 2;
+  }
+  close() { this.readyState = this.CLOSED; }
+}
+global.EventSource = FakeEventSource;
+global._wireSSE = (source) => {
+  const streamId = new URL(source.url, 'http://localhost/').searchParams.get('stream_id');
+  const sid = Object.keys(global.INFLIGHT).find((id) => String(global.INFLIGHT[id].streamId || '') === String(streamId || ''));
+  global.__openSources.push({ sid: sid || null, streamId });
+  if (sid) global.LIVE_STREAMS[sid] = { streamId, source };
+};
+global._runJournalReplayParams = () => '';
+global._scheduleAnchorRegistryCleanup = __EMPTY;
+global._clearOwnerInflightState = __EMPTY;
+global._clearApprovalForOwner = __EMPTY;
+global._clearClarifyForOwner = __EMPTY;
+global._setActivePaneIdleIfOwner = __EMPTY;
+global._clearStreamHidden = __EMPTY;
+global._clearStreamNotificationBackground = __EMPTY;
+global._suspendSessionStreamForLiveChat = __EMPTY;
+global.renderMessages = __EMPTY;
+global.showLiveRunStatus = __EMPTY;
+global.autoResize = __EMPTY;
+global.scrollToBottom = __EMPTY;
+global._queueDrainSid = null;
+global._isMessagePaneNearBottom = () => true;
+global._isMessageReaderUnpinned = () => false;
+global._isActiveSession = () => global.S && global.S.session && global.S.session.session_id === global._activeOwnerSid;
+global.setBusy = __EMPTY;
+global.setComposerStatus = __EMPTY;
+global.removeThinking = __EMPTY;
+global._markSessionViewed = __EMPTY;
+global.trackBackgroundError = __EMPTY;
+global._scheduleRender = __EMPTY;
+global._startSessionStream = __EMPTY;
+global._isCurrentOwner = () => true;
+
+function queueStatus(streamId) {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  (global.__apiQueue[streamId] || (global.__apiQueue[streamId] = [])).push({ promise, resolve, reject });
+  return global.__apiQueue[streamId][global.__apiQueue[streamId].length - 1];
+}
+
+global.api = (url) => {
+  const streamId = new URL(String(url), 'http://localhost/').searchParams.get('stream_id');
+  const queue = global.__apiQueue[streamId] || [];
+  const ctl = queue.shift();
+  return ctl ? ctl.promise : Promise.resolve({ active: true });
+};
+
+function resetState(sid, stream, generation) {
+  global._activeOwnerSid = sid;
+  global._loadSessionGeneration = generation;
+  global.S = {
+    session: { session_id: sid, active_stream_id: stream },
+    activeStreamId: stream,
+    messages: [],
+  };
+  global.INFLIGHT = {
+    [sid]: { streamId: stream, messages: [], uploaded: [], toolCalls: [], reattach: true },
+  };
+  global.LIVE_STREAMS = Object.create(null);
+  global.__apiQueue = Object.create(null);
+  global.__openSources = [];
+}
+
+function claimAttach({ sid = 'A', stream = 'stream', generation = 1, ownerToken = 'owner' }) {
+  const claimState = _claimPendingLiveAttach(sid, stream, {
+    isCurrentOwner: () => _isActiveSessionSceneRestoreOwner(sid, stream, generation),
+    ownerToken,
+    loadGeneration: generation,
+    onAttached: () => {
+      const latest = INFLIGHT[sid];
+      if (latest && String(latest.streamId || '') === String(stream)) latest.reattach = false;
+    },
+  });
+  if (claimState && !claimState.shouldStart) { return Promise.resolve(true); }
+  const claim = claimState && claimState.claim;
+  return _attachLiveStreamWithOwnership({
+    activeSid: sid,
+    streamId: stream,
+    reconnecting: true,
+    ownsAttach: () => _ownsPendingLiveAttach(claim),
+    finishAttach: (attached) => _finishPendingLiveAttach(claim, attached),
+    statusDecision: (status) => ({
+      shouldConnect: !!(status && (status.active || status.replay_available)),
+      replayOnly: !!(status && !status.active && status.replay_available),
+    }),
+    replayParamsForAttach: () => '',
+    connectSource: () => new EventSource(new URL('api/chat/stream?stream_id=' + encodeURIComponent(stream), 'http://localhost/').href, { withCredentials: true }),
+    wireSource: global._wireSSE,
+  });
+}
+
+async function run() {
+  const results = {};
+  let gate;
+  let claim;
+
+  resetState('A', 'stale-stream', 1);
+  gate = queueStatus('stale-stream');
+  claim = claimAttach({ sid: 'A', stream: 'stale-stream', generation: 1, ownerToken: 'old' });
+  _loadSessionGeneration = 2;
+  S.session.session_id = 'B';
+  S.session.active_stream_id = 'other';
+  _invalidatePendingLiveAttachClaims();
+  gate.resolve({ active: true });
+  results.stale = await claim;
+  results.staleOpenSources = global.__openSources.length;
+  results.pendingAfterStale = Object.keys(_PENDING_LIVE_ATTACHES).length;
+
+  resetState('D', 'dup-stream', 3);
+  const dupGate = queueStatus('dup-stream');
+  const dupA = claimAttach({ sid: 'D', stream: 'dup-stream', generation: 3, ownerToken: 'dup' });
+  const dupB = claimAttach({ sid: 'D', stream: 'dup-stream', generation: 3, ownerToken: 'dup' });
+  dupGate.resolve({ active: true });
+  results.duplicate = {
+    first: await dupA,
+    second: await dupB,
+    openSources: global.__openSources.filter((s) => s.streamId === 'dup-stream').length,
+    reattach: INFLIGHT.D.reattach,
+  };
+
+  resetState('F', 'fallback-stream', 4);
+  gate = queueStatus('fallback-stream');
+  gate.promise.catch(__EMPTY);
+  claim = claimAttach({ sid: 'F', stream: 'fallback-stream', generation: 4, ownerToken: 'fallback' });
+  gate.reject(new Error('status-api-flake'));
+  results.apiFallback = await claim;
+  results.apiFallbackOpenSources = global.__openSources.filter((s) => s.streamId === 'fallback-stream').length;
+
+  resetState('I', 'inactive-stream', 5);
+  gate = queueStatus('inactive-stream');
+  claim = claimAttach({ sid: 'I', stream: 'inactive-stream', generation: 5, ownerToken: 'inactive' });
+  gate.resolve({ active: false });
+  results.inactive = await claim;
+  results.inactiveOpenSources = global.__openSources.filter((s) => s.streamId === 'inactive-stream').length;
+  results.pendingAfterInactive = Object.keys(_PENDING_LIVE_ATTACHES).length;
+
+  _loadSessionGeneration = 1;
+  resetState('A', 'sup-stream', 1);
+  const oldGate = queueStatus('sup-stream');
+  const old = claimAttach({ sid: 'A', stream: 'sup-stream', generation: 1, ownerToken: 'sup-old' });
+  S.session = { session_id: 'B', active_stream_id: 'sup-stream-other' };
+  _loadSessionGeneration = 2;
+  _invalidatePendingLiveAttachClaims();
+  S.session = { session_id: 'A', active_stream_id: 'sup-stream' };
+  const fresh = claimAttach({ sid: 'A', stream: 'sup-stream', generation: 2, ownerToken: 'sup-new' });
+  const newGate = queueStatus('sup-stream');
+  oldGate.resolve({ active: true });
+  newGate.resolve({ active: true });
+  results.supersession = {
+    old: await old,
+    new: await fresh,
+    openSources: global.__openSources.filter((s) => s.streamId === 'sup-stream').length,
+  };
+
+  resetState('R', 'restore-stream', 1);
+  const order = [];
+  const restoreResult = await _deferActiveSessionSceneRestoreAndAttach(
+    'R',
+    'restore-stream',
+    1,
+    () => { order.push('restore'); throw new Error('restore failed'); },
+    () => { order.push('attach'); return true; },
+  );
+  results.restore = { attached: !!restoreResult.attached, order };
+  results.pendingFinal = Object.keys(_PENDING_LIVE_ATTACHES).length;
+  console.log(JSON.stringify(results));
+}
+
+run();
+"""
+  )
+    return _run_node(js)
+def test_ownership_helpers_are_used_in_attach_and_loadsession_chokepoints():
+    attach_body = re.sub(r"\s+", "", _extract_function(MESSAGES_JS, "attachLiveStream"))
+    load_body = re.sub(r"\s+", "", _extract_function(SESSIONS_JS, "loadSession"))
+    sessions_body = re.sub(r"\s+", "", SESSIONS_JS)
+    assert "_attachLiveStreamWithOwnership(" in attach_body and "_deferActiveSessionSceneRestoreAndAttach(" in load_body and "isCurrentOwner:()=>_isActiveSessionSceneRestoreOwner" in sessions_body
+
+def test_live_ownership_claim_and_restore_sequences_behave():
+    data = _run_ownership_script()
+    assert data["stale"] is False and data["staleOpenSources"] == 0 and data["pendingAfterStale"] == 0
+    assert data["duplicate"]["first"] is True and data["duplicate"]["second"] is True and data["duplicate"]["openSources"] == 1 and data["duplicate"]["reattach"] is False
+    assert data["apiFallback"] is True and data["apiFallbackOpenSources"] == 1
+    assert data["inactive"] is False and data["inactiveOpenSources"] == 0 and data["pendingAfterInactive"] == 0
+    assert data["supersession"]["new"] is True and data["supersession"]["openSources"] == 1
+    assert data["restore"]["order"] == ["restore", "attach"] and data["restore"]["attached"] is True and data["pendingFinal"] == 0

--- a/tests/test_session_switch_active_restore_scheduler.py
+++ b/tests/test_session_switch_active_restore_scheduler.py
@@ -316,7 +316,7 @@ def test_active_load_session_branches_defer_after_transcript_render_while_preser
     idx = body.rfind("if(INFLIGHT[sid]){")
     assert idx != -1, "INFLIGHT branch not found"
     inflight_block = body[idx : idx + 9000]
-    defer_pos = inflight_block.find("_deferActiveSessionSceneRestore(")
+    defer_pos = inflight_block.find("_deferActiveSessionSceneRestoreAndAttach(")
     assert defer_pos != -1, "active in-memory INFLIGHT branch must defer restore/attach"
     sync_topbar_pos = inflight_block.find("syncTopbar();")
     render_messages_pos = inflight_block.find("renderMessages(")
@@ -344,8 +344,8 @@ def test_active_load_session_branches_defer_after_transcript_render_while_preser
 
     idle_idx = body.find("if(activeStreamId){")
     assert idle_idx != -1, "discovered active-stream branch not found"
-    idle_block = body[idle_idx : idle_idx + 2400]
-    idle_defer = idle_block.find("_deferActiveSessionSceneRestore(")
+    idle_block = body[idle_idx : idle_idx + 4200]
+    idle_defer = idle_block.find("_deferActiveSessionSceneRestoreAndAttach(")
     assert idle_defer != -1, "active discovered branch must defer restore/attach"
     idle_sync_topbar_pos = idle_block.find("syncTopbar();")
     idle_render_messages_pos = idle_block.find("renderMessages(")
@@ -375,14 +375,7 @@ def test_active_load_session_branches_defer_after_transcript_render_while_preser
     assert idle_defer_workspace_pos != -1, "active discovered branch should defer workspace refresh before deferring restore"
     assert idle_defer_workspace_pos < idle_defer
 
-    active_inflight_re = re.search(
-        r"_deferActiveSessionSceneRestore\([^\n]*=>\s*\{[\s\S]*?restoreLiveSurfaceForActiveInflight\(\)[\s\S]*?attachLiveSceneForActiveSession\(\)",
-        inflight_block,
-    )
-    assert active_inflight_re is not None, "inflight deferred callback must restore scene before attach"
-
-    active_discovered_re = re.search(
-        r"_deferActiveSessionSceneRestore\([^\n]*=>\s*\{[\s\S]*?restoreLiveSurfaceForIdleInflight\(\)[\s\S]*?attachLiveSceneForIdleSession\(\)",
-        idle_block,
-    )
-    assert active_discovered_re is not None, "discovered active-branch callback must restore scene before attach"
+    assert inflight_block.find("restoreLiveSurfaceForActiveInflight,", defer_pos) > defer_pos
+    assert inflight_block.find("attachLiveSceneForActiveSession,", defer_pos) > defer_pos
+    assert idle_block.find("restoreLiveSurfaceForIdleInflight,", idle_defer) > idle_defer
+    assert idle_block.find("attachLiveSceneForIdleSession,", idle_defer) > idle_defer

--- a/tests/test_session_switch_active_restore_scheduler.py
+++ b/tests/test_session_switch_active_restore_scheduler.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Scheduler behavior tests for active session scene restore deferral."""
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name}() not found"
+    brace = src.find("){", start)
+    assert brace != -1, f"{name}() body not found"
+    brace += 1
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name}() body did not close"
+    return src[brace + 1 : i - 1]
+
+
+def _extract_functions() -> str:
+    owner_body = _function_body(SESSIONS_JS, "_isActiveSessionSceneRestoreOwner")
+    defer_body = _function_body(SESSIONS_JS, "_deferActiveSessionSceneRestore")
+    return (
+        "function _isActiveSessionSceneRestoreOwner(sid, activeStreamId, loadGeneration)"
+        "{" + owner_body + "}\n"
+        "function _deferActiveSessionSceneRestore(sid, activeStreamId, loadGeneration, restoreFn)"
+        "{" + defer_body + "}\n"
+    )
+
+
+def _run_node(script: str) -> str:
+    proc = subprocess.run(
+        ["node", "-e", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        if proc.stderr:
+            raise AssertionError(proc.stderr.strip())
+        raise AssertionError(proc.stdout.strip())
+    return proc.stdout.strip()
+
+
+def _run_script(setup: str, assertions: str) -> None:
+    body = _extract_functions()
+    constants = "var _ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS = 250;\n"
+    wrapped_assertions = f";(async () => {{\n{assertions}\n}})();"
+    script = "const assert = require('assert');\n" + constants + "\n" + body + "\n" + setup + "\n" + wrapped_assertions
+    output = _run_node(script)
+    assert "ok" in output
+
+
+def test_active_session_scene_restore_hidden_timeout_constant_is_1200_ms():
+    """Keep a fast 250ms Node override, and pin the production default."""
+    match = re.search(
+        r"const\s+_ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS\s*=\s*(\d+);",
+        SESSIONS_JS,
+    )
+    assert match is not None, (
+        "Production sessions.js must declare _ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS"
+    )
+    assert match.group(1) == "1200", (
+        "_ACTIVE_SESSION_SCENE_RESTORE_HIDDEN_TIMEOUT_MS should remain at 1200ms in production JS"
+    )
+
+
+def test_defer_active_session_scene_restore_visible_uses_two_frames_and_invokes_once():
+    setup = """
+const state = { sid: 'bench-sid', stream: 'bench-stream', gen: 7 };
+global.S = { session: { session_id: state.sid, active_stream_id: state.stream }, activeStreamId: state.stream };
+global._loadSessionGeneration = state.gen;
+global.document = {
+  visibilityState: 'visible',
+  hidden: false,
+  _handlers: {},
+  addEventListener(type, fn) {
+    (this._handlers[type] || (this._handlers[type] = [])).push(fn);
+  },
+  removeEventListener() {},
+};
+
+const rAFQueue = [];
+let rafId = 1;
+global.requestAnimationFrame = (cb) => {
+  rAFQueue.push(cb);
+  return rafId++;
+};
+global.cancelAnimationFrame = () => {};
+let timeoutCalls = [];
+global.setTimeout = (fn) => {
+  timeoutCalls.push(fn);
+  return 999;
+};
+global.clearTimeout = () => {};
+global.__calls = [];
+
+const restore = () => {
+  global.__calls.push('restored');
+  return 'ok';
+};
+"""
+
+    assertions = """
+const p = _deferActiveSessionSceneRestore(state.sid, state.stream, state.gen, restore);
+assert.strictEqual(rAFQueue.length, 1);
+assert.deepStrictEqual(__calls, []);
+assert.deepStrictEqual(timeoutCalls, []);
+
+const frame1 = rAFQueue.shift();
+frame1();
+assert.strictEqual(rAFQueue.length, 1);
+assert.deepStrictEqual(__calls, []);
+
+const frame2 = rAFQueue.shift();
+frame2();
+
+return p.then((value) => {
+  assert.strictEqual(value, 'ok');
+  assert.deepStrictEqual(__calls, ['restored']);
+  assert.strictEqual(rAFQueue.length, 0);
+  console.log('ok');
+});
+"""
+    _run_script(setup, assertions)
+
+
+def test_defer_active_session_scene_restore_hidden_visibility_fallback_invokes_once():
+    setup = """
+const state = { sid: 'bench-sid', stream: 'bench-stream', gen: 11 };
+global.S = { session: { session_id: state.sid, active_stream_id: state.stream }, activeStreamId: state.stream };
+global._loadSessionGeneration = state.gen;
+global.document = {
+  visibilityState: 'visible',
+  hidden: false,
+  _handlers: {},
+  addEventListener(type, fn) {
+    (this._handlers[type] || (this._handlers[type] = [])).push(fn);
+  },
+  removeEventListener() {},
+  dispatchEvent(event) {
+    const handlers = this._handlers[event.type] || [];
+    for (const fn of handlers) {
+      fn(event);
+    }
+  }
+};
+
+global.requestAnimationFrame = (cb) => cb && cb();
+global.cancelAnimationFrame = () => {};
+
+let timeoutCbs = [];
+global.setTimeout = (fn) => {
+  timeoutCbs.push(fn);
+  return 123;
+};
+global.clearTimeout = () => {};
+global.__calls = [];
+
+const restore = () => {
+  global.__calls.push('restored');
+  return 'ok';
+};
+"""
+
+    assertions = """
+document.hidden = true;
+document.visibilityState = 'hidden';
+const p = _deferActiveSessionSceneRestore(state.sid, state.stream, state.gen, restore);
+document.dispatchEvent({ type: 'visibilitychange' });
+assert.strictEqual(timeoutCbs.length, 1);
+assert.deepStrictEqual(__calls, []);
+
+return Promise.resolve(timeoutCbs.shift())
+  .then((fn) => fn())
+  .then(() => p)
+  .then((value) => {
+    assert.strictEqual(value, 'ok');
+    assert.deepStrictEqual(__calls, ['restored']);
+    console.log('ok');
+  });
+"""
+    _run_script(setup, assertions)
+
+
+def test_defer_active_session_scene_restore_stale_owner_noop_resolves_once():
+    setup = """
+const state = { sid: 'bench-sid', stream: 'bench-stream', gen: 7 };
+global.S = {
+  session: { session_id: 'bench-other', active_stream_id: 'bench-stream' },
+  activeStreamId: 'bench-stream',
+};
+global._loadSessionGeneration = 8;
+
+global.document = {
+  visibilityState: 'visible',
+  hidden: false,
+  addEventListener(type, fn) {},
+  removeEventListener() {},
+};
+
+global.requestAnimationFrame = (cb) => { cb && cb(); return 1; };
+global.cancelAnimationFrame = () => {};
+
+global.setTimeout = () => 1;
+global.clearTimeout = () => {};
+global.__calls = [];
+
+const restore = () => {
+  global.__calls.push('restored');
+  return 'ok';
+};
+"""
+
+    assertions = """
+return _deferActiveSessionSceneRestore(state.sid, state.stream, state.gen, restore).then((value) => {
+  assert.strictEqual(value, undefined);
+  assert.deepStrictEqual(__calls, []);
+  console.log('ok');
+});
+"""
+    _run_script(setup, assertions)
+
+
+def test_defer_active_session_scene_restore_stale_owner_stream_change_noop_resolves_once():
+    setup = """
+const state = { sid: 'bench-sid', stream: 'bench-stream', gen: 7 };
+global.S = {
+  session: { session_id: 'bench-sid', active_stream_id: 'bench-stream-other' },
+  activeStreamId: 'bench-stream-other',
+};
+global._loadSessionGeneration = state.gen;
+
+global.document = {
+  visibilityState: 'visible',
+  hidden: false,
+  addEventListener(type, fn) {},
+  removeEventListener() {},
+};
+
+global.requestAnimationFrame = (cb) => { cb && cb(); return 1; };
+global.cancelAnimationFrame = () => {};
+
+global.setTimeout = () => 1;
+global.clearTimeout = () => {};
+global.__calls = [];
+
+const restore = () => {
+  global.__calls.push('restored');
+  return 'ok';
+};
+"""
+
+    assertions = """
+return _deferActiveSessionSceneRestore(state.sid, state.stream, state.gen, restore).then((value) => {
+  assert.strictEqual(value, undefined);
+  assert.deepStrictEqual(__calls, []);
+  console.log('ok');
+});
+"""
+    _run_script(setup, assertions)
+
+
+def test_defer_active_session_scene_restore_stale_owner_generation_noop_resolves_once():
+    setup = """
+const state = { sid: 'bench-sid', stream: 'bench-stream', gen: 7 };
+global.S = {
+  session: { session_id: 'bench-sid', active_stream_id: 'bench-stream' },
+  activeStreamId: 'bench-stream',
+};
+global._loadSessionGeneration = 8;
+
+global.document = {
+  visibilityState: 'visible',
+  hidden: false,
+  addEventListener(type, fn) {},
+  removeEventListener() {},
+};
+
+global.requestAnimationFrame = (cb) => { cb && cb(); return 1; };
+global.cancelAnimationFrame = () => {};
+
+global.setTimeout = () => 1;
+global.clearTimeout = () => {};
+global.__calls = [];
+
+const restore = () => {
+  global.__calls.push('restored');
+  return 'ok';
+};
+"""
+
+    assertions = """
+return _deferActiveSessionSceneRestore(state.sid, state.stream, state.gen, restore).then((value) => {
+  assert.strictEqual(value, undefined);
+  assert.deepStrictEqual(__calls, []);
+  console.log('ok');
+});
+"""
+    _run_script(setup, assertions)
+
+
+def test_active_load_session_branches_defer_after_transcript_render_while_preserving_immediate_work_effects():
+    body = _function_body(SESSIONS_JS, "loadSession")
+    idx = body.rfind("if(INFLIGHT[sid]){")
+    assert idx != -1, "INFLIGHT branch not found"
+    inflight_block = body[idx : idx + 9000]
+    defer_pos = inflight_block.find("_deferActiveSessionSceneRestore(")
+    assert defer_pos != -1, "active in-memory INFLIGHT branch must defer restore/attach"
+    sync_topbar_pos = inflight_block.find("syncTopbar();")
+    render_messages_pos = inflight_block.find("renderMessages(")
+    busy_pos = inflight_block.find("setBusy(true)")
+    composer_status_pos = inflight_block.find("setComposerStatus('')")
+    start_approval_pos = inflight_block.find("startApprovalPolling(sid)")
+    start_clarify_pos = inflight_block.find("startClarifyPolling(sid)")
+    defer_workspace_pos = inflight_block.find("_deferWorkspaceRefreshForSession(sid)")
+    assert sync_topbar_pos != -1, "inflight branch should call syncTopbar() before deferring restore"
+    assert sync_topbar_pos < defer_pos
+    assert render_messages_pos != -1, "inflight branch should render messages before deferring restore"
+    assert render_messages_pos < defer_pos
+    assert busy_pos != -1, "inflight branch should set busy before deferring restore"
+    assert busy_pos < defer_pos
+    assert composer_status_pos != -1, "inflight branch should clear composer status before deferring restore"
+    assert composer_status_pos < defer_pos
+    assert start_approval_pos != -1, "inflight branch should restart approval polling before deferring restore"
+    assert start_approval_pos < defer_pos
+    assert start_clarify_pos != -1, "inflight branch should restart clarify polling before deferring restore"
+    assert start_clarify_pos < defer_pos
+    assert defer_workspace_pos != -1, "inflight branch should defer workspace refresh before deferring restore"
+    assert defer_workspace_pos < defer_pos
+    assert "scheduledActiveInflight" not in inflight_block, "loadSession active INFLIGHT branch should not snapshot restored snapshot state for reinsertion"
+    assert "restoreScheduledActiveInflight" not in inflight_block, "loadSession active INFLIGHT branch should not reinsert a retained snapshot INFLIGHT"
+
+    idle_idx = body.find("if(activeStreamId){")
+    assert idle_idx != -1, "discovered active-stream branch not found"
+    idle_block = body[idle_idx : idle_idx + 2400]
+    idle_defer = idle_block.find("_deferActiveSessionSceneRestore(")
+    assert idle_defer != -1, "active discovered branch must defer restore/attach"
+    idle_sync_topbar_pos = idle_block.find("syncTopbar();")
+    idle_render_messages_pos = idle_block.find("renderMessages(")
+    idle_busy_pos = idle_block.find("S.busy=true")
+    idle_set_status_pos = idle_block.find("setStatus('')")
+    idle_composer_status_pos = idle_block.find("setComposerStatus('')")
+    idle_update_queue_pos = idle_block.find("updateQueueBadge(sid)")
+    idle_start_approval_pos = idle_block.find("startApprovalPolling(sid)")
+    idle_start_clarify_pos = idle_block.find("startClarifyPolling(sid)")
+    idle_defer_workspace_pos = idle_block.find("_deferWorkspaceRefreshForSession(sid)")
+    assert idle_sync_topbar_pos != -1, "active discovered branch should call syncTopbar() before deferring restore"
+    assert idle_sync_topbar_pos < idle_defer
+    assert idle_render_messages_pos != -1, "active discovered branch should render messages before deferring restore"
+    assert idle_render_messages_pos < idle_defer
+    assert idle_busy_pos != -1, "active discovered branch should set S.busy=true before deferring restore"
+    assert idle_busy_pos < idle_defer
+    assert idle_set_status_pos != -1, "active discovered branch should clear status before deferring restore"
+    assert idle_set_status_pos < idle_defer
+    assert idle_composer_status_pos != -1, "active discovered branch should clear composer status before deferring restore"
+    assert idle_composer_status_pos < idle_defer
+    assert idle_update_queue_pos != -1, "active discovered branch should update queue badge before deferring restore"
+    assert idle_update_queue_pos < idle_defer
+    assert idle_start_approval_pos != -1, "active discovered branch should restart approval polling before deferring restore"
+    assert idle_start_approval_pos < idle_defer
+    assert idle_start_clarify_pos != -1, "active discovered branch should restart clarify polling before deferring restore"
+    assert idle_start_clarify_pos < idle_defer
+    assert idle_defer_workspace_pos != -1, "active discovered branch should defer workspace refresh before deferring restore"
+    assert idle_defer_workspace_pos < idle_defer
+
+    active_inflight_re = re.search(
+        r"_deferActiveSessionSceneRestore\([^\n]*=>\s*\{[\s\S]*?restoreLiveSurfaceForActiveInflight\(\)[\s\S]*?attachLiveSceneForActiveSession\(\)",
+        inflight_block,
+    )
+    assert active_inflight_re is not None, "inflight deferred callback must restore scene before attach"
+
+    active_discovered_re = re.search(
+        r"_deferActiveSessionSceneRestore\([^\n]*=>\s*\{[\s\S]*?restoreLiveSurfaceForIdleInflight\(\)[\s\S]*?attachLiveSceneForIdleSession\(\)",
+        idle_block,
+    )
+    assert active_discovered_re is not None, "discovered active-branch callback must restore scene before attach"


### PR DESCRIPTION
## Thinking Path

- Switching to a very large actively streaming conversation can leave the mobile UI on “Loading conversation…” for several seconds after the bounded transcript response is available.
- The session loader synchronously rebuilt thousands of historical tool and activity entries before the browser could paint the transcript.
- This change renders the transcript first, then restores the active live scene and reconnects its stream after two animation frames.
- Deferred work is bound to the session ID, active stream ID, and load generation so a rapid session switch or completed stream cannot restore stale state.
- Fallible scene reconstruction cannot suppress transport attachment, and delayed status preflights revalidate generation-scoped ownership before constructing or wiring an EventSource.
- Authoritative stream cleanup remains final. An omitted or source-filtered session-list row preserves local state only when the selected session, stream owners, and busy state still agree.

## What Changed

- Added an active-session restore scheduler that yields a transcript paint opportunity before live-scene reconstruction.
- Split immediate transcript and UI state from deferred activity-scene restoration and stream attachment in both active-stream recovery paths.
- Added ownership checks and a hidden-tab timeout fallback so deferred work runs only for the current session and stream.
- Made transport attachment unconditional after deferred scene reconstruction, including auxiliary and reconstruction failure paths.
- Added pending-attach ownership claims so stale A→B and ABA A→B→A status completions cannot wire obsolete or duplicate EventSources.
- Removed retained-snapshot reinsertion across the deferred boundary. Missing-row preservation now fails closed unless active stream ownership is coherent.
- Added a deterministic browser benchmark with 4,410 messages, 2,882 tool calls, 424 replay events, and 129 authoritative live-scene rows.
- Added focused regression coverage for restore ordering, replay, list omission, authoritative cleanup, same-session reload, stale-owner races, hidden-tab fallback, and duplicate tool-card prevention.

## Why It Matters

- On current `master`, the 4×-CPU warm transcript-paint median was 9,017.9 ms. The patched median was 349.1 ms across four warm samples, a 96.1% reduction.
- The corresponding empirical p95 values were 9,441.1 ms and 417.4 ms.
- The transcript paints with zero live-scene rows, then all 129 authoritative rows are restored without duplicate session-wide tool replay.
- The API contract and EventSource replay URL are unchanged.

## Screenshots

The comparison is synchronized to the first visible switch/loading frame (`t=0`). Both panes use Chromium Pixel 5 emulation at a 393×727 CSS-pixel viewport, device scale factor 2.75, touch input, and 4× DevTools CPU throttling.

![Synchronized baseline and patched active-session switch](https://raw.githubusercontent.com/starship-s/hermes-webui/pr-evidence/session-switch-active-render/session-switch-before-after-cpu4.png)

[Short synchronized MP4 comparison](https://raw.githubusercontent.com/starship-s/hermes-webui/pr-evidence/session-switch-active-render/session-switch-before-after-cpu4.mp4)

## Verification

- `137 passed, 1 skipped` across the focused ownership, restore-scheduler, inflight-stream, reload, sidebar, and neighboring regression files on product commit `9269085c`. The skip is the existing agent-dependent test when `hermes-agent` is unavailable.
- The ownership regression failed on the refreshed pre-fix tree because stale A opened one EventSource after A→B, then passed on the fix. It also covers A(old)→B→A(new) single-source supersession, identical-claim deduplication, inactive cleanup, API-status fallback, and successful `onAttached` cleanup.
- The exact 24-test command covering all hosted fixture failures passed locally after the test-only remediation.
- Five Chromium Pixel 5 emulation runs with 4× CPU throttling completed without page, fixture, or sample errors.
- Every browser sample confirmed that the first session-list response omitted the active row, the transcript paint opportunity contained zero scene rows, and all 129 unique authoritative rows were restored afterward.
- All 22 hosted checks passed on tree-identical predecessor `1c36b804`. Checks are rerunning on metadata-only amended head `4ec53518`.
- `node --check static/messages.js`
- `node --check static/sessions.js`
- Python compilation for all changed tests
- `python3 scripts/scope_undef_gate.py .`
- `npm run -s lint:runtime`
- `git diff --check`
- Independent Opus review: focused exact-tree `SIGN-OFF`; no blockers or nits after remediation of its two initial coverage/lifecycle nits.

## Risks / Follow-ups

- The browser benchmark exercises local active-stream recovery through an initially omitted session-list row. The server-discovered active-stream branch has focused scheduler and source-level coverage but not a second browser scenario.
- Full stream attachment remains after scene reconstruction because attaching first mutates anchor state. Attachment runs in an unconditional `finally`, and reconnect status completion cannot construct or wire a source unless its session/stream/load-generation claim is still current.
- Missing-row state is preserved only while the selected session remains busy and every available stream owner agrees. A present idle row or contradictory owner still purges state authoritatively.
- The visual evidence is Chromium mobile emulation, not a physical Android Brave capture.

## Model Used

- OpenAI / `gpt-5.3-codex-spark` for implementation and regression tests through the Codex CLI worker.
- OpenAI / `gpt-5.6-sol` for diagnosis, specification, integration, and verification through Hermes Agent.
- Anthropic / `claude-opus-4-8` for independent exact-tree review in read-only plan mode.
- Greptile / model undisclosed for automated PR review that identified the deferred stream-cleanup race.
