### PR TITLE
fix(sidebar): sort project chips alphabetically (#6393)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7650,8 +7650,9 @@ function renderSessionListFromCache(){
       noneChip.onclick=()=>{_setActiveProjectFilter(NO_PROJECT_FILTER);};
       bar.appendChild(noneChip);
     }
-    // Project chips
-    for(const p of _allProjects){
+    // Project chips — sort alphabetically by name (#6393)
+    const projects = [..._allProjects].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+    for(const p of projects){
       const chip=document.createElement('span');
       chip.className='project-chip'+(p.project_id===_activeProject?' active':'');
       if(p.color){


### PR DESCRIPTION
Closes #6393.

**Problem:** Project filter chips in the sidebar render in insertion/disk order, making the bar hard to scan when many projects exist.

**Fix:** Clone `_allProjects` and sort alphabetically by `p.name` using `localeCompare` before rendering the chip loop in `renderSessionListFromCache()`.

This matches how the workspace dropdown (`static/panels.js`) already sorts — same `localeCompare` pattern from #1464.

**Change:** `static/sessions.js` — one line changed in the project-chip render loop.

**Verification:**
- Projects now render in alphabetical order
- Existing chip behavior (color dots, click, double-click rename, context menu, long-press) unchanged
- "All" and "Unassigned" chips remain at the start of the bar (not sorted)
- No server-side change; purely client-side sort on the already cached `_allProjects`