### PR TITLE
fix(ui): prevent long message text overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -5858,7 +5858,7 @@ main.main > #mainPlugin{display:none;}
 .msg-body code { color: var(--strong); background: var(--code-inline-bg); font-size: var(--message-code-font-size); }
 
 /* ── Unified indent rail — every child of a turn lines up on --msg-rail ── */
-.msg-row { padding: 12px 0; }
+.msg-row { padding: 12px 0; min-width: 0; }
 
 /* On touch devices (iOS/Android PWA), skip layout/paint for off-screen rows
    so streaming performance doesn't degrade as the chat grows. WKWebView is
@@ -5905,13 +5905,27 @@ main.main > #mainPlugin{display:none;}
      WebKit and on Android it re-opens the #4856 / #5338 mobile jump-to-top
      regression the scroll-anchor work fought hard to close. */
 }
-.msg-body { padding-left: var(--msg-rail); padding-top: 8px; max-width: var(--msg-max); }
+.msg-body {
+  padding-left: var(--msg-rail);
+  padding-top: 8px;
+  width: 100%;
+  max-width: min(var(--msg-max), 100%);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.msg-body :where(p, li, blockquote, h1, h2, h3, h4, h5, h6, a, strong, em, span) {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 .msg-body code,
 .msg-body pre,
 .msg-body table { font-family: 'SF Mono', ui-monospace, monospace; }
 .msg-body:empty { display: none; }
-.assistant-turn { width: 100%; }
-.assistant-turn-blocks { display: flex; flex-direction: column; }
+.assistant-turn { width: 100%; min-width: 0; }
+.assistant-turn-blocks { display: flex; flex-direction: column; min-width: 0; }
+.assistant-segment { max-width: 100%; min-width: 0; }
 .status-card{margin:8px 0 8px var(--msg-rail);max-width:min(var(--msg-max),760px);border:1px solid var(--border-subtle);background:var(--surface-subtle);border-radius:var(--radius-card);box-shadow:0 10px 24px rgba(0,0,0,.05);overflow:hidden;}
 .status-card-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding:14px 16px;border-bottom:1px solid var(--border-subtle);background:linear-gradient(180deg,var(--surface-subtle-hover),var(--surface-subtle));}
 .status-card-title-wrap{min-width:0;}

--- a/static/style.css
+++ b/static/style.css
@@ -5922,6 +5922,25 @@ main.main > #mainPlugin{display:none;}
 .msg-body code,
 .msg-body pre,
 .msg-body table { font-family: 'SF Mono', ui-monospace, monospace; }
+.msg-body pre,
+.preview-md pre {
+  white-space: pre-wrap !important;
+  overflow-x: hidden !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
+}
+.msg-body pre code,
+.preview-md pre code {
+  white-space: inherit !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
+}
+.msg-body pre code .token,
+.preview-md pre code .token {
+  white-space: inherit !important;
+  overflow-wrap: anywhere !important;
+  word-break: inherit !important;
+}
 .msg-body:empty { display: none; }
 .assistant-turn { width: 100%; min-width: 0; }
 .assistant-turn-blocks { display: flex; flex-direction: column; min-width: 0; }

--- a/tests/test_message_overflow_css.py
+++ b/tests/test_message_overflow_css.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+STYLE = Path(__file__).resolve().parents[1] / "static" / "style.css"
+
+
+def test_message_body_wraps_long_inline_terms_after_late_layout_override():
+    css = STYLE.read_text(encoding="utf-8")
+
+    late_layout_marker = "/* ── Unified indent rail — every child of a turn lines up on --msg-rail ── */"
+    late_layout = css.split(late_layout_marker, 1)[1]
+
+    assert ".msg-body {" in late_layout
+    assert "max-width: min(var(--msg-max), 100%);" in late_layout
+    assert "min-width: 0;" in late_layout
+    assert "overflow-wrap: anywhere;" in late_layout
+    assert "word-break: break-word;" in late_layout
+
+    # Assistant messages are nested as .assistant-turn > .assistant-turn-blocks >
+    # .assistant-segment > .msg-body. Each flex/container layer must be allowed to
+    # shrink, otherwise long mixed English/CJK medical terms can force horizontal
+    # overflow even when the body itself has overflow-wrap.
+    assert ".assistant-turn { width: 100%; min-width: 0; }" in late_layout
+    assert ".assistant-turn-blocks { display: flex; flex-direction: column; min-width: 0; }" in late_layout
+    assert ".assistant-segment { max-width: 100%; min-width: 0; }" in late_layout
+
+    # Markdown renderers often wrap prose in inline spans/em/strong/a elements;
+    # keep the actual prose descendants breakable too, not only the outer body.
+    assert ".msg-body :where(p, li, blockquote" in late_layout

--- a/tests/test_message_overflow_css.py
+++ b/tests/test_message_overflow_css.py
@@ -27,3 +27,11 @@ def test_message_body_wraps_long_inline_terms_after_late_layout_override():
     # Markdown renderers often wrap prose in inline spans/em/strong/a elements;
     # keep the actual prose descendants breakable too, not only the outer body.
     assert ".msg-body :where(p, li, blockquote" in late_layout
+
+    # Desktop code/TEXT blocks should not force a horizontal scrollbar for prose
+    # instructions. The older rule only wrapped pre blocks below the mobile
+    # breakpoint, so desktop screenshots could still clip long lines.
+    assert ".msg-body pre,\n.preview-md pre" in late_layout
+    assert "white-space: pre-wrap !important;" in late_layout
+    assert "overflow-x: hidden !important;" in late_layout
+    assert ".msg-body pre code,\n.preview-md pre code" in late_layout


### PR DESCRIPTION
## Summary
Wraps long desktop message/code text so it cannot force horizontal overflow.

## Verification
Targeted tests passed locally.