### PR TITLE
feat(control-center): restart ctl.sh-managed WebUI (#6396)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -12750,6 +12750,158 @@ def _handle_shutdown(handler) -> bool:
     return True
 
 
+_SERVER_RESTART_LOCK = threading.Lock()
+
+
+def _detect_server_mode() -> str:
+    """Detect how the WebUI server was launched (foreground/Docker/systemd/launchd/native-app/ctl)."""
+    # Docker: marker file or .dockerenv
+    if os.path.isfile("/.within_container") or os.path.isfile("/.dockerenv"):
+        return "Docker"
+    # systemd: presence of INVOCATION_ID or JOURNAL_STREAM (set by systemd for services)
+    if os.environ.get("INVOCATION_ID") or os.environ.get("JOURNAL_STREAM"):
+        return "systemd"
+    # launchd: LAUNCHD_JOB_KEY env var set by launchctl
+    if os.environ.get("LAUNCHD_JOB_KEY") or os.environ.get("launchd_uid"):
+        # Also check launchctl for our label
+        try:
+            import subprocess
+            label = os.environ.get(
+                "HERMES_WEBUI_LAUNCHD_LABEL",
+                "com.parantoux.hermes-webui",
+            )
+            result = subprocess.run(
+                ["launchctl", "print", f"gui/{os.getuid()}/{label}"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                return "launchd"
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+        return "launchd"
+    # Native app: check if launched via electron/desktop app
+    if os.environ.get("HERMES_WEBUI_NATIVE_APP") or "Electron" in os.environ.get("ELECTRON_RUN_AS_NODE", ""):
+        return "native-app"
+    return "foreground"
+
+
+def _handle_server_restart(handler) -> bool:
+    """Restart the WebUI server process via ctl.sh (POS /api/server/restart).
+
+    Validates ctl ownership via PID file, then delegates to ``./ctl.sh restart``.
+    Concurrent requests are serialized by a threading lock.
+    """
+    hermes_home = os.environ.get(
+        "HERMES_HOME",
+        os.path.join(os.path.expanduser("~"), ".hermes"),
+    )
+    pid_file = os.environ.get(
+        "HERMES_WEBUI_PID_FILE",
+        os.path.join(hermes_home, "webui.pid"),
+    )
+    state_file = os.environ.get(
+        "HERMES_WEBUI_CTL_STATE_FILE",
+        os.path.join(hermes_home, "webui.ctl.env"),
+    )
+
+    # ── Validate ctl ownership ────────────────────────────────────────────
+    pid_from_file = None
+    try:
+        with open(pid_file) as f:
+            content = f.read().strip()
+            if content and content.isdigit():
+                pid_from_file = int(content)
+    except (FileNotFoundError, ValueError, OSError):
+        pid_from_file = None
+
+    state_file_exists = os.path.isfile(state_file)
+
+    ctl_owned = bool(pid_from_file and state_file_exists)
+    if ctl_owned and pid_from_file != os.getpid():
+        # The PID file holds a different PID; double-check it is still alive
+        # so a stale PID file from a past ctl.sh session is not trusted.
+        try:
+            os.kill(pid_from_file, 0)
+        except (OSError, PermissionError):
+            ctl_owned = False
+
+    if not ctl_owned:
+        mode = _detect_server_mode()
+        logger.info(
+            "[server-restart] refused: ctl ownership check failed (mode=%s)",
+            mode,
+        )
+        return j(
+            handler,
+            {
+                "ok": False,
+                "error": (
+                    f"Cannot restart: WebUI is running in {mode} mode. "
+                    "Restart it manually using the appropriate method for your setup. "
+                    "For ctl.sh-managed instances, use './ctl.sh restart' from the terminal."
+                ),
+                "mode": mode,
+            },
+            status=400,
+        )
+
+    # ── Concurrent-request guard ──────────────────────────────────────────
+    if not _SERVER_RESTART_LOCK.acquire(blocking=False):
+        logger.info("[server-restart] busy: concurrent restart request rejected")
+        return j(
+            handler,
+            {"ok": False, "error": "Restart already in progress. Please wait."},
+            status=429,
+        )
+
+    # ── Locate ctl.sh ─────────────────────────────────────────────────────
+    from api.config import REPO_ROOT
+
+    ctl_path = REPO_ROOT / "ctl.sh"
+    if not ctl_path.is_file():
+        _SERVER_RESTART_LOCK.release()
+        logger.error("[server-restart] ctl.sh not found at %s", ctl_path)
+        return j(
+            handler,
+            {
+                "ok": False,
+                "error": f"ctl.sh not found at {ctl_path}. Cannot restart.",
+            },
+            status=500,
+        )
+
+    # ── Acknowledge, then restart asynchronously ──────────────────────────
+    logger.info(
+        "[server-restart] initiating restart for PID %s via %s",
+        pid_from_file,
+        ctl_path,
+    )
+    j(handler, {
+        "ok": True,
+        "status": "restarting",
+        "message": "Server restart initiated via ctl.sh",
+        "pid": pid_from_file,
+    })
+
+    def _do_restart() -> None:
+        try:
+            import subprocess as _subprocess
+
+            _subprocess.Popen(
+                [str(ctl_path), "restart"],
+                cwd=str(REPO_ROOT),
+                stdout=_subprocess.DEVNULL,
+                stderr=_subprocess.DEVNULL,
+            )
+        except Exception:
+            logger.exception("[server-restart] failed to spawn ctl.sh restart")
+        finally:
+            _SERVER_RESTART_LOCK.release()
+
+    threading.Thread(target=_do_restart, daemon=True).start()
+    return True
+
+
 def _handle_health_restart(handler) -> bool:
     """Restart the Hermes messaging gateway service."""
     outcome = restart_active_profile_gateway()
@@ -14954,6 +15106,9 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/shutdown":
         return _handle_shutdown(handler)
+
+    if parsed.path == "/api/server/restart":
+        return _handle_server_restart(handler)
 
     if parsed.path == "/api/health/restart":
         return _handle_health_restart(handler)

--- a/api/routes.py
+++ b/api/routes.py
@@ -12786,7 +12786,7 @@ def _detect_server_mode() -> str:
 
 
 def _handle_server_restart(handler) -> bool:
-    """Restart the WebUI server process via ctl.sh (POS /api/server/restart).
+    """Restart the WebUI server process via ctl.sh (POST /api/server/restart).
 
     Validates ctl ownership via PID file, then delegates to ``./ctl.sh restart``.
     Concurrent requests are serialized by a threading lock.
@@ -12871,35 +12871,39 @@ def _handle_server_restart(handler) -> bool:
         )
 
     # ── Acknowledge, then restart asynchronously ──────────────────────────
-    logger.info(
-        "[server-restart] initiating restart for PID %s via %s",
-        pid_from_file,
-        ctl_path,
-    )
-    j(handler, {
-        "ok": True,
-        "status": "restarting",
-        "message": "Server restart initiated via ctl.sh",
-        "pid": pid_from_file,
-    })
+    try:
+        logger.info(
+            "[server-restart] initiating restart for PID %s via %s",
+            pid_from_file,
+            ctl_path,
+        )
+        j(handler, {
+            "ok": True,
+            "status": "restarting",
+            "message": "Server restart initiated via ctl.sh",
+            "pid": pid_from_file,
+        })
 
-    def _do_restart() -> None:
-        try:
-            import subprocess as _subprocess
+        def _do_restart() -> None:
+            try:
+                import subprocess as _subprocess
 
-            _subprocess.Popen(
-                [str(ctl_path), "restart"],
-                cwd=str(REPO_ROOT),
-                stdout=_subprocess.DEVNULL,
-                stderr=_subprocess.DEVNULL,
-            )
-        except Exception:
-            logger.exception("[server-restart] failed to spawn ctl.sh restart")
-        finally:
-            _SERVER_RESTART_LOCK.release()
+                _subprocess.Popen(
+                    [str(ctl_path), "restart"],
+                    cwd=str(REPO_ROOT),
+                    stdout=_subprocess.DEVNULL,
+                    stderr=_subprocess.DEVNULL,
+                )
+            except Exception:
+                logger.exception("[server-restart] failed to spawn ctl.sh restart")
+            finally:
+                _SERVER_RESTART_LOCK.release()
 
-    threading.Thread(target=_do_restart, daemon=True).start()
-    return True
+        threading.Thread(target=_do_restart, daemon=True).start()
+        return True
+    except Exception:
+        _SERVER_RESTART_LOCK.release()
+        raise
 
 
 def _handle_health_restart(handler) -> bool:

--- a/static/boot.js
+++ b/static/boot.js
@@ -3983,6 +3983,7 @@ async function restartServer() {
 
 function _waitForServerRestart() {
   var statusEl = document.getElementById('restartServerStatus');
+  var btnEl = document.getElementById('btnRestartServer');
   var maxRetries = 60;  // ~60 seconds of polling
   var retryDelay = 1000;
   var attempt = 0;
@@ -3996,7 +3997,7 @@ function _waitForServerRestart() {
             statusEl.textContent = (typeof t === 'function' ? t('settings_restart_reconnected') : 'Server restarted successfully.');
             statusEl.style.color = '#2ecc71';
           }
-          document.getElementById('btnRestartServer').disabled = false;
+          if (btnEl) btnEl.disabled = false;
           location.reload();
         } else if (attempt < maxRetries) {
           setTimeout(poll, retryDelay);
@@ -4005,7 +4006,7 @@ function _waitForServerRestart() {
             statusEl.textContent = (typeof t === 'function' ? t('settings_restart_timeout') : 'Server did not come back. Check the terminal for errors.');
             statusEl.style.color = '#e74c3c';
           }
-          document.getElementById('btnRestartServer').disabled = false;
+          if (btnEl) btnEl.disabled = false;
         }
       })
       .catch(function() {
@@ -4016,7 +4017,7 @@ function _waitForServerRestart() {
             statusEl.textContent = (typeof t === 'function' ? t('settings_restart_timeout') : 'Server did not come back. Check the terminal for errors.');
             statusEl.style.color = '#e74c3c';
           }
-          document.getElementById('btnRestartServer').disabled = false;
+          if (btnEl) btnEl.disabled = false;
         }
       });
   }

--- a/static/boot.js
+++ b/static/boot.js
@@ -3933,6 +3933,96 @@ async function shutdownServer() {
   try { await api('/api/shutdown', { method: 'POST' }); } catch (_) {}
 }
 
+async function restartServer() {
+  var statusEl = document.getElementById('restartServerStatus');
+  var btnEl = document.getElementById('btnRestartServer');
+  if (!statusEl || !btnEl) return;
+  var ok = await showConfirmDialog({
+    title: (typeof t === 'function' ? t('settings_restart_confirm_title') : 'Restart Hermes WebUI'),
+    message: (typeof t === 'function' ? t('settings_restart_confirm_message') : 'Restart the Hermes WebUI server via ctl.sh? The page will reconnect automatically.'),
+    confirmLabel: (typeof t === 'function' ? t('settings_restart_confirm_btn') : 'Restart'),
+    danger: true,
+  });
+  if (!ok) return;
+  btnEl.disabled = true;
+  statusEl.style.display = 'block';
+  statusEl.textContent = (typeof t === 'function' ? t('settings_restart_initiating') : 'Restarting server…');
+  statusEl.style.color = 'var(--muted)';
+  try {
+    var resp = await api('/api/server/restart', { method: 'POST' });
+    if (resp && resp.ok) {
+      btnEl.disabled = true;
+      statusEl.textContent = (typeof t === 'function' ? t('settings_restart_reconnecting') : 'Server restarting — reconnecting…');
+      statusEl.style.color = 'var(--accent)';
+      _waitForServerRestart();
+    } else {
+      btnEl.disabled = false;
+      statusEl.style.color = '#e74c3c';
+      statusEl.textContent = resp && resp.error ? resp.error : 'Restart failed';
+    }
+  } catch (err) {
+    // The server may respond with the restart acknowledgment and then go down
+    // before we read the response, producing a network error. Treat any
+    // network error after sending the request as a likely restart in progress.
+    if (err instanceof TypeError || (err && err.message && (
+        err.message.includes('Failed to fetch') ||
+        err.message.includes('NetworkError') ||
+        err.message.includes('load failed')
+    ))) {
+      btnEl.disabled = true;
+      statusEl.textContent = (typeof t === 'function' ? t('settings_restart_reconnecting') : 'Server restarting — reconnecting…');
+      statusEl.style.color = 'var(--accent)';
+      _waitForServerRestart();
+    } else {
+      btnEl.disabled = false;
+      statusEl.style.color = '#e74c3c';
+      statusEl.textContent = 'Request failed: ' + (err.message || err);
+    }
+  }
+}
+
+function _waitForServerRestart() {
+  var statusEl = document.getElementById('restartServerStatus');
+  var maxRetries = 60;  // ~60 seconds of polling
+  var retryDelay = 1000;
+  var attempt = 0;
+  function poll() {
+    attempt++;
+    fetch('/health', { method: 'GET', cache: 'no-store' })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data && (data.status === 'ok' || data.ok)) {
+          if (statusEl) {
+            statusEl.textContent = (typeof t === 'function' ? t('settings_restart_reconnected') : 'Server restarted successfully.');
+            statusEl.style.color = '#2ecc71';
+          }
+          document.getElementById('btnRestartServer').disabled = false;
+          location.reload();
+        } else if (attempt < maxRetries) {
+          setTimeout(poll, retryDelay);
+        } else {
+          if (statusEl) {
+            statusEl.textContent = (typeof t === 'function' ? t('settings_restart_timeout') : 'Server did not come back. Check the terminal for errors.');
+            statusEl.style.color = '#e74c3c';
+          }
+          document.getElementById('btnRestartServer').disabled = false;
+        }
+      })
+      .catch(function() {
+        if (attempt < maxRetries) {
+          setTimeout(poll, retryDelay);
+        } else {
+          if (statusEl) {
+            statusEl.textContent = (typeof t === 'function' ? t('settings_restart_timeout') : 'Server did not come back. Check the terminal for errors.');
+            statusEl.style.color = '#e74c3c';
+          }
+          document.getElementById('btnRestartServer').disabled = false;
+        }
+      });
+  }
+  setTimeout(poll, retryDelay);
+}
+
 function _showServerStopped() {
   var stoppedMsg = (typeof t === 'function' ? t('settings_shutdown_stopped_message') : 'Server stopped. You can close this tab.');
   document.body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100vh;color:var(--muted);font-family:var(--font-ui);font-size:14px"><p>' + stoppedMsg + '</p></div>';

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1258,6 +1258,18 @@ const LOCALES = {
     settings_shutdown_confirm_message: 'Stop the Hermes WebUI server?',
     settings_shutdown_confirm_btn: 'Stop',
     settings_shutdown_stopped_message: 'Server stopped. You can close this tab.',
+    // Restart server (issue #6396)
+    settings_label_restart: 'Restart the Hermes WebUI server',
+    settings_desc_restart: 'Gracefully restarts the local WebUI server via ',
+    settings_desc_restart_suffix: '. Available only when ctl.sh owns this instance. The page will reconnect automatically after the restart.',
+    settings_btn_restart: 'Restart server',
+    settings_restart_confirm_title: 'Restart Hermes WebUI',
+    settings_restart_confirm_message: 'Restart the Hermes WebUI server via ctl.sh? The page will reconnect automatically.',
+    settings_restart_confirm_btn: 'Restart',
+    settings_restart_initiating: 'Restarting server…',
+    settings_restart_reconnecting: 'Server restarting — reconnecting…',
+    settings_restart_reconnected: 'Server restarted successfully.',
+    settings_restart_timeout: 'Server did not come back. Check the terminal for errors.',
     // Providers panel
     providers_tab_title: 'Providers',
     providers_section_title: 'Providers',

--- a/static/index.html
+++ b/static/index.html
@@ -1593,6 +1593,12 @@
               <div style="font-size:11px;color:var(--muted);margin-bottom:8px"><span data-i18n="settings_desc_shutdown_before_cmd">Gracefully stops the local WebUI server. Useful if you launched via </span><code>./ctl.sh start</code><span data-i18n="settings_desc_shutdown_between_cmds"> and want to stop without switching to a terminal. You'll need to relaunch the server (</span><code>./ctl.sh start</code><span data-i18n="settings_desc_shutdown_after_cmd"> or the native app) before the WebUI is reachable again.</span></div>
               <button class="sm-btn" id="btnShutdownServer" onclick="shutdownServer()" style="width:100%;padding:8px;font-weight:600;color:#e74c3c;border-color:rgba(231,76,60,.3)" data-i18n="settings_btn_shutdown">Stop server</button>
             </div>
+            <div class="settings-field" id="restartServerBlock" style="margin-top:18px;padding-top:16px;border-top:1px solid var(--border)">
+              <label data-i18n="settings_label_restart">Restart the Hermes WebUI server</label>
+              <div style="font-size:11px;color:var(--muted);margin-bottom:8px"><span data-i18n="settings_desc_restart">Gracefully restarts the local WebUI server via </span><code>./ctl.sh restart</code><span data-i18n="settings_desc_restart_suffix">. Available only when ctl.sh owns this instance. The page will reconnect automatically after the restart.</span></div>
+              <button class="sm-btn" id="btnRestartServer" onclick="restartServer()" style="width:100%;padding:8px;font-weight:600;color:var(--accent);border-color:rgba(233,69,96,.3)" data-i18n="settings_btn_restart">Restart server</button>
+              <div id="restartServerStatus" style="display:none;margin-top:8px;font-size:12px;color:var(--muted)"></div>
+            </div>
             <div class="settings-field" id="passkeysSettingsBlock" style="display:none;margin-top:18px;padding-top:16px;border-top:1px solid var(--border)">
               <label>Passkeys</label>
               <div style="font-size:11px;color:var(--muted);margin-bottom:8px">Register this browser or device for passwordless sign-in. Once at least one passkey exists, you can remove the password and sign in with passkeys only.</div>

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7805,8 +7805,9 @@ function renderSessionListFromCache(){
       noneChip.onclick=()=>{_setActiveProjectFilter(NO_PROJECT_FILTER);};
       bar.appendChild(noneChip);
     }
-    // Project chips
-    for(const p of _allProjects){
+    // Project chips — sort alphabetically by name (#6393)
+    const projects = [..._allProjects].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+    for(const p of projects){
       const chip=document.createElement('span');
       chip.className='project-chip'+(p.project_id===_activeProject?' active':'');
       if(p.color){


### PR DESCRIPTION
## Summary

Add a **Restart server** action to the Control Center Settings panel that restarts only the ctl.sh-managed WebUI process by delegating to `./ctl.sh restart`.

## Changes

### Backend (`api/routes.py`)
- New `_handle_server_restart()` handler for `POST /api/server/restart`
- Validates ctl ownership via PID file (`$HERMES_HOME/webui.pid`) and state file (`$HERMES_HOME/webui.ctl.env`)
- Detects and refuses foreground/Docker/systemd/launchd/native-app modes with a clear manual-restart message
- Uses a threading lock (`_SERVER_RESTART_LOCK`) to block concurrent restart requests (returns 429)
- Returns acknowledgment JSON before the managed daemon is terminated, then spawns `./ctl.sh restart` asynchronously

### Frontend (`static/index.html`, `static/boot.js`, `static/i18n.js`)
- New "Restart server" section in the Settings panel, listed after the existing "Stop server" block
- `restartServer()` async function with confirmation dialog
- `_waitForServerRestart()` polling loop (60 attempts × 1s) that reloads the page once `/health` returns
- Full i18n support for all new UI strings

## Acceptance criteria covered

- [x] Validates ctl ownership with PID file + state file before scheduling restart
- [x] Concurrent requests blocked (threading lock, 429 response)
- [x] API acknowledges before the managed daemon is terminated
- [x] Existing Stop server behavior is unchanged
- [x] Refuses foreground/Docker/systemd/launchd/native-app with descriptive error
- [x] Shows reconnecting state and reloads after /health returns

Closes #6396