### PR TITLE
fix(#6459): use the resolved Dashboard target for loopback warning

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -26143,6 +26143,11 @@ function applyLocaleToDOM() {
     const val = t(key);
     if (val && val !== key) el.setAttribute('aria-label', val);
   });
+  // Dashboard labels are stateful, so locale sync restores the translated base
+  // strings first, then reapplies the cached status label when one is active.
+  if (typeof _applyDashboardStatus === 'function' && typeof _dashboardStatusCache !== 'undefined') {
+    _applyDashboardStatus(_dashboardStatusCache);
+  }
   if (typeof syncWorkspacePanelUI === 'function') syncWorkspacePanelUI();
   if (typeof syncAppTitlebar === 'function') syncAppTitlebar();
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1670,9 +1670,12 @@ let _dashboardLastNonNeverMode='auto'; // Server-scoped dashboard config keeps t
 let _dashboardSettingsLoadSeq=0;
 let _dashboardSettingsWriteSeq=0;
 
-function _dashboardIsBrowserLoopback(){
-  const host=(window.location.hostname||'').replace(/^\[|\]$/g,'').toLowerCase();
+function _dashboardIsLoopbackHost(host){
+  host=(host||'').replace(/^\[|\]$/g,'').toLowerCase();
   return host==='127.0.0.1'||host==='localhost'||host==='::1';
+}
+function _dashboardIsBrowserLoopback(){
+  return _dashboardIsLoopbackHost(window.location.hostname);
 }
 
 function _normalizeDashboardEnabledMode(mode){
@@ -1774,7 +1777,9 @@ else _initNavActionMirrors();
 function _applyDashboardStatus(status){
   const running=!!(status&&status.running);
   const url=running?_dashboardBrowserUrl(status):'';
-  const warning=running&&!_dashboardIsBrowserLoopback()?t('dashboard_loopback_warning'):'';
+  let dashboardLoopback=false;
+  try{dashboardLoopback=_dashboardIsLoopbackHost(new URL(url).hostname);}catch(_){ }
+  const warning=running&&!_dashboardIsBrowserLoopback()&&dashboardLoopback?t('dashboard_loopback_warning'):'';
   document.querySelectorAll('[data-dashboard-link]').forEach(btn=>{
     btn.classList.toggle('dashboard-link-visible',running);
     btn.classList.toggle('nav-action-visible',running);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1672,7 +1672,10 @@ let _dashboardSettingsWriteSeq=0;
 
 function _dashboardIsLoopbackHost(host){
   host=(host||'').replace(/^\[|\]$/g,'').toLowerCase();
-  return host==='127.0.0.1'||host==='localhost'||host==='::1';
+  if(host.endsWith('.'))host=host.slice(0,-1);
+  if(host==='localhost'||host==='::1')return true;
+  const parts=host.split('.');
+  return parts.length===4&&parts[0]==='127'&&parts.every(part=>/^\d+$/.test(part)&&Number(part)>=0&&Number(part)<=255);
 }
 function _dashboardIsBrowserLoopback(){
   return _dashboardIsLoopbackHost(window.location.hostname);

--- a/tests/fixtures/webui-PR-TARGET-6459-REPRO.md
+++ b/tests/fixtures/webui-PR-TARGET-6459-REPRO.md
@@ -1,0 +1,37 @@
+# Issue #6459 reproduction artifact
+
+Source: https://github.com/nesquena/hermes-webui/issues/6459
+
+## Reproduction
+
+1. Run Hermes Dashboard on its default loopback bind:
+
+   127.0.0.1:9119
+
+2. Publish it through a reverse proxy at a public HTTPS URL, for example:
+
+   https://dashboard.example.com
+
+3. Configure Hermes WebUI:
+
+```yaml
+webui:
+  dashboard:
+    enabled: always
+    url: https://dashboard.example.com
+```
+
+4. Access Hermes WebUI from a non-loopback browser URL.
+
+## Actual behavior
+
+- The Dashboard link opens https://dashboard.example.com successfully.
+- Its aria-label and tooltip still say:
+
+  Dashboard is loopback-only on the server. Either browse from the server itself or restart it with --host 0.0.0.0 (insecure).
+
+## Expected behavior
+
+When status.browser_url is configured and used as the Dashboard link target, WebUI should not display the loopback-only warning.
+
+The Dashboard service should remain loopback-only. This is a browser-link/UI correction only; it must not cause WebUI to probe the public URL or encourage binding Dashboard to 0.0.0.0.

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -359,6 +359,7 @@ def _run_dashboard_link_driver(
             pass
 
 
+@requires_node
 def test_issue6459_remote_public_dashboard_url_uses_normal_label_from_fixture():
     fixture = (FIXTURES / "webui-PR-TARGET-6459-REPRO.md").read_text(encoding="utf-8")
     dashboard_url = "https://dashboard.example.com"
@@ -374,6 +375,7 @@ def test_issue6459_remote_public_dashboard_url_uses_normal_label_from_fixture():
     assert all(state["tooltip"] == "Dashboard" and state["ariaLabel"] == "Dashboard" for state in out["buttonStates"])
 
 
+@requires_node
 def test_issue6459_remote_loopback_targets_keep_warning():
     for target in ("http://127.0.0.1:9119", "http://localhost:9119", "http://[::1]:9119"):
         out = _run_dashboard_link_driver(
@@ -386,6 +388,7 @@ def test_issue6459_remote_loopback_targets_keep_warning():
         assert all(state["tooltip"] == "Loopback" for state in out["buttonStates"])
 
 
+@requires_node
 def test_issue6459_public_hosts_that_resemble_loopback_do_not_warn():
     for target in ("https://localhost.example.test", "https://127.0.0.1.example.test"):
         out = _run_dashboard_link_driver(
@@ -398,6 +401,7 @@ def test_issue6459_public_hosts_that_resemble_loopback_do_not_warn():
         assert all(state["tooltip"] == "Dashboard" for state in out["buttonStates"])
 
 
+@requires_node
 def test_issue6459_loopback_webui_origin_never_gets_remote_warning():
     out = _run_dashboard_link_driver(
         "save",
@@ -409,6 +413,7 @@ def test_issue6459_loopback_webui_origin_never_gets_remote_warning():
     assert all(state["tooltip"] == "Dashboard" for state in out["buttonStates"])
 
 
+@requires_node
 def test_issue6459_loopback_target_warning_survives_locale_resync():
     out = _run_dashboard_link_driver(
         "save-and-apply-locale",

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -115,6 +115,7 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
     const uiSrc = fs.readFileSync(process.argv[7], 'utf8');
     const i18nSrc = fs.readFileSync(process.argv[8], 'utf8');
     const panelsSrc = fs.readFileSync(process.argv[9], 'utf8');
+    const helperCases = JSON.parse(process.argv[10] || '[]');
 
     const modeEl = makeButton('settingsDashboardMode');
     const urlEl = makeButton('settingsDashboardUrl');
@@ -196,7 +197,7 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
       result.lastRenderMode = modeEl.value;
     };
 
-    const dashboardLoopbackHostFallback = "function _dashboardIsLoopbackHost(host){host=(host||'').replace(/^\\\\[|\\\\]$/g,'').toLowerCase();return host==='127.0.0.1'||host==='localhost'||host==='::1';}";
+    const dashboardLoopbackHostFallback = "function _dashboardIsLoopbackHost(host){host=(host||'').replace(/^\\\\[|\\\\]$/g,'').toLowerCase();if(host.endsWith('.'))host=host.slice(0,-1);if(host==='localhost'||host==='::1')return true;const parts=host.split('.');return parts.length===4&&parts[0]==='127'&&parts.every(part=>/^\\\\d+$/.test(part)&&Number(part)>=0&&Number(part)<=255);}";
 
     for (const name of ['_normalizeDashboardEnabledMode','_setDashboardModeForChip','_getDashboardChipRestoreMode']) {
       eval(extractFn(uiSrc, name));
@@ -234,6 +235,13 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
     }
 
     (async () => {
+      if (action === 'helper-matrix') {
+        console.log(JSON.stringify({
+          helperCases: helperCases.map((host) => ({ host, loopback: _dashboardIsLoopbackHost(host) })),
+        }));
+        return;
+      }
+
       if (action === 'load') {
         await loadDashboardSettings();
         recordButtons();
@@ -325,6 +333,7 @@ def _run_dashboard_link_driver(
     url: str = '',
     origin_hostname: str = '127.0.0.1',
     dashboard_target: str = 'http://127.0.0.1:1234',
+    helper_cases: list[str] | None = None,
 ) -> dict:
     with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as f:
         f.write(_DASHBOARD_LINK_DRIVER)
@@ -342,6 +351,7 @@ def _run_dashboard_link_driver(
                 str(UI_PATH),
                 str(I18N_PATH),
                 str(PANELS_PATH),
+                json.dumps(helper_cases or []),
             ],
             cwd=REPO,
             text=True,
@@ -377,7 +387,14 @@ def test_issue6459_remote_public_dashboard_url_uses_normal_label_from_fixture():
 
 @requires_node
 def test_issue6459_remote_loopback_targets_keep_warning():
-    for target in ("http://127.0.0.1:9119", "http://localhost:9119", "http://[::1]:9119"):
+    for target in (
+        "http://127.0.0.1:9119",
+        "http://127.0.0.2:9119",
+        "http://127.5.5.5:9119",
+        "http://localhost:9119",
+        "http://localhost.:9119",
+        "http://[::1]:9119",
+    ):
         out = _run_dashboard_link_driver(
             "save",
             mode="always",
@@ -386,6 +403,29 @@ def test_issue6459_remote_loopback_targets_keep_warning():
             dashboard_target=target,
         )
         assert all(state["tooltip"] == "Loopback" for state in out["buttonStates"])
+
+
+@requires_node
+def test_issue6459_loopback_helper_classifies_terminal_dot_and_bounds():
+    out = _run_dashboard_link_driver(
+        "helper-matrix",
+        helper_cases=[
+            "127.0.0.2",
+            "127.255.255.255",
+            "localhost.",
+            "126.255.255.255",
+            "127.256.0.1",
+            "localhost.example.test",
+        ],
+    )
+    assert {row["host"]: row["loopback"] for row in out["helperCases"]} == {
+        "127.0.0.2": True,
+        "127.255.255.255": True,
+        "localhost.": True,
+        "126.255.255.255": False,
+        "127.256.0.1": False,
+        "localhost.example.test": False,
+    }
 
 
 @requires_node

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -8,10 +8,12 @@ import re
 import pytest
 
 REPO = pathlib.Path(__file__).parent.parent
+FIXTURES = pathlib.Path(__file__).with_name("fixtures")
 INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 UI_PATH = REPO / "static" / "ui.js"
+I18N_PATH = REPO / "static" / "i18n.js"
 PANELS_PATH = REPO / "static" / "panels.js"
 NODE = shutil.which("node")
 requires_node = pytest.mark.skipif(NODE is None, reason="node not on PATH")
@@ -98,6 +100,8 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
       btn._classes = btn.classList._set;
       if (id === 'dashboardRailBtn' || id === 'dashboardMobileBtn') {
         btn.setAttribute('data-dashboard-link', '');
+        btn.setAttribute('data-tooltip', 'Dashboard');
+        btn.setAttribute('data-i18n-title', 'tab_dashboard');
         btn.setAttribute('aria-label', 'Dashboard');
       }
       return btn;
@@ -106,8 +110,11 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
     const action = process.argv[2] || 'load';
     const mode = process.argv[3] || 'auto';
     const url = process.argv[4] || '';
-    const uiSrc = fs.readFileSync(process.argv[5], 'utf8');
-    const panelsSrc = fs.readFileSync(process.argv[6], 'utf8');
+    const originHostname = process.argv[5] || '127.0.0.1';
+    const dashboardTarget = process.argv[6] || 'http://127.0.0.1:1234';
+    const uiSrc = fs.readFileSync(process.argv[7], 'utf8');
+    const i18nSrc = fs.readFileSync(process.argv[8], 'utf8');
+    const panelsSrc = fs.readFileSync(process.argv[9], 'utf8');
 
     const modeEl = makeButton('settingsDashboardMode');
     const urlEl = makeButton('settingsDashboardUrl');
@@ -127,11 +134,13 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
     global._dashboardStatusFetchedAt = 0;
     global._dashboardSettingsLoadSeq = 0;
     global._dashboardSettingsWriteSeq = 0;
-    global.window = { location: { hostname: '127.0.0.1' } };
+    global.window = { location: { hostname: originHostname } };
     global.document = {
       createElement: () => makeEl(),
       querySelectorAll: (sel) => {
         if (sel === '[data-dashboard-link]') return buttons;
+        if (sel === '[data-i18n-title]') return buttons.filter((btn) => btn.hasAttribute('data-i18n-title'));
+        if (sel === '[data-i18n-aria-label]') return buttons.filter((btn) => btn.hasAttribute('data-i18n-aria-label'));
         return [];
       },
       querySelector: () => null,
@@ -149,8 +158,6 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
       if (key === 'dashboard_loopback_warning') return 'Loopback';
       return key;
     };
-    global._dashboardIsBrowserLoopback = () => false;
-
     global.api = (url, opts = {}) => {
       result.calls.push({ url: String(url), method: (opts.method || 'GET').toUpperCase(), body: opts.body || '', timeoutToast: !!(opts.timeoutToast) });
       if (String(url) === '/api/dashboard/config') {
@@ -179,7 +186,7 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
         result.statusCalls += 1;
         return Promise.resolve({
           running: modeEl.value !== 'never',
-          browser_url: modeEl.value === 'never' ? '' : 'http://127.0.0.1:1234',
+          browser_url: modeEl.value === 'never' ? '' : dashboardTarget,
         });
       }
       return Promise.resolve({ running: false });
@@ -189,10 +196,18 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
       result.lastRenderMode = modeEl.value;
     };
 
+    const dashboardLoopbackHostFallback = "function _dashboardIsLoopbackHost(host){host=(host||'').replace(/^\\\\[|\\\\]$/g,'').toLowerCase();return host==='127.0.0.1'||host==='localhost'||host==='::1';}";
+
     for (const name of ['_normalizeDashboardEnabledMode','_setDashboardModeForChip','_getDashboardChipRestoreMode']) {
       eval(extractFn(uiSrc, name));
     }
-    for (const name of ['_dashboardBrowserUrl', '_applyDashboardStatus', 'refreshDashboardStatus', 'loadDashboardSettings', 'saveDashboardSettings']) {
+    try {
+      eval(extractFn(uiSrc, '_dashboardIsLoopbackHost'));
+    } catch (err) {
+      if (!String(err && err.message || err).includes('_dashboardIsLoopbackHost() not found')) throw err;
+      eval(dashboardLoopbackHostFallback);
+    }
+    for (const name of ['_dashboardIsBrowserLoopback', '_dashboardBrowserUrl', '_applyDashboardStatus', 'refreshDashboardStatus', 'loadDashboardSettings', 'saveDashboardSettings']) {
       let src = extractFn(uiSrc, name);
       if(name === 'saveDashboardSettings'){
         src = src.replace(
@@ -205,14 +220,16 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
     for (const name of ['_dashboardPanelMode', '_toggleDashboardVisibilityChip']) {
       eval(extractFn(panelsSrc, name));
     }
+    eval(extractFn(i18nSrc, 'applyLocaleToDOM'));
 
     function recordButtons() {
       result.buttonStates = buttons.map((btn) => ({
         id: btn.id,
         classes: Array.from(btn.classList._set || []),
         display: btn.style.display || '',
-        dashboardUrl: btn._attrs['data-dashboard-url'] || '',
-        tooltip: btn._attrs['data-tooltip'] || '',
+        dashboardUrl: btn.dataset.dashboardUrl || btn._attrs['data-dashboard-url'] || '',
+        tooltip: btn._attrs['data-tooltip'] || btn.title || '',
+        ariaLabel: btn._attrs['aria-label'] || '',
       }));
     }
 
@@ -279,6 +296,9 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
 
       if (action === 'chip-toggle') {
         _toggleDashboardVisibilityChip();
+      } else if (action === 'save-and-apply-locale') {
+        await saveDashboardSettings();
+        applyLocaleToDOM();
       } else {
         await saveDashboardSettings();
       }
@@ -299,7 +319,13 @@ _DASHBOARD_LINK_DRIVER = textwrap.dedent(
 )
 
 
-def _run_dashboard_link_driver(action: str, mode: str = 'auto', url: str = '') -> dict:
+def _run_dashboard_link_driver(
+    action: str,
+    mode: str = 'auto',
+    url: str = '',
+    origin_hostname: str = '127.0.0.1',
+    dashboard_target: str = 'http://127.0.0.1:1234',
+) -> dict:
     with tempfile.NamedTemporaryFile("w", suffix=".js", encoding="utf-8", delete=False) as f:
         f.write(_DASHBOARD_LINK_DRIVER)
         driver = f.name
@@ -311,7 +337,10 @@ def _run_dashboard_link_driver(action: str, mode: str = 'auto', url: str = '') -
                 action,
                 mode,
                 url,
+                origin_hostname,
+                dashboard_target,
                 str(UI_PATH),
+                str(I18N_PATH),
                 str(PANELS_PATH),
             ],
             cwd=REPO,
@@ -328,6 +357,67 @@ def _run_dashboard_link_driver(action: str, mode: str = 'auto', url: str = '') -
             pathlib.Path(driver).unlink()
         except OSError:
             pass
+
+
+def test_issue6459_remote_public_dashboard_url_uses_normal_label_from_fixture():
+    fixture = (FIXTURES / "webui-PR-TARGET-6459-REPRO.md").read_text(encoding="utf-8")
+    dashboard_url = "https://dashboard.example.com"
+    assert dashboard_url in fixture
+    out = _run_dashboard_link_driver(
+        "save",
+        mode="always",
+        url=dashboard_url,
+        origin_hostname="webui.example.test",
+        dashboard_target=dashboard_url,
+    )
+    assert all(state["dashboardUrl"] == dashboard_url for state in out["buttonStates"])
+    assert all(state["tooltip"] == "Dashboard" and state["ariaLabel"] == "Dashboard" for state in out["buttonStates"])
+
+
+def test_issue6459_remote_loopback_targets_keep_warning():
+    for target in ("http://127.0.0.1:9119", "http://localhost:9119", "http://[::1]:9119"):
+        out = _run_dashboard_link_driver(
+            "save",
+            mode="always",
+            url=target,
+            origin_hostname="webui.example.test",
+            dashboard_target=target,
+        )
+        assert all(state["tooltip"] == "Loopback" for state in out["buttonStates"])
+
+
+def test_issue6459_public_hosts_that_resemble_loopback_do_not_warn():
+    for target in ("https://localhost.example.test", "https://127.0.0.1.example.test"):
+        out = _run_dashboard_link_driver(
+            "save",
+            mode="always",
+            url=target,
+            origin_hostname="webui.example.test",
+            dashboard_target=target,
+        )
+        assert all(state["tooltip"] == "Dashboard" for state in out["buttonStates"])
+
+
+def test_issue6459_loopback_webui_origin_never_gets_remote_warning():
+    out = _run_dashboard_link_driver(
+        "save",
+        mode="always",
+        url="https://dashboard.example.test",
+        origin_hostname="[::1]",
+        dashboard_target="https://dashboard.example.test",
+    )
+    assert all(state["tooltip"] == "Dashboard" for state in out["buttonStates"])
+
+
+def test_issue6459_loopback_target_warning_survives_locale_resync():
+    out = _run_dashboard_link_driver(
+        "save-and-apply-locale",
+        mode="always",
+        url="http://127.0.0.1:9119",
+        origin_hostname="webui.example.test",
+        dashboard_target="http://127.0.0.1:9119",
+    )
+    assert all(state["tooltip"] == "Loopback" and state["ariaLabel"] == "Loopback" for state in out["buttonStates"])
 
 
 def test_dashboard_nav_buttons_are_hidden_by_default_and_subpath_safe():


### PR DESCRIPTION
## Thinking Path

- The backend already distinguishes a browser-only public Dashboard URL from the server-side loopback probe target, but the frontend warning still keys only on whether the WebUI page itself is remote.
- [Maintainer direction](https://github.com/nesquena/hermes-webui/issues/6459#issuecomment-5061163194) narrowed this to a frontend labeling fix, so the probe path and bind-host safety boundary stay unchanged.
- The change reuses the resolved Dashboard target URL, classifies exact `localhost` and `::1` plus bounded `127/8` and single-terminal-dot `localhost.` as loopback, and keeps configured public HTTPS targets on the normal Dashboard label path.

## What Changed

- `static/ui.js`: share loopback hostname normalization between browser-origin and resolved-target checks, trim one terminal dot, and treat bounded `127.x.x.x` aliases as loopback before deciding whether a remote WebUI page should keep the warning.
- `tests/test_dashboard_link_ui.py`: extend the existing behavioral driver with the issue-shaped public-URL regression, alias-expanded loopback-target coverage, direct helper-bounds coverage, loopback-origin preservation, and false-positive public-host boundaries.

## Why It Matters

Users who publish Dashboard through an authenticated reverse proxy stop seeing a false loopback-only warning, while genuine loopback-only Dashboard links keep the existing safety message.

## Verification

The new dashboard-link regression fails on `master` because a remote WebUI page still assigns the loopback warning even when the issue's configured public HTTPS URL is the real link target, and it passes here once the warning keys off the resolved target host. Focused dashboard-link coverage also proves the alias-expanded loopback-target matrix, the direct helper-bounds cases for bounded `127/8` and single-terminal-dot `localhost.`, the loopback-origin preservation row, and the false-positive public-host boundaries, while the existing dashboard-probe regression still proves that the public-URL backend path does not perform a network probe. CI runs the full matrix.

## Risks / Follow-ups

The warning still depends on parsed target-host inference because the status payload does not expose a dedicated `is_loopback_target` field. The added helper-bounds and false-positive hostname regressions cover the one-terminal-dot and bounded-`127/8` cases without widening the backend contract, and no backend change is deferred.

## Upstream

Closes #6459.

Implementation follows the accepted maintainer sketch at https://github.com/nesquena/hermes-webui/issues/6459#issuecomment-5061163194 .

## Screenshots

Before, a remote WebUI page with a configured public Dashboard URL still shows the loopback-only warning on the Dashboard button:

![Before](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui6459-before.png)

After, the same public Dashboard URL keeps its exact click target and uses the normal Dashboard label instead of the loopback-only warning:

![After](https://raw.githubusercontent.com/rodboev/hermes-webui/screenshots/webui6459-after.png)
