### PR TITLE
feat: re-check update banner on tab focus and every 30 min

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -3522,6 +3522,10 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const _checkUpdates=()=>{
     if(_bootSettings.check_for_updates===false||sessionStorage.getItem('hermes-update-dismissed')) return;
     api('api/updates/check',{method:'POST',body:JSON.stringify({force:false}),timeoutMs:300000}).then(d=>{
+      // Re-check dismissed state after fetch — the user may have dismissed
+      // the banner while the request was in flight, preventing a race where
+      // _showUpdateBanner() re-displays a banner the user just closed.
+      if(sessionStorage.getItem('hermes-update-dismissed')) return;
       if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0)) _showUpdateBanner(d);
     }).catch(()=>{});
   };

--- a/static/boot.js
+++ b/static/boot.js
@@ -3516,24 +3516,32 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     _applyComposerFooterVisibilitySettings();
     if(typeof _applyTtsEnabled==='function') _applyTtsEnabled(localStorage.getItem('hermes-tts-enabled')==='true');
   }
-  // Non-blocking update check (re-checks on tab focus + periodic poll)
+  // Non-blocking update check (re-checks on tab focus + periodic poll).
+  // Overlapping triggers (boot, visibilitychange, 30-min timer) are coalesced
+  // behind one boot-scope in-flight promise: callers arriving while a request
+  // is pending share that promise instead of issuing duplicate POSTs, and the
+  // token is cleared in finally so a later trigger can run after settlement.
   // ?test_updates=1 in URL forces banner display for testing (bypasses dismissed guard)
   const _testUpdates=new URLSearchParams(location.search).get('test_updates')==='1';
+  let _updateCheckInFlight=null;
   const _checkUpdates=()=>{
     if(_bootSettings.check_for_updates===false||sessionStorage.getItem('hermes-update-dismissed')) return;
-    api('api/updates/check',{method:'POST',body:JSON.stringify({force:false}),timeoutMs:300000}).then(d=>{
+    if(_updateCheckInFlight) return _updateCheckInFlight;
+    _updateCheckInFlight=api('api/updates/check',{method:'POST',body:JSON.stringify({force:false}),timeoutMs:300000}).then(d=>{
       // Re-check dismissed state after fetch — the user may have dismissed
       // the banner while the request was in flight, preventing a race where
       // _showUpdateBanner() re-displays a banner the user just closed.
       if(sessionStorage.getItem('hermes-update-dismissed')) return;
       if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0)) _showUpdateBanner(d);
-    }).catch(()=>{});
+    }).catch(()=>{}).finally(()=>{_updateCheckInFlight=null;});
+    return _updateCheckInFlight;
   };
   if(_testUpdates){
     api('api/updates/check?simulate=1',{method:'GET',timeoutMs:300000}).then(d=>_showUpdateBanner(d)).catch(()=>{});
   }else{
     _checkUpdates();
-    // Re-check on tab focus (catches background tabs that were closed then re-opened)
+    // Re-check when a background tab becomes visible again (visibilitychange);
+    // a tab that was closed and re-opened is handled by the normal boot path.
     document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='visible') _checkUpdates();});
     // Periodic re-check every 30 minutes for always-open tabs (1,800,000 ms)
     setInterval(_checkUpdates,1800000);

--- a/static/boot.js
+++ b/static/boot.js
@@ -3516,12 +3516,23 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     _applyComposerFooterVisibilitySettings();
     if(typeof _applyTtsEnabled==='function') _applyTtsEnabled(localStorage.getItem('hermes-tts-enabled')==='true');
   }
-  // Non-blocking update check (fire-and-forget, once per tab session)
-  // ?test_updates=1 in URL forces banner display for testing (bypasses sessionStorage guards)
+  // Non-blocking update check (re-checks on tab focus + periodic poll)
+  // ?test_updates=1 in URL forces banner display for testing (bypasses dismissed guard)
   const _testUpdates=new URLSearchParams(location.search).get('test_updates')==='1';
-  if(_testUpdates||(_bootSettings.check_for_updates!==false&&!sessionStorage.getItem('hermes-update-checked')&&!sessionStorage.getItem('hermes-update-dismissed'))){
-    const _checkUrl='api/updates/check'+(_testUpdates?'?simulate=1':'');
-    api(_checkUrl,{method:_testUpdates?'GET':'POST',body:_testUpdates?undefined:JSON.stringify({force:false}),timeoutMs:300000}).then(d=>{if(!_testUpdates)sessionStorage.setItem('hermes-update-checked','1');if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0))_showUpdateBanner(d);}).catch(()=>{});
+  const _checkUpdates=()=>{
+    if(_bootSettings.check_for_updates===false||sessionStorage.getItem('hermes-update-dismissed')) return;
+    api('api/updates/check',{method:'POST',body:JSON.stringify({force:false}),timeoutMs:300000}).then(d=>{
+      if((d.webui&&d.webui.behind>0)||(d.agent&&d.agent.behind>0)) _showUpdateBanner(d);
+    }).catch(()=>{});
+  };
+  if(_testUpdates){
+    api('api/updates/check?simulate=1',{method:'GET',timeoutMs:300000}).then(d=>_showUpdateBanner(d)).catch(()=>{});
+  }else{
+    _checkUpdates();
+    // Re-check on tab focus (catches background tabs that were closed then re-opened)
+    document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='visible') _checkUpdates();});
+    // Periodic re-check every 30 minutes for always-open tabs (1,800,000 ms)
+    setInterval(_checkUpdates,1800000);
   }
   const _bootActiveProfileUnauthRedirectBudget=(()=>{
     const markerKey='hermes-webui-active-profile-bootstrap-401';

--- a/static/boot.js
+++ b/static/boot.js
@@ -3524,6 +3524,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   // ?test_updates=1 in URL forces banner display for testing (bypasses dismissed guard)
   const _testUpdates=new URLSearchParams(location.search).get('test_updates')==='1';
   let _updateCheckInFlight=null;
+  let _updateCheckTimer=null;
   const _checkUpdates=()=>{
     if(_bootSettings.check_for_updates===false||sessionStorage.getItem('hermes-update-dismissed')) return;
     if(_updateCheckInFlight) return _updateCheckInFlight;
@@ -3543,8 +3544,11 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     // Re-check when a background tab becomes visible again (visibilitychange);
     // a tab that was closed and re-opened is handled by the normal boot path.
     document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='visible') _checkUpdates();});
-    // Periodic re-check every 30 minutes for always-open tabs (1,800,000 ms)
-    setInterval(_checkUpdates,1800000);
+    // Periodic re-check every 30 minutes for always-open tabs (1,800,000 ms).
+    // The handle is kept in a boot-scope binding so the poll can be torn down;
+    // when check_for_updates is turned off the callback short-circuits, so an
+    // idle timer costs nothing until it is cleared.
+    _updateCheckTimer=setInterval(_checkUpdates,1800000);
   }
   const _bootActiveProfileUnauthRedirectBudget=(()=>{
     const markerKey='hermes-webui-active-profile-bootstrap-401';

--- a/tests/test_update_check_coalescing.py
+++ b/tests/test_update_check_coalescing.py
@@ -1,0 +1,252 @@
+"""Frontend lifecycle coverage for the periodic update-banner checker.
+
+PR #6480 re-calls `static/boot.js::_checkUpdates()` on boot, on tab
+`visibilitychange`, and on a 30-minute interval. Without a browser-side
+in-flight owner those triggers can overlap and issue duplicate POSTs to
+`api/updates/check`, each with its own response-side effects.
+
+This module runs the REAL `_checkUpdates` arrow function (extracted from
+boot.js) inside a node harness with a controllable `api()` mock and an
+in-memory `sessionStorage`, proving the deferred-promise lifecycle:
+
+- two (or three) triggers while one request is pending issue exactly one POST
+  and share the same in-flight promise;
+- dismiss-before-resolve does not render the banner (the post-response
+  `hermes-update-dismissed` re-check is preserved);
+- a trigger after settlement starts a new request (the in-flight token is
+  cleared in `finally`);
+- disabled and already-dismissed states issue no request;
+- `?test_updates=1` keeps its separate GET simulation path (one GET, no POST,
+  no listener/timer registration), while the normal boot path issues one POST
+  and registers the visibilitychange listener plus the 30-minute timer.
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+REPO = pathlib.Path(__file__).parent.parent
+BOOT_JS = REPO / "static" / "boot.js"
+NODE = shutil.which("node")
+requires_node = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+# The driver extracts the real `_checkUpdates` arrow, the `_testUpdates`
+# expression and the `if(_testUpdates){...}else{...}` trigger block from
+# boot.js, then exercises them against a controllable api() mock. Each action
+# returns a JSON summary that the Python side asserts on.
+_DRIVER = textwrap.dedent(
+    r"""
+    const fs = require('fs');
+    const bootSrc = fs.readFileSync(process.argv[1], 'utf8');
+    const action = process.argv[2] || 'coalesce';
+
+    function extractBalanced(src, braceIdx) {
+      let depth = 0, inString = null, escaped = false, inLineComment = false, inBlockComment = false;
+      for (let i = braceIdx; i < src.length; i++) {
+        const ch = src[i], nxt = src[i + 1] || '';
+        if (inLineComment) { if (ch === '\n') inLineComment = false; continue; }
+        if (inBlockComment) { if (ch === '*' && nxt === '/') inBlockComment = false; continue; }
+        if (inString) {
+          if (escaped) escaped = false;
+          else if (ch === '\\') escaped = true;
+          else if (ch === inString) inString = null;
+          continue;
+        }
+        if (ch === '/' && nxt === '/') { inLineComment = true; continue; }
+        if (ch === '/' && nxt === '*') { inBlockComment = true; continue; }
+        if (ch === "'" || ch === '"' || ch === '`') { inString = ch; continue; }
+        if (ch === '{') depth += 1;
+        if (ch === '}') { depth -= 1; if (depth === 0) return i + 1; }
+      }
+      throw new Error('could not extract balanced block');
+    }
+
+    function extractArrowFn(src, name) {
+      const marker = `const ${name}=`;
+      const start = src.indexOf(marker);
+      if (start < 0) throw new Error(`${name}() not found`);
+      const arrowStart = start + marker.length; // '()=>{...'
+      const brace = src.indexOf('{', arrowStart);
+      if (brace < 0) throw new Error(`${name}() body not found`);
+      const end = extractBalanced(src, brace);
+      return src.slice(arrowStart, end); // '()=>{...}'
+    }
+
+    function extractBlock(src, marker) {
+      const start = src.indexOf(marker);
+      if (start < 0) throw new Error(`block '${marker}' not found`);
+      const brace = src.indexOf('{', start);
+      if (brace < 0) throw new Error(`block '${marker}' has no brace`);
+      let end = extractBalanced(src, brace);
+      // Include a trailing else branch if present.
+      const rest = src.slice(end);
+      const elseMatch = rest.match(/^\s*else\s*\{/);
+      if (elseMatch) {
+        const elseBrace = end + elseMatch[0].lastIndexOf('{');
+        end = extractBalanced(src, elseBrace);
+      }
+      return src.slice(start, end);
+    }
+
+    function extractConstLine(src, name) {
+      const marker = `const ${name}=`;
+      const start = src.indexOf(marker);
+      if (start < 0) throw new Error(`${name} not found`);
+      const semi = src.indexOf(';', start);
+      if (semi < 0) throw new Error(`${name} line has no semicolon`);
+      return src.slice(start + marker.length, semi);
+    }
+
+    const result = { calls: [], postCalls: 0, getCalls: 0, bannerCalls: 0, listeners: [], intervals: [], returnedNull: false, firstReturned: false, secondReturned: false, sharedPromise: false };
+    const store = {};
+    global.sessionStorage = {
+      getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; },
+    };
+    global.location = { search: action === 'test-mode' ? '?test_updates=1' : '' };
+
+    const pending = [];
+    global.api = (url, opts = {}) => {
+      const method = (opts.method || 'GET').toUpperCase();
+      result.calls.push({ url: String(url), method, body: opts.body || '' });
+      if (method === 'POST') {
+        result.postCalls += 1;
+        return new Promise((resolve) => { pending.push({ resolve, url: String(url) }); });
+      }
+      result.getCalls += 1;
+      return Promise.resolve({ webui: { behind: 1 }, agent: { behind: 0 } });
+    };
+    global._showUpdateBanner = () => { result.bannerCalls += 1; };
+    global.document = { addEventListener: (ev) => { result.listeners.push(ev); } };
+    global.setInterval = (fn, ms) => { result.intervals.push(ms); return 42; };
+
+    // Extract the REAL pieces from boot.js and evaluate them in this scope.
+    const checkUpdatesSrc = extractArrowFn(bootSrc, '_checkUpdates');
+    const testUpdatesRhs = extractConstLine(bootSrc, '_testUpdates');
+    const bootBlock = extractBlock(bootSrc, 'if(_testUpdates){');
+
+    let _bootSettings = { check_for_updates: true };
+    let _updateCheckInFlight = null;
+    const _checkUpdates = eval('(' + checkUpdatesSrc + ')');
+    const _testUpdates = eval(testUpdatesRhs);
+
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+
+    (async () => {
+      if (action === 'coalesce') {
+        const p1 = _checkUpdates();
+        const p2 = _checkUpdates();
+        const p3 = _checkUpdates();
+        result.sharedPromise = p1 === p2 && p2 === p3;
+        result.firstReturned = p1 !== null && p1 !== undefined;
+        if (pending.length) pending[0].resolve({ webui: { behind: 1 }, agent: { behind: 0 } });
+        await flush();
+      } else if (action === 'dismiss-before-resolve') {
+        const p1 = _checkUpdates();
+        store['hermes-update-dismissed'] = '1'; // user dismisses while request is in flight
+        if (pending.length) pending[0].resolve({ webui: { behind: 1 }, agent: { behind: 0 } });
+        if (p1 && typeof p1.then === 'function') await p1;
+        await flush();
+      } else if (action === 'after-settlement') {
+        const p1 = _checkUpdates();
+        if (pending.length) pending[0].resolve({ webui: { behind: 0 }, agent: { behind: 0 } });
+        if (p1 && typeof p1.then === 'function') await p1; // finally clears the token
+        const p2 = _checkUpdates(); // new trigger after settlement
+        result.secondReturned = p2 !== null && p2 !== undefined;
+        if (pending.length) pending[pending.length - 1].resolve({ webui: { behind: 1 }, agent: { behind: 0 } });
+        if (p2 && typeof p2.then === 'function') await p2;
+        await flush();
+      } else if (action === 'disabled') {
+        _bootSettings.check_for_updates = false;
+        const r1 = _checkUpdates();
+        result.returnedNull = r1 === null || r1 === undefined;
+      } else if (action === 'dismissed') {
+        store['hermes-update-dismissed'] = '1';
+        const r1 = _checkUpdates();
+        result.returnedNull = r1 === null || r1 === undefined;
+      } else if (action === 'test-mode' || action === 'boot-mode') {
+        eval(bootBlock);
+        if (action === 'boot-mode' && pending.length) {
+          pending[0].resolve({ webui: { behind: 1 }, agent: { behind: 0 } });
+          await flush();
+        }
+      }
+      console.log(JSON.stringify(result));
+    })().catch((e) => { console.error(String((e && e.stack) || e)); process.exit(1); });
+    """
+)
+
+
+def _run(action):
+    proc = subprocess.run(
+        [NODE, "-e", _DRIVER, str(BOOT_JS), action],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"node driver failed for action {action!r}:\n{proc.stderr}"
+    )
+    return json.loads(proc.stdout)
+
+
+@requires_node
+class TestUpdateCheckCoalescing:
+    """Deferred-promise lifecycle of the update banner scheduler (PR #6480)."""
+
+    def test_two_triggers_while_one_request_pending_issue_one_post(self):
+        r = _run("coalesce")
+        assert r["postCalls"] == 1, "overlapping triggers must coalesce into one POST"
+        assert r["getCalls"] == 0
+        assert r["sharedPromise"] is True, "overlapping callers must share the in-flight promise"
+        assert r["firstReturned"] is True
+        assert len(r["calls"]) == 1
+        assert r["calls"][0]["method"] == "POST"
+        assert r["calls"][0]["url"] == "api/updates/check"
+
+    def test_dismiss_before_resolve_does_not_render(self):
+        r = _run("dismiss-before-resolve")
+        assert r["postCalls"] == 1
+        assert r["bannerCalls"] == 0, (
+            "dismissing while a request is in flight must keep the banner hidden"
+        )
+
+    def test_trigger_after_settlement_starts_new_request(self):
+        r = _run("after-settlement")
+        assert r["postCalls"] == 2, (
+            "after the in-flight promise settles, a later trigger must start a new request"
+        )
+        assert r["secondReturned"] is True
+
+    def test_disabled_state_issues_no_request(self):
+        r = _run("disabled")
+        assert r["postCalls"] == 0
+        assert r["calls"] == []
+        assert r["returnedNull"] is True
+
+    def test_already_dismissed_state_issues_no_request(self):
+        r = _run("dismissed")
+        assert r["postCalls"] == 0
+        assert r["calls"] == []
+        assert r["returnedNull"] is True
+
+    def test_test_updates_mode_issues_one_simulation_get_and_no_post(self):
+        r = _run("test-mode")
+        assert r["getCalls"] == 1, "?test_updates=1 must issue exactly one simulation GET"
+        assert r["postCalls"] == 0, "the simulation branch must never POST"
+        assert r["calls"][0]["url"] == "api/updates/check?simulate=1"
+        assert r["calls"][0]["method"] == "GET"
+        assert r["listeners"] == [], "simulation mode must not register lifecycle triggers"
+        assert r["intervals"] == []
+
+    def test_normal_boot_registers_one_post_visibility_listener_and_timer(self):
+        r = _run("boot-mode")
+        assert r["postCalls"] == 1, "boot must run exactly one update check"
+        assert r["getCalls"] == 0
+        assert r["listeners"] == ["visibilitychange"]
+        assert r["intervals"] == [1800000], "periodic re-check must stay at 30 minutes"

--- a/tests/test_update_check_coalescing.py
+++ b/tests/test_update_check_coalescing.py
@@ -18,7 +18,8 @@ in-memory `sessionStorage`, proving the deferred-promise lifecycle:
 - disabled and already-dismissed states issue no request;
 - `?test_updates=1` keeps its separate GET simulation path (one GET, no POST,
   no listener/timer registration), while the normal boot path issues one POST
-  and registers the visibilitychange listener plus the 30-minute timer.
+  and registers the visibilitychange listener plus the 30-minute timer, whose
+  handle is stored in a boot-scope binding so the poll can be torn down.
 """
 
 import json
@@ -101,7 +102,7 @@ _DRIVER = textwrap.dedent(
       return src.slice(start + marker.length, semi);
     }
 
-    const result = { calls: [], postCalls: 0, getCalls: 0, bannerCalls: 0, listeners: [], intervals: [], returnedNull: false, firstReturned: false, secondReturned: false, sharedPromise: false };
+    const result = { calls: [], postCalls: 0, getCalls: 0, bannerCalls: 0, listeners: [], intervals: [], returnedNull: false, firstReturned: false, secondReturned: false, sharedPromise: false, intervalHandleStored: false };
     const store = {};
     global.sessionStorage = {
       getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
@@ -132,6 +133,7 @@ _DRIVER = textwrap.dedent(
 
     let _bootSettings = { check_for_updates: true };
     let _updateCheckInFlight = null;
+    let _updateCheckTimer = null;
     const _checkUpdates = eval('(' + checkUpdatesSrc + ')');
     const _testUpdates = eval(testUpdatesRhs);
 
@@ -171,6 +173,8 @@ _DRIVER = textwrap.dedent(
         result.returnedNull = r1 === null || r1 === undefined;
       } else if (action === 'test-mode' || action === 'boot-mode') {
         eval(bootBlock);
+        // The interval handle must be captured (not discarded) on the real path.
+        result.intervalHandleStored = (_updateCheckTimer === 42);
         if (action === 'boot-mode' && pending.length) {
           pending[0].resolve({ webui: { behind: 1 }, agent: { behind: 0 } });
           await flush();
@@ -243,6 +247,7 @@ class TestUpdateCheckCoalescing:
         assert r["calls"][0]["method"] == "GET"
         assert r["listeners"] == [], "simulation mode must not register lifecycle triggers"
         assert r["intervals"] == []
+        assert r["intervalHandleStored"] is False
 
     def test_normal_boot_registers_one_post_visibility_listener_and_timer(self):
         r = _run("boot-mode")
@@ -250,3 +255,6 @@ class TestUpdateCheckCoalescing:
         assert r["getCalls"] == 0
         assert r["listeners"] == ["visibilitychange"]
         assert r["intervals"] == [1800000], "periodic re-check must stay at 30 minutes"
+        assert r["intervalHandleStored"] is True, (
+            "the periodic poll must keep its setInterval handle so it can be torn down"
+        )


### PR DESCRIPTION
## Problem

The update check in `static/boot.js` runs **once per browser tab** via a `sessionStorage` guard (`hermes-update-checked`). If a user keeps a tab open for days, the yellow update banner never updates — even if new releases become available for the Agent or WebUI.

## Root Cause

```javascript
sessionStorage.setItem('hermes-update-checked','1'); // blocks any future check in this tab
```

No `visibilitychange`, `focus`, or periodic timer re-checks. User only discovers updates by closing/reopening the tab or manually clicking Settings → Check for updates.

## What this PR changes

1. **Initial check on page load** — unchanged behavior (still runs once on boot)
2. **`visibilitychange` listener** — re-checks when the tab gains focus (catches background tabs revisited after hours/days)
3. **`setInterval` every 30 minutes** — catches always-open tabs even without tab focus changes
4. **`hermes-update-dismissed` guard preserved** — if the user explicitly dismisses the banner, it stays dismissed within that session

## Testing

- `?test_updates=1` still works for forced banner display during development
- Open a tab, minimize it, come back hours later — the check runs on `visibilitychange`
- Leave a tab open overnight — `setInterval` catches new releases within 30 min

Fixes #6479