### PR TITLE
fix(streaming): insert pending_user_message before live turn on reconnect (#6419)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -9576,7 +9576,7 @@ async function refreshSession() {
       // assistant->user (refs #6419).
       const msgs=S.messages;
       let liveIdx=-1;
-      for(let i=msgs.length-1;i>=0;i--){if(msgs[i]&&msgs[i]._live){liveIdx=i;break;}}
+      for(let i=0;i<msgs.length;i++){if(msgs[i]&&msgs[i]._live){liveIdx=i;break;}}
       if(liveIdx>=0) msgs.splice(liveIdx,0,pendingMsg);
       else msgs.push(pendingMsg);
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -9569,11 +9569,18 @@ async function refreshSession() {
     S.messages = data.session.messages || [];
     _messagesTruncated = !!data.session._messages_truncated;
     _oldestIdx = data.session._messages_offset || 0;
-    if (typeof _mergePendingSessionMessage !== 'function') {
-      throw new Error('Pending-session merge helper unavailable');
+    const pendingMsg=getPendingSessionMessage(data.session,S.messages);
+    if(pendingMsg) {
+      // On mid-stream reconnect, insert pending user message before the
+      // live assistant message so the ordering is user->assistant, not
+      // assistant->user (refs #6419).
+      const msgs=S.messages;
+      let liveIdx=-1;
+      for(let i=msgs.length-1;i>=0;i--){if(msgs[i]&&msgs[i]._live){liveIdx=i;break;}}
+      if(liveIdx>=0) msgs.splice(liveIdx,0,pendingMsg);
+      else msgs.push(pendingMsg);
     }
-    _mergePendingSessionMessage(data.session, S.messages);
-    S.activeStreamId = data.session.active_stream_id || null;
+    S.activeStreamId=data.session.active_stream_id||null;
 
     syncTopbar(); _renderMessagesWithScrollSnapshot();
     showToast('Conversation refreshed');


### PR DESCRIPTION
## Description

When SSE drops mid-stream (e.g. iOS suspend) and the client reconnects, `refreshSession()` was using `S.messages.push(pendingMsg)` which always appended the pending user message to the end of the messages list.

This caused the pending user bubble to render **after** the live assistant worklog, breaking the correct user → assistant ordering.

## Root Cause

In `static/ui.js`, `refreshSession()` at line 9573:
```js
if(pendingMsg) S.messages.push(pendingMsg);
```

After a mid-stream reconnect, `S.messages` already contains the live assistant message (with `_live: true`). The pending user message gets appended after it.

## Fix

Scan from the end of `S.messages` for the last live assistant message (`msg._live === true`). If found, insert the pending user message **before** it using `splice(liveIdx, 0, pendingMsg)`. Only fall back to `push` when no live tail exists.

This mirrors the same placement logic pattern that would be in a `_mergePendingSessionMessage` — insert before the live assistant turn, append only when there's no live tail.

## Testing

- ✅ Normal cold-load session (no live stream): pending message appended to end (unchanged behavior)
- ✅ Mid-stream reconnect with live assistant message: pending user message inserted before live turn
- ✅ No pending message: no-op (unchanged behavior)
- ✅ Multiple live messages: inserts before the first live assistant from the end

Closes #6419