### PR TITLE
perf: avoid full session rewrites during draft autosave

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1349,6 +1349,7 @@ class Session:
                  compression_anchor_message_key=None,
                  compression_anchor_summary=None,
                  pre_compression_snapshot: bool=False,
+                 pre_compression_continuation_session_id: str=None,
                  context_engine=None,
                  compression_anchor_engine=None,
                  compression_anchor_mode=None,
@@ -1418,6 +1419,11 @@ class Session:
         self.compression_anchor_message_key = compression_anchor_message_key
         self.compression_anchor_summary = compression_anchor_summary
         self.pre_compression_snapshot = bool(pre_compression_snapshot)
+        self.pre_compression_continuation_session_id = (
+            str(pre_compression_continuation_session_id).strip()
+            if pre_compression_continuation_session_id
+            else None
+        )
         self.context_engine = context_engine
         self.compression_anchor_engine = compression_anchor_engine
         self.compression_anchor_mode = compression_anchor_mode
@@ -1521,6 +1527,7 @@ class Session:
             'pending_user_message', 'pending_attachments', 'pending_started_at', 'pending_user_source',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
             'compression_anchor_summary', 'pre_compression_snapshot',
+            'pre_compression_continuation_session_id',
             'context_engine', 'compression_anchor_engine', 'compression_anchor_mode',
             'compression_anchor_details', 'context_engine_state',
             'context_length', 'threshold_tokens', 'last_prompt_tokens',

--- a/api/models.py
+++ b/api/models.py
@@ -176,6 +176,94 @@ def _safe_replace(src: Path, dst: Path) -> None:
             delay *= 2  # 50 -> 100 -> 200 -> 400 -> 800 ms
 
 
+def _session_draft_path(session_id: str) -> Path:
+    """Return the per-session draft sidecar path.
+
+    This is deliberately separate from the full session sidecar so draft edits do
+    not force multi-MB full-session rewrites.
+    """
+    sid = _normalize_session_id_for_path(session_id)
+    if not sid:
+        raise ValueError(f"Unsafe session_id {session_id!r}; refusing to resolve draft path")
+    return _session_draft_dir() / f'{sid}.json'
+
+
+def _normalize_session_id_for_path(session_id) -> str | None:
+    sid = str(session_id or "").strip()
+    if not sid or not is_safe_session_id(sid):
+        return None
+    return sid
+
+
+def _session_draft_dir() -> Path:
+    return SESSION_DIR / ".drafts"
+
+
+def _load_session_draft(session_id: str) -> dict | None:
+    """Load a dedicated draft payload if it exists, else return None."""
+    if not _normalize_session_id_for_path(session_id):
+        return None
+    try:
+        path = _session_draft_path(session_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        if isinstance(payload, dict):
+            return payload
+        logger.warning("Ignoring non-dict draft payload in %s", path)
+        return None
+    except json.JSONDecodeError as exc:
+        logger.warning("Ignoring malformed draft sidecar %s: %s", path, exc)
+        return None
+    except Exception as exc:
+        logger.debug("Failed to load draft sidecar %s: %s", path, exc)
+        return None
+
+
+def _apply_session_draft_overlay(data: dict, session_id: str) -> dict:
+    """Overlay dedicated draft payload onto an already-parsed session payload."""
+    if not isinstance(data, dict):
+        return data
+    draft = _load_session_draft(session_id)
+    if isinstance(draft, dict):
+        data["composer_draft"] = draft
+    return data
+
+
+def _save_session_draft(session_id: str, draft) -> None:
+    """Persist a draft payload to the dedicated per-session draft sidecar."""
+    if not _normalize_session_id_for_path(session_id):
+        raise ValueError(f"Unsafe session_id {session_id!r}; refusing to persist dedicated draft")
+    _session_draft_dir().mkdir(parents=True, exist_ok=True)
+    path = _session_draft_path(session_id)
+    payload = draft if isinstance(draft, dict) else {}
+    tmp = path.with_name(f'{path.name}.tmp.{os.getpid()}.{threading.current_thread().ident}')
+    body = json.dumps(payload, ensure_ascii=False, indent=2)
+    try:
+        with open(tmp, 'w', encoding='utf-8') as f:
+            f.write(body)
+            f.flush()
+            os.fsync(f.fileno())
+        _safe_replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+def _delete_session_draft(session_id: str) -> None:
+    """Delete the dedicated draft sidecar for *session_id*."""
+    if not _normalize_session_id_for_path(session_id):
+        return
+    try:
+        path = _session_draft_path(session_id)
+        path.unlink(missing_ok=True)
+    except Exception:
+        logger.debug("Failed to delete draft sidecar for %s", session_id, exc_info=True)
+
+
 # Serializes index writers so concurrent Session.save() calls cannot race on
 # stale baselines while still allowing LOCK to be released before disk I/O.
 _INDEX_WRITE_LOCK = threading.RLock()
@@ -230,16 +318,17 @@ def _cleanup_stale_tmp_files() -> None:
     prevent startup.
     """
     cutoff = time.time() - _STALE_TMP_AGE_SECONDS
-    try:
-        for p in SESSION_DIR.glob('*.tmp.*'):
-            try:
-                if p.stat().st_mtime < cutoff:
-                    p.unlink(missing_ok=True)
-                    logger.debug("Cleaned up stale tmp file: %s", p.name)
-            except OSError:
-                pass  # best-effort
-    except Exception:
-        pass  # SESSION_DIR may not exist yet; that's fine
+    for base in (SESSION_DIR, _session_draft_dir()):
+        try:
+            for p in base.glob('*.tmp.*'):
+                try:
+                    if p.stat().st_mtime < cutoff:
+                        p.unlink(missing_ok=True)
+                        logger.debug("Cleaned up stale tmp file: %s", p)
+                except OSError:
+                    pass  # best-effort
+        except Exception:
+            pass  # SESSION_DIR may not exist yet; that's fine
 
 
 _PERSISTED_SESSION_IDS_CACHE: tuple[Path | None, int | None, frozenset[str]] = (None, None, frozenset())
@@ -1118,6 +1207,11 @@ def _load_session_from_path(path: Path) -> "Session | None":
     except Exception:
         return None
     data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+    session_id = data.get('session_id')
+    if not isinstance(session_id, str) or not session_id:
+        session_id = path.stem
+    if path.parent == SESSION_DIR:
+        data = _apply_session_draft_overlay(data, session_id)
     return Session(**data)
 
 
@@ -1539,6 +1633,7 @@ class Session:
         _pre_read_sig = _sidecar_stat_signature(p)
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+        data = _apply_session_draft_overlay(data, sid)
         session = cls(**data)
         if _collapsed_partials:
             try:
@@ -1597,6 +1692,7 @@ class Session:
                 return cls.load(sid)
             parsed['messages'] = []
             parsed['tool_calls'] = []
+            parsed = _apply_session_draft_overlay(parsed, sid)
             session = cls(**parsed)
             sidecar_message_count = _parse_nonnegative_int(parsed.get('message_count'))
             index_message_count = None
@@ -9791,6 +9887,17 @@ def _delete_cli_session_locked(sid, hermes_home) -> bool:
                             suffix,
                             exc_info=True,
                         )
+                draft_artifact = sessions_dir / ".drafts" / f"{removed_id}.json"
+                if draft_artifact.exists():
+                    try:
+                        draft_artifact.unlink(missing_ok=True)
+                    except OSError:
+                        ok = False
+                        logger.warning(
+                            "Failed to remove draft sidecar %s",
+                            removed_id,
+                            exc_info=True,
+                        )
                 try:
                     for path in list(
                         sessions_dir.glob(f"request_dump_{removed_id}_*.json")
@@ -9971,6 +10078,12 @@ def _clean_pending_artifact(sessions_dir, removed_id):
             continue
         try:
             artifact.unlink(missing_ok=True)
+        except OSError:
+            ok = False
+    draft_artifact = sessions_dir / ".drafts" / f"{removed_id}.json"
+    if draft_artifact.exists():
+        try:
+            draft_artifact.unlink(missing_ok=True)
         except OSError:
             ok = False
     try:

--- a/api/models.py
+++ b/api/models.py
@@ -176,6 +176,25 @@ def _safe_replace(src: Path, dst: Path) -> None:
             delay *= 2  # 50 -> 100 -> 200 -> 400 -> 800 ms
 
 
+_DRAFT_LIFECYCLE_LOCK_STRIPES: "tuple[threading.Lock, ...]" = tuple(
+    threading.Lock() for _ in range(64)
+)
+_DRAFT_LIFECYCLE_LOCK_STRIPE_COUNT = len(_DRAFT_LIFECYCLE_LOCK_STRIPES)
+
+
+def _draft_lifecycle_lock_for_session_id(session_id: str) -> threading.Lock:
+    """Return the per-session lock that serializes draft save/delete operations."""
+    sid = _normalize_session_id_for_path(session_id)
+    if not sid:
+        raise ValueError(f"Unsafe session_id {session_id!r}; refusing to lock draft lifecycle")
+    sid_index = int(hashlib.sha256(sid.encode("utf-8")).hexdigest(), 16)
+    lock_index = sid_index % _DRAFT_LIFECYCLE_LOCK_STRIPE_COUNT
+    # ponytail: fixed 64-way lock striping; occasional unrelated collisions
+    # serialize small sessions, so per-sid locks should only be added if
+    # contention is measured.
+    return _DRAFT_LIFECYCLE_LOCK_STRIPES[lock_index]
+
+
 def _session_draft_path(session_id: str) -> Path:
     """Return the per-session draft sidecar path.
 
@@ -234,34 +253,65 @@ def _save_session_draft(session_id: str, draft) -> None:
     """Persist a draft payload to the dedicated per-session draft sidecar."""
     if not _normalize_session_id_for_path(session_id):
         raise ValueError(f"Unsafe session_id {session_id!r}; refusing to persist dedicated draft")
-    _session_draft_dir().mkdir(parents=True, exist_ok=True)
-    path = _session_draft_path(session_id)
-    payload = draft if isinstance(draft, dict) else {}
-    tmp = path.with_name(f'{path.name}.tmp.{os.getpid()}.{threading.current_thread().ident}')
-    body = json.dumps(payload, ensure_ascii=False, indent=2)
-    try:
-        with open(tmp, 'w', encoding='utf-8') as f:
-            f.write(body)
-            f.flush()
-            os.fsync(f.fileno())
-        _safe_replace(tmp, path)
-    except Exception:
+    sid = _normalize_session_id_for_path(session_id)
+    lock = _draft_lifecycle_lock_for_session_id(sid)
+    with lock:
+        _session_draft_dir().mkdir(parents=True, exist_ok=True)
+        path = _session_draft_path(sid)
+        payload = draft if isinstance(draft, dict) else {}
+        tmp = path.with_name(
+            f'{path.name}.tmp.{os.getpid()}.{threading.current_thread().ident}'
+        )
+        body = json.dumps(payload, ensure_ascii=False, indent=2)
         try:
-            tmp.unlink(missing_ok=True)
+            with open(tmp, 'w', encoding='utf-8') as f:
+                f.write(body)
+                f.flush()
+                os.fsync(f.fileno())
+            if not (SESSION_DIR / f"{sid}.json").exists():
+                return
+            _safe_replace(tmp, path)
         except Exception:
-            pass
-        raise
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+
+def _delete_session_draft_by_dir(session_id: str, sessions_dir: Path) -> bool:
+    """Delete the dedicated draft sidecar for session_id under sessions_dir.
+
+    Returns True when deletion succeeds or the file is already absent; False
+    when the path cannot be removed due to unexpected IO/error.
+    """
+    if not _normalize_session_id_for_path(session_id):
+        return True
+    sid = _normalize_session_id_for_path(session_id)
+    lock = _draft_lifecycle_lock_for_session_id(sid)
+    with lock:
+        try:
+            draft_path = sessions_dir / ".drafts" / f"{sid}.json"
+            draft_path.unlink(missing_ok=True)
+        except Exception:
+            logger.debug(
+                "Failed to delete draft sidecar for %s in %s",
+                session_id,
+                sessions_dir,
+                exc_info=True,
+            )
+            return False
+        return True
 
 
 def _delete_session_draft(session_id: str) -> None:
     """Delete the dedicated draft sidecar for *session_id*."""
-    if not _normalize_session_id_for_path(session_id):
-        return
-    try:
-        path = _session_draft_path(session_id)
-        path.unlink(missing_ok=True)
-    except Exception:
-        logger.debug("Failed to delete draft sidecar for %s", session_id, exc_info=True)
+    _delete_session_draft_by_dir(session_id, SESSION_DIR)
 
 
 # Serializes index writers so concurrent Session.save() calls cannot race on
@@ -9887,17 +9937,13 @@ def _delete_cli_session_locked(sid, hermes_home) -> bool:
                             suffix,
                             exc_info=True,
                         )
-                draft_artifact = sessions_dir / ".drafts" / f"{removed_id}.json"
-                if draft_artifact.exists():
-                    try:
-                        draft_artifact.unlink(missing_ok=True)
-                    except OSError:
-                        ok = False
-                        logger.warning(
-                            "Failed to remove draft sidecar %s",
-                            removed_id,
-                            exc_info=True,
-                        )
+                if not _delete_session_draft_by_dir(removed_id, sessions_dir):
+                    ok = False
+                    logger.warning(
+                        "Failed to remove draft sidecar %s",
+                        removed_id,
+                        exc_info=True,
+                    )
                 try:
                     for path in list(
                         sessions_dir.glob(f"request_dump_{removed_id}_*.json")
@@ -10080,12 +10126,8 @@ def _clean_pending_artifact(sessions_dir, removed_id):
             artifact.unlink(missing_ok=True)
         except OSError:
             ok = False
-    draft_artifact = sessions_dir / ".drafts" / f"{removed_id}.json"
-    if draft_artifact.exists():
-        try:
-            draft_artifact.unlink(missing_ok=True)
-        except OSError:
-            ok = False
+    if not _delete_session_draft_by_dir(removed_id, sessions_dir):
+        ok = False
     try:
         for path in list(sessions_dir.glob(f"request_dump_{removed_id}_*.json")):
             try:

--- a/api/models.py
+++ b/api/models.py
@@ -189,9 +189,9 @@ def _draft_lifecycle_lock_for_session_id(session_id: str) -> threading.Lock:
         raise ValueError(f"Unsafe session_id {session_id!r}; refusing to lock draft lifecycle")
     sid_index = int(hashlib.sha256(sid.encode("utf-8")).hexdigest(), 16)
     lock_index = sid_index % _DRAFT_LIFECYCLE_LOCK_STRIPE_COUNT
-    # ponytail: fixed 64-way lock striping; occasional unrelated collisions
-    # serialize small sessions, so per-sid locks should only be added if
-    # contention is measured.
+    # Fixed lock striping bounds registry growth. Rare hash collisions only
+    # serialize small draft operations; increase the stripe count if measured
+    # contention warrants it.
     return _DRAFT_LIFECYCLE_LOCK_STRIPES[lock_index]
 
 
@@ -309,9 +309,9 @@ def _delete_session_draft_by_dir(session_id: str, sessions_dir: Path) -> bool:
         return True
 
 
-def _delete_session_draft(session_id: str) -> None:
+def _delete_session_draft(session_id: str) -> bool:
     """Delete the dedicated draft sidecar for *session_id*."""
-    _delete_session_draft_by_dir(session_id, SESSION_DIR)
+    return _delete_session_draft_by_dir(session_id, SESSION_DIR)
 
 
 # Serializes index writers so concurrent Session.save() calls cannot race on
@@ -4873,6 +4873,8 @@ def _resolve_session(sid, metadata_only=False, *, promote_cache=True, cache_on_m
     if s:
         if cache_on_miss:
             with LOCK:
+                if not (SESSION_DIR / f"{sid}.json").exists():
+                    raise KeyError(sid)
                 SESSIONS[sid] = s
                 if promote_cache:
                     SESSIONS.move_to_end(sid)

--- a/api/routes.py
+++ b/api/routes.py
@@ -14762,83 +14762,170 @@ def handle_post(handler, parsed) -> bool:
         _draft_mark("after_get_session")
         unchanged = False
         request_sid = sid
-        with _get_session_agent_lock(sid):
-            _draft_mark("acquired_lock")
-            resolved_sid = str(getattr(s, "session_id", "") or "").strip()
-            if not resolved_sid or not is_safe_session_id(resolved_sid):
-                return j(
-                    handler,
-                    {"ok": False, "error": "Session moved", "session_id": request_sid},
-                    status=409,
-                )
-            if resolved_sid != request_sid:
-                return j(
-                    handler,
-                    {"ok": False, "error": "Session moved", "session_id": resolved_sid},
-                    status=409,
-                )
-            current_draft = dict(getattr(s, "composer_draft", {}) or {})
-            next_draft = dict(current_draft)
-            if text is not None:
-                next_draft["text"] = text
-            if files is not None:
-                next_draft["files"] = files
-            if next_draft == current_draft:
-                unchanged = True
-                saved_draft = current_draft
-            else:
-                _draft_text = str(next_draft.get("text", "") or "")
-                _draft_files = next_draft.get("files", []) or []
-                _has_meaningful_draft = bool(_draft_text) or bool(_draft_files)
-                if not (SESSION_DIR / f"{sid}.json").exists() and _has_meaningful_draft:
-                    with LOCK:
-                        if SESSIONS.get(sid) is not s:
-                            return j(
-                                handler,
-                                {
-                                    "ok": False,
-                                    "error": "Session no longer active",
-                                    "session_id": sid,
-                                },
-                                status=409,
-                            )
-                        if len(getattr(s, "messages", []) or []) != 0:
-                            return j(
-                                handler,
-                                {
-                                    "ok": False,
-                                    "error": "Session no longer active",
-                                    "session_id": sid,
-                                },
-                                status=409,
-                            )
-                        if (SESSION_DIR / f"{sid}.json").exists():
-                            # Owner appeared while acquiring the shared lock; skip
-                            # materialization and proceed with sidecar save only.
-                            pass
-                        else:
-                            # Publish the small owner record while cache state is locked
-                            # so deletion cannot race first-draft ownership.
-                            draft_session = copy.copy(s)
-                            draft_session.composer_draft = {}
-                            # LOCK is non-reentrant; indexing here would acquire it again.
-                            draft_session.save(
-                                touch_updated_at=False,
-                                skip_index=True,
-                            )
-                # Draft persistence is not conversation activity. Touching updated_at
-                # here makes the active-session external-refresh poll force-reload the
-                # current chat every few seconds while the user is typing, and that
-                # delayed reload can restore an older draft over newer local input.
-                _draft_mark("before_save")
-                _save_session_draft(sid, next_draft)
-                _draft_mark("after_save")
-                s.composer_draft = next_draft
-                saved_draft = s.composer_draft
+        request_session = s
+        request_profile = getattr(request_session, "profile", None)
+        authoritative_sid = request_sid
+        _MAX_DRAFT_AUTHORITY_HOPS = 4
+        _seen_authority_sids = {authoritative_sid}
+        resolved_once = False
+        for _hop in range(_MAX_DRAFT_AUTHORITY_HOPS):
+            with _get_session_agent_lock(authoritative_sid):
+                _draft_mark("acquired_lock")
+                if _hop == 0 and request_session is not None:
+                    resolved_sid = str(getattr(request_session, "session_id", "") or "").strip()
+                    if not resolved_sid or not is_safe_session_id(resolved_sid):
+                        return j(
+                            handler,
+                            {"ok": False, "error": "Session moved", "session_id": request_sid},
+                            status=409,
+                        )
+                    if resolved_sid != authoritative_sid:
+                        with LOCK:
+                            if SESSIONS.get(resolved_sid) is request_session:
+                                if resolved_sid in _seen_authority_sids:
+                                    return j(
+                                        handler,
+                                        {
+                                            "ok": False,
+                                            "error": "Session moved",
+                                            "session_id": resolved_sid,
+                                        },
+                                        status=409,
+                                    )
+                                _seen_authority_sids.add(resolved_sid)
+                                authoritative_sid = resolved_sid
+                                continue
+                try:
+                    request_session = get_session(authoritative_sid)
+                except KeyError:
+                    return j(
+                        handler,
+                        {
+                            "ok": False,
+                            "error": "Session no longer active",
+                            "session_id": authoritative_sid,
+                        },
+                        status=409,
+                    )
+
+                resolved_sid = str(getattr(request_session, "session_id", "") or "").strip()
+                if not resolved_sid or not is_safe_session_id(resolved_sid):
+                    return j(
+                        handler,
+                        {"ok": False, "error": "Session moved", "session_id": authoritative_sid},
+                        status=409,
+                    )
+                if not _profiles_match(getattr(request_session, "profile", None), request_profile):
+                    return j(
+                        handler,
+                        {"ok": False, "error": "Session moved", "session_id": authoritative_sid},
+                        status=409,
+                    )
+
+                if resolved_sid != authoritative_sid:
+                    if resolved_sid in _seen_authority_sids:
+                        return j(
+                            handler,
+                            {"ok": False, "error": "Session moved", "session_id": resolved_sid},
+                            status=409,
+                        )
+                    _seen_authority_sids.add(resolved_sid)
+                    authoritative_sid = resolved_sid
+                    continue
+
+                continuation_sid = None
+                if getattr(request_session, "pre_compression_snapshot", False):
+                    continuation_sid = _pre_compression_continuation_session_id(request_session)
+
+                if continuation_sid:
+                    if not is_safe_session_id(continuation_sid):
+                        return j(
+                            handler,
+                            {"ok": False, "error": "Session moved", "session_id": authoritative_sid},
+                            status=409,
+                        )
+                    if continuation_sid in _seen_authority_sids:
+                        return j(
+                            handler,
+                            {"ok": False, "error": "Session moved", "session_id": continuation_sid},
+                            status=409,
+                        )
+                    _seen_authority_sids.add(continuation_sid)
+                    authoritative_sid = continuation_sid
+                    continue
+
+                current_draft = dict(getattr(request_session, "composer_draft", {}) or {})
+                next_draft = dict(current_draft)
+                if text is not None:
+                    next_draft["text"] = text
+                if files is not None:
+                    next_draft["files"] = files
+                if next_draft == current_draft:
+                    unchanged = True
+                    saved_draft = current_draft
+                else:
+                    _draft_text = str(next_draft.get("text", "") or "")
+                    _draft_files = next_draft.get("files", []) or []
+                    _has_meaningful_draft = bool(_draft_text) or bool(_draft_files)
+                    if not (SESSION_DIR / f"{authoritative_sid}.json").exists() and _has_meaningful_draft:
+                        with LOCK:
+                            if SESSIONS.get(authoritative_sid) is not request_session:
+                                return j(
+                                    handler,
+                                    {
+                                        "ok": False,
+                                        "error": "Session no longer active",
+                                        "session_id": authoritative_sid,
+                                    },
+                                    status=409,
+                                )
+                            if len(getattr(request_session, "messages", []) or []) != 0:
+                                return j(
+                                    handler,
+                                    {
+                                        "ok": False,
+                                        "error": "Session no longer active",
+                                        "session_id": authoritative_sid,
+                                    },
+                                    status=409,
+                                )
+                            if (SESSION_DIR / f"{authoritative_sid}.json").exists():
+                                # Owner appeared while acquiring the shared lock; skip
+                                # materialization and proceed with sidecar save only.
+                                pass
+                            else:
+                                # Publish the small owner record while cache state is locked
+                                # so deletion cannot race first-draft ownership.
+                                draft_session = copy.copy(request_session)
+                                draft_session.composer_draft = {}
+                                # LOCK is non-reentrant; indexing here would acquire it again.
+                                draft_session.save(
+                                    touch_updated_at=False,
+                                    skip_index=True,
+                                )
+                    # Draft persistence is not conversation activity. Touching updated_at
+                    # here makes the active-session external-refresh poll force-reload the
+                    # current chat every few seconds while the user is typing, and that
+                    # delayed reload can restore an older draft over newer local input.
+                    _draft_mark("before_save")
+                    _save_session_draft(authoritative_sid, next_draft)
+                    _draft_mark("after_save")
+                    request_session.composer_draft = next_draft
+                    saved_draft = request_session.composer_draft
+                sid = authoritative_sid
+                resolved_once = True
+                break
+        if not resolved_once:
+            return j(
+                handler,
+                {"ok": False, "error": "Session moved", "session_id": request_sid},
+                status=409,
+            )
         _draft_mark("released_lock")
         payload = {"ok": True, "draft": saved_draft}
         if unchanged:
             payload["unchanged"] = True
+        payload["session_id"] = sid
         _draft_mark("before_json")
         j(handler, payload)
         _draft_mark("after_json")

--- a/api/routes.py
+++ b/api/routes.py
@@ -14761,8 +14761,22 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Session not found", 404)
         _draft_mark("after_get_session")
         unchanged = False
+        request_sid = sid
         with _get_session_agent_lock(sid):
             _draft_mark("acquired_lock")
+            resolved_sid = str(getattr(s, "session_id", "") or "").strip()
+            if not resolved_sid or not is_safe_session_id(resolved_sid):
+                return j(
+                    handler,
+                    {"ok": False, "error": "Session moved", "session_id": request_sid},
+                    status=409,
+                )
+            if resolved_sid != request_sid:
+                return j(
+                    handler,
+                    {"ok": False, "error": "Session moved", "session_id": resolved_sid},
+                    status=409,
+                )
             current_draft = dict(getattr(s, "composer_draft", {}) or {})
             next_draft = dict(current_draft)
             if text is not None:
@@ -14773,7 +14787,45 @@ def handle_post(handler, parsed) -> bool:
                 unchanged = True
                 saved_draft = current_draft
             else:
-                s.composer_draft = next_draft
+                _draft_text = str(next_draft.get("text", "") or "")
+                _draft_files = next_draft.get("files", []) or []
+                _has_meaningful_draft = bool(_draft_text) or bool(_draft_files)
+                if not (SESSION_DIR / f"{sid}.json").exists() and _has_meaningful_draft:
+                    with LOCK:
+                        if SESSIONS.get(sid) is not s:
+                            return j(
+                                handler,
+                                {
+                                    "ok": False,
+                                    "error": "Session no longer active",
+                                    "session_id": sid,
+                                },
+                                status=409,
+                            )
+                        if len(getattr(s, "messages", []) or []) != 0:
+                            return j(
+                                handler,
+                                {
+                                    "ok": False,
+                                    "error": "Session no longer active",
+                                    "session_id": sid,
+                                },
+                                status=409,
+                            )
+                        if (SESSION_DIR / f"{sid}.json").exists():
+                            # Owner appeared while acquiring the shared lock; skip
+                            # materialization and proceed with sidecar save only.
+                            pass
+                        else:
+                            # Publish the small owner record while cache state is locked
+                            # so deletion cannot race first-draft ownership.
+                            draft_session = copy.copy(s)
+                            draft_session.composer_draft = {}
+                            # LOCK is non-reentrant; indexing here would acquire it again.
+                            draft_session.save(
+                                touch_updated_at=False,
+                                skip_index=True,
+                            )
                 # Draft persistence is not conversation activity. Touching updated_at
                 # here makes the active-session external-refresh poll force-reload the
                 # current chat every few seconds while the user is typing, and that
@@ -14781,6 +14833,7 @@ def handle_post(handler, parsed) -> bool:
                 _draft_mark("before_save")
                 _save_session_draft(sid, next_draft)
                 _draft_mark("after_save")
+                s.composer_draft = next_draft
                 saved_draft = s.composer_draft
         _draft_mark("released_lock")
         payload = {"ok": True, "draft": saved_draft}
@@ -14905,6 +14958,7 @@ def handle_post(handler, parsed) -> bool:
         session_lock = _get_session_agent_lock(sid)
         if not session_lock.acquire(timeout=5):
             return bad(handler, "Session busy, try again", 503)
+        draft_delete_failed = False
         try:
             with LOCK:
                 SESSIONS.pop(sid, None)
@@ -14919,7 +14973,12 @@ def handle_post(handler, parsed) -> bool:
             except Exception:
                 logger.debug("Failed to unlink session file %s", p)
             sidecar_deleted = not p.exists()
-            _delete_session_draft(sid)
+            try:
+                draft_deleted = bool(_delete_session_draft(sid))
+            except Exception:
+                logger.debug("Failed to delete draft sidecar for session %s", sid, exc_info=True)
+                draft_deleted = False
+            draft_delete_failed = not draft_deleted
             try:
                 prune_session_from_index(sid)
             except Exception:
@@ -14990,14 +15049,18 @@ def handle_post(handler, parsed) -> bool:
                 state_db_cleanup_failed = True
                 logger.warning("Failed to delete CLI session %s", sid, exc_info=True)
         _publish_session_list_changed("session_delete", profile=event_profile)
-        return j(
-            handler,
-            {
-                "ok": True,
-                "state_db_cleanup_failed": state_db_cleanup_failed,
-                **worktree_retained,
-            },
-        )
+        response = {
+            "state_db_cleanup_failed": state_db_cleanup_failed,
+            **worktree_retained,
+        }
+        if draft_delete_failed:
+            response["draft_delete_failed"] = True
+            response.update(
+                {"ok": False, "error": "Failed to delete session draft"}
+            )
+            return j(handler, response, status=500)
+        response["ok"] = True
+        return j(handler, response)
 
     if parsed.path == "/api/session/clear":
         try:
@@ -20657,6 +20720,7 @@ def _handle_memory_read(handler, parsed=None):
 def _handle_sessions_cleanup(handler, body, zero_only=False):
     cleaned = 0
     phase1_removed_ids = set()
+    draft_delete_failed = False
 
     # Phase 1: Clean orphan session files (existing behavior).
     for p in SESSION_DIR.glob("*.json"):
@@ -20671,10 +20735,20 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
             if should_delete:
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
-                p.unlink(missing_ok=True)
-                _delete_session_draft(p.stem)
-                cleaned += 1
-                phase1_removed_ids.add(p.stem)
+                    p.unlink(missing_ok=True)
+                session_deleted = not p.exists()
+                if session_deleted:
+                    phase1_removed_ids.add(p.stem)
+                try:
+                    draft_deleted = bool(_delete_session_draft(p.stem))
+                except Exception:
+                    logger.debug("Failed to delete draft sidecar during cleanup for %s", p.stem, exc_info=True)
+                    draft_delete_failed = True
+                    draft_deleted = False
+                if not draft_deleted:
+                    draft_delete_failed = True
+                if session_deleted:
+                    cleaned += 1
         except Exception:
             logger.debug("Failed to clean up session file %s", p)
 
@@ -20755,6 +20829,17 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
     if phase1_touched and not phase2_rewrote_index and SESSION_INDEX_FILE.exists():
         SESSION_INDEX_FILE.unlink(missing_ok=True)
 
+    if draft_delete_failed:
+        return j(
+            handler,
+            {
+                "ok": False,
+                "error": "Failed to delete one or more session drafts",
+                "cleaned": cleaned,
+                "draft_delete_failed": True,
+            },
+            status=500,
+        )
     return j(handler, {"ok": True, "cleaned": cleaned})
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -14913,13 +14913,13 @@ def handle_post(handler, parsed) -> bool:
                 p.relative_to(SESSION_DIR.resolve())
             except Exception:
                 return bad(handler, "Invalid session_id", 400)
-            _delete_session_draft(sid)
             sidecar_deleted = False
             try:
                 p.unlink(missing_ok=True)
             except Exception:
                 logger.debug("Failed to unlink session file %s", p)
             sidecar_deleted = not p.exists()
+            _delete_session_draft(sid)
             try:
                 prune_session_from_index(sid)
             except Exception:
@@ -20671,8 +20671,8 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
             if should_delete:
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
-                _delete_session_draft(p.stem)
                 p.unlink(missing_ok=True)
+                _delete_session_draft(p.stem)
                 cleaned += 1
                 phase1_removed_ids.add(p.stem)
         except Exception:

--- a/api/routes.py
+++ b/api/routes.py
@@ -9426,6 +9426,8 @@ from api.models import (
     _clear_webui_zero_message_orphan_tombstone,
     _load_webui_deleted_session_tombstone,
     _record_webui_deleted_session_tombstone,
+    _save_session_draft,
+    _delete_session_draft,
     ensure_cron_project,
     _profile_has_user_projects,
     is_cron_session,
@@ -14777,7 +14779,7 @@ def handle_post(handler, parsed) -> bool:
                 # current chat every few seconds while the user is typing, and that
                 # delayed reload can restore an older draft over newer local input.
                 _draft_mark("before_save")
-                s.save(touch_updated_at=False, skip_index=True)
+                _save_session_draft(sid, next_draft)
                 _draft_mark("after_save")
                 saved_draft = s.composer_draft
         _draft_mark("released_lock")
@@ -14911,6 +14913,7 @@ def handle_post(handler, parsed) -> bool:
                 p.relative_to(SESSION_DIR.resolve())
             except Exception:
                 return bad(handler, "Invalid session_id", 400)
+            _delete_session_draft(sid)
             sidecar_deleted = False
             try:
                 p.unlink(missing_ok=True)
@@ -20668,6 +20671,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
             if should_delete:
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
+                _delete_session_draft(p.stem)
                 p.unlink(missing_ok=True)
                 cleaned += 1
                 phase1_removed_ids.add(p.stem)

--- a/api/routes.py
+++ b/api/routes.py
@@ -9614,6 +9614,46 @@ def _pre_compression_continuation_session_id(session) -> str | None:
     rows.extend(_child_rows_from_sidecars(memory_seen_ids))
     return _resolve_from_rows(rows)
 
+
+def _draft_pre_compression_continuation_session_authority(
+    session,
+    *,
+    request_profile,
+    seen_authority_sids: set[str],
+) -> tuple[str | None, str]:
+    """Validate one authoritative compression transition from a snapshot.
+
+    Returns:
+        (next_session, next_sid) when a validated transition exists.
+        (None, best_known_sid) when authority cannot be confirmed.
+    """
+    snapshot_sid = _safe_first(getattr(session, "session_id", None))
+    if not snapshot_sid or not is_safe_session_id(snapshot_sid):
+        return None, snapshot_sid
+
+    continuation_sid = _safe_first(
+        getattr(session, "pre_compression_continuation_session_id", None)
+    )
+    if not continuation_sid or not is_safe_session_id(continuation_sid):
+        return None, snapshot_sid
+    if continuation_sid in seen_authority_sids:
+        return None, continuation_sid
+
+    try:
+        continuation_session = get_session(continuation_sid)
+    except KeyError:
+        return None, continuation_sid
+
+    if not _profiles_match(
+        getattr(continuation_session, "profile", None), request_profile
+    ):
+        return None, continuation_sid
+
+    if _safe_first(getattr(continuation_session, "parent_session_id", None)) != snapshot_sid:
+        return None, continuation_sid
+
+    return continuation_session, continuation_sid
+
 from api.workspace import (
     load_workspaces,
     save_workspaces,
@@ -14776,7 +14816,12 @@ def handle_post(handler, parsed) -> bool:
                     if not resolved_sid or not is_safe_session_id(resolved_sid):
                         return j(
                             handler,
-                            {"ok": False, "error": "Session moved", "session_id": request_sid},
+                            {
+                                "ok": False,
+                                "error": "Session moved",
+                                "session_id": request_sid,
+                                "code": "session_moved",
+                            },
                             status=409,
                         )
                     if resolved_sid != authoritative_sid:
@@ -14789,6 +14834,7 @@ def handle_post(handler, parsed) -> bool:
                                             "ok": False,
                                             "error": "Session moved",
                                             "session_id": resolved_sid,
+                                            "code": "session_moved",
                                         },
                                         status=409,
                                     )
@@ -14812,13 +14858,23 @@ def handle_post(handler, parsed) -> bool:
                 if not resolved_sid or not is_safe_session_id(resolved_sid):
                     return j(
                         handler,
-                        {"ok": False, "error": "Session moved", "session_id": authoritative_sid},
+                        {
+                            "ok": False,
+                            "error": "Session moved",
+                            "session_id": authoritative_sid,
+                            "code": "session_moved",
+                        },
                         status=409,
                     )
                 if not _profiles_match(getattr(request_session, "profile", None), request_profile):
                     return j(
                         handler,
-                        {"ok": False, "error": "Session moved", "session_id": authoritative_sid},
+                        {
+                            "ok": False,
+                            "error": "Session moved",
+                            "session_id": authoritative_sid,
+                            "code": "session_moved",
+                        },
                         status=409,
                     )
 
@@ -14826,7 +14882,12 @@ def handle_post(handler, parsed) -> bool:
                     if resolved_sid in _seen_authority_sids:
                         return j(
                             handler,
-                            {"ok": False, "error": "Session moved", "session_id": resolved_sid},
+                            {
+                                "ok": False,
+                                "error": "Session moved",
+                                "session_id": resolved_sid,
+                                "code": "session_moved",
+                            },
                             status=409,
                         )
                     _seen_authority_sids.add(resolved_sid)
@@ -14835,21 +14896,25 @@ def handle_post(handler, parsed) -> bool:
 
                 continuation_sid = None
                 if getattr(request_session, "pre_compression_snapshot", False):
-                    continuation_sid = _pre_compression_continuation_session_id(request_session)
-
-                if continuation_sid:
-                    if not is_safe_session_id(continuation_sid):
+                    continuation_session, continuation_sid = (
+                        _draft_pre_compression_continuation_session_authority(
+                            request_session,
+                            request_profile=request_profile,
+                            seen_authority_sids=_seen_authority_sids,
+                        )
+                    )
+                    if not continuation_session:
                         return j(
                             handler,
-                            {"ok": False, "error": "Session moved", "session_id": authoritative_sid},
+                            {
+                                "ok": False,
+                                "error": "Session moved",
+                                "session_id": continuation_sid or authoritative_sid,
+                                "code": "session_moved",
+                            },
                             status=409,
                         )
-                    if continuation_sid in _seen_authority_sids:
-                        return j(
-                            handler,
-                            {"ok": False, "error": "Session moved", "session_id": continuation_sid},
-                            status=409,
-                        )
+                    request_session = continuation_session
                     _seen_authority_sids.add(continuation_sid)
                     authoritative_sid = continuation_sid
                     continue
@@ -14918,7 +14983,12 @@ def handle_post(handler, parsed) -> bool:
         if not resolved_once:
             return j(
                 handler,
-                {"ok": False, "error": "Session moved", "session_id": request_sid},
+                {
+                    "ok": False,
+                    "error": "Session moved",
+                    "session_id": authoritative_sid,
+                    "code": "session_moved",
+                },
                 status=409,
             )
         _draft_mark("released_lock")

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4549,10 +4549,13 @@ def _migrate_compression_session_ownership(
                     new_sid,
                 )
                 return False
+            SESSION_AGENT_LOCKS[old_sid] = agent_lock
             SESSION_AGENT_LOCKS[new_sid] = agent_lock
 
     if not _preserve_pre_compression_snapshot(s, old_sid, new_sid):
         with SESSION_AGENT_LOCKS_LOCK:
+            if old_lock is missing and SESSION_AGENT_LOCKS.get(old_sid) is agent_lock:
+                SESSION_AGENT_LOCKS.pop(old_sid, None)
             if new_lock is missing and SESSION_AGENT_LOCKS.get(new_sid) is agent_lock:
                 SESSION_AGENT_LOCKS.pop(new_sid, None)
         return False
@@ -4582,8 +4585,7 @@ def _migrate_compression_session_ownership(
 
                 if SESSIONS.get(old_sid) is s:
                     SESSIONS.pop(old_sid, None)
-                if SESSION_AGENT_LOCKS.get(old_sid) is agent_lock:
-                    SESSION_AGENT_LOCKS.pop(old_sid, None)
+
     except Exception:
         with LOCK:
             with _models._INDEX_WRITE_LOCK:
@@ -4600,6 +4602,11 @@ def _migrate_compression_session_ownership(
                 SESSIONS[old_sid] = s
             s.session_id, s.pre_compression_snapshot, s.pre_compression_continuation_session_id, s.parent_session_id = previous_state
             with SESSION_AGENT_LOCKS_LOCK:
+                if SESSION_AGENT_LOCKS.get(old_sid) is agent_lock:
+                    if old_lock is missing:
+                        SESSION_AGENT_LOCKS.pop(old_sid, None)
+                    else:
+                        SESSION_AGENT_LOCKS[old_sid] = old_lock
                 if SESSION_AGENT_LOCKS.get(new_sid) is agent_lock:
                     if new_lock is missing:
                         SESSION_AGENT_LOCKS.pop(new_sid, None)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4371,7 +4371,7 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     return None, llm_status or 'empty_title', raw_preview
 
 
-def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
+def _preserve_pre_compression_snapshot(s, old_sid: str, continuation_sid: str | None = None) -> None:
     """Persist old_sid as a read-only pre-compression snapshot.
 
     Context compression rotates the active WebUI session id from old_sid to the
@@ -4399,9 +4399,19 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             # pre-existing parent_session_id lineage.
             saved_sid = s.session_id
             saved_snapshot = bool(getattr(s, 'pre_compression_snapshot', False))
+            saved_continuation_sid = (
+                str(getattr(s, 'pre_compression_continuation_session_id', None) or '')
+                if getattr(s, 'pre_compression_continuation_session_id', None)
+                else None
+            )
             saved_pinned = bool(getattr(s, 'pinned', False))
             s.session_id = old_sid
             s.pre_compression_snapshot = True
+            s.pre_compression_continuation_session_id = (
+                str(continuation_sid).strip()
+                if continuation_sid
+                else None
+            )
             s.pinned = False
             # Stage-359 / PR #2295: clear runtime stream-state fields on the
             # archived snapshot so the sidebar does not reopen the parent as
@@ -4431,6 +4441,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             finally:
                 s.session_id = saved_sid
                 s.pre_compression_snapshot = saved_snapshot
+                s.pre_compression_continuation_session_id = saved_continuation_sid
                 s.pinned = saved_pinned
                 s.active_stream_id = saved_active_stream_id
                 s.pending_user_message = saved_pending_user_message
@@ -4445,6 +4456,11 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
         snapshot = Session.load(old_sid)
         if snapshot:
             snapshot.pre_compression_snapshot = True
+            snapshot.pre_compression_continuation_session_id = (
+                str(continuation_sid).strip()
+                if continuation_sid
+                else None
+            )
             snapshot.pinned = False
             # Stage-359 Opus SHOULD-FIX: clear runtime fields on the loaded
             # snapshot too. If the disk snapshot was last persisted while the
@@ -4467,6 +4483,36 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
         logger.debug("Could not read old session file before preservation")
     except Exception:
         logger.debug("Failed to preserve pre-compression session file", exc_info=True)
+
+
+def _migrate_compression_session_ownership(s, old_sid: str, new_sid: str, agent_lock) -> None:
+    """Move live session and lock ownership to a compression continuation."""
+    s.session_id = new_sid
+    _preserve_pre_compression_snapshot(s, old_sid, new_sid)
+    s.pre_compression_snapshot = False
+    s.pre_compression_continuation_session_id = None
+    s.parent_session_id = old_sid
+
+    with LOCK:
+        cached_old_session = SESSIONS.pop(old_sid, None)
+        if cached_old_session is not None and cached_old_session is not s:
+            cached_old_sid = str(getattr(cached_old_session, 'session_id', '') or '')
+            if cached_old_sid == str(old_sid):
+                SESSIONS[old_sid] = cached_old_session
+            else:
+                logger.warning(
+                    "compression cache migration skipped stale object: old_sid=%s new_sid=%s cached_session_id=%s",
+                    old_sid,
+                    new_sid,
+                    cached_old_sid or None,
+                )
+        SESSIONS[new_sid] = s
+        SESSIONS.move_to_end(new_sid)
+        _evict_sessions_over_cap()
+
+    with SESSION_AGENT_LOCKS_LOCK:
+        SESSION_AGENT_LOCKS[new_sid] = agent_lock
+        SESSION_AGENT_LOCKS.pop(old_sid, None)
 
 
 def _maybe_schedule_title_refresh(session, put_event, agent):
@@ -9791,59 +9837,7 @@ def _run_agent_streaming(
                             "Stamped profile=%r on continuation session %s after compression",
                             _resolved_profile_name, new_sid,
                         )
-                    # Preserve the original session file so the full pre-compression
-                    # history survives even when summarisation fails. The previous
-                    # implementation renamed old_sid.json → new_sid.json, which
-                    # destroyed the only persistent copy of the uncompressed history
-                    # before the new (possibly summary-only) session had been saved.
-                    # If the LLM summariser also failed, the user was left with zero
-                    # recoverable messages. (#2223)
-                    # ---
-                    # Archive the old session: write its current state to disk so
-                    # the full conversation history survives even when context
-                    # compression removes messages from the model's context. Skip
-                    # the write when the file already contains up-to-date data
-                    # (i.e. it was just saved by a checkpoint).
-                    _preserve_pre_compression_snapshot(s, old_sid)
-                    # The continuation is the live/tip session, not another archived
-                    # snapshot. If the in-memory object was itself loaded from a
-                    # pre-compression snapshot (possible on repeated compression chains
-                    # or stale-cache repair paths), _preserve_pre_compression_snapshot()
-                    # intentionally restores that old flag; clear it before saving the
-                    # new continuation so sidebar/discoverability code does not hide the
-                    # session that owns the completed turn.
-                    s.pre_compression_snapshot = False
-                    # Always link the continuation session to its immediate predecessor
-                    # (the preserved snapshot). This OVERRIDES any prior
-                    # parent_session_id because the new continuation IS the next link
-                    # in the chain: traversal walks new → old → old.parent → ... root.
-                    # Stage-353 Opus SHOULD-FIX: previous `if not s.parent_session_id`
-                    # guard skipped this stamp on fork-of-fork compressions, so a
-                    # subsequent traversal from the new continuation would jump
-                    # over the just-preserved snapshot back to the original fork
-                    # parent, losing access to the recoverable history in old_sid.json.
-                    s.parent_session_id = old_sid
-                    with LOCK:
-                        cached_old_session = SESSIONS.pop(old_sid, None)
-                        if cached_old_session is not None and cached_old_session is not s:
-                            cached_old_sid = str(getattr(cached_old_session, 'session_id', '') or '')
-                            if cached_old_sid == str(old_sid):
-                                SESSIONS[old_sid] = cached_old_session
-                            else:
-                                logger.warning(
-                                    "compression cache migration skipped stale object: old_sid=%s new_sid=%s cached_session_id=%s",
-                                    old_sid,
-                                    new_sid,
-                                    cached_old_sid or None,
-                                )
-                        SESSIONS[new_sid] = s
-                        SESSIONS.move_to_end(new_sid)
-                        _evict_sessions_over_cap()  # #4765: safe LRU eviction (never active/unsaved)
-                    # Migrate the per-session lock by aliasing new_sid to the
-                    # held _agent_lock reference directly. Keep old_sid aliased
-                    # too until the weak registry can reclaim both safely after
-                    # all old-ID holders and waiters release the lock.
-                    _alias_session_agent_lock(old_sid, new_sid, _agent_lock)
+                    _migrate_compression_session_ownership(s, old_sid, new_sid, _agent_lock)
                     # Migrate cached agent to the new session ID so the turn
                     # count survives context compression.
                     from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4497,8 +4497,8 @@ def _migrate_compression_session_ownership(
     agent_lock,
 ) -> bool:
     """Atomically publish a durable compression continuation."""
-    if not _preserve_pre_compression_snapshot(s, old_sid, new_sid):
-        return False
+    from api import models as _models
+    from api.paths import _atomic_write_text
 
     missing = object()
     previous_state = (
@@ -4507,6 +4507,15 @@ def _migrate_compression_session_ownership(
         getattr(s, 'pre_compression_continuation_session_id', None),
         getattr(s, 'parent_session_id', None),
     )
+    old_path = SESSION_DIR / f'{old_sid}.json'
+    index_path = _models.SESSION_INDEX_FILE
+    try:
+        old_preimage = old_path.read_text(encoding='utf-8')
+        index_preimage = index_path.read_text(encoding='utf-8') if index_path.exists() else None
+    except OSError:
+        logger.debug("Could not capture compression marker preimage", exc_info=True)
+        return False
+
     with LOCK:
         if SESSIONS.get(old_sid) is not s or str(getattr(s, 'session_id', '') or '') != old_sid:
             logger.warning(
@@ -4523,7 +4532,6 @@ def _migrate_compression_session_ownership(
                 new_sid,
             )
             return False
-
         with SESSION_AGENT_LOCKS_LOCK:
             old_lock = SESSION_AGENT_LOCKS.get(old_sid, missing)
             new_lock = SESSION_AGENT_LOCKS.get(new_sid, missing)
@@ -4541,9 +4549,29 @@ def _migrate_compression_session_ownership(
                     new_sid,
                 )
                 return False
-
             SESSION_AGENT_LOCKS[new_sid] = agent_lock
-            try:
+
+    if not _preserve_pre_compression_snapshot(s, old_sid, new_sid):
+        with SESSION_AGENT_LOCKS_LOCK:
+            if new_lock is missing and SESSION_AGENT_LOCKS.get(new_sid) is agent_lock:
+                SESSION_AGENT_LOCKS.pop(new_sid, None)
+        return False
+
+    try:
+        with LOCK:
+            if SESSIONS.get(old_sid) is not s or str(getattr(s, 'session_id', '') or '') != old_sid:
+                raise RuntimeError("stale owner while publishing")
+            if existing_new_session is missing:
+                if SESSIONS.get(new_sid) is not None and SESSIONS.get(new_sid) is not s:
+                    raise RuntimeError("continuation owner changed during publish")
+            elif SESSIONS.get(new_sid) is not existing_new_session:
+                raise RuntimeError("continuation owner changed during publish")
+            with SESSION_AGENT_LOCKS_LOCK:
+                if SESSION_AGENT_LOCKS.get(old_sid, missing) not in (missing, agent_lock):
+                    raise RuntimeError("stale old-lock while publishing")
+                if SESSION_AGENT_LOCKS.get(new_sid) is not agent_lock:
+                    raise RuntimeError("continuation lock changed during publish")
+
                 s.session_id = new_sid
                 s.pre_compression_snapshot = False
                 s.pre_compression_continuation_session_id = None
@@ -4551,31 +4579,39 @@ def _migrate_compression_session_ownership(
                 SESSIONS[new_sid] = s
                 SESSIONS.move_to_end(new_sid)
                 _evict_sessions_over_cap()
-            except Exception:
-                if SESSIONS.get(new_sid) is s:
-                    SESSIONS.pop(new_sid, None)
-                if existing_new_session is not missing:
-                    SESSIONS[new_sid] = existing_new_session
-                if SESSIONS.get(old_sid) is None:
-                    SESSIONS[old_sid] = s
-                s.session_id, s.pre_compression_snapshot, s.pre_compression_continuation_session_id, s.parent_session_id = previous_state
+
+                if SESSIONS.get(old_sid) is s:
+                    SESSIONS.pop(old_sid, None)
+                if SESSION_AGENT_LOCKS.get(old_sid) is agent_lock:
+                    SESSION_AGENT_LOCKS.pop(old_sid, None)
+    except Exception:
+        with LOCK:
+            with _models._INDEX_WRITE_LOCK:
+                _atomic_write_text(old_path, old_preimage, encoding='utf-8')
+                if index_preimage is None:
+                    index_path.unlink(missing_ok=True)
+                else:
+                    _atomic_write_text(index_path, index_preimage, encoding='utf-8')
+            if SESSIONS.get(new_sid) is s:
+                SESSIONS.pop(new_sid, None)
+            if existing_new_session is not missing:
+                SESSIONS[new_sid] = existing_new_session
+            if SESSIONS.get(old_sid) is None:
+                SESSIONS[old_sid] = s
+            s.session_id, s.pre_compression_snapshot, s.pre_compression_continuation_session_id, s.parent_session_id = previous_state
+            with SESSION_AGENT_LOCKS_LOCK:
                 if SESSION_AGENT_LOCKS.get(new_sid) is agent_lock:
                     if new_lock is missing:
                         SESSION_AGENT_LOCKS.pop(new_sid, None)
                     else:
                         SESSION_AGENT_LOCKS[new_sid] = new_lock
-                logger.debug(
-                    "Compression ownership migration aborted: old_sid=%s new_sid=%s",
-                    old_sid,
-                    new_sid,
-                    exc_info=True,
-                )
-                return False
-
-            if SESSIONS.get(old_sid) is s:
-                SESSIONS.pop(old_sid, None)
-            if SESSION_AGENT_LOCKS.get(old_sid) is agent_lock:
-                SESSION_AGENT_LOCKS.pop(old_sid, None)
+        logger.debug(
+            "Compression ownership migration aborted: old_sid=%s new_sid=%s",
+            old_sid,
+            new_sid,
+            exc_info=True,
+        )
+        return False
     return True
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4509,12 +4509,71 @@ def _migrate_compression_session_ownership(
     )
     old_path = SESSION_DIR / f'{old_sid}.json'
     index_path = _models.SESSION_INDEX_FILE
+    index_row_snapshot = None
+    index_file_existed = False
     try:
         old_preimage = old_path.read_text(encoding='utf-8')
-        index_preimage = index_path.read_text(encoding='utf-8') if index_path.exists() else None
+        with _models._INDEX_WRITE_LOCK:
+            index_file_existed = index_path.exists()
+            if index_file_existed:
+                try:
+                    index_payload = json.loads(index_path.read_bytes())
+                except (OSError, json.JSONDecodeError):
+                    logger.debug(
+                        "Could not capture compression marker index row",
+                        exc_info=True,
+                    )
+                    return False
+                if not isinstance(index_payload, list):
+                    logger.debug(
+                        "Could not capture compression marker index row: index is not a list",
+                        exc_info=True,
+                    )
+                    return False
+                for row in index_payload:
+                    if (
+                        isinstance(row, dict)
+                        and str(row.get('session_id') or '') == old_sid
+                    ):
+                        index_row_snapshot = copy.deepcopy(row)
+                        break
     except OSError:
         logger.debug("Could not capture compression marker preimage", exc_info=True)
         return False
+
+    def _restore_durable_snapshot() -> None:
+        def _updated_at_key(entry):
+            try:
+                return float((entry or {}).get('updated_at') or 0)
+            except (TypeError, ValueError):
+                return 0.0
+
+        with _models._INDEX_WRITE_LOCK:
+            _atomic_write_text(old_path, old_preimage, encoding='utf-8')
+            if not index_path.exists():
+                if not index_file_existed:
+                    return
+                current_rows = []
+            else:
+                current_rows = json.loads(index_path.read_bytes())
+                if not isinstance(current_rows, list):
+                    raise ValueError("session index must be a list")
+
+            filtered = [
+                row for row in current_rows
+                if not (isinstance(row, dict) and str(row.get('session_id') or '') == old_sid)
+            ]
+            if index_row_snapshot is not None:
+                filtered.append(index_row_snapshot)
+                filtered.sort(key=_updated_at_key, reverse=True)
+            elif filtered == current_rows:
+                return
+            _payload = json.dumps(
+                filtered,
+                ensure_ascii=False,
+                indent=2,
+            )
+            _atomic_write_text(index_path, _payload, encoding='utf-8')
 
     with LOCK:
         if SESSIONS.get(old_sid) is not s or str(getattr(s, 'session_id', '') or '') != old_sid:
@@ -4587,13 +4646,14 @@ def _migrate_compression_session_ownership(
                     SESSIONS.pop(old_sid, None)
 
     except Exception:
+        try:
+            _restore_durable_snapshot()
+        except Exception:
+            logger.debug(
+                "Failed to restore compression marker durable state",
+                exc_info=True,
+            )
         with LOCK:
-            with _models._INDEX_WRITE_LOCK:
-                _atomic_write_text(old_path, old_preimage, encoding='utf-8')
-                if index_preimage is None:
-                    index_path.unlink(missing_ok=True)
-                else:
-                    _atomic_write_text(index_path, index_preimage, encoding='utf-8')
             if SESSIONS.get(new_sid) is s:
                 SESSIONS.pop(new_sid, None)
             if existing_new_session is not missing:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4371,7 +4371,11 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     return None, llm_status or 'empty_title', raw_preview
 
 
-def _preserve_pre_compression_snapshot(s, old_sid: str, continuation_sid: str | None = None) -> None:
+def _preserve_pre_compression_snapshot(
+    s,
+    old_sid: str,
+    continuation_sid: str | None = None,
+) -> bool:
     """Persist old_sid as a read-only pre-compression snapshot.
 
     Context compression rotates the active WebUI session id from old_sid to the
@@ -4380,19 +4384,17 @@ def _preserve_pre_compression_snapshot(s, old_sid: str, continuation_sid: str | 
     """
     old_path = SESSION_DIR / f'{old_sid}.json'
     if not old_path.exists():
-        return
+        return False
     try:
         existing_text = old_path.read_text(encoding='utf-8')
         try:
             existing = json.loads(existing_text)
             existing_msgs = len(existing.get('messages') or [])
-            existing_snapshot = bool(existing.get('pre_compression_snapshot'))
         except (json.JSONDecodeError, ValueError):
             # Treat corrupt/malformed old JSON as missing history and rewrite it
             # from the in-memory pre-compression messages below. That is safer
             # than leaving an unreadable recovery snapshot behind.
             existing_msgs = -1
-            existing_snapshot = False
         if len(s.messages) > existing_msgs:
             # In-memory messages are newer than the file; save the full old
             # snapshot from the current session object while preserving its
@@ -4448,7 +4450,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str, continuation_sid: str | 
                 s.pending_attachments = saved_pending_attachments
                 s.pending_started_at = saved_pending_started_at
                 s.pending_user_source = saved_pending_user_source
-            return
+            return True
         # Existing file is already at least as complete as memory; stamp only
         # the snapshot marker so index/sidebar projection can hide it without
         # rewriting a shorter messages array over a fuller transcript.
@@ -4479,40 +4481,102 @@ def _preserve_pre_compression_snapshot(s, old_sid: str, continuation_sid: str | 
                 "Marked pre-compression session %s as sidebar-hidden snapshot",
                 old_sid,
             )
+            return True
+        return False
     except OSError:
         logger.debug("Could not read old session file before preservation")
     except Exception:
         logger.debug("Failed to preserve pre-compression session file", exc_info=True)
+    return False
 
 
-def _migrate_compression_session_ownership(s, old_sid: str, new_sid: str, agent_lock) -> None:
-    """Move live session and lock ownership to a compression continuation."""
-    s.session_id = new_sid
-    _preserve_pre_compression_snapshot(s, old_sid, new_sid)
-    s.pre_compression_snapshot = False
-    s.pre_compression_continuation_session_id = None
-    s.parent_session_id = old_sid
+def _migrate_compression_session_ownership(
+    s,
+    old_sid: str,
+    new_sid: str,
+    agent_lock,
+) -> bool:
+    """Atomically publish a durable compression continuation."""
+    if not _preserve_pre_compression_snapshot(s, old_sid, new_sid):
+        return False
 
+    missing = object()
+    previous_state = (
+        s.session_id,
+        bool(getattr(s, 'pre_compression_snapshot', False)),
+        getattr(s, 'pre_compression_continuation_session_id', None),
+        getattr(s, 'parent_session_id', None),
+    )
     with LOCK:
-        cached_old_session = SESSIONS.pop(old_sid, None)
-        if cached_old_session is not None and cached_old_session is not s:
-            cached_old_sid = str(getattr(cached_old_session, 'session_id', '') or '')
-            if cached_old_sid == str(old_sid):
-                SESSIONS[old_sid] = cached_old_session
-            else:
+        if SESSIONS.get(old_sid) is not s or str(getattr(s, 'session_id', '') or '') != old_sid:
+            logger.warning(
+                "compression cache migration blocked by stale owner: old_sid=%s new_sid=%s",
+                old_sid,
+                new_sid,
+            )
+            return False
+        existing_new_session = SESSIONS.get(new_sid, missing)
+        if existing_new_session is not missing and existing_new_session is not s:
+            logger.warning(
+                "compression cache migration blocked by existing continuation owner: old_sid=%s new_sid=%s",
+                old_sid,
+                new_sid,
+            )
+            return False
+
+        with SESSION_AGENT_LOCKS_LOCK:
+            old_lock = SESSION_AGENT_LOCKS.get(old_sid, missing)
+            new_lock = SESSION_AGENT_LOCKS.get(new_sid, missing)
+            if old_lock is not missing and old_lock is not agent_lock:
                 logger.warning(
-                    "compression cache migration skipped stale object: old_sid=%s new_sid=%s cached_session_id=%s",
+                    "compression lock migration blocked by stale owner: old_sid=%s new_sid=%s",
                     old_sid,
                     new_sid,
-                    cached_old_sid or None,
                 )
-        SESSIONS[new_sid] = s
-        SESSIONS.move_to_end(new_sid)
-        _evict_sessions_over_cap()
+                return False
+            if new_lock is not missing and new_lock is not agent_lock:
+                logger.warning(
+                    "compression lock migration blocked by existing continuation lock: old_sid=%s new_sid=%s",
+                    old_sid,
+                    new_sid,
+                )
+                return False
 
-    with SESSION_AGENT_LOCKS_LOCK:
-        SESSION_AGENT_LOCKS[new_sid] = agent_lock
-        SESSION_AGENT_LOCKS.pop(old_sid, None)
+            SESSION_AGENT_LOCKS[new_sid] = agent_lock
+            try:
+                s.session_id = new_sid
+                s.pre_compression_snapshot = False
+                s.pre_compression_continuation_session_id = None
+                s.parent_session_id = old_sid
+                SESSIONS[new_sid] = s
+                SESSIONS.move_to_end(new_sid)
+                _evict_sessions_over_cap()
+            except Exception:
+                if SESSIONS.get(new_sid) is s:
+                    SESSIONS.pop(new_sid, None)
+                if existing_new_session is not missing:
+                    SESSIONS[new_sid] = existing_new_session
+                if SESSIONS.get(old_sid) is None:
+                    SESSIONS[old_sid] = s
+                s.session_id, s.pre_compression_snapshot, s.pre_compression_continuation_session_id, s.parent_session_id = previous_state
+                if SESSION_AGENT_LOCKS.get(new_sid) is agent_lock:
+                    if new_lock is missing:
+                        SESSION_AGENT_LOCKS.pop(new_sid, None)
+                    else:
+                        SESSION_AGENT_LOCKS[new_sid] = new_lock
+                logger.debug(
+                    "Compression ownership migration aborted: old_sid=%s new_sid=%s",
+                    old_sid,
+                    new_sid,
+                    exc_info=True,
+                )
+                return False
+
+            if SESSIONS.get(old_sid) is s:
+                SESSIONS.pop(old_sid, None)
+            if SESSION_AGENT_LOCKS.get(old_sid) is agent_lock:
+                SESSION_AGENT_LOCKS.pop(old_sid, None)
+    return True
 
 
 def _maybe_schedule_title_refresh(session, put_event, agent):
@@ -9820,7 +9884,7 @@ def _run_agent_streaming(
                     new_sid = _agent_sid
                     _compression_origin_session_id = old_sid
                     _compression_continuation_session_id = new_sid
-                    s.session_id = new_sid
+                    _pre_migration_profile = s.profile
                     # Carry profile identity across the compression boundary.
                     # Without this, s.profile stays None on the continuation
                     # session. On the next request, _run_agent_streaming calls
@@ -9837,7 +9901,11 @@ def _run_agent_streaming(
                             "Stamped profile=%r on continuation session %s after compression",
                             _resolved_profile_name, new_sid,
                         )
-                    _migrate_compression_session_ownership(s, old_sid, new_sid, _agent_lock)
+                    if not _migrate_compression_session_ownership(s, old_sid, new_sid, _agent_lock):
+                        s.profile = _pre_migration_profile
+                        raise RuntimeError(
+                            f"Failed to migrate compressed-session ownership: {old_sid}->{new_sid}",
+                        )
                     # Migrate cached agent to the new session ID so the turn
                     # count survives context compression.
                     from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK

--- a/static/commands.js
+++ b/static/commands.js
@@ -1504,8 +1504,19 @@ function _steerIndicatorText(originalMsg, filesSnapshot){
 }
 
 async function _steerPersistDraftForOwner(ownerSid, originalMsg, explicitSteer, filesSnapshot){
-  if(!ownerSid||typeof _saveComposerDraftNow!=='function')return;
-  await _saveComposerDraftNow(ownerSid,_steerRestoreText(originalMsg,explicitSteer),filesSnapshot);
+  if(!ownerSid||typeof _saveComposerDraftNow!=='function') return false;
+  const persistedText = _steerRestoreText(originalMsg,explicitSteer);
+  const persistedFiles = Array.isArray(filesSnapshot) ? [...filesSnapshot] : [];
+  try{
+    const result = _saveComposerDraftNow(ownerSid,persistedText,persistedFiles);
+    if(result&&typeof result.catch==='function'){
+      return result.catch((error)=>_handleComposerDraftPostFailure(error,ownerSid,persistedText,persistedFiles));
+    }
+    return result;
+  }catch(error){
+    _handleComposerDraftPostFailure(error,ownerSid,persistedText,persistedFiles);
+    return false;
+  }
 }
 
 // #5459 gate: cache successful steer uploads by owner session so a failed-steer

--- a/static/messages.js
+++ b/static/messages.js
@@ -1238,7 +1238,7 @@ function applySessionTitleUpdate(sid, titleText, options={}){
 // actually typed, not the transformed send payload.
 function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, clearPromise){
   const restore=String(draftText||'');
-  const files=Array.isArray(filesSnapshot)?filesSnapshot.filter(Boolean):[];
+  const files=Array.isArray(filesSnapshot)?[...filesSnapshot]:[];
   if(!restore&&!files.length) return false;
 
   // Only mutate the VISIBLE composer / staged tray when the failed send belongs
@@ -1274,22 +1274,36 @@ function _restoreComposerDraftAfterFailedSend(draftText, filesSnapshot, sid, cle
   // session-switch save path already persisted this session's composer).
   if(sid&&typeof _saveComposerDraftNow==='function'){
     const _persist=()=>{
-      try{
-        const stillVisible=(S.session&&S.session.session_id)===sid;
-        if(stillVisible){
-          const inp=$('msg');
-          const liveText=inp?String(inp.value||''):restore;
-          _saveComposerDraftNow(sid, liveText, S.pendingFiles?[...S.pendingFiles]:[]);
-        } else if(!restoredVisible){
-          // Background failure (sid was never the visible session): no live
-          // composer to read, so persist the captured snapshot — it's the only copy.
-          _saveComposerDraftNow(sid, restore, []);
-        }
-        // else: restored the visible composer, then the user switched away — the
+      let persistedText=restore;
+      let persistedFiles=files;
+      const stillVisible=(S.session&&S.session.session_id)===sid;
+      if(stillVisible){
+        const inp=$('msg');
+        const liveText=inp?String(inp.value||''):restore;
+        persistedText=liveText;
+        persistedFiles=S.pendingFiles?[...S.pendingFiles]:files;
+      } else if(!restoredVisible){
+        // Background failure (sid was never the visible session): no live
+        // composer to read, so persist the captured snapshot — it's the only copy.
+        persistedText=restore;
+        persistedFiles=files;
+      } else {
+        // Restored the visible composer, then user switched away — the
         // session-switch save path already saved sid's composer; skip stale write.
-      }catch(_){ }
+        return;
+      }
+      try{
+        const result=_saveComposerDraftNow(sid,persistedText,persistedFiles);
+        if(result&&typeof result.catch==='function'){
+          return result.catch((error)=>_handleComposerDraftPostFailure(error,sid,persistedText,persistedFiles));
+        }
+        return result;
+      }catch(error){
+        _handleComposerDraftPostFailure(error,sid,persistedText,persistedFiles);
+        return;
+      }
     };
-    if(clearPromise&&typeof clearPromise.then==='function') clearPromise.then(_persist,_persist);
+    if(clearPromise&&typeof clearPromise.then==='function') clearPromise.then(_persist,_persist).catch(()=>{});
     else _persist();
   }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -213,18 +213,82 @@ function _saveComposerDraft(sid, text, files) {
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
+  const normalizedDraft = { text: normalizedText, files: normalizedFiles };
   if (_composerDraftHasPayload(normalizedText, normalizedFiles)) {
     _clearComposerDraftRestoreSuppression(sid);
     _composerDraftKnownPayloadSessions.add(sid);
   }
   _draftSaveTimer = setTimeout(() => {
-    api('/api/session/draft', {
-      method: 'POST',
-      body: JSON.stringify({ session_id: sid, text: normalizedText, files: normalizedFiles }),
-    }).then(() => {
-      _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
-    }).catch(() => {});
+    _postComposerDraftPayload(sid, normalizedDraft).catch(() => {});
   }, _DRAFT_SAVE_DELAY_MS);
+}
+
+function _safeDraftSessionId(sid) {
+  if (typeof sid !== 'string') return '';
+  const trimmed = sid.trim();
+  if (!trimmed) return '';
+  return /^[0-9A-Za-z_-]+$/.test(trimmed) ? trimmed : '';
+}
+
+function _parseSessionMovedDraftError(error) {
+  const body = error && error.body;
+  if (typeof body !== 'string') return null;
+  let parsed = null;
+  try {
+    parsed = JSON.parse(body);
+  } catch (err) {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const code = String(parsed.code || '').trim();
+  const nextSid = _safeDraftSessionId(parsed.session_id || '');
+  if (code !== 'session_moved' || !nextSid) return null;
+  return nextSid;
+}
+
+function _composerDraftResponseSessionId(response, fallbackSid) {
+  if (!response || response.session_id === undefined || response.session_id === null) return fallbackSid;
+  const sid = _safeDraftSessionId(response.session_id);
+  if (!sid) throw new Error('Invalid composer draft session response');
+  return sid;
+}
+
+function _postComposerDraftPayload(sid, draft) {
+  const requestSid = _safeDraftSessionId(sid);
+  if (!requestSid) return Promise.resolve();
+  const normalizedText = String((draft && draft.text) || '');
+  const normalizedFiles = Array.isArray(draft && draft.files) ? draft.files.filter(Boolean) : [];
+  const bodyPayload = { text: normalizedText, files: normalizedFiles };
+  const post = (targetSid) => api('/api/session/draft', {
+    method: 'POST',
+    body: JSON.stringify({
+      session_id: targetSid,
+      text: bodyPayload.text,
+      files: bodyPayload.files,
+    }),
+  });
+
+  return post(requestSid).then((response) => {
+    sid = _composerDraftResponseSessionId(response, requestSid);
+    if (sid !== requestSid) _composerDraftKnownPayloadSessions.delete(requestSid);
+    _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
+    return response;
+  }).catch((error) => {
+    const movedSid = _parseSessionMovedDraftError(error);
+    if (
+      !error || error.status !== 409
+      || !movedSid
+      || movedSid === requestSid
+    ) {
+      throw error;
+    }
+    return post(movedSid).then((response) => {
+      sid = _composerDraftResponseSessionId(response, movedSid);
+      _composerDraftKnownPayloadSessions.delete(requestSid);
+      _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
+      return response;
+    });
+  });
 }
 
 function _composerDraftHasPayload(text, files) {
@@ -256,6 +320,7 @@ function _saveComposerDraftNow(sid, text, files) {
   clearTimeout(_draftSaveTimer);
   const normalizedText = String(text || '');
   const normalizedFiles = _composerDraftFilesForPersist(files);
+  const normalizedDraft = { text: normalizedText, files: normalizedFiles };
   if (_composerDraftHasPayload(normalizedText, normalizedFiles)) {
     _clearComposerDraftRestoreSuppression(sid);
   }
@@ -268,12 +333,7 @@ function _saveComposerDraftNow(sid, text, files) {
       && !_composerDraftKnownPayloadSessions.has(sid)) {
     return Promise.resolve();
   }
-  return api('/api/session/draft', {
-    method: 'POST',
-    body: JSON.stringify({ session_id: sid, text: normalizedText, files: normalizedFiles }),
-  }).then(() => {
-    _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
-  }).catch(() => {});
+  return _postComposerDraftPayload(sid, normalizedDraft).catch(() => {});
 }
 
 // Restore composer draft from server onto #msg textarea.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -219,7 +219,9 @@ function _saveComposerDraft(sid, text, files) {
     _composerDraftKnownPayloadSessions.add(sid);
   }
   _draftSaveTimer = setTimeout(() => {
-    _postComposerDraftPayload(sid, normalizedDraft).catch(() => {});
+    _postComposerDraftPayload(sid, normalizedDraft).catch((error) => {
+      _handleComposerDraftPostFailure(error, sid, normalizedText, normalizedFiles);
+    });
   }, _DRAFT_SAVE_DELAY_MS);
 }
 
@@ -253,6 +255,23 @@ function _composerDraftResponseSessionId(response, fallbackSid) {
   return sid;
 }
 
+function _handleComposerDraftPostFailure(error, sid, text, files) {
+  const normalizedText = String(text || '');
+  const normalizedFiles = Array.isArray(files) ? files.filter(Boolean) : [];
+  if (S.session && S.session.session_id === sid) {
+    S.session.composer_draft = { text: normalizedText, files: normalizedFiles };
+  }
+  if (_composerDraftHasPayload(normalizedText, normalizedFiles)) {
+    _composerDraftKnownPayloadSessions.add(sid);
+  }
+  if (typeof console !== 'undefined' && console.warn) {
+    console.warn(
+      '[composer draft] failed to persist draft',
+      { session_id: sid, error: String(error && error.message ? error.message : error || '') },
+    );
+  }
+}
+
 function _postComposerDraftPayload(sid, draft) {
   const requestSid = _safeDraftSessionId(sid);
   if (!requestSid) return Promise.resolve();
@@ -267,11 +286,16 @@ function _postComposerDraftPayload(sid, draft) {
       files: bodyPayload.files,
     }),
   });
+  const remember = (responseSid) => {
+    if (responseSid !== requestSid) {
+      _composerDraftKnownPayloadSessions.delete(requestSid);
+    }
+    _rememberComposerDraftPayloadState(responseSid, normalizedText, normalizedFiles);
+  };
 
   return post(requestSid).then((response) => {
-    sid = _composerDraftResponseSessionId(response, requestSid);
-    if (sid !== requestSid) _composerDraftKnownPayloadSessions.delete(requestSid);
-    _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
+    const responseSid = _composerDraftResponseSessionId(response, requestSid);
+    remember(responseSid);
     return response;
   }).catch((error) => {
     const movedSid = _parseSessionMovedDraftError(error);
@@ -283,9 +307,8 @@ function _postComposerDraftPayload(sid, draft) {
       throw error;
     }
     return post(movedSid).then((response) => {
-      sid = _composerDraftResponseSessionId(response, movedSid);
-      _composerDraftKnownPayloadSessions.delete(requestSid);
-      _rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);
+      const responseSid = _composerDraftResponseSessionId(response, movedSid);
+      remember(responseSid);
       return response;
     });
   });
@@ -333,7 +356,7 @@ function _saveComposerDraftNow(sid, text, files) {
       && !_composerDraftKnownPayloadSessions.has(sid)) {
     return Promise.resolve();
   }
-  return _postComposerDraftPayload(sid, normalizedDraft).catch(() => {});
+  return _postComposerDraftPayload(sid, normalizedDraft);
 }
 
 // Restore composer draft from server onto #msg textarea.

--- a/static/ui.js
+++ b/static/ui.js
@@ -7753,7 +7753,16 @@ function lockComposerForClarify(placeholderText){
   // card is active (and survives page refresh / syncs across clients).
   const sid = S && S.session && S.session.session_id;
   if (sid && typeof _saveComposerDraftNow === 'function') {
-    _saveComposerDraftNow(sid, input.value || '', S.pendingFiles ? [...S.pendingFiles] : []);
+    const saveText = String(input.value || '');
+    const saveFiles = Array.isArray(S && S.pendingFiles) ? [...S.pendingFiles] : [];
+    try {
+      const saveResult = _saveComposerDraftNow(sid, saveText, saveFiles);
+      if (saveResult && typeof saveResult.catch === 'function') {
+        saveResult.catch((error)=>_handleComposerDraftPostFailure(error,sid,saveText,saveFiles));
+      }
+    } catch (error) {
+      _handleComposerDraftPostFailure(error,sid,saveText,saveFiles);
+    }
   }
   if(!_composerLockState){
     _composerLockState={

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -1,12 +1,16 @@
 """Regression coverage for compression-exhausted stream finalization."""
 
 import copy
+from collections import OrderedDict
 import json
 import queue
 import sys
 import types
 from pathlib import Path
 
+import pytest
+
+from api import config
 from api import models, streaming
 from api.models import Session
 from api.streaming import (
@@ -154,6 +158,120 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     assert "Context compression exhausted" in new_payload["messages"][-1]["content"]
     assert old_sid not in streaming.SESSIONS
     assert streaming.SESSIONS[new_sid].session_id == new_sid
+
+
+@pytest.mark.parametrize("scenario", ["marker-failure", "cache-conflict", "publication-boundary"])
+def test_compression_rotation_publication_is_fail_closed(tmp_path, monkeypatch, scenario):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    old_sid = f"old-{scenario}"
+    new_sid = f"new-{scenario}"
+    stream_id = f"stream-{scenario}"
+    session = Session(
+        session_id=old_sid,
+        title="Compression publication",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=[],
+        context_messages=[],
+    )
+    session.active_stream_id = stream_id
+    session.pending_user_message = "Compress this turn."
+    session.pending_started_at = 1.0
+    session.save()
+
+    observed = {}
+
+    class ObservedSessions(OrderedDict):
+        def __setitem__(self, key, value):
+            if key == new_sid:
+                observed["lock_at_publish"] = streaming.SESSION_AGENT_LOCKS.get(new_sid)
+                observed["old_owner_at_publish"] = self.get(old_sid)
+            super().__setitem__(key, value)
+
+    sessions = ObservedSessions({old_sid: session})
+    models.SESSIONS.clear()
+    monkeypatch.setattr(streaming, "SESSIONS", sessions)
+    streaming.STREAMS.clear()
+    streaming.AGENT_INSTANCES.clear()
+    with streaming.SESSION_AGENT_LOCKS_LOCK:
+        streaming.SESSION_AGENT_LOCKS.clear()
+    with config.SESSION_AGENT_CACHE_LOCK:
+        config.SESSION_AGENT_CACHE.clear()
+    streaming.STREAMS[stream_id] = queue.Queue()
+
+    class FakeAgent:
+        def __init__(self, session_id=None, **kwargs):
+            self.session_id = session_id
+            self.stream_delta_callback = kwargs.get("stream_delta_callback")
+            self.context_compressor = None
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = None
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            if scenario == "cache-conflict":
+                with streaming.LOCK:
+                    sessions[old_sid] = Session(session_id=old_sid, title="Different owner")
+            self.session_id = new_sid
+            return {
+                "messages": [
+                    {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                    {"role": "assistant", "content": "Compressed answer."},
+                ],
+            }
+
+        def interrupt(self, _message):
+            return None
+
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = lambda *_args, **_kwargs: object()
+
+    try:
+        with monkeypatch.context() as m:
+            m.setattr(streaming, "get_session", lambda _sid: session)
+            m.setattr(streaming, "_get_ai_agent", lambda: FakeAgent)
+            m.setattr(streaming, "resolve_model_provider", lambda *_args, **_kwargs: ("gpt-4o", "openai", None))
+            m.setattr("api.config.get_config", lambda *_args, **_kwargs: {})
+            m.setattr("api.config._resolve_cli_toolsets", lambda *_args, **_kwargs: [])
+            m.setitem(sys.modules, "hermes_state", fake_hermes_state)
+            if scenario == "marker-failure":
+                m.setattr(streaming, "_preserve_pre_compression_snapshot", lambda *_args, **_kwargs: False)
+            streaming._run_agent_streaming(
+                session_id=old_sid,
+                msg_text="Compress this turn.",
+                model="gpt-4o",
+                workspace=str(tmp_path),
+                stream_id=stream_id,
+            )
+
+        if scenario == "publication-boundary":
+            assert sessions.get(new_sid) is session
+            assert observed["lock_at_publish"] is not None
+            assert observed["lock_at_publish"] is streaming.SESSION_AGENT_LOCKS.get(new_sid)
+            assert observed["old_owner_at_publish"] is session
+        else:
+            assert sessions.get(new_sid) is None
+            assert session.session_id == old_sid
+            assert new_sid not in streaming.SESSION_AGENT_LOCKS
+            assert new_sid not in config.SESSION_AGENT_CACHE
+    finally:
+        streaming.STREAMS.clear()
+        streaming.AGENT_INSTANCES.clear()
+        models.SESSIONS.clear()
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.clear()
+        with config.SESSION_AGENT_CACHE_LOCK:
+            config.SESSION_AGENT_CACHE.clear()
 
 
 def test_compression_exhausted_result_is_terminal_failure_even_after_streamed_text():

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -1,5 +1,11 @@
 """Regression coverage for stale composer_draft restoration after send."""
 from pathlib import Path
+import json
+import shutil
+import subprocess
+import textwrap
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SESSIONS_JS = ROOT.joinpath("static", "sessions.js").read_text(encoding="utf-8")
@@ -11,6 +17,160 @@ def _block(source: str, start_marker: str, end_marker: str) -> str:
     start = source.index(start_marker)
     end = source.index(end_marker, start)
     return source[start:end]
+
+
+def _draft_save_helper_block() -> str:
+    start = SESSIONS_JS.find("let _draftSaveTimer = null;")
+    end = SESSIONS_JS.find("function _restoreComposerDraft(draft, targetSid, opts={}) {")
+    assert start != -1, "draft helper block start marker not found"
+    assert end != -1, "draft helper block end marker not found"
+    return SESSIONS_JS[start:end]
+
+
+def _run_draft_save_helper(caller: str, api_responses: list[dict]) -> dict:
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+
+    harness = textwrap.dedent(
+        """
+        const responses = %(responses)s;
+        const filesInput = %(files)s;
+        const initialSid = 'sid_old';
+        const expectedPayload = {
+          text: 'hello from harness',
+          files: _composerDraftFilesForPersist(filesInput),
+        };
+        let callIndex = 0;
+        const state = {
+          calls: [],
+          rememberCalls: [],
+        };
+
+        async function api(path, opts) {
+          const body = (typeof opts.body === 'string') ? JSON.parse(opts.body) : {};
+          state.calls.push(body);
+          const next = responses[callIndex++];
+          if (!next) {
+            throw new Error('unexpected /api/session/draft call');
+          }
+          if (Number(next.status) === 409) {
+            const err = new Error(next.error || 'Session moved');
+            err.status = 409;
+            err.body = typeof next.body === 'string' ? next.body : JSON.stringify(next.body || {});
+            throw err;
+          }
+          return Object.assign({ok: true}, next.response || {});
+        }
+
+        setTimeout = (fn, _ms) => {
+          if (typeof fn === 'function') fn();
+          return 0;
+        };
+        clearTimeout = () => {};
+
+        %(draft_helpers)s
+
+        const S = { session: { session_id: initialSid, profile: 'default' } };
+        const _rememberComposerDraftPayloadStateOriginal = _rememberComposerDraftPayloadState;
+        _rememberComposerDraftPayloadState = (sid, text, files) => {
+          state.rememberCalls.push({
+            sid,
+            text: String(text || ''),
+            files: Array.isArray(files) ? files.filter(Boolean) : [],
+          });
+          _rememberComposerDraftPayloadStateOriginal(sid, text, files);
+        };
+
+        (async () => {
+          if ('%(caller)s' === 'immediate') {
+            await _saveComposerDraftNow(initialSid, expectedPayload.text, filesInput);
+          } else {
+            _saveComposerDraft(initialSid, expectedPayload.text, filesInput);
+            await new Promise(resolve => setImmediate(resolve));
+          }
+          console.log(JSON.stringify({
+            calls: state.calls,
+            rememberCalls: state.rememberCalls,
+            knownPayloadSids: Array.from(_composerDraftKnownPayloadSessions).sort(),
+            expectedPayload,
+          }));
+        })().catch(error => {
+          const serialized = {
+            error: String(error && error.message ? error.message : error || ''),
+            status: error && Number(error.status),
+          };
+          console.log(JSON.stringify(serialized));
+          process.exit(1);
+        });
+        """
+    ) % {
+        "responses": json.dumps(api_responses),
+        "files": json.dumps(
+            [
+                {
+                    "name": "proof.txt",
+                    "size": 42,
+                    "type": "text/plain",
+                    "path": "/tmp/proof.txt",
+                    "lastModified": 123,
+                    "extra": "ignored",
+                },
+            ]
+        ),
+        "draft_helpers": _draft_save_helper_block(),
+        "caller": caller,
+    }
+    proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+    return json.loads(proc.stdout.strip())
+
+
+@pytest.mark.parametrize("caller", ["debounced", "immediate"])
+@pytest.mark.parametrize("scenario", ["changed-200", "structured-409"])
+def test_draft_save_paths_use_authoritative_session_id_after_rotation(caller, scenario):
+    if scenario == "changed-200":
+        responses = [{"status": 200, "response": {"ok": True, "session_id": "sid_authoritative"}}]
+    else:
+        responses = [
+            {
+                "status": 409,
+                "error": "Session moved",
+                "body": {
+                    "error": "Session moved",
+                    "code": "session_moved",
+                    "session_id": "sid_authoritative",
+                },
+            },
+            {"status": 200, "response": {"ok": True, "session_id": "sid_authoritative"}},
+        ]
+
+    out = _run_draft_save_helper(caller, responses)
+
+    expected_sid = "sid_authoritative"
+    old_sid = "sid_old"
+    if scenario == "changed-200":
+        assert len(out["calls"]) == 1
+        first = out["calls"][0]
+        assert first["session_id"] == old_sid
+    else:
+        assert len(out["calls"]) == 2
+        assert out["calls"][0]["session_id"] == old_sid
+        assert out["calls"][1]["session_id"] == expected_sid
+
+    first_call = out["calls"][0]
+    last_call = out["calls"][-1]
+    assert first_call["text"] == out["expectedPayload"]["text"]
+    assert last_call["text"] == out["expectedPayload"]["text"]
+    assert first_call["files"] == out["expectedPayload"]["files"]
+    assert last_call["files"] == out["expectedPayload"]["files"]
+    assert out["rememberCalls"][0]["sid"] == expected_sid
+    assert len(out["rememberCalls"]) == 1
+    assert out["knownPayloadSids"] == [expected_sid]
+    if scenario == "structured-409":
+        assert last_call["session_id"] == expected_sid
+    else:
+        assert first_call["session_id"] == old_sid
 
 
 def test_clear_composer_draft_suppresses_same_session_stale_restore():

--- a/tests/test_composer_draft_after_send.py
+++ b/tests/test_composer_draft_after_send.py
@@ -45,6 +45,16 @@ def _run_draft_save_helper(caller: str, api_responses: list[dict]) -> dict:
         const state = {
           calls: [],
           rememberCalls: [],
+          warns: [],
+          expectedPayload,
+        };
+
+        const originalWarn = console.warn;
+        console.warn = (...args) => {
+          state.warns.push(args.map((value) => String(value)).join(' '));
+          if (typeof originalWarn === 'function') {
+            originalWarn.apply(console, args);
+          }
         };
 
         async function api(path, opts) {
@@ -53,6 +63,18 @@ def _run_draft_save_helper(caller: str, api_responses: list[dict]) -> dict:
           const next = responses[callIndex++];
           if (!next) {
             throw new Error('unexpected /api/session/draft call');
+          }
+          if (next.throw) {
+            const err = new Error(next.error || 'draft draft save failed');
+            if (next.status) {
+              err.status = Number(next.status);
+            }
+            if (typeof next.body === 'string') {
+              err.body = next.body;
+            } else if (next.body) {
+              err.body = JSON.stringify(next.body);
+            }
+            throw err;
           }
           if (Number(next.status) === 409) {
             const err = new Error(next.error || 'Session moved');
@@ -93,15 +115,24 @@ def _run_draft_save_helper(caller: str, api_responses: list[dict]) -> dict:
             calls: state.calls,
             rememberCalls: state.rememberCalls,
             knownPayloadSids: Array.from(_composerDraftKnownPayloadSessions).sort(),
+            localDraft: S.session.composer_draft || null,
             expectedPayload,
+            warns: state.warns,
+            ok: true,
           }));
         })().catch(error => {
           const serialized = {
+            ok: false,
             error: String(error && error.message ? error.message : error || ''),
             status: error && Number(error.status),
+            calls: state.calls,
+            rememberCalls: state.rememberCalls,
+            knownPayloadSids: Array.from(_composerDraftKnownPayloadSessions).sort(),
+            localDraft: S.session.composer_draft || null,
+            expectedPayload,
+            warns: state.warns,
           };
           console.log(JSON.stringify(serialized));
-          process.exit(1);
         });
         """
     ) % {
@@ -146,6 +177,7 @@ def test_draft_save_paths_use_authoritative_session_id_after_rotation(caller, sc
         ]
 
     out = _run_draft_save_helper(caller, responses)
+    assert out["ok"] is True
 
     expected_sid = "sid_authoritative"
     old_sid = "sid_old"
@@ -171,6 +203,94 @@ def test_draft_save_paths_use_authoritative_session_id_after_rotation(caller, sc
         assert last_call["session_id"] == expected_sid
     else:
         assert first_call["session_id"] == old_sid
+
+
+@pytest.mark.parametrize("caller", ["debounced", "immediate"])
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "second-redirect",
+        "replay-failure",
+        "invalid-sid",
+    ],
+)
+def test_draft_save_paths_reject_replayed_authority_or_bad_response(caller, scenario):
+    if scenario == "second-redirect":
+        responses = [
+            {
+                "status": 409,
+                "error": "Session moved",
+                "body": {
+                    "error": "Session moved",
+                    "code": "session_moved",
+                    "session_id": "sid_authoritative",
+                },
+            },
+            {
+                "status": 409,
+                "error": "Session moved",
+                "body": {
+                    "error": "Session moved",
+                    "code": "session_moved",
+                    "session_id": "sid_authoritative",
+                },
+            },
+        ]
+    elif scenario == "replay-failure":
+        responses = [
+            {
+                "status": 409,
+                "error": "Session moved",
+                "body": {
+                    "error": "Session moved",
+                    "code": "session_moved",
+                    "session_id": "sid_authoritative",
+                },
+            },
+            {
+                "throw": True,
+                "status": 503,
+                "error": "server down",
+            },
+        ]
+    else:
+        responses = [
+            {
+                "status": 200,
+                "response": {
+                    "ok": True,
+                    "session_id": "sid_!@#",
+                },
+            },
+        ]
+
+    out = _run_draft_save_helper(caller, responses)
+    sid_old = "sid_old"
+    assert out["calls"]
+    assert out["rememberCalls"] == []
+    for call in out["calls"]:
+        assert call["text"] == out["expectedPayload"]["text"]
+        assert call["files"] == out["expectedPayload"]["files"]
+    if caller == "immediate":
+        assert out["knownPayloadSids"] == []
+    else:
+        assert out["knownPayloadSids"] == [sid_old]
+    if scenario == "second-redirect":
+        assert len(out["calls"]) == 2
+    elif scenario == "replay-failure":
+        assert len(out["calls"]) == 2
+    else:
+        assert len(out["calls"]) == 1
+
+    if caller == "immediate":
+        assert out["ok"] is False
+        assert out["error"]
+        assert out["status"] in (None, 409, 500, 503)
+        assert not out["warns"]
+    else:
+        assert out["ok"] is True
+        assert out["warns"]
+        assert out["localDraft"] == out["expectedPayload"]
 
 
 def test_clear_composer_draft_suppresses_same_session_stale_restore():

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -665,11 +665,15 @@ def test_draft_pre_compression_snapshot_marker_write_failure(tmp_path, monkeypat
 def test_draft_compression_migration_rejects_different_old_sid_cache_object(tmp_path, monkeypatch):
     models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
     monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
-    monkeypatch.setattr(streaming, "_preserve_pre_compression_snapshot", lambda *args, **kwargs: True)
 
     old_sid = "sid-rotation-old-mismatch"
     new_sid = "sid-rotation-new-mismatch"
     cache_owner = models.Session(session_id=old_sid, title="old owner")
+    cache_owner.save(touch_updated_at=False)
+    old_path = session_dir / f"{old_sid}.json"
+    index_path = session_dir / "_index.json"
+    old_preimage = old_path.read_bytes()
+    index_preimage = index_path.read_bytes()
     migrating = models.Session(session_id=old_sid, title="migrating")
 
     lock = routes._get_session_agent_lock(old_sid)
@@ -682,6 +686,50 @@ def test_draft_compression_migration_rejects_different_old_sid_cache_object(tmp_
         assert result is False
         with routes.LOCK:
             assert routes.SESSIONS.get(old_sid) is cache_owner
+        assert routes.SESSIONS.get(new_sid) is None
+        assert old_path.read_bytes() == old_preimage
+        assert index_path.read_bytes() == index_preimage
+        assert models.Session.load(old_sid).pre_compression_continuation_session_id is None
+    finally:
+        with routes.LOCK:
+            routes.SESSIONS.clear()
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(new_sid, None)
+def test_draft_compression_migration_rollback_restores_durable_marker_after_new_lock_conflict(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    old_sid = "sid-rotation-old-lock-conflict"
+    new_sid = "sid-rotation-new-lock-conflict"
+    index_file = session_dir / "_index.json"
+    existing = models.Session(session_id=old_sid, title="old lock", messages=[{"role": "user", "content": "lock conflict"}])
+    existing.save(touch_updated_at=False)
+    sidecar_before = (session_dir / f"{old_sid}.json").read_bytes()
+    index_before = index_file.read_bytes()
+    third_party_lock = routes._get_session_agent_lock(f"third-party-{new_sid}")
+
+    migrating = models.Session(session_id=old_sid, title="migrating", messages=[{"role": "assistant", "content": "new content"}])
+    lock = routes._get_session_agent_lock(old_sid)
+    with routes.LOCK:
+        routes.SESSIONS.clear()
+        routes.SESSIONS[old_sid] = migrating
+    with routes.SESSION_AGENT_LOCKS_LOCK:
+        routes.SESSION_AGENT_LOCKS[new_sid] = third_party_lock
+
+    try:
+        result = streaming._migrate_compression_session_ownership(migrating, old_sid, new_sid, lock)
+        assert result is False
+        assert (session_dir / f"{old_sid}.json").read_bytes() == sidecar_before
+        assert index_file.read_bytes() == index_before
+        persisted = models.Session.load(old_sid)
+        assert persisted is not None
+        assert persisted.pre_compression_snapshot is False
+        assert persisted.pre_compression_continuation_session_id is None
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            assert routes.SESSION_AGENT_LOCKS.get(new_sid) is third_party_lock
+        with routes.LOCK:
+            assert routes.SESSIONS.get(old_sid) is migrating
             assert routes.SESSIONS.get(new_sid) is None
     finally:
         with routes.LOCK:
@@ -694,11 +742,19 @@ def test_draft_compression_migration_rejects_different_old_sid_cache_object(tmp_
 def test_draft_compression_migration_rollback_when_evictor_interleaves_after_lock_alias(tmp_path, monkeypatch):
     models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
     monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
-    monkeypatch.setattr(streaming, "_preserve_pre_compression_snapshot", lambda *args, **kwargs: True)
 
     old_sid = "sid-rotation-old-evict"
     new_sid = "sid-rotation-new-evict"
     migrating = models.Session(session_id=old_sid, title="migrating")
+    index_file = session_dir / "_index.json"
+    old_session = models.Session(
+        session_id=old_sid,
+        title="old evict marker",
+        messages=[{"role": "user", "content": "persisted for rollback"}],
+    )
+    old_session.save(touch_updated_at=False)
+    sidecar_before = (session_dir / f"{old_sid}.json").read_bytes()
+    index_before = index_file.read_bytes()
 
     observed = {}
 
@@ -717,6 +773,12 @@ def test_draft_compression_migration_rollback_when_evictor_interleaves_after_loc
         monkeypatch.setattr(streaming, "_evict_sessions_over_cap", _evict_sessions_over_cap)
         result = streaming._migrate_compression_session_ownership(migrating, old_sid, new_sid, lock)
         assert result is False
+        assert (session_dir / f"{old_sid}.json").read_bytes() == sidecar_before
+        assert index_file.read_bytes() == index_before
+        persisted = models.Session.load(old_sid)
+        assert persisted is not None
+        assert persisted.pre_compression_snapshot is False
+        assert persisted.pre_compression_continuation_session_id is None
         assert observed["locked"] is lock
         with routes.LOCK:
             assert routes.SESSIONS.get(old_sid) is migrating

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -1,0 +1,295 @@
+"""Runtime regression coverage for dedicated composer draft sidecars."""
+
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+
+def _build_draft_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_BASE_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_WEBUI_DEFAULT_WORKSPACE", str(tmp_path / "workspace"))
+
+    import api.models as models
+    import api.routes as routes
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    return models, routes, session_dir
+
+
+def _post_json(monkeypatch, routes, path, body):
+    captured = {}
+    handler = SimpleNamespace(
+        command="POST",
+        wfile=None,
+        send_response=lambda status: None,
+        send_header=lambda key, value: None,
+        end_headers=lambda: None,
+    )
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: body)
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, extra_headers=None: captured.update(
+            payload=payload,
+            status=status,
+        )
+        or True,
+    )
+
+    parsed = SimpleNamespace(path=path)
+    assert routes.handle_post(handler, parsed) is True
+    return captured["status"], captured["payload"]
+
+
+def _cleanup_route(monkeypatch, routes, *, zero_only=False):
+    captured = {}
+    handler = SimpleNamespace(
+        wfile=None,
+        send_response=lambda status: None,
+        send_header=lambda key, value: None,
+        end_headers=lambda: None,
+    )
+
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, extra_headers=None: captured.update(
+            payload=payload,
+            status=status,
+        )
+        or True,
+    )
+
+    assert routes._handle_sessions_cleanup(handler, {}, zero_only=zero_only) is True
+    return captured["payload"]
+
+
+def _write_cli_db(path):
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                title TEXT,
+                parent_session_id TEXT
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT
+            );
+            INSERT INTO sessions (id, source, title, parent_session_id)
+            VALUES ('sid-model-delete', 'cli', 'model deleted', NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_dedicated_draft_overlays_full_and_metadata_loads(tmp_path, monkeypatch):
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-overlay"
+    models.Session(
+        session_id=sid,
+        title="Session",
+        composer_draft={"text": "legacy", "files": []},
+    ).save(touch_updated_at=False, skip_index=True)
+    models._save_session_draft(sid, {"text": "dedicated", "files": []})
+
+    loaded = models.Session.load(sid)
+    loaded_meta = models.Session.load_metadata_only(sid)
+    assert loaded.composer_draft == {"text": "dedicated", "files": []}
+    assert loaded_meta.composer_draft == {"text": "dedicated", "files": []}
+
+    models._delete_session_draft(sid)
+    fallback = models.Session.load(sid)
+    fallback_meta = models.Session.load_metadata_only(sid)
+    assert fallback.composer_draft == {"text": "legacy", "files": []}
+    assert fallback_meta.composer_draft == {"text": "legacy", "files": []}
+    assert (session_dir / ".drafts" / f"{sid}.json").exists() is False
+
+
+def test_corrupted_draft_file_falls_back_to_legacy_with_warning(tmp_path, monkeypatch, caplog):
+    models, _, _ = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-corrupt"
+    models.Session(
+        session_id=sid,
+        title="Session",
+        composer_draft={"text": "from-sidecar"},
+    ).save(touch_updated_at=False, skip_index=True)
+
+    draft_dir = models._session_draft_dir()
+    draft_dir.mkdir(exist_ok=True)
+    (draft_dir / f"{sid}.json").write_text("{malformed", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        loaded = models.Session.load(sid)
+
+    assert loaded.composer_draft == {"text": "from-sidecar"}
+    assert any("Ignoring malformed draft sidecar" in record.getMessage() for record in caplog.records)
+
+
+def test_drafts_directory_is_ignored_by_session_file_scanners(tmp_path, monkeypatch):
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-scan"
+    models.Session(session_id=sid, title="Session").save(touch_updated_at=False, skip_index=True)
+    models._save_session_draft(sid, {"text": "scan draft", "files": []})
+
+    top_level = {p.name for p in session_dir.glob("*.json")}
+    session_ids = models._persisted_session_ids_snapshot()
+
+    assert sid in session_ids
+    assert f"{sid}.json" in top_level
+    assert all(p.parent == session_dir for p in session_dir.glob("*.json"))
+
+
+def test_draft_post_uses_dedicated_sidecar_without_main_sidecar_rewrite(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-large"
+    models.Session(
+        session_id=sid,
+        title="Large",
+        messages=[{"role": "assistant", "content": "x" * 300_000}],
+    ).save(skip_index=True)
+    main_sidecar = session_dir / f"{sid}.json"
+    before_payload = main_sidecar.read_bytes()
+    before_mtime_ns = main_sidecar.stat().st_mtime_ns
+
+    save_calls = []
+    real_save = models.Session.save
+
+    def save_spy(*args, **kwargs):
+        save_calls.append((args, kwargs))
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(models.Session, "save", save_spy)
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/draft",
+        {"session_id": sid, "text": "drafted payload", "files": []},
+    )
+
+    assert status == 200
+    assert payload["draft"] == {"text": "drafted payload", "files": []}
+    assert not save_calls
+    assert (session_dir / ".drafts" / f"{sid}.json").exists()
+    assert main_sidecar.stat().st_mtime_ns == before_mtime_ns
+    assert main_sidecar.read_bytes() == before_payload
+
+
+def test_draft_explicit_empty_stays_authoritative_after_reload(tmp_path, monkeypatch):
+    models, routes, _ = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-empty"
+    models.Session(session_id=sid, title="Session").save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/draft",
+        {"session_id": sid, "text": "", "files": []},
+    )
+    assert status == 200
+    assert payload["draft"] == {"text": "", "files": []}
+
+    loaded = models.Session.load(sid)
+    loaded.title = "touch"
+    loaded.save(touch_updated_at=False, skip_index=True)
+    assert models.Session.load(sid).composer_draft == {"text": "", "files": []}
+
+
+def test_session_delete_removes_dedicated_draft_file(tmp_path, monkeypatch):
+    import api.routes as routes
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-delete"
+    models.Session(session_id=sid, title="Session").save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+    routes._save_session_draft(sid, {"text": "in-memory draft", "files": []})
+    assert (session_dir / ".drafts" / f"{sid}.json").exists()
+
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda value: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_id", lambda value: False)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda value: False)
+
+    _, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/delete",
+        {"session_id": sid},
+    )
+
+    assert payload["ok"] is True
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
+def test_sessions_cleanup_phase1_removes_dedicated_draft_file(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-orphan"
+    models.Session(session_id=sid, title="Untitled").save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+    routes._save_session_draft(sid, {"text": "draft", "files": []})
+
+    result = _cleanup_route(monkeypatch, routes)
+
+    assert result["cleaned"] == 1
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
+def test_model_cleanup_removes_draft_artifact(tmp_path, monkeypatch):
+    import api.profiles as profiles
+
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    sid = "sid-model-delete"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(tmp_path))
+
+    _write_cli_db(tmp_path / "state.db")
+
+    (session_dir / f"{sid}.json").write_text('{"session_id": "sid-model-delete"}', encoding="utf-8")
+    draft_path = session_dir / ".drafts" / f"{sid}.json"
+    draft_path.parent.mkdir(parents=True, exist_ok=True)
+    draft_path.write_text('{"text": "x", "files": []}', encoding="utf-8")
+
+    assert models.delete_cli_session(sid) is True
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not draft_path.exists()
+
+
+def test_draft_path_error_shows_original_input(tmp_path, monkeypatch):
+    models, _, _ = _build_draft_env(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError) as exc:
+        models._session_draft_path("../unsafe")
+    assert "Unsafe session_id '../unsafe'" in str(exc.value)

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -1,6 +1,5 @@
 """Runtime regression coverage for dedicated composer draft sidecars."""
 
-import json
 import sqlite3
 from types import SimpleNamespace
 

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -795,6 +795,197 @@ def test_draft_compression_migration_rollback_when_evictor_interleaves_after_loc
             streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
 
 
+def test_draft_compression_migration_rollback_restores_marker_and_unrelated_index_row(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    old_sid = "sid-rotation-old-row-rollback"
+    new_sid = "sid-rotation-new-row-rollback"
+    unrelated_sid = "sid-rotation-unrelated-row-rollback"
+    index_path = session_dir / "_index.json"
+
+    models.Session(
+        session_id=old_sid,
+        title="old marker",
+        messages=[{"role": "user", "content": "before migration"}],
+    ).save(touch_updated_at=False)
+    models.Session(
+        session_id=unrelated_sid,
+        title="unrelated stale marker",
+        messages=[{"role": "user", "content": "unrelated"}],
+    ).save(touch_updated_at=False)
+
+    pre_sidecar = (session_dir / f"{old_sid}.json").read_bytes()
+    pre_index = json.loads(index_path.read_text(encoding="utf-8"))
+    pre_old_row = next(
+        row for row in pre_index
+        if row.get("session_id") == old_sid
+    )
+
+    migrating = models.Session(
+        session_id=old_sid,
+        title="old marker",
+        messages=[{"role": "user", "content": "compressed"}],
+    )
+    lock = routes._get_session_agent_lock(old_sid)
+    with routes.LOCK:
+        routes.SESSIONS.clear()
+        routes.SESSIONS[old_sid] = migrating
+
+    unrelated = models.Session.load(unrelated_sid)
+    original_preserve = streaming._preserve_pre_compression_snapshot
+
+    def _preserve_then_save_unrelated(session, preserve_old_sid, preserve_new_sid):
+        assert original_preserve(session, preserve_old_sid, preserve_new_sid) is True
+        unrelated.title = "updated unrelated marker"
+        unrelated.messages = [
+            {"role": "assistant", "content": "interleaved"},
+        ]
+        unrelated.save(touch_updated_at=False, skip_index=False)
+        return True
+
+    def _evict_with_publication_failure(_cap=None):
+        raise RuntimeError("injected publication failure")
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            streaming,
+            "_preserve_pre_compression_snapshot",
+            _preserve_then_save_unrelated,
+        )
+        m.setattr(streaming, "_evict_sessions_over_cap", _evict_with_publication_failure)
+        try:
+            result = streaming._migrate_compression_session_ownership(
+                migrating,
+                old_sid,
+                new_sid,
+                lock,
+            )
+        finally:
+            with routes.LOCK:
+                routes.SESSIONS.clear()
+            with streaming.SESSION_AGENT_LOCKS_LOCK:
+                streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+                streaming.SESSION_AGENT_LOCKS.pop(new_sid, None)
+
+    assert result is False
+
+    post_sidecar = (session_dir / f"{old_sid}.json").read_bytes()
+    assert post_sidecar == pre_sidecar
+
+    post_index = json.loads(index_path.read_text(encoding="utf-8"))
+    post_old_row = next(
+        row for row in post_index
+        if row.get("session_id") == old_sid
+    )
+    assert post_old_row == pre_old_row
+    assert any(
+        row.get("session_id") == unrelated_sid and row.get("title") == "updated unrelated marker"
+        for row in post_index
+    )
+    assert any(row.get("session_id") == unrelated_sid for row in pre_index)
+    assert len({row.get("session_id") for row in post_index}) >= 2
+
+
+def test_draft_compression_migration_rollback_avoids_lock_order_deadlock(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    old_sid = "sid-rotation-old-deadlock"
+    new_sid = "sid-rotation-new-deadlock"
+
+    models.Session(
+        session_id=old_sid,
+        title="old deadlock marker",
+        messages=[{"role": "user", "content": "marker"}],
+    ).save(touch_updated_at=False)
+
+    migrating = models.Session(
+        session_id=old_sid,
+        title="old deadlock marker",
+        messages=[{"role": "assistant", "content": "compressed"}],
+    )
+    lock = routes._get_session_agent_lock(old_sid)
+    with routes.LOCK:
+        routes.SESSIONS.clear()
+        routes.SESSIONS[old_sid] = migrating
+
+    writer_holding_index = threading.Event()
+    writer_acquired_lock = threading.Event()
+    writer_completed = threading.Event()
+    evict_writer_thread = {}
+
+    def _index_writer():
+        acquired_index_lock = models._INDEX_WRITE_LOCK.acquire(timeout=3)
+        if not acquired_index_lock:
+            writer_completed.set()
+            return
+        try:
+            writer_holding_index.set()
+            lock_acquired = models.LOCK.acquire(timeout=3)
+            if lock_acquired:
+                writer_acquired_lock.set()
+                models.LOCK.release()
+        finally:
+            writer_completed.set()
+            models._INDEX_WRITE_LOCK.release()
+
+    def _evict_sessions_over_cap(_cap=None):
+        writer_holding_index.clear()
+        writer_completed.clear()
+        writer_acquired_lock.clear()
+        writer = threading.Thread(
+            target=_index_writer,
+            name="compression-index-lock-writer",
+        )
+        evict_writer_thread["thread"] = writer
+        writer.start()
+        if not writer_holding_index.wait(timeout=2):
+            writer.join(timeout=1)
+            raise RuntimeError("index writer failed to hold index lock")
+        raise RuntimeError("inject publication failure")
+
+    with monkeypatch.context() as m:
+        m.setattr(streaming, "_preserve_pre_compression_snapshot", lambda *_args, **_kwargs: True)
+        m.setattr(streaming, "_evict_sessions_over_cap", _evict_sessions_over_cap)
+
+        outcome = {}
+
+        def _run_migration():
+            outcome["result"] = streaming._migrate_compression_session_ownership(
+                migrating,
+                old_sid,
+                new_sid,
+                lock,
+            )
+
+        migration_thread = threading.Thread(target=_run_migration, name="compression-migration")
+        migration_thread.start()
+        try:
+            migration_thread.join(timeout=4)
+            evicted_writer = evict_writer_thread.get("thread")
+            if evicted_writer is not None:
+                evicted_writer.join(timeout=4)
+            assert not migration_thread.is_alive()
+            assert (evicted_writer is None or not evicted_writer.is_alive())
+            assert writer_completed.is_set()
+            assert writer_acquired_lock.is_set()
+            assert outcome.get("result") is False
+            assert not (session_dir / f"{new_sid}.json").exists()
+            assert not migration_thread.daemon
+
+            with routes.LOCK:
+                assert routes.SESSIONS.get(old_sid) is not None
+            with streaming.SESSION_AGENT_LOCKS_LOCK:
+                assert streaming.SESSION_AGENT_LOCKS.get(old_sid) is lock
+        finally:
+            with routes.LOCK:
+                routes.SESSIONS.clear()
+            with streaming.SESSION_AGENT_LOCKS_LOCK:
+                streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+                streaming.SESSION_AGENT_LOCKS.pop(new_sid, None)
+
+
 def test_draft_post_for_stale_pre_compression_snapshot_hops_exhausted_rejected(tmp_path, monkeypatch):
     models, routes, session_dir, old_sid, continuation_sid, fork_sid = _build_pre_compression_migration_state(
         tmp_path,

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -101,6 +101,46 @@ def _write_cli_db(path):
         conn.close()
 
 
+def _build_pre_compression_migration_state(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    import api.streaming as streaming
+
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    old_sid = "sid-rotation-old"
+    continuation_sid = "sid-rotation-new"
+    old_session = models.Session(
+        session_id=old_sid,
+        title="Compression snapshot",
+        messages=[{"role": "user", "content": "question"}],
+    )
+    old_session.save(touch_updated_at=False, skip_index=True)
+
+    continuation = models.Session(
+        session_id=continuation_sid,
+        title="Compression snapshot",
+        parent_session_id=old_sid,
+        messages=[
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "compressed reply"},
+        ],
+    )
+    continuation.save(touch_updated_at=False, skip_index=True)
+    streaming._preserve_pre_compression_snapshot(continuation, old_sid)
+    continuation.save(touch_updated_at=False, skip_index=True)
+
+    with routes.LOCK:
+        models.SESSIONS.clear()
+        models.SESSIONS[continuation_sid] = continuation
+
+    old_lock = routes._get_session_agent_lock(old_sid)
+    with routes.SESSION_AGENT_LOCKS_LOCK:
+        routes.SESSION_AGENT_LOCKS[continuation_sid] = old_lock
+        routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+
+    return models, routes, session_dir, old_sid, continuation_sid
+
+
 def test_dedicated_draft_overlays_full_and_metadata_loads(tmp_path, monkeypatch):
     models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
 
@@ -357,12 +397,12 @@ def test_draft_post_for_stale_request_sid_does_not_write_under_old_sid(tmp_path,
         def __enter__(self):
             s.session_id = rotated_sid
             with routes.LOCK:
-                routes.SESSIONS.pop(sid, None)
+                routes.SESSIONS[sid] = s
                 routes.SESSIONS[rotated_sid] = s
                 routes.SESSIONS.move_to_end(rotated_sid)
             assert s.session_id == rotated_sid
             assert routes.SESSIONS.get(rotated_sid) is s
-            assert sid not in routes.SESSIONS
+            assert routes.SESSIONS.get(sid) is s
 
         def __exit__(self, exc_type, exc, tb):
             return None
@@ -376,15 +416,161 @@ def test_draft_post_for_stale_request_sid_does_not_write_under_old_sid(tmp_path,
         {"session_id": sid, "text": "rotating", "files": []},
     )
 
-    assert status == 409
-    assert payload["ok"] is False
-    assert payload["error"] == "Session moved"
+    assert status == 200
     assert payload["session_id"] == rotated_sid
-    assert s.composer_draft == {"text": "original", "files": []}
+    assert payload["draft"] == {"text": "rotating", "files": []}
+    assert s.composer_draft == {"text": "rotating", "files": []}
     assert not (session_dir / f"{sid}.json").exists()
-    assert not (session_dir / f"{rotated_sid}.json").exists()
+    assert (session_dir / f"{rotated_sid}.json").exists()
     assert not (session_dir / ".drafts" / f"{sid}.json").exists()
-    assert not (session_dir / ".drafts" / f"{rotated_sid}.json").exists()
+    assert (session_dir / ".drafts" / f"{rotated_sid}.json").exists()
+
+
+def test_draft_post_for_stale_pre_compression_snapshot_writes_to_continuation(tmp_path, monkeypatch):
+    models, routes, session_dir, old_sid, continuation_sid = _build_pre_compression_migration_state(
+        tmp_path, monkeypatch
+    )
+
+    try:
+        status, payload = _post_json(
+            monkeypatch,
+            routes,
+            "/api/session/draft",
+            {"session_id": old_sid, "text": "recover from archived snapshot", "files": []},
+        )
+
+        assert status == 200
+        assert payload["session_id"] == continuation_sid
+        assert payload["draft"] == {"text": "recover from archived snapshot", "files": []}
+
+        assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
+        assert (session_dir / ".drafts" / f"{continuation_sid}.json").exists()
+
+        models.SESSIONS.clear()
+        loaded = models.Session.load(continuation_sid)
+        assert loaded.composer_draft == {"text": "recover from archived snapshot", "files": []}
+        assert (session_dir / f"{old_sid}.json").exists()
+    finally:
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+
+
+def test_draft_post_for_stale_pre_compression_snapshot_profile_mismatch_rejected(
+    tmp_path, monkeypatch
+):
+    models, routes, session_dir, old_sid, continuation_sid = _build_pre_compression_migration_state(
+        tmp_path,
+        monkeypatch,
+    )
+
+    continuation = models.Session.load(continuation_sid)
+    assert continuation is not None
+    continuation.save(touch_updated_at=False, skip_index=False)
+
+    continuation_path = session_dir / f"{continuation_sid}.json"
+    continuation_payload = json.loads(continuation_path.read_text(encoding="utf-8"))
+    continuation_payload["profile"] = "mismatch-profile"
+    continuation_path.write_text(json.dumps(continuation_payload, ensure_ascii=False), encoding="utf-8")
+
+    with routes.LOCK:
+        routes.SESSIONS.pop(continuation_sid, None)
+
+    try:
+        status, payload = _post_json(
+            monkeypatch,
+            routes,
+            "/api/session/draft",
+            {"session_id": old_sid, "text": "must fail by profile", "files": []},
+        )
+
+        assert status == 409
+        assert payload["ok"] is False
+        assert payload["error"] == "Session moved"
+        assert payload["session_id"] == continuation_sid
+        assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
+        assert not (session_dir / ".drafts" / f"{continuation_sid}.json").exists()
+    finally:
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+
+
+def test_draft_post_waits_for_rotation_while_lock_waits_for_authority(tmp_path, monkeypatch):
+    models, routes, session_dir, old_sid, continuation_sid = _build_pre_compression_migration_state(
+        tmp_path,
+        monkeypatch,
+    )
+    lock = routes._get_session_agent_lock(continuation_sid)
+    lock.acquire()
+    lock_waiting = threading.Event()
+
+    result = {}
+    started = threading.Event()
+    done = threading.Event()
+
+    original_get_session_agent_lock = routes._get_session_agent_lock
+
+    class _TrackingLock:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __enter__(self):
+            lock_waiting.set()
+            self._wrapped.acquire()
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self._wrapped.release()
+            return None
+
+    def _get_session_agent_lock(sid):
+        if sid in (old_sid, continuation_sid):
+            return _TrackingLock(lock)
+        return original_get_session_agent_lock(sid)
+
+    monkeypatch.setattr(routes, "_get_session_agent_lock", _get_session_agent_lock)
+
+    def _call():
+        started.set()
+        status, payload = _post_json(
+            monkeypatch,
+            routes,
+            "/api/session/draft",
+            {"session_id": old_sid, "text": "rotating while waiting", "files": []},
+        )
+        result["status"] = status
+        result["payload"] = payload
+        done.set()
+
+    thread = threading.Thread(target=_call)
+    thread.start()
+    assert started.wait(timeout=2), "draft request did not start"
+    try:
+        assert lock_waiting.wait(timeout=2), "draft request did not block on authority lock"
+        assert not done.is_set()
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS[continuation_sid] = lock
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+        lock.release()
+
+        assert done.wait(timeout=5), "draft request did not complete after rotation lock handoff"
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+    finally:
+        if lock.locked():
+            lock.release()
+        thread.join(timeout=1)
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+
+    assert result["status"] == 200
+    assert result["payload"]["session_id"] == continuation_sid
+    models.SESSIONS.clear()
+    loaded = models.Session.load(continuation_sid)
+    assert loaded.composer_draft == {"text": "rotating while waiting", "files": []}
+    assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
 
 
 @pytest.mark.parametrize(("cached", "messageful"), [(False, False), (True, True)])

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -472,9 +472,9 @@ def test_draft_post_for_stale_pre_compression_snapshot_writes_to_continuation(tm
         assert loaded.composer_draft == {"text": "recover from archived snapshot", "files": [{"name": "proof.txt"}]}
         assert (session_dir / f"{old_sid}.json").exists()
     finally:
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
 
 
 def test_draft_post_for_stale_pre_compression_snapshot_profile_mismatch_rejected(
@@ -513,9 +513,9 @@ def test_draft_post_for_stale_pre_compression_snapshot_profile_mismatch_rejected
         assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
         assert not (session_dir / ".drafts" / f"{continuation_sid}.json").exists()
     finally:
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
 
 
 def test_draft_post_waits_for_rotation_while_lock_waits_for_authority(tmp_path, monkeypatch):
@@ -571,9 +571,9 @@ def test_draft_post_waits_for_rotation_while_lock_waits_for_authority(tmp_path, 
     try:
         assert lock_waiting.wait(timeout=2), "draft request did not block on authority lock"
         assert not done.is_set()
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS[continuation_sid] = lock
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS[continuation_sid] = lock
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
         lock.release()
 
         assert done.wait(timeout=5), "draft request did not complete after rotation lock handoff"
@@ -583,9 +583,9 @@ def test_draft_post_waits_for_rotation_while_lock_waits_for_authority(tmp_path, 
         if lock.locked():
             lock.release()
         thread.join(timeout=1)
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
 
     assert result["status"] == 200
     assert result["payload"]["session_id"] == continuation_sid
@@ -622,9 +622,9 @@ def test_draft_post_for_stale_pre_compression_snapshot_cycles_rejected(tmp_path,
         assert payload["session_id"] == old_sid
         assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
     finally:
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
 
 
 def test_draft_pre_compression_snapshot_marker_write_failure(tmp_path, monkeypatch):
@@ -693,9 +693,9 @@ def test_draft_compression_migration_rejects_different_old_sid_cache_object(tmp_
     finally:
         with routes.LOCK:
             routes.SESSIONS.clear()
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(new_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(new_sid, None)
 def test_draft_compression_migration_rollback_restores_durable_marker_after_new_lock_conflict(tmp_path, monkeypatch):
     models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
     monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
@@ -714,8 +714,8 @@ def test_draft_compression_migration_rollback_restores_durable_marker_after_new_
     with routes.LOCK:
         routes.SESSIONS.clear()
         routes.SESSIONS[old_sid] = migrating
-    with routes.SESSION_AGENT_LOCKS_LOCK:
-        routes.SESSION_AGENT_LOCKS[new_sid] = third_party_lock
+    with streaming.SESSION_AGENT_LOCKS_LOCK:
+        streaming.SESSION_AGENT_LOCKS[new_sid] = third_party_lock
 
     try:
         result = streaming._migrate_compression_session_ownership(migrating, old_sid, new_sid, lock)
@@ -726,17 +726,17 @@ def test_draft_compression_migration_rollback_restores_durable_marker_after_new_
         assert persisted is not None
         assert persisted.pre_compression_snapshot is False
         assert persisted.pre_compression_continuation_session_id is None
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            assert routes.SESSION_AGENT_LOCKS.get(new_sid) is third_party_lock
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            assert streaming.SESSION_AGENT_LOCKS.get(new_sid) is third_party_lock
         with routes.LOCK:
             assert routes.SESSIONS.get(old_sid) is migrating
             assert routes.SESSIONS.get(new_sid) is None
     finally:
         with routes.LOCK:
             routes.SESSIONS.clear()
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(new_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(new_sid, None)
 
 
 def test_draft_compression_migration_rollback_when_evictor_interleaves_after_lock_alias(tmp_path, monkeypatch):
@@ -759,7 +759,7 @@ def test_draft_compression_migration_rollback_when_evictor_interleaves_after_loc
     observed = {}
 
     def _evict_sessions_over_cap(_cap=None):
-        observed["locked"] = routes.SESSION_AGENT_LOCKS.get(new_sid)
+        observed["locked"] = streaming.SESSION_AGENT_LOCKS.get(new_sid)
         routes.SESSIONS.pop(old_sid, None)
         raise RuntimeError("evictor interleave")
 
@@ -783,16 +783,16 @@ def test_draft_compression_migration_rollback_when_evictor_interleaves_after_loc
         with routes.LOCK:
             assert routes.SESSIONS.get(old_sid) is migrating
             assert routes.SESSIONS.get(new_sid) is None
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            assert new_sid not in routes.SESSION_AGENT_LOCKS
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            assert new_sid not in streaming.SESSION_AGENT_LOCKS
     finally:
         streaming._evict_sessions_over_cap = old_evict
         with routes.LOCK:
             routes.SESSIONS.clear()
             routes.SESSIONS.pop(old_sid, None)
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(new_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(new_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
 
 
 def test_draft_post_for_stale_pre_compression_snapshot_hops_exhausted_rejected(tmp_path, monkeypatch):
@@ -836,9 +836,9 @@ def test_draft_post_for_stale_pre_compression_snapshot_hops_exhausted_rejected(t
         assert payload["session_id"] == chain_sid
         assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
     finally:
-        with routes.SESSION_AGENT_LOCKS_LOCK:
-            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
-            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+        with streaming.SESSION_AGENT_LOCKS_LOCK:
+            streaming.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            streaming.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
 
 
 @pytest.mark.parametrize(("cached", "messageful"), [(False, False), (True, True)])

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -1,5 +1,6 @@
 """Runtime regression coverage for dedicated composer draft sidecars."""
 
+import json
 import sqlite3
 import threading
 from types import SimpleNamespace
@@ -73,7 +74,7 @@ def _cleanup_route(monkeypatch, routes, *, zero_only=False):
     )
 
     assert routes._handle_sessions_cleanup(handler, {}, zero_only=zero_only) is True
-    return captured["payload"]
+    return captured["status"], captured["payload"]
 
 
 def _write_cli_db(path):
@@ -268,8 +269,9 @@ def test_route_session_delete_is_final_after_inflight_autosave(tmp_path, monkeyp
     real_delete_session_draft = routes._delete_session_draft
 
     def delete_session_draft_and_race(sid_to_delete):
-        real_delete_session_draft(sid_to_delete)
+        deleted = real_delete_session_draft(sid_to_delete)
         models._save_session_draft(sid_to_delete, {"text": "inflight", "files": []})
+        return deleted
 
     monkeypatch.setattr(routes, "_delete_session_draft", delete_session_draft_and_race)
 
@@ -288,6 +290,180 @@ def test_route_session_delete_is_final_after_inflight_autosave(tmp_path, monkeyp
     assert not (session_dir / ".drafts" / f"{sid}.json").exists()
 
 
+@pytest.mark.parametrize(
+    ("text", "files"),
+    [
+        ("non-empty", []),
+        ("   ", []),
+        ("", [{"name": "notes.txt"}]),
+    ],
+)
+def test_draft_post_for_diskless_session_materializes_main_session_and_sidecar(
+    tmp_path, monkeypatch, text, files
+):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = models.new_session().session_id
+    assert not (session_dir / f"{sid}.json").exists()
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/draft",
+        {"session_id": sid, "text": text, "files": files},
+    )
+
+    assert status == 200
+    assert payload["draft"] == {"text": text, "files": files}
+    assert (session_dir / f"{sid}.json").exists()
+    assert (session_dir / ".drafts" / f"{sid}.json").exists()
+    raw_session = json.loads((session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    assert raw_session.get("composer_draft") == {}
+    assert raw_session.get("message_count") == 0
+
+    models.SESSIONS.clear()
+    loaded = models.Session.load(sid)
+    assert loaded.composer_draft == {"text": text, "files": files}
+
+
+def test_empty_draft_on_diskless_new_chat_does_not_create_draft_file(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = models.new_session().session_id
+    assert not (session_dir / f"{sid}.json").exists()
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/draft",
+        {"session_id": sid, "text": "", "files": []},
+    )
+
+    assert status == 200
+    assert payload["draft"] == {"text": "", "files": []}
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
+def test_draft_post_for_stale_request_sid_does_not_write_under_old_sid(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = models.new_session().session_id
+    rotated_sid = f"{sid}-rotated"
+    s = models.get_session(sid)
+    s.composer_draft = {"text": "original", "files": []}
+
+    class _RotateLock:
+        def __enter__(self):
+            s.session_id = rotated_sid
+            with routes.LOCK:
+                routes.SESSIONS.pop(sid, None)
+                routes.SESSIONS[rotated_sid] = s
+                routes.SESSIONS.move_to_end(rotated_sid)
+            assert s.session_id == rotated_sid
+            assert routes.SESSIONS.get(rotated_sid) is s
+            assert sid not in routes.SESSIONS
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda _sid: _RotateLock())
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/draft",
+        {"session_id": sid, "text": "rotating", "files": []},
+    )
+
+    assert status == 409
+    assert payload["ok"] is False
+    assert payload["error"] == "Session moved"
+    assert payload["session_id"] == rotated_sid
+    assert s.composer_draft == {"text": "original", "files": []}
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / f"{rotated_sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{rotated_sid}.json").exists()
+
+
+@pytest.mark.parametrize(("cached", "messageful"), [(False, False), (True, True)])
+def test_draft_post_for_missing_owner_rejected(tmp_path, monkeypatch, cached, messageful):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-messageful-missing"
+    messages = [{"role": "assistant", "content": "persisted"}] if messageful else []
+    s = models.Session(
+        session_id=sid,
+        title="Route Race",
+        messages=messages,
+        composer_draft={"text": "original", "files": []},
+    )
+    s.save(touch_updated_at=False, skip_index=True)
+    assert (session_dir / f"{sid}.json").exists()
+    s = models.get_session(sid)
+    s.composer_draft = {"text": "original", "files": []}
+    (session_dir / f"{sid}.json").unlink(missing_ok=True)
+
+    if not cached:
+        models._record_webui_deleted_session_tombstone(sid)
+
+    class _DeleteLock:
+        def __enter__(self):
+            if not cached:
+                with routes.LOCK:
+                    routes.SESSIONS.pop(sid, None)
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda _sid: _DeleteLock())
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/draft",
+        {"session_id": sid, "text": "autosave", "files": []},
+    )
+
+    assert status == 409
+    assert payload["ok"] is False
+    assert payload["error"] == "Session no longer active"
+    assert payload["session_id"] == sid
+    assert s.composer_draft == {"text": "original", "files": []}
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+    if not cached:
+        assert sid in models._load_webui_deleted_session_tombstone()
+
+
+def test_resolve_session_does_not_cache_if_owner_vanishes_before_recache(
+    tmp_path, monkeypatch
+):
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-cold-load-race"
+    models.Session(
+        session_id=sid,
+        title="Load Race",
+        messages=[{"role": "assistant", "content": "persisted"}],
+    ).save(touch_updated_at=False, skip_index=True)
+    real_load = models.Session.load
+
+    def load_and_delete(loaded_sid):
+        loaded = real_load(loaded_sid)
+        (session_dir / f"{loaded_sid}.json").unlink(missing_ok=True)
+        models.SESSIONS.clear()
+        return loaded
+
+    monkeypatch.setattr(models.Session, "load", load_and_delete)
+
+    with pytest.raises(KeyError):
+        models.get_session(sid)
+    assert sid not in models.SESSIONS
+    assert not (session_dir / f"{sid}.json").exists()
+
+
 def test_sessions_cleanup_phase1_removes_dedicated_draft_file(tmp_path, monkeypatch):
     models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
 
@@ -298,11 +474,66 @@ def test_sessions_cleanup_phase1_removes_dedicated_draft_file(tmp_path, monkeypa
     )
     routes._save_session_draft(sid, {"text": "draft", "files": []})
 
-    result = _cleanup_route(monkeypatch, routes)
+    status, result = _cleanup_route(monkeypatch, routes)
 
+    assert status == 200
     assert result["cleaned"] == 1
     assert not (session_dir / f"{sid}.json").exists()
     assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
+def test_sessions_cleanup_reports_draft_delete_failure(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "sid-cleanup-fail"
+    models.Session(session_id=sid, title="Untitled").save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+    routes._save_session_draft(sid, {"text": "from-route", "files": []})
+
+    monkeypatch.setattr(routes, "_delete_session_draft", lambda _sid: False)
+
+    status, result = _cleanup_route(monkeypatch, routes)
+
+    assert status == 500
+    assert result["cleaned"] == 1
+    assert result["ok"] is False
+    assert result["error"] == "Failed to delete one or more session drafts"
+    assert result["draft_delete_failed"] is True
+    assert not (session_dir / f"{sid}.json").exists()
+    assert (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
+def test_session_delete_reports_draft_delete_failure(tmp_path, monkeypatch):
+    import api.routes as routes
+
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    sid = "sid-delete-fail"
+    models.Session(session_id=sid, title="Delete Fail").save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+    routes._save_session_draft(sid, {"text": "delete fail", "files": []})
+
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda value: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_id", lambda value: False)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda value: False)
+    monkeypatch.setattr(routes, "_delete_session_draft", lambda sid_value: False)
+
+    status, payload = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/delete",
+        {"session_id": sid},
+    )
+
+    assert status == 500
+    assert payload["ok"] is False
+    assert payload["error"] == "Failed to delete session draft"
+    assert payload["draft_delete_failed"] is True
+    assert not (session_dir / f"{sid}.json").exists()
+    assert (session_dir / ".drafts" / f"{sid}.json").exists()
 
 
 def test_model_cleanup_removes_draft_artifact(tmp_path, monkeypatch):
@@ -387,10 +618,9 @@ def test_autosave_and_delete_lock_step_does_not_recreate_draft(tmp_path, monkeyp
 
 def test_save_after_missing_main_session_does_not_create_dedicated_draft(tmp_path, monkeypatch):
     models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
-    sid = "sid-missing-main"
-    assert not (session_dir / f"{sid}.json").exists()
-    models._save_session_draft(sid, {"text": "discarded", "files": []})
-    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+    models._save_session_draft("sid-missing-main", {"text": "discarded", "files": []})
+    assert not (session_dir / "sid-missing-main.json").exists()
+    assert not (session_dir / ".drafts" / "sid-missing-main.json").exists()
 
 
 def test_draft_path_error_shows_original_input(tmp_path, monkeypatch):

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -5,6 +5,8 @@ import sqlite3
 import threading
 from types import SimpleNamespace
 
+from api import streaming
+
 import pytest
 
 
@@ -118,16 +120,14 @@ def _build_pre_compression_migration_state(tmp_path, monkeypatch):
     old_session.save(touch_updated_at=False, skip_index=True)
 
     continuation = models.Session(
-        session_id=continuation_sid,
+        session_id=old_sid,
         title="Compression snapshot",
-        parent_session_id=old_sid,
         messages=[
             {"role": "user", "content": "question"},
             {"role": "assistant", "content": "compressed reply"},
         ],
         updated_at=1234.0,
     )
-    continuation.save(touch_updated_at=False, skip_index=True)
     fork = models.Session(
         session_id=fork_sid,
         title="Ordinary fork sibling",
@@ -142,12 +142,12 @@ def _build_pre_compression_migration_state(tmp_path, monkeypatch):
     with routes.LOCK:
         models.SESSIONS.clear()
         models.SESSIONS[old_sid] = continuation
-    streaming._migrate_compression_session_ownership(
+    assert streaming._migrate_compression_session_ownership(
         continuation,
         old_sid,
         continuation_sid,
         old_lock,
-    )
+    ) is True
     continuation.save(touch_updated_at=False, skip_index=True)
 
     return models, routes, session_dir, old_sid, continuation_sid, fork_sid
@@ -625,6 +625,112 @@ def test_draft_post_for_stale_pre_compression_snapshot_cycles_rejected(tmp_path,
         with routes.SESSION_AGENT_LOCKS_LOCK:
             routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
             routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+
+
+def test_draft_pre_compression_snapshot_marker_write_failure(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+
+    old_sid = "sid-rotation-marker-fail-old"
+    new_sid = "sid-rotation-marker-fail-new"
+    (session_dir / f"{old_sid}.json").write_text(
+        json.dumps({"session_id": old_sid, "messages": [{"role": "user", "content": "old"}]},
+                   ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    class _WriteFailSession:
+        def __init__(self):
+            self.session_id = new_sid
+            self.parent_session_id = ""
+            self.pre_compression_snapshot = False
+            self.pinned = False
+            self.messages = [
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "new"},
+            ]
+            self.active_stream_id = "stream"
+            self.pending_user_message = "inflight"
+            self.pending_attachments = [{"name": "file.txt"}]
+            self.pending_started_at = 123.0
+            self.pending_user_source = "webui"
+
+        def save(self, *args, **kwargs):
+            raise OSError("write failed")
+
+    result = streaming._preserve_pre_compression_snapshot(_WriteFailSession(), old_sid)
+    assert result is False
+
+
+def test_draft_compression_migration_rejects_different_old_sid_cache_object(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(streaming, "_preserve_pre_compression_snapshot", lambda *args, **kwargs: True)
+
+    old_sid = "sid-rotation-old-mismatch"
+    new_sid = "sid-rotation-new-mismatch"
+    cache_owner = models.Session(session_id=old_sid, title="old owner")
+    migrating = models.Session(session_id=old_sid, title="migrating")
+
+    lock = routes._get_session_agent_lock(old_sid)
+    with routes.LOCK:
+        routes.SESSIONS.clear()
+        routes.SESSIONS[old_sid] = cache_owner
+
+    try:
+        result = streaming._migrate_compression_session_ownership(migrating, old_sid, new_sid, lock)
+        assert result is False
+        with routes.LOCK:
+            assert routes.SESSIONS.get(old_sid) is cache_owner
+            assert routes.SESSIONS.get(new_sid) is None
+    finally:
+        with routes.LOCK:
+            routes.SESSIONS.clear()
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(new_sid, None)
+
+
+def test_draft_compression_migration_rollback_when_evictor_interleaves_after_lock_alias(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(streaming, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(streaming, "_preserve_pre_compression_snapshot", lambda *args, **kwargs: True)
+
+    old_sid = "sid-rotation-old-evict"
+    new_sid = "sid-rotation-new-evict"
+    migrating = models.Session(session_id=old_sid, title="migrating")
+
+    observed = {}
+
+    def _evict_sessions_over_cap(_cap=None):
+        observed["locked"] = routes.SESSION_AGENT_LOCKS.get(new_sid)
+        routes.SESSIONS.pop(old_sid, None)
+        raise RuntimeError("evictor interleave")
+
+    lock = routes._get_session_agent_lock(old_sid)
+    with routes.LOCK:
+        routes.SESSIONS.clear()
+        routes.SESSIONS[old_sid] = migrating
+
+    old_evict = streaming._evict_sessions_over_cap
+    try:
+        monkeypatch.setattr(streaming, "_evict_sessions_over_cap", _evict_sessions_over_cap)
+        result = streaming._migrate_compression_session_ownership(migrating, old_sid, new_sid, lock)
+        assert result is False
+        assert observed["locked"] is lock
+        with routes.LOCK:
+            assert routes.SESSIONS.get(old_sid) is migrating
+            assert routes.SESSIONS.get(new_sid) is None
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            assert new_sid not in routes.SESSION_AGENT_LOCKS
+    finally:
+        streaming._evict_sessions_over_cap = old_evict
+        with routes.LOCK:
+            routes.SESSIONS.clear()
+            routes.SESSIONS.pop(old_sid, None)
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(new_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
 
 
 def test_draft_post_for_stale_pre_compression_snapshot_hops_exhausted_rejected(tmp_path, monkeypatch):

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -109,6 +109,7 @@ def _build_pre_compression_migration_state(tmp_path, monkeypatch):
 
     old_sid = "sid-rotation-old"
     continuation_sid = "sid-rotation-new"
+    fork_sid = "sid-rotation-fork"
     old_session = models.Session(
         session_id=old_sid,
         title="Compression snapshot",
@@ -124,21 +125,32 @@ def _build_pre_compression_migration_state(tmp_path, monkeypatch):
             {"role": "user", "content": "question"},
             {"role": "assistant", "content": "compressed reply"},
         ],
+        updated_at=1234.0,
     )
     continuation.save(touch_updated_at=False, skip_index=True)
-    streaming._preserve_pre_compression_snapshot(continuation, old_sid)
-    continuation.save(touch_updated_at=False, skip_index=True)
-
-    with routes.LOCK:
-        models.SESSIONS.clear()
-        models.SESSIONS[continuation_sid] = continuation
+    fork = models.Session(
+        session_id=fork_sid,
+        title="Ordinary fork sibling",
+        parent_session_id=old_sid,
+        session_source="fork",
+        messages=[{"role": "user", "content": "forked question"}],
+        updated_at=1250.0,
+    )
+    fork.save(touch_updated_at=False, skip_index=True)
 
     old_lock = routes._get_session_agent_lock(old_sid)
-    with routes.SESSION_AGENT_LOCKS_LOCK:
-        routes.SESSION_AGENT_LOCKS[continuation_sid] = old_lock
-        routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+    with routes.LOCK:
+        models.SESSIONS.clear()
+        models.SESSIONS[old_sid] = continuation
+    streaming._migrate_compression_session_ownership(
+        continuation,
+        old_sid,
+        continuation_sid,
+        old_lock,
+    )
+    continuation.save(touch_updated_at=False, skip_index=True)
 
-    return models, routes, session_dir, old_sid, continuation_sid
+    return models, routes, session_dir, old_sid, continuation_sid, fork_sid
 
 
 def test_dedicated_draft_overlays_full_and_metadata_loads(tmp_path, monkeypatch):
@@ -427,7 +439,7 @@ def test_draft_post_for_stale_request_sid_does_not_write_under_old_sid(tmp_path,
 
 
 def test_draft_post_for_stale_pre_compression_snapshot_writes_to_continuation(tmp_path, monkeypatch):
-    models, routes, session_dir, old_sid, continuation_sid = _build_pre_compression_migration_state(
+    models, routes, session_dir, old_sid, continuation_sid, fork_sid = _build_pre_compression_migration_state(
         tmp_path, monkeypatch
     )
 
@@ -436,19 +448,28 @@ def test_draft_post_for_stale_pre_compression_snapshot_writes_to_continuation(tm
             monkeypatch,
             routes,
             "/api/session/draft",
-            {"session_id": old_sid, "text": "recover from archived snapshot", "files": []},
+            {
+                "session_id": old_sid,
+                "text": "recover from archived snapshot",
+                "files": [{"name": "proof.txt"}],
+            },
         )
 
         assert status == 200
         assert payload["session_id"] == continuation_sid
-        assert payload["draft"] == {"text": "recover from archived snapshot", "files": []}
+        assert payload["draft"] == {"text": "recover from archived snapshot", "files": [{"name": "proof.txt"}]}
 
         assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
         assert (session_dir / ".drafts" / f"{continuation_sid}.json").exists()
+        assert not (session_dir / ".drafts" / f"{fork_sid}.json").exists()
+        assert (session_dir / f"{old_sid}.json").exists()
+        assert json.loads((session_dir / f"{old_sid}.json").read_text(encoding="utf-8")).get(
+            "pre_compression_continuation_session_id"
+        ) == continuation_sid
 
         models.SESSIONS.clear()
         loaded = models.Session.load(continuation_sid)
-        assert loaded.composer_draft == {"text": "recover from archived snapshot", "files": []}
+        assert loaded.composer_draft == {"text": "recover from archived snapshot", "files": [{"name": "proof.txt"}]}
         assert (session_dir / f"{old_sid}.json").exists()
     finally:
         with routes.SESSION_AGENT_LOCKS_LOCK:
@@ -459,7 +480,7 @@ def test_draft_post_for_stale_pre_compression_snapshot_writes_to_continuation(tm
 def test_draft_post_for_stale_pre_compression_snapshot_profile_mismatch_rejected(
     tmp_path, monkeypatch
 ):
-    models, routes, session_dir, old_sid, continuation_sid = _build_pre_compression_migration_state(
+    models, routes, session_dir, old_sid, continuation_sid, fork_sid = _build_pre_compression_migration_state(
         tmp_path,
         monkeypatch,
     )
@@ -487,6 +508,7 @@ def test_draft_post_for_stale_pre_compression_snapshot_profile_mismatch_rejected
         assert status == 409
         assert payload["ok"] is False
         assert payload["error"] == "Session moved"
+        assert payload["code"] == "session_moved"
         assert payload["session_id"] == continuation_sid
         assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
         assert not (session_dir / ".drafts" / f"{continuation_sid}.json").exists()
@@ -497,7 +519,7 @@ def test_draft_post_for_stale_pre_compression_snapshot_profile_mismatch_rejected
 
 
 def test_draft_post_waits_for_rotation_while_lock_waits_for_authority(tmp_path, monkeypatch):
-    models, routes, session_dir, old_sid, continuation_sid = _build_pre_compression_migration_state(
+    models, routes, session_dir, old_sid, continuation_sid, fork_sid = _build_pre_compression_migration_state(
         tmp_path,
         monkeypatch,
     )
@@ -571,6 +593,84 @@ def test_draft_post_waits_for_rotation_while_lock_waits_for_authority(tmp_path, 
     loaded = models.Session.load(continuation_sid)
     assert loaded.composer_draft == {"text": "rotating while waiting", "files": []}
     assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
+
+
+def test_draft_post_for_stale_pre_compression_snapshot_cycles_rejected(tmp_path, monkeypatch):
+    models, routes, session_dir, old_sid, continuation_sid, fork_sid = _build_pre_compression_migration_state(
+        tmp_path,
+        monkeypatch,
+    )
+
+    continuation = models.Session.load(continuation_sid)
+    continuation.pre_compression_snapshot = True
+    continuation.pre_compression_continuation_session_id = old_sid
+    continuation.save(touch_updated_at=False, skip_index=True)
+    models.SESSIONS.clear()
+
+    try:
+        status, payload = _post_json(
+            monkeypatch,
+            routes,
+            "/api/session/draft",
+            {"session_id": old_sid, "text": "cycle rejected", "files": []},
+        )
+
+        assert status == 409
+        assert payload["ok"] is False
+        assert payload["error"] == "Session moved"
+        assert payload["code"] == "session_moved"
+        assert payload["session_id"] == old_sid
+        assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
+    finally:
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
+
+
+def test_draft_post_for_stale_pre_compression_snapshot_hops_exhausted_rejected(tmp_path, monkeypatch):
+    models, routes, session_dir, old_sid, continuation_sid, fork_sid = _build_pre_compression_migration_state(
+        tmp_path,
+        monkeypatch,
+    )
+
+    continuation = models.Session.load(continuation_sid)
+    continuation.pre_compression_snapshot = True
+
+    chain_tail = continuation
+    chain_sid = None
+    for idx in range(3):
+        chain_sid = f"sid-rotation-hop-{idx}"
+        chain = models.Session(
+            session_id=chain_sid,
+            title="Compression hop",
+            parent_session_id=chain_tail.session_id,
+            pre_compression_snapshot=True,
+            messages=[{"role": "assistant", "content": "hop"}],
+        )
+        chain.save(touch_updated_at=False, skip_index=True)
+        chain_tail.pre_compression_continuation_session_id = chain_sid
+        chain_tail.save(touch_updated_at=False, skip_index=True)
+        chain_tail = chain
+    models.SESSIONS.clear()
+
+    try:
+        status, payload = _post_json(
+            monkeypatch,
+            routes,
+            "/api/session/draft",
+            {"session_id": old_sid, "text": "exhausted", "files": []},
+        )
+
+        assert status == 409
+        assert payload["ok"] is False
+        assert payload["error"] == "Session moved"
+        assert payload["code"] == "session_moved"
+        assert payload["session_id"] == chain_sid
+        assert not (session_dir / ".drafts" / f"{old_sid}.json").exists()
+    finally:
+        with routes.SESSION_AGENT_LOCKS_LOCK:
+            routes.SESSION_AGENT_LOCKS.pop(old_sid, None)
+            routes.SESSION_AGENT_LOCKS.pop(continuation_sid, None)
 
 
 @pytest.mark.parametrize(("cached", "messageful"), [(False, False), (True, True)])

--- a/tests/test_composer_draft_sidecar_regressions.py
+++ b/tests/test_composer_draft_sidecar_regressions.py
@@ -1,6 +1,7 @@
 """Runtime regression coverage for dedicated composer draft sidecars."""
 
 import sqlite3
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -248,6 +249,45 @@ def test_session_delete_removes_dedicated_draft_file(tmp_path, monkeypatch):
     assert not (session_dir / ".drafts" / f"{sid}.json").exists()
 
 
+def test_route_session_delete_is_final_after_inflight_autosave(tmp_path, monkeypatch):
+    models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    sid = "sid-route-race"
+    models.Session(
+        session_id=sid,
+        title="Route Race",
+        messages=[{"role": "assistant", "content": "x"}],
+    ).save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda value: {})
+    monkeypatch.setattr(routes, "_is_messaging_session_id", lambda value: False)
+    monkeypatch.setattr(routes, "_session_is_subagent_view_only", lambda value: False)
+
+    real_delete_session_draft = routes._delete_session_draft
+
+    def delete_session_draft_and_race(sid_to_delete):
+        real_delete_session_draft(sid_to_delete)
+        models._save_session_draft(sid_to_delete, {"text": "inflight", "files": []})
+
+    monkeypatch.setattr(routes, "_delete_session_draft", delete_session_draft_and_race)
+
+    delete_status = {}
+
+    delete_status["status"], delete_status["payload"] = _post_json(
+        monkeypatch,
+        routes,
+        "/api/session/delete",
+        {"session_id": sid},
+    )
+
+    assert delete_status["status"] == 200
+    assert delete_status["payload"]["ok"] is True
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
 def test_sessions_cleanup_phase1_removes_dedicated_draft_file(tmp_path, monkeypatch):
     models, routes, session_dir = _build_draft_env(tmp_path, monkeypatch)
 
@@ -284,6 +324,73 @@ def test_model_cleanup_removes_draft_artifact(tmp_path, monkeypatch):
     assert models.delete_cli_session(sid) is True
     assert not (session_dir / f"{sid}.json").exists()
     assert not draft_path.exists()
+
+
+def test_autosave_and_delete_lock_step_does_not_recreate_draft(tmp_path, monkeypatch):
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    sid = "sid-race"
+    models.Session(session_id=sid, title="Race", messages=[{"role": "assistant", "content": "x"}]).save(
+        touch_updated_at=False,
+        skip_index=True,
+    )
+
+    saved_to_replace = threading.Event()
+    allow_replace = threading.Event()
+    original_safe_replace = models._safe_replace
+    replace_error = {}
+
+    def slow_safe_replace(src, dst):
+        saved_to_replace.set()
+        allow_replace.wait()
+        try:
+            return original_safe_replace(src, dst)
+        except Exception as exc:
+            replace_error["error"] = exc
+            raise
+
+    monkeypatch.setattr(models, "_safe_replace", slow_safe_replace)
+
+    def autosave_worker(errors):
+        try:
+            models._save_session_draft(sid, {"text": "inflight", "files": []})
+        except Exception as exc:
+            errors["autosave"] = str(exc)
+
+    def delete_worker(errors):
+        try:
+            (session_dir / f"{sid}.json").unlink(missing_ok=True)
+            models._delete_session_draft(sid)
+        except Exception as exc:
+            errors["delete"] = str(exc)
+
+    autosave_errors: dict[str, str] = {}
+    delete_errors: dict[str, str] = {}
+    autosave_thread = threading.Thread(target=autosave_worker, args=(autosave_errors,))
+    delete_thread = threading.Thread(target=delete_worker, args=(delete_errors,))
+
+    autosave_thread.start()
+    assert saved_to_replace.wait(timeout=2), "autosave did not reach replace wait point"
+    delete_thread.start()
+
+    allow_replace.set()
+    autosave_thread.join(timeout=5)
+    delete_thread.join(timeout=5)
+
+    assert not autosave_thread.is_alive()
+    assert not delete_thread.is_alive()
+    assert not autosave_errors
+    assert not delete_errors
+    assert not replace_error
+    assert not (session_dir / f"{sid}.json").exists()
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
+
+
+def test_save_after_missing_main_session_does_not_create_dedicated_draft(tmp_path, monkeypatch):
+    models, _, session_dir = _build_draft_env(tmp_path, monkeypatch)
+    sid = "sid-missing-main"
+    assert not (session_dir / f"{sid}.json").exists()
+    models._save_session_draft(sid, {"text": "discarded", "files": []})
+    assert not (session_dir / ".drafts" / f"{sid}.json").exists()
 
 
 def test_draft_path_error_shows_original_input(tmp_path, monkeypatch):

--- a/tests/test_file_manager_external_session.py
+++ b/tests/test_file_manager_external_session.py
@@ -629,7 +629,9 @@ def test_compression_lock_alias_keeps_old_and_new_ids_on_one_live_lock():
     streaming_source = (Path(__file__).parents[1] / "api" / "streaming.py").read_text(
         encoding="utf-8"
     )
-    assert "_alias_session_agent_lock(old_sid, new_sid, _agent_lock)" in streaming_source
+    assert "_migrate_compression_session_ownership(s, old_sid, new_sid, _agent_lock)" in streaming_source
+    assert "SESSION_AGENT_LOCKS[old_sid] = agent_lock" in streaming_source
+    assert "SESSION_AGENT_LOCKS[new_sid] = agent_lock" in streaming_source
 
 
 def test_get_session_for_file_ops_does_not_fallback_existing_untrusted_workspace(

--- a/tests/test_issue5472_preserve_draft_on_failed_send.py
+++ b/tests/test_issue5472_preserve_draft_on_failed_send.py
@@ -32,6 +32,16 @@ import pytest
 
 ROOT = Path(__file__).parents[1]
 MESSAGES_JS = ROOT.joinpath("static", "messages.js").read_text(encoding="utf-8")
+UI_JS = ROOT.joinpath("static", "ui.js").read_text(encoding="utf-8")
+SESSIONS_JS = ROOT.joinpath("static", "sessions.js").read_text(encoding="utf-8")
+
+
+def _source_between(src: str, start: str, end: str) -> str:
+    start_idx = src.find(start)
+    assert start_idx != -1, f"{start} must exist in source"
+    end_idx = src.find(end, start_idx)
+    assert end_idx != -1, f"{end} must exist after {start}"
+    return src[start_idx:end_idx]
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +218,196 @@ def _run_helper_in_node(draft_text, files_snapshot, initial_input, visible_sid, 
     proc = subprocess.run([node, "-e", harness], capture_output=True, text=True, timeout=30)
     assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
     return json.loads(proc.stdout.strip())
+
+
+def _run_node_script(script):
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+    return json.loads(proc.stdout.strip())
+
+
+def _lock_clarify_body() -> str:
+    return _source_between(
+        UI_JS,
+        "function lockComposerForClarify(",
+        "\nfunction unlockComposerForClarify(",
+    )
+
+
+def _draft_failure_reporting_body() -> str:
+    return (
+        _source_between(
+            SESSIONS_JS,
+            "function _handleComposerDraftPostFailure(",
+            "\nfunction _postComposerDraftPayload",
+        )
+        + "\n"
+        + _source_between(
+            SESSIONS_JS,
+            "function _composerDraftHasPayload(",
+            "\nfunction _sessionComposerDraftHasPayload",
+        )
+    )
+
+
+def test_lock_composer_for_clarify_rejects_persistence_without_unhandled_and_retains_payload():
+    body = _lock_clarify_body()
+    script = textwrap.dedent(
+        """
+        const assert = require('assert');
+        let unhandled = 0;
+        process.on('unhandledRejection', () => {{ unhandled += 1; }});
+
+        const sid = 'sid-clarify';
+        const pending = [{{name:'clarify-a', size:10}}, {{name:'clarify-b', size:11}}];
+        const S = {{
+          session: {{session_id: sid, composer_draft: null}},
+          pendingFiles: pending,
+        }};
+        const input = {{
+          value: 'Need clarification',
+          disabled: false,
+          placeholder: '',
+        }};
+        const saveCalls = [];
+        const warnCalls = [];
+        const known = new Set();
+        const failBody = %(failure_body)s;
+        const _composerDraftKnownPayloadSessions = known;
+        eval(failBody);
+        const oldWarn = console.warn;
+        console.warn = (...args) => {{ warnCalls.push(args); }};
+        let _composerLockState = null;
+
+        const $ = (id) => (id === 'msg' ? input : null);
+        function autoResize() {{}}
+        function updateSendBtn() {{}}
+
+        function _saveComposerDraftNow(sid, text, files) {{
+          saveCalls.push({{sid, text, files: (Array.isArray(files)?files.filter(Boolean):[])}});
+          return Promise.reject(new Error('draft persist failed'));
+        }}
+
+        function showToast() {{}}
+
+        %(lock_fn)s
+
+        S.pendingFiles.push({{name: 'later'}});
+        lockComposerForClarify('Locked for clarify');
+        assert.strictEqual(input.disabled, true);
+        Promise.resolve().then(() => {{
+          console.warn = oldWarn;
+          const draft = S.session && S.session.composer_draft ? S.session.composer_draft : null;
+          console.log(JSON.stringify({{
+            sid,
+            unhandled,
+            saveCalls,
+            warnCount: warnCalls.length,
+            composerDraft: draft,
+            placeholder: input.placeholder,
+            warning: warnCalls[0] || null,
+            hasKnown: known.has(sid),
+            restoredText: input.value,
+            inputDisabled: input.disabled,
+          }}));
+        }}).catch((error) => {{
+          console.log(JSON.stringify({{error: String(error && error.message || error || 'failure')}}));
+        }});
+        """
+    ).strip().replace("{{", "{").replace("}}", "}")
+    script = script % {
+        "lock_fn": body,
+        "failure_body": json.dumps(_draft_failure_reporting_body()),
+    }
+    out = _run_node_script(script)
+    assert out["sid"] == "sid-clarify"
+    assert out["unhandled"] == 0
+    assert out["saveCalls"] == [{
+        "sid": "sid-clarify",
+        "text": "Need clarification",
+        "files": [{"name": "clarify-a", "size": 10}, {"name": "clarify-b", "size": 11}, {"name": "later"}],
+    }], out
+    assert out["warnCount"] == 1
+    assert out["hasKnown"] is True
+    assert out["composerDraft"] == {
+        "text": "Need clarification",
+        "files": [{"name": "clarify-a", "size": 10}, {"name": "clarify-b", "size": 11}, {"name": "later"}],
+    }
+    assert out["inputDisabled"] is True
+    assert out["restoredText"] == "Need clarification"
+
+
+def test_restore_after_failed_send_persistence_rejection_is_consumed_and_owned_payload_retained():
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node not available")
+    body = _helper_body()
+    failure_body = _draft_failure_reporting_body()
+    script = textwrap.dedent(
+        """
+        const assert = require('assert');
+        let unhandled = 0;
+        process.on('unhandledRejection', () => { unhandled += 1; });
+
+        const sid = 'sid-1';
+        const state = {
+          input: {value: ''},
+          pendingFiles: [{name: 'queued.png'}],
+        };
+        const S = {
+          session: {session_id: sid, composer_draft: {text: '', files: []}},
+          pendingFiles: state.pendingFiles,
+        };
+        const known = new Set();
+        const saveCalls = [];
+
+        const $ = (id) => (id === 'msg' ? state.input : null);
+        function autoResize() {}
+        function updateSendBtn() {}
+        function renderTray() {}
+        const failureBody = %(failure_body)s;
+        const _composerDraftKnownPayloadSessions = known;
+        eval(failureBody);
+        function _saveComposerDraftNow(sid, text, files) {
+          saveCalls.push({sid, text, files: (Array.isArray(files)?files.filter(Boolean):[])});
+          return Promise.reject(new Error('forced save failure'));
+        }
+
+        %(restore_fn)s
+
+        _restoreComposerDraftAfterFailedSend('failed in send', [{name: 'recover.pdf'}], sid);
+        Promise.resolve().then(() => {
+          const draft = S.session && S.session.composer_draft ? S.session.composer_draft : null;
+          console.log(JSON.stringify({
+            sid,
+            unhandled,
+            saveCalls,
+            draft,
+            knownPayload: known.has(sid),
+            inputValue: state.input.value,
+          }));
+        }).catch((error) => {
+          console.log(JSON.stringify({error: String(error && error.message || error || 'failure')}));
+        });
+        """
+    ).strip() % {
+        "failure_body": json.dumps(failure_body),
+        "restore_fn": body,
+    }
+    out = _run_node_script(script)
+    assert out["sid"] == "sid-1"
+    assert out["unhandled"] == 0
+    assert out["saveCalls"] == [{
+        "sid": "sid-1",
+        "text": "failed in send",
+        "files": [{"name": "recover.pdf"}],
+    }], out
+    assert out["knownPayload"] is True
+    assert out["draft"] == {"text": "failed in send", "files": [{"name": "recover.pdf"}]}
+    assert out["inputValue"] == "failed in send"
 
 
 def test_restores_typed_text_into_empty_composer():

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -798,6 +798,7 @@ class TestIssue765FollowupHardening:
         streaming.py performs inside the compression rotation block.
         """
         from api.config import (
+            _alias_session_agent_lock,
             _get_session_agent_lock,
             SESSION_AGENT_LOCKS,
             SESSION_AGENT_LOCKS_LOCK,
@@ -808,12 +809,9 @@ class TestIssue765FollowupHardening:
         # Acquire the lock under the old ID
         old_lock = _get_session_agent_lock(old_sid)
 
-        # Simulate the migration that streaming.py does during compression:
-        # alias new_sid → held _agent_lock reference, then pop old_sid.
+        # Simulate the migration that streaming.py does during compression.
         _agent_lock = old_lock
-        with SESSION_AGENT_LOCKS_LOCK:
-            SESSION_AGENT_LOCKS[new_sid] = _agent_lock
-            SESSION_AGENT_LOCKS.pop(old_sid, None)
+        _alias_session_agent_lock(old_sid, new_sid, _agent_lock)
 
         # Now looking up the new ID must return the exact same Lock object
         new_lock = _get_session_agent_lock(new_sid)
@@ -823,15 +821,12 @@ class TestIssue765FollowupHardening:
             f"got {new_lock!r} vs {old_lock!r}"
         )
 
-        # The old ID entry must no longer exist (it was popped)
-        with SESSION_AGENT_LOCKS_LOCK:
-            assert old_sid not in SESSION_AGENT_LOCKS, (
-                f"Old session ID {old_sid!r} must be removed from "
-                f"SESSION_AGENT_LOCKS after rotation"
-            )
+        # Late old-ID callers must stay serialized with the continuation.
+        assert _get_session_agent_lock(old_sid) is old_lock
 
         # Cleanup
         with SESSION_AGENT_LOCKS_LOCK:
+            SESSION_AGENT_LOCKS.pop(old_sid, None)
             SESSION_AGENT_LOCKS.pop(new_sid, None)
 
     def test_lock_rotation_migration_survives_old_id_already_pruned(self):

--- a/tests/test_issue_new_chat_draft_restore.py
+++ b/tests/test_issue_new_chat_draft_restore.py
@@ -113,11 +113,13 @@ def test_immediate_empty_draft_flush_clears_locally_known_server_draft():
     assert "_composerDraftKnownPayloadSessions.add(sid);" in save_body, (
         "debounced non-empty draft saves must mark the session as having server-side draft payload"
     )
-    assert "_rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);" in save_body
+    assert "_postComposerDraftPayload(sid," in save_body
     assert "!_composerDraftKnownPayloadSessions.has(sid)" in now_body, (
         "empty immediate switch-away saves may only be skipped when no local/server draft payload is known"
     )
-    assert "_rememberComposerDraftPayloadState(sid, normalizedText, normalizedFiles);" in now_body
+    assert "_postComposerDraftPayload(sid," in now_body, (
+        "debounced and immediate draft saves must share authoritative-session handling"
+    )
 
 
 def test_pre_switch_draft_flush_rechecks_stale_loading_guard():

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -840,6 +840,120 @@ class TestFrontendWiring:
         )
         subprocess.run([node, "-e", script], check=True, capture_output=True, text=True)
 
+    def test_old_owner_steer_recovery_persistence_rejection_is_consumed(self):
+        import json
+        import shutil
+        import subprocess
+        import textwrap
+
+        node = shutil.which("node")
+        if not node:  # pragma: no cover
+            pytest.skip("node not available")
+        assert node is not None
+
+        steer_src = _source_between(
+            self.cmds,
+            "function _steerUploadedAttachmentPaths",
+            "\nasync function cmdTitle",
+        )
+        sessions_src = (Path(__file__).parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
+        failure_src = _source_between(
+            sessions_src,
+            "function _handleComposerDraftPostFailure(",
+            "\nfunction _postComposerDraftPayload",
+        )
+        failure_src += "\n" + _source_between(
+            sessions_src,
+            "function _composerDraftHasPayload(",
+            "\nfunction _sessionComposerDraftHasPayload",
+        )
+
+        script = textwrap.dedent(
+            """
+            const assert = require('assert');
+            let unhandled = 0;
+            process.on('unhandledRejection', () => { unhandled += 1; });
+
+            const failureSrc = %(failure_src)s;
+            const steerSrc = %(steer_src)s;
+            const toasts = [];
+            const saveCalls = [];
+            const known = new Set();
+            const pending = [{name:'steer-a', size:1}];
+            const originalText = 'recover me';
+
+            let S = {
+              session: {session_id:'A', active_stream_id:'stream-1'},
+              activeStreamId: 'stream-1',
+              activeProfile: 'work',
+              busy: true,
+              pendingFiles: [...pending],
+            };
+            let INFLIGHT = {A:{messages:[]}};
+
+            function t(k){ return k; }
+            function $(id) { return null; }
+            function autoResize() {}
+            function renderTray() {}
+            function updateSendBtn() {}
+            function _showSteerRecovery() {}
+            function _steerFailureMessageKey(fallback){ return 'steer_fail_'+fallback; }
+            function _clearComposerDraft() {}
+            function setComposerStatus() {}
+            function showToast(key) { toasts.push(key); }
+            const _composerDraftKnownPayloadSessions = known;
+            eval(failureSrc);
+            eval(steerSrc);
+
+            _steerOwnerIsCurrent = () => false;
+            _saveComposerDraftNow = (sid, text, files) => {
+              saveCalls.push({sid, text, files: (Array.isArray(files)?files.filter(Boolean):[])});
+              return Promise.reject(new Error('steer save failed'));
+            };
+            api = async (url, options) => {
+              assert.strictEqual(url, '/api/chat/steer');
+              return {accepted:false, fallback:'stream_dead'};
+            };
+            uploadPendingFiles = async () => [];
+
+            (async()=> {
+              const delivered = await _trySteer(originalText, false);
+              assert.strictEqual(delivered, false);
+              await Promise.resolve();
+              const draft = S.session && S.session.composer_draft ? S.session.composer_draft : null;
+              console.log(JSON.stringify({
+                unhandled,
+                toasts,
+                saveCalls,
+                draft,
+                knownPayload: known.has('A'),
+                busy: S.busy,
+                activeStreamId: S.activeStreamId,
+                activeSessionStream: S.session && S.session.active_stream_id,
+              }));
+            })().catch(err => { console.log(JSON.stringify({error: String(err && err.message || err || 'failure')})); });
+            """
+        ) % {
+            "steer_src": json.dumps(steer_src),
+            "failure_src": json.dumps(failure_src),
+        }
+
+        proc = subprocess.run([node, "-e", script], capture_output=True, text=True, timeout=30)
+        assert proc.returncode == 0, f"node harness failed: {proc.stderr}"
+        out = json.loads(proc.stdout.strip())
+        assert out["unhandled"] == 0
+        assert out["toasts"] == []
+        assert out["saveCalls"] == [{
+            "sid": "A",
+            "text": "recover me",
+            "files": [{"name": "steer-a", "size": 1}],
+        }], out
+        assert out["knownPayload"] is True
+        assert out["busy"] is True
+        assert out["activeStreamId"] == "stream-1"
+        assert out["activeSessionStream"] == "stream-1"
+        assert out["draft"] == {"text": "recover me", "files": [{"name": "steer-a", "size": 1}]}
+
     def test_send_busy_steer_accepts_file_only_input(self):
         idx = self.msgs.find("if(S.busy||compressionRunning)")
         assert idx >= 0

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -354,7 +354,7 @@ def test_server_delete_prunes_session_index(cleanup_test_sessions):
             text.find('if parsed.path == "/api/session/delete":'),
         )
         if delete_idx >= 0:
-            delete_block = text[delete_idx:delete_idx+2400]
+            delete_block = text[delete_idx:delete_idx+4000]
             assert "prune_session_from_index(sid)" in delete_block, \
                 f"{label} session/delete must prune SESSION_INDEX_FILE"
             return
@@ -369,7 +369,7 @@ def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
         routes_src.find('if parsed.path == "/api/session/delete":'),
     )
     assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
-    delete_block = routes_src[delete_idx:delete_idx+2400]
+    delete_block = routes_src[delete_idx:delete_idx+4000]
     assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
         "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
 

--- a/tests/test_session_cache_ownership.py
+++ b/tests/test_session_cache_ownership.py
@@ -68,7 +68,7 @@ def test_compression_cache_migration_never_moves_unverified_cached_object_to_new
     streaming_src = open("api/streaming.py", encoding="utf-8").read()
 
     assert "SESSIONS[new_sid] = SESSIONS.pop(old_sid)" not in streaming_src
-    assert "cached_old_session is not s" in streaming_src
+    assert "SESSIONS.get(old_sid) is not s" in streaming_src
     assert "SESSIONS[new_sid] = s" in streaming_src
 
 

--- a/tests/test_stage326_composer_draft_validation.py
+++ b/tests/test_stage326_composer_draft_validation.py
@@ -9,110 +9,280 @@ debounced auto-save. The hardening:
 - files: must be list; clamped to 50 entries
 """
 import json
-import os
-import sys
-import threading
-import urllib.request
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from pathlib import Path
-
-import pytest
-
-# These tests directly call the handler logic by importing the routes module
-# and exercising the validation through a minimal mock handler. We don't need
-# a full HTTP server.
+from types import SimpleNamespace
 
 
-@pytest.fixture
-def isolated_state_dir(tmp_path, monkeypatch):
-    """Point STATE_DIR at a tmpdir so saved sessions don't pollute reality."""
+def _build_draft_env(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("HERMES_BASE_HOME", str(tmp_path))
-    yield tmp_path
+    monkeypatch.setenv("HERMES_WEBUI_DEFAULT_WORKSPACE", str(tmp_path / "workspace"))
+
+    import api.models as models
+    import api.routes as routes
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+    return models, routes
 
 
-def test_draft_text_clamped_to_50kb(isolated_state_dir):
-    """Posting a >50KB text field should be silently truncated to 50_000 chars."""
-    # Read the routes.py source and assert the clamp logic is present.
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-
-    # The clamp constant must exist.
-    assert "_MAX_DRAFT_TEXT = 50_000" in src or "_MAX_DRAFT_TEXT=50_000" in src.replace(" ", ""), (
-        "routes.py must define _MAX_DRAFT_TEXT clamp for the composer-draft POST handler"
+def _draft_post(monkeypatch, routes, body):
+    captured = {}
+    handler = SimpleNamespace(
+        command="POST",
+        wfile=None,
+        send_response=lambda status: None,
+        send_header=lambda key, value: None,
+        end_headers=lambda: None,
     )
 
-    # And the truncation must be applied.
-    assert "text = text[:_MAX_DRAFT_TEXT]" in src, (
-        "routes.py must truncate over-large draft text to _MAX_DRAFT_TEXT"
+    monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+    monkeypatch.setattr(routes, "read_body", lambda _handler: body)
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda _handler, payload, status=200, extra_headers=None: captured.update(
+            payload=payload,
+            status=status,
+        )
+        or True,
+    )
+
+    assert routes.handle_post(handler, SimpleNamespace(path="/api/session/draft")) is True
+    return captured
+
+
+def test_draft_text_clamped_to_50kb(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "draft-save-text-clamp"
+    models.Session(
+        session_id=sid,
+        title="Draft validation",
+        messages=[{"role": "assistant", "content": "x" * 10}],
+    ).save(touch_updated_at=False, skip_index=True)
+
+    captured = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": "x" * 60_000,
+            "files": [],
+        },
+    )
+
+    draft_path = models.SESSION_DIR / ".drafts" / f"{sid}.json"
+    draft_payload = json.loads(draft_path.read_text(encoding="utf-8"))
+    assert len(draft_payload["text"]) == 50_000
+    assert captured["payload"]["draft"]["text"] == "x" * 50_000
+
+
+def test_draft_files_clamped_to_50_entries(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "draft-save-files-clamp"
+    models.Session(
+        session_id=sid,
+        title="Draft validation",
+        messages=[{"role": "assistant", "content": "x" * 10}],
+    ).save(touch_updated_at=False, skip_index=True)
+
+    captured = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": "",
+            "files": list(range(60)),
+        },
+    )
+
+    draft_path = models.SESSION_DIR / ".drafts" / f"{sid}.json"
+    draft_payload = json.loads(draft_path.read_text(encoding="utf-8"))
+    assert len(draft_payload["files"]) == 50
+    assert len(captured["payload"]["draft"]["files"]) == 50
+
+
+def test_draft_text_type_coerced_to_string(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "draft-save-text-nonstring"
+    models.Session(
+        session_id=sid,
+        title="Draft validation",
+        messages=[{"role": "assistant", "content": "x" * 10}],
+    ).save(touch_updated_at=False, skip_index=True)
+
+    observed = {}
+    original_save = routes._save_session_draft
+
+    def save_draft_spy(sid_value, draft_payload):
+        observed["payload"] = draft_payload
+        return original_save(sid_value, draft_payload)
+
+    monkeypatch.setattr(routes, "_save_session_draft", save_draft_spy)
+    captured = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": 1234,
+            "files": [],
+        },
+    )
+
+    assert captured["payload"]["draft"]["text"] == ""
+    assert observed["payload"]["text"] == ""
+
+
+def test_draft_files_type_coerced_to_list(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "draft-save-files-nonlist"
+    models.Session(
+        session_id=sid,
+        title="Draft validation",
+        messages=[{"role": "assistant", "content": "x" * 10}],
+    ).save(touch_updated_at=False, skip_index=True)
+
+    observed = {}
+    original_save = routes._save_session_draft
+
+    def save_draft_spy(sid_value, draft_payload):
+        observed["payload"] = draft_payload
+        return original_save(sid_value, draft_payload)
+
+    monkeypatch.setattr(routes, "_save_session_draft", save_draft_spy)
+    captured = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": "text",
+            "files": {"not": "a-list"},
+        },
+    )
+
+    assert captured["payload"]["draft"]["files"] == []
+    assert observed["payload"]["files"] == []
+
+
+def test_draft_validation_appears_before_persist(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "draft-validation-order"
+    models.Session(
+        session_id=sid,
+        title="Draft validation",
+        messages=[{"role": "assistant", "content": "x" * 10}],
+    ).save(touch_updated_at=False, skip_index=True)
+
+    entered_lock = []
+
+    class LockProbe:
+        def __enter__(self):
+            entered_lock.append("entered")
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda _sid: LockProbe())
+
+    original_save = routes._save_session_draft
+
+    def save_draft_spy(sid_value, draft_payload):
+        assert entered_lock
+        assert draft_payload["text"] == ""
+        assert draft_payload["files"] == []
+        return original_save(sid_value, draft_payload)
+
+    monkeypatch.setattr(routes, "_save_session_draft", save_draft_spy)
+    _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": 999,
+            "files": {"not": "a-list"},
+        },
     )
 
 
-def test_draft_files_clamped_to_50_entries():
-    """Posting a >50-entry files list should be silently truncated."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    assert "_MAX_DRAFT_FILES = 50" in src, (
-        "routes.py must define _MAX_DRAFT_FILES clamp"
-    )
-    assert "files = files[:_MAX_DRAFT_FILES]" in src, (
-        "routes.py must truncate over-large draft files list"
-    )
+def test_draft_save_does_not_touch_session_updated_at(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
 
+    sid = "draft-save-activity"
+    models.Session(
+        session_id=sid,
+        title="Draft validation",
+        messages=[{"role": "assistant", "content": "x" * 200_000}],
+        updated_at=1234.0,
+    ).save(touch_updated_at=False, skip_index=True)
 
-def test_draft_text_type_coerced_to_string():
-    """Non-string text must be coerced to empty string, not stored as-is."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    # The type-coerce pattern must be present.
-    assert 'if text is not None and not isinstance(text, str):' in src, (
-        "routes.py must coerce non-string text to empty string before persist"
-    )
+    session_sidecar = models.SESSION_DIR / f"{sid}.json"
+    before = json.loads(session_sidecar.read_text(encoding="utf-8"))
 
-
-def test_draft_files_type_coerced_to_list():
-    """Non-list files must be coerced to empty list."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    assert 'if files is not None and not isinstance(files, list):' in src, (
-        "routes.py must coerce non-list files to empty list before persist"
+    captured = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": "new draft text",
+            "files": [],
+        },
     )
 
+    after = json.loads(session_sidecar.read_text(encoding="utf-8"))
+    assert captured["payload"]["draft"] == {"text": "new draft text", "files": []}
+    assert after["updated_at"] == before["updated_at"]
+    assert after["composer_draft"] == before["composer_draft"]
 
-def test_draft_validation_appears_before_persist():
-    """The validation must run BEFORE the lock acquire / save, not after."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    # Anchor on the unique POST-validation comment marker.
-    marker_idx = src.find("Stage-326 hardening (per Opus advisor)")
-    persist_idx = src.find("s.composer_draft = next_draft\n                # Draft persistence is not conversation activity")
-    assert marker_idx != -1 and persist_idx != -1, (
-        "could not locate validation marker or persist site"
+
+def test_draft_save_skips_unchanged_payload_before_persist(monkeypatch, tmp_path):
+    models, routes = _build_draft_env(tmp_path, monkeypatch)
+
+    sid = "draft-save-noop"
+    models.Session(
+        session_id=sid,
+        title="Draft validation noop",
+        messages=[{"role": "user", "content": "hello"}],
+    ).save(touch_updated_at=False, skip_index=True)
+
+    draft_calls = []
+    original_save_draft = routes._save_session_draft
+
+    def save_draft_spy(sid_value, draft_payload):
+        draft_calls.append((sid_value, draft_payload))
+        return original_save_draft(sid_value, draft_payload)
+
+    monkeypatch.setattr(routes, "_save_session_draft", save_draft_spy)
+
+    first = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": "persistent draft",
+            "files": [],
+        },
     )
-    assert marker_idx < persist_idx, (
-        "validation block must run before composer_draft persist"
+    second = _draft_post(
+        monkeypatch,
+        routes,
+        {
+            "session_id": sid,
+            "text": "persistent draft",
+            "files": [],
+        },
     )
 
-
-def test_draft_save_does_not_touch_session_updated_at():
-    """Autosaving the composer must not look like conversation activity.
-
-    If POST /api/session/draft bumps updated_at, the frontend's active-session
-    external refresh poll treats every keystroke autosave as a remote session
-    update and force-reloads the current chat a few seconds later.
-    """
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    persist_idx = src.find("s.composer_draft = next_draft")
-    assert persist_idx != -1, "could not locate composer draft persist site"
-    save_idx = src.find("s.save(touch_updated_at=False, skip_index=True)", persist_idx)
-    assert save_idx != -1, "composer draft save must preserve session updated_at and skip index churn"
-
-
-def test_draft_save_skips_unchanged_payload_before_persist():
-    """Duplicate debounced draft POSTs should not rewrite the full session JSON."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    draft_idx = src.find('current_draft = dict(getattr(s, "composer_draft", {}) or {})')
-    unchanged_idx = src.find("if next_draft == current_draft", draft_idx)
-    save_idx = src.find("s.save(touch_updated_at=False, skip_index=True)", draft_idx)
-
-    assert draft_idx != -1, "draft route should snapshot current composer_draft"
-    assert unchanged_idx != -1, "draft route should no-op unchanged normalized payloads"
-    assert save_idx != -1, "draft route should still save changed drafts"
-    assert unchanged_idx < save_idx, "unchanged guard must run before full session save"
-    assert 'payload["unchanged"] = True' in src
+    assert second["payload"].get("unchanged") is True
+    assert len(draft_calls) == 1
+    assert first["payload"]["draft"] == {"text": "persistent draft", "files": []}


### PR DESCRIPTION
## Thinking Path

- Typing in a large conversation can stall because each changed composer draft waits on a server write whose cost grows with the full transcript.
- `POST /api/session/draft` updated a small draft payload but persisted it through `Session.save()`, serializing and replacing the entire session JSON file on every changed autosave.
- The narrow fix is to persist composer drafts in small atomic per-session files and overlay them when canonical session data is loaded.
- The endpoint contract, validation limits, session activity timestamps, index behavior, and frontend draft flow remain unchanged; embedded drafts remain the compatibility fallback for existing sessions.
- An explicit empty dedicated draft remains authoritative so clearing a migrated legacy draft cannot resurrect stale text after reload.
- Sidebar/session-list caching and textarea layout work are intentionally outside this persistence-focused change.

## What Changed

- Added atomic per-session draft persistence under the session store's hidden `.drafts` directory.
- Changed draft autosaves to write only the draft payload instead of calling the full session save path.
- Overlaid dedicated drafts on full and metadata-only canonical session loads, with legacy embedded drafts as fallback.
- Removed dedicated drafts when their owning session is deleted or cleaned up.
- Serialized draft saves and deletes with bounded lock striping, made main-session deletion precede final draft cleanup, and discarded autosaves whose owning session had already been removed.
- Preserved diskless New Chat durability by materializing one small zero-message owner record before its first meaningful draft; subsequent autosaves remain sidecar-only.
- Revalidated session identity after the agent lock, routed stale pre-compression draft writes to the authoritative live continuation, and paired cache eviction/unlink with cold-load recache checks so deletion cannot resurrect an owner.
- Propagated draft-unlink failures from single-session deletion and orphan cleanup instead of reporting complete success while plaintext draft data remains.
- Replaced source-presence draft validation checks with runtime coverage and added regression tests for large-session no-rewrite behavior, migration precedence, explicit clears, malformed fallback, scanner isolation, first-write restore, real compression snapshot migration, SID rotation, deletion races, and cleanup failures.

## Why It Matters

- Draft-save latency no longer scales with transcript size.
- A 6.0 MB isolated session benchmark reduced median changed-draft persistence from `39.378 ms` to `4.144 ms` across 20 writes, while the main session file remained untouched.
- Existing sessions continue to restore embedded drafts until a dedicated draft is written.
- Normal session ordering and external-refresh behavior remain stable because draft saves still do not update conversation activity metadata.

## Verification

Focused draft and neighboring composer coverage:

`python -m pytest -q tests/test_stage326_composer_draft_validation.py tests/test_composer_draft_sidecar_regressions.py tests/test_issue_new_chat_draft_restore.py tests/test_composer_draft_after_send.py tests/test_issue5472_preserve_draft_on_failed_send.py`

Result: `51 passed in 6.07s`

Session recovery, deletion, security, and claim-path coverage:

`python -m pytest -q tests/test_session_recovery_audit.py tests/test_session_recovery_api.py tests/test_sprint3.py tests/test_chat_start_claim_cli_session.py`

Result: `82 passed in 4.87s`

Maintainer-feedback and broad regression coverage:

- Composer-draft, New Chat restore, compression, session recovery, and regression coverage: `202 passed in 9.67s`.
- The continuation regressions use real snapshot preservation, session-cache migration, lock alias/removal, cold loading of the archived SID, and process-state eviction/reload.
- Final independent review exercised 102 `get_session` / `_resolve_session`-related test files repeatedly: `1871 passed, 1 skipped`, with one independently confirmed unrelated timing flake.

Changed-line lint:

`python scripts/ruff_lint.py --diff origin/master`

Result: zero findings on added or modified lines.

Syntax and hygiene:

`python -m py_compile api/models.py api/routes.py tests/test_stage326_composer_draft_validation.py tests/test_composer_draft_sidecar_regressions.py`

`git diff --check`

Result: pass.

Isolated endpoint benchmark, 20 changed drafts against a ~6.0 MB session:

- Before: median `39.378 ms`, p95 `48.402 ms`; main session file rewritten.
- After: median `4.144 ms`, p95 `6.181 ms`; main session file unchanged.

## Risks / Follow-ups

- This changes draft storage ownership but not the HTTP or frontend contract. Existing embedded drafts remain readable as a migration fallback.
- Concurrent autosave/deletion interleavings are serialized in process; deterministic regressions cover lifecycle locking, route ordering, cold-load recache, and zero-message owner materialization.
- No screenshots are included because this is a backend persistence change with no visual or layout changes.
- Sidebar refresh and model-catalog latency are separate concerns and are not changed here.

## Model Used

- OpenAI / `gpt-5.6-sol` for investigation, specification, orchestration, and verification.
- OpenAI / `gpt-5.3-codex-spark` (`xhigh`) through Codex for implementation and code review.
- Anthropic / `claude-opus-4-8` and `claude-opus-5` (`high`) through Claude Code for independent review and concurrency remediation.
- Maintainer `nesquena-hermes` reviewer / model undisclosed for the first-write durability, SID-rotation, and deletion-failure review probe.


