### PR TITLE
fix(sessions): preserve active chat across hard refresh

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -132,6 +132,9 @@ function _rootPrefillNeedsFreshComposer(urlSession, savedLocal, prefillIntent){
 function _profileQueryBlocksSavedLocalRestore(profileIntent, urlSession){
   return !!(profileIntent&&profileIntent.hasParam&&profileIntent.valid&&!urlSession);
 }
+function _shouldStartFreshPwaChat(action,urlSession){
+  return action==='new-chat'&&!urlSession;
+}
 async function _applyComposerPrefillOnBoot(prefillIntent){
   if(!prefillIntent||!prefillIntent.hasText) return;
   const msg=(typeof $==='function')?$('msg'):document.getElementById('msg');
@@ -3676,7 +3679,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   const pwaLaunchAction=(window.HermesPWA&&typeof window.HermesPWA.launchAction==='function')
     ? window.HermesPWA.launchAction()
     : null;
-  if(pwaLaunchAction==='new-chat'){
+  if(_shouldStartFreshPwaChat(pwaLaunchAction,urlSession)){
     try{
       await newSession(true);
       // New-chat PWA launches need the empty conversation visible immediately.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4151,6 +4151,7 @@ function _sessionUrlForSid(sid){
     const current=new URL(window.location.href);
     current.searchParams.delete('session');
     current.searchParams.delete('session_id');
+    current.searchParams.delete('action');
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -4151,11 +4151,14 @@ function _sessionUrlForSid(sid){
     const current=new URL(window.location.href);
     current.searchParams.delete('session');
     current.searchParams.delete('session_id');
-    current.searchParams.delete('action');
     current.searchParams.delete('q');
     current.searchParams.delete('prompt');
     current.searchParams.delete('send');
-    base.search=current.searchParams.toString();
+    const retained=new URLSearchParams();
+    current.searchParams.forEach((value,key)=>{
+      if(key!=='action'||value!=='new-chat') retained.append(key,value);
+    });
+    base.search=retained.toString();
     base.hash=current.hash;
   }catch(_e){}
   return base.pathname+base.search+base.hash;
@@ -4164,7 +4167,13 @@ function _setActiveSessionUrl(sid){
   if(typeof window==='undefined'||!window.history||!sid) return;
   const next=_sessionUrlForSid(sid);
   if(next && next!==(window.location.pathname+window.location.search+window.location.hash)){
-    window.history.pushState({session_id:sid},'',next);
+    let consumeLaunchAction=false;
+    try{
+      const current=new URL(window.location.href);
+      consumeLaunchAction=current.searchParams.getAll('action').includes('new-chat');
+    }catch(_e){}
+    const method=consumeLaunchAction?'replaceState':'pushState';
+    window.history[method]({session_id:sid},'',next);
   }
 }
 

--- a/tests/test_hard_refresh_session_restore.py
+++ b/tests/test_hard_refresh_session_restore.py
@@ -1,0 +1,110 @@
+"""Regression coverage for one-shot PWA launch actions on hard refresh."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+BOOT_JS = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> dict:
+    result = subprocess.run(
+        [NODE],
+        input=source,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        encoding="utf-8",
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return json.loads(result.stdout)
+
+
+def test_new_chat_launch_action_is_consumed_before_hard_refresh():
+    source = f"""
+const sessionsSrc = {SESSIONS_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function applyUrl(rel) {{
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}}
+global.window = {{ location: {{}} }};
+global.document = {{ baseURI: 'https://example.test/app/' }};
+applyUrl('/app/?action=new-chat&keep=1#frag');
+globalThis._sessionUrlForSid = (0, eval)('(' + extractFunc(sessionsSrc, '_sessionUrlForSid') + ')');
+const promoted = _sessionUrlForSid('session-123');
+const promotedUrl = new URL(promoted, 'https://example.test');
+console.log(JSON.stringify({{
+  promoted,
+  launchAction: promotedUrl.searchParams.get('action'),
+  keep: promotedUrl.searchParams.get('keep'),
+}}));
+"""
+    payload = _run_node(source)
+
+    assert payload == {
+        "promoted": "/app/session/session-123?keep=1#frag",
+        "launchAction": None,
+        "keep": "1",
+    }
+
+
+def test_stale_new_chat_action_does_not_override_explicit_session_url():
+    source = f"""
+const bootSrc = {BOOT_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+globalThis._shouldStartFreshPwaChat = (0, eval)(
+  '(' + extractFunc(bootSrc, '_shouldStartFreshPwaChat') + ')'
+);
+console.log(JSON.stringify({{
+  freshRootLaunch: _shouldStartFreshPwaChat('new-chat', null),
+  staleSessionLaunch: _shouldStartFreshPwaChat('new-chat', 'session-123'),
+  ordinarySessionLoad: _shouldStartFreshPwaChat(null, 'session-123'),
+}}));
+"""
+    payload = _run_node(source)
+
+    assert payload == {
+        "freshRootLaunch": True,
+        "staleSessionLaunch": False,
+        "ordinarySessionLoad": False,
+    }
+    assert "if(_shouldStartFreshPwaChat(pwaLaunchAction,urlSession)){" in BOOT_JS

--- a/tests/test_hard_refresh_session_restore.py
+++ b/tests/test_hard_refresh_session_restore.py
@@ -31,7 +31,7 @@ def _run_node(source: str) -> dict:
     return json.loads(result.stdout)
 
 
-def test_new_chat_launch_action_is_consumed_before_hard_refresh():
+def test_only_exact_new_chat_launch_action_is_consumed_before_hard_refresh():
     source = f"""
 const sessionsSrc = {SESSIONS_JS!r};
 function extractFunc(src, name) {{
@@ -56,22 +56,22 @@ function applyUrl(rel) {{
 }}
 global.window = {{ location: {{}} }};
 global.document = {{ baseURI: 'https://example.test/app/' }};
-applyUrl('/app/?action=new-chat&keep=1#frag');
+applyUrl('/app/?action=new-chat&action=continue&keep=1&keep=2#frag');
 globalThis._sessionUrlForSid = (0, eval)('(' + extractFunc(sessionsSrc, '_sessionUrlForSid') + ')');
 const promoted = _sessionUrlForSid('session-123');
 const promotedUrl = new URL(promoted, 'https://example.test');
 console.log(JSON.stringify({{
   promoted,
-  launchAction: promotedUrl.searchParams.get('action'),
-  keep: promotedUrl.searchParams.get('keep'),
+  launchActions: promotedUrl.searchParams.getAll('action'),
+  keep: promotedUrl.searchParams.getAll('keep'),
 }}));
 """
     payload = _run_node(source)
 
     assert payload == {
-        "promoted": "/app/session/session-123?keep=1#frag",
-        "launchAction": None,
-        "keep": "1",
+        "promoted": "/app/session/session-123?action=continue&keep=1&keep=2#frag",
+        "launchActions": ["continue"],
+        "keep": ["1", "2"],
     }
 
 
@@ -108,3 +108,162 @@ console.log(JSON.stringify({{
         "ordinarySessionLoad": False,
     }
     assert "if(_shouldStartFreshPwaChat(pwaLaunchAction,urlSession)){" in BOOT_JS
+
+
+def test_root_pwa_launch_replaces_source_history_before_boot_reentry():
+    source = f"""
+const sessionsSrc = {SESSIONS_JS!r};
+const bootSrc = {BOOT_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function applyUrl(rel) {{
+  const next = new URL(rel, 'https://example.test');
+  window.location.href = next.href;
+  window.location.pathname = next.pathname;
+  window.location.search = next.search;
+  window.location.hash = next.hash;
+}}
+const entries = ['/app/?source=pwa&action=new-chat'];
+let index = 0;
+global.window = {{
+  location: {{}},
+  history: {{
+    state: null,
+    pushState(state, _title, url) {{
+      entries.splice(index + 1);
+      entries.push(url);
+      index++;
+      this.state = state;
+      applyUrl(url);
+    }},
+    replaceState(state, _title, url) {{
+      entries[index] = url;
+      this.state = state;
+      applyUrl(url);
+    }},
+  }},
+}};
+global.document = {{ baseURI: 'https://example.test/app/' }};
+applyUrl(entries[0]);
+globalThis._sessionUrlForSid = (0, eval)('(' + extractFunc(sessionsSrc, '_sessionUrlForSid') + ')');
+globalThis._setActiveSessionUrl = (0, eval)('(' + extractFunc(sessionsSrc, '_setActiveSessionUrl') + ')');
+globalThis._shouldStartFreshPwaChat = (0, eval)('(' + extractFunc(bootSrc, '_shouldStartFreshPwaChat') + ')');
+let newSessionCalls = 0;
+let loadSessionCalls = 0;
+function simulatedBoot() {{
+  const url = new URL(window.location.href);
+  const explicitSid = url.pathname.split('/session/')[1] || url.searchParams.get('session');
+  if (_shouldStartFreshPwaChat(url.searchParams.get('action'), explicitSid)) newSessionCalls++;
+  else if (explicitSid) loadSessionCalls++;
+}}
+newSessionCalls++;
+_setActiveSessionUrl('session-123');
+const backTarget = entries[index - 1] || entries[index];
+applyUrl(backTarget);
+simulatedBoot();
+console.log(JSON.stringify({{entries, index, newSessionCalls, loadSessionCalls, href: window.location.href}}));
+"""
+    payload = _run_node(source)
+
+    assert payload == {
+        "entries": ["/app/session/session-123?source=pwa"],
+        "index": 0,
+        "newSessionCalls": 1,
+        "loadSessionCalls": 1,
+        "href": "https://example.test/app/session/session-123?source=pwa",
+    }
+
+
+@pytest.mark.parametrize(
+    ("initial_url", "expected_url"),
+    [
+        (
+            "/app/session/session-123?action=new-chat&action=continue&keep=1#frag",
+            "/app/session/session-123?action=continue&keep=1#frag",
+        ),
+        (
+            "/app/?session=session-123&action=new-chat&action=continue&keep=1#frag",
+            "/app/session/session-123?action=continue&keep=1#frag",
+        ),
+    ],
+)
+def test_explicit_session_wins_and_replaces_stale_launch_history(initial_url, expected_url):
+    source = f"""
+const sessionsSrc = {SESSIONS_JS!r};
+const bootSrc = {BOOT_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+function applyUrl(rel) {{
+  const next = new URL(rel, 'https://example.test');
+  Object.assign(window.location, {{href: next.href, pathname: next.pathname, search: next.search, hash: next.hash}});
+}}
+const calls = [];
+global.window = {{location: {{}}, history: {{
+  pushState(_state, _title, url) {{ calls.push(['push', url]); applyUrl(url); }},
+  replaceState(_state, _title, url) {{ calls.push(['replace', url]); applyUrl(url); }},
+}}}};
+global.document = {{baseURI: 'https://example.test/app/'}};
+applyUrl({initial_url!r});
+globalThis._sessionUrlForSid = (0, eval)('(' + extractFunc(sessionsSrc, '_sessionUrlForSid') + ')');
+globalThis._setActiveSessionUrl = (0, eval)('(' + extractFunc(sessionsSrc, '_setActiveSessionUrl') + ')');
+globalThis._shouldStartFreshPwaChat = (0, eval)('(' + extractFunc(bootSrc, '_shouldStartFreshPwaChat') + ')');
+const before = new URL(window.location.href);
+const explicitSid = before.pathname.split('/session/')[1] || before.searchParams.get('session');
+const shouldStartFresh = _shouldStartFreshPwaChat(before.searchParams.get('action'), explicitSid);
+_setActiveSessionUrl(explicitSid);
+console.log(JSON.stringify({{shouldStartFresh, calls, finalUrl: window.location.pathname + window.location.search + window.location.hash}}));
+"""
+    payload = _run_node(source)
+
+    assert payload == {
+        "shouldStartFresh": False,
+        "calls": [["replace", expected_url]],
+        "finalUrl": expected_url,
+    }
+
+
+def test_ordinary_session_navigation_keeps_push_state_semantics():
+    source = f"""
+const sessionsSrc = {SESSIONS_JS!r};
+function extractFunc(src, name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  let i = src.indexOf('{{', start), depth = 1; i++;
+  while (depth > 0) {{ if (src[i] === '{{') depth++; else if (src[i] === '}}') depth--; i++; }}
+  return src.slice(start, i);
+}}
+global.window = {{
+  location: {{href: 'https://example.test/app/?keep=1', pathname: '/app/', search: '?keep=1', hash: ''}},
+  history: {{pushState(_state, _title, url) {{ console.log(JSON.stringify({{method: 'push', url}})); }}, replaceState() {{ throw new Error('unexpected replace'); }}}},
+}};
+global.document = {{baseURI: 'https://example.test/app/'}};
+globalThis._sessionUrlForSid = (0, eval)('(' + extractFunc(sessionsSrc, '_sessionUrlForSid') + ')');
+globalThis._setActiveSessionUrl = (0, eval)('(' + extractFunc(sessionsSrc, '_setActiveSessionUrl') + ')');
+_setActiveSessionUrl('session-123');
+"""
+    assert _run_node(source) == {
+        "method": "push",
+        "url": "/app/session/session-123?keep=1",
+    }

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -71,7 +71,7 @@ def test_hard_refresh_hydrates_saved_session_model_before_revealing_model_chip()
 
 def test_pwa_new_chat_launch_does_not_block_first_paint_on_model_catalog():
     boot_js = Path("static/boot.js").read_text(encoding="utf-8")
-    launch_marker = "if(pwaLaunchAction==='new-chat'){"
+    launch_marker = "if(_shouldStartFreshPwaChat(pwaLaunchAction,urlSession)){"
     assert launch_marker in boot_js
     launch_branch = boot_js[boot_js.index(launch_marker) : boot_js.index("const savedLocal=localStorage.getItem", boot_js.index(launch_marker))]
     assert "await newSession(true);" in launch_branch

--- a/tests/test_pwa_manifest_sw.py
+++ b/tests/test_pwa_manifest_sw.py
@@ -339,7 +339,8 @@ class TestIndexHtmlIntegration:
         src = BOOT.read_text(encoding="utf-8")
         assert "pwaLaunchAction" in src
         assert "launchAction()" in src
-        assert "pwaLaunchAction==='new-chat'" in src
+        assert "function _shouldStartFreshPwaChat(action,urlSession)" in src
+        assert "_shouldStartFreshPwaChat(pwaLaunchAction,urlSession)" in src
         assert "await newSession(true)" in src
 
     def test_index_route_url_encodes_asset_version(self):


### PR DESCRIPTION
## Summary

- consume the one-shot `action=new-chat` query parameter when a fresh chat is promoted to its canonical `/session/<id>` URL
- only honor the PWA new-chat launch action when there is no explicit session target in the URL
- add regression coverage for both URL canonicalization and stale-action boot behavior

## Root cause

The PWA new-chat shortcut uses `?action=new-chat`. After the new session was created, `_sessionUrlForSid()` preserved that query parameter in the canonical session URL. On a hard refresh, boot processed the launch action before restoring the explicit session and created another conversation.

An explicit `/session/<id>` target should take precedence over a stale one-shot launch action.

## Behavior after this change

- `/?action=new-chat` still opens one fresh conversation
- promotion to `/session/<id>` consumes `action=new-chat` while preserving unrelated query parameters
- `/session/<id>?action=new-chat` restores `<id>` instead of creating another conversation, then canonicalizes the URL

## Verification

- `./scripts/test.sh tests/test_hard_refresh_session_restore.py tests/test_new_chat_default_model_frontend.py tests/test_pwa_manifest_sw.py tests/test_session_cross_tab_sync.py tests/test_4961_url_query_prefill.py tests/test_bugfix_sweep.py tests/test_regressions.py -q` — **152 passed**
- `.venv/bin/ruff check tests/test_hard_refresh_session_restore.py tests/test_new_chat_default_model_frontend.py tests/test_pwa_manifest_sw.py`
- `node --check static/boot.js`
- `node --check static/sessions.js`
- `git diff --check origin/master..HEAD`
- browser smoke: created a chat from `?action=new-chat`, persisted a draft, loaded `/session/<id>?action=new-chat`, and confirmed the same session ID, one session, preserved draft, and canonical `/session/<id>` URL
