### PR TITLE
feat(sessions): temporary chats excluded from default history

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1234,6 +1234,7 @@ class Session:
                  process_wakeup_pause=None,
                  share_token=None,
                  share_created_at=None,
+                 temporary: bool=False,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
@@ -1322,6 +1323,11 @@ class Session:
         self.process_wakeup_pause = process_wakeup_pause if isinstance(process_wakeup_pause, dict) else {}
         self.share_token = str(share_token).strip() if share_token else None
         self.share_created_at = share_created_at
+        # Temporary chats are WebUI-owned sessions with memory commit skipped.
+        # Ephemeral WebUI chat: excluded from default /api/sessions + search,
+        # skipped for durable memory commit. Still persisted on first message so
+        # the active tab can reload mid-conversation; clients delete on leave.
+        self.temporary = bool(temporary)
         # #5854: a compact fingerprint of anchor_activity_scenes ({scene_key:
         # updated_at}) persisted BEFORE the messages array so the sidebar-poll
         # freshness check can compare scene freshness without parsing the full
@@ -1393,6 +1399,7 @@ class Session:
             'enabled_toolsets', 'composer_draft',
             'process_wakeup_pause',
             'share_token', 'share_created_at',
+            'temporary',
         ]
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
         # #5854: message_count and a compact anchor-scene fingerprint go in the
@@ -1776,6 +1783,7 @@ class Session:
             'process_wakeup_pause': self.process_wakeup_pause if isinstance(self.process_wakeup_pause, dict) else {},
             'share_token': self.share_token,
             'share_created_at': self.share_created_at,
+            'temporary': bool(getattr(self, 'temporary', False)),
             'is_streaming': _is_streaming_session(
                 self.active_stream_id, active_stream_ids
             ) if include_runtime else False,
@@ -4650,7 +4658,7 @@ def _profile_default_model_state(profile=None):
     return default_model or get_effective_default_model(), default_provider
 
 
-def new_session(workspace=None, model=None, profile=None, model_provider=None, project_id=None, worktree_info=None, enabled_toolsets=None):
+def new_session(workspace=None, model=None, profile=None, model_provider=None, project_id=None, worktree_info=None, enabled_toolsets=None, temporary=False):
     """Create a new in-memory session.
 
     The session lives in the SESSIONS dict only — no disk write happens until
@@ -4674,6 +4682,13 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None, p
     on different profiles don't fight over a shared process-global.  If not
     supplied, we fall back to the process-level active profile (the pre-#798
     behaviour, preserved for calls that originate outside a request context).
+
+    *temporary* — when True, the session is flagged as an ephemeral WebUI chat:
+    excluded from the default ``GET /api/sessions`` history list and search
+    (opt in with ``?include_temporary=1``), skipped for durable memory commit.
+    Still saved on first message so the active tab can reload mid-conversation;
+    clients are expected to delete on leave / tab close. Direct
+    ``GET /api/session?session_id=`` remains available while the sidecar exists.
     """
     if profile is None:
         # Fallback: read process-level global (single-client or startup path)
@@ -4704,6 +4719,7 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None, p
         worktree_repo_root=wt.get('repo_root') if wt else None,
         worktree_created_at=wt.get('created_at') if wt else None,
         enabled_toolsets=enabled_toolsets,
+        temporary=bool(temporary),
     )
     # #4985: defensive — auto-generated uuids don't collide with the
     # tombstone, but if a future caller ever passes an explicit id that

--- a/api/routes.py
+++ b/api/routes.py
@@ -1911,6 +1911,7 @@ def _session_list_cache_key(
     archived_limit: int | None = None,
     archived_offset: int = 0,
     show_claude_code_sessions: bool = True,
+    exclude_temporary: bool = False,
 ) -> tuple:
     return _route_session_list_cache_key(
         active_profile=active_profile,
@@ -1926,7 +1927,7 @@ def _session_list_cache_key(
         sidebar_source=sidebar_source,
         archived_limit=archived_limit,
         archived_offset=archived_offset,
-    ) + (bool(show_claude_code_sessions),)
+    ) + (bool(show_claude_code_sessions), bool(exclude_temporary))
 
 _ROUTE_SESSION_LIST_CACHE_DYNAMIC_EXPORTS = {
     "_SESSIONS_CACHE_ALL_PROFILES_INVALIDATION_VERSION",
@@ -2171,6 +2172,7 @@ def _build_session_list_cache_payload(
     sidebar_source: str | None = None,
     archived_limit: int | None = None,
     archived_offset: int = 0,
+    exclude_temporary: bool = False,
     diag=None,
 ) -> dict:
     diag_stage = diag.stage if diag is not None else lambda *_a, **_k: None
@@ -2219,6 +2221,10 @@ def _build_session_list_cache_payload(
     show_cron_sessions = bool(show_cron_sessions)
     show_webhook_sessions = bool(show_webhook_sessions)
     webui_sessions = [_normalize_sidebar_source_flags(s) for s in webui_sessions]
+    # Temporary chats are addressable by id but excluded from the default
+    # history/sidebar list unless the caller opts in (?include_temporary=1).
+    if exclude_temporary:
+        webui_sessions = [s for s in webui_sessions if not s.get("temporary")]
     if show_cli_sessions:
         diag_stage("get_cli_sessions")
         if _callable_accepts_kwarg(get_cli_sessions, "include_claude_code"):
@@ -9818,6 +9824,7 @@ _SIDEBAR_SESSION_RESPONSE_FIELDS = {
     "worktree_branch",
     "parent_session_id",
     "parent_title",
+    "temporary",
     "parent_source",
     "relationship_type",
     "pre_compression_snapshot",
@@ -13128,6 +13135,9 @@ def handle_get(handler, parsed) -> bool:
             all_profiles = _all_profiles_enabled(parsed)
             include_archived = _query_flag(parsed, "include_archived")
             exclude_hidden = _query_flag(parsed, "exclude_hidden")
+            # Default sidebar/history excludes temporary chats; opt in with
+            # ?include_temporary=1 (admin/debug). Direct GET /api/session?id= still works.
+            exclude_temporary = not _query_flag(parsed, "include_temporary")
             archived_limit = _query_positive_int(parsed, "archived_limit", default=None, maximum=2000)
             archived_offset = _query_positive_int(parsed, "archived_offset", default=0, maximum=200000)
             sidebar_source = parse_qs(parsed.query).get("sidebar_source", [""])[0].strip().lower() or None
@@ -13150,6 +13160,7 @@ def handle_get(handler, parsed) -> bool:
                 sidebar_source=sidebar_source,
                 archived_limit=archived_limit,
                 archived_offset=archived_offset,
+                exclude_temporary=exclude_temporary,
             )
             # Keep the visible /api/sessions contract unchanged even though the
             # heavy lifting now lives in the cache builder: profile scoping via
@@ -13172,6 +13183,7 @@ def handle_get(handler, parsed) -> bool:
                     sidebar_source=sidebar_source,
                     archived_limit=archived_limit,
                     archived_offset=archived_offset,
+                    exclude_temporary=exclude_temporary,
                     diag=diag,
                 ),
                 diag=diag,
@@ -14296,6 +14308,15 @@ def handle_post(handler, parsed) -> bool:
                 # the new session (#5420).
                 prev_session_id = None
             if prev_session_id:
+                # Skip durable memory commit for temporary chats — they are
+                # ephemeral by contract and must not seed long-term memory.
+                try:
+                    prev_obj = get_session(prev_session_id)
+                except Exception:
+                    prev_obj = None
+                if prev_obj is not None and bool(getattr(prev_obj, "temporary", False)):
+                    prev_session_id = None
+            if prev_session_id:
                 # Fire-and-forget: commit_memory_session() can take 1-5+ seconds
                 # (extraction call to the memory provider), and blocking the
                 # response here made "+ New Chat" feel slow/unresponsive.
@@ -14339,6 +14360,11 @@ def handle_post(handler, parsed) -> bool:
                 # thread the drain snapshot already missed).
                 if _register_background_commit_thread(t):
                     t.start()
+        raw_temporary = body.get("temporary")
+        temporary = (
+            raw_temporary is True
+            or str(raw_temporary).strip().lower() in {"1", "true", "yes", "on"}
+        ) if raw_temporary is not None else False
         s = new_session(
             workspace=workspace,
             model=model,
@@ -14347,6 +14373,7 @@ def handle_post(handler, parsed) -> bool:
             project_id=body.get("project_id") or None,
             worktree_info=worktree_info,
             enabled_toolsets=enabled_toolsets,
+            temporary=temporary,
         )
         if worktree_info:
             publish_session_list_changed(
@@ -16858,6 +16885,10 @@ def _handle_sessions_search(handler, parsed):
             s for s in sessions
             if _profiles_match(s.get("profile"), active_profile)
         ]
+    # Match /api/sessions: temporary chats stay out of default search unless
+    # ?include_temporary=1. Direct open-by-id remains available.
+    if not _query_flag(parsed, "include_temporary"):
+        sessions = [s for s in sessions if not s.get("temporary")]
     # Reject a malformed depth instead of letting int() raise ValueError and
     # surface as a confusing 500. Clamp to >= 0 so a negative value can't reach
     # the messages[:depth] slice below — messages[:-n] would silently exclude

--- a/api/session_lifecycle.py
+++ b/api/session_lifecycle.py
@@ -190,8 +190,22 @@ def mark_turn_completed(session_id: str, *, agent=None) -> int:
             segments[-1]["end"] = generation
         else:
             segments.append({"start": generation, "end": generation, "agent": owner})
+        _discard_temporary_uncommitted_work(session_id, entry)
         _condition.notify_all()
         return generation
+
+
+def _discard_temporary_uncommitted_work(session_id: str, entry: dict) -> None:
+    """Temporary chats skip durable memory — do not retain phantom uncommitted work."""
+    try:
+        from api.models import get_session
+
+        session = get_session(session_id, metadata_only=True)
+        if session is None or not bool(getattr(session, "temporary", False)):
+            return
+    except Exception:
+        return
+    entry["committed_generation"] = entry["generation"]
 
 
 def has_uncommitted_work(session_id: str) -> bool:

--- a/api/session_lifecycle.py
+++ b/api/session_lifecycle.py
@@ -215,6 +215,14 @@ def _first_uncommitted_segment(entry: dict) -> dict | None:
 def commit_session_memory(session_id: str, agent=None, *, wait: bool = False, timeout: float | None = None) -> bool:
     if not session_id:
         return False
+    # Temporary chats must never seed durable memory.
+    try:
+        from api.models import get_session
+        session = get_session(session_id)
+        if session is not None and bool(getattr(session, "temporary", False)):
+            return False
+    except Exception:
+        pass
     deadline = time.monotonic() + timeout if timeout is not None else None
     with _condition:
         entry = _sessions.get(session_id)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -719,6 +719,10 @@ def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
         "- Write to external notes or durable memory only for explicit captures, durable user preferences, decisions, blockers/open issues, runbook-worthy workflows, or other clearly reusable signals; otherwise leave notes unchanged.",
         "- When you do write or update a durable note, briefly tell the user what note/section changed so the write is reviewable.",
     ]
+    if surface_context.get("temporary"):
+        lines.append(
+            "- This is a temporary chat: do not write durable memory or external notes unless the user explicitly asks."
+        )
     fields = (
         ("source", "Source"),
         ("session_id", "Session ID"),
@@ -8970,6 +8974,7 @@ def _run_agent_streaming(
                     'session_id': session_id,
                     'profile': getattr(s, 'profile', None),
                     'workspace': s.workspace,
+                    'temporary': bool(getattr(s, 'temporary', False)),
                 },
                 config_data=_cfg,
             )

--- a/static/boot.js
+++ b/static/boot.js
@@ -1357,6 +1357,28 @@ window._readPersistedDefaultMessageMode=_readPersistedDefaultMessageMode;
 // the boot window honor the persisted preference instead of the raw default.
 window._defaultMessageMode=_readPersistedDefaultMessageMode();
 
+function _readPersistedTemporaryNewChat(){
+  try{return localStorage.getItem('hermes-temporary-new-chat')==='1';}catch(_){return false;}
+}
+function _persistTemporaryNewChat(on){
+  window._temporaryNewChat=!!on;
+  try{localStorage.setItem('hermes-temporary-new-chat',on?'1':'0');}catch(_){}
+}
+window._persistTemporaryNewChat=_persistTemporaryNewChat;
+window._temporaryNewChat=_readPersistedTemporaryNewChat();
+function toggleTemporaryNewChat(){
+  _persistTemporaryNewChat(!window._temporaryNewChat);
+  if(typeof _syncTemporaryNewChatButton==='function') _syncTemporaryNewChatButton();
+}
+window.toggleTemporaryNewChat=toggleTemporaryNewChat;
+function _syncTemporaryNewChatButton(){
+  const btn=$('btnTemporaryChat');
+  if(!btn) return;
+  btn.classList.toggle('on', window._temporaryNewChat);
+  btn.setAttribute('aria-pressed', window._temporaryNewChat?'true':'false');
+}
+window._syncTemporaryNewChatButton=_syncTemporaryNewChatButton;
+
 // ── Extension TTS-engine registry (registerHermesTtsEngine) ──────────────────
 // Defined at MODULE scope (not inside the voice-mode IIFE below) so the public
 // API exists even on browsers without SpeechRecognition / speechSynthesis — an
@@ -3780,6 +3802,7 @@ window._mirrorSpeechSettingsFromServer=_mirrorSpeechSettingsFromServer;
   // no saved session - show empty state, wait for user to hit +
   S._bootReady=true;
   syncTopbar();
+  if(typeof _syncTemporaryNewChatButton==='function') _syncTemporaryNewChatButton();
   // Restore panel pref so the workspace panel stays visible on a fresh load if the
   // user had it open during their last session (#workspace-persist).
   const _freshPanelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'

--- a/static/index.html
+++ b/static/index.html
@@ -597,6 +597,7 @@
         <div class="composer-footer">
           <div class="composer-left">
             <input type="file" id="fileInput" class="file-input-visually-hidden" multiple accept="image/*,text/*,application/pdf,application/json,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.md,.py,.js,.ts,.yaml,.yml,.toml,.csv,.sh,.txt,.log,.env,.xls,.xlsx,.doc,.docx,.zip,.tar,.gz,.tgz,.bz2,.xz">
+            <button type="button" class="composer-temp-chip" id="btnTemporaryChat" onclick="toggleTemporaryNewChat()" aria-pressed="false" title="Temporary chat — new chats stay out of default history and skip durable memory">Temp</button>
             <button type="button" class="icon-btn has-tooltip" id="btnAttach" data-tooltip="Attach files" data-i18n-title="composer_control_attach" data-i18n-aria-label="composer_control_attach" aria-label="Attach files">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
             </button>

--- a/static/panels.js
+++ b/static/panels.js
@@ -6306,7 +6306,7 @@ async function promptWorkspacePath(){
     try{
       // System-minted session (#6022): worktree:false is explicit so a config
       // worktree default can't leak a worktree from a workspace prompt.
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false,...(window._temporaryNewChat?{temporary:true}:{})})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];if(typeof syncTopbar==='function')syncTopbar();if(typeof renderMessages==='function')renderMessages();if(typeof renderSessionList==='function')await renderSessionList();}
     }catch(e){showToast(t('workspace_switch_failed')+e.message);return;}
     if(!S.session)return;
@@ -6344,7 +6344,7 @@ async function switchToWorkspace(path,name){
     try{
       // System-minted session (#6022): explicit worktree:false — a workspace
       // switch from a blank page is not deliberate New Chat intent.
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false,...(window._temporaryNewChat?{temporary:true}:{})})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];if(typeof syncTopbar==='function')syncTopbar();if(typeof renderMessages==='function')renderMessages();if(typeof renderSessionList==='function')await renderSessionList();}
     }catch(e){if(typeof setStatus==='function')setStatus(t('switch_failed')+e.message);return;}
     if(!S.session)return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1402,6 +1402,7 @@ async function newSession(flash, options={}){
       workspace:inheritWs,
       profile:S.activeProfile||'default',
     };
+    if(window._temporaryNewChat) reqBody.temporary=true;
     if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
     // Three-value worktree contract (#6022): explicit true/false is forwarded
     // verbatim; an ABSENT key lets the server apply the agent's config-level

--- a/static/style.css
+++ b/static/style.css
@@ -2606,6 +2606,9 @@
   .composer-toolsets-wrap,
   .composer-model-wrap{position:relative;flex:0 0 auto;}
   .composer-profile-chip{display:inline-flex;align-items:center;gap:8px;max-width:180px;padding:8px 10px 8px 12px;border-radius:999px;border:1px solid transparent;background-color:transparent;font-weight:500;cursor:pointer;transition:color .15s,background-color .15s,border-color .15s;}
+  .composer-temp-chip{display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;padding:6px 10px;border-radius:999px;border:1px dashed var(--border2);background:transparent;color:var(--muted);cursor:pointer;white-space:nowrap;}
+  .composer-temp-chip:hover{color:var(--text);border-color:var(--accent);}
+  .composer-temp-chip.on{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 45%,var(--border2));background:color-mix(in srgb,var(--accent) 12%,transparent);}
   .composer-profile-chip:hover{background-color:var(--hover-bg);}
   .composer-profile-chip.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);}
   .composer-profile-chip.switching{opacity:.65;cursor:wait;pointer-events:none;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -20393,7 +20393,7 @@ async function promptNewFile(targetDir = S.currentDir || '.'){
     try{
       // System-minted session (#6022): explicit worktree:false — creating a
       // file from a blank page must not inherit the config worktree default.
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false,...(window._temporaryNewChat?{temporary:true}:{})})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];syncTopbar();renderMessages();await renderSessionList();}
     }catch(e){setStatus(t('create_failed')+e.message);return;}
   }
@@ -20426,7 +20426,7 @@ async function promptNewFolder(targetDir = S.currentDir || '.'){
     try{
       // System-minted session (#6022): explicit worktree:false — creating a
       // folder from a blank page must not inherit the config worktree default.
-      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false})});
+      const r=await api('/api/session/new',{method:'POST',body:JSON.stringify({workspace:ws,worktree:false,...(window._temporaryNewChat?{temporary:true}:{})})});
       if(r&&r.session){S._pendingSessionToolsets=null;S.session=r.session;S.messages=[];syncTopbar();renderMessages();await renderSessionList();}
     }catch(e){setStatus(t('folder_create_failed')+e.message);return;}
   }

--- a/tests/test_temporary_chats.py
+++ b/tests/test_temporary_chats.py
@@ -1,0 +1,215 @@
+"""Tests for temporary session creation and list/search exclusion."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from urllib.parse import urlparse
+
+import api.routes as routes
+
+
+def _post(path: str, body: dict, monkeypatch):
+    cap = {}
+
+    def _j(_handler, payload, *_, status=200, **__):
+        cap["ok"] = payload
+        cap["status"] = status
+        return True
+
+    def _bad(_handler, msg, status=400, **__):
+        cap["bad"] = (msg, status)
+        return True
+
+    handler = MagicMock()
+    handler.command = "POST"
+    handler.headers = {}
+
+    monkeypatch.setattr(routes, "read_body", lambda _h: body)
+    monkeypatch.setattr(routes, "_check_csrf", lambda _h: True)
+    monkeypatch.setattr(routes, "_csrf_exempt_path", lambda _p: False)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_a, **_k: True)
+    monkeypatch.setattr(routes, "j", _j)
+    monkeypatch.setattr(routes, "bad", _bad)
+
+    routes.handle_post(handler, urlparse(path))
+    return cap
+
+
+def test_session_new_accepts_temporary_flag(monkeypatch):
+    captured = {}
+
+    class _Session:
+        def __init__(self):
+            self.session_id = "tmp1"
+            self.profile = "default"
+            self.messages = []
+            self.temporary = False
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "temporary": self.temporary,
+            }
+
+    def _new_session(**kwargs):
+        captured.update(kwargs)
+        s = _Session()
+        s.temporary = bool(kwargs.get("temporary"))
+        return s
+
+    monkeypatch.setattr(routes, "new_session", _new_session)
+    monkeypatch.setattr(
+        routes,
+        "_session_id_visible_to_request_profile",
+        lambda *_a, **_k: True,
+    )
+
+    cap = _post("/api/session/new", {"temporary": True}, monkeypatch)
+    assert "bad" not in cap
+    assert captured.get("temporary") is True
+    assert cap["ok"]["session"]["temporary"] is True
+
+
+def test_session_new_defaults_temporary_false(monkeypatch):
+    captured = {}
+
+    class _Session:
+        def __init__(self):
+            self.session_id = "norm1"
+            self.profile = "default"
+            self.messages = []
+            self.temporary = False
+
+        def compact(self):
+            return {"session_id": self.session_id, "temporary": self.temporary}
+
+    def _new_session(**kwargs):
+        captured.update(kwargs)
+        s = _Session()
+        s.temporary = bool(kwargs.get("temporary"))
+        return s
+
+    monkeypatch.setattr(routes, "new_session", _new_session)
+
+    cap = _post("/api/session/new", {}, monkeypatch)
+    assert "bad" not in cap
+    assert captured.get("temporary") is False
+    assert cap["ok"]["session"]["temporary"] is False
+
+
+def _webui_row(sid: str, *, temporary: bool = False, message_count: int = 1) -> dict:
+    return {
+        "session_id": sid,
+        "title": sid,
+        "profile": "default",
+        "updated_at": 100,
+        "last_message_at": 100,
+        "message_count": message_count,
+        "read_only": False,
+        "source_tag": "webui",
+        "raw_source": "webui",
+        "session_source": "webui",
+        "source_label": "WebUI",
+        "is_cli_session": False,
+        "temporary": temporary,
+    }
+
+
+def test_session_list_excludes_temporary_by_default(monkeypatch):
+    """Default history/sidebar list must not surface temporary chats."""
+    rows = [
+        _webui_row("keep-me", temporary=False),
+        _webui_row("tmp-me", temporary=True),
+    ]
+    monkeypatch.setattr(routes, "all_sessions", lambda **_k: list(rows))
+    monkeypatch.setattr(routes, "get_cli_sessions", lambda **_k: [])
+    monkeypatch.setattr(
+        routes, "_reconcile_stale_stream_state_for_session_rows", lambda *_a, **_k: False
+    )
+    monkeypatch.setattr(
+        routes, "_prune_orphaned_webui_zero_message_sessions", lambda rows, **_k: rows
+    )
+
+    excluded = routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+        exclude_temporary=True,
+    )
+    ids = [s["session_id"] for s in excluded["sessions"]]
+    assert "keep-me" in ids
+    assert "tmp-me" not in ids
+
+    included = routes._build_session_list_cache_payload(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+        exclude_temporary=False,
+    )
+    ids_in = [s["session_id"] for s in included["sessions"]]
+    assert "keep-me" in ids_in
+    assert "tmp-me" in ids_in
+
+
+def test_session_list_cache_key_includes_exclude_temporary():
+    base = dict(
+        active_profile="default",
+        all_profiles=False,
+        show_cli_sessions=False,
+        show_previous_messaging_sessions=False,
+        show_cron_sessions=False,
+    )
+    key_ex = routes._session_list_cache_key(**base, exclude_temporary=True)
+    key_in = routes._session_list_cache_key(**base, exclude_temporary=False)
+    assert key_ex != key_in
+    assert key_ex[-1] is True
+    assert key_in[-1] is False
+
+
+def test_sessions_search_excludes_temporary_by_default(monkeypatch):
+    rows = [
+        _webui_row("keep-search", temporary=False),
+        _webui_row("tmp-search", temporary=True),
+    ]
+    # Titles match the query so both would hit without the temporary filter.
+    rows[0]["title"] = "alpha keep"
+    rows[1]["title"] = "alpha tmp"
+
+    monkeypatch.setattr(routes, "all_sessions", lambda **_k: list(rows))
+    monkeypatch.setattr(routes, "_all_profiles_enabled", lambda _p: False)
+    monkeypatch.setattr(routes, "_profiles_match", lambda a, b: True)
+    monkeypatch.setattr(routes, "load_settings", lambda: {})
+
+    import api.profiles as profiles
+
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    captured = {}
+
+    def _j(_handler, payload, *_, **__):
+        captured["payload"] = payload
+        return True
+
+    handler = MagicMock()
+    monkeypatch.setattr(routes, "j", _j)
+
+    # Default: temporary excluded
+    routes._handle_sessions_search(
+        handler, urlparse("/api/sessions/search?q=alpha&content=0")
+    )
+    default_ids = [s["session_id"] for s in captured["payload"].get("sessions", [])]
+    assert "keep-search" in default_ids
+    assert "tmp-search" not in default_ids
+
+    # Opt-in: temporary included
+    routes._handle_sessions_search(
+        handler,
+        urlparse("/api/sessions/search?q=alpha&content=0&include_temporary=1"),
+    )
+    opt_ids = [s["session_id"] for s in captured["payload"].get("sessions", [])]
+    assert "keep-search" in opt_ids
+    assert "tmp-search" in opt_ids

--- a/tests/test_temporary_chats.py
+++ b/tests/test_temporary_chats.py
@@ -213,3 +213,16 @@ def test_sessions_search_excludes_temporary_by_default(monkeypatch):
     opt_ids = [s["session_id"] for s in captured["payload"].get("sessions", [])]
     assert "keep-search" in opt_ids
     assert "tmp-search" in opt_ids
+
+
+def test_mark_turn_completed_discards_temporary_uncommitted_work(monkeypatch):
+    from api.session_lifecycle import mark_turn_completed, has_uncommitted_work, _reset_for_tests
+
+    _reset_for_tests()
+    sid = "tmp-lifecycle"
+    monkeypatch.setattr(
+        "api.models.get_session",
+        lambda _sid, metadata_only=False: type("S", (), {"temporary": True})(),
+    )
+    mark_turn_completed(sid, agent=object())
+    assert has_uncommitted_work(sid) is False

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -38,6 +38,20 @@ def test_webui_ephemeral_prompt_includes_browser_surface_context():
     assert "Need script" in prompt
     assert "Need inspect email" in prompt
     assert "clear user-facing progress" in prompt
+    assert "temporary chat" not in prompt.lower()
+
+
+def test_webui_ephemeral_prompt_temporary_hint():
+    prompt = _webui_ephemeral_system_prompt(
+        None,
+        surface_context={
+            "source": "webui",
+            "session_id": "temp-1",
+            "temporary": True,
+        },
+    )
+    assert "temporary chat" in prompt.lower()
+    assert "do not write durable memory" in prompt.lower()
 
 
 def test_webui_ephemeral_prompt_skips_empty_surface_fields():


### PR DESCRIPTION
## Summary
- Add `temporary` session flag end-to-end (create, compact, sidebar fields, surface context).
- Skip durable memory commit for temporary chats.
- Exclude temporary sessions from default `/api/sessions` and search unless `?include_temporary=1`.

## Test plan
- [x] `./scripts/test.sh tests/test_temporary_chats.py tests/test_webui_surface_context.py`
- [ ] Manual: create temporary chat, confirm absent from sidebar, still openable by id

Made with [Cursor](https://cursor.com)