### PR TITLE
docs(setup): correct WebUI installer agent-autoinstall copy

### DIFF
--- a/setup/index.html
+++ b/setup/index.html
@@ -355,14 +355,14 @@
     <div class="section-head reveal">
       <div class="step-eyebrow"><span class="step-dot">1</span> Run the server</div>
       <h2>Stand up Hermes WebUI</h2>
-      <p class="lead">On any machine you control — macOS, Linux, or Windows via WSL2 — with <code>Python 3.11+</code> and <code>git</code>. The bootstrap finds or installs Hermes Agent, sets up the environment, and walks you through first-run onboarding.</p>
+      <p class="lead">On any machine you control — macOS, Linux, or Windows via WSL2 — with <code>Python 3.11+</code> and <code>git</code>. The bootstrap checks for Hermes Agent (and shows you how to install it if it's missing), sets up the environment, and walks you through first-run onboarding.</p>
     </div>
 
     <div class="code reveal">
       <div class="code-head"><span class="code-label">bash — one-liner</span><button class="code-copy">Copy</button></div>
       <pre><code>curl -fsSL https://get-hermes.ai/install.sh | bash</code></pre>
     </div>
-    <p class="reveal">Clones the Web UI to <code>~/hermes-webui</code>, installs Hermes Agent if it's missing, and starts the server on <code>127.0.0.1:8787</code>. Safe to re-run to update. Open that URL in any browser and the full Web UI is there. To relaunch later, run <code>./start.sh</code>.</p>
+    <p class="reveal">Clones the Web UI to <code>~/hermes-webui</code>, checks that Hermes Agent is installed (printing the one-line agent installer if it's missing), and starts the server on <code>127.0.0.1:8787</code>. Safe to re-run to update. Open that URL in any browser and the full Web UI is there. To relaunch later, run <code>./start.sh</code>.</p>
 
     <details class="adv-reveal reveal">
       <summary>Install manually, or set up Hermes Agent yourself</summary>
@@ -376,7 +376,7 @@ python3 bootstrap.py</code></pre>
         </div>
 
         <h3 class="sub">Need Hermes Agent first?</h3>
-        <p>Hermes WebUI runs on the <a href="https://hermes-agent.nousresearch.com/" target="_blank">Hermes Agent</a>. The one-liner installs it automatically if it's missing — or set it up directly:</p>
+        <p>Hermes WebUI runs on the <a href="https://hermes-agent.nousresearch.com/" target="_blank">Hermes Agent</a>. If the <code>hermes</code> CLI is missing, the one-liner points you here to install it first — set it up directly:</p>
         <div class="code">
           <div class="code-head"><span class="code-label">bash — install Hermes Agent</span><button class="code-copy">Copy</button></div>
           <pre><code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash

--- a/setup/index.html
+++ b/setup/index.html
@@ -355,14 +355,14 @@
     <div class="section-head reveal">
       <div class="step-eyebrow"><span class="step-dot">1</span> Run the server</div>
       <h2>Stand up Hermes WebUI</h2>
-      <p class="lead">On any machine you control — macOS, Linux, or Windows via WSL2 — with <code>Python 3.11+</code> and <code>git</code>. The bootstrap checks for Hermes Agent (and shows you how to install it if it's missing), sets up the environment, and walks you through first-run onboarding.</p>
+      <p class="lead">On any machine you control — macOS, Linux, or Windows via WSL2 — with <code>Python 3.11+</code> and <code>git</code>. The bootstrap checks for Hermes Agent first: if it's missing it prints the Agent install command and stops, so install the Agent and re-run this command. Once the Agent is present it sets up the environment and walks you through first-run onboarding.</p>
     </div>
 
     <div class="code reveal">
       <div class="code-head"><span class="code-label">bash — one-liner</span><button class="code-copy">Copy</button></div>
       <pre><code>curl -fsSL https://get-hermes.ai/install.sh | bash</code></pre>
     </div>
-    <p class="reveal">Clones the Web UI to <code>~/hermes-webui</code>, checks that Hermes Agent is installed (printing the one-line agent installer if it's missing), and starts the server on <code>127.0.0.1:8787</code>. Safe to re-run to update. Open that URL in any browser and the full Web UI is there. To relaunch later, run <code>./start.sh</code>.</p>
+    <p class="reveal">Checks for Hermes Agent first. If the <code>hermes</code> CLI is missing, the installer prints the Agent install command and exits without cloning anything — install the Agent, then run this command again. With the Agent present it clones the Web UI to <code>~/hermes-webui</code> (or updates an existing checkout) and starts the server on <code>127.0.0.1:8787</code>. Safe to re-run to update. Open that URL in any browser and the full Web UI is there. To relaunch later, run <code>./start.sh</code>.</p>
 
     <details class="adv-reveal reveal">
       <summary>Install manually, or set up Hermes Agent yourself</summary>
@@ -376,7 +376,7 @@ python3 bootstrap.py</code></pre>
         </div>
 
         <h3 class="sub">Need Hermes Agent first?</h3>
-        <p>Hermes WebUI runs on the <a href="https://hermes-agent.nousresearch.com/" target="_blank">Hermes Agent</a>. If the <code>hermes</code> CLI is missing, the one-liner points you here to install it first — set it up directly:</p>
+        <p>Hermes WebUI runs on the <a href="https://hermes-agent.nousresearch.com/" target="_blank">Hermes Agent</a>. If the <code>hermes</code> CLI is missing, the one-liner stops here and points you at the Agent installer; install it, then run the WebUI one-liner again — or set it up directly:</p>
         <div class="code">
           <div class="code-head"><span class="code-label">bash — install Hermes Agent</span><button class="code-copy">Copy</button></div>
           <pre><code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash


### PR DESCRIPTION
Closes #5886

The `/setup/` page said the one-liner "installs Hermes Agent automatically if it's missing," but `install.sh` intentionally does not — it checks for the `hermes` CLI and, when absent, prints the agent install command and exits. Reworded the three passages (lines 358, 365, 379) to describe the actual two-step flow so users aren't surprised when the installer stops for a manual agent install.

AI-assisted: written with AI assistance. Provider: GitHub Copilot; model: Claude Opus 4.8.
