### PR TITLE
Add Codex plugin mentions

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8914,6 +8914,7 @@ def get_gateway_caps(base_url: str, api_key: str = "") -> dict:
             features = {}
         caps["approval_events"] = bool(features.get("approval_events"))
         caps["run_approval_response"] = bool(features.get("run_approval_response"))
+        caps["plugin_mentions"] = bool(features.get("plugin_mentions"))
     except urllib.error.HTTPError as exc:
         caps["capabilities_reachable"] = True
         caps["probe_error"] = f"{type(exc).__name__}: {exc}"
@@ -8951,6 +8952,11 @@ def gateway_supports_approval(base_url: str, api_key: str = "") -> bool:
     """True only when the gateway advertises both approval_events and run_approval_response."""
     caps = get_gateway_caps(base_url, api_key)
     return bool(caps.get("approval_events") and caps.get("run_approval_response"))
+
+
+def gateway_supports_plugin_mentions(base_url: str, api_key: str = "") -> bool:
+    """True only when the gateway explicitly advertises structured plugin mentions."""
+    return bool(get_gateway_caps(base_url, api_key).get("plugin_mentions"))
 
 
 def invalidate_gateway_caps(base_url: str | None = None) -> None:

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -26,6 +26,7 @@ from api.config import (
     coerce_reasoning_effort_for_model,
     gateway_approval_unavailable_reason,
     gateway_supports_approval,
+    gateway_supports_plugin_mentions,
     register_active_run,
     unregister_active_run,
     unregister_stream_owner,
@@ -45,6 +46,10 @@ _WEBUI_GATEWAY_BASE_URL_ENV = "HERMES_WEBUI_GATEWAY_BASE_URL"
 _WEBUI_GATEWAY_API_KEY_ENV = "HERMES_WEBUI_GATEWAY_API_KEY"
 _WEBUI_GATEWAY_USE_RUNS_API_ENV = "HERMES_WEBUI_GATEWAY_USE_RUNS_API"
 _GATEWAY_CHAT_BACKENDS = {"gateway", "api_server", "api-server"}
+
+
+def gateway_accepts_plugin_mentions(cfg) -> bool:
+    return gateway_supports_plugin_mentions(_gateway_base_url(cfg), _gateway_api_key())
 
 
 # Total byte-silence budget (seconds) for the gateway SSE socket, applied via
@@ -653,6 +658,7 @@ def _run_gateway_chat_streaming(
     *,
     model_provider=None,
     goal_related=False,
+    plugin_mentions=None,
 ):
     """Bridge a WebUI chat turn through Hermes Gateway's API server.
 
@@ -785,6 +791,11 @@ def _run_gateway_chat_streaming(
         _use_runs_api = _gateway_use_runs_api_enabled(cfg) and gateway_supports_approval(base_url, api_key)
         if _use_runs_api:
             body_extras = {}
+            if plugin_mentions:
+                body_extras["original_user_message"] = {
+                    "content": msg_text,
+                    "plugin_mentions": plugin_mentions,
+                }
             if model_provider:
                 body_extras["provider"] = model_provider
             if reasoning_effort is not None:
@@ -860,6 +871,11 @@ def _run_gateway_chat_streaming(
                 "stream": True,
                 "messages": [*prefill_messages, {"role": "user", "content": message_content}],
             }
+            if plugin_mentions:
+                body["original_user_message"] = {
+                    "content": msg_text,
+                    "plugin_mentions": plugin_mentions,
+                }
             if model_provider:
                 body["provider"] = model_provider
             if reasoning_effort is not None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9662,7 +9662,7 @@ from api.streaming import (
     _compact_for_echo_compare,
     _strip_compact_echo_suffix,
 )
-from api.gateway_chat import _run_gateway_chat_streaming, webui_gateway_chat_enabled
+from api.gateway_chat import _run_gateway_chat_streaming, gateway_accepts_plugin_mentions, webui_gateway_chat_enabled
 from api.run_journal import (
     _parse_run_journal_event_id as _shared_parse_run_journal_event_id,
     bound_run_journal_snapshot_args,
@@ -13290,6 +13290,9 @@ def handle_get(handler, parsed) -> bool:
             "is_git": True,
         }
         return j(handler, {"git": info})
+
+    if parsed.path == "/api/codex/plugins":
+        return _handle_codex_plugins(handler)
 
     if parsed.path == "/api/commands":
         from api.commands import list_commands
@@ -21072,12 +21075,19 @@ def _start_chat_stream_for_session(
     goal_related: bool = False,
     source: str = "webui",
     moa_config=None,
+    plugin_mentions=None,
     external_runtime_owned: bool | None = None,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     if external_runtime_owned is None:
         external_runtime_owned = webui_gateway_chat_enabled(get_config())
     backend_is_gateway = bool(external_runtime_owned)
+    if backend_is_gateway and plugin_mentions and not gateway_accepts_plugin_mentions(get_config()):
+        return {
+            "error": "The connected Hermes gateway does not advertise plugin mention support. Your draft and selected plugins were kept.",
+            "type": "plugin_mentions_gateway_unsupported",
+            "_status": 409,
+        }
     stale_response = _agent_runtime_barrier_response(
         external_runtime_owned=backend_is_gateway,
     )
@@ -21204,6 +21214,8 @@ def _start_chat_stream_for_session(
     diag.stage("worker_thread_start") if diag else None
     worker_target = _run_gateway_chat_streaming if backend_is_gateway else _run_agent_streaming
     worker_kwargs = {"model_provider": model_provider, "goal_related": goal_related}
+    if plugin_mentions:
+        worker_kwargs["plugin_mentions"] = plugin_mentions
     if moa_config and not backend_is_gateway:
         worker_kwargs["moa_config"] = moa_config
     thr = threading.Thread(
@@ -21293,6 +21305,7 @@ def _start_run(
     diag=None,
     moa_config=None,
     gateway_chat_enabled: bool | None = None,
+    plugin_mentions=None,
 ):
     """Shared start-run helper for /api/chat/start and start_session_turn.
 
@@ -21334,6 +21347,7 @@ def _start_run(
                 source=request.source or source,
                 moa_config=moa_config,
                 external_runtime_owned=gateway_chat_enabled,
+                plugin_mentions=plugin_mentions,
             )
 
         def _legacy_adapter_factory():
@@ -21356,7 +21370,7 @@ def _start_run(
                     provider=model_provider,
                     model=model,
                     source=source,
-                    metadata={"route": route},
+                    metadata={"route": route, **({"plugin_mentions": plugin_mentions} if plugin_mentions else {})},
                 )
             )
         except NotImplementedError as exc:
@@ -21375,6 +21389,7 @@ def _start_run(
         source=source,
         moa_config=moa_config,
         external_runtime_owned=gateway_chat_enabled,
+        plugin_mentions=plugin_mentions,
     )
 
 
@@ -21967,6 +21982,10 @@ def _handle_chat_start(handler, body, diag=None):
             require(body, "session_id")
         except ValueError as e:
             return bad(handler, str(e))
+        try:
+            plugin_mentions = _normalize_codex_plugin_mentions(body.get("plugin_mentions"))
+        except ValueError as exc:
+            return bad(handler, str(exc), 400)
         # Reject a stale local Agent runtime before materialising, claiming, or
         # mutating any session state. Gateway-backed turns run in the gateway's
         # process and do not depend on this WebUI process's imported checkout.
@@ -22188,6 +22207,7 @@ def _handle_chat_start(handler, body, diag=None):
             "route": "/api/chat/start",
             "diag": diag,
             "gateway_chat_enabled": gateway_chat_enabled,
+            "plugin_mentions": plugin_mentions,
         }
         if not gateway_chat_enabled and moa_config is not None:
             start_run_kwargs["moa_config"] = moa_config
@@ -22252,6 +22272,98 @@ def _resolve_chat_workspace_with_recovery(s, requested_workspace) -> str:
     except Exception:
         pass
     return fallback
+
+
+_CODEX_PLUGIN_MENTION_LIMIT = 20
+_CODEX_PLUGIN_NAME_LIMIT = 128
+_CODEX_PLUGIN_PATH_LIMIT = 1024
+
+
+def _normalize_codex_plugin_mentions(raw_mentions):
+    """Validate and order-dedupe the optional browser plugin selection."""
+    if raw_mentions is None:
+        return []
+    if not isinstance(raw_mentions, list):
+        raise ValueError("plugin_mentions must be a list")
+    if len(raw_mentions) > _CODEX_PLUGIN_MENTION_LIMIT:
+        raise ValueError(f"plugin_mentions must contain at most {_CODEX_PLUGIN_MENTION_LIMIT} items")
+
+    normalized = []
+    seen = set()
+    for item in raw_mentions:
+        if not isinstance(item, dict) or set(item) != {"name", "path"}:
+            raise ValueError("each plugin mention must contain only name and path")
+        name = item.get("name")
+        path = item.get("path")
+        if not isinstance(name, str) or not name.strip() or len(name) > _CODEX_PLUGIN_NAME_LIMIT:
+            raise ValueError("plugin mention name is invalid")
+        if not isinstance(path, str) or not path.strip() or len(path) > _CODEX_PLUGIN_PATH_LIMIT:
+            raise ValueError("plugin mention path is invalid")
+        name = name.strip()
+        path = path.strip()
+        parsed = urlsplit(path)
+        if (
+            parsed.scheme != "plugin"
+            or not parsed.netloc
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or any(part in (".", "..") for part in parsed.path.split("/"))
+            or any(ch.isspace() for ch in path)
+        ):
+            raise ValueError("plugin mention path must be a valid plugin:// path")
+        key = (name, path)
+        if key not in seen:
+            seen.add(key)
+            normalized.append({"name": name, "path": path})
+    return normalized
+
+
+def _handle_codex_plugins(handler):
+    """Return the sanitized Codex app-server plugin inventory, when supported."""
+    try:
+        from agent.codex_runtime import list_codex_plugins
+    except (ImportError, AttributeError):
+        return j(handler, {"plugins": [], "available": False})
+
+    try:
+        inventory = list_codex_plugins()
+    except Exception:
+        logger.warning("Codex plugin inventory is unavailable", exc_info=True)
+        return j(handler, {"plugins": [], "available": False})
+
+    raw_plugins = inventory.get("plugins", []) if isinstance(inventory, dict) else inventory
+    if not isinstance(raw_plugins, list):
+        return j(handler, {"plugins": [], "available": False})
+    if len(raw_plugins) > _CODEX_PLUGIN_MENTION_LIMIT:
+        logger.warning("Codex plugin inventory exceeds the WebUI limit; truncating")
+        raw_plugins = raw_plugins[:_CODEX_PLUGIN_MENTION_LIMIT]
+    plugins = []
+    for raw in raw_plugins:
+        if not isinstance(raw, dict):
+            continue
+        item = {}
+        valid = True
+        for key, limit in (("name", 128), ("path", 1024), ("description", 4096)):
+            value = raw.get(key, "")
+            if not isinstance(value, str) or len(value) > limit or (key in {"name", "path"} and not value.strip()):
+                valid = False
+                break
+            item[key] = value.strip() if key in {"name", "path"} else value
+        keywords = raw.get("keywords", [])
+        if not valid or not isinstance(keywords, list) or len(keywords) > 100:
+            continue
+        if not all(isinstance(value, str) and len(value) <= 128 for value in keywords):
+            continue
+        try:
+            identity = _normalize_codex_plugin_mentions([{"name": item["name"], "path": item["path"]}])[0]
+        except (ValueError, IndexError):
+            continue
+        item.update(identity)
+        item["keywords"] = keywords
+        plugins.append(item)
+    return j(handler, {"plugins": plugins, "available": True})
 
 
 def _normalize_chat_attachments(raw_attachments):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -7096,6 +7096,26 @@ def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
             rt['is_anthropic_oauth'] = getattr(agent, '_is_anthropic_oauth')
 
 
+def _add_plugin_mentions_to_run_kwargs(agent, run_kwargs, *, msg_text, plugin_mentions):
+    """Use the companion Hermes structured-message keyword when it exists."""
+    if not plugin_mentions:
+        return True
+    try:
+        import inspect
+
+        parameters = inspect.signature(agent.run_conversation).parameters
+        supports_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+        if "original_user_message" in parameters or supports_kwargs:
+            run_kwargs["original_user_message"] = {
+                "content": msg_text,
+                "plugin_mentions": plugin_mentions,
+            }
+            return True
+    except (TypeError, ValueError):
+        logger.debug("Could not inspect Hermes run_conversation signature", exc_info=True)
+    return False
+
+
 def _run_agent_streaming(
     session_id,
     msg_text,
@@ -7108,6 +7128,7 @@ def _run_agent_streaming(
     model_provider=None,
     goal_related=False,
     moa_config=None,
+    plugin_mentions=None,
 ):
     """Run agent in background thread, writing SSE events to STREAMS[stream_id].
 
@@ -9057,6 +9078,17 @@ def _run_agent_streaming(
             # run_conversation() predates the moa_config kwarg.
             if moa_config is not None:
                 _run_conversation_kwargs["moa_config"] = moa_config
+            _plugin_mentions_supported = _add_plugin_mentions_to_run_kwargs(
+                agent,
+                _run_conversation_kwargs,
+                msg_text=msg_text,
+                plugin_mentions=plugin_mentions,
+            )
+            if plugin_mentions and not _plugin_mentions_supported:
+                put('warning', {
+                    'type': 'plugin_mentions_unsupported',
+                    'message': 'Selected plugins were not used because this Hermes runtime does not support plugin mentions.',
+                })
 
             # Finalize durable delegation claims at the current-turn acceptance
             # boundary: immediately before invoking the agent with the message

--- a/static/boot.js
+++ b/static/boot.js
@@ -2235,7 +2235,7 @@ $('modelSelect').onchange=async()=>{
     if(warn&&typeof showToast==='function') showToast(warn,4000);
   }
 };
-$('msg').addEventListener('input',()=>{
+$('msg').addEventListener('input',(event)=>{
   updateSendBtn();
   scheduleComposerAutoResize();
   // Persist composer draft to server (debounced in _saveComposerDraft).
@@ -2244,6 +2244,7 @@ $('msg').addEventListener('input',()=>{
     _saveComposerDraft(sid, $('msg').value, S.pendingFiles ? [...S.pendingFiles] : []);
   }
   const text=$('msg').value;
+  if(typeof updatePluginMentionAutocomplete==='function') updatePluginMentionAutocomplete(event);
   const _slashIdx=typeof _activeSlashCommandOffset==='function'?_activeSlashCommandOffset(text):-1;
   if(_slashIdx>=0&&text.indexOf('\n')===-1){
     if(typeof getSlashAutocompleteMatches==='function'){
@@ -2327,6 +2328,7 @@ function _isNumpadEnter(e){
   return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);
 }
 $('msg').addEventListener('keydown',e=>{
+  if(typeof handlePluginMentionKeydown==='function'&&handlePluginMentionKeydown(e)) return;
   // Autocomplete navigation when dropdown is open
   const dd=$('cmdDropdown');
   const dropdownOpen=dd&&dd.classList.contains('open');

--- a/static/index.html
+++ b/static/index.html
@@ -582,6 +582,7 @@
       <div id="composerSelectionChips" class="composer-selection-chips" hidden aria-live="polite"></div>
       <div class="composer-box" id="composerBox">
         <div class="cmd-dropdown" id="cmdDropdown"></div>
+        <div class="plugin-mention-dropdown" id="pluginMentionDropdown" role="listbox" aria-label="Plugins" hidden></div>
         <div class="drop-hint" id="dropHint">
           <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
           <span id="dropHintText">Drop files to attach</span>
@@ -1770,6 +1771,7 @@
 <script src="static/terminal.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/sessions.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/commands.js?v=__WEBUI_VERSION__" defer></script>
+<script src="static/plugin_mentions.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/messages.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/extension_settings.js?v=__WEBUI_VERSION__" defer></script>
 <script src="static/panels.js?v=__WEBUI_VERSION__" defer></script>

--- a/static/messages.js
+++ b/static/messages.js
@@ -1305,6 +1305,11 @@ async function send(){
   // instead of silently dropping it.
   if (_sendInProgress) {
     const _text=_composerTextWithPendingSelections().trim();
+    const _mentions=typeof getPluginMentions==='function'?getPluginMentions():[];
+    if(_mentions.length){
+      showToast('Plugin mentions cannot be queued or steered. Wait for the current turn to finish.',3200);
+      return;
+    }
     // Use the in-flight session's sid, not the currently viewed session,
     // so the queued message goes to the chat that owns the active stream.
     const _targetSid=_sendInProgressSid||(S.session&&S.session.session_id);
@@ -1344,6 +1349,7 @@ async function send(){
   // immutable snapshot so later reassignments to `text` don't leak into it.
   const _failedSendDraftText=text;
   const _failedSendFilesSnapshot=Array.isArray(S.pendingFiles)?[...S.pendingFiles]:[];
+  const _submittedPluginMentions=typeof getPluginMentions==='function'?getPluginMentions():[];
 
   // Dismiss handoff hint when user sends a message (resets seen_at).
   if(S.session&&S.session.session_id&&typeof _dismissHandoffHint==='function'){
@@ -1355,6 +1361,10 @@ async function send(){
   // If busy or a manual compression is still running, handle based on default_message_mode
   if(S.busy||compressionRunning){
     if(text||S.pendingFiles.length){
+      if(_submittedPluginMentions.length){
+        showToast('Plugin mentions cannot be queued or steered. Wait for the current turn to finish.',3200);
+        return;
+      }
       if(!S.session){await newSession();await renderSessionList();}
       // Busy-control slash commands must be intercepted HERE, before the
       // defaultMessageMode routing block, so the user can always type /steer, /interrupt,
@@ -1746,7 +1756,7 @@ async function send(){
     // pick. (#3739/#3737, Codex catch)
     if(_pendingPickMatch && typeof _clearPendingSessionModel==='function') _clearPendingSessionModel(activeSid);
     explicitPickForPostStart=_explicitPick;
-    const startData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
+    const _plainStartPayload={
       session_id:activeSid,message:msgText,
       // S.session.model remains authoritative; the helper only resolves a
       // matching provider fallback for the same outgoing model.
@@ -1756,7 +1766,16 @@ async function send(){
       explicit_model_pick:_explicitPick||undefined,
       attachments:uploaded.length?uploaded:undefined,
       moa_config:_pendingMoaConfig?true:undefined
-    })});
+    };
+    const _pluginPayloadHelperAvailable=typeof PluginMentions!=='undefined'&&PluginMentions&&typeof PluginMentions.withPayload==='function';
+    if(_submittedPluginMentions.length&&!_pluginPayloadHelperAvailable){
+      throw new Error('Plugin mentions are unavailable because the WebUI assets are out of sync. Reload and try again.');
+    }
+    const _startPayload=_pluginPayloadHelperAvailable
+      ? PluginMentions.withPayload(_plainStartPayload,_submittedPluginMentions)
+      : _plainStartPayload;
+    const startData=await api('/api/chat/start',{method:'POST',body:JSON.stringify(_startPayload)});
+    if(_submittedPluginMentions.length&&typeof clearPluginMentions==='function') clearPluginMentions(_submittedPluginMentions);
     _pendingMoaConfig=null;
     postStartData = startData;
   }catch(e){

--- a/static/plugin_mentions.js
+++ b/static/plugin_mentions.js
@@ -1,0 +1,191 @@
+(function(root,factory){
+  const api=factory();
+  if(typeof module==='object'&&module.exports) module.exports=api;
+  if(root) root.PluginMentions=api;
+})(typeof globalThis!=='undefined'?globalThis:this,function(){
+  'use strict';
+
+  function activeToken(text,cursor){
+    const value=String(text||'');
+    const raw=Number(cursor);
+    const pos=Number.isFinite(raw)?Math.max(0,Math.min(raw,value.length)):value.length;
+    let start=pos;
+    while(start>0&&!/\s/.test(value[start-1])) start--;
+    if(value[start]!=='@') return null;
+    if(start>0&&!/\s/.test(value[start-1])) return null;
+    const query=value.slice(start+1,pos);
+    if(/\s/.test(query)) return null;
+    let end=pos;
+    while(end<value.length&&!/\s/.test(value[end])) end++;
+    return {start,end,query};
+  }
+
+  function words(value){
+    return String(value||'').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  }
+
+  function rankPlugins(plugins,query){
+    const needle=String(query||'').toLowerCase();
+    if(!needle) return [];
+    return (Array.isArray(plugins)?plugins:[]).map((plugin,index)=>{
+      const name=String(plugin&&plugin.name||'');
+      const nameLower=name.toLowerCase();
+      const keywords=Array.isArray(plugin&&plugin.keywords)?plugin.keywords.map(String):[];
+      let tier=-1;
+      if(nameLower.startsWith(needle)||words(name).some(word=>word.startsWith(needle))) tier=0;
+      else if(keywords.some(keyword=>keyword.toLowerCase().includes(needle))) tier=1;
+      else if(String(plugin&&plugin.description||'').toLowerCase().includes(needle)) tier=2;
+      return {plugin,tier,index,name:nameLower,path:String(plugin&&plugin.path||'')};
+    }).filter(row=>row.tier>=0).sort((a,b)=>
+      a.tier-b.tier||a.name.localeCompare(b.name)||a.path.localeCompare(b.path)||a.index-b.index
+    ).map(row=>row.plugin);
+  }
+
+  function addMention(mentions,plugin){
+    const current=Array.isArray(mentions)?mentions:[];
+    const mention={name:String(plugin&&plugin.name||''),path:String(plugin&&plugin.path||'')};
+    if(!mention.name||!mention.path||current.some(item=>item.path===mention.path)) return current.slice();
+    return current.concat(mention);
+  }
+
+  function removeToken(text,token){
+    const value=String(text||'');
+    if(!token) return value;
+    return value.slice(0,token.start)+value.slice(token.end);
+  }
+
+  function withPayload(payload,mentions){
+    const next={...(payload||{})};
+    if(Array.isArray(mentions)&&mentions.length){
+      next.plugin_mentions=mentions.map(item=>({name:item.name,path:item.path}));
+    }
+    return next;
+  }
+
+  function afterSend(current,submitted,accepted){
+    const items=Array.isArray(current)?current:[];
+    if(!accepted) return items.slice();
+    const paths=new Set((Array.isArray(submitted)?submitted:[]).map(item=>item.path));
+    return items.filter(item=>!paths.has(item.path));
+  }
+
+  return {activeToken,rankPlugins,addMention,removeToken,withPayload,afterSend};
+});
+
+(function(root){
+  'use strict';
+  if(!root||!root.document||!root.PluginMentions) return;
+  let mentions=[];
+  let inventory=[];
+  let loadPromise=null;
+  let matches=[];
+  let selected=0;
+  let active=null;
+
+  function elements(){
+    return {input:document.getElementById('msg'),dropdown:document.getElementById('pluginMentionDropdown')};
+  }
+
+  function loadInventory(){
+    if(!loadPromise){
+      loadPromise=(typeof root.api==='function'?root.api('/api/codex/plugins'):Promise.resolve({plugins:[]}))
+        .then(data=>{inventory=Array.isArray(data&&data.plugins)?data.plugins:[];return inventory;})
+        .catch(()=>{inventory=[];return inventory;});
+    }
+    return loadPromise;
+  }
+
+  function close(){
+    const {input,dropdown}=elements();
+    matches=[];active=null;selected=0;
+    if(dropdown){dropdown.hidden=true;dropdown.innerHTML='';}
+    if(input){input.removeAttribute('aria-activedescendant');input.setAttribute('aria-expanded','false');}
+  }
+
+  function renderChips(){
+    const input=document.getElementById('msg');
+    if(!input)return;
+    let wrap=document.getElementById('pluginMentionChips');
+    if(!wrap){
+      wrap=document.createElement('div');
+      wrap.id='pluginMentionChips';wrap.className='plugin-mention-chips';wrap.setAttribute('aria-label','Selected plugins');
+      input.parentNode.insertBefore(wrap,input);
+    }
+    wrap.innerHTML='';wrap.hidden=!mentions.length;
+    mentions.forEach(mention=>{
+      const chip=document.createElement('span');chip.className='plugin-mention-chip';
+      const name=document.createElement('span');name.className='plugin-mention-chip-name';name.textContent='@'+mention.name;
+      const remove=document.createElement('button');remove.type='button';remove.className='plugin-mention-chip-remove';remove.textContent='×';remove.setAttribute('aria-label','Remove '+mention.name);
+      remove.addEventListener('click',()=>{mentions=mentions.filter(item=>item.path!==mention.path);renderChips();input.focus();});
+      chip.append(name,remove);wrap.appendChild(chip);
+    });
+  }
+
+  function choose(index){
+    const plugin=matches[index];
+    const {input}=elements();
+    if(!plugin||!input||!active)return;
+    mentions=root.PluginMentions.addMention(mentions,plugin);
+    const next=root.PluginMentions.removeToken(input.value,active);
+    const caret=active.start;
+    input.value=next;input.focus();input.setSelectionRange(caret,caret);
+    renderChips();close();
+    input.dispatchEvent(new Event('input',{bubbles:true}));
+  }
+
+  function render(){
+    const {input,dropdown}=elements();
+    if(!input||!dropdown||!matches.length){close();return;}
+    dropdown.innerHTML='';
+    matches.forEach((plugin,index)=>{
+      const option=document.createElement('button');
+      option.type='button';option.id='pluginMentionOption'+index;option.className='plugin-mention-option'+(index===selected?' selected':'');
+      option.setAttribute('role','option');option.setAttribute('aria-selected',index===selected?'true':'false');
+      const name=document.createElement('span');name.className='plugin-mention-option-name';name.textContent='@'+String(plugin.name||'');
+      option.appendChild(name);
+      if(plugin.description){const desc=document.createElement('span');desc.className='plugin-mention-option-desc';desc.textContent=String(plugin.description);option.appendChild(desc);}
+      option.addEventListener('pointerdown',event=>{event.preventDefault();choose(index);});
+      dropdown.appendChild(option);
+    });
+    dropdown.hidden=false;input.setAttribute('role','combobox');input.setAttribute('aria-autocomplete','list');input.setAttribute('aria-controls',dropdown.id);input.setAttribute('aria-expanded','true');input.setAttribute('aria-activedescendant','pluginMentionOption'+selected);
+  }
+
+  function update(event){
+    const {input}=elements();
+    if(!input)return;
+    if(event&&(event.isComposing||event.inputType==='insertCompositionText')){close();return;}
+    const token=root.PluginMentions.activeToken(input.value,input.selectionStart);
+    if(!token||!token.query){close();return;}
+    active=token;
+    loadInventory().then(()=>{
+      const live=root.PluginMentions.activeToken(input.value,input.selectionStart);
+      if(!live||live.start!==token.start||live.query!==token.query){return;}
+      active=live;matches=root.PluginMentions.rankPlugins(inventory,live.query);selected=0;
+      if(matches.length){
+        if(typeof root.hideCmdDropdown==='function') root.hideCmdDropdown();
+        render();
+      }else close();
+    });
+  }
+
+  function move(delta){
+    if(!matches.length)return;
+    selected=(selected+delta+matches.length)%matches.length;render();
+    const option=document.getElementById('pluginMentionOption'+selected);if(option)option.scrollIntoView({block:'nearest'});
+  }
+
+  root.updatePluginMentionAutocomplete=update;
+  root.handlePluginMentionKeydown=function(event){
+    const {dropdown}=elements();
+    if(!dropdown||dropdown.hidden)return false;
+    if(event.isComposing||event.keyCode===229)return false;
+    if(event.key==='ArrowUp'||event.key==='ArrowDown'){event.preventDefault();move(event.key==='ArrowUp'?-1:1);return true;}
+    if(event.key==='Enter'||event.key==='Tab'){event.preventDefault();choose(selected);return true;}
+    if(event.key==='Escape'){event.preventDefault();event.stopPropagation();close();return true;}
+    return false;
+  };
+  root.getPluginMentions=()=>mentions.map(item=>({name:item.name,path:item.path}));
+  root.clearPluginMentions=function(submitted){
+    mentions=root.PluginMentions.afterSend(mentions,Array.isArray(submitted)?submitted:mentions,true);renderChips();
+  };
+})(typeof window!=='undefined'?window:null);

--- a/static/style.css
+++ b/static/style.css
@@ -3375,6 +3375,17 @@
 .cmd-item-desc{font-size:11px;color:var(--muted);margin-top:1px;}
 .cmd-item-badge{flex-shrink:0;font-size:10px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:2px 6px;border-radius:999px;border:1px solid var(--border2);color:var(--muted);background:var(--hover-bg);}
 .cmd-item-badge-skill{color:var(--accent-text);background:var(--accent-bg);border-color:var(--accent-bg-strong);}
+.plugin-mention-dropdown{position:absolute;left:0;right:0;bottom:calc(100% + 4px);max-width:100%;max-height:min(240px,40vh);overflow-y:auto;overscroll-behavior:contain;background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -8px 24px rgba(0,0,0,.4);z-index:210;box-sizing:border-box;}
+.plugin-mention-dropdown[hidden]{display:none;}
+.plugin-mention-option{display:block;width:100%;min-width:0;padding:8px 14px;border:0;background:transparent;color:var(--text);text-align:left;cursor:pointer;box-sizing:border-box;}
+.plugin-mention-option:hover,.plugin-mention-option.selected{background:var(--accent-bg);outline:1px solid var(--accent-bg-strong);}
+.plugin-mention-option-name{display:block;font-size:13px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.plugin-mention-option-desc{display:block;margin-top:1px;font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.plugin-mention-chips{display:flex;flex-wrap:wrap;gap:6px;padding:10px 14px 0;max-width:100%;overflow:hidden;}
+.plugin-mention-chip{display:inline-flex;align-items:center;gap:5px;min-width:0;max-width:100%;padding:4px 8px 4px 10px;border:1px solid var(--accent-bg-strong);border-radius:999px;background:var(--accent-bg);color:var(--accent-text);font-size:12px;}
+.plugin-mention-chip-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.plugin-mention-chip-remove{flex:0 0 auto;border:0;background:transparent;color:inherit;cursor:pointer;font-size:15px;line-height:1;padding:2px 3px;}
+@media (hover:none) and (pointer:coarse){.plugin-mention-option,.plugin-mention-chip-remove{min-height:44px;}.plugin-mention-dropdown{max-height:min(36dvh,240px);}}
 .ws-action-btn.danger:hover{background:rgba(239,83,80,.1);color:var(--error);border-color:var(--error);}
 .ws-add-row{display:flex;gap:8px;align-items:center;padding:10px 0 4px;}
 .ws-add-input-wrap{flex:1;min-width:0;}

--- a/tests/test_codex_plugin_mentions.py
+++ b/tests/test_codex_plugin_mentions.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import types
+from urllib.parse import urlparse
+
+import pytest
+
+from api import config, routes, streaming
+
+
+class _Handler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.sent_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+
+def _payload(handler):
+    return json.loads(handler.wfile.getvalue())
+
+
+def test_codex_plugins_route_is_covered_by_api_auth(monkeypatch):
+    from api import auth
+
+    handler = _Handler()
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: True)
+    monkeypatch.setattr(auth, "parse_cookie", lambda _handler: None)
+    monkeypatch.setattr(auth, "ensure_trusted_auth_session", lambda _handler: None)
+
+    assert auth.check_auth(handler, urlparse("/api/codex/plugins")) is False
+    assert handler.status == 401
+
+
+def test_codex_plugins_route_returns_sanitized_inventory(monkeypatch):
+    agent_module = types.ModuleType("agent")
+    runtime_module = types.ModuleType("agent.codex_runtime")
+    runtime_module.list_codex_plugins = lambda: [
+        {
+            "name": "research",
+            "path": "plugin://research",
+            "description": "Search helpers",
+            "keywords": ["papers"],
+            "raw_protocol": {"secret": "not exposed"},
+        }
+    ]
+    monkeypatch.setitem(sys.modules, "agent", agent_module)
+    monkeypatch.setitem(sys.modules, "agent.codex_runtime", runtime_module)
+    handler = _Handler()
+
+    routes.handle_get(handler, urlparse("/api/codex/plugins"))
+    assert handler.status == 200
+    assert _payload(handler) == {
+        "plugins": [{
+            "name": "research",
+            "path": "plugin://research",
+            "description": "Search helpers",
+            "keywords": ["papers"],
+        }],
+        "available": True,
+    }
+
+
+def test_codex_plugins_route_rejects_blank_identity_and_limits_count(monkeypatch):
+    agent_module = types.ModuleType("agent")
+    runtime_module = types.ModuleType("agent.codex_runtime")
+    runtime_module.list_codex_plugins = lambda: [
+        {"name": " ", "path": "plugin://blank", "description": "", "keywords": []},
+        {"name": "bad", "path": "https://example.com", "description": "", "keywords": []},
+        *[
+            {"name": f"p{i}", "path": f"plugin://p{i}", "description": "", "keywords": []}
+            for i in range(routes._CODEX_PLUGIN_MENTION_LIMIT + 5)
+        ],
+    ]
+    monkeypatch.setitem(sys.modules, "agent", agent_module)
+    monkeypatch.setitem(sys.modules, "agent.codex_runtime", runtime_module)
+    handler = _Handler()
+
+    routes.handle_get(handler, urlparse("/api/codex/plugins"))
+
+    payload = _payload(handler)
+    assert payload["available"] is True
+    assert len(payload["plugins"]) == routes._CODEX_PLUGIN_MENTION_LIMIT - 2
+    assert all(item["name"].strip() and item["path"].strip() for item in payload["plugins"])
+
+
+def test_codex_plugins_route_degrades_when_companion_helper_is_missing(monkeypatch):
+    agent_module = types.ModuleType("agent")
+    monkeypatch.setitem(sys.modules, "agent", agent_module)
+    monkeypatch.delitem(sys.modules, "agent.codex_runtime", raising=False)
+    handler = _Handler()
+
+    routes.handle_get(handler, urlparse("/api/codex/plugins"))
+
+    assert handler.status == 200
+    assert _payload(handler) == {"plugins": [], "available": False}
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["plugin://x", [{}], [{"name": "x", "path": "https://example.com"}],
+     [{"name": "x", "path": "plugin://x", "extra": True}]],
+)
+def test_plugin_mentions_reject_malformed_input(value):
+    with pytest.raises(ValueError):
+        routes._normalize_codex_plugin_mentions(value)
+
+
+def test_chat_start_rejects_malformed_mentions_before_session_lookup(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "_get_or_materialize_session",
+        lambda *_args, **_kwargs: pytest.fail("malformed request reached session lookup"),
+    )
+    handler = _Handler()
+
+    routes._handle_chat_start(
+        handler,
+        {"session_id": "s1", "message": "hello", "plugin_mentions": "plugin://one"},
+    )
+
+    assert handler.status == 400
+    assert "plugin_mentions must be a list" in _payload(handler)["error"]
+
+
+def test_plugin_mentions_dedupe_preserving_order():
+    mentions = [
+        {"name": "one", "path": "plugin://one"},
+        {"name": "two", "path": "plugin://two/path"},
+        {"name": "one", "path": "plugin://one"},
+    ]
+    assert routes._normalize_codex_plugin_mentions(mentions) == mentions[:2]
+
+
+def test_structured_mentions_forward_without_changing_visible_message():
+    captured = {}
+
+    class NewHermesAgent:
+        def run_conversation(self, *, user_message, original_user_message=None):
+            pass
+
+    kwargs = {"user_message": "visible text", "persist_user_message": "visible text"}
+    mentions = [{"name": "one", "path": "plugin://one"}]
+    streaming._add_plugin_mentions_to_run_kwargs(
+        NewHermesAgent(), kwargs, msg_text="visible text", plugin_mentions=mentions
+    )
+    captured.update(kwargs)
+
+    assert captured["user_message"] == "visible text"
+    assert captured["persist_user_message"] == "visible text"
+    assert captured["original_user_message"] == {
+        "content": "visible text",
+        "plugin_mentions": mentions,
+    }
+
+
+def test_plain_request_and_older_hermes_remain_compatible():
+    class OldHermesAgent:
+        def run_conversation(self, *, user_message):
+            pass
+
+    kwargs = {"user_message": "hello"}
+    streaming._add_plugin_mentions_to_run_kwargs(
+        OldHermesAgent(), kwargs, msg_text="hello", plugin_mentions=[]
+    )
+    assert kwargs == {"user_message": "hello"}
+
+
+def test_runner_signature_accepts_original_message_through_kwargs():
+    class FlexibleHermesAgent:
+        def run_conversation(self, *, user_message, **kwargs):
+            pass
+
+    kwargs = {"user_message": "hello"}
+    mentions = [{"name": "one", "path": "plugin://one"}]
+    assert streaming._add_plugin_mentions_to_run_kwargs(
+        FlexibleHermesAgent(), kwargs, msg_text="hello", plugin_mentions=mentions
+    ) is True
+    assert kwargs["original_user_message"]["plugin_mentions"] == mentions
+
+
+def test_runner_transport_receives_structured_original_message(monkeypatch):
+    captured = []
+
+    class RunnerClient:
+        def start_run(self, request):
+            captured.append(request)
+            return {
+                "run_id": "run-1",
+                "stream_id": "run-1",
+                "session_id": request.session_id,
+            }
+
+    monkeypatch.setenv("HERMES_WEBUI_RUNTIME_ADAPTER", "runner-local")
+    monkeypatch.setattr(routes, "_runtime_runner_client_factory", lambda: RunnerClient())
+    session = types.SimpleNamespace(session_id="s1", profile="default")
+    mentions = [{"name": "one", "path": "plugin://one"}]
+
+    routes._start_run(
+        session,
+        msg="visible text",
+        attachments=[],
+        workspace="/tmp/workspace",
+        model="gpt-test",
+        model_provider="openai-codex",
+        normalized_model=False,
+        source="webui",
+        route="/api/chat/start",
+        plugin_mentions=mentions,
+    )
+
+    assert captured[0].message == "visible text"
+    assert captured[0].metadata == {
+        "route": "/api/chat/start",
+        "plugin_mentions": mentions,
+    }
+
+
+def test_gateway_mentions_require_explicit_capability(monkeypatch):
+    monkeypatch.setattr(config, "get_gateway_caps", lambda *_args, **_kwargs: {})
+    assert config.gateway_supports_plugin_mentions("http://gateway") is False
+    monkeypatch.setattr(
+        config,
+        "get_gateway_caps",
+        lambda *_args, **_kwargs: {"plugin_mentions": True},
+    )
+    assert config.gateway_supports_plugin_mentions("http://gateway") is True

--- a/tests/test_plugin_mentions_frontend.py
+++ b/tests/test_plugin_mentions_frontend.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_node(source: str):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+    proc = subprocess.run(
+        [node, "-e", source], cwd=ROOT, text=True, capture_output=True, timeout=20
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_token_detection_ranking_dedupe_and_payload_semantics():
+    result = _run_node(
+        r"""
+const p=require('./static/plugin_mentions.js');
+const plugins=[
+  {name:'Research Tools',path:'plugin://research',description:'Search journals',keywords:['papers']},
+  {name:'Paper Helper',path:'plugin://paper',description:'Research assistant',keywords:['citations']},
+  {name:'Other',path:'plugin://other',description:'Misc',keywords:['research']},
+  {name:'research-z',path:'plugin://z',description:'',keywords:[]}
+];
+let mentions=p.addMention([],plugins[0]);
+mentions=p.addMention(mentions,{name:'Renamed',path:'plugin://research'});
+const plain={session_id:'s',message:'hello'};
+console.log(JSON.stringify({
+  start:p.activeToken('@res',4),
+  spaced:p.activeToken('ask @res now',8),
+  embedded:p.activeToken('mail@res',8),
+  afterWhitespace:p.activeToken('x\n@res',6),
+  ranked:p.rankPlugins(plugins,'res').map(x=>x.path),
+  mentions,
+  removed:p.removeToken('ask @res now',{start:4,end:8}),
+  plain:p.withPayload(plain,[]),
+  enriched:p.withPayload(plain,mentions),
+  retainedOnFailure:p.afterSend(mentions,mentions,false),
+  retainedNewOnSuccess:p.afterSend(mentions.concat({name:'New',path:'plugin://new'}),mentions,true),
+  unchanged:!Object.prototype.hasOwnProperty.call(plain,'plugin_mentions')
+}));
+"""
+    )
+    assert result["start"] == {"start": 0, "end": 4, "query": "res"}
+    assert result["spaced"] == {"start": 4, "end": 8, "query": "res"}
+    assert result["embedded"] is None
+    assert result["afterWhitespace"] == {"start": 2, "end": 6, "query": "res"}
+    assert result["ranked"] == ["plugin://research", "plugin://z", "plugin://other", "plugin://paper"]
+    assert result["mentions"] == [{"name": "Research Tools", "path": "plugin://research"}]
+    assert result["removed"] == "ask  now"
+    assert result["plain"] == {"session_id": "s", "message": "hello"}
+    assert result["enriched"]["plugin_mentions"] == result["mentions"]
+    assert result["retainedOnFailure"] == result["mentions"]
+    assert result["retainedNewOnSuccess"] == [{"name": "New", "path": "plugin://new"}]
+    assert result["unchanged"] is True
+
+
+def test_integration_wires_accept_clear_after_chat_start_only():
+    messages = (ROOT / "static/messages.js").read_text(encoding="utf-8")
+    index = (ROOT / "static/index.html").read_text(encoding="utf-8")
+    assert "typeof PluginMentions!=='undefined'" in messages
+    assert "PluginMentions.withPayload(_plainStartPayload,_submittedPluginMentions)" in messages
+    assert "if(_submittedPluginMentions.length&&!_pluginPayloadHelperAvailable)" in messages
+    clear = "if(_submittedPluginMentions.length&&typeof clearPluginMentions==='function') clearPluginMentions(_submittedPluginMentions);"
+    assert messages.index(clear) > messages.index("const startData=await api('/api/chat/start'")
+    assert 'static/plugin_mentions.js?v=__WEBUI_VERSION__' in index
+    assert 'role="listbox"' in index
+
+
+def test_busy_send_keeps_mentions_and_declines_queue_or_steer():
+    messages = (ROOT / "static/messages.js").read_text(encoding="utf-8")
+    guard = "if(_submittedPluginMentions.length){"
+    busy = "if(S.busy||compressionRunning){"
+    assert messages.index(guard, messages.index(busy)) < messages.index("defaultMessageMode", messages.index(busy))
+    assert "Plugin mentions cannot be queued or steered" in messages
+
+
+def test_plugin_popup_handles_ime_and_excludes_slash_popup():
+    plugin_js = (ROOT / "static/plugin_mentions.js").read_text(encoding="utf-8")
+    boot_js = (ROOT / "static/boot.js").read_text(encoding="utf-8")
+    assert "event.isComposing||event.inputType==='insertCompositionText'" in plugin_js
+    assert "if(event.isComposing||event.keyCode===229)return false" in plugin_js
+    assert "root.hideCmdDropdown" in plugin_js
+    assert "updatePluginMentionAutocomplete(event)" in boot_js


### PR DESCRIPTION
## Motivation

Add a Codex-mobile-style `@` popup so users can discover, select, and retain plugin mentions while composing prompts.

## What changed

- Backend: authenticated plugin inventory plus structured local and gateway forwarding.
- Frontend: lazy ranked popup, mention chips, keyboard and touch interaction, ARIA semantics, IME handling, and slash-command exclusion.
- Compatibility: preserves existing behavior when plugin inventory or structured forwarding is unavailable, and retains failures instead of silently dropping mention state.

## Dependency

Core gateway/runtime support is provided by https://github.com/NousResearch/hermes-agent/pull/69722 and should land alongside this WebUI change.

## Verification

- Feature tests: 19 passed.
- Neighboring tests: 179 passed.
- Lint, compile, and diff checks passed.
- Broad suite remains blocked by an unrelated upstream macOS `setgid` failure.
- Fable review: APPROVE, no P0/P1 findings.
