### PR TITLE
fix(composer): clear context usage for a blank composer

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -3702,6 +3702,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           try{localStorage.removeItem('hermes-webui-session');}catch(_){}
         }
         S.session=null; S.messages=[]; S.activeStreamId=null; S.busy=false;
+        if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
         S._bootReady=true;
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
@@ -3710,6 +3711,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       }
       if(_rootPrefillNeedsFreshComposer(urlSession, savedLocal, prefillIntent)){
         S.session=null; S.messages=[]; S.activeStreamId=null; S.busy=false;
+        if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
         S._bootReady=true;
         const _ephPanelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
           || localStorage.getItem('hermes-webui-workspace-panel')==='open';
@@ -3746,6 +3748,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
       const _restoredHasDraft = !!(_restoredDraftText || _restoredDraftFiles.length);
       if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight && !_restoredHasDraft){
         S.session=null; S.messages=[];
+        if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
         S._bootReady=true;
         // Restore panel pref before syncing so the workspace panel stays visible
         // even though there is no active session (#workspace-persist).
@@ -3771,6 +3774,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     catch(e){localStorage.removeItem('hermes-webui-session');}
   }
   // no saved session - show empty state, wait for user to hit +
+  if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
   S._bootReady=true;
   syncTopbar();
   // Restore panel pref so the workspace panel stays visible on a fresh load if the
@@ -3823,6 +3827,8 @@ window.addEventListener('pageshow', async (event) => {
         try { await checkInflightOnBoot(S.session.session_id); } catch (_) {}
       }
     } catch (_) {}
+  } else if (typeof _resetCtxIndicatorForEmptyComposer === 'function') {
+    _resetCtxIndicatorForEmptyComposer();
   }
   // Re-synchronise layout chrome that the boot IIFE sets up but bfcache
   // doesn't re-run. Each call is guarded so missing helpers degrade silently.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1384,6 +1384,7 @@ async function newSession(flash, options={}){
   }
   _setNewSessionPending(true);
   _newSessionInFlight=(async()=>{
+    if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
     // Starting a brand-new chat must not carry named context blocks selected in
     // the previous conversation (#2543). loadSession() clears these on a sidebar
     // switch, but the New Chat path replaces S.session here without going through
@@ -4272,6 +4273,7 @@ function _renderBatchActionBar(){
       ids.forEach(_clearHandoffStorageForSession);
       if(S.session&&ids.includes(S.session.session_id)){
         S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
+        if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
@@ -9015,6 +9017,7 @@ async function deleteSession(sid, beforeDelete=null){
   }
   if(S.session&&S.session.session_id===sid){
     S.session=null;S.messages=[];S.entries=[];
+    if(typeof _resetCtxIndicatorForEmptyComposer==='function') _resetCtxIndicatorForEmptyComposer();
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
     localStorage.removeItem('hermes-webui-session');
     // load the most recent remaining session, or show blank if none left

--- a/static/ui.js
+++ b/static/ui.js
@@ -6566,6 +6566,14 @@ function _mergeUsageForCtxIndicator(latest, fallback){
   return merged;
 }
 
+function _resetCtxIndicatorForEmptyComposer(){
+  // Context usage belongs to one conversation. An empty composer has no
+  // conversation yet, so never carry the previous session's transient usage
+  // cache or its visible ring across a new-chat / blank-page boundary.
+  if(typeof S!=='undefined') S.lastUsage={};
+  _syncCtxIndicator({});
+}
+
 // Context usage indicator in composer footer
 function _syncCtxIndicator(usage){
   const wrap=$('ctxIndicatorWrap');

--- a/tests/test_empty_composer_context_indicator_reset.py
+++ b/tests/test_empty_composer_context_indicator_reset.py
@@ -1,0 +1,54 @@
+"""Regression coverage for stale context usage leaking into an empty composer."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+def test_empty_composer_reset_clears_transient_usage_and_hides_ring():
+    start = UI_JS.find("function _resetCtxIndicatorForEmptyComposer()")
+    assert start != -1
+    end = UI_JS.find("// Context usage indicator in composer footer", start)
+    assert end != -1
+    block = UI_JS[start:end]
+
+    assert "S.lastUsage={};" in block
+    assert "_syncCtxIndicator({});" in block
+
+
+def test_new_session_clears_context_indicator_before_network_create():
+    start = SESSIONS_JS.find("async function newSession(")
+    assert start != -1
+    post = SESSIONS_JS.find("const data=await api('/api/session/new'", start)
+    assert post != -1
+    block = SESSIONS_JS[start:post]
+
+    assert "_resetCtxIndicatorForEmptyComposer()" in block
+
+
+def test_blank_boot_and_bfcache_paths_clear_context_indicator():
+    no_saved = BOOT_JS.find("// no saved session - show empty state")
+    assert no_saved != -1
+    no_saved_end = BOOT_JS.find("S._bootReady=true;", no_saved)
+    assert no_saved_end != -1
+    assert "_resetCtxIndicatorForEmptyComposer()" in BOOT_JS[no_saved:no_saved_end]
+
+    pageshow = BOOT_JS.find("window.addEventListener('pageshow'")
+    assert pageshow != -1
+    pageshow_end = BOOT_JS.find("// Re-synchronise layout chrome", pageshow)
+    assert pageshow_end != -1
+    block = BOOT_JS[pageshow:pageshow_end]
+    assert "else if (typeof _resetCtxIndicatorForEmptyComposer === 'function')" in block
+    assert "_resetCtxIndicatorForEmptyComposer();" in block
+
+
+def test_deleting_active_session_clears_context_indicator_before_fallback():
+    reset_call = (
+        "if(typeof _resetCtxIndicatorForEmptyComposer==='function') "
+        "_resetCtxIndicatorForEmptyComposer();"
+    )
+    assert SESSIONS_JS.count(reset_call) >= 3


### PR DESCRIPTION
## Summary
Resets the displayed context usage when the composer has no text.

## Verification
Four focused tests and `node --check` passed locally.