### PR TITLE
fix: require any-hover:hover in _hasFinePointerCoexisting to exclude passive stylus digitizers

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2331,7 +2331,7 @@ window._isImeEnter=_isImeEnter;
 // strongest signal browsers expose for "there is a real keyboard /
 // trackpad in the picture too". Skip the mobile default in that case.
 function _hasFinePointerCoexisting(){
-  try{ return matchMedia('(any-pointer:fine)').matches&&matchMedia('(any-hover:hover)').matches; }catch(_){ return false; }
+  try{ return matchMedia('(any-pointer:fine) and (any-hover:hover)').matches; }catch(_){ return false; }
 }
 function _isNumpadEnter(e){
   return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2331,7 +2331,7 @@ window._isImeEnter=_isImeEnter;
 // strongest signal browsers expose for "there is a real keyboard /
 // trackpad in the picture too". Skip the mobile default in that case.
 function _hasFinePointerCoexisting(){
-  try{ return matchMedia('(any-pointer:fine)').matches; }catch(_){ return false; }
+  try{ return matchMedia('(any-pointer:fine)').matches&&matchMedia('(any-hover:hover)').matches; }catch(_){ return false; }
 }
 function _isNumpadEnter(e){
   return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2326,35 +2326,12 @@ window._isImeEnter=_isImeEnter;
 // detachable Surface in tablet mode, iPad + Magic Keyboard). When that
 // happens we should NOT force the mobile newline-on-Enter override
 // because Shift+Enter / Ctrl+Enter come from real keys and the user
-// expects desktop semantics.
-//
-// Detection strategy (layered):
-// 1. Runtime keyboard detection: physical keyboards emit KeyboardEvent.code
-//    values (e.g. 'KeyA', 'Space'); virtual/software keyboards emit code===''.
-//    Once a physical keypress is observed, we treat the session as having a
-//    hardware keyboard until the page is reloaded. This handles keyboard-only
-//    BT accessories that lack a trackpad (no hover, no fine pointer from the
-//    keyboard itself).
-// 2. Media query fallback: `(any-pointer:fine) and (any-hover:hover)` detects
-//    a trackpad/mouse co-existing with touch. This catches the case before any
-//    key is pressed (e.g. user taps send button with trackpad).
-//
-// Together these cover: passive-stylus phones (no false positive from
-// digitizer), active-stylus tablets, keyboard-only BT accessories, and
-// traditional keyboard+trackpad setups.
-let _physicalKeyboardDetected=false;
-(()=>{const _c=$('msg');if(!_c)return;
-  _c.addEventListener('keydown',function(e){
-    if(!_physicalKeyboardDetected&&e.code&&e.code!==''&&!e.isComposing&&e.key!=='Process'){
-      _physicalKeyboardDetected=true;
-    }
-  },true);
-})();
+// expects desktop semantics. `matchMedia('(any-pointer:fine)')` is true
+// whenever ANY available pointing device is fine-grained — which is the
+// strongest signal browsers expose for "there is a real keyboard /
+// trackpad in the picture too". Skip the mobile default in that case.
 function _hasFinePointerCoexisting(){
-  try{
-    if(_physicalKeyboardDetected) return true;
-    return matchMedia('(any-pointer:fine) and (any-hover:hover)').matches;
-  }catch(_){ return false; }
+  try{ return matchMedia('(any-pointer:fine) and (any-hover:hover)').matches; }catch(_){ return false; }
 }
 function _isNumpadEnter(e){
   return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);

--- a/static/boot.js
+++ b/static/boot.js
@@ -2326,12 +2326,35 @@ window._isImeEnter=_isImeEnter;
 // detachable Surface in tablet mode, iPad + Magic Keyboard). When that
 // happens we should NOT force the mobile newline-on-Enter override
 // because Shift+Enter / Ctrl+Enter come from real keys and the user
-// expects desktop semantics. `matchMedia('(any-pointer:fine)')` is true
-// whenever ANY available pointing device is fine-grained — which is the
-// strongest signal browsers expose for "there is a real keyboard /
-// trackpad in the picture too". Skip the mobile default in that case.
+// expects desktop semantics.
+//
+// Detection strategy (layered):
+// 1. Runtime keyboard detection: physical keyboards emit KeyboardEvent.code
+//    values (e.g. 'KeyA', 'Space'); virtual/software keyboards emit code===''.
+//    Once a physical keypress is observed, we treat the session as having a
+//    hardware keyboard until the page is reloaded. This handles keyboard-only
+//    BT accessories that lack a trackpad (no hover, no fine pointer from the
+//    keyboard itself).
+// 2. Media query fallback: `(any-pointer:fine) and (any-hover:hover)` detects
+//    a trackpad/mouse co-existing with touch. This catches the case before any
+//    key is pressed (e.g. user taps send button with trackpad).
+//
+// Together these cover: passive-stylus phones (no false positive from
+// digitizer), active-stylus tablets, keyboard-only BT accessories, and
+// traditional keyboard+trackpad setups.
+let _physicalKeyboardDetected=false;
+(()=>{const _c=$('msg');if(!_c)return;
+  _c.addEventListener('keydown',function(e){
+    if(!_physicalKeyboardDetected&&e.code&&e.code!==''&&!e.isComposing&&e.key!=='Process'){
+      _physicalKeyboardDetected=true;
+    }
+  },true);
+})();
 function _hasFinePointerCoexisting(){
-  try{ return matchMedia('(any-pointer:fine) and (any-hover:hover)').matches; }catch(_){ return false; }
+  try{
+    if(_physicalKeyboardDetected) return true;
+    return matchMedia('(any-pointer:fine) and (any-hover:hover)').matches;
+  }catch(_){ return false; }
 }
 function _isNumpadEnter(e){
   return e.key==='Enter'&&(e.code==='NumpadEnter'||e.location===KeyboardEvent.DOM_KEY_LOCATION_NUMPAD);

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1694,6 +1694,54 @@ def test_mobile_enter_newline_respects_hardware_keyboard_on_touch_devices():
         "mobile Enter newline override must skip touch devices that also expose a fine pointer"
 
 
+def test_fine_pointer_coexisting_requires_hover_for_media_query():
+    """Media query path must require both fine pointer AND hover to exclude passive stylus digitizers."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    import re
+    match = re.search(r'function _hasFinePointerCoexisting\(\)\{[^}]+\}', boot_js, re.DOTALL)
+    assert match, "_hasFinePointerCoexisting function not found"
+    body = match.group(0)
+    assert "any-pointer:fine" in body, "must check any-pointer:fine"
+    assert "any-hover:hover" in body, \
+        "must also check any-hover:hover to exclude passive stylus digitizers"
+
+
+def test_fine_pointer_coexisting_uses_compound_media_query():
+    """Media queries should be combined into a single compound query for atomic evaluation."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    assert "(any-pointer:fine) and (any-hover:hover)" in boot_js, \
+        "_hasFinePointerCoexisting must use a compound media query for atomic evaluation"
+
+
+def test_physical_keyboard_detection_uses_event_code():
+    """Runtime physical keyboard detection must use KeyboardEvent.code to distinguish HW from SW keyboards."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    assert "_physicalKeyboardDetected" in boot_js, \
+        "boot.js must track physical keyboard detection at runtime"
+    assert "e.code" in boot_js, \
+        "physical keyboard detection must inspect KeyboardEvent.code (empty for virtual keyboards)"
+
+
+def test_physical_keyboard_detection_gates_fine_pointer():
+    """Once a physical keyboard is detected, _hasFinePointerCoexisting must return true."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    import re
+    match = re.search(r'function _hasFinePointerCoexisting\(\)\{[^}]+\}', boot_js, re.DOTALL)
+    assert match, "_hasFinePointerCoexisting function not found"
+    body = match.group(0)
+    assert "_physicalKeyboardDetected" in body, \
+        "_hasFinePointerCoexisting must check _physicalKeyboardDetected before media queries"
+
+
+def test_physical_keyboard_detection_excludes_ime_composing():
+    """Physical keyboard detection must not trigger during IME composition (isComposing or Process key)."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    assert "isComposing" in boot_js, \
+        "physical keyboard detection must guard against IME composition events"
+    assert "Process" in boot_js, \
+        "physical keyboard detection must guard against Process key (IME placeholder)"
+
+
 def test_mobile_enter_newline_only_overrides_enter_default():
     """Mobile newline override must only apply when _sendKey is the default 'enter'."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1694,54 +1694,6 @@ def test_mobile_enter_newline_respects_hardware_keyboard_on_touch_devices():
         "mobile Enter newline override must skip touch devices that also expose a fine pointer"
 
 
-def test_fine_pointer_coexisting_requires_hover_for_media_query():
-    """Media query path must require both fine pointer AND hover to exclude passive stylus digitizers."""
-    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    import re
-    match = re.search(r'function _hasFinePointerCoexisting\(\)\{[^}]+\}', boot_js, re.DOTALL)
-    assert match, "_hasFinePointerCoexisting function not found"
-    body = match.group(0)
-    assert "any-pointer:fine" in body, "must check any-pointer:fine"
-    assert "any-hover:hover" in body, \
-        "must also check any-hover:hover to exclude passive stylus digitizers"
-
-
-def test_fine_pointer_coexisting_uses_compound_media_query():
-    """Media queries should be combined into a single compound query for atomic evaluation."""
-    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "(any-pointer:fine) and (any-hover:hover)" in boot_js, \
-        "_hasFinePointerCoexisting must use a compound media query for atomic evaluation"
-
-
-def test_physical_keyboard_detection_uses_event_code():
-    """Runtime physical keyboard detection must use KeyboardEvent.code to distinguish HW from SW keyboards."""
-    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "_physicalKeyboardDetected" in boot_js, \
-        "boot.js must track physical keyboard detection at runtime"
-    assert "e.code" in boot_js, \
-        "physical keyboard detection must inspect KeyboardEvent.code (empty for virtual keyboards)"
-
-
-def test_physical_keyboard_detection_gates_fine_pointer():
-    """Once a physical keyboard is detected, _hasFinePointerCoexisting must return true."""
-    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    import re
-    match = re.search(r'function _hasFinePointerCoexisting\(\)\{[^}]+\}', boot_js, re.DOTALL)
-    assert match, "_hasFinePointerCoexisting function not found"
-    body = match.group(0)
-    assert "_physicalKeyboardDetected" in body, \
-        "_hasFinePointerCoexisting must check _physicalKeyboardDetected before media queries"
-
-
-def test_physical_keyboard_detection_excludes_ime_composing():
-    """Physical keyboard detection must not trigger during IME composition (isComposing or Process key)."""
-    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "isComposing" in boot_js, \
-        "physical keyboard detection must guard against IME composition events"
-    assert "Process" in boot_js, \
-        "physical keyboard detection must guard against Process key (IME placeholder)"
-
-
 def test_mobile_enter_newline_only_overrides_enter_default():
     """Mobile newline override must only apply when _sendKey is the default 'enter'."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")


### PR DESCRIPTION
**Problem**

On Android devices whose display panel advertises a stylus digitizer (Vivo X300 Ultra, Samsung S-Pen devices, Xiaomi stylus-capable tablets), `matchMedia('(any-pointer:fine)')` returns `true` despite no hardware keyboard or trackpad being present.

`_hasFinePointerCoexisting()` uses `(any-pointer:fine)` alone to infer a hardware keyboard is attached, which disables the mobile Enter-as-newline override. On affected devices, bare Enter submits the message instead of inserting a newline - breaking the core mobile input contract established in #3076.

**Root cause**

A passive stylus digitizer satisfies `(any-pointer:fine)` without providing hover capability. The heuristic needs a second signal to distinguish "real keyboard + trackpad" (which always supports hover) from "phone with an embedded stylus digitizer" (which does not).

**Fix**

Add `(any-hover:hover)` as a required co-condition in `_hasFinePointerCoexisting()`. A trackpad or mouse always supports hover; a passive stylus digitizer does not.

| Device | any-pointer:fine | any-hover:hover | Before | After |
|---|---|---|---|---|
| Phone, no stylus | false | false | mobile (correct) | mobile (correct) |
| Phone + stylus digitizer | true | false | **desktop (wrong)** | mobile (correct) |
| Tablet + BT keyboard/trackpad | true | true | desktop (correct) | desktop (correct) |
| Desktop | true | true | desktop (correct) | desktop (correct) |

**Testing**

Verified manually on Vivo android phone (OriginOS, Chrome + Edge) - Enter now inserts a newline. Desktop behaviour unchanged. `test_mobile_layout.py` passes (76/76).

No new automated test added: the existing test suite asserts call-site wiring (`!_hasFinePointerCoexisting()` present in the mobile override path). The function body itself is a one-expression media query check with no branching or state - the only meaningful test would be an integration test running on a real device with a stylus digitizer, which the CI environment cannot provide.