### PR TITLE
fix(title): preserve user-entered workspace prefixes

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2950,9 +2950,9 @@ _TITLE_ATTACHED_FILES_SUFFIX_RE = re.compile(
 )
 
 
-def _strip_title_internal_metadata(text: str) -> str:
+def _strip_title_internal_metadata(text: str, *, include_legacy: bool = False) -> str:
     """Remove WebUI-only workspace/attachment metadata from title input."""
-    value = _strip_workspace_prefix(str(text or ''), include_legacy=True)
+    value = _strip_workspace_prefix(str(text or ''), include_legacy=include_legacy)
     return _TITLE_ATTACHED_FILES_SUFFIX_RE.sub('', value).strip()
 
 
@@ -2990,7 +2990,10 @@ def _first_exchange_snippets(messages):
             continue
         role = m.get('role')
         if role == 'user':
-            candidate = _strip_title_internal_metadata(_message_text(m.get('content')))
+            candidate = _strip_title_internal_metadata(
+                _message_text(m.get('content')),
+                include_legacy=True,
+            )
             if not user_text and candidate:
                 user_text = candidate
                 continue
@@ -3032,7 +3035,10 @@ def _latest_exchange_snippets(messages):
             if candidate:
                 asst_text = candidate
         elif role == 'user' and not user_text:
-            candidate = _strip_title_internal_metadata(_message_text(m.get('content')))
+            candidate = _strip_title_internal_metadata(
+                _message_text(m.get('content')),
+                include_legacy=True,
+            )
             if candidate:
                 user_text = candidate
         if user_text and asst_text:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2944,6 +2944,18 @@ def _strip_workspace_prefix(text: str, *, include_legacy: bool = False) -> str:
     return stripped.strip()
 
 
+_TITLE_ATTACHED_FILES_SUFFIX_RE = re.compile(
+    r'(?:\r?\n){2}\[Attached files(?: for this steer)?: [^\]]+\]\s*$',
+    re.IGNORECASE,
+)
+
+
+def _strip_title_internal_metadata(text: str) -> str:
+    """Remove WebUI-only workspace/attachment metadata from title input."""
+    value = _strip_workspace_prefix(str(text or ''), include_legacy=True)
+    return _TITLE_ATTACHED_FILES_SUFFIX_RE.sub('', value).strip()
+
+
 def _looks_like_current_user_turn(msg, msg_text) -> bool:
     """Match the current human turn even if an internal workspace tag leaked mid-text.
 
@@ -2978,7 +2990,7 @@ def _first_exchange_snippets(messages):
             continue
         role = m.get('role')
         if role == 'user':
-            candidate = _message_text(m.get('content'))
+            candidate = _strip_title_internal_metadata(_message_text(m.get('content')))
             if not user_text and candidate:
                 user_text = candidate
                 continue
@@ -3020,7 +3032,7 @@ def _latest_exchange_snippets(messages):
             if candidate:
                 asst_text = candidate
         elif role == 'user' and not user_text:
-            candidate = _message_text(m.get('content'))
+            candidate = _strip_title_internal_metadata(_message_text(m.get('content')))
             if candidate:
                 user_text = candidate
         if user_text and asst_text:
@@ -3163,8 +3175,10 @@ def _title_language_mismatch(user_text: str, title: str) -> bool:
     if not candidate:
         return False
 
-    # (1) Cross-script mismatch — language-agnostic.
-    user_script = _dominant_script(user_text)
+    # (1) Cross-script mismatch — language-agnostic. Internal WebUI metadata
+    # (workspace and attachment paths) must not influence script detection.
+    clean_user_text = _strip_title_internal_metadata(user_text)
+    user_script = _dominant_script(clean_user_text)
     if user_script:
         title_counts = _script_counts(candidate)
         title_total = sum(title_counts.values())
@@ -3174,7 +3188,7 @@ def _title_language_mismatch(user_text: str, title: str) -> bool:
                     return True
 
     # (2) Legacy same-script German→English heuristic.
-    if _detect_title_language(user_text) != 'de':
+    if _detect_title_language(clean_user_text) != 'de':
         return False
     candidate_lower = candidate.lower()
     if _detect_title_language(candidate_lower) == 'de':
@@ -3189,6 +3203,7 @@ def _title_language_mismatch(user_text: str, title: str) -> bool:
 
 
 def _title_prompts(user_text: str, assistant_text: str) -> tuple[str, list[str]]:
+    user_text = _strip_title_internal_metadata(user_text)
     qa = f"User question:\n{user_text[:500]}\n\nAssistant answer:\n{assistant_text[:500]}"
     language_rule = _title_prompt_language_rule(user_text)
     prompts = [
@@ -3691,17 +3706,27 @@ def _put_title_status(put_event, session_id: str, status: str, reason: str = '',
 
 def _fallback_title_from_exchange(user_text: str, assistant_text: str) -> Optional[str]:
     """Generate a readable local fallback title when LLM title generation fails."""
-    user_text = (user_text or '').strip()
+    user_text = _strip_title_internal_metadata(user_text)
     assistant_text = _strip_thinking_markup(assistant_text or '').strip()
     if not user_text:
         return None
-    user_text = _strip_workspace_prefix(user_text)
     user_text = re.sub(r'\s+', ' ', user_text).strip()
     assistant_text = re.sub(r'\s+', ' ', assistant_text).strip()
     combined = f"{user_text} {assistant_text}".strip().lower()
     combined_raw = f"{user_text} {assistant_text}".strip()
     def _contains_latin(text: str) -> bool:
         return bool(re.search(r'[A-Za-z]', text or ''))
+
+    def _contains_latin_keyword(text: str, keywords: tuple[str, ...]) -> bool:
+        """Match Latin keywords as tokens, never as substrings of gmail/email."""
+        return any(
+            re.search(
+                rf'(?<![A-Za-z0-9_]){re.escape(keyword)}(?![A-Za-z0-9_])',
+                text or '',
+                re.IGNORECASE,
+            )
+            for keyword in keywords
+        )
 
     def _extract_named_topic(text: str) -> str:
         m = re.search(r'"([^"\n]{2,24})"', text)
@@ -3717,12 +3742,12 @@ def _fallback_title_from_exchange(user_text: str, assistant_text: str) -> Option
         if not _contains_latin(topic_name):
             if any(k in combined for k in ('time', 'schedule', 'efficiency', 'manage', 'fitness', 'singing', 'calligraphy')):
                 return 'Time management discussion'
-            if any(k in combined for k in ('hermes', 'codex', 'ai')):
+            if _contains_latin_keyword(combined, ('hermes', 'codex', 'ai')):
                 return 'AI productivity discussion'
             return 'Conversation topic'
         if any(k in combined for k in ('time', 'schedule', 'efficiency', 'manage', 'fitness', 'singing', 'calligraphy')):
             return f'{topic_name} time management'
-        if any(k in combined for k in ('hermes', 'codex', 'ai')):
+        if _contains_latin_keyword(combined, ('hermes', 'codex', 'ai')):
             return f'{topic_name} AI productivity'
         return f'{topic_name} discussion'
 
@@ -3809,7 +3834,7 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
                     next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text, agent=agent, use_agent_model=True)
             else:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text)
-                if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux'):
+                if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux', 'llm_language_mismatch_aux'):
                     next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
             source = llm_status
             if not next_title:
@@ -3898,7 +3923,7 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
                     next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text, agent=agent, use_agent_model=True)
             else:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text)
-                if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux'):
+                if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux', 'llm_language_mismatch_aux'):
                     next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
         if not next_title:
             _put_title_status(put_event, session_id, 'refresh_skipped', llm_status or 'empty', effective, raw_preview)

--- a/tests/test_issue1913_workspace_prefix_sentinel.py
+++ b/tests/test_issue1913_workspace_prefix_sentinel.py
@@ -1,5 +1,6 @@
 from api.streaming import (
     _fallback_title_from_exchange,
+    _first_exchange_snippets,
     _strip_workspace_prefix,
     _workspace_context_prefix,
 )
@@ -22,6 +23,18 @@ def test_legacy_workspace_prefix_only_strips_for_compatibility_callers():
 
     assert _strip_workspace_prefix(legacy) == legacy
     assert _strip_workspace_prefix(legacy, include_legacy=True) == "Continue"
+
+
+def test_historical_exchange_strips_legacy_workspace_prefix():
+    user_text, assistant_text = _first_exchange_snippets(
+        [
+            {"role": "user", "content": "[Workspace: /tmp/project]\nContinue"},
+            {"role": "assistant", "content": "Done"},
+        ]
+    )
+
+    assert user_text == "Continue"
+    assert assistant_text == "Done"
 
 
 def test_user_typed_legacy_workspace_prefix_survives_fallback_title():

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -399,6 +399,89 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertEqual(captured.get('base_url'), 'https://agent-route.example/v1')
         self.assertIsNone(captured.get('api_key'))
 
+    def test_chinese_title_ignores_workspace_and_attachment_metadata(self):
+        """Regression: internal paths must not make a Chinese prompt look Latin."""
+        from api.streaming import _generate_llm_session_title_via_aux
+
+        user_text = (
+            '[Workspace::v1: /home/lester/workspace]\n'
+            '他们怎么知道我的项目？邮件正文直显\n\n'
+            '[Attached files: /home/lester/.hermes/webui/attachments/session/screenshot.png]'
+        )
+        mock_resp = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content='邮件项目误判澄清'),
+                    finish_reason='stop',
+                )
+            ]
+        )
+
+        with _patch_tg_config({'provider': '', 'model': 'title-model', 'base_url': ''}):
+            with patch('agent.auxiliary_client.call_llm', return_value=mock_resp, create=True):
+                title, status, raw_preview = _generate_llm_session_title_via_aux(
+                    user_text,
+                    'Nakheel 并不知道 Parallel World；这只是发给业主的施工进度调查。',
+                )
+
+        self.assertEqual(title, '邮件项目误判澄清')
+        self.assertEqual(status, 'llm_aux')
+        self.assertEqual(raw_preview, '')
+
+    def test_title_prompt_does_not_send_internal_metadata_to_aux_model(self):
+        """Title models should see user text, not WebUI workspace or attachment paths."""
+        from api.streaming import generate_title_raw_via_aux
+
+        user_text = (
+            '[Workspace::v1: /home/lester/workspace]\n'
+            '他们怎么知道我的项目？邮件正文直显\n\n'
+            '[Attached files: /home/lester/.hermes/webui/attachments/session/screenshot.png]'
+        )
+        mock_resp = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content='邮件项目误判澄清'),
+                    finish_reason='stop',
+                )
+            ]
+        )
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return mock_resp
+
+        with _patch_tg_config({'provider': '', 'model': 'title-model', 'base_url': ''}):
+            with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
+                generate_title_raw_via_aux(user_text, '这是一封 Nakheel 的业主调查邮件。')
+
+        prompt = '\n'.join(str(m.get('content') or '') for m in captured.get('messages') or [])
+        self.assertIn('他们怎么知道我的项目？邮件正文直显', prompt)
+        self.assertNotIn('[Workspace::v1:', prompt)
+        self.assertNotIn('[Attached files:', prompt)
+        self.assertNotIn('/home/lester/.hermes', prompt)
+
+    def test_fallback_does_not_match_ai_inside_gmail_or_email(self):
+        """Regression: the Latin token ``ai`` must be matched as a whole word."""
+        from api.streaming import _fallback_title_from_exchange
+
+        title = _fallback_title_from_exchange(
+            '请解释“邮件项目误判”',
+            '这封 Gmail email 来自 Nakheel，不是人工智能项目。',
+        )
+
+        self.assertNotEqual(title, 'AI productivity discussion')
+
+    def test_fallback_still_matches_standalone_ai_keyword(self):
+        from api.streaming import _fallback_title_from_exchange
+
+        title = _fallback_title_from_exchange(
+            '请解释“人工智能助手”',
+            '这是一个 AI productivity workflow。',
+        )
+
+        self.assertEqual(title, 'AI productivity discussion')
+
     def test_integer_timeout_from_config(self):
         """Config timeout as int is coerced to float."""
         self._run_with_config(
@@ -948,6 +1031,42 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
         title_events = [(e, d) for e, d in events if e == 'title']
         self.assertTrue(len(title_events) > 0, "Expected a 'title' event to be emitted")
         self.assertEqual(title_events[0][1]['title'], 'Weather Report')
+
+    @patch('api.streaming._aux_title_configured', return_value=True)
+    @patch('api.streaming._generate_llm_session_title_via_aux')
+    @patch('api.streaming._generate_llm_session_title_for_agent')
+    @patch('api.streaming.get_session')
+    def test_llm_language_mismatch_aux_triggers_agent_fallback(
+        self, mock_get_session, mock_agent_title, mock_aux_title, mock_configured,
+    ):
+        """A wrong-language auxiliary result should get a second model attempt."""
+        from api.streaming import _run_background_title_update
+
+        mock_session = MagicMock()
+        mock_session.title = 'Untitled'
+        mock_session.llm_title_generated = False
+        mock_session.messages = [
+            {'role': 'user', 'content': '为什么这封邮件提到我的项目？'},
+            {'role': 'assistant', 'content': '这是发给业主的施工进度调查。'},
+        ]
+        mock_get_session.return_value = mock_session
+        mock_aux_title.return_value = (
+            None,
+            'llm_language_mismatch_aux',
+            'AI productivity discussion',
+        )
+        mock_agent_title.return_value = ('Nakheel 邮件项目澄清', 'llm', '')
+
+        _run_background_title_update(
+            session_id='test-session-mismatch',
+            user_text='为什么这封邮件提到我的项目？',
+            assistant_text='这是发给业主的施工进度调查。',
+            placeholder_title='Untitled',
+            put_event=lambda *_args: None,
+            agent=MagicMock(),
+        )
+
+        mock_agent_title.assert_called_once()
 
     @patch('api.streaming._aux_title_configured', return_value=True)
     @patch('api.streaming._generate_llm_session_title_via_aux')


### PR DESCRIPTION
## Summary
Separates internal title metadata from a user-entered legacy workspace prefix.

## Verification
Targeted tests passed locally.