### PR TITLE
Fix composer quota display for the active session provider

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -2260,6 +2260,7 @@ $('modelSelect').onchange=async()=>{
   else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
   if(!S.session){
     if(typeof _rememberEmptyComposerModelOverride==='function') _rememberEmptyComposerModelOverride(modelState.model,modelState.model_provider);
+    if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(modelState.model_provider||null);
     if(typeof syncModelChip==='function') syncModelChip();
     if(typeof syncReasoningChip==='function') syncReasoningChip();
     return;
@@ -2267,6 +2268,7 @@ $('modelSelect').onchange=async()=>{
   if(typeof _rememberPendingSessionModel==='function') _rememberPendingSessionModel(S.session.session_id,modelState.model,modelState.model_provider);
   S.session.model=modelState.model;
   S.session.model_provider=modelState.model_provider||null;
+  if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);
   if(typeof syncModelChip==='function') syncModelChip();
   if(typeof syncReasoningChip==='function') syncReasoningChip();
   syncTopbar();
@@ -3730,7 +3732,9 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   // re-run when the browser restores the page from bfcache.
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
   if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
-  if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
+  const _refreshQuotaForEmptyComposer=()=>{
+    if(!S.session&&typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(null);
+  };
   const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
   const pwaLaunchAction=(window.HermesPWA&&typeof window.HermesPWA.launchAction==='function')
     ? window.HermesPWA.launchAction()
@@ -3768,6 +3772,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           try{localStorage.removeItem('hermes-webui-session');}catch(_){}
         }
         S.session=null; S.messages=[]; S.activeStreamId=null; S.busy=false;
+        _refreshQuotaForEmptyComposer();
         S._bootReady=true;
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
@@ -3781,6 +3786,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           || localStorage.getItem('hermes-webui-workspace-panel')==='open';
         if(_ephPanelPref&&!_isCompactWorkspaceViewport()) _workspacePanelMode='browse';
         await _maybeBindFreshDefaultWorkspaceSession(prefillIntent);
+        _refreshQuotaForEmptyComposer();
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
         await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);if(typeof startGatewaySSE==='function')startGatewaySSE();
@@ -3819,6 +3825,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           || localStorage.getItem('hermes-webui-workspace-panel')==='open';
         if(_ephPanelPref&&!_isCompactWorkspaceViewport()) _workspacePanelMode='browse';
         await _maybeBindFreshDefaultWorkspaceSession(prefillIntent);
+        _refreshQuotaForEmptyComposer();
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
         await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);if(typeof startGatewaySSE==='function')startGatewaySSE();
@@ -3845,6 +3852,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     || localStorage.getItem('hermes-webui-workspace-panel')==='open';
   if(_freshPanelPref&&!_isCompactWorkspaceViewport()) _workspacePanelMode='browse';
   await _maybeBindFreshDefaultWorkspaceSession(prefillIntent);
+  _refreshQuotaForEmptyComposer();
   syncWorkspacePanelState();
   $('emptyState').style.display='';
   await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);

--- a/static/boot.js
+++ b/static/boot.js
@@ -3822,6 +3822,9 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
         : [];
       const _restoredHasDraft = !!(_restoredDraftText || _restoredDraftFiles.length);
       if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight && !_restoredHasDraft){
+        if(typeof _rememberEmptyComposerModelOverride==='function'){
+          _rememberEmptyComposerModelOverride(S.session.model, S.session.model_provider);
+        }
         S.session=null; S.messages=[];
         S._bootReady=true;
         // Restore panel pref before syncing so the workspace panel stays visible

--- a/static/boot.js
+++ b/static/boot.js
@@ -2260,7 +2260,7 @@ $('modelSelect').onchange=async()=>{
   else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
   if(!S.session){
     if(typeof _rememberEmptyComposerModelOverride==='function') _rememberEmptyComposerModelOverride(modelState.model,modelState.model_provider);
-    if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(modelState.model_provider||null);
+    if(typeof _syncProviderQuotaForActiveContext==='function') _syncProviderQuotaForActiveContext();
     if(typeof syncModelChip==='function') syncModelChip();
     if(typeof syncReasoningChip==='function') syncReasoningChip();
     return;
@@ -2268,7 +2268,6 @@ $('modelSelect').onchange=async()=>{
   if(typeof _rememberPendingSessionModel==='function') _rememberPendingSessionModel(S.session.session_id,modelState.model,modelState.model_provider);
   S.session.model=modelState.model;
   S.session.model_provider=modelState.model_provider||null;
-  if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);
   if(typeof syncModelChip==='function') syncModelChip();
   if(typeof syncReasoningChip==='function') syncReasoningChip();
   syncTopbar();
@@ -3732,12 +3731,9 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   // re-run when the browser restores the page from bfcache.
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
   if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
-  const _refreshQuotaForEmptyComposer=()=>{
-    if(!S.session&&typeof refreshProviderQuotaIndicator==='function'){
-      const provider=(typeof _currentQuotaProvider==='function')
-        ? _currentQuotaProvider()
-        : null;
-      void refreshProviderQuotaIndicator(provider);
+  const _syncQuotaForBootContext=()=>{
+    if(typeof _syncProviderQuotaForActiveContext==='function'){
+      _syncProviderQuotaForActiveContext();
     }
   };
   const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
@@ -3777,7 +3773,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           try{localStorage.removeItem('hermes-webui-session');}catch(_){}
         }
         S.session=null; S.messages=[]; S.activeStreamId=null; S.busy=false;
-        _refreshQuotaForEmptyComposer();
+        _syncQuotaForBootContext();
         S._bootReady=true;
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
@@ -3791,7 +3787,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           || localStorage.getItem('hermes-webui-workspace-panel')==='open';
         if(_ephPanelPref&&!_isCompactWorkspaceViewport()) _workspacePanelMode='browse';
         await _maybeBindFreshDefaultWorkspaceSession(prefillIntent);
-        _refreshQuotaForEmptyComposer();
+        _syncQuotaForBootContext();
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
         await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);if(typeof startGatewaySSE==='function')startGatewaySSE();
@@ -3833,7 +3829,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
           || localStorage.getItem('hermes-webui-workspace-panel')==='open';
         if(_ephPanelPref&&!_isCompactWorkspaceViewport()) _workspacePanelMode='browse';
         await _maybeBindFreshDefaultWorkspaceSession(prefillIntent);
-        _refreshQuotaForEmptyComposer();
+        _syncQuotaForBootContext();
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
         await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);if(typeof startGatewaySSE==='function')startGatewaySSE();
@@ -3860,7 +3856,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
     || localStorage.getItem('hermes-webui-workspace-panel')==='open';
   if(_freshPanelPref&&!_isCompactWorkspaceViewport()) _workspacePanelMode='browse';
   await _maybeBindFreshDefaultWorkspaceSession(prefillIntent);
-  _refreshQuotaForEmptyComposer();
+  _syncQuotaForBootContext();
   syncWorkspacePanelState();
   $('emptyState').style.display='';
   await renderSessionList();await _finalizeComposerPrefillOnBoot(prefillIntent);

--- a/static/boot.js
+++ b/static/boot.js
@@ -3733,7 +3733,12 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
   if (typeof syncSessionSearchClear === 'function') syncSessionSearchClear();
   const _refreshQuotaForEmptyComposer=()=>{
-    if(!S.session&&typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(null);
+    if(!S.session&&typeof refreshProviderQuotaIndicator==='function'){
+      const provider=(typeof _currentQuotaProvider==='function')
+        ? _currentQuotaProvider()
+        : null;
+      void refreshProviderQuotaIndicator(provider);
+    }
   };
   const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
   const pwaLaunchAction=(window.HermesPWA&&typeof window.HermesPWA.launchAction==='function')

--- a/static/index.html
+++ b/static/index.html
@@ -733,7 +733,7 @@
               <span class="composer-model-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg></span>
               <span class="composer-mobile-config-copy"><span class="composer-mobile-config-kicker" data-i18n="composer_mobile_model">Model</span><span class="composer-mobile-config-value" id="composerMobileModelLabel"></span></span>
             </button>
-            <button class="composer-mobile-config-action" id="composerMobileQuotaAction" type="button" onclick="switchPanel('settings');switchSettingsSection('providers')" title="Provider quota" style="display:none">
+            <button class="composer-mobile-config-action" id="composerMobileQuotaAction" type="button" onclick="switchPanel('settings');switchSettingsSection('providers')" title="Provider quota" hidden>
               <span class="composer-model-icon" aria-hidden="true"><span class="provider-quota-chip-dot" style="box-shadow:none"></span></span>
               <span class="composer-mobile-config-copy"><span class="composer-mobile-config-kicker" data-i18n="composer_mobile_quota">Quota</span><span class="composer-mobile-config-value" id="composerMobileQuotaLabel"></span></span>
             </button>

--- a/static/messages.js
+++ b/static/messages.js
@@ -1831,6 +1831,7 @@ async function send(){
       if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       removeThinking();
       S.session=null;S.messages=[];
+      if(typeof _syncProviderQuotaForActiveContext==='function') _syncProviderQuotaForActiveContext();
       setBusy(false);setComposerStatus('');
       if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
       if(typeof renderMessages==='function') renderMessages();

--- a/static/panels.js
+++ b/static/panels.js
@@ -9361,7 +9361,9 @@ async function loadSettingsPanel(){
       showQuotaChipCb.addEventListener('change',()=>{
         window._showQuotaChip=showQuotaChipCb.checked;
         if(typeof refreshProviderQuotaIndicator==='function'){
-          const provider=(typeof S!=='undefined'&&S&&S.session&&S.session.model_provider)||null;
+          const provider=(typeof _currentQuotaProvider==='function')
+            ? _currentQuotaProvider()
+            : ((typeof S!=='undefined'&&S&&S.session&&S.session.model_provider)||null);
           void refreshProviderQuotaIndicator(provider);
         }
         _schedulePreferencesAutosave();

--- a/static/panels.js
+++ b/static/panels.js
@@ -9360,7 +9360,10 @@ async function loadSettingsPanel(){
       window._showQuotaChip=showQuotaChipCb.checked;
       showQuotaChipCb.addEventListener('change',()=>{
         window._showQuotaChip=showQuotaChipCb.checked;
-        if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
+        if(typeof refreshProviderQuotaIndicator==='function'){
+          const provider=(typeof S!=='undefined'&&S&&S.session&&S.session.model_provider)||null;
+          void refreshProviderQuotaIndicator(provider);
+        }
         _schedulePreferencesAutosave();
       },{once:false});
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1551,7 +1551,6 @@ async function newSession(flash, options={}){
       });
     }
     updateQueueBadge(S.session.session_id);
-    if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);
     syncTopbar();renderMessages();
     if(typeof _announceNewSessionWorkspace==='function') _announceNewSessionWorkspace(S.session);
     // Keep new-chat first paint instant. The workspace tree / git badge can
@@ -2005,7 +2004,6 @@ async function loadSession(sid){
     try { window._resetScrollDirectionTracker(); } catch (_) {}
   }
   if(typeof _applyPendingSessionModelForSession==='function') _applyPendingSessionModelForSession(sid);
-  if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);
   _resolveSessionModelForDisplaySoon(sid);
   // Sync workspace display immediately so the chip label reflects the new session's workspace
   // before any async message-loading begins (mirrors how model is handled).
@@ -4317,6 +4315,7 @@ function _renderBatchActionBar(){
       ids.forEach(_clearHandoffStorageForSession);
       if(S.session&&ids.includes(S.session.session_id)){
         S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
+        if(typeof _syncProviderQuotaForActiveContext==='function') _syncProviderQuotaForActiveContext();
         if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions'+_sessionListQueryString());
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
@@ -9066,6 +9065,7 @@ async function deleteSession(sid, beforeDelete=null){
   }
   if(S.session&&S.session.session_id===sid){
     S.session=null;S.messages=[];S.entries=[];
+    if(typeof _syncProviderQuotaForActiveContext==='function') _syncProviderQuotaForActiveContext();
     if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
     localStorage.removeItem('hermes-webui-session');
     // load the most recent remaining session, or show blank if none left

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1551,6 +1551,7 @@ async function newSession(flash, options={}){
       });
     }
     updateQueueBadge(S.session.session_id);
+    if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);
     syncTopbar();renderMessages();
     if(typeof _announceNewSessionWorkspace==='function') _announceNewSessionWorkspace(S.session);
     // Keep new-chat first paint instant. The workspace tree / git badge can
@@ -2004,6 +2005,7 @@ async function loadSession(sid){
     try { window._resetScrollDirectionTracker(); } catch (_) {}
   }
   if(typeof _applyPendingSessionModelForSession==='function') _applyPendingSessionModelForSession(sid);
+  if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);
   _resolveSessionModelForDisplaySoon(sid);
   // Sync workspace display immediately so the chip label reflects the new session's workspace
   // before any async message-loading begins (mirrors how model is handled).

--- a/static/style.css
+++ b/static/style.css
@@ -2684,6 +2684,7 @@
   .composer-mobile-config-panel{display:none;position:absolute;left:8px;right:8px;bottom:calc(100% + 6px);z-index:180;padding:8px;gap:8px;align-items:stretch;justify-content:flex-start;flex-wrap:wrap;background:var(--surface);border:1px solid var(--border2);border-radius:12px;box-shadow:0 -6px 28px rgba(0,0,0,.35);overflow:visible;}
   .composer-mobile-config-panel.open{display:flex;}
   .composer-mobile-config-action{box-sizing:border-box;display:inline-flex;align-items:center;gap:10px;min-width:0;min-height:44px;padding:8px 10px;border-radius:10px;border:1px solid transparent;background:transparent;color:var(--muted);font:inherit;text-align:left;cursor:pointer;overflow:hidden;}
+  .composer-mobile-config-action[hidden]{display:none!important;}
   .composer-mobile-config-action.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);}
   .composer-mobile-config-copy{display:flex;flex-direction:column;gap:1px;min-width:0;line-height:1.2;}
   /* The kicker labels (WORKSPACE / MODEL / REASONING / CONTEXT) duplicate the

--- a/static/ui.js
+++ b/static/ui.js
@@ -2766,6 +2766,7 @@ setTimeout(_initMediaPlaybackObserver,0);
 // Only the newest request may update the composer; otherwise an old Codex result
 // can reappear while the active conversation uses another provider.
 let _providerQuotaRefreshSeq=0;
+let _providerQuotaContextIdentity;
 
 function _formatQuotaMoneyShort(value){
   const n=Number(value);
@@ -2863,14 +2864,32 @@ async function refreshProviderQuotaIndicator(providerId){
 // back to the retained empty-composer model override so a non-default provider
 // selected before opening a conversation still scopes the quota request.
 function _currentQuotaProvider(){
-  if(typeof S!=='undefined'&&S&&S.session&&S.session.model_provider){
-    return S.session.model_provider;
+  if(typeof S!=='undefined'&&S&&S.session){
+    return S.session.model_provider||null;
   }
   if(typeof _readEmptyComposerModelOverride==='function'){
     const override=_readEmptyComposerModelOverride();
     if(override&&override.model_provider) return override.model_provider;
   }
   return null;
+}
+// Keep account-quota state aligned with the authoritative session/composer
+// context without turning syncTopbar() into a high-frequency network poll.
+// Session identity is part of the key so switching between conversations is a
+// real refresh even when both use the same provider. Explicit visibility and
+// Settings refreshes intentionally bypass this de-duplication.
+function _syncProviderQuotaForActiveContext(){
+  if(typeof S==='undefined'||!S||S._bootReady!==true) return;
+  const provider=_currentQuotaProvider();
+  const providerIdentity=String(provider||'').trim();
+  const contextIdentity=S.session
+    ? 'session:'+String(S.session.session_id||'')+'|provider:'+providerIdentity
+    : 'composer|provider:'+providerIdentity;
+  if(contextIdentity===_providerQuotaContextIdentity) return;
+  _providerQuotaContextIdentity=contextIdentity;
+  if(typeof refreshProviderQuotaIndicator==='function'){
+    void refreshProviderQuotaIndicator(provider);
+  }
 }
 window.addEventListener('visibilitychange',()=>{
   if(document.visibilityState==='visible'&&typeof refreshProviderQuotaIndicator==='function'){
@@ -10705,6 +10724,7 @@ function syncTopbar(){
     if(_profileLabel) _profileLabel.textContent=S.activeProfile||'default';
     const _titleLabel=$('titlebarProfileLabel');
     if(_titleLabel) _titleLabel.textContent=S.activeProfile||'default';
+    if(typeof _syncProviderQuotaForActiveContext==='function') _syncProviderQuotaForActiveContext();
     return;
   }
   const sessionTitle=S.session.title||t('untitled');
@@ -10832,6 +10852,7 @@ function syncTopbar(){
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
   const titleLabel=$('titlebarProfileLabel');
   if(titleLabel) titleLabel.textContent=S.activeProfile||'default';
+  if(typeof _syncProviderQuotaForActiveContext==='function') _syncProviderQuotaForActiveContext();
 }
 
 function msgContent(m){

--- a/static/ui.js
+++ b/static/ui.js
@@ -2858,10 +2858,23 @@ async function refreshProviderQuotaIndicator(providerId){
     clearProviderQuotaIndicator();
   }
 }
+// Resolve the provider that should drive the composer quota request.
+// Prefers the active session's provider; when the composer is empty, falls
+// back to the retained empty-composer model override so a non-default provider
+// selected before opening a conversation still scopes the quota request.
+function _currentQuotaProvider(){
+  if(typeof S!=='undefined'&&S&&S.session&&S.session.model_provider){
+    return S.session.model_provider;
+  }
+  if(typeof _readEmptyComposerModelOverride==='function'){
+    const override=_readEmptyComposerModelOverride();
+    if(override&&override.model_provider) return override.model_provider;
+  }
+  return null;
+}
 window.addEventListener('visibilitychange',()=>{
   if(document.visibilityState==='visible'&&typeof refreshProviderQuotaIndicator==='function'){
-    const provider=(typeof S!=='undefined'&&S&&S.session&&S.session.model_provider)||null;
-    void refreshProviderQuotaIndicator(provider);
+    void refreshProviderQuotaIndicator(_currentQuotaProvider());
   }
 });
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -2762,7 +2762,10 @@ else _initMediaPlaybackObserver();
 setTimeout(_initMediaPlaybackObserver,0);
 
 // ── Ambient provider quota indicator (#1766) ────────────────────────────────
-let _providerQuotaRefreshInFlight=false;
+// A provider switch can complete before an older account-quota request returns.
+// Only the newest request may update the composer; otherwise an old Codex result
+// can reappear while the active conversation uses another provider.
+let _providerQuotaRefreshSeq=0;
 
 function _formatQuotaMoneyShort(value){
   const n=Number(value);
@@ -2799,62 +2802,67 @@ function _providerQuotaIndicatorText(status){
   }
   return null;
 }
+function clearProviderQuotaIndicator(){
+  const chip=$('providerQuotaChip');
+  const label=$('providerQuotaChipLabel');
+  const mobileAction=$('composerMobileQuotaAction');
+  const mobileLabel=$('composerMobileQuotaLabel');
+  if(chip){chip.hidden=true;chip.removeAttribute('title');}
+  if(label) label.textContent='';
+  if(mobileAction){mobileAction.hidden=true;mobileAction.removeAttribute('title');}
+  if(mobileLabel) mobileLabel.textContent='';
+}
 function renderProviderQuotaIndicator(status){
   const chip=$('providerQuotaChip');
   const label=$('providerQuotaChipLabel');
   const mobileAction=$('composerMobileQuotaAction');
   const mobileLabel=$('composerMobileQuotaLabel');
-  if(!chip||!label) return;
+  if(!chip||!label){
+    clearProviderQuotaIndicator();
+    return;
+  }
   // Hide entirely when the user has disabled the ambient quota chip in Settings.
   // Boot defaults this on; an explicit false preference suppresses it.
   if(window._showQuotaChip!==true){
-    chip.hidden=true;
-    label.textContent='';
-    chip.removeAttribute('title');
-    if(mobileAction){mobileAction.style.display='none';mobileAction.removeAttribute('title');}
-    if(mobileLabel) mobileLabel.textContent='';
+    clearProviderQuotaIndicator();
     return;
   }
   const text=_providerQuotaIndicatorText(status);
   if(!text||status.status!=='available'||(!status.quota&&!status.account_limits)){
-    chip.hidden=true;
-    label.textContent='';
-    chip.removeAttribute('title');
-    if(mobileAction){mobileAction.style.display='none';mobileAction.removeAttribute('title');}
-    if(mobileLabel) mobileLabel.textContent='';
+    clearProviderQuotaIndicator();
     return;
   }
   label.textContent=text.label;
   chip.title=text.title;
-  chip.hidden=false;
-  if(mobileAction){mobileAction.style.display='';mobileAction.title=text.title;}
   if(mobileLabel) mobileLabel.textContent=text.label;
+  if(mobileAction) mobileAction.title=text.title;
+  chip.hidden=false;
+  if(mobileAction) mobileAction.hidden=false;
 }
-async function refreshProviderQuotaIndicator(){
+async function refreshProviderQuotaIndicator(providerId){
+  const requestSeq=++_providerQuotaRefreshSeq;
+  // Clear before the request so the old provider's account state is not visible
+  // or keyboard-reachable while the active session changes provider.
+  clearProviderQuotaIndicator();
   // Short-circuit before the fetch when the chip is disabled — no point asking
   // the server for quota data the UI will throw away.
-  if(window._showQuotaChip!==true){
-    const chip=$('providerQuotaChip');
-    if(chip){chip.hidden=true;chip.removeAttribute('title');}
-    const mobileAction=$('composerMobileQuotaAction');
-    if(mobileAction){mobileAction.style.display='none';mobileAction.removeAttribute('title');}
-    const mobileLabel=$('composerMobileQuotaLabel');
-    if(mobileLabel) mobileLabel.textContent='';
-    return;
-  }
-  if(_providerQuotaRefreshInFlight) return;
-  _providerQuotaRefreshInFlight=true;
+  if(window._showQuotaChip!==true) return;
+  const provider=String(providerId||'').trim();
+  const query=provider?'?provider='+encodeURIComponent(provider):'';
   try{
-    const status=await api('/api/provider/quota');
+    const status=await api('/api/provider/quota'+query);
+    if(requestSeq!==_providerQuotaRefreshSeq) return;
     renderProviderQuotaIndicator(status);
   }catch(_e){
-    renderProviderQuotaIndicator(null);
-  }finally{
-    _providerQuotaRefreshInFlight=false;
+    if(requestSeq!==_providerQuotaRefreshSeq) return;
+    clearProviderQuotaIndicator();
   }
 }
 window.addEventListener('visibilitychange',()=>{
-  if(document.visibilityState==='visible'&&typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
+  if(document.visibilityState==='visible'&&typeof refreshProviderQuotaIndicator==='function'){
+    const provider=(typeof S!=='undefined'&&S&&S.session&&S.session.model_provider)||null;
+    void refreshProviderQuotaIndicator(provider);
+  }
 });
 
 // Dynamic model labels -- populated by populateModelDropdown(), fallback to static map

--- a/tests/test_issue1766_quota_topbar.py
+++ b/tests/test_issue1766_quota_topbar.py
@@ -23,21 +23,27 @@ def test_quota_indicator_is_near_model_picker_in_composer_chrome():
     assert 'hidden' in INDEX[quota_idx - 200 : quota_idx + 400]
 
 
-def test_quota_indicator_fetches_provider_quota_on_boot():
+def test_quota_indicator_fetches_provider_quota_after_provider_state_is_known():
     assert "function refreshProviderQuotaIndicator" in UI_JS
-    assert "api('/api/provider/quota')" in UI_JS
-    assert "refreshProviderQuotaIndicator" in BOOT_JS
+    assert "'/api/provider/quota'+query" in UI_JS
+    assert "encodeURIComponent(provider)" in UI_JS
+    assert "refreshProviderQuotaIndicator(S.session.model_provider||null)" in BOOT_JS
 
 
 def test_quota_indicator_hides_unsupported_or_failed_statuses():
+    clear_idx = UI_JS.find("function clearProviderQuotaIndicator")
     render_idx = UI_JS.find("function renderProviderQuotaIndicator")
+    assert clear_idx != -1, "quota clearing helper must exist"
     assert render_idx != -1, "renderProviderQuotaIndicator helper must exist"
-    render_block = UI_JS[render_idx : UI_JS.find("function ", render_idx + 1)]
+    clear_block = UI_JS[clear_idx:render_idx]
+    render_block = UI_JS[render_idx : UI_JS.find("async function", render_idx + 1)]
 
-    assert "providerQuotaChip" in render_block
-    assert "chip.hidden=true" in render_block
+    assert "providerQuotaChip" in clear_block
+    assert "chip.hidden=true" in clear_block
+    assert "mobileAction.hidden=true" in clear_block
     assert "status.status!=='available'" in render_block
     assert "!status.quota" in render_block
+    assert "clearProviderQuotaIndicator()" in render_block
     assert "unsupported" not in render_block.lower(), "ambient chip should disappear instead of showing noisy unsupported text"
 
 

--- a/tests/test_issue1766_quota_topbar.py
+++ b/tests/test_issue1766_quota_topbar.py
@@ -27,7 +27,11 @@ def test_quota_indicator_fetches_provider_quota_after_provider_state_is_known():
     assert "function refreshProviderQuotaIndicator" in UI_JS
     assert "'/api/provider/quota'+query" in UI_JS
     assert "encodeURIComponent(provider)" in UI_JS
-    assert "refreshProviderQuotaIndicator(S.session.model_provider||null)" in BOOT_JS
+    assert "function _syncProviderQuotaForActiveContext" in UI_JS
+    topbar_start = UI_JS.index("function syncTopbar(){")
+    topbar_end = UI_JS.index("function msgContent", topbar_start)
+    assert "_syncProviderQuotaForActiveContext()" in UI_JS[topbar_start:topbar_end]
+    assert "_syncProviderQuotaForActiveContext()" in BOOT_JS
 
 
 def test_quota_indicator_hides_unsupported_or_failed_statuses():

--- a/tests/test_provider_quota_session_identity.py
+++ b/tests/test_provider_quota_session_identity.py
@@ -235,6 +235,18 @@ return {provider};
     assert report["provider"] == "anthropic"
 
 
+def test_current_quota_provider_does_not_fall_back_past_an_active_session():
+    report = _run_quota_scenario(
+        """
+S.session = {session_id: 's1', model_provider: null};
+_emptyComposerModelOverride = {model: 'ollama-cloud/llama-3.3', model_provider: 'ollama-cloud'};
+return {provider: _currentQuotaProvider()};
+"""
+    )
+
+    assert report["provider"] is None
+
+
 def test_current_quota_provider_returns_null_when_no_session_and_no_override():
     report = _run_quota_scenario(
         """
@@ -246,38 +258,114 @@ return {provider};
     assert report["provider"] is None
 
 
+def test_active_context_sync_refreshes_only_when_provider_identity_changes():
+    report = _run_quota_scenario(
+        """
+S._bootReady = false;
+S.session = {session_id: 's1', model_provider: 'openai-codex'};
+_syncProviderQuotaForActiveContext();
+const beforeBoot = requests.length;
+
+S._bootReady = true;
+_syncProviderQuotaForActiveContext();
+_syncProviderQuotaForActiveContext();
+S.session = {session_id: 's2', model_provider: 'anthropic'};
+_syncProviderQuotaForActiveContext();
+S.session = null;
+_emptyComposerModelOverride = {model: 'llama-3.3', model_provider: 'ollama-cloud'};
+_syncProviderQuotaForActiveContext();
+_emptyComposerModelOverride = null;
+_syncProviderQuotaForActiveContext();
+
+return {beforeBoot, requests, pendingCount: pending.length};
+"""
+    )
+
+    assert report == {
+        "beforeBoot": 0,
+        "requests": [
+            "/api/provider/quota?provider=openai-codex",
+            "/api/provider/quota?provider=anthropic",
+            "/api/provider/quota?provider=ollama-cloud",
+            "/api/provider/quota",
+        ],
+        "pendingCount": 4,
+    }
+
+
 def _between(source: str, start: str, end: str) -> str:
     start_at = source.index(start)
     return source[start_at : source.index(end, start_at)]
 
 
 def test_provider_quota_refresh_follows_each_authoritative_provider_transition():
+    ui_js = UI_JS.read_text(encoding="utf-8")
     boot = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
     sessions = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    messages = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+    topbar = _between(ui_js, "function syncTopbar(){", "function msgContent")
+    empty_topbar = _between(topbar, "if(!S.session){", "const sessionTitle")
+    assert "_syncProviderQuotaForActiveContext()" in empty_topbar
+    assert topbar.rstrip().endswith("_syncProviderQuotaForActiveContext();\n}")
 
     onchange = _between(boot, "$('modelSelect').onchange=async()=>", "$('msg').addEventListener")
     active_assign = onchange.index("S.session.model_provider=modelState.model_provider||null;")
-    active_refresh = onchange.index("refreshProviderQuotaIndicator(S.session.model_provider||null)")
+    active_sync = onchange.index("syncTopbar()")
     update = onchange.index("await api('/api/session/update'")
-    assert active_assign < active_refresh < update
+    assert active_assign < active_sync < update
 
     empty_branch = _between(onchange, "if(!S.session){", "if(typeof _rememberPendingSessionModel")
-    assert "refreshProviderQuotaIndicator(modelState.model_provider||null)" in empty_branch
+    assert "_syncProviderQuotaForActiveContext()" in empty_branch
 
     load = _between(sessions, "async function loadSession", "activeStreamId=S.session.active_stream_id")
     pending_model = load.index("_applyPendingSessionModelForSession(sid)")
-    loaded_refresh = load.index("refreshProviderQuotaIndicator(S.session.model_provider||null)")
     first_topbar = load.index("syncTopbar()")
-    assert pending_model < loaded_refresh < first_topbar
+    assert pending_model < first_topbar
 
     new_session = _between(sessions, "async function newSession", "function _clearStuckSessionOnBoot")
     server_session = new_session.index("S.session=data.session;S.messages=data.session.messages||[];")
-    new_refresh = new_session.index("refreshProviderQuotaIndicator(S.session.model_provider||null)")
     new_topbar = new_session.index("syncTopbar();renderMessages();")
-    assert server_session < new_refresh < new_topbar
+    assert server_session < new_topbar
+
+    # Direct refreshes are reserved for explicit force-refresh events. Normal
+    # state transitions converge on the de-duplicated active-context helper.
+    assert "refreshProviderQuotaIndicator(" not in boot
+    assert "refreshProviderQuotaIndicator(" not in sessions
+    assert "refreshProviderQuotaIndicator(" not in messages
+
+    batch_clear = _between(sessions, "if(S.session&&ids.includes(S.session.session_id)){", "const remaining=await api")
+    single_clear = _between(sessions, "if(S.session&&S.session.session_id===sid){", "const remaining=await api")
+    terminal_clear = _between(messages, "if(e&&e.status===404){", "const conflictActiveStream")
+    assert "_syncProviderQuotaForActiveContext()" in batch_clear
+    assert "_syncProviderQuotaForActiveContext()" in single_clear
+    assert "_syncProviderQuotaForActiveContext()" in terminal_clear
 
     boot_prefix = boot[: boot.index("const saved=urlSession||savedLocal;")]
     assert "refreshProviderQuotaIndicator();" not in boot_prefix
+
+
+def test_reviewer_identified_direct_session_transitions_reach_sync_topbar():
+    ui_js = UI_JS.read_text(encoding="utf-8")
+    panels = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    messages = (ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+    start_correction = _between(
+        messages,
+        "if(startData&&startData.effective_model && S.session){",
+        "if(S.session&&typeof startData.pending_started_at==='number')",
+    )
+    assert start_correction.count("syncTopbar()") == 2
+    assert "S.session.model_provider=startData.effective_model_provider||S.session.model_provider||null;" in start_correction
+    assert "S.session.model_provider=startData.effective_model_provider;" in start_correction
+
+    new_file = _between(ui_js, "async function promptNewFile", "async function promptNewFolder")
+    new_folder = _between(ui_js, "async function promptNewFolder", "async function uploadPendingFiles")
+    workspace_prompt = _between(panels, "async function promptWorkspacePath", "async function switchToWorkspace")
+    workspace_switch = _between(panels, "async function switchToWorkspace", "// ── Profile panel + dropdown")
+    for transition in (new_file, new_folder, workspace_prompt, workspace_switch):
+        assert "S.session=r.session" in transition
+        assert "syncTopbar()" in transition
 
 
 def test_restored_empty_session_keeps_provider_through_boot_demotion():
@@ -298,10 +386,10 @@ def test_restored_empty_session_keeps_provider_through_boot_demotion():
         "S.session=data.session;",
         "// Loading a real existing session abandons",
     )
-    load_quota_refresh = "if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);"
-    assert load_quota_refresh in sessions
+    direct_load_refresh = "if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);"
+    assert direct_load_refresh not in sessions
     quota_provider = _between(ui_js, "function _currentQuotaProvider", "window.addEventListener('visibilitychange'")
-    refresh_helper = _between(boot, "const _refreshQuotaForEmptyComposer=()=>", "const urlSession")
+    refresh_helper = _between(boot, "const _syncQuotaForBootContext=()=>", "const urlSession")
     demotion = _between(
         boot,
         "if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight && !_restoredHasDraft){",
@@ -351,7 +439,6 @@ async function run(session) {{
   window._emptyComposerModelOverride = {{model: 'stale-model', model_provider: 'stale-provider'}};
   const data = {{session}};
   {load_transition}
-  {load_quota_refresh}
   const _restoredInFlight = false;
   const _restoredHasDraft = false;
   const prefillIntent = null;
@@ -368,14 +455,9 @@ async function main() {{
   await run({{session_id: 'saved-empty', message_count: 0, model: 'llama-3.3', model_provider: 'ollama-cloud'}});
   const retainedRequests = requests.splice(0);
   const retainedPending = pending.splice(0);
-  retainedPending[1].resolve({{
+  retainedPending[0].resolve({{
     status: 'available', display_name: 'Ollama Cloud',
     account_limits: {{windows: [{{remaining_percent: 25}}]}},
-  }});
-  await Promise.resolve();
-  retainedPending[0].resolve({{
-    status: 'available', display_name: 'Stale provider',
-    account_limits: {{windows: [{{remaining_percent: 50}}]}},
   }});
   await Promise.all(retainedPending);
   const retained = {{requests: retainedRequests, finalState: snapshot()}};
@@ -403,13 +485,12 @@ main().then(report => process.stdout.write(JSON.stringify(report))).catch(error 
     report = json.loads(result.stdout)
     assert report["retained"]["requests"] == [
         "/api/provider/quota?provider=ollama-cloud",
-        "/api/provider/quota?provider=ollama-cloud",
     ]
     assert report["retained"]["finalState"] == {
         "desktop": {"hidden": False, "label": "25%"},
         "mobile": {"hidden": False, "label": "25%"},
     }
-    assert report["fallback"]["requests"] == ["/api/provider/quota", "/api/provider/quota"]
+    assert report["fallback"]["requests"] == ["/api/provider/quota"]
 
 
 def test_visibility_and_settings_refresh_use_current_quota_provider_helper():

--- a/tests/test_provider_quota_session_identity.py
+++ b/tests/test_provider_quota_session_identity.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def _quota_region() -> str:
     source = UI_JS.read_text(encoding="utf-8")
     start = source.index("// ── Ambient provider quota indicator")
-    end = source.index("window.addEventListener('visibilitychange'", start)
+    end = source.index("// Dynamic model labels", start)
     return source[start:end]
 
 
@@ -54,7 +54,12 @@ const nodes = {{
   composerMobileQuotaLabel: makeNode(),
 }};
 function $(id) {{ return nodes[id] || null; }}
-const window = {{_showQuotaChip: true}};
+const window = {{_showQuotaChip: true, addEventListener: () => {{}}}};
+const S = {{session: null}};
+let _emptyComposerModelOverride = null;
+function _readEmptyComposerModelOverride() {{
+  return _emptyComposerModelOverride;
+}}
 function api(url) {{
   requests.push(url);
   return new Promise((resolve, reject) => pending.push({{resolve, reject}}));
@@ -201,6 +206,46 @@ return {requests, finalState: snapshot()};
     }
 
 
+def test_current_quota_provider_falls_back_to_empty_composer_override():
+    report = _run_quota_scenario(
+        """
+// Simulate an empty composer with a non-default provider selected.
+_emptyComposerModelOverride = {model: 'ollama-cloud/llama-3.3', model_provider: 'ollama-cloud'};
+const provider = _currentQuotaProvider();
+const request = refreshProviderQuotaIndicator(provider);
+return {requests, provider, pendingCount: pending.length};
+"""
+    )
+
+    assert report["provider"] == "ollama-cloud"
+    assert report["requests"] == ["/api/provider/quota?provider=ollama-cloud"]
+
+
+def test_current_quota_provider_prefers_session_provider_over_empty_composer_override():
+    report = _run_quota_scenario(
+        """
+// Active session takes priority over the empty-composer override.
+S.session = {session_id: 's1', model_provider: 'anthropic'};
+_emptyComposerModelOverride = {model: 'ollama-cloud/llama-3.3', model_provider: 'ollama-cloud'};
+const provider = _currentQuotaProvider();
+return {provider};
+"""
+    )
+
+    assert report["provider"] == "anthropic"
+
+
+def test_current_quota_provider_returns_null_when_no_session_and_no_override():
+    report = _run_quota_scenario(
+        """
+const provider = _currentQuotaProvider();
+return {provider};
+"""
+    )
+
+    assert report["provider"] is None
+
+
 def _between(source: str, start: str, end: str) -> str:
     start_at = source.index(start)
     return source[start_at : source.index(end, start_at)]
@@ -233,3 +278,16 @@ def test_provider_quota_refresh_follows_each_authoritative_provider_transition()
 
     boot_prefix = boot[: boot.index("const saved=urlSession||savedLocal;")]
     assert "refreshProviderQuotaIndicator();" not in boot_prefix
+
+
+def test_visibility_and_settings_refresh_use_current_quota_provider_helper():
+    ui_js = UI_JS.read_text(encoding="utf-8")
+    panels_js = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+    # visibilitychange in ui.js uses _currentQuotaProvider
+    vis_region = _between(ui_js, "window.addEventListener('visibilitychange'", ");")
+    assert "_currentQuotaProvider()" in vis_region
+
+    # Settings toggle in panels.js uses _currentQuotaProvider
+    toggle_region = _between(panels_js, "showQuotaChipCb.addEventListener('change'", "_schedulePreferencesAutosave();")
+    assert "_currentQuotaProvider()" in toggle_region

--- a/tests/test_provider_quota_session_identity.py
+++ b/tests/test_provider_quota_session_identity.py
@@ -280,24 +280,117 @@ def test_provider_quota_refresh_follows_each_authoritative_provider_transition()
     assert "refreshProviderQuotaIndicator();" not in boot_prefix
 
 
-def test_empty_composer_boot_refresh_uses_retained_provider_or_default_fallback():
+def test_restored_empty_session_keeps_provider_through_boot_demotion():
     assert NODE is not None
     boot = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
-    helper = _between(boot, "const _refreshQuotaForEmptyComposer=()=>", "const urlSession")
+    sessions = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    ui_js = UI_JS.read_text(encoding="utf-8")
+    remember_override = _between(
+        sessions,
+        "function _rememberEmptyComposerModelOverride",
+        "let _newSessionWorkspaceAnnouncementClearTimer",
+    )
+    clear_override = "if(typeof _clearEmptyComposerModelOverride==='function') _clearEmptyComposerModelOverride();"
+    assert clear_override in sessions
+    load_session = sessions[sessions.index("async function loadSession") :]
+    load_transition = _between(
+        load_session,
+        "S.session=data.session;",
+        "// Loading a real existing session abandons",
+    )
+    load_quota_refresh = "if(typeof refreshProviderQuotaIndicator==='function') void refreshProviderQuotaIndicator(S.session.model_provider||null);"
+    assert load_quota_refresh in sessions
+    quota_provider = _between(ui_js, "function _currentQuotaProvider", "window.addEventListener('visibilitychange'")
+    refresh_helper = _between(boot, "const _refreshQuotaForEmptyComposer=()=>", "const urlSession")
+    demotion = _between(
+        boot,
+        "if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight && !_restoredHasDraft){",
+        "// Restore the panel from localStorage when the session has a workspace.",
+    )
     script = f"""
-function run(provider) {{
-  const calls = [];
-  const S = {{session: null}};
-  const refreshProviderQuotaIndicator = value => calls.push(value);
-  const _currentQuotaProvider = provider === undefined ? undefined : () => provider;
-  const refresh = (function() {{
-    {helper}
-    return _refreshQuotaForEmptyComposer;
-  }})();
-  refresh();
-  return calls;
+const source = {json.dumps(_quota_region())};
+const requests = [];
+const pending = [];
+const window = {{_showQuotaChip: true, addEventListener: () => {{}}}};
+const localStorage = {{getItem: () => null}};
+const S = {{session: null, messages: []}};
+const _emptyComposerModelOverrideHost = window;
+function makeNode() {{
+  return {{
+    hidden: false,
+    title: '',
+    textContent: '',
+    style: {{display: ''}},
+    removeAttribute(name) {{ if(name === 'title') this.title = ''; }},
+  }};
 }}
-process.stdout.write(JSON.stringify({{retained: run('ollama-cloud'), fallback: run(undefined)}}));
+const nodes = {{
+  providerQuotaChip: makeNode(),
+  providerQuotaChipLabel: makeNode(),
+  composerMobileQuotaAction: makeNode(),
+  composerMobileQuotaLabel: makeNode(),
+  emptyState: makeNode(),
+}};
+function $(id) {{ return nodes[id] || null; }}
+{remember_override}
+{quota_provider}
+function api(url) {{
+  requests.push(url);
+  return new Promise((resolve, reject) => pending.push({{resolve, reject}}));
+}}
+eval(source);
+async function _maybeBindFreshDefaultWorkspaceSession() {{}}
+function _isCompactWorkspaceViewport() {{ return false; }}
+function syncTopbar() {{}}
+function syncWorkspacePanelState() {{}}
+async function renderSessionList() {{}}
+async function _finalizeComposerPrefillOnBoot() {{}}
+function startGatewaySSE() {{}}
+{refresh_helper}
+async function run(session) {{
+  window._emptyComposerModelOverride = {{model: 'stale-model', model_provider: 'stale-provider'}};
+  const data = {{session}};
+  {load_transition}
+  {load_quota_refresh}
+  const _restoredInFlight = false;
+  const _restoredHasDraft = false;
+  const prefillIntent = null;
+  let _workspacePanelMode = null;
+  {demotion}
+}}
+function snapshot() {{
+  return {{
+    desktop: {{hidden: nodes.providerQuotaChip.hidden, label: nodes.providerQuotaChipLabel.textContent}},
+    mobile: {{hidden: nodes.composerMobileQuotaAction.hidden, label: nodes.composerMobileQuotaLabel.textContent}},
+  }};
+}}
+async function main() {{
+  await run({{session_id: 'saved-empty', message_count: 0, model: 'llama-3.3', model_provider: 'ollama-cloud'}});
+  const retainedRequests = requests.splice(0);
+  const retainedPending = pending.splice(0);
+  retainedPending[1].resolve({{
+    status: 'available', display_name: 'Ollama Cloud',
+    account_limits: {{windows: [{{remaining_percent: 25}}]}},
+  }});
+  await Promise.resolve();
+  retainedPending[0].resolve({{
+    status: 'available', display_name: 'Stale provider',
+    account_limits: {{windows: [{{remaining_percent: 50}}]}},
+  }});
+  await Promise.all(retainedPending);
+  const retained = {{requests: retainedRequests, finalState: snapshot()}};
+  nodes.providerQuotaChip.hidden = false;
+  nodes.providerQuotaChipLabel.textContent = 'old';
+  nodes.composerMobileQuotaAction.hidden = false;
+  nodes.composerMobileQuotaLabel.textContent = 'old';
+  await run({{session_id: 'saved-empty-default', message_count: 0, model: 'default-model', model_provider: null}});
+  const fallback = {{requests: requests.splice(0)}};
+  return {{retained, fallback}};
+}}
+main().then(report => process.stdout.write(JSON.stringify(report))).catch(error => {{
+  console.error(error && error.stack || String(error));
+  process.exit(1);
+}});
 """
     result = subprocess.run(
         [NODE, "-e", script],
@@ -308,8 +401,15 @@ process.stdout.write(JSON.stringify({{retained: run('ollama-cloud'), fallback: r
     )
     assert result.returncode == 0, result.stderr
     report = json.loads(result.stdout)
-    assert report["retained"] == ["ollama-cloud"]
-    assert report["fallback"] == [None]
+    assert report["retained"]["requests"] == [
+        "/api/provider/quota?provider=ollama-cloud",
+        "/api/provider/quota?provider=ollama-cloud",
+    ]
+    assert report["retained"]["finalState"] == {
+        "desktop": {"hidden": False, "label": "25%"},
+        "mobile": {"hidden": False, "label": "25%"},
+    }
+    assert report["fallback"]["requests"] == ["/api/provider/quota", "/api/provider/quota"]
 
 
 def test_visibility_and_settings_refresh_use_current_quota_provider_helper():

--- a/tests/test_provider_quota_session_identity.py
+++ b/tests/test_provider_quota_session_identity.py
@@ -1,0 +1,235 @@
+"""Behavioral regression coverage for session-scoped composer quota state.
+
+The production quota helpers are executed in a small Node DOM harness.  These
+checks deliberately exercise the request/DOM boundary instead of only asserting
+source-string placement: a provider switch must immediately remove old quota
+content, request the selected provider, and never let an older response restore
+stale account information.
+"""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _quota_region() -> str:
+    source = UI_JS.read_text(encoding="utf-8")
+    start = source.index("// ── Ambient provider quota indicator")
+    end = source.index("window.addEventListener('visibilitychange'", start)
+    return source[start:end]
+
+
+def _run_quota_scenario(body: str) -> dict:
+    assert NODE is not None
+    source = json.dumps(_quota_region())
+    script = f"""
+const source = {source};
+const requests = [];
+const pending = [];
+function makeNode() {{
+  return {{
+    hidden: false,
+    title: '',
+    textContent: '',
+    style: {{display: ''}},
+    removeAttribute(name) {{
+      if (name === 'title') this.title = '';
+    }},
+  }};
+}}
+const nodes = {{
+  providerQuotaChip: makeNode(),
+  providerQuotaChipLabel: makeNode(),
+  composerMobileQuotaAction: makeNode(),
+  composerMobileQuotaLabel: makeNode(),
+}};
+function $(id) {{ return nodes[id] || null; }}
+const window = {{_showQuotaChip: true}};
+function api(url) {{
+  requests.push(url);
+  return new Promise((resolve, reject) => pending.push({{resolve, reject}}));
+}}
+eval(source);
+function snapshot() {{
+  return {{
+    desktop: {{
+      hidden: nodes.providerQuotaChip.hidden,
+      label: nodes.providerQuotaChipLabel.textContent,
+      title: nodes.providerQuotaChip.title,
+    }},
+    mobile: {{
+      hidden: nodes.composerMobileQuotaAction.hidden,
+      display: nodes.composerMobileQuotaAction.style.display,
+      label: nodes.composerMobileQuotaLabel.textContent,
+      title: nodes.composerMobileQuotaAction.title,
+    }},
+  }};
+}}
+async function main() {{
+  {body}
+}}
+main().then(result => process.stdout.write(JSON.stringify(result))).catch(error => {{
+  console.error(error && error.stack || String(error));
+  process.exit(1);
+}});
+"""
+    result = subprocess.run(
+        [NODE, "-e", script],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )
+    if result.returncode:
+        raise RuntimeError(f"Node quota harness failed:\n{result.stderr}")
+    return json.loads(result.stdout)
+
+
+def _seed_stale_codex() -> str:
+    return """
+nodes.providerQuotaChip.hidden = false;
+nodes.providerQuotaChip.title = 'OpenAI Codex — 42% remaining';
+nodes.providerQuotaChipLabel.textContent = '42%';
+nodes.composerMobileQuotaAction.hidden = false;
+nodes.composerMobileQuotaAction.style.display = '';
+nodes.composerMobileQuotaAction.title = 'OpenAI Codex — 42% remaining';
+nodes.composerMobileQuotaLabel.textContent = '42%';
+"""
+
+
+def test_refresh_scopes_request_to_explicit_session_provider_and_clears_codex_dom_first():
+    report = _run_quota_scenario(
+        _seed_stale_codex()
+        + """
+const request = refreshProviderQuotaIndicator('ollama-cloud');
+return {requests, beforeResponse: snapshot(), pendingCount: pending.length};
+"""
+    )
+
+    assert report["requests"] == ["/api/provider/quota?provider=ollama-cloud"]
+    assert report["pendingCount"] == 1
+    assert report["beforeResponse"]["desktop"] == {"hidden": True, "label": "", "title": ""}
+    assert report["beforeResponse"]["mobile"] == {
+        "hidden": True,
+        "display": "",
+        "label": "",
+        "title": "",
+    }
+
+
+def test_unsupported_selected_provider_keeps_desktop_and_mobile_quota_controls_hidden():
+    report = _run_quota_scenario(
+        _seed_stale_codex()
+        + """
+const request = refreshProviderQuotaIndicator('ollama-cloud');
+pending[0].resolve({status: 'unsupported', quota: null, account_limits: null});
+await request;
+return snapshot();
+"""
+    )
+
+    assert report["desktop"] == {"hidden": True, "label": "", "title": ""}
+    assert report["mobile"] == {"hidden": True, "display": "", "label": "", "title": ""}
+
+
+def test_late_codex_quota_response_cannot_overwrite_newer_provider_state():
+    report = _run_quota_scenario(
+        """
+const codex = refreshProviderQuotaIndicator('openai-codex');
+const ollama = refreshProviderQuotaIndicator('ollama-cloud');
+pending[1].resolve({status: 'unsupported', quota: null, account_limits: null});
+await ollama;
+pending[0].resolve({
+  status: 'available',
+  provider: 'openai-codex',
+  display_name: 'OpenAI Codex',
+  message: 'Account usage loaded',
+  account_limits: {windows: [{remaining_percent: 50}]},
+});
+await codex;
+return {requests, finalState: snapshot()};
+"""
+    )
+
+    assert report["requests"] == [
+        "/api/provider/quota?provider=openai-codex",
+        "/api/provider/quota?provider=ollama-cloud",
+    ]
+    assert report["finalState"]["desktop"] == {"hidden": True, "label": "", "title": ""}
+    assert report["finalState"]["mobile"] == {
+        "hidden": True,
+        "display": "",
+        "label": "",
+        "title": "",
+    }
+
+
+def test_disabled_setting_invalidates_any_inflight_quota_response():
+    report = _run_quota_scenario(
+        """
+const request = refreshProviderQuotaIndicator('openai-codex');
+window._showQuotaChip = false;
+const disabled = refreshProviderQuotaIndicator('ollama-cloud');
+pending[0].resolve({
+  status: 'available',
+  provider: 'openai-codex',
+  display_name: 'OpenAI Codex',
+  account_limits: {windows: [{remaining_percent: 50}]},
+});
+await Promise.all([request, disabled]);
+return {requests, finalState: snapshot()};
+"""
+    )
+
+    assert report["requests"] == ["/api/provider/quota?provider=openai-codex"]
+    assert report["finalState"]["desktop"] == {"hidden": True, "label": "", "title": ""}
+    assert report["finalState"]["mobile"] == {
+        "hidden": True,
+        "display": "",
+        "label": "",
+        "title": "",
+    }
+
+
+def _between(source: str, start: str, end: str) -> str:
+    start_at = source.index(start)
+    return source[start_at : source.index(end, start_at)]
+
+
+def test_provider_quota_refresh_follows_each_authoritative_provider_transition():
+    boot = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+    sessions = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    onchange = _between(boot, "$('modelSelect').onchange=async()=>", "$('msg').addEventListener")
+    active_assign = onchange.index("S.session.model_provider=modelState.model_provider||null;")
+    active_refresh = onchange.index("refreshProviderQuotaIndicator(S.session.model_provider||null)")
+    update = onchange.index("await api('/api/session/update'")
+    assert active_assign < active_refresh < update
+
+    empty_branch = _between(onchange, "if(!S.session){", "if(typeof _rememberPendingSessionModel")
+    assert "refreshProviderQuotaIndicator(modelState.model_provider||null)" in empty_branch
+
+    load = _between(sessions, "async function loadSession", "activeStreamId=S.session.active_stream_id")
+    pending_model = load.index("_applyPendingSessionModelForSession(sid)")
+    loaded_refresh = load.index("refreshProviderQuotaIndicator(S.session.model_provider||null)")
+    first_topbar = load.index("syncTopbar()")
+    assert pending_model < loaded_refresh < first_topbar
+
+    new_session = _between(sessions, "async function newSession", "function _clearStuckSessionOnBoot")
+    server_session = new_session.index("S.session=data.session;S.messages=data.session.messages||[];")
+    new_refresh = new_session.index("refreshProviderQuotaIndicator(S.session.model_provider||null)")
+    new_topbar = new_session.index("syncTopbar();renderMessages();")
+    assert server_session < new_refresh < new_topbar
+
+    boot_prefix = boot[: boot.index("const saved=urlSession||savedLocal;")]
+    assert "refreshProviderQuotaIndicator();" not in boot_prefix

--- a/tests/test_provider_quota_session_identity.py
+++ b/tests/test_provider_quota_session_identity.py
@@ -280,6 +280,38 @@ def test_provider_quota_refresh_follows_each_authoritative_provider_transition()
     assert "refreshProviderQuotaIndicator();" not in boot_prefix
 
 
+def test_empty_composer_boot_refresh_uses_retained_provider_or_default_fallback():
+    assert NODE is not None
+    boot = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+    helper = _between(boot, "const _refreshQuotaForEmptyComposer=()=>", "const urlSession")
+    script = f"""
+function run(provider) {{
+  const calls = [];
+  const S = {{session: null}};
+  const refreshProviderQuotaIndicator = value => calls.push(value);
+  const _currentQuotaProvider = provider === undefined ? undefined : () => provider;
+  const refresh = (function() {{
+    {helper}
+    return _refreshQuotaForEmptyComposer;
+  }})();
+  refresh();
+  return calls;
+}}
+process.stdout.write(JSON.stringify({{retained: run('ollama-cloud'), fallback: run(undefined)}}));
+"""
+    result = subprocess.run(
+        [NODE, "-e", script],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["retained"] == ["ollama-cloud"]
+    assert report["fallback"] == [None]
+
+
 def test_visibility_and_settings_refresh_use_current_quota_provider_helper():
     ui_js = UI_JS.read_text(encoding="utf-8")
     panels_js = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")

--- a/tests/test_quota_chip_settings_toggle.py
+++ b/tests/test_quota_chip_settings_toggle.py
@@ -50,7 +50,7 @@ def test_quota_chip_render_short_circuits_when_disabled():
     )
 
     # Refresher must short-circuit fetch when disabled
-    refresh_start = js.index("async function refreshProviderQuotaIndicator(){")
+    refresh_start = js.index("async function refreshProviderQuotaIndicator(providerId){")
     # Find the closing brace of the function — first 'try{' line marks the live body
     # Just check the entire snippet ahead of try{
     refresh_head = js[refresh_start:js.index("try{", refresh_start)]
@@ -82,8 +82,10 @@ def test_quota_chip_panels_round_trip():
     assert "showQuotaChipCb.checked=settings.show_quota_chip===true;" in js
     # Window-state propagation
     assert "window._showQuotaChip=showQuotaChip===true;" in js
-    # Live refresh on toggle (immediate visual feedback)
-    assert "if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();" in js
+    # Live refresh uses the active session provider (immediate visual feedback without
+    # falling back to a different configured default during a provider-specific chat).
+    assert "refreshProviderQuotaIndicator(provider)" in js
+    assert "S.session.model_provider" in js
 
 
 def test_quota_chip_localized_in_all_locales():


### PR DESCRIPTION
## Summary

The composer quota control should reflect the provider selected for the active conversation. A saved session can use a provider that differs from the configured default.

Previously, boot requested `/api/provider/quota` before restoring the saved session and without passing its provider. The backend then fell back to the configured default provider, allowing OpenAI Codex quota information to remain visible after a provider switch or hard refresh.

This change resolves quota state from the active session provider, clears stale controls before replacement data arrives, and ignores superseded responses.

## What Changed

Quota requests now include the selected session provider when it is known. The initial refresh now waits until session restoration, new-session creation, or model selection has established the provider state.

The desktop and mobile quota controls are cleared before an updated request starts. The mobile control now uses the semantic `hidden` state as well. Late responses from older requests are ignored, so a delayed Codex result cannot overwrite a newer provider selection.

Settings changes and page visibility refreshes also use the active session provider rather than implicitly falling back to the configured default. The change adds behavior-driven Node/pytest coverage for provider scoping, stale-state removal, unsupported providers, disabled settings, and out-of-order responses.

## Why It Matters

The composer no longer presents one provider's quota while another provider is selected. In particular, a saved Ollama Cloud or API-key-provider session no longer leaves stale OpenAI Codex quota controls visible or reachable through screen-reader navigation after a hard refresh.

## Scope

This is a narrow composer UI state-consistency and accessibility fix. It covers composer quota display state, model and provider selection, saved-session restoration, new-session creation, and desktop or narrow/mobile control visibility.

It does not add or remove provider quota API support, or change token and context usage, model routing, credentials, or backend quota-provider policy.

## Verification

Manual verification passed in the Desktop WebUI with NVDA and the quota chip enabled. After switching to the alternate provider, the Codex quota control was removed and was no longer reachable through NVDA navigation. The deployed desktop provider-switch path also behaved correctly.
