### PR TITLE
ci: add workflow_dispatch, feature-branch push trigger, and read-only permissions

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -20,6 +20,12 @@ on:
     branches: [master]
   push:
     branches: [master]
+  workflow_dispatch:
+
+# Pin to read-only — smoke boots the server without credentials and never
+# writes back to the repo.
+permissions:
+  contents: read
 
 jobs:
   changes:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,13 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master]
+    branches: [master, '**']
+  workflow_dispatch:
+
+# Pin to read-only — these jobs checkout code and run tests; they never write
+# back to the repo, create releases, or push packages.
+permissions:
+  contents: read
 
 # Docs-only fast path: a CHANGELOG/README/docs-only PR does not need the full pytest
 # matrix or the JS/lint runtime guards — nothing executable changed. But the `test (…)`


### PR DESCRIPTION
All CI workflows were scoped to `push/pull_request: branches: [master]` only, meaning CI never ran on feature branches and could not be manually triggered. This made the CI status undetectable to monitoring tools ("CI unavailable").

**Approach:** Two purely additive changes to the two main workflows, preserving all existing triggers:

- `tests.yml`: add `workflow_dispatch` (allows manual + dashboard-detectable triggering) and extend `push` to cover all branches so CI fires on feature branch pushes.
- `browser-smoke.yml`: add `workflow_dispatch` only -- the smoke suite installs Playwright/Chromium so keeping it scoped to master for automatic runs avoids unnecessary cost on every branch push.

**Security hardening:** Both workflows now declare `permissions: contents: read`, pinning the GITHUB_TOKEN to the minimum required scope. Neither workflow uses secrets; the smoke suite boots the server agent-free.

**Validation:** YAML validated locally. `workflow_dispatch` confirmed working -- CI run triggered successfully on branch `maksym-mishchenko-add-webui-ci` immediately after the change was pushed.