### PR TITLE
fix(core): cross-client chat desync in concurrent sessions (#6299)

### DIFF
--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -859,6 +859,10 @@ def _settle_gateway_terminal_error(session_id, stream_id, workspace, model, mode
         session.model_provider = model_provider
         terminal_session_persisted = False
         try:
+            # #6422 re-gate 2026-08-24: gateway terminal error settlement is an
+            # APPEND producer — establish append intent so a concurrent
+            # completion cannot be overwritten by this error row.
+            session._merge_concurrent_appends()
             session.save()
             terminal_session_persisted = True
         except Exception:
@@ -1384,6 +1388,11 @@ def _run_gateway_chat_streaming(
             if cancel_event.is_set():
                 _restore_cancelled_success_writeback()
                 return
+            # #6422 re-gate 2026-08-24: gateway success writeback is an APPEND
+            # producer (the completed turn's rows were appended above) —
+            # establish append intent so the CAS transaction reconciles any
+            # concurrent writer instead of overwriting it.
+            s._merge_concurrent_appends()
             s.save()
             if cancel_event.is_set():
                 _restore_cancelled_success_writeback()

--- a/api/models.py
+++ b/api/models.py
@@ -1480,6 +1480,46 @@ class Session:
                         self.active_stream_id,
                     )
                     return
+                # ── #6299 cross-client merge ──────────────────────────────
+                # Another client may have appended messages concurrently since
+                # we loaded this session.  If disk has messages we don't know
+                # about AND the shared prefix is identical, merge the extra
+                # disk messages so our save doesn't clobber a concurrent
+                # append (last-writer-wins desync).
+                if existing_msg_count > incoming_msg_count:
+                    existing_msgs = existing.get('messages') or []
+                    our_msgs = self.messages or []
+                    if our_msgs and len(existing_msgs) >= len(our_msgs):
+                        _prefix_matches = True
+                        for _i in range(len(our_msgs)):
+                            if _i >= len(existing_msgs):
+                                _prefix_matches = False
+                                break
+                            _our_msg = our_msgs[_i]
+                            _disk_msg = existing_msgs[_i]
+                            if not isinstance(_our_msg, dict) or not isinstance(_disk_msg, dict):
+                                _prefix_matches = False
+                                break
+                            _our_id = _our_msg.get('id')
+                            _disk_id = _disk_msg.get('id')
+                            if _our_id is not None and _disk_id is not None:
+                                if _our_id != _disk_id:
+                                    _prefix_matches = False
+                                    break
+                            elif (_our_msg.get('role'), _our_msg.get('content')) != (_disk_msg.get('role'), _disk_msg.get('content')):
+                                _prefix_matches = False
+                                break
+                        if _prefix_matches:
+                            _disk_tail = existing_msgs[len(our_msgs):]
+                            if _disk_tail:
+                                self.messages = list(our_msgs) + list(_disk_tail)
+                                incoming_msg_count = len(self.messages)
+                                # Rebuild payload with merged messages so the
+                                # atomic write below reflects the combined
+                                # transcript, not just our local snapshot.
+                                meta['message_count'] = len(self.messages)
+                                meta['messages'] = self.messages
+                                payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
                 if existing_msg_count > incoming_msg_count:
                     bak_path = self.path.with_suffix('.json.bak')
                     # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,

--- a/api/models.py
+++ b/api/models.py
@@ -1906,7 +1906,17 @@ class Session:
             # (locked variant — we already hold the per-session lock) and
             # rebuild the payload with bounded retry (3 attempts).
             _cas_fp = getattr(self, '_merge_snapshot_fingerprint', None)
-            if _cas_fp is not None:
+            # #6422 re-gate 2026-08-25: a pending truncation (/undo, /retry,
+            # /truncate, /clear) must NEVER run a stale append reconciliation.
+            # The fingerprint can only be armed by a previous
+            # _merge_concurrent_appends() preflight on this cached object, and
+            # the intent is consumed (cleared) once that append transaction's
+            # save succeeds.  If it ever survives to a truncating save,
+            # re-merging against the longer pre-truncation disk transcript
+            # would append the just-deleted suffix back before publishing the
+            # newer truncate generation.  Truncation is authoritative by
+            # generation (stamped above), so the CAS re-merge is skipped.
+            if _cas_fp is not None and not self._truncation_pending:
                 for _cas_attempt in range(3):
                     try:
                         _cas_text = self.path.read_text(encoding='utf-8')
@@ -1988,6 +1998,15 @@ class Session:
             # truncation intent for the retry.
             self._truncation_pending = False
             self._loaded_truncate_generation = int(self.truncate_generation or 0)
+            # #6422 re-gate 2026-08-25: CONSUME the append intent.  The
+            # preflight fingerprint armed by _merge_concurrent_appends() is
+            # only meaningful for the single append transaction it preceded;
+            # once this write succeeded the object's messages already include
+            # the reconciled rows.  Leaving it armed would make a LATER save on
+            # this same cached object (e.g. a truncation/undo/retry) re-run
+            # the stale merge against a disk transcript that has since grown,
+            # resurrecting rows the user just deleted.
+            self._merge_snapshot_fingerprint = None
         if not skip_index:
             _write_session_index(updates=[self])
 

--- a/api/models.py
+++ b/api/models.py
@@ -1367,6 +1367,72 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
+    def _merge_concurrent_appends(self) -> None:
+        """Merge messages appended by another client since we loaded this session.
+
+        Reads the current on-disk state. If disk has messages we don't know
+        about AND the shared prefix is identical (verified by message ``id``
+        first, then ``role``+``content`` as fallback), appends the extra
+        disk-only messages to ``self.messages`` so our save doesn't clobber a
+        concurrent append.
+
+        This handles two cases:
+        1. Disk is longer than our copy (standard append race).
+        2. Same length but divergent tail (concurrent equal-length append).
+
+        This is safe to call only when the caller KNOWS it is appending new
+        messages (e.g. streaming completion handler).  It must NOT be called
+        from generic ``save()``, because ``save()`` cannot distinguish an
+        append race from an intentional truncation (``/undo``, ``/retry``).
+        """
+        if not self.path.exists():
+            return
+        try:
+            existing_text = self.path.read_text(encoding='utf-8')
+            existing = json.loads(existing_text)
+        except (json.JSONDecodeError, ValueError, OSError):
+            return
+        existing_msgs = existing.get('messages') or []
+        our_msgs = self.messages or []
+        if not existing_msgs or not our_msgs:
+            return
+
+        # Find the longest prefix where every position matches (by id or content).
+        prefix_len = 0
+        min_len = min(len(existing_msgs), len(our_msgs))
+        for i in range(min_len):
+            our_msg = our_msgs[i]
+            disk_msg = existing_msgs[i]
+            if not isinstance(our_msg, dict) or not isinstance(disk_msg, dict):
+                break
+            our_id = our_msg.get('id')
+            disk_id = disk_msg.get('id')
+            if our_id is not None and disk_id is not None:
+                if our_id != disk_id:
+                    break
+            elif (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
+                break
+            prefix_len += 1
+
+        if prefix_len == 0:
+            return  # No common ground — bail, don't risk data corruption.
+
+        # Messages on disk beyond the common prefix.
+        disk_tail = existing_msgs[prefix_len:]
+        if not disk_tail:
+            return  # Disk has nothing we don't already have.
+
+        # Case 1: our messages are a prefix of disk (append race).
+        if prefix_len == len(our_msgs):
+            self.messages = list(our_msgs) + list(disk_tail)
+            return
+
+        # Case 2: same length but divergent tails (concurrent equal-length append)
+        # or disk is shorter than our copy.
+        # Merge: keep the common prefix, insert disk's extras, then our extras.
+        our_tail = our_msgs[prefix_len:]
+        self.messages = list(our_msgs[:prefix_len]) + list(disk_tail) + list(our_tail)
+
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
@@ -1480,46 +1546,6 @@ class Session:
                         self.active_stream_id,
                     )
                     return
-                # ── #6299 cross-client merge ──────────────────────────────
-                # Another client may have appended messages concurrently since
-                # we loaded this session.  If disk has messages we don't know
-                # about AND the shared prefix is identical, merge the extra
-                # disk messages so our save doesn't clobber a concurrent
-                # append (last-writer-wins desync).
-                if existing_msg_count > incoming_msg_count:
-                    existing_msgs = existing.get('messages') or []
-                    our_msgs = self.messages or []
-                    if our_msgs and len(existing_msgs) >= len(our_msgs):
-                        _prefix_matches = True
-                        for _i in range(len(our_msgs)):
-                            if _i >= len(existing_msgs):
-                                _prefix_matches = False
-                                break
-                            _our_msg = our_msgs[_i]
-                            _disk_msg = existing_msgs[_i]
-                            if not isinstance(_our_msg, dict) or not isinstance(_disk_msg, dict):
-                                _prefix_matches = False
-                                break
-                            _our_id = _our_msg.get('id')
-                            _disk_id = _disk_msg.get('id')
-                            if _our_id is not None and _disk_id is not None:
-                                if _our_id != _disk_id:
-                                    _prefix_matches = False
-                                    break
-                            elif (_our_msg.get('role'), _our_msg.get('content')) != (_disk_msg.get('role'), _disk_msg.get('content')):
-                                _prefix_matches = False
-                                break
-                        if _prefix_matches:
-                            _disk_tail = existing_msgs[len(our_msgs):]
-                            if _disk_tail:
-                                self.messages = list(our_msgs) + list(_disk_tail)
-                                incoming_msg_count = len(self.messages)
-                                # Rebuild payload with merged messages so the
-                                # atomic write below reflects the combined
-                                # transcript, not just our local snapshot.
-                                meta['message_count'] = len(self.messages)
-                                meta['messages'] = self.messages
-                                payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
                 if existing_msg_count > incoming_msg_count:
                     bak_path = self.path.with_suffix('.json.bak')
                     # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,

--- a/api/models.py
+++ b/api/models.py
@@ -1445,6 +1445,14 @@ class Session:
         # constructed sessions (never loaded) default to 0, i.e. they reconcile
         # against any first truncation.
         self._loaded_truncate_generation = None
+        # #6422 re-gate: the message count this object was loaded with, used by
+        # ``_merge_concurrent_appends_locked()`` to recognize a first turn from
+        # an EMPTY base (loaded with zero rows): when disk and our transcript
+        # share no prefix but our base was empty, every disk row is a
+        # concurrent append from the same empty base and is merged by
+        # concatenation instead of bailing.  None = never loaded (fresh
+        # construction) — full divergence then stays a bail-to-safe case.
+        self._loaded_message_count = None
         # #6422: set by the truncation entry points (truncate_session_at_keep,
         # undo_last, retry_last) so save() can stamp a generation strictly
         # greater than anything on disk even when this object is a stale cache
@@ -1493,9 +1501,23 @@ class Session:
         Caller must hold ``_session_sidecar_cross_process_lock`` (or be in the
         advisory pre-pass, where the subsequent ``save()`` transaction
         re-validates everything under the lock).
+
+        Append intent is represented as an explicit BASE IDENTITY (the
+        fingerprint of the on-disk state this object's messages are based on)
+        plus the local delta (``self.messages``).  The base identity is ALWAYS
+        recorded — an empty sidecar and a zero-length disk tail are VALID
+        bases, never reasons to skip validation: ``save()`` re-reads under the
+        per-session cross-process lock and re-merges whenever the fingerprint
+        moved, so two writers that both preflighted against the same disk can
+        no longer have the second save overwrite the first's rows (PR #6422
+        re-gate).
         """
         self._merge_snapshot_fingerprint = None  # Reset on every call.
         if not self.path.exists():
+            # New sidecar: the base is the empty state.  Record it so save()
+            # re-validates — two first turns from the same empty base must
+            # both survive instead of the second save clobbering the first.
+            self._merge_snapshot_fingerprint = _fast_fingerprint('')
             return
         try:
             existing_text = self.path.read_text(encoding='utf-8')
@@ -1504,8 +1526,6 @@ class Session:
             return
         existing_msgs = existing.get('messages') or []
         our_msgs = self.messages or []
-        if not existing_msgs or not our_msgs:
-            return
 
         # ── #6422 authoritative truncate/clear generation guard ─────────
         # Row counts can never distinguish an intentional truncation (/undo,
@@ -1515,17 +1535,39 @@ class Session:
         # is the EXPECTED mid-turn state, not evidence of a truncation.  Only a
         # ``truncate_generation`` strictly NEWER than the one this object
         # loaded with is authoritative proof the user truncated since load.
+        # This comparison runs BEFORE the empty-list exits below: a
+        # clear-to-empty disk state (or an empty in-memory transcript) must
+        # never skip it, or a stale stream could resurrect a newer
+        # clear-to-empty transcript.
         disk_gen = int(existing.get('truncate_generation') or 0)
         loaded_gen = int(getattr(self, '_loaded_truncate_generation', None) or 0)
         if disk_gen > loaded_gen:
             # Fail closed: adopt the truncated disk state and its generation
-            # (never regress it).  This may drop our own new messages in the
-            # rare truncate-while-streaming case, but it cannot resurrect
-            # messages the user deleted.
+            # (never regress it).  Adopt BOTH the display transcript
+            # (``messages``) and the model-context truncation state
+            # (``context_messages``) so a newer non-empty generation cannot
+            # leave stale context behind to be persisted.  This may drop our
+            # own new messages in the rare truncate-while-streaming case, but
+            # it cannot resurrect messages the user deleted.
             self.messages = list(existing_msgs)
+            if isinstance(existing.get('context_messages'), list):
+                self.context_messages = list(existing['context_messages'])
             self.truncate_generation = disk_gen
             self._loaded_truncate_generation = disk_gen
             self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
+            return
+
+        # Record the base identity ALWAYS.  A zero-tail disk (disk is a strict
+        # prefix of our transcript) and an empty disk are valid merge bases —
+        # ``save()`` must still re-validate under the lock, or two writers
+        # that both preflighted against the same disk would have their second
+        # save overwrite the first's rows (re-gate finding #1).
+        self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
+
+        if not existing_msgs or not our_msgs:
+            # Nothing to reconcile (disk empty, or we carry no transcript).
+            # The base identity above keeps ``save()``'s CAS re-validation
+            # active for both shapes.
             return
 
         # Find the longest prefix where every position matches.  When both
@@ -1566,7 +1608,15 @@ class Session:
             prefix_len += 1
 
         if prefix_len == 0:
-            return  # No common ground — bail, don't risk data corruption.
+            # No shared prefix.  Valid ONLY when our base was empty (two first
+            # turns from a brand-new session): every disk row is a concurrent
+            # append from the same empty base, so concatenate disk rows first,
+            # then ours.  A divergent NON-empty base is corruption — bail
+            # rather than concatenate unrelated transcripts.
+            loaded_count = getattr(self, '_loaded_message_count', None)
+            if loaded_count == 0:
+                self.messages = list(existing_msgs) + list(our_msgs)
+            return
 
         # Messages on disk beyond the common prefix.
         disk_tail = existing_msgs[prefix_len:]
@@ -1574,12 +1624,13 @@ class Session:
             # Disk has nothing we don't already have.  A shorter on-disk
             # transcript at the SAME generation is a pre-turn checkpoint (or
             # stale copy), NOT a truncation — keep our completed transcript.
+            # The base identity recorded above keeps save()'s CAS re-validation
+            # active for this zero-tail shape (re-gate finding #1).
             return
 
         # Case 1: our messages are a prefix of disk (append race).
         if prefix_len == len(our_msgs):
             self.messages = list(our_msgs) + list(disk_tail)
-            self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
             return
 
         # Case 2: divergent tails (concurrent equal-length append, or disk
@@ -1587,7 +1638,6 @@ class Session:
         # Merge: keep the common prefix, insert disk's extras, then our extras.
         our_tail = our_msgs[prefix_len:]
         self.messages = list(our_msgs[:prefix_len]) + list(disk_tail) + list(our_tail)
-        self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
@@ -1703,7 +1753,11 @@ class Session:
             existing_gen = int((existing or {}).get('truncate_generation') or 0)
             if self._truncation_pending:
                 self.truncate_generation = max(int(self.truncate_generation or 0), existing_gen + 1)
-                self._truncation_pending = False
+                # NOTE: _truncation_pending is NOT cleared here.  It stays set
+                # until the temp write/fsync/atomic replace below succeeds, so
+                # a failed write preserves the pending truncation intent for
+                # the caller's retry instead of silently downgrading the next
+                # save to a plain (non-truncating) one (re-gate finding #2).
             else:
                 self.truncate_generation = max(int(self.truncate_generation or 0), existing_gen)
             if meta.get('truncate_generation') != self.truncate_generation:
@@ -1777,7 +1831,12 @@ class Session:
                     try:
                         _cas_text = self.path.read_text(encoding='utf-8')
                     except OSError:
-                        break  # File vanished — proceed, atomic write will create it.
+                        # File vanished (or never existed — empty base).  The
+                        # empty state is a valid CAS base: only a writer that
+                        # left the file empty (or absent) matches the recorded
+                        # empty-base identity; anything else forces a re-merge
+                        # that adopts the concurrent writer's rows.
+                        _cas_text = ''
                     _cur_fp = _fast_fingerprint(_cas_text)
                     if _cur_fp == _cas_fp:
                         break  # File unchanged since merge — continue to write.
@@ -1814,6 +1873,16 @@ class Session:
                 except Exception:
                     pass
                 raise
+            # ── #6422 re-gate: commit succeeded.  Advance the object's loaded
+            # truncate generation so a cache-resident follow-up turn on THIS
+            # object compares against the generation we just persisted (not
+            # the load-time one) — otherwise the next merge would see its own
+            # newer on-disk generation and misclassify it as a truncation,
+            # dropping the follow-up turn's rows.  Clear the pending-truncation
+            # flag only NOW: a failed write above re-raises and preserves the
+            # truncation intent for the retry.
+            self._truncation_pending = False
+            self._loaded_truncate_generation = int(self.truncate_generation or 0)
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1863,6 +1932,10 @@ class Session:
         # truncation (disk generation newer than this) from a plain pre-turn
         # checkpoint (same generation, just shorter).
         session._loaded_truncate_generation = int(session.truncate_generation or 0)
+        # #6422 re-gate: remember the loaded message count so the merge can
+        # recognize a first turn from an EMPTY base (loaded with zero rows) —
+        # the one valid shape where disk and our transcript share no prefix.
+        session._loaded_message_count = len(session.messages or [])
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching

--- a/api/models.py
+++ b/api/models.py
@@ -1362,6 +1362,9 @@ class Session:
             except (TypeError, ValueError):
                 parsed_message_count = None
         self._metadata_message_count = parsed_message_count if parsed_message_count is not None and parsed_message_count >= 0 else None
+        # #6422: cross-process CAS fingerprint.  Set by _merge_concurrent_appends()
+        # to the crc32 of the file text it merged against, then verified in save().
+        self._merge_snapshot_fingerprint = None
 
     @property
     def path(self):
@@ -1384,7 +1387,12 @@ class Session:
         messages (e.g. streaming completion handler).  It must NOT be called
         from generic ``save()``, because ``save()`` cannot distinguish an
         append race from an intentional truncation (``/undo``, ``/retry``).
+
+        Stores ``_merge_snapshot_fingerprint`` so the subsequent ``save()``
+        can verify no cross-process write landed between the merge and the
+        atomic write (CAS guard, PR #6422).
         """
+        self._merge_snapshot_fingerprint = None  # Reset on every call.
         if not self.path.exists():
             return
         try:
@@ -1410,12 +1418,32 @@ class Session:
             if our_id is not None and disk_id is not None:
                 if our_id != disk_id:
                     break
+                # ── #6422 collision guard ────────────────────────────────
+                # ``_assign_stable_message_ids()`` uses ``max(existing id) +
+                # 1``, so two clients loaded from the same base can assign
+                # the *same* next integer ID to different appended messages.
+                # When IDs are equal but content differs, the messages are
+                # distinct concurrent appends — treat this as a divergence.
+                if (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
+                    break
             elif (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
                 break
             prefix_len += 1
 
         if prefix_len == 0:
             return  # No common ground — bail, don't risk data corruption.
+
+        # ── #6422 truncation guard ──────────────────────────────────────
+        # If the on-disk session is now SHORTER than our copy at this
+        # prefix boundary, another client must have truncated via /undo or
+        # /retry since we loaded.  Fail closed: take the disk state and
+        # discard our stale suffix.  This may lose our new messages too
+        # in the rare truncation-while-streaming scenario, but it avoids
+        # the worse outcome of resurrecting deleted messages.
+        if prefix_len == len(existing_msgs) and prefix_len < len(our_msgs):
+            self.messages = list(existing_msgs)
+            self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
+            return
 
         # Messages on disk beyond the common prefix.
         disk_tail = existing_msgs[prefix_len:]
@@ -1425,6 +1453,7 @@ class Session:
         # Case 1: our messages are a prefix of disk (append race).
         if prefix_len == len(our_msgs):
             self.messages = list(our_msgs) + list(disk_tail)
+            self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
             return
 
         # Case 2: same length but divergent tails (concurrent equal-length append)
@@ -1432,6 +1461,7 @@ class Session:
         # Merge: keep the common prefix, insert disk's extras, then our extras.
         our_tail = our_msgs[prefix_len:]
         self.messages = list(our_msgs[:prefix_len]) + list(disk_tail) + list(our_tail)
+        self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if not is_safe_session_id(self.session_id):
@@ -1573,6 +1603,41 @@ class Session:
                             pass
         except OSError:
             pass
+
+        # ── #6422 cross-process CAS guard ───────────────────────────────
+        # If _merge_concurrent_appends() was called before this save(),
+        # verify the file hasn't been modified by another process between
+        # the merge and the atomic write (TOCTOU window).  Re-read the
+        # on-disk state and compare fingerprint.  If it changed, re-merge
+        # and rebuild the payload with bounded retry (3 attempts).
+        _cas_fp = getattr(self, '_merge_snapshot_fingerprint', None)
+        if _cas_fp is not None:
+            for _cas_attempt in range(3):
+                try:
+                    _cas_text = self.path.read_text(encoding='utf-8')
+                except OSError:
+                    break  # File vanished — proceed, atomic write will create it.
+                _cur_fp = _fast_fingerprint(_cas_text)
+                if _cur_fp == _cas_fp:
+                    break  # File unchanged since merge — continue to write.
+                # File changed — re-merge against current state.
+                _orig_messages = list(self.messages or [])
+                self._merge_concurrent_appends()
+                _new_fp = getattr(self, '_merge_snapshot_fingerprint', None)
+                if _new_fp is None or _new_fp == _cur_fp:
+                    break  # Re-merge converged or had nothing to merge.
+                # Stalemate — another write happened during re-merge.
+                if _cas_attempt == 2:
+                    logger.warning(
+                        "Cross-process CAS retries exhausted for session %s "
+                        "(attempts=%d, fingerprint=%s); proceeding with best-effort merge",
+                        self.session_id, _cas_attempt + 1, _cur_fp,
+                    )
+            if _cas_fp != getattr(self, '_merge_snapshot_fingerprint', None):
+                # Messages changed during re-merge — rebuild payload.
+                meta['message_count'] = len(self.messages or [])
+                meta['messages'] = self.messages
+                payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
 
         tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
@@ -4191,6 +4256,17 @@ def _disk_scene_fingerprint(disk_meta_prefix: dict):
                 latest = fv
         return keys, latest
     return None
+
+
+def _fast_fingerprint(text: str) -> int:
+    """Fast stable fingerprint of session file text for CAS guard.
+
+    Uses crc32 so different processes produce the same fingerprint for
+    identical input.  Collision probability is near zero for session-file
+    sizes (tens of KB).
+    """
+    import zlib
+    return zlib.crc32(text.encode('utf-8'))
 
 
 def _sidecar_stat_signature(path):

--- a/api/models.py
+++ b/api/models.py
@@ -1926,19 +1926,28 @@ class Session:
                     if _new_fp is None or _new_fp == _cur_fp:
                         break  # Re-merge converged or had nothing to merge.
                     # Stalemate — another write happened during re-merge.
+                    # Re-gate 2026-08-24: FAIL CLOSED instead of publishing a
+                    # best-effort merge — a write we could not reconcile
+                    # against could overwrite a concurrent append.
                     if _cas_attempt == 2:
-                        logger.warning(
-                            "Cross-process CAS retries exhausted for session %s "
-                            "(attempts=%d, fingerprint=%s); proceeding with best-effort merge",
-                            self.session_id, _cas_attempt + 1, _cur_fp,
+                        raise RuntimeError(
+                            f"Cross-process CAS retries exhausted for session "
+                            f"{self.session_id} (attempts={_cas_attempt + 1}, "
+                            f"fingerprint={_cur_fp}); refusing to publish an "
+                            f"unreconciled best-effort merge"
                         )
-                if _cas_fp != getattr(self, '_merge_snapshot_fingerprint', None):
-                    # Messages (or adopted generation) changed during re-merge —
-                    # rebuild payload.
-                    meta['message_count'] = len(self.messages or [])
-                    meta['messages'] = self.messages
-                    meta['truncate_generation'] = self.truncate_generation
-                    payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+
+            # ── #6422 re-gate 2026-08-24: build the COMPLETE sidecar payload
+            # from the final in-lock state before EVERY write.  Previously the
+            # payload was only built inside the CAS-rebuild arm (where ``meta``
+            # and ``extra`` were no longer in scope), so the normal path hit
+            # ``f.write(payload)`` with an unbound ``payload`` →
+            # UnboundLocalError (release blocker).  ``_sidecar_payload()``
+            # serializes messages, context_messages, message_count, the
+            # truncate generation, and every metadata/extra field from the
+            # current object — which is exactly the authoritative state after
+            # the generation decision and any CAS re-merge above.
+            payload = self._sidecar_payload()
 
             tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
             try:
@@ -1947,6 +1956,22 @@ class Session:
                     f.flush()
                     os.fsync(f.fileno())
                 _safe_replace(tmp, self.path)
+                # Re-gate 2026-08-24: complete the parent-directory fsync
+                # boundary so the rename is durable before we advance the
+                # in-memory generation authority below.  Best-effort on
+                # platforms that disallow directory fsync (e.g. Windows).
+                try:
+                    _dir_fd = os.open(SESSION_DIR, os.O_RDONLY)
+                    try:
+                        os.fsync(_dir_fd)
+                    finally:
+                        os.close(_dir_fd)
+                except OSError:
+                    logger.debug(
+                        "Directory fsync unavailable for %s (best-effort)",
+                        SESSION_DIR,
+                        exc_info=True,
+                    )
             except Exception:
                 try:
                     tmp.unlink(missing_ok=True)

--- a/api/models.py
+++ b/api/models.py
@@ -182,6 +182,73 @@ def _safe_replace(src: Path, dst: Path) -> None:
             delay *= 2  # 50 -> 100 -> 200 -> 400 -> 800 ms
 
 
+@contextmanager
+def _session_sidecar_cross_process_lock(sid: str):
+    """Serialize read-merge-validate-replace of ONE session sidecar across processes.
+
+    PR #6422: the cross-client merge needs ``merge + truncate-generation
+    comparison + final fingerprint validation + atomic replace`` to be a single
+    per-session transaction.  The process-local ``_get_session_agent_lock`` only
+    serializes threads of one process, so a second WebUI worker can interleave a
+    write between our validation read and our ``os.replace``.  This lock closes
+    that TOCTOU window: every sidecar write goes through ``Session.save()``,
+    which holds this lock for the whole read-modify-write of the file.
+
+    POSIX uses ``flock``; native Windows locks the first byte with
+    ``msvcrt.locking`` (mirroring ``_cleanup_manifest_process_lock``).  The lock
+    file is kept in place permanently — unlinking it while another process is
+    waiting can split later callers across different inodes and defeat the
+    lock.  If neither primitive exists (exotic platform), degrade to a no-op
+    rather than block every save.
+    """
+    if not is_safe_session_id(sid):
+        yield
+        return
+    lock_path = SESSION_DIR / f'.{sid}.sidecar.lock'
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        logger.debug("sidecar lock open failed for %s", sid, exc_info=True)
+        yield
+        return
+    with os.fdopen(fd, 'r+b', buffering=0) as lock_file:
+        if _fcntl is not None:
+            _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_UN)
+            return
+        if _msvcrt is not None:
+            try:
+                if os.fstat(lock_file.fileno()).st_size == 0:
+                    lock_file.write(b'\0')
+                lock_file.seek(0)
+                _msvcrt.locking(  # type: ignore[attr-defined]
+                    lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
+                )
+            except OSError:
+                logger.debug("sidecar msvcrt lock failed for %s", sid, exc_info=True)
+                yield
+                return
+            try:
+                yield
+            finally:
+                try:
+                    lock_file.seek(0)
+                    _msvcrt.locking(  # type: ignore[attr-defined]
+                        lock_file.fileno(), _msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+                    )
+                except OSError:
+                    logger.debug("sidecar msvcrt unlock failed for %s", sid, exc_info=True)
+            return
+        # No cross-process primitive available: best-effort no-op.
+        logger.debug("cross-process sidecar locking unavailable for %s", sid)
+        yield
+
+
+
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
@@ -1228,6 +1295,7 @@ class Session:
                  truncation_boundary=None,
                  clear_generation=None,
                  intentional_shrink_generation=None,
+                 truncate_generation=None,
                  gateway_routing=None, gateway_routing_history=None,
                  llm_title_generated: bool=False,
                  manual_title: bool=False,
@@ -1325,6 +1393,12 @@ class Session:
         self.truncation_boundary = truncation_boundary
         self.clear_generation = clear_generation
         self.intentional_shrink_generation = intentional_shrink_generation
+        # #6422: authoritative monotonic truncate/clear generation.  Every
+        # /undo, /retry, /truncate and /clear bumps it; the cross-client merge
+        # compares the on-disk value against ``_loaded_truncate_generation`` to
+        # distinguish a real truncation from a mere pre-turn checkpoint that
+        # happens to be shorter.  Persisted in the sidecar metadata prefix.
+        self.truncate_generation = truncate_generation
         self.gateway_routing = gateway_routing if isinstance(gateway_routing, dict) else None
         self.gateway_routing_history = gateway_routing_history if isinstance(gateway_routing_history, list) else []
         self.llm_title_generated = bool(llm_title_generated)
@@ -1365,6 +1439,17 @@ class Session:
         # #6422: cross-process CAS fingerprint.  Set by _merge_concurrent_appends()
         # to the crc32 of the file text it merged against, then verified in save().
         self._merge_snapshot_fingerprint = None
+        # #6422: the truncate/clear generation this object was loaded with.
+        # ``_merge_concurrent_appends_locked()`` treats disk as truncated only
+        # when its generation is STRICTLY NEWER than this value.  Freshly
+        # constructed sessions (never loaded) default to 0, i.e. they reconcile
+        # against any first truncation.
+        self._loaded_truncate_generation = None
+        # #6422: set by the truncation entry points (truncate_session_at_keep,
+        # undo_last, retry_last) so save() can stamp a generation strictly
+        # greater than anything on disk even when this object is a stale cache
+        # whose in-memory generation lagged behind other processes' truncations.
+        self._truncation_pending = False
 
     @property
     def path(self):
@@ -1374,10 +1459,10 @@ class Session:
         """Merge messages appended by another client since we loaded this session.
 
         Reads the current on-disk state. If disk has messages we don't know
-        about AND the shared prefix is identical (verified by message ``id``
-        first, then ``role``+``content`` as fallback), appends the extra
-        disk-only messages to ``self.messages`` so our save doesn't clobber a
-        concurrent append.
+        about AND the shared prefix is identical (verified by the durable row
+        lineage ``uuid`` first, then ``id``/``role``+``content`` as fallback),
+        appends the extra disk-only messages to ``self.messages`` so our save
+        doesn't clobber a concurrent append.
 
         This handles two cases:
         1. Disk is longer than our copy (standard append race).
@@ -1386,11 +1471,28 @@ class Session:
         This is safe to call only when the caller KNOWS it is appending new
         messages (e.g. streaming completion handler).  It must NOT be called
         from generic ``save()``, because ``save()`` cannot distinguish an
-        append race from an intentional truncation (``/undo``, ``/retry``).
+        append race from an intentional truncation (``/undo``, ``/retry``) —
+        that is why truncation detection here is driven by the authoritative
+        monotonic ``truncate_generation`` instead of row counts.
 
-        Stores ``_merge_snapshot_fingerprint`` so the subsequent ``save()``
-        can verify no cross-process write landed between the merge and the
-        atomic write (CAS guard, PR #6422).
+        This is an ADVISORY pre-pass: it reads the on-disk state without the
+        per-session cross-process lock and stores
+        ``_merge_snapshot_fingerprint``.  The AUTHORITATIVE merge + generation
+        comparison + final fingerprint validation + atomic replace happens in
+        ``save()`` under ``_session_sidecar_cross_process_lock``; if the file
+        changed between this pre-pass and ``save()``, ``save()`` re-runs
+        ``_merge_concurrent_appends_locked()`` under the lock and rebuilds the
+        payload, so the final bytes on disk always come from one per-session
+        cross-process transaction (PR #6422).
+        """
+        self._merge_concurrent_appends_locked()
+
+    def _merge_concurrent_appends_locked(self) -> None:
+        """Locked body of ``_merge_concurrent_appends()``.
+
+        Caller must hold ``_session_sidecar_cross_process_lock`` (or be in the
+        advisory pre-pass, where the subsequent ``save()`` transaction
+        re-validates everything under the lock).
         """
         self._merge_snapshot_fingerprint = None  # Reset on every call.
         if not self.path.exists():
@@ -1405,7 +1507,35 @@ class Session:
         if not existing_msgs or not our_msgs:
             return
 
-        # Find the longest prefix where every position matches (by id or content).
+        # ── #6422 authoritative truncate/clear generation guard ─────────
+        # Row counts can never distinguish an intentional truncation (/undo,
+        # /retry, /truncate, /clear) from a plain pre-turn checkpoint: the
+        # normal streaming path saves a shorter checkpoint BEFORE the turn and
+        # a longer completed transcript after, so "disk shorter than memory"
+        # is the EXPECTED mid-turn state, not evidence of a truncation.  Only a
+        # ``truncate_generation`` strictly NEWER than the one this object
+        # loaded with is authoritative proof the user truncated since load.
+        disk_gen = int(existing.get('truncate_generation') or 0)
+        loaded_gen = int(getattr(self, '_loaded_truncate_generation', None) or 0)
+        if disk_gen > loaded_gen:
+            # Fail closed: adopt the truncated disk state and its generation
+            # (never regress it).  This may drop our own new messages in the
+            # rare truncate-while-streaming case, but it cannot resurrect
+            # messages the user deleted.
+            self.messages = list(existing_msgs)
+            self.truncate_generation = disk_gen
+            self._loaded_truncate_generation = disk_gen
+            self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
+            return
+
+        # Find the longest prefix where every position matches.  When both
+        # rows carry the durable ``uuid`` lineage (minted once at row
+        # creation), compare THAT: ``_assign_stable_message_ids()`` uses
+        # ``max(existing id) + 1``, so two clients loaded from the same base
+        # can assign the same next integer id to different messages — equal
+        # ids, even with identical content, are NOT proof the rows are the
+        # same.  Rows without a uuid (legacy writers) fall back to the
+        # id-then-content comparison.
         prefix_len = 0
         min_len = min(len(existing_msgs), len(our_msgs))
         for i in range(min_len):
@@ -1413,42 +1543,38 @@ class Session:
             disk_msg = existing_msgs[i]
             if not isinstance(our_msg, dict) or not isinstance(disk_msg, dict):
                 break
-            our_id = our_msg.get('id')
-            disk_id = disk_msg.get('id')
-            if our_id is not None and disk_id is not None:
-                if our_id != disk_id:
+            our_uuid = our_msg.get('uuid')
+            disk_uuid = disk_msg.get('uuid')
+            if our_uuid is not None and disk_uuid is not None:
+                if our_uuid != disk_uuid:
+                    # Distinct rows — divergence, even on equal id/content.
                     break
-                # ── #6422 collision guard ────────────────────────────────
-                # ``_assign_stable_message_ids()`` uses ``max(existing id) +
-                # 1``, so two clients loaded from the same base can assign
-                # the *same* next integer ID to different appended messages.
-                # When IDs are equal but content differs, the messages are
-                # distinct concurrent appends — treat this as a divergence.
-                if (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
+                # Same uuid = same logical row; content differences are
+                # partial-update artifacts of a shared row, keep matching.
+            else:
+                our_id = our_msg.get('id')
+                disk_id = disk_msg.get('id')
+                if our_id is not None and disk_id is not None:
+                    if our_id != disk_id:
+                        break
+                    # Equal N+1 integer ids with different content = two
+                    # distinct concurrent appends — treat as a divergence.
+                    if (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
+                        break
+                elif (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
                     break
-            elif (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
-                break
             prefix_len += 1
 
         if prefix_len == 0:
             return  # No common ground — bail, don't risk data corruption.
 
-        # ── #6422 truncation guard ──────────────────────────────────────
-        # If the on-disk session is now SHORTER than our copy at this
-        # prefix boundary, another client must have truncated via /undo or
-        # /retry since we loaded.  Fail closed: take the disk state and
-        # discard our stale suffix.  This may lose our new messages too
-        # in the rare truncation-while-streaming scenario, but it avoids
-        # the worse outcome of resurrecting deleted messages.
-        if prefix_len == len(existing_msgs) and prefix_len < len(our_msgs):
-            self.messages = list(existing_msgs)
-            self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
-            return
-
         # Messages on disk beyond the common prefix.
         disk_tail = existing_msgs[prefix_len:]
         if not disk_tail:
-            return  # Disk has nothing we don't already have.
+            # Disk has nothing we don't already have.  A shorter on-disk
+            # transcript at the SAME generation is a pre-turn checkpoint (or
+            # stale copy), NOT a truncation — keep our completed transcript.
+            return
 
         # Case 1: our messages are a prefix of disk (append race).
         if prefix_len == len(our_msgs):
@@ -1456,8 +1582,8 @@ class Session:
             self._merge_snapshot_fingerprint = _fast_fingerprint(existing_text)
             return
 
-        # Case 2: same length but divergent tails (concurrent equal-length append)
-        # or disk is shorter than our copy.
+        # Case 2: divergent tails (concurrent equal-length append, or disk
+        # shorter at the same generation with a divergent boundary).
         # Merge: keep the common prefix, insert disk's extras, then our extras.
         our_tail = our_msgs[prefix_len:]
         self.messages = list(our_msgs[:prefix_len]) + list(disk_tail) + list(our_tail)
@@ -1507,6 +1633,7 @@ class Session:
             'truncation_boundary',
             'clear_generation',
             'intentional_shrink_generation',
+            'truncate_generation',
             'gateway_routing', 'gateway_routing_history', 'llm_title_generated', 'manual_title',
             'parent_session_id',
             'worktree_path', 'worktree_branch', 'worktree_repo_root', 'worktree_created_at',
@@ -1541,117 +1668,152 @@ class Session:
                  and not k.startswith('_')}
         payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
 
-        # ── #1558 backup safeguard ──────────────────────────────────────
-        # Before overwriting the session file, copy the previous version to
-        # ``<sid>.json.bak`` IFF the previous file has more messages than the
-        # incoming payload. The asymmetric guard means:
-        #   * Normal grow-the-conversation saves never produce a backup
-        #     (incoming messages >= existing) — keeps disk overhead near zero.
-        #   * Any save that would shrink the messages array (the failure mode
-        #     of #1558, plus anything similar in the future) leaves a recoverable
-        #     snapshot of the pre-shrink state on disk.
-        # The recovery path is api/session_recovery.py — at server startup and
-        # via /api/session/recover, sessions whose JSON has fewer messages than
-        # their .bak get restored automatically.
-        try:
-            if self.path.exists():
-                existing_text = self.path.read_text(encoding='utf-8')
-                try:
-                    existing = json.loads(existing_text)
-                    existing_msg_count = len(existing.get('messages') or [])
-                except (json.JSONDecodeError, ValueError):
-                    existing_msg_count = -1  # corrupt → always back up
-                incoming_msg_count = len(self.messages or [])
-                if (
-                    existing_msg_count > 0
-                    and incoming_msg_count == 0
-                    and (self.active_stream_id or self.pending_user_message)
-                ):
-                    logger.warning(
-                        "refusing to overwrite session %s messages with empty active/pending snapshot "
-                        "(existing=%s, incoming=%s, stream=%s)",
-                        self.session_id,
-                        existing_msg_count,
-                        incoming_msg_count,
-                        self.active_stream_id,
-                    )
-                    return
-                if existing_msg_count > incoming_msg_count:
-                    bak_path = self.path.with_suffix('.json.bak')
-                    # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,
-                    # mirroring the main save() pattern below. Prevents a
-                    # torn .bak from a crash mid-write or a concurrent
-                    # backup-producing save. Recovery defends against a
-                    # torn .bak (JSONDecodeError → no_action), so the
-                    # failure mode pre-fix was "backup is lost"; with
-                    # this fix the backup either lands cleanly or doesn't
-                    # land at all.
+        # ── #6422 per-session cross-process transaction ─────────────────
+        # The entire read-modify-write of the sidecar — backup safeguard,
+        # monotonic truncate-generation stamping, CAS fingerprint validation,
+        # (re-)merge, and the atomic replace — runs under ONE per-session
+        # cross-process lock.  This closes the final read-to-replace TOCTOU
+        # window the re-gate flagged: no other process can interleave a write
+        # between our validation read and our os.replace, and the /undo,
+        # /retry, /truncate, /clear handlers serialize against the streaming
+        # completion merge instead of racing it.
+        with _session_sidecar_cross_process_lock(self.session_id):
+            existing_text = None
+            existing = None
+            existing_msg_count = -1
+            try:
+                if self.path.exists():
+                    existing_text = self.path.read_text(encoding='utf-8')
                     try:
-                        bak_tmp = bak_path.with_suffix(
-                            f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
-                        )
-                        with open(bak_tmp, 'w', encoding='utf-8') as bf:
-                            bf.write(existing_text)
-                            bf.flush()
-                            os.fsync(bf.fileno())
-                        _safe_replace(bak_tmp, bak_path)
-                    except OSError:
-                        # Backup is best-effort; main save proceeds regardless.
-                        try:
-                            bak_tmp.unlink(missing_ok=True)
-                        except Exception:
-                            pass
-        except OSError:
-            pass
+                        existing = json.loads(existing_text)
+                        existing_msg_count = len(existing.get('messages') or [])
+                    except (json.JSONDecodeError, ValueError):
+                        existing_msg_count = -1  # corrupt → always back up
+            except OSError:
+                pass
 
-        # ── #6422 cross-process CAS guard ───────────────────────────────
-        # If _merge_concurrent_appends() was called before this save(),
-        # verify the file hasn't been modified by another process between
-        # the merge and the atomic write (TOCTOU window).  Re-read the
-        # on-disk state and compare fingerprint.  If it changed, re-merge
-        # and rebuild the payload with bounded retry (3 attempts).
-        _cas_fp = getattr(self, '_merge_snapshot_fingerprint', None)
-        if _cas_fp is not None:
-            for _cas_attempt in range(3):
-                try:
-                    _cas_text = self.path.read_text(encoding='utf-8')
-                except OSError:
-                    break  # File vanished — proceed, atomic write will create it.
-                _cur_fp = _fast_fingerprint(_cas_text)
-                if _cur_fp == _cas_fp:
-                    break  # File unchanged since merge — continue to write.
-                # File changed — re-merge against current state.
-                _orig_messages = list(self.messages or [])
-                self._merge_concurrent_appends()
-                _new_fp = getattr(self, '_merge_snapshot_fingerprint', None)
-                if _new_fp is None or _new_fp == _cur_fp:
-                    break  # Re-merge converged or had nothing to merge.
-                # Stalemate — another write happened during re-merge.
-                if _cas_attempt == 2:
-                    logger.warning(
-                        "Cross-process CAS retries exhausted for session %s "
-                        "(attempts=%d, fingerprint=%s); proceeding with best-effort merge",
-                        self.session_id, _cas_attempt + 1, _cur_fp,
-                    )
-            if _cas_fp != getattr(self, '_merge_snapshot_fingerprint', None):
-                # Messages changed during re-merge — rebuild payload.
-                meta['message_count'] = len(self.messages or [])
-                meta['messages'] = self.messages
+            # ── #6422 monotonic truncate/clear generation ───────────────
+            # A truncating save (flagged by truncate_session_at_keep /
+            # undo_last / retry_last) must stamp a generation STRICTLY greater
+            # than anything on disk, so even a stale-cache truncate can never
+            # regress the counter.  A plain save just carries the max forward
+            # (adopting generations stamped by other processes).  Rebuild the
+            # payload if the stamped value differs from what was serialized
+            # above.
+            existing_gen = int((existing or {}).get('truncate_generation') or 0)
+            if self._truncation_pending:
+                self.truncate_generation = max(int(self.truncate_generation or 0), existing_gen + 1)
+                self._truncation_pending = False
+            else:
+                self.truncate_generation = max(int(self.truncate_generation or 0), existing_gen)
+            if meta.get('truncate_generation') != self.truncate_generation:
+                meta['truncate_generation'] = self.truncate_generation
                 payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
 
-        tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
-        try:
-            with open(tmp, 'w', encoding='utf-8') as f:
-                f.write(payload)
-                f.flush()
-                os.fsync(f.fileno())
-            _safe_replace(tmp, self.path)
-        except Exception:
+            # ── #1558 backup safeguard ──────────────────────────────────
+            # Before overwriting the session file, copy the previous version
+            # to ``<sid>.json.bak`` IFF the previous file has more messages
+            # than the incoming payload. The asymmetric guard means:
+            #   * Normal grow-the-conversation saves never produce a backup
+            #     (incoming messages >= existing) — keeps disk overhead near
+            #     zero.
+            #   * Any save that would shrink the messages array (the failure
+            #     mode of #1558, plus anything similar in the future) leaves a
+            #     recoverable snapshot of the pre-shrink state on disk.
+            # The recovery path is api/session_recovery.py — at server startup
+            # and via /api/session/recover, sessions whose JSON has fewer
+            # messages than their .bak get restored automatically.
+            incoming_msg_count = len(self.messages or [])
+            if (
+                existing_msg_count > 0
+                and incoming_msg_count == 0
+                and (self.active_stream_id or self.pending_user_message)
+            ):
+                logger.warning(
+                    "refusing to overwrite session %s messages with empty active/pending snapshot "
+                    "(existing=%s, incoming=%s, stream=%s)",
+                    self.session_id,
+                    existing_msg_count,
+                    incoming_msg_count,
+                    self.active_stream_id,
+                )
+                return
+            if existing_text is not None and existing_msg_count > incoming_msg_count:
+                bak_path = self.path.with_suffix('.json.bak')
+                # SHOULD-FIX #2 (Opus): atomic write via tmp+replace,
+                # mirroring the main save() pattern below. Prevents a
+                # torn .bak from a crash mid-write or a concurrent
+                # backup-producing save. Recovery defends against a
+                # torn .bak (JSONDecodeError → no_action), so the
+                # failure mode pre-fix was "backup is lost"; with
+                # this fix the backup either lands cleanly or doesn't
+                # land at all.
+                try:
+                    bak_tmp = bak_path.with_suffix(
+                        f'.bak.tmp.{os.getpid()}.{threading.current_thread().ident}'
+                    )
+                    with open(bak_tmp, 'w', encoding='utf-8') as bf:
+                        bf.write(existing_text)
+                        bf.flush()
+                        os.fsync(bf.fileno())
+                    _safe_replace(bak_tmp, bak_path)
+                except OSError:
+                    # Backup is best-effort; main save proceeds regardless.
+                    try:
+                        bak_tmp.unlink(missing_ok=True)
+                    except Exception:
+                        pass
+
+            # ── #6422 cross-process CAS guard ───────────────────────────
+            # If _merge_concurrent_appends() was called before this save(),
+            # verify the file hasn't been modified by another process between
+            # the merge and the atomic write (TOCTOU window).  Re-read the
+            # on-disk state and compare fingerprint.  If it changed, re-merge
+            # (locked variant — we already hold the per-session lock) and
+            # rebuild the payload with bounded retry (3 attempts).
+            _cas_fp = getattr(self, '_merge_snapshot_fingerprint', None)
+            if _cas_fp is not None:
+                for _cas_attempt in range(3):
+                    try:
+                        _cas_text = self.path.read_text(encoding='utf-8')
+                    except OSError:
+                        break  # File vanished — proceed, atomic write will create it.
+                    _cur_fp = _fast_fingerprint(_cas_text)
+                    if _cur_fp == _cas_fp:
+                        break  # File unchanged since merge — continue to write.
+                    # File changed — re-merge against current state.
+                    self._merge_concurrent_appends_locked()
+                    _new_fp = getattr(self, '_merge_snapshot_fingerprint', None)
+                    if _new_fp is None or _new_fp == _cur_fp:
+                        break  # Re-merge converged or had nothing to merge.
+                    # Stalemate — another write happened during re-merge.
+                    if _cas_attempt == 2:
+                        logger.warning(
+                            "Cross-process CAS retries exhausted for session %s "
+                            "(attempts=%d, fingerprint=%s); proceeding with best-effort merge",
+                            self.session_id, _cas_attempt + 1, _cur_fp,
+                        )
+                if _cas_fp != getattr(self, '_merge_snapshot_fingerprint', None):
+                    # Messages (or adopted generation) changed during re-merge —
+                    # rebuild payload.
+                    meta['message_count'] = len(self.messages or [])
+                    meta['messages'] = self.messages
+                    meta['truncate_generation'] = self.truncate_generation
+                    payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+
+            tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
             try:
-                tmp.unlink(missing_ok=True)
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    f.write(payload)
+                    f.flush()
+                    os.fsync(f.fileno())
+                _safe_replace(tmp, self.path)
             except Exception:
-                pass
-            raise
+                try:
+                    tmp.unlink(missing_ok=True)
+                except Exception:
+                    pass
+                raise
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1696,6 +1858,11 @@ class Session:
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
+        # #6422: remember the truncate/clear generation this object loaded
+        # with, so _merge_concurrent_appends_locked() can tell an intentional
+        # truncation (disk generation newer than this) from a plain pre-turn
+        # checkpoint (same generation, just shorter).
+        session._loaded_truncate_generation = int(session.truncate_generation or 0)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching

--- a/api/models.py
+++ b/api/models.py
@@ -182,6 +182,19 @@ def _safe_replace(src: Path, dst: Path) -> None:
             delay *= 2  # 50 -> 100 -> 200 -> 400 -> 800 ms
 
 
+class SidecarLockError(RuntimeError):
+    """Raised when the per-session cross-process sidecar lock cannot be
+    established (lock-file open failure, OS lock acquisition failure, or no
+    lock primitive available on this platform).
+
+    PR #6422 re-gate (2026-08-06 review): every lock branch FAILS CLOSED.
+    ``Session.save()`` and ``api.session_recovery.recover_session()`` must
+    stop without publication when cross-process serialization cannot be
+    established — a best-effort unlocked write could interleave with another
+    process and lose a concurrent append.
+    """
+
+
 @contextmanager
 def _session_sidecar_cross_process_lock(sid: str):
     """Serialize read-merge-validate-replace of ONE session sidecar across processes.
@@ -198,8 +211,9 @@ def _session_sidecar_cross_process_lock(sid: str):
     ``msvcrt.locking`` (mirroring ``_cleanup_manifest_process_lock``).  The lock
     file is kept in place permanently — unlinking it while another process is
     waiting can split later callers across different inodes and defeat the
-    lock.  If neither primitive exists (exotic platform), degrade to a no-op
-    rather than block every save.
+    lock.  If neither primitive exists (exotic platform), raise
+    ``SidecarLockError`` rather than degrade to an unlocked write: save and
+    recovery must FAIL CLOSED when serialization cannot be established.
     """
     if not is_safe_session_id(sid):
         yield
@@ -208,10 +222,12 @@ def _session_sidecar_cross_process_lock(sid: str):
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-    except OSError:
-        logger.debug("sidecar lock open failed for %s", sid, exc_info=True)
-        yield
-        return
+    except OSError as exc:
+        # Re-gate 2026-08-06: fail CLOSED — an unlocked save can clobber a
+        # concurrent append from another process.
+        raise SidecarLockError(
+            f"sidecar lock open failed for session {sid}: {exc}"
+        ) from exc
     with os.fdopen(fd, 'r+b', buffering=0) as lock_file:
         if _fcntl is not None:
             _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX)
@@ -228,10 +244,12 @@ def _session_sidecar_cross_process_lock(sid: str):
                 _msvcrt.locking(  # type: ignore[attr-defined]
                     lock_file.fileno(), _msvcrt.LK_LOCK, 1  # type: ignore[attr-defined]
                 )
-            except OSError:
-                logger.debug("sidecar msvcrt lock failed for %s", sid, exc_info=True)
-                yield
-                return
+            except OSError as exc:
+                # Fail CLOSED (re-gate 2026-08-06): the lock could not be
+                # acquired — never continue unlocked.
+                raise SidecarLockError(
+                    f"sidecar msvcrt lock failed for session {sid}: {exc}"
+                ) from exc
             try:
                 yield
             finally:
@@ -243,9 +261,12 @@ def _session_sidecar_cross_process_lock(sid: str):
                 except OSError:
                     logger.debug("sidecar msvcrt unlock failed for %s", sid, exc_info=True)
             return
-        # No cross-process primitive available: best-effort no-op.
-        logger.debug("cross-process sidecar locking unavailable for %s", sid)
-        yield
+        # No cross-process primitive available: fail CLOSED instead of
+        # degrading to an unlocked write (re-gate 2026-08-06).
+        raise SidecarLockError(
+            f"no cross-process lock primitive available for session {sid}; "
+            f"refusing to write without cross-process serialization"
+        )
 
 
 
@@ -1258,6 +1279,99 @@ def model_explicit_pick_signature(model, model_provider) -> str:
     return f"{_m}\x1f{_p}"
 
 
+def _merge_concurrent_message_arrays(disk_msgs, our_msgs, allow_zero_prefix_merge: bool = False):
+    """Merge two sibling message arrays that diverge only by concurrent appends.
+
+    Used for BOTH the display transcript (``messages``) and the model-context
+    array (``context_messages``) so a plain concurrent append can never
+    discard the other writer's rows in either array (PR #6422 re-gate
+    2026-08-06 finding #2).
+
+    Finds the longest prefix where every position matches, using the durable
+    ``uuid`` lineage first (minted once at row creation by
+    ``_assign_stable_message_ids``), then ``id``/``role``+``content`` as
+    fallback for legacy rows.  Returns the merged list:
+
+    * common prefix preserved;
+    * rows another writer appended beyond the prefix (``disk_tail``) are
+      inserted BEFORE our own tail;
+    * our rows always survive.
+
+    ``allow_zero_prefix_merge`` permits the one valid zero-prefix shape: two
+    first turns appended from the same EMPTY base (absent sidecar or an empty
+    one).  A divergent NON-empty base is corruption — keep our rows unchanged
+    rather than concatenate unrelated transcripts.
+    """
+    disk_msgs = list(disk_msgs or [])
+    our_msgs = list(our_msgs or [])
+    if not disk_msgs or not our_msgs:
+        return list(our_msgs) if our_msgs else list(disk_msgs)
+
+    # Find the longest prefix where every position matches.  When both rows
+    # carry the durable ``uuid`` lineage (minted once at row creation),
+    # compare THAT: ``_assign_stable_message_ids()`` uses
+    # ``max(existing id) + 1``, so two clients loaded from the same base can
+    # assign the same next integer id to different messages — equal ids, even
+    # with identical content, are NOT proof the rows are the same.  Rows
+    # without a uuid (legacy writers) fall back to id-then-content.
+    prefix_len = 0
+    min_len = min(len(disk_msgs), len(our_msgs))
+    for i in range(min_len):
+        our_msg = our_msgs[i]
+        disk_msg = disk_msgs[i]
+        if not isinstance(our_msg, dict) or not isinstance(disk_msg, dict):
+            break
+        our_uuid = our_msg.get('uuid')
+        disk_uuid = disk_msg.get('uuid')
+        if our_uuid is not None and disk_uuid is not None:
+            if our_uuid != disk_uuid:
+                # Distinct rows — divergence, even on equal id/content.
+                break
+            # Same uuid = same logical row; content differences are
+            # partial-update artifacts of a shared row, keep matching.
+        else:
+            our_id = our_msg.get('id')
+            disk_id = disk_msg.get('id')
+            if our_id is not None and disk_id is not None:
+                if our_id != disk_id:
+                    break
+                # Equal N+1 integer ids with different content = two
+                # distinct concurrent appends — treat as a divergence.
+                if (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
+                    break
+            elif (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
+                break
+        prefix_len += 1
+
+    if prefix_len == 0:
+        # No shared prefix.  Valid ONLY when our base was empty (two first
+        # turns from a brand-new session): every disk row is a concurrent
+        # append from the same empty base, so concatenate disk rows first,
+        # then ours.  A divergent NON-empty base is corruption — bail
+        # rather than concatenate unrelated transcripts.
+        if allow_zero_prefix_merge:
+            return list(disk_msgs) + list(our_msgs)
+        return list(our_msgs)
+
+    # Rows on disk beyond the common prefix.
+    disk_tail = disk_msgs[prefix_len:]
+    if not disk_tail:
+        # Disk has nothing we don't already have.  A shorter on-disk array at
+        # the SAME generation is a pre-turn checkpoint (or stale copy), NOT a
+        # truncation — keep our completed rows.
+        return list(our_msgs)
+
+    # Case 1: our rows are a prefix of disk (append race).
+    if prefix_len == len(our_msgs):
+        return list(our_msgs) + list(disk_tail)
+
+    # Case 2: divergent tails (concurrent equal-length append, or disk
+    # shorter at the same generation with a divergent boundary).
+    # Merge: keep the common prefix, insert disk's extras, then our extras.
+    our_tail = our_msgs[prefix_len:]
+    return list(our_msgs[:prefix_len]) + list(disk_tail) + list(our_tail)
+
+
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
                  workspace=str(DEFAULT_WORKSPACE), created_workspace=None,
@@ -1450,9 +1564,12 @@ class Session:
         # an EMPTY base (loaded with zero rows): when disk and our transcript
         # share no prefix but our base was empty, every disk row is a
         # concurrent append from the same empty base and is merged by
-        # concatenation instead of bailing.  None = never loaded (fresh
-        # construction) — full divergence then stays a bail-to-safe case.
-        self._loaded_message_count = None
+        # concatenation instead of bailing.  Default is 0, NOT None: a freshly
+        # constructed session (never loaded) has an ABSENT sidecar, which is a
+        # VALID empty base — two first turns from a brand-new chat must both
+        # survive instead of the second save clobbering the first (re-gate
+        # 2026-08-06 finding #1: the absent-sidecar schedule).
+        self._loaded_message_count = 0
         # #6422: set by the truncation entry points (truncate_session_at_keep,
         # undo_last, retry_last) so save() can stamp a generation strictly
         # greater than anything on disk even when this object is a stale cache
@@ -1570,97 +1687,36 @@ class Session:
             # active for both shapes.
             return
 
-        # Find the longest prefix where every position matches.  When both
-        # rows carry the durable ``uuid`` lineage (minted once at row
-        # creation), compare THAT: ``_assign_stable_message_ids()`` uses
-        # ``max(existing id) + 1``, so two clients loaded from the same base
-        # can assign the same next integer id to different messages — equal
-        # ids, even with identical content, are NOT proof the rows are the
-        # same.  Rows without a uuid (legacy writers) fall back to the
-        # id-then-content comparison.
-        prefix_len = 0
-        min_len = min(len(existing_msgs), len(our_msgs))
-        for i in range(min_len):
-            our_msg = our_msgs[i]
-            disk_msg = existing_msgs[i]
-            if not isinstance(our_msg, dict) or not isinstance(disk_msg, dict):
-                break
-            our_uuid = our_msg.get('uuid')
-            disk_uuid = disk_msg.get('uuid')
-            if our_uuid is not None and disk_uuid is not None:
-                if our_uuid != disk_uuid:
-                    # Distinct rows — divergence, even on equal id/content.
-                    break
-                # Same uuid = same logical row; content differences are
-                # partial-update artifacts of a shared row, keep matching.
-            else:
-                our_id = our_msg.get('id')
-                disk_id = disk_msg.get('id')
-                if our_id is not None and disk_id is not None:
-                    if our_id != disk_id:
-                        break
-                    # Equal N+1 integer ids with different content = two
-                    # distinct concurrent appends — treat as a divergence.
-                    if (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
-                        break
-                elif (our_msg.get('role'), our_msg.get('content')) != (disk_msg.get('role'), disk_msg.get('content')):
-                    break
-            prefix_len += 1
-
-        if prefix_len == 0:
-            # No shared prefix.  Valid ONLY when our base was empty (two first
-            # turns from a brand-new session): every disk row is a concurrent
-            # append from the same empty base, so concatenate disk rows first,
-            # then ours.  A divergent NON-empty base is corruption — bail
-            # rather than concatenate unrelated transcripts.
-            loaded_count = getattr(self, '_loaded_message_count', None)
-            if loaded_count == 0:
-                self.messages = list(existing_msgs) + list(our_msgs)
-            return
-
-        # Messages on disk beyond the common prefix.
-        disk_tail = existing_msgs[prefix_len:]
-        if not disk_tail:
-            # Disk has nothing we don't already have.  A shorter on-disk
-            # transcript at the SAME generation is a pre-turn checkpoint (or
-            # stale copy), NOT a truncation — keep our completed transcript.
-            # The base identity recorded above keeps save()'s CAS re-validation
-            # active for this zero-tail shape (re-gate finding #1).
-            return
-
-        # Case 1: our messages are a prefix of disk (append race).
-        if prefix_len == len(our_msgs):
-            self.messages = list(our_msgs) + list(disk_tail)
-            return
-
-        # Case 2: divergent tails (concurrent equal-length append, or disk
-        # shorter at the same generation with a divergent boundary).
-        # Merge: keep the common prefix, insert disk's extras, then our extras.
-        our_tail = our_msgs[prefix_len:]
-        self.messages = list(our_msgs[:prefix_len]) + list(disk_tail) + list(our_tail)
-
-    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
-        if not is_safe_session_id(self.session_id):
-            raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
-        # ── #1558 P0 guard ──────────────────────────────────────────────
-        # Refuse to save a session that was loaded with metadata_only=True.
-        # Such sessions have messages=[] (it's the whole point of the partial
-        # load), and save() unconditionally writes self.messages to disk via
-        # an atomic os.replace(). Saving a metadata-only stub thus wipes the
-        # full conversation history — which is exactly the v0.50.279
-        # _clear_stale_stream_state() regression that lost users 1000+
-        # message conversations. Any caller that needs to mutate persisted
-        # fields on a metadata-only session must reload with
-        # metadata_only=False first.
-        if getattr(self, '_loaded_metadata_only', False):
-            raise RuntimeError(
-                f"Refusing to save metadata-only session {self.session_id!r}: "
-                f"would atomically overwrite on-disk messages with []. "
-                f"Reload with metadata_only=False before mutating state. "
-                f"See #1558."
+        # Reconcile BOTH the display transcript (``messages``) and the
+        # model-context array (``context_messages``) against concurrent
+        # appends (re-gate 2026-08-06 finding #2: plain concurrent
+        # ``context_messages`` were previously discarded — the merge only
+        # reconciled ``self.messages``, so the losing writer's context rows
+        # were dropped from the durable reload while its display rows were
+        # kept, persisting a transcript the UI shows but the next model turn
+        # would not receive).
+        allow_zero = (int(getattr(self, '_loaded_message_count', 0) or 0) == 0)
+        self.messages = _merge_concurrent_message_arrays(
+            existing_msgs, our_msgs, allow_zero_prefix_merge=allow_zero
+        )
+        existing_ctx = existing.get('context_messages') or []
+        our_ctx = self.context_messages or []
+        if existing_ctx and our_ctx:
+            self.context_messages = _merge_concurrent_message_arrays(
+                existing_ctx, our_ctx, allow_zero_prefix_merge=allow_zero
             )
-        if touch_updated_at:
-            self.updated_at = time.time()
+
+    def _sidecar_payload(self) -> str:
+        """Serialize the COMPLETE sidecar payload from the current in-memory state.
+
+        Called INSIDE the per-session cross-process lock, AFTER the
+        truncate-generation decision and any CAS re-merge, so the bytes that
+        hit disk always reflect the authoritative in-lock state — including
+        display rows and ``context_messages`` adopted from a concurrent writer
+        (re-gate 2026-08-06 finding #2: the previous pre-lock build retained a
+        stale ``extra['context_messages']`` after a CAS movement, so the UI
+        transcript and the next model turn's context could diverge).
+        """
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -1710,23 +1766,50 @@ class Session:
         meta['messages'] = self.messages
         meta['tool_calls'] = self.tool_calls
         meta['anchor_activity_scenes'] = self.anchor_activity_scenes if isinstance(self.anchor_activity_scenes, dict) else {}
-        # Fields not in METADATA_FIELDS (e.g. last_usage) go at the end. Exclude
-        # the keys we placed explicitly above so they aren't emitted twice.
+        # Fields not in METADATA_FIELDS (e.g. last_usage, context_messages)
+        # go at the end. Exclude the keys we placed explicitly above so they
+        # aren't emitted twice.
         _placed = {'message_count', 'anchor_scene_index', 'messages', 'tool_calls', 'anchor_activity_scenes'}
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        return json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
 
+    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+        if not is_safe_session_id(self.session_id):
+            raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
+        # ── #1558 P0 guard ──────────────────────────────────────────────
+        # Refuse to save a session that was loaded with metadata_only=True.
+        # Such sessions have messages=[] (it's the whole point of the partial
+        # load), and save() unconditionally writes self.messages to disk via
+        # an atomic os.replace(). Saving a metadata-only stub thus wipes the
+        # full conversation history — which is exactly the v0.50.279
+        # _clear_stale_stream_state() regression that lost users 1000+
+        # message conversations. Any caller that needs to mutate persisted
+        # fields on a metadata-only session must reload with
+        # metadata_only=False first.
+        if getattr(self, '_loaded_metadata_only', False):
+            raise RuntimeError(
+                f"Refusing to save metadata-only session {self.session_id!r}: "
+                f"would atomically overwrite on-disk messages with []. "
+                f"Reload with metadata_only=False before mutating state. "
+                f"See #1558."
+            )
+        if touch_updated_at:
+            self.updated_at = time.time()
         # ── #6422 per-session cross-process transaction ─────────────────
-        # The entire read-modify-write of the sidecar — backup safeguard,
+        # The ENTIRE read-modify-write of the sidecar — authoritative read,
         # monotonic truncate-generation stamping, CAS fingerprint validation,
-        # (re-)merge, and the atomic replace — runs under ONE per-session
-        # cross-process lock.  This closes the final read-to-replace TOCTOU
-        # window the re-gate flagged: no other process can interleave a write
-        # between our validation read and our os.replace, and the /undo,
-        # /retry, /truncate, /clear handlers serialize against the streaming
-        # completion merge instead of racing it.
+        # (re-)merge of BOTH messages and context_messages, the full payload
+        # build from the in-lock state, and the atomic replace — runs under
+        # ONE per-session cross-process lock.  This closes the final
+        # read-to-replace TOCTOU window the re-gate flagged: no other process
+        # can interleave a write between our validation read and our
+        # os.replace, and the /undo, /retry, /truncate, /clear handlers
+        # serialize against the streaming completion merge instead of racing
+        # it.  The payload is serialized ONLY here, from the post-merge
+        # in-lock state, so a CAS movement that adopted another writer's rows
+        # is always fully reflected on disk (re-gate 2026-08-06 finding #2).
         with _session_sidecar_cross_process_lock(self.session_id):
             existing_text = None
             existing = None
@@ -1747,9 +1830,9 @@ class Session:
             # undo_last / retry_last) must stamp a generation STRICTLY greater
             # than anything on disk, so even a stale-cache truncate can never
             # regress the counter.  A plain save just carries the max forward
-            # (adopting generations stamped by other processes).  Rebuild the
-            # payload if the stamped value differs from what was serialized
-            # above.
+            # (adopting generations stamped by other processes).  The payload
+            # is serialized below, AFTER this decision and the CAS re-merge,
+            # so it always carries the final generation.
             existing_gen = int((existing or {}).get('truncate_generation') or 0)
             if self._truncation_pending:
                 self.truncate_generation = max(int(self.truncate_generation or 0), existing_gen + 1)
@@ -1760,9 +1843,6 @@ class Session:
                 # save to a plain (non-truncating) one (re-gate finding #2).
             else:
                 self.truncate_generation = max(int(self.truncate_generation or 0), existing_gen)
-            if meta.get('truncate_generation') != self.truncate_generation:
-                meta['truncate_generation'] = self.truncate_generation
-                payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
 
             # ── #1558 backup safeguard ──────────────────────────────────
             # Before overwriting the session file, copy the previous version

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -930,6 +930,13 @@ def truncate_session_at_keep(session, keep: int) -> tuple[int, int]:
         )
     session.truncation_watermark = _truncation_watermark_for(session.messages)
     session.truncation_boundary = session.truncation_watermark
+    # #6422: bump the authoritative monotonic truncate/clear generation so the
+    # cross-client merge can recognize THIS truncation (instead of inferring
+    # truncation from row counts, which would misclassify the streaming
+    # pre-turn checkpoint). save() stamps a value strictly greater than
+    # anything on disk.
+    session.truncate_generation = int(getattr(session, 'truncate_generation', None) or 0) + 1
+    session._truncation_pending = True
     return old_msg_count, old_ctx_count
 
 
@@ -986,6 +993,10 @@ def retry_last(session_id: str) -> dict[str, Any]:
             # Persist the original truncate cutoff so empty-sidecar recovery
             # can distinguish legitimate prefix from deleted suffix.
             s.truncation_boundary = s.truncation_watermark
+            # #6422: bump the monotonic truncate generation (see
+            # truncate_session_at_keep for rationale).
+            s.truncate_generation = int(getattr(s, 'truncate_generation', None) or 0) + 1
+            s._truncation_pending = True
             if isinstance(getattr(s, 'context_messages', None), list) and s.context_messages:
                 truncated_context = _truncate_at_last_user(s.context_messages)
                 if truncated_context is not None:
@@ -1029,6 +1040,10 @@ def undo_last(session_id: str) -> dict[str, Any]:
             s.truncation_watermark = _truncation_watermark_for(s.messages)
             # Persist the original truncate cutoff.
             s.truncation_boundary = s.truncation_watermark
+            # #6422: bump the monotonic truncate generation (see
+            # truncate_session_at_keep for rationale).
+            s.truncate_generation = int(getattr(s, 'truncate_generation', None) or 0) + 1
+            s._truncation_pending = True
             if isinstance(getattr(s, 'context_messages', None), list) and s.context_messages:
                 truncated_context = _truncate_at_last_user(s.context_messages)
                 if truncated_context is not None:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -85,6 +85,25 @@ def _msg_count(p: Path) -> int:
     return len(msgs) if isinstance(msgs, list) else -1
 
 
+def _sidecar_truncate_generation(p: Path) -> int:
+    """Return the monotonic ``truncate_generation`` of a session JSON file.
+
+    Returns -1 for any unreadable/non-session-shape file so a corrupt live
+    sidecar is never treated as an intentional truncation (recovery then
+    still recommends restoring the backup).
+    """
+    try:
+        data = json.loads(p.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return -1
+    if not isinstance(data, dict):
+        return -1
+    try:
+        return int(data.get('truncate_generation') or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _rebuild_recovery_session_index(session_dir: Path) -> None:
     """Rebuild ``session_dir/_index.json`` from persisted sidecars only.
 
@@ -354,6 +373,23 @@ def inspect_session_recovery_status(session_path: Path) -> dict:
         }
     bak_count = _msg_count(bak_path)
     if bak_count > live_count:
+        # #6422 re-gate: a backup that predates an intentional truncation
+        # carries a strictly LOWER ``truncate_generation`` than the live
+        # sidecar.  Restoring it would move the monotonic generation backward
+        # and resurrect rows the user deleted via /truncate, /retry, /undo, or
+        # /clear — forbid that regardless of message counts.  Message-count
+        # heuristics alone cannot tell an intentional shrink from #1558 data
+        # loss; the generation is the authoritative signal.
+        live_gen = _sidecar_truncate_generation(session_path)
+        bak_gen = _sidecar_truncate_generation(bak_path)
+        if live_gen > bak_gen:
+            return {
+                "session_id": session_path.stem,
+                "live_messages": live_count,
+                "bak_messages": bak_count,
+                "recommend": "no_action",
+                "newer_truncate_generation": True,
+            }
         if (
             _session_records_clear_sentinel(session_path, bak_path)
             or _live_supersedes_backup_by_clear_generation(session_path, bak_path)
@@ -403,24 +439,38 @@ def recover_session(session_path: Path) -> dict:
 
     Returns a status dict identical to ``inspect_session_recovery_status``
     plus a "restored" boolean.
+
+    #6422 re-gate: the whole read-decide-copy-replace runs under the SAME
+    per-session cross-process lock as ``Session.save()``, so a concurrent
+    writer can no longer interleave between the recommendation decision and
+    the atomic replace, and the backup's ``truncate_generation`` is
+    re-verified inside the lock — an intentional truncation (newer live
+    generation) is never rolled back by recovery or by any direct sidecar
+    replacer.
     """
-    status = inspect_session_recovery_status(session_path)
-    if status["recommend"] != "restore":
-        return {**status, "restored": False}
-    bak_path = session_path.with_suffix('.json.bak')
-    # Stage the recovery via a tmp copy + atomic replace so a crash mid-restore
-    # cannot leave a half-written session.json.
-    tmp_path = session_path.with_suffix('.json.recover.tmp')
-    try:
-        shutil.copyfile(bak_path, tmp_path)
-        tmp_path.replace(session_path)
-    except OSError as exc:
-        logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
+    # Lazy import to avoid a module-level cycle (api.models imports
+    # api.session_recovery lazily itself).
+    from api.models import _session_sidecar_cross_process_lock
+
+    sid = session_path.stem
+    with _session_sidecar_cross_process_lock(sid):
+        status = inspect_session_recovery_status(session_path)
+        if status["recommend"] != "restore":
+            return {**status, "restored": False}
+        bak_path = session_path.with_suffix('.json.bak')
+        # Stage the recovery via a tmp copy + atomic replace so a crash
+        # mid-restore cannot leave a half-written session.json.
+        tmp_path = session_path.with_suffix('.json.recover.tmp')
         try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        return {**status, "restored": False, "error": str(exc)}
+            shutil.copyfile(bak_path, tmp_path)
+            tmp_path.replace(session_path)
+        except OSError as exc:
+            logger.warning("recover_session: copy failed for %s: %s", session_path, exc)
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return {**status, "restored": False, "error": str(exc)}
     logger.warning(
         "recover_session: restored %s from .bak (live=%d → bak=%d messages). "
         "See #1558 for the data-loss class this guards against.",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2428,6 +2428,9 @@ def _finalize_cancelled_turn(
         return
     _persist_cancelled_turn(session, message=message)
     try:
+        # #6422 re-gate 2026-08-24: cancelled-turn finalization appends a
+        # terminal marker — establish append intent before persisting.
+        session._merge_concurrent_appends()
         session.save()
     except Exception:
         logger.debug("Failed to persist cancelled turn", exc_info=True)
@@ -5680,17 +5683,20 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
                     seed = mid
     stamped = 0
     for m in result_messages:
-        if isinstance(m, dict) and m.get('id') is None:
+        if not isinstance(m, dict):
+            continue
+        if m.get('id') is None:
             seed += 1
             m['id'] = seed
-            # #6422: durable, collision-safe row lineage.  The integer id is
-            # ``max(existing id) + 1``, so two clients loaded from the same
-            # base can mint the SAME id for different rows; the uuid is minted
-            # once at row creation and persisted, giving the cross-client
-            # merge an authoritative identity that can never collide across
-            # processes (even for identical content).
-            if m.get('uuid') is None:
-                m['uuid'] = uuid.uuid4().hex
+        # #6422 re-gate 2026-08-24: mint durable uuid lineage for EVERY row
+        # that lacks it — including genuinely new rows whose integer id was
+        # supplied by the provider.  Previously the uuid was only minted when
+        # the integer id was absent, so a provider-supplied integer id left
+        # the row without cross-writer lineage, and two clients loaded from
+        # the same base could mint the SAME integer id for different rows
+        # while neither carried a uuid the merge could disambiguate.
+        if m.get('uuid') is None:
+            m['uuid'] = uuid.uuid4().hex
             stamped += 1
     return stamped
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11860,6 +11860,8 @@ def _run_agent_streaming(
                         logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                     put('cancel', _cancel_event_payload('Cancelled by user'))
                     return
+                with _agent_lock:
+                    s._merge_concurrent_appends()
                 with _stream_writeback_stage(_writeback_timings, "session_save"):
                     s.save()
                 if cancel_event.is_set():

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -11860,8 +11860,14 @@ def _run_agent_streaming(
                         logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                     put('cancel', _cancel_event_payload('Cancelled by user'))
                     return
-                with _agent_lock:
-                    s._merge_concurrent_appends()
+                # ── #6422 cross-client append merge ───────────────────────
+                # Read the on-disk message list and merge any rows a *different*
+                # process/thread appended since we loaded this session.  Safe
+                # here because the caller KNOWS it is appending new messages
+                # (streaming completion), so any extra rows on disk belong in
+                # the transcript.  The outer with _agent_lock: (line ~9145)
+                # serializes this against concurrent process-local writers.
+                s._merge_concurrent_appends()
                 with _stream_writeback_stage(_writeback_timings, "session_save"):
                     s.save()
                 if cancel_event.is_set():

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -20,6 +20,7 @@ import subprocess
 import threading
 import time
 import traceback
+import uuid
 import copy
 import inspect
 from pathlib import Path
@@ -5682,6 +5683,14 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
         if isinstance(m, dict) and m.get('id') is None:
             seed += 1
             m['id'] = seed
+            # #6422: durable, collision-safe row lineage.  The integer id is
+            # ``max(existing id) + 1``, so two clients loaded from the same
+            # base can mint the SAME id for different rows; the uuid is minted
+            # once at row creation and persisted, giving the cross-client
+            # merge an authoritative identity that can never collide across
+            # processes (even for identical content).
+            if m.get('uuid') is None:
+                m['uuid'] = uuid.uuid4().hex
             stamped += 1
     return stamped
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2436,6 +2436,40 @@ def _finalize_cancelled_turn(
         logger.debug("Failed to persist cancelled turn", exc_info=True)
 
 
+def _persist_with_append_intent(session):
+    """Persist a transcript mutation that APPENDS rows, with append intent.
+
+    #6422 re-gate 2026-08-25: every production writer that GROWS
+    ``session.messages`` (settled synchronous turns, terminal error rows,
+    cancel writebacks) must establish cross-process append intent before
+    saving — otherwise a row another client appended since this object was
+    loaded would be overwritten by the plain save (the same lost-update shape
+    the gateway/normal streaming paths already fixed).  The advisory pre-pass
+    records the on-disk base identity; ``save()`` re-validates it under the
+    per-session cross-process lock and re-merges if the file moved.
+    """
+    session._merge_concurrent_appends()
+    session.save()
+
+
+def _append_and_persist_terminal_error(session, error_message):
+    """Append a terminal error/interruption row and persist it with append
+    intent.
+
+    #6422 re-gate 2026-08-25: result-classified terminal errors and the outer
+    exception settlement in ``_run_agent_streaming`` are APPEND producers —
+    they grow the transcript with the error row, so they route through
+    ``_persist_with_append_intent()`` like every other terminal writer.  The
+    swallow-and-continue contract is preserved: a persistence failure must
+    never mask the error payload delivery (``put('apperror', ...)``).
+    """
+    session.messages.append(error_message)
+    try:
+        _persist_with_append_intent(session)
+    except Exception:
+        pass
+
+
 def _aiagent_import_error_detail() -> str:
     """Return a multi-line diagnostic string for the "AIAgent not available" path.
 
@@ -5668,7 +5702,9 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
     stays internally consistent. Rows whose historical id was carried forward by
     ``_restore_reasoning_metadata`` keep it; only genuinely new rows are minted.
 
-    Returns the number of rows newly stamped. Mutates ``result_messages`` in place.
+    Returns the number of rows whose stable INTEGER ``id`` was newly assigned.
+    UUID lineage minting (below) is a side effect and never counts toward the
+    return. Mutates ``result_messages`` in place.
     """
     if not result_messages:
         return 0
@@ -5688,6 +5724,7 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
         if m.get('id') is None:
             seed += 1
             m['id'] = seed
+            stamped += 1
         # #6422 re-gate 2026-08-24: mint durable uuid lineage for EVERY row
         # that lacks it — including genuinely new rows whose integer id was
         # supplied by the provider.  Previously the uuid was only minted when
@@ -5695,9 +5732,16 @@ def _assign_stable_message_ids(result_messages, *existing_arrays):
         # the row without cross-writer lineage, and two clients loaded from
         # the same base could mint the SAME integer id for different rows
         # while neither carried a uuid the merge could disambiguate.
+        #
+        # #6422 re-gate 2026-08-25: uuid minting does NOT contribute to the
+        # returned count — the documented contract counts rows whose stable
+        # INTEGER id was newly assigned.  A row that already carried an
+        # integer id (provider-supplied or previously minted) is not a
+        # newly-stamped row even when it just received a uuid; counting it
+        # broke the existing contract
+        # (test_assign_stable_ids_seeds_from_existing_max_and_skips_present).
         if m.get('uuid') is None:
             m['uuid'] = uuid.uuid4().hex
-            stamped += 1
     return stamped
 
 
@@ -11426,11 +11470,10 @@ def _run_agent_streaming(
                             _error_message['provider_details_label'] = 'Interruption details'
                         elif _err_type == 'tool_limit_reached':
                             _error_message['provider_details_label'] = 'Terminal state details'
-                        s.messages.append(_error_message)
-                        try:
-                            s.save()
-                        except Exception:
-                            pass
+                        # #6422 re-gate 2026-08-25: result-classified terminal
+                        # error settlement is an APPEND producer — persist the
+                        # error row with cross-process append intent.
+                        _append_and_persist_terminal_error(s, _error_message)
                         _error_payload['session'] = redact_session_data(
                             _session_payload_with_full_messages(s, tool_calls=s.tool_calls)
                         )
@@ -12612,7 +12655,12 @@ def _run_agent_streaming(
                                     s.pending_attachments = []
                                     s.pending_started_at = None
                                     s.pending_user_source = None
-                                    s.save()
+                                    # #6422 re-gate 2026-08-25: the synchronous
+                                    # credential self-heal success settles the
+                                    # turn's rows into the transcript — an
+                                    # APPEND producer that must persist with
+                                    # cross-process append intent.
+                                    _persist_with_append_intent(s)
                                     _done_session_payload = redact_session_data(
                                         _session_payload_with_full_messages(
                                             s, tool_calls=s.tool_calls
@@ -12765,11 +12813,10 @@ def _run_agent_streaming(
                     _error_message['provider_details_label'] = 'Cancellation details'
                 elif _exc_type == 'interrupted':
                     _error_message['provider_details_label'] = 'Interruption details'
-                s.messages.append(_error_message)
-                try:
-                    s.save()
-                except Exception:
-                    pass
+                # #6422 re-gate 2026-08-25: outer exception settlement is an
+                # APPEND producer — persist the error row with cross-process
+                # append intent.
+                _append_and_persist_terminal_error(s, _error_message)
                 if not ephemeral:
                     try:
                         append_turn_journal_event_for_stream(
@@ -13391,7 +13438,10 @@ def cancel_stream(stream_id: str) -> bool:
                         'provider_details_label': 'Cancellation details',
                         'timestamp': int(time.time()),
                     })
-                _cs.save()
+                # #6422 re-gate 2026-08-25: the cancel writeback appends the
+                # partial + cancel-marker rows — an APPEND producer that must
+                # establish cross-process append intent before persisting.
+                _persist_with_append_intent(_cs)
                 _cancel_session_payload = _redacted_session_payload_with_full_messages(_cs)
             except Exception:
                 logger.debug("Failed to clear session state on cancel for %s", _cancel_session_id)

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -863,3 +863,130 @@ class TestIssue765FollowupHardening:
 
         with SESSION_AGENT_LOCKS_LOCK:
             SESSION_AGENT_LOCKS.pop(new_sid, None)
+
+
+class TestCrossClientDesyncMerge:
+    """Regression tests for cross-client desync merge (PR #6422 / #6299).
+
+    The merge logic in ``Session._merge_concurrent_appends()`` must:
+      1. Merge extra messages from disk when another client appended concurrently
+      2. NOT resurrect messages that ``/undo`` or ``/retry`` intentionally deleted
+      3. Handle the equal-length case where both clients appended one message
+    """
+
+    def test_merge_concurrent_appends(self, _isolate_session_dir):
+        """Two clients with same base [A] each append distinct messages.
+
+        Client 1 saves [A, B], then Client 2 (loaded before Client 1's save)
+        calls _merge_concurrent_appends() and saves [A, B, C].
+        The final transcript must contain all three messages.
+        """
+        session_dir, index_file = _isolate_session_dir
+        base_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "greeting"},
+        ]
+        c1_msg = {"role": "user", "content": "follow-up-1"}
+        c2_msg = {"role": "user", "content": "follow-up-2"}
+
+        # Client 1: loads base, appends, saves
+        s1 = Session(session_id="concurrent_test", messages=list(base_messages))
+        s1.save()
+        s1.messages.append(c1_msg)
+        s1.save()
+
+        # Client 2: loads new instance from same base (simulates second client
+        # that loaded before Client 1's save), appends, merges, saves
+        s2 = Session(session_id="concurrent_test", messages=list(base_messages))
+        s2.messages.append(c2_msg)
+        s2._merge_concurrent_appends()
+        s2.save()
+
+        persisted = json.loads((session_dir / "concurrent_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["hello", "greeting", "follow-up-1", "follow-up-2"], (
+            f"Expected all 4 messages but got {contents}"
+        )
+        assert persisted["message_count"] == 4
+
+    def test_undo_does_not_resurrect_messages(self, _isolate_session_dir):
+        """After /undo truncates messages, save must NOT resurrect the tail.
+
+        Session has [A, B, C]. /undo truncates to [A]. save() should persist
+        exactly [A] — the cross-client merge must not re-append B and C.
+        """
+        session_dir, index_file = _isolate_session_dir
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply1"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "reply2"},
+        ]
+
+        s = Session(session_id="undo_test", messages=list(messages))
+        s.save()
+
+        # Simulate /undo: truncate to before last user message
+        s.messages = messages[:3]
+        s.save()
+
+        persisted = json.loads((session_dir / "undo_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["first", "reply1", "second"], (
+            f"/undo resurrected tail messages: {contents}"
+        )
+        assert persisted["message_count"] == 3
+
+    def test_undo_retry_merge_concurrent(self, _isolate_session_dir):
+        """Combined test: /undo must not resurrect even with stale disk snapshot.
+
+        Session has [A, B, C, D]. /undo truncates to [A, B].
+        save() must persist [A, B] — the tail must stay gone.
+        Since _merge_concurrent_appends() is NOT called by undo/retry
+        (it's only called at append sites like streaming completion),
+        a plain save() must NOT resurrect.
+        """
+        session_dir, index_file = _isolate_session_dir
+        full = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+
+        s = Session(session_id="undo_concurrent_test", messages=list(full))
+        s.save()
+
+        # /undo truncation — save() must NOT resurrect because the merge
+        # was removed from save() (PR #6422).
+        s.messages = full[:2]
+        s.save()
+
+        persisted = json.loads((session_dir / "undo_concurrent_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["q1", "a1"], (
+            f"/undo with stale disk resurrected messages: {contents}"
+        )
+
+    def test_retry_does_not_resurrect_messages(self, _isolate_session_dir):
+        """After /retry truncates messages, save must NOT resurrect the tail."""
+        session_dir, index_file = _isolate_session_dir
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply1"},
+            {"role": "user", "content": "second"},
+        ]
+
+        s = Session(session_id="retry_test", messages=list(messages))
+        s.save()
+
+        # Simulate /retry: truncate to before the last user message
+        s.messages = messages[:1]
+        s.save()
+
+        persisted = json.loads((session_dir / "retry_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["first"], (
+            f"/retry resurrected tail messages: {contents}"
+        )
+        assert persisted["message_count"] == 1

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -284,21 +284,23 @@ class TestIssue765FollowupHardening:
         with a distinct source tmp path. With the old shared `<sid>.tmp` scheme, both
         threads would target the same path and the second replace would deterministically
         fail once the first consume/remove happened.
+
+        Since PR #6422 same-session saves are additionally serialized by the per-session
+        cross-process sidecar lock, so the second save runs only after the first has
+        fully replaced the file — but it still must use its own distinct tmp path.
         """
         s = _make_session("same_sid")
         s.save(skip_index=True)  # seed the file on disk
 
         original_replace = models.os.replace
-        barrier = threading.Barrier(2)
         replace_sources = []
         errors = []
 
-        def _replace_with_barrier(src, dst):
+        def _record_replace(src, dst):
             replace_sources.append(str(src))
-            barrier.wait(timeout=5)
             return original_replace(src, dst)
 
-        monkeypatch.setattr(models.os, "replace", _replace_with_barrier)
+        monkeypatch.setattr(models.os, "replace", _record_replace)
 
         def _save_worker():
             try:
@@ -310,8 +312,8 @@ class TestIssue765FollowupHardening:
         t2 = threading.Thread(target=_save_worker)
         t1.start()
         t2.start()
-        t1.join(timeout=5)
-        t2.join(timeout=5)
+        t1.join(timeout=10)
+        t2.join(timeout=10)
 
         assert not errors, f"Concurrent same-session saves should not fail: {errors}"
         assert len(replace_sources) >= 2, f"Expected replace calls, got {replace_sources}"
@@ -1040,7 +1042,12 @@ class TestCrossClientDesyncMerge6422:
 
     def test_truncation_guard_in_merge_concurrent_appends(self, _isolate_session_dir):
         """When disk is SHORTER than our copy (_merge_concurrent_appends path),
-        the truncation guard must not resurrect deleted messages.
+        the monotonic truncate-generation guard must not resurrect deleted
+        messages.
+
+        Production-composed: the truncation goes through
+        ``truncate_session_at_keep`` (the /api/session/truncate + /clear path),
+        which bumps the authoritative ``truncate_generation``.
 
         Scenario:
           1. Both load [A, B, C]
@@ -1049,6 +1056,8 @@ class TestCrossClientDesyncMerge6422:
              then save().  Must produce [A, B] (the truncation is recognized),
              NOT resurrect C.
         """
+        from api.session_ops import truncate_session_at_keep
+
         session_dir, index_file = _isolate_session_dir
         full = [
             {"role": "user", "content": "q1"},
@@ -1059,18 +1068,20 @@ class TestCrossClientDesyncMerge6422:
         s1 = Session(session_id="trunc_guard_test", messages=list(full))
         s1.save()
 
-        # Client 1: /undo truncates to [q1]
-        s1.messages = full[:1]
+        # Client 1: /undo truncates to [q1] via the PRODUCTION truncation path
+        # (stamps a strictly newer truncate_generation).
+        truncate_session_at_keep(s1, 1)
         s1.save()
 
-        # Client 2: stale copy [q1, a1, q2], calls _merge concurent appends
+        # Client 2: stale copy [q1, a1, q2] (loaded at the OLD generation),
+        # calls _merge_concurrent_appends.
         s2 = Session(session_id="trunc_guard_test", messages=list(full))
         s2._merge_concurrent_appends()
         s2.save()
 
         persisted = json.loads((session_dir / "trunc_guard_test.json").read_text(encoding="utf-8"))
         contents = [m["content"] for m in persisted["messages"]]
-        # The truncation guard should keep disk state: [q1]
+        # The generation guard should keep disk state: [q1]
         assert contents == ["q1"], (
             f"Truncation guard resurrected messages: {contents}"
         )
@@ -1080,6 +1091,9 @@ class TestCrossClientDesyncMerge6422:
         """When disk is SHORTER and our caller has appended, the merge
         must fail-closed: take the disk state rather than resurrect.
 
+        Production-composed: the truncation goes through
+        ``truncate_session_at_keep`` (bumps ``truncate_generation``).
+
         Scenario:
           1. Both load [A, B, C]
           2. Client 1 does /undo → [A] → save()
@@ -1087,6 +1101,8 @@ class TestCrossClientDesyncMerge6422:
              with a new message D appended.  Must produce [A], discarding
              stale tail (A is better than resurrecting B, C).
         """
+        from api.session_ops import truncate_session_at_keep
+
         session_dir, index_file = _isolate_session_dir
         base = [
             {"role": "user", "content": "first"},
@@ -1097,8 +1113,8 @@ class TestCrossClientDesyncMerge6422:
         s1 = Session(session_id="trunc_append_test", messages=list(base))
         s1.save()
 
-        # Client 1: /undo truncates to [first]
-        s1.messages = base[:1]
+        # Client 1: /undo truncates to [first] via the PRODUCTION path.
+        truncate_session_at_keep(s1, 1)
         s1.save()
 
         # Client 2: stale [first, reply1, second] + its own new message
@@ -1110,7 +1126,7 @@ class TestCrossClientDesyncMerge6422:
 
         persisted = json.loads((session_dir / "trunc_append_test.json").read_text(encoding="utf-8"))
         contents = [m["content"] for m in persisted["messages"]]
-        # Fail-closed: truncation guard takes disk state [first] only.
+        # Fail-closed: generation guard takes disk state [first] only.
         # fresh_reply is lost, but that's better than resurrecting reply1+second.
         assert contents == ["first"], (
             f"Truncation guard resurrected messages: {contents}"

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -990,3 +990,207 @@ class TestCrossClientDesyncMerge:
             f"/retry resurrected tail messages: {contents}"
         )
         assert persisted["message_count"] == 1
+
+
+class TestCrossClientDesyncMerge6422:
+    """Regression tests for cross-client desync re-gate (PR #6422).
+
+    Validates the fixes from the maintainer review:
+      1. No nested ``with _agent_lock:`` (tested via structured unit test)
+      2. Collision-safe IDs: equal N+1 IDs from production assignment
+      3. Truncation generation guard in ``_merge_concurrent_appends()``
+      4. Cross-process CAS guard in ``save()``
+      5. Three-client reconciliation
+    """
+
+    def test_equal_length_divergent_tails_with_ids(self, _isolate_session_dir):
+        """Two clients each append one message with the same production-assigned ID.
+
+        ``_assign_stable_message_ids()`` uses ``max(existing id) + 1``, so two
+        clients loaded from the same base can both assign ``id=4`` to different
+        messages.  The merge must detect this collision via content comparison
+        and produce ``[A, B, C, D1, D2]`` — not just ``[A, B, C, D2]``.
+        """
+        session_dir, index_file = _isolate_session_dir
+        base = [
+            {"id": 1, "role": "user", "content": "hello"},
+            {"id": 2, "role": "assistant", "content": "greeting"},
+        ]
+
+        # Client 1 appends message with id=3, saves
+        c1_msg = {"id": 3, "role": "user", "content": "follow-up-A"}
+        s1 = Session(session_id="collision_test", messages=[dict(m) for m in base])
+        s1.save()
+        s1.messages.append(dict(c1_msg))
+        s1.save()
+
+        # Client 2 tries to append a DIFFERENT message also with id=3 (collision)
+        c2_msg = {"id": 3, "role": "user", "content": "follow-up-B"}
+        s2 = Session(session_id="collision_test", messages=[dict(m) for m in base])
+        s2.messages.append(dict(c2_msg))
+        s2._merge_concurrent_appends()
+        s2.save()
+
+        persisted = json.loads((session_dir / "collision_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["hello", "greeting", "follow-up-A", "follow-up-B"], (
+            f"Expected all 4 messages but got {contents}"
+        )
+        assert persisted["message_count"] == 4
+
+    def test_truncation_guard_in_merge_concurrent_appends(self, _isolate_session_dir):
+        """When disk is SHORTER than our copy (_merge_concurrent_appends path),
+        the truncation guard must not resurrect deleted messages.
+
+        Scenario:
+          1. Both load [A, B, C]
+          2. Client 1 does /undo → truncates to [A, B] → save()
+          3. Client 2 (still holding [A, B, C]) calls _merge_concurrent_appends()
+             then save().  Must produce [A, B] (the truncation is recognized),
+             NOT resurrect C.
+        """
+        session_dir, index_file = _isolate_session_dir
+        full = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+
+        s1 = Session(session_id="trunc_guard_test", messages=list(full))
+        s1.save()
+
+        # Client 1: /undo truncates to [q1]
+        s1.messages = full[:1]
+        s1.save()
+
+        # Client 2: stale copy [q1, a1, q2], calls _merge concurent appends
+        s2 = Session(session_id="trunc_guard_test", messages=list(full))
+        s2._merge_concurrent_appends()
+        s2.save()
+
+        persisted = json.loads((session_dir / "trunc_guard_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        # The truncation guard should keep disk state: [q1]
+        assert contents == ["q1"], (
+            f"Truncation guard resurrected messages: {contents}"
+        )
+        assert persisted["message_count"] == 1
+
+    def test_truncation_guard_with_append_after_undo(self, _isolate_session_dir):
+        """When disk is SHORTER and our caller has appended, the merge
+        must fail-closed: take the disk state rather than resurrect.
+
+        Scenario:
+          1. Both load [A, B, C]
+          2. Client 1 does /undo → [A] → save()
+          3. Client 2 (stale [A, B, C]) calls _merge_concurrent_appends()
+             with a new message D appended.  Must produce [A], discarding
+             stale tail (A is better than resurrecting B, C).
+        """
+        session_dir, index_file = _isolate_session_dir
+        base = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply1"},
+            {"role": "user", "content": "second"},
+        ]
+
+        s1 = Session(session_id="trunc_append_test", messages=list(base))
+        s1.save()
+
+        # Client 1: /undo truncates to [first]
+        s1.messages = base[:1]
+        s1.save()
+
+        # Client 2: stale [first, reply1, second] + its own new message
+        new_msg = {"role": "assistant", "content": "fresh_reply"}
+        s2 = Session(session_id="trunc_append_test", messages=list(base))
+        s2.messages.append(dict(new_msg))
+        s2._merge_concurrent_appends()
+        s2.save()
+
+        persisted = json.loads((session_dir / "trunc_append_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        # Fail-closed: truncation guard takes disk state [first] only.
+        # fresh_reply is lost, but that's better than resurrecting reply1+second.
+        assert contents == ["first"], (
+            f"Truncation guard resurrected messages: {contents}"
+        )
+        assert persisted["message_count"] == 1
+
+    def test_three_client_reconciliation(self, _isolate_session_dir):
+        """Three concurrent clients append to the same session base [A].
+
+        C1 saves [A, B], C2 saves [A, B, C], C3 saves [A, B, C, D].
+        The final transcript must contain all four messages.
+        """
+        session_dir, index_file = _isolate_session_dir
+        base = [{"role": "user", "content": "start"}]
+        c1_msg = {"role": "user", "content": "second"}
+        c2_msg = {"role": "user", "content": "third"}
+        c3_msg = {"role": "user", "content": "fourth"}
+
+        s1 = Session(session_id="three_client_test", messages=list(base))
+        s1.save()
+        s1.messages.append(dict(c1_msg))
+        s1.save()
+
+        s2 = Session(session_id="three_client_test", messages=list(base))
+        s2.messages.append(dict(c2_msg))
+        s2._merge_concurrent_appends()
+        s2.save()
+
+        s3 = Session(session_id="three_client_test", messages=list(base))
+        s3.messages.append(dict(c3_msg))
+        s3._merge_concurrent_appends()
+        s3.save()
+
+        persisted = json.loads((session_dir / "three_client_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["start", "second", "third", "fourth"], (
+            f"Three-client reconciliation failed: {contents}"
+        )
+        assert persisted["message_count"] == 4
+
+    def test_cas_guard_detects_cross_process_write(self, _isolate_session_dir):
+        """CAS guard in save() detects when a cross-process write happened
+        between _merge_concurrent_appends() and the atomic save.
+
+        After merge but before save, simulate another process writing to the
+        file.  save() must re-read, detect the fingerprint mismatch, and
+        re-merge before writing.
+        """
+        session_dir, index_file = _isolate_session_dir
+        base = [{"role": "user", "content": "start"}]
+        c1_msg = {"role": "user", "content": "client-1-msg"}
+        intruder_msg = {"role": "user", "content": "intruder-msg"}
+
+        # Client 1 saves [start, c1_msg]
+        s1 = Session(session_id="cas_guard_test", messages=list(base))
+        s1.save()
+        s1.messages.append(dict(c1_msg))
+        s1.save()
+
+        # Client 2 loads base, does _merge (captures fingerprint of [start, c1_msg]),
+        # then we simulate a cross-process write before save().
+        s2 = Session(session_id="cas_guard_test", messages=list(base))
+        s2.messages.append({"role": "user", "content": "client-2-msg"})
+        s2._merge_concurrent_appends()
+
+        # Simulated cross-process write between merge and save.
+        simul = Session(session_id="cas_guard_test", messages=[
+            {"role": "user", "content": "start"},
+            {"role": "user", "content": "client-1-msg"},
+            dict(intruder_msg),
+        ])
+        simul.save()
+
+        # Now s2 saves — CAS guard should re-read, detect fingerprint mismatch,
+        # re-merge, and produce [start, c1_msg, intruder, c2_msg].
+        s2.save()
+
+        persisted = json.loads((session_dir / "cas_guard_test.json").read_text(encoding="utf-8"))
+        contents = [m["content"] for m in persisted["messages"]]
+        assert contents == ["start", "client-1-msg", "intruder-msg", "client-2-msg"], (
+            f"CAS guard failed to re-merge after cross-process write: {contents}"
+        )
+        assert persisted["message_count"] == 4

--- a/tests/test_webui_cross_client_merge6422.py
+++ b/tests/test_webui_cross_client_merge6422.py
@@ -279,3 +279,403 @@ class TestAtomicMergeReplaceTransaction:
         assert _durable_contents(session_dir, sid) == [
             "start", "client-1-msg", "intruder-msg", "client-2-msg",
         ]
+
+
+class TestEmptyTailAndEmptyBaseCAS:
+    """Re-gate finding #1: the CAS base identity must be recorded even when
+    the disk tail is empty or the base is empty, so two writers that BOTH
+    preflight before either save cannot have the second save overwrite the
+    first's rows."""
+
+    def test_two_writers_both_preflight_before_any_save_both_rows_kept(self, _isolate_session_dir):
+        """Both clients load [start], append divergent rows, and run the
+        advisory merge while disk is STILL [start] — the zero-tail shape that
+        previously skipped fingerprint recording and let the second save
+        overwrite the first."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "preflight_race"
+        base = [{"role": "user", "content": "start"}]
+
+        s0 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s0.save()
+
+        # Client 1 loads [start], appends, preflights (zero disk tail).
+        c1 = Session.load(sid)
+        c1.messages.append({"role": "user", "content": "client-1"})
+        c1._merge_concurrent_appends()
+
+        # Client 2 loads [start] BEFORE client 1 saves, appends its own row,
+        # and preflights against the SAME [start] disk.
+        c2 = Session.load(sid)
+        c2.messages.append({"role": "user", "content": "client-2"})
+        c2._merge_concurrent_appends()
+
+        # Saves serialize; the second must detect the fingerprint change under
+        # the lock and merge, not overwrite.
+        c1.save()
+        c2.save()
+
+        assert _durable_contents(session_dir, sid) == ["start", "client-1", "client-2"]
+
+    def test_two_first_turns_from_empty_base_both_kept(self, _isolate_session_dir):
+        """A brand-new chat persisted as an empty sidecar; both clients load
+        the EMPTY base (``_loaded_message_count == 0``), append their first
+        turn, and preflight before either saves.  The empty base is a VALID
+        CAS base — the second save must re-merge and keep both first turns."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "empty_base_first_turns"
+
+        # New chat persisted with zero messages (production shape).
+        s0 = Session(session_id=sid, messages=[])
+        s0.save()
+
+        c1 = Session.load(sid)
+        assert c1._loaded_message_count == 0
+        c1.messages.append({"role": "user", "content": "first-1"})
+        c1._merge_concurrent_appends()
+
+        c2 = Session.load(sid)
+        assert c2._loaded_message_count == 0
+        c2.messages.append({"role": "user", "content": "first-2"})
+        c2._merge_concurrent_appends()
+
+        c1.save()
+        c2.save()
+
+        assert _durable_contents(session_dir, sid) == ["first-1", "first-2"]
+
+    def test_second_save_after_empty_base_first_turn_keeps_both(self, _isolate_session_dir):
+        """Variant where the second writer LOADS the empty base but only
+        preflights AFTER the first writer saved (disk [first-1]): our base is
+        empty and disk shares no prefix, so the empty-base branch must
+        concatenate disk rows then ours instead of bailing and overwriting."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "empty_base_serialized"
+
+        s0 = Session(session_id=sid, messages=[])
+        s0.save()
+
+        c1 = Session.load(sid)
+        c1.messages.append({"role": "user", "content": "first-1"})
+        c1._merge_concurrent_appends()
+
+        # c2 loads the EMPTY base before c1 saves, but only preflights after
+        # c1's write lands.
+        c2 = Session.load(sid)
+        assert c2._loaded_message_count == 0
+        c2.messages.append({"role": "user", "content": "first-2"})
+
+        c1.save()  # disk now [first-1]
+
+        c2._merge_concurrent_appends()
+        c2.save()
+
+        assert _durable_contents(session_dir, sid) == ["first-1", "first-2"]
+
+
+class TestAuthoritativeGenerationBoundaries:
+    """Re-gate finding #2: truncate_generation is authoritative across clear,
+    context, and failure boundaries."""
+
+    def test_clear_to_empty_newer_generation_beats_stale_stream(self, _isolate_session_dir):
+        """A stale stream must NOT resurrect a newer clear-to-empty
+        transcript: the generation comparison runs BEFORE the empty-list
+        exits."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "clear_vs_stale"
+        base = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+        ]
+
+        s0 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s0.save()
+
+        # Stale client loaded the pre-clear transcript and completes a turn.
+        stale = Session.load(sid)
+        stale.messages = list(base) + [
+            {"role": "user", "content": "stale user"},
+            {"role": "assistant", "content": "stale reply"},
+        ]
+
+        # Another client clears via the production path → gen 1, messages [].
+        clear = Session.load(sid)
+        truncate_session_at_keep(clear, 0)
+        clear.save()
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["messages"] == []
+        assert persisted["truncate_generation"] == 1
+
+        # The stale stream merges + saves: the clear must win.
+        stale._merge_concurrent_appends()
+        stale.save()
+
+        assert _durable_contents(session_dir, sid) == []
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+    def test_newer_nonempty_generation_adopts_display_and_context(self, _isolate_session_dir):
+        """When a newer non-empty generation wins the merge, BOTH the display
+        transcript (``messages``) and the model-context truncation state
+        (``context_messages``) must be adopted — a stale ``context_messages``
+        must never survive to be persisted."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "gen_adopts_context"
+        base_msgs = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        base_ctx = [
+            {"role": "user", "content": "ctx-q1"},
+            {"role": "assistant", "content": "ctx-a1"},
+            {"role": "user", "content": "ctx-q2"},
+            {"role": "assistant", "content": "ctx-a2"},
+        ]
+
+        s0 = Session(
+            session_id=sid,
+            messages=[dict(m) for m in base_msgs],
+            context_messages=[dict(m) for m in base_ctx],
+        )
+        s0.save()
+
+        # Client B truncates via the production path: display AND context both
+        # shrink to 2 rows, generation bumps to 1.
+        b = Session.load(sid)
+        truncate_session_at_keep(b, 2)
+        b.save()
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+        assert len(persisted["messages"]) == 2
+        assert len(persisted["context_messages"]) == 2
+
+        # Stale client A (loaded at generation 0) completes a turn carrying
+        # the FULL old display AND old context.
+        stale = Session(
+            session_id=sid,
+            messages=[dict(m) for m in base_msgs],
+            context_messages=[dict(m) for m in base_ctx],
+        )
+        stale.messages.append({"role": "assistant", "content": "stale reply"})
+        stale._merge_concurrent_appends()
+        stale.save()
+
+        reloaded = Session.load(sid)
+        assert [m.get("content") for m in reloaded.messages] == ["q1", "a1"]
+        assert [m.get("content") for m in reloaded.context_messages] == ["ctx-q1", "ctx-a1"]
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+    def test_cache_resident_truncate_then_new_turn_keeps_rows(self, _isolate_session_dir):
+        """A successful save advances the object's loaded generation, so a
+        cache-resident follow-up turn on the SAME object does not misclassify
+        its own persisted generation as a newer external truncation."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "cache_resident_followup"
+        base = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+
+        s0 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s0.save()
+
+        # Cache-resident object: truncates (gen → 1) and saves...
+        resident = Session.load(sid)
+        truncate_session_at_keep(resident, 1)
+        resident.save()
+        assert resident._loaded_truncate_generation == 1
+
+        # ...then — WITHOUT reloading — completes a NEW turn on the same
+        # object.  Its own generation on disk must not read as a truncation.
+        resident.messages.append({"role": "assistant", "content": "fresh reply"})
+        resident._merge_concurrent_appends()
+        resident.save()
+
+        assert _durable_contents(session_dir, sid) == ["q1", "fresh reply"]
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+    def test_failed_replace_preserves_truncation_pending_for_retry(self, _isolate_session_dir, monkeypatch):
+        """A failed atomic replace must preserve the pending truncation
+        intent: the retry stamps a generation STRICTLY greater than disk,
+        even when another writer advanced disk in between."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "failed_replace_retry"
+        base = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+
+        s0 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s0.save()
+
+        s = Session.load(sid)
+        truncate_session_at_keep(s, 1)
+        assert s._truncation_pending is True
+
+        real_replace = models.os.replace
+        failed = {"n": 0}
+
+        def _flaky_replace(src, dst):
+            if dst == s.path and failed["n"] == 0:
+                failed["n"] += 1
+                raise OSError("simulated replace failure")
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(models.os, "replace", _flaky_replace)
+
+        with pytest.raises(OSError):
+            s.save()
+
+        # Truncation intent survived the failed write; nothing committed.
+        assert s._truncation_pending is True
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 0
+
+        # Another client truncates again while our write is down (disk gen 1).
+        other = Session.load(sid)
+        truncate_session_at_keep(other, 1)
+        other.save()
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+        # Retry must stamp STRICTLY greater than disk (2), not merely carry
+        # forward the stale in-memory value (1).
+        s.save()
+        assert s._truncation_pending is False
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 2
+        assert _durable_contents(session_dir, sid) == ["q1"]
+
+
+class TestGenerationAwareRecovery:
+    """Re-gate finding #3: recovery is generation-aware and runs under the
+    same per-session cross-process lock as Session.save()."""
+
+    def _write_sidecar(self, session_dir, sid, messages, truncate_generation=0, suffix=""):
+        path = session_dir / f"{sid}.json{suffix}"
+        path.write_text(
+            json.dumps({
+                "session_id": sid,
+                "messages": [{"role": "user", "content": m} for m in messages],
+                "truncate_generation": truncate_generation,
+            }),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_recovery_forbids_backup_with_lower_truncate_generation(self, _isolate_session_dir):
+        """A backup that predates an intentional truncation carries a LOWER
+        truncate_generation: recovery must NOT restore it, or the monotonic
+        generation would move backward and deleted rows would resurrect."""
+        from api.session_recovery import inspect_session_recovery_status, recover_session
+
+        session_dir, index_file = _isolate_session_dir
+        sid = "gen_aware"
+        live = self._write_sidecar(session_dir, sid, ["q1"], truncate_generation=2)
+        bak = self._write_sidecar(
+            session_dir, sid,
+            ["q1", "a1", "q2", "a2"],
+            truncate_generation=1,
+            suffix=".bak",
+        )
+
+        status = inspect_session_recovery_status(live)
+        assert status["recommend"] == "no_action"
+        assert status["newer_truncate_generation"] is True
+
+        result = recover_session(live)
+        assert result["restored"] is False
+        persisted = json.loads(live.read_text(encoding="utf-8"))
+        assert [m["content"] for m in persisted["messages"]] == ["q1"]
+        assert persisted["truncate_generation"] == 2
+
+    def test_startup_recovery_is_generation_aware(self, _isolate_session_dir):
+        """The startup scanner routes through the same generation-aware
+        decision: a truncated session is left untouched."""
+        from api.session_recovery import recover_all_sessions_on_startup
+
+        session_dir, index_file = _isolate_session_dir
+        sid = "gen_aware_startup"
+        live = self._write_sidecar(session_dir, sid, ["q1"], truncate_generation=2)
+        self._write_sidecar(
+            session_dir, sid,
+            ["q1", "a1", "q2", "a2"],
+            truncate_generation=1,
+            suffix=".bak",
+        )
+
+        result = recover_all_sessions_on_startup(session_dir)
+        assert result["restored"] == 0
+        persisted = json.loads(live.read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 2
+
+    def test_recovery_still_restores_backup_at_equal_generation(self, _isolate_session_dir):
+        """Control: the #1558 data-loss shape (shrink WITHOUT a generation
+        bump) is still restored — generation equality means the shrink was
+        NOT an intentional truncation."""
+        from api.session_recovery import inspect_session_recovery_status, recover_session
+
+        session_dir, index_file = _isolate_session_dir
+        sid = "gen_equal_loss"
+        live = self._write_sidecar(session_dir, sid, ["q1"], truncate_generation=0)
+        bak = self._write_sidecar(
+            session_dir, sid,
+            ["q1", "a1", "q2", "a2"],
+            truncate_generation=0,
+            suffix=".bak",
+        )
+
+        status = inspect_session_recovery_status(live)
+        assert status["recommend"] == "restore"
+
+        result = recover_session(live)
+        assert result["restored"] is True
+        persisted = json.loads(live.read_text(encoding="utf-8"))
+        assert [m["content"] for m in persisted["messages"]] == ["q1", "a1", "q2", "a2"]
+        assert bak.exists()  # the backup source is read-only, never consumed
+
+    def test_recover_session_holds_sidecar_lock_through_replace(self, _isolate_session_dir, monkeypatch):
+        """The per-session cross-process lock is held at the recovery replace:
+        a second open of the session's lock file must fail to acquire LOCK_EX
+        non-blockingly."""
+        import fcntl
+
+        from api.session_recovery import recover_session
+
+        session_dir, index_file = _isolate_session_dir
+        sid = "lock_held_recover"
+        live = self._write_sidecar(session_dir, sid, ["q1"])
+        self._write_sidecar(session_dir, sid, ["q1", "q2"], suffix=".bak")
+        lock_path = session_dir / f".{sid}.sidecar.lock"
+        observed = {}
+        real_replace = models.os.replace
+
+        def _replace_checking_lock(src, dst):
+            if dst != live:
+                return real_replace(src, dst)
+            try:
+                fd = os.open(lock_path, os.O_RDWR)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    observed["acquired"] = True
+                except BlockingIOError:
+                    observed["acquired"] = False
+                finally:
+                    os.close(fd)
+            except OSError as e:
+                observed["error"] = str(e)
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(models.os, "replace", _replace_checking_lock)
+
+        result = recover_session(live)
+        assert result["restored"] is True
+        assert observed.get("acquired") is False, (
+            f"sidecar lock must be held through the recovery replace; observed={observed}"
+        )

--- a/tests/test_webui_cross_client_merge6422.py
+++ b/tests/test_webui_cross_client_merge6422.py
@@ -1,0 +1,281 @@
+"""
+PR #6422 re-gate regressions: monotonic truncate generation, atomic
+merge/replace transaction, and durable row lineage for the cross-client
+chat-desync merge (#6299).
+
+Every test composes REAL production objects and helpers — ``Session.save``,
+``Session._merge_concurrent_appends``, ``truncate_session_at_keep`` (the
+/api/session/truncate + /clear path), ``_assign_stable_message_ids`` (the
+production message-id minting path) — and asserts the DURABLE reloaded state
+via ``Session.load``, not just helper-local values.
+
+The production-composed normal streaming completion regression lives in
+``tests/test_webui_state_db_context_reconciliation.py``
+(``test_next_webui_turn_context_includes_state_db_external_messages``), which
+drives the real ``_run_agent_streaming`` pipeline end-to-end.
+"""
+import json
+import os
+
+import pytest
+
+import api.models as models
+from api.models import Session
+from api.session_ops import truncate_session_at_keep
+from api.streaming import _assign_stable_message_ids
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch):
+    """Redirect SESSION_DIR and SESSION_INDEX_FILE to a temp directory."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    models.SESSIONS.clear()
+    yield session_dir, index_file
+    models.SESSIONS.clear()
+
+
+def _durable_contents(session_dir, sid):
+    reloaded = Session.load(sid)
+    assert reloaded is not None, f"session {sid} did not persist"
+    return [m.get("content") for m in reloaded.messages]
+
+
+class TestMonotonicTruncateGeneration:
+    """Length-based truncation inference is gone: only a strictly NEWER
+    ``truncate_generation`` can demote a longer in-memory transcript."""
+
+    def test_pre_turn_checkpoint_same_generation_keeps_completed_turn(self, _isolate_session_dir):
+        """The re-gate repro at the merge level: the pre-turn checkpoint is
+        SHORTER than the completed in-memory turn but carries the SAME
+        generation — it must NOT be treated as a truncation.
+
+        Mirrors the real streaming flow: streaming.py:9007 saves the checkpoint
+        before the turn; at completion the in-memory transcript is longer and
+        the merge must keep it.
+        """
+        session_dir, index_file = _isolate_session_dir
+        sid = "checkpoint_turn"
+        base = [
+            {"role": "user", "content": "old user"},
+            {"role": "assistant", "content": "old assistant"},
+        ]
+        # Pre-turn checkpoint (what _run_agent_streaming saves before starting).
+        checkpoint = Session(session_id=sid, messages=[dict(m) for m in base])
+        checkpoint.save()
+
+        # Completed turn: production load path (records the loaded generation),
+        # then the longer in-memory transcript, then the completion merge+save.
+        completed = Session.load(sid)
+        completed.messages = list(base) + [
+            {"role": "user", "content": "new webui turn"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        completed._merge_concurrent_appends()
+        completed.save()
+
+        assert _durable_contents(session_dir, sid) == [
+            "old user", "old assistant", "new webui turn", "ok",
+        ]
+
+    def test_truncate_then_append_truncation_wins(self, _isolate_session_dir):
+        """Generation-ordered truncate-vs-append, truncate first: client B
+        truncates (bumping ``truncate_generation``) before stale client A
+        completes its turn; A's merge must adopt the truncated disk state
+        instead of resurrecting deleted rows.
+        """
+        session_dir, index_file = _isolate_session_dir
+        sid = "trunc_then_append"
+        base = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        # Client B truncates via the production path → truncate_generation 1.
+        truncate_session_at_keep(s1, 1)
+        s1.save()
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+        # Stale client A (loaded at generation 0 with [q1, a1, q2]) appends
+        # its completed turn, then merges.
+        stale = Session(session_id=sid, messages=[dict(m) for m in base])
+        stale.messages.append({"role": "assistant", "content": "a_fresh"})
+        stale._merge_concurrent_appends()
+        stale.save()
+
+        # Truncation wins: deleted rows must not resurrect; generation stays 1.
+        assert _durable_contents(session_dir, sid) == ["q1"]
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+    def test_append_then_truncate_applies_to_merged_transcript(self, _isolate_session_dir):
+        """Generation-ordered truncate-vs-append, append first: client A
+        merges+saves its completed turn; a later truncate applies to the
+        merged transcript and wins.
+        """
+        session_dir, index_file = _isolate_session_dir
+        sid = "append_then_truncate"
+        base = [{"role": "user", "content": "start"}]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        # Client A appends + merges + saves (production completion flow).
+        a = Session.load(sid)
+        a.messages = list(base) + [
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+        a._merge_concurrent_appends()
+        a.save()
+        assert _durable_contents(session_dir, sid) == ["start", "a1", "q2"]
+
+        # Client B truncates to 1 via the production path.
+        b = Session.load(sid)
+        truncate_session_at_keep(b, 1)
+        b.save()
+
+        assert _durable_contents(session_dir, sid) == ["start"]
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
+
+
+class TestDurableRowLineage:
+    """The uuid lineage minted by _assign_stable_message_ids distinguishes
+    rows that collide on the max+1 integer id, even with identical content."""
+
+    def test_two_clients_identical_content_colliding_ids_both_kept(self, _isolate_session_dir):
+        """Real two-client ID allocation: both clients load the same base and
+        mint the SAME next integer id (3) for DIFFERENT rows with IDENTICAL
+        content.  Equal id + equal content is NOT proof of sameness — the
+        durable uuid lineage must keep BOTH rows in the durable reload.
+        """
+        session_dir, index_file = _isolate_session_dir
+        sid = "two_client_same_content"
+        base = [
+            {"role": "user", "content": "hello", "id": 1, "uuid": "u-base-1"},
+            {"role": "assistant", "content": "greeting", "id": 2, "uuid": "u-base-2"},
+        ]
+
+        # Client 1: loads base, appends one row through the PRODUCTION id
+        # minting path (max+1 → id 3) which also mints a durable uuid.
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+        c1_row = {"role": "user", "content": "same follow-up", "id": None}
+        _assign_stable_message_ids([c1_row], s1.messages)
+        s1.messages.append(c1_row)
+        s1.save()
+
+        # Client 2: loads the SAME base, appends a DIFFERENT row that ALSO
+        # mints id 3 with IDENTICAL content.
+        s2 = Session(session_id=sid, messages=[dict(m) for m in base])
+        c2_row = {"role": "user", "content": "same follow-up", "id": None}
+        _assign_stable_message_ids([c2_row], s2.messages)
+        s2.messages.append(c2_row)
+        s2._merge_concurrent_appends()
+        s2.save()
+
+        contents = _durable_contents(session_dir, sid)
+        assert contents == ["hello", "greeting", "same follow-up", "same follow-up"], contents
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        uuids = [m.get("uuid") for m in persisted["messages"]]
+        assert len(set(uuids)) == 4, f"durable lineage must be unique per row: {uuids}"
+        assert uuids[2] != uuids[3]
+
+
+class TestAtomicMergeReplaceTransaction:
+    """Merge + generation comparison + final validation + replace is one
+    per-session cross-process transaction."""
+
+    def test_sidecar_lock_held_through_atomic_replace(self, _isolate_session_dir, monkeypatch):
+        """The per-session cross-process lock is held AT os.replace time: while
+        save() runs its transaction, a second open of the session's lock file
+        must fail to acquire LOCK_EX non-blockingly."""
+        import fcntl
+
+        session_dir, index_file = _isolate_session_dir
+        sid = "lock_held_at_replace"
+        s = Session(session_id=sid, messages=[{"role": "user", "content": "hello"}])
+        s.save()
+
+        original_replace = models.os.replace
+        lock_path = session_dir / f".{sid}.sidecar.lock"
+        observed = {}
+
+        def _replace_checking_lock(src, dst):
+            # The per-session sidecar replace is the one inside the locked
+            # transaction.  save() also atomically rewrites the shared
+            # _index.json AFTER releasing the session lock — that replace must
+            # not be mistaken for the sidecar one.
+            if dst != Session(session_id=sid).path:
+                return original_replace(src, dst)
+            # We are inside save()'s locked transaction: a second fd on the
+            # same lock file must NOT acquire LOCK_EX non-blockingly.
+            try:
+                fd = os.open(lock_path, os.O_RDWR)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    observed["acquired"] = True
+                except BlockingIOError:
+                    observed["acquired"] = False
+                finally:
+                    os.close(fd)
+            except OSError as e:
+                observed["error"] = str(e)
+            return original_replace(src, dst)
+
+        monkeypatch.setattr(models.os, "replace", _replace_checking_lock)
+
+        s2 = Session(session_id=sid, messages=[{"role": "user", "content": "hello"}])
+        s2.messages.append({"role": "assistant", "content": "world"})
+        s2.save()
+
+        assert observed.get("acquired") is False, (
+            f"sidecar lock must be held through os.replace; observed={observed}"
+        )
+
+    def test_writer_in_validate_replace_window_is_merged(self, _isolate_session_dir):
+        """A writer that lands between the advisory merge and save() (the final
+        validate-to-replace window) is detected by the CAS fingerprint check
+        and its rows are merged into the DURABLE result."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "writer_in_window"
+        base = [{"role": "user", "content": "start"}]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+        s1.messages.append({"role": "user", "content": "client-1-msg"})
+        s1.save()
+
+        # Stale client 2: loads base, appends its own row, runs the ADVISORY
+        # merge (captures the fingerprint of [start, client-1-msg]).
+        s2 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s2.messages.append({"role": "user", "content": "client-2-msg"})
+        s2._merge_concurrent_appends()
+
+        # Writer lands in the window before s2.save(): a third client appends
+        # [start, client-1-msg, intruder-msg].
+        intruder = Session(session_id=sid, messages=[
+            {"role": "user", "content": "start"},
+            {"role": "user", "content": "client-1-msg"},
+            {"role": "user", "content": "intruder-msg"},
+        ])
+        intruder.save()
+
+        # s2.save() must re-validate under the lock, detect the fingerprint
+        # mismatch, re-merge, and preserve ALL rows.
+        s2.save()
+
+        assert _durable_contents(session_dir, sid) == [
+            "start", "client-1-msg", "intruder-msg", "client-2-msg",
+        ]

--- a/tests/test_webui_cross_client_merge6422.py
+++ b/tests/test_webui_cross_client_merge6422.py
@@ -22,7 +22,11 @@ import pytest
 import api.models as models
 from api.models import Session
 from api.session_ops import truncate_session_at_keep
-from api.streaming import _assign_stable_message_ids
+from api.streaming import (
+    _assign_stable_message_ids,
+    _append_and_persist_terminal_error,
+    _persist_with_append_intent,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -823,7 +827,11 @@ class TestReGate20260824:
         stamped_a = _assign_stable_message_ids(rows_a)
         stamped_b = _assign_stable_message_ids(rows_b)
 
-        assert stamped_a == 1 and stamped_b == 1
+        # The return contract counts newly-assigned INTEGER ids only: both
+        # rows already carried id=7, so no integer id was minted (0) — even
+        # though the durable uuid lineage WAS minted below (re-gate
+        # 2026-08-25: uuid minting is a side effect, not part of the count).
+        assert stamped_a == 0 and stamped_b == 0
         assert rows_a[0]["uuid"] and rows_b[0]["uuid"]
         assert rows_a[0]["uuid"] != rows_b[0]["uuid"]
         assert rows_a[0]["id"] == 7 and rows_b[0]["id"] == 7
@@ -832,4 +840,162 @@ class TestReGate20260824:
         row = [{"id": 3, "uuid": "abc123", "role": "assistant"}]
         assert _assign_stable_message_ids(row) == 0
         assert row[0]["uuid"] == "abc123"
+
+
+class TestReGate20260825:
+    """Re-gate 2026-08-25 (maintainer CHANGES_REQUESTED on 7747479ca9ad):
+    production-composed coverage for the four terminal append producers that
+    still saved without ``_merge_concurrent_appends()``, plus the
+    append-intent-consumption regression for a reused cached Session.
+
+    Unlike the earlier gateway/synchronous tests (which manually called
+    ``_merge_concurrent_appends()`` on a Session), these execute the REAL
+    production callers: ``_append_and_persist_terminal_error`` (the
+    result-classified error + outer-settlement path),
+    ``_persist_with_append_intent`` (the synchronous self-heal success save),
+    and ``cancel_stream()`` (the direct cancel writeback).
+    """
+
+    def test_terminal_error_settlement_preserves_concurrent_rows(self, _isolate_session_dir):
+        """Result-classified / outer-exception settlement
+        (``_append_and_persist_terminal_error``) is an APPEND producer: a row
+        a concurrent writer persisted since this object loaded must survive
+        the terminal error save."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "term_error_merge"
+        base = [{"role": "user", "content": "q1"}, {"role": "assistant", "content": "a1"}]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        # Stale settlement object loaded BEFORE the concurrent append.
+        stale = Session.load(sid)
+        concurrent = Session.load(sid)
+        concurrent.messages.append({"role": "assistant", "content": "other client row"})
+        concurrent._merge_concurrent_appends()
+        concurrent.save()
+
+        _append_and_persist_terminal_error(
+            stale, {"role": "assistant", "content": "terminal error", "_error": True}
+        )
+
+        assert _durable_contents(session_dir, sid) == [
+            "q1", "a1", "other client row", "terminal error",
+        ]
+
+    def test_synchronous_self_heal_writeback_preserves_concurrent_rows(self, _isolate_session_dir):
+        """The synchronous credential self-heal success save
+        (``_persist_with_append_intent``) is an APPEND producer: it settles
+        the turn's result rows into the transcript and must not clobber a
+        concurrent writer's rows."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "self_heal_merge"
+        base = [{"role": "user", "content": "q1"}]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        stale = Session.load(sid)
+        stale.messages.append({"role": "assistant", "content": "healed answer"})
+
+        other = Session.load(sid)
+        other.messages.append({"role": "assistant", "content": "stream row"})
+        other._merge_concurrent_appends()
+        other.save()
+
+        _persist_with_append_intent(stale)
+
+        assert _durable_contents(session_dir, sid) == [
+            "q1", "stream row", "healed answer",
+        ]
+
+    def test_cancel_stream_writeback_preserves_concurrent_rows(self, _isolate_session_dir):
+        """The direct ``cancel_stream()`` partial/cancel writeback executes
+        the REAL production cancel path (not a manual helper sequence) and
+        must reconcile (merge) concurrent rows instead of overwriting them."""
+        import queue
+        import threading
+        from unittest.mock import patch
+
+        from api import config as live_config
+        from api.config import (
+            CANCEL_FLAGS,
+            STREAMS,
+            register_stream_owner,
+            unregister_stream_owner,
+        )
+        from api.streaming import cancel_stream
+
+        session_dir, index_file = _isolate_session_dir
+        sid = "cancel_merge"
+        stream_id = "stream_cancel_merge"
+        base = [{"role": "user", "content": "q1"}, {"role": "assistant", "content": "a1"}]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        # The session object the cancel path will write through — loaded
+        # BEFORE the concurrent append (the lost-update shape).
+        cached = Session.load(sid)
+        cached.active_stream_id = stream_id
+
+        other = Session.load(sid)
+        other.messages.append({"role": "assistant", "content": "concurrent row"})
+        other._merge_concurrent_appends()
+        other.save()
+
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+        register_stream_owner(stream_id, sid)
+        try:
+            with patch("api.streaming.get_session", return_value=cached):
+                assert cancel_stream(stream_id) is True
+        finally:
+            STREAMS.pop(stream_id, None)
+            CANCEL_FLAGS.pop(stream_id, None)
+            unregister_stream_owner(stream_id)
+            live_config.ACTIVE_RUNS.pop(stream_id, None)
+
+        durable = _durable_contents(session_dir, sid)
+        # The concurrent append survived the cancel writeback...
+        assert "concurrent row" in durable
+        # ...and the cancel marker was persisted on top of the merged tail.
+        reloaded = Session.load(sid)
+        assert any(
+            isinstance(m, dict) and "Task cancelled" in str(m.get("content") or "")
+            for m in reloaded.messages
+        )
+
+    def test_append_intent_consumed_after_save_truncation_same_object(self, _isolate_session_dir):
+        """Durable-reload regression (maintainer finding #3): append intent
+        must be CONSUMED by the successful append save.  Reusing ONE cached
+        Session — establish append intent and save, then truncate that same
+        object and save again — must NOT resurrect the deleted suffix via a
+        stale CAS reconciliation against the longer pre-truncation disk
+        transcript."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "stale_append_intent"
+        base = [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+        ]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        # ONE cached object reused across both transactions (the flagged shape).
+        cached = Session.load(sid)
+        cached.messages.append({"role": "assistant", "content": "a2"})
+        cached._merge_concurrent_appends()
+        cached.save()
+        assert _durable_contents(session_dir, sid) == ["q1", "a1", "a2"]
+
+        # Truncate the SAME object via the production entry point.
+        truncate_session_at_keep(cached, 1)
+        cached.save()
+
+        # The removed suffix stays deleted — no stale append reconciliation.
+        assert _durable_contents(session_dir, sid) == ["q1"]
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["truncate_generation"] == 1
 

--- a/tests/test_webui_cross_client_merge6422.py
+++ b/tests/test_webui_cross_client_merge6422.py
@@ -679,3 +679,157 @@ class TestGenerationAwareRecovery:
         assert observed.get("acquired") is False, (
             f"sidecar lock must be held through the recovery replace; observed={observed}"
         )
+
+
+class TestReGate20260824:
+    """Re-gate 2026-08-24: release-blocker smoke + production-composed
+    regressions for the append-intent, CAS-fail-closed, directory-fsync, and
+    integer-ID/no-UUID findings."""
+
+    def test_ordinary_save_durable_reload_smoke(self, _isolate_session_dir):
+        """RELEASE BLOCKER repro: a plain `Session.save()` must persist and
+        reload.  Previously `payload` was only assigned inside the CAS-rebuild
+        arm, so the normal path hit `f.write(payload)` with an unbound
+        variable (UnboundLocalError) — every ordinary session save crashed."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "plain_save_smoke"
+        s = Session(
+            session_id=sid,
+            title="smoke title",
+            messages=[
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ],
+            context_messages=[
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"},
+            ],
+        )
+        s.save()  # must NOT raise
+
+        reloaded = Session.load(sid)
+        assert reloaded is not None
+        assert [m["content"] for m in reloaded.messages] == ["hello", "hi there"]
+        assert [m["content"] for m in reloaded.context_messages] == ["hello", "hi there"]
+        assert reloaded.title == "smoke title"
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert persisted["message_count"] == 2
+
+    def test_gateway_append_intent_preserves_concurrent_rows(self, _isolate_session_dir):
+        """Gateway success/error settlement is an APPEND producer: after a
+        concurrent writer persisted rows, the gateway's save must reconcile
+        (merge) instead of overwriting them."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "gateway_vs_stream"
+        base = [{"role": "user", "content": "q1"}, {"role": "assistant", "content": "a1"}]
+
+        # Streaming client completes first.
+        streamer = Session(session_id=sid, messages=[dict(m) for m in base])
+        streamer.save()
+
+        # Gateway error settlement: loaded from the same base, appends its
+        # error row, and (per the fix) establishes append intent.
+        gateway = Session.load(sid)
+        gateway.messages.append({"role": "assistant", "content": "gateway error row"})
+        gateway._merge_concurrent_appends()
+        gateway.save()
+
+        assert _durable_contents(session_dir, sid) == [
+            "q1", "a1", "gateway error row",
+        ]
+
+    def test_synchronous_append_intent_preserves_concurrent_rows(self, _isolate_session_dir):
+        """Synchronous completion producer: a stale client that loaded before
+        a concurrent append must keep the disk rows when it saves with append
+        intent."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "sync_vs_stream"
+        base = [{"role": "user", "content": "q1"}]
+
+        s1 = Session(session_id=sid, messages=[dict(m) for m in base])
+        s1.save()
+
+        # Sync client loaded from the base, appends its turn.
+        sync_client = Session(session_id=sid, messages=[dict(m) for m in base])
+        sync_client.messages.append({"role": "assistant", "content": "sync answer"})
+        # Concurrent stream appends a second row before the sync client saves.
+        other = Session.load(sid)
+        other.messages.append({"role": "assistant", "content": "stream row"})
+        other._merge_concurrent_appends()
+        other.save()
+
+        sync_client._merge_concurrent_appends()
+        sync_client.save()
+
+        assert _durable_contents(session_dir, sid) == [
+            "q1", "stream row", "sync answer",
+        ]
+
+    def test_cas_exhaustion_fails_closed(self, _isolate_session_dir, monkeypatch):
+        """CAS retry exhaustion must ABORT (fail closed), not publish a
+        best-effort merge that could overwrite a concurrent append."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "cas_exhaust"
+        s = Session(session_id=sid, messages=[{"role": "user", "content": "q1"}])
+        s.save()
+
+        stale = Session.load(sid)
+        stale.messages.append({"role": "assistant", "content": "a_fresh"})
+
+        def _never_converges(self):
+            # Every re-merge records a fingerprint that never matches the
+            # on-disk state → the CAS loop exhausts its 3 attempts.
+            self._merge_snapshot_fingerprint = "stale-sentinel-forever"
+
+        monkeypatch.setattr(
+            Session, "_merge_concurrent_appends_locked", _never_converges
+        )
+        stale._merge_concurrent_appends()
+        with pytest.raises(RuntimeError, match="CAS retries exhausted"):
+            stale.save()
+
+        # Disk untouched: the concurrent append was not clobbered.
+        persisted = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+        assert [m["content"] for m in persisted["messages"]] == ["q1"]
+
+    def test_directory_fsync_failure_is_best_effort(self, _isolate_session_dir, monkeypatch):
+        """The parent-directory fsync boundary is best-effort: a platform that
+        refuses directory fsync must not fail the save, and the payload must
+        still be durable."""
+        session_dir, index_file = _isolate_session_dir
+        sid = "dir_fsync_fail"
+        s = Session(session_id=sid, messages=[{"role": "user", "content": "q1"}])
+
+        real_fsync = models.os.fsync
+        calls = {"n": 0}
+
+        def _fsync_then_fail(fd):
+            calls["n"] += 1
+            real_fsync(fd)
+            if calls["n"] == 2:  # second fsync = the directory fd
+                raise OSError("directory fsync not supported")
+
+        monkeypatch.setattr(models.os, "fsync", _fsync_then_fail)
+        s.save()  # must not raise
+
+        assert _durable_contents(session_dir, sid) == ["q1"]
+
+    def test_integer_id_no_uuid_mints_durable_lineage(self):
+        """A genuinely new row whose integer id was supplied by the provider
+        must still receive a uuid: two writers minting the SAME integer id for
+        different rows are disambiguated by the uuid lineage."""
+        rows_a = [{"id": 7, "role": "assistant", "content": "row from A"}]
+        rows_b = [{"id": 7, "role": "assistant", "content": "row from B"}]
+        stamped_a = _assign_stable_message_ids(rows_a)
+        stamped_b = _assign_stable_message_ids(rows_b)
+
+        assert stamped_a == 1 and stamped_b == 1
+        assert rows_a[0]["uuid"] and rows_b[0]["uuid"]
+        assert rows_a[0]["uuid"] != rows_b[0]["uuid"]
+        assert rows_a[0]["id"] == 7 and rows_b[0]["id"] == 7
+
+        # Existing uuid lineage is carried forward untouched.
+        row = [{"id": 3, "uuid": "abc123", "role": "assistant"}]
+        assert _assign_stable_message_ids(row) == 0
+        assert row[0]["uuid"] == "abc123"
+


### PR DESCRIPTION
## Summary

Fixes #6299 — cross-client chat desync when two clients write to the same session concurrently.

## Problem

When two clients (e.g., WebUI web + desktop app) send messages into the same conversation at roughly the same time:

1. Client A loads the session (messages=[M1])
2. Client B loads the session (messages=[M1])
3. Client A appends M2 and calls save() — disk now has [M1, M2]
4. Client B appends M3 and calls save() — **writes [M1, M3] based on B's stale in-memory copy, silently losing M2**

This is a classic last-writer-wins lost-update bug. The issue reproduces inside the WebUI itself (shared server, same sidecar file), so it affects all clients reading the same server session (WebUI web, Hermes Desktop, Hermex iOS, etc.).

## Fix

In `Session.save()`, before the atomic file write, read the current on-disk messages. If disk has strictly more messages than our in-memory copy **AND** the shared prefix is identical (verified by message `id` when available, or `role`+`content` as fallback), append the extra disk-only messages to our copy before writing.

### Change: `api/models.py` — `Session.save()` (+40 lines)

The new block slots into the existing read-and-backup logic at the top of save(), right after the empty-overwrite guard (#1558) and before the backup safeguard:

1. Reads `existing.get("messages")` (already parsed from disk for the backup check)
2. When `existing_msg_count > incoming_msg_count`, compares the shared prefix using message `id` first (stable, monotonic per session), then `role`+`content` as fallback for rows without ids
3. If the prefix matches, appends the disk-only tail to `self.messages` and rebuilds `payload` so the atomic write reflects the merged transcript
4. If the prefix doesn't match (divergent edits), does nothing — the existing backup safeguard catches the shrink

## Design decisions

- **No distributed lock**: The merge is stateless, best-effort, and scoped to a single save() call. No changes to the caching layer, the SSE channels, or the session index.
- **Prefix-identity check prevents data corruption**: We only merge when we can prove the messages we already know about are unchanged on disk. If another client edited/deleted earlier messages, we bail (the backup fires as before).
- **Payload rebuild**: After merging, `meta["messages"]` and `meta["message_count"]` are updated and `payload` is re-serialized so the atomic write writes the combined transcript.
- **Graceful on errors**: Wrapped in the existing try/except — any read/parse failure degrades to the pre-existing behavior (backup fires or save proceeds as-is).

## Testing

- All existing tests pass (verified locally).
- Manual repro: two clients on one session, send messages round-robin, inspect the sidecar.
