### PR TITLE
fix(models): add grok family to reasoning chip detection, cap effort at high (#6437)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3565,6 +3565,8 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
         idx = tokens.index("deepseek")
         if idx + 1 < len(tokens) and tokens[idx + 1].startswith(("v", "r")):
             return True
+    if "grok" in token_set or normalized.startswith("grok"):
+        return True
     return False
 
 
@@ -3775,6 +3777,9 @@ def _filter_reasoning_efforts_for_provider(
     }
     if provider in _anthropic_lanes and "claude" in bare and _is_pre_adaptive_anthropic(bare):
         return [eff for eff in normalized if eff != "max"]
+    # xAI / Grok-4.5 tops out at 'high' (does not support xhigh/max).
+    if provider == "xai" and re.search(r"grok[._-]?4[._-]?5", bare):
+        return [eff for eff in normalized if eff in {"low", "medium", "high"}]
     # Z.AI / GLM native-endpoint gate: see _zai_glm_reasoning_efforts_supported.
     # True → keep the full ladder (GLM-5.2+); False → strip it entirely (pre-5.2
     # GLM and forced-thinking GLM-4.7); None → not a zai GLM case, defer.

--- a/api/config.py
+++ b/api/config.py
@@ -3566,7 +3566,11 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
         if idx + 1 < len(tokens) and tokens[idx + 1].startswith(("v", "r")):
             return True
     if "grok" in token_set or normalized.startswith("grok"):
-        return True
+        # Restrict to Grok 4+ (exclude Grok-1, Grok-2, Grok-3 — no reasoning).
+        m = re.search(r"grok[._-]?(\d+)", normalized)
+        if m and int(m.group(1)) >= 4:
+            return True
+        return False
     return False
 
 
@@ -3778,7 +3782,7 @@ def _filter_reasoning_efforts_for_provider(
     if provider in _anthropic_lanes and "claude" in bare and _is_pre_adaptive_anthropic(bare):
         return [eff for eff in normalized if eff != "max"]
     # xAI / Grok-4.5 tops out at 'high' (does not support xhigh/max).
-    if provider == "xai" and re.search(r"grok[._-]?4[._-]?5", bare):
+    if provider == "xai" and re.search(r"grok[._-]?4[._-]?5(?![0-9])", bare):
         return [eff for eff in normalized if eff in {"low", "medium", "high"}]
     # Z.AI / GLM native-endpoint gate: see _zai_glm_reasoning_efforts_supported.
     # True → keep the full ladder (GLM-5.2+); False → strip it entirely (pre-5.2

--- a/api/config.py
+++ b/api/config.py
@@ -3492,6 +3492,109 @@ def _reasoning_name_candidates(model_id: str) -> list[str]:
     return candidates
 
 
+# xAI / Grok reasoning ladder. Verified against xAI's model-capabilities doc
+# (docs.x.ai/developers/model-capabilities/text/reasoning): Grok 4.x accepts
+# reasoning_effort low|medium|high (default high); xhigh/max exist only from
+# Grok 4.6 on. Reasoning cannot be turned OFF on the 4.x reasoning models — the
+# transport just omits the field — so the composer must not offer "None".
+_GROK_REASONING_MIN_MAJOR = 4
+_GROK_FULL_LADDER_MIN_MINOR = 6
+_GROK_CAPPED_EFFORTS = frozenset({"low", "medium", "high"})
+# Both credential lanes hit the same xAI backend and share one model ladder: the
+# API-key lane is `xai`, the OAuth lane canonicalizes to `xai-oauth`. `x-ai`
+# ("x-ai/grok-4.5" ids) and `grok` normally resolve to `xai` via the alias table
+# and are listed here so a future alias-table change cannot silently reopen the
+# bypass.
+_XAI_REASONING_PROVIDERS = frozenset({"xai", "xai-oauth", "x-ai", "x.ai", "grok"})
+
+
+def _grok_version(model_id: str | None) -> tuple[int, int | None] | None:
+    """Return ``(major, minor|None)`` for the first clean ``grok`` version token.
+
+    Deliberately boundary-aware, because the previous ``grok[._-]?4[._-]?5``
+    regex both under- and over-matched: it missed the unversioned ``grok-4`` /
+    ``grok4`` ids AND treated lookalikes (``grok-45``, ``grok-4.5x``) as grok-4.5.
+
+      - the major version may be glued to the family name (``grok4``) but a
+        separator IS required between major and minor (``grok-4.5`` ok,
+        ``grok-45`` reads as major 45, i.e. not 4.5);
+      - a letter strapped straight onto the minor (``grok-4.5x``) is a DIFFERENT
+        id, not grok-4.5 — the parse is rejected outright rather than falling
+        back to the bare major (which would wrongly cap it);
+      - delimiter-separated suffixes are fine (``grok-4.5-mini``);
+      - date-stamped snapshots (``grok-4-0709``) carry the BASE version, so a
+        leading-zero group is a release stamp, not ``minor=709``.
+
+    ``None`` means "no clean grok version in this id".
+    """
+    text = str(model_id or "").strip().lower()
+    pos = 0
+    while True:
+        idx = text.find("grok", pos)
+        if idx < 0:
+            return None
+        pos = idx + len("grok")
+        if idx > 0 and text[idx - 1].isalnum():
+            # Embedded in a larger token ("notgrok-4") — not the family name.
+            continue
+        cursor = pos + 1 if pos < len(text) and text[pos] in "._-" else pos
+        end = cursor
+        while end < len(text) and text[end].isdigit():
+            end += 1
+        if end == cursor:
+            # "grok-beta", "grokking-4": no version digits after the family name.
+            continue
+        major = int(text[cursor:end])
+        minor: int | None = None
+        if end < len(text) and text[end] in "._-":
+            digits_start = end + 1
+            digits_end = digits_start
+            while digits_end < len(text) and text[digits_end].isdigit():
+                digits_end += 1
+            if digits_end > digits_start:
+                digits = text[digits_start:digits_end]
+                if digits_end < len(text) and text[digits_end].isalpha():
+                    return None
+                if len(digits) == 1 or not digits.startswith("0"):
+                    minor = int(digits)
+        return (major, minor)
+
+
+def _grok_reasoning_profile(model_id: str | None) -> dict | None:
+    """Single source of truth for the Grok/xAI reasoning surface.
+
+    Returns ``None`` when the id is not a reasoning-capable Grok model (Grok
+    1-3, ``grok-beta``, non-Grok ids, unparseable lookalikes). Otherwise:
+
+      ``supports``    — whether the reasoning chip exists for this id at all
+      ``max_effort``  — highest ladder level the backend accepts: "high" for
+                        Grok 4.0-4.5 (including the unversioned ``grok-4`` /
+                        ``grok-4-fast`` ids), "max" for Grok 4.6+
+      ``can_disable`` — whether the on/off ("None") control exists at all
+
+    ``_candidate_supports_reasoning``, ``_filter_reasoning_efforts_for_provider``
+    and the stored-``none`` gate all consult this, so the ceiling and the
+    toggle decision cannot drift apart (review: one strict version parse).
+    """
+    version = _grok_version(model_id)
+    if version is None:
+        return None
+    major, minor = version
+    if major < _GROK_REASONING_MIN_MAJOR:
+        return None
+    capped = major == _GROK_REASONING_MIN_MAJOR and (
+        minor is None or minor < _GROK_FULL_LADDER_MIN_MINOR
+    )
+    return {
+        "supports": True,
+        "max_effort": "high" if capped else "max",
+        # xAI exposes no "reasoning off" switch on the 4.x reasoning models: the
+        # transport omits the field and the model runs at its default effort, so
+        # offering "None" would be a dead control.
+        "can_disable": False,
+    }
+
+
 def _candidate_supports_reasoning(candidate: str) -> bool:
     normalized = re.sub(r"[^a-z0-9]+", "-", str(candidate or "").strip().lower()).strip("-")
     if not normalized:
@@ -3566,11 +3669,9 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
         if idx + 1 < len(tokens) and tokens[idx + 1].startswith(("v", "r")):
             return True
     if "grok" in token_set or normalized.startswith("grok"):
-        # Restrict to Grok 4+ (exclude Grok-1, Grok-2, Grok-3 — no reasoning).
-        m = re.search(r"grok[._-]?(\d+)", normalized)
-        if m and int(m.group(1)) >= 4:
-            return True
-        return False
+        # Restrict to Grok 4+ (exclude Grok-1, Grok-2, Grok-3 — no reasoning)
+        # via the single strict version parse in _grok_reasoning_profile.
+        return _grok_reasoning_profile(normalized) is not None
     return False
 
 
@@ -3781,9 +3882,15 @@ def _filter_reasoning_efforts_for_provider(
     }
     if provider in _anthropic_lanes and "claude" in bare and _is_pre_adaptive_anthropic(bare):
         return [eff for eff in normalized if eff != "max"]
-    # xAI / Grok-4.5 tops out at 'high' (does not support xhigh/max).
-    if provider == "xai" and re.search(r"grok[._-]?4[._-]?5(?![0-9])", bare):
-        return [eff for eff in normalized if eff in {"low", "medium", "high"}]
+    # xAI / Grok 4.x tops out at 'high' ("xhigh" is Grok 4.6+; the unversioned
+    # 'grok-4' / 'grok-4-fast' ids cap too). The ceiling follows the MODEL and
+    # must hold on BOTH credential lanes — `xai` (API key) and `xai-oauth`
+    # (OAuth) route to the same xAI backend — so the decision lives in
+    # _grok_reasoning_profile alongside the chip/None-gate logic.
+    if provider in _XAI_REASONING_PROVIDERS:
+        grok_profile = _grok_reasoning_profile(bare)
+        if grok_profile and grok_profile["max_effort"] == "high":
+            return [eff for eff in normalized if eff in _GROK_CAPPED_EFFORTS]
     # Z.AI / GLM native-endpoint gate: see _zai_glm_reasoning_efforts_supported.
     # True → keep the full ladder (GLM-5.2+); False → strip it entirely (pre-5.2
     # GLM and forced-thinking GLM-4.7); None → not a zai GLM case, defer.
@@ -4301,6 +4408,14 @@ def coerce_reasoning_effort_for_model(
     # early-return below so the forced-tier contract wins. (#6219 round-3)
     if raw == "none" and _zai_glm_classification(model_id, provider_id) == "forced":
         return ""
+    # Grok 4.x reasoning cannot be switched off either: xAI has no disable
+    # signal, the transport just omits the field and the model runs at its
+    # default effort. A stored 'none' must therefore coerce to '' (provider
+    # default) instead of a dead disable — same contract as the forced-thinking
+    # gate above, read from the same profile the chip and the ceiling use.
+    # (#6437 review)
+    if raw == "none" and (_grok_reasoning_profile(model_id) or {}).get("can_disable") is False:
+        return ""
     if raw == "none":
         return "none"
     if raw not in VALID_REASONING_EFFORTS:
@@ -4434,7 +4549,18 @@ def get_reasoning_status(
     zai_thinking = _zai_glm_thinking_toggle_supported(
         resolve_model, resolve_provider
     )
-    supports_thinking_toggle = bool(supported_efforts) or (zai_thinking is True)
+    # Grok 4.x is the mirror image of the ZAI case above: it HAS an effort ladder
+    # but NO off switch. For every other effort-capable family the ladder implies
+    # the toggle, so the flag has to be narrowed here — it is what hides the
+    # "None" option in the composer, and a model that cannot disable reasoning
+    # must not advertise a disable control. (#6437 review)
+    grok_profile = _grok_reasoning_profile(resolve_model)
+    grok_can_disable = (
+        bool(grok_profile["can_disable"]) if grok_profile is not None else True
+    )
+    supports_thinking_toggle = (
+        bool(supported_efforts) and grok_can_disable
+    ) or (zai_thinking is True)
     return {
         # Match CLI default (True if unset in config.yaml)
         "show_reasoning": bool(show_raw) if isinstance(show_raw, bool) else True,

--- a/api/config.py
+++ b/api/config.py
@@ -3517,10 +3517,12 @@ def _grok_version(model_id: str | None) -> tuple[int, int | None] | None:
 
       - the major version may be glued to the family name (``grok4``) but a
         separator IS required between major and minor (``grok-4.5`` ok,
-        ``grok-45`` reads as major 45, i.e. not 4.5);
-      - a letter strapped straight onto the minor (``grok-4.5x``) is a DIFFERENT
-        id, not grok-4.5 — the parse is rejected outright rather than falling
-        back to the bare major (which would wrongly cap it);
+        ``grok-45`` is rejected: a multi-digit major is a different/
+        hypothetical id, not a Grok family release);
+      - a letter strapped straight onto the major or the minor (``grok4x``,
+        ``grok-4.5x``) is a DIFFERENT id, not grok-4/4.5 — the parse is
+        rejected outright rather than falling back to the bare major (which
+        would wrongly cap it);
       - delimiter-separated suffixes are fine (``grok-4.5-mini``);
       - date-stamped snapshots (``grok-4-0709``) carry the BASE version, so a
         leading-zero group is a release stamp, not ``minor=709``.
@@ -3544,6 +3546,10 @@ def _grok_version(model_id: str | None) -> tuple[int, int | None] | None:
         if end == cursor:
             # "grok-beta", "grokking-4": no version digits after the family name.
             continue
+        if end - cursor > 1 or (end < len(text) and text[end].isalpha()):
+            # "grok45"/"grok-45": a multi-digit major is not a Grok release.
+            # "grok4x": a letter glued onto the major is a different id.
+            return None
         major = int(text[cursor:end])
         minor: int | None = None
         if end < len(text) and text[end] in "._-":

--- a/static/ui.js
+++ b/static/ui.js
@@ -5235,21 +5235,32 @@ function _reasoningEffortQuery(){
   return qs?('?'+qs):'';
 }
 
-function _applyReasoningOptions(supportedEfforts){
+function _applyReasoningOptions(supportedEfforts,toggleSupported){
   const dd=$('composerReasoningDropdown');
   if(!dd) return;
   const supported=new Set(Array.isArray(supportedEfforts)?supportedEfforts:[]);
+  // The backend's supports_thinking_toggle flag decides whether an off switch
+  // exists AT ALL. Default true preserves prior behavior when the field is
+  // absent (older backend / unknown model).
+  const toggle=(typeof toggleSupported==='boolean')?toggleSupported:true;
   dd.querySelectorAll('.reasoning-option').forEach(function(opt){
     const effort=opt.dataset.effort;
-    // 'none' (turn thinking off) and '' (Default = clear override, provider
-    // default = thinking on) are meta-options outside the effort ladder. They
-    // are always shown so a thinking-toggle-only model (GLM-4.5–5.1 on native
-    // zai, where the ladder is empty) still has an operable two-state control:
-    // Default (on) + None (off). Without the Default option the toggle is
-    // one-way off-only — the user can disable thinking but cannot re-enable it.
-    // (#6219 round-3)
-    if(effort==='none'||effort===''){
+    // '' (Default = clear override, provider default = thinking on) is a
+    // meta-option outside the effort ladder and is always shown, so a
+    // thinking-toggle-only model (GLM-4.5–5.1 on native zai, where the ladder is
+    // empty) still has an operable two-state control: Default (on) + None (off).
+    // Without the Default option the toggle is one-way off-only — the user can
+    // disable thinking but cannot re-enable it. (#6219 round-3)
+    if(effort===''){
       opt.style.display='';
+      return;
+    }
+    // 'none' (turn thinking off) only exists where the model HAS an off switch.
+    // Grok 4.x reports supports_thinking_toggle=false (xAI cannot disable
+    // reasoning on those ids), so offering "None" there would POST an effort the
+    // backend ignores — a dead control. (#6437 review)
+    if(effort==='none'){
+      opt.style.display=toggle?'':'none';
       return;
     }
     if(!supported.size){
@@ -5301,7 +5312,7 @@ function _applyReasoningChip(eff){
   }
   wrap.style.display='';
   if(mobileAction) mobileAction.style.display='';
-  if(typeof _applyReasoningOptions==='function') _applyReasoningOptions(supportedEfforts);
+  if(typeof _applyReasoningOptions==='function') _applyReasoningOptions(supportedEfforts,toggleSupported);
   const text=_formatReasoningEffortLabel(effort);
   label.textContent=text;
   if(mobileLabel) mobileLabel.textContent=text;

--- a/tests/test_issue6437_grok_reasoning_cap.py
+++ b/tests/test_issue6437_grok_reasoning_cap.py
@@ -1,0 +1,291 @@
+"""Grok / xAI reasoning surface: effort cap + off-switch contract (issue #6437).
+
+Covers the review findings on PR #6497:
+
+* one strict version parse drives every Grok decision (no drifting regexes),
+* the ladder cap holds on BOTH xAI credential lanes (`xai`, `xai-oauth`),
+* unversioned `grok-4`/`grok4`/`grok-4-fast` are capped, `grok-4.6+` is not,
+* lookalikes (`grok-45`, `grok-4.5x`) never masquerade as grok-4.5,
+* Grok 4.x cannot disable reasoning, so the "None" option must be hidden in the
+  composer and a stored 'none' must coerce to the provider default.
+
+The last one is exercised behaviourally against the real `static/ui.js` through
+node (same driver style as test_reasoning_chip_js_behaviour.py) — no source
+regexes, the option's actual `style.display` is asserted.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from api import config as cfg
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+CAPPED = ["low", "medium", "high"]
+FULL = ["minimal", "low", "medium", "high", "xhigh", "max"]
+
+# Models whose ladder must stop at 'high' (Grok 4.0-4.5, incl. the unversioned
+# ids) vs models that keep xhigh/max (Grok 4.6+).
+CAPPED_MODELS = [
+    "grok-4.5",
+    "grok-4.5-latest",
+    "x-ai/grok-4.5",
+    "@xai:grok-4.5",
+    "Grok-4.5",
+    "grok-4.5-mini",
+    "grok-4-5",
+    "grok-4",
+    "grok4",
+    "grok-4-fast",
+    "grok-4-0709",  # release stamp, not minor=709
+]
+UNCAPPED_MODELS = ["grok-4.6", "grok-4.7", "grok-4.6-fast", "grok-4.6-0712"]
+NON_REASONING_GROK = ["grok-3", "grok-3-mini", "grok-beta", "grok-2", "grok-1"]
+LOOKALIKES = ["grok-45", "grok45", "grok-4.5x", "grok4x", "notgrok-4.5"]
+
+
+# ── one parse, one profile: no drifting regexes ─────────────────────────────
+
+
+def test_profile_and_supports_never_drift():
+    """`_candidate_supports_reasoning` must agree with the profile for every id."""
+    for model in CAPPED_MODELS + UNCAPPED_MODELS + NON_REASONING_GROK + LOOKALIKES:
+        profile = cfg._grok_reasoning_profile(model)
+        supports = cfg._candidate_supports_reasoning(model)
+        assert (profile is not None) == supports, model
+        if profile is None:
+            continue
+        assert profile["supports"] is supports, model
+
+
+def test_resolved_ladder_matches_profile_ceiling_on_both_lanes():
+    """The cap must follow the model, on `xai` AND the OAuth lane `xai-oauth`.
+
+    `_resolve_provider_alias("xai-oauth")` does not collapse to `xai`, so the
+    lane reaches the filter verbatim — a provider check that only listed `xai`
+    left the OAuth lane with the full ladder.
+    """
+    assert cfg._resolve_provider_alias("xai-oauth") != "xai"
+    for provider in ("xai", "xai-oauth"):
+        for model in CAPPED_MODELS:
+            efforts = cfg.resolve_model_reasoning_efforts(model, provider_id=provider)
+            assert efforts == CAPPED, f"{model}@{provider} must cap at high: {efforts}"
+        for model in UNCAPPED_MODELS:
+            efforts = cfg.resolve_model_reasoning_efforts(model, provider_id=provider)
+            assert "xhigh" in efforts and "max" in efforts, f"{model}@{provider}: {efforts}"
+
+
+def test_unversioned_grok4_ids_are_capped():
+    """`grok-4` / `grok4` / `grok-4-fast` used to fall through the 4.5 regex."""
+    for model in ("grok-4", "grok4", "grok-4-fast"):
+        assert cfg._grok_reasoning_profile(model)["max_effort"] == "high", model
+        assert "xhigh" not in cfg.resolve_model_reasoning_efforts(
+            model, provider_id="xai"
+        ), model
+
+
+def test_release_stamp_is_not_read_as_minor_version():
+    """`grok-4-0709` is a snapshot of grok-4, not grok-4.709 (which would be 4.6+)."""
+    assert cfg._grok_reasoning_profile("grok-4-0709")["max_effort"] == "high"
+    assert cfg._grok_reasoning_profile("grok-4.6-0712")["max_effort"] == "max"
+
+
+def test_grok_46_and_later_keep_full_ladder():
+    assert cfg._grok_reasoning_profile("grok-4.6")["max_effort"] == "max"
+    assert cfg.resolve_model_reasoning_efforts("grok-4.6", provider_id="xai") == FULL
+    # a future minor keeps the wider ladder rather than being silently capped
+    assert cfg._grok_reasoning_profile("grok-5")["max_effort"] == "max"
+
+
+def test_lookalike_ids_never_get_the_grok_45_ceiling():
+    """`grok-45` is not 4.5 (multi-digit major) and `grok-4.5x` is not 4.5.
+
+    The strict parse rejects the attached alphanumerics instead of falling back
+    to the bare major, so neither id is capped *as if* it were grok-4.5 — and a
+    rejected id exposes no ladder at all rather than a wrong one.
+    """
+    for model in LOOKALIKES:
+        assert cfg._grok_reasoning_profile(model) is None, model
+        assert cfg.resolve_model_reasoning_efforts(model, provider_id="xai") == [], model
+
+
+def test_pre_grok4_models_are_not_reasoning_capable():
+    for model in NON_REASONING_GROK:
+        assert cfg._candidate_supports_reasoning(model) is False, model
+        assert cfg.resolve_model_reasoning_efforts(model, provider_id="xai") == [], model
+
+
+# ── the off switch: status flag, coercion, and the composer option ──────────
+
+
+def test_grok_status_reports_no_thinking_toggle():
+    """xAI has no disable signal, so the flag that hides "None" must be false."""
+    status = cfg.get_reasoning_status(model_id="grok-4.5", provider_id="xai")
+    assert status["supports_reasoning_effort"] is True
+    assert status["supported_efforts"] == CAPPED
+    assert status["supports_thinking_toggle"] is False
+
+
+def test_grok_oauth_lane_status_reports_no_thinking_toggle():
+    status = cfg.get_reasoning_status(model_id="grok-4.5", provider_id="xai-oauth")
+    assert status["supported_efforts"] == CAPPED
+    assert status["supports_thinking_toggle"] is False
+
+
+def test_status_keeps_toggle_for_non_grok_reasoning_models(monkeypatch):
+    monkeypatch.setattr(
+        cfg, "_load_yaml_config_file", lambda *a, **k: {"agent": {"reasoning_effort": "xhigh"}}
+    )
+    status = cfg.get_reasoning_status(model_id="gpt-5.5", provider_id="openai-codex")
+    assert status["supports_thinking_toggle"] is True
+
+
+def test_stored_none_coerces_to_provider_default_for_grok(monkeypatch):
+    """A 'none' saved before the chip stopped offering it must not reach xAI."""
+    for provider in ("xai", "xai-oauth"):
+        assert cfg.coerce_reasoning_effort_for_model(
+            "none", model_id="grok-4.5", provider_id=provider
+        ) == "", provider
+    # non-grok models keep the real disable signal
+    assert cfg.coerce_reasoning_effort_for_model(
+        "none", model_id="gpt-5.5", provider_id="openai-codex"
+    ) == "none"
+
+
+def test_status_coerces_stale_none_to_default_for_grok(monkeypatch):
+    monkeypatch.setattr(
+        cfg, "_load_yaml_config_file", lambda *a, **k: {"agent": {"reasoning_effort": "none"}}
+    )
+    status = cfg.get_reasoning_status(model_id="grok-4.5", provider_id="xai")
+    assert status["reasoning_effort"] == ""
+
+
+def test_status_coerces_stale_max_down_to_high_for_grok_45(monkeypatch):
+    monkeypatch.setattr(
+        cfg, "_load_yaml_config_file", lambda *a, **k: {"agent": {"reasoning_effort": "max"}}
+    )
+    for provider in ("xai", "xai-oauth"):
+        status = cfg.get_reasoning_status(model_id="grok-4.5", provider_id=provider)
+        assert status["reasoning_effort"] == "high", provider
+    # grok-4.6 legitimately keeps 'max'
+    status = cfg.get_reasoning_status(model_id="grok-4.6", provider_id="xai")
+    assert status["reasoning_effort"] == "max"
+
+
+# ── composer: the "None" option is hidden when there is no off switch ───────
+
+_OPTIONS = ["", "none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+const options = JSON.parse(process.argv[3]).map(function (effort) {
+  return { dataset: { effort: effort }, style: { display: 'unset' } };
+});
+
+const dropdown = {
+  querySelectorAll: function () { return options; },
+};
+
+global.window = {};
+global.document = {
+  createElement: function () { return {}; },
+  addEventListener: function () {},
+  querySelectorAll: function () { return []; },
+  querySelector: function () { return null; },
+};
+global.$ = function (id) {
+  return id === 'composerReasoningDropdown' ? dropdown : null;
+};
+
+eval(extractFunc('_applyReasoningOptions'));
+
+const input = JSON.parse(process.argv[4]);
+if (Object.prototype.hasOwnProperty.call(input, 'toggle')) {
+  _applyReasoningOptions(input.efforts, input.toggle);
+} else {
+  // legacy call shape: older backends send no toggle flag at all
+  _applyReasoningOptions(input.efforts);
+}
+
+const out = {};
+options.forEach(function (opt) {
+  out[opt.dataset.effort === '' ? '(default)' : opt.dataset.effort] = opt.style.display;
+});
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("reasoning_options_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+class TestReasoningOptionsVisibility:
+
+    def _run(self, driver_path, efforts, toggle=_OPTIONS):
+        payload = {"efforts": efforts}
+        if toggle is not _OPTIONS:
+            payload["toggle"] = toggle
+        result = subprocess.run(
+            [NODE, driver_path, str(UI_JS_PATH), json.dumps(_OPTIONS), json.dumps(payload)],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"node driver failed: {result.stderr}")
+        return json.loads(result.stdout)
+
+    def test_none_hidden_when_model_cannot_disable_reasoning(self, driver_path):
+        """grok-4.5: ladder low|medium|high, no off switch → no "None" option."""
+        out = self._run(driver_path, CAPPED, toggle=False)
+        assert out["none"] == "none", out
+        assert out["(default)"] == "", out
+        for effort in CAPPED:
+            assert out[effort] == "", out
+        for hidden in ("minimal", "xhigh", "max"):
+            assert out[hidden] == "none", out
+
+    def test_none_shown_when_model_has_a_toggle(self, driver_path):
+        out = self._run(driver_path, CAPPED, toggle=True)
+        assert out["none"] == "", out
+
+    def test_none_shown_when_backend_sends_no_toggle_flag(self, driver_path):
+        out = self._run(driver_path, CAPPED)
+        assert out["none"] == "", out
+
+    def test_default_option_always_visible_even_without_ladder(self, driver_path):
+        """GLM-4.5-5.1 on native zai: empty ladder + toggle → Default + None only."""
+        out = self._run(driver_path, [], toggle=True)
+        assert out["(default)"] == "", out
+        assert out["none"] == "", out
+        assert out["low"] == "none" and out["high"] == "none", out
+
+    def test_grok_46_full_ladder_keeps_none_hidden(self, driver_path):
+        out = self._run(driver_path, FULL, toggle=False)
+        for effort in FULL:
+            assert out[effort] == "", out
+        assert out["none"] == "none", out

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -24,7 +24,10 @@ def test_models_dev_true_returns_full_efforts(monkeypatch):
 
     import api.config as cfg
 
-    assert cfg._models_dev_reasoning_efforts("grok-4.3", "xai-oauth") == list(
+    # Grok 4.6+ keeps the full ladder (xhigh is 4.6+ only per the xAI docs);
+    # pre-4.6 Grok ids are covered by
+    # test_models_dev_metadata_respects_grok_ceiling below (#6437).
+    assert cfg._models_dev_reasoning_efforts("grok-4.6", "xai-oauth") == list(
         cfg.VALID_REASONING_EFFORTS
     )
 
@@ -61,10 +64,32 @@ def test_xai_oauth_grok_uses_agent_metadata(monkeypatch):
 
     import api.config as cfg
 
+    # xai-oauth routes to the same xAI backend as the API-key lane, so the Grok
+    # 4.x ceiling applies here too; the metadata lookup is still what decides
+    # whether reasoning is offered at all (#6437, PR #6497).
     assert cfg.resolve_model_reasoning_efforts(
         "@xai-oauth:grok-4.3", provider_id="xai-oauth"
-    ) == list(cfg.VALID_REASONING_EFFORTS)
+    ) == ["low", "medium", "high"]
     assert seen == [("xai-oauth", "grok-4.3")]
+
+
+def test_models_dev_metadata_respects_grok_ceiling(monkeypatch):
+    """Agent metadata yields to the Grok 4.x ceiling (#6437)."""
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=True),
+    )
+
+    import api.config as cfg
+
+    assert cfg._models_dev_reasoning_efforts("grok-4.5", "xai-oauth") == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert cfg._models_dev_reasoning_efforts("grok-4.6", "xai-oauth") == list(
+        cfg.VALID_REASONING_EFFORTS
+    )
 
 
 def test_models_dev_false_suppresses_prefix_heuristic(monkeypatch):
@@ -150,5 +175,7 @@ display:
     status = cfg.get_reasoning_status()
 
     assert status["reasoning_effort"] == "medium"
-    assert status["supported_efforts"] == list(cfg.VALID_REASONING_EFFORTS)
+    # grok-4.3 < 4.6 caps at high: 'medium' stays valid, xhigh/max are not
+    # offered (#6437).
+    assert status["supported_efforts"] == ["low", "medium", "high"]
     assert status["supports_reasoning_effort"] is True

--- a/tests/test_reasoning_effort_model_capabilities.py
+++ b/tests/test_reasoning_effort_model_capabilities.py
@@ -594,3 +594,62 @@ def test_qwen_prefixed_alias_reasoning_detection():
             f"{model} must remain reasoning-capable (DeepSeek-R1 hybrid, "
             f"Qwen 2.x must not shadow the DeepSeek detector)"
         )
+
+
+# ── Grok / xAI ladder (#6437, PR #6497 review) ──────────────────────────────
+# Grok 4.x accepts only low|medium|high up to 4.5; 4.6+ adds xhigh. The family is
+# recognised from one strict version parse and the cap holds on BOTH xAI lanes
+# (`xai` and the OAuth lane `xai-oauth`, which does NOT alias to `xai`). That
+# same profile decides the off switch: xAI cannot disable reasoning, so the
+# composer's "None" row must be hidden and a stored 'none' must coerce away.
+
+
+def test_grok_4_without_minor_caps_at_high():
+    # Unversioned `grok-4` / `grok4` / `grok-4-fast` slipped through the old
+    # `grok[._-]?4[._-]?5` regex and exposed xhigh/max.
+    for model in ("grok-4", "grok4", "grok-4-fast"):
+        efforts = cfg.resolve_model_reasoning_efforts(model, provider_id="xai")
+        assert efforts == ["low", "medium", "high"], f"{model}: {efforts}"
+
+
+def test_grok_45_caps_at_high_on_both_xai_lanes():
+    for provider in ("xai", "xai-oauth"):
+        assert cfg.resolve_model_reasoning_efforts(
+            "grok-4.5", provider_id=provider
+        ) == ["low", "medium", "high"], provider
+    # OpenRouter-shaped id keeps the same ceiling
+    assert cfg.resolve_model_reasoning_efforts(
+        "x-ai/grok-4.5", provider_id="xai"
+    ) == ["low", "medium", "high"]
+
+
+def test_grok_46_keeps_xhigh():
+    efforts = cfg.resolve_model_reasoning_efforts("grok-4.6", provider_id="xai")
+    assert "xhigh" in efforts and "max" in efforts, efforts
+
+
+def test_grok_3_has_no_reasoning():
+    for model in ("grok-3", "grok-3-mini"):
+        assert cfg._candidate_supports_reasoning(model) is False, model
+        assert cfg.resolve_model_reasoning_efforts(
+            model, provider_id="xai"
+        ) == [], model
+
+
+def test_grok_lookalikes_are_not_read_as_grok_45():
+    # `grok-45` is a multi-digit major, not 4.5; `grok-4.5x` is a different id.
+    # Both are rejected outright instead of being capped *as* grok-4.5.
+    for model in ("grok-45", "grok45", "grok-4.5x"):
+        assert cfg._grok_reasoning_profile(model) is None, model
+        assert cfg.resolve_model_reasoning_efforts(
+            model, provider_id="xai"
+        ) == [], model
+
+
+def test_grok_45_offers_no_none_option():
+    status = cfg.get_reasoning_status(model_id="grok-4.5", provider_id="xai")
+    assert status["supported_efforts"] == ["low", "medium", "high"]
+    assert status["supports_thinking_toggle"] is False
+    assert cfg.coerce_reasoning_effort_for_model(
+        "none", model_id="grok-4.5", provider_id="xai"
+    ) == ""


### PR DESCRIPTION
## Description

Fixes #6437 — bare `grok-4.5` was hiding the Reasoning chip because `_candidate_supports_reasoning` didn't recognize the Grok family.

## Changes

1. **`api/config.py` — `_candidate_supports_reasoning`**: Added Grok family detection ('grok' in token_set or starts-with), so bare Grok model IDs (e.g., `grok-4.5`) are recognized as reasoning-capable.

2. **`api/config.py` — `_filter_reasoning_efforts_for_provider`**: Added Grok-4.5 effort cap at `high` (`xhigh`/`max` are removed), since Grok-4.5 only supports effort levels up to 'high'.

## Testing

- `grok-4.5` (bare) will now show the Reasoning chip
- `grok-4.5` effort dropdown will be capped at `low/medium/high`
- Future Grok models (4.6+) get full effort ladder via the family detection