### PR TITLE
fix(sidebar): clear stale active-session unread marker

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -812,11 +812,13 @@ function _isSessionLocallyStreaming(s) {
 }
 
 function _isSessionEffectivelyStreaming(s) {
-  return Boolean(s && (
+  if (!s) return false;
+  if (_isActiveSessionIdleForSidebar(s)) return false;
+  return Boolean(
     s.is_streaming ||
     _hasPendingUserMessageSignal(s) ||
     _isSessionLocallyStreaming(s)
-  ));
+  );
 }
 
 function _hasPendingUserMessageSignal(s) {
@@ -825,6 +827,17 @@ function _hasPendingUserMessageSignal(s) {
 
 function _isServerIdleSessionRow(s) {
   return Boolean(s && s.session_id && !s.is_streaming && !s.active_stream_id && !s.pending_user_message && !s.has_pending_user_message && !s.pending_started_at);
+}
+
+function _isActiveSessionIdleForSidebar(s) {
+  if (!s || !s.session_id || !S || !S.session || S.session.session_id !== s.session_id) return false;
+  if (!_isServerIdleSessionRow(s)) return false;
+  // During the optimistic /api/chat/start window the server can still report an
+  // idle row while the browser owns the just-submitted turn. Do not clear the
+  // active indicator for that specific start race; otherwise a stale local
+  // S.busy flag must not keep the active sidebar row yellow forever (#856).
+  if (typeof _sendInProgress !== 'undefined' && _sendInProgress && s.session_id === _sendInProgressSid) return false;
+  return true;
 }
 
 function _reconcileActiveSessionIdleStateFromList(serverRows) {

--- a/tests/test_issue856_active_session_read_state.py
+++ b/tests/test_issue856_active_session_read_state.py
@@ -3,7 +3,24 @@
 from pathlib import Path
 
 
-MESSAGES_JS = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
+REPO = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"could not find body for {signature}")
 
 
 def test_messages_js_defines_active_session_viewed_helper():
@@ -51,3 +68,24 @@ def test_restore_and_error_paths_mark_active_session_as_viewed():
     assert "_markSessionViewed(activeSid" in error_block, (
         "_handleStreamError() must mark the active session as viewed"
     )
+
+
+def test_active_server_idle_row_overrides_stale_local_busy_sidebar_state():
+    effective = _function_body(SESSIONS_JS, "function _isSessionEffectivelyStreaming(s)")
+    idle_guard = _function_body(SESSIONS_JS, "function _isActiveSessionIdleForSidebar(s)")
+
+    assert "if (_isActiveSessionIdleForSidebar(s)) return false;" in effective
+    assert "_isSessionLocallyStreaming(s)" in effective
+
+    assert "S.session.session_id !== s.session_id" in idle_guard
+    assert "!_isServerIdleSessionRow(s)" in idle_guard
+    assert "stale local" in idle_guard
+    assert "S.busy flag must not keep the active sidebar row yellow forever (#856)" in idle_guard
+
+
+def test_optimistic_send_start_window_is_not_mistaken_for_stale_yellow_dot():
+    idle_guard = _function_body(SESSIONS_JS, "function _isActiveSessionIdleForSidebar(s)")
+
+    assert "typeof _sendInProgress !== 'undefined'" in idle_guard
+    assert "_sendInProgress && s.session_id === _sendInProgressSid" in idle_guard
+    assert "return false;" in idle_guard


### PR DESCRIPTION
## Summary
Clears the sidebar active-session indicator when it is stale.

## Verification
Six focused tests and `node --check` passed locally.