### PR TITLE
feat(lightbox): pinch-zoom, drag-pan and double-tap-zoom for message images

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2423,7 +2423,9 @@
   .msg-media-img:hover{opacity:.85;}
   .img-lightbox{position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,.82);display:flex;align-items:center;justify-content:center;cursor:zoom-out;animation:lb-in .15s ease;}
   @keyframes lb-in{from{opacity:0}to{opacity:1}}
-  .img-lightbox img{max-width:90vw;max-height:90vh;object-fit:contain;border-radius:8px;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
+  .img-lightbox img{max-width:90vw;max-height:90vh;object-fit:contain;border-radius:8px;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;touch-action:none;transform-origin:center center;will-change:transform;transition:transform .08s ease-out;}
+  .img-lightbox--zoomed{cursor:default;}
+  .img-lightbox--zoomed img{transition:none;}
   .mermaid-viewer{display:flex;flex-direction:column;gap:6px;max-width:100%;min-width:0;}
   .mermaid-viewer-toolbar{display:flex;flex-wrap:wrap;justify-content:flex-end;gap:4px;align-items:center;flex-shrink:0;}
   .mermaid-viewer-btn{width:28px;height:28px;border:1px solid var(--border2);border-radius:6px;background:var(--input-bg);color:var(--muted);display:inline-flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s,color .15s,border-color .15s,transform .15s;flex:0 0 auto;padding:0;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -2382,19 +2382,39 @@ function _openMermaidLightbox(svgEl) {
 function _attachImgZoom(lb, img) {
   const st = { scale: 1, tx: 0, ty: 0, minScale: 1, maxScale: 6 };
   lb._imgZoom = st;
+  // Gesture state — declared up front so st.reset() can clear it too (a bare
+  // scale/translate reset would otherwise leave an in-flight drag/pinch/tap
+  // pointed at the previous image after prev/next navigation).
+  let pinchStartDist = 0, pinchStartScale = 1, pinchCx = 0, pinchCy = 0;
+  let panStartX = 0, panStartY = 0, panTx = 0, panTy = 0, panning = false;
+  let lastTapTime = 0, lastTapX = 0, lastTapY = 0;
+  let mDown = false, mStartX = 0, mStartY = 0, mTx = 0, mTy = 0;
+  const _clearGestures = () => {
+    pinchStartDist = 0; panning = false; mDown = false; lastTapTime = 0;
+    img.style.cursor = st.scale > 1.01 ? 'grab' : 'default';
+  };
   const apply = () => {
     img.style.transform = 'translate(' + st.tx + 'px,' + st.ty + 'px) scale(' + st.scale + ')';
     img.style.cursor = st.scale > 1.01 ? 'grab' : 'default';
     lb.classList.toggle('img-lightbox--zoomed', st.scale > 1.01);
   };
-  // Reset on nav/src change — exposed so _navigateLightbox can call it.
-  st.reset = () => { st.scale = 1; st.tx = 0; st.ty = 0; apply(); };
-  const clampPan = () => {
+  // Reset on nav/src change — exposed so _navigateLightbox can call it. Clears
+  // both the transform AND any in-flight gesture so the next image starts clean.
+  st.reset = () => { st.scale = 1; st.tx = 0; st.ty = 0; _clearGestures(); apply(); };
+  const clampPan = (projectedScale) => {
     // Keep the image roughly within the viewport so it can't be flung away.
+    // getBoundingClientRect() reflects the CURRENTLY rendered scale, but the
+    // caller may be clamping a translation computed for a scale that apply()
+    // hasn't painted yet. Project the rendered size to the target scale so the
+    // bounds match the image the user will actually see — otherwise the first
+    // zoom step from 1x clamps against the un-scaled size and discards most of
+    // the cursor-anchoring offset (zooming around the center instead).
     const r = img.getBoundingClientRect();
+    const factor = (projectedScale && st.scale) ? (projectedScale / st.scale) : 1;
+    const projW = r.width * factor, projH = r.height * factor;
     const vw = window.innerWidth, vh = window.innerHeight;
-    const maxX = Math.max(0, (r.width - vw) / 2 + 40);
-    const maxY = Math.max(0, (r.height - vh) / 2 + 40);
+    const maxX = Math.max(0, (projW - vw) / 2 + 40);
+    const maxY = Math.max(0, (projH - vh) / 2 + 40);
     st.tx = Math.max(-maxX, Math.min(maxX, st.tx));
     st.ty = Math.max(-maxY, Math.min(maxY, st.ty));
   };
@@ -2407,15 +2427,13 @@ function _attachImgZoom(lb, img) {
     const ratio = nextScale / st.scale;
     st.tx = st.tx - ox * (ratio - 1);
     st.ty = st.ty - oy * (ratio - 1);
-    st.scale = nextScale;
-    if(st.scale <= 1.01){ st.scale = 1; st.tx = 0; st.ty = 0; }
-    else clampPan();
+    // Clamp against the size the image will have at nextScale (rect is still at
+    // the old scale here — apply() runs after), so the cursor anchor survives.
+    if(nextScale <= 1.01){ st.scale = 1; st.tx = 0; st.ty = 0; }
+    else { clampPan(nextScale); st.scale = nextScale; }
     apply();
   };
   // ── Touch gestures ──
-  let pinchStartDist = 0, pinchStartScale = 1, pinchCx = 0, pinchCy = 0;
-  let panStartX = 0, panStartY = 0, panTx = 0, panTy = 0, panning = false;
-  let lastTapTime = 0, lastTapX = 0, lastTapY = 0;
   const dist = (t1, t2) => Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
   img.addEventListener('touchstart', e => {
     if(e.touches.length === 2){
@@ -2467,7 +2485,6 @@ function _attachImgZoom(lb, img) {
     const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
     zoomAt(e.clientX, e.clientY, st.scale * factor);
   }, { passive: false });
-  let mDown = false, mStartX = 0, mStartY = 0, mTx = 0, mTy = 0;
   img.addEventListener('mousedown', e => {
     if(st.scale <= 1.01) return;
     e.preventDefault(); e.stopPropagation();

--- a/static/ui.js
+++ b/static/ui.js
@@ -2373,6 +2373,124 @@ function _openMermaidLightbox(svgEl) {
   document.addEventListener('keydown', lb._keyHandler);
   return lb;
 }
+// ── Lightbox image pinch-zoom / drag-pan / double-tap-zoom ────────────────
+// Gives message-attached images the same zoom affordance mermaid diagrams have.
+// Touch: pinch to zoom, one-finger drag to pan when zoomed, double-tap toggles
+// 2.5x at the tap point. Desktop: mouse wheel zooms toward the cursor, drag pans,
+// double-click toggles zoom. Panning/zoom gestures stop propagation so the
+// backdrop-click close and prev/next nav only fire when not interacting.
+function _attachImgZoom(lb, img) {
+  const st = { scale: 1, tx: 0, ty: 0, minScale: 1, maxScale: 6 };
+  lb._imgZoom = st;
+  const apply = () => {
+    img.style.transform = 'translate(' + st.tx + 'px,' + st.ty + 'px) scale(' + st.scale + ')';
+    img.style.cursor = st.scale > 1.01 ? 'grab' : 'default';
+    lb.classList.toggle('img-lightbox--zoomed', st.scale > 1.01);
+  };
+  // Reset on nav/src change — exposed so _navigateLightbox can call it.
+  st.reset = () => { st.scale = 1; st.tx = 0; st.ty = 0; apply(); };
+  const clampPan = () => {
+    // Keep the image roughly within the viewport so it can't be flung away.
+    const r = img.getBoundingClientRect();
+    const vw = window.innerWidth, vh = window.innerHeight;
+    const maxX = Math.max(0, (r.width - vw) / 2 + 40);
+    const maxY = Math.max(0, (r.height - vh) / 2 + 40);
+    st.tx = Math.max(-maxX, Math.min(maxX, st.tx));
+    st.ty = Math.max(-maxY, Math.min(maxY, st.ty));
+  };
+  const zoomAt = (cx, cy, nextScale) => {
+    nextScale = Math.max(st.minScale, Math.min(st.maxScale, nextScale));
+    const rect = img.getBoundingClientRect();
+    // Point on the (untransformed) image under the cursor, relative to its center.
+    const ox = cx - (rect.left + rect.width / 2);
+    const oy = cy - (rect.top + rect.height / 2);
+    const ratio = nextScale / st.scale;
+    st.tx = st.tx - ox * (ratio - 1);
+    st.ty = st.ty - oy * (ratio - 1);
+    st.scale = nextScale;
+    if(st.scale <= 1.01){ st.scale = 1; st.tx = 0; st.ty = 0; }
+    else clampPan();
+    apply();
+  };
+  // ── Touch gestures ──
+  let pinchStartDist = 0, pinchStartScale = 1, pinchCx = 0, pinchCy = 0;
+  let panStartX = 0, panStartY = 0, panTx = 0, panTy = 0, panning = false;
+  let lastTapTime = 0, lastTapX = 0, lastTapY = 0;
+  const dist = (t1, t2) => Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+  img.addEventListener('touchstart', e => {
+    if(e.touches.length === 2){
+      e.preventDefault(); e.stopPropagation();
+      pinchStartDist = dist(e.touches[0], e.touches[1]);
+      pinchStartScale = st.scale;
+      pinchCx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+      pinchCy = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+      panning = false;
+    } else if(e.touches.length === 1){
+      const now = Date.now();
+      const t = e.touches[0];
+      if(now - lastTapTime < 300 && Math.abs(t.clientX - lastTapX) < 30 && Math.abs(t.clientY - lastTapY) < 30){
+        // Double-tap → toggle zoom at tap point.
+        e.preventDefault(); e.stopPropagation();
+        zoomAt(t.clientX, t.clientY, st.scale > 1.01 ? 1 : 2.5);
+        lastTapTime = 0;
+        return;
+      }
+      lastTapTime = now; lastTapX = t.clientX; lastTapY = t.clientY;
+      if(st.scale > 1.01){
+        e.stopPropagation();
+        panning = true;
+        panStartX = t.clientX; panStartY = t.clientY; panTx = st.tx; panTy = st.ty;
+      }
+    }
+  }, { passive: false });
+  img.addEventListener('touchmove', e => {
+    if(e.touches.length === 2 && pinchStartDist > 0){
+      e.preventDefault(); e.stopPropagation();
+      const d = dist(e.touches[0], e.touches[1]);
+      zoomAt(pinchCx, pinchCy, pinchStartScale * (d / pinchStartDist));
+    } else if(e.touches.length === 1 && panning){
+      e.preventDefault(); e.stopPropagation();
+      st.tx = panTx + (e.touches[0].clientX - panStartX);
+      st.ty = panTy + (e.touches[0].clientY - panStartY);
+      clampPan(); apply();
+    }
+  }, { passive: false });
+  img.addEventListener('touchend', e => {
+    if(e.touches.length < 2) pinchStartDist = 0;
+    if(e.touches.length === 0) panning = false;
+    // When zoomed, swallow the click so the backdrop close doesn't fire.
+    if(st.scale > 1.01) e.stopPropagation();
+  }, { passive: false });
+  // ── Desktop: wheel zoom + drag pan + double-click ──
+  img.addEventListener('wheel', e => {
+    e.preventDefault(); e.stopPropagation();
+    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+    zoomAt(e.clientX, e.clientY, st.scale * factor);
+  }, { passive: false });
+  let mDown = false, mStartX = 0, mStartY = 0, mTx = 0, mTy = 0;
+  img.addEventListener('mousedown', e => {
+    if(st.scale <= 1.01) return;
+    e.preventDefault(); e.stopPropagation();
+    mDown = true;
+    mStartX = e.clientX; mStartY = e.clientY; mTx = st.tx; mTy = st.ty;
+    img.style.cursor = 'grabbing';
+  });
+  window.addEventListener('mousemove', lb._imgZoomMove = e => {
+    if(!mDown) return;
+    st.tx = mTx + (e.clientX - mStartX);
+    st.ty = mTy + (e.clientY - mStartY);
+    clampPan(); apply();
+  });
+  window.addEventListener('mouseup', lb._imgZoomUp = () => {
+    if(mDown){ mDown = false; img.style.cursor = st.scale > 1.01 ? 'grab' : 'default'; }
+  });
+  img.addEventListener('dblclick', e => {
+    e.preventDefault(); e.stopPropagation();
+    zoomAt(e.clientX, e.clientY, st.scale > 1.01 ? 1 : 2.5);
+  });
+  apply();
+}
+
 function _openImgLightboxWithNav(src, alt, images, index) {
   const lb = document.createElement('div');
   lb.className = 'img-lightbox';
@@ -2383,6 +2501,7 @@ function _openImgLightboxWithNav(src, alt, images, index) {
   img.src = src;
   img.alt = alt || '';
   img.onclick = e => e.stopPropagation();
+  _attachImgZoom(lb, img);
   const cls = document.createElement('button');
   cls.className = 'img-lightbox-close';
   cls.setAttribute('aria-label', 'Close');
@@ -2436,12 +2555,21 @@ function _navigateLightbox(lb, direction) {
   lbImg.src = nextImg.src;
   lbImg.alt = nextImg.alt || '';
   lb.setAttribute('aria-label', nextImg.alt || 'Image');
+  // Reset any zoom/pan when switching images.
+  if(lb._imgZoom && typeof lb._imgZoom.reset === 'function') lb._imgZoom.reset();
   // Update counter via stored reference — no DOM query.
   if(lb._counterEl) lb._counterEl.textContent = (newIndex+1) + ' / ' + images.length;
 }
 function _closeImgLightbox(lb) {
   if(!lb || !lb.parentNode) return;
   document.removeEventListener('keydown', lb._keyHandler);
+  // Detach the window-level pan listeners added by _attachImgZoom.
+  if(lb._imgZoomMove && window && typeof window.removeEventListener === 'function'){
+    window.removeEventListener('mousemove', lb._imgZoomMove);
+  }
+  if(lb._imgZoomUp && window && typeof window.removeEventListener === 'function'){
+    window.removeEventListener('mouseup', lb._imgZoomUp);
+  }
   if(lb._mermaidResizeHandler && window && typeof window.removeEventListener === 'function'){
     window.removeEventListener('resize', lb._mermaidResizeHandler);
   }

--- a/tests/test_lightbox_zoom_fixes.js
+++ b/tests/test_lightbox_zoom_fixes.js
@@ -1,0 +1,118 @@
+// Test harness for the two greptile-flagged fixes in _attachImgZoom.
+// Extracts the real function body from static/ui.js, runs it against a
+// mock DOM, and asserts the two bugs are fixed. Mutation-checked: reverting
+// either fix must make the corresponding test FAIL.
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'static', 'ui.js'), 'utf8');
+
+// Extract the _attachImgZoom function body verbatim (balanced-brace scan).
+function extractFn(name) {
+  const start = src.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error('fn not found: ' + name);
+  let i = src.indexOf('{', start), depth = 0, end = -1;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+  }
+  return src.slice(start, end);
+}
+
+const attachSrc = extractFn('_attachImgZoom');
+
+// ── Mock DOM ──
+function makeImg(scale0 = 1, natW = 800, natH = 600) {
+  const listeners = {};
+  const img = {
+    style: {},
+    _rectW: natW, _rectH: natH, _cx: 500, _cy: 400,
+    getBoundingClientRect() {
+      // Rendered size scales with the CURRENT applied scale (parsed from transform).
+      const m = /scale\(([\d.]+)\)/.exec(img.style.transform || 'scale(1)');
+      const s = m ? parseFloat(m[1]) : 1;
+      const w = img._rectW * s, h = img._rectH * s;
+      return { width: w, height: h, left: img._cx - w / 2, top: img._cy - h / 2 };
+    },
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+    _fire(type, ev) { (listeners[type] || []).forEach(fn => fn(ev)); },
+  };
+  return img;
+}
+function makeLb() { return { classList: { toggle() {} }, _imgZoom: null }; }
+
+global.window = {
+  innerWidth: 1000, innerHeight: 800,
+  addEventListener() {}, removeEventListener() {},
+};
+global.document = { addEventListener() {}, removeEventListener() {} };
+global.Math = Math;
+
+function instantiate() {
+  const lb = makeLb(), img = makeImg();
+  const fn = new Function('lb', 'img', 'window', 'document', 'Math',
+    attachSrc + '\n_attachImgZoom(lb, img);');
+  fn(lb, img, global.window, global.document, Math);
+  return { lb, img };
+}
+
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log('  PASS ' + msg); } else { fail++; console.log('  FAIL ' + msg); } }
+
+// ── TEST 1: cursor-anchored zoom survives the first zoom step from 1x ──
+// Bug: clampPan used old (1x) size → bounds ~0 → offset clamped to ~0 → zoom
+// snaps to center. Fixed: clampPan projects to nextScale so the offset survives.
+console.log('TEST 1: cursor-anchored double-click zoom from 1x');
+{
+  const { lb, img } = instantiate();
+  const st = lb._imgZoom;
+  // double-click near the right edge of the image (cx=500 center; click at 800)
+  img._fire('dblclick', { clientX: 800, clientY: 400, preventDefault(){}, stopPropagation(){} });
+  // After zooming to 2.5x anchored at x=800 (300px right of center), tx should be
+  // pulled strongly negative (image shifts left so the clicked point stays put),
+  // NOT clamped to ~0 (which is the bug = center zoom).
+  // Expected raw offset before clamp: tx = -300*(2.5-1) = -450. Projected bounds at
+  // 2.5x: projW=800*2.5=2000, maxX=(2000-1000)/2+40=540. So -450 is within ±540 → survives.
+  assert(st.scale === 2.5, 'scale became 2.5 (got ' + st.scale + ')');
+  assert(st.tx < -300, 'tx anchored to cursor, strongly negative (got ' + st.tx.toFixed(1) + ', bug would give ~0)');
+}
+
+// ── TEST 2: navigation reset clears in-flight mouse drag ──
+// Bug: st.reset() left mDown=true → the next mousemove (button still held while
+// arrow-key navigating) applies the previous image's drag to the new image.
+// Fixed: reset() calls _clearGestures() which sets mDown=false.
+// Note: the drag must be probed while the NEW image is zoomed, otherwise
+// clampPan at scale=1 forces tx to 0 and masks the stale-drag regardless.
+console.log('TEST 2: nav reset clears active drag gesture');
+{
+  const captured = {};
+  const savedWin = global.window;
+  global.window = { innerWidth:1000, innerHeight:800,
+    addEventListener(t, fn){ captured[t] = fn; }, removeEventListener(){} };
+  const lb = makeLb(), img = makeImg();
+  const fn = new Function('lb','img','window','document','Math',
+    attachSrc + '\n_attachImgZoom(lb, img);');
+  fn(lb, img, global.window, global.document, Math);
+  const st = lb._imgZoom;
+  // Zoom in, then press the mouse button (arming a drag: mDown=true).
+  img._fire('dblclick', { clientX:500, clientY:400, preventDefault(){}, stopPropagation(){} });
+  img._fire('mousedown', { clientX:500, clientY:400, preventDefault(){}, stopPropagation(){} });
+  // Navigate to the next image → reset(). With the fix this also clears mDown.
+  st.reset();
+  assert(st.scale === 1 && st.tx === 0, 'reset zeroed transform');
+  // The new image is zoomed by the user (its own gesture). If the OLD drag's
+  // mDown leaked through reset, the very first mousemove would fire the stale
+  // drag branch. Zoom the new image so a leaked drag is observable (clampPan
+  // won't force tx to 0 at 2.5x).
+  img._fire('dblclick', { clientX:500, clientY:400, preventDefault(){}, stopPropagation(){} });
+  // Stray mousemove with NO fresh mousedown. Fixed: mDown was cleared by reset,
+  // so this is a no-op and tx stays at the (centered) zoom value 0. Buggy:
+  // mDown still true → st.tx = mTx + (900-500) = 400 (stale drag applied).
+  if (captured.mousemove) captured.mousemove({ clientX: 900, clientY: 700 });
+  assert(st.tx === 0,
+    'stray mousemove after reset is ignored (tx=' + st.tx + '; bug would apply stale drag → ~400)');
+  global.window = savedWin;
+}
+
+console.log('\n' + (fail === 0 ? 'ALL PASS' : fail + ' FAILED') + ' (' + pass + ' passed)');
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What & why

Message-attached images open in a lightbox, but the lightbox image was a plain static `<img>` with no zoom or pan. Mermaid diagrams already get a full zoom viewer (`_mountMermaidViewer`), so images felt inconsistent — on a phone you couldn't pinch to inspect detail, and on desktop there was no way to zoom into a region.

This adds the same zoom affordance to lightbox images.

## Behavior

**Touch (mobile):**
- Pinch to zoom (anchored at the pinch midpoint)
- One-finger drag to pan when zoomed in
- Double-tap toggles 2.5x at the tap point

**Desktop:**
- Mouse wheel zooms toward the cursor
- Drag to pan when zoomed
- Double-click toggles zoom

## Implementation notes

- New `_attachImgZoom(lb, img)` wires the gesture handlers; called once when the lightbox image is created in `_openImgLightboxWithNav`.
- Zoom/pan state resets when navigating prev/next (`_navigateLightbox`).
- The two `window`-level pan listeners are removed in `_closeImgLightbox`, so nothing leaks after the lightbox closes.
- `touch-action:none` on `.img-lightbox img` stops the browser's native pinch-zoom from fighting the custom handler.
- Zoom gestures `stopPropagation()` so the backdrop-click-to-close and prev/next nav only fire when you're not actively zooming/panning.
- No change to the click-to-open flow, the nav buttons, or the keyboard handlers.

## Scope

Two files, additive only: `static/ui.js` and `static/style.css`. No behavior change for existing click-to-open, navigation, or close paths.
