### PR TITLE
fix: keep tool previews out of Output tab

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -11339,7 +11339,11 @@ function _transparentToolDetailHtml(tc, status){
   // duration meta when present. (Trifecta finding V6 — reduce redundancy.)
   const meta=[];
   if(tc&&tc.duration!==undefined&&tc.duration!==null) meta.push(['duration', String(tc.duration)]);
-  const preview=String((tc&&(tc.snippet||tc.preview||tc.result||tc.output))||'').trim();
+  // `preview` describes the invocation (for execute_code it can be the Python
+  // source itself); it is not tool stdout. Only explicit result-bearing fields
+  // belong in the Output tab. Falling back to preview makes blocked/interrupted
+  // calls falsely present their input as output.
+  const output=String((tc&&(tc.snippet||tc.result||tc.output))||'').trim();
   const argHtml=[...meta,...argEntries].map(([k,v])=>{
     let sv=typeof v==='string'?v:JSON.stringify(v,null,2);
     // Redact secret-bearing arg values before rendering the transparent Full
@@ -11348,7 +11352,7 @@ function _transparentToolDetailHtml(tc, status){
     if(typeof _redactToolTargetLabel==='function'){ try{ sv=_redactToolTargetLabel(sv); }catch(e){} }
     return `<div class="tool-arg-pair"><span class="tool-arg-key">${esc(String(k))}</span><span class="tool-arg-val">${esc(sv)}</span></div>`;
   }).join('');
-  return `<div class="tool-card-detail" data-transparent-detail-mode="full"><div class="transparent-detail-modes" role="tablist"><span class="transparent-detail-mode active" role="tab" tabindex="0" data-mode="full" onclick="_setTransparentDetailMode(this,'full')">Full</span><span class="transparent-detail-mode" role="tab" tabindex="0" data-mode="output" onclick="_setTransparentDetailMode(this,'output')">Output</span></div><div class="tool-card-args">${argHtml}</div>${preview?`<div class="tool-card-result"><pre>${esc(preview)}</pre></div>`:''}</div>`;
+  return `<div class="tool-card-detail" data-transparent-detail-mode="full"><div class="transparent-detail-modes" role="tablist"><span class="transparent-detail-mode active" role="tab" tabindex="0" data-mode="full" onclick="_setTransparentDetailMode(this,'full')">Full</span><span class="transparent-detail-mode" role="tab" tabindex="0" data-mode="output" onclick="_setTransparentDetailMode(this,'output')">Output</span></div><div class="tool-card-args">${argHtml}</div>${output?`<div class="tool-card-result"><pre>${esc(output)}</pre></div>`:''}</div>`;
 }
 function _syncTransparentEventControls(turn){
   if(!turn||!isTransparentStream()) return;
@@ -16011,7 +16015,7 @@ function renderMessages(options){
       persisted.forEach(tc=>{
         if(!tc||typeof tc!=='object') return;
         const ptid=tc.tid||tc.id||tc.tool_call_id||tc.call_id||'';
-        const psnip=tc.snippet||tc.result||tc.output||tc.preview||'';
+        const psnip=tc.snippet||tc.result||tc.output||'';
         if(ptid&&psnip&&!transparentPersistedSnippetByTid[ptid]) transparentPersistedSnippetByTid[ptid]=String(psnip);
       });
     }catch(e){}
@@ -16540,7 +16544,7 @@ function renderMessages(options){
       persisted.forEach(tc=>{
         if(!tc||typeof tc!=='object') return;
         const ptid=tc.tid||tc.id||tc.tool_call_id||tc.call_id||'';
-        const psnip=tc.snippet||tc.result||tc.output||tc.preview||'';
+        const psnip=tc.snippet||tc.result||tc.output||'';
         if(ptid&&psnip&&!persistedSnippetByTid[ptid]) persistedSnippetByTid[ptid]=String(psnip);
       });
     }catch(e){}
@@ -16633,7 +16637,7 @@ function renderMessages(options){
         }
         const tid=tc.tid||tc.id||tc.tool_call_id||tc.call_id||'';
         const patchSnippet=_cliPatchSnippetFromArgs(name,args);
-        const resultSnippet=resultsByTid[tid]||tc.snippet||tc.preview||persistedSnippetByTid[tid]||'';
+        const resultSnippet=resultsByTid[tid]||tc.snippet||tc.result||tc.output||persistedSnippetByTid[tid]||'';
         const argsSnap=_toolArgsSnapshot(args);
         derived.push(copyLiveToolMetadata({
           name,
@@ -16675,7 +16679,7 @@ function renderMessages(options){
           const args=tc.args||{};
           const tid=tc.id||tc.call_id||tc.tool_call_id||tc.tid||'';
           const patchSnippet=_cliPatchSnippetFromArgs(name,args);
-          const resultSnippet=_cliToolResultSnippet(tc.snippet||tc.result||tc.output||tc.preview||'');
+          const resultSnippet=_cliToolResultSnippet(tc.snippet||tc.result||tc.output||'');
           const argsSnap=_toolArgsSnapshot(args,4);
           derived.push(copyLiveToolMetadata({
             name,

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -90,7 +90,8 @@ def test_rendermessages_rebuilds_tool_cards_from_partial_tool_calls():
     assert "Array.isArray(message._partial_tool_calls)&&message._partial_tool_calls.length>0" in UI_JS
     assert "if(_legacySettledFallbackHasToolMetadata(m)) fallbackToolSources.push({m,rawIdx});" in UI_JS
     assert "if(Array.isArray(m._partial_tool_calls)){" in UI_JS
-    assert "tc.snippet||tc.result||tc.output||tc.preview" in UI_JS
+    assert "tc.snippet||tc.result||tc.output||''" in UI_JS
+    assert "tc.snippet||tc.result||tc.output||tc.preview" not in UI_JS
     assert "done:true" in UI_JS
 
 

--- a/tests/test_transparent_output_semantics.py
+++ b/tests/test_transparent_output_semantics.py
@@ -1,0 +1,106 @@
+"""Regression coverage for invocation previews leaking into the Output tab."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+_DRIVER = r"""
+'use strict';
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+
+function extractFunc(name) {
+  const start = src.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start) + 1;
+  let depth = 1;
+  while (depth && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+const esc = value => String(value)
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;');
+const _redactToolTargetLabel = value => value;
+const renderToolDetail = eval('(' + extractFunc('_transparentToolDetailHtml') + ')');
+
+let input = '';
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  process.stdout.write(renderToolDetail(JSON.parse(input), 'Failed'));
+});
+"""
+
+
+@pytest.fixture(scope="module")
+def driver(tmp_path_factory):
+    path = tmp_path_factory.mktemp("transparent-output") / "driver.js"
+    path.write_text(_DRIVER, encoding="utf-8")
+    return path
+
+
+def _render(driver: Path, tool_call: dict) -> str:
+    assert NODE is not None
+    result = subprocess.run(
+        [NODE, str(driver), str(UI_JS)],
+        input=json.dumps(tool_call),
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Node driver failed:\n{result.stderr}")
+    return result.stdout
+
+
+def test_execute_code_preview_is_input_not_output(driver):
+    html = _render(
+        driver,
+        {
+            "name": "execute_code",
+            "args": {"code": "print('Hello, world!')"},
+            "preview": "print('Hello, world!')",
+            "done": True,
+            "is_error": True,
+        },
+    )
+
+    assert "tool-card-args" in html
+    assert "print('Hello, world!')" in html
+    assert "tool-card-result" not in html
+
+
+@pytest.mark.parametrize("field", ["snippet", "result", "output"])
+def test_explicit_result_fields_render_in_output(driver, field):
+    html = _render(
+        driver,
+        {
+            "name": "execute_code",
+            "args": {"code": "print('Hello, world!')"},
+            "preview": "print('Hello, world!')",
+            field: "Hello, world!\n",
+            "done": True,
+        },
+    )
+
+    assert "tool-card-result" in html
+    assert "Hello, world!" in html


### PR DESCRIPTION
Thinking Path

- Transparent Stream exposes separate Full and Output tabs for tool details.
- Gateway/interrupted tool records can carry an invocation preview without any tool result.
- The settled/partial fallback paths treated preview as a result snippet, so execute_code displayed Python source under Output even when execution was blocked.
- Preview remains useful as invocation/header metadata, but it must not be promoted to stdout.

What Changed

- Render Output only from explicit snippet/result/output fields.
- Remove preview fallback from persisted and partial tool-result reconstruction.
- Keep argument rendering unchanged, so execute_code source remains visible under Full.
- Add executable regression coverage for preview-only and real-result cases.

Why It Matters

A blocked or interrupted tool must not claim its input was output. This restores the semantic boundary between invocation metadata and tool results while preserving actual stdout/diffs.

Verification

- ./scripts/test.sh tests/test_transparent_output_semantics.py tests/test_issue4622_settled_toolcard_body.py tests/test_issue2592_partial_dedupe.py tests/test_issue401.py
  - 43 passed
- ./.venv/bin/ruff check tests/test_transparent_output_semantics.py tests/test_issue401.py
  - passed
- git diff --check
  - passed
- Full-suite attempt was killed by the constrained container during collection with exit 137; no full-suite result is claimed.

Before / After

- Before: execute_code with preview `print('Hello, world!')` and no result rendered that source in Output.
- After: Full retains the code argument; Output has no result body. Supplying snippet, result, or output renders `Hello, world!` normally.

Responsive States

No layout or control geometry changed. The existing Full/Output interaction is unchanged; only the data source for Output is corrected.

Risks / Follow-ups

- Very old records that stored result text only in preview will no longer expose that text as Output. This is intentional: preview is invocation metadata and cannot be safely classified as stdout.
- Gateway APIs should continue moving toward explicit result-bearing fields for live tool completions.

Contract Routing

Task type: UI semantics bug fix
Touched areas: Transparent Stream tool detail and settled/partial reconstruction
Relevant public docs:
- AGENTS.md
- CONTRIBUTING.md
- docs/CONTRACTS.md
- docs/UIUX-GUIDE.md
- DESIGN.md
Scope boundaries: no streaming protocol, layout, or gateway execution changes
Evidence: executable DOM-string regression plus neighboring settled/partial tests

Model Used

OpenAI Codex gpt-5.6-sol via Hermes Agent. Tool-assisted source inspection, patching, and test execution.

Release note

Fix Transparent Stream's Output tab showing tool invocation previews, such as execute_code source, when no actual result exists.
