### PR TITLE
fix: defer WebUI restart until active streams finish

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -1921,9 +1921,6 @@ def apply_force_update(target: str, channel=None) -> dict:
     if channel is None:
         channel = _read_update_channel()
     channel = _normalize_channel(channel)
-    blocker_snapshot = _restart_blocker_snapshot()
-    if blocker_snapshot.get('restart_blocked'):
-        return _restart_blocked_response(target, blocker_snapshot)
 
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
@@ -2032,6 +2029,7 @@ def apply_force_update(target: str, channel=None) -> dict:
                     'gateway_restart': gateway_result.get('status'),
                 }
 
+        restart_deferred = bool(_restart_blocker_snapshot().get('restart_blocked'))
         _schedule_restart()
 
         response = {
@@ -2039,6 +2037,7 @@ def apply_force_update(target: str, channel=None) -> dict:
             'message': f'{target} force-updated to {compare_ref}',
             'target': target,
             'restart_scheduled': True,
+            'restart_deferred': restart_deferred,
         }
         if target == 'agent':
             response['gateway_restart'] = gateway_result.get('status')
@@ -2052,9 +2051,6 @@ def apply_update(target, channel=None):
     if channel is None:
         channel = _read_update_channel()
     channel = _normalize_channel(channel)
-    blocker_snapshot = _restart_blocker_snapshot()
-    if blocker_snapshot.get('restart_blocked'):
-        return _restart_blocked_response(target, blocker_snapshot)
 
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
@@ -2335,7 +2331,6 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 }
             with _cache_lock:
                 _update_cache['checked_at'] = 0
-
             if target == 'agent':
                 gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
                 if not gateway_ok:
@@ -2345,6 +2340,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                         'target': target,
                         'gateway_restart': gateway_result.get('status'),
                     }
+            restart_deferred = bool(_restart_blocker_snapshot().get('restart_blocked'))
             _schedule_restart()
             response = {
                 'ok': True,
@@ -2358,6 +2354,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
                 ),
                 'target': target,
                 'restart_scheduled': True,
+                'restart_deferred': restart_deferred,
                 'stash_conflict': True,
             }
             if target == 'agent':
@@ -2368,6 +2365,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     with _cache_lock:
         _update_cache['checked_at'] = 0
 
+    gateway_result = {}
     if target == 'agent':
         gateway_ok, gateway_result = _ensure_gateway_restart_for_agent_update()
         if not gateway_ok:
@@ -2389,6 +2387,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
     # the process replaces itself.  The client already does
     # setTimeout(() => location.reload(), 1500) on success, so the page reload
     # and the restart land at roughly the same time.
+    restart_deferred = bool(_restart_blocker_snapshot().get('restart_blocked'))
     _schedule_restart()
     message = f'{target} updated successfully'
     if stash_drop_failed:
@@ -2402,6 +2401,7 @@ def _apply_update_inner(target, channel=DEFAULT_UPDATE_CHANNEL):
         'message': message,
         'target': target,
         'restart_scheduled': True,
+        'restart_deferred': restart_deferred,
     }
     if target == 'agent':
         response['gateway_restart'] = gateway_result.get('status')

--- a/static/ui.js
+++ b/static/ui.js
@@ -9940,6 +9940,28 @@ function _formatUpdateApplyExceptionMessage(error){
   const message=(error&&error.message)||String(error||'unknown error');
   return _i18nUpdateText('update_failed_prefix','Update failed: ')+message;
 }
+function _formatUpdateRestartMessage(restartDeferred){
+  return restartDeferred
+    ? 'Update applied — WebUI will restart once your chat finishes.'
+    : 'Update applied — restarting now…';
+}
+function _setUpdateApplyStatus(message,opts){
+  opts=opts||{};
+  const msg=$('updateMsg');
+  if(msg) msg.textContent=message;
+  const banner=$('updateBanner');
+  if(banner) banner.classList.add('visible');
+  const errEl=$('updateError');
+  if(errEl&&!opts.keepError){errEl.style.display='none';errEl.textContent='';}
+}
+function _updateRestartWaitOptions(baselineServerIdentity,restartDeferred){
+  const opts={baselineServerIdentity};
+  if(restartDeferred){
+    opts.maxMs=310000;
+    opts.message='⏳ Update applied — waiting for chat to finish before restart';
+  }
+  return opts;
+}
 async function applyUpdates(){
   if(window._updateApplyInFlight) return;
   window._updateApplyInFlight=true;
@@ -9972,6 +9994,7 @@ async function applyUpdates(){
   }
   try{
     const stashConflictMessages=[];
+    let restartDeferred=false;
     const baselineServerIdentity = await _readHealthServerIdentity();
     for(const target of targets){
       // Send the channel the CHECK reported for this target (what was actually
@@ -9988,16 +10011,20 @@ async function applyUpdates(){
         resetApplyButton(0);
         return;
       }
+      restartDeferred=restartDeferred||res.restart_deferred===true;
       if(res.stash_conflict){
         stashConflictMessages.push('Update applied ('+target+'): '+(res.message||'Local changes were preserved in git stash.'));
         if(errEl){errEl.textContent=stashConflictMessages.join('\n\n');errEl.style.display='block';}
       }
     }
     const stashConflictMessage=stashConflictMessages.join('\n\n');
-    showToast(stashConflictMessage||'Update applied — restarting…',stashConflictMessages.length?10000:undefined,stashConflictMessages.length?'warning':undefined);
+    const restartMessage=_formatUpdateRestartMessage(restartDeferred);
+    const toastMessage=stashConflictMessage?(stashConflictMessage+'\n\n'+restartMessage):restartMessage;
+    _setUpdateApplyStatus(restartMessage,{keepError:stashConflictMessages.length>0});
+    showToast(toastMessage,stashConflictMessages.length?10000:undefined,stashConflictMessages.length?'warning':undefined);
     sessionStorage.removeItem('hermes-update-checked');
     sessionStorage.removeItem('hermes-update-dismissed');
-    _waitForServerThenReload({baselineServerIdentity});
+    _waitForServerThenReload(_updateRestartWaitOptions(baselineServerIdentity,restartDeferred));
   }catch(e){
     const msg=_formatUpdateApplyExceptionMessage(e);
     if(errEl){errEl.textContent=msg;errEl.style.display='block';}
@@ -10190,10 +10217,13 @@ async function forceUpdate(btn){
       btn.disabled=false;btn.textContent='Force update';
       return;
     }
-    showToast('Force update applied — restarting…');
+    const restartDeferred=res.restart_deferred===true;
+    const restartMessage=_formatUpdateRestartMessage(restartDeferred);
+    _setUpdateApplyStatus(restartMessage);
+    showToast(restartMessage);
     sessionStorage.removeItem('hermes-update-checked');
     sessionStorage.removeItem('hermes-update-dismissed');
-    _waitForServerThenReload({baselineServerIdentity});
+    _waitForServerThenReload(_updateRestartWaitOptions(baselineServerIdentity,restartDeferred));
   }catch(e){
     if(errEl){errEl.textContent='Force update failed: '+e.message;errEl.style.display='block';}
     btn.disabled=false;btn.textContent='Force update';
@@ -10223,7 +10253,7 @@ async function _waitForServerThenReload(opts){
   window._restartingForUpdate=true;
   const msgEl=$('reconnectMsg');
   const banner=$('reconnectBanner');
-  if(msgEl) msgEl.textContent='⏳ Restarting… please wait';
+  if(msgEl) msgEl.textContent=opts.message||'⏳ Restarting… please wait';
   if(banner) banner.classList.add('visible');
   const deadline=Date.now()+maxMs;
   // Track restart-outage evidence. An outage (failed or non-OK /health probes)

--- a/tests/test_update_apply_ui.py
+++ b/tests/test_update_apply_ui.py
@@ -67,6 +67,12 @@ function _waitForServerThenReload(opts) {
 }
 function _showUpdateError(target, res) { errors.push({ target, message: res.message || '' }); }
 function _formatUpdateApplyExceptionMessage(e) { return 'Update failed: ' + e.message; }
+function _isUpdateApplyNetworkError() { return false; }
+function _formatUpdateRestartMessage(restartDeferred) { return restartDeferred ? 'Deferred' : 'Restarting'; }
+function _setUpdateApplyStatus() {}
+function _updateRestartWaitOptions(baselineServerIdentity, restartDeferred) {
+  return { baselineServerIdentity, restartDeferred };
+}
 function showToast(message, duration, kind) {
   showToasts.push({ message, duration, kind });
 }
@@ -156,7 +162,8 @@ def test_update_apply_successful_stash_conflict_displays_recovery_message():
     restart_wait = body.index("_waitForServerThenReload", message_join)
 
     assert messages_decl < stash_branch < message_push < persistent_display < message_join < restart_wait
-    assert "showToast(stashConflictMessage||'Update applied" in body
+    assert "const toastMessage=stashConflictMessage?" in body
+    assert "showToast(toastMessage" in body
     assert "stashConflictMessages.length?10000" in body
 
 
@@ -173,7 +180,8 @@ def test_update_apply_multiple_stash_conflicts_are_aggregated_not_overwritten():
     assert "stashConflictMessages.push('Update applied ('+target+'): " in body
     assert "errEl.textContent=stashConflictMessages.join('\\n\\n')" in body
     assert "const stashConflictMessage=stashConflictMessages.join('\\n\\n');" in body
-    assert "showToast(stashConflictMessage||'Update applied" in body
+    assert "const toastMessage=stashConflictMessage?" in body
+    assert "showToast(toastMessage" in body
 
 
 def test_update_apply_network_error_classifier_ignores_http_status_errors():

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -493,7 +493,40 @@ class TestScheduleRestart:
 class TestApplyUpdateRestartSafety:
     """Self-update must not re-exec while chat streams are active."""
 
-    def test_apply_update_refuses_when_stream_active(self, tmp_path, monkeypatch):
+    @staticmethod
+    def _successful_git(calls):
+        def fake_run(args, cwd, timeout=10):
+            calls.append(args)
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[:2] == ['status', '--porcelain']:
+                return '', True
+            if args[0] == 'pull':
+                return 'Already up to date.', True
+            if args[:2] == ['merge-base', '--is-ancestor']:
+                # A non-zero exit is Git's normal "not an ancestor" result;
+                # exercise update instead of the safe refusal to rewind.
+                return '', False
+            if args[0] == 'checkout':
+                return '', True
+            if args[0] == 'reset':
+                return '', True
+            return '', True
+
+        return fake_run
+
+    def test_apply_update_defers_restart_when_stream_active(self, tmp_path, monkeypatch):
+        """Apply must proceed during the caller's own stream.
+
+        The old restart_blocked assertion encoded a catch-22: clicking Update
+        Now from a streaming chat made that same stream block the update. The
+        apply step now completes and _schedule_restart performs the bounded
+        wait before re-exec.
+        """
         import queue
         import api.updates as upd
         from api.config import STREAMS, STREAMS_LOCK
@@ -501,9 +534,11 @@ class TestApplyUpdateRestartSafety:
         (tmp_path / '.git').mkdir()
         monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
         monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        called = []
-        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (called.append(a) or ('', True)))
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        git_calls = []
+        restart_calls = []
+        monkeypatch.setattr(upd, '_run_git', self._successful_git(git_calls))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: restart_calls.append(delay))
+        monkeypatch.setattr(upd, '_ensure_gateway_restart_for_agent_update', lambda: (True, {'status': 'skipped'}))
 
         with STREAMS_LOCK:
             old = dict(STREAMS)
@@ -516,13 +551,14 @@ class TestApplyUpdateRestartSafety:
                 STREAMS.clear()
                 STREAMS.update(old)
 
-        assert result['ok'] is False
-        assert result.get('active_streams') == 1
-        assert result.get('restart_blocked') is True
-        assert 'active chat stream' in result['message']
-        assert called == []
+        assert result['ok'] is True
+        assert result.get('restart_deferred') is True
+        assert result.get('restart_blocked') in (None, False)
+        assert ['pull', '--ff-only', 'origin', 'master'] in git_calls
+        assert restart_calls == [2.0]
 
-    def test_force_update_refuses_when_stream_active(self, tmp_path, monkeypatch):
+    def test_force_update_defers_restart_when_stream_active(self, tmp_path, monkeypatch):
+        """Force apply also queues restart instead of refusing active streams."""
         import queue
         import api.updates as upd
         from api.config import STREAMS, STREAMS_LOCK
@@ -530,8 +566,11 @@ class TestApplyUpdateRestartSafety:
         (tmp_path / '.git').mkdir()
         monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
         monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (_ for _ in ()).throw(AssertionError('must not run git')))
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        git_calls = []
+        restart_calls = []
+        monkeypatch.setattr(upd, '_run_git', self._successful_git(git_calls))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: restart_calls.append(delay))
+        monkeypatch.setattr(upd, '_ensure_gateway_restart_for_agent_update', lambda: (True, {'status': 'skipped'}))
 
         with STREAMS_LOCK:
             old = dict(STREAMS)
@@ -544,21 +583,25 @@ class TestApplyUpdateRestartSafety:
                 STREAMS.clear()
                 STREAMS.update(old)
 
-        assert result['ok'] is False
-        assert result.get('active_streams') == 1
-        assert result.get('restart_blocked') is True
-        assert 'active chat stream' in result['message']
+        assert result['ok'] is True
+        assert result.get('restart_deferred') is True
+        assert result.get('restart_blocked') in (None, False)
+        assert ['reset', '--hard', 'origin/master'] in git_calls
+        assert restart_calls == [2.0]
 
-    def test_apply_update_refuses_when_active_run_without_stream(self, tmp_path, monkeypatch):
+    def test_apply_update_defers_restart_when_active_run_without_stream(self, tmp_path, monkeypatch):
+        """Detached active runs are reported as deferred restarts, not apply failures."""
         import api.updates as upd
         from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK, STREAMS, STREAMS_LOCK
 
         (tmp_path / '.git').mkdir()
         monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
         monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        called = []
-        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (called.append(a) or ('', True)))
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        git_calls = []
+        restart_calls = []
+        monkeypatch.setattr(upd, '_run_git', self._successful_git(git_calls))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: restart_calls.append(delay))
+        monkeypatch.setattr(upd, '_ensure_gateway_restart_for_agent_update', lambda: (True, {'status': 'skipped'}))
 
         with STREAMS_LOCK:
             old_streams = dict(STREAMS)
@@ -577,22 +620,25 @@ class TestApplyUpdateRestartSafety:
                 STREAMS.clear()
                 STREAMS.update(old_streams)
 
-        assert result['ok'] is False
-        assert result.get('active_streams') == 0
-        assert result.get('active_runs') == 1
-        assert result.get('restart_blocked') is True
-        assert 'active agent run' in result['message']
-        assert called == []
+        assert result['ok'] is True
+        assert result.get('restart_deferred') is True
+        assert result.get('restart_blocked') in (None, False)
+        assert ['pull', '--ff-only', 'origin', 'master'] in git_calls
+        assert restart_calls == [2.0]
 
-    def test_force_update_refuses_when_active_run_without_stream(self, tmp_path, monkeypatch):
+    def test_force_update_defers_restart_when_active_run_without_stream(self, tmp_path, monkeypatch):
+        """Force update keeps the restart wait in _schedule_restart for active runs."""
         import api.updates as upd
         from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK, STREAMS, STREAMS_LOCK
 
         (tmp_path / '.git').mkdir()
         monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
         monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (_ for _ in ()).throw(AssertionError('must not run git')))
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        git_calls = []
+        restart_calls = []
+        monkeypatch.setattr(upd, '_run_git', self._successful_git(git_calls))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: restart_calls.append(delay))
+        monkeypatch.setattr(upd, '_ensure_gateway_restart_for_agent_update', lambda: (True, {'status': 'skipped'}))
 
         with STREAMS_LOCK:
             old_streams = dict(STREAMS)
@@ -611,11 +657,47 @@ class TestApplyUpdateRestartSafety:
                 STREAMS.clear()
                 STREAMS.update(old_streams)
 
-        assert result['ok'] is False
-        assert result.get('active_streams') == 0
-        assert result.get('active_runs') == 1
-        assert result.get('restart_blocked') is True
-        assert 'active agent run' in result['message']
+        assert result['ok'] is True
+        assert result.get('restart_deferred') is True
+        assert result.get('restart_blocked') in (None, False)
+        assert ['reset', '--hard', 'origin/master'] in git_calls
+        assert restart_calls == [2.0]
+
+    def test_apply_update_reports_restart_not_deferred_without_active_work(self, tmp_path, monkeypatch):
+        """No active streams/runs means the success response says restart now."""
+        import api.updates as upd
+        from api.config import ACTIVE_RUNS, ACTIVE_RUNS_LOCK, STREAMS, STREAMS_LOCK
+
+        (tmp_path / '.git').mkdir()
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        git_calls = []
+        restart_calls = []
+        monkeypatch.setattr(upd, '_run_git', self._successful_git(git_calls))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: restart_calls.append(delay))
+        monkeypatch.setattr(upd, '_ensure_gateway_restart_for_agent_update', lambda: (True, {'status': 'skipped'}))
+
+        with STREAMS_LOCK:
+            old_streams = dict(STREAMS)
+            STREAMS.clear()
+        with ACTIVE_RUNS_LOCK:
+            old_runs = dict(ACTIVE_RUNS)
+            ACTIVE_RUNS.clear()
+        try:
+            result = upd.apply_update('webui')
+        finally:
+            with ACTIVE_RUNS_LOCK:
+                ACTIVE_RUNS.clear()
+                ACTIVE_RUNS.update(old_runs)
+            with STREAMS_LOCK:
+                STREAMS.clear()
+                STREAMS.update(old_streams)
+
+        assert result['ok'] is True
+        assert result.get('restart_deferred') is False
+        assert result.get('restart_blocked') in (None, False)
+        assert ['pull', '--ff-only', 'origin', 'master'] in git_calls
+        assert restart_calls == [2.0]
 
     def test_wait_until_restart_safe_waits_for_active_run_to_clear(self, monkeypatch):
         import api.updates as upd
@@ -1829,13 +1911,19 @@ class TestUiJsUpdateBanner:
             "forceUpdate() must POST to /api/updates/force"
         )
 
-    def test_success_toast_says_restarting(self):
+    def test_success_toast_distinguishes_immediate_and_deferred_restart(self):
         src = read('static/ui.js')
         m = re.search(r'function applyUpdates\b.*?\n\}', src, re.DOTALL)
         assert m, "applyUpdates() not found"
         fn = m.group(0)
-        assert 'restarting' in fn.lower(), (
-            "success toast must mention 'restarting' (server self-restarts after update)"
+        assert 'restart_deferred' in src, (
+            "applyUpdates must read restart_deferred so active chats are not shown as update failures"
+        )
+        assert 'Update applied — restarting now…' in src, (
+            "success copy must mention restarting when restart is immediate"
+        )
+        assert 'Update applied — WebUI will restart once your chat finishes.' in src, (
+            "deferred-restart copy must tell the user the update applied and will restart after chat finishes"
         )
         assert 'Reloading' not in fn, (
             "success toast must not say 'Reloading' — server restarts, page reloads after"
@@ -2229,13 +2317,13 @@ global.fetch = async () => {{
         assert '_readHealthServerIdentity()' in force_body, (
             "forceUpdate() must call _readHealthServerIdentity() before reload wait"
         )
-        assert '_waitForServerThenReload({baselineServerIdentity})' in apply_body, (
-            "applyUpdates() must pass baselineServerIdentity to _waitForServerThenReload()"
+        assert '_waitForServerThenReload(_updateRestartWaitOptions(baselineServerIdentity,restartDeferred))' in apply_body, (
+            "applyUpdates() must pass baselineServerIdentity and restartDeferred to _waitForServerThenReload()"
         )
-        assert '_waitForServerThenReload({baselineServerIdentity})' in force_body, (
-            "forceUpdate() must pass baselineServerIdentity to _waitForServerThenReload()"
+        assert '_waitForServerThenReload(_updateRestartWaitOptions(baselineServerIdentity,restartDeferred))' in force_body, (
+            "forceUpdate() must pass baselineServerIdentity and restartDeferred to _waitForServerThenReload()"
         )
-        assert apply_body.index('_readHealthServerIdentity()') < apply_body.index('_waitForServerThenReload({baselineServerIdentity})'), (
+        assert apply_body.index('_readHealthServerIdentity()') < apply_body.index('_waitForServerThenReload(_updateRestartWaitOptions'), (
             "applyUpdates() must capture baseline before reload scheduling"
         )
         assert force_body.index('_readHealthServerIdentity()') < force_body.index("const res=await api('/api/updates/force'"), (


### PR DESCRIPTION
## Summary
Prevents a self-update restart from interrupting an active response; applies the update and restarts once the stream is idle.

## Verification
Targeted update-banner tests passed locally.