### PR TITLE
fix(mobile): close composer-keyboard gap on Edge Android via interactive-widget viewport hint

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-content">
 <title>Hermes</title>
 <!-- base href enables subpath mount support; all static paths must stay relative (no leading slash).
      MUST appear before manifest/favicon links so browsers resolve relative URLs against the

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1010,7 +1010,24 @@ def test_100dvh_viewport_height():
 
 def test_viewport_disables_page_zoom_for_native_pwa_shell():
     """Installed PWA launches should not rubber-band into browser-style page zoom."""
-    assert 'name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"' in HTML
+    m = re.search(r'<meta\s+name="viewport"\s+content="([^"]+)"', HTML)
+    assert m, "viewport meta tag not found in index.html"
+    content = m.group(1)
+    assert 'width=device-width' in content, "viewport must set width=device-width"
+    assert 'initial-scale=1' in content, "viewport must set initial-scale=1"
+    assert 'maximum-scale=1' in content, "viewport must set maximum-scale=1"
+    assert 'user-scalable=no' in content, "viewport must set user-scalable=no"
+
+
+def test_viewport_requests_keyboard_content_resize():
+    """Edge Android does not resize the layout viewport when the virtual keyboard
+    appears unless interactive-widget=resizes-content is set. Without it, 100dvh
+    stays at full-screen height and the composer floats above a dead gap."""
+    m = re.search(r'<meta\s+name="viewport"\s+content="([^"]+)"', HTML)
+    assert m, "viewport meta tag not found in index.html"
+    content = m.group(1)
+    assert 'interactive-widget=resizes-content' in content, \
+        "viewport must include interactive-widget=resizes-content for Edge Android keyboard resize"
 
 
 def test_pwa_safe_area_top_stays_scoped_to_installed_modes():


### PR DESCRIPTION
### Problem

On Edge Android, the virtual keyboard does not trigger a layout viewport
resize. The body height (`100dvh`) stays at full-screen height, so the
composer (`position: relative` at the bottom of the flex column) renders
above a dead gap between itself and the keyboard. Chrome Android resizes
the layout viewport by default, so the composer sits flush.

### Root cause

The CSS Viewport spec defines `interactive-widget` as the mechanism for
browsers to decide whether `dvh`/`svh`/`vh` should account for the
virtual keyboard. Chrome defaults to `resizes-content` behaviour; Edge
does not. Without the explicit hint, Edge keeps the ICB tall and relies
on `visualViewport` events alone - which the existing JS handler
(`_syncKeyboardBottomInset`) already listens for, but it adds
`--keyboard-bottom-inset` as bottom padding rather than shrinking the
layout, leaving a visual gap.

### Fix

Add `interactive-widget=resizes-content` to the viewport meta tag. This
is the W3C-standard way to opt all Chromium browsers into layout
viewport resizing on keyboard show/hide. The existing
`_syncKeyboardBottomInset()` JS continues to function as a supplementary
guard for edge cases (pinch-zoom, non-Chromium browsers).

### Tests

- `test_viewport_disables_page_zoom_for_native_pwa_shell`: refactored
  from a single monolithic substring assertion to per-directive checks,
  resilient to future viewport attribute additions.
- `test_viewport_requests_keyboard_content_resize`: new regression test
  asserting the `interactive-widget=resizes-content` directive is present.
- All three viewport-related tests pass.

### Manual verification

- Edge Android: gap eliminated, composer flush
  against keyboard.
- Chrome Android (same device): no regression, behaviour unchanged.

### Scope

One attribute added in `static/index.html`, one test refactored and one
test added in `tests/test_mobile_layout.py`. No JS, CSS, or backend
changes. No behavioural change on desktop or non-Chromium mobile
browsers. The directive is defined in the CSS Viewport Module Level 1
spec and supported by all Chromium 108+ browsers.
