### PR TITLE
feat: per-turn footer for state.db-imported sessions (subagent, CLI, cron)

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1194,7 +1194,12 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
     return metadata
 
 
-def read_agent_session_turn_footer_stats(db_path: Path, session_id: str | None) -> dict:
+def read_agent_session_turn_footer_stats(
+    db_path: Path,
+    session_id: str | None,
+    *,
+    include_inactive: bool = False,
+) -> dict:
     """Return per-turn footer stats for one state.db-backed session.
 
     Imported agent sessions (delegated subagents, CLI, TUI, cron, messaging)
@@ -1208,7 +1213,10 @@ def read_agent_session_turn_footer_stats(db_path: Path, session_id: str | None) 
     row, so read it here and let the existing renderer do its job.
     ``own_message_count`` is returned so the caller can verify the transcript it
     is about to stamp really belongs to this one session (see
-    ``stamp_imported_turn_footers``).
+    ``stamp_imported_turn_footers``). It is counted under the SAME visibility
+    predicate ``get_state_db_session_messages`` applies, so ``include_inactive``
+    must mirror whatever that reader was called with — otherwise the count and
+    the transcript it is compared against are in different coordinate spaces.
 
     Returns ``{}`` on a missing db, an older schema, or an unknown session.
     """
@@ -1264,16 +1272,29 @@ def read_agent_session_turn_footer_stats(db_path: Path, session_id: str | None) 
             message_cols = {r[1] for r in cur.fetchall()}
             own_count = None
             if 'session_id' in message_cols:
+                # Mirror get_state_db_session_messages' active predicate exactly
+                # (api/models.py). That reader excludes ``active = 0`` rows —
+                # compacted/archived pre-compression history — by default, so
+                # counting every row here would report more messages than the
+                # transcript can ever contain for a compressed session. The
+                # ownership guard in stamp_imported_turn_footers would then read
+                # that mismatch as a stitched lineage and suppress the footer on
+                # a perfectly ordinary single-segment session.
+                active_clause = ""
+                if 'active' in message_cols and not include_inactive:
+                    active_clause = " AND (active IS NULL OR active != 0)"
                 cur.execute(
-                    "SELECT COUNT(*) AS c FROM messages WHERE session_id = ?",
+                    "SELECT COUNT(*) AS c FROM messages WHERE session_id = ?" + active_clause,
                     (sid,),
                 )
                 count_row = cur.fetchone()
                 own_count = int((count_row['c'] if count_row else 0) or 0)
+            has_tool_calls_col = 'tool_calls' in message_cols
     except Exception:
         return {}
 
     return {
+        'tool_calls_column_present': has_tool_calls_col,
         'model': str(stats.get('model') or '').strip(),
         'input_tokens': _as_positive_int(stats.get('input_tokens')),
         'output_tokens': _as_positive_int(stats.get('output_tokens')),
@@ -1285,7 +1306,7 @@ def read_agent_session_turn_footer_stats(db_path: Path, session_id: str | None) 
     }
 
 
-def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
+def stamp_imported_turn_footers(msgs: list, stats: dict, *, detach: bool = False) -> list:
     """Add display-only per-turn footer fields to an imported transcript.
 
     Writes the same message keys the in-process streaming path writes, so the
@@ -1309,7 +1330,23 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
     and render two footers for one turn. This matches the in-process path, which
     walks ``reversed(s.messages)`` and stamps exactly one assistant per turn, and
     the frontend contract that settled metadata belongs on the last
-    metadata-bearing assistant row of a multi-segment turn.
+    metadata-bearing assistant row of a multi-segment turn. On a legacy schema
+    with no ``tool_calls`` column that key is absent from every row and cannot
+    discriminate; ``_is_settled_assistant`` degrades to a content check there
+    rather than admitting both rows.
+
+    ``msgs`` must be the FULL visible segment for the session, not a paginated
+    slice of it: the ownership guard below compares transcript length against the
+    session's own message count, and a window would never match. Stamp first,
+    then slice.
+
+    With ``detach=True`` neither ``msgs`` nor any dict inside it is mutated — the
+    return value is a new list in which only the stamped rows are replaced by
+    copies. Response paths must use it. The messages reaching this function are
+    the same dicts the sidecar holds and the same ones that feed model-context
+    reconstruction, and display-only keys have no business in either; mutating in
+    place would put them there. Untouched rows are shared by reference, so the
+    copy cost is one dict per settled turn rather than per transcript row.
 
     Bails out entirely unless the transcript length matches the session's own
     message count. ``get_state_db_session_messages`` stitches compression /
@@ -1321,7 +1358,8 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
     TTFT is absent by design: the agent does not record a first-token time for
     these runs, so there is nothing to surface.
 
-    Mutates and returns ``msgs``.
+    Returns the transcript to render. Mutates ``msgs`` in place unless
+    ``detach=True``.
     """
     if not isinstance(msgs, list) or not msgs or not isinstance(stats, dict) or not stats:
         return msgs
@@ -1330,7 +1368,11 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
     if not isinstance(own_count, int) or own_count != len(msgs):
         return msgs
 
-    assistant_idxs = [i for i, m in enumerate(msgs) if _is_settled_assistant(m)]
+    has_tool_calls_col = bool(stats.get('tool_calls_column_present'))
+    assistant_idxs = [
+        i for i, m in enumerate(msgs)
+        if _is_settled_assistant(m, tool_calls_column_present=has_tool_calls_col)
+    ]
     if not assistant_idxs:
         return msgs
 
@@ -1360,31 +1402,55 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
             'cache_hit_percent': cache_hit_percent,
         }
 
+    out = list(msgs) if detach else msgs
     for idx in assistant_idxs:
-        msg = msgs[idx]
+        msg = dict(msgs[idx]) if detach else msgs[idx]
         if model and not msg.get('_usedModel'):
             msg['_usedModel'] = model
         if msg.get('_turnDuration') is None:
+            # Read the preceding user row off the ORIGINAL list: only assistant
+            # rows are copied, so timestamps are identical either way, and this
+            # keeps the lookup independent of how far the copying has progressed.
             duration = _turn_duration_from_preceding_user(msgs, idx)
             if duration is not None:
                 msg['_turnDuration'] = duration
         if usage is not None and not msg.get('_turnUsage'):
             msg['_turnUsage'] = dict(usage)
+        out[idx] = msg
 
-    return msgs
+    return out
 
 
-def _is_settled_assistant(message) -> bool:
+def _is_settled_assistant(message, *, tool_calls_column_present: bool = False) -> bool:
     """Return True for an assistant row that is a turn's answer, not a tool call.
 
     An assistant row with ``tool_calls`` is an intermediate segment: the turn is
     still running and its elapsed time is not yet meaningful.
+
+    That key is the discriminator only when the ``messages`` table HAS a
+    ``tool_calls`` column. Without it ``get_state_db_session_messages`` omits the
+    key from every row, so a tool-call segment is byte-identical to an answer by
+    key presence and the check silently admits both — putting a premature elapsed
+    time on the segment and rendering two footers for one turn, exactly the
+    ownership bug this predicate exists to prevent.
+
+    On such a schema fall back to the one signal that survives: the agent writes
+    tool-call segments with empty content and answers with content. A
+    blank-content assistant row is then refused rather than guessed at, which
+    also covers a turn aborted before its tool results were recorded. Defaults to
+    the strict fallback so a caller that did not get the flag from
+    ``read_agent_session_turn_footer_stats`` cannot accidentally opt into the
+    stronger claim.
     """
-    return (
-        isinstance(message, dict)
-        and _safe_lower(message.get('role')) == 'assistant'
-        and not message.get('tool_calls')
-    )
+    if not isinstance(message, dict):
+        return False
+    if _safe_lower(message.get('role')) != 'assistant':
+        return False
+    if message.get('tool_calls'):
+        return False
+    if not tool_calls_column_present:
+        return bool(str(message.get('content') or '').strip())
+    return True
 
 
 def _turn_duration_from_preceding_user(msgs: list, assistant_idx: int) -> float | None:

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1430,22 +1430,30 @@ def _settled_assistant_indices(msgs: list) -> list[int]:
     per turn, and the frontend contract that settled metadata belongs on the last
     metadata-bearing assistant row of a multi-segment tool turn.
 
-    Two shapes yield no settled row for the turn, so nothing is stamped:
+    Three shapes yield no settled row for the turn, so nothing is stamped:
 
     * the last assistant carries explicit ``tool_calls`` — it is a request, not
       an answer;
     * a ``tool`` row follows the last assistant — the turn was aborted or is
-      still running, and its elapsed time is not yet meaningful.
+      still running, and its elapsed time is not yet meaningful;
+    * the last assistant is blank AND its tool metadata is unreliable — the
+      ``tool_calls`` key absent (legacy schema) or NULL (migrated schema). An
+      empty terminal row is then indistinguishable from an incomplete or
+      aborted tool segment, so this fails closed rather than stamping it. An
+      explicitly parsed empty ``tool_calls`` list is reliable "requested no
+      tools" metadata and does not trip this refusal.
 
     Failing closed on those is deliberate: a premature footer asserts a duration
     and a model for a turn that never finished.
 
     Known residual, only on the metadata-less shapes: a turn whose LAST assistant
-    requested a tool and was then interrupted by the user's next message — no tool
-    row ever recorded — is indistinguishable from an answer by structure alone,
-    and is stamped. With ``tool_calls`` populated (every current Agent write) the
-    explicit check above rejects it, so this is confined to legacy/migrated rows
-    where the metadata was never recorded in the first place.
+    requested a tool, narrated the request, and was then interrupted by the
+    user's next message — no tool row ever recorded — is indistinguishable from
+    an answer by structure alone, and is stamped. With ``tool_calls`` populated
+    (every current Agent write) the explicit check above rejects it, and the
+    blank refusal above removes the silent variant, so this is confined to
+    narrated legacy/migrated rows where the metadata was never recorded in the
+    first place.
     """
     if not isinstance(msgs, list):
         return []
@@ -1479,7 +1487,19 @@ def _settled_assistant_indices(msgs: list) -> list[int]:
             continue
         if tool_follows_last_assistant:
             continue
-        if msgs[last_assistant].get('tool_calls'):
+        candidate = msgs[last_assistant]
+        if candidate.get('tool_calls'):
+            continue
+        # Fail closed on a blank terminal row whose tool metadata cannot be
+        # trusted: with no tool_calls key (legacy schema) or a NULL one
+        # (migrated schema), an empty answer is indistinguishable from an
+        # incomplete/aborted tool segment that never recorded its tool row.
+        # ``.get()`` returning None covers both unreliable shapes; an explicitly
+        # parsed empty list IS reliable "no tools" metadata and is not refused.
+        if (
+            candidate.get('tool_calls') is None
+            and not str(candidate.get('content') or '').strip()
+        ):
             continue
         settled.append(last_assistant)
     return settled

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1192,3 +1192,193 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
             entry['_compression_segment_count'] = max(segment_count, tip_depth)
 
     return metadata
+
+
+def read_agent_session_turn_footer_stats(db_path: Path, session_id: str | None) -> dict:
+    """Return per-turn footer stats for one state.db-backed session.
+
+    Imported agent sessions (delegated subagents, CLI, TUI, cron, messaging)
+    are not executed by the WebUI, so nothing ever stamps the per-turn footer
+    metadata that ``_run_agent_streaming`` writes for in-process turns. Their
+    transcripts therefore render with no footer at all — no model, no duration,
+    no tokens — which makes it impossible to confirm, for example, that a
+    ``delegate_task`` per-task model override actually took effect.
+
+    Everything the footer needs except TTFT is already recorded on the session
+    row, so read it here and let the existing renderer do its job.
+    ``own_message_count`` is returned so the caller can verify the transcript it
+    is about to stamp really belongs to this one session (see
+    ``stamp_imported_turn_footers``).
+
+    Returns ``{}`` on a missing db, an older schema, or an unknown session.
+    """
+    sid = str(session_id or '').strip()
+    if not sid:
+        return {}
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return {}
+
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            session_cols = {row[1] for row in cur.fetchall()}
+            if 'id' not in session_cols:
+                return {}
+
+            model_expr = _optional_col('model', session_cols)
+            input_expr = _optional_col('input_tokens', session_cols, '0')
+            output_expr = _optional_col('output_tokens', session_cols, '0')
+            cache_read_expr = _optional_col('cache_read_tokens', session_cols, '0')
+            cache_write_expr = _optional_col('cache_write_tokens', session_cols, '0')
+            cost_expr = _optional_col('estimated_cost_usd', session_cols)
+            calls_expr = _optional_col('api_call_count', session_cols, '0')
+
+            cur.execute(
+                f"""
+                SELECT s.id,
+                       {model_expr},
+                       {input_expr},
+                       {output_expr},
+                       {cache_read_expr},
+                       {cache_write_expr},
+                       {cost_expr},
+                       {calls_expr}
+                FROM sessions s
+                WHERE s.id = ?
+                """,
+                (sid,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return {}
+            stats = dict(row)
+
+            cur.execute("PRAGMA table_info(messages)")
+            message_cols = {r[1] for r in cur.fetchall()}
+            own_count = None
+            if 'session_id' in message_cols:
+                cur.execute(
+                    "SELECT COUNT(*) AS c FROM messages WHERE session_id = ?",
+                    (sid,),
+                )
+                count_row = cur.fetchone()
+                own_count = int((count_row['c'] if count_row else 0) or 0)
+    except Exception:
+        return {}
+
+    return {
+        'model': str(stats.get('model') or '').strip(),
+        'input_tokens': _as_positive_int(stats.get('input_tokens')),
+        'output_tokens': _as_positive_int(stats.get('output_tokens')),
+        'cache_read_tokens': _as_positive_int(stats.get('cache_read_tokens')),
+        'cache_write_tokens': _as_positive_int(stats.get('cache_write_tokens')),
+        'estimated_cost': stats.get('estimated_cost_usd'),
+        'api_call_count': _as_positive_int(stats.get('api_call_count')),
+        'own_message_count': own_count,
+    }
+
+
+def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
+    """Add display-only per-turn footer fields to an imported transcript.
+
+    Writes the same message keys the in-process streaming path writes, so the
+    existing footer renderer picks them up with no frontend change:
+
+    * ``_usedModel``    — from the session's recorded model.
+    * ``_turnDuration`` — assistant timestamp minus the preceding user
+      timestamp, i.e. genuinely per-turn.
+    * ``_turnUsage``    — session token/cache/cost totals, and ONLY when they
+      provably describe a single turn (``api_call_count == 1`` and exactly one
+      assistant message). ``messages.token_count`` is not populated for these
+      sessions, so there is no way to split totals across turns; showing
+      session-wide figures inside a per-turn footer would misattribute them.
+
+    Bails out entirely unless the transcript length matches the session's own
+    message count. ``get_state_db_session_messages`` stitches compression /
+    cli-close continuation segments together, and those segments are separate
+    session rows with their own models and totals — stamping this session's
+    stats across a stitched chain would attribute the wrong model to earlier
+    segments. Single-segment sessions (every delegated subagent) are unaffected.
+
+    TTFT is absent by design: the agent does not record a first-token time for
+    these runs, so there is nothing to surface.
+
+    Mutates and returns ``msgs``.
+    """
+    if not isinstance(msgs, list) or not msgs or not isinstance(stats, dict) or not stats:
+        return msgs
+
+    own_count = stats.get('own_message_count')
+    if not isinstance(own_count, int) or own_count != len(msgs):
+        return msgs
+
+    assistant_idxs = [
+        i for i, m in enumerate(msgs)
+        if isinstance(m, dict) and _safe_lower(m.get('role')) == 'assistant'
+    ]
+    if not assistant_idxs:
+        return msgs
+
+    model = str(stats.get('model') or '').strip()
+    single_turn = len(assistant_idxs) == 1 and stats.get('api_call_count') == 1
+
+    usage = None
+    if single_turn:
+        try:
+            from api.usage import prompt_cache_hit_percent
+        except Exception:
+            prompt_cache_hit_percent = None
+        input_tokens = stats.get('input_tokens') or 0
+        cache_read = stats.get('cache_read_tokens') or 0
+        cache_write = stats.get('cache_write_tokens') or 0
+        cache_hit_percent = None
+        if prompt_cache_hit_percent is not None:
+            # Match the in-process path: the denominator is the FULL prompt
+            # total (ordinary input + cache reads + cache writes).
+            cache_hit_percent = prompt_cache_hit_percent(
+                cache_read, input_tokens + cache_read + cache_write
+            )
+        usage = {
+            'input_tokens': input_tokens,
+            'output_tokens': stats.get('output_tokens') or 0,
+            'estimated_cost': stats.get('estimated_cost'),
+            'cache_hit_percent': cache_hit_percent,
+        }
+
+    for idx in assistant_idxs:
+        msg = msgs[idx]
+        if model and not msg.get('_usedModel'):
+            msg['_usedModel'] = model
+        if msg.get('_turnDuration') is None:
+            duration = _turn_duration_from_preceding_user(msgs, idx)
+            if duration is not None:
+                msg['_turnDuration'] = duration
+        if usage is not None and not msg.get('_turnUsage'):
+            msg['_turnUsage'] = dict(usage)
+
+    return msgs
+
+
+def _turn_duration_from_preceding_user(msgs: list, assistant_idx: int) -> float | None:
+    """Seconds from the user message that opened this turn to its reply."""
+    try:
+        end = float(msgs[assistant_idx].get('timestamp'))
+    except (TypeError, ValueError):
+        return None
+    for i in range(assistant_idx - 1, -1, -1):
+        candidate = msgs[i]
+        if not isinstance(candidate, dict):
+            continue
+        if _safe_lower(candidate.get('role')) != 'user':
+            continue
+        try:
+            start = float(candidate.get('timestamp'))
+        except (TypeError, ValueError):
+            return None
+        if end < start:
+            return None
+        return round(end - start, 3)
+    return None

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1220,7 +1220,11 @@ def read_agent_session_turn_footer_stats(db_path: Path, session_id: str | None) 
         return {}
 
     try:
-        with closing(sqlite3.connect(str(db_path))) as conn:
+        # Pure read of the live, WAL state.db — use the module's read-only opener
+        # for the same reason the other projections here do (#5455): a
+        # write-capable handle adds needless checkpoint/lock surface while the
+        # agent is streaming into it.
+        with closing(open_state_db_readonly(db_path)) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
             cur.execute("PRAGMA table_info(sessions)")
@@ -1292,9 +1296,20 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
       timestamp, i.e. genuinely per-turn.
     * ``_turnUsage``    — session token/cache/cost totals, and ONLY when they
       provably describe a single turn (``api_call_count == 1`` and exactly one
-      assistant message). ``messages.token_count`` is not populated for these
-      sessions, so there is no way to split totals across turns; showing
+      settled assistant message). ``messages.token_count`` is not populated for
+      these sessions, so there is no way to split totals across turns; showing
       session-wide figures inside a per-turn footer would misattribute them.
+
+    Only *settled* assistant rows are stamped — an assistant row carrying
+    ``tool_calls`` is an intermediate segment of a still-running turn, not its
+    answer. `get_state_db_session_messages` preserves `tool_calls` for imported
+    transcripts, so a tool-using turn arrives as
+    ``user -> assistant(tool_calls) -> tool -> assistant``; stamping both
+    assistant rows would put a premature elapsed time on the tool-call segment
+    and render two footers for one turn. This matches the in-process path, which
+    walks ``reversed(s.messages)`` and stamps exactly one assistant per turn, and
+    the frontend contract that settled metadata belongs on the last
+    metadata-bearing assistant row of a multi-segment turn.
 
     Bails out entirely unless the transcript length matches the session's own
     message count. ``get_state_db_session_messages`` stitches compression /
@@ -1315,10 +1330,7 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
     if not isinstance(own_count, int) or own_count != len(msgs):
         return msgs
 
-    assistant_idxs = [
-        i for i, m in enumerate(msgs)
-        if isinstance(m, dict) and _safe_lower(m.get('role')) == 'assistant'
-    ]
+    assistant_idxs = [i for i, m in enumerate(msgs) if _is_settled_assistant(m)]
     if not assistant_idxs:
         return msgs
 
@@ -1360,6 +1372,19 @@ def stamp_imported_turn_footers(msgs: list, stats: dict) -> list:
             msg['_turnUsage'] = dict(usage)
 
     return msgs
+
+
+def _is_settled_assistant(message) -> bool:
+    """Return True for an assistant row that is a turn's answer, not a tool call.
+
+    An assistant row with ``tool_calls`` is an intermediate segment: the turn is
+    still running and its elapsed time is not yet meaningful.
+    """
+    return (
+        isinstance(message, dict)
+        and _safe_lower(message.get('role')) == 'assistant'
+        and not message.get('tool_calls')
+    )
 
 
 def _turn_duration_from_preceding_user(msgs: list, assistant_idx: int) -> float | None:

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1289,12 +1289,10 @@ def read_agent_session_turn_footer_stats(
                 )
                 count_row = cur.fetchone()
                 own_count = int((count_row['c'] if count_row else 0) or 0)
-            has_tool_calls_col = 'tool_calls' in message_cols
     except Exception:
         return {}
 
     return {
-        'tool_calls_column_present': has_tool_calls_col,
         'model': str(stats.get('model') or '').strip(),
         'input_tokens': _as_positive_int(stats.get('input_tokens')),
         'output_tokens': _as_positive_int(stats.get('output_tokens')),
@@ -1321,19 +1319,13 @@ def stamp_imported_turn_footers(msgs: list, stats: dict, *, detach: bool = False
       these sessions, so there is no way to split totals across turns; showing
       session-wide figures inside a per-turn footer would misattribute them.
 
-    Only *settled* assistant rows are stamped — an assistant row carrying
-    ``tool_calls`` is an intermediate segment of a still-running turn, not its
-    answer. `get_state_db_session_messages` preserves `tool_calls` for imported
-    transcripts, so a tool-using turn arrives as
-    ``user -> assistant(tool_calls) -> tool -> assistant``; stamping both
+    Only *settled* assistant rows are stamped — the row that is a turn's answer,
+    not one of the tool-call segments leading up to it. A tool-using turn arrives
+    as ``user -> assistant(tool_calls) -> tool -> assistant``, and stamping both
     assistant rows would put a premature elapsed time on the tool-call segment
-    and render two footers for one turn. This matches the in-process path, which
-    walks ``reversed(s.messages)`` and stamps exactly one assistant per turn, and
-    the frontend contract that settled metadata belongs on the last
-    metadata-bearing assistant row of a multi-segment turn. On a legacy schema
-    with no ``tool_calls`` column that key is absent from every row and cannot
-    discriminate; ``_is_settled_assistant`` degrades to a content check there
-    rather than admitting both rows.
+    and render two footers for one turn. ``_settled_assistant_indices`` decides
+    this from transcript structure rather than from the ``tool_calls`` key, which
+    is absent on a legacy schema and NULL on a migrated one; see its docstring.
 
     ``msgs`` must be the FULL visible segment for the session, not a paginated
     slice of it: the ownership guard below compares transcript length against the
@@ -1368,11 +1360,7 @@ def stamp_imported_turn_footers(msgs: list, stats: dict, *, detach: bool = False
     if not isinstance(own_count, int) or own_count != len(msgs):
         return msgs
 
-    has_tool_calls_col = bool(stats.get('tool_calls_column_present'))
-    assistant_idxs = [
-        i for i, m in enumerate(msgs)
-        if _is_settled_assistant(m, tool_calls_column_present=has_tool_calls_col)
-    ]
+    assistant_idxs = _settled_assistant_indices(msgs)
     if not assistant_idxs:
         return msgs
 
@@ -1421,36 +1409,80 @@ def stamp_imported_turn_footers(msgs: list, stats: dict, *, detach: bool = False
     return out
 
 
-def _is_settled_assistant(message, *, tool_calls_column_present: bool = False) -> bool:
-    """Return True for an assistant row that is a turn's answer, not a tool call.
+def _settled_assistant_indices(msgs: list) -> list[int]:
+    """Indices of the assistant rows that are their turn's final answer.
 
-    An assistant row with ``tool_calls`` is an intermediate segment: the turn is
-    still running and its elapsed time is not yet meaningful.
+    Derived from transcript STRUCTURE rather than from schema column presence or
+    content truthiness, because neither of those is a reliable discriminator:
 
-    That key is the discriminator only when the ``messages`` table HAS a
-    ``tool_calls`` column. Without it ``get_state_db_session_messages`` omits the
-    key from every row, so a tool-call segment is byte-identical to an answer by
-    key presence and the check silently admits both — putting a premature elapsed
-    time on the segment and rendering two footers for one turn, exactly the
-    ownership bug this predicate exists to prevent.
+    * A ``tool_calls`` column may be missing entirely on a legacy database, in
+      which case ``get_state_db_session_messages`` omits the key from every row.
+    * Agent startup back-fills missing message columns, so a migrated database
+      can have the column PRESENT but NULL on all historical rows — which looks
+      identical to "this assistant requested no tools".
+    * Content is not a discriminator either: real CLI transcripts record narrated
+      tool-call assistants with non-empty content ("Let me search") ahead of the
+      tool row, so a nonblank assistant is not necessarily an answer.
 
-    On such a schema fall back to the one signal that survives: the agent writes
-    tool-call segments with empty content and answers with content. A
-    blank-content assistant row is then refused rather than guessed at, which
-    also covers a turn aborted before its tool results were recorded. Defaults to
-    the strict fallback so a caller that did not get the flag from
-    ``read_agent_session_turn_footer_stats`` cannot accidentally opt into the
-    stronger claim.
+    The structure survives all three. Turns are delimited by ``user`` rows, and
+    within a turn the answer is the LAST assistant row — matching the in-process
+    path, which walks ``reversed(s.messages)`` and stamps exactly one assistant
+    per turn, and the frontend contract that settled metadata belongs on the last
+    metadata-bearing assistant row of a multi-segment tool turn.
+
+    Two shapes yield no settled row for the turn, so nothing is stamped:
+
+    * the last assistant carries explicit ``tool_calls`` — it is a request, not
+      an answer;
+    * a ``tool`` row follows the last assistant — the turn was aborted or is
+      still running, and its elapsed time is not yet meaningful.
+
+    Failing closed on those is deliberate: a premature footer asserts a duration
+    and a model for a turn that never finished.
+
+    Known residual, only on the metadata-less shapes: a turn whose LAST assistant
+    requested a tool and was then interrupted by the user's next message — no tool
+    row ever recorded — is indistinguishable from an answer by structure alone,
+    and is stamped. With ``tool_calls`` populated (every current Agent write) the
+    explicit check above rejects it, so this is confined to legacy/migrated rows
+    where the metadata was never recorded in the first place.
     """
-    if not isinstance(message, dict):
-        return False
-    if _safe_lower(message.get('role')) != 'assistant':
-        return False
-    if message.get('tool_calls'):
-        return False
-    if not tool_calls_column_present:
-        return bool(str(message.get('content') or '').strip())
-    return True
+    if not isinstance(msgs, list):
+        return []
+
+    total = len(msgs)
+    turn_starts = [
+        i for i, m in enumerate(msgs)
+        if isinstance(m, dict) and _safe_lower(m.get('role')) == 'user'
+    ]
+    # A transcript can open with assistant/system rows before any user row (a
+    # replayed or seeded segment); treat that leading run as its own turn.
+    if not turn_starts or turn_starts[0] != 0:
+        turn_starts.insert(0, 0)
+
+    settled: list[int] = []
+    for position, start in enumerate(turn_starts):
+        end = turn_starts[position + 1] if position + 1 < len(turn_starts) else total
+        last_assistant = None
+        tool_follows_last_assistant = False
+        for i in range(start, end):
+            message = msgs[i]
+            if not isinstance(message, dict):
+                continue
+            role = _safe_lower(message.get('role'))
+            if role == 'assistant':
+                last_assistant = i
+                tool_follows_last_assistant = False
+            elif role == 'tool' and last_assistant is not None:
+                tool_follows_last_assistant = True
+        if last_assistant is None:
+            continue
+        if tool_follows_last_assistant:
+            continue
+        if msgs[last_assistant].get('tool_calls'):
+            continue
+        settled.append(last_assistant)
+    return settled
 
 
 def _turn_duration_from_preceding_user(msgs: list, assistant_idx: int) -> float | None:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9168,6 +9168,29 @@ def _session_source_is_webui(session: dict) -> bool:
     return False
 
 
+def _footer_gate_source_markers(candidate) -> set[str]:
+    """Normalized source markers from one metadata authority.
+
+    Deliberately the SAME key set the canonical ``is_cli_session_row()``
+    classifier reads, ``source_label`` included, and normalized through
+    ``_normalized_source_marker`` so ``"WebUI"`` and ``"WebUI Session"`` both
+    reduce to ``webui``. Accepts either a sidecar/Session object or a state.db
+    metadata dict.
+    """
+    if candidate is None:
+        return set()
+    markers = set()
+    for key in ("source_tag", "raw_source", "session_source", "source", "source_label"):
+        value = (
+            candidate.get(key) if isinstance(candidate, dict)
+            else getattr(candidate, key, None)
+        )
+        marker = _normalized_source_marker(value)
+        if marker:
+            markers.add(marker)
+    return markers
+
+
 def _session_ran_outside_webui(session, cli_meta) -> bool:
     """Return True when this session's turns were executed by another surface.
 
@@ -9175,28 +9198,30 @@ def _session_ran_outside_webui(session, cli_meta) -> bool:
     same one ``_session_requires_cli_metadata_lookup`` already answers for
     metadata — an imported/foreign row carries source markers, a WebUI-native
     session carries none — so reuse it rather than invent a second notion of
-    foreign. ``_session_source_is_webui`` then subtracts the one case that gate
-    admits but must not be stamped: a WebUI-origin session later touched through
-    another surface (Gateway API server) has a state.db row and source markers,
-    yet the WebUI ran its turns and already stamped their footers itself.
+    foreign. The veto below then subtracts the case that gate admits but must not
+    be stamped: a WebUI-origin session later touched through another surface
+    (Gateway API server) has a state.db row and source markers, yet the WebUI ran
+    its turns and already stamped their footers itself.
 
-    Both arguments are consulted because neither alone is authoritative — a
+    The veto reads the FULL marker set rather than ``_session_source_is_webui``,
+    which omits ``source_label``. ``_session_requires_cli_metadata_lookup``
+    accepts ``source_label`` as a source marker and ``is_cli_session_row``
+    accepts ``source_label == "webui"`` as native authority, so a narrower veto
+    lets a native row whose only surviving native marker is
+    ``source_label="WebUI"`` through the gate — and same-ID session totals then
+    get stamped onto a WebUI transcript as false model/duration/token
+    attribution. ``_session_source_is_webui`` itself is left alone: five other
+    callers depend on its current semantics.
+
+    Both authorities are consulted because neither alone is authoritative — a
     legacy sidecar can predate the source fields while the state.db row has them,
     and a synthesized session has them before any sidecar exists. A ``webui``
-    marker on EITHER wins: they are checked separately rather than merged, so a
-    foreign marker on one cannot mask a ``webui`` marker on the other.
+    marker on EITHER denies backfill, checked per-authority rather than on a
+    merged set, so a foreign marker on one cannot mask a ``webui`` marker on the
+    other.
     """
     for candidate in (session, cli_meta):
-        if candidate is None:
-            continue
-        markers = {
-            key: (
-                candidate.get(key) if isinstance(candidate, dict)
-                else getattr(candidate, key, None)
-            )
-            for key in ("source_tag", "raw_source", "session_source", "source")
-        }
-        if _session_source_is_webui(markers):
+        if "webui" in _footer_gate_source_markers(candidate):
             return False
     return bool(
         _session_requires_cli_metadata_lookup(session)

--- a/api/routes.py
+++ b/api/routes.py
@@ -44,7 +44,9 @@ from api.agent_sessions import (
     _looks_like_default_cli_title,
     is_cli_session_row,
     is_cli_session_row_visible,
+    read_agent_session_turn_footer_stats,
     read_session_lineage_report,
+    stamp_imported_turn_footers,
 )
 from api.compression_anchor import visible_messages_for_anchor
 from api.compression_recovery import (
@@ -13058,6 +13060,16 @@ def handle_get(handler, parsed) -> bool:
                 "messages": msgs,
                 "tool_calls": [],
             }
+            # Imported agent transcripts (delegated subagents, CLI, cron, ...)
+            # are not run by the WebUI, so no per-turn footer metadata was ever
+            # stamped and they render with an empty footer — no model, no
+            # duration, no tokens. Populate it from the session row here, on the
+            # response path only, so nothing display-only reaches the reader
+            # that feeds model context.
+            stamp_imported_turn_footers(
+                msgs,
+                read_agent_session_turn_footer_stats(_active_state_db_path(), sid),
+            )
             attach_todo_state(sess, msgs)
             sess = _merge_cli_sidebar_metadata(sess, cli_meta)
             return j(handler, {"session": redact_session_data(sess)})

--- a/api/routes.py
+++ b/api/routes.py
@@ -9168,6 +9168,82 @@ def _session_source_is_webui(session: dict) -> bool:
     return False
 
 
+def _session_ran_outside_webui(session, cli_meta) -> bool:
+    """Return True when this session's turns were executed by another surface.
+
+    Ownership gate for imported per-turn footer backfill. The question is the
+    same one ``_session_requires_cli_metadata_lookup`` already answers for
+    metadata — an imported/foreign row carries source markers, a WebUI-native
+    session carries none — so reuse it rather than invent a second notion of
+    foreign. ``_session_source_is_webui`` then subtracts the one case that gate
+    admits but must not be stamped: a WebUI-origin session later touched through
+    another surface (Gateway API server) has a state.db row and source markers,
+    yet the WebUI ran its turns and already stamped their footers itself.
+
+    Both arguments are consulted because neither alone is authoritative — a
+    legacy sidecar can predate the source fields while the state.db row has them,
+    and a synthesized session has them before any sidecar exists. A ``webui``
+    marker on EITHER wins: they are checked separately rather than merged, so a
+    foreign marker on one cannot mask a ``webui`` marker on the other.
+    """
+    for candidate in (session, cli_meta):
+        if candidate is None:
+            continue
+        markers = {
+            key: (
+                candidate.get(key) if isinstance(candidate, dict)
+                else getattr(candidate, key, None)
+            )
+            for key in ("source_tag", "raw_source", "session_source", "source")
+        }
+        if _session_source_is_webui(markers):
+            return False
+    return bool(
+        _session_requires_cli_metadata_lookup(session)
+        or _session_requires_cli_metadata_lookup(cli_meta)
+    )
+
+
+def _imported_session_response_messages(sid, msgs, *, session=None, cli_meta=None) -> list:
+    """Return the transcript to serialize for an imported session's response.
+
+    Single entry point for per-turn footer backfill, shared by both /api/session
+    branches — the persisted-sidecar path and the no-sidecar synthesized path —
+    so a CLI/TUI/cron session does not lose its footer the moment a sidecar
+    exists for it.
+
+    Call this with the FULL visible segment, BEFORE any pagination slice.
+    ``stamp_imported_turn_footers`` proves transcript ownership by length against
+    the session's own message count, which a window can never satisfy; stamping
+    first also lets a windowed assistant row still resolve the user row that
+    opened its turn even when that row sits outside the window. The stamps
+    survive slicing because ``_messages_for_limited_payload`` and
+    ``_hydrate_anchor_activity_scenes`` copy rows rather than rebuild them.
+
+    Nothing is mutated: ``detach=True`` means the caller receives a new list
+    whose stamped rows are copies, so these display-only keys never reach the
+    persisted sidecar or the reader that feeds model context.
+
+    Returns ``msgs`` unchanged for WebUI-native sessions, an unreadable or
+    older-schema state.db, or a stitched lineage.
+    """
+    if not isinstance(msgs, list) or not msgs:
+        return msgs
+    if not _session_ran_outside_webui(session, cli_meta):
+        return msgs
+    try:
+        # _active_state_db_path() is the right db without threading profile
+        # through: /api/session rejects any session whose profile does not match
+        # the active one before reaching here, so the session's state.db IS the
+        # active profile's.
+        stats = read_agent_session_turn_footer_stats(_active_state_db_path(), sid)
+    except Exception:
+        return msgs
+    if not stats:
+        return msgs
+    return stamp_imported_turn_footers(msgs, stats, detach=True)
+
+
 def _normalized_source_marker(value) -> str:
     marker = str(value or "").strip().lower()
     if marker.endswith(" session"):
@@ -12740,6 +12816,18 @@ def handle_get(handler, parsed) -> bool:
                 _summary_message_count = None
                 _summary_last_message_at = None
             if load_messages:
+                # Imported agent transcripts (delegated subagents, CLI, TUI,
+                # cron, messaging) are not run by the WebUI, so no per-turn
+                # footer metadata was ever stamped and they render with no model,
+                # duration, or token information at all. Backfill it from the
+                # session row here — on the full visible segment, before the
+                # pagination slice below, because the ownership check is a length
+                # comparison and a window would never match. Returns a detached
+                # list, so nothing display-only reaches the sidecar or the reader
+                # that feeds model context. No-op for WebUI-native sessions.
+                _all_msgs = _imported_session_response_messages(
+                    sid, _all_msgs, session=s, cli_meta=cli_meta,
+                )
                 _truncated_msgs, _messages_offset = _message_window_for_display(
                     _all_msgs,
                     msg_limit=msg_limit,
@@ -13018,6 +13106,14 @@ def handle_get(handler, parsed) -> bool:
             # the wire shape stays byte-equivalent to the previous inline
             # synthesis (the frontend has been reading these exact keys).
             msgs = list(synth.messages or [])
+            # Same per-turn footer backfill the persisted-sidecar branch above
+            # applies, through the same helper: whether an imported session has a
+            # WebUI sidecar yet must not decide whether its transcript shows a
+            # model, a duration, or token counts. This branch is never paginated,
+            # so the synthesized list is already the full visible segment.
+            msgs = _imported_session_response_messages(
+                sid, msgs, session=synth, cli_meta=cli_meta,
+            )
             sess = {
                 "session_id": synth.session_id,
                 "title": synth.title,
@@ -13060,16 +13156,6 @@ def handle_get(handler, parsed) -> bool:
                 "messages": msgs,
                 "tool_calls": [],
             }
-            # Imported agent transcripts (delegated subagents, CLI, cron, ...)
-            # are not run by the WebUI, so no per-turn footer metadata was ever
-            # stamped and they render with an empty footer — no model, no
-            # duration, no tokens. Populate it from the session row here, on the
-            # response path only, so nothing display-only reaches the reader
-            # that feeds model context.
-            stamp_imported_turn_footers(
-                msgs,
-                read_agent_session_turn_footer_stats(_active_state_db_path(), sid),
-            )
             attach_todo_state(sess, msgs)
             sess = _merge_cli_sidebar_metadata(sess, cli_meta)
             return j(handler, {"session": redact_session_data(sess)})

--- a/tests/test_imported_session_turn_footer.py
+++ b/tests/test_imported_session_turn_footer.py
@@ -8,6 +8,7 @@ row instead.
 """
 
 import sqlite3
+from unittest.mock import patch
 
 import api.agent_sessions as agent_sessions
 
@@ -128,6 +129,101 @@ def test_multi_call_session_gets_model_and_duration_but_no_token_totals(tmp_path
     assert [m["_usedModel"] for m in assistants] == ["x-ai/grok-4.5", "x-ai/grok-4.5"]
     assert [m["_turnDuration"] for m in assistants] == [6.404, 10.574]
     assert all("_turnUsage" not in m for m in assistants)
+
+
+def test_tool_using_turn_stamps_only_the_settled_assistant(tmp_path):
+    """An assistant row that requests tools is not the turn's answer.
+
+    `get_state_db_session_messages` preserves `tool_calls`, so an imported
+    tool-using turn arrives as user -> assistant(tool_calls) -> tool ->
+    assistant. Stamping both assistant rows would put a premature elapsed time
+    on the tool-call segment and render two footers for one logical turn; the
+    frontend contract puts settled metadata on the last metadata-bearing
+    assistant row. The final answer must carry the full user-to-completion
+    duration.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        # A tool-using turn is at least two API calls, so usage is withheld
+        # regardless; this test is about model/duration ownership.
+        _add_session(conn, "sub_tools", api_calls=2)
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("t_u1", "sub_tools", "user", "do the thing", 1000.0),
+                ("t_a1", "sub_tools", "assistant", "", 1002.0),
+                ("t_r1", "sub_tools", "tool", "tool output", 1003.0),
+                ("t_a2", "sub_tools", "assistant", "done", 1008.5),
+            ],
+        )
+        conn.commit()
+        msgs = _transcript(conn, "sub_tools")
+    finally:
+        conn.close()
+
+    # The reader parses tool_calls onto the intermediate assistant row.
+    msgs[1]["tool_calls"] = [{"id": "call_1", "function": {"name": "read_file"}}]
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "sub_tools")
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+
+    intermediate, final = msgs[1], msgs[3]
+    assert "_usedModel" not in intermediate
+    assert "_turnDuration" not in intermediate
+    assert "_turnUsage" not in intermediate
+    assert final["_usedModel"] == "x-ai/grok-4.5"
+    # Full user -> final answer, not user -> tool-call segment (which would be 2.0).
+    assert final["_turnDuration"] == 8.5
+    assert "_turnUsage" not in final
+
+
+def test_single_call_turn_without_tool_calls_is_the_direct_control(tmp_path):
+    """Control for the tool-using case: a plain turn still gets full metadata."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "sub_plain", api_calls=1)
+        _add_turn(conn, "sub_plain", 1, user_ts=1000.0, assistant_ts=1003.0)
+        msgs = _transcript(conn, "sub_plain")
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "sub_plain")
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+
+    assistant = msgs[-1]
+    assert assistant["_usedModel"] == "x-ai/grok-4.5"
+    assert assistant["_turnDuration"] == 3.0
+    assert assistant["_turnUsage"]["input_tokens"] == 10189
+
+
+def test_footer_stats_read_state_db_through_the_read_only_opener(tmp_path):
+    """A pure-read projection must not take a write-capable handle on state.db.
+
+    Mirrors the module's existing rule (#5455): the live WAL state.db is opened
+    via ``open_state_db_readonly`` so a read never adds checkpoint/lock surface.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "ro_check")
+        _add_turn(conn, "ro_check", 1, user_ts=1.0, assistant_ts=2.0)
+    finally:
+        conn.close()
+
+    calls = []
+    real_opener = agent_sessions.open_state_db_readonly
+
+    def _spy(path, *args, **kwargs):
+        calls.append(str(path))
+        return real_opener(path, *args, **kwargs)
+
+    with patch.object(agent_sessions, "open_state_db_readonly", side_effect=_spy):
+        stats = agent_sessions.read_agent_session_turn_footer_stats(db, "ro_check")
+
+    assert calls == [str(db)], "stats read did not go through open_state_db_readonly"
+    assert stats["model"] == "x-ai/grok-4.5"
 
 
 def test_stitched_transcript_is_not_stamped_with_one_segments_stats(tmp_path):

--- a/tests/test_imported_session_turn_footer.py
+++ b/tests/test_imported_session_turn_footer.py
@@ -13,6 +13,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 from urllib.parse import urlparse
 
+import pytest
+
 import api.agent_sessions as agent_sessions
 
 
@@ -515,7 +517,7 @@ class _NativeWebuiSidecar(_ImportedSidecar):
         self.platform = None
 
 
-def _get_api_session(db, sid, *, session, cli_meta, query="", synth=None):
+def _get_api_session(db, sid, *, session, cli_meta, query="", synth=None, spy_stats=False):
     """Drive GET /api/session against a purpose-built state.db.
 
     The real ``get_state_db_session_messages`` reads the transcript so the
@@ -550,10 +552,24 @@ def _get_api_session(db, sid, *, session, cli_meta, query="", synth=None):
         stack.append(
             patch.object(routes, "_claim_or_synthesize_cli_session", return_value=(synth, "")),
         )
+    stats_reads = []
+    if spy_stats:
+        real_reader = routes.read_agent_session_turn_footer_stats
+
+        def _spy_reader(*args, **kwargs):
+            stats_reads.append(args[:2])
+            return real_reader(*args, **kwargs)
+
+        stack.append(
+            patch.object(
+                routes, "read_agent_session_turn_footer_stats", side_effect=_spy_reader
+            )
+        )
     with ExitStack() as es:
         for cm in stack:
             es.enter_context(cm)
         routes.handle_get(SimpleNamespace(), parsed)
+    captured["stats_reads"] = stats_reads
     return captured
 
 
@@ -776,19 +792,25 @@ def test_webui_origin_session_touched_by_another_surface_is_left_alone(tmp_path)
     )
 
 
+
+
 # --------------------------------------------------------------------------
-# Legacy schema with no tool_calls column
+# Turn ownership across schema shapes: absent, migrated-NULL, and populated
+# tool_calls metadata
 # --------------------------------------------------------------------------
 
 
-def _make_legacy_state_db(path):
-    """A ``messages`` table predating the ``tool_calls`` column.
+def _make_state_db_with_shape(path, *, tool_calls_column: bool):
+    """Build a state.db with or without the ``messages.tool_calls`` column.
 
-    ``get_state_db_session_messages`` only emits optional keys for columns that
-    exist, so on this schema NO row carries ``tool_calls`` — and the settled
-    check cannot use its absence to mean "this is an answer".
+    ``tool_calls_column=False`` is a legacy database predating the column.
+    ``True`` with NULL values is the *migrated* shape: Agent startup back-fills
+    missing message columns, so the column exists on an upgraded database while
+    every historical row leaves it NULL. Neither shape can be told apart from
+    "this assistant requested no tools" by looking at the key.
     """
     conn = sqlite3.connect(str(path))
+    tool_calls_ddl = "            tool_calls TEXT,\n" if tool_calls_column else ""
     conn.executescript(
         """
         CREATE TABLE sessions (
@@ -807,89 +829,292 @@ def _make_legacy_state_db(path):
             session_id TEXT,
             role TEXT,
             content TEXT,
-            timestamp REAL
+"""
+        + tool_calls_ddl
+        + """            timestamp REAL
         );
         """
     )
     return conn
 
 
-def test_legacy_schema_without_tool_calls_still_stamps_one_footer_per_turn(tmp_path):
-    """The round-one ownership fix must not be defeated by an older schema.
-
-    With no ``tool_calls`` column the discriminator is absent from every row, so
-    a key-presence check admits the intermediate segment as well and puts a
-    premature 2.0s elapsed time on it alongside a second footer for the same
-    turn. Only the final answer may be stamped.
-    """
+def _read_real_transcript(db, sid):
+    """Read through the production reader so the fixture cannot drift from it."""
     import api.models as models
 
-    db = tmp_path / "state.db"
-    conn = _make_legacy_state_db(db)
+    with patch.object(models, "_active_state_db_path", return_value=db):
+        return models.get_state_db_session_messages(sid)
+
+
+def _seed_shape(db, sid, rows, *, api_calls=2, tool_calls_column):
+    conn = _make_state_db_with_shape(db, tool_calls_column=tool_calls_column)
     try:
         conn.execute(
-            "INSERT INTO sessions VALUES ('legacy_tools', 'cli', 'openai/gpt-5', "
-            "100, 10, 0, 0, 0.001, 2)"
+            "INSERT INTO sessions VALUES (?, 'cli', 'openai/gpt-5', 100, 10, 0, 0, 0.001, ?)",
+            (sid, api_calls),
         )
         conn.executemany(
             "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
-            [
-                ("legacy_tools", "user", "do the thing", 1000.0),
-                # Tool-call segment: the agent writes these with empty content.
-                ("legacy_tools", "assistant", "", 1002.0),
-                ("legacy_tools", "tool", "tool output", 1003.0),
-                ("legacy_tools", "assistant", "done", 1008.5),
-            ],
+            [(sid, role, content, ts) for role, content, ts in rows],
         )
         conn.commit()
     finally:
         conn.close()
 
-    with patch.object(models, "_active_state_db_path", return_value=db):
-        msgs = models.get_state_db_session_messages("legacy_tools")
 
-    assert all("tool_calls" not in m for m in msgs), (
-        "fixture must reproduce the schema where the discriminator is absent"
+# Both production shapes the review named. Neither leaves a usable tool_calls
+# value on the rows, so the settled-assistant decision cannot come from the key.
+_AMBIGUOUS_SHAPES = [
+    pytest.param(False, id="column-physically-absent"),
+    pytest.param(True, id="column-present-but-null"),
+]
+
+
+@pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
+def test_narrated_tool_segment_is_not_mistaken_for_the_answer(tmp_path, tool_calls_column):
+    """A tool-call assistant can carry real prose, so content is not a discriminator.
+
+    Real CLI transcripts record narrated tool-call assistants — "Let me search" —
+    ahead of the tool row. Treating any nonblank assistant as settled hands the
+    intermediate segment a premature 2.0s duration and renders two footers for
+    one turn. Only the final answer may be stamped, with the full
+    user-to-completion duration.
+    """
+    db = tmp_path / "state.db"
+    _seed_shape(
+        db,
+        "narrated",
+        [
+            ("user", "find the config", 1000.0),
+            ("assistant", "Let me search", 1002.0),
+            ("tool", "3 matches", 1003.0),
+            ("assistant", "It lives in config.json", 1008.5),
+        ],
+        tool_calls_column=tool_calls_column,
     )
-    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "legacy_tools")
-    assert stats["tool_calls_column_present"] is False
+
+    msgs = _read_real_transcript(db, "narrated")
+    assert all(not m.get("tool_calls") for m in msgs), (
+        "fixture must reproduce a shape where tool_calls cannot discriminate"
+    )
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "narrated")
     stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
 
-    intermediate, final = stamped[1], stamped[3]
-    assert "_usedModel" not in intermediate, "tool-call segment was stamped"
-    assert "_turnDuration" not in intermediate, "tool-call segment got a premature 2.0s"
+    narrated, final = stamped[1], stamped[3]
+    assert "_usedModel" not in narrated, "narrated tool segment was stamped"
+    assert "_turnDuration" not in narrated, "narrated tool segment got a premature 2.0s"
+    assert "_turnUsage" not in narrated
     assert final["_usedModel"] == "openai/gpt-5"
     assert final["_turnDuration"] == 8.5
 
 
-def test_legacy_schema_plain_turn_keeps_its_footer(tmp_path):
-    """Degrading the discriminator must not cost every legacy session its footer."""
-    import api.models as models
+@pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
+@pytest.mark.parametrize(
+    "narration", ["Let me search", ""], ids=["narrated", "blank"]
+)
+def test_aborted_turn_with_no_final_answer_stamps_nothing(
+    tmp_path, tool_calls_column, narration
+):
+    """Tool work outstanding and no answer recorded: fail closed.
 
+    A footer here would assert a duration and a model for a turn that never
+    finished. Covers both the narrated and the blank intermediate, since neither
+    content shape tells you an answer arrived.
+    """
     db = tmp_path / "state.db"
-    conn = _make_legacy_state_db(db)
+    _seed_shape(
+        db,
+        "aborted",
+        [
+            ("user", "find the config", 1000.0),
+            ("assistant", narration, 1002.0),
+            ("tool", "3 matches", 1003.0),
+        ],
+        tool_calls_column=tool_calls_column,
+    )
+
+    msgs = _read_real_transcript(db, "aborted")
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "aborted")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert all("_usedModel" not in m for m in stamped), (
+        "an unfinished turn was given a footer"
+    )
+    assert all("_turnDuration" not in m for m in stamped)
+    assert all("_turnUsage" not in m for m in stamped)
+
+
+@pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
+def test_plain_answer_control_keeps_its_footer(tmp_path, tool_calls_column):
+    """Control: hardening ownership must not cost ordinary turns their footer."""
+    db = tmp_path / "state.db"
+    _seed_shape(
+        db,
+        "plain",
+        [
+            ("user", "hello", 1000.0),
+            ("assistant", "hi there", 1003.0),
+        ],
+        api_calls=1,
+        tool_calls_column=tool_calls_column,
+    )
+
+    msgs = _read_real_transcript(db, "plain")
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "plain")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert stamped[-1]["_usedModel"] == "openai/gpt-5"
+    assert stamped[-1]["_turnDuration"] == 3.0
+    assert stamped[-1]["_turnUsage"]["output_tokens"] == 10
+
+
+@pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
+def test_multi_round_tool_turn_stamps_only_the_last_answer(tmp_path, tool_calls_column):
+    """Several tool rounds inside one turn still yield exactly one footer."""
+    db = tmp_path / "state.db"
+    _seed_shape(
+        db,
+        "rounds",
+        [
+            ("user", "do it", 1000.0),
+            ("assistant", "Let me look", 1001.0),
+            ("tool", "partial", 1002.0),
+            ("assistant", "Now let me check the other file", 1003.0),
+            ("tool", "more", 1004.0),
+            ("assistant", "All set", 1009.0),
+        ],
+        tool_calls_column=tool_calls_column,
+    )
+
+    msgs = _read_real_transcript(db, "rounds")
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "rounds")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    stamped_idxs = [i for i, m in enumerate(stamped) if "_usedModel" in m]
+    assert stamped_idxs == [5], "exactly one footer belongs to a multi-round turn"
+    assert stamped[5]["_turnDuration"] == 9.0
+
+
+def test_populated_tool_calls_metadata_is_still_honoured(tmp_path):
+    """The explicit signal must keep working where the schema does supply it.
+
+    Structural inference is the fallback, not a replacement: an assistant that
+    declares tool_calls is intermediate even if nothing follows it yet.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
     try:
-        conn.execute(
-            "INSERT INTO sessions VALUES ('legacy_plain', 'cli', 'openai/gpt-5', "
-            "512, 64, 0, 0, 0.002, 1)"
-        )
+        _add_session(conn, "explicit", api_calls=2)
         conn.executemany(
-            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            "INSERT INTO messages (id, session_id, role, content, timestamp, tool_calls) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             [
-                ("legacy_plain", "user", "hello", 1000.0),
-                ("legacy_plain", "assistant", "hi there", 1003.0),
+                ("e_u1", "explicit", "user", "do it", 1000.0, None),
+                ("e_a1", "explicit", "assistant", "Let me search", 1002.0,
+                 '[{"id": "c1", "function": {"name": "grep"}}]'),
             ],
         )
         conn.commit()
     finally:
         conn.close()
 
-    with patch.object(models, "_active_state_db_path", return_value=db):
-        msgs = models.get_state_db_session_messages("legacy_plain")
-
-    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "legacy_plain")
+    msgs = _read_real_transcript(db, "explicit")
+    assert msgs[1].get("tool_calls"), "reader should have parsed the tool_calls column"
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "explicit")
     stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
 
-    assert stamped[-1]["_usedModel"] == "openai/gpt-5"
-    assert stamped[-1]["_turnDuration"] == 3.0
-    assert stamped[-1]["_turnUsage"]["output_tokens"] == 64
+    assert all("_usedModel" not in m for m in stamped), (
+        "an assistant declaring tool_calls is a request, not an answer"
+    )
+
+
+@pytest.mark.parametrize("native_on", ["sidecar", "state_metadata"])
+def test_source_label_webui_alone_denies_backfill(tmp_path, native_on):
+    """``source_label="WebUI"`` is a native marker and must veto the backfill.
+
+    ``_session_requires_cli_metadata_lookup`` accepts ``source_label`` as a source
+    marker, and the canonical ``is_cli_session_row`` accepts
+    ``source_label == "webui"`` as native authority — but the narrower
+    ``_session_source_is_webui`` does not read that key at all. A native row whose
+    only surviving native marker is ``source_label`` therefore passed the foreign
+    gate, and same-ID session totals got stamped onto a WebUI transcript as false
+    model/duration/token attribution.
+
+    Parametrized over which authority carries the native marker, with the other
+    deliberately carrying a foreign one, so the veto is proven per-authority
+    rather than on a merged marker set.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "label_native", model="should-not-appear", api_calls=1)
+        _add_turn(conn, "label_native", 1, user_ts=1000.0, assistant_ts=1004.0)
+    finally:
+        conn.close()
+
+    mirror = [
+        {"role": "user", "content": "x", "timestamp": 1000.0},
+        {"role": "assistant", "content": "x", "timestamp": 1004.0},
+    ]
+    sidecar = _ImportedSidecar("label_native")
+    sidecar.messages = mirror
+    # Strip the markers the narrow veto would have caught, leaving source_label
+    # as the only native signal on whichever authority is under test.
+    sidecar.source_tag = None
+    sidecar.raw_source = None
+    sidecar.session_source = None
+    sidecar.source = None
+
+    if native_on == "sidecar":
+        sidecar.source_label = "WebUI"
+        cli_meta = {"session_id": "label_native", "source_tag": "cli", "raw_source": "cli"}
+    else:
+        sidecar.source_label = None
+        sidecar.is_cli_session = True  # foreign marker on the sidecar authority
+        cli_meta = {"session_id": "label_native", "source_label": "WebUI"}
+
+    captured = _get_api_session(
+        db, "label_native", session=sidecar, cli_meta=cli_meta, spy_stats=True
+    )
+
+    msgs = captured["data"]["session"]["messages"]
+    assert len(msgs) == 2, "the length guard must not be what blocks this case"
+    assert captured["stats_reads"] == [], (
+        "a WebUI marker must deny backfill BEFORE the state.db stats read"
+    )
+    assert all("_usedModel" not in m for m in msgs), (
+        "session totals were stamped onto a WebUI-native transcript"
+    )
+    assert all("_turnUsage" not in m for m in msgs)
+
+
+def test_source_label_foreign_value_still_allows_backfill(tmp_path):
+    """Control: widening the veto to source_label must not deny genuine imports."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "label_cli", model="openai/gpt-5", api_calls=1)
+        _add_turn(conn, "label_cli", 1, user_ts=1000.0, assistant_ts=1005.5)
+    finally:
+        conn.close()
+
+    sidecar = _ImportedSidecar("label_cli")
+    sidecar.source_tag = None
+    sidecar.raw_source = None
+    sidecar.session_source = None
+    sidecar.source = None
+    sidecar.source_label = "CLI"
+
+    captured = _get_api_session(
+        db,
+        "label_cli",
+        session=sidecar,
+        cli_meta={"session_id": "label_cli", "source_label": "CLI"},
+        spy_stats=True,
+    )
+
+    msgs = captured["data"]["session"]["messages"]
+    assistant = [m for m in msgs if m.get("role") == "assistant"][-1]
+    assert captured["stats_reads"], "a genuine import should still read stats"
+    assert assistant["_usedModel"] == "openai/gpt-5"
+    assert assistant["_turnDuration"] == 5.5

--- a/tests/test_imported_session_turn_footer.py
+++ b/tests/test_imported_session_turn_footer.py
@@ -1,0 +1,217 @@
+"""Per-turn footer metadata for state.db-imported sessions.
+
+Imported agent transcripts (delegated subagents, CLI, TUI, cron) are not run by
+the WebUI, so ``_run_agent_streaming`` never stamps the per-turn footer fields
+and the transcript renders with no model, duration, or token information at all.
+These tests pin the server-side backfill that reads those facts off the session
+row instead.
+"""
+
+import sqlite3
+
+import api.agent_sessions as agent_sessions
+
+
+def _make_state_db(path):
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            model TEXT,
+            started_at REAL,
+            ended_at REAL,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            cache_read_tokens INTEGER,
+            cache_write_tokens INTEGER,
+            estimated_cost_usd REAL,
+            api_call_count INTEGER
+        );
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        """
+    )
+    return conn
+
+
+def _add_session(conn, sid, *, model="x-ai/grok-4.5", api_calls=1, input_tokens=10189,
+                 output_tokens=221, cache_read=128, cache_write=0, cost=0.0025):
+    conn.execute(
+        """
+        INSERT INTO sessions (id, source, model, started_at, ended_at, input_tokens,
+                              output_tokens, cache_read_tokens, cache_write_tokens,
+                              estimated_cost_usd, api_call_count)
+        VALUES (?, 'subagent', ?, 1000.0, 1010.0, ?, ?, ?, ?, ?, ?)
+        """,
+        (sid, model, input_tokens, output_tokens, cache_read, cache_write, cost, api_calls),
+    )
+    conn.commit()
+
+
+def _add_turn(conn, sid, n, *, user_ts, assistant_ts):
+    conn.executemany(
+        "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, ?, 'x', ?)",
+        [
+            (f"{sid}_u{n}", sid, "user", user_ts),
+            (f"{sid}_a{n}", sid, "assistant", assistant_ts),
+        ],
+    )
+    conn.commit()
+
+
+def _transcript(conn, sid):
+    """Message dicts in the shape get_state_db_session_messages returns."""
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT role, content, timestamp FROM messages WHERE session_id = ? ORDER BY timestamp ASC",
+        (sid,),
+    ).fetchall()
+    return [{"role": r["role"], "content": r["content"], "timestamp": r["timestamp"]} for r in rows]
+
+
+def test_single_call_subagent_turn_gets_model_duration_and_usage(tmp_path):
+    """The common delegate_task child: one call, so totals provably describe it."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "sub_single", api_calls=1)
+        _add_turn(conn, "sub_single", 1, user_ts=1000.0, assistant_ts=1004.076)
+        msgs = _transcript(conn, "sub_single")
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "sub_single")
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+
+    assistant = msgs[-1]
+    assert assistant["_usedModel"] == "x-ai/grok-4.5"
+    assert assistant["_turnDuration"] == 4.076
+    assert assistant["_turnUsage"]["input_tokens"] == 10189
+    assert assistant["_turnUsage"]["output_tokens"] == 221
+    assert assistant["_turnUsage"]["estimated_cost"] == 0.0025
+    # cache_read / (input + cache_read + cache_write) — same denominator the
+    # in-process path uses via prompt_cache_hit_percent.
+    assert assistant["_turnUsage"]["cache_hit_percent"] == 1
+    # The user message is never a turn footer carrier.
+    assert "_usedModel" not in msgs[0]
+
+
+def test_multi_call_session_gets_model_and_duration_but_no_token_totals(tmp_path):
+    """Session totals must not be presented as one turn's usage.
+
+    ``messages.token_count`` is not populated for imported sessions, so with
+    more than one API call there is no way to split the totals. Model and
+    per-turn duration are still exact and are still shown.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "sub_multi", api_calls=2)
+        _add_turn(conn, "sub_multi", 1, user_ts=1000.0, assistant_ts=1006.404)
+        _add_turn(conn, "sub_multi", 2, user_ts=1010.0, assistant_ts=1020.574)
+        msgs = _transcript(conn, "sub_multi")
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "sub_multi")
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+
+    assistants = [m for m in msgs if m["role"] == "assistant"]
+    assert len(assistants) == 2
+    assert [m["_usedModel"] for m in assistants] == ["x-ai/grok-4.5", "x-ai/grok-4.5"]
+    assert [m["_turnDuration"] for m in assistants] == [6.404, 10.574]
+    assert all("_turnUsage" not in m for m in assistants)
+
+
+def test_stitched_transcript_is_not_stamped_with_one_segments_stats(tmp_path):
+    """A stitched continuation chain spans session rows with their own models.
+
+    ``get_state_db_session_messages`` returns segments stitched together, so a
+    transcript longer than the requested session's own message count must be
+    left alone rather than attributed to this segment's model and totals.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "tip", model="openai/gpt-5", api_calls=1)
+        _add_turn(conn, "tip", 1, user_ts=2000.0, assistant_ts=2001.0)
+        msgs = _transcript(conn, "tip")
+        # Simulate the stitched parent segment prepended by the reader.
+        msgs = [
+            {"role": "user", "content": "older", "timestamp": 1000.0},
+            {"role": "assistant", "content": "older reply", "timestamp": 1001.0},
+        ] + msgs
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "tip")
+    assert stats["own_message_count"] == 2
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+
+    assert all("_usedModel" not in m for m in msgs)
+    assert all("_turnUsage" not in m for m in msgs)
+
+
+def test_footer_stats_degrade_quietly(tmp_path):
+    """Missing db, unknown session, and empty input must never raise."""
+    missing = tmp_path / "nope.db"
+    assert agent_sessions.read_agent_session_turn_footer_stats(missing, "whatever") == {}
+
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "known")
+    finally:
+        conn.close()
+
+    assert agent_sessions.read_agent_session_turn_footer_stats(db, "unknown") == {}
+    assert agent_sessions.read_agent_session_turn_footer_stats(db, "") == {}
+    assert agent_sessions.read_agent_session_turn_footer_stats(db, None) == {}
+    # No-op paths on the stamping side.
+    assert agent_sessions.stamp_imported_turn_footers([], {"own_message_count": 0}) == []
+    assert agent_sessions.stamp_imported_turn_footers(None, {}) is None
+
+
+def test_transcript_without_an_assistant_reply_is_untouched(tmp_path):
+    """A user-only transcript has no turn to attribute anything to."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "pending")
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES ('p_u1','pending','user','x',5.0)"
+        )
+        conn.commit()
+        msgs = _transcript(conn, "pending")
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "pending")
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+    assert msgs == [{"role": "user", "content": "x", "timestamp": 5.0}]
+
+
+def test_missing_model_does_not_stamp_an_empty_model_chip(tmp_path):
+    """An unrecorded model must leave the chip absent, not blank."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "no_model", model=None, api_calls=1)
+        _add_turn(conn, "no_model", 1, user_ts=1.0, assistant_ts=2.5)
+        msgs = _transcript(conn, "no_model")
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "no_model")
+    agent_sessions.stamp_imported_turn_footers(msgs, stats)
+
+    assistant = msgs[-1]
+    assert "_usedModel" not in assistant
+    assert assistant["_turnDuration"] == 1.5

--- a/tests/test_imported_session_turn_footer.py
+++ b/tests/test_imported_session_turn_footer.py
@@ -945,6 +945,107 @@ def test_aborted_turn_with_no_final_answer_stamps_nothing(
 
 
 @pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
+@pytest.mark.parametrize("blank", ["", "  \n\t  "], ids=["empty", "whitespace"])
+def test_blank_terminal_assistant_stamps_nothing(tmp_path, tool_calls_column, blank):
+    """A blank terminal row is not proof an answer settled.
+
+    With tool metadata untrustworthy, ``user -> assistant(content="")`` can be
+    an incomplete or aborted tool segment just as well as an empty answer. The
+    aborted-turn matrix above always appends a tool row after the blank
+    assistant, so it exits through the trailing-tool rejection; here the blank
+    row TERMINATES the turn, reaching the append the matrix never exercises.
+    Fail closed: no footer.
+    """
+    db = tmp_path / "state.db"
+    _seed_shape(
+        db,
+        "blank_terminal",
+        [
+            ("user", "find the config", 1000.0),
+            ("assistant", blank, 1002.0),
+        ],
+        tool_calls_column=tool_calls_column,
+    )
+
+    msgs = _read_real_transcript(db, "blank_terminal")
+    assert all(not m.get("tool_calls") for m in msgs), (
+        "fixture must reproduce a shape where tool_calls cannot discriminate"
+    )
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "blank_terminal")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert all("_usedModel" not in m for m in stamped), (
+        "a blank terminal row with unreliable tool metadata was stamped"
+    )
+    assert all("_turnDuration" not in m for m in stamped)
+    assert all("_turnUsage" not in m for m in stamped)
+
+
+@pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
+def test_blank_terminal_assistant_does_not_block_later_turns(tmp_path, tool_calls_column):
+    """The blank refusal is per-turn: a later plain answer keeps its footer.
+
+    user -> blank assistant -> next user -> plain answer. The first turn fails
+    closed; the second is an ordinary settled turn and must still be stamped,
+    proving the refusal does not leak across the user delimiter.
+    """
+    db = tmp_path / "state.db"
+    _seed_shape(
+        db,
+        "blank_then_plain",
+        [
+            ("user", "find the config", 1000.0),
+            ("assistant", "", 1002.0),
+            ("user", "never mind, just tell me", 1010.0),
+            ("assistant", "It lives in config.json", 1014.0),
+        ],
+        tool_calls_column=tool_calls_column,
+    )
+
+    msgs = _read_real_transcript(db, "blank_then_plain")
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "blank_then_plain")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert "_usedModel" not in stamped[1], "blank terminal row was stamped"
+    assert "_turnDuration" not in stamped[1]
+    assert stamped[3]["_usedModel"] == "openai/gpt-5"
+    assert stamped[3]["_turnDuration"] == 4.0
+
+
+def test_explicit_empty_tool_calls_list_keeps_blank_answer_stampable(tmp_path):
+    """An explicitly parsed empty tool_calls list is reliable metadata.
+
+    The blank refusal exists only for rows whose tool metadata cannot be
+    trusted. A current-schema row recording ``'[]'`` says "requested no tools"
+    positively, so a blank answer there is a settled (if empty) answer and
+    keeps its footer.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "explicit_empty", api_calls=1)
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp, tool_calls) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("ee_u1", "explicit_empty", "user", "quiet ok?", 1000.0, None),
+                ("ee_a1", "explicit_empty", "assistant", "", 1003.0, "[]"),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    msgs = _read_real_transcript(db, "explicit_empty")
+    assert msgs[1].get("tool_calls") == [], "reader should parse the empty list"
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "explicit_empty")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert stamped[1]["_usedModel"] == "x-ai/grok-4.5"
+    assert stamped[1]["_turnDuration"] == 3.0
+
+
+@pytest.mark.parametrize("tool_calls_column", _AMBIGUOUS_SHAPES)
 def test_plain_answer_control_keeps_its_footer(tmp_path, tool_calls_column):
     """Control: hardening ownership must not cost ordinary turns their footer."""
     db = tmp_path / "state.db"

--- a/tests/test_imported_session_turn_footer.py
+++ b/tests/test_imported_session_turn_footer.py
@@ -8,7 +8,10 @@ row instead.
 """
 
 import sqlite3
+from contextlib import ExitStack
+from types import SimpleNamespace
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import api.agent_sessions as agent_sessions
 
@@ -35,7 +38,9 @@ def _make_state_db(path):
             session_id TEXT,
             role TEXT,
             content TEXT,
-            timestamp REAL
+            timestamp REAL,
+            tool_calls TEXT,
+            active INTEGER
         );
         """
     )
@@ -311,3 +316,580 @@ def test_missing_model_does_not_stamp_an_empty_model_chip(tmp_path):
     assistant = msgs[-1]
     assert "_usedModel" not in assistant
     assert assistant["_turnDuration"] == 1.5
+
+
+# --------------------------------------------------------------------------
+# Ownership count under the reader's visibility predicate
+# --------------------------------------------------------------------------
+
+
+def test_own_message_count_excludes_inactive_rows_like_the_reader(tmp_path):
+    """The count must live in the same coordinate space as the transcript.
+
+    ``get_state_db_session_messages`` drops ``active = 0`` rows — compacted
+    pre-compression history — by default, so a compressed session returns fewer
+    messages than its ``messages`` table holds. Counting every row here reports a
+    transcript this session can never produce, and the stitched-lineage guard
+    reads that mismatch as a stitched chain and suppresses the footer on an
+    ordinary single-segment session.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "compressed", api_calls=1)
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp, active) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                # Archived by a compression pass: invisible to the reader.
+                ("c_u0", "compressed", "user", "ancient", 900.0, 0),
+                ("c_u1", "compressed", "user", "current", 1000.0, 1),
+                ("c_a1", "compressed", "assistant", "reply", 1003.5, 1),
+            ],
+        )
+        conn.commit()
+        # The visible transcript, exactly as the reader would return it.
+        msgs = [
+            {"role": "user", "content": "current", "timestamp": 1000.0},
+            {"role": "assistant", "content": "reply", "timestamp": 1003.5},
+        ]
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "compressed")
+    assert stats["own_message_count"] == 2, (
+        "own_message_count must exclude active=0 rows so it matches the "
+        "transcript get_state_db_session_messages actually returns"
+    )
+
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+    assert stamped[-1]["_usedModel"] == "x-ai/grok-4.5"
+    assert stamped[-1]["_turnDuration"] == 3.5
+
+
+def test_include_inactive_count_mirrors_the_readers_recovery_mode(tmp_path):
+    """``include_inactive`` exists so the two stay paired, not as a default."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "recovery", api_calls=1)
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp, active) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("r_u0", "recovery", "user", "ancient", 900.0, 0),
+                ("r_u1", "recovery", "user", "current", 1000.0, 1),
+                ("r_a1", "recovery", "assistant", "reply", 1002.0, 1),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert agent_sessions.read_agent_session_turn_footer_stats(
+        db, "recovery"
+    )["own_message_count"] == 2
+    assert agent_sessions.read_agent_session_turn_footer_stats(
+        db, "recovery", include_inactive=True
+    )["own_message_count"] == 3
+
+
+def test_detach_leaves_the_caller_transcript_untouched(tmp_path):
+    """Response-path stamping must not reach the sidecar or model context.
+
+    The dicts handed in are the same objects the sidecar holds and the same ones
+    that feed model-context reconstruction, so display-only keys must land on
+    copies.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "detached", api_calls=1)
+        _add_turn(conn, "detached", 1, user_ts=1000.0, assistant_ts=1002.0)
+        msgs = _transcript(conn, "detached")
+    finally:
+        conn.close()
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "detached")
+    stored_assistant = msgs[-1]
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert stamped is not msgs
+    assert stamped[-1]["_usedModel"] == "x-ai/grok-4.5"
+    assert "_usedModel" not in stored_assistant, "stamped a dict the sidecar still holds"
+    assert stamped[-1] is not stored_assistant
+    # Untouched rows are shared by reference: only settled turns are copied.
+    assert stamped[0] is msgs[0]
+
+
+# --------------------------------------------------------------------------
+# GET /api/session — both branches must reach the same backfill
+# --------------------------------------------------------------------------
+
+
+class _ImportedSidecar:
+    """Persisted WebUI sidecar for a session another surface executed.
+
+    Read-only imported sidecars carry the source markers and an empty message
+    list: the transcript itself lives in state.db and is merged in on load.
+    """
+
+    def __init__(self, sid, *, source_tag="cli", messages=None):
+        self.session_id = sid
+        self.title = "Imported"
+        self.workspace = "/tmp"
+        self.model = "openai/gpt-5"
+        self.model_provider = None
+        self.messages = list(messages or [])
+        self.tool_calls = []
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.estimated_cost = 0
+        self.context_length = 1
+        self.threshold_tokens = 0
+        self.last_prompt_tokens = 0
+        self.active_stream_id = None
+        self.pending_user_message = None
+        self.pending_attachments = []
+        self.pending_started_at = None
+        self.pending_user_source = None
+        self.composer_draft = {}
+        self.is_cli_session = True
+        self.read_only = True
+        self.session_source = source_tag
+        self.source_tag = source_tag
+        self.raw_source = source_tag
+        self.source_label = source_tag
+        self.truncation_watermark = None
+        self.truncation_boundary = None
+        self.anchor_activity_scenes = None
+        self.profile = None
+        self.created_at = 1000.0
+        self.updated_at = 1010.0
+        self.last_message_at = 1010.0
+        self.pinned = False
+        self.archived = False
+        self.project_id = None
+
+    def compact(self, **kwargs):
+        return {
+            "session_id": self.session_id,
+            "title": self.title,
+            "workspace": self.workspace,
+            "model": self.model,
+            "model_provider": self.model_provider,
+            "message_count": len(self.messages),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_message_at": self.last_message_at,
+            "context_length": self.context_length,
+            "threshold_tokens": self.threshold_tokens,
+            "last_prompt_tokens": self.last_prompt_tokens,
+            "active_stream_id": self.active_stream_id,
+            "pending_user_message": self.pending_user_message,
+            "composer_draft": self.composer_draft,
+            "is_cli_session": self.is_cli_session,
+            "read_only": self.read_only,
+            "session_source": self.session_source,
+            "source_tag": self.source_tag,
+            "raw_source": self.raw_source,
+            "source_label": self.source_label,
+            "pinned": self.pinned,
+            "archived": self.archived,
+            "project_id": self.project_id,
+            "profile": self.profile,
+        }
+
+
+class _NativeWebuiSidecar(_ImportedSidecar):
+    """A session the WebUI itself ran: no foreign source markers at all."""
+
+    def __init__(self, sid, *, messages=None):
+        super().__init__(sid, messages=messages)
+        self.is_cli_session = False
+        self.read_only = False
+        self.session_source = None
+        self.source_tag = None
+        self.raw_source = None
+        self.source_label = None
+        self.platform = None
+
+
+def _get_api_session(db, sid, *, session, cli_meta, query="", synth=None):
+    """Drive GET /api/session against a purpose-built state.db.
+
+    The real ``get_state_db_session_messages`` reads the transcript so the
+    ownership count and the transcript it gates are produced by the same schema
+    the production reader sees, rather than by a hand-written fixture pair.
+    """
+    import api.models as models
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    def fake_get_session(_sid, **kwargs):
+        if session is None:
+            raise KeyError(_sid)
+        return session
+
+    parsed = urlparse(f"/api/session?session_id={sid}&messages=1&resolve_model=0{query}")
+    stack = [
+        patch.object(models, "_active_state_db_path", return_value=db),
+        patch.object(routes, "_active_state_db_path", return_value=db),
+        patch.object(routes, "get_session", side_effect=fake_get_session),
+        patch.object(routes, "_clear_stale_stream_state", return_value=False),
+        patch.object(routes, "_lookup_cli_session_metadata", return_value=cli_meta),
+        patch.object(routes, "j", side_effect=fake_j),
+    ]
+    if synth is not None:
+        stack.append(
+            patch.object(routes, "_claim_or_synthesize_cli_session", return_value=(synth, "")),
+        )
+    with ExitStack() as es:
+        for cm in stack:
+            es.enter_context(cm)
+        routes.handle_get(SimpleNamespace(), parsed)
+    return captured
+
+
+def test_persisted_imported_sidecar_gets_the_footer_on_the_normal_branch(tmp_path):
+    """The gap the first round left open.
+
+    A CLI/TUI session imported into a WebUI sidecar takes the ordinary
+    ``get_session`` branch, which returned the transcript without ever calling
+    the backfill — so the footer appeared once, on the synthesized load, and
+    vanished on every load after a sidecar existed.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "cli_persisted", model="openai/gpt-5", api_calls=1)
+        _add_turn(conn, "cli_persisted", 1, user_ts=1000.0, assistant_ts=1007.25)
+    finally:
+        conn.close()
+
+    captured = _get_api_session(
+        db,
+        "cli_persisted",
+        session=_ImportedSidecar("cli_persisted"),
+        cli_meta={"session_id": "cli_persisted", "source_tag": "cli", "raw_source": "cli"},
+    )
+
+    assert captured["status"] == 200
+    msgs = captured["data"]["session"]["messages"]
+    assistant = [m for m in msgs if m.get("role") == "assistant"][-1]
+    assert assistant["_usedModel"] == "openai/gpt-5"
+    assert assistant["_turnDuration"] == 7.25
+    assert assistant["_turnUsage"]["output_tokens"] == 221
+
+
+def test_no_sidecar_subagent_branch_still_gets_the_footer(tmp_path):
+    """The synthesized branch must keep working through the shared helper."""
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "sub_synth", model="x-ai/grok-4.5", api_calls=1)
+        _add_turn(conn, "sub_synth", 1, user_ts=2000.0, assistant_ts=2004.5)
+        conn.row_factory = sqlite3.Row
+        transcript = _transcript(conn, "sub_synth")
+    finally:
+        conn.close()
+
+    synth = _ImportedSidecar("sub_synth", source_tag="subagent", messages=transcript)
+    synth.is_cli_session = False
+    captured = _get_api_session(
+        db,
+        "sub_synth",
+        session=None,  # no WebUI sidecar -> KeyError -> synthesized branch
+        cli_meta={"session_id": "sub_synth", "source_tag": "subagent", "raw_source": "subagent"},
+        synth=synth,
+    )
+
+    assert captured["status"] == 200
+    msgs = captured["data"]["session"]["messages"]
+    assistant = [m for m in msgs if m.get("role") == "assistant"][-1]
+    assert assistant["_usedModel"] == "x-ai/grok-4.5"
+    assert assistant["_turnDuration"] == 4.5
+    # The synthesized Session's own message dicts must not have been stamped.
+    assert all("_usedModel" not in m for m in transcript)
+
+
+def test_compressed_imported_session_is_stamped_through_the_route(tmp_path):
+    """One inactive row plus one visible turn: the two counts must agree.
+
+    End-to-end proof of the ownership-count fix — the real reader hides the
+    ``active = 0`` row, so a whole-table count would suppress the footer here.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "cli_compressed", model="openai/gpt-5", api_calls=1)
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp, active) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("z_u0", "cli_compressed", "user", "archived by compression", 900.0, 0),
+                ("z_u1", "cli_compressed", "user", "current question", 1000.0, 1),
+                ("z_a1", "cli_compressed", "assistant", "current answer", 1006.0, 1),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    captured = _get_api_session(
+        db,
+        "cli_compressed",
+        session=_ImportedSidecar("cli_compressed"),
+        cli_meta={"session_id": "cli_compressed", "source_tag": "cli", "raw_source": "cli"},
+    )
+
+    msgs = captured["data"]["session"]["messages"]
+    assert [m.get("content") for m in msgs] == ["current question", "current answer"], (
+        "the reader should have hidden the active=0 row"
+    )
+    assistant = msgs[-1]
+    assert assistant["_usedModel"] == "openai/gpt-5", (
+        "an inactive row inflated own_message_count and suppressed the footer"
+    )
+    assert assistant["_turnDuration"] == 6.0
+
+
+def test_paginated_imported_load_still_stamps_the_visible_assistant(tmp_path):
+    """Ownership is judged on the full visible segment, not the returned window.
+
+    A window can never match the session's own message count, so gating on the
+    sliced list would leave every paginated load unstamped. Stamping runs before
+    the slice, which also lets the newest assistant resolve the user row that
+    opened its turn even when that row falls outside the window.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "cli_paged", model="openai/gpt-5", api_calls=3)
+        _add_turn(conn, "cli_paged", 1, user_ts=1000.0, assistant_ts=1002.0)
+        _add_turn(conn, "cli_paged", 2, user_ts=1010.0, assistant_ts=1013.0)
+        _add_turn(conn, "cli_paged", 3, user_ts=1020.0, assistant_ts=1029.5)
+    finally:
+        conn.close()
+
+    sidecar = _ImportedSidecar("cli_paged")
+    captured = _get_api_session(
+        db,
+        "cli_paged",
+        session=sidecar,
+        cli_meta={"session_id": "cli_paged", "source_tag": "cli", "raw_source": "cli"},
+        # A one-row window, so the user message that opened this turn is
+        # provably outside it.
+        query="&msg_limit=1",
+    )
+
+    session_payload = captured["data"]["session"]
+    msgs = session_payload["messages"]
+    assert [m.get("role") for m in msgs] == ["assistant"]
+    assert session_payload["_messages_offset"] == 5, "expected the tail window of six rows"
+    assistant = msgs[0]
+    assert assistant["_usedModel"] == "openai/gpt-5"
+    # 1029.5 - 1020.0: resolved from a user row the window does not contain,
+    # which is only possible because stamping ran before the slice.
+    assert assistant["_turnDuration"] == 9.5
+    # Three API calls: session totals cannot be attributed to one turn.
+    assert "_turnUsage" not in assistant
+    # Nothing display-only may have been written back to the stored session.
+    assert all("_usedModel" not in m for m in sidecar.messages)
+
+
+def test_webui_native_session_is_left_alone(tmp_path):
+    """The ownership gate: the WebUI stamps its own turns and must not be double-stamped.
+
+    A native session has no foreign source markers, so the backfill must not run
+    even when a state.db row happens to exist for the same id.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "native_sess", model="should-not-appear", api_calls=1)
+        _add_turn(conn, "native_sess", 1, user_ts=1000.0, assistant_ts=1004.0)
+    finally:
+        conn.close()
+
+    # Mirror the state.db rows exactly so the merge dedupes to a transcript whose
+    # length DOES match own_message_count. Otherwise the stitched-lineage length
+    # guard would suppress the footer on its own and this test would pass without
+    # the ownership gate ever being consulted.
+    native = _NativeWebuiSidecar(
+        "native_sess",
+        messages=[
+            {"role": "user", "content": "x", "timestamp": 1000.0},
+            {"role": "assistant", "content": "x", "timestamp": 1004.0},
+        ],
+    )
+    captured = _get_api_session(db, "native_sess", session=native, cli_meta={})
+
+    msgs = captured["data"]["session"]["messages"]
+    assert len(msgs) == 2, "the length guard must not be what blocks this case"
+    assert all("_usedModel" not in m for m in msgs), (
+        "WebUI-native sessions must not be backfilled from state.db"
+    )
+    assert all("_turnUsage" not in m for m in msgs)
+
+
+def test_webui_origin_session_touched_by_another_surface_is_left_alone(tmp_path):
+    """A ``webui`` marker on either source wins over a foreign marker on the other.
+
+    A WebUI-origin session later updated through the Gateway API server does get a
+    state.db row, and its sidebar row can carry an ``api`` source marker — but the
+    WebUI ran those turns and already stamped their footers. Merging the two
+    sources' markers into one dict would let the ``api`` marker mask the ``webui``
+    one and backfill session-wide totals over correct per-turn ones.
+    """
+    db = tmp_path / "state.db"
+    conn = _make_state_db(db)
+    try:
+        _add_session(conn, "webui_via_api", model="should-not-appear", api_calls=1)
+        _add_turn(conn, "webui_via_api", 1, user_ts=1000.0, assistant_ts=1004.0)
+    finally:
+        conn.close()
+
+    sidecar = _ImportedSidecar("webui_via_api", source_tag="webui")
+    sidecar.messages = [
+        {"role": "user", "content": "x", "timestamp": 1000.0},
+        {"role": "assistant", "content": "x", "timestamp": 1004.0},
+    ]
+    captured = _get_api_session(
+        db,
+        "webui_via_api",
+        session=sidecar,
+        # The sidebar row disagrees: it saw the session through the API server.
+        cli_meta={"session_id": "webui_via_api", "source_tag": "api", "raw_source": "api"},
+    )
+
+    msgs = captured["data"]["session"]["messages"]
+    assert len(msgs) == 2, "the length guard must not be what blocks this case"
+    assert all("_usedModel" not in m for m in msgs), (
+        "a foreign marker on the sidebar row masked the sidecar's webui marker"
+    )
+
+
+# --------------------------------------------------------------------------
+# Legacy schema with no tool_calls column
+# --------------------------------------------------------------------------
+
+
+def _make_legacy_state_db(path):
+    """A ``messages`` table predating the ``tool_calls`` column.
+
+    ``get_state_db_session_messages`` only emits optional keys for columns that
+    exist, so on this schema NO row carries ``tool_calls`` — and the settled
+    check cannot use its absence to mean "this is an answer".
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            model TEXT,
+            input_tokens INTEGER,
+            output_tokens INTEGER,
+            cache_read_tokens INTEGER,
+            cache_write_tokens INTEGER,
+            estimated_cost_usd REAL,
+            api_call_count INTEGER
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        );
+        """
+    )
+    return conn
+
+
+def test_legacy_schema_without_tool_calls_still_stamps_one_footer_per_turn(tmp_path):
+    """The round-one ownership fix must not be defeated by an older schema.
+
+    With no ``tool_calls`` column the discriminator is absent from every row, so
+    a key-presence check admits the intermediate segment as well and puts a
+    premature 2.0s elapsed time on it alongside a second footer for the same
+    turn. Only the final answer may be stamped.
+    """
+    import api.models as models
+
+    db = tmp_path / "state.db"
+    conn = _make_legacy_state_db(db)
+    try:
+        conn.execute(
+            "INSERT INTO sessions VALUES ('legacy_tools', 'cli', 'openai/gpt-5', "
+            "100, 10, 0, 0, 0.001, 2)"
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            [
+                ("legacy_tools", "user", "do the thing", 1000.0),
+                # Tool-call segment: the agent writes these with empty content.
+                ("legacy_tools", "assistant", "", 1002.0),
+                ("legacy_tools", "tool", "tool output", 1003.0),
+                ("legacy_tools", "assistant", "done", 1008.5),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with patch.object(models, "_active_state_db_path", return_value=db):
+        msgs = models.get_state_db_session_messages("legacy_tools")
+
+    assert all("tool_calls" not in m for m in msgs), (
+        "fixture must reproduce the schema where the discriminator is absent"
+    )
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "legacy_tools")
+    assert stats["tool_calls_column_present"] is False
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    intermediate, final = stamped[1], stamped[3]
+    assert "_usedModel" not in intermediate, "tool-call segment was stamped"
+    assert "_turnDuration" not in intermediate, "tool-call segment got a premature 2.0s"
+    assert final["_usedModel"] == "openai/gpt-5"
+    assert final["_turnDuration"] == 8.5
+
+
+def test_legacy_schema_plain_turn_keeps_its_footer(tmp_path):
+    """Degrading the discriminator must not cost every legacy session its footer."""
+    import api.models as models
+
+    db = tmp_path / "state.db"
+    conn = _make_legacy_state_db(db)
+    try:
+        conn.execute(
+            "INSERT INTO sessions VALUES ('legacy_plain', 'cli', 'openai/gpt-5', "
+            "512, 64, 0, 0, 0.002, 1)"
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            [
+                ("legacy_plain", "user", "hello", 1000.0),
+                ("legacy_plain", "assistant", "hi there", 1003.0),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with patch.object(models, "_active_state_db_path", return_value=db):
+        msgs = models.get_state_db_session_messages("legacy_plain")
+
+    stats = agent_sessions.read_agent_session_turn_footer_stats(db, "legacy_plain")
+    stamped = agent_sessions.stamp_imported_turn_footers(msgs, stats, detach=True)
+
+    assert stamped[-1]["_usedModel"] == "openai/gpt-5"
+    assert stamped[-1]["_turnDuration"] == 3.0
+    assert stamped[-1]["_turnUsage"]["output_tokens"] == 64


### PR DESCRIPTION
## Thinking Path

I opened a delegated subagent transcript expecting to confirm which model it had run on,
and found the turn footer completely empty — no model, no duration, no tokens. My first
guess was a stale build, since the model chip had shipped recently. It wasn't: grepping
for the writer showed every per-turn footer field is stamped in exactly one place,
`_run_agent_streaming` in `api/streaming.py`. Imported sessions are not executed by the
WebUI, so nothing had ever written them. Confirmed against a live session file — the
assistant message had *none* of the underscore keys, not just a missing model.

Before proposing anything I checked what the data could actually support. The session row
already carries `model`, `input_tokens`, `output_tokens`, `cache_read_tokens`,
`cache_write_tokens`, `estimated_cost_usd`, and `api_call_count`, and message rows carry
`timestamp`. So model and per-turn duration are exactly derivable. Tokens are not:
`messages.token_count` is NULL for these sessions, so totals exist only per session.

That last point drove the design. I could have attached session totals to the final
assistant turn so a number always appears, but on a multi-call session those figures would
be session-wide while sitting in a per-turn footer — precise-looking and wrong. I chose to
emit the token chip only where it provably describes one turn, and accept a footer with
model and duration alone otherwise.

I also rejected a first attempt that put the model on the sidebar's nested child row
instead. Two problems: model differences only appear for users of a per-task routing
plugin, so it is noise for everyone else, and the label truncates at the sidebar's width.
The footer is where this belongs, and it needs no frontend change at all.

## What Changed

`api/agent_sessions.py` — two new helpers:

- `read_agent_session_turn_footer_stats(db_path, session_id)` — reads the footer-relevant
  columns for one session, plus its own message count. Returns `{}` on a missing db, older
  schema, or unknown session.
- `stamp_imported_turn_footers(msgs, stats)` — writes the same message keys the in-process
  path writes, so the existing settled-turn footer renders them with no frontend change:
  - `_usedModel` — the session's recorded model
  - `_turnDuration` — assistant timestamp minus the preceding user timestamp, genuinely
    per-turn
  - `_turnUsage` — token/cache/cost, **only** when `api_call_count == 1` and there is one
    assistant message

`api/routes.py` — call both from the `GET /api/session` imported-session response, +12
lines.

Cache percentage goes through the shared `prompt_cache_hit_percent` so the denominator
matches the in-process path rather than being reinvented.

Three deliberate boundaries:

1. **Stamping happens on the response path**, not inside `get_state_db_session_messages`.
   That reader also feeds model-context reconstruction, and display-only fields have no
   business going there.
2. **Stitched transcripts bail out.** That reader concatenates compression/cli-close
   continuation segments, which are separate session rows with their own models and
   totals, so the stamp is skipped unless transcript length matches the session's own
   message count. Single-segment sessions — every delegated subagent — are unaffected.
3. **TTFT stays absent.** The agent records no first-token time for these runs, so there
   is nothing to surface and nothing is invented.

## Why It Matters

Applies to every `state.db`-imported session — delegated subagents, CLI, TUI, cron. All of
them currently render a transcript with no execution metadata whatsoever.

For delegated subagents it is the difference between being able and unable to confirm a
per-task model override took effect. Worth noting as motivation: stock hermes-agent
advertises `tasks[].model` and `tasks[].provider` in the `delegate_task` schema, and a
delegation whose override is silently ignored looks identical in the UI to one that
worked — the children just run on the parent's model. With no footer there was no way to
see it. This does not fix that behaviour, it makes it visible.

## Verification

`./scripts/test.sh` on this branch, via the repo runner's own `.venv` (Python 3.12.3):

```
13669 passed, 194 skipped, 2 xfailed, 1 xpassed, 34 subtests passed in 490.51s
```

Also run green on a Python 3.13 venv (13,634 passed there, where the two
`test_issue2695_packaged_runtime_layout.py` wheel tests skip for lack of `pip`).

Six new tests in `tests/test_imported_session_turn_footer.py`, each against a purpose-built
temp `state.db`: single-call stamping (including the cache-percent denominator),
multi-call withholding of the token chip, stitched-transcript bail-out, quiet degradation
on missing db / unknown session / empty input, a user-only transcript, and an unrecorded
model not producing a blank chip.

The behaviour was also confirmed against real data on a live deployment rather than only
against fixtures — three actual subagent children, read back through `GET /api/session`:

```
0b91bd  model=x-ai/grok-4.5                    dur=4.076  usage={10189 in, 221 out, 1% cached}
b02703  model=google/gemini-flash-lite-latest  dur=0.6    usage={9701 in, 6 out, cost 0.0024}
53df02  model=x-ai/grok-4.5                    dur=6.404  usage=null   <- api_call_count=2
        model=x-ai/grok-4.5                    dur=10.574 usage=null
```

The two-call session correctly gets both exact per-turn durations and no token chip.
Rendered in a real browser (Chromium via Playwright, live deployment) the footer reads
`grok-4.5   10.2k in · 221 out · 1% cached`, with duration surfaced as `Processed 4s` in
the activity line. Screenshot ready to attach.

`scripts/ruff_lint.py --diff origin/master` reports no new violations on added lines.

## Risks / Follow-ups

- **Read-only and additive.** No existing field is overwritten (each stamp is guarded), no
  session file is mutated, and nothing changes for WebUI-native sessions.
- **Multi-call sessions show no token chip.** A deliberate accuracy-over-completeness
  call. If `messages.token_count` were populated for these sessions, per-turn attribution
  would become possible and the restriction could be lifted.
- **Stitched lineages get no footer at all.** Correct but conservative — per-segment
  stamping would need the reader to return which session each message came from.
- **TTFT remains unavailable** for imported sessions. Closing that gap needs the agent to
  record a first-token time; it is not a WebUI-side fix.
- Related but out of scope: on gateway-backed deployments the *main* session's turns are
  also missing these metrics, because `gateway_chat` stamps none of them either. That is a
  separate change and I have not attempted it here.

Release-note wording, if useful:

> **Imported agent transcripts now show a per-turn footer.** Subagent, CLI, TUI, and cron
> sessions previously rendered with no model, duration, or token information, because that
> metadata is only stamped for turns the WebUI executes itself. It is now backfilled from
> the session record on the response path. Token and cache figures appear only where they
> provably describe a single turn; TTFT is not available for these runs.

## Model Used

AI-assisted. Provider: Anthropic. Model: Claude Opus 5 (`claude-opus-5`), via Claude Code.

Notable tool use that mattered: the design was driven by first querying a live `state.db`
to establish exactly which columns are populated for these sessions — that is what ruled
out per-turn token attribution and set the `api_call_count == 1` condition, rather than
assuming the data was there. The stamped output was then verified end-to-end through the
real `GET /api/session` response and a real browser render.
