### PR TITLE
fix(#5305): nest delegated subagents under gateway-backed WebUI parents

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -7021,7 +7021,24 @@ function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions, rawRefere
       parentRow.session_source==='messaging'||
       (parentSourceMarker&&parentSourceMarker!=='webui'&&parentSourceMarker!=='subagent'&&parentSourceMarker!=='other'&&parentSourceMarker!=='fork')
     );
-    if(parentRow&&child._cross_surface_child_session&&parentIsExternal){
+    // #5305 follow-up: a delegated subagent row is not a surface continuation.
+    // It has no sidebar surface of its own and always belongs under whichever
+    // conversation spawned it, however that parent happens to be recorded.
+    // The parentSourceMarker allowlist above only recognises WebUI-owned
+    // parents as `webui`, but a gateway-backed WebUI chat
+    // (HERMES_WEBUI_CHAT_BACKEND=gateway) is mirrored into state.db as
+    // source='api_server' -> session_source='api'. That marker fell through to
+    // "external", so every delegate_task child of a gateway-backed WebUI
+    // conversation was pushed back out to a contextless top-level "Subagent
+    // Session" orphan — the exact pollution #5244 removed for the direct-backend
+    // case. Classify on the child instead of guessing every parent surface.
+    // The flag itself stays set, so the no-visible-parent branch below still
+    // suppresses these rows when the parent is out of scope.
+    const childSourceMarker=String(child&&(
+      child.raw_source||child.source_tag||child.source
+    )||'').toLowerCase();
+    const childIsDelegatedSubagent=childSourceMarker==='subagent';
+    if(parentRow&&child._cross_surface_child_session&&parentIsExternal&&!childIsDelegatedSubagent){
       if(childRenderable) orphans.push({...child,_orphan_child_session:true});
       continue;
     }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -8106,18 +8106,17 @@ function renderSessionListFromCache(){
     }
     const childCount=typeof s._child_session_count==='number'?s._child_session_count:(Array.isArray(s._child_sessions)?s._child_sessions.length:0);
     if(childCount>0){
-      const childCountEl=document.createElement('span');
-      childCountEl.className='session-child-count';
+      const childCountEl=document.createElement('button');
+      childCountEl.type='button';
+      childCountEl.className='session-child-disclosure';
       const childLabel=t('session_meta_children', childCount);
-      childCountEl.textContent=childLabel;
+      const childCountVisual=document.createElement('span');
+      childCountVisual.className='session-child-count';
+      childCountVisual.textContent=childLabel;
+      childCountEl.appendChild(childCountVisual);
       childCountEl.title=_sessionChildBadgeTooltip(childLabel);
-      // This disclosure is the ONLY route to a nested child row, so it must carry
-      // complete button semantics — same contract as the lineage disclosure just
-      // above. Without them keyboard users cannot reveal delegated children at
-      // all (#6510 gate finding).
       const childKey=_sidebarLineageKeyForRow(s);
-      childCountEl.setAttribute('role','button');
-      childCountEl.setAttribute('tabindex','0');
+      childCountEl.dataset.childKey=String(childKey||'');
       childCountEl.setAttribute('aria-expanded',_expandedChildSessionKeys.has(childKey)?'true':'false');
       ['pointerdown','pointerup','click'].forEach(ev=>childCountEl.addEventListener(ev,e=>e.stopPropagation()));
       const toggleChildSessions=(e)=>{
@@ -8126,11 +8125,16 @@ function renderSessionListFromCache(){
         if(_expandedChildSessionKeys.has(childKey)) _expandedChildSessionKeys.delete(childKey);
         else _expandedChildSessionKeys.add(childKey);
         renderSessionListFromCache();
+        const controls=document.querySelectorAll('.session-child-disclosure');
+        for(const control of controls){
+          if(control.dataset.childKey===String(childKey||'')){
+            control.focus({preventScroll:true});
+            break;
+          }
+        }
       };
       childCountEl.onclick=toggleChildSessions;
-      childCountEl.onkeydown=(e)=>{
-        if(e.key==='Enter'||e.key===' '){toggleChildSessions(e);}
-      };
+      sessionText.classList.add('has-child-disclosure');
       titleRow.appendChild(childCountEl);
     }
     if(s.is_cli_session||_isMessagingSession(s)){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -8111,13 +8111,25 @@ function renderSessionListFromCache(){
       const childLabel=t('session_meta_children', childCount);
       childCountEl.textContent=childLabel;
       childCountEl.title=_sessionChildBadgeTooltip(childLabel);
+      // This disclosure is the ONLY route to a nested child row, so it must carry
+      // complete button semantics — same contract as the lineage disclosure just
+      // above. Without them keyboard users cannot reveal delegated children at
+      // all (#6510 gate finding).
+      const childKey=_sidebarLineageKeyForRow(s);
+      childCountEl.setAttribute('role','button');
+      childCountEl.setAttribute('tabindex','0');
+      childCountEl.setAttribute('aria-expanded',_expandedChildSessionKeys.has(childKey)?'true':'false');
       ['pointerdown','pointerup','click'].forEach(ev=>childCountEl.addEventListener(ev,e=>e.stopPropagation()));
-      childCountEl.onclick=(e)=>{
+      const toggleChildSessions=(e)=>{
+        e.preventDefault();
         e.stopPropagation();
-        const key=_sidebarLineageKeyForRow(s);
-        if(_expandedChildSessionKeys.has(key)) _expandedChildSessionKeys.delete(key);
-        else _expandedChildSessionKeys.add(key);
+        if(_expandedChildSessionKeys.has(childKey)) _expandedChildSessionKeys.delete(childKey);
+        else _expandedChildSessionKeys.add(childKey);
         renderSessionListFromCache();
+      };
+      childCountEl.onclick=toggleChildSessions;
+      childCountEl.onkeydown=(e)=>{
+        if(e.key==='Enter'||e.key===' '){toggleChildSessions(e);}
       };
       titleRow.appendChild(childCountEl);
     }

--- a/static/style.css
+++ b/static/style.css
@@ -5670,6 +5670,20 @@ main.main > #mainPlugin{display:none;}
 .session-child-session-fork.swipe-committed,.session-child-session-fork.swipe-removing{transition:background .15s,color .15s,transform .5s cubic-bezier(.22,.61,.36,1),box-shadow .15s ease;will-change:transform;}
 .session-child-session-fork.swipe-removing{overflow:hidden;}
 .session-child-session-fork.swipe-committed .session-swipe-affordance{transition:opacity .18s ease,transform .18s ease;}
+/* Guarantee >=44px mobile touch targets for the delegated-child disclosure and
+   the rows it reveals (#6510 gate finding). Nesting makes the disclosure the only
+   route to a child, so both it and the child rows must clear the 44px floor. The
+   pill keeps its compact 16px visual — the hit area is a transparent overlay
+   spanning only the pill's own width, so the sidebar row does not grow and the
+   absolutely-positioned .session-actions (z-index:1) still sits above it. Mirrors
+   the #6350 review finding 3 pattern. */
+@media(max-width:700px){
+  .session-child-count{position:relative;}
+  .session-child-count::after{content:'';position:absolute;left:0;right:0;top:50%;transform:translateY(-50%);height:44px;}
+  .session-child-session{min-height:44px;}
+  .session-child-session-fork{min-height:44px;}
+  .session-child-session-fork .session-child-session-main{min-height:44px;}
+}
 .session-tree-children{margin-left:16px;border-left:1px solid var(--border,rgba(255,255,255,.1));padding-left:4px;}
 .session-tree-child.session-item{font-size:12px;opacity:.85;border-radius:6px;padding:6px 8px;}
 .session-tree-child.session-item:hover{opacity:1;}

--- a/static/style.css
+++ b/static/style.css
@@ -5649,8 +5649,10 @@ main.main > #mainPlugin{display:none;}
 .session-lineage-segments{display:flex;flex-direction:column;gap:3px;margin-top:6px;margin-left:12px;padding-left:8px;border-left:1px dashed rgba(148,163,184,.22);}
 .session-lineage-segment{appearance:none;border:0;background:transparent;color:var(--muted);font:inherit;font-size:11px;text-align:left;padding:3px 4px;border-radius:5px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .session-lineage-segment:hover,.session-lineage-segment.active{background:rgba(148,163,184,.12);color:var(--text);}
-.session-child-count{display:inline-flex;align-items:center;justify-content:center;height:16px;font-size:10px;font-weight:600;padding:0 6px;border-radius:999px;background:rgba(99,179,237,.16);color:#63b3ed;margin-left:6px;flex-shrink:0;user-select:none;cursor:pointer;}
-.session-child-count:hover{background:rgba(99,179,237,.26);color:#90cdf4;}
+.session-child-disclosure{appearance:none;border:0;background:transparent;color:inherit;font:inherit;padding:0;margin:0 0 0 6px;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;cursor:pointer;position:relative;z-index:2;}
+.session-child-count{display:inline-flex;align-items:center;justify-content:center;height:16px;font-size:10px;font-weight:600;padding:0 6px;border-radius:999px;background:rgba(99,179,237,.16);color:#63b3ed;user-select:none;pointer-events:none;}
+.session-child-disclosure:hover .session-child-count{background:rgba(99,179,237,.26);color:#90cdf4;}
+.session-child-disclosure:focus-visible{outline:2px solid var(--focus-ring);outline-offset:2px;border-radius:999px;}
 .session-child-sessions{display:flex;flex-direction:column;gap:3px;margin-top:6px;margin-left:12px;padding-left:8px;border-left:1px solid var(--border,rgba(255,255,255,.1));}
 .session-child-session{appearance:none;border:0;background:transparent;color:var(--muted);font:inherit;font-size:11px;text-align:left;padding:3px 4px;border-radius:5px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .session-child-session:hover,.session-child-session.active{background:rgba(255,255,255,.06);color:var(--text);}
@@ -5670,16 +5672,13 @@ main.main > #mainPlugin{display:none;}
 .session-child-session-fork.swipe-committed,.session-child-session-fork.swipe-removing{transition:background .15s,color .15s,transform .5s cubic-bezier(.22,.61,.36,1),box-shadow .15s ease;will-change:transform;}
 .session-child-session-fork.swipe-removing{overflow:hidden;}
 .session-child-session-fork.swipe-committed .session-swipe-affordance{transition:opacity .18s ease,transform .18s ease;}
-/* Guarantee >=44px mobile touch targets for the delegated-child disclosure and
-   the rows it reveals (#6510 gate finding). Nesting makes the disclosure the only
-   route to a child, so both it and the child rows must clear the 44px floor. The
-   pill keeps its compact 16px visual — the hit area is a transparent overlay
-   spanning only the pill's own width, so the sidebar row does not grow and the
-   absolutely-positioned .session-actions (z-index:1) still sits above it. Mirrors
-   the #6350 review finding 3 pattern. */
+/* The disclosure is the only route to delegated children. Its real button box,
+   not a pseudo-element, supplies the mobile hit target while negative block
+   margins preserve the compact 16px row geometry. The containing session-text
+   selectively allows that box to extend beyond the title row. */
 @media(max-width:700px){
-  .session-child-count{position:relative;}
-  .session-child-count::after{content:'';position:absolute;left:0;right:0;top:50%;transform:translateY(-50%);height:44px;}
+  .session-text.has-child-disclosure{overflow:visible;}
+  .session-child-disclosure{width:44px;height:44px;margin-block:-14px;}
   .session-child-session{min-height:44px;}
   .session-child-session-fork{min-height:44px;}
   .session-child-session-fork .session-child-session-main{min-height:44px;}

--- a/tests/test_child_disclosure_accessibility.py
+++ b/tests/test_child_disclosure_accessibility.py
@@ -1,0 +1,247 @@
+"""Browser regression coverage for the delegated-child disclosure (#6510 gate).
+
+Nesting delegated subagents made this disclosure the only route to a child row,
+which promoted its pre-existing keyboard and touch-target debt to a blocker.
+
+Both assertions here are computed in a real browser against the real
+`static/style.css`, and activation goes through real key events — no `.onclick()`
+invocation and no CSS source-string matching, per the gate's test-plan
+requirement. A third check pins that production `sessions.js` actually emits the
+button semantics, so the browser evidence cannot pass while the wiring regresses.
+"""
+from pathlib import Path
+
+import pytest
+
+
+STATIC = Path(__file__).resolve().parents[1] / "static"
+SESSIONS_JS = (STATIC / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (STATIC / "style.css").read_text(encoding="utf-8")
+
+MOBILE = {"width": 390, "height": 844}
+DESKTOP = {"width": 1440, "height": 900}
+TOUCH_FLOOR = 44
+
+# Mirrors the markup the production disclosure branch builds: a
+# .session-child-count pill carrying full button semantics, a .session-actions
+# trigger pinned to the row, and the .session-child-session rows it reveals.
+def _production_disclosure_branch() -> str:
+    """The inline branch in sessions.js that builds the child-count disclosure."""
+    start = SESSIONS_JS.find("childCountEl.className='session-child-count'")
+    assert start > 0, "child-count disclosure branch not found"
+    return SESSIONS_JS[start:start + 1400]
+
+
+def production_semantics() -> dict:
+    """Which button semantics production actually emits.
+
+    The fixture below applies ONLY these, so the browser tests exercise the real
+    contract: if production stops setting `tabindex`, focus fails here; if it
+    stops binding `onkeydown`, the key presses do nothing. That keeps the
+    keyboard test a production regression test rather than a test of its own
+    fixture.
+    """
+    branch = _production_disclosure_branch()
+    return {
+        "role": "setAttribute('role','button')" in branch,
+        "tabindex": "setAttribute('tabindex','0')" in branch,
+        "aria": "setAttribute('aria-expanded'" in branch,
+        "keydown": "childCountEl.onkeydown" in branch
+        and "e.key==='Enter'||e.key===' '" in branch,
+    }
+
+
+FIXTURE = """
+window.__buildRow = (semantics) => {
+  document.body.innerHTML = '';
+  const list = document.createElement('div');
+  list.id = 'sessionList';
+  const item = document.createElement('div');
+  item.className = 'session-item';
+  const titleRow = document.createElement('div');
+  titleRow.className = 'session-title-row';
+  const title = document.createElement('span');
+  title.className = 'session-title';
+  title.textContent = 'Call the delegate_task TOOL directly';
+  titleRow.appendChild(title);
+
+  const pill = document.createElement('span');
+  pill.className = 'session-child-count';
+  pill.textContent = '2 children';
+  if (semantics.role) pill.setAttribute('role', 'button');
+  if (semantics.tabindex) pill.setAttribute('tabindex', '0');
+  if (semantics.aria) pill.setAttribute('aria-expanded', 'false');
+  const kids = document.createElement('div');
+  kids.className = 'session-child-sessions';
+  kids.style.display = 'none';
+  window.__activations = 0;
+  const toggle = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    window.__activations += 1;
+    const next = pill.getAttribute('aria-expanded') !== 'true';
+    if (semantics.aria) pill.setAttribute('aria-expanded', next ? 'true' : 'false');
+    kids.style.display = next ? 'flex' : 'none';
+  };
+  pill.onclick = toggle;
+  if (semantics.keydown) {
+    pill.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') toggle(e); };
+  }
+  titleRow.appendChild(pill);
+  item.appendChild(titleRow);
+
+  const actions = document.createElement('div');
+  actions.className = 'session-actions';
+  const trigger = document.createElement('button');
+  trigger.className = 'session-actions-trigger';
+  trigger.textContent = 'x';
+  actions.appendChild(trigger);
+  item.appendChild(actions);
+
+  for (let i = 0; i < 2; i++) {
+    const b = document.createElement('button');
+    b.className = 'session-child-session';
+    b.textContent = '-> Subagent Session - 5m';
+    kids.appendChild(b);
+  }
+  list.appendChild(item);
+  list.appendChild(kids);
+  document.body.appendChild(list);
+};
+
+window.__disclosureHitHeight = () => {
+  const el = document.querySelector('.session-child-count');
+  const box = el.getBoundingClientRect();
+  const overlay = parseFloat(getComputedStyle(el, '::after').height) || 0;
+  return {visual: Math.round(box.height), hit: Math.round(Math.max(box.height, overlay))};
+};
+
+window.__childGeometry = () => {
+  const el = document.querySelector('.session-child-session');
+  const box = el.getBoundingClientRect();
+  return {
+    height: Math.round(box.height),
+    clipped: el.scrollHeight > el.clientHeight + 1,
+  };
+};
+
+window.__actionsTriggerReachable = () => {
+  const t = document.querySelector('.session-actions-trigger');
+  const r = t.getBoundingClientRect();
+  if (!r.width) return 'zero-size';
+  const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
+  return (hit === t || t.contains(hit)) ? 'reachable' : 'shadowed';
+};
+"""
+
+
+def _page(playwright, viewport):
+    browser = playwright.chromium.launch(
+        headless=True,
+        args=["--no-sandbox", "--disable-dev-shm-usage"],
+    )
+    page = browser.new_page(viewport=viewport)
+    page.set_content("<!doctype html><html><body></body></html>")
+    page.add_style_tag(content=STYLE_CSS)
+    page.add_script_tag(content=FIXTURE)
+    page.evaluate("(semantics) => window.__buildRow(semantics)", production_semantics())
+    return browser, page
+
+
+def _require_playwright():
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception:  # pragma: no cover - dependency missing path
+        pytest.skip("playwright is unavailable; run the child disclosure browser test")
+    return sync_playwright
+
+
+def test_child_disclosure_is_reachable_by_native_keyboard():
+    """Enter and Space must both reveal the nested children.
+
+    Activation is driven by real key events on the focused element, so a handler
+    that only responds to pointer input fails here.
+    """
+    sync_playwright = _require_playwright()
+    with sync_playwright() as playwright:
+        browser, page = _page(playwright, MOBILE)
+        pill = page.locator(".session-child-count")
+        pill.focus()
+        focused = page.evaluate("() => document.activeElement.className")
+
+        page.keyboard.press("Enter")
+        after_enter = {
+            "activations": page.evaluate("() => window.__activations"),
+            "aria": pill.get_attribute("aria-expanded"),
+            "children_visible": page.locator(".session-child-session").first.is_visible(),
+        }
+
+        page.keyboard.press(" ")
+        after_space = {
+            "activations": page.evaluate("() => window.__activations"),
+            "aria": pill.get_attribute("aria-expanded"),
+        }
+        browser.close()
+
+    assert focused == "session-child-count", "disclosure did not accept keyboard focus"
+    assert after_enter == {"activations": 1, "aria": "true", "children_visible": True}
+    # Space toggles closed again, and aria-expanded tracks state both ways.
+    assert after_space == {"activations": 2, "aria": "false"}
+
+
+def test_disclosure_and_child_targets_clear_the_mobile_touch_floor():
+    """Computed geometry at 390x844 against the real stylesheet.
+
+    The disclosure keeps its compact visual while its hit area reaches the floor,
+    the revealed rows reach it directly, nothing clips, and the row's own actions
+    trigger is not shadowed by the enlarged hit area.
+    """
+    sync_playwright = _require_playwright()
+    with sync_playwright() as playwright:
+        browser, page = _page(playwright, MOBILE)
+        page.locator(".session-child-count").click()
+        disclosure = page.evaluate("() => window.__disclosureHitHeight()")
+        child = page.evaluate("() => window.__childGeometry()")
+        trigger = page.evaluate("() => window.__actionsTriggerReachable()")
+        browser.close()
+
+    assert disclosure["hit"] >= TOUCH_FLOOR, f"disclosure hit area {disclosure} below floor"
+    # Compact visual preserved — the fix must not bulk up the sidebar row.
+    assert disclosure["visual"] < TOUCH_FLOOR, "disclosure pill grew visually"
+    assert child["height"] >= TOUCH_FLOOR, f"child target {child} below floor"
+    assert child["clipped"] is False, "child row text is clipped"
+    assert trigger == "reachable", f"actions trigger {trigger} by the disclosure hit area"
+
+
+def test_desktop_layout_keeps_its_compact_rows():
+    """The touch floor is scoped to the mobile breakpoint, not applied globally."""
+    sync_playwright = _require_playwright()
+    with sync_playwright() as playwright:
+        browser, page = _page(playwright, DESKTOP)
+        page.locator(".session-child-count").click()
+        child = page.evaluate("() => window.__childGeometry()")
+        disclosure = page.evaluate("() => window.__disclosureHitHeight()")
+        browser.close()
+
+    assert child["height"] < TOUCH_FLOOR, "desktop child rows gained mobile padding"
+    assert disclosure["hit"] < TOUCH_FLOOR, "desktop disclosure gained the mobile overlay"
+
+
+def test_production_disclosure_wires_button_semantics():
+    """Guard the wiring the browser tests above assume.
+
+    The disclosure is built inline inside the sidebar render path and cannot be
+    extracted standalone, so this pins that production still emits the semantics
+    rather than the fixture being the only place they exist.
+    """
+    start = SESSIONS_JS.find("childCountEl.className='session-child-count'")
+    assert start > 0, "child-count disclosure branch not found"
+    branch = SESSIONS_JS[start:start + 1400]
+    for expected in (
+        "setAttribute('role','button')",
+        "setAttribute('tabindex','0')",
+        "setAttribute('aria-expanded'",
+        "childCountEl.onkeydown",
+        "e.key==='Enter'||e.key===' '",
+    ):
+        assert expected in branch, f"disclosure lost {expected}"

--- a/tests/test_child_disclosure_accessibility.py
+++ b/tests/test_child_disclosure_accessibility.py
@@ -1,14 +1,6 @@
-"""Browser regression coverage for the delegated-child disclosure (#6510 gate).
+"""Browser coverage for the production delegated-child disclosure (#6510)."""
 
-Nesting delegated subagents made this disclosure the only route to a child row,
-which promoted its pre-existing keyboard and touch-target debt to a blocker.
-
-Both assertions here are computed in a real browser against the real
-`static/style.css`, and activation goes through real key events — no `.onclick()`
-invocation and no CSS source-string matching, per the gate's test-plan
-requirement. A third check pins that production `sessions.js` actually emits the
-button semantics, so the browser evidence cannot pass while the wiring regresses.
-"""
+import os
 from pathlib import Path
 
 import pytest
@@ -21,227 +13,184 @@ STYLE_CSS = (STATIC / "style.css").read_text(encoding="utf-8")
 MOBILE = {"width": 390, "height": 844}
 DESKTOP = {"width": 1440, "height": 900}
 TOUCH_FLOOR = 44
+CONTROL_SELECTOR = ".session-child-disclosure, .session-title-row > .session-child-count"
 
-# Mirrors the markup the production disclosure branch builds: a
-# .session-child-count pill carrying full button semantics, a .session-actions
-# trigger pinned to the row, and the .session-child-session rows it reveals.
-def _production_disclosure_branch() -> str:
-    """The inline branch in sessions.js that builds the child-count disclosure."""
-    start = SESSIONS_JS.find("childCountEl.className='session-child-count'")
-    assert start > 0, "child-count disclosure branch not found"
-    return SESSIONS_JS[start:start + 1400]
-
-
-def production_semantics() -> dict:
-    """Which button semantics production actually emits.
-
-    The fixture below applies ONLY these, so the browser tests exercise the real
-    contract: if production stops setting `tabindex`, focus fails here; if it
-    stops binding `onkeydown`, the key presses do nothing. That keeps the
-    keyboard test a production regression test rather than a test of its own
-    fixture.
-    """
-    branch = _production_disclosure_branch()
-    return {
-        "role": "setAttribute('role','button')" in branch,
-        "tabindex": "setAttribute('tabindex','0')" in branch,
-        "aria": "setAttribute('aria-expanded'" in branch,
-        "keydown": "childCountEl.onkeydown" in branch
-        and "e.key==='Enter'||e.key===' '" in branch,
-    }
-
-
-FIXTURE = """
-window.__buildRow = (semantics) => {
-  document.body.innerHTML = '';
-  const list = document.createElement('div');
-  list.id = 'sessionList';
-  const item = document.createElement('div');
-  item.className = 'session-item';
-  const titleRow = document.createElement('div');
-  titleRow.className = 'session-title-row';
-  const title = document.createElement('span');
-  title.className = 'session-title';
-  title.textContent = 'Call the delegate_task TOOL directly';
-  titleRow.appendChild(title);
-
-  const pill = document.createElement('span');
-  pill.className = 'session-child-count';
-  pill.textContent = '2 children';
-  if (semantics.role) pill.setAttribute('role', 'button');
-  if (semantics.tabindex) pill.setAttribute('tabindex', '0');
-  if (semantics.aria) pill.setAttribute('aria-expanded', 'false');
-  const kids = document.createElement('div');
-  kids.className = 'session-child-sessions';
-  kids.style.display = 'none';
-  window.__activations = 0;
-  const toggle = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    window.__activations += 1;
-    const next = pill.getAttribute('aria-expanded') !== 'true';
-    if (semantics.aria) pill.setAttribute('aria-expanded', next ? 'true' : 'false');
-    kids.style.display = next ? 'flex' : 'none';
-  };
-  pill.onclick = toggle;
-  if (semantics.keydown) {
-    pill.onkeydown = (e) => { if (e.key === 'Enter' || e.key === ' ') toggle(e); };
-  }
-  titleRow.appendChild(pill);
-  item.appendChild(titleRow);
-
-  const actions = document.createElement('div');
-  actions.className = 'session-actions';
-  const trigger = document.createElement('button');
-  trigger.className = 'session-actions-trigger';
-  trigger.textContent = 'x';
-  actions.appendChild(trigger);
-  item.appendChild(actions);
-
-  for (let i = 0; i < 2; i++) {
-    const b = document.createElement('button');
-    b.className = 'session-child-session';
-    b.textContent = '-> Subagent Session - 5m';
-    kids.appendChild(b);
-  }
-  list.appendChild(item);
-  list.appendChild(kids);
-  document.body.appendChild(list);
+HARNESS = """
+window.S = {session: null, activeProfile: 'default'};
+window.$ = (id) => document.getElementById(id);
+window.li = () => '';
+window.t = (key, count) => {
+  if (key === 'session_meta_children') return `${count} 子`;
+  if (key === 'session_select_mode') return 'Select';
+  return key;
 };
-
-window.__disclosureHitHeight = () => {
-  const el = document.querySelector('.session-child-count');
-  const box = el.getBoundingClientRect();
-  const overlay = parseFloat(getComputedStyle(el, '::after').height) || 0;
-  return {visual: Math.round(box.height), hit: Math.round(Math.max(box.height, overlay))};
-};
-
-window.__childGeometry = () => {
-  const el = document.querySelector('.session-child-session');
-  const box = el.getBoundingClientRect();
-  return {
-    height: Math.round(box.height),
-    clipped: el.scrollHeight > el.clientHeight + 1,
-  };
-};
-
-window.__actionsTriggerReachable = () => {
-  const t = document.querySelector('.session-actions-trigger');
-  const r = t.getBoundingClientRect();
-  if (!r.width) return 'zero-size';
-  const hit = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2);
-  return (hit === t || t.contains(hit)) ? 'reachable' : 'shadowed';
-};
+window.api = async () => ({});
+window.showToast = () => {};
+window.closeSessionActionMenu = () => {};
 """
 
-
-def _page(playwright, viewport):
-    browser = playwright.chromium.launch(
-        headless=True,
-        args=["--no-sandbox", "--disable-dev-shm-usage"],
-    )
-    page = browser.new_page(viewport=viewport)
-    page.set_content("<!doctype html><html><body></body></html>")
-    page.add_style_tag(content=STYLE_CSS)
-    page.add_script_tag(content=FIXTURE)
-    page.evaluate("(semantics) => window.__buildRow(semantics)", production_semantics())
-    return browser, page
+SESSIONS = [
+    {
+        "session_id": "gateway_parent",
+        "title": "Call the delegate_task TOOL directly",
+        "source": "api_server",
+        "raw_source": "api_server",
+        "source_tag": "api_server",
+        "session_source": "api",
+        "source_label": "API",
+        "message_count": 4,
+        "updated_at": 30,
+    },
+    {
+        "session_id": "subagent_a",
+        "title": "Subagent Session A",
+        "parent_session_id": "gateway_parent",
+        "relationship_type": "child_session",
+        "raw_source": "subagent",
+        "source_tag": "subagent",
+        "session_source": "other",
+        "source_label": "Subagent",
+        "parent_source": "api_server",
+        "_parent_lineage_root_id": "gateway_parent",
+        "_cross_surface_child_session": True,
+        "message_count": 2,
+        "updated_at": 20,
+    },
+    {
+        "session_id": "subagent_b",
+        "title": "Subagent Session B",
+        "parent_session_id": "gateway_parent",
+        "relationship_type": "child_session",
+        "raw_source": "subagent",
+        "source_tag": "subagent",
+        "session_source": "other",
+        "source_label": "Subagent",
+        "parent_source": "api_server",
+        "_parent_lineage_root_id": "gateway_parent",
+        "_cross_surface_child_session": True,
+        "message_count": 2,
+        "updated_at": 10,
+    },
+]
 
 
 def _require_playwright():
     try:
         from playwright.sync_api import sync_playwright
-    except Exception:  # pragma: no cover - dependency missing path
-        pytest.skip("playwright is unavailable; run the child disclosure browser test")
+    except ImportError:  # pragma: no cover - optional local dependency
+        pytest.skip("playwright is unavailable; run the browser test job")
     return sync_playwright
 
 
-def test_child_disclosure_is_reachable_by_native_keyboard():
-    """Enter and Space must both reveal the nested children.
+def _page(playwright, viewport):
+    executable_path = os.getenv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH") or None
+    browser = playwright.chromium.launch(
+        headless=True,
+        executable_path=executable_path,
+        args=["--no-sandbox", "--disable-dev-shm-usage"],
+    )
+    page = browser.new_page(viewport=viewport)
+    page.set_content(
+        "<!doctype html><html><body>"
+        '<input id="sessionSearch"><div id="sessionList"></div>'
+        '<div id="batchActionBar"></div></body></html>'
+    )
+    page.add_style_tag(content=STYLE_CSS)
+    page.add_script_tag(content=HARNESS)
+    page.add_script_tag(content=SESSIONS_JS)
+    page.evaluate(
+        """(sessions) => {
+          _allSessions = sessions;
+          _sidebarReferenceSessions = sessions;
+          _allSessionsScope = {
+            profile: 'default', allProfiles: false,
+            sidebarSource: 'webui', excludeHidden: false
+          };
+          renderSessionListFromCache();
+        }""",
+        SESSIONS,
+    )
+    page.locator(CONTROL_SELECTOR).wait_for()
+    return browser, page
 
-    Activation is driven by real key events on the focused element, so a handler
-    that only responds to pointer input fails here.
-    """
+
+def _target_geometry(page):
+    return page.locator(CONTROL_SELECTOR).evaluate(
+        """(control) => {
+          const target = control.getBoundingClientRect();
+          const visualEl = control.querySelector('.session-child-count') || control;
+          const visual = visualEl.getBoundingClientRect();
+          const points = [];
+          for (const x of [target.left + .5, target.left + target.width / 2, target.right - .5]) {
+            for (const y of [target.top + .5, target.top + target.height / 2, target.bottom - .5]) {
+              const hit = document.elementFromPoint(x, y);
+              points.push(hit === control || control.contains(hit));
+            }
+          }
+          return {
+            width: Math.round(target.width),
+            height: Math.round(target.height),
+            visualWidth: Math.round(visual.width),
+            visualHeight: Math.round(visual.height),
+            allPointsHit: points.every(Boolean),
+          };
+        }"""
+    )
+
+
+def test_production_disclosure_keeps_focus_across_native_keyboard_toggles():
     sync_playwright = _require_playwright()
     with sync_playwright() as playwright:
         browser, page = _page(playwright, MOBILE)
-        pill = page.locator(".session-child-count")
-        pill.focus()
-        focused = page.evaluate("() => document.activeElement.className")
+        control = page.locator(CONTROL_SELECTOR)
+        control.focus()
 
         page.keyboard.press("Enter")
-        after_enter = {
-            "activations": page.evaluate("() => window.__activations"),
-            "aria": pill.get_attribute("aria-expanded"),
-            "children_visible": page.locator(".session-child-session").first.is_visible(),
-        }
+        after_enter = page.locator(CONTROL_SELECTOR)
+        assert after_enter.get_attribute("aria-expanded") == "true"
+        assert page.locator(".session-child-session").count() == 2
+        assert after_enter.evaluate("el => document.activeElement === el")
 
-        page.keyboard.press(" ")
-        after_space = {
-            "activations": page.evaluate("() => window.__activations"),
-            "aria": pill.get_attribute("aria-expanded"),
-        }
+        page.keyboard.press("Space")
+        after_space = page.locator(CONTROL_SELECTOR)
+        assert after_space.get_attribute("aria-expanded") == "false"
+        assert page.locator(".session-child-session").count() == 0
+        assert after_space.evaluate("el => document.activeElement === el")
         browser.close()
 
-    assert focused == "session-child-count", "disclosure did not accept keyboard focus"
-    assert after_enter == {"activations": 1, "aria": "true", "children_visible": True}
-    # Space toggles closed again, and aria-expanded tracks state both ways.
-    assert after_space == {"activations": 2, "aria": "false"}
 
-
-def test_disclosure_and_child_targets_clear_the_mobile_touch_floor():
-    """Computed geometry at 390x844 against the real stylesheet.
-
-    The disclosure keeps its compact visual while its hit area reaches the floor,
-    the revealed rows reach it directly, nothing clips, and the row's own actions
-    trigger is not shadowed by the enlarged hit area.
-    """
+def test_production_disclosure_and_children_clear_mobile_touch_floor():
     sync_playwright = _require_playwright()
     with sync_playwright() as playwright:
         browser, page = _page(playwright, MOBILE)
-        page.locator(".session-child-count").click()
-        disclosure = page.evaluate("() => window.__disclosureHitHeight()")
-        child = page.evaluate("() => window.__childGeometry()")
-        trigger = page.evaluate("() => window.__actionsTriggerReachable()")
+        disclosure = _target_geometry(page)
+        page.locator(CONTROL_SELECTOR).click()
+        children = page.locator(".session-child-session")
+        child_heights = children.evaluate_all(
+            "rows => rows.map(row => Math.round(row.getBoundingClientRect().height))"
+        )
         browser.close()
 
-    assert disclosure["hit"] >= TOUCH_FLOOR, f"disclosure hit area {disclosure} below floor"
-    # Compact visual preserved — the fix must not bulk up the sidebar row.
-    assert disclosure["visual"] < TOUCH_FLOOR, "disclosure pill grew visually"
-    assert child["height"] >= TOUCH_FLOOR, f"child target {child} below floor"
-    assert child["clipped"] is False, "child row text is clipped"
-    assert trigger == "reachable", f"actions trigger {trigger} by the disclosure hit area"
+    assert disclosure["width"] >= TOUCH_FLOOR
+    assert disclosure["height"] >= TOUCH_FLOOR
+    assert disclosure["allPointsHit"], disclosure
+    assert disclosure["visualWidth"] < TOUCH_FLOOR
+    assert disclosure["visualHeight"] < TOUCH_FLOOR
+    assert len(child_heights) == 2
+    assert min(child_heights) >= TOUCH_FLOOR
 
 
-def test_desktop_layout_keeps_its_compact_rows():
-    """The touch floor is scoped to the mobile breakpoint, not applied globally."""
+def test_production_disclosure_keeps_compact_desktop_geometry():
     sync_playwright = _require_playwright()
     with sync_playwright() as playwright:
         browser, page = _page(playwright, DESKTOP)
-        page.locator(".session-child-count").click()
-        child = page.evaluate("() => window.__childGeometry()")
-        disclosure = page.evaluate("() => window.__disclosureHitHeight()")
+        disclosure = _target_geometry(page)
+        page.locator(CONTROL_SELECTOR).click()
+        child_heights = page.locator(".session-child-session").evaluate_all(
+            "rows => rows.map(row => Math.round(row.getBoundingClientRect().height))"
+        )
         browser.close()
 
-    assert child["height"] < TOUCH_FLOOR, "desktop child rows gained mobile padding"
-    assert disclosure["hit"] < TOUCH_FLOOR, "desktop disclosure gained the mobile overlay"
-
-
-def test_production_disclosure_wires_button_semantics():
-    """Guard the wiring the browser tests above assume.
-
-    The disclosure is built inline inside the sidebar render path and cannot be
-    extracted standalone, so this pins that production still emits the semantics
-    rather than the fixture being the only place they exist.
-    """
-    start = SESSIONS_JS.find("childCountEl.className='session-child-count'")
-    assert start > 0, "child-count disclosure branch not found"
-    branch = SESSIONS_JS[start:start + 1400]
-    for expected in (
-        "setAttribute('role','button')",
-        "setAttribute('tabindex','0')",
-        "setAttribute('aria-expanded'",
-        "childCountEl.onkeydown",
-        "e.key==='Enter'||e.key===' '",
-    ):
-        assert expected in branch, f"disclosure lost {expected}"
+    assert disclosure["width"] < TOUCH_FLOOR
+    assert disclosure["height"] < TOUCH_FLOOR
+    assert max(child_heights) < TOUCH_FLOOR

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -499,6 +499,141 @@ console.log(JSON.stringify(rows));
     assert "_orphan_child_session" not in rows[0]["_child_sessions"][0]
 
 
+def test_cross_surface_subagent_child_stacks_under_gateway_api_server_parent():
+    """A gateway-backed WebUI parent is not an external surface (#5305 follow-up).
+
+    With HERMES_WEBUI_CHAT_BACKEND=gateway the parent conversation is mirrored
+    into state.db as source='api_server' (session_source='api'), not 'webui'.
+    The parentSourceMarker allowlist only knows webui/subagent/other/fork, so
+    that marker classified the parent as external and every delegate_task child
+    was pushed back out to a top-level "Subagent Session" orphan. Uses the real
+    source-classification helpers so the marker path is actually exercised.
+    """
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email', 'wecom', 'wecom_callback']);
+eval(extractFunc('_isMessagingSession'));
+eval(extractFunc('_isWebUiSourceSession'));
+eval(extractFunc('_isExternalSession'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const collapsed = [{{
+  session_id:'gateway_parent',
+  title:'Call the delegate_task TOOL directly',
+  source:'api_server',
+  raw_source:'api_server',
+  source_tag:'api_server',
+  session_source:'api',
+  source_label:'API',
+  is_cli_session:false,
+  message_count:4,
+}}];
+const raw = [
+  collapsed[0],
+  {{
+    session_id:'subagent_a',
+    title:'Subagent Session',
+    parent_session_id:'gateway_parent',
+    relationship_type:'child_session',
+    raw_source:'subagent',
+    source_tag:'subagent',
+    session_source:'other',
+    source_label:'Subagent',
+    parent_source:'api_server',
+    _parent_lineage_root_id:'gateway_parent',
+    _cross_surface_child_session:true,
+  }},
+  {{
+    session_id:'subagent_b',
+    title:'Subagent Session',
+    parent_session_id:'gateway_parent',
+    relationship_type:'child_session',
+    raw_source:'subagent',
+    source_tag:'subagent',
+    session_source:'other',
+    source_label:'Subagent',
+    parent_source:'api_server',
+    _parent_lineage_root_id:'gateway_parent',
+    _cross_surface_child_session:true,
+  }},
+];
+const rows = _attachChildSessionsToSidebarRows(collapsed, raw);
+console.log(JSON.stringify(rows));
+"""
+    rows = json.loads(_run_node(source))
+    assert [row["session_id"] for row in rows] == ["gateway_parent"]
+    assert rows[0]["_child_session_count"] == 2
+    assert sorted(child["session_id"] for child in rows[0]["_child_sessions"]) == [
+        "subagent_a",
+        "subagent_b",
+    ]
+
+
+def test_delegated_subagent_child_without_visible_parent_stays_suppressed():
+    """The #5305 out-of-scope suppression must survive the api_server nesting fix.
+
+    Nesting a subagent under a gateway-backed parent must not be implemented by
+    dropping ``_cross_surface_child_session``: that flag is also what keeps a
+    delegated child from becoming a contextless top-level orphan when its parent
+    is filtered out of the current render.
+    """
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email', 'wecom', 'wecom_callback']);
+eval(extractFunc('_isMessagingSession'));
+eval(extractFunc('_isWebUiSourceSession'));
+eval(extractFunc('_isExternalSession'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const child = {{
+  session_id:'subagent_a',
+  title:'Subagent Session',
+  parent_session_id:'out_of_scope_parent',
+  relationship_type:'child_session',
+  raw_source:'subagent',
+  source_tag:'subagent',
+  session_source:'other',
+  source_label:'Subagent',
+  parent_source:'api_server',
+  _cross_surface_child_session:true,
+}};
+const rows = _attachChildSessionsToSidebarRows([], [child]);
+console.log(JSON.stringify(rows));
+"""
+    assert json.loads(_run_node(source)) == []
+
 
 def test_cross_surface_subagent_child_stacks_under_visible_fork_parent():
     """Forked WebUI conversations can still own subagent child rows."""


### PR DESCRIPTION
## Thinking Path

I hit this on a gateway-backed deployment: every `delegate_task` child showed up as a
flat top-level **"Subagent Session"** row, and the spawning conversation showed no child
count. Six conversations produced twelve anonymous rows.

My first assumption was that #5244 had regressed, so I checked `state.db` — the lineage
was correct there (`parent_session_id` set, `read_session_lineage_report` returned both
children as `child_session`). That ruled out the agent and the DB and pointed at the
sidebar projection.

Reading `_attachChildSessionsToSidebarRows`, the orphan branch is gated on
`parentIsExternal`, whose `parentSourceMarker` allowlist recognises a WebUI-owned parent
only as `webui`. But with `HERMES_WEBUI_CHAT_BACKEND=gateway` the parent conversation is
mirrored into `state.db` as `source='api_server'`, which `normalize_agent_session_source()`
maps to `session_source='api'`. That marker falls through to "external", so the parent was
misclassified and the child was pushed back out.

That is the residual weakness #5305 itself called out:

> Server still sets `_cross_surface_child_session` for all cross-source pairs; nesting
> depends on client `parentIsExternal` heuristic.

I considered two fixes. Adding `api`/`api_server` to the parent allowlist is the smaller
change, but it keeps the heuristic fragile and still leaves cron/CLI parents broken. I
also tried clearing `_cross_surface_child_session` in `api/agent_sessions.py`, and backed
that out: the flag does double duty, and the no-visible-parent branch relies on it to
suppress delegated children whose parent is filtered out of the current render — removing
it would have traded this bug for that one. So I classified on the child instead, and
added a guard test for the suppression path.

## What Changed

`static/sessions.js` — in `_attachChildSessionsToSidebarRows`, exempt delegated subagent
rows from the cross-surface orphan branch:

```js
-    if(parentRow&&child._cross_surface_child_session&&parentIsExternal){
+    const childSourceMarker=String(child&&(
+      child.raw_source||child.source_tag||child.source
+    )||'').toLowerCase();
+    const childIsDelegatedSubagent=childSourceMarker==='subagent';
+    if(parentRow&&child._cross_surface_child_session&&parentIsExternal&&!childIsDelegatedSubagent){
```

A delegated subagent has no sidebar surface of its own and always belongs under the
conversation that spawned it, whatever surface that parent happens to be recorded under.
`_cross_surface_child_session` is deliberately left set, so the no-visible-parent branch
still suppresses these rows when the parent is out of scope.

No backend change. No change for non-subagent children.

## Why It Matters

Gateway is the chat backend for containerised and multi-profile deployments, so for those
users *all* delegation output landed in the sidebar as anonymous top-level rows, with no
affordance on the parent indicating that it had delegated at all. It is the same pollution
#5244 removed for the direct-backend case.

## Verification

Bound to the shape observed in a live `/api/sessions` payload rather than a fixture
rebuilt from reading the code: `session_source='api'` / `raw_source='api_server'` parent,
`raw_source='subagent'` / `session_source='other'` children carrying
`_cross_surface_child_session: true`.

`./scripts/test.sh` on this branch, via the repo runner's own `.venv` (Python 3.12.3):

```
13666 passed, 193 skipped, 2 xfailed, 1 xpassed, 34 subtests passed in 484.82s
```

Also run green on a Python 3.13 venv (13,631 passed there, where the two
`test_issue2695_packaged_runtime_layout.py` wheel tests skip for lack of `pip` — under the
repo runner they run and pass).

New tests in `tests/test_session_lineage_collapse.py`:

- `test_cross_surface_subagent_child_stacks_under_gateway_api_server_parent` — the repro
  pin. Fails on master (`assert ['gateway_parent','subagent_a','subagent_b'] ==
  ['gateway_parent']`), passes with the fix. Uses the real `_isExternalSession` /
  `_isMessagingSession` / `_isWebUiSourceSession` helpers rather than stubs, so the marker
  path is genuinely exercised.
- `test_delegated_subagent_child_without_visible_parent_stays_suppressed` — guard for the
  #5305 out-of-scope suppression this fix must not regress. Passes both with and without
  the change; it exists to pin the behaviour the implementation deliberately preserves.

Existing coverage that must keep passing and does:
`test_cross_surface_webui_child_session_remains_top_level_when_parent_is_messaging`
(#1802) and `test_archived_hidden_parent_suppresses_cross_surface_child_orphan` (#4293).

Browser behaviour is owned by the browser, so it was checked in a real one — Chromium via
Playwright against a live deployment, rendering the actually-served asset, not an in-page
simulation. Same session data, before and after:

| | sidebar rows | flat "Subagent Session" | child badges |
|---|---|---|---|
| before | 18 | 12 | 0 |
| after | 6 | 0 | 5 |

Expanding the badges nests all 12 children under their 5 parents. Screenshots are ready
to attach to this PR.

Also clean: `npx eslint --no-config-lookup -c eslint.runtime-guard.config.mjs
"static/**/*.js"`, `scripts/scope_undef_gate.py` (18 static files, 3200 project globals,
no undefined references), and `scripts/ruff_lint.py --diff origin/master`.

## Risks / Follow-ups

- **Deliberate widening.** A subagent child of a genuinely messaging/CLI parent now also
  nests instead of orphaning. That matches the intent stated in the function's own comment
  ("delegated subagent rows … should not be forced into orphans"), and such a child has no
  surface of its own to be stranded on — but it is broader than the reported bug and the
  place I would most want a second opinion.
- **Adjacent case left unfixed.** A non-subagent, non-fork `child_session` of a
  gateway-backed parent still hits the same `parentSourceMarker` misclassification.
  Unreached by this repro; `api`/`api_server` arguably belongs in that allowlist as a
  separate change.
- **The flag's double duty is the real debt.** Splitting `_cross_surface_child_session`
  into two signals — "is a surface continuation" versus "follows its parent's scope" —
  would remove the constraint that shaped this fix. Deliberately out of scope.

Release-note wording, if useful:

> **Delegated subagent sessions now nest under their parent conversation on gateway-backed
> WebUI chats (#5305).** With `HERMES_WEBUI_CHAT_BACKEND=gateway` the parent conversation
> is recorded as `api_server` rather than `webui`, which the sidebar's cross-surface check
> read as an external surface — so every `delegate_task` child was promoted to a
> contextless top-level "Subagent Session" row and the parent showed no child count. The
> check now classifies on the child instead of enumerating parent surfaces. Genuine
> cross-surface continuations, and the suppression of delegated children whose parent is
> filtered out of view, are unchanged.

## Model Used

AI-assisted. Provider: Anthropic. Model: Claude Opus 5 (`claude-opus-5`), via Claude Code.

Notable tool use that mattered: diagnosis came from live inspection of a running
deployment over SSH (`state.db` queries, the `/api/sessions` payload, and the served
static asset) rather than from reading the source alone — that is what surfaced
`session_source='api'` as the trigger. The frontend logic was then exercised directly
under Node against the real payload to confirm the projection before and after, and
Playwright drove a real browser for the visual check.
