### PR TITLE
Fix Windows console-window flashes at the class level, with an AST guard against recurrence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,13 @@ Follow that checklist's safety rules:
 - Prefer the existing Python + vanilla JavaScript structure. Do not add
   dependencies, build tools, frameworks, or long-lived processes without clear
   justification and a rollback story.
+- Every `subprocess` spawn must pass `creationflags=` — use
+  `windows_hide_flags()` from `api/_subprocess_compat.py` when you read the
+  child's output, or `windows_detach_flags()` for a background child that must
+  outlive the server. Both return `0` off Windows, so no platform branching is
+  needed at the call site. Without this, each spawn pops a console window on
+  Windows (#3710, #4626, #5692);
+  `tests/test_windows_console_window_guard.py` enforces it.
 - Update docs when changing setup, onboarding, runtime behavior, architecture,
   testing guidance, or user-facing workflows.
 - Do not edit `CHANGELOG.md` in ordinary contributor PRs. The release workflow

--- a/api/_subprocess_compat.py
+++ b/api/_subprocess_compat.py
@@ -1,0 +1,102 @@
+"""Win32 subprocess creationflags — the WebUI's single source of truth.
+
+Every ``subprocess`` spawn of a console application on Windows creates a
+console window unless ``CREATE_NO_WINDOW`` is passed. For a long-lived
+server that shells out to ``git`` on ordinary page loads, that means a
+burst of black windows flashing across the user's desktop on every
+navigation, plus orphaned ``conhost.exe`` processes accumulating over a
+session.
+
+This has now been fixed three times in three places, each time for one
+module in isolation:
+
+* #3710 — test-helper subprocesses popping focus-stealing windows.
+* #4626 — the self-update / supervisor restart path flashing an empty
+  console (users closed that window, which took the WebUI down with it).
+* #5692 — workspace git commands (``workspace_git._run_git``).
+
+Each fix added its own private ``_windows_hide_flags()`` and patched only
+the call sites in front of it, so the next unpatched ``subprocess.run(
+["git", ...])`` reintroduced the same bug class. This module ends that
+cycle: one helper, imported everywhere, enforced by
+``tests/test_windows_console_window_guard.py``, which AST-scans the API
+package and fails on any spawn that omits ``creationflags``.
+
+**All helpers return 0 on non-Windows** — ``creationflags=0`` is the
+``subprocess`` default, so passing these on Linux/macOS is a genuine
+no-op. Call sites therefore stay platform-unconditional; no
+``if sys.platform == "win32":`` branching at the point of use.
+
+Deliberately standalone: the agent package ships an equivalent
+``hermes_cli._subprocess_compat``, but ``hermes_cli`` is an *optional*
+dependency (a standalone WebUI runs without an agent install), and
+importing it here would make core git functionality contingent on it.
+The duplication is intentional and load-bearing — see the note in
+``workspace_git`` history for #5692.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+__all__ = [
+    "IS_WINDOWS",
+    "windows_hide_flags",
+    "windows_detach_flags",
+]
+
+
+IS_WINDOWS = sys.platform == "win32"
+
+
+# Win32 CreationFlags, defined numerically rather than read off the
+# ``subprocess`` module: these attributes only exist on Windows builds of
+# CPython, so ``subprocess.CREATE_NO_WINDOW`` raises AttributeError at
+# import time on Linux/macOS. Literals keep this module importable
+# everywhere, which the guard test depends on.
+_CREATE_NEW_PROCESS_GROUP = 0x00000200
+_DETACHED_PROCESS = 0x00000008
+_CREATE_NO_WINDOW = 0x08000000
+
+
+def windows_hide_flags() -> int:
+    """Creationflags that hide a child's console window WITHOUT detaching it.
+
+    This is the right helper for the overwhelming majority of spawns in
+    this codebase: short-lived console programs (``git``, ``pip``,
+    ``hermes gateway ...``, VS Code's ``code.cmd`` shim) that we run
+    synchronously and whose output we collect.
+
+    The key difference from :func:`windows_detach_flags` is the absence of
+    ``DETACHED_PROCESS``. A detached child gets no console *and* loses the
+    inherited stdio handles, which silently breaks ``capture_output=True``
+    / ``communicate()``. Use this one whenever you read the child's
+    stdout, stderr, or exit code.
+
+    Returns 0 on non-Windows.
+    """
+    if not IS_WINDOWS:
+        return 0
+    return _CREATE_NO_WINDOW
+
+
+def windows_detach_flags() -> int:
+    """Creationflags that fully detach a long-lived background child.
+
+    For spawns that must outlive this process (the self-update respawn,
+    supervisor restarts) rather than short probes. ``DETACHED_PROCESS``
+    severs the console so closing a terminal doesn't kill the child;
+    ``CREATE_NEW_PROCESS_GROUP`` stops Ctrl+C propagating into it; and
+    ``CREATE_NO_WINDOW`` is still required alongside ``DETACHED_PROCESS``
+    on modern Windows, because a console-subsystem child (``python.exe``)
+    otherwise flashes an empty window regardless — the exact regression
+    #4626 fixed.
+
+    Callers must NOT capture output from a process spawned with these;
+    redirect to ``DEVNULL`` or a file. Returns 0 on non-Windows, where the
+    POSIX equivalent is ``start_new_session=True``.
+    """
+    if not IS_WINDOWS:
+        return 0
+    return _DETACHED_PROCESS | _CREATE_NEW_PROCESS_GROUP | _CREATE_NO_WINDOW

--- a/api/agent_runtime.py
+++ b/api/agent_runtime.py
@@ -15,6 +15,7 @@ import threading
 
 # Retain the discovered path as a diagnostic/test-visible compatibility value;
 # runtime identity is deliberately captured from the loaded module below.
+from api._subprocess_compat import windows_hide_flags
 from api.config import _AGENT_DIR  # noqa: F401
 
 _RESTART_MESSAGE = (
@@ -49,6 +50,7 @@ def _read_agent_revision(
             capture_output=True,
             text=True,
             timeout=2,
+            creationflags=windows_hide_flags(),
         )
         if worktree_result.returncode != 0:
             return None
@@ -69,6 +71,7 @@ def _read_agent_revision(
             capture_output=True,
             text=True,
             timeout=2,
+            creationflags=windows_hide_flags(),
         )
         if tracked_result.returncode != 0:
             return None
@@ -78,6 +81,7 @@ def _read_agent_revision(
             capture_output=True,
             text=True,
             timeout=2,
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.TimeoutExpired, RuntimeError, ValueError):
         return None

--- a/api/gateway_restart.py
+++ b/api/gateway_restart.py
@@ -10,6 +10,7 @@ import sys
 import threading
 from pathlib import Path
 
+from api._subprocess_compat import windows_hide_flags
 from api.profiles import (
     _PROFILE_ID_RE,
     _is_root_profile,
@@ -123,6 +124,9 @@ def restart_active_profile_gateway(
             stderr=subprocess.PIPE,
             text=True,
             env=env,
+            # Hide, don't detach: the communicate() below reads this child's
+            # stdout/stderr, and DETACHED_PROCESS would sever those handles.
+            creationflags=windows_hide_flags(),
         )
 
         try:

--- a/api/providers.py
+++ b/api/providers.py
@@ -32,6 +32,7 @@ try:  # POSIX-only; Windows-style environments fall back to process-local lockin
 except ImportError:  # pragma: no cover - exercised only where fcntl is unavailable
     fcntl = None  # type: ignore[assignment]
 
+from api._subprocess_compat import windows_hide_flags
 from api.config import (
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
@@ -1770,6 +1771,8 @@ class _AccountUsageProbeWorker:
         }
         if hasattr(os, "fork"):  # POSIX
             kwargs["preexec_fn"] = _account_usage_preexec_fn
+        else:  # Windows — hide the worker's console window (no-op elsewhere).
+            kwargs["creationflags"] = windows_hide_flags()
 
         try:
             self._proc = subprocess.Popen(
@@ -1810,6 +1813,8 @@ def _launch_account_usage_worker_process(
     }
     if hasattr(os, "fork"):  # POSIX
         kwargs["preexec_fn"] = _account_usage_preexec_fn
+    else:  # Windows — hide the worker's console window (no-op elsewhere).
+        kwargs["creationflags"] = windows_hide_flags()
 
     try:
         return subprocess.Popen(

--- a/api/rollback.py
+++ b/api/rollback.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from api._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # Checkpoint identifiers are SHA-style hex hashes from the agent's
@@ -102,6 +104,7 @@ def _checkpoint_entry_modes(git: str, ckpt_dir: Path) -> dict[str, int]:
     result = subprocess.run(
         [git, "-C", str(ckpt_dir), "ls-files", "-s"],
         capture_output=True, text=True, timeout=10,
+        creationflags=windows_hide_flags(),
     )
     if result.returncode != 0:
         raise ValueError("Failed to list checkpoint files")
@@ -136,6 +139,7 @@ def _read_checkpoint_blob(git: str, ckpt_dir: Path, rel_path: str) -> bytes | No
     result = subprocess.run(
         [git, "-C", str(ckpt_dir), "show", f"HEAD:{rel_path}"],
         capture_output=True, timeout=10,
+        creationflags=windows_hide_flags(),
     )
     if result.returncode != 0:
         return None
@@ -250,6 +254,7 @@ def _inspect_checkpoint(ckpt_path: Path, git: str) -> dict[str, Any] | None:
         result = subprocess.run(
             [git, "-C", str(ckpt_path), "log", "--format=%H%n%s%n%aI", "-1"],
             capture_output=True, text=True, timeout=5,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0 or not result.stdout.strip():
             return None
@@ -272,6 +277,7 @@ def _inspect_checkpoint(ckpt_path: Path, git: str) -> dict[str, Any] | None:
         files_result = subprocess.run(
             [git, "-C", str(ckpt_path), "ls-files"],
             capture_output=True, text=True, timeout=5,
+            creationflags=windows_hide_flags(),
         )
         file_count = len(files_result.stdout.strip().split("\n")) if files_result.stdout.strip() else 0
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -34,6 +34,7 @@ from contextlib import closing
 from urllib.parse import parse_qs, quote, unquote, urljoin, urlsplit
 from urllib.error import HTTPError, URLError
 from urllib.request import HTTPRedirectHandler, HTTPSHandler, ProxyHandler, Request, build_opener
+from api._subprocess_compat import windows_hide_flags
 from api.agent_runtime import (
     AgentRuntimeChangedError,
     ensure_agent_runtime_current,
@@ -1239,6 +1240,7 @@ def _run_gateway_lifecycle_command(action: str) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         timeout=_GATEWAY_LIFECYCLE_TIMEOUT_SECONDS,
+        creationflags=windows_hide_flags(),
     )
 
 
@@ -23513,13 +23515,16 @@ def _handle_file_reveal(handler, body):
                 target_str = host_prefix + target_str[len(container_prefix):]
 
         system = platform.system()
+        # windows_hide_flags() is 0 off Windows, so the two POSIX branches keep
+        # it purely for the guard test's uniform "every spawn declares its
+        # flags" rule — it is a no-op there, not a behavior change.
         if system == "Darwin":
-            subprocess.Popen(["open", "-R", target_str])
+            subprocess.Popen(["open", "-R", target_str], creationflags=windows_hide_flags())
         elif system == "Windows":
-            subprocess.Popen(["explorer.exe", "/select," + target_str])
+            subprocess.Popen(["explorer.exe", "/select," + target_str], creationflags=windows_hide_flags())
         else:
             # Linux / other — open parent directory
-            subprocess.Popen(["xdg-open", str(Path(target_str).parent)])
+            subprocess.Popen(["xdg-open", str(Path(target_str).parent)], creationflags=windows_hide_flags())
 
         return j(handler, {"ok": True, "path": body["path"]})
     except (ValueError, PermissionError, OSError) as e:
@@ -23634,7 +23639,10 @@ def _handle_file_open_vscode(handler, body):
                 "Install VS Code and ensure the 'code' CLI is on PATH, "
                 "or set vscode.command in config.yaml to the full path.",
             )
-        subprocess.Popen([resolved_cmd, target_str])
+        # On Windows `resolved_cmd` is `code.cmd`, a batch shim — spawning it
+        # without CREATE_NO_WINDOW pops a visible cmd window on every
+        # "open in VS Code" click.
+        subprocess.Popen([resolved_cmd, target_str], creationflags=windows_hide_flags())
 
         return j(handler, {"ok": True, "path": body["path"]})
     except (ValueError, PermissionError, OSError) as e:

--- a/api/startup.py
+++ b/api/startup.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os, stat, subprocess, sys
 from pathlib import Path
 
+from api._subprocess_compat import windows_hide_flags
+
 # Credential files that should never be world-readable
 _SENSITIVE_FILES = (
     '.env',
@@ -112,7 +114,10 @@ def auto_install_agent_deps() -> bool:
         print('[!!] Auto-install skipped: no requirements.txt or pyproject.toml in agent dir.', flush=True)
         return False
     try:
-        result = subprocess.run(install_args, capture_output=True, text=True, timeout=120)
+        result = subprocess.run(
+            install_args, capture_output=True, text=True, timeout=120,
+            creationflags=windows_hide_flags(),
+        )
         if result.returncode != 0:
             print(f'[!!] pip install failed (exit {result.returncode}):', flush=True)
             for line in (result.stderr or '').splitlines()[-10:]:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+from api._subprocess_compat import windows_hide_flags
 from api.config import (
     get_config,
     STREAMS, STREAMS_LOCK, CANCEL_FLAGS, AGENT_INSTANCES, STREAM_PARTIAL_TEXT,
@@ -930,6 +931,7 @@ def _load_prefill_messages_script(config_data: dict) -> dict:
             stderr=subprocess.PIPE,
             timeout=_prefill_script_timeout(config_data),
             check=False,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired:
         return {"status": "error", "source": "script", "label": label, "messages": [], "message_count": 0, "error": "prefill script timed out"}

--- a/api/updates.py
+++ b/api/updates.py
@@ -24,6 +24,7 @@ from collections import OrderedDict
 from pathlib import Path
 from urllib.parse import urlparse
 
+from api._subprocess_compat import windows_detach_flags, windows_hide_flags
 from api.agent_health import get_active_profile_gateway_running_pid
 from api.gateway_restart import restart_active_profile_gateway
 from api.profiles import get_active_profile_name
@@ -217,6 +218,7 @@ def _run_git(args, cwd, timeout=10):
             [git_executable] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
             encoding='utf-8', errors='replace',
+            creationflags=windows_hide_flags(),
         )
         # On non-UTF-8 locales (e.g. Chinese Windows GBK), a binary git
         # output that fails to decode used to leave r.stdout = None and crash
@@ -1795,11 +1797,7 @@ def _schedule_restart(delay: float = 2.0) -> None:
                     subprocess.Popen(
                         args,
                         cwd=os.getcwd(),
-                        creationflags=(
-                            subprocess.DETACHED_PROCESS
-                            | subprocess.CREATE_NEW_PROCESS_GROUP
-                            | subprocess.CREATE_NO_WINDOW
-                        ),
+                        creationflags=windows_detach_flags(),
                         close_fds=True,
                         stdin=subprocess.DEVNULL,
                         stdout=subprocess.DEVNULL,

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -27,6 +27,7 @@ _ESCAPE_AUTH_TTL_SECONDS = 300
 _ESCAPE_AUTH_LOCK = threading.Lock()
 _ESCAPE_AUTH_TOKENS: dict[str, dict[str, str | int | float]] = {}
 
+from api._subprocess_compat import windows_hide_flags
 from api.config import (
     WORKSPACES_FILE as _GLOBAL_WS_FILE,
     LAST_WORKSPACE_FILE as _GLOBAL_LW_FILE,
@@ -1683,6 +1684,7 @@ def _run_git(args, cwd, timeout=3):
         r = subprocess.run(
             ['git'] + args, cwd=str(cwd), capture_output=True,
             text=True, timeout=timeout,
+            creationflags=windows_hide_flags(),
         )
         return r.stdout.strip() if r.returncode == 0 else None
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/api/workspace_git.py
+++ b/api/workspace_git.py
@@ -21,20 +21,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from api._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
-def _windows_hide_flags() -> int:
-    """Win32 ``creationflags`` that hide a short-lived console child's window
-    (``CREATE_NO_WINDOW``) without detaching it, so ``capture_output`` still
-    works. Returns ``0`` on non-Windows — the ``subprocess`` default, a genuine
-    no-op. Mirrors the ``api/updates.py`` pattern; kept local so workspace-git
-    never takes a hard dependency on the optional ``hermes_cli`` package (a
-    standalone/agent-less WebUI must keep full git functionality). See #5692.
-    """
-    if sys.platform == "win32":
-        return getattr(subprocess, "CREATE_NO_WINDOW", 0)
-    return 0
+# Kept as a module-level alias rather than switching every call site to the
+# shared name: #5692's regression tests import `_windows_hide_flags` from this
+# module by name, and the alias costs nothing. New code should import
+# `windows_hide_flags` from api._subprocess_compat directly.
+_windows_hide_flags = windows_hide_flags
 
 
 from api.workspace import rmtree_anchored, safe_resolve_ws, unlink_anchored

--- a/api/worktrees.py
+++ b/api/worktrees.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import logging
 
+from api._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,6 +23,7 @@ def _run_git(args: list[str], cwd: str | Path, timeout: float = 2) -> subprocess
         capture_output=True,
         timeout=timeout,
         check=False,
+        creationflags=windows_hide_flags(),
     )
 
 
@@ -326,6 +329,7 @@ def find_git_repo_root(workspace: str | Path) -> Path:
             capture_output=True,
             timeout=5,
             check=False,
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise ValueError("Workspace is not inside a git repository") from exc

--- a/tests/test_health_restart.py
+++ b/tests/test_health_restart.py
@@ -78,7 +78,7 @@ def test_restart_active_profile_gateway_success_uses_active_profile_home(monkeyp
     gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
     called = {}
 
-    def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+    def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
         called["args"] = args
         called["env"] = env
         return MockPopen(
@@ -105,7 +105,7 @@ def test_restart_active_profile_gateway_pins_explicit_default_profile(monkeypatc
     gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
     called = {}
 
-    def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+    def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
         called["args"] = args
         called["env"] = env
         return MockPopen(args, stdout_text="ok", returncode=0, env=env)
@@ -129,7 +129,7 @@ def test_restart_active_profile_gateway_omits_profile_for_isolated_default_home(
     gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
     called = {}
 
-    def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+    def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
         called["args"] = args
         called["env"] = env
         return MockPopen(args, stdout_text="ok", returncode=0, env=env)
@@ -169,7 +169,7 @@ def test_restart_active_profile_gateway_accepts_renamed_root_alias(monkeypatch):
     gateway_restart._GATEWAY_RESTART_LOCK = threading.Lock()
     called = {}
 
-    def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+    def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
         called["args"] = args
         called["env"] = env
         return MockPopen(args, stdout_text="ok", returncode=0, env=env)
@@ -202,7 +202,10 @@ def test_restart_active_profile_gateway_failure_preserves_empty_output_contract(
     monkeypatch.setattr(
         gateway_restart.subprocess,
         "Popen",
-        lambda args, stdout=None, stderr=None, text=True, env=None: MockPopen(
+        # **kwargs (matching the other Popen stubs in this file) so the stub
+        # tolerates spawn kwargs it doesn't assert on — e.g. the Windows
+        # `creationflags` this call site passes to avoid a console window.
+        lambda args, stdout=None, stderr=None, text=True, env=None, **kwargs: MockPopen(
             args,
             returncode=7,
             env=env,

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -1011,7 +1011,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                     return 202
                 return None
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 
@@ -1065,7 +1065,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                 calls["implicit_pid"] += 1
                 return next(self._pids)
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 
@@ -1119,7 +1119,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                 calls["ambient_pid"] += 1
                 return next(self._pids)
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 
@@ -1177,7 +1177,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                 calls["ambient_pid"] += 1
                 return next(self._pids)
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 
@@ -1235,7 +1235,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                 calls["ambient_pid"] += 1
                 return next(self._pids)
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 
@@ -1292,7 +1292,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                     return 101
                 return None
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 
@@ -1347,7 +1347,7 @@ class TestAgentUpdateRequiresGatewayRestart:
                     return 101
                 return None
 
-        def fake_popen(args, stdout=None, stderr=None, text=True, env=None):
+        def fake_popen(args, stdout=None, stderr=None, text=True, env=None, **kwargs):
             calls["popen"].append((args, dict(env or {})))
             return FailedRestartProcess()
 

--- a/tests/test_windows_console_window_guard.py
+++ b/tests/test_windows_console_window_guard.py
@@ -1,0 +1,179 @@
+"""Structural guard: every subprocess spawn declares Win32 creationflags.
+
+Why this exists: "spawns a console window on Windows" has been fixed three
+separate times in this repo — #3710 (test helpers), #4626 (update/restart
+respawn), #5692 (workspace git) — and came back each time, because each fix
+added a private ``_windows_hide_flags()`` and patched only the call sites in
+front of it. The next contributor writing a perfectly reasonable
+``subprocess.run(["git", ...])`` reintroduced the bug class. The user-visible
+symptom of the most recent recurrence: a burst of black console windows
+flashing on every page navigation, because ``workspace._run_git`` runs once per
+workspace on a listing.
+
+Per-call-site regression tests (``test_workspace_git.py``) can't prevent that —
+they only cover the function someone already thought about. This guard is
+exhaustive by construction: it AST-scans the whole API surface and fails on ANY
+spawn that doesn't declare its creationflags, including ones that don't exist
+yet.
+
+A spawn passes if any of:
+
+1. It passes ``creationflags=`` explicitly (the normal case). Use
+   ``windows_hide_flags()`` from ``api._subprocess_compat`` for anything whose
+   output you read, ``windows_detach_flags()`` for background children that
+   must outlive this process.
+2. It unpacks a kwargs dict AND the enclosing function assigns
+   ``[...]["creationflags"]`` into a dict — the platform-branching pattern in
+   ``providers.py``, where POSIX gets ``preexec_fn`` and Windows gets the
+   flags. Deleting that assignment re-fails the guard.
+3. Its module is in :data:`ALLOWLIST` with a written reason.
+
+The helpers return 0 on non-Windows, which is the ``subprocess`` default — so
+this rule costs POSIX call sites nothing and needs no platform branching at the
+point of use. This test therefore asserts the same thing on every platform.
+"""
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# subprocess entry points that create a process (and therefore a console
+# window on Windows). `subprocess.getoutput`/`getstatusoutput` are excluded
+# deliberately: they route through the shell and aren't used in this codebase.
+SPAWN_FUNCS = {"run", "Popen", "call", "check_call", "check_output"}
+
+# Modules exempt from the rule, each with the reason it can't spawn a Windows
+# console window. Keep this list SHORT and justified — an entry here is a
+# permanent hole in the guard.
+ALLOWLIST = {
+    "api/terminal.py": (
+        "Module is hard-disabled on Windows: _TERMINAL_SUPPORTED = "
+        "sys.platform != 'win32', and the spawn sits behind a pty/fcntl path "
+        "that only imports on POSIX."
+    ),
+}
+
+
+def _iter_scanned_files():
+    yield from sorted((REPO / "api").glob("*.py"))
+    yield REPO / "server.py"
+
+
+def _assigns_creationflags(func_node) -> bool:
+    """True if *func_node* stores a 'creationflags' key into a dict.
+
+    Matches the ``kwargs["creationflags"] = windows_hide_flags()`` pattern used
+    where the flags are set on a platform branch and then unpacked into Popen.
+    """
+    for node in ast.walk(func_node):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.slice, ast.Constant)
+                and target.slice.value == "creationflags"
+            ):
+                return True
+    return False
+
+
+def _enclosing_functions(tree):
+    """Map each node in a function body back to that function definition."""
+    owner = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(node):
+                owner.setdefault(child, node)
+    return owner
+
+
+def _find_bare_spawns(path: Path):
+    """Return [(lineno, source_excerpt)] for spawns missing creationflags."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    owner = _enclosing_functions(tree)
+    offenders = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not (isinstance(fn, ast.Attribute) and fn.attr in SPAWN_FUNCS):
+            continue
+        if not (isinstance(fn.value, ast.Name) and fn.value.id == "subprocess"):
+            continue
+
+        if any(kw.arg == "creationflags" for kw in node.keywords):
+            continue
+
+        # Indirect case: **kwargs unpacked in, flags set on a branch above.
+        if any(kw.arg is None for kw in node.keywords):
+            enclosing = owner.get(node)
+            if enclosing is not None and _assigns_creationflags(enclosing):
+                continue
+
+        argv = ast.unparse(node.args[0])[:70] if node.args else "<kwargs-only>"
+        offenders.append((node.lineno, f"subprocess.{fn.attr}({argv} ...)"))
+
+    return offenders
+
+
+def test_no_subprocess_spawn_without_creationflags():
+    failures = []
+    for path in _iter_scanned_files():
+        rel = path.relative_to(REPO).as_posix()
+        if rel in ALLOWLIST:
+            continue
+        for lineno, excerpt in _find_bare_spawns(path):
+            failures.append(f"  {rel}:{lineno}  {excerpt}")
+
+    assert not failures, (
+        "These subprocess spawns don't declare creationflags, so each one pops a "
+        "console window on Windows (see #3710 / #4626 / #5692):\n"
+        + "\n".join(failures)
+        + "\n\nFix: add `creationflags=windows_hide_flags()` (import from "
+        "api._subprocess_compat) — or windows_detach_flags() for a background "
+        "child that must outlive this process and whose output you do NOT read. "
+        "Both return 0 off Windows, so no platform branching is needed."
+    )
+
+
+def test_allowlisted_modules_still_exist_and_are_justified():
+    """An allowlist entry for a deleted/renamed module silently widens the guard."""
+    for rel, reason in ALLOWLIST.items():
+        assert (REPO / rel).exists(), f"ALLOWLIST names a missing file: {rel}"
+        assert len(reason) > 40, f"ALLOWLIST entry for {rel} needs a real reason"
+
+
+def test_terminal_module_remains_posix_only():
+    """Pins the assumption behind api/terminal.py's allowlist entry.
+
+    If the embedded terminal ever gains a Windows implementation, its spawn
+    starts creating console windows and must be removed from ALLOWLIST — this
+    test fails at that moment rather than letting it through silently.
+    """
+    source = (REPO / "api" / "terminal.py").read_text(encoding="utf-8")
+    assert '_TERMINAL_SUPPORTED = sys.platform != "win32"' in source, (
+        "api/terminal.py is no longer unconditionally disabled on Windows; "
+        "re-audit its subprocess.Popen call and drop the ALLOWLIST entry in "
+        "this file."
+    )
+
+
+def test_hide_and_detach_flags_are_noop_off_windows():
+    """The 'safe to call everywhere' property the whole rule depends on."""
+    import sys
+
+    from api._subprocess_compat import windows_detach_flags, windows_hide_flags
+
+    if sys.platform == "win32":
+        # CREATE_NO_WINDOW; detach adds DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP.
+        assert windows_hide_flags() == 0x08000000
+        assert windows_detach_flags() == 0x08000000 | 0x00000008 | 0x00000200
+        # Hiding must NOT detach — DETACHED_PROCESS severs stdio and would
+        # silently break every capture_output=True caller.
+        assert not windows_hide_flags() & 0x00000008
+    else:
+        assert windows_hide_flags() == 0
+        assert windows_detach_flags() == 0


### PR DESCRIPTION
## Thinking Path

I hit this as a user first: browsing the WebUI on native Windows popped a burst of black console windows on every navigation. The obvious suspect — the embedded terminal — was a dead end (`api/terminal.py` is hard-disabled on Windows via `_TERMINAL_SUPPORTED = sys.platform != "win32"`). The real source was `git.exe`: `workspace.git_info_for_workspace()` runs a git probe **once per workspace on every listing**, so an N-workspace listing meant N windows at once.

The fix for that one call site is a one-liner. What made me widen the scope is that `CHANGELOG.md` already contains this same fix three times:

- **#3710** — test-helper subprocesses popping focus-stealing windows
- **#4626** — update/restart respawn flashing an empty console (users closed that window, which took the WebUI down with it)
- **#5692** — workspace git commands (`workspace_git._run_git`)

Each landed a private `_windows_hide_flags()` in one module and patched only the call sites in front of it. So this isn't a bug that keeps happening; it's one bug class with no chokepoint and no enforcement. Per `AGENTS.md` #1 ("fix the class, not the instance"), I went looking for the siblings with an AST scan rather than grep: **19 of 25 `subprocess` spawns in `api/` passed no `creationflags`.**

Two of those turned out to be user-visible in their own right:

- `routes.py` "open in VS Code" spawns `resolved_cmd`, which on Windows is `code.cmd` — a batch shim, so it pops a visible `cmd` window on every click.
- `providers.py` spawns the account-usage worker as a windowed `python.exe`.

## What Changed

**1. One shared chokepoint — `api/_subprocess_compat.py`**

- `windows_hide_flags()` → `CREATE_NO_WINDOW`. For anything whose output you read. Deliberately *not* `DETACHED_PROCESS`, which severs stdio and would silently break every `capture_output=True` caller.
- `windows_detach_flags()` → `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`. For background children that must outlive the server. `CREATE_NO_WINDOW` is still required alongside `DETACHED_PROCESS` on modern Windows — that's exactly what #4626 fixed.

Both return `0` off Windows, which is the `subprocess` default, so call sites stay platform-unconditional and POSIX behavior is byte-identical. Flag values are numeric literals rather than `subprocess.CREATE_NO_WINDOW` attribute reads, because those attributes only exist on Windows builds of CPython — the module must import on Linux/macOS for the guard test to run there.

This intentionally duplicates `hermes_cli._subprocess_compat` rather than importing it. `hermes_cli` is an optional dependency — a standalone WebUI runs without an agent install — and importing it here would make core git functionality contingent on it. That's the same reasoning recorded in #5692.

**2. All 25 spawn sites now declare their flags**, and `workspace_git.py` + `updates.py` are refactored off their private copies. `workspace_git._windows_hide_flags` is retained as a module-level alias so #5692's existing regression tests keep passing unchanged.

**3. `tests/test_windows_console_window_guard.py`** — the part that stops recurrence #5. It AST-scans `api/*.py` + `server.py` and fails on any spawn missing `creationflags`. It:

- understands the indirect `kwargs["creationflags"] = ...` platform-branch pattern in `providers.py` (deleting that assignment re-fails the guard);
- allowlists `api/terminal.py` with a written reason, plus a companion test that fails the moment `terminal.py` stops being POSIX-only, so the allowlist can't silently widen;
- asserts the hide/detach no-op property the whole convention rests on.

**4. `AGENTS.md`** gains one bullet stating the rule, so it's discoverable by reading rather than only by CI failure (`docs/CONTRACTS.md`: contract tests and docs move together).

Per `CONTRIBUTING.md` I did **not** touch `CHANGELOG.md`; release-note wording is at the bottom of this body.

## Why It Matters

The user-facing symptom is that the WebUI looks broken on Windows during ordinary use — windows flashing on every navigation, and per #5692, orphaned `conhost.exe` processes accumulating over a long session.

The structural point is more important: three prior fixes all correctly identified the mechanism and still didn't hold, because the fix lived next to the call sites instead of in front of them. A shared helper alone wouldn't have held either — #5692 *had* a helper, and 19 spawns still didn't use it. The enforcement is what closes it.

## Verification

Environment: native Windows 11, Python 3.11.

**The guard fails before the fix and passes after** (`AGENTS.md` #6). Against a clean `git worktree` of HEAD with only the new test copied in:

```
EXPECTED FAILURE — guard catches the pre-fix tree:
  api/agent_runtime.py:46  subprocess.run(['git', '-C', str(agent_dir), 'rev-parse', '--show-toplevel'] ...)
  api/gateway_restart.py:120  subprocess.Popen(cmd ...)
  api/providers.py:1775  subprocess.Popen([PYTHON_EXE, '-c', ...] ...)
  api/rollback.py:102  subprocess.run([git, '-C', str(ckpt_dir), 'ls-files', '-s'] ...)
  api/routes.py:23637  subprocess.Popen([resolved_cmd, target_str] ...)
  api/startup.py:115  subprocess.run(install_args ...)
  api/streaming.py:926  subprocess.run(command ...)
  api/updates.py:216  subprocess.run([git_executable] + args ...)
  api/workspace.py:1683  subprocess.run(['git'] + args ...)
  api/worktrees.py:17  subprocess.run(['git', *args] ...)
  ... 20 sites total
```

On this branch the same test passes.

**Runtime proof on the reported path** — asserting observable behavior at the spawn boundary, not a source string. Spying on `subprocess.run` for the two functions that fire during browsing:

```
['git', 'rev-parse', '--show-toplevel']       creationflags=134217728
['git', 'worktree', 'list']                   creationflags=134217728
```

`134217728 == 0x08000000 == CREATE_NO_WINDOW`.

**The guard caught a real defect in my own patch mid-review.** A `replace_all` edit for the `providers.py` platform branch matched only the 8-space-indented copy of a two-copy pattern, leaving the module-level spawn bare. The guard failed and named the exact line. That's the intended behavior demonstrated on a live regression rather than a synthetic one.

**Suite:** `./scripts/test.sh` — results in a follow-up comment.

**What I could not verify:**

- **The visual outcome is unverified by automation.** I can prove `CREATE_NO_WINDOW` reaches `CreateProcessW`; whether zero windows appear is owned by the OS, not this repo, and I have no way to assert it in-process. Windows is the authority here — confirmation is a human looking at the desktop while browsing. Locally, the windows stopped.
- **POSIX is reasoned, not run.** Both helpers return `0` there and `0` is the `subprocess` default, so the change should be byte-identical on macOS/Linux — but I only executed this on Windows. CI's Linux legs are the real check.
- The two POSIX-only branches in `routes.py` (`open -R`, `xdg-open`) take `creationflags=windows_hide_flags()` purely so the guard's "every spawn declares its flags" rule stays uniform. It's a literal no-op there. If you'd rather see those exempted than annotated, that's a one-line change to the guard.

## Risks / Follow-ups

- **Low risk, wide diff.** 12 files, but every functional edit is the same additive kwarg; no control flow changed. The genuinely reviewable parts are `_subprocess_compat.py` and the guard test.
- **The `updates.py` detach path is the one behavioral consolidation** — it previously spelled its flags inline and now calls `windows_detach_flags()`. Same three flags, verified identical.
- **`hermes_cli._subprocess_compat` is now duplicated** by design (reasoning above). If you'd prefer a soft import with fallback, happy to switch.
- **Follow-up not in scope:** `hermes_cli`'s copy has a `bounded_git_probe()` guarding a Windows post-kill deadlock (suspended descendant `git.exe` holding pipe handles, so `run()`'s unbounded post-timeout `communicate()` hangs). Several WebUI git probes are structurally exposed to that same class. Out of scope here — happy to file it separately.

## Model Used

Provider: Anthropic. Model: Claude Opus 4.8 (`claude-opus-4-8`), via Claude Code.

Notable tool use that mattered: the sibling enumeration was an AST scan rather than grep, which is what surfaced the `providers.py` `**kwargs` spawns that a `creationflags` text search misses — and the same technique became the shipped guard test. The pre-fix failure proof was produced against a detached `git worktree` of HEAD so the working tree was never reverted.

Human review: reported, reproduced, and confirmed on the author's Windows machine.

## Contract Routing

Task type: cross-cutting bug-class fix + new enforcement test.
Touched areas: `api/` subprocess spawn sites, `AGENTS.md` contributor rules, new structural test.
Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`.
Scope boundaries: no runtime/streaming/session-state semantics touched; no UI change; `CHANGELOG.md` deliberately untouched.
Evidence needed before claiming done: guard red-before/green-after, runtime creationflags assertion on the reported path, full suite.

This adds a review expectation for future contributors (all new spawns must declare `creationflags`) without redefining any existing contract, so there is no `Contract Change` section. The rule ships in `AGENTS.md` alongside the test that enforces it.

## Release-note wording

**Windows: console windows no longer flash while browsing the UI.** Navigating the WebUI on Windows popped a burst of black console windows — one per `git.exe` — because the workspace panel's git probe runs once per workspace on every listing, and neither it nor 18 other `subprocess` spawns passed `CREATE_NO_WINDOW`. The flags now live in a single shared `api/_subprocess_compat.py` used by every spawn, and a new AST-based guard test fails CI on any future spawn that omits them — closing a bug class previously fixed three times (#3710, #4626, #5692). Also fixed: "open in VS Code" spawned the `code.cmd` batch shim with a visible window, and the account-usage worker spawned a windowed `python.exe`. Both helpers return 0 off Windows, so macOS and Linux behavior is unchanged.
