### PR TITLE
fix: dedupe current user after tool-call reattach

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13083,6 +13083,12 @@ def handle_get(handler, parsed) -> bool:
                 "threshold_tokens": _threshold_tokens,
                 "last_prompt_tokens": getattr(s, "last_prompt_tokens", 0) or 0,
             }
+            from api.process_event_utils import build_active_turn_token
+
+            raw["active_turn_token"] = build_active_turn_token(
+                getattr(s, "active_stream_id", None),
+                getattr(s, "pending_started_at", None),
+            )
             if original_stream_id:
                 try:
                     journal = find_run_summary(original_stream_id)
@@ -20221,6 +20227,7 @@ def _handle_session_sse_stream(handler, parsed):
         persisted_message_count_for_session,
         should_emit_session_updated,
     )
+    from api.process_event_utils import build_active_turn_token
 
     # Atomic get-or-create + subscribe under SESSION_CHANNELS_LOCK. Doing these
     # two steps separately (get_or_create_session_channel then ch.subscribe)
@@ -20301,6 +20308,9 @@ def _handle_session_sse_stream(handler, parsed):
                     "session_id": sid,
                     "stream_id": recover_stream_id,
                     "pending_started_at": pending_started_at,
+                    "active_turn_token": build_active_turn_token(
+                        recover_stream_id, pending_started_at
+                    ),
                     "source": "subscribe_recovery",
                     "recovered": True,
                 })
@@ -21925,13 +21935,13 @@ def _start_chat_stream_for_session(
             except Exception:
                 logger.debug("Failed to record gateway run-start failure for stream %s", stream_id, exc_info=True)
         raise
-    response = {
+    response = _chat_start_response_with_turn_identity({
         "stream_id": stream_id,
         "session_id": s.session_id,
         "pending_started_at": s.pending_started_at,
         "turn_id": journal_event.get("turn_id"),
         "title": s.title,
-    }
+    })
     if normalized_model:
         response["effective_model"] = model
     if model_provider:
@@ -21956,6 +21966,20 @@ def _runtime_runner_client_factory():
     return HttpRunnerClient.from_env()
 
 
+def _chat_start_response_with_turn_identity(response, *, stream_id=None, pending_started_at=None):
+    """Add the server-owned active-turn identity to a successful start response."""
+    from api.process_event_utils import build_active_turn_token
+
+    normalized = dict(response or {})
+    normalized.setdefault("stream_id", stream_id)
+    if normalized.get("pending_started_at") is None:
+        normalized["pending_started_at"] = pending_started_at
+    normalized["active_turn_token"] = build_active_turn_token(
+        normalized.get("stream_id"), normalized.get("pending_started_at")
+    )
+    return normalized
+
+
 def _chat_start_response_from_run_start(result):
     """Expose only the legacy browser-facing chat-start response fields."""
     payload = dict(getattr(result, "payload", {}) or {})
@@ -21974,9 +21998,16 @@ def _chat_start_response_from_run_start(result):
     ):
         if key in payload:
             response[key] = payload[key]
-    response.setdefault("stream_id", result.stream_id)
-    response.setdefault("session_id", result.session_id)
-    return response
+    response["stream_id"] = result.stream_id
+    response["session_id"] = result.session_id
+    pending_started_at = response.get("pending_started_at")
+    if pending_started_at is None:
+        pending_started_at = getattr(result, "started_at", None)
+    return _chat_start_response_with_turn_identity(
+        response,
+        stream_id=result.stream_id,
+        pending_started_at=pending_started_at,
+    )
 
 
 def _runtime_adapter_goal_action(goal_args: str) -> str:
@@ -22374,6 +22405,7 @@ def start_session_turn(
                         "session_id": str(session_id),
                         "stream_id": str(stream_id),
                         "pending_started_at": (resp or {}).get("pending_started_at"),
+                        "active_turn_token": (resp or {}).get("active_turn_token"),
                         "source": source,
                     },
                 )

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -549,6 +549,9 @@ def session_status(session_id: str) -> dict[str, Any]:
         hermes_home = str(get_hermes_home_for_profile(profile))
     except Exception:
         hermes_home = ''
+    live_stream_id = _live_active_stream_id(s)
+    from api.process_event_utils import build_active_turn_token
+
     return {
         'session_id': s.session_id,
         'title': s.title,
@@ -576,7 +579,10 @@ def session_status(session_id: str) -> dict[str, Any]:
         # only if it's in STREAMS (SSE channel open) or ACTIVE_RUNS (worker
         # bookkeeping). Otherwise report None so the poller waits for a REAL
         # server_turn_started instead of latching a ghost.
-        'active_stream_id': _live_active_stream_id(s),
+        'active_stream_id': live_stream_id,
+        'active_turn_token': build_active_turn_token(
+            live_stream_id, getattr(s, 'pending_started_at', None)
+        ),
         'input_tokens': inp,
         'output_tokens': out,
         'total_tokens': inp + out,

--- a/static/commands.js
+++ b/static/commands.js
@@ -1259,7 +1259,7 @@ async function cmdGoal(args){
       if(!r||!r.stream_id)return;
       const messages=activeMessages.slice();
       if(statusMessage)messages.push(statusMessage);
-      INFLIGHT[activeSid]={streamId:r.stream_id,messages,uploaded:[],toolCalls:[],activeTurnToken};
+      INFLIGHT[activeSid]={streamId:r.stream_id,messages,uploaded:[],toolCalls:[],activeTurnToken,reattach:true};
       if(typeof saveInflightState==='function')saveInflightState(activeSid,{streamId:r.stream_id,messages,uploaded:[],toolCalls:[],activeTurnToken});
       return;
     }

--- a/static/commands.js
+++ b/static/commands.js
@@ -1231,6 +1231,7 @@ async function cmdGoal(args){
   if(!S.session){await newSession();await renderSessionList();}
   if(!S.session||!S.session.session_id){showToast(t('no_active_session'));return;}
   const activeSid=S.session.session_id;
+  const activeMessages=Array.isArray(S.messages)?[...S.messages]:[];
   try{
     const r=await api('/api/goal',{method:'POST',body:JSON.stringify({
       session_id:activeSid,
@@ -1251,8 +1252,19 @@ async function cmdGoal(args){
       }
       return raw;
     })();
-    if(msg){
-      S.messages.push({role:'assistant',content:msg,_ts:Date.now()/1000,_goalStatus:true,_transient:true});
+    const statusMessage=msg?{role:'assistant',content:msg,_ts:Date.now()/1000,_goalStatus:true,_transient:true}:null;
+    const activeTurnToken=typeof _opaqueActiveTurnToken==='function'
+      ?_opaqueActiveTurnToken(r&&r.active_turn_token):null;
+    if(!_isSessionCurrentPane(activeSid)){
+      if(!r||!r.stream_id)return;
+      const messages=activeMessages.slice();
+      if(statusMessage)messages.push(statusMessage);
+      INFLIGHT[activeSid]={streamId:r.stream_id,messages,uploaded:[],toolCalls:[],activeTurnToken};
+      if(typeof saveInflightState==='function')saveInflightState(activeSid,{streamId:r.stream_id,messages,uploaded:[],toolCalls:[],activeTurnToken});
+      return;
+    }
+    if(statusMessage){
+      S.messages.push(statusMessage);
       renderMessages({preserveScroll:true});
       showToast(msg.split('\n')[0],2600);
     }
@@ -1265,13 +1277,11 @@ async function cmdGoal(args){
     if(S.session&&S.session.session_id===activeSid){
       S.session.active_stream_id=r.stream_id;
       if(typeof r.pending_started_at==='number')S.session.pending_started_at=r.pending_started_at;
-      S.session.active_turn_token=typeof _opaqueActiveTurnToken==='function'
-        ?_opaqueActiveTurnToken(r.active_turn_token):null;
+      S.session.active_turn_token=activeTurnToken;
       if(r.effective_model)S.session.model=r.effective_model;
       if(r.effective_model_provider)S.session.model_provider=r.effective_model_provider;
     }
-    const activeTurnToken=S.session&&S.session.active_turn_token||null;
-    INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[],toolCalls:[],activeTurnToken};
+    INFLIGHT[activeSid]={streamId:r.stream_id,messages:[...S.messages],uploaded:[],toolCalls:[],activeTurnToken};
     if(typeof markInflight==='function')markInflight(activeSid,r.stream_id);
     if(typeof saveInflightState==='function')saveInflightState(activeSid,{streamId:r.stream_id,messages:INFLIGHT[activeSid].messages,uploaded:[],toolCalls:[],activeTurnToken});
     startApprovalPolling(activeSid);
@@ -1280,6 +1290,7 @@ async function cmdGoal(args){
     attachLiveStream(activeSid,r.stream_id,[]);
     if(typeof renderSessionList==='function')void renderSessionList();
   }catch(e){
+    if(!_isSessionCurrentPane(activeSid))return;
     const err=String((e&&e.message)||e||'Goal command failed');
     S.messages.push({role:'assistant',content:`**Goal command failed:** ${err}`,_ts:Date.now()/1000,_error:true});
     renderMessages({preserveScroll:true});

--- a/static/commands.js
+++ b/static/commands.js
@@ -1265,12 +1265,15 @@ async function cmdGoal(args){
     if(S.session&&S.session.session_id===activeSid){
       S.session.active_stream_id=r.stream_id;
       if(typeof r.pending_started_at==='number')S.session.pending_started_at=r.pending_started_at;
+      S.session.active_turn_token=typeof _opaqueActiveTurnToken==='function'
+        ?_opaqueActiveTurnToken(r.active_turn_token):null;
       if(r.effective_model)S.session.model=r.effective_model;
       if(r.effective_model_provider)S.session.model_provider=r.effective_model_provider;
     }
-    INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[],toolCalls:[]};
+    const activeTurnToken=S.session&&S.session.active_turn_token||null;
+    INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[],toolCalls:[],activeTurnToken};
     if(typeof markInflight==='function')markInflight(activeSid,r.stream_id);
-    if(typeof saveInflightState==='function')saveInflightState(activeSid,{streamId:r.stream_id,messages:INFLIGHT[activeSid].messages,uploaded:[],toolCalls:[]});
+    if(typeof saveInflightState==='function')saveInflightState(activeSid,{streamId:r.stream_id,messages:INFLIGHT[activeSid].messages,uploaded:[],toolCalls:[],activeTurnToken});
     startApprovalPolling(activeSid);
     startClarifyPolling(activeSid);
     if(typeof _fetchYoloState==='function')_fetchYoloState(activeSid);

--- a/static/messages.js
+++ b/static/messages.js
@@ -1295,8 +1295,9 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
   // Only mutate the VISIBLE composer / staged tray when the failed send belongs
   // to the session the user is currently looking at — otherwise a background
   // send failure would pollute another session's composer. (Codex #5484 catch.)
-  const visibleSid=(S.session&&S.session.session_id)||null;
-  const belongsToVisible=!(sid&&visibleSid&&sid!==visibleSid);
+  const belongsToVisible=typeof _isSessionCurrentPane==='function'
+    ?_isSessionCurrentPane(sid)
+    :!(sid&&S.session&&S.session.session_id&&sid!==S.session.session_id);
   let restoredVisible=false;
   if(belongsToVisible){
     const inp=$('msg');
@@ -1326,7 +1327,9 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
   if(sid&&typeof _saveComposerDraftNow==='function'){
     const _persist=()=>{
       try{
-        const stillVisible=(S.session&&S.session.session_id)===sid;
+        const stillVisible=typeof _isSessionCurrentPane==='function'
+          ?_isSessionCurrentPane(sid)
+          :(S.session&&S.session.session_id)===sid;
         if(stillVisible){
           const inp=$('msg');
           const liveText=inp?String(inp.value||''):restore;
@@ -1334,7 +1337,7 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
         } else if(!restoredVisible){
           // Background failure (sid was never the visible session): no live
           // composer to read, so persist the captured snapshot — it's the only copy.
-          _saveComposerDraftNow(sid, restore, []);
+          _saveComposerDraftNow(sid, restore, files);
         }
         // else: restored the visible composer, then the user switched away — the
         // session-switch save path already saved sid's composer; skip stale write.
@@ -1406,7 +1409,7 @@ async function send(){
   // If busy or a manual compression is still running, handle based on default_message_mode
   if(S.busy||compressionRunning){
     if(text||S.pendingFiles.length){
-      if(!S.session){await newSession();await renderSessionList();}
+      if(!S.session){const _createdSession=await newSession();if(!_createdSession)return;await renderSessionList();}
       // Busy-control slash commands must be intercepted HERE, before the
       // defaultMessageMode routing block, so the user can always type /steer, /interrupt,
       // /queue, /terminal, /goal, or /yolo while the agent is running and have
@@ -1470,6 +1473,34 @@ async function send(){
   }
   let _slashDisplayTextOverride=null;
   let _pendingMoaConfig=null;
+  const _captureSlashPane=()=>({
+    sessionId:S.session&&S.session.session_id||null,
+    loadingSessionId:typeof _loadingSessionId!=='undefined'?_loadingSessionId:null,
+    loadGeneration:typeof _loadSessionGeneration!=='undefined'?_loadSessionGeneration:null,
+  });
+  const _slashPaneStillCurrent=(owner)=>{
+    const currentGeneration=typeof _loadSessionGeneration!=='undefined'?_loadSessionGeneration:null;
+    if(owner.loadGeneration!==null&&currentGeneration!==owner.loadGeneration) return false;
+    if(owner.sessionId){
+      const currentLoadingSessionId=typeof _loadingSessionId!=='undefined'?_loadingSessionId:null;
+      return typeof _isSessionCurrentPane==='function'
+        ?_isSessionCurrentPane(owner.sessionId)
+        :!!(S.session&&S.session.session_id===owner.sessionId
+          &&(!currentLoadingSessionId||currentLoadingSessionId===owner.sessionId));
+    }
+    return !(S.session&&S.session.session_id)
+      &&!(typeof _loadingSessionId!=='undefined'&&_loadingSessionId);
+  };
+  const _ensureSlashSession=async()=>{
+    if(S.session)return true;
+    const _createdSession=await newSession();
+    if(!_createdSession)return false;
+    const _generation=typeof _loadSessionGeneration!=='undefined'?_loadSessionGeneration:null;
+    await renderSessionList();
+    if(typeof _loadSessionGeneration!=='undefined'&&_loadSessionGeneration!==_generation)return false;
+    if(typeof _loadingSessionId!=='undefined'&&_loadingSessionId)return false;
+    return !!S.session;
+  };
   // Slash command intercept -- local commands handled without agent round-trip.
   // We push the user message BEFORE running the handler for echo-worthy
   // commands so chat order is correct: some handlers (e.g. cmdHelp) push
@@ -1482,7 +1513,7 @@ async function send(){
     if(_cmd){
       let _pushedUser=false;
       if(!_cmd.noEcho){
-        if(!S.session){await newSession();await renderSessionList();}
+        if(!S.session){const _createdSession=await newSession();if(!_createdSession)return;await renderSessionList();}
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         _pushedUser=true;
         renderMessages();
@@ -1500,7 +1531,7 @@ async function send(){
     }
     if(_parsedCmd&&!_cmd){
       if(_parsedCmd.name==='pet'){
-        if(!S.session){await newSession();await renderSessionList();}
+        if(!S.session){const _createdSession=await newSession();if(!_createdSession)return;await renderSessionList();}
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         let _petOutput=null;
         try{
@@ -1525,11 +1556,13 @@ async function send(){
         if(typeof renderSessionList==='function') await renderSessionList();
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }
+      const _agentCmdPane=_captureSlashPane();
       const _agentCmd=typeof getAgentCommandMetadata==='function'
         ? await getAgentCommandMetadata(_parsedCmd.name)
         : null;
+      if(!_slashPaneStillCurrent(_agentCmdPane)) return;
       if(_agentCmd&&_agentCmd.cli_only){
-        if(!S.session){await newSession();await renderSessionList();}
+        if(!(await _ensureSlashSession()))return;
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         S.messages.push({role:'assistant',content:cliOnlyCommandResponse(_parsedCmd.name,_agentCmd),_ts:Date.now()/1000});
         renderMessages();
@@ -1537,14 +1570,17 @@ async function send(){
       }
       const _agentCmdName=String(_agentCmd&&_agentCmd.name||_parsedCmd&&_parsedCmd.name||'').trim().toLowerCase();
       if(_AGENT_COMMANDS_RUN_ON_WEBUI.has(_agentCmdName)){
-        if(!S.session){await newSession();await renderSessionList();}
+        if(!(await _ensureSlashSession()))return;
+        const _agentRunPane=_captureSlashPane();
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         let _agentOutput='(no output)';
         try{
           _agentOutput=typeof executeAgentCommand==='function'
             ? await executeAgentCommand(text,_agentCmd||{name:_agentCmdName})
             : 'Agent command runtime unavailable in WebUI.';
+          if(!_slashPaneStillCurrent(_agentRunPane))return;
         }catch(e){
+          if(!_slashPaneStillCurrent(_agentRunPane))return;
           _agentOutput=`Agent command error: ${e&&e.message||e}`;
         }
         S.messages.push({role:'assistant',content:String(_agentOutput||'(no output)'),_ts:Date.now()/1000});
@@ -1552,14 +1588,17 @@ async function send(){
         $('msg').value='';autoResize();hideCmdDropdown();return;
       }
       if(_agentCmd&&_agentCmd.category==='Plugin'){
-        if(!S.session){await newSession();await renderSessionList();}
+        if(!(await _ensureSlashSession()))return;
+        const _pluginRunPane=_captureSlashPane();
         S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
         let _pluginOutput='(no output)';
         try{
           _pluginOutput=typeof executeAgentPluginCommand==='function'
             ? await executeAgentPluginCommand(text,_agentCmd)
             : 'Plugin command runtime unavailable in WebUI.';
+          if(!_slashPaneStillCurrent(_pluginRunPane))return;
         }catch(e){
+          if(!_slashPaneStillCurrent(_pluginRunPane))return;
           _pluginOutput=`Plugin command error: ${e&&e.message||e}`;
         }
         S.messages.push({role:'assistant',content:String(_pluginOutput||'(no output)'),_ts:Date.now()/1000});
@@ -1568,39 +1607,48 @@ async function send(){
       }
       if(_agentCmdName==='moa'){
         const _moaArgs=(text.split(/\s+/).slice(1).join(' ')||'').trim();
-        if(!S.session){await newSession();await renderSessionList();}
+        if(!(await _ensureSlashSession()))return;
         if(!_moaArgs){
           let _moaUsage='/moa <prompt>';
-          try{const _moaCfgU=await api('/api/commands/moa/resolve');_moaUsage=_moaCfgU.usage||_moaUsage;}catch(_eu){}
+          const _moaUsagePane=_captureSlashPane();
+          try{const _moaCfgU=await api('/api/commands/moa/resolve');if(!_slashPaneStillCurrent(_moaUsagePane))return;_moaUsage=_moaCfgU.usage||_moaUsage;}catch(_eu){if(!_slashPaneStillCurrent(_moaUsagePane))return;}
           S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
           S.messages.push({role:'assistant',content:_moaUsage,_ts:Date.now()/1000});
           renderMessages();$('msg').value='';autoResize();hideCmdDropdown();return;
         }
+        const _moaResolvePane=_captureSlashPane();
         try{
           await api('/api/commands/moa/resolve');
+          if(!_slashPaneStillCurrent(_moaResolvePane))return;
           _slashDisplayTextOverride=text;
           text=_moaArgs;
           _pendingMoaConfig=true;
         }catch(_e){
+          if(!_slashPaneStillCurrent(_moaResolvePane))return;
           S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
           S.messages.push({role:'assistant',content:'MoA unavailable: '+(_e&&_e.message||_e),_ts:Date.now()/1000});
           renderMessages();$('msg').value='';autoResize();hideCmdDropdown();return;
         }
       }
+      const _bundleMetadataPane=_captureSlashPane();
       const _bundleCmd=!_agentCmd&&typeof getBundleCommandMetadata==='function'
         ? await getBundleCommandMetadata(_parsedCmd.name)
         : null;
+      if(!_slashPaneStillCurrent(_bundleMetadataPane)) return;
       if(_bundleCmd){
+        const _bundleResolvePane=_captureSlashPane();
         try{
           const _bundleResolved=typeof resolveBundleCommand==='function'
             ? await resolveBundleCommand(text,_bundleCmd)
             : null;
+          if(!_slashPaneStillCurrent(_bundleResolvePane))return;
           const _bundleMessage=String(_bundleResolved&&_bundleResolved.message||'').trim();
           if(!_bundleMessage) throw new Error('Bundle command runtime returned no invocation text.');
           _slashDisplayTextOverride=text;
           text=_bundleMessage;
         }catch(e){
-          if(!S.session){await newSession();await renderSessionList();}
+          if(!_slashPaneStillCurrent(_bundleResolvePane))return;
+          if(!(await _ensureSlashSession()))return;
           S.messages.push({role:'user',content:text,_ts:Date.now()/1000});
           S.messages.push({role:'assistant',content:`Bundle command error: ${e&&e.message||e}`,_ts:Date.now()/1000});
           renderMessages();
@@ -1609,11 +1657,33 @@ async function send(){
       }
     }
   }
-  if(!S.session){await newSession();await renderSessionList();}
+  if(!(await _ensureSlashSession()))return;
 
   const activeSid=S.session.session_id;
   const _ownsSendPane=()=>_isSessionCurrentPane(activeSid);
   _sendInProgressSid=activeSid;
+  const _submittedText=text;
+  const _submittedSessionWorkspace=S.session.workspace;
+  const _submittedProfile=S.activeProfile||S.session.profile||'default';
+  const _submittedModelState={..._chatPayloadModelState()};
+  const _submittedTranscript=Array.isArray(S.messages)
+    ?S.messages.map(row=>row&&typeof row==='object'?{...row}:row):[];
+  const _submittedPendingPick=typeof _readPendingSessionModel==='function'
+    ?_readPendingSessionModel(activeSid):null;
+  const _submittedDefaultModel=(typeof window!=='undefined'&&window._defaultModel)||'';
+  const _submittedActiveProvider=(typeof window!=='undefined'&&window._activeProvider)||null;
+  const _pendingPickMatch=!!(_submittedPendingPick
+    &&_submittedPendingPick.model===_submittedModelState.model
+    &&String(_submittedPendingPick.model_provider||'')===String(_submittedModelState.model_provider||''));
+  const _submittedCrossProviderPick=!!(_submittedModelState.model
+    &&_submittedModelState.model_provider
+    &&_submittedDefaultModel
+    &&_submittedActiveProvider
+    &&_submittedModelState.model!==_submittedDefaultModel
+    &&String(_submittedModelState.model_provider||'')!==String(_submittedActiveProvider||''));
+  const _submittedPickFlag=_pendingPickMatch||_submittedCrossProviderPick;
+  const _submittedMoaConfig=!!_pendingMoaConfig;
+  const _submittedForcedSkill=_forcedSkillDirectivePending;
 
   // Salvage of #4750 (@harryazj): capture the composer text and clear the
   // textarea NOW — immediately after capture and BEFORE the uploadPendingFiles()
@@ -1650,22 +1720,22 @@ async function send(){
   setComposerStatus(_submittedFiles.length?'Uploading…':'');
   let uploaded=[];
   try{uploaded=await uploadPendingFiles({files:_submittedFiles, sessionId:activeSid, clearPending:false});}
-  catch(e){if(!text){setComposerStatus(`Upload error: ${e.message}`);return;}}
+  catch(e){if(!_submittedText){if(_ownsSendPane()) setComposerStatus(`Upload error: ${e.message}`);return;}}
   // Clear the uploading status now that upload is done — if we don't clear here
   // it stays visible for the entire duration of the agent stream, since
   // setComposerStatus('') is only called in setBusy(false), not setBusy(true).
-  setComposerStatus('');
+  if(_ownsSendPane()) setComposerStatus('');
 
   const uploadedNames=uploaded.map(u=>u.name||u);
   const uploadedPaths=uploaded.map(u=>u&&u.path?u.path:(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
-  let msgText=text;
+  let msgText=_submittedText;
   if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
-  else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;
-  if(_forcedSkillDirectivePending){
-    const _pending=_forcedSkillDirectivePending;
+  else if(uploaded.length)msgText=`${_submittedText}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;
+  if(_submittedForcedSkill){
+    const _pending=_submittedForcedSkill;
     if(!_pending.sessionId||_pending.sessionId===activeSid){
+      if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending=null;
       const _directivePayload = await _pending.promise;
-      if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending = null;
       if(_directivePayload){
         const _directive = typeof _directivePayload==='string'
           ? _directivePayload
@@ -1683,135 +1753,114 @@ async function send(){
       }
     }
   }
-  if(!msgText){setComposerStatus('Nothing to send');return;}
+  if(!msgText){if(_ownsSendPane()) setComposerStatus('Nothing to send');return;}
   // Composer textarea + persisted draft were already captured and cleared
   // immediately after capture (above, salvage of #4750 + #5912 gate fix) to close
   // the re-entrant double-send race AND avoid clobbering a draft typed during the
   // upload window. _composerDraftClearPromise / _submittedDraftFilesForClear are
   // set there; nothing to re-declare here.
-  const displayText=_slashDisplayTextOverride||text||(uploaded.length?`Uploaded: ${uploadedNames.join(', ')}`:'(file upload)');
+  const displayText=_slashDisplayTextOverride||_submittedText||(uploaded.length?`Uploaded: ${uploadedNames.join(', ')}`:'(file upload)');
   const userMsg={role:'user',content:displayText,attachments:uploaded.length?uploadedNames:undefined,_ts:Date.now()/1000,_pending:true};
-  S.toolCalls=[];  // clear tool calls from previous turn
-  clearLiveToolCards();  // clear any leftover live cards from last turn
-  let optimisticMessages;
-  try{
-    S.messages.push(userMsg);renderMessages();setBusy(true);
-    if(S.session&&!S.session.pending_started_at) S.session.pending_started_at=Date.now()/1000;
-    if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
-    else appendThinking('',{pending:true});
-    // First optimistic pass: make the local user turn visible before /api/chat/start
-    // can save pending state on the server.
-    _runOptionalPreStartUiStep('upsertActiveSessionForLocalTurn.initial', ()=>{
-      if(typeof upsertActiveSessionForLocalTurn==='function'){
-        upsertActiveSessionForLocalTurn({title:displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
-      }
-    });
-    optimisticMessages=[...S.messages];
-    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
-    if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null});
-    }
-    _runOptionalPreStartUiStep('renderSessionListFromCache.initial', ()=>{
-      if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
-    });
-    _runOptionalPreStartUiStep('startApprovalPolling.prestart', ()=>startApprovalPolling(activeSid));
-    _runOptionalPreStartUiStep('startClarifyPolling.prestart', ()=>startClarifyPolling(activeSid));
-    _runOptionalPreStartUiStep('fetchYoloState.prestart', ()=>_fetchYoloState(activeSid));  // sync YOLO pill with backend state
-    S.activeStreamId = null;  // will be set after stream starts
-    _runOptionalPreStartUiStep('updateSendBtn.prestart', ()=>{
-      if(typeof updateSendBtn==='function') updateSendBtn();
-    });
-
-    // Set provisional title from user message immediately so session appears
-    // in the sidebar right away with a meaningful name. /api/chat/start persists
-    // the server-side provisional title and may refine this optimistic text.
-    if(S.session&&(S.session.title==='Untitled'||!S.session.title)){
-      const provisionalTitle=displayText.slice(0,64);
-      _runOptionalPreStartUiStep('applySessionTitleUpdate.provisional', ()=>{
-        applySessionTitleUpdate(activeSid, provisionalTitle, {force:true, rememberProvisional:true});
-      });
-      _runOptionalPreStartUiStep('upsertActiveSessionForLocalTurn.provisional', ()=>{
+  let optimisticMessages=[..._submittedTranscript,userMsg];
+  if(_ownsSendPane()){
+    try{
+      S.toolCalls=[];  // clear tool calls from previous turn
+      clearLiveToolCards();  // clear any leftover live cards from last turn
+      S.messages.push(userMsg);renderMessages();setBusy(true);
+      if(S.session&&!S.session.pending_started_at) S.session.pending_started_at=Date.now()/1000;
+      if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+      else appendThinking('',{pending:true});
+      // First optimistic pass: make the local user turn visible before /api/chat/start
+      // can save pending state on the server.
+      _runOptionalPreStartUiStep('upsertActiveSessionForLocalTurn.initial', ()=>{
         if(typeof upsertActiveSessionForLocalTurn==='function'){
-          // Second optimistic pass: carry the provisional title into the cached row
-          // without re-fetching /api/sessions before pending state exists server-side.
-          upsertActiveSessionForLocalTurn({title:provisionalTitle,messageCount:S.messages.length,timestampMs:Date.now()});
+          upsertActiveSessionForLocalTurn({title:displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
         }
       });
-    } else if(typeof upsertActiveSessionForLocalTurn==='function'){
-      _runOptionalPreStartUiStep('upsertActiveSessionForLocalTurn.titled', ()=>{
-        upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
+      optimisticMessages=[...S.messages];
+      _runOptionalPreStartUiStep('renderSessionListFromCache.initial', ()=>{
+        if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
       });
-    } else {
-      _runOptionalPreStartUiStep('renderSessionListFromCache.prestart', ()=>{
-        renderSessionListFromCache();  // ensure it's visible even if already titled
+      _runOptionalPreStartUiStep('startApprovalPolling.prestart', ()=>startApprovalPolling(activeSid));
+      _runOptionalPreStartUiStep('startClarifyPolling.prestart', ()=>startClarifyPolling(activeSid));
+      _runOptionalPreStartUiStep('fetchYoloState.prestart', ()=>_fetchYoloState(activeSid));  // sync YOLO pill with backend state
+      S.activeStreamId = null;  // will be set after stream starts
+      _runOptionalPreStartUiStep('updateSendBtn.prestart', ()=>{
+        if(typeof updateSendBtn==='function') updateSendBtn();
+      });
+
+      // Set provisional title from user message immediately so session appears
+      // in the sidebar right away with a meaningful name. /api/chat/start persists
+      // the server-side provisional title and may refine this optimistic text.
+      if(S.session&&(S.session.title==='Untitled'||!S.session.title)){
+        const provisionalTitle=displayText.slice(0,64);
+        _runOptionalPreStartUiStep('applySessionTitleUpdate.provisional', ()=>{
+          applySessionTitleUpdate(activeSid, provisionalTitle, {force:true, rememberProvisional:true});
+        });
+        _runOptionalPreStartUiStep('upsertActiveSessionForLocalTurn.provisional', ()=>{
+          if(typeof upsertActiveSessionForLocalTurn==='function'){
+            // Second optimistic pass: carry the provisional title into the cached row
+            // without re-fetching /api/sessions before pending state exists server-side.
+            upsertActiveSessionForLocalTurn({title:provisionalTitle,messageCount:S.messages.length,timestampMs:Date.now()});
+          }
+        });
+      } else if(typeof upsertActiveSessionForLocalTurn==='function'){
+        _runOptionalPreStartUiStep('upsertActiveSessionForLocalTurn.titled', ()=>{
+          upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
+        });
+      } else {
+        _runOptionalPreStartUiStep('renderSessionListFromCache.prestart', ()=>{
+          renderSessionListFromCache();  // ensure it's visible even if already titled
+        });
+      }
+    }catch(preStartError){
+      // The user turn must reach /api/chat/start even if local optimistic UI
+      // bookkeeping (render cache, storage quota, sidebar reconciliation, etc.)
+      // throws. Otherwise the pane can show a user bubble + spinner while the
+      // backend never receives the turn.
+      const message=preStartError&&preStartError.message?preStartError.message:String(preStartError||'unknown error');
+      try{console.warn('[webui] pre-start optimistic UI failed; continuing to /api/chat/start', message);}catch(_){ }
+      if(!S.messages.includes(userMsg)) S.messages.push(userMsg);
+      optimisticMessages=[...S.messages];
+      try{setBusy(true);}catch(_){S.busy=true;}
+      if(S.session&&!S.session.pending_started_at) S.session.pending_started_at=Date.now()/1000;
+      S.activeStreamId=null;
+      _runOptionalPreStartUiStep('ensureLiveWorklogShell.fallback',()=>{
+        if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
       });
     }
-  }catch(preStartError){
-    // The user turn must reach /api/chat/start even if local optimistic UI
-    // bookkeeping (render cache, storage quota, sidebar reconciliation, etc.)
-    // throws. Otherwise the pane can show a user bubble + spinner while the
-    // backend never receives the turn.
-    const message=preStartError&&preStartError.message?preStartError.message:String(preStartError||'unknown error');
-    try{console.warn('[webui] pre-start optimistic UI failed; continuing to /api/chat/start', message);}catch(_){ }
-    if(!S.messages.includes(userMsg)) S.messages.push(userMsg);
-    optimisticMessages=[...S.messages];
-    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
-    try{setBusy(true);}catch(_){S.busy=true;}
-    if(S.session&&!S.session.pending_started_at) S.session.pending_started_at=Date.now()/1000;
-    S.activeStreamId=null;
-    if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+  }
+  INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
+  if(typeof saveInflightState==='function'){
+    saveInflightState(activeSid,{streamId:null,messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null});
   }
 
   // Start the agent via POST, get a stream_id back
   let streamId;
   let postStartData;
-  let modelStateForPostStart;
-  let explicitPickForPostStart;
-  let profileForPostStart;
+  let modelStateForPostStart=_submittedModelState;
+  let profileForPostStart=_submittedProfile;
+  const _explicitPick=_submittedPickFlag;
   try{
-    const _modelState=_chatPayloadModelState();
-    modelStateForPostStart=_modelState;
-    profileForPostStart=S.activeProfile||S.session.profile||'default';
-    const _pendingPick=(typeof _readPendingSessionModel==='function')
-      ? _readPendingSessionModel(activeSid)
-      : null;
-    const _pendingPickMatch=_pendingPick
-      && _pendingPick.model===_modelState.model
-      && String(_pendingPick.model_provider||'')===String(_modelState.model_provider||'');
-    // ── Persisted cross-provider pick (#3737 follow-up) ──
-    // The onchange marker is consumed after the first send, so subsequent sends
-    // lose explicit_model_pick and the server "repairs" the model back to the
-    // profile default.  When the session has a non-default model from a different
-    // provider than the profile's active provider, treat every send as explicit
-    // so the server honors the user's choice across the entire conversation.
-    const _defaultModel=(typeof window!=='undefined' && window._defaultModel)||'';
-    const _activeProvider=(typeof window!=='undefined' && window._activeProvider)||null;
-    const _isCrossProviderPick = _modelState.model
-      && _modelState.model_provider
-      && _defaultModel
-      && _activeProvider
-      && _modelState.model !== _defaultModel
-      && String(_modelState.model_provider||'') !== String(_activeProvider||'');
-    const _explicitPick = _pendingPickMatch || _isCrossProviderPick;
     // Consume the pending explicit-pick marker for THIS send only. The marker is
     // recorded on modelSelect.onchange and intentionally kept (not cleared on
     // session-update) so it survives the normal pick→update→send flow; clear it here
     // once read so a later send of an unchanged dropdown isn't treated as an explicit
     // pick. (#3739/#3737, Codex catch)
-    if(_pendingPickMatch && typeof _clearPendingSessionModel==='function') _clearPendingSessionModel(activeSid);
-    explicitPickForPostStart=_explicitPick;
+    if(_pendingPickMatch&&typeof _clearPendingSessionModel==='function'){
+      _clearPendingSessionModel(activeSid);
+    }
     const startData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
       session_id:activeSid,message:msgText,
       // S.session.model remains authoritative; the helper only resolves a
       // matching provider fallback for the same outgoing model.
-      model:_modelState.model,workspace:S.session.workspace,
-      model_provider:_modelState.model_provider,
+      model:_submittedModelState.model,workspace:_submittedSessionWorkspace,
+      model_provider:_submittedModelState.model_provider,
       profile:profileForPostStart,
       explicit_model_pick:_explicitPick||undefined,
       attachments:uploaded.length?uploaded:undefined,
-      moa_config:_pendingMoaConfig?true:undefined
+      moa_config:_submittedMoaConfig?true:undefined
     })});
-    _pendingMoaConfig=null;
     postStartData = startData;
   }catch(e){
     const errMsg=String((e&&e.message)||'');
@@ -1841,8 +1890,8 @@ async function send(){
         if($('emptyState')) $('emptyState').style.display='';
         if($('msgInner')) $('msgInner').innerHTML='';
       }
-      if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
-      if(typeof renderSessionList==='function') void renderSessionList();
+      if(_ownsPane&&typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
+      if(_ownsPane&&typeof renderSessionList==='function') void renderSessionList();
       return;
     }
     const conflictActiveStream=/session already has an active stream/i.test(errMsg);
@@ -1852,10 +1901,9 @@ async function send(){
       stopApprovalPollingForSession(activeSid);
       stopClarifyPollingForSession(activeSid);
       // Keep the user's attempted turn by queueing it for after the current run.
-      const _retryModelState=modelStateForPostStart||_chatPayloadModelState();
-      queueSessionMessage(activeSid,{text:msgText,files:[],model:_retryModelState.model,model_provider:_retryModelState.model_provider,profile:profileForPostStart||S.activeProfile||'default'});
+      const _retryModelState=modelStateForPostStart;
+      queueSessionMessage(activeSid,{text:msgText,files:[],model:_retryModelState.model,model_provider:_retryModelState.model_provider,profile:profileForPostStart});
       if(!_ownsSendPane()){
-        if(typeof renderSessionList==='function') void renderSessionList();
         return;
       }
       updateQueueBadge(activeSid);
@@ -1868,7 +1916,6 @@ async function send(){
         // Fall through to standard error handling if session reload fails.
       }
       if(!_ownsSendPane()){
-        if(typeof renderSessionList==='function') void renderSessionList();
         return;
       }
     }
@@ -1889,9 +1936,9 @@ async function send(){
     // lost. Put back the ORIGINAL captured draft (not the mutated /moa/bundle
     // payload) and re-stage files so the user can re-send without retyping.
     _restoreComposerDraftAfterFailedSend(_failedSendDraftText, _failedSendFilesSnapshot, activeSid, _composerDraftClearPromise);
-    if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
+    if(_ownsSendPane()&&typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
     // Reconcile with server truth after immediately clearing the optimistic spinner.
-    if(typeof renderSessionList==='function') void renderSessionList();
+    if(_ownsSendPane()&&typeof renderSessionList==='function') void renderSessionList();
     return;
   }
 
@@ -1958,13 +2005,13 @@ async function send(){
     if(typeof updateSendBtn==='function') updateSendBtn();
   }
   _runOptionalPostStartUiStep('post-start ui/bookkeeping', ()=>{
-    const _modelState=modelStateForPostStart || _chatPayloadModelState();
-    const _explicitPick=explicitPickForPostStart;
+    const _modelState=modelStateForPostStart;
+    const _postStartExplicitPick=_explicitPick;
     if(_ownsSendPane()&&startData&&startData.title) applySessionTitleUpdate(activeSid, startData.title, {provisionalText:displayText.slice(0,64), rememberProvisional:true});
 
     if(_ownsSendPane()&&startData&&startData.effective_model && S.session){
       const _sentModel=_modelState&&_modelState.model;
-      if(_explicitPick && _sentModel && startData.effective_model!==_sentModel && typeof showToast==='function'){
+      if(_postStartExplicitPick && _sentModel && startData.effective_model!==_sentModel && typeof showToast==='function'){
         showToast('Model '+_sentModel+' changed to '+startData.effective_model+' — profile provider mismatch', 5000);
       }
       S.session.model=startData.effective_model;
@@ -2011,11 +2058,11 @@ async function send(){
     const currentInflight=_stampInflightTurnState();
     if(_ownsSendPane()) markInflight(activeSid, streamId);
     if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[],activeTurnToken:currentInflight.activeTurnToken||null});
+      saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[],activeTurnToken:currentInflight.activeTurnToken||null,reattach:!!currentInflight.reattach});
     }
     // Refresh session list so background streaming indicators appear immediately for the
     // session that was just started and any others that may already be running.
-    if(typeof renderSessionList === 'function') {
+    if(_ownsSendPane()&&typeof renderSessionList === 'function') {
       void renderSessionList();
     }
   });

--- a/static/messages.js
+++ b/static/messages.js
@@ -2009,7 +2009,7 @@ async function send(){
       upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
     }
     const currentInflight=_stampInflightTurnState();
-    markInflight(activeSid, streamId);
+    if(_ownsSendPane()) markInflight(activeSid, streamId);
     if(typeof saveInflightState==='function'){
       saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[],activeTurnToken:currentInflight.activeTurnToken||null});
     }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1706,9 +1706,9 @@ async function send(){
       }
     });
     optimisticMessages=[...S.messages];
-    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
     if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[]});
+      saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null});
     }
     _runOptionalPreStartUiStep('renderSessionListFromCache.initial', ()=>{
       if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
@@ -1754,7 +1754,7 @@ async function send(){
     try{console.warn('[webui] pre-start optimistic UI failed; continuing to /api/chat/start', message);}catch(_){ }
     if(!S.messages.includes(userMsg)) S.messages.push(userMsg);
     optimisticMessages=[...S.messages];
-    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
     try{setBusy(true);}catch(_){S.busy=true;}
     if(S.session&&!S.session.pending_started_at) S.session.pending_started_at=Date.now()/1000;
     S.activeStreamId=null;
@@ -1881,6 +1881,59 @@ async function send(){
   const startData = postStartData || {};
   streamId = postStartData ? postStartData.stream_id : null;
   S.activeStreamId = streamId;
+  const _activeTurnToken=typeof _opaqueActiveTurnToken==='function'
+    ?_opaqueActiveTurnToken(startData.active_turn_token):null;
+  if(S.session) S.session.active_turn_token=_activeTurnToken;
+  const _stampActiveTurnRows=()=>{
+    if(!INFLIGHT[activeSid]){
+      INFLIGHT[activeSid]={messages:optimisticMessages||[...S.messages],uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
+    }
+    const currentInflight=INFLIGHT[activeSid];
+    if(!Array.isArray(currentInflight.messages)) currentInflight.messages=[];
+    currentInflight.activeTurnToken=_activeTurnToken;
+    if(!_activeTurnToken) return currentInflight;
+    const _findCurrentOptimisticRow=(messages)=>{
+      if(!Array.isArray(messages)) return null;
+      const direct=messages.find(row=>row===userMsg);
+      if(direct) return direct;
+      const exact=messages.filter(row=>row&&row.role==='user'
+        &&row._active_turn_token===_activeTurnToken
+        &&(row.timestamp===startData.pending_started_at
+          ||row._ts===startData.pending_started_at));
+      if(exact.length===1) return exact[0];
+      for(let i=messages.length-1;i>=0;i--){
+        const row=messages[i];
+        if(!row) continue;
+        if(row._live) continue;
+        if(row.role==='user'&&row._pending===true&&row._ts===userMsg._ts) return row;
+        if(row.role==='assistant'||row.role==='tool') return null;
+      }
+      return null;
+    };
+    const _insertCurrentOptimisticRow=(messages,row)=>{
+      if(!Array.isArray(messages)||!row||messages.includes(row)) return;
+      const liveIdx=messages.findIndex(item=>item&&item._live);
+      if(liveIdx>=0) messages.splice(liveIdx,0,row);
+      else messages.push(row);
+    };
+    let visibleRow=_findCurrentOptimisticRow(S.messages);
+    let inflightRow=_findCurrentOptimisticRow(currentInflight.messages);
+    const currentRow=inflightRow||visibleRow||userMsg;
+    if(!visibleRow) _insertCurrentOptimisticRow(S.messages,currentRow);
+    if(!inflightRow) _insertCurrentOptimisticRow(currentInflight.messages,currentRow);
+    visibleRow=_findCurrentOptimisticRow(S.messages)||currentRow;
+    inflightRow=_findCurrentOptimisticRow(currentInflight.messages)||currentRow;
+    for(const row of [visibleRow,inflightRow]){
+      if(!row) continue;
+      row._active_turn_token=_activeTurnToken;
+      if(Array.isArray(userMsg.attachments)&&userMsg.attachments.length
+        &&(!Array.isArray(row.attachments)||!row.attachments.length)){
+        row.attachments=[...userMsg.attachments];
+      }
+    }
+    return currentInflight;
+  };
+  _stampActiveTurnRows();
   // setBusy(true) already ran with activeStreamId=null; refresh now that we
   // have a stream id so the primary button can switch to Stop (see
   // getComposerPrimaryAction).
@@ -1932,13 +1985,10 @@ async function send(){
       // against real active-stream metadata before the background refresh lands.
       upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
     }
-    if(!INFLIGHT[activeSid]){
-      INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
-    }
-    const currentInflight=INFLIGHT[activeSid];
+    const currentInflight=_stampActiveTurnRows();
     markInflight(activeSid, streamId);
     if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[]});
+      saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[],activeTurnToken:currentInflight.activeTurnToken||null});
     }
     // Refresh session list so background streaming indicators appear immediately for the
     // session that was just started and any others that may already be running.
@@ -2043,6 +2093,7 @@ function closeLiveStream(sessionId, streamId, source){
         messages:INFLIGHT[sessionId].messages||[],
         uploaded:INFLIGHT[sessionId].uploaded||[],
         toolCalls:INFLIGHT[sessionId].toolCalls||[],
+        activeTurnToken:INFLIGHT[sessionId].activeTurnToken||null,
         lastAssistantText:INFLIGHT[sessionId].lastAssistantText||'',
         lastReasoningText:INFLIGHT[sessionId].lastReasoningText||'',
         lastRunJournalSeq:INFLIGHT[sessionId].lastRunJournalSeq||0,
@@ -2103,10 +2154,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _STREAM_NOTIFICATION_BACKGROUND[activeSid]={streamId,wasBackgrounded:_desktopBackgroundedForNotifications};
     }
   }
-  if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
+  const sessionTurnToken=typeof _opaqueActiveTurnToken==='function'
+    ?_opaqueActiveTurnToken(S.session&&S.session.active_turn_token):null;
+  if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[],activeTurnToken:sessionTurnToken};
   else {
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
     if(!Array.isArray(INFLIGHT[activeSid].toolCalls)) INFLIGHT[activeSid].toolCalls=[];
+    if(!_opaqueActiveTurnToken(INFLIGHT[activeSid].activeTurnToken)){
+      INFLIGHT[activeSid].activeTurnToken=sessionTurnToken;
+    }
   }
   const _priorInflightStreamId=String(INFLIGHT[activeSid].streamId||'');
   if(_priorInflightStreamId&&_priorInflightStreamId!==streamId){
@@ -2326,6 +2382,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       messages:inflight.messages||[],
       uploaded:inflight.uploaded||[...uploaded],
       toolCalls:inflight.toolCalls||[],
+      activeTurnToken:inflight.activeTurnToken||null,
       lastAssistantText:inflight.lastAssistantText||'',
       lastReasoningText:inflight.lastReasoningText||'',
       lastRunJournalSeq:inflight.lastRunJournalSeq||0,
@@ -2503,10 +2560,23 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       inflight.messages[assistantIdx].content=split.content;
       inflight.messages[assistantIdx].reasoning=split.reasoning||undefined;
       inflight.messages[assistantIdx]._ts=inflight.messages[assistantIdx]._ts||ts;
+      if(typeof _opaqueActiveTurnToken==='function'
+        &&_opaqueActiveTurnToken(inflight.activeTurnToken)){
+        inflight.messages[assistantIdx]._active_turn_token=inflight.activeTurnToken;
+      }
       _throttledPersist();
       return;
     }
-    inflight.messages.push({role:'assistant',content:split.content,reasoning:split.reasoning||undefined,_live:true,_ts:ts});
+    inflight.messages.push({
+      role:'assistant',
+      content:split.content,
+      reasoning:split.reasoning||undefined,
+      _live:true,
+      _ts:ts,
+      _active_turn_token:typeof _opaqueActiveTurnToken==='function'
+        ? _opaqueActiveTurnToken(inflight.activeTurnToken)||undefined
+        : undefined,
+    });
     _throttledPersist();
   }
   function recordActivityBoundary(){
@@ -5429,6 +5499,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       messages:[...S.messages],
       uploaded:[...uploaded],
       toolCalls:[],
+      activeTurnToken:_opaqueActiveTurnToken(S.session&&S.session.active_turn_token),
     });
     if(!Array.isArray(inflight.toolCalls)) inflight.toolCalls=[];
     if(!Array.isArray(inflight.messages)) inflight.messages=[...(inflight.messages||[])];
@@ -7765,7 +7836,7 @@ const _SESSION_STREAM_HIDDEN_POLL_MAX_FALSE = 20; // ~2 min at the 6s cadence
 // signal, a poll that fires while another session is in the current pane
 // would attach nothing AND stop polling, leaving the turn invisible until
 // the next user interaction.
-function _attachServerInitiatedStream(sid, streamId, recovered) {
+function _attachServerInitiatedStream(sid, streamId, recovered, activeTurnToken=null) {
   let handedOff = false;
   try {
     streamId = String(streamId || '');
@@ -7778,14 +7849,69 @@ function _attachServerInitiatedStream(sid, streamId, recovered) {
     if (!isCurrent) return false;
     // Already rendering this exact stream — treat as success so the poll
     // stops cleanly (renderer owns the stream from here).
-    if (S.activeStreamId === streamId) return true;
+    const turnToken=typeof _opaqueActiveTurnToken==='function'
+      ?_opaqueActiveTurnToken(activeTurnToken):null;
+    const applyTurnToken=()=>{
+      if(!turnToken) return;
+      if(S.session&&S.session.session_id===sid) S.session.active_turn_token=turnToken;
+      if(typeof INFLIGHT==='undefined') return;
+      if(!INFLIGHT[sid]){
+        INFLIGHT[sid]={
+          messages:Array.isArray(S.messages)?[...S.messages]:[],
+          uploaded:(S.session&&S.session.pending_attachments)||[],
+          toolCalls:[],
+          activeTurnToken:null,
+        };
+      }
+      const inflight=INFLIGHT[sid];
+      inflight.activeTurnToken=turnToken;
+      for(const messages of [S.messages,inflight.messages]){
+        if(!Array.isArray(messages)) continue;
+        for(const row of messages){
+          if(row&&row.role==='assistant'&&row._live) row._active_turn_token=turnToken;
+        }
+      }
+      if(typeof saveInflightState==='function'){
+        saveInflightState(sid,{
+          streamId,
+          messages:inflight.messages||[],
+          uploaded:inflight.uploaded||[],
+          toolCalls:inflight.toolCalls||[],
+          activeTurnToken:inflight.activeTurnToken,
+          lastAssistantText:inflight.lastAssistantText||'',
+          lastReasoningText:inflight.lastReasoningText||'',
+          lastRunJournalSeq:inflight.lastRunJournalSeq||0,
+          lastRunJournalEventId:inflight.lastRunJournalEventId||'',
+          journalReplayFromStart:!!inflight.journalReplayFromStart,
+          anchorActivityScene:inflight.anchorActivityScene||null,
+          currentActivityBurstId:inflight.currentActivityBurstId||0,
+          currentLiveSegmentSeq:inflight.currentLiveSegmentSeq||0,
+          activityBurstAnchors:Array.isArray(inflight.activityBurstAnchors)?inflight.activityBurstAnchors:[],
+          todos:Array.isArray(inflight.todos)?inflight.todos:S.todos,
+          todoStateMeta:inflight.todoStateMeta||S.todoStateMeta||null,
+        });
+      }
+    };
+    applyTurnToken();
     const existingLive = (typeof LIVE_STREAMS !== 'undefined') ? LIVE_STREAMS[sid] : null;
-    if (existingLive && existingLive.streamId === streamId) return true;
+    if (S.activeStreamId === streamId || (existingLive && existingLive.streamId === streamId)) {
+      return true;
+    }
     S.busy = true;
     S.activeStreamId = streamId;
     if (S.session && S.session.session_id === sid) {
       S.session.active_stream_id = streamId;
       if (!S.session.pending_started_at) S.session.pending_started_at = Date.now()/1000;
+    }
+    if (typeof INFLIGHT !== 'undefined') {
+      if (!INFLIGHT[sid]) {
+        INFLIGHT[sid]={
+          messages:Array.isArray(S.messages)?[...S.messages]:[],
+          uploaded:(S.session&&S.session.pending_attachments)||[],
+          toolCalls:[],
+          activeTurnToken:null,
+        };
+      }
     }
     if (typeof ensureLiveWorklogShell === 'function') ensureLiveWorklogShell();
     else if (typeof appendThinking === 'function') appendThinking();
@@ -7871,7 +7997,9 @@ function _startHiddenActiveStreamPoll(sid) {
               _sessionStreamHiddenPollFalseStreamId = streamKey;
               _sessionStreamHiddenPollFalseCount = 0;
             }
-            const attached = _attachServerInitiatedStream(sid, streamId, true);
+            const attached = _attachServerInitiatedStream(
+              sid, streamId, true, d.active_turn_token,
+            );
             if (attached) {
               _stopHiddenActiveStreamPoll();
             } else {
@@ -8083,42 +8211,14 @@ function startSessionStream(sid) {
         // expecting token 0 (which would render a truncated turn). A fresh
         // (non-recovered) frame still attaches from the first token.
         const recovered = !!d.recovered;
-        // Only drive the renderer when this session is the one on screen.
-        const isCurrent = (typeof _isSessionCurrentPane === 'function')
+        if (typeof _isSessionCurrentPane === 'function'
           ? _isSessionCurrentPane(sid)
-          : (S.session && S.session.session_id === sid);
-        if (!isCurrent) return;
-        // A turn is already rendering in this tab (user-initiated, or we
-        // already attached to this very stream). attachLiveStream is
-        // idempotent per (sid, streamId); bail if we're already on it.
-        if (S.activeStreamId === streamId) return;
-        const existingLive = (typeof LIVE_STREAMS !== 'undefined') ? LIVE_STREAMS[sid] : null;
-        if (existingLive && existingLive.streamId === streamId) return;
-        // Mirror the loadSession reattach setup. For a fresh frame the turn
-        // renders from its first token; for a recovered (replay) frame
-        // attachLiveStream reconstructs the in-progress stream.
-        S.busy = true;
-        S.activeStreamId = streamId;
-        if (S.session && S.session.session_id === sid) {
-          S.session.active_stream_id = streamId;
-          if (typeof d.pending_started_at === 'number') S.session.pending_started_at = d.pending_started_at;
-          else if (!S.session.pending_started_at) S.session.pending_started_at = Date.now()/1000;
+          : (S.session && S.session.session_id === sid)) {
+          if (S.session && typeof d.pending_started_at === 'number') {
+            S.session.pending_started_at=d.pending_started_at;
+          }
+          _attachServerInitiatedStream(sid,streamId,recovered,d.active_turn_token);
         }
-        if (typeof ensureLiveWorklogShell === 'function') ensureLiveWorklogShell();
-        else if (typeof appendThinking === 'function') appendThinking();
-        if (typeof updateSendBtn === 'function') updateSendBtn();
-        if (typeof setComposerStatus === 'function') setComposerStatus('');
-        if (typeof syncTopbar === 'function') syncTopbar();
-        if (typeof startApprovalPolling === 'function') startApprovalPolling(sid);
-        if (typeof startClarifyPolling === 'function') startClarifyPolling(sid);
-        if (typeof attachLiveStream === 'function') {
-          attachLiveStream(
-            sid, streamId,
-            (S.session && S.session.pending_attachments) || [],
-            recovered ? {reconnecting: true} : {},
-          );
-        }
-        if (typeof renderSessionList === 'function') void renderSessionList();
       } catch (_) {}
     });
     es.onerror = () => {

--- a/static/messages.js
+++ b/static/messages.js
@@ -1612,6 +1612,7 @@ async function send(){
   if(!S.session){await newSession();await renderSessionList();}
 
   const activeSid=S.session.session_id;
+  const _ownsSendPane=()=>!!(S.session&&S.session.session_id===activeSid);
   _sendInProgressSid=activeSid;
 
   // Salvage of #4750 (@harryazj): capture the composer text and clear the
@@ -1766,9 +1767,11 @@ async function send(){
   let postStartData;
   let modelStateForPostStart;
   let explicitPickForPostStart;
+  let profileForPostStart;
   try{
     const _modelState=_chatPayloadModelState();
     modelStateForPostStart=_modelState;
+    profileForPostStart=S.activeProfile||S.session.profile||'default';
     const _pendingPick=(typeof _readPendingSessionModel==='function')
       ? _readPendingSessionModel(activeSid)
       : null;
@@ -1803,7 +1806,7 @@ async function send(){
       // matching provider fallback for the same outgoing model.
       model:_modelState.model,workspace:S.session.workspace,
       model_provider:_modelState.model_provider,
-      profile:S.activeProfile||S.session.profile||'default',
+      profile:profileForPostStart,
       explicit_model_pick:_explicitPick||undefined,
       attachments:uploaded.length?uploaded:undefined,
       moa_config:_pendingMoaConfig?true:undefined
@@ -1818,24 +1821,27 @@ async function send(){
     // re-inject the dead id via _sessionIdFromLocation(), then reset to the
     // empty state instead of pushing a confusing error bubble into the chat.
     if(e&&e.status===404){
-      try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
-      try{
-        if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
-        else history.replaceState(null,'',window.location.pathname.replace(/\/session\/[^/]+/,'')+window.location.search);
-      }catch(_){ }
+      const _ownsPane=_ownsSendPane();
       delete INFLIGHT[activeSid];
       if(typeof clearInflightState==='function') clearInflightState(activeSid);
-      stopApprovalPolling();
-      stopClarifyPolling();
-      if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
-      if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
-      removeThinking();
-      S.session=null;S.messages=[];
-      setBusy(false);setComposerStatus('');
+      stopApprovalPollingForSession(activeSid);
+      stopClarifyPollingForSession(activeSid);
+      if(_ownsPane){
+        try{ localStorage.removeItem('hermes-webui-session'); }catch(_){ }
+        try{
+          if(typeof _appRootPath==='function') history.replaceState(null,'',_appRootPath());
+          else history.replaceState(null,'',window.location.pathname.replace(/\/session\/[^/]+/,'')+window.location.search);
+        }catch(_){ }
+        if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
+        if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
+        removeThinking();
+        S.session=null;S.messages=[];
+        setBusy(false);setComposerStatus('');
+        if(typeof renderMessages==='function') renderMessages();
+        if($('emptyState')) $('emptyState').style.display='';
+        if($('msgInner')) $('msgInner').innerHTML='';
+      }
       if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
-      if(typeof renderMessages==='function') renderMessages();
-      if($('emptyState')) $('emptyState').style.display='';
-      if($('msgInner')) $('msgInner').innerHTML='';
       if(typeof renderSessionList==='function') void renderSessionList();
       return;
     }
@@ -1843,30 +1849,41 @@ async function send(){
     if(conflictActiveStream){
       delete INFLIGHT[activeSid];
       if(typeof clearInflightState==='function') clearInflightState(activeSid);
-      stopApprovalPolling();
-      stopClarifyPolling();
+      stopApprovalPollingForSession(activeSid);
+      stopClarifyPollingForSession(activeSid);
       // Keep the user's attempted turn by queueing it for after the current run.
-      const _retryModelState=_chatPayloadModelState();
-      queueSessionMessage(activeSid,{text:msgText,files:[],model:_retryModelState.model,model_provider:_retryModelState.model_provider,profile:S.activeProfile||'default'});
+      const _retryModelState=modelStateForPostStart||_chatPayloadModelState();
+      queueSessionMessage(activeSid,{text:msgText,files:[],model:_retryModelState.model,model_provider:_retryModelState.model_provider,profile:profileForPostStart||S.activeProfile||'default'});
+      if(!_ownsSendPane()){
+        if(typeof renderSessionList==='function') void renderSessionList();
+        return;
+      }
       updateQueueBadge(activeSid);
       showToast('Current session is still running. Reconnected and queued your message.',2600);
       try{
         await loadSession(activeSid);
-        setComposerStatus('');
+        if(_ownsSendPane()) setComposerStatus('');
         return;
       }catch(_){
         // Fall through to standard error handling if session reload fails.
       }
+      if(!_ownsSendPane()){
+        if(typeof renderSessionList==='function') void renderSessionList();
+        return;
+      }
     }
 
     delete INFLIGHT[activeSid];
-    stopApprovalPolling();
-    stopClarifyPolling();
-    // Only hide approval card if it belongs to the session that just finished
-    if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);removeThinking();
-    if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
-    S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
-    _queueDrainSid=activeSid;renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
+    stopApprovalPollingForSession(activeSid);
+    stopClarifyPollingForSession(activeSid);
+    if(_ownsSendPane()){
+      // Only hide approval card if it belongs to the session that just finished
+      if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
+      removeThinking();
+      if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
+      S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
+      _queueDrainSid=activeSid;renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
+    }
     // #5472: the send was rejected before the turn was durably started, so the
     // composer text + attachments (cleared at send time) would otherwise be
     // lost. Put back the ORIGINAL captured draft (not the mutated /moa/bundle
@@ -1880,29 +1897,23 @@ async function send(){
 
   const startData = postStartData || {};
   streamId = postStartData ? postStartData.stream_id : null;
-  S.activeStreamId = streamId;
+  if(_ownsSendPane()) S.activeStreamId = streamId;
   const _activeTurnToken=typeof _opaqueActiveTurnToken==='function'
     ?_opaqueActiveTurnToken(startData.active_turn_token):null;
-  if(S.session) S.session.active_turn_token=_activeTurnToken;
-  const _stampActiveTurnRows=()=>{
-    if(!INFLIGHT[activeSid]){
-      INFLIGHT[activeSid]={messages:optimisticMessages||[...S.messages],uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
-    }
-    const currentInflight=INFLIGHT[activeSid];
-    if(!Array.isArray(currentInflight.messages)) currentInflight.messages=[];
-    currentInflight.activeTurnToken=_activeTurnToken;
-    if(!_activeTurnToken) return currentInflight;
-    const _findCurrentOptimisticRow=(messages)=>{
-      if(!Array.isArray(messages)) return null;
-      const direct=messages.find(row=>row===userMsg);
+  if(_ownsSendPane()) S.session.active_turn_token=_activeTurnToken;
+  const _stampActiveTurnRows=(messages, preferredRow=null)=>{
+    if(!Array.isArray(messages)||!_activeTurnToken) return null;
+    const _findCurrentOptimisticRow=(rows)=>{
+      if(!Array.isArray(rows)) return null;
+      const direct=rows.find(row=>row===userMsg);
       if(direct) return direct;
-      const exact=messages.filter(row=>row&&row.role==='user'
+      const exact=rows.filter(row=>row&&row.role==='user'
         &&row._active_turn_token===_activeTurnToken
         &&(row.timestamp===startData.pending_started_at
           ||row._ts===startData.pending_started_at));
       if(exact.length===1) return exact[0];
-      for(let i=messages.length-1;i>=0;i--){
-        const row=messages[i];
+      for(let i=rows.length-1;i>=0;i--){
+        const row=rows[i];
         if(!row) continue;
         if(row._live) continue;
         if(row.role==='user'&&row._pending===true&&row._ts===userMsg._ts) return row;
@@ -1910,40 +1921,48 @@ async function send(){
       }
       return null;
     };
-    const _insertCurrentOptimisticRow=(messages,row)=>{
-      if(!Array.isArray(messages)||!row||messages.includes(row)) return;
-      const liveIdx=messages.findIndex(item=>item&&item._live);
-      if(liveIdx>=0) messages.splice(liveIdx,0,row);
-      else messages.push(row);
+    const _insertCurrentOptimisticRow=(rows,row)=>{
+      if(!Array.isArray(rows)||!row||rows.includes(row)) return;
+      const liveIdx=rows.findIndex(item=>item&&item._live);
+      if(liveIdx>=0) rows.splice(liveIdx,0,row);
+      else rows.push(row);
     };
-    let visibleRow=_findCurrentOptimisticRow(S.messages);
-    let inflightRow=_findCurrentOptimisticRow(currentInflight.messages);
-    const currentRow=inflightRow||visibleRow||userMsg;
-    if(!visibleRow) _insertCurrentOptimisticRow(S.messages,currentRow);
-    if(!inflightRow) _insertCurrentOptimisticRow(currentInflight.messages,currentRow);
-    visibleRow=_findCurrentOptimisticRow(S.messages)||currentRow;
-    inflightRow=_findCurrentOptimisticRow(currentInflight.messages)||currentRow;
-    for(const row of [visibleRow,inflightRow]){
-      if(!row) continue;
-      row._active_turn_token=_activeTurnToken;
-      if(Array.isArray(userMsg.attachments)&&userMsg.attachments.length
-        &&(!Array.isArray(row.attachments)||!row.attachments.length)){
-        row.attachments=[...userMsg.attachments];
-      }
+    let currentRow=_findCurrentOptimisticRow(messages)||preferredRow||userMsg;
+    _insertCurrentOptimisticRow(messages,currentRow);
+    currentRow=_findCurrentOptimisticRow(messages)||currentRow;
+    currentRow._active_turn_token=_activeTurnToken;
+    if(Array.isArray(userMsg.attachments)&&userMsg.attachments.length
+      &&(!Array.isArray(currentRow.attachments)||!currentRow.attachments.length)){
+      currentRow.attachments=[...userMsg.attachments];
     }
+    return currentRow;
+  };
+  const _stampInflightTurnState=()=>{
+    if(!INFLIGHT[activeSid]){
+      INFLIGHT[activeSid]={messages:optimisticMessages||[...S.messages],uploaded:uploadedNames,toolCalls:[],activeTurnToken:null};
+    }
+    const currentInflight=INFLIGHT[activeSid];
+    if(!Array.isArray(currentInflight.messages)) currentInflight.messages=[];
+    currentInflight.activeTurnToken=_activeTurnToken;
+    currentInflight.streamId=streamId;
+    currentInflight.reattach=!_ownsSendPane();
+    const inflightRow=_stampActiveTurnRows(currentInflight.messages);
+    if(_ownsSendPane()) _stampActiveTurnRows(S.messages,inflightRow);
     return currentInflight;
   };
-  _stampActiveTurnRows();
+  _stampInflightTurnState();
   // setBusy(true) already ran with activeStreamId=null; refresh now that we
   // have a stream id so the primary button can switch to Stop (see
   // getComposerPrimaryAction).
-  if(typeof updateSendBtn==='function') updateSendBtn();
+  if(_ownsSendPane()){
+    if(typeof updateSendBtn==='function') updateSendBtn();
+  }
   _runOptionalPostStartUiStep('post-start ui/bookkeeping', ()=>{
     const _modelState=modelStateForPostStart || _chatPayloadModelState();
     const _explicitPick=explicitPickForPostStart;
-    if(startData&&startData.title) applySessionTitleUpdate(activeSid, startData.title, {provisionalText:displayText.slice(0,64), rememberProvisional:true});
+    if(_ownsSendPane()&&startData&&startData.title) applySessionTitleUpdate(activeSid, startData.title, {provisionalText:displayText.slice(0,64), rememberProvisional:true});
 
-    if(startData&&startData.effective_model && S.session){
+    if(_ownsSendPane()&&startData&&startData.effective_model && S.session){
       const _sentModel=_modelState&&_modelState.model;
       if(_explicitPick && _sentModel && startData.effective_model!==_sentModel && typeof showToast==='function'){
         showToast('Model '+_sentModel+' changed to '+startData.effective_model+' — profile provider mismatch', 5000);
@@ -1954,7 +1973,7 @@ async function send(){
       if(typeof _writePersistedModelState==='function') _writePersistedModelState(startData.effective_model,S.session.model_provider||null);
       if($('modelSelect')) _applyModelToDropdown(startData.effective_model, $('modelSelect'),S.session.model_provider||null);
       if(typeof syncTopbar==='function') syncTopbar();
-    }else if(startData&&startData.effective_model_provider && S.session){
+    }else if(_ownsSendPane()&&startData&&startData.effective_model_provider && S.session){
       S.session.model_provider=startData.effective_model_provider;
       if(typeof _writePersistedModelState==='function') _writePersistedModelState(S.session.model||'',S.session.model_provider||null);
       if($('modelSelect')&&typeof _applyModelToDropdown==='function') _applyModelToDropdown(S.session.model||'', $('modelSelect'), S.session.model_provider||null);
@@ -1962,15 +1981,19 @@ async function send(){
       if(typeof syncTopbar==='function') syncTopbar();
     }
 
-    if(S.session&&typeof startData.pending_started_at==='number'){
+    if(_ownsSendPane()&&S.session&&typeof startData.pending_started_at==='number'){
       S.session.pending_started_at=startData.pending_started_at;
     }
-    if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
-    else if(typeof appendThinking==='function') appendThinking('',{pending:true});
+    if(_ownsSendPane()){
+      if(typeof ensureLiveWorklogShell==='function') ensureLiveWorklogShell();
+      else if(typeof appendThinking==='function') appendThinking('',{pending:true});
+    }
     // setBusy(true) already ran with activeStreamId=null; refresh now that we
     // have a stream id so the primary button can switch to Stop (see
     // getComposerPrimaryAction).
-    if(typeof updateSendBtn==='function') updateSendBtn();
+    if(_ownsSendPane()){
+      if(typeof updateSendBtn==='function') updateSendBtn();
+    }
     if(S.session&&S.session.session_id===activeSid){
       S.session.active_stream_id = streamId;
     }
@@ -1980,12 +2003,12 @@ async function send(){
         : (S.session.pending_started_at||Date.now()/1000);
       showLiveRunStatus(activeSid,{startedAt:_startedAt});
     }
-    if(typeof upsertActiveSessionForLocalTurn==='function'){
+    if(_ownsSendPane()&&typeof upsertActiveSessionForLocalTurn==='function'){
       // Third optimistic pass: stream_id is now known, so the row can reconcile
       // against real active-stream metadata before the background refresh lands.
       upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
     }
-    const currentInflight=_stampActiveTurnRows();
+    const currentInflight=_stampInflightTurnState();
     markInflight(activeSid, streamId);
     if(typeof saveInflightState==='function'){
       saveInflightState(activeSid,{streamId,messages:currentInflight.messages||optimisticMessages,uploaded:uploadedNames,toolCalls:currentInflight.toolCalls||[],activeTurnToken:currentInflight.activeTurnToken||null});
@@ -1998,7 +2021,7 @@ async function send(){
   });
 
   // Open SSE stream and render tokens live
-  attachLiveStream(activeSid, streamId, uploadedNames);
+  if(_ownsSendPane()) attachLiveStream(activeSid, streamId, uploadedNames);
 
   }finally{ _sendInProgress=false; _sendInProgressSid=null; }
 }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1612,7 +1612,7 @@ async function send(){
   if(!S.session){await newSession();await renderSessionList();}
 
   const activeSid=S.session.session_id;
-  const _ownsSendPane=()=>!!(S.session&&S.session.session_id===activeSid);
+  const _ownsSendPane=()=>_isSessionCurrentPane(activeSid);
   _sendInProgressSid=activeSid;
 
   // Salvage of #4750 (@harryazj): capture the composer text and clear the
@@ -1994,10 +1994,10 @@ async function send(){
     if(_ownsSendPane()){
       if(typeof updateSendBtn==='function') updateSendBtn();
     }
-    if(S.session&&S.session.session_id===activeSid){
+    if(_ownsSendPane()){
       S.session.active_stream_id = streamId;
     }
-    if(S.session&&S.session.session_id===activeSid&&typeof showLiveRunStatus==='function'){
+    if(_ownsSendPane()&&typeof showLiveRunStatus==='function'){
       const _startedAt=typeof startData?.pending_started_at==='number'
         ? startData.pending_started_at
         : (S.session.pending_started_at||Date.now()/1000);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3340,8 +3340,10 @@ function _currentTailUserMessage(messages,candidateStart,candidateTimestamp,cand
     }
     if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
       ||String(msg.role||'')==='tool'){
-      if(msg._active_turn_token!==undefined
-        &&msg._active_turn_token!==authoritativeToken) return null;
+      if(Object.prototype.hasOwnProperty.call(msg,'_active_turn_token')){
+        if(!authoritativeToken||msg._active_turn_token!==authoritativeToken) return null;
+      }else if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
+        ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
       crossedActivity=true;
       continue;
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1505,8 +1505,8 @@ async function newSession(flash, options={}){
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
     if(!_newSessionOwnsPane()) return null;
-    _loadSessionGeneration++;
-    _loadingSessionId=null;
+    if(typeof _loadSessionGeneration!=='undefined') _loadSessionGeneration++;
+    if(typeof _loadingSessionId!=='undefined') _loadingSessionId=null;
     if(consumedExplicitModelOverride&&typeof _clearEmptyComposerModelOverride==='function'){
       _clearEmptyComposerModelOverride();
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1390,6 +1390,22 @@ async function newSession(flash, options={}){
   }
   _setNewSessionPending(true);
   _newSessionInFlight=(async()=>{
+    const _newSessionOwnerSid=S.session&&S.session.session_id||null;
+    const _newSessionOwnerGeneration=typeof _loadSessionGeneration!=='undefined'
+      ?_loadSessionGeneration:null;
+    const _newSessionOwnsPane=()=>{
+      if(typeof _loadSessionGeneration!=='undefined'
+        &&_loadSessionGeneration!==_newSessionOwnerGeneration) return false;
+      if(_newSessionOwnerSid){
+        return typeof _isSessionCurrentPane==='function'
+          ?_isSessionCurrentPane(_newSessionOwnerSid)
+          :!!(S.session&&S.session.session_id===_newSessionOwnerSid
+            &&!(typeof _loadingSessionId!=='undefined'&&_loadingSessionId
+              &&_loadingSessionId!==_newSessionOwnerSid));
+      }
+      return !(S.session&&S.session.session_id)
+        &&!(typeof _loadingSessionId!=='undefined'&&_loadingSessionId);
+    };
     // Starting a brand-new chat must not carry named context blocks selected in
     // the previous conversation (#2543). loadSession() clears these on a sidebar
     // switch, but the New Chat path replaces S.session here without going through
@@ -1488,6 +1504,9 @@ async function newSession(flash, options={}){
         ||null;
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
+    if(!_newSessionOwnsPane()) return null;
+    _loadSessionGeneration++;
+    _loadingSessionId=null;
     if(consumedExplicitModelOverride&&typeof _clearEmptyComposerModelOverride==='function'){
       _clearEmptyComposerModelOverride();
     }
@@ -1566,6 +1585,7 @@ async function newSession(flash, options={}){
     }
     // Refresh sidebar to include the newly created session (#3874).
     if(typeof refreshSessionList==='function'){Promise.resolve(refreshSessionList('new-session')).catch(()=>{})}
+    return S.session;
   })();
   try{
     return await _newSessionInFlight;
@@ -1727,7 +1747,10 @@ async function loadSession(sid){
   const _loadGeneration = ++_loadSessionGeneration;
   const _isCurrentLoad = () => _loadingSessionId === sid && _loadSessionGeneration === _loadGeneration;
   _loadingSessionId = sid;
-  if(currentSid!==sid&&typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
+  if(currentSid!==sid){
+    if(typeof setComposerStatus==='function')setComposerStatus('');
+    if(typeof _uploadPendingFilesSyncProgressForSession==='function')_uploadPendingFilesSyncProgressForSession(sid);
+  }
   // Reset scroll state for fresh session navigation — the reader expects to
   // land at the bottom of the new transcript, not wherever a stale unpin flag
   // from a prior session or a stray touch event during loading would place them.
@@ -3342,6 +3365,8 @@ function _currentTailUserMessage(messages,candidateStart,candidateTimestamp,cand
       ||String(msg.role||'')==='tool'){
       if(Object.prototype.hasOwnProperty.call(msg,'_active_turn_token')){
         if(!authoritativeToken||msg._active_turn_token!==authoritativeToken) return null;
+      }else if(authoritativeToken){
+        return null;
       }else if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
         ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
       crossedActivity=true;
@@ -3391,8 +3416,10 @@ function _mergePendingSessionMessage(session,messages){
       &&_opaqueActiveTurnToken(row._active_turn_token)===activeTurnToken):[];
   const ambiguousTokenRows=!!(activeTurnToken&&matchingUsers.length>1);
   if(activeTurnToken&&pendingText){
-    if(matchingUsers.length===1){
-      const existing=matchingUsers[0];
+    const existing=matchingUsers.length===1?matchingUsers[0]:null;
+    const pendingOwner=typeof _pendingActiveTurnUserMessage==='function'
+      ?_pendingActiveTurnUserMessage(messages,session):null;
+    if(existing&&pendingOwner===existing){
       const pendingAttachments=Array.isArray(session.pending_attachments)
         ?session.pending_attachments.filter(Boolean):[];
       if(pendingAttachments.length&&(!Array.isArray(existing.attachments)||!existing.attachments.length)){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1776,6 +1776,7 @@ async function loadSession(sid){
           messages:Array.isArray(S.messages)?[...S.messages]:[],
           uploaded:[],
           toolCalls:Array.isArray(S.toolCalls)?[...S.toolCalls]:[],
+          activeTurnToken:_opaqueActiveTurnToken(S.session&&S.session.active_turn_token),
         };
       }
       snapshotLiveTurnHtmlForSession(currentSid);
@@ -2084,6 +2085,7 @@ async function loadSession(sid){
         currentActivityBurstId:Number(stored.currentActivityBurstId||0)||0,
         currentLiveSegmentSeq:Number(stored.currentLiveSegmentSeq||0)||0,
         activityBurstAnchors:Array.isArray(stored.activityBurstAnchors)?stored.activityBurstAnchors:[],
+        activeTurnToken:_opaqueActiveTurnToken(stored.activeTurnToken),
       };
     }
   }
@@ -2113,6 +2115,10 @@ async function loadSession(sid){
   }
 
   if(INFLIGHT[sid]){
+    const sessionTurnToken=_opaqueActiveTurnToken(
+      S.session&&(S.session.active_turn_token??S.session.activeTurnToken),
+    );
+    if(sessionTurnToken) INFLIGHT[sid].activeTurnToken=sessionTurnToken;
     _ensureInflightLiveAssistantMessage(INFLIGHT[sid]);
     const inflightMessages=_projectInflightMessagesForActivityBursts(INFLIGHT[sid]);
     S.toolCalls=[];
@@ -2132,11 +2138,12 @@ async function loadSession(sid){
       _rearmActiveSessionStream();
       return;
     }
-    const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);
+    const activeTurnToken=sessionTurnToken;
+    const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages,activeTurnToken);
     if(liveTailPrepared){
-      S.messages=_dropCurrentTurnAssistantMessages(S.messages);
+      S.messages=_dropCurrentTurnAssistantMessages(S.messages,activeTurnToken);
     }
-    S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
+    S.messages=_mergeInflightTailMessages(S.messages,inflightMessages,activeTurnToken);
     S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
     if(_mergePendingSessionMessage(S.session,S.messages)&&inflightMessages===(INFLIGHT[sid].messages||[])){
       INFLIGHT[sid].messages=S.messages;
@@ -3300,32 +3307,71 @@ function _sameTranscriptMessage(a,b){
   return false;
 }
 
-function _currentTailUserMessage(messages,candidateStart,candidateTimestamp){
+function _opaqueActiveTurnToken(value){
+  return typeof value==='string'&&value.trim().length?value:null;
+}
+
+function _currentTailUserMessage(messages,candidateStart,candidateTimestamp,candidate,activeTurnToken){
   const list=Array.isArray(messages)?messages:[];
+  let crossedActivity=false;
+  const candidateToken=_opaqueActiveTurnToken(candidate&&candidate._active_turn_token);
+  const authoritativeToken=_opaqueActiveTurnToken(activeTurnToken);
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
     if(String(msg.role||'')==='user'){
       // Compaction rows are synthetic user-role markers, not submitted turns.
       if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      const existingToken=_opaqueActiveTurnToken(msg._active_turn_token);
+      if(crossedActivity){
+        if(!authoritativeToken||candidateToken!==authoritativeToken
+          ||existingToken!==authoritativeToken) return null;
+        const matchingUsers=list.filter(row=>row&&String(row.role||'')==='user'
+          &&_opaqueActiveTurnToken(row._active_turn_token)===authoritativeToken);
+        if(matchingUsers.length!==1) return null;
+      }
       return msg;
+    }
+    if(msg._live){
+      if(!authoritativeToken||candidateToken!==authoritativeToken
+        ||_opaqueActiveTurnToken(msg._active_turn_token)!==authoritativeToken) return null;
+      crossedActivity=true;
+      continue;
     }
     if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
       ||String(msg.role||'')==='tool'){
-      if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
-        ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
+      if(msg._active_turn_token!==undefined
+        &&msg._active_turn_token!==authoritativeToken) return null;
+      crossedActivity=true;
       continue;
     }
-    if(msg._live) continue;
     return null;
   }
   return null;
 }
 
-function _hasCurrentTailUserDuplicate(messages,candidate){
+function _hasCurrentTailUserDuplicate(messages,candidate,activeTurnToken){
   if(!candidate||String(candidate.role||'')!=='user') return false;
-  const existing=_currentTailUserMessage(messages,candidate._ts,candidate.timestamp);
-  return !!(existing&&_sameTranscriptMessage(existing,candidate));
+  const existing=_currentTailUserMessage(
+    messages,
+    candidate._ts,
+    candidate.timestamp,
+    candidate,
+    activeTurnToken,
+  );
+  if(!existing) return false;
+  const token=_opaqueActiveTurnToken(activeTurnToken);
+  if(!token||_opaqueActiveTurnToken(candidate._active_turn_token)!==token) return false;
+  const matchingUsers=(Array.isArray(messages)?messages:[]).filter(row=>
+    row&&String(row.role||'')==='user'
+    &&_opaqueActiveTurnToken(row._active_turn_token)===token
+  );
+  if(matchingUsers.length!==1||matchingUsers[0]!==existing) return false;
+  if(Array.isArray(candidate.attachments)&&candidate.attachments.length
+    &&(!Array.isArray(existing.attachments)||!existing.attachments.length)){
+    existing.attachments=[...candidate.attachments];
+  }
+  return true;
 }
 
 // Keep pending-user recovery ordering identical across load, reconnect, and
@@ -3335,11 +3381,37 @@ function _mergePendingSessionMessage(session,messages){
   if(!Array.isArray(messages)) return false;
   const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
   const currentTurnMessages=liveAssistantIdx>=0?messages.slice(0,liveAssistantIdx):messages;
-  const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,currentTurnMessages):null;
+  const activeTurnToken=_opaqueActiveTurnToken(
+    session&&(session.active_turn_token??session.activeTurnToken),
+  );
+  const pendingText=String(session&&session.pending_user_message||'').trim();
+  const matchingUsers=activeTurnToken?messages.filter(row=>row&&String(row.role||'')==='user'
+      &&_opaqueActiveTurnToken(row._active_turn_token)===activeTurnToken):[];
+  const ambiguousTokenRows=!!(activeTurnToken&&matchingUsers.length>1);
+  if(activeTurnToken&&pendingText){
+    if(matchingUsers.length===1){
+      const existing=matchingUsers[0];
+      const pendingAttachments=Array.isArray(session.pending_attachments)
+        ?session.pending_attachments.filter(Boolean):[];
+      if(pendingAttachments.length&&(!Array.isArray(existing.attachments)||!existing.attachments.length)){
+        existing.attachments=[...pendingAttachments];
+      }
+      if(liveAssistantIdx>=0){
+        const existingIdx=messages.indexOf(existing);
+        if(existingIdx>liveAssistantIdx){
+          messages.splice(existingIdx,1);
+          messages.splice(liveAssistantIdx,0,existing);
+        }
+      }
+      return false;
+    }
+  }
+  const pendingSourceMessages=ambiguousTokenRows?messages:currentTurnMessages;
+  const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,pendingSourceMessages):null;
   if(!pendingMsg) return false;
-  if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
+  if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg,activeTurnToken)) return false;
   if(liveAssistantIdx>=0){
-    const misplacedIdx=messages.findIndex((m,idx)=>
+    const misplacedIdx=activeTurnToken?-1:messages.findIndex((m,idx)=>
       idx>liveAssistantIdx&&m&&m.role==='user'&&_sameTranscriptMessage(m,pendingMsg)
     );
     if(misplacedIdx>=0){
@@ -3374,13 +3446,19 @@ function _compactTranscriptText(text){
   return String(text||'').replace(/\s+/g,' ').trim();
 }
 
-function _dropCurrentTurnAssistantMessages(messages){
+function _dropCurrentTurnAssistantMessages(messages,activeTurnToken){
   const list=Array.isArray(messages)?messages:[];
+  const token=_opaqueActiveTurnToken(activeTurnToken);
+  if(!token) return list;
   let start=-1;
   for(let i=list.length-1;i>=0;i--){
-    if(list[i]&&list[i].role==='user'){start=i;break;}
+    if(list[i]&&list[i].role==='user'
+      &&!(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(list[i]))){
+      start=i;
+      break;
+    }
   }
-  if(start<0) return list;
+  if(start<0||_opaqueActiveTurnToken(list[start]._active_turn_token)!==token) return list;
   return list.filter((msg,idx)=>idx<=start||!(msg&&msg.role==='assistant'));
 }
 
@@ -3401,6 +3479,9 @@ function _ensureInflightLiveAssistantMessage(inflight){
       live.content=text;
     }
     if(reasoning&&!live.reasoning) live.reasoning=reasoning;
+    if(_opaqueActiveTurnToken(inflight.activeTurnToken)){
+      live._active_turn_token=inflight.activeTurnToken;
+    }
     return true;
   }
   inflight.messages.push({
@@ -3409,6 +3490,7 @@ function _ensureInflightLiveAssistantMessage(inflight){
     reasoning:reasoning||undefined,
     _live:true,
     _ts:Date.now()/1000,
+    _active_turn_token:_opaqueActiveTurnToken(inflight.activeTurnToken)||undefined,
   });
   return true;
 }
@@ -3606,9 +3688,22 @@ function _projectInflightMessagesForActivityBursts(inflight){
   return [...messages.slice(0,replaceStartIdx),...projected,...messages.slice(liveIdx+1)];
 }
 
-function _prepareRunningLiveTail(baseMessages,inflightMessages){
+function _prepareRunningLiveTail(baseMessages,inflightMessages,activeTurnToken){
   const inflight=Array.isArray(inflightMessages)?inflightMessages:[];
   const liveMessages=inflight.filter(m=>m&&m.role==='assistant'&&m._live);
+  const token=_opaqueActiveTurnToken(activeTurnToken);
+  if(!token) return false;
+  const base=Array.isArray(baseMessages)?baseMessages:[];
+  let currentUser=null;
+  for(let i=base.length-1;i>=0;i--){
+    const msg=base[i];
+    if(msg&&msg.role==='user'
+      &&!(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg))){
+      currentUser=msg;
+      break;
+    }
+  }
+  if(!currentUser||_opaqueActiveTurnToken(currentUser._active_turn_token)!==token) return false;
   if(liveMessages.length>1) return liveMessages.some(m=>!!_messageComparableText(m));
   const live=liveMessages[0]||null;
   if(!live) return false;
@@ -3631,7 +3726,7 @@ function _prepareRunningLiveTail(baseMessages,inflightMessages){
   return !!_messageComparableText(live);
 }
 
-function _mergeInflightTailMessages(baseMessages, inflightMessages){
+function _mergeInflightTailMessages(baseMessages, inflightMessages,activeTurnToken){
   const base=Array.isArray(baseMessages)?baseMessages:[];
   const inflight=Array.isArray(inflightMessages)?inflightMessages:[];
   let firstLiveIdx=-1;
@@ -3647,7 +3742,7 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
     let candidate=msg;
     if(!candidate) continue;
     const duplicate=String(candidate.role||'')==='user'
-      ? _hasCurrentTailUserDuplicate(merged,candidate)
+      ? _hasCurrentTailUserDuplicate(merged,candidate,activeTurnToken)
       : merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,candidate));
     if(!duplicate) merged.push(candidate);
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3408,6 +3408,8 @@ function _mergePendingSessionMessage(session,messages){
   if(!Array.isArray(messages)) return false;
   const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
   const currentTurnMessages=liveAssistantIdx>=0?messages.slice(0,liveAssistantIdx):messages;
+  const liveAssistant=liveAssistantIdx>=0?messages[liveAssistantIdx]:null;
+  const liveBoundaryToken=_opaqueActiveTurnToken(liveAssistant&&liveAssistant._active_turn_token);
   const activeTurnToken=_opaqueActiveTurnToken(
     session&&(session.active_turn_token??session.activeTurnToken),
   );
@@ -3435,10 +3437,10 @@ function _mergePendingSessionMessage(session,messages){
       return false;
     }
   }
-  const pendingSourceMessages=ambiguousTokenRows?messages:currentTurnMessages;
+  const pendingSourceMessages=ambiguousTokenRows||liveBoundaryToken?messages:currentTurnMessages;
   const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,pendingSourceMessages):null;
   if(!pendingMsg) return false;
-  if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg,activeTurnToken)) return false;
+  if(_hasCurrentTailUserDuplicate(pendingSourceMessages,pendingMsg,activeTurnToken)) return false;
   if(liveAssistantIdx>=0){
     const misplacedIdx=activeTurnToken?-1:messages.findIndex((m,idx)=>
       idx>liveAssistantIdx&&m&&m.role==='user'&&_sameTranscriptMessage(m,pendingMsg)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3408,15 +3408,15 @@ function _mergePendingSessionMessage(session,messages){
   if(!Array.isArray(messages)) return false;
   const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
   const currentTurnMessages=liveAssistantIdx>=0?messages.slice(0,liveAssistantIdx):messages;
-  const liveAssistant=liveAssistantIdx>=0?messages[liveAssistantIdx]:null;
-  const liveBoundaryToken=_opaqueActiveTurnToken(liveAssistant&&liveAssistant._active_turn_token);
+  const suffixHasToken=liveAssistantIdx>=0&&messages.slice(liveAssistantIdx).some(row=>
+    _opaqueActiveTurnToken(row&&row._active_turn_token)
+  );
   const activeTurnToken=_opaqueActiveTurnToken(
     session&&(session.active_turn_token??session.activeTurnToken),
   );
   const pendingText=String(session&&session.pending_user_message||'').trim();
   const matchingUsers=activeTurnToken?messages.filter(row=>row&&String(row.role||'')==='user'
       &&_opaqueActiveTurnToken(row._active_turn_token)===activeTurnToken):[];
-  const ambiguousTokenRows=!!(activeTurnToken&&matchingUsers.length>1);
   if(activeTurnToken&&pendingText){
     const existing=matchingUsers.length===1?matchingUsers[0]:null;
     const pendingOwner=typeof _pendingActiveTurnUserMessage==='function'
@@ -3437,7 +3437,7 @@ function _mergePendingSessionMessage(session,messages){
       return false;
     }
   }
-  const pendingSourceMessages=ambiguousTokenRows||liveBoundaryToken?messages:currentTurnMessages;
+  const pendingSourceMessages=activeTurnToken||suffixHasToken?messages:currentTurnMessages;
   const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,pendingSourceMessages):null;
   if(!pendingMsg) return false;
   if(_hasCurrentTailUserDuplicate(pendingSourceMessages,pendingMsg,activeTurnToken)) return false;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3300,7 +3300,7 @@ function _sameTranscriptMessage(a,b){
   return false;
 }
 
-function _currentTailUserMessage(messages){
+function _currentTailUserMessage(messages,candidateStart,candidateTimestamp){
   const list=Array.isArray(messages)?messages:[];
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
@@ -3310,7 +3310,13 @@ function _currentTailUserMessage(messages){
       if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
       return msg;
     }
-    if(msg._live||String(msg.role||'')==='tool') continue;
+    if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
+      ||String(msg.role||'')==='tool'){
+      if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
+        ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
+      continue;
+    }
+    if(msg._live) continue;
     return null;
   }
   return null;
@@ -3318,7 +3324,7 @@ function _currentTailUserMessage(messages){
 
 function _hasCurrentTailUserDuplicate(messages,candidate){
   if(!candidate||String(candidate.role||'')!=='user') return false;
-  const existing=_currentTailUserMessage(messages);
+  const existing=_currentTailUserMessage(messages,candidate._ts,candidate.timestamp);
   return !!(existing&&_sameTranscriptMessage(existing,candidate));
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -6518,6 +6518,27 @@ function _firstValidTimestampSeconds(...values){
   }
   return null;
 }
+function _isTailActivityOwnedByCandidateTurn(message,...candidateStarts){
+  const candidateStart=_firstValidTimestampSeconds(...candidateStarts);
+  const activityTimestamp=_firstValidTimestampSeconds(message&&message._ts,message&&message.timestamp);
+  return candidateStart!==null&&activityTimestamp!==null&&activityTimestamp>=candidateStart;
+}
+function _isCanonicalAssistantToolCallEnvelope(msg){
+  if(!msg||String(msg.role||'')!=='assistant') return false;
+  const calls=msg.tool_calls;
+  if(!Array.isArray(calls)||calls.length===0) return false;
+  for(const call of calls){
+    if(!call||typeof call!=='object'||Array.isArray(call)) return false;
+    const hasCallId=(typeof call.id==='string'&&call.id.trim().length>0)
+      ||(typeof call.call_id==='string'&&call.call_id.trim().length>0);
+    const fn=call.function;
+    const hasName=(typeof call.name==='string'&&call.name.trim().length>0)
+      ||(fn&&typeof fn==='object'&&!Array.isArray(fn)
+        &&typeof fn.name==='string'&&fn.name.trim().length>0);
+    if(!hasCallId||!hasName) return false;
+  }
+  return true;
+}
 function _transparentEventTimestampSeconds(row, opts){
   opts=opts||{};
   for(const key of ['ts','timestamp','created_at']){
@@ -10628,7 +10649,7 @@ async function _waitForServerThenReload(opts){
   if(msgEl) msgEl.textContent='⚠️ Server is taking longer than expected — click Reload when ready';
 }
 
-function _pendingCurrentTailUserMessage(messages){
+function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimestamp){
   const list=Array.isArray(messages)?messages:[];
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
@@ -10638,7 +10659,13 @@ function _pendingCurrentTailUserMessage(messages){
       if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
       return msg;
     }
-    if(msg._live||String(msg.role||'')==='tool') continue;
+    if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
+      ||String(msg.role||'')==='tool'){
+      if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
+        ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
+      continue;
+    }
+    if(msg._live) continue;
     return null;
   }
   return null;
@@ -10748,7 +10775,7 @@ function getPendingSessionMessage(session, messagesOverride=null){
     if(attachments.length&&!row.attachments?.length) row.attachments=attachments;
     return null;
   };
-  const currentTailUser=_pendingCurrentTailUserMessage(messages);
+  const currentTailUser=_pendingCurrentTailUserMessage(messages,session?.pending_started_at);
   if(currentTailUser){
     const sameCurrentTurn=_matchesPending(currentTailUser);
     if(sameCurrentTurn) return _adoptExistingRow(currentTailUser);

--- a/static/ui.js
+++ b/static/ui.js
@@ -10685,7 +10685,10 @@ function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimesta
       crossedActivity=true;
       continue;
     }
-    if(msg._live) continue;
+    if(msg._live){
+      crossedActivity=true;
+      continue;
+    }
     return null;
   }
   return null;

--- a/static/ui.js
+++ b/static/ui.js
@@ -10653,16 +10653,23 @@ async function _waitForServerThenReload(opts){
 function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimestamp,activeTurnToken){
   const list=Array.isArray(messages)?messages:[];
   let crossedActivity=false;
+  const authoritativeToken=typeof activeTurnToken==='string'&&activeTurnToken.trim().length
+    ?activeTurnToken:null;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
     if(String(msg.role||'')==='user'){
       // Compaction rows are synthetic user-role markers, not submitted turns.
       if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      if(authoritativeToken){
+        if(msg._active_turn_token!==authoritativeToken) return null;
+        const matchingUsers=list.filter(row=>row&&String(row.role||'')==='user'
+          &&row._active_turn_token===authoritativeToken);
+        if(matchingUsers.length!==1) return null;
+      }
       if(crossedActivity){
-        if(Object.prototype.hasOwnProperty.call(msg,'_active_turn_token')){
-          if(typeof activeTurnToken!=='string'||!activeTurnToken.trim().length
-            ||msg._active_turn_token!==activeTurnToken) return null;
+        if(authoritativeToken){
+          if(msg._active_turn_token!==authoritativeToken) return null;
         }else{
           const rowTimestamp=_messageTimestampSeconds(msg);
           const candidateTimestampValue=_firstValidTimestampSeconds(candidateStart,candidateTimestamp);
@@ -10674,18 +10681,21 @@ function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimesta
     }
     if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
       ||String(msg.role||'')==='tool'){
-      if(msg._active_turn_token!==undefined){
-        if(typeof activeTurnToken!=='string'||!activeTurnToken.trim().length
-          ||msg._active_turn_token!==activeTurnToken) return null;
-        crossedActivity=true;
-        continue;
-      }
-      if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
+      if(authoritativeToken){
+        if(msg._active_turn_token!==authoritativeToken) return null;
+      }else if(msg._active_turn_token!==undefined){
+        return null;
+      }else if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
         ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
       crossedActivity=true;
       continue;
     }
     if(msg._live){
+      if(authoritativeToken){
+        if(msg._active_turn_token!==authoritativeToken) return null;
+      }else if(msg._active_turn_token!==undefined){
+        return null;
+      }
       crossedActivity=true;
       continue;
     }
@@ -10753,34 +10763,44 @@ function _pendingActiveTurnUserMessage(messages, session){
   const startedAt=Number(session?.pending_started_at);
   if(!Number.isFinite(startedAt)||startedAt<=0) return null;
   const list=Array.isArray(messages)?messages:[];
-  let tokenMatch=null;
-  let timestampMatch=null;
-  let timestampAmbiguous=false;
+  const activeToken=session&&(session.active_turn_token??session.activeTurnToken);
+  const hasActiveToken=typeof activeToken==='string'&&activeToken.trim().length>0;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
-    if(!msg||String(msg.role||'')!=='user') continue;
+    if(!msg) continue;
+    const isActivity=!!(msg._live
+      ||(typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
+      ||String(msg.role||'')==='tool');
+    if(isActivity){
+      if(hasActiveToken){
+        if(msg._active_turn_token!==activeToken) return null;
+      }
+      continue;
+    }
+    if(String(msg.role||'')!=='user') continue;
     if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
-    // Unambiguous: the row carries the active turn's exact token
-    // opaque token stamped by the server's eager-checkpoint path.
-    if(typeof _activeTurnTokenMatches==='function'&&_activeTurnTokenMatches(msg,session)){
-      if(tokenMatch) return null;
-      tokenMatch=msg;
+    // The newest non-compaction user is the active-turn boundary. Never skip
+    // it to adopt an older repeated prompt when its identity is absent or
+    // contradictory.
+    if(hasActiveToken){
+      if(typeof _activeTurnTokenMatches==='function'&&_activeTurnTokenMatches(msg,session)){
+        const owners=list.filter(row=>row&&String(row.role||'')==='user'
+          &&!(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(row))
+          &&typeof _activeTurnTokenMatches==='function'&&_activeTurnTokenMatches(row,session));
+        return owners.length===1?msg:null;
+      }
+      return null;
     }
-    // Unambiguous: the row's timestamp IS pending_started_at within
-    // precision-only float drift (never a whole second).
     const ts=_messageTimestampSeconds(msg);
-    if(ts===null) continue;
-    if(Math.abs(ts-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON){
-      if(timestampMatch) timestampAmbiguous=true;
-      else timestampMatch=msg;
-    }
+    if(ts===null||Math.abs(ts-startedAt)>_PENDING_ACTIVE_TURN_TS_EPSILON)return null;
+    const owners=list.filter(row=>{
+      if(!row||String(row.role||'')!=='user')return false;
+      if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(row))return false;
+      const rowTs=_messageTimestampSeconds(row);
+      return rowTs!==null&&Math.abs(rowTs-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON;
+    });
+    return owners.length===1?msg:null;
   }
-  if(tokenMatch) return tokenMatch;
-  if(timestampAmbiguous) return null;
-  if(timestampMatch) return timestampMatch;
-  // Any wider drift (whole-second truncation, a rapid repeat ~1s later) is
-  // ambiguous: return null so getPendingSessionMessage() materializes the
-  // pending turn rather than guessing.
   return null;
 }
 
@@ -21470,7 +21490,9 @@ function addFiles(files){
 }
 const _uploadPendingFilesProgressBySession=new Map();
 function _uploadPendingFilesCurrentSession(sessionId){
-  return !!(!sessionId||(S.session&&S.session.session_id===sessionId));
+  if(!sessionId) return true;
+  if(typeof _isSessionCurrentPane==='function') return _isSessionCurrentPane(sessionId);
+  return !!(S.session&&S.session.session_id===sessionId);
 }
 function _uploadPendingFilesHideProgressBar(){
   const bar=$('uploadBar');const barWrap=$('uploadBarWrap');
@@ -21540,7 +21562,10 @@ async function uploadPendingFiles(options={}){
       }else{
         names.push({name: data.filename, path: data.path, mime: data.mime, size: data.size, is_image: !!data.is_image});
       }
-    }catch(e){failures++;setStatus(`\u274c ${t('upload_failed')}${f.name} \u2014 ${e.message}`);}
+    }catch(e){
+      failures++;
+      if(_uploadPendingFilesCurrentSession(sessionId)) setStatus(`\u274c ${t('upload_failed')}${f.name} \u2014 ${e.message}`);
+    }
     _uploadPendingFilesUpdateProgress(sessionId,Math.round((i+1)/total*100));
   }
   _uploadPendingFilesUpdateProgress(sessionId,null);
@@ -21549,6 +21574,6 @@ async function uploadPendingFiles(options={}){
   if(failures===total&&total>0)throw new Error(t('all_uploads_failed',total));
   // Show extraction summary
   const extracted=names.filter(n=>n.extracted);
-  if(extracted.length)showToast(t('archive_extracted',extracted.reduce((s,n)=>s+n.extracted,0),extracted.length));
+  if(extracted.length&&_uploadPendingFilesCurrentSession(sessionId))showToast(t('archive_extracted',extracted.reduce((s,n)=>s+n.extracted,0),extracted.length));
   return names;
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -10763,8 +10763,9 @@ function _pendingActiveTurnUserMessage(messages, session){
   const startedAt=Number(session?.pending_started_at);
   if(!Number.isFinite(startedAt)||startedAt<=0) return null;
   const list=Array.isArray(messages)?messages:[];
-  const activeToken=session&&(session.active_turn_token??session.activeTurnToken);
-  const hasActiveToken=typeof activeToken==='string'&&activeToken.trim().length>0;
+  const activeTokenValue=session&&(session.active_turn_token??session.activeTurnToken);
+  const activeToken=typeof activeTokenValue==='string'?activeTokenValue.trim():'';
+  const hasActiveToken=!!activeToken;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
@@ -10772,9 +10773,8 @@ function _pendingActiveTurnUserMessage(messages, session){
       ||(typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
       ||String(msg.role||'')==='tool');
     if(isActivity){
-      if(hasActiveToken){
-        if(msg._active_turn_token!==activeToken) return null;
-      }
+      const rowToken=typeof msg._active_turn_token==='string'?msg._active_turn_token.trim():'';
+      if(hasActiveToken?rowToken!==activeToken:!!rowToken) return null;
       continue;
     }
     if(String(msg.role||'')!=='user') continue;

--- a/static/ui.js
+++ b/static/ui.js
@@ -10652,12 +10652,24 @@ async function _waitForServerThenReload(opts){
 
 function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimestamp,activeTurnToken){
   const list=Array.isArray(messages)?messages:[];
+  let crossedActivity=false;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
     if(String(msg.role||'')==='user'){
       // Compaction rows are synthetic user-role markers, not submitted turns.
       if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
+      if(crossedActivity){
+        if(Object.prototype.hasOwnProperty.call(msg,'_active_turn_token')){
+          if(typeof activeTurnToken!=='string'||!activeTurnToken.trim().length
+            ||msg._active_turn_token!==activeTurnToken) return null;
+        }else{
+          const rowTimestamp=_messageTimestampSeconds(msg);
+          const candidateTimestampValue=_firstValidTimestampSeconds(candidateStart,candidateTimestamp);
+          if(rowTimestamp===null||candidateTimestampValue===null
+            ||Math.abs(rowTimestamp-candidateTimestampValue)>_PENDING_ACTIVE_TURN_TS_EPSILON) return null;
+        }
+      }
       return msg;
     }
     if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
@@ -10665,10 +10677,12 @@ function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimesta
       if(msg._active_turn_token!==undefined){
         if(typeof activeTurnToken!=='string'||!activeTurnToken.trim().length
           ||msg._active_turn_token!==activeTurnToken) return null;
+        crossedActivity=true;
         continue;
       }
       if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
         ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
+      crossedActivity=true;
       continue;
     }
     if(msg._live) continue;

--- a/static/ui.js
+++ b/static/ui.js
@@ -10755,6 +10755,7 @@ function _pendingActiveTurnUserMessage(messages, session){
   const list=Array.isArray(messages)?messages:[];
   let tokenMatch=null;
   let timestampMatch=null;
+  let timestampAmbiguous=false;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg||String(msg.role||'')!=='user') continue;
@@ -10769,9 +10770,13 @@ function _pendingActiveTurnUserMessage(messages, session){
     // precision-only float drift (never a whole second).
     const ts=_messageTimestampSeconds(msg);
     if(ts===null) continue;
-    if(Math.abs(ts-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON&&!timestampMatch) timestampMatch=msg;
+    if(Math.abs(ts-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON){
+      if(timestampMatch) timestampAmbiguous=true;
+      else timestampMatch=msg;
+    }
   }
   if(tokenMatch) return tokenMatch;
+  if(timestampAmbiguous) return null;
   if(timestampMatch) return timestampMatch;
   // Any wider drift (whole-second truncation, a rapid repeat ~1s later) is
   // ambiguous: return null so getPendingSessionMessage() materializes the
@@ -10789,12 +10794,18 @@ function getPendingSessionMessage(session, messagesOverride=null){
   const activeTokenRows=typeof _activeTurnTokenMatches==='function'
     ?messages.filter(row=>_activeTurnTokenMatches(row,session))
     :[];
+  const activeTurnUser=typeof _pendingActiveTurnUserMessage==='function'
+    ?_pendingActiveTurnUserMessage(messages,session)
+    :null;
+  const activeToken=session&&(session.active_turn_token??session.activeTurnToken);
+  const hasActiveToken=typeof activeToken==='string'&&activeToken.trim().length>0;
   const _matchesPending=(row)=>{
     if(!row) return false;
     if(typeof _activeTurnTokenMatches==='function'
       &&Object.prototype.hasOwnProperty.call(row,'_active_turn_token')){
       return activeTokenRows.length===1&&activeTokenRows[0]===row;
     }
+    if(hasActiveToken&&row!==activeTurnUser) return false;
     return typeof _sameTranscriptMessage==='function'
       ? _sameTranscriptMessage(row,pendingCandidate)
       : String(msgContent(row)||'').trim()===text;
@@ -10819,9 +10830,6 @@ function getPendingSessionMessage(session, messagesOverride=null){
   // repeat the same text are unaffected. Guarded with typeof so a partial load
   // (or a static probe that extracts only some helpers) degrades to the
   // original strict-tail behaviour instead of throwing.
-  const activeTurnUser=typeof _pendingActiveTurnUserMessage==='function'
-    ? _pendingActiveTurnUserMessage(messages,session)
-    : null;
   if(activeTurnUser&&activeTurnUser!==currentTailUser&&_matchesPending(activeTurnUser)){
     return _adoptExistingRow(activeTurnUser);
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -10764,8 +10764,8 @@ function _pendingActiveTurnUserMessage(messages, session){
   if(!Number.isFinite(startedAt)||startedAt<=0) return null;
   const list=Array.isArray(messages)?messages:[];
   const activeTokenValue=session&&(session.active_turn_token??session.activeTurnToken);
-  const activeToken=typeof activeTokenValue==='string'?activeTokenValue.trim():'';
-  const hasActiveToken=!!activeToken;
+  const activeToken=typeof activeTokenValue==='string'?activeTokenValue:'';
+  const hasActiveToken=typeof activeTokenValue==='string'&&activeTokenValue.trim().length>0;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg) continue;
@@ -10773,8 +10773,10 @@ function _pendingActiveTurnUserMessage(messages, session){
       ||(typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
       ||String(msg.role||'')==='tool');
     if(isActivity){
-      const rowToken=typeof msg._active_turn_token==='string'?msg._active_turn_token.trim():'';
-      if(hasActiveToken?rowToken!==activeToken:!!rowToken) return null;
+      const rowToken=typeof msg._active_turn_token==='string'?msg._active_turn_token:'';
+      const hasRowToken=typeof msg._active_turn_token==='string'
+        &&msg._active_turn_token.trim().length>0;
+      if(hasActiveToken?(!hasRowToken||rowToken!==activeToken):hasRowToken) return null;
       continue;
     }
     if(String(msg.role||'')!=='user') continue;

--- a/static/ui.js
+++ b/static/ui.js
@@ -9259,6 +9259,7 @@ function _compactInflightState(state){
   const todoStateMeta=(state.todoStateMeta&&typeof state.todoStateMeta==='object')?state.todoStateMeta:null;
   return _truncateInflightValue({
     streamId:state.streamId||null,
+    activeTurnToken:state.activeTurnToken??state.active_turn_token??null,
     messages,
     uploaded:Array.isArray(state.uploaded)?state.uploaded.slice(-20):[],
     toolCalls,
@@ -10649,7 +10650,7 @@ async function _waitForServerThenReload(opts){
   if(msgEl) msgEl.textContent='⚠️ Server is taking longer than expected — click Reload when ready';
 }
 
-function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimestamp){
+function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimestamp,activeTurnToken){
   const list=Array.isArray(messages)?messages:[];
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
@@ -10661,6 +10662,11 @@ function _pendingCurrentTailUserMessage(messages,candidateStart,candidateTimesta
     }
     if((typeof _isCanonicalAssistantToolCallEnvelope==='function'&&_isCanonicalAssistantToolCallEnvelope(msg))
       ||String(msg.role||'')==='tool'){
+      if(msg._active_turn_token!==undefined){
+        if(typeof activeTurnToken!=='string'||!activeTurnToken.trim().length
+          ||msg._active_turn_token!==activeTurnToken) return null;
+        continue;
+      }
       if(typeof _isTailActivityOwnedByCandidateTurn!=='function'
         ||!_isTailActivityOwnedByCandidateTurn(msg,candidateStart,candidateTimestamp)) return null;
       continue;
@@ -10690,23 +10696,15 @@ function _messageTimestampSeconds(msg){
 }
 
 /**
- * Exact-identity match for the active turn's user row via its
- * `_active_turn_token`, mirroring the server's `build_active_turn_token`
- * ("{stream_id}:{started_at}") stamped by the eager-checkpoint path. The token
- * embeds the stream_id, which no other turn can share, so a row carrying the
- * current session's token IS the active turn — no timestamp tolerance needed.
+ * Exact-identity match for the active turn's user row via the opaque,
+ * server-issued `_active_turn_token`. JavaScript deliberately does not parse,
+ * trim, or reconstruct this value; trim() below only rejects blank spellings.
  */
 function _activeTurnTokenMatches(msg, session){
-  if(!msg||typeof msg._active_turn_token!=='string') return false;
-  const streamId=session&&session.active_stream_id;
-  const startedAt=Number(session&&session.pending_started_at);
-  if(!streamId||!Number.isFinite(startedAt)||startedAt<=0) return false;
-  const sep=msg._active_turn_token.lastIndexOf(':');
-  if(sep<=0) return false;
-  if(msg._active_turn_token.slice(0,sep).trim()!==String(streamId).trim()) return false;
-  const tokenStarted=Number(msg._active_turn_token.slice(sep+1));
-  return Number.isFinite(tokenStarted)&&tokenStarted>0
-    && Math.abs(tokenStarted-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON;
+  const activeToken=session&&(session.active_turn_token??session.activeTurnToken);
+  return !!(msg&&typeof msg._active_turn_token==='string'&&msg._active_turn_token.trim().length
+    &&typeof activeToken==='string'&&activeToken.trim().length
+    &&msg._active_turn_token===activeToken);
 }
 
 /**
@@ -10726,8 +10724,7 @@ function _activeTurnTokenMatches(msg, session){
  * same text twice in a row (a plain "继续" follow-up) legitimately gets two
  * identical user turns, and matching on text would swallow the new one. The
  * discriminator is therefore exact identity, never proximity: the active turn's
- * row either carries the server-stamped `_active_turn_token` (stream_id +
- * started_at — unique to this turn), or its timestamp equals `pending_started_at`
+ * row either carries the server-stamped opaque `_active_turn_token`, or its timestamp equals `pending_started_at`
  * within a precision-only epsilon that absorbs float/state.db drift but never a
  * full second. A whole-second (or sub-second) mismatch is ambiguous and returns
  * null so the caller materializes the pending turn — the transient duplicate is
@@ -10739,19 +10736,26 @@ function _pendingActiveTurnUserMessage(messages, session){
   const startedAt=Number(session?.pending_started_at);
   if(!Number.isFinite(startedAt)||startedAt<=0) return null;
   const list=Array.isArray(messages)?messages:[];
+  let tokenMatch=null;
+  let timestampMatch=null;
   for(let i=list.length-1;i>=0;i--){
     const msg=list[i];
     if(!msg||String(msg.role||'')!=='user') continue;
     if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(msg)) continue;
     // Unambiguous: the row carries the active turn's exact token
-    // (stream_id + started_at) stamped by the server's eager-checkpoint path.
-    if(typeof _activeTurnTokenMatches==='function'&&_activeTurnTokenMatches(msg,session)) return msg;
+    // opaque token stamped by the server's eager-checkpoint path.
+    if(typeof _activeTurnTokenMatches==='function'&&_activeTurnTokenMatches(msg,session)){
+      if(tokenMatch) return null;
+      tokenMatch=msg;
+    }
     // Unambiguous: the row's timestamp IS pending_started_at within
     // precision-only float drift (never a whole second).
     const ts=_messageTimestampSeconds(msg);
     if(ts===null) continue;
-    if(Math.abs(ts-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON) return msg;
+    if(Math.abs(ts-startedAt)<=_PENDING_ACTIVE_TURN_TS_EPSILON&&!timestampMatch) timestampMatch=msg;
   }
+  if(tokenMatch) return tokenMatch;
+  if(timestampMatch) return timestampMatch;
   // Any wider drift (whole-second truncation, a rapid repeat ~1s later) is
   // ambiguous: return null so getPendingSessionMessage() materializes the
   // pending turn rather than guessing.
@@ -10765,8 +10769,15 @@ function getPendingSessionMessage(session, messagesOverride=null){
   const sourceMessages=Array.isArray(messagesOverride)?messagesOverride:session?.messages;
   const messages=Array.isArray(sourceMessages)?sourceMessages:[];
   const pendingCandidate={role:'user',content:text};
+  const activeTokenRows=typeof _activeTurnTokenMatches==='function'
+    ?messages.filter(row=>_activeTurnTokenMatches(row,session))
+    :[];
   const _matchesPending=(row)=>{
     if(!row) return false;
+    if(typeof _activeTurnTokenMatches==='function'
+      &&Object.prototype.hasOwnProperty.call(row,'_active_turn_token')){
+      return activeTokenRows.length===1&&activeTokenRows[0]===row;
+    }
     return typeof _sameTranscriptMessage==='function'
       ? _sameTranscriptMessage(row,pendingCandidate)
       : String(msgContent(row)||'').trim()===text;
@@ -10775,7 +10786,12 @@ function getPendingSessionMessage(session, messagesOverride=null){
     if(attachments.length&&!row.attachments?.length) row.attachments=attachments;
     return null;
   };
-  const currentTailUser=_pendingCurrentTailUserMessage(messages,session?.pending_started_at);
+  const currentTailUser=_pendingCurrentTailUserMessage(
+    messages,
+    session?.pending_started_at,
+    undefined,
+    session&&(session.active_turn_token??session.activeTurnToken),
+  );
   if(currentTailUser){
     const sameCurrentTurn=_matchesPending(currentTailUser);
     if(sameCurrentTurn) return _adoptExistingRow(currentTailUser);

--- a/tests/test_chat_start_provider_fallback.py
+++ b/tests/test_chat_start_provider_fallback.py
@@ -5,6 +5,7 @@ fresh session. The provider must follow only when that dropdown/persisted state
 describes the same model being sent.
 """
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -17,6 +18,105 @@ MESSAGES_JS_PATH = REPO_ROOT / "static" / "messages.js"
 NODE = shutil.which("node")
 
 
+def _function_source(source: str, marker: str) -> str:
+    start = source.find(marker)
+    assert start >= 0, f"{marker!r} not found"
+    body_start = source.find("{", source.find(")", start))
+    assert body_start >= 0, f"{marker!r} has no body"
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    i = body_start
+    while i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+        elif block_comment:
+            if ch == "*" and nxt == "/":
+                block_comment = False
+                i += 1
+        elif quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch == "/" and nxt == "/":
+            line_comment = True
+            i += 1
+        elif ch == "/" and nxt == "*":
+            block_comment = True
+            i += 1
+        elif ch in "'\"`":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+        i += 1
+    raise AssertionError(f"{marker!r} body is not balanced")
+
+
+def _balanced_call(source: str, marker: str, start: int = 0) -> tuple[str, int]:
+    call_start = source.find(marker, start)
+    assert call_start >= 0, f"{marker!r} not found"
+    open_at = source.find("(", call_start)
+    assert open_at >= 0, f"{marker!r} has no opening parenthesis"
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    for i in range(open_at, len(source)):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+        elif block_comment:
+            if ch == "*" and nxt == "/":
+                block_comment = False
+        elif quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch == "/" and nxt == "/":
+            line_comment = True
+        elif ch == "/" and nxt == "*":
+            block_comment = True
+        elif ch in "'\"`":
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return source[call_start : i + 1], i + 1
+    raise AssertionError(f"{marker!r} call is not balanced")
+
+
+def _calls(source: str, marker: str) -> list[str]:
+    calls = []
+    start = 0
+    while True:
+        marker_pos = source.find(marker, start)
+        if marker_pos < 0:
+            return calls
+        call, start = _balanced_call(source, marker, marker_pos)
+        calls.append(call)
+    return calls
+
+
 def test_messages_payloads_use_model_tied_provider_helper():
     ui_src = UI_JS_PATH.read_text(encoding="utf-8")
     messages_src = MESSAGES_JS_PATH.read_text(encoding="utf-8")
@@ -25,17 +125,29 @@ def test_messages_payloads_use_model_tied_provider_helper():
     assert "function _chatPayloadModelState" in messages_src
     assert "_modelProviderForSend(model)" in messages_src
 
-    chat_start_idx = messages_src.find("api('/api/chat/start'")
-    assert chat_start_idx >= 0, "could not find /api/chat/start POST in messages.js"
-    payload_block = messages_src[chat_start_idx:chat_start_idx + 500]
-    assert "model:_modelState.model" in payload_block
-    assert "model_provider:_modelState.model_provider" in payload_block
-    assert "model_provider:S.session.model_provider||null" not in payload_block
+    send_src = _function_source(messages_src, "async function send(")
+    snapshot = "const _submittedModelState={..._chatPayloadModelState()};"
+    snapshot_pos = send_src.index(snapshot)
+    upload_pos = send_src.index("await uploadPendingFiles")
+    forced_skill_pos = send_src.index("await _pending.promise")
+    chat_start_call, _ = _balanced_call(send_src, "await api('/api/chat/start'")
+    chat_start_pos = send_src.index(chat_start_call)
+    assert snapshot_pos < upload_pos < forced_skill_pos < chat_start_pos
+    assert not re.search(r"_submittedModelState\.(?:model|model_provider)\s*=", send_src[snapshot_pos:])
 
-    for idx in [m.start() for m in __import__("re").finditer("queueSessionMessage\\(", messages_src)]:
-        block = messages_src[idx:idx + 260]
-        if "model_provider:" in block:
-            assert "S.session.model_provider||null" not in block
+    assert "model:_submittedModelState.model" in chat_start_call
+    assert "model_provider:_submittedModelState.model_provider" in chat_start_call
+    assert "_chatPayloadModelState()" not in chat_start_call
+    assert "_modelState.model" not in chat_start_call
+    assert "_modelState.model_provider" not in chat_start_call
+
+    queue_calls = _calls(messages_src, "queueSessionMessage(")
+    assert queue_calls, "messages.js must retain synchronous queue-path coverage"
+    for queue_call in queue_calls:
+        model = re.search(r"\bmodel:\s*([A-Za-z_$][\w$]*)\.model\b", queue_call)
+        provider = re.search(r"\bmodel_provider:\s*([A-Za-z_$][\w$]*)\.model_provider\b", queue_call)
+        assert model and provider, queue_call
+        assert model.group(1) == provider.group(1), queue_call
 
 
 _DRIVER_SRC = r"""

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -91,6 +91,7 @@ LOAD_SESSION_SRC = _extract_function(SESSIONS_SRC, "loadSession")
 ENSURE_MESSAGES_LOADED_SRC = _extract_function(SESSIONS_SRC, "_ensureMessagesLoaded")
 INFLIGHT_HAS_VISIBLE_STATE_SRC = _extract_function(SESSIONS_SRC, "_inflightHasVisibleLiveState")
 SELECT_LIVE_RECOVERY_INFLIGHT_SRC = _extract_function(SESSIONS_SRC, "_selectLiveRecoveryInflight")
+OPAQUE_ACTIVE_TURN_TOKEN_SRC = _extract_function(SESSIONS_SRC, "_opaqueActiveTurnToken")
 MERGE_PENDING_SESSION_MESSAGE_SRC = _extract_function(SESSIONS_SRC, "_mergePendingSessionMessage")
 
 
@@ -349,6 +350,7 @@ let toastCalls = [];
 // Source under test
 __INFLIGHT_HAS_VISIBLE_STATE_SRC__
 __SELECT_LIVE_RECOVERY_INFLIGHT_SRC__
+__OPAQUE_ACTIVE_TURN_TOKEN_SRC__
 __MERGE_PENDING_SESSION_MESSAGE_SRC__
 __LOAD_SESSION_SRC__
 __ENSURE_MESSAGES_LOADED_SRC__
@@ -605,6 +607,7 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior(tmp_path):
         .replace(
             "__SELECT_LIVE_RECOVERY_INFLIGHT_SRC__", SELECT_LIVE_RECOVERY_INFLIGHT_SRC
         )
+        .replace("__OPAQUE_ACTIVE_TURN_TOKEN_SRC__", OPAQUE_ACTIVE_TURN_TOKEN_SRC)
         .replace(
             "__MERGE_PENDING_SESSION_MESSAGE_SRC__", MERGE_PENDING_SESSION_MESSAGE_SRC
         )

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -627,6 +627,7 @@ async function cmdGoal(args) {{{cmd_goal_body}}}
   assert.strictEqual(savedA.messages.at(-1).content, 'A goal status');
 
   if ({json.dumps(pane_state)} === 'same') {{
+    assert.strictEqual(INFLIGHT.A.reattach, undefined);
     assert.strictEqual(S.activeStreamId, 'A-stream');
     assert.strictEqual(S.busy, true);
     assert.strictEqual(S.session.active_stream_id, 'A-stream');
@@ -650,6 +651,7 @@ async function cmdGoal(args) {{{cmd_goal_body}}}
       sid:'A', streamId:'A-stream', ts:123,
     }});
   }} else {{
+    assert.strictEqual(INFLIGHT.A.reattach, true);
     assert.deepStrictEqual(S.session, visibleSessionBefore);
     assert.deepStrictEqual(S.messages, visibleMessagesBefore);
     assert.deepStrictEqual(S.toolCalls, visibleToolCallsBefore);

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -1,7 +1,7 @@
 """Regression tests for first-class WebUI /goal command parity."""
 
-import io
 import json
+import subprocess
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +13,20 @@ COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 1
+    i = brace + 1
+    while depth and i < len(src):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    return src[brace + 1 : i - 1]
 
 
 def test_goal_command_payload_matches_gateway_controls(monkeypatch):
@@ -477,6 +491,194 @@ def test_frontend_has_goal_slash_command_and_status_event_handler():
     assert "source.addEventListener('goal_continue'" in MESSAGES_JS
     assert "['steer','interrupt','queue','terminal','goal','yolo'].includes(_pc.name)" in MESSAGES_JS
     assert "queueSessionMessage" in MESSAGES_JS
+
+
+@pytest.mark.parametrize("pane_state", ("same", "assigned", "loading"))
+def test_frontend_cmd_goal_keeps_late_a_response_out_of_b_pane(pane_state):
+    """cmdGoal() must keep late A responses in A recovery state after a pane switch."""
+    cmd_goal_body = _function_body(COMMANDS_JS, "async function cmdGoal")
+    script = f"""
+const assert = require('assert');
+let releaseGoal;
+let goalCalled;
+const goalCalledPromise = new Promise(resolve => goalCalled = resolve);
+const goalResponse = new Promise(resolve => releaseGoal = resolve);
+const calls = {{
+  attach: [], approval: [], clarify: [], yolo: [], marked: [], saved: [],
+  render: 0, clear: 0, thinking: 0, busy: [], composer: [], list: 0, toasts: [],
+}};
+const localStorage = {{
+  values: Object.create(null),
+  getItem(key) {{ return this.values[key] || null; }},
+  setItem(key, value) {{ this.values[key] = String(value); }},
+  removeItem(key) {{ delete this.values[key]; }},
+}};
+const A = {{
+  session_id: 'A', workspace: '/a', model: 'A model', model_provider: 'provider-a',
+  profile: 'profile-a', active_stream_id: null, active_turn_token: 'A-old-token',
+}};
+const B = {{
+  session_id: 'B', workspace: '/b', model: 'B model', model_provider: 'provider-b',
+  profile: 'profile-b', active_stream_id: 'B-stream', active_turn_token: 'B-token',
+}};
+const aMessages = [
+  {{role:'user', content:'A prompt', attachments:['a.txt'], _ts:10}},
+  {{role:'assistant', content:'A reply', _ts:11}},
+];
+const bMessages = [
+  {{role:'user', content:'B prompt', _active_turn_token:'B-token', _ts:20}},
+  {{role:'assistant', content:'B reply', _active_turn_token:'B-token', _ts:21}},
+];
+const bToolCalls = [{{call_id:'b-call', name:'inspect'}}];
+const S = {{
+  session: A,
+  messages: aMessages.slice(),
+  toolCalls: [],
+  busy: false,
+  activeStreamId: null,
+  activeProfile: 'profile-a',
+}};
+const INFLIGHT = Object.create(null);
+let _loadingSessionId = null;
+function _isSessionCurrentPane(sid) {{
+  if(!sid || !S.session || S.session.session_id!==sid) return false;
+  if(typeof _loadingSessionId!=='undefined' && _loadingSessionId && _loadingSessionId!==sid) return false;
+  return true;
+}}
+function _opaqueActiveTurnToken(value) {{
+  return typeof value === 'string' && value.trim() ? value : null;
+}}
+function api(path) {{
+  assert.strictEqual(path, '/api/goal');
+  goalCalled();
+  return goalResponse;
+}}
+function t(key) {{ return key; }}
+function renderMessages() {{ calls.render++; }}
+function showToast(...args) {{ calls.toasts.push(args); }}
+function clearLiveToolCards() {{ calls.clear++; }}
+function appendThinking() {{ calls.thinking++; }}
+function setBusy(value) {{ calls.busy.push(value); S.busy = value; }}
+function setComposerStatus(value) {{ calls.composer.push(value); }}
+function renderSessionList() {{ calls.list++; return Promise.resolve(); }}
+function startApprovalPolling(sid) {{ calls.approval.push(sid); }}
+function startClarifyPolling(sid) {{ calls.clarify.push(sid); }}
+function _fetchYoloState(sid) {{ calls.yolo.push(sid); }}
+function attachLiveStream(sid, streamId, uploaded) {{ calls.attach.push([sid, streamId, uploaded]); }}
+function markInflight(sid, streamId) {{
+  localStorage.setItem('hermes-webui-inflight', JSON.stringify({{sid, streamId, ts:123}}));
+  calls.marked.push([sid, streamId]);
+}}
+function saveInflightState(sid, state) {{
+  calls.saved.push([sid, JSON.parse(JSON.stringify(state))]);
+}}
+async function cmdGoal(args) {{{cmd_goal_body}}}
+
+(async () => {{
+  const goalPromise = cmdGoal('ship A');
+  await goalCalledPromise;
+  const expectedA = JSON.parse(JSON.stringify(aMessages));
+  if ({json.dumps(pane_state)} !== 'same') {{
+    S.messages = bMessages.slice();
+    S.toolCalls = bToolCalls.slice();
+    S.busy = true;
+    S.activeStreamId = 'B-stream';
+    S.activeProfile = 'profile-b';
+  }}
+  INFLIGHT.B = {{
+    streamId:'B-stream', activeTurnToken:'B-token', messages:bMessages.slice(),
+    uploaded:['b.txt'], toolCalls:bToolCalls.slice(),
+  }};
+  const bMarker = JSON.stringify({{sid:'B', streamId:'B-stream', ts:123}});
+  localStorage.setItem('hermes-webui-inflight', bMarker);
+  const bSessionBefore = JSON.parse(JSON.stringify(B));
+  if ({json.dumps(pane_state)} === 'assigned') S.session = B;
+  else if ({json.dumps(pane_state)} === 'loading') _loadingSessionId = 'B';
+  const visibleSessionBefore = JSON.parse(JSON.stringify(S.session));
+  const visibleMessagesBefore = JSON.parse(JSON.stringify(S.messages));
+  const visibleToolCallsBefore = JSON.parse(JSON.stringify(S.toolCalls));
+  const visibleBusyBefore = S.busy;
+  const visibleStreamBefore = S.activeStreamId;
+  const visibleProfileBefore = S.activeProfile;
+  const visibleInflightBefore = JSON.parse(JSON.stringify(INFLIGHT.B));
+
+  releaseGoal({{
+    message:'A goal status', stream_id:'A-stream', active_turn_token:'A-token',
+    pending_started_at:30, effective_model:'A effective model',
+    effective_model_provider:'provider-a-effective',
+  }});
+  await goalPromise;
+
+  const a = INFLIGHT.A;
+  assert(a);
+  assert.strictEqual(a.streamId, 'A-stream');
+  assert.strictEqual(a.activeTurnToken, 'A-token');
+  assert.deepStrictEqual(a.messages.slice(0, expectedA.length), expectedA);
+  const aStatus = a.messages.at(-1);
+  assert.strictEqual(aStatus.content, 'A goal status');
+  assert.strictEqual(aStatus._goalStatus, true);
+  assert.strictEqual(aStatus._transient, true);
+  assert(!JSON.stringify(a.messages).includes('B prompt'));
+  assert(!JSON.stringify(a.messages).includes('B-token'));
+  const savedA = calls.saved.filter(item => item[0] === 'A').at(-1)[1];
+  assert.strictEqual(savedA.streamId, 'A-stream');
+  assert.strictEqual(savedA.activeTurnToken, 'A-token');
+  assert.deepStrictEqual(savedA.messages.slice(0, expectedA.length), expectedA);
+  assert.strictEqual(savedA.messages.at(-1).content, 'A goal status');
+
+  if ({json.dumps(pane_state)} === 'same') {{
+    assert.strictEqual(S.activeStreamId, 'A-stream');
+    assert.strictEqual(S.busy, true);
+    assert.strictEqual(S.session.active_stream_id, 'A-stream');
+    assert.strictEqual(S.session.pending_started_at, 30);
+    assert.strictEqual(S.session.active_turn_token, 'A-token');
+    assert.strictEqual(S.session.model, 'A effective model');
+    assert.strictEqual(S.session.model_provider, 'provider-a-effective');
+    assert.strictEqual(calls.render, 1);
+    assert.strictEqual(calls.clear, 1);
+    assert.strictEqual(calls.thinking, 1);
+    assert.deepStrictEqual(calls.busy, [true]);
+    assert.deepStrictEqual(calls.composer, ['goal_working_toward']);
+    assert.deepStrictEqual(calls.marked, [['A', 'A-stream']]);
+    assert.deepStrictEqual(calls.approval, ['A']);
+    assert.deepStrictEqual(calls.clarify, ['A']);
+    assert.deepStrictEqual(calls.yolo, ['A']);
+    assert.deepStrictEqual(calls.attach, [['A', 'A-stream', []]]);
+    assert.strictEqual(calls.list, 1);
+    assert.deepStrictEqual(calls.toasts, [['A goal status', 2600]]);
+    assert.deepStrictEqual(JSON.parse(localStorage.getItem('hermes-webui-inflight')), {{
+      sid:'A', streamId:'A-stream', ts:123,
+    }});
+  }} else {{
+    assert.deepStrictEqual(S.session, visibleSessionBefore);
+    assert.deepStrictEqual(S.messages, visibleMessagesBefore);
+    assert.deepStrictEqual(S.toolCalls, visibleToolCallsBefore);
+    assert.strictEqual(S.busy, visibleBusyBefore);
+    assert.strictEqual(S.activeStreamId, visibleStreamBefore);
+    assert.strictEqual(S.activeProfile, visibleProfileBefore);
+    assert.deepStrictEqual(B, bSessionBefore);
+    assert.deepStrictEqual(INFLIGHT.B, visibleInflightBefore);
+    assert.strictEqual(localStorage.getItem('hermes-webui-inflight'), bMarker);
+    assert.strictEqual(calls.render, 0);
+    assert.strictEqual(calls.clear, 0);
+    assert.strictEqual(calls.thinking, 0);
+    assert.deepStrictEqual(calls.busy, []);
+    assert.deepStrictEqual(calls.composer, []);
+    assert.strictEqual(calls.list, 0);
+    assert.deepStrictEqual(calls.toasts, []);
+    assert.deepStrictEqual(calls.marked, []);
+    assert.deepStrictEqual(calls.approval, []);
+    assert.deepStrictEqual(calls.clarify, []);
+    assert.deepStrictEqual(calls.yolo, []);
+    assert.deepStrictEqual(calls.attach, []);
+  }}
+}})().catch(error => {{
+  console.error(error.stack || error);
+  process.exitCode = 1;
+}});
+"""
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_frontend_goal_evaluating_state_uses_calm_composer_indicator():

--- a/tests/test_hidden_tab_server_initiated_turn.py
+++ b/tests/test_hidden_tab_server_initiated_turn.py
@@ -21,11 +21,28 @@ tests pinning the contract:
   tab that transitions to hidden via the ``visibilitychange`` hook.
 """
 
+import json
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 SESSION_OPS = (REPO_ROOT / "api" / "session_ops.py").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(signature)
 
 
 # ── Backend: session_status exposes a LIVE-validated active_stream_id ───────
@@ -36,6 +53,7 @@ def test_session_status_exposes_active_stream_id_field():
     # It is derived through the live-validation helper, not the raw attribute,
     # so a stale id from a crashed/restarted run is not surfaced.
     assert "_live_active_stream_id(" in SESSION_OPS
+    assert "'active_turn_token': build_active_turn_token(" in SESSION_OPS
 
 
 def test_live_active_stream_id_is_stale_safe():
@@ -76,7 +94,140 @@ def test_frontend_declares_hidden_poll_lifecycle():
     """The hidden-tab active-stream poll start/stop/attach functions exist."""
     assert "function _startHiddenActiveStreamPoll(sid)" in MESSAGES_JS
     assert "function _stopHiddenActiveStreamPoll()" in MESSAGES_JS
-    assert "function _attachServerInitiatedStream(sid, streamId, recovered)" in MESSAGES_JS
+    assert "function _attachServerInitiatedStream(sid, streamId, recovered, activeTurnToken=null)" in MESSAGES_JS
+
+
+def test_frontend_server_attach_propagates_exact_token_before_renderer():
+    attach = _function_body(
+        MESSAGES_JS,
+        "function _attachServerInitiatedStream(sid, streamId, recovered, activeTurnToken=null)",
+    )
+    script = f"""
+const S={{session:{{session_id:'sid',pending_attachments:[]}},messages:[],activeStreamId:null,busy:false}};
+const INFLIGHT={{}};
+const LIVE_STREAMS={{}};
+function _opaqueActiveTurnToken(value){{return typeof value==='string'&&value.trim().length?value:null;}}
+let rendererState=null;
+function attachLiveStream(sid,streamId,uploaded,options){{
+  rendererState={{token:S.session.active_turn_token,inflight:INFLIGHT[sid].activeTurnToken}};
+}}
+{attach}
+_attachServerInitiatedStream('sid','server-stream',true,'opaque:token with spaces');
+process.stdout.write(JSON.stringify({{session:S.session.active_turn_token,inflight:INFLIGHT.sid.activeTurnToken,renderer:rendererState}}));
+"""
+    result = json.loads(
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True).stdout
+    )
+    assert result == {
+        "session": "opaque:token with spaces",
+        "inflight": "opaque:token with spaces",
+        "renderer": {
+            "token": "opaque:token with spaces",
+            "inflight": "opaque:token with spaces",
+        },
+    }
+
+
+def test_late_server_token_stamps_attached_live_rows_and_persists():
+    attach = _function_body(
+        MESSAGES_JS,
+        "function _attachServerInitiatedStream(sid, streamId, recovered, activeTurnToken=null)",
+    )
+    sessions_helpers = "\n".join(
+        [
+            _function_body(SESSIONS_JS, "function _opaqueActiveTurnToken"),
+            _function_body(SESSIONS_JS, "function _currentTailUserMessage"),
+            _function_body(SESSIONS_JS, "function _hasCurrentTailUserDuplicate"),
+            _function_body(SESSIONS_JS, "function _mergeInflightTailMessages"),
+        ]
+    )
+    script = f"""
+{sessions_helpers}
+const token='opaque:late-token';
+const liveVisible={{role:'assistant',content:'working',_live:true}};
+const liveInflight={{role:'assistant',content:'working',_live:true}};
+const priorUser={{role:'user',content:'same prompt',_active_turn_token:token}};
+const candidate={{role:'user',content:'same prompt',_active_turn_token:token,attachments:[{{name:'new.txt'}}]}};
+const S={{
+  session:{{session_id:'sid',pending_attachments:[],active_turn_token:null}},
+  messages:[priorUser,liveVisible],activeStreamId:'stream-1',busy:true,
+  todos:[{{id:'todo-1'}}],todoStateMeta:{{version:1}},
+}};
+const INFLIGHT={{sid:{{
+  streamId:'stream-1',messages:[priorUser,liveInflight],uploaded:['old.txt'],
+  toolCalls:[{{id:'call-1'}}],lastAssistantText:'answer',lastReasoningText:'thinking',
+  lastRunJournalSeq:7,lastRunJournalEventId:'event-7',journalReplayFromStart:true,
+  anchorActivityScene:'scene',currentActivityBurstId:3,currentLiveSegmentSeq:4,
+  activityBurstAnchors:[{{seq:3}}],todos:[{{id:'todo-1'}}],todoStateMeta:{{version:1}},
+  activeTurnToken:null,
+}}}};
+const LIVE_STREAMS={{sid:{{streamId:'stream-1'}}}};
+const saved=[];
+function saveInflightState(sid,state){{saved.push({{sid,state:JSON.parse(JSON.stringify(state))}});}}
+function _opaqueActiveTurnToken(value){{return typeof value==='string'&&value.trim().length?value:null;}}
+function _sameTranscriptMessage(a,b){{return !!(a&&b&&a.role===b.role&&a.content===b.content);}}
+{attach}
+_attachServerInitiatedStream('sid','stream-1',true,token);
+_attachServerInitiatedStream('sid','stream-1',true,'   ');
+const merged=_mergeInflightTailMessages(
+  S.messages,
+  [candidate,{{role:'assistant',content:'working',_live:true,_active_turn_token:token}}],
+  token,
+);
+const missing={{...candidate}}; delete missing._active_turn_token;
+const preserved=_mergeInflightTailMessages(
+  S.messages,
+  [missing,{{role:'assistant',content:'working',_live:true,_active_turn_token:token}}],
+  token,
+);
+process.stdout.write(JSON.stringify({{
+  sessionToken:S.session.active_turn_token,
+  visibleToken:S.messages[1]._active_turn_token,
+  inflightToken:INFLIGHT.sid.activeTurnToken,
+  inflightRowToken:INFLIGHT.sid.messages[1]._active_turn_token,
+  savedToken:saved[0].state.activeTurnToken,
+  savedCount:saved.length,
+  savedStreamId:saved[0].state.streamId,
+  savedUploaded:saved[0].state.uploaded,
+  savedToolCalls:saved[0].state.toolCalls,
+  savedText:saved[0].state.lastAssistantText,
+  savedReasoning:saved[0].state.lastReasoningText,
+  savedJournal:[saved[0].state.lastRunJournalSeq,saved[0].state.lastRunJournalEventId],
+  savedReplay:saved[0].state.journalReplayFromStart,
+  savedAnchor:saved[0].state.anchorActivityScene,
+  savedActivity:[saved[0].state.currentActivityBurstId,saved[0].state.currentLiveSegmentSeq],
+  savedTodos:saved[0].state.todos,
+  savedTodoMeta:saved[0].state.todoStateMeta,
+  mergedUserCount:merged.filter(m=>m&&m.role==='user').length,
+  mergedAttachments:merged.filter(m=>m&&m.role==='user').map(m=>m.attachments||[]),
+  preservedUserCount:preserved.filter(m=>m&&m.role==='user').length,
+}}));
+"""
+    result = json.loads(
+        subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True).stdout
+    )
+    assert result == {
+        "sessionToken": "opaque:late-token",
+        "visibleToken": "opaque:late-token",
+        "inflightToken": "opaque:late-token",
+        "inflightRowToken": "opaque:late-token",
+        "savedToken": "opaque:late-token",
+        "savedCount": 1,
+        "savedStreamId": "stream-1",
+        "savedUploaded": ["old.txt"],
+        "savedToolCalls": [{"id": "call-1"}],
+        "savedText": "answer",
+        "savedReasoning": "thinking",
+        "savedJournal": [7, "event-7"],
+        "savedReplay": True,
+        "savedAnchor": "scene",
+        "savedActivity": [3, 4],
+        "savedTodos": [{"id": "todo-1"}],
+        "savedTodoMeta": {"version": 1},
+        "mergedUserCount": 1,
+        "mergedAttachments": [[{"name": "new.txt"}]],
+        "preservedUserCount": 2,
+    }
 
 
 def test_hidden_poll_hits_session_status_and_attaches_as_replay():
@@ -93,7 +244,8 @@ def test_hidden_poll_hits_session_status_and_attaches_as_replay():
     assert "api/session/status?session_id=" in body
     assert "d.active_stream_id" in body
     # attaches as replay (recovered=true) — turn is already mid-flight
-    assert "_attachServerInitiatedStream(sid, streamId, true)" in body
+    assert "_attachServerInitiatedStream(" in body
+    assert "d.active_turn_token" in body
 
 
 def test_hidden_poll_started_on_both_hidden_paths():
@@ -138,9 +290,11 @@ def test_attach_returns_bool_and_bails_false_on_non_current_pane():
     false (so the poll keeps retrying for the right pane) — never a bare
     `return;` that the caller can't distinguish from success.
     """
-    fn_idx = MESSAGES_JS.find("function _attachServerInitiatedStream(sid, streamId, recovered)")
+    fn_idx = MESSAGES_JS.find(
+        "function _attachServerInitiatedStream(sid, streamId, recovered, activeTurnToken=null)"
+    )
     assert fn_idx != -1, "_attachServerInitiatedStream signature not found"
-    body = MESSAGES_JS[fn_idx:fn_idx + 4000]
+    body = MESSAGES_JS[fn_idx:MESSAGES_JS.index("\n}\n\n// Poll", fn_idx) + 2]
     # Non-current pane bails with an explicit false, not a bare return.
     assert "if (!isCurrent) return false;" in body
     # Bad/empty args also bail false; success paths return true.
@@ -175,7 +329,8 @@ def test_poll_stops_only_when_attach_succeeds():
     # Window 2400: the multi-pane follow-up adds an explanatory comment block
     # before the attach call, pushing it past a narrower slice.
     body = MESSAGES_JS[start:start + 3200]
-    assert "const attached = _attachServerInitiatedStream(sid, streamId, true)" in body
+    assert "const attached = _attachServerInitiatedStream(" in body
+    assert "d.active_turn_token" in body
     # Stop the poll only on a true attach (the false branch keeps polling within
     # the bounded-retry budget rather than stopping).
     assert "if (attached) {" in body

--- a/tests/test_inflight_send_start_race.py
+++ b/tests/test_inflight_send_start_race.py
@@ -8,12 +8,13 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def _function_body(src: str, name: str) -> str:
     marker = f"function {name}"
     start = src.index(marker)
-    brace = src.index("{", start)
+    brace = src.index("{", src.index(")", start))
     depth = 1
     i = brace + 1
     while depth and i < len(src):
@@ -23,6 +24,61 @@ def _function_body(src: str, name: str) -> str:
             depth -= 1
         i += 1
     return src[brace + 1 : i - 1]
+
+
+def _source_slice(src: str, start: str, end: str, offset: int = 0) -> str:
+    begin = src.index(start, offset)
+    finish = src.index(end, begin)
+    return src[begin:finish]
+
+
+_LOAD_SESSION_START = SESSIONS_JS.index("async function loadSession(sid)")
+_LOAD_SESSION_SWITCH_BODY = _source_slice(
+    SESSIONS_JS,
+    "  const _loadGeneration = ++_loadSessionGeneration;",
+    "  // Phase 1: Load metadata only",
+    _LOAD_SESSION_START,
+)
+_LOAD_SESSION_METADATA_BODY = _source_slice(
+    SESSIONS_JS,
+    "  S.session=data.session;",
+    "  // _mergePendingSessionMessage is the global identity-aware helper shared by",
+    _LOAD_SESSION_START,
+)
+_LOAD_SESSION_REATTACH_BODY = _source_slice(
+    SESSIONS_JS,
+    "    if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function')",
+    "    syncTopbar();renderMessages",
+    _LOAD_SESSION_START,
+)
+_LOAD_SESSION_ACTIVE_BODY = _source_slice(
+    SESSIONS_JS,
+    "      S.busy=true;\n      S.activeStreamId=activeStreamId;",
+    "      const restoredAnchorScene",
+    SESSIONS_JS.index("  // Phase 2b: Idle session", _LOAD_SESSION_START),
+)
+_LOAD_SESSION_IDLE_BODY = _source_slice(
+    SESSIONS_JS,
+    "      S.busy=false;",
+    "\n    }\n  }\n\n  // Sync context usage indicator",
+    SESSIONS_JS.index("  // Phase 2b: Idle session", _LOAD_SESSION_START),
+)
+_UPLOAD_PROGRESS_HIDE_BODY = _function_body(
+    UI_JS, "_uploadPendingFilesHideProgressBar"
+)
+_UPLOAD_PROGRESS_SHOW_BODY = _function_body(
+    UI_JS, "_uploadPendingFilesShowProgressBar"
+)
+_UPLOAD_PROGRESS_SYNC_BODY = _function_body(
+    UI_JS, "_uploadPendingFilesSyncProgressForSession"
+)
+_UPLOAD_CURRENT_BODY = _function_body(UI_JS, "_uploadPendingFilesCurrentSession")
+_UPLOAD_UPDATE_BODY = _function_body(UI_JS, "_uploadPendingFilesUpdateProgress")
+_UPLOAD_BODY = _function_body(UI_JS, "uploadPendingFiles")
+_CURRENT_PANE_BODY = _function_body(MESSAGES_JS, "_isSessionCurrentPane")
+_PRE_START_STEP_BODY = _function_body(MESSAGES_JS, "_runOptionalPreStartUiStep")
+_POST_START_STEP_BODY = _function_body(MESSAGES_JS, "_runOptionalPostStartUiStep")
+_NEW_SESSION_BODY = _function_body(SESSIONS_JS, "newSession")
 
 
 def test_send_preserves_optimistic_messages_across_chat_start_await():
@@ -166,7 +222,8 @@ def test_post_start_bookkeeping_errors_cannot_block_live_attach():
 
 
 @pytest.mark.parametrize("pane_state", ("assigned", "loading"))
-def test_delayed_chat_start_keeps_a_owned_state_out_of_visible_b_pane(pane_state):
+@pytest.mark.parametrize("worklog_throws", (False, True))
+def test_delayed_chat_start_keeps_a_owned_state_out_of_visible_b_pane(pane_state, worklog_throws):
     """A delayed A start must finish in A's recovery state after the pane switches to B."""
     send_body = _function_body(MESSAGES_JS, "send")
     script = f"""
@@ -231,14 +288,20 @@ function _isSessionCurrentPane(sid) {{
 function visibleCall(name) {{
   if (switched) calls.visibleAfterSwitch.push(name);
 }}
-function renderMessages() {{}}
+function renderMessages() {{
+  if ({json.dumps(worklog_throws)}) throw new Error('optimistic render failed');
+}}
 function renderTray() {{}}
 function autoResize() {{}}
 function setComposerStatus() {{}}
 function setStatus() {{}}
 function setBusy(value) {{ S.busy = value; visibleCall('busy'); }}
 function updateSendBtn() {{ calls.busyUi++; visibleCall('send'); }}
-function ensureLiveWorklogShell() {{ calls.worklog++; visibleCall('worklog'); }}
+function ensureLiveWorklogShell() {{
+  calls.worklog++;
+  visibleCall('worklog');
+  if ({json.dumps(worklog_throws)}) throw new Error('worklog failed');
+}}
 function appendThinking() {{ calls.worklog++; visibleCall('worklog'); }}
 function syncTopbar() {{ calls.topbar++; visibleCall('topbar'); }}
 function syncModelChip() {{ calls.modelControls.push(['provider-chip', S.session && S.session.session_id]); visibleCall('model'); }}
@@ -283,8 +346,8 @@ function _chatPayloadModelState() {{
 function _readPendingSessionModel() {{ return null; }}
 function _opaqueActiveTurnToken(value) {{ return typeof value === 'string' && value.trim() ? value : null; }}
 function _restoreComposerDraftAfterFailedSend() {{}}
-function _runOptionalPreStartUiStep(label, fn) {{ return fn(); }}
-function _runOptionalPostStartUiStep(label, fn) {{ return fn(); }}
+function _runOptionalPreStartUiStep(label, fn) {{{_PRE_START_STEP_BODY}}}
+function _runOptionalPostStartUiStep(label, fn) {{{_POST_START_STEP_BODY}}}
 function api(path, options) {{
   assert.strictEqual(path, '/api/chat/start');
   startCalled();
@@ -343,7 +406,7 @@ async function send() {{{send_body}}}
   assert.strictEqual(calls.topbar, 0);
   assert.strictEqual(calls.persistedModels.length, 0);
   assert.strictEqual(calls.modelControls.length, 0);
-  assert.strictEqual(calls.busyUi, 1);
+  assert.strictEqual(calls.busyUi, {0 if worklog_throws else 1});
   assert.deepStrictEqual(calls.visibleAfterSwitch, []);
 
   const a = INFLIGHT.A;
@@ -365,6 +428,1612 @@ async function send() {{{send_body}}}
   process.exitCode = 1;
 }});
 """
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize(
+    "pane_state,start_outcome",
+    (
+        ("assigned", "success"),
+        ("assigned", "error"),
+        ("loading", "success"),
+        ("loading", "error"),
+        ("visible", "404"),
+        ("assigned", "404"),
+        ("loading", "404"),
+    ),
+)
+def test_delayed_upload_skill_and_start_keep_a_ownership_through_production_reconcile(
+    pane_state, start_outcome
+):
+    """Delayed A work must not repaint or reconcile an installed/pending B pane."""
+    send_body = _function_body(MESSAGES_JS, "send")
+    restore_body = _function_body(MESSAGES_JS, "_restoreComposerDraftAfterFailedSend")
+    idle_row_body = _function_body(SESSIONS_JS, "_isServerIdleSessionRow")
+    reconcile_body = _function_body(SESSIONS_JS, "_reconcileActiveSessionIdleStateFromList")
+    script = f"""
+const assert = require('assert');
+let switched = false;
+let releaseUpload, releaseSkill, releaseStart, rejectStart, resolveSkillGate;
+let uploadCalled, skillCalled, startCalled, bMetadataCalled;
+const uploadCalledPromise = new Promise(resolve => uploadCalled = resolve);
+const skillCalledPromise = new Promise(resolve => skillCalled = resolve);
+const startCalledPromise = new Promise(resolve => startCalled = resolve);
+const bMetadataCalledPromise = new Promise(resolve => bMetadataCalled = resolve);
+const uploadResponse = new Promise(resolve => releaseUpload = resolve);
+const skillGate = new Promise(resolve => resolveSkillGate = resolve);
+const skillResponse = {{then(resolve, reject) {{ skillCalled(); return skillGate.then(resolve, reject); }}}};
+releaseSkill = value => resolveSkillGate(value);
+const startResponse = new Promise((resolve, reject) => {{ releaseStart = resolve; rejectStart = reject; }});
+let releaseBMetadata;
+const bMetadataResponse = new Promise(resolve => releaseBMetadata = resolve);
+const calls = {{
+  attach: [], saved: [], marked: [], uploaded: [], requests: [], drafts: [],
+  visibleAfterSwitch: [], renderSessionList: 0, reconcile: 0, reload: 0,
+  optimisticOwners: [], renderOwners: [],
+  stopped: [], cleared: [], sidebar: 0, worklog: 0, topbar: 0,
+  modelControls: [], persistedModels: [], busyUi: 0,
+}};
+const elements = {{
+  msg: {{value: 'A prompt'}},
+  modelSelect: {{value: 'A requested model'}},
+  emptyState: {{style: {{display: ''}}}},
+  msgInner: {{innerHTML: ''}},
+  uploadBar: {{style: {{width: '0%'}}}},
+  uploadBarWrap: {{classList: {{add() {{}}, remove() {{}}, contains() {{return false;}}}}, dataset: {{}}}},
+}};
+function $(id) {{ return elements[id] || null; }}
+const document = {{querySelector: () => null}};
+const localStorage = {{
+  values: Object.create(null),
+  getItem(key) {{ return this.values[key] || null; }},
+  setItem(key, value) {{ this.values[key] = String(value); }},
+  removeItem(key) {{ delete this.values[key]; }},
+}};
+const window = {{_defaultMessageMode: 'steer', _defaultModel: 'A default', _activeProvider: 'provider-a'}};
+const historyCalls = [];
+const history = {{replaceState(...args) {{ historyCalls.push(args); }}}};
+const A = {{
+  session_id: 'A', title: 'Untitled', model: 'A requested model', model_provider: 'provider-a',
+  workspace: '/a', profile: 'session-profile-a', active_turn_token: 'A-old-token',
+  pending_started_at: 10, active_stream_id: 'A-stream', pending_attachments: [],
+}};
+const B = {{
+  session_id: 'B', title: 'B', model: 'B visible model', model_provider: 'provider-b',
+  workspace: '/b', profile: 'session-profile-b', active_turn_token: 'B-token',
+  pending_started_at: 20, active_stream_id: 'B-stream', pending_attachments: ['b.txt'],
+}};
+const serverSessions = {{
+  A: {{session: A, messages: [{{role: 'assistant', content: 'A history'}}]}},
+  B: {{session: B, messages: [{{role: 'user', content: 'B existing'}}, {{role: 'assistant', content: 'B reply'}}]}},
+}};
+const cards = {{approval: 'B approval', clarify: 'B clarify', live: 'B live', tools: ['B tool']}};
+const polling = {{approval: 'B approval poll', clarify: 'B clarify poll'}};
+const sidebarState = {{rows: ['A', 'B'], selected: 'B'}};
+const S = {{
+  session: A,
+  messages: [{{role: 'assistant', content: 'A history'}}],
+  pendingFiles: [{{name: 'a.txt'}}],
+  busy: false, activeStreamId: null, activeProfile: 'profile-a',
+  toolCalls: [], todos: [{{text: 'A todo'}}], todoStateMeta: {{owner: 'A'}},
+}};
+const INFLIGHT = Object.create(null);
+const _sessionStreamingById = new Map();
+let _sendInProgress = false;
+let _sendInProgressSid = null;
+let _pendingSelections = [];
+let _forcedSkillDirectivePending = {{sessionId: 'A', promise: skillResponse}};
+let _queueDrainSid = null;
+let _approvalSessionId = 'A';
+let _clarifySessionId = 'A';
+let _loadingSessionId = null, _loadSessionGeneration = 0;
+let _messageUserUnpinned = false, _scrollPinned = true, _loadingOlder = false;
+let _messagesTruncated = false, _oldestIdx = 0, _pendingCarryForwardSnapshot = null;
+const _uploadPendingFilesProgressBySession = new Map();
+function _isSessionCurrentPane(sid) {{
+  if(!sid || !S.session || S.session.session_id!==sid) return false;
+  if(typeof _loadingSessionId!=='undefined' && _loadingSessionId && _loadingSessionId!==sid) return false;
+  return true;
+}}
+function visibleCall(name) {{ if(switched) calls.visibleAfterSwitch.push(name); }}
+function renderMessages() {{ visibleCall('messages'); }}
+function renderTray() {{ visibleCall('tray'); }}
+function autoResize() {{ visibleCall('resize'); }}
+let composerStatus = '';
+function setComposerStatus(value) {{ composerStatus = String(value || ''); visibleCall('composer-status'); }}
+function setStatus() {{ visibleCall('status'); }}
+function setBusy(value) {{ S.busy = value; visibleCall('busy'); }}
+function updateSendBtn() {{ calls.busyUi++; visibleCall('send-button'); }}
+function ensureLiveWorklogShell() {{ calls.worklog++; visibleCall('worklog'); }}
+function appendThinking() {{ calls.worklog++; visibleCall('worklog'); }}
+function syncTopbar() {{ calls.topbar++; visibleCall('topbar'); }}
+function syncModelChip() {{ calls.modelControls.push(['provider-chip', S.session && S.session.session_id]); visibleCall('model'); }}
+function _applyModelToDropdown() {{ calls.modelControls.push(['dropdown', S.session && S.session.session_id]); visibleCall('model'); }}
+function _writePersistedModelState(model, provider) {{ calls.persistedModels.push([model, provider, S.session && S.session.session_id]); }}
+function showLiveRunStatus() {{ cards.live = 'changed'; visibleCall('live-status'); }}
+function upsertActiveSessionForLocalTurn() {{ calls.sidebar++; sidebarState.rows = ['changed']; visibleCall('sidebar'); }}
+function applySessionTitleUpdate() {{ calls.sidebar++; sidebarState.rows = ['changed-title']; visibleCall('sidebar'); }}
+function renderSessionListFromCache() {{ calls.sidebar++; sidebarState.rows = ['changed-cache']; visibleCall('sidebar'); }}
+function startApprovalPolling() {{ polling.approval = 'changed'; visibleCall('approval-poll'); }}
+function startClarifyPolling() {{ polling.clarify = 'changed'; visibleCall('clarify-poll'); }}
+function stopApprovalPolling() {{ calls.stopped.push('approval-visible'); visibleCall('approval'); }}
+function stopClarifyPolling() {{ calls.stopped.push('clarify-visible'); visibleCall('clarify'); }}
+function stopApprovalPollingForSession(sid) {{ calls.stopped.push('approval:' + sid); }}
+function stopClarifyPollingForSession(sid) {{ calls.stopped.push('clarify:' + sid); }}
+function hideApprovalCard() {{ cards.approval = null; visibleCall('approval'); }}
+function hideClarifyCard() {{ cards.clarify = null; visibleCall('clarify'); }}
+function hideLiveRunStatus() {{ cards.live = null; visibleCall('live-status'); }}
+function removeThinking() {{ cards.live = null; visibleCall('worklog'); }}
+function clearLiveToolCards() {{ cards.tools = []; visibleCall('tools'); }}
+function _fetchYoloState() {{ visibleCall('yolo'); }}
+function _forgetObservedStreamingSession() {{}}
+function _scheduleActiveSessionIdleReload() {{ calls.reload++; }}
+function _isServerIdleSessionRow(row) {{{idle_row_body}}}
+function _reconcileActiveSessionIdleStateFromList(serverRows) {{{reconcile_body}}}
+function renderSessionList() {{
+  calls.renderSessionList++;
+  calls.renderOwners.push(S.session && S.session.session_id || null);
+  return Promise.resolve().then(() => {{
+    calls.reconcile++;
+    _reconcileActiveSessionIdleStateFromList([
+      {{session_id: 'A', is_streaming: true, active_stream_id: 'A-stream', pending_user_message: 'A prompt', pending_started_at: 30}},
+      {{session_id: 'B', is_streaming: false, active_stream_id: null, pending_user_message: null, has_pending_user_message: false, pending_started_at: null}},
+    ]);
+  }});
+}}
+function markInflight(sid, streamId) {{
+  localStorage.setItem('hermes-webui-inflight', JSON.stringify({{sid, streamId, ts: 123}}));
+  calls.marked.push([sid, streamId]);
+}}
+function saveInflightState(sid, state) {{ calls.saved.push([sid, JSON.parse(JSON.stringify(state))]); }}
+function clearInflightState(sid) {{ calls.cleared.push(sid); }}
+function clearOptimisticSessionStreaming(sid) {{
+  calls.cleared.push('optimistic:' + sid);
+  calls.optimisticOwners.push(S.session && S.session.session_id || null);
+  visibleCall('clear-optimistic');
+}}
+function attachLiveStream(sid, streamId, uploaded, options) {{
+  calls.attach.push([sid, streamId, uploaded, options || null]);
+  if(sid === 'B') cards.live = 'B live';
+}}
+function _clearComposerDraft(sid, text, files) {{ calls.drafts.push({{sid, text, files: files.map(file => file.name)}}); return Promise.resolve(); }}
+function _saveComposerDraftNow(sid, text, files) {{ calls.drafts.push({{sid, text, files: files.map(file => file.name)}}); return Promise.resolve(); }}
+function uploadPendingFiles(options) {{
+  calls.uploaded.push({{sessionId: options.sessionId, files: options.files.map(file => file.name)}});
+  uploadCalled();
+  return uploadResponse;
+}}
+function _clearStaleBusyStateBeforeSend() {{}}
+function isCompressionUiRunning() {{ return false; }}
+function _composerTextWithPendingSelections() {{ return elements.msg.value; }}
+function _flushSelectionBlocksToComposer() {{}}
+function _chatPayloadModelState() {{
+  return {{model: S.session.model, model_provider: S.session.model_provider}};
+}}
+function _readPendingSessionModel(sid) {{
+  return sid === 'A' ? {{model: 'A requested model', model_provider: 'provider-a'}} : null;
+}}
+function _clearPendingSessionModel(sid) {{ calls.cleared.push('pick:' + sid); }}
+function _opaqueActiveTurnToken(value) {{ return typeof value === 'string' && value.trim() ? value : null; }}
+function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, clearPromise) {{
+{restore_body}
+}}
+function _runOptionalPreStartUiStep(label, fn) {{ return fn(); }}
+function _runOptionalPostStartUiStep(label, fn) {{ return fn(); }}
+function _dismissHandoffHint() {{}}
+function queueSessionMessage() {{}}
+function updateQueueBadge() {{}}
+function showToast() {{ visibleCall('toast'); }}
+function _clearQueueCardDisplay() {{}}
+function _clearDeferredActiveSessionExternalRefresh() {{}}
+function _clearSameSessionForceReloadHint() {{}}
+function _captureSameSessionForceReloadHint() {{}}
+function _rearmActiveSessionStream() {{}}
+function _updateYoloPill() {{}}
+function _clearEmptyComposerModelOverride() {{}}
+function clearCompressionUi() {{}}
+function stopSessionStream() {{}}
+function closeOtherLiveStreams() {{}}
+function snapshotLiveTurnHtmlForSession() {{}}
+function _deferWorkspaceRefreshForSession() {{}}
+function _setActiveSessionUrl() {{}}
+function startSessionStream() {{}}
+function _hydrateTodosFromSession(session) {{
+  S.todos = [{{text: session.session_id + ' todo'}}];
+  S.todoStateMeta = {{owner: session.session_id}};
+}}
+function _applyPendingSessionModelForSession() {{ return false; }}
+function _resolveSessionModelForDisplaySoon(sid) {{
+  const session = serverSessions[sid].session;
+  S.activeProfile = session.profile;
+  elements.modelSelect.value = session.model;
+  window._defaultModel = session.model;
+  window._activeProvider = session.model_provider;
+}}
+function _acknowledgeSessionVisit(sid) {{ sidebarState.selected = sid; }}
+localStorage.setItem('hermes-webui-session', 'A');
+    function _uploadPendingFilesHideProgressBar() {{
+    {_UPLOAD_PROGRESS_HIDE_BODY}
+    }}
+    function _uploadPendingFilesShowProgressBar(owner, percent) {{
+    {_UPLOAD_PROGRESS_SHOW_BODY}
+    }}
+    function _uploadPendingFilesSyncProgressForSession(sessionId) {{
+{_UPLOAD_PROGRESS_SYNC_BODY}
+}}
+function loadInflightState(sid) {{
+  if(sid !== 'B') return null;
+  return {{streamId: 'B-stream', messages: serverSessions.B.messages.slice(), uploaded: ['b.txt'], toolCalls: [{{id: 'B-tool'}}], activeTurnToken: 'B-token'}};
+}}
+async function _ensureMessagesLoaded(sid) {{
+  S.messages = INFLIGHT[sid] ? INFLIGHT[sid].messages.map(row => ({{...row}})) : serverSessions[sid].messages.map(row => ({{...row}}));
+}}
+async function loadSession(sid, opts = {{}}) {{
+  const forceReload = !!opts.force;
+  const currentSid = S.session ? S.session.session_id : null;
+  const sameSessionForceReload = forceReload && currentSid === sid;
+  {_LOAD_SESSION_SWITCH_BODY}
+  const data = await api(`/api/session?session_id=${{encodeURIComponent(sid)}}&messages=0&resolve_model=0`);
+  if(!data || !_isCurrentLoad()) return;
+  {_LOAD_SESSION_METADATA_BODY}
+  if(!INFLIGHT[sid] && activeStreamId && typeof loadInflightState === 'function') {{
+    const stored = loadInflightState(sid, activeStreamId);
+    if(stored) INFLIGHT[sid] = {{...stored, reattach: true}};
+  }}
+  await _ensureMessagesLoaded(sid, {{force: _keepStaleUntilLoaded, loadGeneration: _loadGeneration}});
+  if(!_isCurrentLoad()) return;
+  if(activeStreamId && INFLIGHT[sid]) {{
+    S.busy = true;
+    S.activeStreamId = activeStreamId;
+    let didReconnect = false;
+    {_LOAD_SESSION_REATTACH_BODY}
+    setComposerStatus('');
+    startApprovalPolling(sid);
+    startClarifyPolling(sid);
+  }} else if(activeStreamId) {{
+    {_LOAD_SESSION_ACTIVE_BODY}
+  }} else {{
+    {_LOAD_SESSION_IDLE_BODY}
+  }}
+  if(_isCurrentLoad()) _loadingSessionId = null;
+}}
+function _appRootPath() {{ return '/'; }}
+function api(path, options) {{
+  if(path.startsWith('/api/session?')) {{
+    const sid = new URLSearchParams(path.split('?')[1]).get('session_id');
+    if(sid === 'B') {{ bMetadataCalled(); return bMetadataResponse; }}
+    return Promise.resolve(serverSessions[sid]);
+  }}
+  assert.strictEqual(path, '/api/chat/start');
+  calls.requests.push(JSON.parse(options.body));
+  startCalled();
+  return startResponse;
+}}
+const startResult = {{
+  stream_id: 'A-stream', active_turn_token: 'A-token', pending_started_at: 30,
+  title: 'A server title', effective_model: 'A effective model',
+  effective_model_provider: 'provider-a-effective',
+}};
+async function send() {{{send_body}}}
+
+function bSnapshot() {{
+  return JSON.stringify({{
+    session: S.session, messages: S.messages, pendingFiles: S.pendingFiles,
+    busy: S.busy, activeStreamId: S.activeStreamId, activeProfile: S.activeProfile,
+    toolCalls: S.toolCalls, todos: S.todos, todoStateMeta: S.todoStateMeta,
+    composerStatus, composer: elements.msg.value, modelSelect: elements.modelSelect.value,
+    modelDefault: window._defaultModel, activeProvider: window._activeProvider,
+    uploadWidth: elements.uploadBar.style.width,
+    uploadOwner: elements.uploadBarWrap.dataset.uploadSessionId || null,
+    cards, polling, sidebarState, inflight: INFLIGHT.B,
+    marker: localStorage.getItem('hermes-webui-inflight'),
+    savedSession: localStorage.getItem('hermes-webui-session'),
+  }});
+}}
+
+(async () => {{
+  const sendPromise = send();
+  await uploadCalledPromise;
+  _uploadPendingFilesProgressBySession.set('A', {{percent: 42}});
+  _uploadPendingFilesShowProgressBar('A', 42);
+  const paneState = {json.dumps(pane_state)};
+  const bLoadPromise = paneState === 'visible' ? null : loadSession('B');
+  if (paneState !== 'visible') await bMetadataCalledPromise;
+  if (paneState === 'visible') {{
+    switched = false;
+  }} else if (paneState === 'assigned') {{
+    releaseBMetadata(serverSessions.B);
+    await bLoadPromise;
+    switched = true;
+  }} else {{
+    switched = true;
+  }}
+  let visibleB = paneState === 'visible' ? null : bSnapshot();
+  if (paneState === 'loading') {{
+    assert.strictEqual(JSON.parse(visibleB).composerStatus, '');
+  }}
+  if (paneState === 'assigned') {{
+    assert.strictEqual(JSON.parse(visibleB).composerStatus, '');
+    assert.strictEqual(JSON.parse(visibleB).uploadWidth, '0%');
+    assert.strictEqual(JSON.parse(visibleB).uploadOwner, null);
+  }}
+  const attachBefore = calls.attach.length;
+  releaseUpload([{{name: 'a.txt', path: '/a/a.txt'}}]);
+  await skillCalledPromise;
+  assert.strictEqual(calls.uploaded[0].sessionId, 'A');
+  assert.deepStrictEqual(calls.uploaded[0].files, ['a.txt']);
+  if (paneState !== 'visible') assert.strictEqual(bSnapshot(), visibleB);
+  releaseSkill({{directive: 'Use A skill', name: 'skill-a', content: 'A-only context'}});
+  await startCalledPromise;
+  const request = calls.requests[0];
+  assert.strictEqual(request.session_id, 'A');
+  if ({json.dumps(start_outcome)} !== '404') {{
+    assert.strictEqual(request.model, 'A requested model');
+    assert.strictEqual(request.model_provider, 'provider-a');
+    assert.strictEqual(request.workspace, '/a');
+    assert.strictEqual(request.profile, 'profile-a');
+    assert.strictEqual(request.explicit_model_pick, true);
+    assert.strictEqual(request.attachments[0].path, '/a/a.txt');
+    assert(request.message.includes('A-only context'));
+  }}
+  if (paneState !== 'visible') assert.strictEqual(bSnapshot(), visibleB);
+  if ({json.dumps(start_outcome)} === 'success') releaseStart(startResult);
+  else if ({json.dumps(start_outcome)} === '404') rejectStart(Object.assign(new Error('A session is gone'), {{status: 404}}));
+  else rejectStart(Object.assign(new Error('A start failed'), {{status: 500}}));
+  await sendPromise;
+  await new Promise(resolve => setImmediate(() => setImmediate(resolve)));
+  if (paneState === 'loading') {{
+    assert.strictEqual(bSnapshot(), visibleB);
+    switched = false;
+    releaseBMetadata(serverSessions.B);
+    await bLoadPromise;
+    switched = true;
+    visibleB = bSnapshot();
+    assert.strictEqual(JSON.parse(visibleB).composerStatus, '');
+    assert.strictEqual(JSON.parse(visibleB).uploadWidth, '0%');
+    assert.strictEqual(JSON.parse(visibleB).uploadOwner, null);
+  }}
+  if (paneState !== 'visible') {{
+    assert.strictEqual(bSnapshot(), visibleB);
+    assert.deepStrictEqual(calls.visibleAfterSwitch, []);
+    assert.strictEqual(calls.renderSessionList, 0);
+    assert.strictEqual(calls.reconcile, 0);
+    assert.strictEqual(calls.reload, 0);
+  }}
+  assert.deepStrictEqual(calls.attach.slice(attachBefore).filter(call => call[0] === 'A'), []);
+  assert.deepStrictEqual(calls.marked, []);
+  assert.deepStrictEqual(calls.modelControls, []);
+  assert.deepStrictEqual(calls.persistedModels, []);
+
+  if ({json.dumps(start_outcome)} === 'error') {{
+    const recovery = calls.drafts.filter(item => item.sid === 'A').at(-1);
+    assert.strictEqual(recovery.text, 'A prompt');
+    assert.deepStrictEqual(recovery.files, ['a.txt']);
+    assert.strictEqual(JSON.parse(bSnapshot()).composer, '');
+  }} else if ({json.dumps(start_outcome)} === '404') {{
+    assert.strictEqual(INFLIGHT.A, undefined);
+    assert.strictEqual(calls.cleared.filter(item => item === 'optimistic:A').length,
+      paneState === 'visible' ? 1 : 0);
+    assert.strictEqual(calls.renderSessionList, paneState === 'visible' ? 1 : 0);
+    if (paneState === 'visible') {{
+      assert.strictEqual(S.session, null);
+      assert.deepStrictEqual(S.messages, []);
+      assert.deepStrictEqual(calls.optimisticOwners, [null]);
+      assert.deepStrictEqual(calls.renderOwners, [null]);
+      assert.strictEqual(localStorage.getItem('hermes-webui-session'), null);
+      assert.strictEqual(historyCalls.length, 1);
+      assert.strictEqual(historyCalls[0][2], '/');
+    }}
+  }} else {{
+  const a = INFLIGHT.A;
+  assert(a);
+  assert.strictEqual(a.streamId, 'A-stream');
+  assert.strictEqual(a.activeTurnToken, 'A-token');
+  assert.strictEqual(a.reattach, true);
+  const aUser = a.messages.find(row => row && row.role === 'user' && row.content === 'A prompt');
+  assert(aUser);
+  assert.deepStrictEqual(aUser.attachments, ['a.txt']);
+  assert.strictEqual(aUser._active_turn_token, 'A-token');
+  const persisted = calls.saved.filter(item => item[0] === 'A').at(-1)[1];
+  assert.strictEqual(persisted.streamId, 'A-stream');
+  assert.strictEqual(persisted.activeTurnToken, 'A-token');
+  assert.strictEqual(persisted.reattach, true);
+  assert.deepStrictEqual(persisted.messages.find(row => row.content === 'A prompt').attachments, ['a.txt']);
+  switched = false;
+  await loadSession('A');
+  switched = true;
+  const aAttach = calls.attach.filter(call => call[0] === 'A');
+  assert.strictEqual(aAttach.length, 1);
+  assert.strictEqual(aAttach[0][1], 'A-stream');
+  assert.strictEqual(aAttach[0][3].reconnecting, true);
+  assert.strictEqual(S.session.session_id, 'A');
+  assert.strictEqual(S.activeStreamId, 'A-stream');
+  const loadedUser = S.messages.find(row => row && row.role === 'user' && row.content === 'A prompt');
+  assert(loadedUser);
+  assert.deepStrictEqual(loadedUser.attachments, ['a.txt']);
+  assert.strictEqual(loadedUser._active_turn_token, 'A-token');
+  }}
+}})().catch(error => {{
+  console.error(error.stack || error);
+  process.exitCode = 1;
+}});
+"""
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize("pane_state", ("pending-load", "assigned", "same"))
+@pytest.mark.parametrize("upload_outcome", ("file", "archive", "error"))
+def test_production_upload_side_effects_follow_canonical_owner(pane_state, upload_outcome):
+    """The real upload helper must not repaint a pane that replaced its owner."""
+    script = f"""
+const assert = require('assert');
+const paneState = {json.dumps(pane_state)};
+const outcome = {json.dumps(upload_outcome)};
+let releaseFetch;
+let fetchStarted;
+const fetchStartedPromise = new Promise(resolve => fetchStarted = resolve);
+const fetchResponse = new Promise(resolve => releaseFetch = resolve);
+const activeClasses = new Set(['active']);
+const elements = {{
+  uploadBar: {{style: {{width: '77%'}}}},
+  uploadBarWrap: {{
+    dataset: {{uploadSessionId: paneState === 'same' ? 'A' : 'B'}},
+    classList: {{
+      add(name) {{ activeClasses.add(name); }},
+      remove(name) {{ activeClasses.delete(name); }},
+    }},
+  }},
+}};
+function $(id) {{ return elements[id] || null; }}
+const document = {{baseURI: 'https://hermes.test/'}};
+const location = {{href: document.baseURI}};
+class FormData {{ constructor() {{ this.values = []; }} append(...value) {{ this.values.push(value); }} }}
+const A = {{session_id: 'A'}};
+const B = {{session_id: 'B'}};
+const S = {{
+  session: paneState === 'assigned' ? B : A,
+  pendingFiles: [{{name: paneState === 'same' ? 'a-existing.txt' : 'b-existing.txt'}}],
+  currentDir: paneState === 'same' ? '/a' : '/b',
+  workspace: paneState === 'same' ? '/a' : '/b',
+}};
+let _loadingSessionId = paneState === 'pending-load' ? 'B' : null;
+const _uploadPendingFilesProgressBySession = new Map();
+const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+const _ARCHIVE_EXTS = /\\.(zip|tar|gz|tgz|bz2|xz|7z|rar)$/i;
+let status = paneState === 'same' ? 'A status' : 'B status';
+let toasts = [paneState === 'same' ? 'A toast' : 'B toast'];
+let trayRenders = 7;
+let loadCalls = [paneState === 'same' ? '/a' : '/b'];
+let statusCalls = [];
+let toastCalls = [];
+function _isSessionCurrentPane(sid) {{{_CURRENT_PANE_BODY}}}
+function _uploadPendingFilesCurrentSession(sessionId) {{{_UPLOAD_CURRENT_BODY}}}
+function _uploadPendingFilesHideProgressBar() {{{_UPLOAD_PROGRESS_HIDE_BODY}}}
+function _uploadPendingFilesShowProgressBar(owner, percent) {{{_UPLOAD_PROGRESS_SHOW_BODY}}}
+function _uploadPendingFilesUpdateProgress(sessionId, percent) {{{_UPLOAD_UPDATE_BODY}}}
+function renderTray() {{ trayRenders++; }}
+function loadDir(path) {{ loadCalls.push(path); }}
+function setStatus(value) {{ status = String(value); statusCalls.push(status); }}
+function showToast(value) {{ toasts.push(String(value)); toastCalls.push(String(value)); }}
+function _redirectIfUnauth() {{ return false; }}
+function _uploadTooLargeMessage() {{ return 'too large'; }}
+function t(key, ...args) {{ return key + (args.length ? ':' + args.join(',') : ''); }}
+function fetch(url, options) {{
+  fetchStarted({{url, sessionId: options.body.values[0][1]}});
+  return fetchResponse;
+}}
+async function uploadPendingFiles(options = {{}}) {{{_UPLOAD_BODY}}}
+function snapshot() {{
+  return JSON.stringify({{
+    session: S.session.session_id,
+    loading: _loadingSessionId,
+    pending: S.pendingFiles.map(file => file.name),
+    currentDir: S.currentDir,
+    workspace: S.workspace,
+    status,
+    toasts,
+    trayRenders,
+    loadCalls,
+    statusCalls,
+    toastCalls,
+    width: elements.uploadBar.style.width,
+    uploadOwner: elements.uploadBarWrap.dataset.uploadSessionId || null,
+    active: activeClasses.has('active'),
+  }});
+}}
+const fileName = outcome === 'archive' ? 'bundle.zip' : 'note.txt';
+const file = {{name: fileName, size: 12}};
+const response = outcome === 'error'
+  ? {{ok: false, text: async () => 'server rejected upload'}}
+  : outcome === 'archive'
+    ? {{ok: true, json: async () => ({{dest: '/uploaded/bundle', extracted: 2}})}}
+    : {{ok: true, json: async () => ({{filename: 'note.txt', path: '/uploaded/note.txt', mime: 'text/plain', size: 12, is_image: false}})}};
+(async () => {{
+  const uploadPromise = uploadPendingFiles({{sessionId: 'A', files: [file]}});
+  await Promise.race([
+    fetchStartedPromise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('upload did not reach fetch')), 1000)),
+  ]);
+  const before = snapshot();
+  _uploadPendingFilesUpdateProgress('A', 42);
+  if (paneState !== 'same') assert.strictEqual(snapshot(), before);
+  else {{
+    assert.strictEqual(elements.uploadBar.style.width, '42%');
+    assert.strictEqual(elements.uploadBarWrap.dataset.uploadSessionId, 'A');
+  }}
+  releaseFetch(response);
+  let result = null;
+  let error = null;
+  try {{ result = await uploadPromise; }} catch (exc) {{ error = String(exc && exc.message || exc); }}
+
+  if (paneState !== 'same') {{
+    assert.strictEqual(snapshot(), before);
+    assert.strictEqual(statusCalls.length, 0);
+    assert.strictEqual(toastCalls.length, 0);
+    assert.strictEqual(loadCalls.length, 1);
+    assert.strictEqual(trayRenders, 7);
+    if (outcome === 'error') assert(error && result === null);
+    else assert.strictEqual(result.length, 1);
+  }} else {{
+    if (outcome === 'error') {{
+      assert(error && result === null);
+    }} else {{
+      assert.strictEqual(error, null);
+      assert.strictEqual(result.length, 1);
+    }}
+    assert.deepStrictEqual(S.pendingFiles, []);
+    assert.strictEqual(elements.uploadBar.style.width, '0%');
+    assert.strictEqual(elements.uploadBarWrap.dataset.uploadSessionId, undefined);
+    assert.strictEqual(activeClasses.has('active'), false);
+    assert.strictEqual(trayRenders, 8);
+    if (outcome === 'archive') {{
+      assert.strictEqual(loadCalls.length, 2);
+      assert.strictEqual(loadCalls[1], '/a');
+      assert.strictEqual(toastCalls.length, 1);
+    }} else if (outcome === 'error') {{
+      assert.strictEqual(statusCalls.length, 1);
+      assert.strictEqual(toastCalls.length, 0);
+      assert.strictEqual(loadCalls.length, 1);
+    }} else {{
+      assert.strictEqual(statusCalls.length, 0);
+      assert.strictEqual(toastCalls.length, 0);
+      assert.strictEqual(loadCalls.length, 1);
+    }}
+  }}
+}})().catch(error => {{
+  console.error(error.stack || error);
+  process.exitCode = 1;
+}});
+"""
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    (
+        "assigned-agent",
+        "pending-agent",
+        "assigned-resolve",
+        "pending-resolve",
+        "assigned-bundle-resolve",
+        "same-moa",
+        "same-reload-moa",
+        "same-reload-bundle-resolve",
+    ),
+)
+def test_pre_owner_slash_awaits_abort_or_send_from_production_pane(scenario):
+    """Agent-bound slash awaits must not transform or send into a new pane."""
+    send_body = _function_body(MESSAGES_JS, "send")
+    script = r"""
+const assert = require('assert');
+const scenario = __SCENARIO__;
+const paneState = scenario.startsWith('pending-') ? 'pending' : scenario.startsWith('assigned-') ? 'assigned' : 'same';
+const command = scenario.includes('bundle') ? 'bundle' : 'moa';
+const stage = scenario.includes('agent') ? 'agent' : scenario.includes('bundle') ? 'bundle-resolve' : 'resolve';
+const forceReloadSamePane = scenario.startsWith('same-reload-');
+let releaseAgent, releaseResolve, releaseBundleResolve, releaseBMetadata, releaseReload;
+let agentCalled, resolveCalled, bundleResolveCalled, bMetadataCalled, startCalled;
+let reloadCalled;
+const agentCalledPromise = new Promise(resolve => agentCalled = resolve);
+const resolveCalledPromise = new Promise(resolve => resolveCalled = resolve);
+const bundleResolveCalledPromise = new Promise(resolve => bundleResolveCalled = resolve);
+const bMetadataCalledPromise = new Promise(resolve => bMetadataCalled = resolve);
+const reloadCalledPromise = new Promise(resolve => reloadCalled = resolve);
+const agentResponse = new Promise(resolve => releaseAgent = resolve);
+const resolveResponse = new Promise(resolve => releaseResolve = resolve);
+const bundleResolveResponse = new Promise(resolve => releaseBundleResolve = resolve);
+const bMetadataResponse = new Promise(resolve => releaseBMetadata = resolve);
+const reloadResponse = new Promise(resolve => releaseReload = resolve);
+const calls = {starts: [], drafts: [], status: [], attach: []};
+const elements = {
+  msg: {value: command === 'bundle' ? '/bundle A prompt' : '/moa A prompt'},
+  modelSelect: {value: 'A model'},
+  msgInner: {innerHTML: ''},
+  emptyState: {style: {display: ''}},
+};
+function $(id) { return elements[id] || null; }
+const document = {querySelector: () => null};
+const localStorage = {
+  values: Object.create(null),
+  getItem(key) { return this.values[key] || null; },
+  setItem(key, value) { this.values[key] = String(value); },
+  removeItem(key) { delete this.values[key]; },
+};
+const window = {_defaultMessageMode: 'steer', _defaultModel: 'A default', _activeProvider: 'provider-a'};
+const history = {replaceState() {}};
+const A = {session_id: 'A', title: 'A', model: 'A model', model_provider: 'provider-a', workspace: '/a', profile: 'profile-a', active_stream_id: null};
+const B = {session_id: 'B', title: 'B', model: 'B model', model_provider: 'provider-b', workspace: '/b', profile: 'profile-b', active_stream_id: null};
+const serverSessions = {A: {session: A, messages: [{role: 'assistant', content: 'A history'}]}, B: {session: B, messages: [{role: 'assistant', content: 'B history'}]}};
+const S = {session: A, messages: serverSessions.A.messages.slice(), pendingFiles: [], busy: false, activeStreamId: null, activeProfile: 'profile-a', toolCalls: [], todos: [], todoStateMeta: {}};
+const INFLIGHT = Object.create(null);
+let _sendInProgress = false, _sendInProgressSid = null;
+let _loadingSessionId = null, _loadSessionGeneration = 0;
+let _messageUserUnpinned = false, _scrollPinned = true, _loadingOlder = false;
+let _messagesTruncated = false, _oldestIdx = 0, _pendingCarryForwardSnapshot = null;
+let _yoloEnabled = false;
+let _pendingSelections = [], _forcedSkillDirectivePending = null;
+let _pendingMoaConfig = null;
+let _approvalSessionId = null, _clarifySessionId = null, _queueDrainSid = null;
+const noop = () => {};
+[
+  'stopApprovalPolling','hideApprovalCard','stopSessionStream','_updateYoloPill',
+  'stopClarifyPolling','hideClarifyCard','clearCompressionUi','_clearQueueCardDisplay',
+  'stopApprovalPollingForSession','stopClarifyPollingForSession',
+  'snapshotLiveTurnHtmlForSession','_captureSameSessionForceReloadHint',
+  '_clearSameSessionForceReloadHint','closeOtherLiveStreams','clearLiveToolCards',
+  'updateSendBtn','renderMessages','renderSessionListFromCache','startApprovalPolling',
+  'startClarifyPolling','_fetchYoloState','applySessionTitleUpdate','markInflight',
+  'syncTopbar','startSessionStream','_deferWorkspaceRefreshForSession',
+  '_setActiveSessionUrl','updateQueueBadge','resumeManualCompressionForSession',
+  '_clearDeferredActiveSessionExternalRefresh','_rearmActiveSessionStream',
+  '_clearEmptyComposerModelOverride','_applyPendingSessionModelForSession',
+  '_acknowledgeSessionVisit','_resolveSessionModelForDisplaySoon',
+  '_uploadPendingFilesSyncProgressForSession',
+  'clearInflightState','_clearQueueCardDisplay','_clearStuckSessionOnBoot',
+].forEach(name => globalThis[name] = noop);
+function setComposerStatus(value) { calls.status.push(String(value || '')); }
+function setStatus() {}
+function setBusy(value) { S.busy = !!value; }
+function autoResize() {}
+function renderTray() {}
+function ensureLiveWorklogShell() {}
+function appendThinking() {}
+function upsertActiveSessionForLocalTurn() {}
+function showLiveRunStatus() {}
+function attachLiveStream(sid, streamId, uploaded, options) { calls.attach.push([sid, streamId, options || null]); }
+function saveInflightState() {}
+function clearOptimisticSessionStreaming() {}
+function hideLiveRunStatus() {}
+function removeThinking() {}
+function startApprovalPollingForSession() {}
+function startClarifyPollingForSession() {}
+function showToast() {}
+function queueSessionMessage() {}
+function _clearStaleBusyStateBeforeSend() {}
+function isCompressionUiRunning() { return false; }
+function shouldInterceptCompressionRecoveryContinuation() { return false; }
+function _composerTextWithPendingSelections() { return elements.msg.value; }
+function _flushSelectionBlocksToComposer() {}
+function _chatPayloadModelState() { return {model: S.session.model, model_provider: S.session.model_provider}; }
+function _readPendingSessionModel() { return null; }
+function _opaqueActiveTurnToken(value) { return typeof value === 'string' && value.trim() ? value : null; }
+function _clearComposerDraft() { return Promise.resolve(); }
+function _saveComposerDraftNow(sid, text, files) { calls.drafts.push({sid, text, files: files.map(file => file.name)}); return Promise.resolve(); }
+function _restoreComposerDraftAfterFailedSend() {}
+function uploadPendingFiles() { return Promise.resolve([]); }
+function _isSessionCurrentPane(sid) { __CURRENT_PANE_BODY__ }
+function parseCommand(text) { return {name: text.split(/\s+/, 1)[0].slice(1)}; }
+const COMMANDS = [];
+const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set();
+function getAgentCommandMetadata(name) {
+  if (command !== 'moa') return Promise.resolve(null);
+  if (stage !== 'agent') return Promise.resolve({name: 'moa'});
+  agentCalled();
+  return agentResponse;
+}
+function getBundleCommandMetadata() {
+  if (command !== 'bundle') return null;
+  return Promise.resolve({name: 'bundle'});
+}
+function resolveBundleCommand() {
+  bundleResolveCalled();
+  return bundleResolveResponse;
+}
+function _runOptionalPreStartUiStep(label, fn) { return fn(); }
+function _runOptionalPostStartUiStep(label, fn) { return fn(); }
+function _dismissHandoffHint() {}
+function _clearPendingSessionModel() {}
+function api(path, options) {
+  if (path.startsWith('/api/session?')) {
+    const sid = new URLSearchParams(path.split('?')[1]).get('session_id');
+    if (sid === 'A' && forceReloadSamePane) {
+      reloadCalled();
+      return reloadResponse;
+    }
+    if (sid === 'B') {
+      bMetadataCalled();
+      return paneState === 'pending' ? bMetadataResponse : Promise.resolve(serverSessions.B);
+    }
+    return Promise.resolve(serverSessions[sid]);
+  }
+  if (path === '/api/commands/moa/resolve') {
+    resolveCalled();
+    return resolveResponse;
+  }
+  if (path === '/api/chat/start') {
+    calls.starts.push(JSON.parse(options.body));
+    startCalled();
+    return Promise.resolve({stream_id: 'A-stream', active_turn_token: 'A-token', pending_started_at: 30});
+  }
+  throw new Error('unexpected API ' + path);
+}
+async function _ensureMessagesLoaded(sid) { S.messages = serverSessions[sid].messages.slice(); }
+async function loadSession(sid, opts = {}) {
+  const forceReload = !!opts.force;
+  const currentSid = S.session ? S.session.session_id : null;
+  const sameSessionForceReload = forceReload && currentSid === sid;
+  __LOAD_SWITCH_BODY__
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+  if (!data || !_isCurrentLoad()) return;
+  __LOAD_METADATA_BODY__
+  await _ensureMessagesLoaded(sid, {loadGeneration: _loadGeneration});
+  if (!_isCurrentLoad()) return;
+  if (activeStreamId) {
+    S.busy = true;
+  } else {
+    __LOAD_IDLE_BODY__
+  }
+  if (_isCurrentLoad()) _loadingSessionId = null;
+}
+const startResult = {stream_id: 'A-stream', active_turn_token: 'A-token', pending_started_at: 30};
+async function send() { __SEND_BODY__ }
+function bSnapshot() {
+  return JSON.stringify({session: S.session && S.session.session_id, messages: S.messages, busy: S.busy,
+    activeStreamId: S.activeStreamId, activeProfile: S.activeProfile, status: calls.status.at(-1) || '',
+    model: elements.modelSelect.value, composer: elements.msg.value});
+}
+(async () => {
+  const sendPromise = send();
+  let bLoadPromise = null;
+  let sameReloadPromise = null;
+  let sameReloadBefore = null;
+  const switchToB = async () => {
+    bLoadPromise = loadSession('B');
+    if (paneState === 'pending') await bMetadataCalledPromise;
+    else await bLoadPromise;
+  };
+  const switchToSameReload = async () => {
+    sameReloadPromise = loadSession('A', {force: true});
+    await reloadCalledPromise;
+    sameReloadBefore = bSnapshot();
+  };
+  if (stage === 'agent') {
+    await agentCalledPromise;
+    if (paneState !== 'same') await switchToB();
+    releaseAgent({name: 'moa'});
+    releaseResolve({preset: 'moa-default'});
+  } else if (stage === 'resolve') {
+    await resolveCalledPromise;
+    if (forceReloadSamePane) await switchToSameReload();
+    else if (paneState !== 'same') await switchToB();
+    releaseResolve({preset: 'moa-default'});
+  } else {
+    await bundleResolveCalledPromise;
+    if (forceReloadSamePane) await switchToSameReload();
+    else await switchToB();
+    releaseBundleResolve({message: 'A bundle invocation'});
+  }
+  await sendPromise;
+  assert.strictEqual(calls.starts.length, forceReloadSamePane ? 0 : paneState === 'same' ? 1 : 0);
+  if (forceReloadSamePane) {
+    assert.strictEqual(bSnapshot(), sameReloadBefore);
+    releaseReload(serverSessions.A);
+    await sameReloadPromise;
+    return;
+  }
+  if (paneState !== 'same') {
+    assert.deepStrictEqual(calls.drafts.at(-1), {sid: 'A', text: command === 'bundle' ? '/bundle A prompt' : '/moa A prompt', files: []});
+    if (paneState === 'pending') {
+      assert.strictEqual(calls.status.at(-1), '');
+      releaseBMetadata(serverSessions.B);
+      await bLoadPromise;
+    }
+    const b = bSnapshot();
+    assert.strictEqual(JSON.parse(b).session, 'B');
+    assert.strictEqual(JSON.parse(b).status, '');
+    assert.strictEqual(b, bSnapshot());
+  } else {
+    const request = calls.starts[0];
+    assert.strictEqual(request.session_id, 'A');
+    assert.strictEqual(request.model, 'A model');
+    assert.strictEqual(request.model_provider, 'provider-a');
+    assert.strictEqual(request.workspace, '/a');
+    assert.strictEqual(request.profile, 'profile-a');
+    assert.strictEqual(request.moa_config, true);
+    assert.strictEqual(request.message, 'A prompt');
+  }
+})().catch(error => { console.error(error.stack || error); process.exitCode = 1; });
+"""
+    script = (
+        script.replace("__SCENARIO__", json.dumps(scenario))
+        .replace("__CURRENT_PANE_BODY__", _CURRENT_PANE_BODY)
+        .replace("__LOAD_SWITCH_BODY__", _LOAD_SESSION_SWITCH_BODY)
+        .replace("__LOAD_METADATA_BODY__", _LOAD_SESSION_METADATA_BODY)
+        .replace("__LOAD_IDLE_BODY__", _LOAD_SESSION_IDLE_BODY)
+        .replace("__SEND_BODY__", send_body)
+    )
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize("pane_state", ("assigned", "pending", "same"))
+def test_new_session_response_respects_production_pane_owner(pane_state):
+    """A stale New Chat response must not replace an installed/loading pane."""
+    script = r"""
+const assert = require('assert');
+const paneState = __PANE_STATE__;
+let releaseNew, releaseBMetadata, newCalled, bMetadataCalled;
+let startCalled = () => {};
+const newCalledPromise = new Promise(resolve => newCalled = resolve);
+const bMetadataCalledPromise = new Promise(resolve => bMetadataCalled = resolve);
+const newResponse = new Promise(resolve => releaseNew = resolve);
+const bMetadataResponse = new Promise(resolve => releaseBMetadata = resolve);
+const calls = {starts: [], urls: [], renders: 0, applied: 0, pending: [], newResult: undefined};
+const elements = {
+  msg: {value: '/moa A prompt'},
+  modelSelect: {value: 'A model', dataset: {provider: 'provider-a'}, appendChild() {}},
+  msgInner: {innerHTML: ''},
+  emptyState: {style: {display: ''}},
+  composerStatus: {textContent: ''},
+  a11yAnnouncer: {textContent: ''},
+  composerWorkspaceContext: {textContent: ''},
+};
+function $(id) { return elements[id] || null; }
+const document = {
+  querySelector: () => null,
+  visibilityState: 'visible',
+  hasFocus: () => true,
+  createElement: () => ({dataset: {}, appendChild() {}}),
+};
+const localStorage = {
+  values: {"hermes-webui-session": 'old-session'},
+  getItem(key) { return this.values[key] || null; },
+  setItem(key, value) { this.values[key] = String(value); },
+  removeItem(key) { delete this.values[key]; },
+};
+const window = {
+  _defaultModel: 'A model', _activeProvider: 'provider-a', _defaultMessageMode: 'steer',
+  _clearPendingSelections() {},
+};
+const history = {replaceState() {}};
+const A = {
+  session_id: 'A-new', title: 'A new chat', model: 'A model', model_provider: 'provider-a',
+  workspace: '/new', profile: 'profile-a', messages: [], last_usage: {},
+};
+const B = {
+  session_id: 'B', title: 'B', model: 'B model', model_provider: 'provider-b',
+  workspace: '/b', profile: 'profile-b', active_stream_id: null, messages: [],
+};
+const serverSessions = {
+  B: {session: B, messages: [{role: 'assistant', content: 'B history'}]},
+};
+const S = {
+  session: null, messages: [], pendingFiles: [], toolCalls: [], todos: [], todoStateMeta: {},
+  busy: false, activeStreamId: null, activeProfile: 'profile-a', lastUsage: {},
+  _profileDefaultWorkspace: '/empty', _profileSwitchWorkspace: null,
+  _pendingSessionToolsets: null,
+};
+const INFLIGHT = Object.create(null);
+let _loadingSessionId = null, _loadSessionGeneration = 0;
+let _newSessionInFlight = null;
+let _sessionSourceFilter = 'webui';
+let _activeProject = null;
+const NO_PROJECT_FILTER = '__none__';
+let _messagesTruncated = false, _oldestIdx = 0, _pendingCarryForwardSnapshot = null;
+let _messageUserUnpinned = false, _scrollPinned = true, _loadingOlder = false;
+let _yoloEnabled = false;
+let _sendInProgress = false, _sendInProgressSid = null;
+let _pendingSelections = [], _forcedSkillDirectivePending = null;
+let _pendingMoaConfig = null, _approvalSessionId = null, _clarifySessionId = null, _queueDrainSid = null;
+const _sessionStreamingById = new Map();
+function _isSessionCurrentPane(sid) {
+  if (!sid || !S.session || S.session.session_id !== sid) return false;
+  return !(_loadingSessionId && _loadingSessionId !== sid);
+}
+function _setNewSessionPending(value) { calls.pending.push(!!value); }
+function _newSessionPendingText() { return 'Creating new conversation…'; }
+function updateQueueBadge() {}
+function clearLiveToolCards() {}
+function _readEmptyComposerModelOverride() { return null; }
+function _clearEmptyComposerModelOverride() { calls.applied++; }
+function _modelStateForSelect(select) { return {model: select.value, model_provider: select.dataset.provider}; }
+function _readPersistedModelState() { return null; }
+function _hydrateTodosFromSession() {}
+function _rememberNewChatDraftSession() {}
+function _setActiveSessionUrl(sid) { calls.urls.push('/session/' + sid); }
+function startSessionStream() {}
+function _setSessionViewedCount() {}
+function _applyModelToDropdown() { return true; }
+function syncModelChip() {}
+function _setLiveAssistantTps() {}
+function _syncCtxIndicator() {}
+function setStatus() {}
+function setComposerStatus(value) { elements.composerStatus.textContent = String(value || ''); }
+function updateSendBtn() {}
+function syncTopbar() {}
+function renderMessages() { calls.renders++; }
+function _announceNewSessionWorkspace() {}
+function _deferWorkspaceRefreshForSession() {}
+function loadDir() { return Promise.resolve(); }
+function refreshSessionList() { return Promise.resolve(); }
+function _clearDeferredActiveSessionExternalRefresh() {}
+function _resetScrollDirectionTracker() {}
+function _applyPendingSessionModelForSession() { return false; }
+function _clearSameSessionForceReloadHint() {}
+function _captureSameSessionForceReloadHint() {}
+function _resolveSessionModelForDisplaySoon(sid) {
+  const session = serverSessions[sid].session;
+  S.activeProfile = session.profile;
+  elements.modelSelect.value = session.model;
+  window._defaultModel = session.model;
+  window._activeProvider = session.model_provider;
+}
+function _acknowledgeSessionVisit() {}
+function populateModelDropdown() { return Promise.resolve(); }
+function _deferSessionSideEffect(sid, fn) { return Promise.resolve().then(fn); }
+function stopApprovalPolling() {}
+function startApprovalPolling() {}
+function hideApprovalCard() {}
+function stopSessionStream() {}
+function _updateYoloPill() {}
+function stopClarifyPolling() {}
+function startClarifyPolling() {}
+function hideClarifyCard() {}
+function clearCompressionUi() {}
+function _clearQueueCardDisplay() {}
+function closeOtherLiveStreams() {}
+function snapshotLiveTurnHtmlForSession() {}
+function resumeManualCompressionForSession() {}
+function _uploadPendingFilesSyncProgressForSession() {}
+function clearInflightState() {}
+function _rearmActiveSessionStream() {}
+function _clearStuckSessionOnBoot() {}
+function _isServerIdleSessionRow(row) { return !!row; }
+function loadInflightState() { return null; }
+async function _ensureMessagesLoaded(sid) { S.messages = serverSessions[sid].messages.map(row => ({...row})); }
+function _appRootPath() { return '/'; }
+function setBusy(value) { S.busy = !!value; }
+function autoResize() {}
+function renderTray() {}
+function ensureLiveWorklogShell() {}
+function appendThinking() {}
+function upsertActiveSessionForLocalTurn() {}
+function showLiveRunStatus() {}
+function attachLiveStream() {}
+function markInflight() {}
+function saveInflightState() {}
+function clearOptimisticSessionStreaming() {}
+function hideLiveRunStatus() {}
+function removeThinking() {}
+function startApprovalPollingForSession() {}
+function startClarifyPollingForSession() {}
+function startApprovalPolling() {}
+function startClarifyPolling() {}
+function _fetchYoloState() {}
+function applySessionTitleUpdate() {}
+function renderSessionListFromCache() {}
+function showToast() {}
+function queueSessionMessage() {}
+function _clearStaleBusyStateBeforeSend() {}
+function isCompressionUiRunning() { return false; }
+function shouldInterceptCompressionRecoveryContinuation() { return false; }
+function _composerTextWithPendingSelections() { return elements.msg.value; }
+function _flushSelectionBlocksToComposer() {}
+function _chatPayloadModelState() { return {model: S.session.model, model_provider: S.session.model_provider}; }
+function _readPendingSessionModel() { return null; }
+function _opaqueActiveTurnToken(value) { return typeof value === 'string' && value.trim() ? value : null; }
+function _clearComposerDraft() { return Promise.resolve(); }
+function _restoreComposerDraftAfterFailedSend() {}
+function uploadPendingFiles() { return Promise.resolve([]); }
+function parseCommand(text) { return {name: text.split(/\s+/, 1)[0].slice(1)}; }
+const COMMANDS = [];
+const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set();
+function getAgentCommandMetadata() { return Promise.resolve({name: 'moa'}); }
+function getBundleCommandMetadata() { return null; }
+function _runOptionalPreStartUiStep(label, fn) { return fn(); }
+function _runOptionalPostStartUiStep(label, fn) { return fn(); }
+function _dismissHandoffHint() {}
+function _clearPendingSessionModel() {}
+function hideCmdDropdown() {}
+function _isCompressionUiRunning() { return false; }
+function api(path, options) {
+  if (path === '/api/session/new') {
+    newCalled();
+    return newResponse;
+  }
+  if (path.startsWith('/api/session?')) {
+    bMetadataCalled();
+    return bMetadataResponse;
+  }
+  if (path === '/api/commands/moa/resolve') return Promise.resolve({preset: 'moa-default'});
+  if (path === '/api/chat/start') {
+    calls.starts.push(JSON.parse(options.body));
+    startCalled();
+    return Promise.resolve({stream_id: 'A-stream', active_turn_token: 'A-token', pending_started_at: 3});
+  }
+  throw new Error('unexpected API ' + path);
+}
+async function _newSessionProduction(flash, options = {}) { __NEW_SESSION_BODY__ }
+async function newSession(flash, options = {}) {
+  const result = await _newSessionProduction(flash, options);
+  calls.newResult = result;
+  return result;
+}
+async function loadSession(sid, opts = {}) {
+  const forceReload = !!opts.force;
+  const currentSid = S.session ? S.session.session_id : null;
+  const sameSessionForceReload = forceReload && currentSid === sid;
+  __LOAD_SWITCH_BODY__
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+  if (!data || !_isCurrentLoad()) return;
+  __LOAD_METADATA_BODY__
+  await _ensureMessagesLoaded(sid, {loadGeneration: _loadGeneration});
+  if (!_isCurrentLoad()) return;
+  if (activeStreamId) {
+    S.busy = true;
+    S.activeStreamId = activeStreamId;
+  } else {
+    __LOAD_IDLE_BODY__
+  }
+  if (_isCurrentLoad()) _loadingSessionId = null;
+}
+async function send() { __SEND_BODY__ }
+function renderSessionList() { calls.renders++; return Promise.resolve(); }
+function snapshot() {
+  return JSON.stringify({
+    session: S.session, messages: S.messages, pendingFiles: S.pendingFiles,
+    busy: S.busy, activeStreamId: S.activeStreamId, activeProfile: S.activeProfile,
+    model: elements.modelSelect.value, modelDefault: window._defaultModel,
+    activeProvider: window._activeProvider, composerStatus: elements.composerStatus.textContent,
+    msgInner: elements.msgInner.innerHTML, url: calls.urls.at(-1) || '/',
+    savedSession: localStorage.getItem('hermes-webui-session'),
+  });
+}
+(async () => {
+  if (paneState === 'same') {
+    const sendPromise = send();
+    await newCalledPromise;
+    releaseNew({session: A});
+    await sendPromise;
+    assert.strictEqual(calls.starts.length, 1);
+    assert.strictEqual(calls.starts[0].session_id, 'A-new');
+    assert.strictEqual(calls.starts[0].model, 'A model');
+    assert.strictEqual(calls.starts[0].model_provider, 'provider-a');
+    assert.strictEqual(calls.starts[0].workspace, '/new');
+    assert.strictEqual(calls.starts[0].profile, 'profile-a');
+    assert.strictEqual(calls.starts[0].moa_config, true);
+    assert.strictEqual(S.session.session_id, 'A-new');
+    return;
+  }
+  const sendPromise = send();
+  await newCalledPromise;
+  const bLoadPromise = loadSession('B');
+  await bMetadataCalledPromise;
+  if (paneState === 'assigned') {
+    releaseBMetadata(serverSessions.B);
+    await bLoadPromise;
+  }
+  const before = snapshot();
+  const rendersBefore = calls.renders;
+  releaseNew({session: A});
+  await sendPromise;
+  assert.strictEqual(calls.starts.length, 0);
+  assert.strictEqual(snapshot(), before);
+  assert.strictEqual(calls.newResult, null);
+  assert.strictEqual(calls.renders, rendersBefore);
+  if (paneState === 'pending') {
+    releaseBMetadata(serverSessions.B);
+    await bLoadPromise;
+    const b = JSON.parse(snapshot());
+    assert.strictEqual(b.session.session_id, 'B');
+    assert.strictEqual(b.url, '/session/B');
+    assert.strictEqual(b.savedSession, 'B');
+    assert.strictEqual(b.model, 'B model');
+    assert.strictEqual(b.activeProvider, 'provider-b');
+    assert.strictEqual(b.session.workspace, '/b');
+  }
+})().catch(error => { console.error(error.stack || error); process.exitCode = 1; });
+"""
+    script = (
+        script.replace("__PANE_STATE__", json.dumps(pane_state))
+        .replace("__NEW_SESSION_BODY__", _NEW_SESSION_BODY)
+        .replace("__LOAD_SWITCH_BODY__", _LOAD_SESSION_SWITCH_BODY)
+        .replace("__LOAD_METADATA_BODY__", _LOAD_SESSION_METADATA_BODY)
+        .replace("__LOAD_IDLE_BODY__", _LOAD_SESSION_IDLE_BODY)
+        .replace("__SEND_BODY__", _function_body(MESSAGES_JS, "send"))
+    )
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize("order", ("reload-new", "new-reload", "ordinary"))
+def test_new_session_and_force_reload_use_production_generation_order(order):
+    """New Chat and a same-pane force reload must resolve by latest intent."""
+    script = r"""
+const assert = require('assert');
+const order = __ORDER__;
+let releaseReload, releaseNew, reloadCalled, newCalled;
+const reloadCalledPromise = new Promise(resolve => reloadCalled = resolve);
+const newCalledPromise = new Promise(resolve => newCalled = resolve);
+const reloadResponse = new Promise(resolve => releaseReload = resolve);
+const newResponse = new Promise(resolve => releaseNew = resolve);
+const calls = {urls: ['/session/A'], renders: 0};
+const elements = {
+  msg: {value: 'A draft'},
+  modelSelect: {value: 'A model', dataset: {provider: 'provider-a'}, appendChild() {}},
+  msgInner: {innerHTML: '<div>A</div>'},
+  emptyState: {style: {display: 'none'}},
+  composerStatus: {textContent: ''},
+};
+function $(id) { return elements[id] || null; }
+const document = {createElement: () => ({dataset: {}, appendChild() {}})};
+const localStorage = {
+  values: {'hermes-webui-session': 'A'},
+  getItem(key) { return this.values[key] || null; },
+  setItem(key, value) { this.values[key] = String(value); },
+  removeItem(key) { delete this.values[key]; },
+};
+const window = {
+  _defaultModel: 'A model', _activeProvider: 'provider-a',
+  _clearPendingSelections() {},
+};
+const history = {replaceState() {}};
+const A = {
+  session_id: 'A', title: 'A', model: 'A model', model_provider: 'provider-a',
+  workspace: '/a', profile: 'profile-a', active_stream_id: null,
+};
+const reloadedA = {
+  session_id: 'A', title: 'A refreshed', model: 'A reload model',
+  model_provider: 'provider-a-reload', workspace: '/a-reloaded', profile: 'profile-a-reload',
+  active_stream_id: null,
+};
+const created = {
+  session_id: 'C', title: 'Created', model: 'C model', model_provider: 'provider-c',
+  workspace: '/c', profile: 'profile-c', messages: [], last_usage: {},
+};
+const serverSessions = {
+  A: {session: reloadedA, messages: [{role: 'user', content: 'reloaded A'}]},
+};
+const S = {
+  session: A, messages: [{role: 'user', content: 'original A'}], pendingFiles: [],
+  busy: false, activeStreamId: null, activeProfile: 'profile-a', lastUsage: {},
+  toolCalls: [], todos: [], todoStateMeta: {}, _profileDefaultWorkspace: null,
+  _profileSwitchWorkspace: null, _pendingSessionToolsets: null,
+};
+const INFLIGHT = Object.create(null);
+let _loadingSessionId = null, _loadSessionGeneration = 0;
+let _newSessionInFlight = null;
+let _sessionSourceFilter = 'webui';
+let _activeProject = null;
+const NO_PROJECT_FILTER = '__none__';
+let _messagesTruncated = false, _oldestIdx = 0, _pendingCarryForwardSnapshot = null;
+let _messageUserUnpinned = false, _scrollPinned = true, _loadingOlder = false;
+function _isSessionCurrentPane(sid) {
+  if (!sid || !S.session || S.session.session_id !== sid) return false;
+  return !(_loadingSessionId && _loadingSessionId !== sid);
+}
+function _setNewSessionPending() {}
+function _newSessionPendingText() { return 'Creating new conversation…'; }
+function _readEmptyComposerModelOverride() { return null; }
+function _clearEmptyComposerModelOverride() {}
+function _modelStateForSelect(select) { return {model: select.value, model_provider: select.dataset.provider}; }
+function _readPersistedModelState() { return null; }
+function _hydrateTodosFromSession() {}
+function _rememberNewChatDraftSession() {}
+function _setActiveSessionUrl(sid) { calls.urls.push('/session/' + sid); }
+function startSessionStream() {}
+function _setSessionViewedCount() {}
+function _applyModelToDropdown(model, select) { if (select) select.value = model; return true; }
+function syncModelChip() {}
+function _setLiveAssistantTps() {}
+function _syncCtxIndicator() {}
+function setStatus() {}
+function setComposerStatus(value) { elements.composerStatus.textContent = String(value || ''); }
+function updateSendBtn() {}
+function syncTopbar() {}
+function renderMessages() { calls.renders++; }
+function _announceNewSessionWorkspace() {}
+function _deferWorkspaceRefreshForSession() {}
+function loadDir() { return Promise.resolve(); }
+function refreshSessionList() { return Promise.resolve(); }
+function _deferSessionSideEffect(sid, fn) { return Promise.resolve().then(fn); }
+function populateModelDropdown() { return Promise.resolve(); }
+function _resolveSessionModelForDisplaySoon() {
+  const session = serverSessions.A.session;
+  elements.modelSelect.value = session.model;
+  S.activeProfile = session.profile;
+  window._defaultModel = session.model;
+  window._activeProvider = session.model_provider;
+}
+function _acknowledgeSessionVisit() {}
+function _applyPendingSessionModelForSession() {}
+function _clearDeferredActiveSessionExternalRefresh() {}
+function _resetScrollDirectionTracker() {}
+function _uploadPendingFilesSyncProgressForSession() {}
+function clearInflightState() {}
+function _rearmActiveSessionStream() {}
+function clearCompressionUi() {}
+function _clearQueueCardDisplay() {}
+function stopApprovalPolling() {}
+function startApprovalPolling() {}
+function hideApprovalCard() {}
+function stopSessionStream() {}
+function _updateYoloPill() {}
+function stopClarifyPolling() {}
+function startClarifyPolling() {}
+function hideClarifyCard() {}
+function closeOtherLiveStreams() {}
+function snapshotLiveTurnHtmlForSession() {}
+function _captureSameSessionForceReloadHint() {}
+function _clearSameSessionForceReloadHint() {}
+function _clearStuckSessionOnBoot() {}
+function _opaqueActiveTurnToken(value) { return typeof value === 'string' ? value : null; }
+function _isServerIdleSessionRow() { return true; }
+function loadInflightState() { return null; }
+function _mergePendingSessionMessage() {}
+function _mergeInflightTailMessages() {}
+function _prepareRunningLiveTail() {}
+function _dropCurrentTurnAssistantMessages() {}
+function _currentTurnAssistantText() { return ''; }
+function _compactTranscriptText() { return ''; }
+async function _ensureMessagesLoaded(sid) {
+  S.messages = serverSessions[sid].messages.map(row => ({...row}));
+}
+function _isSessionActivelyViewed() { return true; }
+function _sessionVisitHasUnreadState() { return false; }
+async function _saveComposerDraftNow() { return undefined; }
+function clearLiveToolCards() {}
+function updateQueueBadge() {}
+function _appRootPath() { return '/'; }
+function api(path) {
+  if (path === '/api/session/new') {
+    newCalled();
+    return newResponse;
+  }
+  if (path.startsWith('/api/session?')) {
+    reloadCalled();
+    return reloadResponse;
+  }
+  throw new Error('unexpected API ' + path);
+}
+async function loadSession(sid, opts = {}) {
+  const forceReload = !!opts.force;
+  const currentSid = S.session ? S.session.session_id : null;
+  const sameSessionForceReload = forceReload && currentSid === sid;
+  __LOAD_SWITCH_BODY__
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+  if (!data || !_isCurrentLoad()) return;
+  __LOAD_METADATA_BODY__
+  await _ensureMessagesLoaded(sid, {loadGeneration: _loadGeneration});
+  if (!_isCurrentLoad()) return;
+  if (activeStreamId) {
+    S.busy = true;
+    S.activeStreamId = activeStreamId;
+  } else {
+    __LOAD_IDLE_BODY__
+  }
+  if (_isCurrentLoad()) _loadingSessionId = null;
+}
+async function newSession(flash, options = {}) { __NEW_SESSION_BODY__ }
+function snapshot() {
+  return JSON.stringify({
+    session: S.session, messages: S.messages, model: elements.modelSelect.value,
+    activeProfile: S.activeProfile, defaultModel: window._defaultModel,
+    provider: window._activeProvider, workspace: S.session && S.session.workspace,
+    url: calls.urls.at(-1), saved: localStorage.getItem('hermes-webui-session'),
+  });
+}
+(async () => {
+  if (order === 'reload-new') {
+    const oldLoad = loadSession('A', {force: true});
+    await reloadCalledPromise;
+    const newChat = newSession();
+    await newCalledPromise;
+    releaseNew({session: created});
+    await newChat;
+    assert.strictEqual(S.session.session_id, 'C');
+    const expected = snapshot();
+    releaseReload(serverSessions.A);
+    await oldLoad;
+    assert.strictEqual(snapshot(), expected);
+    return;
+  }
+  if (order === 'new-reload') {
+    const newChat = newSession();
+    await newCalledPromise;
+    const oldLoad = loadSession('A', {force: true});
+    await reloadCalledPromise;
+    releaseReload(serverSessions.A);
+    await oldLoad;
+    const expected = snapshot();
+    releaseNew({session: created});
+    assert.ok((await newChat) == null);
+    assert.strictEqual(snapshot(), expected);
+    return;
+  }
+  const newChat = newSession();
+  await newCalledPromise;
+  releaseNew({session: created});
+  await newChat;
+  assert.strictEqual(S.session.session_id, 'C');
+  assert.strictEqual(S.session.workspace, '/c');
+})().catch(error => { console.error(error.stack || error); process.exitCode = 1; });
+"""
+    script = (
+        script.replace("__ORDER__", json.dumps(order))
+        .replace("__NEW_SESSION_BODY__", _NEW_SESSION_BODY)
+        .replace("__LOAD_SWITCH_BODY__", _LOAD_SESSION_SWITCH_BODY)
+        .replace("__LOAD_METADATA_BODY__", _LOAD_SESSION_METADATA_BODY)
+        .replace("__LOAD_IDLE_BODY__", _LOAD_SESSION_IDLE_BODY)
+    )
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.mark.parametrize("command", ("goal", "pet", "busy-goal"))
+def test_empty_send_commands_abort_after_production_new_session_returns_null(command):
+    """An empty-pane command must stop when New Chat loses pane ownership."""
+    script = r"""
+const assert = require('assert');
+const command = __COMMAND__;
+const busyPath = command === 'busy-goal';
+let releaseNew, releaseBMetadata, newCalled, bMetadataCalled;
+const newCalledPromise = new Promise(resolve => newCalled = resolve);
+const bMetadataCalledPromise = new Promise(resolve => bMetadataCalled = resolve);
+const newResponse = new Promise(resolve => releaseNew = resolve);
+const bMetadataResponse = new Promise(resolve => releaseBMetadata = resolve);
+const calls = {goal: 0, pet: 0, queue: 0, starts: 0, renders: 0, resizes: 0, trays: 0};
+const elements = {
+  msg: {value: command === 'pet' ? '/pet hello' : '/goal stop'},
+  modelSelect: {value: 'A model', dataset: {provider: 'provider-a'}, appendChild() {}},
+  msgInner: {innerHTML: '<div>B history</div>'},
+  emptyState: {style: {display: 'none'}},
+  composerStatus: {textContent: ''},
+  a11yAnnouncer: {textContent: ''},
+  composerWorkspaceContext: {textContent: ''},
+};
+function $(id) { return elements[id] || null; }
+const document = {querySelector: () => null, createElement: () => ({dataset: {}, appendChild() {}})};
+const localStorage = {
+  values: {'hermes-webui-session': 'B'},
+  getItem(key) { return this.values[key] || null; },
+  setItem(key, value) { this.values[key] = String(value); },
+  removeItem(key) { delete this.values[key]; },
+};
+const window = {
+  _defaultMessageMode: 'queue', _defaultModel: 'A model', _activeProvider: 'provider-a',
+  _clearPendingSelections() {},
+};
+const history = {replaceState() {}};
+const B = {
+  session_id: 'B', title: 'B', model: 'B model', model_provider: 'provider-b',
+  workspace: '/b', profile: 'profile-b', active_stream_id: 'B-stream',
+};
+const created = {
+  session_id: 'C', title: 'Created', model: 'C model', model_provider: 'provider-c',
+  workspace: '/c', profile: 'profile-c', messages: [], last_usage: {},
+};
+const serverSessions = {B: {session: B, messages: [{role: 'assistant', content: 'B history'}]}};
+const S = {
+  session: null, messages: [], pendingFiles: [], busy: busyPath, activeStreamId: null,
+  activeProfile: 'profile-a', lastUsage: {}, toolCalls: [], todos: [], todoStateMeta: {},
+  _profileDefaultWorkspace: '/empty', _profileSwitchWorkspace: null,
+  _pendingSessionToolsets: null,
+};
+const INFLIGHT = Object.create(null);
+let _loadingSessionId = null, _loadSessionGeneration = 0;
+let _newSessionInFlight = null;
+let _sessionSourceFilter = 'webui';
+let _activeProject = null;
+const NO_PROJECT_FILTER = '__none__';
+let _messagesTruncated = false, _oldestIdx = 0, _pendingCarryForwardSnapshot = null;
+let _messageUserUnpinned = false, _scrollPinned = true, _loadingOlder = false;
+let _yoloEnabled = false;
+let _pendingSelections = [], _forcedSkillDirectivePending = null;
+let _pendingMoaConfig = null, _approvalSessionId = null, _clarifySessionId = null, _queueDrainSid = null;
+const _sessionStreamingById = new Map();
+let _sendInProgress = false, _sendInProgressSid = null;
+function _isSessionCurrentPane(sid) {
+  if (!sid || !S.session || S.session.session_id !== sid) return false;
+  return !(_loadingSessionId && _loadingSessionId !== sid);
+}
+function _setNewSessionPending(value) {
+  if (value) setComposerStatus('Creating new conversation…');
+  else if (elements.composerStatus.textContent === 'Creating new conversation…') setComposerStatus('');
+}
+function _newSessionPendingText() { return 'Creating new conversation…'; }
+function updateQueueBadge() {}
+function clearLiveToolCards() {}
+function _readEmptyComposerModelOverride() { return null; }
+function _clearEmptyComposerModelOverride() {}
+function _modelStateForSelect(select) { return {model: select.value, model_provider: select.dataset.provider}; }
+function _readPersistedModelState() { return null; }
+function _hydrateTodosFromSession() {}
+function _rememberNewChatDraftSession() {}
+function _setActiveSessionUrl() {}
+function startSessionStream() {}
+function _setSessionViewedCount() {}
+function _applyModelToDropdown(model, select) { select.value = model; return true; }
+function syncModelChip() {}
+function _setLiveAssistantTps() {}
+function _syncCtxIndicator() {}
+function setStatus() {}
+function setComposerStatus(value) { elements.composerStatus.textContent = String(value || ''); }
+function updateSendBtn() {}
+function syncTopbar() {}
+function renderMessages() { calls.renders++; }
+function _announceNewSessionWorkspace() {}
+function _deferWorkspaceRefreshForSession() {}
+function loadDir() { return Promise.resolve(); }
+function refreshSessionList() { calls.renders++; return Promise.resolve(); }
+function renderSessionList() { calls.renders++; return Promise.resolve(); }
+function _deferSessionSideEffect(sid, fn) { return Promise.resolve().then(fn); }
+function populateModelDropdown() { return Promise.resolve(); }
+function _resolveSessionModelForDisplaySoon(sid) {
+  const session = serverSessions[sid].session;
+  elements.modelSelect.value = session.model;
+  S.activeProfile = session.profile;
+  window._defaultModel = session.model;
+  window._activeProvider = session.model_provider;
+}
+function _acknowledgeSessionVisit() {}
+function _applyPendingSessionModelForSession() {}
+function _clearDeferredActiveSessionExternalRefresh() {}
+function _resetScrollDirectionTracker() {}
+function _uploadPendingFilesSyncProgressForSession() {}
+function clearInflightState() {}
+function _rearmActiveSessionStream() {}
+function clearCompressionUi() {}
+function _clearQueueCardDisplay() {}
+function stopApprovalPolling() {}
+function startApprovalPolling() {}
+function hideApprovalCard() {}
+function stopSessionStream() {}
+function _updateYoloPill() {}
+function stopClarifyPolling() {}
+function startClarifyPolling() {}
+function hideClarifyCard() {}
+function closeOtherLiveStreams() {}
+function snapshotLiveTurnHtmlForSession() {}
+function _captureSameSessionForceReloadHint() {}
+function _clearSameSessionForceReloadHint() {}
+function _clearStuckSessionOnBoot() {}
+function _opaqueActiveTurnToken(value) { return typeof value === 'string' ? value : null; }
+function _isServerIdleSessionRow() { return true; }
+function loadInflightState() { return null; }
+function _mergePendingSessionMessage() {}
+function _mergeInflightTailMessages() {}
+function _prepareRunningLiveTail() {}
+function _dropCurrentTurnAssistantMessages() {}
+function _currentTurnAssistantText() { return ''; }
+function _compactTranscriptText() { return ''; }
+function _isSessionActivelyViewed() { return true; }
+function _sessionVisitHasUnreadState() { return false; }
+async function _saveComposerDraftNow() { return undefined; }
+async function _ensureMessagesLoaded(sid) {
+  S.messages = serverSessions[sid].messages.map(row => ({...row}));
+}
+function autoResize() { calls.resizes++; }
+function renderTray() { calls.trays++; }
+function ensureLiveWorklogShell() {}
+function appendThinking() {}
+function upsertActiveSessionForLocalTurn() {}
+function showLiveRunStatus() {}
+function attachLiveStream() {}
+function markInflight() {}
+function saveInflightState() {}
+function clearOptimisticSessionStreaming() {}
+function hideLiveRunStatus() {}
+function removeThinking() {}
+function startApprovalPollingForSession() {}
+function startClarifyPollingForSession() {}
+function showToast() {}
+function queueSessionMessage() { calls.queue++; }
+function _clearStaleBusyStateBeforeSend() {}
+function isCompressionUiRunning() { return false; }
+function shouldInterceptCompressionRecoveryContinuation() { return false; }
+function _composerTextWithPendingSelections() { return elements.msg.value; }
+function _flushSelectionBlocksToComposer() {}
+function _chatPayloadModelState() { return {model: S.session.model, model_provider: S.session.model_provider}; }
+function _readPendingSessionModel() { return null; }
+function _opaqueActiveTurnToken(value) { return typeof value === 'string' && value.trim() ? value : null; }
+function _clearComposerDraft() { return Promise.resolve(); }
+function _restoreComposerDraftAfterFailedSend() {}
+function uploadPendingFiles() { return Promise.resolve([]); }
+function parseCommand(text) { return {name: text.split(/\s+/, 1)[0].slice(1), args: text.split(/\s+/).slice(1)}; }
+function hideCmdDropdown() {}
+const COMMANDS = [{name: 'goal', noEcho: false, fn() { calls.goal++; }}];
+const _AGENT_COMMANDS_RUN_ON_WEBUI = new Set();
+function getAgentCommandMetadata() { return Promise.resolve(null); }
+function getBundleCommandMetadata() { return null; }
+function _runOptionalPreStartUiStep(label, fn) { return fn(); }
+function _runOptionalPostStartUiStep(label, fn) { return fn(); }
+function _dismissHandoffHint() {}
+function _clearPendingSessionModel() {}
+function handlePetSlashCommand() { calls.pet++; return {handled: true, message: 'pet handled'}; }
+function api(path, options) {
+  if (path === '/api/session/new') {
+    newCalled();
+    return newResponse;
+  }
+  if (path.startsWith('/api/session?')) {
+    bMetadataCalled();
+    return bMetadataResponse;
+  }
+  if (path === '/api/chat/start') {
+    calls.starts++;
+    return Promise.resolve({stream_id: 'C-stream', active_turn_token: 'C-token', pending_started_at: 4});
+  }
+  throw new Error('unexpected API ' + path);
+}
+async function loadSession(sid, opts = {}) {
+  const forceReload = !!opts.force;
+  const currentSid = S.session ? S.session.session_id : null;
+  const sameSessionForceReload = forceReload && currentSid === sid;
+  __LOAD_SWITCH_BODY__
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+  if (!data || !_isCurrentLoad()) return;
+  __LOAD_METADATA_BODY__
+  await _ensureMessagesLoaded(sid, {loadGeneration: _loadGeneration});
+  if (!_isCurrentLoad()) return;
+  if (activeStreamId) {
+    S.busy = true;
+    S.activeStreamId = activeStreamId;
+  } else {
+    __LOAD_IDLE_BODY__
+  }
+  if (_isCurrentLoad()) _loadingSessionId = null;
+}
+async function newSession(flash, options = {}) { __NEW_SESSION_BODY__ }
+async function send() { __SEND_BODY__ }
+function snapshot() {
+  return JSON.stringify({
+    session: S.session, messages: S.messages, busy: S.busy, activeStreamId: S.activeStreamId,
+    activeProfile: S.activeProfile, model: elements.modelSelect.value,
+    defaultModel: window._defaultModel, provider: window._activeProvider,
+    composer: elements.msg.value, status: elements.composerStatus.textContent,
+  });
+}
+(async () => {
+  const sendPromise = send();
+  await newCalledPromise;
+  const loadPromise = loadSession('B');
+  await bMetadataCalledPromise;
+  releaseBMetadata(serverSessions.B);
+  await loadPromise;
+  const before = snapshot();
+  const counts = {...calls};
+  releaseNew({session: created});
+  await sendPromise;
+  assert.strictEqual(snapshot(), before);
+  assert.deepStrictEqual(calls, counts);
+  assert.strictEqual(calls.goal, 0);
+  assert.strictEqual(calls.pet, 0);
+  assert.strictEqual(calls.queue, 0);
+  assert.strictEqual(calls.starts, 0);
+})().catch(error => { console.error(error.stack || error); process.exitCode = 1; });
+"""
+    script = (
+        script.replace("__COMMAND__", json.dumps(command))
+        .replace("__NEW_SESSION_BODY__", _NEW_SESSION_BODY)
+        .replace("__LOAD_SWITCH_BODY__", _LOAD_SESSION_SWITCH_BODY)
+        .replace("__LOAD_METADATA_BODY__", _LOAD_SESSION_METADATA_BODY)
+        .replace("__LOAD_IDLE_BODY__", _LOAD_SESSION_IDLE_BODY)
+        .replace("__SEND_BODY__", _function_body(MESSAGES_JS, "send"))
+    )
     result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr or result.stdout
 

--- a/tests/test_inflight_send_start_race.py
+++ b/tests/test_inflight_send_start_race.py
@@ -1,4 +1,6 @@
 """Regression coverage for send/start optimistic INFLIGHT races."""
+import json
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -159,6 +161,72 @@ def test_post_start_bookkeeping_errors_cannot_block_live_attach():
     assert "S.messages.push({role:'assistant',content:`**Error:**" not in body[optional_idx : attach_idx], (
         "post-start optional failures should not append assistant error messages before stream attach"
     )
+
+
+def test_chat_start_stamps_shared_optimistic_row_with_server_turn_token():
+    body = _function_body(MESSAGES_JS, "send")
+    stamp_start = body.index("const _stampActiveTurnRows=()=>{")
+    stamp_end = body.index("  _stampActiveTurnRows();", stamp_start)
+    stamp = body[stamp_start:stamp_end]
+
+    script = f"""
+const userMsg = {{role:'user', content:'repeat me', _ts:50, _pending:true}};
+const S = {{messages:[
+  {{role:'user', content:'repeat me', _ts:100}},
+  {{role:'assistant', content:'completed', _ts:101}},
+]}};
+const INFLIGHT = {{sid:{{messages:[
+  {{role:'user', content:'repeat me', _ts:100}},
+  {{role:'assistant', content:'working', _live:true, _ts:102}},
+]}}}};
+const activeSid = 'sid';
+const streamId = 'new-stream';
+const _activeTurnToken = 'opaque-server-token';
+const startData = {{pending_started_at:200}};
+const uploadedNames = [];
+const optimisticMessages = [];
+{stamp}
+_stampActiveTurnRows();
+S.messages=[{{role:'user',content:'repeat me',_pending:true,_ts:100}}];
+INFLIGHT.sid.messages=[{{role:'user',content:'repeat me',_pending:true,_ts:100}}];
+_stampActiveTurnRows();
+process.stdout.write(JSON.stringify({{
+  visibleTokens:S.messages.filter(m=>m&&m.role==='user').map(m=>m._active_turn_token||null),
+  inflightTokens:INFLIGHT.sid.messages.filter(m=>m&&m.role==='user').map(m=>m._active_turn_token||null),
+  visibleAttachmentRow:S.messages.filter(m=>m&&m.role==='user').find(m=>m._active_turn_token===_activeTurnToken)===userMsg,
+  inflightAttachmentRow:INFLIGHT.sid.messages.filter(m=>m&&m.role==='user').find(m=>m._active_turn_token===_activeTurnToken)===userMsg,
+  replacedPendingRows:S.messages.filter(m=>m&&m.role==='user').map(m=>m._ts),
+  replacedPendingOwner:S.messages.find(m=>m&&m._active_turn_token===_activeTurnToken)===userMsg,
+}}));
+"""
+    result = json.loads(subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    ).stdout)
+
+    assert result == {
+        "visibleTokens": [None, "opaque-server-token"],
+        "inflightTokens": [None, "opaque-server-token"],
+        "visibleAttachmentRow": True,
+        "inflightAttachmentRow": True,
+        "replacedPendingRows": [100, 50],
+        "replacedPendingOwner": True,
+    }
+
+
+def test_inflight_storage_compaction_preserves_opaque_turn_token():
+    ui_src = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    compact = _function_body(ui_src, "_compactInflightState")
+    script = f"""
+function _getInflightStateLimits(){{return {{messages:24, toolCalls:48, stringChars:60000}};}}
+function _truncateInflightValue(value){{return value;}}
+function _compactInflightState(state){{{compact}}}
+const state = _compactInflightState({{activeTurnToken:'opaque:token with spaces', messages:[], toolCalls:[]}});
+process.stdout.write(JSON.stringify(state));
+"""
+    result = json.loads(subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    ).stdout)
+    assert result["activeTurnToken"] == "opaque:token with spaces"
 
 
 def test_server_absent_optimistic_first_turn_rows_are_not_kept_forever():

--- a/tests/test_inflight_send_start_race.py
+++ b/tests/test_inflight_send_start_race.py
@@ -3,6 +3,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
@@ -163,7 +165,8 @@ def test_post_start_bookkeeping_errors_cannot_block_live_attach():
     )
 
 
-def test_delayed_chat_start_keeps_a_owned_state_out_of_visible_b_pane():
+@pytest.mark.parametrize("pane_state", ("assigned", "loading"))
+def test_delayed_chat_start_keeps_a_owned_state_out_of_visible_b_pane(pane_state):
     """A delayed A start must finish in A's recovery state after the pane switches to B."""
     send_body = _function_body(MESSAGES_JS, "send")
     script = f"""
@@ -219,6 +222,12 @@ let _queueDrainSid = null;
 let _approvalSessionId = 'A';
 let _clarifySessionId = 'A';
 let uploadedName = 'a.txt';
+let _loadingSessionId = null;
+function _isSessionCurrentPane(sid) {{
+  if(!sid || !S.session || S.session.session_id!==sid) return false;
+  if(typeof _loadingSessionId!=='undefined' && _loadingSessionId && _loadingSessionId!==sid) return false;
+  return true;
+}}
 function visibleCall(name) {{
   if (switched) calls.visibleAfterSwitch.push(name);
 }}
@@ -292,11 +301,17 @@ async function send() {{{send_body}}}
   const sendPromise = send();
   await startCalledPromise;
 
-  S.session = B;
-  S.messages = [{{role: 'user', content: 'B existing'}}, {{role: 'assistant', content: 'B reply'}}];
-  S.activeStreamId = 'B-stream';
-  S.busy = true;
-  S.activeProfile = 'profile-b';
+  const paneState = {json.dumps(pane_state)};
+  if (paneState === 'assigned') {{
+    S.session = B;
+    S.messages = [{{role: 'user', content: 'B existing'}}, {{role: 'assistant', content: 'B reply'}}];
+    S.activeStreamId = 'B-stream';
+    S.busy = true;
+    S.activeProfile = 'profile-b';
+  }} else {{
+    S.messages = [];
+    _loadingSessionId = 'B';
+  }}
   INFLIGHT.B = {{
     streamId: 'B-stream', activeTurnToken: 'B-token',
     messages: S.messages.slice(), uploaded: [], toolCalls: [],
@@ -305,6 +320,8 @@ async function send() {{{send_body}}}
   localStorage.setItem('hermes-webui-inflight', bMarker);
   const visibleSessionBefore = JSON.parse(JSON.stringify(S.session));
   const visibleMessagesBefore = JSON.parse(JSON.stringify(S.messages));
+  const visibleActiveStreamBefore = S.activeStreamId;
+  const visibleBusyBefore = S.busy;
   const visibleInflightBefore = JSON.parse(JSON.stringify(INFLIGHT.B));
   switched = true;
 
@@ -313,8 +330,12 @@ async function send() {{{send_body}}}
 
   assert.deepStrictEqual(S.session, visibleSessionBefore);
   assert.deepStrictEqual(S.messages, visibleMessagesBefore);
-  assert.strictEqual(S.activeStreamId, 'B-stream');
-  assert.strictEqual(S.busy, true);
+  assert.strictEqual(S.activeStreamId, visibleActiveStreamBefore);
+  assert.strictEqual(S.busy, visibleBusyBefore);
+  if (paneState === 'assigned') {{
+    assert.strictEqual(S.activeStreamId, 'B-stream');
+    assert.strictEqual(S.busy, true);
+  }}
   assert.deepStrictEqual(INFLIGHT.B, visibleInflightBefore);
   assert.strictEqual(localStorage.getItem('hermes-webui-inflight'), bMarker);
   assert.strictEqual(calls.attach.length, 0);

--- a/tests/test_inflight_send_start_race.py
+++ b/tests/test_inflight_send_start_race.py
@@ -163,10 +163,188 @@ def test_post_start_bookkeeping_errors_cannot_block_live_attach():
     )
 
 
+def test_delayed_chat_start_keeps_a_owned_state_out_of_visible_b_pane():
+    """A delayed A start must finish in A's recovery state after the pane switches to B."""
+    send_body = _function_body(MESSAGES_JS, "send")
+    script = f"""
+const assert = require('assert');
+let switched = false;
+let releaseStart;
+let startCalled;
+const startCalledPromise = new Promise(resolve => startCalled = resolve);
+const startResponse = new Promise(resolve => releaseStart = resolve);
+const calls = {{
+  attach: [], saved: [], marked: [], visibleAfterSwitch: [], persistedModels: [],
+  modelControls: [], worklog: 0, topbar: 0, busyUi: 0, sidebar: 0,
+}};
+const elements = {{
+  msg: {{value: 'A prompt'}},
+  modelSelect: {{value: 'A requested model'}},
+}};
+function $(id) {{ return elements[id] || null; }}
+const document = {{querySelector: () => null}};
+const localStorage = {{
+  values: Object.create(null),
+  getItem(key) {{ return this.values[key] || null; }},
+  setItem(key, value) {{ this.values[key] = String(value); }},
+  removeItem(key) {{ delete this.values[key]; }},
+}};
+const window = {{_defaultMessageMode: 'steer', _defaultModel: 'A requested model', _activeProvider: 'provider-a'}};
+const A = {{
+  session_id: 'A', title: 'A', model: 'A requested model', model_provider: 'provider-a',
+  workspace: '/a', active_turn_token: 'A-old-token', pending_started_at: 10,
+}};
+const B = {{
+  session_id: 'B', title: 'B', model: 'B visible model', model_provider: 'provider-b',
+  workspace: '/b', active_turn_token: 'B-token', pending_started_at: 20,
+  active_stream_id: 'B-stream',
+}};
+const S = {{
+  session: A,
+  messages: [{{role: 'assistant', content: 'A history'}}],
+  pendingFiles: [{{name: 'a.txt'}}],
+  busy: false,
+  activeStreamId: null,
+  activeProfile: 'profile-a',
+  toolCalls: [],
+  todos: [],
+  todoStateMeta: null,
+}};
+const INFLIGHT = Object.create(null);
+let _sendInProgress = false;
+let _sendInProgressSid = null;
+let _pendingSelections = [];
+let _forcedSkillDirectivePending = null;
+let _queueDrainSid = null;
+let _approvalSessionId = 'A';
+let _clarifySessionId = 'A';
+let uploadedName = 'a.txt';
+function visibleCall(name) {{
+  if (switched) calls.visibleAfterSwitch.push(name);
+}}
+function renderMessages() {{}}
+function renderTray() {{}}
+function autoResize() {{}}
+function setComposerStatus() {{}}
+function setStatus() {{}}
+function setBusy(value) {{ S.busy = value; visibleCall('busy'); }}
+function updateSendBtn() {{ calls.busyUi++; visibleCall('send'); }}
+function ensureLiveWorklogShell() {{ calls.worklog++; visibleCall('worklog'); }}
+function appendThinking() {{ calls.worklog++; visibleCall('worklog'); }}
+function syncTopbar() {{ calls.topbar++; visibleCall('topbar'); }}
+function syncModelChip() {{ calls.modelControls.push(['provider-chip', S.session && S.session.session_id]); visibleCall('model'); }}
+function _applyModelToDropdown() {{ calls.modelControls.push(['dropdown', S.session && S.session.session_id]); visibleCall('model'); }}
+function _writePersistedModelState(model, provider) {{ calls.persistedModels.push([model, provider, S.session && S.session.session_id]); }}
+function showLiveRunStatus() {{ visibleCall('worklog-status'); }}
+function upsertActiveSessionForLocalTurn() {{ calls.sidebar++; visibleCall('sidebar'); }}
+function applySessionTitleUpdate() {{ calls.sidebar++; visibleCall('sidebar'); }}
+function renderSessionList() {{ calls.sidebar++; return Promise.resolve(); }}
+function renderSessionListFromCache() {{ calls.sidebar++; visibleCall('sidebar'); }}
+function startApprovalPolling() {{}}
+function startClarifyPolling() {{}}
+function stopApprovalPolling() {{ visibleCall('approval'); }}
+function stopClarifyPolling() {{ visibleCall('clarify'); }}
+function stopApprovalPollingForSession() {{}}
+function stopClarifyPollingForSession() {{}}
+function hideApprovalCard() {{ visibleCall('approval'); }}
+function hideClarifyCard() {{ visibleCall('clarify'); }}
+function removeThinking() {{ visibleCall('worklog'); }}
+function clearLiveToolCards() {{}}
+function _fetchYoloState() {{}}
+function markInflight(sid, streamId) {{ calls.marked.push([sid, streamId]); }}
+function saveInflightState(sid, state) {{
+  calls.saved.push([sid, JSON.parse(JSON.stringify(state))]);
+}}
+function clearInflightState() {{}}
+function clearOptimisticSessionStreaming() {{}}
+function attachLiveStream(sid, streamId, uploaded) {{ calls.attach.push([sid, streamId, uploaded]); }}
+function _clearComposerDraft() {{ return Promise.resolve(); }}
+function uploadPendingFiles() {{ return Promise.resolve([{{name: uploadedName, path: uploadedName}}]); }}
+function _clearStaleBusyStateBeforeSend() {{}}
+function isCompressionUiRunning() {{ return false; }}
+function _composerTextWithPendingSelections() {{ return elements.msg.value; }}
+function _flushSelectionBlocksToComposer() {{}}
+function _chatPayloadModelState() {{
+  return {{model: S.session.model, model_provider: S.session.model_provider}};
+}}
+function _readPendingSessionModel() {{ return null; }}
+function _opaqueActiveTurnToken(value) {{ return typeof value === 'string' && value.trim() ? value : null; }}
+function _restoreComposerDraftAfterFailedSend() {{}}
+function _runOptionalPreStartUiStep(label, fn) {{ return fn(); }}
+function _runOptionalPostStartUiStep(label, fn) {{ return fn(); }}
+function api(path, options) {{
+  assert.strictEqual(path, '/api/chat/start');
+  startCalled();
+  return startResponse;
+}}
+const startResult = {{
+  stream_id: 'A-stream', active_turn_token: 'A-token', pending_started_at: 30,
+  title: 'A server title', effective_model: 'A effective model',
+  effective_model_provider: 'provider-a-effective',
+}};
+async function send() {{{send_body}}}
+
+(async () => {{
+  const sendPromise = send();
+  await startCalledPromise;
+
+  S.session = B;
+  S.messages = [{{role: 'user', content: 'B existing'}}, {{role: 'assistant', content: 'B reply'}}];
+  S.activeStreamId = 'B-stream';
+  S.busy = true;
+  S.activeProfile = 'profile-b';
+  INFLIGHT.B = {{
+    streamId: 'B-stream', activeTurnToken: 'B-token',
+    messages: S.messages.slice(), uploaded: [], toolCalls: [],
+  }};
+  const visibleSessionBefore = JSON.parse(JSON.stringify(S.session));
+  const visibleMessagesBefore = JSON.parse(JSON.stringify(S.messages));
+  const visibleInflightBefore = JSON.parse(JSON.stringify(INFLIGHT.B));
+  switched = true;
+
+  releaseStart(startResult);
+  await sendPromise;
+
+  assert.deepStrictEqual(S.session, visibleSessionBefore);
+  assert.deepStrictEqual(S.messages, visibleMessagesBefore);
+  assert.strictEqual(S.activeStreamId, 'B-stream');
+  assert.strictEqual(S.busy, true);
+  assert.deepStrictEqual(INFLIGHT.B, visibleInflightBefore);
+  assert.strictEqual(calls.attach.length, 0);
+  assert.strictEqual(calls.worklog, 1);
+  assert.strictEqual(calls.topbar, 0);
+  assert.strictEqual(calls.persistedModels.length, 0);
+  assert.strictEqual(calls.modelControls.length, 0);
+  assert.strictEqual(calls.busyUi, 1);
+  assert.deepStrictEqual(calls.visibleAfterSwitch, []);
+
+  const a = INFLIGHT.A;
+  assert(a);
+  assert.strictEqual(a.streamId, 'A-stream');
+  assert.strictEqual(a.activeTurnToken, 'A-token');
+  assert.strictEqual(a.reattach, true);
+  const aUser = a.messages.find(row => row && row.role === 'user' && row.content === 'A prompt');
+  assert(aUser);
+  assert.deepStrictEqual(aUser.attachments, ['a.txt']);
+  assert.strictEqual(aUser._active_turn_token, 'A-token');
+  assert.deepStrictEqual(calls.marked, [['A', 'A-stream']]);
+  const persisted = calls.saved.filter(item => item[0] === 'A').at(-1)[1];
+  assert.strictEqual(persisted.streamId, 'A-stream');
+  assert.strictEqual(persisted.activeTurnToken, 'A-token');
+  assert.deepStrictEqual(persisted.messages.find(row => row.content === 'A prompt').attachments, ['a.txt']);
+}})().catch(error => {{
+  console.error(error.stack || error);
+  process.exitCode = 1;
+}});
+"""
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def test_chat_start_stamps_shared_optimistic_row_with_server_turn_token():
     body = _function_body(MESSAGES_JS, "send")
-    stamp_start = body.index("const _stampActiveTurnRows=()=>{")
-    stamp_end = body.index("  _stampActiveTurnRows();", stamp_start)
+    stamp_start = body.index("const _stampActiveTurnRows=(messages, preferredRow=null)=>{")
+    stamp_end = body.index("  const _stampInflightTurnState=()=>{", stamp_start)
     stamp = body[stamp_start:stamp_end]
 
     script = f"""
@@ -186,10 +364,12 @@ const startData = {{pending_started_at:200}};
 const uploadedNames = [];
 const optimisticMessages = [];
 {stamp}
-_stampActiveTurnRows();
+_stampActiveTurnRows(S.messages);
+_stampActiveTurnRows(INFLIGHT.sid.messages);
 S.messages=[{{role:'user',content:'repeat me',_pending:true,_ts:100}}];
 INFLIGHT.sid.messages=[{{role:'user',content:'repeat me',_pending:true,_ts:100}}];
-_stampActiveTurnRows();
+_stampActiveTurnRows(S.messages);
+_stampActiveTurnRows(INFLIGHT.sid.messages);
 process.stdout.write(JSON.stringify({{
   visibleTokens:S.messages.filter(m=>m&&m.role==='user').map(m=>m._active_turn_token||null),
   inflightTokens:INFLIGHT.sid.messages.filter(m=>m&&m.role==='user').map(m=>m._active_turn_token||null),

--- a/tests/test_inflight_send_start_race.py
+++ b/tests/test_inflight_send_start_race.py
@@ -251,7 +251,11 @@ function hideClarifyCard() {{ visibleCall('clarify'); }}
 function removeThinking() {{ visibleCall('worklog'); }}
 function clearLiveToolCards() {{}}
 function _fetchYoloState() {{}}
-function markInflight(sid, streamId) {{ calls.marked.push([sid, streamId]); }}
+function markInflight(sid, streamId) {{
+  const payload = JSON.stringify({{sid, streamId, ts: Date.now()}});
+  localStorage.setItem('hermes-webui-inflight', payload);
+  calls.marked.push([sid, streamId]);
+}}
 function saveInflightState(sid, state) {{
   calls.saved.push([sid, JSON.parse(JSON.stringify(state))]);
 }}
@@ -297,6 +301,8 @@ async function send() {{{send_body}}}
     streamId: 'B-stream', activeTurnToken: 'B-token',
     messages: S.messages.slice(), uploaded: [], toolCalls: [],
   }};
+  const bMarker = JSON.stringify({{sid: 'B', streamId: 'B-stream', ts: 123}});
+  localStorage.setItem('hermes-webui-inflight', bMarker);
   const visibleSessionBefore = JSON.parse(JSON.stringify(S.session));
   const visibleMessagesBefore = JSON.parse(JSON.stringify(S.messages));
   const visibleInflightBefore = JSON.parse(JSON.stringify(INFLIGHT.B));
@@ -310,6 +316,7 @@ async function send() {{{send_body}}}
   assert.strictEqual(S.activeStreamId, 'B-stream');
   assert.strictEqual(S.busy, true);
   assert.deepStrictEqual(INFLIGHT.B, visibleInflightBefore);
+  assert.strictEqual(localStorage.getItem('hermes-webui-inflight'), bMarker);
   assert.strictEqual(calls.attach.length, 0);
   assert.strictEqual(calls.worklog, 1);
   assert.strictEqual(calls.topbar, 0);
@@ -327,7 +334,7 @@ async function send() {{{send_body}}}
   assert(aUser);
   assert.deepStrictEqual(aUser.attachments, ['a.txt']);
   assert.strictEqual(aUser._active_turn_token, 'A-token');
-  assert.deepStrictEqual(calls.marked, [['A', 'A-stream']]);
+  assert.deepStrictEqual(calls.marked, []);
   const persisted = calls.saved.filter(item => item[0] === 'A').at(-1)[1];
   assert.strictEqual(persisted.streamId, 'A-stream');
   assert.strictEqual(persisted.activeTurnToken, 'A-token');

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -347,37 +347,37 @@ const assert = require('assert');
 {helper_src}
 
 let base = [
-  {{role:'user', content:'go'}},
+  {{role:'user', content:'go', _active_turn_token:'turn:1'}},
   {{role:'assistant', content:'First progress.'}},
   {{role:'tool', content:'{{}}'}},
   {{role:'assistant', content:'Second progress.'}},
 ];
 let inflight = [
-  {{role:'user', content:'go'}},
-  {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.\\n\\nSecond progress.'}},
+  {{role:'user', content:'go', _active_turn_token:'turn:1'}},
+  {{role:'assistant', _live:true, _active_turn_token:'turn:1', content:'First progress.\\n\\nSecond progress.\\n\\nSecond progress.'}},
 ];
-assert.strictEqual(_prepareRunningLiveTail(base, inflight), true);
+assert.strictEqual(_prepareRunningLiveTail(base, inflight, 'turn:1'), true);
 assert.strictEqual(inflight[1].content, 'First progress.\\n\\nSecond progress.');
-base = _dropCurrentTurnAssistantMessages(base);
-let merged = _mergeInflightTailMessages(base, inflight);
+base = _dropCurrentTurnAssistantMessages(base, 'turn:1');
+let merged = _mergeInflightTailMessages(base, inflight, 'turn:1');
 assert.strictEqual(merged.filter(m => m.role === 'assistant').length, 1);
 assert.strictEqual(merged[merged.length - 1]._live, true);
 assert.strictEqual(merged[merged.length - 1].content, 'First progress.\\n\\nSecond progress.');
 
 base = [
-  {{role:'user', content:'go'}},
+  {{role:'user', content:'go', _active_turn_token:'turn:1'}},
   {{role:'assistant', content:'First progress.'}},
   {{role:'tool', content:'{{}}'}},
   {{role:'assistant', content:'Second progress.'}},
 ];
 inflight = [
-  {{role:'user', content:'go'}},
-  {{role:'assistant', _live:true, content:'First progress.'}},
+  {{role:'user', content:'go', _active_turn_token:'turn:1'}},
+  {{role:'assistant', _live:true, _active_turn_token:'turn:1', content:'First progress.'}},
 ];
-assert.strictEqual(_prepareRunningLiveTail(base, inflight), true);
+assert.strictEqual(_prepareRunningLiveTail(base, inflight, 'turn:1'), true);
 assert.strictEqual(inflight[1].content, 'First progress.\\n\\nSecond progress.');
-base = _dropCurrentTurnAssistantMessages(base);
-merged = _mergeInflightTailMessages(base, inflight);
+base = _dropCurrentTurnAssistantMessages(base, 'turn:1');
+merged = _mergeInflightTailMessages(base, inflight, 'turn:1');
 assert.strictEqual(merged.filter(m => m.role === 'assistant').length, 1);
 assert.strictEqual(merged[merged.length - 1]._live, true);
 assert.strictEqual(merged[merged.length - 1].content, 'First progress.\\n\\nSecond progress.');
@@ -403,19 +403,20 @@ def test_running_reattach_rebuilds_live_assistant_from_last_text_before_activity
 const assert = require('assert');
 {helper_src}
 
-let base = [{{role:'user', content:'go'}}];
+let base = [{{role:'user', content:'go', _active_turn_token:'turn:1'}}];
 let inflightState = {{
   lastAssistantText:'Recovered progress text.',
   lastReasoningText:'',
-  messages:[{{role:'user', content:'go'}}],
+  activeTurnToken:'turn:1',
+  messages:[{{role:'user', content:'go', _active_turn_token:'turn:1'}}],
 }};
 assert.strictEqual(_ensureInflightLiveAssistantMessage(inflightState), true);
 assert.strictEqual(inflightState.messages.length, 2);
 assert.strictEqual(inflightState.messages[1]._live, true);
 assert.strictEqual(inflightState.messages[1].content, 'Recovered progress text.');
-assert.strictEqual(_prepareRunningLiveTail(base, inflightState.messages), true);
-base = _dropCurrentTurnAssistantMessages(base);
-const merged = _mergeInflightTailMessages(base, inflightState.messages);
+assert.strictEqual(_prepareRunningLiveTail(base, inflightState.messages, 'turn:1'), true);
+base = _dropCurrentTurnAssistantMessages(base, 'turn:1');
+const merged = _mergeInflightTailMessages(base, inflightState.messages, 'turn:1');
 assert.strictEqual(merged.filter(m => m.role === 'assistant').length, 1);
 assert.strictEqual(merged[merged.length - 1]._live, true);
 assert.strictEqual(merged[merged.length - 1].content, 'Recovered progress text.');
@@ -643,6 +644,7 @@ def test_upsert_live_tool_call_preserves_start_seq_for_complete():
         _function_decl(MESSAGES_JS, "_currentLiveToolAnchor"),
         _function_decl(MESSAGES_JS, "_findPendingLiveToolCallIndex"),
         _function_decl(MESSAGES_JS, "upsertLiveToolCall"),
+        _function_decl(SESSIONS_JS, "_opaqueActiveTurnToken"),
     ])
     script = (
         "const assert = require('assert');\n"
@@ -700,6 +702,7 @@ def test_upsert_live_tool_call_complete_matches_by_name_burst_without_tid():
         _function_decl(MESSAGES_JS, "_currentLiveToolAnchor"),
         _function_decl(MESSAGES_JS, "_findPendingLiveToolCallIndex"),
         _function_decl(MESSAGES_JS, "upsertLiveToolCall"),
+        _function_decl(SESSIONS_JS, "_opaqueActiveTurnToken"),
     ])
     script = (
         "const assert = require('assert');\n"
@@ -751,6 +754,7 @@ def test_upsert_flags_orphan_complete_but_not_normal_start_complete():
         _function_decl(MESSAGES_JS, "_currentLiveToolAnchor"),
         _function_decl(MESSAGES_JS, "_findPendingLiveToolCallIndex"),
         _function_decl(MESSAGES_JS, "upsertLiveToolCall"),
+        _function_decl(SESSIONS_JS, "_opaqueActiveTurnToken"),
     ])
     script = (
         "const assert = require('assert');\n"
@@ -856,9 +860,9 @@ def test_load_session_rebuilds_live_tail_before_snapshot_fallback():
     body = _function_body(SESSIONS_JS, "loadSession")
     ensure_pos = body.find("_ensureInflightLiveAssistantMessage(INFLIGHT[sid]);")
     inflight_pos = body.find("const inflightMessages=_projectInflightMessagesForActivityBursts(INFLIGHT[sid]);")
-    prepare_pos = body.find("const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);")
-    drop_assistant_pos = body.find("S.messages=_dropCurrentTurnAssistantMessages(S.messages);")
-    merge_pos = body.find("S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);")
+    prepare_pos = body.find("const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages,activeTurnToken);")
+    drop_assistant_pos = body.find("S.messages=_dropCurrentTurnAssistantMessages(S.messages,activeTurnToken);")
+    merge_pos = body.find("S.messages=_mergeInflightTailMessages(S.messages,inflightMessages,activeTurnToken);")
     restore_pos = body.find("restoreLiveTurnHtmlForSession(sid)")
     assert ensure_pos != -1 and inflight_pos != -1
     assert prepare_pos != -1
@@ -978,7 +982,7 @@ def test_merge_inflight_tail_preserves_all_segmented_live_progress():
     groups whose burst ids point to those anchors pile up at the bottom.
     """
     assert NODE, "node not on PATH"
-    helper_start = SESSIONS_JS.index("function _currentTailUserMessage")
+    helper_start = SESSIONS_JS.index("function _opaqueActiveTurnToken")
     fn_start = SESSIONS_JS.index("function _mergeInflightTailMessages")
     fn_end = SESSIONS_JS.index("// Load older messages", fn_start)
     tail_user_helpers = SESSIONS_JS[helper_start:fn_start]
@@ -998,7 +1002,7 @@ const inflight = [
   {{role:'assistant', _live:true, content:'second progress', _activityBurstId:2}},
   {{role:'assistant', _live:true, content:'third progress', _activityBurstId:3}},
 ];
-const merged = _mergeInflightTailMessages(base, inflight);
+const merged = _mergeInflightTailMessages(base, inflight, null);
 assert.deepStrictEqual(
   merged.filter(m => m.role === 'assistant').map(m => m.content),
   ['first progress', 'second progress', 'third progress']

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -64,7 +64,7 @@ def test_pending_user_message_dedup_checks_current_message_array():
         "Pending-message dedup must inspect the current S.messages/INFLIGHT "
         "array, not only session.messages from the metadata response"
     )
-    assert "_pendingCurrentTailUserMessage(messages)" in helper, (
+    assert "_pendingCurrentTailUserMessage(messages,session?.pending_started_at)" in helper.replace(" ", ""), (
         "Pending-message dedup must inspect only the current tail user row, "
         "not a historical same-text row"
     )

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -64,9 +64,18 @@ def test_pending_user_message_dedup_checks_current_message_array():
         "Pending-message dedup must inspect the current S.messages/INFLIGHT "
         "array, not only session.messages from the metadata response"
     )
-    assert "_pendingCurrentTailUserMessage(messages,session?.pending_started_at)" in helper.replace(" ", ""), (
-        "Pending-message dedup must inspect only the current tail user row, "
-        "not a historical same-text row"
+    compact_helper = "".join(helper.split())
+    assert "_pendingCurrentTailUserMessage(messages,session?.pending_started_at,undefined,session&&(session.active_turn_token??session.activeTurnToken),);" in compact_helper, (
+        "Pending-message dedup must inspect only the current tail user row and "
+        "carry the server-issued opaque active-turn token"
+    )
+    tail_start = UI_JS.find("function _pendingCurrentTailUserMessage")
+    tail_end = UI_JS.find("// Precision-only epsilon", tail_start)
+    assert tail_start != -1 and tail_end > tail_start
+    tail_helper = "".join(UI_JS[tail_start:tail_end].split())
+    assert "msg._active_turn_token!==activeTurnToken" in tail_helper, (
+        "Pending tool activity carrying a token must match the exact "
+        "server-issued active-turn token"
     )
     assert "sameCurrentTurn" in helper and "return null;" in helper, (
         "Pending-message merge must still suppress duplicates when the current "

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -73,7 +73,7 @@ def test_pending_user_message_dedup_checks_current_message_array():
     tail_end = UI_JS.find("// Precision-only epsilon", tail_start)
     assert tail_start != -1 and tail_end > tail_start
     tail_helper = "".join(UI_JS[tail_start:tail_end].split())
-    assert "msg._active_turn_token!==activeTurnToken" in tail_helper, (
+    assert "msg._active_turn_token!==authoritativeToken" in tail_helper, (
         "Pending tool activity carrying a token must match the exact "
         "server-issued active-turn token"
     )

--- a/tests/test_issue2518_active_provider_fallback.py
+++ b/tests/test_issue2518_active_provider_fallback.py
@@ -41,6 +41,52 @@ def _read(rel_path: str) -> str:
     return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
 
 
+def _function_source(source: str, marker: str) -> str:
+    start = source.find(marker)
+    assert start >= 0, f"{marker!r} not found"
+    body_start = source.find("{", source.find(")", start))
+    assert body_start >= 0, f"{marker!r} has no body"
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    i = body_start
+    while i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+        elif block_comment:
+            if ch == "*" and nxt == "/":
+                block_comment = False
+                i += 1
+        elif quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch == "/" and nxt == "/":
+            line_comment = True
+            i += 1
+        elif ch == "/" and nxt == "*":
+            block_comment = True
+            i += 1
+        elif ch in "'\"`":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+        i += 1
+    raise AssertionError(f"{marker!r} body is not balanced")
+
+
 # ---------------------------------------------------------------------------
 # Client-side: source-shape check that the fallback is wired in newSession().
 # ---------------------------------------------------------------------------
@@ -50,10 +96,7 @@ class TestClientFallbackSourceShape:
     """Static checks that the fallback chain lives inside newSession()."""
 
     def test_active_provider_fallback_present(self):
-        src = _read("static/sessions.js")
-        idx = src.find("async function newSession(flash, options={}){")
-        assert idx != -1
-        body = src[idx:idx + 6000]
+        body = _function_source(_read("static/sessions.js"), "async function newSession(")
         assert "window._activeProvider" in body, (
             "newSession() must consult window._activeProvider when the dropdown "
             "did not yield a truthy model_provider (cold boot, empty "
@@ -61,9 +104,7 @@ class TestClientFallbackSourceShape:
         )
 
     def test_previous_session_fallback_present(self):
-        src = _read("static/sessions.js")
-        idx = src.find("async function newSession(flash, options={}){")
-        body = src[idx:idx + 6000]
+        body = _function_source(_read("static/sessions.js"), "async function newSession(")
         assert "S.session&&S.session.model_provider" in body, (
             "newSession() must fall back to the previous session's "
             "model_provider when neither the dropdown nor window._activeProvider "
@@ -72,27 +113,25 @@ class TestClientFallbackSourceShape:
 
     def test_fallback_chain_order(self):
         """Fallback order: explicit > _activeProvider > prev-session > null."""
-        src = _read("static/sessions.js")
-        idx = src.find("async function newSession(flash, options={}){")
-        body = src[idx:idx + 6000]
-        explicit = body.find("newModelState.model_provider")
+        body = _provider_assignment_in_new_session()
+        assignment = body[body.index("reqBody.model_provider=") :]
+        explicit = assignment.find("newModelState.model_provider")
+        fallback = assignment.find("_fallbackProvider")
         active = body.find("window._activeProvider")
         prev = body.find("S.session&&S.session.model_provider")
-        assert -1 < explicit < active < prev, (
-            f"Fallback chain order broken: explicit={explicit}, "
-            f"_activeProvider={active}, prev-session={prev}. "
+        assert -1 < explicit < fallback, (
+            f"Explicit provider must precede fallback: explicit={explicit}, "
+            f"fallback={fallback}. "
+        )
+        assert -1 < active < prev, (
+            f"Fallback chain order broken: _activeProvider={active}, prev-session={prev}. "
             "Explicit selection must beat _activeProvider which must beat "
             "the previous session's model_provider."
         )
 
     def test_issue_referenced_in_source(self):
         """Future readers should be able to trace this back to the issue."""
-        src = _read("static/sessions.js")
-        idx = src.find("async function newSession(flash, options={}){")
-        # Window covers the model-fallback region of newSession(); the function
-        # has grown over time (e.g. pre-session toolset staging #4490), so keep
-        # the window comfortably larger than the fallback block it guards.
-        body = src[idx:idx + 5000]
+        body = _function_source(_read("static/sessions.js"), "async function newSession(")
         assert "#2518" in body, (
             "newSession()'s fallback comment should reference #2518 so the "
             "follow-up provenance survives future refactors."
@@ -205,16 +244,10 @@ def _provider_assignment_in_new_session() -> str:
             || (_bareModel ? (window._activeProvider || (S.session && S.session.model_provider)) : null)
             || null;
 
-    Both lines live in the same 4000-char slice of newSession()'s
-    function body, so the helper can read them as a single contract
-    unit. Anchors on the ``=`` of the assignment (not a prose mention
-    in a comment) and on the guard declaration so future comments
-    referencing ``reqBody.model_provider`` cannot confuse it.
+    The helper balances the complete newSession() body first, then anchors on
+    the guard and assignment so comments or later code cannot confuse it.
     """
-    src = _read("static/sessions.js")
-    idx = src.find("async function newSession(flash, options={}){")
-    assert idx != -1, "newSession() must be defined in static/sessions.js"
-    body = src[idx : idx + 7000]
+    body = _function_source(_read("static/sessions.js"), "async function newSession(")
     guard_start = body.find("const _bareModel")
     assert guard_start != -1, (
         "newSession() must declare a 'const _bareModel' guard for the "

--- a/tests/test_issue2977_use_command.py
+++ b/tests/test_issue2977_use_command.py
@@ -8,6 +8,98 @@ def read(path):
     return (ROOT / path).read_text(encoding="utf-8")
 
 
+def _function_source(source, marker):
+    start = source.find(marker)
+    assert start >= 0, f"{marker!r} not found"
+    body_start = source.find("{", source.find(")", start))
+    assert body_start >= 0, f"{marker!r} has no body"
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    i = body_start
+    while i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+        elif block_comment:
+            if ch == "*" and nxt == "/":
+                block_comment = False
+                i += 1
+        elif quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch == "/" and nxt == "/":
+            line_comment = True
+            i += 1
+        elif ch == "/" and nxt == "*":
+            block_comment = True
+            i += 1
+        elif ch in "'\"`":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+        i += 1
+    raise AssertionError(f"{marker!r} body is not balanced")
+
+
+def _balanced_block(source, marker):
+    start = source.find(marker)
+    assert start >= 0, f"{marker!r} not found"
+    brace = source.find("{", start)
+    assert brace >= 0, f"{marker!r} has no opening brace"
+    depth = 0
+    quote = None
+    escaped = False
+    line_comment = False
+    block_comment = False
+    i = brace
+    while i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+        elif block_comment:
+            if ch == "*" and nxt == "/":
+                block_comment = False
+                i += 1
+        elif quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch == "/" and nxt == "/":
+            line_comment = True
+            i += 1
+        elif ch == "/" and nxt == "*":
+            block_comment = True
+            i += 1
+        elif ch in "'\"`":
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+        i += 1
+    raise AssertionError(f"{marker!r} block is not balanced")
+
+
 def test_use_entry_in_commands_array():
     src = read("static/commands.js")
     assert "{name:'use'," in src, "COMMANDS must contain a {name:'use', ...} entry"
@@ -57,20 +149,39 @@ def test_use_entry_has_subArgs_skills():
 
 def test_directive_consumed_at_injection_site():
     """_forcedSkillDirectivePending is cleared at the consume site, not in finally."""
-    src = read("static/messages.js")
-    finally_part = src.split("finally")[1] if "finally" in src else ""
-    assert "_forcedSkillDirectivePending = null;" not in finally_part, \
+    send = _function_source(read("static/messages.js"), "async function send(")
+    forced = _balanced_block(send, "if(_submittedForcedSkill){")
+    session_match = _balanced_block(forced, "if(!_pending.sessionId||_pending.sessionId===activeSid){")
+    finally_block = _balanced_block(send, "finally{")
+    assert "_forcedSkillDirectivePending" not in finally_block, \
         "_forcedSkillDirectivePending must NOT be cleared in the finally block"
-    assert "const _directivePayload = await _pending.promise;" in src, \
+    submitted_pos = send.index("const _submittedForcedSkill=_forcedSkillDirectivePending;")
+    upload_pos = send.index("await uploadPendingFiles")
+    directive_await_pos = send.index("const _directivePayload = await _pending.promise;")
+    chat_start_pos = send.index("api('/api/chat/start'")
+    assert submitted_pos < upload_pos < directive_await_pos < chat_start_pos
+    assert "const _submittedForcedSkill=_forcedSkillDirectivePending;" in send, \
+        "send() must snapshot the forced-skill owner before awaiting"
+    assert "const _pending=_submittedForcedSkill;" in forced, \
+        "the injection site must consume the snapshotted owner"
+    assert "const _pending=_forcedSkillDirectivePending;" not in send, \
+        "the consume site must not re-read the mutable global"
+    assert "const _directivePayload = await _pending.promise;" in session_match, \
         "consume site must await the pending promise"
-    assert "_forcedSkillDirectivePending = null;" in src, \
+    owner_check = session_match.index("if(_forcedSkillDirectivePending===_pending)")
+    clear_pos = session_match.index("_forcedSkillDirectivePending=null;")
+    context_pos = session_match.index("const _forcedSkillBlock")
+    assert owner_check < clear_pos < context_pos
+    assert "if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending=null;" in session_match, \
         "_forcedSkillDirectivePending must be cleared somewhere in messages.js"
+    assert session_match.count("_forcedSkillDirectivePending") == 2, \
+        "the consume block may only inspect the global for the equality-guarded clear"
 
 
 def test_directive_injection_before_empty_guard():
-    src = read("static/messages.js")
-    inject_pos = src.index("_forcedSkillDirectivePending")
-    guard_pos = src.index("if(!msgText){setComposerStatus('Nothing to send');return;}")
+    send = _function_source(read("static/messages.js"), "async function send(")
+    inject_pos = send.index("const _forcedSkillBlock")
+    guard_pos = send.index("if(!msgText){if(_ownsSendPane()) setComposerStatus('Nothing to send');return;}")
     assert inject_pos < guard_pos, "directive injection must appear before the if(!msgText) guard"
 
 
@@ -118,12 +229,29 @@ def test_directive_pending_captures_session_id():
 
 
 def test_directive_only_consumed_by_matching_session():
-    src = read("static/messages.js")
-    assert "const _pending=_forcedSkillDirectivePending;" in src, \
+    src = _function_source(read("static/messages.js"), "async function send(")
+    forced = _balanced_block(src, "if(_submittedForcedSkill){")
+    session_match = _balanced_block(forced, "if(!_pending.sessionId||_pending.sessionId===activeSid){")
+    assert "const _submittedForcedSkill=_forcedSkillDirectivePending;" in src, \
         "send() must snapshot the pending directive before awaiting it"
-    assert "if(!_pending.sessionId||_pending.sessionId===activeSid){" in src, \
+    assert "const _pending=_submittedForcedSkill;" in forced, \
+        "the consume site must use the frozen directive owner"
+    assert "if(!_pending.sessionId||_pending.sessionId===activeSid){" in forced, \
         "send() must only consume /use directives issued for the active session"
-    assert "if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending = null;" in src, \
+    assert "if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending=null;" in session_match, \
         "send() must not clear a newer pending directive created while awaiting"
-    assert "[FORCED SKILL CONTEXT: ${_forcedSkillName}]" in src, \
+    assert "[FORCED SKILL CONTEXT: ${_forcedSkillName}]" in session_match, \
         "send() must prepend deterministic forced-skill content before the user message"
+
+
+def test_older_directive_cannot_clear_newer_pending_owner():
+    """The old owner can clear the global only while it is still current."""
+    send = _function_source(read("static/messages.js"), "async function send(")
+    session_match = _balanced_block(
+        _balanced_block(send, "if(_submittedForcedSkill){"),
+        "if(!_pending.sessionId||_pending.sessionId===activeSid){",
+    )
+    clear = "if(_forcedSkillDirectivePending===_pending)_forcedSkillDirectivePending=null;"
+    assert session_match.count(clear) == 1
+    assert session_match.count("_forcedSkillDirectivePending=null;") == 1
+    assert "_forcedSkillDirectivePending=null;" not in session_match.replace(clear, "")

--- a/tests/test_issue4843_pet_webui_command.py
+++ b/tests/test_issue4843_pet_webui_command.py
@@ -180,7 +180,9 @@ def _run_send_js(*, command, status, adapter_status=None, hook_result=None, hook
           updateSendBtn(){{}},
           clearOptimisticSessionStreaming(){{}},
           newSession: async () => {{
-            ctx.S.session = {{ session_id: 'sid-1', title: 'New Chat' }};
+            const created = {{ session_id: 'sid-1', title: 'New Chat' }};
+            ctx.S.session = created;
+            return created;
           }},
           $: id => {{
             if (id === 'msg') return msgInput;

--- a/tests/test_issue5057_moa_webui_route.py
+++ b/tests/test_issue5057_moa_webui_route.py
@@ -163,8 +163,18 @@ def test_moa_config_is_per_turn_not_persisted():
     assert "MoA override is unavailable on gateway-backed sessions" in routes_source
     js_path = Path(__file__).resolve().parent.parent / "static" / "messages.js"
     js_source = js_path.read_text(encoding="utf-8")
-    assert "moa_config:_pendingMoaConfig?true:undefined" in js_source
-    assert "_pendingMoaConfig=null" in js_source
+    send_start = js_source.index("async function send(){")
+    send_end = js_source.index("\n}\n\nconst LIVE_STREAMS", send_start)
+    send_body = js_source[send_start:send_end]
+    capture = "const _submittedMoaConfig=!!_pendingMoaConfig;"
+    assert capture in send_body, "MoA selection must be frozen in the per-send local payload"
+    assert "moa_config:_submittedMoaConfig?true:undefined" in send_body
+    capture_idx = send_body.index(capture)
+    assert send_body.index("let _pendingMoaConfig=null;") < capture_idx
+    assert capture_idx < send_body.index("const startData=await api('/api/chat/start'")
+    assert re.search(r"(?m)^\s*_pendingMoaConfig=null;", send_body) is None, (
+        "the per-send MoA marker must not be cleared by a later continuation"
+    )
 
 
 def test_moa_gateway_chat_start_fails_closed(monkeypatch, tmp_path):

--- a/tests/test_issue5472_preserve_draft_on_failed_send.py
+++ b/tests/test_issue5472_preserve_draft_on_failed_send.py
@@ -11,7 +11,7 @@ must retype.
 Fix: ``send()`` snapshots the ORIGINAL typed text + staged files BEFORE slash
 rewrites (/moa, bundles) mutate the payload and BEFORE the upload drains
 ``S.pendingFiles``. On a start-time throw,
-``_restoreComposerDraftAfterFailedSend(text, files, sid)`` restores that exact
+``_restoreComposerDraftAfterFailedSend(text, files, sid, clearPromise)`` restores that exact
 snapshot, re-stages the files, and re-persists the draft. It is session-aware
 (never pollutes a different session's visible composer) and never clobbers a new
 message the user began typing during the async window.
@@ -46,14 +46,15 @@ def _helper_body() -> str:
     return MESSAGES_JS[start:end]
 
 
-def test_helper_has_new_three_arg_signature_and_guards():
+def test_helper_has_load_aware_signature_and_guards():
     body = _helper_body()
     assert "function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, clearPromise)" in body
     # No-op when there is nothing to restore (no text AND no staged files).
     assert "if(!restore&&!files.length) return false;" in body
-    # Session-aware: never mutate a different session's visible composer.
-    assert "const visibleSid=(S.session&&S.session.session_id)||null;" in body
-    assert "const belongsToVisible=!(sid&&visibleSid&&sid!==visibleSid);" in body
+    # Session-aware: a pending load owns the pane even while S.session still
+    # names the old session, so visible mutations use the shared load-aware gate.
+    assert "const belongsToVisible=typeof _isSessionCurrentPane==='function'" in body
+    assert "_isSessionCurrentPane(sid)" in body
     # Never clobber a message the user began typing during the async window.
     assert "if(inp && !String(inp.value||'').trim()){" in body
     # Restores text and re-stages files.
@@ -62,8 +63,9 @@ def test_helper_has_new_three_arg_signature_and_guards():
     # The deferred persist is stale-aware: re-reads the LIVE composer when the
     # failed session is still visible (Codex #5488 catch), rather than the
     # captured snapshot.
-    assert "const stillVisible=(S.session&&S.session.session_id)===sid;" in body
+    assert "const stillVisible=typeof _isSessionCurrentPane==='function'" in body
     assert "const liveText=inp?String(inp.value||''):restore;" in body
+    assert "_saveComposerDraftNow(sid, restore, files);" in body
 
 
 def test_send_captures_immutable_snapshot_before_rewrites_and_upload():
@@ -161,7 +163,9 @@ def test_restore_persist_chains_after_the_clear_promise():
 # Behavioral test — actually execute the helper in a JS sandbox
 # ---------------------------------------------------------------------------
 
-def _run_helper_in_node(draft_text, files_snapshot, initial_input, visible_sid, sid="sid-1"):
+def _run_helper_in_node(
+    draft_text, files_snapshot, initial_input, visible_sid, sid="sid-1", loading_sid=None
+):
     """Execute _restoreComposerDraftAfterFailedSend in a node vm sandbox."""
     node = shutil.which("node")
     if not node:  # pragma: no cover
@@ -179,6 +183,11 @@ def _run_helper_in_node(draft_text, files_snapshot, initial_input, visible_sid, 
         };
         const $ = (id) => (id === 'msg' ? state.input : null);
         const S = {pendingFiles: state.pendingFiles, session: %(session)s};
+        const _loadingSessionId = %(loading_sid)s;
+        function _isSessionCurrentPane(sid){
+          return !!(sid && S.session && S.session.session_id === sid
+            && (!_loadingSessionId || _loadingSessionId === sid));
+        }
         function autoResize(){ state.input.resized = true; }
         function updateSendBtn(){ state.sendBtnUpdated = true; }
         function renderTray(){ state.trayRendered = true; }
@@ -204,6 +213,7 @@ def _run_helper_in_node(draft_text, files_snapshot, initial_input, visible_sid, 
         "draft_text": json.dumps(draft_text),
         "files": json.dumps(files_snapshot),
         "sid": json.dumps(sid),
+        "loading_sid": json.dumps(loading_sid),
     }
     proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
@@ -257,6 +267,26 @@ def test_does_not_pollute_a_different_visible_session():
     assert out["inputValue"] == ""
     assert out["pendingFiles"] == []
     assert out["saved"] == {"sid": "sid-1", "text": "failed on old session", "files": []}
+
+
+def test_pending_load_owns_the_new_pane_for_background_failure_recovery():
+    """A pending B load makes an installed A send background-owned at the boundary."""
+    files = [{"name": "a.txt"}]
+    out = _run_helper_in_node(
+        "failed while switching",
+        files,
+        "",
+        visible_sid="sid-1",
+        loading_sid="sid-2",
+    )
+    assert out["ret"] is False
+    assert out["inputValue"] == ""
+    assert out["pendingFiles"] == []
+    assert out["saved"] == {
+        "sid": "sid-1",
+        "text": "failed while switching",
+        "files": files,
+    }
 
 
 def test_noop_when_nothing_to_restore():

--- a/tests/test_issue6419_pending_user_reconnect_order.py
+++ b/tests/test_issue6419_pending_user_reconnect_order.py
@@ -37,6 +37,46 @@ def _function_body(src: str, name: str) -> str:
     return source[source.find("{") :]
 
 
+def _production_pending_helpers() -> str:
+    epsilon_start = UI_JS.find("const _PENDING_ACTIVE_TURN_TS_EPSILON=")
+    assert epsilon_start >= 0
+    epsilon_end = UI_JS.find("\n", epsilon_start)
+    return "\n".join(
+        [
+            UI_JS[epsilon_start:epsilon_end],
+            _function_source(UI_JS, "_timestampSeconds"),
+            _function_source(UI_JS, "_firstValidTimestampSeconds"),
+            _function_source(UI_JS, "_isTailActivityOwnedByCandidateTurn"),
+            _function_source(UI_JS, "_isCanonicalAssistantToolCallEnvelope"),
+            _function_source(UI_JS, "_pendingCurrentTailUserMessage"),
+            _function_source(UI_JS, "_messageTimestampSeconds"),
+            _function_source(UI_JS, "_activeTurnTokenMatches"),
+            _function_source(UI_JS, "_pendingActiveTurnUserMessage"),
+            _function_source(UI_JS, "msgContent"),
+            _function_source(UI_JS, "_isContextCompactionText"),
+            _function_source(UI_JS, "_isContextCompactionMessage"),
+            _function_source(UI_JS, "getPendingSessionMessage"),
+        ]
+    )
+
+
+def _merge_helpers() -> str:
+    return "\n".join(
+        [
+            _function_source(SESSIONS_JS, "_messageComparableText"),
+            _function_source(SESSIONS_JS, "_stripAttachedFilesMarker"),
+            _function_source(SESSIONS_JS, "_stripForcedSkillEnvelope"),
+            _function_source(SESSIONS_JS, "_normalizeUserTranscriptText"),
+            _function_source(SESSIONS_JS, "_sameTranscriptMessage"),
+            _function_source(SESSIONS_JS, "_opaqueActiveTurnToken"),
+            _function_source(SESSIONS_JS, "_currentTailUserMessage"),
+            _function_source(SESSIONS_JS, "_hasCurrentTailUserDuplicate"),
+            _production_pending_helpers(),
+            _function_source(SESSIONS_JS, "_mergePendingSessionMessage"),
+        ]
+    )
+
+
 # ─── Shared helper contract ────────────────────────────────────────────────
 
 def test_merge_pending_session_message_is_a_global_helper():
@@ -131,29 +171,12 @@ def test_merge_helper_repairs_malformed_order_and_is_idempotent():
     """A reconnect can already contain [live assistant, pending user]. The
     canonical helper must move that exact user row before the live boundary,
     preserve its metadata/attachments, and remain ordered on repeated probes."""
-    helpers = "\n".join(
-        [
-            _function_source(SESSIONS_JS, "_messageComparableText"),
-            _function_source(SESSIONS_JS, "_stripAttachedFilesMarker"),
-            _function_source(SESSIONS_JS, "_stripForcedSkillEnvelope"),
-            _function_source(SESSIONS_JS, "_normalizeUserTranscriptText"),
-            _function_source(SESSIONS_JS, "_sameTranscriptMessage"),
-            _function_source(SESSIONS_JS, "_opaqueActiveTurnToken"),
-            _function_source(SESSIONS_JS, "_currentTailUserMessage"),
-            _function_source(SESSIONS_JS, "_hasCurrentTailUserDuplicate"),
-            _function_source(SESSIONS_JS, "_mergePendingSessionMessage"),
-        ]
-    )
+    helpers = _merge_helpers()
     script = f"""
 {helpers}
-function getPendingSessionMessage(session, messages){{
-  const text=String(session.pending_user_message||'').trim();
-  if(!text) return null;
-  return {{role:'user',content:text,_pending:true,_ts:session.pending_started_at,_active_turn_token:session.active_turn_token}};
-}}
 const historical={{role:'user',content:'same prompt',_ts:1}};
 const settled={{role:'assistant',content:'old answer',_ts:2}};
-const live={{role:'assistant',content:'working',_live:true,_ts:4}};
+const live={{role:'assistant',content:'working',_live:true,_ts:4,_active_turn_token:'opaque:turn-3'}};
 const misplaced={{
   role:'user',content:'same prompt',_pending:true,_ts:3,
   attachments:[{{path:'proof.txt'}}],_source:'resume',_active_turn_token:'opaque:turn-3'
@@ -185,22 +208,75 @@ process.stdout.write(JSON.stringify({{first,second,afterFirst,final:messages}}))
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_merge_helper_fails_closed_without_exact_pending_owner():
+    """Unknown identity must materialize safely without adopting attachments."""
+    helpers = _merge_helpers()
+    script = f"""
+{helpers}
+function summarize(rows){{
+  return rows.map(row=>({{
+    id:row.id,
+    role:row.role,
+    content:row.content,
+    token:row._active_turn_token,
+    ts:row._ts,
+    live:!!row._live,
+    pending:!!row._pending,
+    attachments:row.attachments,
+  }}));
+}}
+function runCase(name, messages, session, tracked){{
+  const before=tracked.map(row=>({{id:row.id,attachments:row.attachments}}));
+  const pendingOwner=_pendingActiveTurnUserMessage(messages,session);
+  const merged=_mergePendingSessionMessage(session,messages);
+  const after=tracked.map(row=>({{id:row.id,attachments:row.attachments}}));
+  return {{name,merged,pendingOwner:pendingOwner&&pendingOwner.id,before,after,rows:summarize(messages)}};
+}}
+const missingLive={{role:'assistant',content:'working',_live:true,_ts:4,_active_turn_token:'opaque:missing'}};
+const missingOwner={{id:'missing-owner',role:'user',content:'same prompt',_ts:3,attachments:[{{path:'original-missing'}}]}};
+const missingMessages=[{{role:'user',content:'old',_ts:1}},missingLive,missingOwner];
+const missingSession={{pending_user_message:'same prompt',pending_started_at:3,active_turn_token:'opaque:missing',pending_attachments:[{{path:'pending'}}]}};
+
+const duplicateLive={{role:'assistant',content:'working',_live:true,_ts:4,_active_turn_token:'opaque:duplicate'}};
+const duplicateOne={{id:'duplicate-one',role:'user',content:'same prompt',_ts:3,_active_turn_token:'opaque:duplicate',attachments:[{{path:'original-one'}}]}};
+const duplicateTwo={{id:'duplicate-two',role:'user',content:'same prompt',_ts:3,_active_turn_token:'opaque:duplicate',attachments:[{{path:'original-two'}}]}};
+const duplicateMessages=[{{role:'user',content:'old',_ts:1}},duplicateLive,duplicateOne,duplicateTwo];
+const duplicateSession={{pending_user_message:'same prompt',pending_started_at:3,active_turn_token:'opaque:duplicate',pending_attachments:[{{path:'pending'}}]}};
+
+const newerLive={{role:'assistant',content:'working',_live:true,_ts:5}};
+const newerRealUser={{id:'newer-real-user',role:'user',content:'same prompt',_ts:4,attachments:[]}};
+const newerMessages=[newerLive,newerRealUser];
+const newerSession={{pending_user_message:'same prompt',pending_started_at:3,pending_attachments:[{{path:'pending'}}]}};
+
+const exact={{id:'exact',role:'user',content:'same prompt',_ts:3}};
+const exactSession={{pending_user_message:'same prompt',pending_started_at:3}};
+const exactOwner=_pendingActiveTurnUserMessage([exact],exactSession);
+const results=[
+  runCase('missing-token',missingMessages,missingSession,[missingOwner]),
+  runCase('duplicate-token',duplicateMessages,duplicateSession,[duplicateOne,duplicateTwo]),
+  runCase('newer-conflicting-user',newerMessages,newerSession,[newerRealUser]),
+];
+process.stdout.write(JSON.stringify({{results,exactOwner:exactOwner&&exactOwner.id}}));
+"""
+    result = _run_node(script)
+
+    assert result["exactOwner"] == "exact"
+    assert {case["name"] for case in result["results"]} == {
+        "missing-token",
+        "duplicate-token",
+        "newer-conflicting-user",
+    }
+    for case in result["results"]:
+        assert case["pendingOwner"] is None, case
+        assert case["before"] == case["after"], case
+        assert case["merged"] is True, case
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_refresh_session_uses_canonical_helper_before_render():
     """The actual refresh path must project [user, live assistant] and render
     once when the canonical helper is available."""
-    helpers = "\n".join(
-        [
-            _function_source(SESSIONS_JS, "_messageComparableText"),
-            _function_source(SESSIONS_JS, "_stripAttachedFilesMarker"),
-            _function_source(SESSIONS_JS, "_stripForcedSkillEnvelope"),
-            _function_source(SESSIONS_JS, "_normalizeUserTranscriptText"),
-            _function_source(SESSIONS_JS, "_sameTranscriptMessage"),
-            _function_source(SESSIONS_JS, "_opaqueActiveTurnToken"),
-            _function_source(SESSIONS_JS, "_currentTailUserMessage"),
-            _function_source(SESSIONS_JS, "_hasCurrentTailUserDuplicate"),
-            _function_source(SESSIONS_JS, "_mergePendingSessionMessage"),
-        ]
-    )
+    helpers = _merge_helpers()
     refresh = "async " + _function_source(UI_JS, "refreshSession")
     script = f"""
 {helpers}
@@ -209,11 +285,6 @@ let status='';
 const S={{session:{{session_id:'sid-1'}},messages:[]}};
 const window={{_restartingForUpdate:false}};
 function dismissReconnect(){{}}
-function getPendingSessionMessage(session, messages){{
-  const text=String(session.pending_user_message||'').trim();
-  if(!text) return null;
-  return {{role:'user',content:text,_pending:true,_ts:session.pending_started_at}};
-}}
 async function api(){{return {{session:{{
   session_id:'sid-1',
   active_stream_id:'stream-1',

--- a/tests/test_issue6419_pending_user_reconnect_order.py
+++ b/tests/test_issue6419_pending_user_reconnect_order.py
@@ -138,6 +138,7 @@ def test_merge_helper_repairs_malformed_order_and_is_idempotent():
             _function_source(SESSIONS_JS, "_stripForcedSkillEnvelope"),
             _function_source(SESSIONS_JS, "_normalizeUserTranscriptText"),
             _function_source(SESSIONS_JS, "_sameTranscriptMessage"),
+            _function_source(SESSIONS_JS, "_opaqueActiveTurnToken"),
             _function_source(SESSIONS_JS, "_currentTailUserMessage"),
             _function_source(SESSIONS_JS, "_hasCurrentTailUserDuplicate"),
             _function_source(SESSIONS_JS, "_mergePendingSessionMessage"),
@@ -148,17 +149,17 @@ def test_merge_helper_repairs_malformed_order_and_is_idempotent():
 function getPendingSessionMessage(session, messages){{
   const text=String(session.pending_user_message||'').trim();
   if(!text) return null;
-  return {{role:'user',content:text,_pending:true,_ts:session.pending_started_at}};
+  return {{role:'user',content:text,_pending:true,_ts:session.pending_started_at,_active_turn_token:session.active_turn_token}};
 }}
 const historical={{role:'user',content:'same prompt',_ts:1}};
 const settled={{role:'assistant',content:'old answer',_ts:2}};
 const live={{role:'assistant',content:'working',_live:true,_ts:4}};
 const misplaced={{
   role:'user',content:'same prompt',_pending:true,_ts:3,
-  attachments:[{{path:'proof.txt'}}],_source:'resume'
+  attachments:[{{path:'proof.txt'}}],_source:'resume',_active_turn_token:'opaque:turn-3'
 }};
 const messages=[historical,settled,live,misplaced];
-const session={{pending_user_message:'same prompt',pending_started_at:3}};
+const session={{pending_user_message:'same prompt',pending_started_at:3,active_turn_token:'opaque:turn-3'}};
 const first=_mergePendingSessionMessage(session,messages);
 const afterFirst=messages.map(m=>({{role:m.role,content:m.content,live:!!m._live,ts:m._ts,attachments:m.attachments,source:m._source}}));
 const second=_mergePendingSessionMessage(session,messages);
@@ -166,7 +167,7 @@ process.stdout.write(JSON.stringify({{first,second,afterFirst,final:messages}}))
 """
     result = _run_node(script)
 
-    assert result["first"] is True
+    assert result["first"] is False
     assert result["second"] is False
     assert [row["role"] for row in result["afterFirst"]] == [
         "user",
@@ -174,6 +175,8 @@ process.stdout.write(JSON.stringify({{first,second,afterFirst,final:messages}}))
         "user",
         "assistant",
     ]
+    assert result["afterFirst"][2]["live"] is False
+    assert result["afterFirst"][3]["live"] is True
     repaired = result["afterFirst"][2]
     assert repaired["ts"] == 3
     assert repaired["attachments"] == [{"path": "proof.txt"}]
@@ -192,6 +195,7 @@ def test_refresh_session_uses_canonical_helper_before_render():
             _function_source(SESSIONS_JS, "_stripForcedSkillEnvelope"),
             _function_source(SESSIONS_JS, "_normalizeUserTranscriptText"),
             _function_source(SESSIONS_JS, "_sameTranscriptMessage"),
+            _function_source(SESSIONS_JS, "_opaqueActiveTurnToken"),
             _function_source(SESSIONS_JS, "_currentTailUserMessage"),
             _function_source(SESSIONS_JS, "_hasCurrentTailUserDuplicate"),
             _function_source(SESSIONS_JS, "_mergePendingSessionMessage"),

--- a/tests/test_issue6419_pending_user_reconnect_order.py
+++ b/tests/test_issue6419_pending_user_reconnect_order.py
@@ -273,6 +273,90 @@ process.stdout.write(JSON.stringify({{results,exactOwner:exactOwner&&exactOwner.
 
 
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_tokenless_tagged_activity_does_not_adopt_legacy_timestamp_owner():
+    """A tagged activity boundary is not tokenless legacy history.
+
+    Every case exercises the production merge helper, including tagged live
+    activity with and without a matching session token.
+    """
+    helpers = _merge_helpers()
+    script = f"""
+{helpers}
+function summarizePending(row){{
+  return row&&{{
+    role:row.role,
+    content:row.content,
+    pending:!!row._pending,
+    attachments:row.attachments,
+  }};
+}}
+function runCase(name, boundary, merge, activeTurnToken){{
+  const older={{id:name+'-older',role:'user',content:'same prompt',_ts:3,
+    attachments:[{{path:'older-'+name}}]}};
+  const messages=[older,boundary];
+  const session={{pending_user_message:'same prompt',pending_started_at:3,
+    pending_attachments:[{{path:'pending-'+name}}]}};
+  if(activeTurnToken) session.active_turn_token=activeTurnToken;
+  const before=JSON.stringify(older.attachments);
+  const pendingOwner=_pendingActiveTurnUserMessage(messages,session);
+  const pending=getPendingSessionMessage(session,messages);
+  const merged=merge?_mergePendingSessionMessage(session,messages):null;
+  return {{name,pendingOwner:pendingOwner&&pendingOwner.id,pending:summarizePending(pending),
+    merged,before,after:JSON.stringify(older.attachments),
+    pendingIndex:messages.findIndex(row=>row&&row._pending),
+    boundaryIndex:messages.indexOf(boundary),rows:messages.map(summarizePending)}};
+}}
+const cases=[
+  runCase('live',{{role:'assistant',content:'working',_live:true,_ts:4,
+    _active_turn_token:' tagged-live '}},true),
+  runCase('canonical-tool-call',{{role:'assistant',_ts:4,
+    tool_calls:[{{id:'call-1',function:{{name:'lookup'}}}}],
+    _active_turn_token:' tagged-call '}},true),
+  runCase('tool-result',{{role:'tool',content:'result',_ts:4,
+    _active_turn_token:' tagged-tool '}},true),
+  runCase('mismatched-live',{{role:'assistant',content:'working',_live:true,_ts:4,
+    _active_turn_token:' live-token '}},true,'session-token'),
+];
+const exactUser={{id:'exact-user',role:'user',content:'same prompt',_ts:3,
+  _active_turn_token:' exact-turn '}};
+const exactMessages=[exactUser,{{role:'assistant',content:'working',_live:true,_ts:4,
+  _active_turn_token:'exact-turn'}}];
+const exactSession={{pending_user_message:'same prompt',pending_started_at:3,
+  active_turn_token:' exact-turn '}};
+const legacyUser={{id:'legacy-user',role:'user',content:'same prompt',_ts:3}};
+const legacyMessages=[legacyUser,{{role:'assistant',content:'working',_live:true,_ts:4}}];
+const legacySession={{pending_user_message:'same prompt',pending_started_at:3}};
+process.stdout.write(JSON.stringify({{cases,
+  exactOwner:_pendingActiveTurnUserMessage(exactMessages,exactSession)?.id,
+  legacyOwner:_pendingActiveTurnUserMessage(legacyMessages,legacySession)?.id
+}}));
+"""
+    result = _run_node(script)
+
+    assert {case["name"] for case in result["cases"]} == {
+        "live",
+        "canonical-tool-call",
+        "tool-result",
+        "mismatched-live",
+    }
+    assert result["exactOwner"] == "exact-user"
+    assert result["legacyOwner"] == "legacy-user"
+    for case in result["cases"]:
+        assert case["pendingOwner"] is None, case
+        assert case["pending"] == {
+            "role": "user",
+            "content": "same prompt",
+            "pending": True,
+            "attachments": [{"path": f"pending-{case['name']}"}],
+        }, case
+        assert case["before"] == case["after"], case
+        assert case["merged"] is True, case
+        assert any(row == case["pending"] for row in case["rows"]), case
+        if "live" in case["name"]:
+            assert case["pendingIndex"] < case["boundaryIndex"], case
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_refresh_session_uses_canonical_helper_before_render():
     """The actual refresh path must project [user, live assistant] and render
     once when the canonical helper is available."""

--- a/tests/test_issue6419_pending_user_reconnect_order.py
+++ b/tests/test_issue6419_pending_user_reconnect_order.py
@@ -290,18 +290,24 @@ function summarizePending(row){{
     attachments:row.attachments,
   }};
 }}
-function runCase(name, boundary, merge, activeTurnToken){{
+function runCase(name, boundary, merge, activeTurnToken, userTurnToken, olderAttachments, trailingRows){{
   const older={{id:name+'-older',role:'user',content:'same prompt',_ts:3,
-    attachments:[{{path:'older-'+name}}]}};
-  const messages=[older,boundary];
+    attachments:olderAttachments??[{{path:'older-'+name}}]}};
+  if(userTurnToken) older._active_turn_token=userTurnToken;
+  const messages=[older,boundary,...(trailingRows||[])];
   const session={{pending_user_message:'same prompt',pending_started_at:3,
     pending_attachments:[{{path:'pending-'+name}}]}};
   if(activeTurnToken) session.active_turn_token=activeTurnToken;
   const before=JSON.stringify(older.attachments);
+  const currentTailOwner=_pendingCurrentTailUserMessage(
+    messages,session.pending_started_at,undefined,
+    session.active_turn_token??session.activeTurnToken,
+  );
   const pendingOwner=_pendingActiveTurnUserMessage(messages,session);
   const pending=getPendingSessionMessage(session,messages);
   const merged=merge?_mergePendingSessionMessage(session,messages):null;
-  return {{name,pendingOwner:pendingOwner&&pendingOwner.id,pending:summarizePending(pending),
+  return {{name,currentTailOwner:currentTailOwner&&currentTailOwner.id,
+    pendingOwner:pendingOwner&&pendingOwner.id,pending:summarizePending(pending),
     merged,before,after:JSON.stringify(older.attachments),
     pendingIndex:messages.findIndex(row=>row&&row._pending),
     boundaryIndex:messages.indexOf(boundary),rows:messages.map(summarizePending)}};
@@ -320,13 +326,40 @@ const cases=[
 const exactUser={{id:'exact-user',role:'user',content:'same prompt',_ts:3,
   _active_turn_token:' exact-turn '}};
 const exactMessages=[exactUser,{{role:'assistant',content:'working',_live:true,_ts:4,
-  _active_turn_token:'exact-turn'}}];
+  _active_turn_token:' exact-turn '}}];
 const exactSession={{pending_user_message:'same prompt',pending_started_at:3,
   active_turn_token:' exact-turn '}};
 const legacyUser={{id:'legacy-user',role:'user',content:'same prompt',_ts:3}};
 const legacyMessages=[legacyUser,{{role:'assistant',content:'working',_live:true,_ts:4}}];
 const legacySession={{pending_user_message:'same prompt',pending_started_at:3}};
+const inverseCases=[
+  runCase('raw-distinct-live',{{role:'assistant',content:'working',_live:true,_ts:4,
+    _active_turn_token:'raw-live'}},true,' raw-live ',' raw-live ',[]),
+  runCase('raw-distinct-canonical-tool-call',{{role:'assistant',_ts:4,
+    tool_calls:[{{id:'call-1',function:{{name:'lookup'}}}}],
+    _active_turn_token:'raw-tool-call'}},true,' raw-tool-call ',' raw-tool-call ',[]),
+  runCase('raw-distinct-tool-result',{{role:'tool',content:'result',_ts:4,
+    _active_turn_token:'raw-tool-result'}},true,' raw-tool-result ',' raw-tool-result ',[]),
+  runCase('authoritative-live-missing',{{role:'assistant',content:'working',_live:true,_ts:4}},
+    true,' authoritative-missing ',' authoritative-missing ',[]),
+  runCase('authoritative-live-blank',{{role:'assistant',content:'working',_live:true,_ts:4,
+    _active_turn_token:'   '}},true,' authoritative-blank ',' authoritative-blank ',[]),
+];
+const mixedCases=[
+  runCase('mixed-tagged-live',{{role:'assistant',content:'working',_live:true,_ts:4}},true,
+    undefined,undefined,[],[{{role:'assistant',content:'later working',_live:true,_ts:5,
+      _active_turn_token:'mixed-live'}}]),
+  runCase('mixed-canonical-tool-call',{{role:'assistant',content:'working',_live:true,_ts:4}},true,
+    undefined,undefined,[],[{{role:'assistant',_ts:5,
+      tool_calls:[{{id:'call-2',function:{{name:'lookup'}}}}],
+      _active_turn_token:'mixed-tool-call'}}]),
+  runCase('mixed-tool-result',{{role:'assistant',content:'working',_live:true,_ts:4}},true,
+    undefined,undefined,[],[{{role:'tool',content:'result',_ts:5,
+      _active_turn_token:'mixed-tool-result'}}]),
+];
 process.stdout.write(JSON.stringify({{cases,
+  inverseCases,
+  mixedCases,
   exactOwner:_pendingActiveTurnUserMessage(exactMessages,exactSession)?.id,
   legacyOwner:_pendingActiveTurnUserMessage(legacyMessages,legacySession)?.id
 }}));
@@ -350,6 +383,33 @@ process.stdout.write(JSON.stringify({{cases,
             "attachments": [{"path": f"pending-{case['name']}"}],
         }, case
         assert case["before"] == case["after"], case
+        assert case["merged"] is True, case
+        assert any(row == case["pending"] for row in case["rows"]), case
+        if "live" in case["name"]:
+            assert case["pendingIndex"] < case["boundaryIndex"], case
+    for case in result["mixedCases"]:
+        assert case["before"] == case["after"], case
+        assert case["currentTailOwner"] is None, case
+        assert case["pendingOwner"] is None, case
+        assert case["pending"] == {
+            "role": "user",
+            "content": "same prompt",
+            "pending": True,
+            "attachments": [{"path": f"pending-{case['name']}"}],
+        }, case
+        assert case["merged"] is True, case
+        assert any(row == case["pending"] for row in case["rows"]), case
+        assert case["pendingIndex"] < case["boundaryIndex"], case
+    for case in result["inverseCases"]:
+        assert case["before"] == case["after"], case
+        assert case["currentTailOwner"] is None, case
+        assert case["pendingOwner"] is None, case
+        assert case["pending"] == {
+            "role": "user",
+            "content": "same prompt",
+            "pending": True,
+            "attachments": [{"path": f"pending-{case['name']}"}],
+        }, case
         assert case["merged"] is True, case
         assert any(row == case["pending"] for row in case["rows"]), case
         if "live" in case["name"]:

--- a/tests/test_live_to_final_anchor_visible_order.py
+++ b/tests/test_live_to_final_anchor_visible_order.py
@@ -473,14 +473,20 @@ def test_live_processed_anchor_timer_falls_back_after_real_started_at():
 
 def test_server_started_turn_also_creates_processed_anchor_before_stop_button_refresh():
     listener = _event_listener_body(MESSAGES_JS, "server_turn_started")
+    attach = _function_body(
+        MESSAGES_JS,
+        "_attachServerInitiatedStream",
+    )
 
-    pending_idx = listener.index("S.session.pending_started_at = d.pending_started_at")
-    ensure_idx = listener.index("if (typeof ensureLiveWorklogShell === 'function') ensureLiveWorklogShell();")
-    stop_idx = listener.index("if (typeof updateSendBtn === 'function') updateSendBtn();")
-    assert pending_idx < ensure_idx < stop_idx
-
-    assert "else if (!S.session.pending_started_at) S.session.pending_started_at = Date.now()/1000;" in listener
-    assert "if (typeof appendThinking === 'function') appendThinking();" in listener
+    pending_idx = listener.index("S.session.pending_started_at=d.pending_started_at")
+    attach_idx = listener.index("_attachServerInitiatedStream(sid,streamId,recovered,d.active_turn_token)")
+    ensure_idx = attach.index("if (typeof ensureLiveWorklogShell === 'function') ensureLiveWorklogShell();")
+    stop_idx = attach.index("if (typeof updateSendBtn === 'function') updateSendBtn();")
+    assert pending_idx < attach_idx
+    assert ensure_idx < stop_idx
+    assert "const applyTurnToken=()=>{" in attach
+    assert "S.session.active_turn_token=turnToken;" in attach
+    assert "if (typeof appendThinking === 'function') appendThinking();" in attach
 
 
 def test_server_started_turn_payload_carries_pending_started_at():
@@ -488,8 +494,10 @@ def test_server_started_turn_payload_carries_pending_started_at():
     assert "recover_session = get_session(sid, metadata_only=True)" in recovery
     assert "pending_started_at = getattr(recover_session, \"pending_started_at\", None)" in recovery
     assert '"pending_started_at": pending_started_at' in ROUTES_PY
+    assert '"active_turn_token": build_active_turn_token(' in ROUTES_PY
     assert '"pending_started_at": getattr(session, "pending_started_at", None)' not in ROUTES_PY
     assert '"pending_started_at": (resp or {}).get("pending_started_at")' in ROUTES_PY
+    assert '"active_turn_token": (resp or {}).get("active_turn_token")' in ROUTES_PY
 
 
 def test_live_processed_anchor_is_deduped_across_restore_paths():

--- a/tests/test_optionz_liveview_perf.py
+++ b/tests/test_optionz_liveview_perf.py
@@ -51,7 +51,13 @@ def test_server_turn_streams_to_session_channel(monkeypatch):
     # Patch the heavy turn-start core so the test stays unit-fast: pretend a
     # turn started and return the same dict shape the real function returns.
     def _fake_start_chat_stream_for_session(s, **kwargs):
-        return {"stream_id": fake_stream_id, "session_id": s.session_id, "_status": 200}
+        return {
+            "stream_id": fake_stream_id,
+            "session_id": s.session_id,
+            "pending_started_at": 12.5,
+            "active_turn_token": "opaque-server-token",
+            "_status": 200,
+        }
 
     class _FakeSession:
         session_id = sid
@@ -85,6 +91,8 @@ def test_server_turn_streams_to_session_channel(monkeypatch):
         )
         assert data["stream_id"] == fake_stream_id
         assert data["session_id"] == sid
+        assert data["pending_started_at"] == 12.5
+        assert data["active_turn_token"] == "opaque-server-token"
     finally:
         ch.unsubscribe(q)
         with bp.SESSION_CHANNELS_LOCK:
@@ -102,7 +110,13 @@ def test_server_turn_no_session_channel_is_noop(monkeypatch):
     fake_stream_id = "stream-optz-notab-1"
 
     def _fake_start_chat_stream_for_session(s, **kwargs):
-        return {"stream_id": fake_stream_id, "session_id": s.session_id, "_status": 200}
+        return {
+            "stream_id": fake_stream_id,
+            "session_id": s.session_id,
+            "pending_started_at": 12.5,
+            "active_turn_token": "opaque-server-token",
+            "_status": 200,
+        }
 
     class _FakeSession:
         session_id = sid
@@ -334,6 +348,7 @@ def test_session_sse_on_subscribe_recovers_lost_server_turn_started():
     server-initiated wakeup turn live (needs a hard refresh).
     """
     from api import background_process as bp, config as cfg
+    from api.process_event_utils import build_active_turn_token
 
     sid = "sess-recover-onsub"
     stream_id = "stream-recover-onsub-1"
@@ -352,6 +367,8 @@ def test_session_sse_on_subscribe_recovers_lost_server_turn_started():
         recovery_frame = {
             "session_id": sid,
             "stream_id": recover_stream_id,
+            "pending_started_at": 12.5,
+            "active_turn_token": build_active_turn_token(stream_id, 12.5),
             "source": "subscribe_recovery",
             "recovered": True,
         }
@@ -361,6 +378,9 @@ def test_session_sse_on_subscribe_recovers_lost_server_turn_started():
         assert recovery_frame["stream_id"] == stream_id
         assert recovery_frame["recovered"] is True
         assert recovery_frame["session_id"] == sid
+        assert recovery_frame["active_turn_token"] == build_active_turn_token(
+            stream_id, 12.5
+        )
 
         # And when the session is idle (no live run) the recovery is a no-op
         # — no spurious attach frame for a session with nothing running.
@@ -385,6 +405,7 @@ def test_session_sse_handler_wires_on_subscribe_recovery():
     handler_src = src[handler_ix:handler_ix + 9000]
     assert "active_stream_id_for_session" in handler_src
     assert '"recovered": True' in handler_src
+    assert '"active_turn_token": build_active_turn_token(' in handler_src
     assert "server_turn_started" in handler_src
     # Recovery CALL must come AFTER the channel subscription so a frame emitted
     # between subscribe and recovery is still caught by the queue (no lost-frame
@@ -408,7 +429,7 @@ def test_frontend_recovered_frame_uses_reconnecting_attach():
     assert "d.recovered" in h_src
     assert "reconnecting" in h_src
     # Still reuses the single renderer — no second hand-rolled stream.
-    assert "attachLiveStream" in h_src
+    assert "_attachServerInitiatedStream" in h_src
 
 
 # ---------------------------------------------------------------------------
@@ -774,4 +795,3 @@ def test_loadsession_idle_cleanup_does_not_clobber_concurrent_live_stream():
     assert reread_ix != -1 and branch_ix != -1 and reread_ix < branch_ix, (
         "race-guard re-read must precede the attach/idle branch"
     )
-

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -764,12 +764,12 @@ def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test
     # grab the wrong one. (rfind = the substantive restore branch.)
     inflight_idx = src.rfind("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+1200]
+    inflight_block = src[inflight_idx:inflight_idx+1600]
 
     assert "await _ensureMessagesLoaded(sid" in inflight_block, (
         "returning to an active stream should load the persisted transcript before adding the live tail"
     )
-    assert "_mergeInflightTailMessages(S.messages,inflightMessages)" in inflight_block, (
+    assert "_mergeInflightTailMessages(S.messages,inflightMessages,activeTurnToken)" in inflight_block, (
         "INFLIGHT messages should be merged as a tail, not replace the full transcript"
     )
     assert "function _mergeInflightTailMessages" in src, (

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -844,9 +844,14 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     )
     pending_idx = src.find("function _mergePendingSessionMessage")
     assert pending_idx >= 0, "pending session merge helper not found"
-    pending_block = src[pending_idx:pending_idx+500]
-    assert "_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)" in pending_block, (
-        "pending-user merge should dedupe only against the current active-turn user row"
+    pending_end = src.find("\nfunction ", pending_idx + 1)
+    assert pending_end > pending_idx, "pending session merge helper end not found"
+    pending_block = src[pending_idx:pending_end]
+    assert "_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg,activeTurnToken)" in pending_block, (
+        "pending-user merge should dedupe only against the current authoritative active-turn user row"
+    )
+    assert "matchingUsers.length===1" in pending_block, (
+        "pending-user merge should adopt attachments only from one exact active-turn identity match"
     )
     assert "messages.some(" not in pending_block, (
         "pending-user merge must not scan historical user rows by normalized content"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -847,8 +847,8 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     pending_end = src.find("\nfunction ", pending_idx + 1)
     assert pending_end > pending_idx, "pending session merge helper end not found"
     pending_block = src[pending_idx:pending_end]
-    assert "_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg,activeTurnToken)" in pending_block, (
-        "pending-user merge should dedupe only against the current authoritative active-turn user row"
+    assert "_hasCurrentTailUserDuplicate(pendingSourceMessages,pendingMsg,activeTurnToken)" in pending_block, (
+        "pending-user identity and duplicate checks must share the selected source"
     )
     assert "matchingUsers.length===1" in pending_block, (
         "pending-user merge should adopt attachments only from one exact active-turn identity match"

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -59,6 +59,7 @@ def _run_session_identity_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
             _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
             _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
             _function_body(SESSIONS_SRC, "function _inflightHasVisibleLiveState"),
@@ -102,6 +103,7 @@ def _run_current_turn_scope_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
             _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
             _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
             _function_body(SESSIONS_SRC, "function _mergePendingSessionMessage"),
@@ -118,12 +120,14 @@ function getPendingSessionMessage(session, messages){{
     content:text,
     _ts:session.pending_started_at||10,
     _pending:true,
+    _active_turn_token:session.active_turn_token,
   }};
 }}
 const historical = {{role:'user', content:{json.dumps(historical_workspace_prompt)}, _ts:1}};
 const historicalAnswer = {{role:'assistant', content:'done', _ts:2}};
 const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4}};
-const pendingSession = {{pending_user_message:{json.dumps(prompt)}, pending_started_at:3}};
+const activeTurnToken = 'turn-current:3';
+const pendingSession = {{pending_user_message:{json.dumps(prompt)}, pending_started_at:3, active_turn_token:activeTurnToken}};
 
 const pendingAfterHistory = [historical, historicalAnswer];
 const insertedAfterHistory = _mergePendingSessionMessage(pendingSession, pendingAfterHistory);
@@ -131,18 +135,20 @@ const insertedAfterHistory = _mergePendingSessionMessage(pendingSession, pending
 const pendingBeforeLive = [historical, historicalAnswer, liveAssistant];
 const insertedBeforeLive = _mergePendingSessionMessage(pendingSession, pendingBeforeLive);
 
-const optimisticCurrent = {{role:'user', content:{json.dumps(current_workspace_prompt)}, _ts:3}};
+const optimisticCurrent = {{role:'user', content:{json.dumps(current_workspace_prompt)}, _ts:3, _active_turn_token:activeTurnToken}};
 const pendingWithCurrent = [historical, historicalAnswer, optimisticCurrent, liveAssistant];
 const insertedWithCurrent = _mergePendingSessionMessage(pendingSession, pendingWithCurrent);
 
 const inflightAfterHistory = _mergeInflightTailMessages(
   [historical, historicalAnswer],
-  [{{role:'user', content:{json.dumps(prompt)}, _ts:3}}, liveAssistant]
+  [{{role:'user', content:{json.dumps(prompt)}, _ts:3, _active_turn_token:activeTurnToken}}, liveAssistant],
+  activeTurnToken
 );
 
 const inflightWithCurrent = _mergeInflightTailMessages(
   [historical, historicalAnswer, optimisticCurrent],
-  [{{role:'user', content:{json.dumps(prompt)}, _ts:3}}, liveAssistant]
+  [{{role:'user', content:{json.dumps(prompt)}, _ts:3, _active_turn_token:activeTurnToken}}, liveAssistant],
+  activeTurnToken
 );
 
 const compaction = {{
@@ -151,12 +157,13 @@ const compaction = {{
   _ts:3.5,
 }};
 const compactionBase = [historical, historicalAnswer, optimisticCurrent, compaction];
-const compactionCandidate = {{role:'user', content:{json.dumps(prompt)}, _ts:3}};
+const compactionCandidate = {{role:'user', content:{json.dumps(prompt)}, _ts:3, _active_turn_token:activeTurnToken}};
 const compactionCurrentTail = _currentTailUserMessage(compactionBase);
-const compactionTailDuplicate = _hasCurrentTailUserDuplicate(compactionBase, compactionCandidate);
+const compactionTailDuplicate = _hasCurrentTailUserDuplicate(compactionBase, compactionCandidate, activeTurnToken);
 const compactionMerged = _mergeInflightTailMessages(
   compactionBase,
-  [compactionCandidate, liveAssistant]
+  [compactionCandidate, liveAssistant],
+  activeTurnToken
 );
 const insertedAfterCompaction = _mergePendingSessionMessage(pendingSession, compactionMerged);
 const compactionPromptCount = compactionMerged.filter(
@@ -168,7 +175,8 @@ const compactionLiveAssistantRetained = compactionMerged.some(
 );
 const completedBoundaryDedupe = _hasCurrentTailUserDuplicate(
   [historical, historicalAnswer, compaction],
-  {{role:'user', content:{json.dumps(prompt)}, _ts:3}}
+  {{role:'user', content:{json.dumps(prompt)}, _ts:3, _active_turn_token:activeTurnToken}},
+  activeTurnToken
 );
 const distinctCompletedTurnPromptCount = inflightAfterHistory.filter(
   m=>m&&m.role==='user'&&_normalizeUserTranscriptText(m.content)==={json.dumps(prompt)}
@@ -210,6 +218,7 @@ def _run_pending_session_message_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
             _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
             _optional_function_body(UI_SRC, "function _messageTimestampSeconds"),
             _optional_function_body(UI_SRC, "function _activeTurnTokenMatches"),
@@ -354,7 +363,7 @@ const tokenIdentityTranscript = [
   {{role:'assistant', content:'partial', timestamp:560}},
 ];
 const tokenIdentityResult = getPendingSessionMessage(
-  {{pending_user_message:prompt, pending_started_at:midRunStartedAt, active_stream_id:'stream-abc'}},
+  {{pending_user_message:prompt, pending_started_at:midRunStartedAt, active_turn_token:'stream-abc:500'}},
   tokenIdentityTranscript
 );
 
@@ -403,6 +412,7 @@ def _run_tail_scanner_boundary_probe() -> list[dict]:
             _function_body(UI_SRC, "function msgContent"),
             _function_body(UI_SRC, "function _isContextCompactionText"),
             _function_body(UI_SRC, "function _isContextCompactionMessage"),
+            _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
             _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
             _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
             _function_body(SESSIONS_SRC, "function _mergeInflightTailMessages"),
@@ -415,14 +425,15 @@ function _sameTranscriptMessage(a,b){{
 }}
 const prompt = {json.dumps(prompt)};
 const priorUser = {{role:'user', content:'older prompt', _ts:1}};
-const currentUser = {{role:'user', content:prompt, _ts:10}};
+const currentUser = {{role:'user', content:prompt, _ts:10, _active_turn_token:'turn-1:10'}};
+const currentCandidate = {{role:'user', content:prompt, _ts:10, _active_turn_token:'turn-1:10'}};
 const canonicalCall = {{id:'call-1', type:'function', function:{{name:'inspect'}}}};
 const canonicalTopNameCall = {{call_id:'call-2', name:'inspect'}};
 const sameTurnEnvelope = {{role:'assistant', content:'', _ts:10, tool_calls:[canonicalCall]}};
 const topNameEnvelope = {{role:'assistant', content:'', _ts:10, tool_calls:[canonicalTopNameCall]}};
 const sameTurnTool = {{role:'tool', content:'result', tool_call_id:'call-1', _ts:11}};
 const ordinaryAssistant = {{role:'assistant', content:'done', _ts:12}};
-const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:12}};
+const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:12, _active_turn_token:'turn-1:10'}};
 const compaction = {{role:'user', content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.', _ts:10.5}};
 
 const malformed = [
@@ -440,22 +451,31 @@ const cases = [
   {{name:'canonical envelope plus tool result', messages:[priorUser,currentUser,sameTurnEnvelope,sameTurnTool], expect:prompt}},
   {{name:'tool result only', messages:[priorUser,currentUser,sameTurnTool], expect:prompt}},
   {{name:'ordinary assistant boundary', messages:[priorUser,currentUser,ordinaryAssistant], expect:null}},
-  {{name:'older envelope activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:9}}], expect:null}},
-  {{name:'older tool activity', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:9}}], expect:null}},
-  {{name:'missing envelope timestamp', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:undefined}}], expect:null}},
-  {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], expect:null}},
-  {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, expect:null}},
+  {{name:'older envelope activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:9}}], currentExpect:prompt, pendingExpect:null}},
+  {{name:'older tool activity', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:9}}], currentExpect:prompt, pendingExpect:null}},
+  {{name:'missing envelope timestamp', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:undefined}}], currentExpect:prompt, pendingExpect:null}},
+  {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], currentExpect:prompt, pendingExpect:null}},
+  {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, currentExpect:prompt, pendingExpect:null}},
   {{name:'same-turn activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,timestamp:10,_ts:undefined}},{{...sameTurnTool,timestamp:10.1,_ts:undefined}}], expect:prompt}},
   {{name:'compaction marker', messages:[priorUser,currentUser,compaction,sameTurnEnvelope], expect:prompt}},
   {{name:'live tail', messages:[priorUser,currentUser,liveAssistant], expect:prompt}},
+  {{name:'live tail missing token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12}}], currentExpect:null, pendingExpect:prompt}},
+  {{name:'live tail mismatched token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12, _active_turn_token:'turn-2:10'}}], currentExpect:null, pendingExpect:prompt}},
   ...malformed.map(tc=>({{name:tc.name, messages:[priorUser,currentUser,tc.msg], expect:null}})),
 ];
 const tailPrompt = (row) => row&&row.role==='user' ? String(row.content||'') : null;
 const results = cases.map(tc=>({{
   name:tc.name,
-  current:tailPrompt(_currentTailUserMessage(tc.messages,tc.candidateStart===undefined?10:tc.candidateStart)),
+    current:tailPrompt(_currentTailUserMessage(
+    tc.messages,
+    tc.candidateStart===undefined?10:tc.candidateStart,
+    undefined,
+    tc.candidate===undefined?currentCandidate:tc.candidate,
+    tc.activeTurnToken===undefined?'turn-1:10':tc.activeTurnToken,
+  )),
   pending:tailPrompt(_pendingCurrentTailUserMessage(tc.messages,tc.candidateStart===undefined?10:tc.candidateStart)),
-  expect:tc.expect,
+  currentExpect:tc.currentExpect===undefined?tc.expect:tc.currentExpect,
+  pendingExpect:tc.pendingExpect===undefined?tc.expect:tc.pendingExpect,
 }}));
 
 // A newer repeated prompt must survive an older no-final-assistant tool tail.
@@ -467,7 +487,8 @@ const olderToolTail = [
 const newerPrompt = {{role:'user',content:prompt,_ts:10}};
 const merged = _mergeInflightTailMessages(
   olderToolTail,
-  [newerPrompt,{{role:'assistant',content:'working',_live:true,_ts:11}}]
+  [newerPrompt,{{role:'assistant',content:'working',_live:true,_ts:11}}],
+  'new-turn-token'
 );
 const timestampOnlyCandidate = {{role:'user',content:prompt,timestamp:10}};
 results.push({{
@@ -479,10 +500,315 @@ results.push({{
 }});
 results.push({{
   name:'candidate timestamp field',
-  currentDuplicate:_hasCurrentTailUserDuplicate([currentUser,sameTurnEnvelope],timestampOnlyCandidate),
+  currentDuplicate:_hasCurrentTailUserDuplicate([currentUser,sameTurnEnvelope],timestampOnlyCandidate,'turn-1:10'),
+  expect:false,
+}});
+results.push({{
+  name:'same-token candidate after tool activity',
+  currentDuplicate:_hasCurrentTailUserDuplicate([currentUser,sameTurnEnvelope],currentCandidate,'turn-1:10'),
   expect:true,
 }});
 process.stdout.write(JSON.stringify(results));
+"""
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
+def _run_cross_clock_inflight_probe() -> dict:
+    """Exercise inflight dedupe with server-ahead persisted activity."""
+    helpers = "\n".join(
+        [
+            _function_body(UI_SRC, "function _timestampSeconds"),
+            _function_body(UI_SRC, "function _firstValidTimestampSeconds"),
+            _function_body(UI_SRC, "function _isTailActivityOwnedByCandidateTurn"),
+            _function_body(UI_SRC, "function _isCanonicalAssistantToolCallEnvelope"),
+            _function_body(UI_SRC, "function msgContent"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
+            _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
+            _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
+            _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
+            _function_body(SESSIONS_SRC, "function _mergeInflightTailMessages"),
+        ]
+    )
+    script = f"""
+{helpers}
+function _sameTranscriptMessage(a,b){{
+  return !!(a&&b&&a.role===b.role&&String(a.content||'').trim()===String(b.content||'').trim());
+}}
+const prompt = {json.dumps("repeat me")};
+const oldCall = {{id:'old-call', function:{{name:'inspect'}}}};
+const streamId = 'new-stream';
+const pendingStartedAt = 200;
+const newToken = `${{streamId}}:${{pendingStartedAt}}`;
+const attachment = {{name:'new.txt', path:'new.txt', mime:'text/plain'}};
+const candidate = {{
+  role:'user', content:prompt, _ts:50, _pending:true,
+  _active_turn_token:newToken, attachments:[attachment],
+}};
+const priorActivity = [
+  {{role:'user', content:prompt, timestamp:100, _active_turn_token:'old-stream:100'}},
+  {{role:'assistant', content:'', timestamp:101, tool_calls:[oldCall]}},
+  {{role:'tool', content:'old result', timestamp:102, tool_call_id:'old-call'}},
+];
+const live = {{role:'assistant', content:'working', _live:true, _ts:51}};
+const skewMerged = _mergeInflightTailMessages(priorActivity, [candidate, live], newToken);
+const missingTokenCandidate = {{...candidate}};
+delete missingTokenCandidate._active_turn_token;
+const missingTokenMerged = _mergeInflightTailMessages(priorActivity, [missingTokenCandidate, live], newToken);
+
+const sameTurnActivity = [
+  {{role:'user', content:prompt, timestamp:100, _active_turn_token:newToken}},
+  {{role:'assistant', content:'', timestamp:101, tool_calls:[oldCall]}},
+  {{role:'tool', content:'current result', timestamp:102, tool_call_id:'old-call'}},
+];
+const sameTokenMerged = _mergeInflightTailMessages(sameTurnActivity, [candidate, live], newToken);
+process.stdout.write(JSON.stringify({{
+  skewUserCount:skewMerged.filter(m=>m&&m.role==='user').length,
+  skewAttachments:skewMerged.filter(m=>m&&m.role==='user').map(m=>m.attachments||[]),
+  missingTokenUserCount:missingTokenMerged.filter(m=>m&&m.role==='user').length,
+  sameTokenUserCount:sameTokenMerged.filter(m=>m&&m.role==='user').length,
+}}));
+"""
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
+def _run_turn_ownership_adversarial_probe() -> dict:
+    """Exercise recovery, opaque-token dedupe, and fail-closed ownership."""
+    helpers = "\n".join(
+        [
+            _function_body(UI_SRC, "function _timestampSeconds"),
+            _function_body(UI_SRC, "function _firstValidTimestampSeconds"),
+            _function_body(UI_SRC, "function _isTailActivityOwnedByCandidateTurn"),
+            _function_body(UI_SRC, "function _isCanonicalAssistantToolCallEnvelope"),
+            _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+            _function_body(UI_SRC, "function _activeTurnTokenMatches"),
+            _function_body(UI_SRC, "function msgContent"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
+            _function_body(UI_SRC, "function getPendingSessionMessage"),
+            _function_body(SESSIONS_SRC, "function _messageComparableText"),
+            _function_body(SESSIONS_SRC, "function _stripAttachedFilesMarker"),
+            _function_body(SESSIONS_SRC, "function _stripForcedSkillEnvelope"),
+            _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
+            _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
+            _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
+            _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
+            _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
+            _function_body(SESSIONS_SRC, "function _mergePendingSessionMessage"),
+            _function_body(SESSIONS_SRC, "function _currentTurnAssistantText"),
+            _function_body(SESSIONS_SRC, "function _compactTranscriptText"),
+            _function_body(SESSIONS_SRC, "function _dropCurrentTurnAssistantMessages"),
+            _function_body(SESSIONS_SRC, "function _prepareRunningLiveTail"),
+            _function_body(SESSIONS_SRC, "function _mergeInflightTailMessages"),
+        ]
+    )
+    script = f"""
+{helpers}
+const prompt = 'same prompt';
+const newToken = 'opaque:new-turn';
+const oldToken = 'opaque:old-turn';
+const attachment = {{name:'new.txt', path:'new.txt'}};
+const toolCall = {{id:'call-1', function:{{name:'inspect'}}}};
+
+// A: loadSession-style prepare -> drop -> inflight merge -> pending merge.
+const priorUser = {{role:'user', content:prompt, timestamp:100, _active_turn_token:oldToken}};
+const priorAssistant = {{role:'assistant', content:'completed', timestamp:101}};
+const newCandidate = {{
+  role:'user', content:prompt, _ts:50, _pending:true,
+  _active_turn_token:newToken, attachments:[attachment],
+}};
+const newLive = {{role:'assistant', content:'working', _live:true, _active_turn_token:newToken}};
+let recovery = [priorUser, priorAssistant];
+const prepared = _prepareRunningLiveTail(recovery, [newCandidate, newLive], newToken);
+if(prepared) recovery = _dropCurrentTurnAssistantMessages(recovery, newToken);
+recovery = _mergeInflightTailMessages(recovery, [newCandidate, newLive], newToken);
+const pendingMerge = _mergePendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:200, active_turn_token:newToken, pending_attachments:[attachment]}},
+  recovery,
+);
+const recoveredUsers = recovery.filter(m=>m&&m.role==='user');
+
+// C: token ownership wins over transformed display/model text and adopts files.
+const sameTurnBase = [
+  {{role:'user', content:'upload-only', timestamp:100, _active_turn_token:newToken}},
+  {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall]}},
+  {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1'}},
+];
+const transformedCandidate = {{
+  role:'user', content:'/moa same prompt', _ts:50, _active_turn_token:newToken,
+  attachments:[attachment],
+}};
+const sameTokenMerged = _mergeInflightTailMessages(
+  sameTurnBase,
+  [transformedCandidate, {{role:'assistant', content:'live', _live:true}}],
+  newToken,
+);
+const sameTokenUsers = sameTokenMerged.filter(m=>m&&m.role==='user');
+const transformedDisplays = [
+  'upload-only',
+  '/moa same prompt',
+  '/bundle invoke same prompt',
+  '[FORCED SKILL CONTEXT: demo]\\ncontext\\n[/FORCED SKILL CONTEXT]\\nsame prompt',
+];
+const transformedTokenResults = transformedDisplays.map(content=>{{
+  const base=[
+    {{role:'user', content:'original prompt', timestamp:100, _active_turn_token:newToken}},
+    {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall]}},
+    {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1'}},
+  ];
+  const candidate={{role:'user', content, _ts:50, _active_turn_token:newToken, attachments:[attachment]}};
+  const users=_mergeInflightTailMessages(
+    base,
+    [candidate, {{role:'assistant', content:'live', _live:true}}],
+    newToken,
+  ).filter(m=>m&&m.role==='user');
+  return {{count:users.length, attachments:users[0]&&users[0].attachments||[]}};
+}});
+
+// B/D: old cross-clock activity and all uncertain token forms preserve the row.
+const oldToolBase = [
+  {{role:'user', content:prompt, timestamp:100, _active_turn_token:oldToken}},
+  {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall]}},
+  {{role:'tool', content:'old result', timestamp:102, tool_call_id:'call-1'}},
+];
+const skewMerged = _mergeInflightTailMessages(
+  oldToolBase,
+  [{{...newCandidate, attachments:[attachment]}}, {{role:'assistant', content:'live', _live:true}}],
+  newToken,
+);
+const uncertainTokens = [undefined, '', 'opaque:new-turn ', 'opaque:other-turn'];
+const uncertainUserCounts = uncertainTokens.map(token=>{{
+  const candidate={{...newCandidate}};
+  if(token===undefined) delete candidate._active_turn_token;
+  else candidate._active_turn_token=token;
+  return _mergeInflightTailMessages(
+    oldToolBase,
+    [candidate, {{role:'assistant', content:'live', _live:true}}],
+    newToken,
+  ).filter(m=>m&&m.role==='user').length;
+}});
+const liveBoundaryMerged = _mergeInflightTailMessages(
+  [{{role:'user', content:prompt, _active_turn_token:oldToken}}, {{role:'assistant', content:'live', _live:true}}],
+  [{{...newCandidate}}, {{role:'assistant', content:'new live', _live:true}}],
+  newToken,
+);
+const sameLiveMerged = _mergeInflightTailMessages(
+  [
+    {{role:'user', content:'original prompt', _active_turn_token:newToken}},
+    {{role:'assistant', content:'live', _live:true, _active_turn_token:newToken}},
+  ],
+  [{{...transformedCandidate}}, {{role:'assistant', content:'new live', _live:true, _active_turn_token:newToken}}],
+  newToken,
+);
+
+// No activity is still not permission for tokenless or ambiguous text dedupe.
+const noActivityBase = [
+  {{role:'user', content:'original prompt', _active_turn_token:newToken}},
+];
+const noActivityCounts = [undefined, '', '   ', oldToken, newToken].map(token=>{{
+  const candidate={{...transformedCandidate}};
+  if(token===undefined) delete candidate._active_turn_token;
+  else candidate._active_turn_token=token;
+  return _mergeInflightTailMessages(
+    noActivityBase,
+    [candidate, {{role:'assistant', content:'live', _live:true, _active_turn_token:newToken}}],
+    newToken,
+  ).filter(m=>m&&m.role==='user').length;
+}});
+const duplicateAdjacent = _mergeInflightTailMessages(
+  [
+    {{role:'user', content:'first', _active_turn_token:newToken}},
+    {{role:'user', content:'second', _active_turn_token:newToken}},
+  ],
+  [{{...transformedCandidate}}, {{role:'assistant', content:'live', _live:true, _active_turn_token:newToken}}],
+  newToken,
+).filter(m=>m&&m.role==='user').length;
+const duplicateSeparated = _mergeInflightTailMessages(
+  [
+    {{role:'user', content:'first', _active_turn_token:newToken}},
+    {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall]}},
+    {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1'}},
+    {{role:'user', content:'second', _active_turn_token:newToken}},
+  ],
+  [{{...transformedCandidate}}, {{role:'assistant', content:'live', _live:true, _active_turn_token:newToken}}],
+  newToken,
+).filter(m=>m&&m.role==='user').length;
+
+// H: duplicate imported rows with the same token are ambiguous and preserved.
+const ambiguousBase = [
+  {{role:'user', content:'first', _active_turn_token:newToken}},
+  {{role:'tool', content:'one', timestamp:101}},
+  {{role:'user', content:'imported duplicate', _active_turn_token:newToken}},
+  {{role:'tool', content:'two', timestamp:102}},
+];
+const ambiguousMerged = _mergeInflightTailMessages(
+  ambiguousBase,
+  [{{...transformedCandidate}}, {{role:'assistant', content:'live', _live:true}}],
+  newToken,
+);
+
+// I: a unique current-token user row can sit after a live boundary in a
+// recovered transcript; reconcile it before synthesizing the pending row.
+const pendingSession = {{
+  pending_user_message:prompt,
+  pending_started_at:200,
+  active_turn_token:newToken,
+  pending_attachments:[attachment],
+}};
+const pendingAfterLive = [
+  {{role:'user', content:'old prompt', _active_turn_token:oldToken}},
+  {{role:'assistant', content:'working', _live:true, _active_turn_token:newToken}},
+  {{role:'user', content:'/bundle transformed', _active_turn_token:newToken}},
+];
+const pendingUniqueInserted = _mergePendingSessionMessage(pendingSession, pendingAfterLive);
+const pendingZeroMatch = [
+  {{role:'user', content:prompt, _active_turn_token:oldToken}},
+  {{role:'assistant', content:'working', _live:true, _active_turn_token:newToken}},
+  {{role:'user', content:prompt}},
+];
+const pendingZeroMatchOriginal = pendingZeroMatch[2];
+const pendingZeroMatchInserted = _mergePendingSessionMessage(pendingSession, pendingZeroMatch);
+const pendingAmbiguous = [
+  {{role:'user', content:'old prompt', _active_turn_token:oldToken}},
+  {{role:'assistant', content:'working', _live:true, _active_turn_token:newToken}},
+  {{role:'user', content:'first imported', _active_turn_token:newToken}},
+  {{role:'user', content:'second imported', _active_turn_token:newToken}},
+];
+const pendingAmbiguousInserted = _mergePendingSessionMessage(pendingSession, pendingAmbiguous);
+
+process.stdout.write(JSON.stringify({{
+  prepared,
+  pendingMerge,
+  recoveredUserCount:recoveredUsers.length,
+  recoveredAttachments:recoveredUsers.map(m=>m.attachments||[]),
+  sameTokenUserCount:sameTokenUsers.length,
+  sameTokenContent:sameTokenUsers[0]&&sameTokenUsers[0].content,
+  sameTokenAttachments:sameTokenUsers[0]&&sameTokenUsers[0].attachments||[],
+  transformedTokenResults,
+  skewUserCount:skewMerged.filter(m=>m&&m.role==='user').length,
+  uncertainUserCounts,
+  liveBoundaryUserCount:liveBoundaryMerged.filter(m=>m&&m.role==='user').length,
+  ambiguousUserCount:ambiguousMerged.filter(m=>m&&m.role==='user').length,
+  sameLiveUserCount:sameLiveMerged.filter(m=>m&&m.role==='user').length,
+  sameLiveAttachments:sameLiveMerged.filter(m=>m&&m.role==='user').map(m=>m.attachments||[]),
+  opaqueWhitespace:_opaqueActiveTurnToken('   '),
+  noActivityCounts,
+  duplicateAdjacent,
+  duplicateSeparated,
+  pendingUniqueInserted,
+  pendingUniqueRoles:pendingAfterLive.map(m=>m.role),
+  pendingUniqueAttachments:pendingAfterLive.filter(m=>m&&m.role==='user').map(m=>m.attachments||[]),
+  pendingZeroMatchInserted,
+  pendingZeroMatchRoles:pendingZeroMatch.map(m=>m.role),
+  pendingZeroMatchUserCount:pendingZeroMatch.filter(m=>m&&m.role==='user').length,
+  pendingZeroMatchMoved:pendingZeroMatch.indexOf(pendingZeroMatchOriginal)
+    <pendingZeroMatch.findIndex(m=>m&&m.role==='assistant'&&m._live),
+  pendingZeroMatchSyntheticCount:pendingZeroMatch.filter(m=>m&&m.role==='user'&&m._pending).length,
+  pendingAmbiguousInserted,
+  pendingAmbiguousUserCount:pendingAmbiguous.filter(m=>m&&m.role==='user').length,
+}}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
     return json.loads(proc.stdout)
@@ -714,11 +1040,58 @@ def test_tail_scanners_fail_closed_and_share_turn_ownership_rules():
             assert row["currentDuplicate"] is row["expect"]
             assert row["mergedUserTimestamps"] == row["mergedExpect"]
             continue
-        if row["name"] == "candidate timestamp field":
+        if row["name"] in {"candidate timestamp field", "same-token candidate after tool activity"}:
             assert row["currentDuplicate"] is row["expect"]
             continue
-        assert row["current"] == row["expect"], row["name"]
-        assert row["pending"] == row["expect"], row["name"]
+        assert row["current"] == row["currentExpect"], row["name"]
+        assert row["pending"] == row["pendingExpect"], row["name"]
+
+
+def test_inflight_dedupe_uses_active_turn_token_across_clock_skew():
+    result = _run_cross_clock_inflight_probe()
+
+    assert result["skewUserCount"] == 2
+    assert result["skewAttachments"] == [[], [{"name": "new.txt", "path": "new.txt", "mime": "text/plain"}]]
+    assert result["missingTokenUserCount"] == 2
+    assert result["sameTokenUserCount"] == 1
+
+
+def test_turn_ownership_adversarial_recovery_and_fail_closed_cases():
+    result = _run_turn_ownership_adversarial_probe()
+
+    assert result["prepared"] is False
+    assert result["pendingMerge"] is False
+    assert result["recoveredUserCount"] == 2
+    assert result["recoveredAttachments"] == [[], [{"name": "new.txt", "path": "new.txt"}]]
+    assert result["sameTokenUserCount"] == 1
+    assert result["sameTokenContent"] == "upload-only"
+    assert result["sameTokenAttachments"] == [{"name": "new.txt", "path": "new.txt"}]
+    assert result["transformedTokenResults"] == [
+        {"count": 1, "attachments": [{"name": "new.txt", "path": "new.txt"}]},
+        {"count": 1, "attachments": [{"name": "new.txt", "path": "new.txt"}]},
+        {"count": 1, "attachments": [{"name": "new.txt", "path": "new.txt"}]},
+        {"count": 1, "attachments": [{"name": "new.txt", "path": "new.txt"}]},
+    ]
+    assert result["skewUserCount"] == 2
+    assert result["uncertainUserCounts"] == [2, 2, 2, 2]
+    assert result["liveBoundaryUserCount"] == 2
+    assert result["ambiguousUserCount"] == 3
+    assert result["sameLiveUserCount"] == 1
+    assert result["sameLiveAttachments"] == [[{"name": "new.txt", "path": "new.txt"}]]
+    assert result["opaqueWhitespace"] is None
+    assert result["noActivityCounts"] == [2, 2, 2, 2, 1]
+    assert result["duplicateAdjacent"] == 3
+    assert result["duplicateSeparated"] == 3
+    assert result["pendingUniqueInserted"] is False
+    assert result["pendingUniqueRoles"] == ["user", "user", "assistant"]
+    assert result["pendingUniqueAttachments"] == [[], [{"name": "new.txt", "path": "new.txt"}]]
+    assert result["pendingZeroMatchInserted"] is True
+    assert result["pendingZeroMatchRoles"] == ["user", "user", "assistant", "user"]
+    assert result["pendingZeroMatchUserCount"] == 3
+    assert result["pendingZeroMatchMoved"] is False
+    assert result["pendingZeroMatchSyntheticCount"] == 1
+    assert result["pendingAmbiguousInserted"] is True
+    assert result["pendingAmbiguousUserCount"] == 4
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():
@@ -727,7 +1100,7 @@ def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():
     find_pos = MESSAGES_SRC.index("function _findPendingLiveToolCallIndex")
     find_block = MESSAGES_SRC[find_pos : find_pos + 900]
     upsert_pos = MESSAGES_SRC.index("function upsertLiveToolCall")
-    upsert_block = MESSAGES_SRC[upsert_pos : upsert_pos + 600]
+    upsert_block = MESSAGES_SRC[upsert_pos : upsert_pos + 1000]
 
     for key in ("tid", "id", "tool_call_id", "tool_use_id", "call_id"):
         assert key in live_tid_block

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -385,6 +385,109 @@ process.stdout.write(JSON.stringify({{
     return json.loads(proc.stdout)
 
 
+def _run_tail_scanner_boundary_probe() -> list[dict]:
+    prompt = "scan me"
+    canonical_helper = _optional_function_body(
+        UI_SRC, "function _isCanonicalAssistantToolCallEnvelope"
+    ) or "function _isCanonicalAssistantToolCallEnvelope(){return false;}"
+    ownership_helper = _optional_function_body(
+        UI_SRC, "function _isTailActivityOwnedByCandidateTurn"
+    ) or "function _isTailActivityOwnedByCandidateTurn(){return false;}"
+    helpers = "\n".join(
+        [
+            _function_body(UI_SRC, "function _timestampSeconds"),
+            _function_body(UI_SRC, "function _firstValidTimestampSeconds"),
+            ownership_helper,
+            canonical_helper,
+            _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+            _function_body(UI_SRC, "function msgContent"),
+            _function_body(UI_SRC, "function _isContextCompactionText"),
+            _function_body(UI_SRC, "function _isContextCompactionMessage"),
+            _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
+            _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
+            _function_body(SESSIONS_SRC, "function _mergeInflightTailMessages"),
+        ]
+    )
+    script = f"""
+{helpers}
+function _sameTranscriptMessage(a,b){{
+  return !!(a&&b&&a.role===b.role&&String(a.content||'').trim()===String(b.content||'').trim());
+}}
+const prompt = {json.dumps(prompt)};
+const priorUser = {{role:'user', content:'older prompt', _ts:1}};
+const currentUser = {{role:'user', content:prompt, _ts:10}};
+const canonicalCall = {{id:'call-1', type:'function', function:{{name:'inspect'}}}};
+const canonicalTopNameCall = {{call_id:'call-2', name:'inspect'}};
+const sameTurnEnvelope = {{role:'assistant', content:'', _ts:10, tool_calls:[canonicalCall]}};
+const topNameEnvelope = {{role:'assistant', content:'', _ts:10, tool_calls:[canonicalTopNameCall]}};
+const sameTurnTool = {{role:'tool', content:'result', tool_call_id:'call-1', _ts:11}};
+const ordinaryAssistant = {{role:'assistant', content:'done', _ts:12}};
+const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:12}};
+const compaction = {{role:'user', content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.', _ts:10.5}};
+
+const malformed = [
+  {{name:'empty array', msg:{{role:'assistant', _ts:10, tool_calls:[]}}}},
+  {{name:'non-array', msg:{{role:'assistant', _ts:10, tool_calls:'not-an-array'}}}},
+  {{name:'null entry', msg:{{role:'assistant', _ts:10, tool_calls:[null]}}}},
+  {{name:'primitive entry', msg:{{role:'assistant', _ts:10, tool_calls:[1]}}}},
+  {{name:'missing id', msg:{{role:'assistant', _ts:10, tool_calls:[{{function:{{name:'inspect'}}}}]}}}},
+  {{name:'missing name', msg:{{role:'assistant', _ts:10, tool_calls:[{{id:'call-3'}}]}}}},
+  {{name:'mixed valid and invalid', msg:{{role:'assistant', _ts:10, tool_calls:[canonicalCall,{{id:'call-4'}}]}}}},
+];
+const cases = [
+  {{name:'canonical envelope', messages:[priorUser,currentUser,sameTurnEnvelope], expect:prompt}},
+  {{name:'canonical top-level name', messages:[priorUser,currentUser,topNameEnvelope], expect:prompt}},
+  {{name:'canonical envelope plus tool result', messages:[priorUser,currentUser,sameTurnEnvelope,sameTurnTool], expect:prompt}},
+  {{name:'tool result only', messages:[priorUser,currentUser,sameTurnTool], expect:prompt}},
+  {{name:'ordinary assistant boundary', messages:[priorUser,currentUser,ordinaryAssistant], expect:null}},
+  {{name:'older envelope activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:9}}], expect:null}},
+  {{name:'older tool activity', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:9}}], expect:null}},
+  {{name:'missing envelope timestamp', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:undefined}}], expect:null}},
+  {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], expect:null}},
+  {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, expect:null}},
+  {{name:'same-turn activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,timestamp:10,_ts:undefined}},{{...sameTurnTool,timestamp:10.1,_ts:undefined}}], expect:prompt}},
+  {{name:'compaction marker', messages:[priorUser,currentUser,compaction,sameTurnEnvelope], expect:prompt}},
+  {{name:'live tail', messages:[priorUser,currentUser,liveAssistant], expect:prompt}},
+  ...malformed.map(tc=>({{name:tc.name, messages:[priorUser,currentUser,tc.msg], expect:null}})),
+];
+const tailPrompt = (row) => row&&row.role==='user' ? String(row.content||'') : null;
+const results = cases.map(tc=>({{
+  name:tc.name,
+  current:tailPrompt(_currentTailUserMessage(tc.messages,tc.candidateStart===undefined?10:tc.candidateStart)),
+  pending:tailPrompt(_pendingCurrentTailUserMessage(tc.messages,tc.candidateStart===undefined?10:tc.candidateStart)),
+  expect:tc.expect,
+}}));
+
+// A newer repeated prompt must survive an older no-final-assistant tool tail.
+const olderToolTail = [
+  {{role:'user',content:prompt,_ts:1}},
+  {{role:'assistant',content:'',_ts:2,tool_calls:[canonicalTopNameCall]}},
+  {{role:'tool',content:'old result',_ts:3,tool_call_id:'call-2'}},
+];
+const newerPrompt = {{role:'user',content:prompt,_ts:10}};
+const merged = _mergeInflightTailMessages(
+  olderToolTail,
+  [newerPrompt,{{role:'assistant',content:'working',_live:true,_ts:11}}]
+);
+const timestampOnlyCandidate = {{role:'user',content:prompt,timestamp:10}};
+results.push({{
+  name:'newer repeated prompt after older tool tail',
+  currentDuplicate:_hasCurrentTailUserDuplicate(olderToolTail,newerPrompt),
+  mergedUserTimestamps:merged.filter(m=>m&&m.role==='user').map(m=>m._ts),
+  expect:false,
+  mergedExpect:[1,10],
+}});
+results.push({{
+  name:'candidate timestamp field',
+  currentDuplicate:_hasCurrentTailUserDuplicate([currentUser,sameTurnEnvelope],timestampOnlyCandidate),
+  expect:true,
+}});
+process.stdout.write(JSON.stringify(results));
+"""
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
 def test_reattach_path_uses_replay_when_status_reports_journal():
     reattach_pos = MESSAGES_SRC.index("let replayOnly=false;")
     # Window widened to 2200: the SSE-recovery follow-restore fix (the
@@ -603,6 +706,19 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["tokenIdentityDedupe"] is True
     assert result["isContextCompactionText"] is True
     assert result["isContextCompactionMessage"] is True
+
+
+def test_tail_scanners_fail_closed_and_share_turn_ownership_rules():
+    for row in _run_tail_scanner_boundary_probe():
+        if row["name"] == "newer repeated prompt after older tool tail":
+            assert row["currentDuplicate"] is row["expect"]
+            assert row["mergedUserTimestamps"] == row["mergedExpect"]
+            continue
+        if row["name"] == "candidate timestamp field":
+            assert row["currentDuplicate"] is row["expect"]
+            continue
+        assert row["current"] == row["expect"], row["name"]
+        assert row["pending"] == row["expect"], row["name"]
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -106,6 +106,10 @@ def _run_current_turn_scope_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
             _function_body(SESSIONS_SRC, "function _currentTailUserMessage"),
             _function_body(SESSIONS_SRC, "function _hasCurrentTailUserDuplicate"),
+            _function_body(UI_SRC, "function _isCanonicalAssistantToolCallEnvelope"),
+            _function_body(UI_SRC, "function _messageTimestampSeconds"),
+            _function_body(UI_SRC, "function _activeTurnTokenMatches"),
+            _function_body(UI_SRC, "function _pendingActiveTurnUserMessage"),
             _function_body(SESSIONS_SRC, "function _mergePendingSessionMessage"),
             _function_body(SESSIONS_SRC, "function _mergeInflightTailMessages"),
         ]
@@ -125,8 +129,8 @@ function getPendingSessionMessage(session, messages){{
 }}
 const historical = {{role:'user', content:{json.dumps(historical_workspace_prompt)}, _ts:1}};
 const historicalAnswer = {{role:'assistant', content:'done', _ts:2}};
-const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4}};
 const activeTurnToken = 'turn-current:3';
+const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:4, _active_turn_token:activeTurnToken}};
 const pendingSession = {{pending_user_message:{json.dumps(prompt)}, pending_started_at:3, active_turn_token:activeTurnToken}};
 
 const pendingAfterHistory = [historical, historicalAnswer];
@@ -274,15 +278,33 @@ const exactCurrentResult = getPendingSessionMessage(
   exactCurrentMessages
 );
 const activeTokenDirectTailAttachments = [{{name:'active-token.txt', path:'active-token.txt', mime:'text/plain'}}];
-const activeTokenOldDirectTail = {{role:'user', content:prompt, timestamp:100}};
+const activeTokenOldDirectTail = {{role:'user', content:prompt, timestamp:101}};
 const activeTokenOldDirectTailResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
   [activeTokenOldDirectTail]
 );
-const activeTokenCurrentDirectTail = {{role:'user', content:prompt, timestamp:101}};
+const activeTokenCurrentDirectTail = {{role:'user', content:prompt, timestamp:101, _active_turn_token:'opaque:new'}};
 const activeTokenCurrentDirectTailResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
   [activeTokenCurrentDirectTail]
+);
+const authoritativeOlderExact = {{role:'user', content:prompt, timestamp:100, _active_turn_token:'opaque:new'}};
+const authoritativeNewerMissing = {{role:'user', content:prompt, timestamp:102}};
+const authoritativeNewerMissingResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
+  [authoritativeOlderExact, authoritativeNewerMissing]
+);
+const authoritativeOlderExactForConflict = {{role:'user', content:prompt, timestamp:100, _active_turn_token:'opaque:new'}};
+const authoritativeNewerMismatched = {{role:'user', content:prompt, timestamp:102, _active_turn_token:'opaque:other'}};
+const authoritativeNewerMismatchedResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
+  [authoritativeOlderExactForConflict, authoritativeNewerMismatched]
+);
+const noTokenOlderExact = {{role:'user', content:prompt, timestamp:101}};
+const noTokenNewerBoundary = {{role:'user', content:'newer boundary', timestamp:102}};
+const noTokenNewerBoundaryResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, pending_attachments:activeTokenDirectTailAttachments}},
+  [noTokenOlderExact, noTokenNewerBoundary]
 );
 const duplicateTimestampRows = [
   {{role:'user', content:'other prompt', timestamp:101}},
@@ -322,6 +344,25 @@ const liveBoundaryCurrentRow = {{role:'assistant', content:'working', _live:true
 const liveBoundaryCurrentResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:101, pending_attachments:liveBoundaryAttachments}},
   [liveBoundaryCurrentUser, liveBoundaryCurrentRow]
+);
+const authoritativeMissingLiveUser = {{role:'user', content:prompt, timestamp:101}};
+const authoritativeMissingLive = {{role:'assistant', content:'working', _live:true, timestamp:110}};
+const authoritativeMissingLiveResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:liveBoundaryAttachments}},
+  [authoritativeMissingLiveUser, authoritativeMissingLive]
+);
+const authoritativeMismatchedLiveUser = {{role:'user', content:prompt, timestamp:101}};
+const authoritativeMismatchedLive = {{role:'assistant', content:'working', _live:true, timestamp:110, _active_turn_token:'opaque:old'}};
+const authoritativeMismatchedLiveResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:liveBoundaryAttachments}},
+  [authoritativeMismatchedLiveUser, authoritativeMismatchedLive]
+);
+const authoritativeDuplicateLiveUser = {{role:'user', content:prompt, timestamp:101, _active_turn_token:'opaque:new'}};
+const authoritativeDuplicateLiveUserAgain = {{role:'user', content:prompt, timestamp:102, _active_turn_token:'opaque:new'}};
+const authoritativeDuplicateLive = {{role:'assistant', content:'working', _live:true, timestamp:110, _active_turn_token:'opaque:new'}};
+const authoritativeDuplicateLiveResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:liveBoundaryAttachments}},
+  [authoritativeDuplicateLiveUser, authoritativeDuplicateLiveUserAgain, authoritativeDuplicateLive]
 );
 const differentTailResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4}},
@@ -421,6 +462,12 @@ process.stdout.write(JSON.stringify({{
   activeTokenOldDirectTailClean: !Array.isArray(activeTokenOldDirectTail.attachments),
   activeTokenCurrentDirectTailDedupe: activeTokenCurrentDirectTailResult===null,
   activeTokenCurrentDirectTailAttachmentsCopied: Array.isArray(activeTokenCurrentDirectTail.attachments) && activeTokenCurrentDirectTail.attachments[0].name==='active-token.txt',
+  authoritativeNewerMissingMaterializes: !!authoritativeNewerMissingResult && authoritativeNewerMissingResult._pending===true,
+  authoritativeNewerMissingOldRowClean: !Array.isArray(authoritativeOlderExact.attachments),
+  authoritativeNewerMismatchedMaterializes: !!authoritativeNewerMismatchedResult && authoritativeNewerMismatchedResult._pending===true,
+  authoritativeNewerMismatchedOldRowClean: !Array.isArray(authoritativeOlderExactForConflict.attachments),
+  noTokenNewerBoundaryMaterializes: !!noTokenNewerBoundaryResult && noTokenNewerBoundaryResult._pending===true,
+  noTokenNewerBoundaryOldRowClean: !Array.isArray(noTokenOlderExact.attachments),
   duplicateTimestampMaterializes: !!duplicateTimestampResult && duplicateTimestampResult._pending===true,
   tokenWinsDuplicateTimestampDedupe: tokenWinsDuplicateTimestampResult===null,
   tokenWinsDuplicateTimestampAttachmentsCopied: Array.isArray(tokenWinsDuplicateTimestampRows[1].attachments) && tokenWinsDuplicateTimestampRows[1].attachments[0].name==='active-token.txt',
@@ -431,6 +478,12 @@ process.stdout.write(JSON.stringify({{
   liveBoundaryOldRowClean: !Array.isArray(liveBoundaryOldUser.attachments),
   liveBoundaryExactCurrentDedupe: liveBoundaryCurrentResult===null,
   liveBoundaryExactCurrentAttachmentsCopied: Array.isArray(liveBoundaryCurrentUser.attachments) && liveBoundaryCurrentUser.attachments[0].name==='live-boundary.txt',
+  authoritativeMissingLiveMaterializes: !!authoritativeMissingLiveResult && authoritativeMissingLiveResult._pending===true,
+  authoritativeMissingLiveOldRowClean: !Array.isArray(authoritativeMissingLiveUser.attachments),
+  authoritativeMismatchedLiveMaterializes: !!authoritativeMismatchedLiveResult && authoritativeMismatchedLiveResult._pending===true,
+  authoritativeMismatchedLiveOldRowClean: !Array.isArray(authoritativeMismatchedLiveUser.attachments),
+  authoritativeDuplicateLiveMaterializes: !!authoritativeDuplicateLiveResult && authoritativeDuplicateLiveResult._pending===true,
+  authoritativeDuplicateLiveOldRowClean: !Array.isArray(authoritativeDuplicateLiveUser.attachments) && !Array.isArray(authoritativeDuplicateLiveUserAgain.attachments),
   differentCurrentTailSurvives: !!differentTailResult && differentTailResult.content===prompt && differentTailResult._pending===true,
   compactionBoundaryDedupe: compactionTailResult===null,
   compactionBoundaryCurrentTail: compactionCurrentTail&&compactionCurrentTail.role==='user'&&compactionCurrentTail.content===prompt,
@@ -494,6 +547,8 @@ const sameTurnTool = {{role:'tool', content:'result', tool_call_id:'call-1', _ts
 const taggedEnvelope = {{...sameTurnEnvelope, _ts:undefined, timestamp:undefined, _active_turn_token:'turn-1:10'}};
 const ordinaryAssistant = {{role:'assistant', content:'done', _ts:12}};
 const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:12, _active_turn_token:'turn-1:10'}};
+const priorUserWithoutToken = {{role:'user', content:prompt, _ts:1}};
+const currentUserWithoutToken = {{role:'user', content:prompt, _ts:10}};
 const compaction = {{role:'user', content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.', _ts:10.5}};
 
 const malformed = [
@@ -506,22 +561,25 @@ const malformed = [
   {{name:'mixed valid and invalid', msg:{{role:'assistant', _ts:10, tool_calls:[canonicalCall,{{id:'call-4'}}]}}}},
 ];
 const cases = [
-  {{name:'canonical envelope', messages:[priorUser,currentUser,sameTurnEnvelope], expect:prompt}},
-  {{name:'canonical top-level name', messages:[priorUser,currentUser,topNameEnvelope], expect:prompt}},
-  {{name:'canonical envelope plus tool result', messages:[priorUser,currentUser,sameTurnEnvelope,sameTurnTool], expect:prompt}},
-  {{name:'tool result only', messages:[priorUser,currentUser,sameTurnTool], expect:prompt}},
+  {{name:'canonical envelope missing token', messages:[priorUser,currentUser,sameTurnEnvelope], expect:null}},
+  {{name:'canonical top-level name missing token', messages:[priorUser,currentUser,topNameEnvelope], expect:null}},
+  {{name:'canonical envelope plus tool result missing token', messages:[priorUser,currentUser,sameTurnEnvelope,sameTurnTool], expect:null}},
+  {{name:'tool result missing token', messages:[priorUser,currentUser,sameTurnTool], expect:null}},
   {{name:'ordinary assistant boundary', messages:[priorUser,currentUser,ordinaryAssistant], expect:null}},
   {{name:'older envelope activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:9}}], currentExpect:null, pendingExpect:null}},
   {{name:'older tool activity', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:9}}], currentExpect:null, pendingExpect:null}},
   {{name:'missing envelope timestamp', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:undefined}}], currentExpect:null, pendingExpect:null}},
   {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], currentExpect:null, pendingExpect:null}},
   {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, currentExpect:null, pendingExpect:null}},
-  {{name:'same-turn activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,timestamp:10,_ts:undefined}},{{...sameTurnTool,timestamp:10.1,_ts:undefined}}], expect:prompt}},
+  {{name:'same-turn activity missing token', messages:[priorUser,currentUser,{{...sameTurnEnvelope,timestamp:10,_ts:undefined}},{{...sameTurnTool,timestamp:10.1,_ts:undefined}}], expect:null}},
   {{name:'same-token tagged activity', messages:[priorUser,currentUser,taggedEnvelope], candidateStart:null, expect:prompt, pendingExpect:prompt}},
-  {{name:'compaction marker', messages:[priorUser,currentUser,compaction,sameTurnEnvelope], expect:prompt}},
+  {{name:'compaction marker before missing-token activity', messages:[priorUser,currentUser,compaction,sameTurnEnvelope], expect:null}},
   {{name:'live tail', messages:[priorUser,currentUser,liveAssistant], expect:prompt}},
-  {{name:'live tail missing token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12}}], currentExpect:null, pendingExpect:prompt}},
-  {{name:'live tail mismatched token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12, _active_turn_token:'turn-2:10'}}], currentExpect:null, pendingExpect:prompt}},
+  {{name:'live tail missing token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12}}], currentExpect:null, pendingExpect:null}},
+  {{name:'live tail mismatched token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12, _active_turn_token:'turn-2:10'}}], currentExpect:null, pendingExpect:null}},
+  {{name:'live tail missing user token', messages:[priorUser,currentUserWithoutToken,liveAssistant], currentExpect:null, pendingExpect:null}},
+  {{name:'same-token live rows are one owner', messages:[priorUser,currentUser,liveAssistant,{{...liveAssistant,_ts:13}}], expect:prompt}},
+  {{name:'no authoritative token unique timestamp fallback', messages:[priorUserWithoutToken,currentUserWithoutToken,sameTurnEnvelope], activeTurnToken:null, candidate:null, currentExpect:null, pendingExpect:prompt}},
   ...malformed.map(tc=>({{name:tc.name, messages:[priorUser,currentUser,tc.msg], expect:null}})),
 ];
 const tailPrompt = (row) => row&&row.role==='user' ? String(row.content||'') : null;
@@ -571,7 +629,7 @@ results.push({{
 }});
 results.push({{
   name:'same-token candidate after tool activity',
-  currentDuplicate:_hasCurrentTailUserDuplicate([currentUser,sameTurnEnvelope],currentCandidate,'turn-1:10'),
+  currentDuplicate:_hasCurrentTailUserDuplicate([currentUser,taggedEnvelope],currentCandidate,'turn-1:10'),
   expect:true,
 }});
 process.stdout.write(JSON.stringify(results));
@@ -625,8 +683,8 @@ const missingTokenMerged = _mergeInflightTailMessages(priorActivity, [missingTok
 
 const sameTurnActivity = [
   {{role:'user', content:prompt, timestamp:100, _active_turn_token:newToken}},
-  {{role:'assistant', content:'', timestamp:101, tool_calls:[oldCall]}},
-  {{role:'tool', content:'current result', timestamp:102, tool_call_id:'old-call'}},
+  {{role:'assistant', content:'', timestamp:101, tool_calls:[oldCall], _active_turn_token:newToken}},
+  {{role:'tool', content:'current result', timestamp:102, tool_call_id:'old-call', _active_turn_token:newToken}},
 ];
 const sameTokenMerged = _mergeInflightTailMessages(sameTurnActivity, [candidate, live], newToken);
 process.stdout.write(JSON.stringify({{
@@ -649,7 +707,9 @@ def _run_turn_ownership_adversarial_probe() -> dict:
             _function_body(UI_SRC, "function _isTailActivityOwnedByCandidateTurn"),
             _function_body(UI_SRC, "function _isCanonicalAssistantToolCallEnvelope"),
             _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
+            _function_body(UI_SRC, "function _messageTimestampSeconds"),
             _function_body(UI_SRC, "function _activeTurnTokenMatches"),
+            _function_body(UI_SRC, "function _pendingActiveTurnUserMessage"),
             _function_body(UI_SRC, "function msgContent"),
             _function_body(UI_SRC, "function _isContextCompactionText"),
             _function_body(UI_SRC, "function _isContextCompactionMessage"),
@@ -700,8 +760,8 @@ const recoveredUsers = recovery.filter(m=>m&&m.role==='user');
 // C: token ownership wins over transformed display/model text and adopts files.
 const sameTurnBase = [
   {{role:'user', content:'upload-only', timestamp:100, _active_turn_token:newToken}},
-  {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall]}},
-  {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1'}},
+  {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall], _active_turn_token:newToken}},
+  {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1', _active_turn_token:newToken}},
 ];
 const transformedCandidate = {{
   role:'user', content:'/moa same prompt', _ts:50, _active_turn_token:newToken,
@@ -722,8 +782,8 @@ const transformedDisplays = [
 const transformedTokenResults = transformedDisplays.map(content=>{{
   const base=[
     {{role:'user', content:'original prompt', timestamp:100, _active_turn_token:newToken}},
-    {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall]}},
-    {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1'}},
+    {{role:'assistant', content:'', timestamp:101, tool_calls:[toolCall], _active_turn_token:newToken}},
+    {{role:'tool', content:'result', timestamp:102, tool_call_id:'call-1', _active_turn_token:newToken}},
   ];
   const candidate={{role:'user', content, _ts:50, _active_turn_token:newToken, attachments:[attachment]}};
   const users=_mergeInflightTailMessages(
@@ -830,6 +890,22 @@ const pendingAfterLive = [
   {{role:'user', content:'/bundle transformed', _active_turn_token:newToken}},
 ];
 const pendingUniqueInserted = _mergePendingSessionMessage(pendingSession, pendingAfterLive);
+const pendingOlderExactNewerMissing = [
+  {{role:'user', content:prompt, timestamp:100, _active_turn_token:newToken}},
+  {{role:'user', content:prompt, timestamp:102}},
+];
+const pendingOlderExactNewerMissingInserted = _mergePendingSessionMessage(
+  pendingSession,
+  pendingOlderExactNewerMissing,
+);
+const pendingOlderExactNewerMismatched = [
+  {{role:'user', content:prompt, timestamp:100, _active_turn_token:newToken}},
+  {{role:'user', content:prompt, timestamp:102, _active_turn_token:oldToken}},
+];
+const pendingOlderExactNewerMismatchedInserted = _mergePendingSessionMessage(
+  pendingSession,
+  pendingOlderExactNewerMismatched,
+);
 const pendingZeroMatch = [
   {{role:'user', content:prompt, _active_turn_token:oldToken}},
   {{role:'assistant', content:'working', _live:true, _active_turn_token:newToken}},
@@ -844,6 +920,16 @@ const pendingAmbiguous = [
   {{role:'user', content:'second imported', _active_turn_token:newToken}},
 ];
 const pendingAmbiguousInserted = _mergePendingSessionMessage(pendingSession, pendingAmbiguous);
+const pendingTimestampOwner = {{
+  pending_user_message:prompt,
+  pending_started_at:200,
+  pending_attachments:[attachment],
+}};
+const timestampFallbackRow = {{role:'user', content:prompt, timestamp:200}};
+const timestampFallbackInserted = _mergePendingSessionMessage(
+  pendingTimestampOwner,
+  [timestampFallbackRow],
+);
 
 process.stdout.write(JSON.stringify({{
   prepared,
@@ -867,6 +953,12 @@ process.stdout.write(JSON.stringify({{
   pendingUniqueInserted,
   pendingUniqueRoles:pendingAfterLive.map(m=>m.role),
   pendingUniqueAttachments:pendingAfterLive.filter(m=>m&&m.role==='user').map(m=>m.attachments||[]),
+  pendingOlderExactNewerMissingInserted,
+  pendingOlderExactNewerMissingOldClean:!Array.isArray(pendingOlderExactNewerMissing[0].attachments),
+  pendingOlderExactNewerMissingSyntheticCount:pendingOlderExactNewerMissing.filter(m=>m&&m._pending).length,
+  pendingOlderExactNewerMismatchedInserted,
+  pendingOlderExactNewerMismatchedOldClean:!Array.isArray(pendingOlderExactNewerMismatched[0].attachments),
+  pendingOlderExactNewerMismatchedSyntheticCount:pendingOlderExactNewerMismatched.filter(m=>m&&m._pending).length,
   pendingZeroMatchInserted,
   pendingZeroMatchRoles:pendingZeroMatch.map(m=>m.role),
   pendingZeroMatchUserCount:pendingZeroMatch.filter(m=>m&&m.role==='user').length,
@@ -875,6 +967,9 @@ process.stdout.write(JSON.stringify({{
   pendingZeroMatchSyntheticCount:pendingZeroMatch.filter(m=>m&&m.role==='user'&&m._pending).length,
   pendingAmbiguousInserted,
   pendingAmbiguousUserCount:pendingAmbiguous.filter(m=>m&&m.role==='user').length,
+  pendingAmbiguousRowsClean:pendingAmbiguous.filter(m=>m&&m.role==='user'&&!m._pending).every(m=>!Array.isArray(m.attachments)),
+  timestampFallbackInserted,
+  timestampFallbackAttachments:timestampFallbackRow.attachments||[],
 }}));
 """
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
@@ -1084,6 +1179,12 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["activeTokenOldDirectTailClean"] is True
     assert result["activeTokenCurrentDirectTailDedupe"] is True
     assert result["activeTokenCurrentDirectTailAttachmentsCopied"] is True
+    assert result["authoritativeNewerMissingMaterializes"] is True
+    assert result["authoritativeNewerMissingOldRowClean"] is True
+    assert result["authoritativeNewerMismatchedMaterializes"] is True
+    assert result["authoritativeNewerMismatchedOldRowClean"] is True
+    assert result["noTokenNewerBoundaryMaterializes"] is True
+    assert result["noTokenNewerBoundaryOldRowClean"] is True
     assert result["duplicateTimestampMaterializes"] is True
     assert result["tokenWinsDuplicateTimestampDedupe"] is True
     assert result["tokenWinsDuplicateTimestampAttachmentsCopied"] is True
@@ -1094,6 +1195,12 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["liveBoundaryOldRowClean"] is True
     assert result["liveBoundaryExactCurrentDedupe"] is True
     assert result["liveBoundaryExactCurrentAttachmentsCopied"] is True
+    assert result["authoritativeMissingLiveMaterializes"] is True
+    assert result["authoritativeMissingLiveOldRowClean"] is True
+    assert result["authoritativeMismatchedLiveMaterializes"] is True
+    assert result["authoritativeMismatchedLiveOldRowClean"] is True
+    assert result["authoritativeDuplicateLiveMaterializes"] is True
+    assert result["authoritativeDuplicateLiveOldRowClean"] is True
     assert result["differentCurrentTailSurvives"] is True
     assert result["compactionBoundaryDedupe"] is True
     assert result["compactionBoundaryCurrentTail"] is True
@@ -1164,6 +1271,12 @@ def test_turn_ownership_adversarial_recovery_and_fail_closed_cases():
     assert result["pendingUniqueInserted"] is False
     assert result["pendingUniqueRoles"] == ["user", "user", "assistant"]
     assert result["pendingUniqueAttachments"] == [[], [{"name": "new.txt", "path": "new.txt"}]]
+    assert result["pendingOlderExactNewerMissingInserted"] is True
+    assert result["pendingOlderExactNewerMissingOldClean"] is True
+    assert result["pendingOlderExactNewerMissingSyntheticCount"] == 1
+    assert result["pendingOlderExactNewerMismatchedInserted"] is True
+    assert result["pendingOlderExactNewerMismatchedOldClean"] is True
+    assert result["pendingOlderExactNewerMismatchedSyntheticCount"] == 1
     assert result["pendingZeroMatchInserted"] is True
     assert result["pendingZeroMatchRoles"] == ["user", "user", "assistant", "user"]
     assert result["pendingZeroMatchUserCount"] == 3
@@ -1171,6 +1284,9 @@ def test_turn_ownership_adversarial_recovery_and_fail_closed_cases():
     assert result["pendingZeroMatchSyntheticCount"] == 1
     assert result["pendingAmbiguousInserted"] is True
     assert result["pendingAmbiguousUserCount"] == 4
+    assert result["pendingAmbiguousRowsClean"] is True
+    assert result["timestampFallbackInserted"] is False
+    assert result["timestampFallbackAttachments"] == [{"name": "new.txt", "path": "new.txt"}]
 
 
 def test_live_tool_matching_uses_the_same_aliases_as_live_card_dedup():

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -281,6 +281,19 @@ const liveAfterCurrentResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4}},
   [historical, historicalAnswer, currentWorkspaceTail, liveAssistant]
 );
+const liveBoundaryAttachments = [{{name:'live-boundary.txt', path:'live-boundary.txt', mime:'text/plain'}}];
+const liveBoundaryOldUser = {{role:'user', content:prompt, timestamp:100}};
+const liveBoundaryRow = {{role:'assistant', content:'working', _live:true, timestamp:110}};
+const liveBoundaryResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, pending_attachments:liveBoundaryAttachments}},
+  [liveBoundaryOldUser, liveBoundaryRow]
+);
+const liveBoundaryCurrentUser = {{role:'user', content:prompt, timestamp:101}};
+const liveBoundaryCurrentRow = {{role:'assistant', content:'working', _live:true, timestamp:110}};
+const liveBoundaryCurrentResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, pending_attachments:liveBoundaryAttachments}},
+  [liveBoundaryCurrentUser, liveBoundaryCurrentRow]
+);
 const differentTailResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4}},
   [historical, historicalAnswer, {{role:'user', content:'different prompt', _ts:3}}]
@@ -376,7 +389,11 @@ process.stdout.write(JSON.stringify({{
   exactCurrentTailDedupe: exactCurrentResult===null,
   exactCurrentTailAttachmentsCopied: Array.isArray(currentTail.attachments) && currentTail.attachments[0].name==='note.txt',
   workspaceCurrentTailDedupe: workspaceCurrentResult===null,
-  liveAfterCurrentTailDedupe: liveAfterCurrentResult===null,
+  liveAfterCurrentTailMaterializes: !!liveAfterCurrentResult && liveAfterCurrentResult._pending===true,
+  liveBoundaryMaterializes: !!liveBoundaryResult && liveBoundaryResult._pending===true && liveBoundaryResult.content===prompt && Array.isArray(liveBoundaryResult.attachments) && liveBoundaryResult.attachments[0].name==='live-boundary.txt',
+  liveBoundaryOldRowClean: !Array.isArray(liveBoundaryOldUser.attachments),
+  liveBoundaryExactCurrentDedupe: liveBoundaryCurrentResult===null,
+  liveBoundaryExactCurrentAttachmentsCopied: Array.isArray(liveBoundaryCurrentUser.attachments) && liveBoundaryCurrentUser.attachments[0].name==='live-boundary.txt',
   differentCurrentTailSurvives: !!differentTailResult && differentTailResult.content===prompt && differentTailResult._pending===true,
   compactionBoundaryDedupe: compactionTailResult===null,
   compactionBoundaryCurrentTail: compactionCurrentTail&&compactionCurrentTail.role==='user'&&compactionCurrentTail.content===prompt,
@@ -1027,7 +1044,11 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["exactCurrentTailDedupe"] is True
     assert result["exactCurrentTailAttachmentsCopied"] is True
     assert result["workspaceCurrentTailDedupe"] is True
-    assert result["liveAfterCurrentTailDedupe"] is True
+    assert result["liveAfterCurrentTailMaterializes"] is True
+    assert result["liveBoundaryMaterializes"] is True
+    assert result["liveBoundaryOldRowClean"] is True
+    assert result["liveBoundaryExactCurrentDedupe"] is True
+    assert result["liveBoundaryExactCurrentAttachmentsCopied"] is True
     assert result["differentCurrentTailSurvives"] is True
     assert result["compactionBoundaryDedupe"] is True
     assert result["compactionBoundaryCurrentTail"] is True

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -273,6 +273,35 @@ const exactCurrentResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4, pending_attachments:attachments}},
   exactCurrentMessages
 );
+const activeTokenDirectTailAttachments = [{{name:'active-token.txt', path:'active-token.txt', mime:'text/plain'}}];
+const activeTokenOldDirectTail = {{role:'user', content:prompt, timestamp:100}};
+const activeTokenOldDirectTailResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
+  [activeTokenOldDirectTail]
+);
+const activeTokenCurrentDirectTail = {{role:'user', content:prompt, timestamp:101}};
+const activeTokenCurrentDirectTailResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
+  [activeTokenCurrentDirectTail]
+);
+const duplicateTimestampRows = [
+  {{role:'user', content:'other prompt', timestamp:101}},
+  {{role:'user', content:prompt, timestamp:101}},
+  {{role:'assistant', content:'partial', timestamp:110}},
+];
+const duplicateTimestampResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, pending_attachments:activeTokenDirectTailAttachments}},
+  duplicateTimestampRows
+);
+const tokenWinsDuplicateTimestampRows = [
+  {{role:'user', content:'other prompt', timestamp:101}},
+  {{role:'user', content:prompt, timestamp:101, _active_turn_token:'opaque:new'}},
+  {{role:'assistant', content:'partial', timestamp:110}},
+];
+const tokenWinsDuplicateTimestampResult = getPendingSessionMessage(
+  {{pending_user_message:prompt, pending_started_at:101, active_turn_token:'opaque:new', pending_attachments:activeTokenDirectTailAttachments}},
+  tokenWinsDuplicateTimestampRows
+);
 const workspaceCurrentResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:4}},
   [historical, historicalAnswer, currentWorkspaceTail]
@@ -388,6 +417,14 @@ process.stdout.write(JSON.stringify({{
   historicalWorkspaceSurvives: !!fromHistoricalWorkspace && fromHistoricalWorkspace.content===prompt && fromHistoricalWorkspace._pending===true,
   exactCurrentTailDedupe: exactCurrentResult===null,
   exactCurrentTailAttachmentsCopied: Array.isArray(currentTail.attachments) && currentTail.attachments[0].name==='note.txt',
+  activeTokenOldDirectTailMaterializes: !!activeTokenOldDirectTailResult && activeTokenOldDirectTailResult._pending===true && Array.isArray(activeTokenOldDirectTailResult.attachments) && activeTokenOldDirectTailResult.attachments[0].name==='active-token.txt',
+  activeTokenOldDirectTailClean: !Array.isArray(activeTokenOldDirectTail.attachments),
+  activeTokenCurrentDirectTailDedupe: activeTokenCurrentDirectTailResult===null,
+  activeTokenCurrentDirectTailAttachmentsCopied: Array.isArray(activeTokenCurrentDirectTail.attachments) && activeTokenCurrentDirectTail.attachments[0].name==='active-token.txt',
+  duplicateTimestampMaterializes: !!duplicateTimestampResult && duplicateTimestampResult._pending===true,
+  tokenWinsDuplicateTimestampDedupe: tokenWinsDuplicateTimestampResult===null,
+  tokenWinsDuplicateTimestampAttachmentsCopied: Array.isArray(tokenWinsDuplicateTimestampRows[1].attachments) && tokenWinsDuplicateTimestampRows[1].attachments[0].name==='active-token.txt',
+  tokenWinsDuplicateTimestampTokenlessClean: !Array.isArray(tokenWinsDuplicateTimestampRows[0].attachments),
   workspaceCurrentTailDedupe: workspaceCurrentResult===null,
   liveAfterCurrentTailMaterializes: !!liveAfterCurrentResult && liveAfterCurrentResult._pending===true,
   liveBoundaryMaterializes: !!liveBoundaryResult && liveBoundaryResult._pending===true && liveBoundaryResult.content===prompt && Array.isArray(liveBoundaryResult.attachments) && liveBoundaryResult.attachments[0].name==='live-boundary.txt',
@@ -1043,6 +1080,14 @@ def test_get_pending_session_message_keeps_deferred_repeat_prompt_by_behavior():
     assert result["historicalWorkspaceSurvives"] is True
     assert result["exactCurrentTailDedupe"] is True
     assert result["exactCurrentTailAttachmentsCopied"] is True
+    assert result["activeTokenOldDirectTailMaterializes"] is True
+    assert result["activeTokenOldDirectTailClean"] is True
+    assert result["activeTokenCurrentDirectTailDedupe"] is True
+    assert result["activeTokenCurrentDirectTailAttachmentsCopied"] is True
+    assert result["duplicateTimestampMaterializes"] is True
+    assert result["tokenWinsDuplicateTimestampDedupe"] is True
+    assert result["tokenWinsDuplicateTimestampAttachmentsCopied"] is True
+    assert result["tokenWinsDuplicateTimestampTokenlessClean"] is True
     assert result["workspaceCurrentTailDedupe"] is True
     assert result["liveAfterCurrentTailMaterializes"] is True
     assert result["liveBoundaryMaterializes"] is True

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -219,10 +219,14 @@ def _run_pending_session_message_probe() -> dict:
             _function_body(SESSIONS_SRC, "function _normalizeUserTranscriptText"),
             _function_body(SESSIONS_SRC, "function _sameTranscriptMessage"),
             _function_body(SESSIONS_SRC, "function _opaqueActiveTurnToken"),
+            _function_body(UI_SRC, "function _timestampSeconds"),
+            _function_body(UI_SRC, "function _firstValidTimestampSeconds"),
+            _function_body(UI_SRC, "function _isTailActivityOwnedByCandidateTurn"),
+            _function_body(UI_SRC, "function _isCanonicalAssistantToolCallEnvelope"),
+            _function_body(UI_SRC, "function _messageTimestampSeconds"),
             _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
-            _optional_function_body(UI_SRC, "function _messageTimestampSeconds"),
-            _optional_function_body(UI_SRC, "function _activeTurnTokenMatches"),
-            _optional_function_body(UI_SRC, "function _pendingActiveTurnUserMessage"),
+            _function_body(UI_SRC, "function _activeTurnTokenMatches"),
+            _function_body(UI_SRC, "function _pendingActiveTurnUserMessage"),
             _function_body(UI_SRC, "function _isContextCompactionText"),
             _function_body(UI_SRC, "function _isContextCompactionMessage"),
             _function_body(UI_SRC, "function getPendingSessionMessage"),
@@ -341,17 +345,16 @@ const noStartedAtResult = getPendingSessionMessage(
   midRunTranscript
 );
 
-// Regression (review round 2): two completed identical-text turns whose
-// started_at differ by ~1s. The old 1.5s tolerance adopted the EARLIER row as
-// the "active turn", hiding the second (still-pending) turn and copying its
-// attachments onto the old row. With the precision-only epsilon the second turn
-// is materialized and the first row stays untouched.
+// Regression (review round 2): an older same-text user row at 100 is followed
+// by an untagged tool row at 102 while the pending turn starts at 101. The old
+// tail scan adopted the earlier row, hiding the pending turn and copying its
+// attachments onto the old row. The second turn must materialize instead.
 const rapidRepeatTurnOne = {{role:'user', content:prompt, timestamp:100}};
-const rapidRepeatAnswerOne = {{role:'assistant', content:'done', timestamp:101}};
+const rapidRepeatOldTool = {{role:'tool', content:'old result', timestamp:102, tool_call_id:'old-call'}};
 const rapidRepeatSecondAttachments = [{{name:'second.txt', path:'second.txt', mime:'text/plain'}}];
 const rapidRepeatResult = getPendingSessionMessage(
   {{pending_user_message:prompt, pending_started_at:101, pending_attachments:rapidRepeatSecondAttachments}},
-  [rapidRepeatTurnOne, rapidRepeatAnswerOne]
+  [rapidRepeatTurnOne, rapidRepeatOldTool]
 );
 // Exact token identity: the eager-checkpoint row carries _active_turn_token
 // built from the same stream_id + started_at as the session — adopted even
@@ -408,6 +411,7 @@ def _run_tail_scanner_boundary_probe() -> list[dict]:
             _function_body(UI_SRC, "function _firstValidTimestampSeconds"),
             ownership_helper,
             canonical_helper,
+            _function_body(UI_SRC, "function _messageTimestampSeconds"),
             _function_body(UI_SRC, "function _pendingCurrentTailUserMessage"),
             _function_body(UI_SRC, "function msgContent"),
             _function_body(UI_SRC, "function _isContextCompactionText"),
@@ -420,6 +424,7 @@ def _run_tail_scanner_boundary_probe() -> list[dict]:
     )
     script = f"""
 {helpers}
+const _PENDING_ACTIVE_TURN_TS_EPSILON=1e-6;
 function _sameTranscriptMessage(a,b){{
   return !!(a&&b&&a.role===b.role&&String(a.content||'').trim()===String(b.content||'').trim());
 }}
@@ -458,7 +463,7 @@ const cases = [
   {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], currentExpect:null, pendingExpect:null}},
   {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, currentExpect:null, pendingExpect:null}},
   {{name:'same-turn activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,timestamp:10,_ts:undefined}},{{...sameTurnTool,timestamp:10.1,_ts:undefined}}], expect:prompt}},
-  {{name:'same-token tagged activity', messages:[priorUser,currentUser,taggedEnvelope], candidateStart:null, expect:prompt, pendingExpect:null}},
+  {{name:'same-token tagged activity', messages:[priorUser,currentUser,taggedEnvelope], candidateStart:null, expect:prompt, pendingExpect:prompt}},
   {{name:'compaction marker', messages:[priorUser,currentUser,compaction,sameTurnEnvelope], expect:prompt}},
   {{name:'live tail', messages:[priorUser,currentUser,liveAssistant], expect:prompt}},
   {{name:'live tail missing token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12}}], currentExpect:null, pendingExpect:prompt}},
@@ -475,7 +480,12 @@ const results = cases.map(tc=>({{
     tc.candidate===undefined?currentCandidate:tc.candidate,
     tc.activeTurnToken===undefined?'turn-1:10':tc.activeTurnToken,
   )),
-  pending:tailPrompt(_pendingCurrentTailUserMessage(tc.messages,tc.candidateStart===undefined?10:tc.candidateStart)),
+  pending:tailPrompt(_pendingCurrentTailUserMessage(
+    tc.messages,
+    tc.candidateStart===undefined?10:tc.candidateStart,
+    tc.candidateTimestamp,
+    tc.activeTurnToken===undefined?'turn-1:10':tc.activeTurnToken,
+  )),
   currentExpect:tc.currentExpect===undefined?tc.expect:tc.currentExpect,
   pendingExpect:tc.pendingExpect===undefined?tc.expect:tc.pendingExpect,
 }}));
@@ -608,6 +618,7 @@ def _run_turn_ownership_adversarial_probe() -> dict:
     )
     script = f"""
 {helpers}
+const _PENDING_ACTIVE_TURN_TS_EPSILON=1e-6;
 const prompt = 'same prompt';
 const newToken = 'opaque:new-turn';
 const oldToken = 'opaque:old-turn';

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -432,6 +432,7 @@ const canonicalTopNameCall = {{call_id:'call-2', name:'inspect'}};
 const sameTurnEnvelope = {{role:'assistant', content:'', _ts:10, tool_calls:[canonicalCall]}};
 const topNameEnvelope = {{role:'assistant', content:'', _ts:10, tool_calls:[canonicalTopNameCall]}};
 const sameTurnTool = {{role:'tool', content:'result', tool_call_id:'call-1', _ts:11}};
+const taggedEnvelope = {{...sameTurnEnvelope, _ts:undefined, timestamp:undefined, _active_turn_token:'turn-1:10'}};
 const ordinaryAssistant = {{role:'assistant', content:'done', _ts:12}};
 const liveAssistant = {{role:'assistant', content:'working', _live:true, _ts:12, _active_turn_token:'turn-1:10'}};
 const compaction = {{role:'user', content:'[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.', _ts:10.5}};
@@ -451,12 +452,13 @@ const cases = [
   {{name:'canonical envelope plus tool result', messages:[priorUser,currentUser,sameTurnEnvelope,sameTurnTool], expect:prompt}},
   {{name:'tool result only', messages:[priorUser,currentUser,sameTurnTool], expect:prompt}},
   {{name:'ordinary assistant boundary', messages:[priorUser,currentUser,ordinaryAssistant], expect:null}},
-  {{name:'older envelope activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:9}}], currentExpect:prompt, pendingExpect:null}},
-  {{name:'older tool activity', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:9}}], currentExpect:prompt, pendingExpect:null}},
-  {{name:'missing envelope timestamp', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:undefined}}], currentExpect:prompt, pendingExpect:null}},
-  {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], currentExpect:prompt, pendingExpect:null}},
-  {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, currentExpect:prompt, pendingExpect:null}},
+  {{name:'older envelope activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:9}}], currentExpect:null, pendingExpect:null}},
+  {{name:'older tool activity', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:9}}], currentExpect:null, pendingExpect:null}},
+  {{name:'missing envelope timestamp', messages:[priorUser,currentUser,{{...sameTurnEnvelope,_ts:undefined}}], currentExpect:null, pendingExpect:null}},
+  {{name:'missing tool timestamp', messages:[priorUser,currentUser,sameTurnEnvelope,{{...sameTurnTool,_ts:undefined}}], currentExpect:null, pendingExpect:null}},
+  {{name:'missing candidate timestamp', messages:[priorUser,currentUser,sameTurnEnvelope], candidateStart:null, currentExpect:null, pendingExpect:null}},
   {{name:'same-turn activity', messages:[priorUser,currentUser,{{...sameTurnEnvelope,timestamp:10,_ts:undefined}},{{...sameTurnTool,timestamp:10.1,_ts:undefined}}], expect:prompt}},
+  {{name:'same-token tagged activity', messages:[priorUser,currentUser,taggedEnvelope], candidateStart:null, expect:prompt, pendingExpect:null}},
   {{name:'compaction marker', messages:[priorUser,currentUser,compaction,sameTurnEnvelope], expect:prompt}},
   {{name:'live tail', messages:[priorUser,currentUser,liveAssistant], expect:prompt}},
   {{name:'live tail missing token', messages:[priorUser,currentUser,{{role:'assistant', content:'working', _live:true, _ts:12}}], currentExpect:null, pendingExpect:prompt}},

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -470,17 +470,32 @@ def test_chat_start_adapter_path_preserves_legacy_response_shape():
     route must not add fields that the legacy-direct response does not expose.
     """
     routes = importlib.import_module("api.routes")
-    src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
-    helper_idx = src.index("def _chat_start_response_from_run_start")
-    helper_body = src[helper_idx:src.index("def _runtime_adapter_goal_action", helper_idx)]
+    runtime = importlib.import_module("api.runtime_adapter")
+    response = routes._chat_start_response_from_run_start(
+        runtime.RunStartResult(
+            run_id="runner-internal-shape",
+            session_id="s-shape",
+            stream_id="runner-stream-shape",
+            started_at=12.5,
+            status="running",
+            active_controls=["cancel"],
+            payload={
+                "stream_id": "payload-stream-must-not-win",
+                "session_id": "payload-session-must-not-win",
+                "run_id": "runner-internal-shape",
+                "status": "running",
+                "active_controls": ["cancel"],
+            },
+        )
+    )
 
-    assert '"stream_id",' in helper_body
-    assert '"session_id",' in helper_body
-    assert 'response.setdefault("stream_id", result.stream_id)' in helper_body
-    assert 'response.setdefault("session_id", result.session_id)' in helper_body
-    assert '"run_id",' not in helper_body
-    assert '"status",' not in helper_body
-    assert '"active_controls",' not in helper_body
+    assert response["stream_id"] == "runner-stream-shape"
+    assert response["session_id"] == "s-shape"
+    assert response["pending_started_at"] == 12.5
+    assert response["active_turn_token"] == "runner-stream-shape:12.5"
+    assert "run_id" not in response
+    assert "status" not in response
+    assert "active_controls" not in response
 
 
 def test_chat_start_response_from_run_start_filters_adapter_internal_fields():
@@ -513,11 +528,49 @@ def test_chat_start_response_from_run_start_filters_adapter_internal_fields():
         "stream_id": "runner-stream-1",
         "session_id": "s1",
         "pending_started_at": 123.0,
+        "active_turn_token": "runner-stream-1:123",
         "turn_id": "turn-1",
         "title": "Demo",
         "effective_model": "gpt-5.5",
         "effective_model_provider": "openai-codex",
     }
+
+
+def test_runner_start_started_at_fallback_gets_authoritative_opaque_token():
+    routes = importlib.import_module("api.routes")
+    runtime = importlib.import_module("api.runtime_adapter")
+    from api.process_event_utils import build_active_turn_token
+
+    response = routes._chat_start_response_from_run_start(
+        runtime.RunStartResult(
+            run_id="runner-internal-2",
+            session_id="s2",
+            stream_id="runner:stream:2",
+            started_at=456.25,
+            payload={"stream_id": "spoofed-payload-stream", "session_id": "s2"},
+        )
+    )
+
+    assert response["stream_id"] == "runner:stream:2"
+    assert response["pending_started_at"] == 456.25
+    assert response["active_turn_token"] == build_active_turn_token(
+        "runner:stream:2", 456.25
+    )
+
+
+def test_legacy_direct_start_normalization_exposes_exact_opaque_token():
+    routes = importlib.import_module("api.routes")
+    from api.process_event_utils import build_active_turn_token
+
+    response = routes._chat_start_response_with_turn_identity(
+        {"stream_id": "legacy:stream:1", "session_id": "s3"},
+        pending_started_at=789.5,
+    )
+
+    assert response["pending_started_at"] == 789.5
+    assert response["active_turn_token"] == build_active_turn_token(
+        "legacy:stream:1", 789.5
+    )
 
 
 def test_rfc_distinguishes_goal_routing_from_queue_route_staging():


### PR DESCRIPTION
## Thinking Path

- Reloading, reconnecting, or changing sessions during an active tool-using turn could duplicate, hide, or misattribute the current user prompt and attachments.
- The failures came from two contracts: turn ownership used timestamps from different clocks, and delayed continuations mutated pane-global state after another session owned the pane.
- The fix uses one opaque server-issued active-turn token for identity and load-aware pane ownership for visible state. Ambiguous or contradictory identity now fails closed by materializing the pending turn instead of adopting an older row.

## What Changed

- Added an opaque `active_turn_token` derived from server-owned turn state.
- Propagated the token through session payloads, chat-start responses, status, SSE recovery, hidden-tab polling, live rows, and persisted inflight state.
- Preserved raw nonblank token identity at every comparison boundary. Trimming now classifies only blank values.
- Frozen each send's session, model/provider, profile, workspace, transcript, attachments, and forced-skill state before effectful awaits.
- Gated pane-global, DOM, sidebar, reconnect-marker, and upload-status updates with load-aware pane ownership.
- Made delayed chat-start, `/goal`, slash-command, and new-session continuations preserve owner-private recovery state without mutating another pane.
- Applied the same fail-closed token policy to current-tail, pending-tail, active-turn fallback, and pending-session merge paths.
- Preserved the full pending-merge source whenever the session or any row in the live suffix carries nonblank identity evidence. Only fully tokenless legacy traffic uses the pre-live timestamp fallback.
- Added production-composed regressions for delayed uploads, forced skills, session loads, sidebar reconciliation, raw-distinct and missing token identity, mixed tagged live/tool suffixes, repeated prompts, and attachment ownership.

## Contract Routing

- **Run-lifecycle state:** preserved by owner-scoped `INFLIGHT[sessionId]` recovery and explicit background reattach.
- **Persisted/session state:** the server-issued token is carried through session/status/start/recovery payloads.
- **Rendered transcript:** pending and optimistic user rows dedupe only with authoritative identity; ambiguous cases materialize safely.
- **Maintenance activity:** reconciliation and refresh paths do not create synthetic conversation activity.
- **Visible pane ownership:** delayed work may update only the pane still owned by its initiating session.

## Verification

Exact candidate:

- Head: `6bf17e719a9aae70a713e2c5e29c25285fa5f12b`
- Base: `dc3bf44e5751264de3cf0c773421d412ca840c28`

Hosted checks:

- 23/23 completed successfully.
- All 15 Python 3.11/3.12/3.13 shards passed.
- Browser smoke, lint, historical hydration, normal lifecycle, terminal-error lifecycle, and Greptile passed.
- Greptile added no inline findings; GitHub reports no review threads.

Focused verification:

- 82 passed, 1 environment skip: regression, pending merge, and run-journal coverage.
- 79 passed: hosted compatibility cases.
- 97 passed, 1 environment skip: ownership, delayed-send, and recovery coverage.
- Browser smoke, normal lifecycle, terminal-error lifecycle, historical hydration, and hard reload passed.
- Node syntax, Ruff changed-line gate, ESLint 10.8.1 runtime guard, and `git diff --check` passed.
- Fresh Codex adversarial exact-head review: `CLEAN`.
- Claude Opus 5, medium effort, read-only exact-head review: `APPROVE`.

## Risks / Limitations

- Missing or contradictory identity can briefly render a duplicate pending row. This is intentional: a transient duplicate is safer than hiding a real turn or moving its attachments.
- Tokenless legacy activity retains the narrow timestamp fallback. Tagged activity never falls back to timestamp ownership without matching authority.
- The browser/send path remains intentionally global where unchanged upstream behavior already uses a global send lock.

## Release note

- Fixed active-turn reconnect dedupe and cross-session ownership races that could duplicate, hide, or misattribute user prompts and attachments during streaming recovery.

## Model Used

- OpenAI GPT-5.6 via Hermes Agent for investigation, specification, implementation review, and verification.
- OpenAI GPT-5.6 via Codex for implementation and adversarial review.
- Anthropic Claude Opus 5 via Claude Code for independent read-only exact-head review.

## Screenshots or videos

None. This change affects streaming ownership and recovery behavior without visual layout changes.
