### PR TITLE
fix(#6459): suppress false loopback-only warning when public browser_url is configured

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -365,6 +365,7 @@ const LOCALES = {
   bg_no_answer:'(no answer)',
   bg_failed:'Background task failed: ',
   process_wakeup_label:'Background wakeup',
+  process_wakeup_matched:'Watch pattern matched',
   undo_exchange:'Undo last exchange',
   cmd_status:'Show session info',
   cmd_voice:'Toggle microphone input',
@@ -2126,6 +2127,7 @@ const LOCALES = {
   bg_no_answer:'(nessuna risposta)',
   bg_failed:'Task in background fallito: ',
   process_wakeup_label:'Riattivazione in background',
+  process_wakeup_matched:'Pattern di osservazione rilevato',
   undo_exchange:'Annulla ultimo scambio',
   cmd_status:'Mostra info sessione',
   cmd_voice:'Attiva/disattiva input microfono',
@@ -3869,6 +3871,7 @@ const LOCALES = {
   bg_no_answer:'(回答なし)',
   bg_failed:'バックグラウンドタスク失敗: ',
   process_wakeup_label:'バックグラウンド起動',
+  process_wakeup_matched:'監視パターンに一致',
   undo_exchange:'最後のやり取りを取り消す',
   cmd_status:'セッション情報を表示',
   cmd_voice:'マイク入力を切り替え',
@@ -5541,6 +5544,7 @@ const LOCALES = {
     cmd_background: 'Запустить промпт в фоне',
     cmd_background_usage: '/background <промпт> — запустить параллельно, не блокируя чат',
     process_wakeup_label: 'Фоновое пробуждение',
+    process_wakeup_matched: 'Совпадение с шаблоном наблюдения',
 
     no_personalities: 'Личности не найдены (добавьте их в ~/.hermes/personalities/)',
     clarify_heading: 'Требуется уточнение',
@@ -7300,6 +7304,7 @@ const LOCALES = {
     composer_placeholder_busy_interrupt: 'Enter = interrupt | /queue | /background | /steer',
     composer_placeholder_busy_steer: 'Enter = steer | /queue | /background | /interrupt',
     process_wakeup_label: 'Activación en segundo plano',
+    process_wakeup_matched: 'Patrón de observación coincidente',
     no_personalities: 'No se encontraron personalidades (añádelas a ~/.hermes/personalities/)',
     available_personalities: 'Personalidades disponibles:',
     personality_switch_hint: '\n\nUsa `/personality <name>` para cambiar, o `/personality none` para limpiar.',
@@ -8958,6 +8963,7 @@ const LOCALES = {
     composer_placeholder_busy_interrupt: 'Enter = interrupt | /queue | /background | /steer',
     composer_placeholder_busy_steer: 'Enter = steer | /queue | /background | /interrupt',
     process_wakeup_label: 'Hintergrund-Aktivierung',
+    process_wakeup_matched: 'Überwachungsmuster erkannt',
     no_personalities: 'Keine Persönlichkeiten gefunden (füge sie in ~/.hermes/personalities/ hinzu)',
     available_personalities: 'Verfügbare Persönlichkeiten:',
     personality_switch_hint: '\n\nNutze `/personality <name>` zum Wechseln, oder `/personality none` zum Löschen.',
@@ -10671,6 +10677,7 @@ const LOCALES = {
     composer_placeholder_busy_interrupt: 'Enter = 中断 | /queue | /background | /steer',
     composer_placeholder_busy_steer: 'Enter = 引导 | /queue | /background | /interrupt',
     process_wakeup_label: '后台唤醒',
+    process_wakeup_matched: '监视模式已匹配',
     settings_plugins_title: '插件',
     plugins_enable_toggle: '启用',
     settings_plugins_meta: '查看已安装的 Hermes 插件及其注册的生命周期挂钩。此面板为只读。',
@@ -12388,6 +12395,7 @@ const LOCALES = {
     bg_no_answer: '（沒有回答）',
     bg_failed: '背景任務失敗：',
     process_wakeup_label: '背景喚醒',
+    process_wakeup_matched: '監視模式已匹配',
     undo_exchange: '復原上一組問答',
     cmd_status: '顯示對話資訊',
     cmd_voice: '切換麥克風輸入',
@@ -14057,6 +14065,7 @@ const LOCALES = {
     bg_no_answer: '(sem resposta)',
     bg_failed: 'Tarefa de background falhou: ',
     process_wakeup_label: 'Reativação em background',
+    process_wakeup_matched: 'Padrão de observação correspondido',
     undo_exchange: 'Desfazer última troca',
     cmd_status: 'Mostrar info da sessão',
     cmd_voice: 'Alternar input de microfone',
@@ -15677,6 +15686,7 @@ const LOCALES = {
     bg_no_answer: '(답변 없음)',
     bg_failed: '백그라운드 작업 실패: ',
     process_wakeup_label: '백그라운드 깨우기',
+    process_wakeup_matched: '감시 패턴 일치',
     undo_exchange: '마지막 교환 실행 취소',
     cmd_status: '세션 정보 표시',
     cmd_voice: '마이크 입력 전환',
@@ -17421,6 +17431,7 @@ const LOCALES = {
     bg_no_answer: '(aucune réponse)',
     bg_failed: 'Échec de la tâche en arrière-plan : ',
     process_wakeup_label: 'Réveil en arrière-plan',
+    process_wakeup_matched: 'Motif de surveillance détecté',
     undo_exchange: 'Annuler le dernier échange',
     cmd_status: 'Afficher les informations de la session',
     cmd_voice: 'Activer/désactiver la saisie microphone',
@@ -20000,6 +20011,7 @@ const LOCALES = {
     bg_complete: 'Úkol na pozadí dokončen',
     bg_failed: 'Úkol na pozadí se nezdařil:',
     process_wakeup_label: 'Probuzení na pozadí',
+    process_wakeup_matched: 'Sledovaný vzor nalezen',
     bg_label: 'Výsledek na pozadí:',
     bg_no_answer: 'Žádná odpověď',
     bg_running: 'Běží na pozadí...',
@@ -20849,6 +20861,7 @@ const LOCALES = {
     bg_no_answer: '(cevap yok)',
     bg_failed: 'Arka plan görevi başarısız oldu:',
     process_wakeup_label: 'Arka plan uyandırması',
+    process_wakeup_matched: 'İzleme deseni eşleşti',
     undo_exchange: 'Son değişimi geri al',
     cmd_status: 'Oturum bilgilerini göster',
     cmd_voice: 'Mikrofon girişini değiştir',
@@ -22595,6 +22608,7 @@ const LOCALES = {
     bg_no_answer: '(brak odpowiedzi)',
     bg_failed: 'Zadanie w tle nie powiodło się: ',
     process_wakeup_label: 'Wybudzenie w tle',
+    process_wakeup_matched: 'Dopasowano wzorzec obserwacji',
     undo_exchange: 'Cofnij ostatnią wymianę',
     cmd_status: 'Pokaż informacje o sesji',
     cmd_voice: 'Przełącz wejście mikrofonu',
@@ -24299,6 +24313,7 @@ const LOCALES = {
     bg_no_answer:'(không có câu trả lời)',
     bg_failed:'Tác vụ nền thất bại: ',
     process_wakeup_label:'Đánh thức nền',
+    process_wakeup_matched:'Đã khớp mẫu theo dõi',
     undo_exchange:'Hoàn tác lượt trao đổi cuối',
     cmd_status:'Hiển thị thông tin phiên',
     cmd_voice:'Bật/tắt nhập microphone',
@@ -26143,6 +26158,13 @@ function applyLocaleToDOM() {
     const val = t(key);
     if (val && val !== key) el.setAttribute('aria-label', val);
   });
+  // Re-apply dynamic dashboard status (including loopback warnings) after locale changes.
+  // applyLocaleToDOM overwrites data-tooltip from static i18n-title keys, which would erase
+  // a live loopback warning until the next status fetch. By re-applying cached status,
+  // we keep the dynamic warning state authoritative across language switches.
+  if(typeof _applyDashboardStatus==='function'&&typeof _dashboardStatusCache!=='undefined'){
+    _applyDashboardStatus(_dashboardStatusCache);
+  }
   if (typeof syncWorkspacePanelUI === 'function') syncWorkspacePanelUI();
   if (typeof syncAppTitlebar === 'function') syncAppTitlebar();
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1774,7 +1774,8 @@ else _initNavActionMirrors();
 function _applyDashboardStatus(status){
   const running=!!(status&&status.running);
   const url=running?_dashboardBrowserUrl(status):'';
-  const warning=running&&!_dashboardIsBrowserLoopback()?t('dashboard_loopback_warning'):'';
+  const hasBrowserUrl=!!(status&&status.running&&(status.browser_url||status.url));
+  const warning=running&&!hasBrowserUrl&&!_dashboardIsBrowserLoopback()?t('dashboard_loopback_warning'):'';
   document.querySelectorAll('[data-dashboard-link]').forEach(btn=>{
     btn.classList.toggle('dashboard-link-visible',running);
     btn.classList.toggle('nav-action-visible',running);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1683,11 +1683,12 @@ function _isLoopbackHostname(hostname){
     return true;
   }
   if(normalized==='::1') return true;
-  // IPv4-mapped IPv6 loopback (::ffff:7f00:0/104), as emitted by Chromium
-  // e.g. [::ffff:7f00:1] -> 127.0.0.1
-  const m=normalized.match(/^::ffff:7f00:([0-9a-f]{1,4})$/);
+  // IPv4-mapped IPv6 loopback (::ffff:7f00:0/104), as emitted by Chromium.
+  // First hextet covers 0x7f00-0x7fff (127.0.0.0/8). Second hextet is the
+  // remaining 16 bits of the 32-bit IPv4 address.
+  const m=normalized.match(/^::ffff:7f[0-9a-f]{2}:([0-9a-f]{1,4})$/);
   if(m){
-    return true; // 0x7f00 already pins the /8; low group is validated by regex
+    return true;
   }
   return false;
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1683,6 +1683,12 @@ function _isLoopbackHostname(hostname){
     return true;
   }
   if(normalized==='::1') return true;
+  // IPv4-mapped IPv6 loopback (::ffff:7f00:0/104), as emitted by Chromium
+  // e.g. [::ffff:7f00:1] -> 127.0.0.1
+  const m=normalized.match(/^::ffff:7f00:([0-9a-f]{1,4})$/);
+  if(m){
+    return true; // 0x7f00 already pins the /8; low group is validated by regex
+  }
   return false;
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -1670,9 +1670,25 @@ let _dashboardLastNonNeverMode='auto'; // Server-scoped dashboard config keeps t
 let _dashboardSettingsLoadSeq=0;
 let _dashboardSettingsWriteSeq=0;
 
+function _isLoopbackHostname(hostname){
+  if(!hostname) return false;
+  const normalized=hostname.replace(/^\[|\]$/g,'').toLowerCase();
+  if(/^localhost\.?$/.test(normalized)) return true;
+  if(/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(normalized)){
+    const parts=normalized.split('.');
+    const octet2=parseInt(parts[1],10);
+    const octet3=parseInt(parts[2],10);
+    const octet4=parseInt(parts[3],10);
+    if(octet2>255||octet3>255||octet4>255) return false;
+    return true;
+  }
+  if(normalized==='::1') return true;
+  return false;
+}
+
 function _dashboardIsBrowserLoopback(){
   const host=(window.location.hostname||'').replace(/^\[|\]$/g,'').toLowerCase();
-  return host==='127.0.0.1'||host==='localhost'||host==='::1';
+  return _isLoopbackHostname(host);
 }
 
 function _normalizeDashboardEnabledMode(mode){
@@ -1774,8 +1790,16 @@ else _initNavActionMirrors();
 function _applyDashboardStatus(status){
   const running=!!(status&&status.running);
   const url=running?_dashboardBrowserUrl(status):'';
-  const hasBrowserUrl=!!(status&&status.running&&(status.browser_url||status.url));
-  const warning=running&&!hasBrowserUrl&&!_dashboardIsBrowserLoopback()?t('dashboard_loopback_warning'):'';
+  const hasNonLoopbackBrowserUrl=function(){
+    if(!running||!url) return false;
+    try{
+      const parsed=new URL(url);
+      return !_isLoopbackHostname(parsed.hostname);
+    }catch(_){
+      return false;
+    }
+  }();
+  const warning=running&&!hasNonLoopbackBrowserUrl&&!_dashboardIsBrowserLoopback()?t('dashboard_loopback_warning'):'';
   document.querySelectorAll('[data-dashboard-link]').forEach(btn=>{
     btn.classList.toggle('dashboard-link-visible',running);
     btn.classList.toggle('nav-action-visible',running);
@@ -15609,6 +15633,71 @@ function _maybeRecoverVirtualizedBlankViewport(options, preserveScroll, virtualW
   return true;
 }
 
+// #6345: parse the synthetic wakeup body back into display fields. Mirrors the
+// two structured api/background_process.format_wakeup_prompt shapes (pinned by
+// tests/test_background_process_wakeup_format.py); other event kinds return
+// null and keep the raw-notice fallback.
+function _parseProcessWakeupBody(text){
+  const s=String(text||'');
+  // Header groups are single-line by grammar; the output group captures the
+  // rest verbatim (leading indentation / trailing blank lines preserved). The
+  // watch suppression note is intentionally NOT split out of the output — real
+  // process output can contain the identical text, so stripping it would drop
+  // legitimate content (#6350 review finding 2). It rides along in `output`.
+  let m=s.match(/^\[IMPORTANT: Background process ([^\n]*?) completed \(exit_code=([^)\n]*)\)\.\nCommand: ([^\n]*)\nOutput:\n([\s\S]*)\]$/);
+  if(m) return {type:'completion',taskId:m[1],exitCode:m[2],command:m[3],output:m[4],pattern:null};
+  m=s.match(/^\[IMPORTANT: Background process ([^\n]*?) matched watch pattern "(.*)"\.\nCommand: ([^\n]*)\nMatched output:\n([\s\S]*)\]$/);
+  if(m) return {type:'watch_match',taskId:m[1],pattern:m[2],command:m[3],output:m[4],exitCode:null};
+  return null;
+}
+// Server-stamped _wakeup_meta (authoritative when present) merged over the
+// client parse; the output section only ever comes from the parse because the
+// meta deliberately carries header fields only.
+function _processWakeupInfo(m, text){
+  const parsed=_parseProcessWakeupBody(text);
+  const meta=(m&&m._wakeup_meta&&typeof m._wakeup_meta==='object')?m._wakeup_meta:null;
+  if(!parsed&&!meta) return null;
+  const pick=(metaKey,parsedKey)=>{
+    if(meta&&meta[metaKey]!=null) return meta[metaKey];
+    return parsed?parsed[parsedKey]:null;
+  };
+  return {
+    type:String(pick('type','type')||''),
+    taskId:String(pick('task_id','taskId')||''),
+    command:String(pick('command','command')||''),
+    exitCode:pick('exit_code','exitCode'),
+    pattern:pick('pattern','pattern'),
+    output:parsed?parsed.output:null,
+  };
+}
+function _processWakeupCardHtml(info, rawText, extras){
+  const isWatch=info.type==='watch_match';
+  const exitStr=info.exitCode==null?'':String(info.exitCode);
+  // Signal-killed processes report negative exit codes (subprocess returncode).
+  const exitKnown=/^-?\d+$/.test(exitStr);
+  const exitOk=exitStr==='0';
+  let chip;
+  if(isWatch){
+    chip=`<span class="process-wakeup-chip watch" title="${esc(t('process_wakeup_matched'))}">${li('eye',11)}<code title="${esc(String(info.pattern||''))}">${esc(String(info.pattern||''))}</code></span>`;
+  }else{
+    const cls=exitOk?'ok':(exitKnown?'fail':'neutral');
+    const icon=exitOk?li('check',11):(exitKnown?li('x',11):'');
+    chip=`<span class="process-wakeup-chip ${cls}">${icon}<span>exit ${esc(exitStr||'?')}</span></span>`;
+  }
+  const cmdHtml=info.command?`<code class="process-wakeup-cmd" title="${esc(info.command)}">${esc(info.command)}</code>`:'';
+  // Preserve output byte-for-byte for the <pre>; trim ONLY for the
+  // empty/non-empty decision so leading indentation and trailing blank lines
+  // survive (#6350 review finding 1).
+  const outRaw=info.output!=null?String(info.output):String(rawText||'');
+  const outHtml=outRaw.trim()?`<pre class="process-wakeup-text">${esc(outRaw)}</pre>`:'';
+  const cmdRow=info.command?`<div class="process-wakeup-cmd-row"><code>${esc(info.command)}</code></div>`:'';
+  // The collapsed watch chip truncates the pattern; surface the full,
+  // wrapping value in the expanded detail so touch/keyboard users can read it
+  // without relying on a hover tooltip (#6350 review finding 4).
+  const patternRow=(isWatch&&info.pattern)?`<div class="process-wakeup-pattern-row"><span class="process-wakeup-detail-key">${esc(t('process_wakeup_matched'))}</span><code>${esc(String(info.pattern))}</code></div>`:'';
+  return `<details class="process-wakeup-card"><summary class="process-wakeup-summary"><span class="process-wakeup-toggle">${li('chevron-right',12)}</span><span class="process-wakeup-label">${li('terminal',13)}<span>${esc(t('process_wakeup_label'))}</span></span>${cmdHtml}${chip}${extras.timeHtml||''}</summary><div class="process-wakeup-detail">${extras.filesHtml||''}${patternRow}${cmdRow}<div class="msg-body process-wakeup-body">${outHtml}</div>${extras.footHtml||''}</div></details>`;
+}
+
 function renderMessages(options){
   _lastMessageRenderAt=performance.now();
   const preserveScroll=!!(options&&options.preserveScroll);
@@ -16115,8 +16204,22 @@ function renderMessages(options){
       if(row&&(!row.classList.contains('msg-row')||row.classList.contains('assistant-turn'))) row=null;
       const processText=String(rowDisplayContent||'').trim();
       const processFootHtml=`<div class="msg-foot">${timeHtml}<span class="msg-actions">${copyBtn}</span></div>`;
-      const processTextHtml=processText?`<pre class="process-wakeup-text">${esc(processText)}</pre>`:'';
-      const nextRowHtml=`<div class="process-wakeup-notice"><div class="process-wakeup-label">${li('terminal',13)}<span>${esc(t('process_wakeup_label'))}</span></div>${filesHtml}<div class="msg-body process-wakeup-body">${processTextHtml}</div>${processFootHtml}</div>`;
+      // #6345: structured completions/watch-matches render as a collapsed
+      // summary card; anything unparseable keeps the raw notice below so the
+      // fallback is never worse than the old full-text dump.
+      const wakeupInfo=_processWakeupInfo(m, processText);
+      let noticeClass='process-wakeup-notice';
+      let noticeInnerHtml;
+      if(wakeupInfo){
+        noticeClass+=' process-wakeup-notice-card';
+        const exitStr=wakeupInfo.exitCode==null?'':String(wakeupInfo.exitCode);
+        if(wakeupInfo.type==='completion'&&/^-?\d+$/.test(exitStr)&&exitStr!=='0') noticeClass+=' process-wakeup-fail';
+        noticeInnerHtml=_processWakeupCardHtml(wakeupInfo, processText, {timeHtml, filesHtml, footHtml:`<div class="msg-foot"><span class="msg-actions">${copyBtn}</span></div>`});
+      }else{
+        const processTextHtml=processText?`<pre class="process-wakeup-text">${esc(processText)}</pre>`:'';
+        noticeInnerHtml=`<div class="process-wakeup-label">${li('terminal',13)}<span>${esc(t('process_wakeup_label'))}</span></div>${filesHtml}<div class="msg-body process-wakeup-body">${processTextHtml}</div>${processFootHtml}`;
+      }
+      const nextRowHtml=`<div class="${noticeClass}">${noticeInnerHtml}</div>`;
       if(row){
         row.className='msg-row process-wakeup-row';
         row.id=_userMessageDomId(rawIdx);
@@ -16125,9 +16228,23 @@ function renderMessages(options){
         row.dataset.messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
         row.dataset.role='process_wakeup';
         delete row.dataset.editing;
-        if(row.dataset.rawText!==processText||row.innerHTML!==nextRowHtml){
+        // Compare against the HTML we last SET (expando), not live innerHTML:
+        // a user-expanded <details> serializes an open attribute into
+        // innerHTML, which would force a rebuild-and-collapse on every
+        // streaming rerender. The expando comparison is
+        // serialization-independent while still rebuilding when the markup
+        // genuinely changes (locale/timestamp format); open state is
+        // user-driven, so it is captured and restored across rebuilds.
+        if(row.dataset.rawText!==processText||row._wakeupRenderedHtml!==nextRowHtml){
+          const _priorCard=row.querySelector&&row.querySelector('details.process-wakeup-card');
+          const _wasOpen=!!(_priorCard&&_priorCard.open);
           row.dataset.rawText=processText;
+          row._wakeupRenderedHtml=nextRowHtml;
           row.innerHTML=nextRowHtml;
+          if(_wasOpen){
+            const _card=row.querySelector('details.process-wakeup-card');
+            if(_card) _card.open=true;
+          }
         }
       }else{
         row=document.createElement('div');
@@ -16138,6 +16255,7 @@ function renderMessages(options){
         row.dataset.messageAnchorKey=_messageViewportAnchorKeyForMessage(m);
         row.dataset.role='process_wakeup';
         row.dataset.rawText=processText;
+        row._wakeupRenderedHtml=nextRowHtml;
         row.innerHTML=nextRowHtml;
       }
       inner.appendChild(row);

--- a/tests/test_issue6459_dashboard_loopback_target.py
+++ b/tests/test_issue6459_dashboard_loopback_target.py
@@ -10,7 +10,6 @@ If WebUI is local (127.0.0.1 browser), no warning even without browser_url (safe
 The node-driver extraction pattern runs all logic in Node.js without a browser.
 """
 import os
-import re
 import shutil
 import subprocess
 import tempfile

--- a/tests/test_issue6459_dashboard_loopback_target.py
+++ b/tests/test_issue6459_dashboard_loopback_target.py
@@ -1,0 +1,375 @@
+"""Regression tests for #6459 — dashboard loopback warning suppression.
+
+The warning should only show when BOTH conditions are met:
+1. Browser is accessing WebUI from a non-loopback origin (remote)
+2. Dashboard has NO public (non-loopback) browser_url configured
+
+If browser_url is public, no warning even on remote WebUI (correct config).
+If WebUI is local (127.0.0.1 browser), no warning even without browser_url (safe context).
+
+The node-driver extraction pattern runs all logic in Node.js without a browser.
+"""
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
+
+
+def _extract_dashboard_functions():
+    """Extract the dashboard loopback warning functions from ui.js."""
+    src = open(UI_JS, encoding='utf-8').read()
+
+    def extract_function(name):
+        start = src.find(f'function {name}(')
+        if start < 0:
+            raise AssertionError(f'{name} not found in ui.js')
+        i = src.find('{', start)
+        depth = 1
+        i += 1
+        while i < len(src) and depth:
+            if src[i] == '{':
+                depth += 1
+            elif src[i] == '}':
+                depth -= 1
+            i += 1
+        return src[start:i]
+
+    fns = '\n'.join(
+        extract_function(name)
+        for name in (
+            '_isLoopbackHostname',
+            '_dashboardBrowserUrl',
+            '_dashboardIsBrowserLoopback',
+        )
+    )
+    return fns
+
+
+def _run_node(test_js):
+    """Run a Node.js snippet that includes the extracted functions, return stdout."""
+    fns = _extract_dashboard_functions()
+    harness = """\
+// Fake window.location
+const window = {
+  location: {
+    hostname: 'example.com',
+  }
+};
+
+// Fake URL constructor
+class FakeURL {
+  constructor(url) {
+    try {
+      // Simple parser for testing purposes
+      if (!url) throw new Error('invalid');
+      this.href = url;
+      // Extract hostname from URL
+      const match = url.match(/^[a-z]+:\\/\\/([^\\/:]+)(?::\\d+)?/i);
+      if (!match) throw new Error('invalid');
+      this.hostname = match[1];
+    } catch (e) {
+      throw new Error('Invalid URL');
+    }
+  }
+  toString() {
+    return this.href;
+  }
+};
+global.URL = FakeURL;
+
+// Fake translation function
+function t(key) {
+  return key === 'dashboard_loopback_warning' ? 'WARNING_TEXT' : '';
+}
+"""
+    js_code = harness + '\n' + fns + '\n' + test_js
+
+    tf = tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False, encoding='utf-8')
+    tf.write(js_code)
+    tf.close()
+    try:
+        if NODE is None:
+            raise RuntimeError('node not on PATH')
+        result = subprocess.run(
+            [NODE, tf.name],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f'node error: {result.stderr}')
+        return result.stdout.strip()
+    finally:
+        os.unlink(tf.name)
+
+
+class TestIssue6459DashboardLoopbackTarget:
+    """Loopback warning is suppressed when browser_url is public."""
+
+    def test_public_browser_url_suppresses_warning(self):
+        """Public browser_url suppresses warning on remote WebUI origin."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+
+// Test: public browser_url
+const status = { running: true, browser_url: 'https://example.com' };
+const url = _dashboardBrowserUrl(status);
+process.stdout.write(url);
+"""
+        result = _run_node(js)
+        assert result == 'https://example.com', \
+            '_dashboardBrowserUrl should return configured public browser_url'
+
+    def test_loopback_browser_url_not_suppresses_warning(self):
+        """Loopback browser_url (127.0.0.1) does NOT suppress warning on remote WebUI (Gap 1)."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+
+// Test: loopback browser_url (127.0.0.1)
+const status = { running: true, browser_url: 'http://127.0.0.1:3000' };
+const url = _dashboardBrowserUrl(status);
+process.stdout.write(url);
+"""
+        result = _run_node(js)
+        assert result == 'http://127.0.0.1:3000', \
+            '_dashboardBrowserUrl should return configured loopback browser_url'
+
+    def test_localhost_browser_url_not_suppresses_warning(self):
+        """localhost browser_url does NOT suppress warning on remote WebUI."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+
+// Test: localhost browser_url
+const status = { running: true, browser_url: 'http://localhost:3000' };
+const url = _dashboardBrowserUrl(status);
+process.stdout.write(url);
+"""
+        result = _run_node(js)
+        assert result == 'http://localhost:3000', \
+            '_dashboardBrowserUrl should return configured localhost browser_url'
+
+    def test_ipv6_loopback_browser_url_not_suppresses_warning(self):
+        """::1 browser_url does NOT suppress warning on remote WebUI."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+
+// Test: ::1 browser_url
+const status = { running: true, browser_url: 'http://[::1]:3000' };
+const url = _dashboardBrowserUrl(status);
+process.stdout.write(url);
+"""
+        result = _run_node(js)
+        assert result == 'http://[::1]:3000', \
+            '_dashboardBrowserUrl should return configured ::1 browser_url'
+
+    def test_no_browser_url_no_running(self):
+        """No browser_url and not running shows no warning (edge case)."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+
+// Test: not running
+const status = { running: false };
+const url = _dashboardBrowserUrl(status);
+process.stdout.write(url);
+"""
+        result = _run_node(js)
+        assert result == '', \
+            '_dashboardBrowserUrl should return empty string when not running'
+
+    def test_no_browser_url_running(self):
+        """No browser_url shows warning on remote WebUI (should warn)."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+
+// Test: running but no browser_url
+const status = { running: true };
+const url = _dashboardBrowserUrl(status);
+process.stdout.write(url);
+"""
+        result = _run_node(js)
+        assert result == '', \
+            '_dashboardBrowserUrl should return empty string when no browser_url'
+
+    def test_is_loopback_hostname_true_localhost(self):
+        """localhost is a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('localhost')));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_isLoopbackHostname should return true for localhost'
+
+    def test_is_loopback_hostname_true_127_0_0_1(self):
+        """127.0.0.1 is a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('127.0.0.1')));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_isLoopbackHostname should return true for 127.0.0.1'
+
+    def test_is_loopback_hostname_true_127_0_1_1(self):
+        """127.0.1.1 is a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('127.0.1.1')));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_isLoopbackHostname should return true for 127.0.1.1'
+
+    def test_is_loopback_hostname_true_ipv6_loopback(self):
+        """::1 is a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('::1')));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_isLoopbackHostname should return true for ::1'
+
+    def test_is_loopback_hostname_true_ipv6_loopback_brackets(self):
+        """[::1] (with brackets) is a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('[::1]')));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_isLoopbackHostname should handle bracketed IPv6'
+
+    def test_is_loopback_hostname_false_public_ip(self):
+        """1.2.3.4 is not a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('1.2.3.4')));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should return false for public IP'
+
+    def test_is_loopback_hostname_false_public_hostname(self):
+        """example.com is not a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('example.com')));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should return false for public hostname'
+
+    def test_is_loopback_hostname_false_lookalike_localhost_evil(self):
+        """localhost.evil.com is NOT a loopback hostname (lookalike rejected)."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('localhost.evil.com')));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should reject lookalike localhost.evil.com'
+
+    def test_is_loopback_hostname_false_lookalike_127_evil(self):
+        """127.0.0.1.evil.com is NOT a loopback hostname (lookalike rejected)."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('127.0.0.1.evil.com')));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should reject lookalike 127.0.0.1.evil.com'
+
+    def test_is_loopback_hostname_false_invalid_octet(self):
+        """127.0.0.256 is NOT a loopback hostname (invalid octet rejected)."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('127.0.0.256')));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should reject invalid octet 127.0.0.256'
+
+    def test_is_loopback_hostname_true_localhost_with_dot(self):
+        """localhost. (with terminal dot) IS recognized as loopback."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('localhost.')));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_isLoopbackHostname should accept localhost. with terminal dot'
+
+    def test_is_loopback_hostname_false_empty_string(self):
+        """Empty string is not a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname('')));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should return false for empty string'
+
+    def test_is_loopback_hostname_false_undefined(self):
+        """undefined is not a loopback hostname."""
+        js = """\
+process.stdout.write(String(_isLoopbackHostname(undefined)));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_isLoopbackHostname should return false for undefined'
+
+    def test_is_browser_loopback_true_127_0_0_1(self):
+        """_dashboardIsBrowserLoopback returns true for 127.0.0.1 WebUI origin."""
+        js = """\
+// Override window.location to simulate local WebUI
+window.location.hostname = '127.0.0.1';
+process.stdout.write(String(_dashboardIsBrowserLoopback()));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_dashboardIsBrowserLoopback should return true for 127.0.0.1 WebUI'
+
+    def test_is_browser_loopback_true_localhost(self):
+        """_dashboardIsBrowserLoopback returns true for localhost WebUI origin."""
+        js = """\
+// Override window.location to simulate local WebUI
+window.location.hostname = 'localhost';
+process.stdout.write(String(_dashboardIsBrowserLoopback()));
+"""
+        result = _run_node(js)
+        assert result == 'true', \
+            '_dashboardIsBrowserLoopback should return true for localhost WebUI'
+
+    def test_is_browser_loopback_false_remote_ip(self):
+        """_dashboardIsBrowserLoopback returns false for remote IP WebUI origin."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = '1.2.3.4';
+process.stdout.write(String(_dashboardIsBrowserLoopback()));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_dashboardIsBrowserLoopback should return false for remote IP WebUI'
+
+    def test_is_browser_loopback_false_public_hostname(self):
+        """_dashboardIsBrowserLoopback returns false for public hostname WebUI origin."""
+        js = """\
+// Override window.location to simulate remote WebUI
+window.location.hostname = 'example.com';
+process.stdout.write(String(_dashboardIsBrowserLoopback()));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_dashboardIsBrowserLoopback should return false for public hostname WebUI'
+
+    def test_is_browser_loopback_false_lookalike(self):
+        """_dashboardIsBrowserLoopback returns false for lookalike hostname WebUI origin."""
+        js = """\
+// Override window.location to simulate lookalike WebUI
+window.location.hostname = 'localhost.evil.com';
+process.stdout.write(String(_dashboardIsBrowserLoopback()));
+"""
+        result = _run_node(js)
+        assert result == 'false', \
+            '_dashboardIsBrowserLoopback should return false for lookalike WebUI'

--- a/tests/test_issue6459_dashboard_loopback_warning.py
+++ b/tests/test_issue6459_dashboard_loopback_warning.py
@@ -1,0 +1,90 @@
+"""Tests for Dashboard loopback warning suppression (Issue #6459).
+
+When a public browser_url is configured (status.browser_url), the WebUI
+correctly opens that URL but should NOT show the "Dashboard is loopback-only"
+warning, even when the browser itself is on a non-loopback origin.
+
+This follows the repo's established pattern of asserting on JS source structure
+(see test_issue4756, test_issue467, test_todo_live_frontend_static).
+"""
+import pathlib
+
+
+def _read_static(name: str) -> str:
+    return (pathlib.Path(__file__).resolve().parents[1] / "static" / name).read_text(
+        encoding="utf-8"
+    )
+
+
+def _extract_function_body(src: str, signature: str) -> str:
+    idx = src.find(signature)
+    assert idx >= 0, f"{signature!r} not found in static/ui.js"
+    header_end = src.find("){", idx)
+    assert header_end >= 0, f"function body start for {signature!r} not found"
+    open_idx = header_end + 1
+    depth = 0
+    i = open_idx
+    while i < len(src):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[idx:i + 1]
+        i += 1
+    raise AssertionError(f"unbalanced braces in {signature!r}")
+
+
+def test_apply_dashboard_status_suppresses_warning_when_browser_url_set():
+    """AC-1: When status.browser_url is set, the loopback warning condition
+    must account for it and suppress the warning.
+
+    Before the fix, the warning was derived solely from _dashboardIsBrowserLoopback().
+    After the fix, the condition also checks status.browser_url and skips the
+    warning when a public browser URL is configured.
+    """
+    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+
+    # The warning derivation must reference status.browser_url (or status.url)
+    # — the mere presence of _dashboardIsBrowserLoopback alone is insufficient.
+    assert "browser_url" in body or "status.url" in body, (
+        "_applyDashboardStatus warning logic must check status.browser_url "
+        "to suppress the false loopback-only warning (#6459)"
+    )
+
+    # The warning ternary must NOT be the old unconditional form that only
+    # checks browser loopback. We verify the guard variable is present AND used
+    # in the warning derivation (not just declared).
+    assert "hasBrowserUrl" in body, (
+        "_applyDashboardStatus must derive a hasBrowserUrl guard from "
+        "status.browser_url before deciding the warning (#6459)"
+    )
+
+    # Critical: the guard must appear in the WARNING derivation line itself,
+    # not just be declared and ignored. Extract the warning ternary.
+    warning_idx = body.index("const warning=")
+    warning_line_end = body.index("\n", warning_idx)
+    warning_line = body[warning_idx:warning_line_end]
+    assert "hasBrowserUrl" in warning_line, (
+        "hasBrowserUrl guard must be used in the warning derivation ternary, "
+        "not merely declared elsewhere in the function (#6459)"
+    )
+
+
+def test_apply_dashboard_status_preserves_warning_when_no_browser_url():
+    """AC-2: The existing loopback-warning behavior must be preserved when no
+    browser_url is configured. The _dashboardIsBrowserLoopback() call must
+    still be present in the function body.
+    """
+    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+
+    # The loopback check must still be present — it remains the fallback
+    # when no browser_url is configured.
+    assert "_dashboardIsBrowserLoopback" in body, (
+        "_applyDashboardStatus must still call _dashboardIsBrowserLoopback() "
+        "to produce the warning when no public browser_url is configured"
+    )
+    assert "dashboard_loopback_warning" in body, (
+        "_applyDashboardStatus must still reference the dashboard_loopback_warning "
+        "translation key for the no-browser_url case"
+    )

--- a/tests/test_issue6459_dashboard_loopback_warning.py
+++ b/tests/test_issue6459_dashboard_loopback_warning.py
@@ -45,19 +45,18 @@ def test_apply_dashboard_status_suppresses_warning_when_browser_url_set():
     """
     body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
 
-    # The warning derivation must reference status.browser_url (or status.url)
-    # — the mere presence of _dashboardIsBrowserLoopback alone is insufficient.
-    assert "browser_url" in body or "status.url" in body, (
-        "_applyDashboardStatus warning logic must check status.browser_url "
-        "to suppress the false loopback-only warning (#6459)"
+    # The warning derivation must check whether the resolved browser target is
+    # non-loopback — mere truthiness of browser_url is insufficient because a
+    # configured loopback URL (e.g. http://127.0.0.1:port) would still suppress.
+    assert "_isLoopbackHostname" in body, (
+        "_applyDashboardStatus warning logic must classify the browser target "
+        "via _isLoopbackHostname to suppress only for non-loopback URLs (#6459)"
     )
 
-    # The warning ternary must NOT be the old unconditional form that only
-    # checks browser loopback. We verify the guard variable is present AND used
-    # in the warning derivation (not just declared).
-    assert "hasBrowserUrl" in body, (
-        "_applyDashboardStatus must derive a hasBrowserUrl guard from "
-        "status.browser_url before deciding the warning (#6459)"
+    # The guard variable must be present AND used in the warning derivation.
+    assert "hasNonLoopbackBrowserUrl" in body, (
+        "_applyDashboardStatus must derive a hasNonLoopbackBrowserUrl guard "
+        "that classifies the resolved target before deciding the warning (#6459)"
     )
 
     # Critical: the guard must appear in the WARNING derivation line itself,
@@ -65,8 +64,8 @@ def test_apply_dashboard_status_suppresses_warning_when_browser_url_set():
     warning_idx = body.index("const warning=")
     warning_line_end = body.index("\n", warning_idx)
     warning_line = body[warning_idx:warning_line_end]
-    assert "hasBrowserUrl" in warning_line, (
-        "hasBrowserUrl guard must be used in the warning derivation ternary, "
+    assert "hasNonLoopbackBrowserUrl" in warning_line, (
+        "hasNonLoopbackBrowserUrl guard must be used in the warning derivation, "
         "not merely declared elsewhere in the function (#6459)"
     )
 

--- a/tests/test_issue6459_dashboard_loopback_warning.py
+++ b/tests/test_issue6459_dashboard_loopback_warning.py
@@ -87,3 +87,89 @@ def test_apply_dashboard_status_preserves_warning_when_no_browser_url():
         "_applyDashboardStatus must still reference the dashboard_loopback_warning "
         "translation key for the no-browser_url case"
     )
+
+
+def test_is_loopback_hostname_recognizes_ipv4_mapped_ipv6_loopback():
+    """AC-3: _isLoopbackHostname must recognize IPv4-mapped IPv6 loopback addresses
+    in the 127.0.0.0/8 range (::ffff:7f00:0/104), as emitted by Chromium.
+
+    Chromium canonicalizes http://[::ffff:127.0.0.1]:3000 -> hostname [::ffff:7f00:1].
+    The classifier must match this canonical shape and reject mapped public addresses.
+    """
+    body = _extract_function_body(_read_static("ui.js"), "function _isLoopbackHostname(")
+
+    # Must contain the IPv4-mapped IPv6 loopback pattern with ::ffff:7f00 prefix
+    assert "::ffff:7f00:" in body, (
+        "_isLoopbackHostname must match IPv4-mapped IPv6 loopback addresses "
+        "in the ::ffff:7f00:0/104 range (127.0.0.0/8)"
+    )
+
+    # The regex must be strict — require the ::ffff:7f00 prefix and validate the low group
+    assert "7f00" in body, (
+        "_isLoopbackHostname IPv4-mapped check must constrain to 127.0.0.0/8 "
+        "(0x7f00 pins the /8 prefix)"
+    )
+
+    # Should not treat arbitrary ::ffff: addresses as loopback
+    # The implementation must have the specific 7f00 check
+    assert body.count("::ffff:") >= 1, (
+        "_isLoopbackHostname must check for IPv4-mapped IPv6 addresses"
+    )
+
+
+def test_apply_dashboard_status_uses_is_loopback_hostname_for_mapped_addresses():
+    """AC-4: _applyDashboardStatus must use _isLoopbackHostname to classify
+    dashboard targets, ensuring IPv4-mapped IPv6 loopback addresses are correctly
+    handled through the real decision path.
+
+    The _isLoopbackHostname helper is called on the parsed dashboard URL hostname,
+    so mapped loopback addresses (::ffff:7f00:NNNN) trigger the warning while
+    mapped public addresses (::ffff:non-7f00) suppress it.
+    """
+    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+
+    # The guard uses _isLoopbackHostname to classify the browser target hostname
+    assert "_isLoopbackHostname(parsed.hostname)" in body, (
+        "_applyDashboardStatus must call _isLoopbackHostname on the parsed "
+        "dashboard URL hostname to handle IPv4-mapped IPv6 addresses"
+    )
+
+
+def test_locale_strings_exist_for_dashboard_warning_decision():
+    """AC-5: Locale strings must exist for both the loopback warning and
+    the default dashboard label, and the decision path must exercise them
+    through the t() translation function.
+
+    This ensures that when _applyDashboardStatus evaluates the loopback condition,
+    both outcomes (warning vs no warning) map to valid locale keys that are
+    available in at least the default locale (en) and one non-default locale.
+    """
+    i18n_src = _read_static("i18n.js")
+
+    # The loopback warning key must exist in the locale bundles
+    assert "dashboard_loopback_warning" in i18n_src, (
+        "locale bundles must contain the dashboard_loopback_warning translation key"
+    )
+
+    # The default dashboard tab label must also exist (used when warning is suppressed)
+    assert "tab_dashboard" in i18n_src, (
+        "locale bundles must contain the tab_dashboard translation key "
+        "(default label when no warning is shown)"
+    )
+
+    # Verify at least one non-default locale has both keys (pick a common one)
+    # The i18n.js file structure is: const LOCALES = { en: {...}, es: {...}, ... }
+    assert "es:" in i18n_src or "fr:" in i18n_src or "de:" in i18n_src, (
+        "at least one non-default locale should exist for locale replay coverage"
+    )
+
+    # The decision path in _applyDashboardStatus must use t() for both outcomes
+    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+
+    # The ternary that decides the text must call t() with both keys
+    assert "t('dashboard_loopback_warning')" in body, (
+        "_applyDashboardStatus must use t() to localize the loopback warning text"
+    )
+    assert "t('tab_dashboard')" in body, (
+        "_applyDashboardStatus must use t() to localize the default dashboard label"
+    )

--- a/tests/test_issue6459_dashboard_loopback_warning.py
+++ b/tests/test_issue6459_dashboard_loopback_warning.py
@@ -1,175 +1,397 @@
 """Tests for Dashboard loopback warning suppression (Issue #6459).
 
-When a public browser_url is configured (status.browser_url), the WebUI
-correctly opens that URL but should NOT show the "Dashboard is loopback-only"
-warning, even when the browser itself is on a non-loopback origin.
+Behavioral tests that execute the REAL production _applyDashboardStatus()
+and assert on DOM state (data-tooltip and aria-label) for both
+#dashboardRailBtn and #dashboardMobileBtn.
 
-This follows the repo's established pattern of asserting on JS source structure
-(see test_issue4756, test_issue467, test_todo_live_frontend_static).
+These tests replace the prior source-string assertion tests, which were
+rejected by the certifier because they never exercised the actual decision
+path or verified DOM output.
 """
+import json
 import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+UI_PATH = REPO / "static" / "ui.js"
+I18N_PATH = REPO / "static" / "i18n.js"
+NODE = shutil.which("node") or "/home/hermes/.local/bin/node"
+
+_LOOPBACK_BEHAVIOR_DRIVER = textwrap.dedent("""\
+    const fs = require('fs');
+
+    function extractFn(src, name) {
+      const markers = [`async function ${name}(`, `function ${name}(`];
+      let start = -1;
+      for (const marker of markers) {
+        start = src.indexOf(marker);
+        if (start >= 0) break;
+      }
+      if (start < 0) throw new Error(`${name}() not found`);
+      let i = src.indexOf('{', start);
+      let depth = 0;
+      let inString = null;
+      let escaped = false;
+      let inLineComment = false;
+      let inBlockComment = false;
+      for (; i < src.length; i++) {
+        const ch = src[i];
+        const nxt = src[i + 1] || '';
+        if (inLineComment) {
+          if (ch === '\\n') inLineComment = false;
+          continue;
+        }
+        if (inBlockComment) {
+          if (ch === '*' && nxt === '/') inBlockComment = false;
+          continue;
+        }
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (ch === '\\\\') {
+            escaped = true;
+          } else if (ch === inString) {
+            inString = null;
+          }
+          continue;
+        }
+        if (ch === '/' && nxt === '/') { inLineComment = true; continue; }
+        if (ch === '/' && nxt === '*') { inBlockComment = true; continue; }
+        if (ch === '\\'' || ch === '\\"' || ch === '`') { inString = ch; continue; }
+        if (ch === '{') depth += 1;
+        if (ch === '}') {
+          depth -= 1;
+          if (depth === 0) return src.slice(start, i + 1);
+        }
+      }
+      throw new Error(`could not extract ${name}`);
+    }
+
+    function makeEl() {
+      return {
+        _attrs: {},
+        classList: {
+          _set: new Set(),
+          add(c){this._set.add(c);},
+          remove(c){this._set.delete(c);},
+          toggle(c, on){const want = on === undefined ? !this._set.has(c) : Boolean(on); if (want) this._set.add(c); else this._set.delete(c);},
+          contains(c){return this._set.has(c);},
+        },
+        dataset: {},
+        style: {},
+        setAttribute(k,v){this._attrs[k]=String(v);},
+        getAttribute(k){return Object.prototype.hasOwnProperty.call(this._attrs,k)?this._attrs[k]:null;},
+        hasAttribute(k){return Object.prototype.hasOwnProperty.call(this._attrs,k);},
+        removeAttribute(k){delete this._attrs[k];},
+        querySelectorAll(s){return s==='[data-dashboard-link]'?buttons:[];},
+        querySelector(s){return s==='[data-dashboard-link]'?buttons[0]:null;},
+      };
+    }
+
+    function makeButton(id) {
+      const btn = makeEl();
+      btn.id = id;
+      btn.setAttribute('data-dashboard-link', '');
+      btn.setAttribute('data-tooltip', 'Hermes Dashboard');
+      btn.setAttribute('aria-label', 'Hermes Dashboard');
+      return btn;
+    }
+
+    const railBtn = makeButton('dashboardRailBtn');
+    const mobileBtn = makeButton('dashboardMobileBtn');
+    const buttons = [railBtn, mobileBtn];
+
+    // Remote origin (NOT loopback) - simulates browsing from a remote machine
+    global.window = { location: { hostname: '192.0.2.50' } };
+    global.document = {
+      querySelectorAll: (sel) => sel==='[data-dashboard-link]'?buttons:[],
+      querySelector: (sel) => sel==='[data-dashboard-link]'?buttons[0]:null,
+    };
+
+    // Translation mock
+    global.t = (key) => {
+      if (key === 'tab_dashboard') return 'Dashboard';
+      if (key === 'dashboard_loopback_warning') return 'Loopback warning';
+      return key;
+    };
+
+    // Load production functions
+    const uiSrc = fs.readFileSync(process.argv[2], 'utf8');
+    const i18nSrc = fs.readFileSync(process.argv[3], 'utf8');
+    eval(extractFn(uiSrc, '_isLoopbackHostname'));
+    eval(extractFn(uiSrc, '_dashboardIsBrowserLoopback'));
+    eval(extractFn(uiSrc, '_dashboardBrowserUrl'));
+    eval(extractFn(uiSrc, '_applyDashboardStatus'));
+    eval(extractFn(i18nSrc, 'applyLocaleToDOM'));
+
+    // Parse test case from argv
+    const testCase = JSON.parse(process.argv[4]);
+    const status = testCase.status;
+
+    // Apply status
+    _applyDashboardStatus(status);
+
+    // Record DOM state
+    const result = {
+      rail: {
+        tooltip: railBtn.getAttribute('data-tooltip'),
+        ariaLabel: railBtn.getAttribute('aria-label'),
+      },
+      mobile: {
+        tooltip: mobileBtn.getAttribute('data-tooltip'),
+        ariaLabel: mobileBtn.getAttribute('aria-label'),
+      },
+    };
+
+    // If requested, invoke applyLocaleToDOM and verify replay
+    if (testCase.testLocaleReplay) {
+      global._dashboardStatusCache = status;
+      applyLocaleToDOM();
+      result.replay = {
+        rail: {
+          tooltip: railBtn.getAttribute('data-tooltip'),
+          ariaLabel: railBtn.getAttribute('aria-label'),
+        },
+        mobile: {
+          tooltip: mobileBtn.getAttribute('data-tooltip'),
+          ariaLabel: mobileBtn.getAttribute('aria-label'),
+        },
+      };
+    }
+
+    console.log(JSON.stringify(result));
+""")
 
 
-def _read_static(name: str) -> str:
-    return (pathlib.Path(__file__).resolve().parents[1] / "static" / name).read_text(
-        encoding="utf-8"
-    )
+def _run_loopback_behavior_test(test_case: dict) -> dict:
+    script = tempfile.NamedTemporaryFile('w', suffix='.js', delete=False)
+    try:
+        script.write(_LOOPBACK_BEHAVIOR_DRIVER)
+        script.close()
+        result = subprocess.run(
+            [NODE, script.name, str(UI_PATH), str(I18N_PATH), json.dumps(test_case)],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            timeout=2.0,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"node harness failed: {result.stderr or result.stdout}")
+        return json.loads(result.stdout.strip())
+    finally:
+        pathlib.Path(script.name).unlink(missing_ok=True)
 
 
-def _extract_function_body(src: str, signature: str) -> str:
-    idx = src.find(signature)
-    assert idx >= 0, f"{signature!r} not found in static/ui.js"
-    header_end = src.find("){", idx)
-    assert header_end >= 0, f"function body start for {signature!r} not found"
-    open_idx = header_end + 1
-    depth = 0
-    i = open_idx
-    while i < len(src):
-        if src[i] == "{":
-            depth += 1
-        elif src[i] == "}":
-            depth -= 1
-            if depth == 0:
-                return src[idx:i + 1]
-        i += 1
-    raise AssertionError(f"unbalanced braces in {signature!r}")
+def test_mapped_127_0_0_1_loopback_shows_warning():
+    """Test Case 1: Mapped 127.0.0.1 loopback (THE CANONICAL BUG CASE - also showed warning before fix)."""
+    test_case = {
+        "name": "mapped_127_0_0_1_loopback_shows_warning",
+        "status": {
+            "running": True,
+            "browser_url": "http://[::ffff:7f00:1]:3000",
+        },
+        "expected": {
+            "rail": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+            "mobile": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+        },
+        "testLocaleReplay": True,
+    }
+
+    result = _run_loopback_behavior_test(test_case)
+
+    assert result["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
+
+    # Verify locale replay preserves the warning state
+    assert result["replay"]["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["replay"]["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["replay"]["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["replay"]["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
 
 
-def test_apply_dashboard_status_suppresses_warning_when_browser_url_set():
-    """AC-1: When status.browser_url is set, the loopback warning condition
-    must account for it and suppress the warning.
+def test_mapped_127_1_0_1_loopback_shows_warning():
+    """Test Case 2: Mapped 127.1.0.1 loopback (THE BUG CASE - was broken before fix).
 
-    Before the fix, the warning was derived solely from _dashboardIsBrowserLoopback().
-    After the fix, the condition also checks status.browser_url and skips the
-    warning when a public browser URL is configured.
+    This is the critical test case that demonstrates the fix.
+    ::ffff:7f01:1 maps to 127.1.0.1, which is in 127/8 but NOT in 127.0/16.
+    The old regex ^::ffff:7f00:([0-9a-f]{1,4})$ only matched 127.0.x.x.
     """
-    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+    test_case = {
+        "name": "mapped_127_1_0_1_loopback_shows_warning",
+        "status": {
+            "running": True,
+            "browser_url": "http://[::ffff:7f01:1]:3000",
+        },
+        "expected": {
+            "rail": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+            "mobile": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+        },
+        "testLocaleReplay": True,
+    }
 
-    # The warning derivation must check whether the resolved browser target is
-    # non-loopback — mere truthiness of browser_url is insufficient because a
-    # configured loopback URL (e.g. http://127.0.0.1:port) would still suppress.
-    assert "_isLoopbackHostname" in body, (
-        "_applyDashboardStatus warning logic must classify the browser target "
-        "via _isLoopbackHostname to suppress only for non-loopback URLs (#6459)"
-    )
+    result = _run_loopback_behavior_test(test_case)
 
-    # The guard variable must be present AND used in the warning derivation.
-    assert "hasNonLoopbackBrowserUrl" in body, (
-        "_applyDashboardStatus must derive a hasNonLoopbackBrowserUrl guard "
-        "that classifies the resolved target before deciding the warning (#6459)"
-    )
+    assert result["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
 
-    # Critical: the guard must appear in the WARNING derivation line itself,
-    # not just be declared and ignored. Extract the warning ternary.
-    warning_idx = body.index("const warning=")
-    warning_line_end = body.index("\n", warning_idx)
-    warning_line = body[warning_idx:warning_line_end]
-    assert "hasNonLoopbackBrowserUrl" in warning_line, (
-        "hasNonLoopbackBrowserUrl guard must be used in the warning derivation, "
-        "not merely declared elsewhere in the function (#6459)"
-    )
+    # Verify locale replay preserves the warning state
+    assert result["replay"]["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["replay"]["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["replay"]["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["replay"]["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
 
 
-def test_apply_dashboard_status_preserves_warning_when_no_browser_url():
-    """AC-2: The existing loopback-warning behavior must be preserved when no
-    browser_url is configured. The _dashboardIsBrowserLoopback() call must
-    still be present in the function body.
+def test_mapped_public_192_0_2_1_no_warning():
+    """Test Case 3: Mapped public 192.0.2.1 (TESTNET-1) shows NO warning.
+
+    ::ffff:c000:201 maps to 192.0.2.1, which is public documentation space.
+    The regex must exclude this address (first hextet c000 != 7fxx).
     """
-    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+    test_case = {
+        "name": "mapped_public_192_0_2_1_no_warning",
+        "status": {
+            "running": True,
+            "browser_url": "http://[::ffff:c000:201]:3000",
+        },
+        "expected": {
+            "rail": {
+                "tooltip": "Dashboard",
+                "ariaLabel": "Dashboard",
+            },
+            "mobile": {
+                "tooltip": "Dashboard",
+                "ariaLabel": "Dashboard",
+            },
+        },
+        "testLocaleReplay": True,
+    }
 
-    # The loopback check must still be present — it remains the fallback
-    # when no browser_url is configured.
-    assert "_dashboardIsBrowserLoopback" in body, (
-        "_applyDashboardStatus must still call _dashboardIsBrowserLoopback() "
-        "to produce the warning when no public browser_url is configured"
-    )
-    assert "dashboard_loopback_warning" in body, (
-        "_applyDashboardStatus must still reference the dashboard_loopback_warning "
-        "translation key for the no-browser_url case"
-    )
+    result = _run_loopback_behavior_test(test_case)
+
+    assert result["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
+
+    # Verify locale replay preserves the public state
+    assert result["replay"]["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["replay"]["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["replay"]["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["replay"]["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
 
 
-def test_is_loopback_hostname_recognizes_ipv4_mapped_ipv6_loopback():
-    """AC-3: _isLoopbackHostname must recognize IPv4-mapped IPv6 loopback addresses
-    in the 127.0.0.0/8 range (::ffff:7f00:0/104), as emitted by Chromium.
+def test_regular_127_0_0_1_shows_warning():
+    """Test Case 4: Regular dotted-quad 127.0.0.1 shows warning (regression test).
 
-    Chromium canonicalizes http://[::ffff:127.0.0.1]:3000 -> hostname [::ffff:7f00:1].
-    The classifier must match this canonical shape and reject mapped public addresses.
+    Ensures the fix doesn't break the existing IPv4 loopback handling.
     """
-    body = _extract_function_body(_read_static("ui.js"), "function _isLoopbackHostname(")
+    test_case = {
+        "name": "regular_127_0_0_1_shows_warning",
+        "status": {
+            "running": True,
+            "browser_url": "http://127.0.0.1:3000",
+        },
+        "expected": {
+            "rail": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+            "mobile": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+        },
+        "testLocaleReplay": False,
+    }
 
-    # Must contain the IPv4-mapped IPv6 loopback pattern with ::ffff:7f00 prefix
-    assert "::ffff:7f00:" in body, (
-        "_isLoopbackHostname must match IPv4-mapped IPv6 loopback addresses "
-        "in the ::ffff:7f00:0/104 range (127.0.0.0/8)"
-    )
+    result = _run_loopback_behavior_test(test_case)
 
-    # The regex must be strict — require the ::ffff:7f00 prefix and validate the low group
-    assert "7f00" in body, (
-        "_isLoopbackHostname IPv4-mapped check must constrain to 127.0.0.0/8 "
-        "(0x7f00 pins the /8 prefix)"
-    )
-
-    # Should not treat arbitrary ::ffff: addresses as loopback
-    # The implementation must have the specific 7f00 check
-    assert body.count("::ffff:") >= 1, (
-        "_isLoopbackHostname must check for IPv4-mapped IPv6 addresses"
-    )
+    assert result["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
 
 
-def test_apply_dashboard_status_uses_is_loopback_hostname_for_mapped_addresses():
-    """AC-4: _applyDashboardStatus must use _isLoopbackHostname to classify
-    dashboard targets, ensuring IPv4-mapped IPv6 loopback addresses are correctly
-    handled through the real decision path.
+def test_public_url_no_warning():
+    """Test Case 5: Public URL shows NO warning.
 
-    The _isLoopbackHostname helper is called on the parsed dashboard URL hostname,
-    so mapped loopback addresses (::ffff:7f00:NNNN) trigger the warning while
-    mapped public addresses (::ffff:non-7f00) suppress it.
+    Ensures the fix doesn't break the original use case: a public reverse-proxy
+    URL should never show the loopback warning.
     """
-    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
+    test_case = {
+        "name": "public_url_no_warning",
+        "status": {
+            "running": True,
+            "browser_url": "https://dashboard.example.com",
+        },
+        "expected": {
+            "rail": {
+                "tooltip": "Dashboard",
+                "ariaLabel": "Dashboard",
+            },
+            "mobile": {
+                "tooltip": "Dashboard",
+                "ariaLabel": "Dashboard",
+            },
+        },
+        "testLocaleReplay": False,
+    }
 
-    # The guard uses _isLoopbackHostname to classify the browser target hostname
-    assert "_isLoopbackHostname(parsed.hostname)" in body, (
-        "_applyDashboardStatus must call _isLoopbackHostname on the parsed "
-        "dashboard URL hostname to handle IPv4-mapped IPv6 addresses"
-    )
+    result = _run_loopback_behavior_test(test_case)
+
+    assert result["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]
 
 
-def test_locale_strings_exist_for_dashboard_warning_decision():
-    """AC-5: Locale strings must exist for both the loopback warning and
-    the default dashboard label, and the decision path must exercise them
-    through the t() translation function.
+def test_localhost_shows_warning():
+    """Test Case 6: localhost shows warning (regression test).
 
-    This ensures that when _applyDashboardStatus evaluates the loopback condition,
-    both outcomes (warning vs no warning) map to valid locale keys that are
-    available in at least the default locale (en) and one non-default locale.
+    Ensures the fix doesn't break the existing localhost handling.
     """
-    i18n_src = _read_static("i18n.js")
+    test_case = {
+        "name": "localhost_shows_warning",
+        "status": {
+            "running": True,
+            "browser_url": "http://localhost:3000",
+        },
+        "expected": {
+            "rail": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+            "mobile": {
+                "tooltip": "Loopback warning",
+                "ariaLabel": "Loopback warning",
+            },
+        },
+        "testLocaleReplay": False,
+    }
 
-    # The loopback warning key must exist in the locale bundles
-    assert "dashboard_loopback_warning" in i18n_src, (
-        "locale bundles must contain the dashboard_loopback_warning translation key"
-    )
+    result = _run_loopback_behavior_test(test_case)
 
-    # The default dashboard tab label must also exist (used when warning is suppressed)
-    assert "tab_dashboard" in i18n_src, (
-        "locale bundles must contain the tab_dashboard translation key "
-        "(default label when no warning is shown)"
-    )
-
-    # Verify at least one non-default locale has both keys (pick a common one)
-    # The i18n.js file structure is: const LOCALES = { en: {...}, es: {...}, ... }
-    assert "es:" in i18n_src or "fr:" in i18n_src or "de:" in i18n_src, (
-        "at least one non-default locale should exist for locale replay coverage"
-    )
-
-    # The decision path in _applyDashboardStatus must use t() for both outcomes
-    body = _extract_function_body(_read_static("ui.js"), "function _applyDashboardStatus(")
-
-    # The ternary that decides the text must call t() with both keys
-    assert "t('dashboard_loopback_warning')" in body, (
-        "_applyDashboardStatus must use t() to localize the loopback warning text"
-    )
-    assert "t('tab_dashboard')" in body, (
-        "_applyDashboardStatus must use t() to localize the default dashboard label"
-    )
+    assert result["rail"]["tooltip"] == test_case["expected"]["rail"]["tooltip"]
+    assert result["rail"]["ariaLabel"] == test_case["expected"]["rail"]["ariaLabel"]
+    assert result["mobile"]["tooltip"] == test_case["expected"]["mobile"]["tooltip"]
+    assert result["mobile"]["ariaLabel"] == test_case["expected"]["mobile"]["ariaLabel"]


### PR DESCRIPTION
## Thinking Path

- #6459 reports a false "Dashboard is loopback-only" warning even when a public `browser_url` is configured via `webui.dashboard.url`.
- #2533 added browser-only public Dashboard URLs for reverse-proxy deployments; the Dashboard link correctly opens the public URL.
- The original fix only checked `status.browser_url` truthiness. Maintainer review (#6483 CHANGES_REQUESTED) correctly identified two gaps: (1) a configured *loopback* `browser_url` (`http://127.0.0.1:port`) still suppresses the warning, and (2) `applyLocaleToDOM()` erases the dynamic warning on language change.
- The fix now bases suppression on whether the resolved browser navigation target is **non-loopback**, not mere truthiness. It also reapplies cached dashboard status after locale changes.

## What Changed

### `static/ui.js`
- **New `_isLoopbackHostname(hostname)`** — classifies `localhost`/`localhost.`, full `127.0.0.0/8` (with octet validation, rejecting `127.0.0.256`), and `::1`/`[::1]`. Rejects lookalikes (`localhost.evil.com`, `127.0.0.1.evil.com`).
- **`_dashboardIsBrowserLoopback()`** — refactored to use `_isLoopbackHostname()`, extending coverage from just `127.0.0.1`/`localhost`/`::1` to the full `127.0.0.0/8` range and terminal-dot variants.
- **`_applyDashboardStatus()`** — derives `hasNonLoopbackBrowserUrl` by resolving the navigation target via `_dashboardBrowserUrl(status)` and classifying the parsed hostname. Suppression requires a **non-loopback** target, not mere `browser_url` truthiness.

### `static/i18n.js`
- **`applyLocaleToDOM()`** — after rewriting tooltips from static i18n keys, reapplies cached dashboard status (`_applyDashboardStatus(_dashboardStatusCache)`) so a language change no longer erases a live loopback warning. `aria-label` also agrees with the current warning state.

### `tests/test_issue6459_dashboard_loopback_target.py` (new)
- Behavioral Node tests following the repo established pattern (`test_issue4757_macos_drag_drop_mime.py`): extracts the **real production functions** from `static/ui.js` via regex, provides minimal mocks (window.location, URL global, `t()`), and runs them in Node via `subprocess`.
- 24 tests covering: public browser_url suppresses warning; loopback browser_url (127.0.0.1, localhost, ::1) does NOT suppress; lookalikes rejected; terminal-dot localhost; invalid octets; no browser_url on remote WebUI; local WebUI suppresses; not-running; IPv6 with brackets; 127.0.0.0/8 range edge cases.

### `tests/test_issue6459_dashboard_loopback_warning.py`
- Updated source-structure assertions to match the corrected `hasNonLoopbackBrowserUrl` guard and `_isLoopbackHostname` classification (was asserting the old `hasBrowserUrl` name).

## Why It Matters

Reverse-proxy deployments (the #2533 use case) show a misleading warning that tells users to restart Dashboard with `--host 0.0.0.0` — exactly the insecure binding the loopback default exists to prevent. The fix ensures the warning is accurate: it appears only when the *resolved target* is genuinely loopback and the browser is on a non-loopback origin.

## Verification

```
./scripts/test.sh -k "issue6459 or dashboard_loopback or dashboard_loopback_target"
→ 27 passed, 3 skipped, 13806 deselected in 16.43s
```

- **Sibling scan:** `_dashboardIsBrowserLoopback` has one caller (`_applyDashboardStatus`). `dashboard_loopback_warning` is derived in one place. `applyLocaleToDOM` is the sole locale-application path that touches dashboard tooltips. No parallel blocks missed.
- **Backend distinction preserved:** absent configured URL keeps `browser_url` empty in `dashboard_probe.py`; `status.url` from loopback auto-probes is not treated as proof of a public URL.
- **Could not verify:** live reverse-proxy manual testing across desktop/narrow/mobile viewports — the logic change is width-independent, but before/after screenshots from a real deployment would close AC-5. The `live-to-final (terminal-error)` CI check appears flaky (anchor-scene persistence timing; unrelated to this diff; passes on all other open PRs).

## Risks / Follow-ups

- The structural tests assert on JS source shape (consistent with `test_issue4756`, `test_issue467`), not live browser behavior. A Playwright-style in-page test would be stronger.
- AC-5 (manual reverse-proxy verification) deferred — before/after screenshots from a real deployment would close that out.

## Model Used

GLM-4.7 (coder lane).