### PR TITLE
fix(ui): explain Codex-native context estimates

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -9388,7 +9388,11 @@ def _settings_payload_for_write(settings: dict, persisted_speech_keys: set[str])
     persisted = {
         k: v
         for k, v in settings.items()
-        if k not in {"default_model", _SETTINGS_PERSISTED_SPEECH_KEYS_FIELD}
+        if k not in {
+            "default_model",
+            "codex_app_server_auto",
+            _SETTINGS_PERSISTED_SPEECH_KEYS_FIELD,
+        }
     }
     for speech_key in _SETTINGS_SPEECH_KEYS:
         if speech_key not in persisted_speech_keys:
@@ -9459,11 +9463,23 @@ def load_settings() -> dict:
     )
     settings["default_model"] = get_effective_default_model()
     try:
-        model_cfg = get_config().get("model", {})
+        active_cfg = get_config()
+        model_cfg = active_cfg.get("model", {})
         if isinstance(model_cfg, dict) and model_cfg.get("provider"):
             settings["default_model_provider"] = str(model_cfg.get("provider"))
+        compression_cfg = active_cfg.get("compression", {})
+        auto_mode = (
+            compression_cfg.get("codex_app_server_auto", "native")
+            if isinstance(compression_cfg, dict)
+            else "native"
+        )
+        auto_mode = str(auto_mode or "native").strip().lower()
+        settings["codex_app_server_auto"] = (
+            auto_mode if auto_mode in {"native", "hermes", "off"} else "native"
+        )
     except Exception:
-        logger.debug("Failed to resolve default model provider for settings")
+        logger.debug("Failed to resolve model/compression settings")
+        settings["codex_app_server_auto"] = "native"
     return settings
 
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -3285,6 +3285,9 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     window._showTitlebarProfile=!!s.show_titlebar_profile;
     _applyTitlebarProfileVisibility();
     window._botName=s.bot_name||'Hermes';
+    window._codexAppServerAutoCompaction=['native','hermes','off'].includes(s.codex_app_server_auto)
+      ? s.codex_app_server_auto
+      : 'native';
     if(s.default_model_provider) window._activeProvider=s.default_model_provider;
     if(s.default_model){
       window._defaultModel=s.default_model;

--- a/static/style.css
+++ b/static/style.css
@@ -2670,6 +2670,7 @@
   .composer-mobile-context-compress{flex:0 0 auto;width:auto;max-width:128px;align-self:center;text-align:center;white-space:normal;}
   .composer-mobile-context-action.ctx-mid .composer-mobile-config-value{color:var(--warning);}
   .composer-mobile-context-action.ctx-high .composer-mobile-config-value{color:var(--error);}
+  .composer-mobile-context-action.ctx-native .composer-mobile-config-value{color:var(--accent);}
   .composer-mobile-context-action.ctx-high .composer-mobile-context-compress{border-color:var(--error);color:var(--error);}
   .composer-right{display:flex;gap:8px;align-items:center;flex-shrink:0;}
   .composer-status{font-size:11px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:170px;}
@@ -2685,6 +2686,7 @@
   .ctx-ring-center{position:relative;display:flex;width:15px;height:15px;align-items:center;justify-content:center;border-radius:999px;background:var(--bg);font-size:8px;font-weight:600;line-height:1;color:var(--muted);font-variant-numeric:tabular-nums;}
   .ctx-indicator.ctx-mid .ctx-ring-value{stroke:var(--warning);}
   .ctx-indicator.ctx-high .ctx-ring-value{stroke:var(--error);}
+  .ctx-indicator.ctx-native .ctx-ring-value{stroke:var(--accent);}
   .ctx-tooltip{position:absolute;right:0;bottom:calc(100% + 10px);min-width:210px;max-width:250px;padding:10px 12px;border:1px solid var(--border2);border-radius:12px;background:var(--surface);box-shadow:0 12px 30px rgba(0,0,0,.28);font-size:11px;line-height:1.45;color:var(--muted);opacity:0;transform:translateY(4px);pointer-events:none;transition:opacity .14s ease,transform .14s ease;z-index:30;}
   .ctx-tooltip::after{content:'';position:absolute;right:10px;top:100%;border-width:6px 6px 0 6px;border-style:solid;border-color:var(--surface) transparent transparent transparent;}
   .ctx-indicator-wrap:hover .ctx-tooltip,.ctx-indicator-wrap:focus-within .ctx-tooltip,.ctx-tooltip-active{opacity:1;transform:translateY(0);pointer-events:auto;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -6495,17 +6495,17 @@ function _syncMobileCtxDisplay(state){
     }
     return;
   }
-  (function updateCtxRing(pct) {
+  (function updateCtxRing(pct, nativeManaged) {
     var arc = document.getElementById('ctx-arc');
     var num = document.getElementById('ctx-num');
     if (!arc || !num) return;
     var offset = 87.96 * (1 - Math.min(pct, 100) / 100);
     arc.setAttribute('stroke-dashoffset', offset);
     num.textContent = Math.round(pct);
-    arc.setAttribute('stroke',
-      pct <= 50 ? '#22c55e' : pct <= 85 ? '#f97316' : '#ef4444'
-    );
-  })(state.pct);
+    arc.setAttribute('stroke',nativeManaged
+      ? (getComputedStyle(document.documentElement).getPropertyValue('--accent').trim()||'#7cb9ff')
+      : (pct <= 50 ? '#22c55e' : pct <= 85 ? '#f97316' : '#ef4444'));
+  })(state.pct,state.nativeManaged);
   if(mobileConfigBtn){
     mobileConfigBtn.setAttribute('aria-label',`${_MOBILE_CONFIG_BASE_LABEL}; ${state.label}`);
     mobileConfigBtn.setAttribute('title',`${_MOBILE_CONFIG_BASE_LABEL} \u00b7 ${state.label}`);
@@ -6513,8 +6513,9 @@ function _syncMobileCtxDisplay(state){
   if(row){
     row.style.display='';
     row.setAttribute('aria-label',state.label);
-    row.classList.toggle('ctx-mid',state.pct>50&&state.pct<=75);
-    row.classList.toggle('ctx-high',state.pct>75);
+    row.classList.toggle('ctx-native',!!state.nativeManaged);
+    row.classList.toggle('ctx-mid',!state.nativeManaged&&state.pct>50&&state.pct<=75);
+    row.classList.toggle('ctx-high',!state.nativeManaged&&state.pct>75);
   }
   if(usageLine)usageLine.textContent=state.usageText||'';
   if(tokensLine)tokensLine.textContent=state.tokensText||'';
@@ -6566,6 +6567,16 @@ function _mergeUsageForCtxIndicator(latest, fallback){
   return merged;
 }
 
+function _isCodexNativeContext(){
+  const provider=String(
+    (typeof S!=='undefined'&&S.session&&S.session.model_provider)
+    ||window._activeProvider
+    ||''
+  ).trim().toLowerCase();
+  return provider==='openai-codex'
+    &&String(window._codexAppServerAutoCompaction||'native').toLowerCase()==='native';
+}
+
 // Context usage indicator in composer footer
 function _syncCtxIndicator(usage){
   const wrap=$('ctxIndicatorWrap');
@@ -6608,6 +6619,7 @@ function _syncCtxIndicator(usage){
   }
   let hasPromptTok=!!promptTok;
   if(hasPostCompressionEstimate) hasPromptTok=true;
+  const nativeManaged=_isCodexNativeContext();
   const rawPct=hasPromptTok?Math.round((contextPromptTok/ctxWindow)*100):0;
   const pct=Math.min(100,rawPct);
   const overflowed=rawPct>100;
@@ -6624,32 +6636,47 @@ function _syncCtxIndicator(usage){
   }
   if(center) center.textContent=hasPromptTok?String(pct):'\u00b7';
   const hasExplicitCtx=!!usage.context_length;
-  el.classList.toggle('ctx-mid',pct>50&&pct<=75);
-  el.classList.toggle('ctx-high',pct>75);
+  el.classList.toggle('ctx-native',nativeManaged);
+  el.classList.toggle('ctx-mid',!nativeManaged&&pct>50&&pct<=75);
+  el.classList.toggle('ctx-high',!nativeManaged&&pct>75);
   // ── Compress affordance (#524) ──
   // Show a hint in the tooltip when context usage is high so users
   // discover /compress without having to know the slash command.
   const compressWrap=$('ctxTooltipCompress');
   const compressBtn=$('ctxCompressBtn');
-  const compressText=pct>=75?t('ctx_compress_action'):(pct>=50?t('ctx_compress_hint'):'');
+  const compressText=nativeManaged?'':(pct>=75?t('ctx_compress_action'):(pct>=50?t('ctx_compress_hint'):''));
   if(compressWrap) compressWrap.style.display=compressText?'':'none';
   _setCtxCompressButton(compressBtn,compressText);
   const cacheHitPct=usage.cache_hit_percent;
   const cacheText=cacheHitPct!=null?t('usage_cache_hit_detail',cacheHitPct,_fmtTokens(cacheReadTok),_fmtTokens(cacheWriteTok)):'';
   const contextLabel=hasPostCompressionEstimate?'Estimated next model context':'Context window';
-  let label=hasPromptTok?`${contextLabel} ${pct}% used`:`${_fmtTokens(totalTok)} tokens used`;
+  let label=hasPromptTok
+    ? (nativeManaged?`Hermes context estimate ${pct}%`:`${contextLabel} ${pct}% used`)
+    : `${_fmtTokens(totalTok)} tokens used`;
   if(!hasExplicitCtx&&hasPromptTok) label+=' (est. 128K)';
   if(cost) label+=` \u00b7 $${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
   if(cacheText) label+=` \u00b7 ${cacheText}`;
   el.setAttribute('aria-label',label);
-  const usageText=hasPromptTok?(overflowed?`${contextLabel}: ${rawPct}% used (context exceeded)`:`${contextLabel}: ${pct}% used (${100-pct}% left)`):`${_fmtTokens(totalTok)} tokens used`;
-  const tokensText=hasPromptTok?`${contextLabel}: ${_fmtTokens(contextPromptTok)} / ${_fmtTokens(ctxWindow)} tokens used`:`In: ${_fmtTokens(usage.input_tokens||0)} \u00b7 Out: ${_fmtTokens(usage.output_tokens||0)}`;
+  const usageText=hasPromptTok
+    ? (nativeManaged
+      ? `Hermes local estimate: ${pct}%`
+      : (overflowed?`${contextLabel}: ${rawPct}% used (context exceeded)`:`${contextLabel}: ${pct}% used (${100-pct}% left)`))
+    : `${_fmtTokens(totalTok)} tokens used`;
+  const tokensText=hasPromptTok
+    ? (nativeManaged
+      ? `${_fmtTokens(contextPromptTok)} / ${_fmtTokens(ctxWindow)} estimated locally`
+      : `${contextLabel}: ${_fmtTokens(contextPromptTok)} / ${_fmtTokens(ctxWindow)} tokens used`)
+    : `In: ${_fmtTokens(usage.input_tokens||0)} \u00b7 Out: ${_fmtTokens(usage.output_tokens||0)}`;
   if(usageLine) usageLine.textContent=usageText;
   if(tokensLine) tokensLine.textContent=tokensText;
   const threshold=usage.threshold_tokens||0;
   let thresholdText='';
   if(thresholdLine){
-    if(threshold&&ctxWindow){
+    if(nativeManaged){
+      thresholdText='Compaction managed automatically by Codex';
+      thresholdLine.style.display='';
+      thresholdLine.textContent=thresholdText;
+    }else if(threshold&&ctxWindow){
       thresholdText=`Auto-compress at ${_fmtTokens(threshold)} (${Math.round(threshold/ctxWindow*100)}%)`;
       thresholdLine.style.display='';
       thresholdLine.textContent=thresholdText;
@@ -6677,6 +6704,7 @@ function _syncCtxIndicator(usage){
   _syncMobileCtxDisplay({
     visible:true,
     hasPromptTok,
+    nativeManaged,
     pct,
     label,
     usageText,

--- a/tests/test_codex_native_context_indicator.py
+++ b/tests/test_codex_native_context_indicator.py
@@ -1,0 +1,69 @@
+"""Codex-native context usage must not masquerade as a Hermes 75% countdown."""
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("compression", "expected"),
+    [
+        ({}, "native"),
+        ({"codex_app_server_auto": "hermes"}, "hermes"),
+        ({"codex_app_server_auto": "off"}, "off"),
+        ({"codex_app_server_auto": "invalid"}, "native"),
+    ],
+)
+def test_settings_surface_validated_codex_auto_compaction_mode(
+    monkeypatch, compression, expected
+):
+    import api.config as config
+
+    monkeypatch.setattr(config, "_read_raw_settings_file", lambda: {})
+    monkeypatch.setattr(config, "get_effective_default_model", lambda: "gpt-test")
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda: {"model": {"provider": "openai-codex"}, "compression": compression},
+    )
+
+    settings = config.load_settings()
+
+    assert settings["codex_app_server_auto"] == expected
+    assert settings["default_model_provider"] == "openai-codex"
+
+
+def test_codex_auto_mode_is_read_only_and_never_persisted_to_webui_settings():
+    import api.config as config
+
+    persisted = config._settings_payload_for_write(
+        {"theme": "dark", "codex_app_server_auto": "native"}, set()
+    )
+
+    assert persisted == {"theme": "dark"}
+
+
+def test_boot_hydrates_codex_auto_compaction_mode():
+    assert "window._codexAppServerAutoCompaction=" in BOOT_JS
+    assert "? s.codex_app_server_auto" in BOOT_JS
+    assert ": 'native';" in BOOT_JS
+
+
+def test_native_mode_is_provider_scoped_and_not_a_75_percent_promise():
+    assert "function _isCodexNativeContext()" in UI_JS
+    assert "provider==='openai-codex'" in UI_JS
+    assert "Compaction managed automatically by Codex" in UI_JS
+    assert "Hermes local estimate:" in UI_JS
+    assert "const compressText=nativeManaged?'':" in UI_JS
+
+
+def test_native_mode_removes_warning_colours_but_keeps_visible_ring():
+    assert "el.classList.toggle('ctx-native',nativeManaged);" in UI_JS
+    assert "!nativeManaged&&pct>75" in UI_JS
+    assert ".ctx-indicator.ctx-native .ctx-ring-value{stroke:var(--accent);}" in STYLE_CSS

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -135,9 +135,15 @@ def test_boot_primes_visible_default_model_without_catalog_fetch():
 
 def test_settings_exposes_default_model_provider_for_lazy_boot_catalog():
     src = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
+    start = src.index("def load_settings() -> dict:")
+    end = src.index("\n\n_SETTINGS_ALLOWED_KEYS", start)
+    block = src[start:end]
 
-    assert 'settings["default_model_provider"]' in src
-    assert 'model_cfg = get_config().get("model", {})' in src
+    assert 'active_cfg = get_config()' in block
+    assert 'model_cfg = active_cfg.get("model", {})' in block
+    assert 'compression_cfg = active_cfg.get("compression", {})' in block
+    assert 'settings["default_model_provider"]' in block
+    assert block.count('active_cfg = get_config()') == 1
 
 
 def test_boot_renders_session_list_before_workspace_and_onboarding_settle():


### PR DESCRIPTION
## Summary
Clarifies in the UI when a Codex-native context estimate is being displayed.

## Verification
Relevant UI/unit tests passed locally; `node --check static/ui.js` passed.