### PR TITLE
feat(workspace): opt-in strict Add Space registration (#6424)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@
 # Default workspace directory shown on first launch
 # HERMES_WEBUI_DEFAULT_WORKSPACE=~/workspace
 
+# Opt-in: reject Add Space paths outside home / default workspace / allowlisted roots.
+# Keeps the default external-mount behaviour (#953/#991) unless you need a narrower
+# agent-host trust boundary (#6424).
+# HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION=1
+# HERMES_WEBUI_ALLOWED_WORKSPACE_ROOTS=/mnt/projects,/data/shared
+
 # Optional model override. Leave unset to use the active Hermes provider default.
 # HERMES_WEBUI_DEFAULT_MODEL=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in strict workspace registration for Add Space (#6424).** Deployments that must keep the agent/file-API trust boundary narrow can set `HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION=1` so `/api/workspaces/add` only accepts paths under the home directory, the default workspace, or roots listed in `HERMES_WEBUI_ALLOWED_WORKSPACE_ROOTS`. The default remains the existing external-mount registration contract (#953/#991); remote-terminal target paths are unchanged.
+
 ### Changed
 
 - **Background-process completions and watch matches now render as compact, collapsible summary cards.** Routine wakeups no longer fill the transcript with an always-expanded agent-facing prompt: the collapsed row shows the command, exit status or matched watch pattern, and timestamp, while one click reveals the complete command and verbatim output. Failed processes keep a red accent, long watch patterns remain reachable on touch and keyboard when expanded, and unfamiliar future event shapes safely retain the existing raw-notice fallback. Thanks @b3nw. (#6350, #6345)

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -900,6 +900,57 @@ def _strip_surrounding_quotes(path: str) -> str:
     return s
 
 
+STRICT_WORKSPACE_REGISTRATION_ENV = "HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION"
+ALLOWED_WORKSPACE_ROOTS_ENV = "HERMES_WEBUI_ALLOWED_WORKSPACE_ROOTS"
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def strict_workspace_registration_enabled() -> bool:
+    """Return True when Add Space must not expand the trusted-root set.
+
+    Default remains permissive (PR #991 / #953 external mounts). Opt in with
+    ``HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION=1`` for multi-tenant or
+    agent-host deployments where registering an arbitrary existing directory
+    would widen the filesystem boundary the agent and workspace file APIs may
+    later treat as trusted.
+    """
+    return _env_flag_enabled(STRICT_WORKSPACE_REGISTRATION_ENV)
+
+
+def _configured_allowed_workspace_roots() -> list[Path]:
+    """Extra roots permitted under strict registration (comma-separated env)."""
+    raw = os.getenv(ALLOWED_WORKSPACE_ROOTS_ENV, "") or ""
+    roots: list[Path] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            roots.append(_resolve_path(part))
+        except (OSError, ValueError):
+            continue
+    return roots
+
+
+def _is_under_allowed_registration_root(candidate: Path) -> bool:
+    home = _home_path()
+    if home != Path("/") and _is_within(candidate, home):
+        return True
+    for root in _configured_allowed_workspace_roots():
+        if _is_within(candidate, root):
+            return True
+    try:
+        default_ws = _resolve_path(_BOOT_DEFAULT_WORKSPACE)
+        if _is_within(candidate, default_ws):
+            return True
+    except (OSError, ValueError):
+        pass
+    return False
+
+
 def validate_workspace_to_add(path: str) -> Path:
     """Validate a path for *adding* to the workspace list (less restrictive than resolve_trusted_workspace).
 
@@ -913,6 +964,11 @@ def validate_workspace_to_add(path: str) -> Path:
     Surrounding quotes (single or double) are stripped before validation —
     macOS Finder's "Copy as Pathname" wraps paths in single quotes by default,
     and users routinely paste those into the Add Space input.
+
+    When ``HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION`` is enabled, registration
+    is limited to paths under the home directory, the boot default workspace,
+    or roots listed in ``HERMES_WEBUI_ALLOWED_WORKSPACE_ROOTS`` so Add Space
+    cannot silently expand the agent/file-API trust boundary (#6424).
     """
     path = _strip_surrounding_quotes(path)
     candidate = _resolve_path(path)
@@ -937,6 +993,13 @@ def validate_workspace_to_add(path: str) -> Path:
 
     if _is_blocked_workspace_path(candidate, path):
         raise ValueError(f"Path points to a system directory: {candidate}")
+
+    if strict_workspace_registration_enabled() and not _is_under_allowed_registration_root(candidate):
+        raise ValueError(
+            "Strict workspace registration is enabled: path must be under your "
+            "home directory, the default workspace, or a root listed in "
+            f"{ALLOWED_WORKSPACE_ROOTS_ENV}"
+        )
 
     return candidate
 

--- a/tests/test_strict_workspace_registration.py
+++ b/tests/test_strict_workspace_registration.py
@@ -1,0 +1,63 @@
+"""Opt-in strict workspace registration (#6424).
+
+Default Add Space remains permissive for external mounts (#953/#991).
+When HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION is enabled, registration
+cannot widen the trusted filesystem boundary to arbitrary existing dirs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from api import workspace
+
+
+def test_strict_registration_rejects_outside_root(tmp_path, monkeypatch):
+    outside = tmp_path / "outside-agent-root"
+    outside.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv(workspace.STRICT_WORKSPACE_REGISTRATION_ENV, "1")
+    monkeypatch.delenv(workspace.ALLOWED_WORKSPACE_ROOTS_ENV, raising=False)
+    monkeypatch.setattr(workspace, "_home_path", lambda: home)
+    monkeypatch.setattr(workspace, "_BOOT_DEFAULT_WORKSPACE", str(home / "workspace"))
+
+    with pytest.raises(ValueError, match="Strict workspace registration"):
+        workspace.validate_workspace_to_add(str(outside))
+
+
+def test_strict_registration_allows_home_descendant(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    project = home / "projects" / "demo"
+    project.mkdir(parents=True)
+    monkeypatch.setenv(workspace.STRICT_WORKSPACE_REGISTRATION_ENV, "1")
+    monkeypatch.delenv(workspace.ALLOWED_WORKSPACE_ROOTS_ENV, raising=False)
+    monkeypatch.setattr(workspace, "_home_path", lambda: home)
+    monkeypatch.setattr(workspace, "_BOOT_DEFAULT_WORKSPACE", str(home / "workspace"))
+
+    assert workspace.validate_workspace_to_add(str(project)) == project.resolve()
+
+
+def test_strict_registration_allows_configured_extra_root(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    allowed = tmp_path / "mnt" / "projects"
+    allowed.mkdir(parents=True)
+    monkeypatch.setenv(workspace.STRICT_WORKSPACE_REGISTRATION_ENV, "1")
+    monkeypatch.setenv(workspace.ALLOWED_WORKSPACE_ROOTS_ENV, str(allowed))
+    monkeypatch.setattr(workspace, "_home_path", lambda: home)
+    monkeypatch.setattr(workspace, "_BOOT_DEFAULT_WORKSPACE", str(home / "workspace"))
+
+    assert workspace.validate_workspace_to_add(str(allowed)) == allowed.resolve()
+
+
+def test_default_registration_still_allows_external_paths(tmp_path, monkeypatch):
+    outside = tmp_path / "external-mount"
+    outside.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv(workspace.STRICT_WORKSPACE_REGISTRATION_ENV, raising=False)
+    monkeypatch.setattr(workspace, "_home_path", lambda: home)
+
+    assert workspace.validate_workspace_to_add(str(outside)) == outside.resolve()


### PR DESCRIPTION
## Summary

- Addresses the residual trust-boundary concern in #6424 without reversing the intentional external-mount registration contract from #953 / #991.
- When `HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION=1`, `/api/workspaces/add` accepts only paths under the operator home directory, the boot default workspace, or roots listed in `HERMES_WEBUI_ALLOWED_WORKSPACE_ROOTS`.
- Default behaviour is unchanged: authenticated operators may still register existing external directories (for example `/mnt/d/Projects`), and remote-terminal target-side paths continue to use the existing remote candidate path.
- This opt-in mode is intended for multi-tenant or AI-agent-host deployments where registering an arbitrary existing directory would otherwise widen the filesystem boundary later treated as trusted by workspace file APIs and agent tools.

## Why this shape

Maintainer guidance on #6424 correctly notes that a hard containment check against a single `WORKSPACE_ROOT` would break legitimate external mounts. An **opt-in** strict registration gate preserves agent capability for normal single-operator installs while giving hardened hosts a fail-closed registration policy.

## Test plan

- [x] Unit coverage in `tests/test_strict_workspace_registration.py` (reject outside root under strict mode; allow home descendant; allow configured extra root; default mode still permits external paths)
- [ ] Confirm `tests/test_sprint3.py::test_workspace_add_allows_external_valid_paths` still passes with the env unset
- [ ] With `HERMES_WEBUI_STRICT_WORKSPACE_REGISTRATION=1`, Add Space rejects an existing directory outside home / allow-list
- [ ] Remote-terminal workspace registration paths remain unaffected

Closes nothing automatically — policy remains opt-in pending maintainer preference on #6424.