### PR TITLE
fix(streaming): preserve Codex reasoning history items

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 _PUBLIC_MESSAGE_INTERNAL_FIELDS = frozenset({
     "api_content",
+    "codex_reasoning_items",
+    "codex_message_items",
     "_state_db_row_id",
     "_db_row_id",
     "state_db_row_id",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2205,6 +2205,8 @@ from api.workspace import set_last_workspace
 # `reasoning_content` is provider-facing for reasoning-capable models. Display
 # metadata such as `reasoning`, `thinking`, and `_reasoning` stays omitted here.
 _API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal', 'reasoning_content'}
+# Codex replay metadata is internal-Agent-only; it must never become API-safe.
+_CODEX_REPLAY_MSG_KEYS = {'codex_reasoning_items', 'codex_message_items'}
 
 _NATIVE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 
@@ -5013,6 +5015,7 @@ def _sanitize_messages_for_api(
     effective_provider: str | None = None,
     effective_base_url: str | None = None,
     preserve_api_content: bool = False,
+    preserve_codex_replay_items: bool = False,
     requested_provider: str = "",
 ):
     """Return a deep copy of messages with only API-safe fields.
@@ -5096,6 +5099,12 @@ def _sanitize_messages_for_api(
             preserve_message_api_content=preserve_api_content,
             message_records=True,
         )[0]
+        # These fields are intentionally restored after the public scrubber and
+        # only for assistant rows at the internal Agent boundary.
+        if preserve_codex_replay_items and msg.get('role') == 'assistant':
+            for key in _CODEX_REPLAY_MSG_KEYS:
+                if key in msg:
+                    sanitized[key] = copy.deepcopy(msg[key])
         if sanitized.get("role") not in {"user", "assistant"}:
             sanitized.pop("api_content", None)
         elif not isinstance(sanitized.get("api_content"), str) or not sanitized.get("api_content"):
@@ -5192,12 +5201,13 @@ def _sanitize_messages_for_agent(
     effective_base_url: str | None = None,
     requested_provider: str = "",
 ):
-    """Build the internal Agent replay projection with ``api_content`` intact.
+    """Build the internal Agent replay projection with replay metadata intact.
 
     ``api_content`` is a durable provider-facing sidecar, not a direct-provider
-    payload field.  Keep this opt-in at one named boundary so every Agent
-    history call uses the same contract while ordinary API/compression callers
-    continue to use the default-stripping sanitizer.
+    payload field, and Codex replay items are opaque provider metadata. Keep
+    both opt-ins at one named boundary so every Agent history call uses the same
+    contract while ordinary API/compression callers continue to use the
+    default-stripping sanitizer.
     """
     return _sanitize_messages_for_api(
         messages,
@@ -5206,6 +5216,7 @@ def _sanitize_messages_for_agent(
         effective_provider=effective_provider,
         effective_base_url=effective_base_url,
         preserve_api_content=True,
+        preserve_codex_replay_items=True,
         requested_provider=requested_provider,
     )
 

--- a/tests/test_issue6751_api_content_agent_replay.py
+++ b/tests/test_issue6751_api_content_agent_replay.py
@@ -419,6 +419,52 @@ def test_issue6751_provider_projection_still_strips_api_content_by_default():
     assert sanitized == [{"role": "user", "content": "same visible text"}]
 
 
+def test_issue6751_codex_replay_items_are_agent_only_and_deep_copied(monkeypatch):
+    import api.config as config
+    from api.helpers import redact_session_data
+    from api.streaming import _sanitize_messages_for_agent, _sanitize_messages_for_api
+
+    reasoning_items = [{"id": "reasoning-1", "details": {"token": "opaque"}}]
+    message_items = [{"id": "message-1", "text": "opaque"}]
+    messages = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "codex_reasoning_items": reasoning_items,
+            "codex_message_items": message_items,
+        },
+        {
+            "role": "user",
+            "content": "question",
+            "codex_reasoning_items": [{"id": "wrong-role-reasoning"}],
+            "codex_message_items": [{"id": "wrong-role-message"}],
+        },
+    ]
+
+    agent_history = _sanitize_messages_for_agent(messages)
+    assert agent_history[0]["codex_reasoning_items"] == reasoning_items
+    assert agent_history[0]["codex_message_items"] == message_items
+    assert "codex_reasoning_items" not in agent_history[1]
+    assert "codex_message_items" not in agent_history[1]
+
+    agent_history[0]["codex_reasoning_items"][0]["details"]["token"] = "mutated"
+    assert reasoning_items[0]["details"]["token"] == "opaque"
+    agent_history[0]["codex_message_items"][0]["text"] = "mutated"
+    assert message_items[0]["text"] == "opaque"
+
+    assert all(
+        "codex_reasoning_items" not in message and "codex_message_items" not in message
+        for message in _sanitize_messages_for_api(messages)
+    )
+
+    monkeypatch.setattr(config, "load_settings", lambda: {"api_redact_enabled": False})
+    public = redact_session_data({"messages": messages})
+    assert all(
+        "codex_reasoning_items" not in message and "codex_message_items" not in message
+        for message in public["messages"]
+    )
+
+
 def test_issue6751_sync_chat_agent_receives_original_api_content_bytes(monkeypatch, tmp_path):
     """The production sync route must hand the Agent the original wire text."""
     import api.config as config


### PR DESCRIPTION
## Thinking Path

- WebUI persists opaque Codex continuation items, then reconstructs Agent history through a sanitizer.
- Making those fields globally API-safe would expose provider-private metadata through unrelated surfaces.
- The correct boundary is `_sanitize_messages_for_agent()`: preserve replay state there while keeping direct-provider and public projections stripped.

## What Changed

- Added an assistant-only opt-in for `codex_reasoning_items` and `codex_message_items` without adding either field to `_API_SAFE_MSG_KEYS`.
- Enabled that opt-in only from `_sanitize_messages_for_agent()`.
- Added both fields to public session redaction.
- Added regression coverage for Agent preservation, direct-API stripping, public redaction, wrong-role stripping, and deep-copy isolation.

## Why It Matters

OpenAI recommends replaying prior reasoning and output items to preserve reasoning across calls. Without these fields, a later WebUI turn loses Codex Responses continuity before Hermes Agent receives the history. Keeping the fields private avoids exposing opaque provider metadata through generic WebUI/API surfaces.

## Contract Routing

- **State layer:** model-facing context/history projection
- **Invariant:** provider-private continuation state survives only across the internal WebUI-to-Agent boundary
- **Relevant guidance:** `docs/rfcs/webui-run-state-consistency-contract.md`
- **Scope:** sanitizer and public-redaction boundaries only; no UI, provider routing, or persistence format change

## Verification

- The WebUI regression failed on unmodified `master` because Agent history lacked `codex_reasoning_items`.
- Exact WebUI head `c73fc7f6e3977ec33221450ed8355ed3dceeba17`: complete changed sanitizer test file, **59 passed**.
- Agent compatibility fix at NousResearch/hermes-agent#19415 head `b1ccd0388788a2ab74c5b52abed2d44365562a0f`:
  - sequence repair and state-repair caller suites, **35 passed**;
  - gateway API suites, **120 passed**;
  - Codex Responses continuity suite, **44 passed**.
- Before the Agent guard change, the new empty/`None`/mode-less matrix produced **9 expected failures** across `codex_reasoning_items`, `codex_message_items`, and `finish_reason="incomplete"`.
- Ruff, Python compilation, and `git diff --check` passed for the affected Agent and WebUI files.
- Generic `_API_SAFE_MSG_KEYS` remains unchanged and excludes both Codex fields.

## Risks / Follow-ups

The cross-repository provider-switch blocker is addressed in NousResearch/hermes-agent#19415. Only explicit `api_mode == "codex_responses"` preserves adjacent replay turns; Chat Completions, empty, `None`, unknown, and mode-less state-repair callers restore strict alternation.

The WebUI and Agent changes must ship together for end-to-end continuity with safe provider switching.

## Model Used

- OpenAI `gpt-5.6-sol` via Hermes Agent: specification, implementation, review, and PR preparation
- OpenAI `gpt-5.6-luna` via Codex CLI: original implementation and focused verification
