### PR TITLE
fix(recovery): keep the initiating user turn above the live worklog on soft recovery (#6419)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2032,19 +2032,6 @@ async function loadSession(sid){
   _setActiveSessionUrl(S.session.session_id);
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);
 
-
-  function _mergePendingSessionMessage(session,messages){
-    if(!Array.isArray(messages)) return false;
-    const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,messages):null;
-    if(!pendingMsg) return false;
-    const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
-    const currentTurnMessages=liveAssistantIdx>=0?messages.slice(0,liveAssistantIdx):messages;
-    if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
-    if(liveAssistantIdx>=0) messages.splice(liveAssistantIdx,0,pendingMsg);
-    else messages.push(pendingMsg);
-    return true;
-  }
-
   // Phase 2a: If session is streaming, restore the persisted transcript first,
   // then merge the local INFLIGHT live tail. INFLIGHT is a recovery tail, not a
   // complete transcript; treating it as the full source makes long sessions look
@@ -3596,6 +3583,25 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
     if(!duplicate) merged.push(candidate);
   }
   return merged;
+}
+
+// Insert the pending (submitted-but-not-yet-settled) user message into a
+// transcript array at the right position: immediately BEFORE the live
+// assistant turn it started, falling back to the end only when no live turn is
+// present. Shared by every recovery re-render path (loadSession reattach and
+// refreshSession soft-recovery, #6419) so the initiating user row stays above
+// the streaming worklog it triggered (run-state-consistency invariants 2 & 3).
+// Returns true when a row was inserted.
+function _mergePendingSessionMessage(session,messages){
+  if(!Array.isArray(messages)) return false;
+  const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,messages):null;
+  if(!pendingMsg) return false;
+  const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
+  const currentTurnMessages=liveAssistantIdx>=0?messages.slice(0,liveAssistantIdx):messages;
+  if(_hasCurrentTailUserDuplicate(currentTurnMessages,pendingMsg)) return false;
+  if(liveAssistantIdx>=0) messages.splice(liveAssistantIdx,0,pendingMsg);
+  else messages.push(pendingMsg);
+  return true;
 }
 
 // Load older messages when the user scrolls to the top of the conversation.

--- a/static/ui.js
+++ b/static/ui.js
@@ -9569,9 +9569,40 @@ async function refreshSession() {
     S.messages = data.session.messages || [];
     _messagesTruncated = !!data.session._messages_truncated;
     _oldestIdx = data.session._messages_offset || 0;
-    const pendingMsg=getPendingSessionMessage(data.session,S.messages);
-    if(pendingMsg) S.messages.push(pendingMsg);
     S.activeStreamId=data.session.active_stream_id||null;
+    // #6419: a mid-stream soft recovery (iOS background/resume, via
+    // _recoverFromOfflineSoftly) must keep the initiating user turn ABOVE the
+    // live assistant worklog it started, not after it. The server holds that
+    // turn as pending_user_message and omits both it and the live assistant
+    // from session.messages until the turn settles, so rebuild the live tail
+    // from INFLIGHT first — mirroring loadSession's reattach — before merging
+    // the pending row. Without a _live row in S.messages the merge below would
+    // fall back to push()-at-end and reorder the turn (run-state-consistency
+    // invariants 2 & 3).
+    const _sid=S.session&&S.session.session_id;
+    if(S.activeStreamId&&_sid&&INFLIGHT[_sid]
+       &&typeof _ensureInflightLiveAssistantMessage==='function'
+       &&typeof _mergeInflightTailMessages==='function'
+       &&typeof _mergePendingSessionMessage==='function'){
+      _ensureInflightLiveAssistantMessage(INFLIGHT[_sid]);
+      const inflightMessages=typeof _projectInflightMessagesForActivityBursts==='function'
+        ? _projectInflightMessagesForActivityBursts(INFLIGHT[_sid])
+        : (INFLIGHT[_sid].messages||[]);
+      if(typeof _prepareRunningLiveTail==='function'
+         &&_prepareRunningLiveTail(S.messages,inflightMessages)
+         &&typeof _dropCurrentTurnAssistantMessages==='function'){
+        S.messages=_dropCurrentTurnAssistantMessages(S.messages);
+      }
+      S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
+      if(_mergePendingSessionMessage(S.session,S.messages)&&inflightMessages===(INFLIGHT[_sid].messages||[])){
+        INFLIGHT[_sid].messages=S.messages;
+      }
+    }else if(typeof _mergePendingSessionMessage==='function'){
+      _mergePendingSessionMessage(S.session,S.messages);
+    }else{
+      const pendingMsg=getPendingSessionMessage(data.session,S.messages);
+      if(pendingMsg) S.messages.push(pendingMsg);
+    }
 
     syncTopbar(); _renderMessagesWithScrollSnapshot();
     showToast('Conversation refreshed');

--- a/tests/test_cross_session_message_load_isolation.py
+++ b/tests/test_cross_session_message_load_isolation.py
@@ -91,6 +91,11 @@ LOAD_SESSION_SRC = _extract_function(SESSIONS_SRC, "loadSession")
 ENSURE_MESSAGES_LOADED_SRC = _extract_function(SESSIONS_SRC, "_ensureMessagesLoaded")
 INFLIGHT_HAS_VISIBLE_STATE_SRC = _extract_function(SESSIONS_SRC, "_inflightHasVisibleLiveState")
 SELECT_LIVE_RECOVERY_INFLIGHT_SRC = _extract_function(SESSIONS_SRC, "_selectLiveRecoveryInflight")
+# loadSession calls _mergePendingSessionMessage in both its INFLIGHT and idle
+# branches. It is a module-scope helper (shared with ui.js's refreshSession
+# recovery path, #6419), so the isolated loadSession harness must supply it just
+# like the other extracted functions above.
+MERGE_PENDING_SESSION_MESSAGE_SRC = _extract_function(SESSIONS_SRC, "_mergePendingSessionMessage")
 
 
 def _normalise_ws(s: str) -> str:
@@ -348,6 +353,7 @@ let toastCalls = [];
 // Source under test
 __INFLIGHT_HAS_VISIBLE_STATE_SRC__
 __SELECT_LIVE_RECOVERY_INFLIGHT_SRC__
+__MERGE_PENDING_SESSION_MESSAGE_SRC__
 __LOAD_SESSION_SRC__
 __ENSURE_MESSAGES_LOADED_SRC__
 
@@ -601,6 +607,7 @@ def test_loadsession_cross_session_ordering_and_stale_reject_behavior():
         .replace(
             "__SELECT_LIVE_RECOVERY_INFLIGHT_SRC__", SELECT_LIVE_RECOVERY_INFLIGHT_SRC
         )
+        .replace("__MERGE_PENDING_SESSION_MESSAGE_SRC__", MERGE_PENDING_SESSION_MESSAGE_SRC)
         .replace("__LOAD_SESSION_SRC__", LOAD_SESSION_SRC)
         .replace("__ENSURE_MESSAGES_LOADED_SRC__", ENSURE_MESSAGES_LOADED_SRC)
     )

--- a/tests/test_issue6419_refreshsession_pending_order.py
+++ b/tests/test_issue6419_refreshsession_pending_order.py
@@ -1,0 +1,226 @@
+"""Issue #6419: mid-stream reconnect must not render the just-sent user message
+below the live streaming response.
+
+Symptom (iOS webview/PWA): when the chat SSE drops mid-turn (backgrounding /
+screen lock suspends the webview) and the client goes through its soft-recovery
+path, the transcript can re-render with the initiating user bubble ORDERED
+BELOW the live assistant worklog it started. It corrects itself once the turn
+settles (the persisted session JSON is correct), so the flip is display-only
+during the active turn.
+
+Root cause: the server keeps the current turn's prompt in
+``session.pending_user_message`` and omits both it and the live assistant from
+``session.messages`` until the turn settles (deferred merge). ``loadSession``
+handles this by rebuilding the live tail from INFLIGHT (injecting a
+``{role:'assistant', _live:true}`` row) and then splicing the pending user row
+BEFORE it via ``_mergePendingSessionMessage``. ``refreshSession`` in ui.js --
+the re-render path used by ``_recoverFromOfflineSoftly`` on iOS background /
+resume -- did neither: it reset ``S.messages`` to the settled server turns and
+``push()``-ed the pending user row at the END, with no ``_live`` row to anchor
+against. So the pending user ended up after the reconstructed live worklog.
+
+Fix: route ``refreshSession`` through the same live-tail reconstruction +
+``_mergePendingSessionMessage`` placement that ``loadSession`` uses, and promote
+``_mergePendingSessionMessage`` to module scope so both recovery entrypoints
+share the one placement chokepoint.
+
+State layer: this changes the *client* Visible-transcript / Pending-turn
+projection during recovery re-render only (run-state-consistency invariants 2
+"active turn UI keeps its owner" and 3 "reattach preserves order"). It does not
+touch server stream buffering, session persistence, or the settle/merge path --
+those were already verified correct for the same turn in the report.
+"""
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _fn_body(src: str, marker: str) -> str:
+    """Return the balanced-brace body of the function opened at ``marker``."""
+    idx = src.find(marker)
+    assert idx != -1, f"{marker!r} not found"
+    brace = src.find("{", idx)
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{marker!r} body did not close"
+    return src[brace : i]
+
+
+def _extract_fn(src: str, marker: str) -> str:
+    """Return the full ``function name(...) { ... }`` declaration text."""
+    idx = src.find(marker)
+    assert idx != -1, f"{marker!r} not found"
+    return marker + _fn_body(src, marker)
+
+
+def _find_node():
+    import shutil
+    for cand in ("node", "node.exe"):
+        path = shutil.which(cand)
+        if path:
+            try:
+                r = subprocess.run([path, "--version"], capture_output=True, text=True, timeout=5)
+                if r.returncode == 0 and r.stdout.strip().startswith("v"):
+                    return path
+            except Exception:
+                continue
+    pytest.skip("node.js not found -- skipping node-executed behavioral test")
+
+
+# ---------------------------------------------------------------------------
+# Behavioral test: execute the REAL placement/merge functions from sessions.js
+# through the exact sequence refreshSession now runs, and assert the resulting
+# array orders the pending user row immediately BEFORE the live assistant turn.
+# ---------------------------------------------------------------------------
+def test_refresh_recovery_sequence_orders_user_before_live_assistant():
+    node = _find_node()
+
+    ensure_live = _extract_fn(SESSIONS_JS, "function _ensureInflightLiveAssistantMessage(inflight)")
+    merge_tail = _extract_fn(SESSIONS_JS, "function _mergeInflightTailMessages(baseMessages, inflightMessages)")
+    merge_pending = _extract_fn(SESSIONS_JS, "function _mergePendingSessionMessage(session,messages)")
+
+    script = textwrap.dedent(
+        """
+        // --- leaf-helper stubs (peripheral to the ordering logic under test) ---
+        function _messageComparableText(m){ return (m && typeof m.content === 'string') ? m.content.trim() : ''; }
+        function _sameTranscriptMessage(a, b){
+            return !!(a && b && a.role === b.role && String(a.content||'') === String(b.content||''));
+        }
+        // No duplicates in this fixture; keep the guard honest so a real dup
+        // (same current-turn user text) would still be suppressed.
+        function _hasCurrentTailUserDuplicate(messages, candidate){
+            if(!candidate || String(candidate.role||'') !== 'user') return false;
+            for(let i=messages.length-1;i>=0;i--){
+                const m=messages[i];
+                if(m && m.role==='user') return _sameTranscriptMessage(m, candidate);
+                if(m && m.role==='assistant' && m._live) return false;
+            }
+            return false;
+        }
+        function getPendingSessionMessage(session, messages){
+            const text = String(session && session.pending_user_message || '').trim();
+            if(!text) return null;
+            return { role:'user', content:text, _pending:true };
+        }
+        const Date = { now: () => 1000 };  // _ensureInflightLiveAssistantMessage stamps _ts
+
+        __REAL_FUNCS__
+
+        // --- fixture mirrors the reported turn shape --------------------------
+        // A settled prior turn, an active stream whose live assistant text lives
+        // ONLY in INFLIGHT, and the initiating prompt held as pending_user_message.
+        const base = [
+            { role:'user', content:'previous question' },
+            { role:'assistant', content:'previous settled answer' },
+        ];
+        const inflight = { lastAssistantText:'streaming answer in progress', lastReasoningText:'', messages: [] };
+        const session = { pending_user_message:'NEW PROMPT that started this turn' };
+
+        // --- exact refreshSession reconstruction sequence ---------------------
+        _ensureInflightLiveAssistantMessage(inflight);
+        let S_messages = base.slice();
+        S_messages = _mergeInflightTailMessages(S_messages, inflight.messages);
+        _mergePendingSessionMessage(session, S_messages);
+
+        const liveIdx = S_messages.findIndex(m => m && m.role==='assistant' && m._live);
+        const userIdx = S_messages.findIndex(m => m && m._pending);
+
+        let ok = true;
+        function check(cond, msg){ if(!cond){ console.error('FAIL: '+msg); ok=false; } }
+        check(liveIdx !== -1, 'live assistant row was not reconstructed into S.messages');
+        check(userIdx !== -1, 'pending user row was not inserted');
+        check(userIdx < liveIdx, 'pending user row must be ABOVE the live assistant (userIdx='+userIdx+', liveIdx='+liveIdx+')');
+        check(userIdx === liveIdx - 1, 'pending user row must be immediately before the live assistant');
+        // The prior settled turn stays first; the new turn is appended after it.
+        check(S_messages[0] && S_messages[0].content === 'previous question', 'settled history was disturbed');
+        // No duplicate user rows introduced.
+        check(S_messages.filter(m => m && m.role==='user' && m.content==='NEW PROMPT that started this turn').length === 1,
+              'pending user row was duplicated');
+
+        console.log('order: ' + S_messages.map(m => m.role + (m._live?'*':'') + (m._pending?'^':'')).join(','));
+        process.exit(ok ? 0 : 1);
+        """
+    ).replace("__REAL_FUNCS__", "\n".join([ensure_live, merge_tail, merge_pending]))
+
+    result = subprocess.run([node, "-e", script], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        "refreshSession recovery ordering is wrong:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    # Sanity: the reconstructed order is settled-user, settled-assistant,
+    # pending-user(^), live-assistant(*).
+    assert "user,assistant,user^,assistant*" in result.stdout, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Source-structure tests: pin the refreshSession wiring (the actual change).
+# These fail against the pre-fix bare-push refreshSession and pass after.
+# ---------------------------------------------------------------------------
+def test_refresh_session_rebuilds_live_tail_and_splices_pending_before_render():
+    body = _fn_body(UI_JS, "async function refreshSession()")
+
+    # The old path had none of these; it reset S.messages and push()-ed pending.
+    merge_tail_pos = body.find("_mergeInflightTailMessages(S.messages")
+    merge_pending_pos = body.find("_mergePendingSessionMessage(S.session")
+    ensure_live_pos = body.find("_ensureInflightLiveAssistantMessage(INFLIGHT[")
+    render_pos = body.find("_renderMessagesWithScrollSnapshot(")
+
+    assert ensure_live_pos != -1, (
+        "refreshSession must rebuild the live assistant row from INFLIGHT so the "
+        "pending user row has a _live anchor to splice before (#6419)"
+    )
+    assert merge_tail_pos != -1, (
+        "refreshSession must merge the INFLIGHT live tail into S.messages, "
+        "mirroring loadSession's reattach"
+    )
+    assert merge_pending_pos != -1, (
+        "refreshSession must route the pending user row through "
+        "_mergePendingSessionMessage (splice-before-live), not push()-at-end"
+    )
+    assert render_pos != -1, "refreshSession render call not found"
+    assert ensure_live_pos < merge_tail_pos < merge_pending_pos < render_pos, (
+        "Order must be: ensure live row -> merge live tail -> splice pending -> "
+        "render, so the reconstructed transcript is correct before painting"
+    )
+    # The gate must be conditioned on an active stream + an INFLIGHT recovery
+    # cache; an idle refresh degrades to the plain placement helper.
+    assert "S.activeStreamId&&_sid&&INFLIGHT[_sid]" in body.replace(" ", "").replace("\n", "")
+
+
+def test_refresh_session_no_unconditional_push_at_end():
+    body = _fn_body(UI_JS, "async function refreshSession()")
+    # The buggy line was: `if(pendingMsg) S.messages.push(pendingMsg);` used
+    # unconditionally. It may only survive as the defensive else-fallback for
+    # when _mergePendingSessionMessage is somehow unavailable.
+    if "S.messages.push(pendingMsg)" in body:
+        assert "else{" in body.replace(" ", "").replace("\n", ""), (
+            "A bare push(pendingMsg) may only remain inside the else fallback"
+        )
+        # It must not be the primary path: the merge helper is reached first.
+        assert body.find("_mergePendingSessionMessage") < body.find("S.messages.push(pendingMsg)")
+
+
+def test_merge_pending_helper_is_module_scoped_and_shared():
+    # Promoted out of loadSession so refreshSession (ui.js) can call it too.
+    assert "\nfunction _mergePendingSessionMessage(session,messages){" in SESSIONS_JS, (
+        "_mergePendingSessionMessage must be a module-scope function so both "
+        "loadSession and refreshSession share the one placement chokepoint"
+    )
+    # The splice-before-live primitive is intact.
+    assert "messages.findIndex(m=>m&&m.role==='assistant'&&m._live)" in SESSIONS_JS
+    assert "messages.splice(liveAssistantIdx,0,pendingMsg)" in SESSIONS_JS
+    # loadSession still calls it inside its reattach path (no regression to #2341).
+    assert SESSIONS_JS.count("_mergePendingSessionMessage(S.session,S.messages)") >= 2


### PR DESCRIPTION
Fixes #6419.

## Thinking Path

- Hermes WebUI aims for one chronological, user-visible story across live streaming and recovery (run-state-consistency contract, invariants 2 and 3).
- During an active turn the server keeps the prompt in `session.pending_user_message` and, under the default `deferred` save mode, omits both it and the live assistant from `session.messages` until the turn settles.
- Every client recovery re-render therefore has to re-insert that pending prompt itself, and place it correctly relative to the live turn it started.
- `loadSession` gets this right: it rebuilds the live tail from `INFLIGHT` (so a `{role:'assistant', _live:true}` row exists in `S.messages`) and then splices the pending user row immediately before it via `_mergePendingSessionMessage`.
- `refreshSession` (the re-render used by `_recoverFromOfflineSoftly`, i.e. the exact iOS background/resume path in #6419) did neither: it reset `S.messages` to the settled server turns and `push()`-ed the pending row at the end, with no `_live` row to anchor against, so the initiating user bubble ended up ordered after the live worklog.
- This PR routes `refreshSession` through the same live-tail rebuild and placement logic `loadSession` already uses, so the recovered order matches the settled order.

## What Changed

- **`static/ui.js` (`refreshSession`)**: after loading the session, when a stream is active and an `INFLIGHT` recovery cache exists, rebuild the live tail into `S.messages` (`_ensureInflightLiveAssistantMessage` + `_projectInflightMessagesForActivityBursts` + `_prepareRunningLiveTail`/`_dropCurrentTurnAssistantMessages` + `_mergeInflightTailMessages`) and then merge the pending user row through `_mergePendingSessionMessage` (splice-before-live). This mirrors `loadSession`'s reattach path exactly, including the `INFLIGHT[sid].messages` write-back. The idle refresh degrades to the plain placement helper, and there is a defensive fallback to the previous `getPendingSessionMessage` + push only if the shared helper is somehow unavailable.
- **`static/sessions.js`**: promoted `_mergePendingSessionMessage` from a function nested inside `loadSession` to module scope so both recovery entrypoints share the one placement chokepoint (its logic is unchanged; the `loadSession` call sites are unchanged).
- **`tests/test_issue6419_refreshsession_pending_order.py`**: new regression (see Verification).
- **`tests/test_cross_session_message_load_isolation.py`**: that suite extracts `loadSession` and runs it in an isolated Node harness. Since `loadSession` now calls `_mergePendingSessionMessage` as a module-scope helper (rather than a nested one), the harness supplies it via `_extract_function`, exactly like the other extracted functions it already provides (`loadSession`, `_ensureMessagesLoaded`, `_inflightHasVisibleLiveState`, `_selectLiveRecoveryInflight`). No assertion changed; this only keeps the isolated `loadSession` runnable.

No behavior change to the settled/persisted path, which the report already verified correct.

## Why It Matters

While a tool-heavy turn streams (which can be minutes), an iOS webview that backgrounds/locks drops the SSE and, on resume, runs the soft-recovery re-render. Before this fix, the user saw the assistant working with no visible prompt above it, reading response-first, prompt-second, until the turn settled. That violates run-state-consistency invariant 2 ("the user turn that started active work must remain visible before assistant/tool activity") and invariant 3 ("reattach preserves order"). The fix restores the same ordering guarantee the reload/session-switch path (`loadSession`) already provides.

## Verification

- `./scripts/test.sh tests/test_issue6419_refreshsession_pending_order.py` passes (4 tests). The new file has:
  - A `node`-executed behavioral test that runs the real `_ensureInflightLiveAssistantMessage`, `_mergeInflightTailMessages`, and `_mergePendingSessionMessage` (extracted from `sessions.js`) through the exact sequence `refreshSession` now performs, and asserts the reconstructed array orders the pending user row immediately before the `_live` assistant, with the settled history intact and no duplicate user row.
  - Source-structure tests pinning the `refreshSession` wiring (live-tail rebuild before the pending merge before render), mirroring the existing `test_issue2341_pending_user_reattach.py` convention.
- Proof the test bites: with the two source edits reverted, the three structure tests fail (bare `push`, no module-scope helper); with the fix they pass.
- Neighbor sweep green: the closest recovery/reattach/anchor/pending suites, including `test_issue2341_pending_user_reattach`, `test_issue3040_reattach_invariant`, `test_live_to_final_anchor_visible_order`, `test_issue3875_recovery_anchor_dedup`, `test_offline_soft_recovery`, `test_stale_stream_pending_recovery` (99 tests).
- Full `./scripts/test.sh` on Python 3.12: 13597 passed, 178 skipped. The one unrelated failure (`test_5774b_atomic_config_writes::test_atomic_write_preserves_existing_permissions`, a setgid-bit assertion) reproduces identically on clean `master` and is a macOS-specific environment artifact (the OS strips the setgid bit), not from this change.
- ESLint runtime guard clean on both edited files; `node --check` clean.

**Trigger binding (per GUIDELINES rule 6):** the issue pins the bug by its trigger conditions rather than a downloadable capture (deferred `pending_user_message`, the `refreshSession`/`_recoverFromOfflineSoftly` recovery path, a live `INFLIGHT` tail). The test binds to that shape: it reconstructs a session with the prompt only in `pending_user_message` and the live assistant only in `INFLIGHT`, then runs the recovery sequence and asserts order.

**What I could not verify (owner of the truth is the iOS WKWebView + a live agent backend):** I did not reproduce the end-to-end iOS SSE-drop race in a real device, because it needs the iOS webview, a running agent backend, and a provider key. In-page automation would only prove page behavior, not that the webview suspends the connection the way described, so I did not stage a synthetic browser repro and present it as the real thing. The array-level ordering the visible bug depends on is what the test proves. Because this is a timing-dependent recovery re-render (not a static layout), there is no meaningful before/after screenshot; happy to record a desktop simulation if you'd like one.

## Risks / Follow-ups

- Scope is the client recovery re-render only. No server, persistence, or settle/merge change.
- The active-stream branch is gated on `S.activeStreamId && INFLIGHT[sid]`; when either is absent (e.g. the `INFLIGHT` cache was cleared) it degrades to the same placement helper `loadSession`'s idle path uses, and the live turn is still reconstructed by the subsequent `attachLiveStream` in `_recoverFromOfflineSoftly`. So the worst case is the prior behavior, not worse.
- Follow-up (optional): `refreshSession` and `loadSession` now run the same reconstruction sequence with two inline copies of the call chain. A future cleanup could extract a single `rebuildLiveMessagesFromInflight(session, sid)` helper used by both. I kept this PR to the fix and did not do that refactor.
- If you want #6419 recorded in the run-state-consistency RFC's Existing Issue Map (it currently lists #2341/#2342 for the sibling invariant), I'm happy to add the row.

## Model Used

Anthropic Claude (Claude Code). Model: claude-opus-4-8. Used for investigation, the fix, and the regression test; all changes reviewed against `docs/GUIDELINES.md`, `docs/CONTRACTS.md`, and the run-state-consistency RFC.

## Contract Routing

- **Task type:** bug fix (client streaming/recovery re-render ordering).
- **Touched areas:** `static/ui.js` `refreshSession`; `static/sessions.js` shared pending-placement helper; regression test.
- **Relevant public docs:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/GUIDELINES.md`, `docs/CONTRACTS.md`, `docs/rfcs/webui-run-state-consistency-contract.md` (invariants 2 and 3), `docs/rfcs/stable-assistant-turn-anchors.md`.
- **State layer:** Visible transcript / Pending-turn projection during recovery re-render (client). No change to Live stream, Run journal/replay, or persistence.
- **Scope boundaries:** no contract change (behavior is brought into line with existing invariants 2 and 3; no invariant is redefined). No server or persistence change. No new dependency.
- **Evidence needed before claiming done:** a test that reconstructs the pending-only + INFLIGHT-only turn shape and asserts user-before-live order, failing before the fix; neighbor recovery/anchor suites green.
