### PR TITLE
fix: derive subagent titles when state title is null

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -5507,7 +5507,10 @@ def _read_state_db_sidebar_overrides(
                     if (
                         state_source == 'subagent'
                         and sid in count_wanted
-                        and ' '.join(state_title.split()) == 'Subagent Session'
+                        and (
+                            not state_title
+                            or ' '.join(state_title.split()) == 'Subagent Session'
+                        )
                     ):
                         delegated_title_ids.add(sid)
                     if state_source:

--- a/api/models.py
+++ b/api/models.py
@@ -5423,6 +5423,82 @@ def _sidebar_title_is_generic_webui(title: str | None) -> bool:
     return text.startswith(prefix) and text[len(prefix):].isdigit()
 
 
+def _sidebar_title_is_generic_subagent(title: str | None) -> bool:
+    """Treat blank and stock delegated-child labels as non-authoritative."""
+    return ' '.join(str(title or '').split()) in ('', 'Subagent Session')
+
+
+def _read_state_db_subagent_goal_titles(
+    conn,
+    session_ids: set[str],
+) -> dict[str, str]:
+    """Read one deterministic, bounded goal title per delegated child.
+
+    The sidebar is a hot path. Only use an index whose leading column is
+    ``session_id``; otherwise fail closed instead of running one table scan per
+    child. Rows are streamed in canonical ``(timestamp, id/rowid)`` order and
+    only a bounded prefix reaches Python, where ``title_from`` remains the one
+    authority for blank-content and title normalization semantics.
+    """
+    ids = sorted(str(sid) for sid in session_ids if sid)
+    if not ids:
+        return {}
+    try:
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(messages)")
+        message_cols = {str(row[1]) for row in cur.fetchall()}
+        if not {'session_id', 'role', 'content', 'timestamp'}.issubset(message_cols):
+            return {}
+        order_col = 'id' if 'id' in message_cols else 'rowid'
+
+        cur.execute("PRAGMA index_list(messages)")
+        usable_indexes: list[tuple[int, str]] = []
+        for index_row in cur.fetchall():
+            # Partial indexes may omit delegated user rows, so they cannot be
+            # used as a general fail-closed guarantee here.
+            if len(index_row) > 4 and bool(index_row[4]):
+                continue
+            index_name = str(index_row[1])
+            quoted_name = index_name.replace('"', '""')
+            cur.execute(f'PRAGMA index_info("{quoted_name}")')
+            index_cols = [str(row[2]) for row in cur.fetchall()]
+            if index_cols and index_cols[0] == 'session_id':
+                preferred = int(len(index_cols) > 1 and index_cols[1] == 'timestamp')
+                usable_indexes.append((preferred, index_name))
+        if not usable_indexes:
+            return {}
+        _, index_name = max(usable_indexes)
+        quoted_index = index_name.replace('"', '""')
+
+        titles: dict[str, str] = {}
+        for sid in ids:
+            try:
+                cur.execute(
+                    f"""
+                    SELECT substr(CAST(content AS TEXT), 1, 4096) AS content
+                    FROM messages INDEXED BY "{quoted_index}"
+                    WHERE session_id = ? AND role = 'user' AND content IS NOT NULL
+                    ORDER BY timestamp ASC, {order_col} ASC
+                    """,
+                    (sid,),
+                )
+                for row in cur:
+                    display_title = title_from(
+                        [{'role': 'user', 'content': row[0]}],
+                        fallback='',
+                    )
+                    if display_title:
+                        titles[sid] = display_title
+                        break
+            except Exception:
+                # WITHOUT ROWID legacy tables lacking an explicit message id
+                # cannot provide a deterministic tie-breaker. Keep generic.
+                continue
+        return titles
+    except Exception:
+        return {}
+
+
 def _read_state_db_sidebar_overrides(
     db_path: Path,
     session_ids: set[str],
@@ -5474,14 +5550,11 @@ def _read_state_db_sidebar_overrides(
             has_messages_table = cur.fetchone() is not None
             messages_has_session_id = False
             messages_has_timestamp = False
-            messages_has_title_fields = False
-            message_cols: set[str] = set()
             if has_messages_table:
                 cur.execute("PRAGMA table_info(messages)")
                 message_cols = {str(row[1]) for row in cur.fetchall()}
                 messages_has_session_id = 'session_id' in message_cols
                 messages_has_timestamp = 'timestamp' in message_cols
-                messages_has_title_fields = {'session_id', 'role', 'content', 'timestamp'}.issubset(message_cols)
 
             overrides: dict[str, dict] = {}
             delegated_title_ids: set[str] = set()
@@ -5508,10 +5581,7 @@ def _read_state_db_sidebar_overrides(
                     if (
                         state_source == 'subagent'
                         and sid in count_wanted
-                        and (
-                            not state_title
-                            or ' '.join(state_title.split()) == 'Subagent Session'
-                        )
+                        and _sidebar_title_is_generic_subagent(state_title)
                     ):
                         delegated_title_ids.add(sid)
                     if state_source:
@@ -5558,48 +5628,11 @@ def _read_state_db_sidebar_overrides(
                                 entry['_state_db_last_message_at'] = float(row['last_message_at'] or 0)
                             except (TypeError, ValueError):
                                 pass
-            if messages_has_title_fields and delegated_title_ids:
-                delegated_title_ids = list(delegated_title_ids)
-                message_order_col = 'id' if 'id' in message_cols else 'rowid'
-                for i in range(0, len(delegated_title_ids), chunk_size):
-                    chunk = delegated_title_ids[i:i + chunk_size]
-                    candidate_values = ','.join('(?)' for _ in chunk)
-                    try:
-                        cur.execute(
-                            f"""
-                            WITH candidate_sessions(session_id) AS (
-                                VALUES {candidate_values}
-                            )
-                            SELECT candidate_sessions.session_id,
-                                   (
-                                       SELECT substr(CAST(m.content AS TEXT), 1, 4096)
-                                       FROM messages m
-                                       WHERE m.session_id = candidate_sessions.session_id
-                                         AND m.role = 'user'
-                                         AND m.content IS NOT NULL
-                                         AND TRIM(CAST(m.content AS TEXT)) != ''
-                                       ORDER BY m.timestamp ASC, m.{message_order_col} ASC
-                                       LIMIT 1
-                                   ) AS content
-                            FROM candidate_sessions
-                            """,
-                            chunk,
-                        )
-                        title_rows = cur.fetchall()
-                    except Exception:
-                        # Legacy WITHOUT ROWID tables that also lack an explicit
-                        # message id cannot provide a deterministic tie-breaker.
-                        # Keep their generic title while preserving all cheaper
-                        # source/count metadata already collected above.
-                        continue
-                    for row in title_rows:
-                        display_title = title_from(
-                            [{'role': 'user', 'content': row['content']}],
-                            fallback='',
-                        )
-                        if display_title:
-                            sid = str(row['session_id'])
-                            overrides.setdefault(sid, {})['_state_db_display_title'] = display_title
+            for sid, display_title in _read_state_db_subagent_goal_titles(
+                conn,
+                delegated_title_ids,
+            ).items():
+                overrides.setdefault(sid, {})['_state_db_display_title'] = display_title
             return overrides
     except Exception:
         return {}
@@ -5717,7 +5750,7 @@ def _apply_sidebar_state_db_override_metadata(sessions: list[dict], metadata: di
         if (
             state_db_display_title
             and state_db_source == 'subagent'
-            and ' '.join(str(title or '').split()) == 'Subagent Session'
+            and _sidebar_title_is_generic_subagent(title)
         ):
             session['display_title'] = state_db_display_title
 
@@ -7218,7 +7251,10 @@ def _load_cli_sessions_uncached(
         profile = profile_value  # CLI DB has no profile column; use active profile
 
         _source = row['source'] or 'cli'
-        if _source == 'subagent':
+        if (
+            _source == 'subagent'
+            and _sidebar_title_is_generic_subagent(row['title'])
+        ):
             state_projection_subagent_ids.add(str(sid))
         # Honor the deleted-WebUI tombstone: a WebUI row the user deleted must
         # not resurface in this projection (the #5498 ghost). Live sidecar wins.
@@ -7243,7 +7279,10 @@ def _load_cli_sessions_uncached(
         if _sidecar_meta.get('title'):
             _title = _sidecar_meta['title']
         _archived = bool(_sidecar_meta.get('archived'))
-        _display_title = _title or f'{_source.title()} Session'
+        if _source == 'subagent' and _sidebar_title_is_generic_subagent(_title):
+            _display_title = 'Subagent Session'
+        else:
+            _display_title = _title or f'{_source.title()} Session'
         cli_sessions.append({
             'session_id': sid,
             'title': _display_title,
@@ -7282,17 +7321,17 @@ def _load_cli_sessions_uncached(
 
     if state_projection_subagent_ids:
         try:
-            state_projection_metadata = _read_state_db_sidebar_overrides(
-                db_path,
-                state_projection_subagent_ids,
-                count_session_ids=state_projection_subagent_ids,
-            )
+            with open_state_db_readonly(db_path) as state_conn:
+                state_projection_titles = _read_state_db_subagent_goal_titles(
+                    state_conn,
+                    state_projection_subagent_ids,
+                )
         except Exception:
-            state_projection_metadata = {}
-        _apply_sidebar_state_db_override_metadata(
-            cli_sessions,
-            state_projection_metadata,
-        )
+            state_projection_titles = {}
+        for session in cli_sessions:
+            display_title = state_projection_titles.get(str(session.get('session_id') or ''))
+            if display_title and _sidebar_title_is_generic_subagent(session.get('title')):
+                session['display_title'] = display_title
 
     if source_filter is not None:
         return cli_sessions

--- a/api/models.py
+++ b/api/models.py
@@ -5475,6 +5475,7 @@ def _read_state_db_sidebar_overrides(
             messages_has_session_id = False
             messages_has_timestamp = False
             messages_has_title_fields = False
+            message_cols: set[str] = set()
             if has_messages_table:
                 cur.execute("PRAGMA table_info(messages)")
                 message_cols = {str(row[1]) for row in cur.fetchall()}
@@ -5558,27 +5559,46 @@ def _read_state_db_sidebar_overrides(
                             except (TypeError, ValueError):
                                 pass
             if messages_has_title_fields and delegated_title_ids:
-                seen_user_messages: set[str] = set()
                 delegated_title_ids = list(delegated_title_ids)
+                message_order_col = 'id' if 'id' in message_cols else 'rowid'
                 for i in range(0, len(delegated_title_ids), chunk_size):
                     chunk = delegated_title_ids[i:i + chunk_size]
-                    placeholders = ','.join('?' * len(chunk))
-                    cur.execute(
-                        f"""
-                        SELECT session_id, role, content, timestamp
-                        FROM messages
-                        WHERE session_id IN ({placeholders}) AND role = 'user'
-                        ORDER BY session_id, timestamp ASC
-                        """,
-                        chunk,
-                    )
-                    for row in cur.fetchall():
-                        sid = str(row['session_id'])
-                        if sid in seen_user_messages:
-                            continue
-                        display_title = title_from([dict(row)], fallback='')
+                    candidate_values = ','.join('(?)' for _ in chunk)
+                    try:
+                        cur.execute(
+                            f"""
+                            WITH candidate_sessions(session_id) AS (
+                                VALUES {candidate_values}
+                            )
+                            SELECT candidate_sessions.session_id,
+                                   (
+                                       SELECT substr(CAST(m.content AS TEXT), 1, 4096)
+                                       FROM messages m
+                                       WHERE m.session_id = candidate_sessions.session_id
+                                         AND m.role = 'user'
+                                         AND m.content IS NOT NULL
+                                         AND TRIM(CAST(m.content AS TEXT)) != ''
+                                       ORDER BY m.timestamp ASC, m.{message_order_col} ASC
+                                       LIMIT 1
+                                   ) AS content
+                            FROM candidate_sessions
+                            """,
+                            chunk,
+                        )
+                        title_rows = cur.fetchall()
+                    except Exception:
+                        # Legacy WITHOUT ROWID tables that also lack an explicit
+                        # message id cannot provide a deterministic tie-breaker.
+                        # Keep their generic title while preserving all cheaper
+                        # source/count metadata already collected above.
+                        continue
+                    for row in title_rows:
+                        display_title = title_from(
+                            [{'role': 'user', 'content': row['content']}],
+                            fallback='',
+                        )
                         if display_title:
-                            seen_user_messages.add(sid)
+                            sid = str(row['session_id'])
                             overrides.setdefault(sid, {})['_state_db_display_title'] = display_title
             return overrides
     except Exception:
@@ -7169,6 +7189,7 @@ def _load_cli_sessions_uncached(
         return None
 
     profile_value = _cli_profile or 'default'
+    state_projection_subagent_ids: set[str] = set()
     # A deleted WebUI session is tombstoned (see _record_webui_deleted_session_tombstone)
     # so recovery/audit/claim treat it as gone. The sidebar's own state.db projection
     # must honor the same tombstone, or a deleted WebUI session reappears here as an
@@ -7197,6 +7218,8 @@ def _load_cli_sessions_uncached(
         profile = profile_value  # CLI DB has no profile column; use active profile
 
         _source = row['source'] or 'cli'
+        if _source == 'subagent':
+            state_projection_subagent_ids.add(str(sid))
         # Honor the deleted-WebUI tombstone: a WebUI row the user deleted must
         # not resurface in this projection (the #5498 ghost). Live sidecar wins.
         if (
@@ -7256,6 +7279,20 @@ def _load_cli_sessions_uncached(
             '_compression_segment_count': row.get('_compression_segment_count'),
             'is_cli_session': is_cli_session_row({**row, **_source_meta}),
         })
+
+    if state_projection_subagent_ids:
+        try:
+            state_projection_metadata = _read_state_db_sidebar_overrides(
+                db_path,
+                state_projection_subagent_ids,
+                count_session_ids=state_projection_subagent_ids,
+            )
+        except Exception:
+            state_projection_metadata = {}
+        _apply_sidebar_state_db_override_metadata(
+            cli_sessions,
+            state_projection_metadata,
+        )
 
     if source_filter is not None:
         return cli_sessions

--- a/api/routes.py
+++ b/api/routes.py
@@ -2207,6 +2207,28 @@ def _build_session_list_cache_payload(
         # routes.all_sessions with the historical diag-only signature.
         return all_sessions(diag=diag)
 
+    def _get_cli_sessions_for_sidebar(requested_source_filter):
+        if _callable_accepts_kwarg(get_cli_sessions, "include_claude_code"):
+            return get_cli_sessions(
+                source_filter=requested_source_filter,
+                all_profiles=all_profiles,
+                include_claude_code=show_claude_code_sessions,
+            )
+        # Focused tests sometimes monkeypatch routes.get_cli_sessions with
+        # the historical two-keyword signature.
+        return get_cli_sessions(
+            source_filter=requested_source_filter,
+            all_profiles=all_profiles,
+        )
+
+    def _sidebar_row_source(row) -> str:
+        if not isinstance(row, dict):
+            return ""
+        return str(
+            row.get("source_tag") or row.get("raw_source")
+            or row.get("session_source") or row.get("source") or ""
+        ).strip().lower()
+
     diag_stage("all_sessions")
     webui_sessions = _all_sessions_for_sidebar()
     diag_stage("reconcile_stale_stream_state")
@@ -2221,19 +2243,7 @@ def _build_session_list_cache_payload(
     webui_sessions = [_normalize_sidebar_source_flags(s) for s in webui_sessions]
     if show_cli_sessions:
         diag_stage("get_cli_sessions")
-        if _callable_accepts_kwarg(get_cli_sessions, "include_claude_code"):
-            cli = get_cli_sessions(
-                source_filter=source_filter,
-                all_profiles=all_profiles,
-                include_claude_code=show_claude_code_sessions,
-            )
-        else:
-            # Focused tests sometimes monkeypatch routes.get_cli_sessions with
-            # the historical two-keyword signature.
-            cli = get_cli_sessions(
-                source_filter=source_filter,
-                all_profiles=all_profiles,
-            )
+        cli = _get_cli_sessions_for_sidebar(source_filter)
         diag_stage("merge_cli_sessions")
         cli_by_id = {s["session_id"]: s for s in cli}
         # #3238/#4591: reconcile orphaned imported sidecars. When a CLI or
@@ -2381,6 +2391,32 @@ def _build_session_list_cache_payload(
             diag_stage=diag_stage,
         )
         deduped_cli = []
+
+    # Delegated children are non-CLI, read-only rows. Fetch state.db-only
+    # children independently of the user-facing CLI toggle/source filter so
+    # established installs (where show_cli_sessions is grandfathered off) do
+    # not lose children that have no WebUI sidecar.
+    diag_stage("get_state_subagent_sessions")
+    state_subagents = [
+        row for row in _get_cli_sessions_for_sidebar("subagent")
+        if _sidebar_row_source(row) == "subagent"
+    ]
+    represented_ids: set[str] = set()
+    for row in webui_sessions + deduped_cli:
+        represented_ids.update(_session_lineage_ids(row))
+    deduped_subagents = _dedupe_cli_sidebar_sessions_for_api(
+        state_subagents,
+        represented_ids,
+        show_cron_sessions=show_cron_sessions,
+        show_webhook_sessions=show_webhook_sessions,
+    )
+    existing_cli_ids = {
+        str(row.get("session_id") or "") for row in deduped_cli
+    }
+    deduped_cli.extend(
+        row for row in deduped_subagents
+        if str(row.get("session_id") or "") not in existing_cli_ids
+    )
     diag_stage("sort_sessions")
     merged = webui_sessions + deduped_cli
     merged.sort(
@@ -2492,10 +2528,7 @@ def _build_session_list_cache_payload(
         for _r in _rows:
             if not isinstance(_r, dict):
                 continue
-            _src = (
-                str(_r.get("source_tag") or _r.get("raw_source")
-                    or _r.get("session_source") or _r.get("source") or "").strip().lower()
-            )
+            _src = _sidebar_row_source(_r)
             _is_sa = _src == "subagent"
             # A stale index row can say webui/fork while state.db records the
             # row as source='subagent' (the child shares the parent's lineage).

--- a/tests/test_5307_subagent_child_transcript.py
+++ b/tests/test_5307_subagent_child_transcript.py
@@ -36,7 +36,7 @@ SESSIONS_JS = ROOT / "static" / "sessions.js"
 
 
 def _make_state_db(path: Path, sid: str, *, message_count: int = 2,
-                   title: str = "tui session", model: str = "MiniMax-M3",
+                   title: str | None = "tui session", model: str = "MiniMax-M3",
                    source: str = "tui", cwd: str = "/root") -> None:
     """Create a minimal state.db with one session and a few messages.
 
@@ -259,6 +259,53 @@ def test_state_db_source_helper_reads_subagent(routes_module, isolated_state_db)
     assert routes_module._state_db_session_source("sa-1") == "subagent"
     assert routes_module._is_subagent_child_session_id("sa-1") is True
     assert routes_module._is_subagent_child_session_id("does-not-exist") is False
+
+
+def test_state_db_only_null_title_subagent_uses_goal_in_sidebar(isolated_state_db):
+    """A delegated child needs its goal title even when it has no WebUI sidecar."""
+    import api.models as models
+
+    sid = "subagent-no-sidecar-null-title"
+    custom_sid = "subagent-no-sidecar-custom-title"
+    _make_state_db(
+        isolated_state_db["db"],
+        sid,
+        source="subagent",
+        title=None,
+        message_count=2,
+    )
+    _make_state_db(
+        isolated_state_db["db"],
+        custom_sid,
+        source="subagent",
+        title="Human-chosen state title",
+        message_count=2,
+    )
+    conn = sqlite3.connect(str(isolated_state_db["db"]))
+    try:
+        conn.execute(
+            "UPDATE messages SET content = ? WHERE session_id = ? AND role = 'user'",
+            ("Map the state-only delegated child path", sid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rows = models._load_cli_sessions_uncached(
+        isolated_state_db["state_dir"],
+        isolated_state_db["db"],
+        "default",
+        source_filter="subagent",
+        visible_session_limit=20,
+        include_claude_code=False,
+    )
+    row = next(row for row in rows if row["session_id"] == sid)
+    custom_row = next(row for row in rows if row["session_id"] == custom_sid)
+
+    assert row["title"] == "Subagent Session"
+    assert row["display_title"] == "Map the state-only delegated child path"
+    assert custom_row["title"] == "Human-chosen state title"
+    assert "display_title" not in custom_row
 
 
 def test_import_cli_endpoint_does_not_materialize_subagent_child():

--- a/tests/test_5307_subagent_child_transcript.py
+++ b/tests/test_5307_subagent_child_transcript.py
@@ -92,6 +92,8 @@ def _make_state_db(path: Path, sid: str, *, message_count: int = 2,
             tool_calls TEXT,
             tool_call_count INTEGER DEFAULT 0
         );
+        CREATE INDEX IF NOT EXISTS idx_messages_session
+            ON messages(session_id, timestamp);
         """
     )
     conn.execute(
@@ -261,7 +263,14 @@ def test_state_db_source_helper_reads_subagent(routes_module, isolated_state_db)
     assert routes_module._is_subagent_child_session_id("does-not-exist") is False
 
 
-def test_state_db_only_null_title_subagent_uses_goal_in_sidebar(isolated_state_db):
+@pytest.mark.parametrize(
+    "state_title",
+    [pytest.param(None, id="null"), pytest.param("", id="empty"), pytest.param(" \t ", id="whitespace")],
+)
+def test_state_db_only_blank_title_subagent_uses_goal_in_sidebar(
+    isolated_state_db,
+    state_title,
+):
     """A delegated child needs its goal title even when it has no WebUI sidecar."""
     import api.models as models
 
@@ -271,7 +280,7 @@ def test_state_db_only_null_title_subagent_uses_goal_in_sidebar(isolated_state_d
         isolated_state_db["db"],
         sid,
         source="subagent",
-        title=None,
+        title=state_title,
         message_count=2,
     )
     _make_state_db(
@@ -306,6 +315,72 @@ def test_state_db_only_null_title_subagent_uses_goal_in_sidebar(isolated_state_d
     assert row["display_title"] == "Map the state-only delegated child path"
     assert custom_row["title"] == "Human-chosen state title"
     assert "display_title" not in custom_row
+
+
+def test_state_db_only_subagent_ignores_show_agent_sessions_toggle(
+    routes_module,
+    isolated_state_db,
+    monkeypatch,
+):
+    """Delegated children are non-CLI and remain visible for established installs."""
+    import api.models as models
+
+    sid = "subagent-public-payload-no-sidecar"
+    _make_state_db(
+        isolated_state_db["db"],
+        sid,
+        source="subagent",
+        title=None,
+        message_count=2,
+    )
+    conn = sqlite3.connect(str(isolated_state_db["db"]))
+    try:
+        conn.execute(
+            "UPDATE messages SET content = ? WHERE session_id = ? AND role = 'user'",
+            ("Keep delegated children outside the CLI toggle", sid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(routes_module, "all_sessions", lambda diag=None, include_lineage_metadata=False: [])
+
+    def _real_state_projection(
+        source_filter=None,
+        all_profiles=False,
+        include_claude_code=True,
+    ):
+        del all_profiles, include_claude_code
+        return models._load_cli_sessions_uncached(
+            isolated_state_db["state_dir"],
+            isolated_state_db["db"],
+            "default",
+            source_filter=source_filter,
+            visible_session_limit=20,
+            include_claude_code=False,
+        )
+
+    monkeypatch.setattr(routes_module, "get_cli_sessions", _real_state_projection)
+
+    rows_by_toggle = {}
+    for show_cli_sessions in (False, True):
+        payload = routes_module._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=show_cli_sessions,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+            show_webhook_sessions=False,
+        )
+        rows_by_toggle[show_cli_sessions] = {
+            row["session_id"]: row for row in payload["sessions"]
+        }
+
+    for rows in rows_by_toggle.values():
+        row = rows[sid]
+        assert row["display_title"] == "Keep delegated children outside the CLI toggle"
+        assert row["read_only"] is True
+        assert row["is_cli_session"] is False
 
 
 def test_import_cli_endpoint_does_not_materialize_subagent_child():

--- a/tests/test_issue3930_source_filter_pushdown.py
+++ b/tests/test_issue3930_source_filter_pushdown.py
@@ -325,7 +325,12 @@ def test_api_sessions_passes_source_filter_only_on_sidebar_path(monkeypatch):
 
     assert handler.status == 200
     assert handler.json_body()["sessions"] == []
-    assert captured == [{"source_filter": "  TUI  ", "all_profiles": False}]
+    assert captured == [
+        {"source_filter": "  TUI  ", "all_profiles": False},
+        # Delegated children are non-CLI and use a dedicated state projection,
+        # independent of the user-facing CLI source filter.
+        {"source_filter": "subagent", "all_profiles": False},
+    ]
 
 
 def test_non_sidebar_cli_session_callers_keep_default_get_cli_sessions_signature(monkeypatch):

--- a/tests/test_issue4714_claude_code_visibility_toggle.py
+++ b/tests/test_issue4714_claude_code_visibility_toggle.py
@@ -274,7 +274,7 @@ def test_sessions_route_supports_historical_get_cli_sessions_signature(monkeypat
     body = handler.json_body()
 
     assert handler.status == 200
-    assert calls == [(None, False)]
+    assert calls == [(None, False), ("subagent", False)]
     assert {row["session_id"] for row in body["sessions"]} == {"webui-1", "external-cli"}
 
 

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -441,6 +441,42 @@ def test_generic_subagent_title_gets_goal_display_title(_isolate):
         conn.close()
 
 
+def test_generic_subagent_title_uses_goal_when_state_db_title_is_null(_isolate):
+    """Current Agent children leave state.db.title null while WebUI keeps the generic sidecar title."""
+    conn = _ensure_state_db(_isolate)
+    _ensure_messages_table(conn)
+    t0 = time.time() - 100
+    try:
+        _save_webui_session("lineage_api_subagent_null_title", title="Subagent Session", updated_at=t0)
+        _insert_state_row(
+            conn,
+            "lineage_api_subagent_null_title",
+            source="subagent",
+            started_at=t0,
+        )
+        conn.execute(
+            "UPDATE sessions SET title = NULL WHERE id = ?",
+            ("lineage_api_subagent_null_title",),
+        )
+        conn.commit()
+        _insert_state_message(
+            conn,
+            "lineage_api_subagent_null_title",
+            role="user",
+            content="Research lesser-known coding agent harnesses",
+            timestamp=t0 + 1,
+        )
+
+        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}[
+            "lineage_api_subagent_null_title"
+        ]
+
+        assert row["title"] == "Subagent Session"
+        assert row["display_title"] == "Research lesser-known coding agent harnesses"
+    finally:
+        conn.close()
+
+
 def test_custom_subagent_title_stays_authoritative(_isolate):
     conn = _ensure_state_db(_isolate)
     _ensure_messages_table(conn)

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -59,14 +59,16 @@ def _ensure_state_db(path):
 
 
 def _ensure_messages_table(conn):
-    conn.execute(
+    conn.executescript(
         """
         CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id TEXT,
             role TEXT,
             content TEXT,
             timestamp REAL
-        )
+        );
+        CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
         """
     )
 
@@ -489,6 +491,48 @@ def test_subagent_goal_title_handles_blank_state_titles_and_custom_sidecar(
             assert row["display_title"] == expected_display_title
         assert conn.execute("SELECT title FROM sessions WHERE id = ?", (sid,)).fetchone()[0] == state_title
         assert sidecar.path.read_bytes() == sidecar_before
+    finally:
+        conn.close()
+
+
+def test_subagent_goal_title_breaks_equal_timestamps_by_message_id(_isolate):
+    """The first persisted goal wins even when an added index reorders timestamp ties."""
+    conn = _ensure_state_db(_isolate)
+    _ensure_messages_table(conn)
+    sid = "lineage_api_subagent_tied_goals"
+    t0 = time.time() - 100
+    try:
+        _save_webui_session(sid, title="Subagent Session", updated_at=t0)
+        _insert_state_row(conn, sid, source="subagent", started_at=t0)
+        conn.execute("UPDATE sessions SET title = NULL WHERE id = ?", (sid,))
+        _insert_state_message(
+            conn,
+            sid,
+            role="user",
+            content="Alpha goal arrived first",
+            timestamp=t0 + 1,
+        )
+        _insert_state_message(
+            conn,
+            sid,
+            role="user",
+            content="Zulu goal arrived second",
+            timestamp=t0 + 1,
+        )
+        # The old timestamp-only query may legally read this covering index in
+        # content-descending order. A deterministic query must still choose the
+        # lower message id, matching the canonical transcript reader.
+        conn.execute(
+            """
+            CREATE INDEX idx_messages_tied_goal_adversarial
+            ON messages(session_id, timestamp, content DESC, role)
+            """
+        )
+        conn.commit()
+
+        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}[sid]
+
+        assert row["display_title"] == "Alpha goal arrived first"
     finally:
         conn.close()
 

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -537,6 +537,83 @@ def test_subagent_goal_title_breaks_equal_timestamps_by_message_id(_isolate):
         conn.close()
 
 
+def test_subagent_goal_title_fails_closed_without_session_message_index(_isolate):
+    """Legacy/read-only DBs without the session index keep cheaper metadata but skip title work."""
+    conn = _ensure_state_db(_isolate)
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        )
+        """
+    )
+    sid = "lineage_api_subagent_no_message_index"
+    t0 = time.time() - 100
+    try:
+        _save_webui_session(sid, title="Subagent Session", updated_at=t0)
+        _insert_state_row(conn, sid, source="subagent", started_at=t0)
+        conn.execute("UPDATE sessions SET title = NULL WHERE id = ?", (sid,))
+        _insert_state_message(
+            conn,
+            sid,
+            role="user",
+            content="Do not scan the whole table for this title",
+            timestamp=t0 + 1,
+        )
+
+        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}[sid]
+        metadata = models._read_state_db_sidebar_overrides(
+            _isolate,
+            {sid},
+            count_session_ids={sid},
+        )[sid]
+
+        assert row["title"] == "Subagent Session"
+        assert "display_title" not in row
+        assert row["message_count"] == 2
+        assert metadata["_state_db_source"] == "subagent"
+        assert metadata["_state_db_message_count"] == 2
+        assert "_state_db_display_title" not in metadata
+    finally:
+        conn.close()
+
+
+def test_malformed_blob_title_is_isolated_from_healthy_sibling(_isolate):
+    conn = _ensure_state_db(_isolate)
+    _ensure_messages_table(conn)
+    bad_sid = "lineage_api_subagent_bad_blob"
+    good_sid = "lineage_api_subagent_good_sibling"
+    t0 = time.time() - 100
+    try:
+        for sid in (bad_sid, good_sid):
+            _save_webui_session(sid, title="Subagent Session", updated_at=t0)
+            _insert_state_row(conn, sid, source="subagent", started_at=t0)
+            conn.execute("UPDATE sessions SET title = NULL WHERE id = ?", (sid,))
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', ?, ?)",
+            (bad_sid, sqlite3.Binary(b"\xff\xfe"), t0 + 1),
+        )
+        _insert_state_message(
+            conn,
+            good_sid,
+            role="user",
+            content="Healthy sibling goal",
+            timestamp=t0 + 1,
+        )
+        conn.commit()
+
+        rows = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}
+
+        assert "display_title" not in rows[bad_sid]
+        assert rows[good_sid]["display_title"] == "Healthy sibling goal"
+    finally:
+        conn.close()
+
+
 def test_custom_subagent_title_stays_authoritative(_isolate):
     conn = _ensure_state_db(_isolate)
     _ensure_messages_table(conn)
@@ -595,35 +672,44 @@ def test_generic_subagent_title_falls_back_without_first_user_message(_isolate):
         conn.close()
 
 
-def test_generic_subagent_title_skips_null_first_user_message(_isolate):
+@pytest.mark.parametrize(
+    "blank_content",
+    [
+        pytest.param(None, id="null"),
+        pytest.param("\t\n\r", id="python-whitespace"),
+        pytest.param("\n\n[Attached files: /tmp/no-goal.txt]", id="attachment-marker-only"),
+    ],
+)
+def test_generic_subagent_title_skips_blank_first_user_message(_isolate, blank_content):
     conn = _ensure_state_db(_isolate)
     _ensure_messages_table(conn)
     t0 = time.time() - 100
+    sid = "lineage_api_subagent_blank_first"
     try:
-        _save_webui_session("lineage_api_subagent_null_first", title="Subagent Session", updated_at=t0)
+        _save_webui_session(sid, title="Subagent Session", updated_at=t0)
         _insert_state_row(
             conn,
-            "lineage_api_subagent_null_first",
+            sid,
             title="Subagent Session",
             source="subagent",
             started_at=t0,
         )
         _insert_state_message(
             conn,
-            "lineage_api_subagent_null_first",
+            sid,
             role="user",
-            content=None,
+            content=blank_content,
             timestamp=t0 + 1,
         )
         _insert_state_message(
             conn,
-            "lineage_api_subagent_null_first",
+            sid,
             role="user",
             content="Recover the next usable delegated title",
             timestamp=t0 + 2,
         )
 
-        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}["lineage_api_subagent_null_first"]
+        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}[sid]
 
         assert row["title"] == "Subagent Session"
         assert row["display_title"] == "Recover the next usable delegated title"

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -441,38 +441,54 @@ def test_generic_subagent_title_gets_goal_display_title(_isolate):
         conn.close()
 
 
-def test_generic_subagent_title_uses_goal_when_state_db_title_is_null(_isolate):
-    """Current Agent children leave state.db.title null while WebUI keeps the generic sidecar title."""
+@pytest.mark.parametrize(
+    ("state_title", "sidecar_title", "expected_display_title"),
+    [
+        pytest.param(None, "Subagent Session", "Research lesser-known coding agent harnesses", id="null"),
+        pytest.param("", "Subagent Session", "Research lesser-known coding agent harnesses", id="empty"),
+        pytest.param(" \t ", "Subagent Session", "Research lesser-known coding agent harnesses", id="whitespace"),
+        pytest.param(None, "Human-chosen child title", None, id="null-custom-sidecar"),
+    ],
+)
+def test_subagent_goal_title_handles_blank_state_titles_and_custom_sidecar(
+    _isolate,
+    state_title,
+    sidecar_title,
+    expected_display_title,
+):
+    """Blank Agent titles are candidates, but the WebUI sidecar remains authoritative."""
     conn = _ensure_state_db(_isolate)
     _ensure_messages_table(conn)
     t0 = time.time() - 100
+    sid = "lineage_api_subagent_blank_title"
     try:
-        _save_webui_session("lineage_api_subagent_null_title", title="Subagent Session", updated_at=t0)
+        sidecar = _save_webui_session(sid, title=sidecar_title, updated_at=t0)
+        sidecar_before = sidecar.path.read_bytes()
         _insert_state_row(
             conn,
-            "lineage_api_subagent_null_title",
+            sid,
             source="subagent",
             started_at=t0,
         )
-        conn.execute(
-            "UPDATE sessions SET title = NULL WHERE id = ?",
-            ("lineage_api_subagent_null_title",),
-        )
+        conn.execute("UPDATE sessions SET title = ? WHERE id = ?", (state_title, sid))
         conn.commit()
         _insert_state_message(
             conn,
-            "lineage_api_subagent_null_title",
+            sid,
             role="user",
             content="Research lesser-known coding agent harnesses",
             timestamp=t0 + 1,
         )
 
-        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}[
-            "lineage_api_subagent_null_title"
-        ]
+        row = {row["session_id"]: row for row in all_sessions(include_lineage_metadata=False)}[sid]
 
-        assert row["title"] == "Subagent Session"
-        assert row["display_title"] == "Research lesser-known coding agent harnesses"
+        assert row["title"] == sidecar_title
+        if expected_display_title is None:
+            assert "display_title" not in row
+        else:
+            assert row["display_title"] == expected_display_title
+        assert conn.execute("SELECT title FROM sessions WHERE id = ?", (sid,)).fetchone()[0] == state_title
+        assert sidecar.path.read_bytes() == sidecar_before
     finally:
         conn.close()
 


### PR DESCRIPTION
## Thinking Path

Hermes Agent can persist delegated children with `source='subagent'` and `sessions.title=NULL`, while the WebUI sidecar retains the generic `Subagent Session` title. The existing #6056 selector rejected those rows before deriving a display title from the first user goal.

This patch extends that existing read-side selector to treat a null/blank Agent title as absent. The downstream generic-sidecar guard remains authoritative, so custom WebUI titles are preserved and neither state store is mutated.

## What Changed

- Admit null, empty, and whitespace-only Agent titles to the existing subagent goal-title derivation pass.
- Add a focused SQLite matrix covering those candidates plus `NULL` with a custom WebUI sidecar title.
- Assert that both persisted title stores remain unchanged.

## Why It Matters

Current delegated children otherwise remain indistinguishable as `Subagent Session`. This restores their goal-derived sidebar names without changing ownership or write behavior.

## Contract Routing

- **Contract family/layer:** sidebar/session metadata.
- **State owner:** Hermes Agent owns `state.db`; WebUI owns its sidecar and final display-title gate.
- **Mutation:** none; this is a transient `state.db → display_title` projection.
- **Invariant:** invariant 8 in `docs/rfcs/webui-run-state-consistency-contract.md`; the PR names the affected layer and proves it with focused RED/GREEN coverage.
- **Reviewed:** `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/GUIDELINES.md`, `docs/rfcs/README.md`, the run-state consistency RFC, `ARCHITECTURE.md`, `TESTING.md`, `docs/UIUX-GUIDE.md`, and `DESIGN.md`.
- **Scope:** no rename, branch, duplicate, delete, write-through, layout, or CSS changes.

No tracked documentation update is needed because ownership, persistence, layout, and interaction contracts are unchanged.

## Verification

Exact base: `a7180a81081de6bbc2cb3083edf1cb029f29ff01`  
Repaired head: `0209aea12959b5f3f098f42b317dbad96087c506`

```bash
# RED: exact base with the repaired test overlaid
./scripts/test.sh \
  'tests/test_session_lineage_metadata_api.py::test_subagent_goal_title_handles_blank_state_titles_and_custom_sidecar[null]' -q
# 1 failed: KeyError: 'display_title'

# GREEN matrix: NULL, empty, whitespace, and NULL + custom sidecar
./scripts/test.sh \
  tests/test_session_lineage_metadata_api.py::test_subagent_goal_title_handles_blank_state_titles_and_custom_sidecar -q
# 4 passed

./scripts/test.sh tests/test_session_lineage_metadata_api.py -q
# 21 passed

./scripts/test.sh tests/test_session_lineage_metadata_api.py \
  tests/test_session_summary_redaction.py \
  tests/test_5307_subagent_child_transcript.py \
  tests/test_session_lineage_collapse.py -q
# 88 passed

# CI-shaped five-shard run after removing host-only WebUI env overrides
./scripts/test.sh tests/ -q --timeout=60 --shard-id=<0..4> --num-shards=5
# 13,714 passed, 113 skipped, 3 xpassed, 2 failed
# Both failures are self-signed TLS-probe tests that fail identically on the
# exact base under Debian 13 curl/OpenSSL (curl 56 after receiving the valid
# response body at EOF). No metadata/sidebar/persistence/redaction test failed.

.venv/bin/python tests/browser_smoke.py
# /, /#settings, and /#sessions passed with zero console errors

.venv/bin/python scripts/ruff_lint.py --diff a7180a81081de6bbc2cb3083edf1cb029f29ff01
# 0 findings on added/modified lines

git diff --check a7180a81081de6bbc2cb3083edf1cb029f29ff01..0209aea12959b5f3f098f42b317dbad96087c506
# passed
```

<details>
<summary><strong>Sanitized UI evidence</strong> — desktop and narrow/mobile before/after</summary>

The fixture uses SQL `NULL`, a generic sidecar title, and distinct synthetic goals. No private session content is present; images are kept off the feature branch.

| Desktop before | Desktop after |
|---|---|
| ![Desktop before](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/evidence-pr-6535-subagent-title-null/pr-6535/desktop-before.png) | ![Desktop after](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/evidence-pr-6535-subagent-title-null/pr-6535/desktop-after.png) |

| Narrow/mobile before | Narrow/mobile after |
|---|---|
| ![Narrow before](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/evidence-pr-6535-subagent-title-null/pr-6535/narrow-before.png) | ![Narrow after](https://raw.githubusercontent.com/dirtydishes/hermes-webui-upstream/evidence-pr-6535-subagent-title-null/pr-6535/narrow-after.png) |

</details>

## Risks / Follow-ups

- Goal derivation remains bounded by the existing top-N sidebar metadata budget.
- Custom sidecar titles remain authoritative.
- The SQL-`NULL` mechanism is established by current Hermes Agent source: the delegated goal is preserved in the child prompt ([delegate_tool.py](https://github.com/NousResearch/hermes-agent/blob/0e2808729e20e09dfe3581b15ab1018f839ff636/tools/delegate_tool.py#L608-L620)), the child is persisted with `source="subagent"` ([run_agent.py](https://github.com/NousResearch/hermes-agent/blob/0e2808729e20e09dfe3581b15ab1018f839ff636/run_agent.py#L1019-L1023)), and the nullable title is written to SQLite ([hermes_state.py](https://github.com/NousResearch/hermes-agent/blob/0e2808729e20e09dfe3581b15ab1018f839ff636/hermes_state.py#L243-L244)). #6033 reported generic labels but did not itself pin SQL `NULL`.
- Client-side sidebar search already uses `display_title`; the pre-existing server-side search predicate only matches persisted titles and is outside this focused PR.
- Hosted Python/browser/lint/Docker workflows have not reported while the PR is a draft.

## Release Note

Fixed delegated child sessions showing a generic title when Hermes Agent stores a null child-session title; they now display their goal-derived names.

## Model Used

- **Provider:** OpenAI Codex (`openai-codex`)
- **Exact model:** `gpt-5.6-sol`
- **Usage:** production authoring at high reasoning; a discarded preliminary review at low; Round 1 adversarial/contribution review and repair at verified xhigh reasoning with fast service tier; terminal/file tools and Chromium QA.

The PR remains draft pending a separate clean-room xhigh thermo-nuclear review and final verification.
