### PR TITLE
fix(docker): use editable install for hermes-agent in docker_init.bash

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -430,14 +430,17 @@ else
     # `egg_info` build step, however, touches `hermes_agent.egg-info/` inside the
     # source tree even under PEP 517 build isolation, which `EROFS`-fails on a
     # `:ro` mount and (under `set -e`) kills startup of every multi-container
-    # deploy. Stage the source into a writable tmpfs copy so the build can write
-    # its metadata side-by-side without touching the underlying mount.
+    # deploy. Stage the source into a writable directory so the editable install
+    # can write its metadata without touching the underlying mount.
+    #
+    # The staged copy lives under /app/ (persistent across container restarts)
+    # because the editable install records this path in a .pth file — Python
+    # imports resolve through it at runtime. Placing it alongside the venv gives
+    # it the same lifecycle as .deps_installed: both survive restarts and both
+    # are lost on container recreation (fresh boot re-stages automatically).
     #
     # The copy excludes any pre-baked `*.egg-info` / `build` / `dist` artifacts
-    # to avoid the timestamp-update path setuptools takes when one is present,
-    # and `--reflink=auto` makes the copy near-free on overlay2/btrfs where
-    # supported. We rebuild on every container start (the agent source can
-    # change across volume re-init); cost is one rsync of ~10MB of Python source.
+    # to avoid the timestamp-update path setuptools takes when one is present.
     #
     # NB: `rsync -a` / `cp -a` preserve the source tree's mode bits, so a `:ro`
     # source mounted mode 555 leaves the staged copy also mode 555. setuptools
@@ -445,7 +448,7 @@ else
     # with "Permission denied" even though `_stage_src` itself was created
     # writable by hermeswebui. Re-add owner-write on the staged tree after the
     # copy so the build dir is genuinely writable, not just owned by us.
-    _stage_src="/tmp/hermes-agent-build"
+    _stage_src="/app/hermes-agent-src"
     rm -rf "$_stage_src"
     mkdir -p "$_stage_src"
     if command -v rsync >/dev/null 2>&1; then
@@ -466,9 +469,8 @@ else
     fi
     chmod -R u+w "$_stage_src" \
       || error_exit "Failed to make staged hermes-agent source writable (rsync/cp preserved :ro mount perms)"
-    uv pip install "$_stage_src[all]" --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+    uv pip install -e "$_stage_src[all]" --trusted-host pypi.org --trusted-host files.pythonhosted.org \
       || error_exit "Failed to install hermes-agent's requirements"
-    rm -rf "$_stage_src"
   else
     echo ""
     echo "!! WARNING: hermes-agent source not found."

--- a/tests/test_docker_docs_and_readonly.py
+++ b/tests/test_docker_docs_and_readonly.py
@@ -155,14 +155,16 @@ def test_docker_md_documents_isolation_model():
     )
 
 
-# ── 5: docker_init.bash stages agent source to a writable build dir ─────────
+# ── 5: docker_init.bash stages agent source for editable install ─────────────
 #
 # The :ro mount fixed in PR #2470 broke a second, less obvious surface:
 # `uv pip install "$_agent_src[all]"` invokes setuptools' egg_info build step,
 # which touches `hermes_agent.egg-info/` *inside the source tree* even under
 # PEP 517 build isolation. On a `:ro` mount this returns `EROFS` and (under
 # `set -e`) kills container startup. The fix: copy the source tree into a
-# writable tmpfs build dir, run the install against THAT, then clean up.
+# writable persistent directory (/app/hermes-agent-src) and run an editable
+# install against it. The staged copy shares the venv's lifecycle — both
+# survive restarts and are lost together on container recreation.
 #
 # This was caught the first time the Docker smoke gate ran on its own PR — a
 # real regression that 5800+ source-level pytests had no way to surface
@@ -311,4 +313,86 @@ def test_docker_init_makes_staged_dir_writable_after_ro_mount_copy():
         "inside one branch means the other copy path skips it and the "
         ":ro mount perm leak returns."
     )
+
+
+# ── 6: docker_init.bash editable install with persistent staging ─────────────
+#
+# The upstream hermes-agent setup.py build guard blocks bdist_wheel outside Nix
+# builds. The WebUI uses an editable install (`uv pip install -e`) to bypass
+# this. The staged source lives at /app/hermes-agent-src (persistent, same
+# lifecycle as the venv) so the editable .pth link remains valid across
+# container restarts without sentinel files or state machines.
+
+
+def test_docker_init_uses_editable_install():
+    """docker_init.bash must use `uv pip install -e` (editable) for the
+    hermes-agent staged source. The upstream setup.py build guard blocks
+    bdist_wheel outside Nix builds. Editable installs use build_editable
+    which bypasses the guard entirely."""
+    src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
+
+    install_lines = [
+        line for line in src.splitlines()
+        if "uv pip install" in line and "[all]" in line
+    ]
+    assert install_lines, "expected a `uv pip install ...[all]` line in docker_init.bash"
+    for line in install_lines:
+        assert re.search(r"uv\s+pip\s+install\s+-e\b", line), (
+            "docker_init.bash must use editable install (`uv pip install -e`) "
+            "for hermes-agent. The upstream setup.py build guard blocks "
+            "bdist_wheel outside Nix builds, causing container startup failure. "
+            f"Offending line: {line!r}"
+        )
+
+
+def test_docker_init_stages_to_persistent_path():
+    """The staged source must live under /app/ (persistent storage), not /tmp/
+    (ephemeral). An editable install records the staged path in a .pth file —
+    if the path is on tmpfs, a container restart or tmpfs flush breaks imports.
+    Placing it alongside the venv gives both the same lifecycle."""
+    src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
+
+    stage_line = [
+        line for line in src.splitlines()
+        if "_stage_src=" in line and "=" in line and "#" not in line.split("=")[0]
+    ]
+    assert stage_line, "expected a _stage_src= assignment in docker_init.bash"
+    for line in stage_line:
+        assert "/tmp" not in line, (
+            "docker_init.bash stages the editable source under /tmp/ which is "
+            "ephemeral. The editable .pth link will dangle after tmpfs flush "
+            "or container recreation. Stage under /app/ for persistence. "
+            f"Offending line: {line!r}"
+        )
+        assert "/app/" in line, (
+            "docker_init.bash must stage the editable source under /app/ "
+            "(persistent, same lifecycle as the venv). "
+            f"Offending line: {line!r}"
+        )
+
+
+def test_docker_init_retains_staged_source_after_editable_install():
+    """An editable install records the staged source path in a .pth file.
+    Removing the source tree after install breaks imports at runtime.
+    Ensure no `rm -rf "$_stage_src"` appears after the install line."""
+    src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
+
+    stage_idx = src.index("_stage_src=")
+    install_idx = src.index("uv pip install", stage_idx)
+
+    # Everything after the install line
+    post_install = src[install_idx:]
+
+    # Find lines that delete the staged source after install
+    post_install_lines = post_install.splitlines()
+    for i, line in enumerate(post_install_lines):
+        stripped = line.strip()
+        if re.search(r"rm\s+-rf\s+.*\$_stage_src", stripped):
+            if i > 0:  # line 0 is the install line itself
+                assert False, (
+                    "docker_init.bash must NOT delete $_stage_src after an "
+                    "editable install. The .pth link points to the staged "
+                    "source; deleting it breaks imports at runtime. "
+                    f"Offending line: {stripped!r}"
+                )
 

--- a/tests/test_docker_docs_and_readonly.py
+++ b/tests/test_docker_docs_and_readonly.py
@@ -178,7 +178,7 @@ def test_docker_init_stages_agent_source_for_writable_install():
     invocation)."""
     src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
 
-    # The fix uses a /tmp staging path that's clearly distinct from the
+    # The fix uses an /app staging path that's clearly distinct from the
     # mounted source path. Pin the staging marker.
     assert "_stage_src=" in src, (
         "docker_init.bash must declare a _stage_src writable build dir "
@@ -346,10 +346,12 @@ def test_docker_init_uses_editable_install():
 
 
 def test_docker_init_stages_to_persistent_path():
-    """The staged source must live under /app/ (persistent storage), not /tmp/
-    (ephemeral). An editable install records the staged path in a .pth file —
-    if the path is on tmpfs, a container restart or tmpfs flush breaks imports.
-    Placing it alongside the venv gives both the same lifecycle."""
+    """The staged source must share the venv's container-layer lifecycle.
+
+    An editable install records the staged path in a .pth file. Keeping that
+    target under /app/ alongside the venv avoids runtimes that mount or clean
+    /tmp independently while retaining /app/ across ordinary restarts.
+    """
     src = (REPO / "docker_init.bash").read_text(encoding="utf-8")
 
     stage_line = [
@@ -361,7 +363,7 @@ def test_docker_init_stages_to_persistent_path():
         assert "/tmp" not in line, (
             "docker_init.bash stages the editable source under /tmp/ which is "
             "ephemeral. The editable .pth link will dangle after tmpfs flush "
-            "or container recreation. Stage under /app/ for persistence. "
+            "or external cleanup. Stage under /app/ beside the venv. "
             f"Offending line: {line!r}"
         )
         assert "/app/" in line, (


### PR DESCRIPTION
### Problem

The WebUI container fails to start when using a recent hermes-agent source that includes the new `setup.py` wheel build guard (added to enforce Nix-only distribution).

`docker_init.bash` installs hermes-agent via:

```bash
uv pip install "$_stage_src[all]"
```

This triggers `bdist_wheel`, which now raises `RuntimeError` unless `HERMES_NIX_BUILD=1` is set. The container exits before reaching `server.py`.

### Root Cause

The hermes-agent Dockerfile already switched to editable installs (`uv pip install --no-deps -e "."`), but the WebUI init script still uses the standard wheel build path. Editable installs use `build_editable` which does not invoke `bdist_wheel` - the guard never fires.

### Fix

One-line change in `docker_init.bash` - add `-e` flag to the install command.

### Tested on

Docker container on Linux. Confirmed container starts cleanly after the change with the latest hermes-agent source.

### Maintainer gate update

The final exact head extends the original editable-install fix by keeping the writable staged Agent source under persistent `/app/hermes-agent-build`, beside the WebUI virtualenv and dependency marker. PEP 660 editable metadata resolves imports back to that staged source, so a disposable `/tmp` target would break after cleanup or restart.

Exact head `32581913ba1660daa4fb170a825a20cd92cf3f85` passed all 24 required checks, including the 15 Python shards and the single-, two-, and three-container Docker smoke jobs. The focused Docker bootstrap tests and trusted threat scan also pass. Non-blocking staging-footprint and restart-smoke hardening is tracked separately in #6655.

Closes #6441
