### PR TITLE
feat(api): add POST /api/feedback backend endpoint

### DIFF
--- a/api/feedback.py
+++ b/api/feedback.py
@@ -101,6 +101,31 @@ def _assert_session_exists(session_id: str) -> None:
         raise FeedbackValidationError("session not found") from exc
 
 
+def _assert_message_target(
+    session_id: str,
+    message_id: str | None,
+    message_index: int | None,
+) -> None:
+    from api.models import get_session
+
+    session = get_session(session_id, metadata_only=False)
+    messages = list(getattr(session, "messages", None) or [])
+    if message_index is not None:
+        if message_index >= len(messages):
+            raise FeedbackValidationError("index out of range")
+    if message_id is not None:
+        found = False
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            identity = msg.get("id") or msg.get("message_id")
+            if identity is not None and str(identity) == message_id:
+                found = True
+                break
+        if not found:
+            raise FeedbackValidationError("message_id not found in session")
+
+
 def normalize_feedback_payload(body: Any, *, validate_session: bool = True) -> dict:
     """Validate and normalize a POST /api/feedback body. Fail closed."""
     if not isinstance(body, dict):
@@ -127,6 +152,8 @@ def normalize_feedback_payload(body: Any, *, validate_session: bool = True) -> d
 
     if message_id is None and message_index is None:
         raise FeedbackValidationError("message_id or index is required")
+    if validate_session:
+        _assert_message_target(session_id, message_id, message_index)
 
     reason = _optional_str(body.get("reason"), field="reason", max_len=64)
     if reason is not None:
@@ -141,9 +168,11 @@ def normalize_feedback_payload(body: Any, *, validate_session: bool = True) -> d
 
     model = _optional_str(body.get("model"), field="model", max_len=_MAX_MODEL_LEN)
     mode = _optional_str(body.get("mode"), field="mode", max_len=_MAX_MODE_LEN)
-    profile = _optional_str(body.get("profile"), field="profile", max_len=_MAX_PROFILE_LEN)
-    if profile is None:
-        profile = _active_profile_name()
+    active_profile = _active_profile_name()
+    profile_override = _optional_str(body.get("profile"), field="profile", max_len=_MAX_PROFILE_LEN)
+    if profile_override is not None and profile_override != active_profile:
+        raise FeedbackValidationError("profile does not match active profile")
+    profile = active_profile
 
     record = {
         "ts": time.time(),
@@ -164,19 +193,40 @@ def normalize_feedback_payload(body: Any, *, validate_session: bool = True) -> d
     return record
 
 
+def _prune_rate_limit_keys(cutoff: float) -> None:
+    for key in list(_RATE_HITS):
+        timestamps = [ts for ts in _RATE_HITS.get(key, []) if ts >= cutoff]
+        if timestamps:
+            _RATE_HITS[key] = timestamps
+        else:
+            del _RATE_HITS[key]
+
+
 def feedback_rate_limited(session_id: str, *, now: float | None = None) -> bool:
     """Return True when this session has exceeded the feedback write budget."""
     now = time.time() if now is None else now
     cutoff = now - _RATE_LIMIT_WINDOW_SECONDS
     key = str(session_id or "").strip() or "_"
     with _RATE_LOCK:
+        _prune_rate_limit_keys(cutoff)
         timestamps = [ts for ts in _RATE_HITS.get(key, []) if ts >= cutoff]
         if len(timestamps) >= _RATE_LIMIT_MAX:
             _RATE_HITS[key] = timestamps
             return True
-        timestamps.append(now)
         _RATE_HITS[key] = timestamps
     return False
+
+
+def feedback_record_rate_hit(session_id: str, *, now: float | None = None) -> None:
+    """Record a successful feedback write against the session rate budget."""
+    now = time.time() if now is None else now
+    cutoff = now - _RATE_LIMIT_WINDOW_SECONDS
+    key = str(session_id or "").strip() or "_"
+    with _RATE_LOCK:
+        _prune_rate_limit_keys(cutoff)
+        timestamps = [ts for ts in _RATE_HITS.get(key, []) if ts >= cutoff]
+        timestamps.append(now)
+        _RATE_HITS[key] = timestamps
 
 
 def append_feedback(record: dict) -> Path:

--- a/api/feedback.py
+++ b/api/feedback.py
@@ -1,0 +1,192 @@
+"""Persist lightweight thumbs feedback from the WebUI action bar.
+
+Backend-only for now: there is no Svelte/vanilla client caller wired yet.
+Writes append-only JSONL under the active profile's webui_state dir.
+
+Fail closed on bad input; never raise into the request handler for I/O errors
+beyond logging + a 500 response at the route layer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_FEEDBACK_LOCK = threading.Lock()
+_RATE_LOCK = threading.Lock()
+_RATE_HITS: dict[str, list[float]] = {}
+
+ALLOWED_RATINGS = frozenset({"up", "down"})
+ALLOWED_REASONS = frozenset({"inaccurate", "not_helpful", "too_long", "harmful"})
+_MAX_SESSION_ID_LEN = 128
+_MAX_MESSAGE_ID_LEN = 256
+_MAX_MODEL_LEN = 256
+_MAX_MODE_LEN = 64
+_MAX_PROFILE_LEN = 64
+_MAX_FEEDBACK_FILE_BYTES = 5 * 1024 * 1024  # 5 MiB hard cap
+_RATE_LIMIT_WINDOW_SECONDS = 60.0
+_RATE_LIMIT_MAX = 30  # per session_id per window
+
+
+class FeedbackValidationError(ValueError):
+    """Raised when a feedback payload fails validation (fail closed)."""
+
+
+def _profile_state_dir() -> Path:
+    """Resolve webui_state for the active profile (per-call, not module import)."""
+    from api.workspace import _profile_state_dir as _ws_profile_state_dir
+
+    return _ws_profile_state_dir()
+
+
+def feedback_path() -> Path:
+    return _profile_state_dir() / "feedback.jsonl"
+
+
+def _active_profile_name() -> str:
+    try:
+        from api.profiles import get_active_profile_name
+
+        name = get_active_profile_name()
+        if isinstance(name, str) and name.strip():
+            return name.strip()[:_MAX_PROFILE_LEN]
+    except Exception:
+        logger.debug("feedback: could not resolve active profile", exc_info=True)
+    return "default"
+
+
+def _nonempty_str(value: Any, *, field: str, max_len: int) -> str:
+    if value is None:
+        raise FeedbackValidationError(f"{field} is required")
+    if not isinstance(value, str):
+        raise FeedbackValidationError(f"{field} must be a string")
+    text = value.strip()
+    if not text:
+        raise FeedbackValidationError(f"{field} is required")
+    if len(text) > max_len:
+        raise FeedbackValidationError(f"{field} is too long")
+    return text
+
+
+def _optional_str(value: Any, *, field: str, max_len: int) -> str | None:
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise FeedbackValidationError(f"{field} must be a string")
+    text = value.strip()
+    if not text:
+        return None
+    if len(text) > max_len:
+        raise FeedbackValidationError(f"{field} is too long")
+    return text
+
+
+def _assert_session_exists(session_id: str) -> None:
+    from api.models import get_session, is_safe_session_id
+
+    if not is_safe_session_id(session_id):
+        raise FeedbackValidationError("session_id is invalid")
+    try:
+        get_session(session_id, metadata_only=True)
+    except KeyError:
+        raise FeedbackValidationError("session not found") from None
+    except Exception as exc:
+        # Fail closed: unknown session store errors are not "allowed".
+        raise FeedbackValidationError("session not found") from exc
+
+
+def normalize_feedback_payload(body: Any, *, validate_session: bool = True) -> dict:
+    """Validate and normalize a POST /api/feedback body. Fail closed."""
+    if not isinstance(body, dict):
+        raise FeedbackValidationError("body must be a JSON object")
+
+    session_id = _nonempty_str(body.get("session_id"), field="session_id", max_len=_MAX_SESSION_ID_LEN)
+    if validate_session:
+        _assert_session_exists(session_id)
+
+    rating_raw = body.get("rating")
+    if not isinstance(rating_raw, str):
+        raise FeedbackValidationError("rating must be 'up' or 'down'")
+    rating = rating_raw.strip().lower()
+    if rating not in ALLOWED_RATINGS:
+        raise FeedbackValidationError("rating must be 'up' or 'down'")
+
+    message_id = _optional_str(body.get("message_id"), field="message_id", max_len=_MAX_MESSAGE_ID_LEN)
+    message_index = body.get("index", body.get("message_index"))
+    if message_index is not None:
+        if isinstance(message_index, bool) or not isinstance(message_index, int):
+            raise FeedbackValidationError("index must be an integer")
+        if message_index < 0:
+            raise FeedbackValidationError("index must be >= 0")
+
+    if message_id is None and message_index is None:
+        raise FeedbackValidationError("message_id or index is required")
+
+    reason = _optional_str(body.get("reason"), field="reason", max_len=64)
+    if reason is not None:
+        reason = reason.lower().replace(" ", "_").replace("-", "_")
+        if reason not in ALLOWED_REASONS:
+            raise FeedbackValidationError(
+                "reason must be one of: inaccurate, not_helpful, too_long, harmful"
+            )
+    if rating == "up" and reason is not None:
+        # Upvotes don't carry reason chips; ignore silently rather than 400.
+        reason = None
+
+    model = _optional_str(body.get("model"), field="model", max_len=_MAX_MODEL_LEN)
+    mode = _optional_str(body.get("mode"), field="mode", max_len=_MAX_MODE_LEN)
+    profile = _optional_str(body.get("profile"), field="profile", max_len=_MAX_PROFILE_LEN)
+    if profile is None:
+        profile = _active_profile_name()
+
+    record = {
+        "ts": time.time(),
+        "session_id": session_id,
+        "rating": rating,
+        "profile": profile,
+    }
+    if message_id is not None:
+        record["message_id"] = message_id
+    if message_index is not None:
+        record["index"] = message_index
+    if reason is not None:
+        record["reason"] = reason
+    if model is not None:
+        record["model"] = model
+    if mode is not None:
+        record["mode"] = mode
+    return record
+
+
+def feedback_rate_limited(session_id: str, *, now: float | None = None) -> bool:
+    """Return True when this session has exceeded the feedback write budget."""
+    now = time.time() if now is None else now
+    cutoff = now - _RATE_LIMIT_WINDOW_SECONDS
+    key = str(session_id or "").strip() or "_"
+    with _RATE_LOCK:
+        timestamps = [ts for ts in _RATE_HITS.get(key, []) if ts >= cutoff]
+        if len(timestamps) >= _RATE_LIMIT_MAX:
+            _RATE_HITS[key] = timestamps
+            return True
+        timestamps.append(now)
+        _RATE_HITS[key] = timestamps
+    return False
+
+
+def append_feedback(record: dict) -> Path:
+    """Append one normalized feedback record to the profile feedback.jsonl."""
+    path = feedback_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+    with _FEEDBACK_LOCK:
+        if path.exists() and path.stat().st_size + len(line.encode("utf-8")) > _MAX_FEEDBACK_FILE_BYTES:
+            raise FeedbackValidationError("feedback store is full")
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+    return path

--- a/api/routes.py
+++ b/api/routes.py
@@ -14006,6 +14006,27 @@ def handle_post(handler, parsed) -> bool:
             diag.finish()
         return True
 
+    if parsed.path == "/api/feedback":
+        # Backend-only endpoint for now (no client UI wired). See api/feedback.py.
+        from api.feedback import (
+            FeedbackValidationError,
+            append_feedback,
+            feedback_rate_limited,
+            normalize_feedback_payload,
+        )
+
+        try:
+            record = normalize_feedback_payload(body)
+            if feedback_rate_limited(record["session_id"]):
+                return bad(handler, "Too many feedback submissions", status=429)
+            append_feedback(record)
+        except FeedbackValidationError as exc:
+            return bad(handler, str(exc), status=400)
+        except Exception:
+            logger.exception("failed to persist feedback")
+            return bad(handler, "Failed to save feedback", status=500)
+        return j(handler, {"ok": True})
+
     if parsed.path == "/api/escape/authorize":
         return _handle_escape_authorize(handler, parsed, body)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -14012,6 +14012,7 @@ def handle_post(handler, parsed) -> bool:
             FeedbackValidationError,
             append_feedback,
             feedback_rate_limited,
+            feedback_record_rate_hit,
             normalize_feedback_payload,
         )
 
@@ -14020,6 +14021,7 @@ def handle_post(handler, parsed) -> bool:
             if feedback_rate_limited(record["session_id"]):
                 return bad(handler, "Too many feedback submissions", status=429)
             append_feedback(record)
+            feedback_record_rate_hit(record["session_id"])
         except FeedbackValidationError as exc:
             return bad(handler, str(exc), status=400)
         except Exception:

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,195 @@
+"""Tests for POST /api/feedback."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+from urllib.parse import urlparse
+
+import api.feedback as feedback
+import api.routes as routes
+
+
+def _post(path: str, body: dict, monkeypatch):
+    cap = {}
+
+    def _j(_handler, payload, *_, status=200, **__):
+        cap["ok"] = payload
+        cap["status"] = status
+        return True
+
+    def _bad(_handler, msg, status=400, **__):
+        cap["bad"] = (msg, status)
+        return True
+
+    handler = MagicMock()
+    handler.command = "POST"
+    handler.headers = {}
+
+    monkeypatch.setattr(routes, "read_body", lambda _h: body)
+    monkeypatch.setattr(routes, "_check_csrf", lambda _h: True)
+    monkeypatch.setattr(routes, "_csrf_exempt_path", lambda _p: False)
+    monkeypatch.setattr(routes, "_guard_request_session_visibility", lambda *_a, **_k: True)
+    monkeypatch.setattr(routes, "j", _j)
+    monkeypatch.setattr(routes, "bad", _bad)
+
+    routes.handle_post(handler, urlparse(path))
+    return cap
+
+
+def test_normalize_feedback_requires_session_and_target():
+    try:
+        feedback.normalize_feedback_payload({"rating": "up"}, validate_session=False)
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError as exc:
+        assert "session_id" in str(exc)
+
+    try:
+        feedback.normalize_feedback_payload(
+            {"session_id": "abc", "rating": "up"}, validate_session=False
+        )
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError as exc:
+        assert "message_id or index" in str(exc)
+
+
+def test_normalize_feedback_rejects_bad_rating_and_reason():
+    try:
+        feedback.normalize_feedback_payload(
+            {"session_id": "abc", "index": 1, "rating": "meh"},
+            validate_session=False,
+        )
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError:
+        pass
+
+    try:
+        feedback.normalize_feedback_payload(
+            {
+                "session_id": "abc",
+                "index": 1,
+                "rating": "down",
+                "reason": "spam",
+            },
+            validate_session=False,
+        )
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError:
+        pass
+
+
+def test_normalize_feedback_accepts_valid_down_with_reason():
+    record = feedback.normalize_feedback_payload(
+        {
+            "session_id": "sess1",
+            "index": 3,
+            "rating": "down",
+            "reason": "Not helpful",
+            "model": "gpt-test",
+            "mode": "ask",
+        },
+        validate_session=False,
+    )
+    assert record["session_id"] == "sess1"
+    assert record["index"] == 3
+    assert record["rating"] == "down"
+    assert record["reason"] == "not_helpful"
+    assert record["model"] == "gpt-test"
+    assert record["mode"] == "ask"
+    assert record["profile"]
+    assert "ts" in record
+
+
+def test_append_feedback_writes_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setattr(feedback, "_profile_state_dir", lambda: tmp_path)
+    record = feedback.normalize_feedback_payload(
+        {"session_id": "s1", "message_id": "m1", "rating": "up"},
+        validate_session=False,
+    )
+    feedback.append_feedback(record)
+    target = tmp_path / "feedback.jsonl"
+    lines = target.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["rating"] == "up"
+    assert parsed["message_id"] == "m1"
+    assert "profile" in parsed
+
+
+def test_post_feedback_persists_and_returns_ok(tmp_path, monkeypatch):
+    monkeypatch.setattr(feedback, "_profile_state_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        feedback,
+        "_assert_session_exists",
+        lambda _sid: None,
+    )
+    monkeypatch.setattr(feedback, "_RATE_HITS", {})
+
+    cap = _post(
+        "/api/feedback",
+        {
+            "session_id": "sess-a",
+            "index": 2,
+            "rating": "down",
+            "reason": "too_long",
+            "model": "m1",
+            "mode": "build",
+        },
+        monkeypatch,
+    )
+    assert "bad" not in cap
+    assert cap.get("ok", {}).get("ok") is True
+    target = tmp_path / "feedback.jsonl"
+    assert target.exists()
+    row = json.loads(target.read_text(encoding="utf-8").strip())
+    assert row["session_id"] == "sess-a"
+    assert row["reason"] == "too_long"
+    assert row["profile"]
+
+
+def test_post_feedback_fails_closed_on_bad_input(monkeypatch):
+    monkeypatch.setattr(feedback, "_assert_session_exists", lambda _sid: None)
+    cap = _post(
+        "/api/feedback",
+        {"session_id": "x", "rating": "up"},
+        monkeypatch,
+    )
+    assert "ok" not in cap
+    assert cap["bad"][1] == 400
+
+
+def test_feedback_rejects_missing_session(monkeypatch):
+    def _missing(_sid):
+        raise feedback.FeedbackValidationError("session not found")
+
+    monkeypatch.setattr(feedback, "_assert_session_exists", _missing)
+    try:
+        feedback.normalize_feedback_payload(
+            {"session_id": "nope", "index": 0, "rating": "up"}
+        )
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError as exc:
+        assert "session not found" in str(exc)
+
+
+def test_feedback_rate_limit_and_size_cap(tmp_path, monkeypatch):
+    monkeypatch.setattr(feedback, "_profile_state_dir", lambda: tmp_path)
+    monkeypatch.setattr(feedback, "_RATE_HITS", {})
+    monkeypatch.setattr(feedback, "_RATE_LIMIT_MAX", 2)
+    monkeypatch.setattr(feedback, "_MAX_FEEDBACK_FILE_BYTES", 80)
+
+    assert feedback.feedback_rate_limited("s1") is False
+    assert feedback.feedback_rate_limited("s1") is False
+    assert feedback.feedback_rate_limited("s1") is True
+
+    record = feedback.normalize_feedback_payload(
+        {"session_id": "s1", "message_id": "m1", "rating": "up", "profile": "default"},
+        validate_session=False,
+    )
+    # Fill past the size cap with repeated writes.
+    try:
+        for _ in range(20):
+            feedback.append_feedback(record)
+        assert False, "expected size-cap FeedbackValidationError"
+    except feedback.FeedbackValidationError as exc:
+        assert "full" in str(exc).lower()

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -123,6 +123,7 @@ def test_post_feedback_persists_and_returns_ok(tmp_path, monkeypatch):
         "_assert_session_exists",
         lambda _sid: None,
     )
+    monkeypatch.setattr(feedback, "_assert_message_target", lambda *_a, **_k: None)
     monkeypatch.setattr(feedback, "_RATE_HITS", {})
 
     cap = _post(
@@ -172,6 +173,42 @@ def test_feedback_rejects_missing_session(monkeypatch):
         assert "session not found" in str(exc)
 
 
+def test_feedback_rejects_profile_mismatch(monkeypatch):
+    monkeypatch.setattr(feedback, "_active_profile_name", lambda: "default")
+    monkeypatch.setattr(feedback, "_assert_session_exists", lambda _sid: None)
+    monkeypatch.setattr(feedback, "_assert_message_target", lambda *_a, **_k: None)
+    try:
+        feedback.normalize_feedback_payload(
+            {
+                "session_id": "s1",
+                "index": 0,
+                "rating": "up",
+                "profile": "other",
+            }
+        )
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError as exc:
+        assert "profile" in str(exc).lower()
+
+
+def test_feedback_rejects_invalid_message_target(monkeypatch):
+    class _Session:
+        messages = [{"role": "user", "content": "hi", "id": "msg-1"}]
+
+    monkeypatch.setattr(feedback, "_assert_session_exists", lambda _sid: None)
+    monkeypatch.setattr(
+        "api.models.get_session",
+        lambda _sid, metadata_only=False: _Session(),
+    )
+    try:
+        feedback.normalize_feedback_payload(
+            {"session_id": "s1", "message_id": "missing", "rating": "up"}
+        )
+        assert False, "expected FeedbackValidationError"
+    except feedback.FeedbackValidationError as exc:
+        assert "message_id" in str(exc).lower()
+
+
 def test_feedback_rate_limit_and_size_cap(tmp_path, monkeypatch):
     monkeypatch.setattr(feedback, "_profile_state_dir", lambda: tmp_path)
     monkeypatch.setattr(feedback, "_RATE_HITS", {})
@@ -179,7 +216,9 @@ def test_feedback_rate_limit_and_size_cap(tmp_path, monkeypatch):
     monkeypatch.setattr(feedback, "_MAX_FEEDBACK_FILE_BYTES", 80)
 
     assert feedback.feedback_rate_limited("s1") is False
+    feedback.feedback_record_rate_hit("s1")
     assert feedback.feedback_rate_limited("s1") is False
+    feedback.feedback_record_rate_hit("s1")
     assert feedback.feedback_rate_limited("s1") is True
 
     record = feedback.normalize_feedback_payload(


### PR DESCRIPTION
## Summary
- Add `api/feedback.py` with validation, JSONL append, size cap, and rate limiting.
- Wire `POST /api/feedback` (backend-only; no client UI yet).

## Test plan
- [x] `./scripts/test.sh tests/test_feedback.py`

Made with [Cursor](https://cursor.com)