### PR TITLE
fix(webui): strip [screenshot] annotation in reconciliation dedup key (#6460)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -8081,6 +8081,15 @@ def _session_message_content_key(msg: dict):
         content = " ".join(
             _strip_workspace_prefix(content, include_legacy=True).split()
         )
+        # Issue #6460: same class of bug as #5339, different asymmetry
+        # source. hermes-agent's session_db persistence path flattens
+        # image-attachment content and appends a "[screenshot]" placeholder
+        # before writing to state.db; the WebUI sidecar row keeps the
+        # original text with no placeholder. That made a state.db row and
+        # its sidecar counterpart for the SAME image-bearing turn key
+        # differently, defeating dedup the same way the workspace-prefix
+        # mismatch did before #5360. Strip the placeholder here too.
+        content = " ".join(re.sub(r"\[screenshot\]", "", content).split())
     return (
         role,
         content,


### PR DESCRIPTION
Fixes the reported symptom in #6460.

## Root cause
Same class of bug as #5339 (fixed in #5360): a key-function mismatch
between `_session_message_content_key` (reconciliation) and the actual
state.db content. #5360 covered the workspace-prefix asymmetry; this
covers a second asymmetry source the issue identified — hermes-agent's
session_db persistence flattens image attachments to a `[screenshot]`
text placeholder before writing to state.db, but the WebUI sidecar row
keeps the original unflattened text. The two keyed differently,
reconciliation treated the state.db row as new, and the agent-side
merge permanently concatenated it into subsequent turns.

## Fix
Strip `[screenshot]` from user-role content in
`_session_message_content_key`, alongside the existing workspace-prefix
stripping from #5360.

## Scope / what this does NOT fix
The issue documents several other places where state.db and sidecar
content diverge for the same message (tool-result multimodal
summarization, `_compact_image_parts_for_persistence`, context-compressor
`[screenshot removed to save context]` tags, attachment path vs filename
list). This PR only addresses the `[screenshot]` placeholder reported in
#6460's repro. A broader normalization pass covering the other sources
is worth tracking as a separate follow-up rather than bundling here.

## Verification
Manually verified via `python -c` against `_session_message_content_key`
directly (local pytest collection returned 0 tests in my environment,
independent of this change — even the pre-existing #5339 suite didn't
collect, so I couldn't run the full automated suite locally):
- #6460 repro: sidecar key == state.db key with [screenshot] tag → True
- #5339 case still fixed (workspace-prefix stripping unaffected) → True
- non-user roles left untouched → True
- two genuinely distinct image-bearing turns stay distinct → True

## Note for reviewers
The exact `[screenshot]` annotation string is matched against the
issue's documented reproduction, not verified against hermes-agent's
`run_agent.py` directly (that file isn't in this repo — hermes-agent
lives in a separate checkout). Worth double-checking the literal string
before merge. Also worth a maintainer running the actual pytest suite
against this branch since I couldn't get local collection working.

Relates to #5339, #5360.