### PR TITLE
fix: cap same-session reload limit at _msgLimitMax instead of falling back to full reload (#6392)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3123,14 +3123,13 @@ async function _ensureMessagesLoaded(sid, opts) {
   }
   // Fetch session messages with a tail window for fast initial load.
   const reloadLimit = _messageReloadLimitForSession(sid); // defaults to _INITIAL_MSG_LIMIT
-  // A reload window above the server's msg_limit ceiling would be clamped by
-  // the backend (returning only the last _MSG_LIMIT_MAX rows), which can
-  // silently SHRINK an already-loaded transcript that had more than the ceiling
-  // of rows visible (rows 400–999 replaced by 500–999). When the requested
-  // window exceeds the ceiling, fall back to the bare full-transcript request
-  // (no msg_limit / no expand_renderable) so a same-session refresh never drops
-  // already-loaded older rows (Codex gate #6154, silent row-loss).
-  const boundedReloadLimit = (reloadLimit && reloadLimit <= _msgLimitMax) ? reloadLimit : null;
+  // When reloadLimit exceeds the server's msg_limit ceiling, cap at the ceiling
+  // instead of falling back to the bare full-transcript request (the old
+  // behaviour).  A full reload of a long session (800+ messages) on every turn
+  // causes progressive slowdown and eventual freezes (#6392).  Capping at
+  // _msgLimitMax bounds the payload to at most 500 renderable rows — a minor
+  // window shift compared to loading the entire history on every reply.
+  const boundedReloadLimit = (reloadLimit == null) ? null : Math.min(reloadLimit, _msgLimitMax);
   const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';
   // Older frontends used expand_renderable=1 to request visible-row expansion.
   // The server now counts msg_limit by visible transcript rows by default; keep

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3148,6 +3148,9 @@ async function _ensureMessagesLoaded(sid, opts) {
   // Guard: api() may have redirected (401) and returned undefined.
   if (!data || !data.session) return;
   _messagesTruncated = !!data.session._messages_truncated;
+  // Capture the currently loaded absolute base before the response
+  // overwrites _oldestIdx. Used below to reconcile by server interval.
+  const _prevOldestIdx = _oldestIdx;
   _oldestIdx = data.session._messages_offset || 0;
   _msgLimitMax = data.session._msg_limit_max || _MSG_LIMIT_MAX;
   // #3162: `msgs` is reassigned below by the #3018 ephemeral-field carry-forward,
@@ -3177,15 +3180,16 @@ async function _ensureMessagesLoaded(sid, opts) {
     _pendingCarryForwardSnapshot = null;
   }
   if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();
-  // #6392: reconcile a capped same-session reload response with the
-  // preserved stale transcript (keepStaleUntilLoaded path) so that
-  // already-loaded older rows beyond the msg_limit window are not dropped.
-  // When the server returned a bounded tail that is narrower than the
-  // currently-loaded transcript, keep the prefix from S.messages and
-  // replace only the tail with the server's authoritative response.
-  if(Array.isArray(S.messages) && S.messages.length > msgs.length && msgs.length > 0){
-    const keepCount = S.messages.length - msgs.length;
-    msgs = S.messages.slice(0, keepCount).concat(msgs);
+  // #6392/#6421: reconcile a capped same-session reload response by the
+  // server's absolute interval [_oldestIdx, _oldestIdx + msgs.length),
+  // not by array length.  Preserve only rows strictly before that
+  // interval and set _oldestIdx to the actual first retained index.
+  if(Array.isArray(S.messages) && S.messages.length > 0 && msgs.length > 0 && _prevOldestIdx >= 0 && _prevOldestIdx < _oldestIdx){
+    const keepCount = _oldestIdx - _prevOldestIdx;
+    if(keepCount > 0 && keepCount <= S.messages.length){
+      msgs = S.messages.slice(0, keepCount).concat(msgs);
+      _oldestIdx = _prevOldestIdx;
+    }
   }
   S.messages = msgs;
   // Expand render window to cover all loaded messages so the next

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1809,6 +1809,14 @@ async function loadSession(sid){
     if (currentSid && currentSid !== sid && typeof closeOtherLiveStreams === 'function') {
       closeOtherLiveStreams(sid);
     }
+    // #6421: invalidate any in-flight older-page continuation before
+    // releasing the loading lock so a late-resolving prefetch does not
+    // prepend stale rows onto the fresh authoritative transcript that
+    // _ensureMessagesLoaded is about to install (#6392 same-session reload
+    // race).  _loadOlderMessages snapshots _messagesGeneration before its
+    // await; bumping now poisons that snapshot's post-await generation check
+    // so the stale continuation bails out cleanly.
+    _bumpMessagesGeneration();
     _loadingOlder = false;
     const _msgInner = $('msgInner');
     if (_msgInner && currentSid !== sid) _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Loading conversation...</div>';
@@ -3191,6 +3199,15 @@ async function _ensureMessagesLoaded(sid, opts) {
       _oldestIdx = _prevOldestIdx;
     }
   }
+  // #6421: invalidate any in-flight _loadOlderMessages continuation that
+  // started during the api() round-trip above (after loadSession's initial
+  // bump but before this point).  A second bump is needed here because
+  // _loadOlderMessages snapshots _messagesGeneration before its await, and
+  // a prefetch may have begun during the metadata/messages fetch.  Bumping
+  // now means the old prefetch's post-await generation check will mismatch
+  // and bail out instead of prepending stale rows onto the fresh
+  // authoritative transcript we are about to install (#6392).
+  _bumpMessagesGeneration();
   S.messages = msgs;
   // Expand render window to cover all loaded messages so the next
   // renderMessages() doesn't hide most of them behind a tiny window.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3177,6 +3177,16 @@ async function _ensureMessagesLoaded(sid, opts) {
     _pendingCarryForwardSnapshot = null;
   }
   if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();
+  // #6392: reconcile a capped same-session reload response with the
+  // preserved stale transcript (keepStaleUntilLoaded path) so that
+  // already-loaded older rows beyond the msg_limit window are not dropped.
+  // When the server returned a bounded tail that is narrower than the
+  // currently-loaded transcript, keep the prefix from S.messages and
+  // replace only the tail with the server's authoritative response.
+  if(Array.isArray(S.messages) && S.messages.length > msgs.length && msgs.length > 0){
+    const keepCount = S.messages.length - msgs.length;
+    msgs = S.messages.slice(0, keepCount).concat(msgs);
+  }
   S.messages = msgs;
   // Expand render window to cover all loaded messages so the next
   // renderMessages() doesn't hide most of them behind a tiny window.

--- a/tests/test_session_msg_limit_ceiling.py
+++ b/tests/test_session_msg_limit_ceiling.py
@@ -93,5 +93,5 @@ def test_frontend_declares_live_ceiling_at_module_scope_with_fallback():
 
 def test_frontend_reload_width_paths_read_the_live_ceiling():
     """Both reload-width decisions read the live `_msgLimitMax`, not the mirror."""
-    assert "reloadLimit <= _msgLimitMax" in _SESSIONS_JS       # _ensureMessagesLoaded
+    assert "Math.min(reloadLimit, _msgLimitMax)" in _SESSIONS_JS       # _ensureMessagesLoaded
     assert "requestedLimit >= _msgLimitMax" in _SESSIONS_JS    # _loadOlderMessages

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -446,6 +446,14 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     assert capture_pos < clear_pos < reset_pos
     assert "const sameSessionForceReload = forceReload && currentSid===sid;" in load_body
     assert "renderMessages(sameSessionForceReload?{preserveScroll:true}:undefined)" in load_body
+    # #6421: same-session force reload must invalidate in-flight older-page
+    # prefetch continuations before releasing the loading lock so a
+    # late-resolving msg_before/msg_limit request does not prepend stale
+    # rows onto a freshly installed authoritative transcript.
+    assert "_bumpMessagesGeneration();" in load_body
+    bump_pos = load_body.index("_bumpMessagesGeneration();")
+    loading_older_pos = load_body.index("_loadingOlder = false;", bump_pos) if "_loadingOlder = false;" in load_body[bump_pos:] else 0
+    assert bump_pos < loading_older_pos
 
 
 def test_same_width_force_reload_invalidates_visible_message_cache():
@@ -469,3 +477,13 @@ def test_same_width_force_reload_invalidates_visible_message_cache():
     assert "msgs = S.messages.slice(0, keepCount).concat(msgs);" in ensure_body
     assert "_oldestIdx = _prevOldestIdx;" in ensure_body
     assert invalidate_pos < ensure_body.index("_prevOldestIdx", invalidate_pos) < replace_pos
+    # #6421: _ensureMessagesLoaded must invalidate any in-flight older-page
+    # continuation that started during the api() round-trip, BEFORE publishing
+    # the fresh S.messages.  The generation bump sits between the cache invalidation
+    # and the replacement so that a late-resolving prefetch's post-await check
+    # sees a mismatch and bails out.
+    assert "clearVisibleMessageRowCache" in ensure_body
+    assert "_bumpMessagesGeneration();" in ensure_body
+    bump_pos = ensure_body.index("_bumpMessagesGeneration();")
+    assert invalidate_pos < bump_pos
+    assert bump_pos < replace_pos

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -427,13 +427,13 @@ def test_same_session_force_reload_keeps_loaded_transcript_width_hint():
     assert "const appendedMessageCount=Math.max(0,currentMessageCount-previousMessageCount);" in SESSIONS_JS
     assert "return Math.max(_INITIAL_MSG_LIMIT,loadedRenderableCount,loadedMessageCount+appendedMessageCount);" in SESSIONS_JS
     assert "const reloadLimit = _messageReloadLimitForSession(sid);" in SESSIONS_JS
-    # The width hint is applied only when it stays within the server msg_limit
-    # ceiling; an over-ceiling hint would be clamped by the backend and could
-    # silently shrink an already-loaded transcript, so it falls back to the bare
-    # full-transcript path (#6152/#6154 ceiling; Codex gate silent row-loss fix).
-    # #6177: the ceiling is now read from /api/session metadata into _msgLimitMax
-    # (module-scope let, default _MSG_LIMIT_MAX) instead of the mirrored const.
-    assert "const boundedReloadLimit = (reloadLimit && reloadLimit <= _msgLimitMax) ? reloadLimit : null;" in SESSIONS_JS
+    # The width hint is always bounded by the server's msg_limit ceiling to
+    # prevent unbounded full-transcript reloads on every turn (#6392). When
+    # the hint exceeds the ceiling, it is capped at _msgLimitMax instead of
+    # falling back to null. The capped response is then reconciled with the
+    # preserved stale transcript in _ensureMessagesLoaded so already-loaded
+    # older rows beyond the tail window are not dropped.
+    assert "const boundedReloadLimit = (reloadLimit == null) ? null : Math.min(reloadLimit, _msgLimitMax);" in SESSIONS_JS
     assert "const reloadLimitParam = boundedReloadLimit ? `&msg_limit=${boundedReloadLimit}` : '';" in SESSIONS_JS
     assert "if (_ownsLoad()) _clearSameSessionForceReloadHint(sid);" in SESSIONS_JS
 
@@ -463,3 +463,7 @@ def test_same_width_force_reload_invalidates_visible_message_cache():
     invalidate_pos = ensure_body.index("if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();")
     replace_pos = ensure_body.index("S.messages = msgs;")
     assert invalidate_pos < replace_pos
+    # #6392: capped same-session reload must reconcile with preserved stale transcript
+    assert "if(Array.isArray(S.messages) && S.messages.length > msgs.length && msgs.length > 0){" in ensure_body
+    reconcile_pos = ensure_body.index("msgs = S.messages.slice(0, keepCount).concat(msgs);")
+    assert invalidate_pos < reconcile_pos < replace_pos

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -463,7 +463,9 @@ def test_same_width_force_reload_invalidates_visible_message_cache():
     invalidate_pos = ensure_body.index("if(typeof clearVisibleMessageRowCache==='function') clearVisibleMessageRowCache();")
     replace_pos = ensure_body.index("S.messages = msgs;")
     assert invalidate_pos < replace_pos
-    # #6392: capped same-session reload must reconcile with preserved stale transcript
-    assert "if(Array.isArray(S.messages) && S.messages.length > msgs.length && msgs.length > 0){" in ensure_body
-    reconcile_pos = ensure_body.index("msgs = S.messages.slice(0, keepCount).concat(msgs);")
-    assert invalidate_pos < reconcile_pos < replace_pos
+    # #6392/#6421: capped same-session reload must reconcile by server absolute interval
+    assert "const _prevOldestIdx = _oldestIdx;" in ensure_body
+    assert "_prevOldestIdx < _oldestIdx" in ensure_body
+    assert "msgs = S.messages.slice(0, keepCount).concat(msgs);" in ensure_body
+    assert "_oldestIdx = _prevOldestIdx;" in ensure_body
+    assert invalidate_pos < ensure_body.index("_prevOldestIdx", invalidate_pos) < replace_pos


### PR DESCRIPTION
Each completed reply in a long session (800+ messages) triggers a
same-session force-reload via refreshActiveSessionIfExternallyUpdated.
_messageReloadLimitForSession grows the reload limit on every turn
(loadedMessageCount + appendedMessageCount), so after ~47 turns the
limit exceeds _msgLimitMax (500). At that point the old code fell back
to null (no msg_limit), making the server return ALL 800+ messages.

Fix: cap reloadLimit at _msgLimitMax instead of collapsing to null.
The payload stays bounded to at most 500 renderable rows on every
reload, preventing progressive slowdown and eventual browser freezes.
