### PR TITLE
fix(stream): bound StreamChannel offline replay buffer by bytes, not just frames (#6351)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8589,6 +8589,96 @@ def get_sessions_cache_max(config_data: dict | None = None) -> int:
 CHAT_LOCK = threading.Lock()
 
 
+# Bounded traversal limits for _estimate_frame_bytes(). The estimator runs on
+# every offline-buffered frame (thousands per abandoned turn), so it must stay
+# cheap: strings and bytes report len() in O(1), containers are walked only to a
+# shallow depth and a fixed breadth, and a truncated walk EXTRAPOLATES from the
+# sampled elements rather than under-reporting. Over-estimating is the safe
+# direction for a memory guard (it evicts sooner); under-estimating would let
+# the very payloads this cap exists to bound slip through unaccounted.
+_FRAME_SIZE_MAX_DEPTH = 4
+_FRAME_SIZE_MAX_ITEMS = 64
+# Total objects visited per estimate, shared across the WHOLE walk. Depth and
+# breadth limits alone are not enough: nested containers multiply, so
+# depth 4 x breadth 64 would allow ~16.7M visits while holding the channel
+# lock. This budget is the actual hot-path guarantee — the walk is O(1)-bounded
+# regardless of payload shape.
+_FRAME_SIZE_MAX_NODES = 512
+# Flat per-object floor for anything not sized precisely (scalars, opaque
+# objects, and the container bookkeeping itself). Deliberately coarse: this is a
+# memory guard, not an allocator-accurate accounting.
+_FRAME_SIZE_OBJECT_OVERHEAD = 64
+
+
+def _estimate_frame_bytes(value, depth: int = 0, budget: list | None = None) -> int:
+    """Cheap bounded estimate of the retained size of one buffered SSE frame.
+
+    SSE frame payloads are arbitrary Python objects — token-delta strings, tool
+    results, base64 image data, metering dicts — so a frame-COUNT cap alone does
+    not bound memory. This returns an approximate retained byte size so
+    StreamChannel can bound its offline replay buffer by bytes as well.
+
+    Accuracy is deliberately traded for speed: str/bytes dominate real payloads
+    and are measured exactly, containers are sampled with extrapolation, and
+    everything else falls back to a flat per-object floor. The walk is bounded
+    by depth, per-container breadth, AND a total node budget shared across the
+    whole traversal, so it stays O(1) on the hot path for any payload shape.
+
+    ``budget`` is internal (a single-element list used as a shared mutable
+    counter across the recursion); callers pass only ``value``.
+    """
+    if budget is None:
+        budget = [_FRAME_SIZE_MAX_NODES]
+
+    if isinstance(value, str):
+        return len(value) + _FRAME_SIZE_OBJECT_OVERHEAD
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return len(value) + _FRAME_SIZE_OBJECT_OVERHEAD
+    if value is None or isinstance(value, (bool, int, float)):
+        return _FRAME_SIZE_OBJECT_OVERHEAD
+    if depth >= _FRAME_SIZE_MAX_DEPTH or budget[0] <= 0:
+        # Too deep, or the node budget is exhausted: charge the floor rather
+        # than 0 so the payload still counts toward the cap.
+        return _FRAME_SIZE_OBJECT_OVERHEAD
+
+    try:
+        if isinstance(value, dict):
+            total = _FRAME_SIZE_OBJECT_OVERHEAD
+            sampled = 0
+            for key, item in value.items():
+                if sampled >= _FRAME_SIZE_MAX_ITEMS or budget[0] <= 0:
+                    break
+                budget[0] -= 1
+                total += _estimate_frame_bytes(key, depth + 1, budget)
+                total += _estimate_frame_bytes(item, depth + 1, budget)
+                sampled += 1
+            return _extrapolate_sampled_bytes(total, sampled, len(value))
+        if isinstance(value, (list, tuple, set, frozenset)):
+            total = _FRAME_SIZE_OBJECT_OVERHEAD
+            sampled = 0
+            for item in value:
+                if sampled >= _FRAME_SIZE_MAX_ITEMS or budget[0] <= 0:
+                    break
+                budget[0] -= 1
+                total += _estimate_frame_bytes(item, depth + 1, budget)
+                sampled += 1
+            return _extrapolate_sampled_bytes(total, sampled, len(value))
+    except Exception:
+        # A payload with a hostile/lazy __len__ or __iter__ must never break
+        # event delivery — fall back to the floor.
+        logger.debug("frame size estimate failed; charging floor", exc_info=True)
+        return _FRAME_SIZE_OBJECT_OVERHEAD
+
+    return _FRAME_SIZE_OBJECT_OVERHEAD
+
+
+def _extrapolate_sampled_bytes(total: int, sampled: int, actual_len: int) -> int:
+    """Scale a partially-sampled container estimate up to its full length."""
+    if sampled <= 0 or actual_len <= sampled:
+        return total
+    return int(total * (actual_len / sampled))
+
+
 class StreamChannel:
     """Broadcast SSE events to every connected browser tab for a stream.
 
@@ -8611,6 +8701,28 @@ class StreamChannel:
     # the per-subscriber queue cap below (that queue drops on a *slow* reader;
     # this buffer must survive a legitimate reconnect gap).
     _OFFLINE_BUFFER_MAXLEN = 8192
+    # Byte ceiling for the offline replay buffer (drop-oldest), enforced
+    # alongside _OFFLINE_BUFFER_MAXLEN.
+    #
+    # The frame-count cap above bounds memory only if frames are small, and the
+    # comment's "a fixed number of small (event, data, id) tuples" does not hold
+    # in general: frame payloads are arbitrary objects — tool results, base64
+    # image data, large assistant messages — so 8192 frames × an arbitrarily
+    # large payload is still unbounded. That is the same abandoned-turn shape as
+    # #4633, which the count cap only partially closed, and it is the reported
+    # residual growth in #6351 (a backgrounded mobile/PWA client leaves a
+    # long agentic turn running with ZERO subscribers, so every frame of that
+    # turn lands here).
+    #
+    # 32 MiB is far above a legitimate reconnect tail while keeping the
+    # worst-case bounded. Eviction is drop-oldest and counts toward
+    # offline_dropped_events exactly like a count eviction, so a reconnecting
+    # tab still learns its replay tail was truncated and falls back to the run
+    # journal by last_event_id. One frame is always retained even if it alone
+    # exceeds the ceiling — dropping the newest frame would break the
+    # retained-tail contract, and a single frame is bounded by the upload and
+    # tool-result caps elsewhere.
+    _OFFLINE_BUFFER_MAXBYTES = 32 * 1024 * 1024
     # Per-subscriber queue cap (drop-oldest on full). Each connected tab gets its
     # own queue; a slow/backpressured or backgrounded tab used to hold an
     # UNBOUNDED queue.Queue that grew for the WHOLE turn (the producer is the
@@ -8639,6 +8751,15 @@ class StreamChannel:
         self._offline_buffer: collections.deque = collections.deque(
             maxlen=self._OFFLINE_BUFFER_MAXLEN
         )
+        # Per-frame size estimates, kept strictly parallel to _offline_buffer
+        # (same maxlen, appended and evicted in lockstep) so the running byte
+        # total can be maintained without re-walking payloads on eviction. A
+        # frame's estimate is computed once, on append.
+        self._offline_frame_bytes: collections.deque = collections.deque(
+            maxlen=self._OFFLINE_BUFFER_MAXLEN
+        )
+        # Running sum of _offline_frame_bytes.
+        self._offline_bytes = 0
         # Frames evicted at the cap from the CURRENT buffer content. Scoped to
         # the buffer, NOT to an attach cycle: it resets exactly when the buffer
         # itself is cleared (first live broadcast), never on subscribe/
@@ -8743,6 +8864,7 @@ class StreamChannel:
                 self._last_event_id = event_id
             subscribers = list(self._subscribers)
             if not subscribers:
+                frame_bytes = _estimate_frame_bytes(item)
                 # deque(maxlen) evicts the oldest frame automatically when full.
                 # Log once on the first eviction (debug: an abandoned/disconnected
                 # turn is expected to hit this) and keep a running dropped count
@@ -8756,13 +8878,47 @@ class StreamChannel:
                         )
                     self._offline_dropped += 1
                     self._offline_dropped_total += 1
+                    # The append below silently drops the head frame; discount
+                    # its bytes here so the running total stays exact. The
+                    # parallel deque shares maxlen, so it evicts in lockstep.
+                    if self._offline_frame_bytes:
+                        self._offline_bytes -= self._offline_frame_bytes[0]
                 self._offline_buffer.append(item)
+                self._offline_frame_bytes.append(frame_bytes)
+                self._offline_bytes += frame_bytes
+                # Byte ceiling: evict oldest until back under the cap. Always
+                # retain at least the newest frame — a single oversized frame
+                # cannot be evicted without breaking the retained-tail contract.
+                byte_dropped = 0
+                while (
+                    self._offline_bytes > self._OFFLINE_BUFFER_MAXBYTES
+                    and len(self._offline_buffer) > 1
+                ):
+                    self._offline_buffer.popleft()
+                    self._offline_bytes -= self._offline_frame_bytes.popleft()
+                    byte_dropped += 1
+                if byte_dropped:
+                    if self._offline_dropped == 0:  # first eviction this cycle
+                        logger.debug(
+                            "StreamChannel offline buffer over byte ceiling "
+                            "(cap=%d bytes); dropping %d oldest frame(s) while "
+                            "no subscriber is connected",
+                            self._OFFLINE_BUFFER_MAXBYTES,
+                            byte_dropped,
+                        )
+                    # Count toward the SAME truncation signal as count-based
+                    # eviction: a reconnecting tab must fall back to the run
+                    # journal regardless of which ceiling holed its tail.
+                    self._offline_dropped += byte_dropped
+                    self._offline_dropped_total += byte_dropped
                 return
             # A subscriber is live: events now broadcast directly, so the offline
             # tail is drained. Reset the per-cycle eviction count (which also
             # re-arms the one-shot log) so the NEXT disconnect/overflow cycle
             # reports and logs its own truncation, not a stale carry-over.
             self._offline_buffer.clear()
+            self._offline_frame_bytes.clear()
+            self._offline_bytes = 0
             self._offline_dropped = 0
         # Broadcast outside the lock so a slow put_nowait doesn't block other
         # subscribers or producers. The queue is bounded; on queue.Full drop the
@@ -8807,6 +8963,10 @@ class StreamChannel:
             return {
                 "subscriber_count": len(self._subscribers),
                 "offline_buffered_events": len(self._offline_buffer),
+                # Estimated retained bytes in the offline buffer — the signal an
+                # operator needs to tell a benign long tail from the runaway
+                # growth #6351 reports (count alone cannot distinguish them).
+                "offline_buffered_bytes": self._offline_bytes,
                 # Cumulative over the channel lifetime (ops visibility), vs. the
                 # per-cycle count subscribe_with_snapshot() reports for truncation.
                 "offline_dropped_events": self._offline_dropped_total,

--- a/api/routes.py
+++ b/api/routes.py
@@ -11412,12 +11412,14 @@ def _stream_runtime_diagnostics() -> dict:
 
     The WebUI chat path can feel slow or stuck when streams are alive but no
     browser is attached, or when many events are buffering offline. This helper
-    exposes counts only — stream ids plus subscriber/buffer sizes — and avoids
-    event payloads, prompts, tool arguments, or paths.
+    exposes counts and sizes only — stream ids plus subscriber/buffer counts
+    and an estimated offline-buffer byte gauge — and avoids event payloads,
+    prompts, tool arguments, or paths.
     """
     streams = []
     total_subscribers = 0
     total_offline_buffered_events = 0
+    total_offline_buffered_bytes = 0
     with STREAMS_LOCK:
         items = list(STREAMS.items())
     for stream_id, stream in items:
@@ -11432,18 +11434,25 @@ def _stream_runtime_diagnostics() -> dict:
                 snapshot = {}
         subscriber_count = int(snapshot.get("subscriber_count") or 0)
         offline_buffered_events = int(snapshot.get("offline_buffered_events") or 0)
+        # Estimated retained bytes (#6351): frame count alone cannot distinguish
+        # a benign long tail from runaway growth, since frame payloads vary by
+        # orders of magnitude. This is the gauge an operator watches.
+        offline_buffered_bytes = int(snapshot.get("offline_buffered_bytes") or 0)
         total_subscribers += subscriber_count
         total_offline_buffered_events += offline_buffered_events
+        total_offline_buffered_bytes += offline_buffered_bytes
         streams.append({
             "stream_id": str(stream_id),
             "subscriber_count": subscriber_count,
             "offline_buffered_events": offline_buffered_events,
+            "offline_buffered_bytes": offline_buffered_bytes,
         })
     streams.sort(key=lambda item: item["stream_id"])
     return {
         "active_streams": len(streams),
         "total_subscribers": total_subscribers,
         "total_offline_buffered_events": total_offline_buffered_events,
+        "total_offline_buffered_bytes": total_offline_buffered_bytes,
         "streams": streams,
     }
 

--- a/tests/test_stream_offline_buffer_byte_cap.py
+++ b/tests/test_stream_offline_buffer_byte_cap.py
@@ -1,0 +1,258 @@
+"""
+Regression tests for #6351 — StreamChannel's offline replay buffer is capped by
+BYTES as well as by frame count.
+
+``_OFFLINE_BUFFER_MAXLEN`` (#4633) bounds the number of buffered frames, which
+bounds memory only if frames are small. Frame payloads are arbitrary objects —
+tool results, base64 image data, large assistant messages — so a count-only cap
+leaves the worst case unbounded: 8192 frames x an arbitrarily large payload.
+That is the residual growth reported in #6351, where a backgrounded mobile/PWA
+client leaves a long agentic turn running with ZERO subscribers and every frame
+of that turn lands in the offline buffer.
+
+``_OFFLINE_BUFFER_MAXBYTES`` now evicts oldest-first once the running estimate
+exceeds the ceiling. Byte evictions count toward the SAME
+``offline_dropped_events`` truncation signal as count evictions, so a
+reconnecting tab still falls back to the run journal by ``last_event_id``.
+"""
+import logging
+
+from api.config import (
+    StreamChannel,
+    _estimate_frame_bytes,
+    create_stream_channel,
+)
+
+
+def _payload(nbytes: int) -> str:
+    """A payload whose estimated size is at least ``nbytes``."""
+    return "x" * nbytes
+
+
+def test_offline_buffer_capped_by_bytes_well_under_frame_cap():
+    """The byte ceiling holds even when the frame COUNT stays far below the
+    count cap — the exact gap #6351 describes."""
+    ch = create_stream_channel()
+    chunk = 1024 * 1024  # 1 MiB per frame
+    frames = (StreamChannel._OFFLINE_BUFFER_MAXBYTES // chunk) + 16
+
+    for i in range(frames):
+        ch.put_nowait(("token", _payload(chunk), f"id{i}"))
+
+    snap = ch.diagnostic_snapshot()
+    # Far below the frame-count cap, so the count cap alone would NOT have
+    # evicted anything: this is purely the byte ceiling doing the work.
+    assert len(ch._offline_buffer) < StreamChannel._OFFLINE_BUFFER_MAXLEN
+    assert snap["offline_buffered_bytes"] <= StreamChannel._OFFLINE_BUFFER_MAXBYTES
+    assert snap["offline_dropped_events"] > 0
+
+
+def test_byte_eviction_drops_oldest_and_keeps_newest_tail():
+    """Byte eviction is drop-oldest: the retained tail is the newest frames."""
+    ch = create_stream_channel()
+    chunk = 4 * 1024 * 1024  # 4 MiB
+    frames = (StreamChannel._OFFLINE_BUFFER_MAXBYTES // chunk) + 5
+
+    for i in range(frames):
+        ch.put_nowait(("token", _payload(chunk), f"id{i}"))
+
+    retained = list(ch._offline_buffer)
+    assert retained, "buffer must never be fully drained by byte eviction"
+    # Newest frame is always retained.
+    assert retained[-1][2] == f"id{frames - 1}"
+    # The head advanced past the evicted frames.
+    assert retained[0][2] != "id0"
+
+
+def test_running_byte_total_matches_retained_frames():
+    """The running total stays exact across both eviction paths."""
+    ch = create_stream_channel()
+    chunk = 2 * 1024 * 1024
+    frames = (StreamChannel._OFFLINE_BUFFER_MAXBYTES // chunk) + 8
+    for i in range(frames):
+        ch.put_nowait(("token", _payload(chunk), f"id{i}"))
+
+    recomputed = sum(_estimate_frame_bytes(item) for item in ch._offline_buffer)
+    assert ch._offline_bytes == recomputed
+    assert len(ch._offline_frame_bytes) == len(ch._offline_buffer)
+
+
+def test_single_oversized_frame_is_retained():
+    """A lone frame larger than the whole ceiling must still be delivered —
+    dropping the newest frame would break the retained-tail contract (and a
+    terminal frame would strand the client)."""
+    ch = create_stream_channel()
+    huge = StreamChannel._OFFLINE_BUFFER_MAXBYTES * 2
+    ch.put_nowait(("stream_end", _payload(huge), "id-final"))
+
+    assert len(ch._offline_buffer) == 1
+    assert ch._offline_buffer[0][2] == "id-final"
+    # It is over the ceiling by construction; the invariant is retention, not
+    # the ceiling, in this degenerate case.
+    assert ch.diagnostic_snapshot()["offline_buffered_bytes"] > 0
+
+
+def test_oversized_frame_evicts_prior_frames_but_survives():
+    """One huge frame arriving after small ones evicts the small tail rather
+    than being dropped itself."""
+    ch = create_stream_channel()
+    for i in range(50):
+        ch.put_nowait(("token", _payload(1024), f"small{i}"))
+    huge = StreamChannel._OFFLINE_BUFFER_MAXBYTES + 1024
+    ch.put_nowait(("token", _payload(huge), "huge"))
+
+    retained = list(ch._offline_buffer)
+    assert retained[-1][2] == "huge"
+    assert len(retained) == 1, "prior small frames should have been evicted"
+
+
+def test_byte_eviction_sets_truncation_signal_for_reconnect():
+    """A reconnecting subscriber must learn the tail was holed by the BYTE cap,
+    not just the count cap, so it falls back to the run journal."""
+    ch = create_stream_channel()
+    chunk = 1024 * 1024
+    frames = (StreamChannel._OFFLINE_BUFFER_MAXBYTES // chunk) + 10
+    for i in range(frames):
+        ch.put_nowait(("token", _payload(chunk), f"id{i}"))
+
+    _q, snapshot = ch.subscribe_with_snapshot()
+    assert snapshot["offline_dropped_events"] > 0
+    # The replay window starts at the oldest RETAINED frame.
+    assert snapshot["offline_first_event_id"] == ch._offline_buffer[0][2]
+    assert snapshot["last_event_id"] == f"id{frames - 1}"
+
+
+def test_live_broadcast_resets_byte_total():
+    """The byte total resets with the buffer on the first live broadcast, so a
+    later disconnect cycle starts clean."""
+    ch = create_stream_channel()
+    chunk = 1024 * 1024
+    for i in range(8):
+        ch.put_nowait(("token", _payload(chunk), f"id{i}"))
+    assert ch._offline_bytes > 0
+
+    q = ch.subscribe()
+    ch.put_nowait(("token", "live", "id-live"))
+    assert ch._offline_bytes == 0
+    assert len(ch._offline_frame_bytes) == 0
+    ch.unsubscribe(q)
+
+    ch.put_nowait(("token", _payload(chunk), "id-after"))
+    assert ch._offline_bytes == _estimate_frame_bytes(
+        ("token", _payload(chunk), "id-after")
+    )
+
+
+def test_byte_eviction_logs_once_per_cycle(caplog):
+    """The byte-ceiling eviction emits the one-shot per-cycle debug log."""
+    ch = create_stream_channel()
+    chunk = 4 * 1024 * 1024
+    frames = (StreamChannel._OFFLINE_BUFFER_MAXBYTES // chunk) + 4
+    with caplog.at_level(logging.DEBUG, logger="api.config"):
+        for i in range(frames):
+            ch.put_nowait(("token", _payload(chunk), f"id{i}"))
+        assert caplog.text.count("over byte ceiling") == 1
+
+
+def test_small_frames_unaffected_by_byte_cap():
+    """Ordinary small-frame traffic must behave exactly as before: no byte
+    eviction, no truncation signal."""
+    ch = create_stream_channel()
+    for i in range(500):
+        ch.put_nowait(("token", f"delta-{i}", f"id{i}"))
+
+    snap = ch.diagnostic_snapshot()
+    assert snap["offline_buffered_events"] == 500
+    assert snap["offline_dropped_events"] == 0
+    assert snap["offline_buffered_bytes"] <= StreamChannel._OFFLINE_BUFFER_MAXBYTES
+
+
+# ── _estimate_frame_bytes ────────────────────────────────────────────────────
+
+
+def test_estimate_counts_string_payload():
+    small = _estimate_frame_bytes(("token", "a", "id"))
+    large = _estimate_frame_bytes(("token", "a" * 100_000, "id"))
+    assert large - small >= 100_000 - 8
+
+
+def test_estimate_counts_bytes_payload():
+    assert _estimate_frame_bytes(b"a" * 50_000) >= 50_000
+
+
+def test_estimate_counts_nested_dict_payload():
+    """Realistic frames are dicts of strings — those must be accounted for, not
+    charged a flat scalar floor."""
+    payload = {"content": "z" * 200_000, "role": "assistant"}
+    assert _estimate_frame_bytes(("message", payload, "id")) >= 200_000
+
+
+def test_estimate_extrapolates_wide_containers():
+    """A container wider than the sampling breadth is extrapolated, not
+    under-reported (under-reporting is the unsafe direction)."""
+    wide = ["y" * 1000 for _ in range(1000)]
+    estimate = _estimate_frame_bytes(wide)
+    # Sampling stops at _FRAME_SIZE_MAX_ITEMS but extrapolates to full length,
+    # so the estimate must far exceed the sampled-only sum.
+    assert estimate > 500_000
+
+
+def test_estimate_is_bounded_for_deeply_nested_payloads():
+    """Depth is capped so a pathological payload cannot make the estimator walk
+    forever on the hot path."""
+    deep = "leaf"
+    for _ in range(200):
+        deep = {"next": deep}
+    # Must return promptly without recursion error.
+    assert _estimate_frame_bytes(deep) > 0
+
+
+def test_estimate_walk_is_node_bounded_on_hot_path():
+    """Depth x breadth alone would allow ~16.7M visits per frame while holding
+    the channel lock. A shared node budget must bound the WHOLE walk, so a wide
+    nested payload stays fast."""
+    import time
+
+    # Nested wide containers: without a shared budget this explodes
+    # combinatorially (64 * 64 * 64 ... per level).
+    level3 = {f"k{i}": "v" * 64 for i in range(200)}
+    level2 = {f"k{i}": dict(level3) for i in range(200)}
+    level1 = {f"k{i}": dict(level2) for i in range(200)}
+
+    start = time.perf_counter()
+    estimate = _estimate_frame_bytes(("message", level1, "id"))
+    elapsed = time.perf_counter() - start
+
+    assert estimate > 0
+    assert elapsed < 0.5, f"frame size estimate took {elapsed:.3f}s on the hot path"
+
+
+def test_byte_total_exact_across_count_cap_eviction():
+    """The running total must stay exact when the FRAME-COUNT cap is what
+    evicts (deque(maxlen) drops the head silently, so its bytes are discounted
+    ahead of the append). Regression guard for the two deques drifting."""
+    ch = create_stream_channel()
+    n = StreamChannel._OFFLINE_BUFFER_MAXLEN
+    # Small frames so the byte ceiling never fires — isolate the count path.
+    for i in range(n + 300):
+        ch.put_nowait(("token", f"delta-{i}", f"id{i}"))
+
+    assert len(ch._offline_buffer) == n
+    assert len(ch._offline_frame_bytes) == n
+    recomputed = sum(_estimate_frame_bytes(item) for item in ch._offline_buffer)
+    assert ch._offline_bytes == recomputed
+    assert ch._offline_bytes > 0
+
+
+def test_estimate_survives_hostile_payload():
+    """A payload whose iteration raises must not break event delivery."""
+
+    class Hostile(dict):
+        def items(self):
+            raise RuntimeError("boom")
+
+    assert _estimate_frame_bytes(Hostile()) > 0
+
+    ch = create_stream_channel()
+    ch.put_nowait(("token", Hostile(), "id-hostile"))
+    assert len(ch._offline_buffer) == 1

--- a/tests/test_webui_runtime_diagnostics.py
+++ b/tests/test_webui_runtime_diagnostics.py
@@ -6,7 +6,13 @@ def test_stream_channel_exposes_buffer_and_subscriber_counts():
     channel = create_stream_channel()
     channel.put_nowait(("token", {"text": "offline"}))
 
-    assert channel.diagnostic_snapshot() == {
+    snapshot = channel.diagnostic_snapshot()
+    # offline_buffered_bytes (#6351) is an ESTIMATE, so it is asserted as a
+    # positive gauge rather than an exact value; the rest of the contract is
+    # still exact.
+    buffered_bytes = snapshot.pop("offline_buffered_bytes")
+    assert buffered_bytes > 0
+    assert snapshot == {
         "subscriber_count": 0,
         "offline_buffered_events": 1,
         "offline_dropped_events": 0,
@@ -42,12 +48,17 @@ def test_stream_runtime_diagnostics_summarizes_active_stream_channels():
         assert payload["active_streams"] == 1
         assert payload["total_subscribers"] == 1
         assert payload["total_offline_buffered_events"] == 1
-        assert payload["streams"] == [
-            {
-                "stream_id": "stream-one",
-                "subscriber_count": 1,
-                "offline_buffered_events": 1,
-            }
-        ]
+        # Byte gauge (#6351) is an estimate: assert it is present, positive, and
+        # consistent between the per-stream row and the total.
+        assert payload["total_offline_buffered_bytes"] > 0
+        assert len(payload["streams"]) == 1
+        row = dict(payload["streams"][0])
+        row_bytes = row.pop("offline_buffered_bytes")
+        assert row_bytes == payload["total_offline_buffered_bytes"]
+        assert row == {
+            "stream_id": "stream-one",
+            "subscriber_count": 1,
+            "offline_buffered_events": 1,
+        }
     finally:
         channel.unsubscribe(subscriber)


### PR DESCRIPTION
## Problem

`StreamChannel._OFFLINE_BUFFER_MAXLEN` (#4633) caps the offline replay buffer at 8192 frames. That bounds memory only if frames are small, and the existing comment's premise — "a fixed number of small `(event, data, id)` tuples" — does not hold in general. Frame payloads are arbitrary objects: tool results, base64 image data, large assistant messages. So the worst case is **8192 frames × an arbitrarily large payload**, which is still unbounded.

This is the same abandoned-turn shape #4633 addressed but only partially closed, and it matches the residual growth reported in #6351. The trigger is specifically a client that stops subscribing without cancelling:

> a client that disconnects without cancelling leaves the turn running with zero subscribers

A backgrounded mobile/PWA client does exactly this — it drops its SSE subscription while a long agentic turn keeps running, so **every frame of that turn** accumulates in the offline buffer with zero subscribers attached.

Notably, #6351 attributes the growth largely to the `SESSIONS` LRU cache. That cache is already bounded (`DEFAULT_SESSIONS_CACHE_MAX = 100`), and on a small install it never reaches its cap — so it cannot explain multi-GB growth there. The count-only buffer cap is a distinct, still-open path to the same symptom.

## Change

Add `_OFFLINE_BUFFER_MAXBYTES` (32 MiB), enforced alongside the frame cap:

- Per-frame size estimates live in a deque kept strictly parallel to `_offline_buffer` (same `maxlen`, appended and evicted in lockstep), so the running total needs no re-walk on eviction and stays exact across **both** eviction paths.
- Byte eviction is drop-oldest and counts toward the same `offline_dropped_events` truncation signal as count eviction, so a reconnecting tab still falls back to the run journal by `last_event_id`. The retained-tail and `offline_first_event_id` contracts are unchanged.
- One frame is always retained even if it alone exceeds the ceiling. Dropping the newest frame would break the retained-tail contract, and would strand a client if that frame were terminal (`stream_end`/`error`/`cancel`).
- `diagnostic_snapshot()` gains `offline_buffered_bytes`, and `_stream_runtime_diagnostics()` surfaces it per-stream plus a `total_offline_buffered_bytes`. Frame count alone cannot distinguish a benign long tail from runaway growth, since payload sizes vary by orders of magnitude — this is the gauge an operator actually watches. (#6351 asks for memory diagnostics directly.)

`_estimate_frame_bytes()` is deliberately approximate and hard-bounded. `str`/`bytes` are measured exactly; containers are sampled to a shallow depth and fixed breadth **with extrapolation**, since over-estimating is the safe direction for a memory guard while under-estimating would let the very payloads this cap exists to bound slip through unaccounted. A payload that raises during iteration falls back to a flat floor rather than breaking event delivery.

The whole walk shares a 512-node budget. That budget — not the depth/breadth limits — is the real hot-path guarantee: depth 4 × breadth 64 alone would permit ~16.7M node visits per frame **while holding the channel lock**, trading a memory bug for a latency bug. There is a test asserting the walk stays well under 0.5s on a deliberately pathological nested payload.

Small-frame traffic is entirely unaffected: the byte ceiling never fires and no truncation signal is raised.

## Contract Change

`StreamChannel.diagnostic_snapshot()` gains an `offline_buffered_bytes` key, and the `_stream_runtime_diagnostics()` payload gains `offline_buffered_bytes` per stream plus a top-level `total_offline_buffered_bytes`.

`tests/test_webui_runtime_diagnostics.py` asserted both shapes by exact equality and is updated accordingly — deliberately, not silently. The new field is an estimate, so the tests assert it as a positive gauge (and check per-stream/total consistency) while keeping the rest of the contract exact.

This is additive; no existing key changes type or meaning. The diagnostics payload remains counts-and-sizes only — no event payloads, prompts, tool arguments, or paths — and the docstring is updated to say so accurately.

## Testing

Run in a `python:3.13-slim` container with Node available (some tests shell out to `node`).

- New: `tests/test_stream_offline_buffer_byte_cap.py` — 17 tests covering byte-capped eviction below the frame cap, drop-oldest ordering, exact running-total accounting across **both** eviction paths, oversized-frame retention, the truncation signal reaching a reconnecting subscriber, reset on live broadcast, the node-budget hot-path bound, and estimator behavior on strings, bytes, nested dicts, wide containers, deep nesting, and payloads that raise on iteration.
- Existing `#4633` cap tests (`tests/test_stream_offline_buffer_cap.py`) pass **unchanged**.
- Full suite vs. a pristine `399cd7ab` baseline in an identical container:

| | baseline | this branch |
|---|---|---|
| passed | 13596 | 13613 |
| failed | 29 | 29 |

The 29 failures are identical in both runs and pre-existing/environmental (container runs as root, TLS probe fixtures, gitignore-policy checks). **No net-new failures.**

## Notes / follow-ups

- `_SUBSCRIBER_QUEUE_MAXSIZE` has the same count-vs-bytes gap for a slow-but-attached subscriber. It is left alone here to keep this one logical change; the offline path is both the dominant one for a disconnected client and the one #4633/#6351 describe. Happy to follow up.
- The 32 MiB ceiling is a module constant, matching the existing hardcoded `_OFFLINE_BUFFER_MAXLEN` style rather than introducing config plumbing. Glad to route it through `config.yaml` (as `get_sessions_cache_max()` does) if you'd prefer it operator-tunable.
- I have not reproduced #6351's exact 1.7 GB figure, so I would not claim this fully closes it — the reporter's environment differs. It closes a demonstrable unbounded path consistent with the report.

## AI Usage Disclosure

- **Provider:** Anthropic
- **Model:** claude-opus-5[1m] (Claude Opus 5, 1M context), via Claude Code
- **Notable use:** Used to locate the count-vs-bytes gap, write the patch and its tests, and run the full suite against a pristine baseline in Docker. All test runs and the baseline comparison are real executions, not model-asserted results. Reviewed by the submitter before opening.
