### PR TITLE
fix: show reasoning chip for xai/grok-4.5 on custom gateways

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3345,6 +3345,28 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
         idx = tokens.index("deepseek")
         if idx + 1 < len(tokens) and tokens[idx + 1].startswith(("v", "r")):
             return True
+    # xAI Grok models that expose a configurable effort dial. Gateways
+    # commonly advertise them as bare ``grok-4.5``, OpenRouter-style
+    # ``x-ai/grok-4.5``, or Vercel/AI-gateway ``xai/grok-4.5``. Align with
+    # Hermes agent allowlist (grok-3-mini / grok-4.3 / grok-4.5 /
+    # multi-agent) rather than every ``grok-*`` id so image / video / TTS /
+    # non-reasoning variants stay chip-hidden.
+    if "grok" in token_set or normalized.startswith("grok"):
+        if any(tok in token_set for tok in ("image", "imagine", "video", "tts", "stt", "voice")):
+            return False
+        if "non" in token_set and "reasoning" in token_set:
+            return False
+        joined = normalized  # already hyphen-normalized
+        if (
+            "multi-agent" in joined
+            or "grok-3-mini" in joined
+            or "grok-4-5" in joined
+            or "grok-4-3" in joined
+            or "grok-build" in joined
+            or "reasoning" in token_set
+        ):
+            return True
+        return False
     return False
 
 
@@ -3545,6 +3567,30 @@ def _filter_reasoning_efforts_for_provider(
         return normalized
     if zai_supports is False:
         return []
+    # xAI Grok effort ladders are model-specific (docs.x.ai + Hermes agent
+    # allowlist). Keep the UI from advertising levels the API rejects, and
+    # hide the chip entirely for media / non-effort Grok variants.
+    if "grok" in bare:
+        if any(tok in bare for tok in ("image", "imagine", "video", "tts", "stt", "voice")):
+            return []
+        if "non-reasoning" in bare or "non_reasoning" in bare:
+            return []
+        # multi-agent variants accept xhigh as an agent-count / effort tier.
+        if "multi-agent" in bare:
+            return [
+                eff
+                for eff in normalized
+                if eff in {"low", "medium", "high", "xhigh"}
+            ]
+        # Effort-capable chat Grok (4.5 / 4.3 / 3-mini / build / *-reasoning).
+        if (
+            bare.startswith(("grok-4.5", "grok-4.3", "grok-3-mini", "grok-build"))
+            or "reasoning" in bare
+        ):
+            return [eff for eff in normalized if eff in {"low", "medium", "high"}]
+        # Unknown grok-* : fail closed (no chip) rather than advertise a ladder
+        # the API may reject with HTTP 400.
+        return []
     return normalized
 
 
@@ -3630,6 +3676,10 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
         "anthropic/",
         "openai/",
         "x-ai/",
+        # Vercel AI Gateway / some custom proxies use ``xai/`` (no hyphen),
+        # while OpenRouter-style catalogs use ``x-ai/``. Match both so Grok
+        # behind provider=custom keeps the reasoning chip.
+        "xai/",
         "google/gemini-2",
         "google/gemma-4",
         "qwen/qwen3",

--- a/api/config.py
+++ b/api/config.py
@@ -3362,7 +3362,6 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
             or "grok-3-mini" in joined
             or "grok-4-5" in joined
             or "grok-4-3" in joined
-            or "reasoning" in token_set
         ):
             return True
         return False
@@ -3578,11 +3577,8 @@ def _filter_reasoning_efforts_for_provider(
         # so advertise only the effective wire ladder.
         if "multi-agent" in bare:
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]
-        # Effort-capable chat Grok (4.5 / 4.3 / 3-mini / *-reasoning).
-        if (
-            bare.startswith(("grok-4.5", "grok-4.3", "grok-3-mini"))
-            or "reasoning" in bare
-        ):
+        # Effort-capable chat Grok (4.5 / 4.3 / 3-mini).
+        if bare.startswith(("grok-4.5", "grok-4.3", "grok-3-mini")):
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]
         # Unknown grok-* : fail closed (no chip) rather than advertise a ladder
         # the API may reject with HTTP 400.

--- a/api/config.py
+++ b/api/config.py
@@ -3362,7 +3362,6 @@ def _candidate_supports_reasoning(candidate: str) -> bool:
             or "grok-3-mini" in joined
             or "grok-4-5" in joined
             or "grok-4-3" in joined
-            or "grok-build" in joined
             or "reasoning" in token_set
         ):
             return True
@@ -3575,16 +3574,13 @@ def _filter_reasoning_efforts_for_provider(
             return []
         if "non-reasoning" in bare or "non_reasoning" in bare:
             return []
-        # multi-agent variants accept xhigh as an agent-count / effort tier.
+        # Agent's xAI Responses transport clamps stronger generic values to high,
+        # so advertise only the effective wire ladder.
         if "multi-agent" in bare:
-            return [
-                eff
-                for eff in normalized
-                if eff in {"low", "medium", "high", "xhigh"}
-            ]
-        # Effort-capable chat Grok (4.5 / 4.3 / 3-mini / build / *-reasoning).
+            return [eff for eff in normalized if eff in {"low", "medium", "high"}]
+        # Effort-capable chat Grok (4.5 / 4.3 / 3-mini / *-reasoning).
         if (
-            bare.startswith(("grok-4.5", "grok-4.3", "grok-3-mini", "grok-build"))
+            bare.startswith(("grok-4.5", "grok-4.3", "grok-3-mini"))
             or "reasoning" in bare
         ):
             return [eff for eff in normalized if eff in {"low", "medium", "high"}]

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -145,6 +145,50 @@ def test_openrouter_slash_prefix_unaffected():
     assert set(efforts) >= {"low", "medium", "high"}
 
 
+# ── xAI Grok via custom / AI-gateway namespaces ──────────────────────────────
+#
+# Vercel AI Gateway and similar OpenAI-compatible proxies advertise Grok as
+# ``xai/grok-4.5`` (no hyphen) under provider=custom. The OpenRouter-style
+# prefix is ``x-ai/``. Both must expose the reasoning chip; grok-4.5's native
+# ladder is low/medium/high only (no minimal/xhigh/max/none).
+
+
+@pytest.mark.parametrize(
+    "model_id,provider_id",
+    [
+        ("xai/grok-4.5", "custom"),
+        ("xai/grok-4.5", "custom:vercel-vtest314"),
+        ("x-ai/grok-4.5", "custom"),
+        ("grok-4.5", "custom"),
+        ("grok-4.5", "xai"),
+    ],
+)
+def test_grok_45_custom_and_gateway_namespaces_expose_reasoning(model_id, provider_id):
+    efforts = cfg.resolve_model_reasoning_efforts(model_id, provider_id=provider_id)
+    assert efforts == ["low", "medium", "high"], (
+        f"{model_id} via {provider_id} should expose Grok 4.5's low/medium/high "
+        f"ladder, got {efforts!r}"
+    )
+
+
+def test_grok_multi_agent_keeps_xhigh():
+    efforts = cfg.resolve_model_reasoning_efforts(
+        "xai/grok-4.20-multi-agent",
+        provider_id="custom",
+    )
+    assert efforts == ["low", "medium", "high", "xhigh"]
+
+
+def test_grok_media_and_non_reasoning_hide_chip():
+    for model_id in (
+        "xai/grok-imagine-image",
+        "xai/grok-imagine-video",
+        "xai/grok-tts",
+        "xai/grok-4.20-non-reasoning",
+    ):
+        assert cfg.resolve_model_reasoning_efforts(model_id, provider_id="custom") == [], model_id
+
+
 def test_generalized_model_families_and_suffixed_ids():
     test_models = [
         # GPT

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -171,12 +171,19 @@ def test_grok_45_custom_and_gateway_namespaces_expose_reasoning(model_id, provid
     )
 
 
-def test_grok_multi_agent_keeps_xhigh():
+def test_grok_multi_agent_matches_agent_wire_ladder():
     efforts = cfg.resolve_model_reasoning_efforts(
         "xai/grok-4.20-multi-agent",
         provider_id="custom",
     )
-    assert efforts == ["low", "medium", "high", "xhigh"]
+    assert efforts == ["low", "medium", "high"]
+
+
+def test_grok_build_stays_hidden_without_agent_support():
+    assert cfg.resolve_model_reasoning_efforts(
+        "xai/grok-build-latest",
+        provider_id="custom",
+    ) == []
 
 
 def test_grok_media_and_non_reasoning_hide_chip():

--- a/tests/test_custom_provider_bare_model_reasoning.py
+++ b/tests/test_custom_provider_bare_model_reasoning.py
@@ -186,12 +186,14 @@ def test_grok_build_stays_hidden_without_agent_support():
     ) == []
 
 
-def test_grok_media_and_non_reasoning_hide_chip():
+def test_grok_models_outside_agent_allowlist_hide_chip():
     for model_id in (
         "xai/grok-imagine-image",
         "xai/grok-imagine-video",
         "xai/grok-tts",
         "xai/grok-4.20-non-reasoning",
+        "xai/grok-4-fast-reasoning",
+        "xai/grok-4.20-0309-reasoning",
     ):
         assert cfg.resolve_model_reasoning_efforts(model_id, provider_id="custom") == [], model_id
 


### PR DESCRIPTION
## Thinking Path

- WebUI hid the composer reasoning-effort chip for `xai/grok-4.5` when routed through `provider=custom` (Vercel AI Gateway and similar OpenAI-compatible proxies).
- The heuristic recognized the OpenRouter-style `x-ai/` prefix but not `xai/`, and had no conservative Grok family rule.
- The UI capability must match the effective Hermes Agent request contract: advertise only effort-capable Grok models and only levels that survive Agent request shaping.

## What Changed

- Recognize the `xai/` namespace alongside `x-ai/` for custom gateways.
- Recognize Agent-supported Grok effort families: Grok 3 mini, Grok 4.3, Grok 4.5, and Grok 4.20 multi-agent.
- Limit supported Grok effort ladders to `low`, `medium`, and `high`.
- Keep `grok-build`, known rejected `*-reasoning` families, media models, non-reasoning variants, and unknown Grok IDs chip-hidden.
- Add regression coverage for namespace variants, the effective multi-agent wire ladder, `grok-build`, and models outside the Agent allowlist.

## Why It Matters

Users selecting `xai/grok-4.5` through a custom AI gateway regain the reasoning control without being offered values that Hermes Agent will silently clamp or omit downstream.

## Contract Routing

Task type: focused capability bug fix.

Touched areas: custom-provider model capability inference and reasoning-effort filtering.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/GUIDELINES.md`
- `TESTING.md`

Scope boundaries: WebUI is aligned to the current Hermes Agent xAI allowlist and transport shaping; this PR does not expand Agent support.

Evidence needed before claiming done: regression tests must fail for the reviewed mismatches before the correction, then the affected and neighboring capability suites must pass.

## Verification

Regression bite before the review correction:

```text
2 failed, 40 passed
- multi-agent incorrectly exposed xhigh
- grok-build incorrectly exposed low/medium/high
```

Final focused and neighboring suites:

```bash
./scripts/test.sh \
  tests/test_custom_provider_bare_model_reasoning.py \
  tests/test_reasoning_effort_model_capabilities.py -q
# 72 passed in 3.74s

git diff --check
# clean

python3 scripts/ruff_lint.py --diff origin/master
# ruff not found locally; wrapper skipped. CI installs ruff.
```

## Risks / Follow-ups

- Capability truth is cross-repository. The current Agent allowlist excludes `grok-build`, and its xAI Responses transport maps stronger generic values such as `xhigh` to `high`; this PR follows that contract.
- If Agent later expands Grok support, WebUI metadata and tests should be updated with the Agent change.
- Manual composer verification remains advisable after deployment, but the backend capability result is covered directly.

## Model Used

Custom provider / `openai/gpt-5.6-sol`, with Hermes agentic file, shell, GitHub CLI, and test tools.

## Release Notes

Fix the missing reasoning-effort control for Grok 4.5 when served through custom AI gateways using the `xai/` model namespace, while keeping the offered levels aligned with Hermes Agent.
