### PR TITLE
chore: add test.png to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ copilot-instructions.md
 # Generated screenshots and transient artifacts
 screenshot-*.png
 full-UI.png
+test.png
 
 # OS files
 .DS_Store


### PR DESCRIPTION
## Summary

Add `test.png` to `.gitignore` under the existing "Generated screenshots and transient artifacts" section to prevent this untracked test image from being accidentally committed.

## Changes

- `.gitignore`: added `test.png` entry