### PR TITLE
perf(chat/start): reject a busy session before the provider-catalog rebuild (#0612)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -21088,6 +21088,31 @@ def _active_run_stream_for_session(session_id: str | None) -> str | None:
     return None
 
 
+def _blocking_stream_id_for_chat_start_prefilter(session) -> str | None:
+    """Return the stream id that will reject this start, without any discovery.
+
+    ``_start_chat_stream_for_session`` remains the authoritative check (it runs
+    under the per-session lock and so closes the TOCTOU window), but it is only
+    reached after chat/start has resolved the model — which on the human path
+    rebuilds the live provider catalog over the network. A start that is going
+    to be rejected on session state has no business paying for provider
+    discovery, so mirror the decision here as a cheap read-only pre-filter.
+
+    Only an *unambiguous* rejection is reported. A stale ``active_stream_id``
+    returns None so the request still falls through to the full path and its
+    ``_clear_stale_stream_state`` cleanup — a stale id must never become a
+    permanent 409 (#3822).
+    """
+    current_stream_id = getattr(session, "active_stream_id", None)
+    if current_stream_id:
+        if _active_stream_blocks_chat_start(session, current_stream_id):
+            return str(current_stream_id)
+        return None
+    # Sidecar id already cleared by cancel_stream() while the worker unwinds:
+    # ACTIVE_RUNS is the lifecycle truth in that window (#3808).
+    return _active_run_stream_for_session(getattr(session, "session_id", None))
+
+
 def _agent_runtime_barrier_response(
     *,
     runner_local_owned: bool = False,
@@ -22179,6 +22204,22 @@ def _handle_chat_start(handler, body, diag=None):
                 moa_config = resolve_moa_config()
             except RuntimeError as e:
                 return bad(handler, str(e), 503)
+        # Reject a busy session BEFORE resolving the model: the decision below is
+        # a pure read of session/run state, while resolve_model_provider can cost
+        # a full live provider-catalog rebuild. _start_chat_stream_for_session
+        # repeats the check under the session lock and stays authoritative.
+        diag.stage("active_stream_prefilter") if diag else None
+        prefiltered_stream_id = _blocking_stream_id_for_chat_start_prefilter(s)
+        if prefiltered_stream_id:
+            diag.stage("response_write") if diag else None
+            return j(
+                handler,
+                {
+                    "error": "session already has an active stream",
+                    "active_stream_id": prefiltered_stream_id,
+                },
+                status=409,
+            )
         diag.stage("resolve_model_provider") if diag else None
         model, model_provider, normalized_model = _resolve_compatible_session_model_state(
             requested_model,

--- a/tests/test_chat_start_active_stream_prefilter.py
+++ b/tests/test_chat_start_active_stream_prefilter.py
@@ -1,0 +1,157 @@
+"""POST /api/chat/start must not build the provider catalog for a start it will reject.
+
+`_handle_chat_start` resolved the session model — which on the human path
+triggers a full live provider-catalog rebuild with network calls — *before*
+`_start_run` reached the guard that rejects a session already owning an active
+stream. A request destined for `409 session already has an active stream` still
+paid the entire catalog cost (~4.0s of budget timeout in production) on the way
+to being thrown away.
+
+The fix is ordering, not discovery: the blocking-active-stream decision is a
+pure read of session/run state and is hoisted ahead of model resolution. The
+authoritative check stays in `_start_chat_stream_for_session` under the
+per-session lock, so both entry points behave identically and the TOCTOU window
+stays closed.
+
+Coverage:
+
+1. A blocking `active_stream_id` rejects with the same 409 body, without calling
+   `get_available_models()` and without entering `_start_run`.
+2. The cancel-unwind sibling (sidecar stream id already cleared, but the worker
+   still owns the session in ACTIVE_RUNS) rejects the same way.
+3. A *stale* `active_stream_id` must NOT be short-circuited — it still falls
+   through to the full path so `_clear_stale_stream_state` runs and the turn
+   starts (the anti-permanent-409 guarantee of #3822).
+4. An idle session still performs full live discovery — no change to resolved
+   model/provider for human chat/start.
+"""
+
+import queue
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import api.config as config
+import api.routes as routes
+
+
+@pytest.fixture(autouse=True)
+def _clean_stream_registries():
+    with config.STREAMS_LOCK:
+        config.STREAMS.clear()
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+    yield
+    with config.STREAMS_LOCK:
+        config.STREAMS.clear()
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS.clear()
+
+
+def _session(tmp_path, *, active_stream_id=None):
+    return SimpleNamespace(
+        session_id="prefilter-session",
+        workspace=str(tmp_path),
+        model="gpt-5.5",
+        model_provider=None,
+        profile="default",
+        messages=[],
+        context_messages=[],
+        pending_user_message=None,
+        pending_started_at=None,
+        active_stream_id=active_stream_id,
+        save=lambda **_kwargs: None,
+    )
+
+
+def _install_chat_start_stubs(monkeypatch, session, tmp_path):
+    """Wire _handle_chat_start onto in-memory doubles and record the slow paths."""
+    calls = {"catalog": 0, "start_run": 0, "start_run_kwargs": None}
+
+    def _catalog(*, prefer_cache=False):
+        calls["catalog"] += 1
+        return {"groups": [{"provider_id": "openai", "models": [{"id": "gpt-5.5"}]}]}
+
+    def _start_run(s, **kwargs):
+        calls["start_run"] += 1
+        calls["start_run_kwargs"] = kwargs
+        return {"stream_id": "prefilter-new-stream"}
+
+    monkeypatch.setattr(routes, "_get_or_materialize_session", lambda _sid, **_kw: session)
+    monkeypatch.setattr(routes, "_resolve_chat_workspace_with_recovery", lambda _s, _w: str(tmp_path))
+    monkeypatch.setattr(routes, "_read_profile_model_config", lambda _s, _p: (None, None, None))
+    monkeypatch.setattr(routes, "get_available_models", _catalog)
+    monkeypatch.setattr(routes, "_start_run", _start_run)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200: (status, payload))
+    return calls
+
+
+def _post_chat_start(session):
+    return routes._handle_chat_start(
+        None,
+        {"session_id": session.session_id, "message": "continue"},
+    )
+
+
+def test_blocking_active_stream_rejects_before_provider_catalog(monkeypatch, tmp_path):
+    """A live stream 409s without paying for provider discovery."""
+    session = _session(tmp_path, active_stream_id="live-stream")
+    calls = _install_chat_start_stubs(monkeypatch, session, tmp_path)
+    with config.STREAMS_LOCK:
+        config.STREAMS["live-stream"] = queue.Queue()
+
+    status, payload = _post_chat_start(session)
+
+    assert calls["catalog"] == 0, "blocking active stream must skip provider catalog"
+    assert calls["start_run"] == 0, "rejected start must not reach _start_run"
+    assert status == 409
+    assert payload["error"] == "session already has an active stream"
+    assert payload["active_stream_id"] == "live-stream"
+
+
+def test_cancel_unwind_active_run_rejects_before_provider_catalog(monkeypatch, tmp_path):
+    """Sidecar id cleared but the worker still owns the session: same early 409."""
+    session = _session(tmp_path, active_stream_id=None)
+    calls = _install_chat_start_stubs(monkeypatch, session, tmp_path)
+    with config.ACTIVE_RUNS_LOCK:
+        config.ACTIVE_RUNS["unwinding-stream"] = {
+            "stream_id": "unwinding-stream",
+            "session_id": session.session_id,
+            "started_at": time.time(),
+        }
+
+    status, payload = _post_chat_start(session)
+
+    assert calls["catalog"] == 0, "cancel-unwind rejection must skip provider catalog"
+    assert calls["start_run"] == 0
+    assert status == 409
+    assert payload["error"] == "session already has an active stream"
+    assert payload["active_stream_id"] == "unwinding-stream"
+
+
+def test_stale_active_stream_still_falls_through_to_full_start(monkeypatch, tmp_path):
+    """A stale id is not a rejection — it must reach the cleanup + start path."""
+    session = _session(tmp_path, active_stream_id="stale-stream")
+    calls = _install_chat_start_stubs(monkeypatch, session, tmp_path)
+
+    status, payload = _post_chat_start(session)
+
+    assert status == 200
+    assert payload == {"stream_id": "prefilter-new-stream"}
+    assert calls["start_run"] == 1, "stale stream must still fall through to _start_run"
+    assert calls["catalog"] == 1, "stale stream must still resolve the model normally"
+
+
+def test_idle_start_still_performs_live_discovery(monkeypatch, tmp_path):
+    """An accepted start keeps the existing live-discovery behaviour."""
+    session = _session(tmp_path, active_stream_id=None)
+    calls = _install_chat_start_stubs(monkeypatch, session, tmp_path)
+
+    status, payload = _post_chat_start(session)
+
+    assert status == 200
+    assert payload == {"stream_id": "prefilter-new-stream"}
+    assert calls["catalog"] == 1, "idle starts must still build the live catalog"
+    assert calls["start_run"] == 1
+    assert calls["start_run_kwargs"]["model"] == "gpt-5.5"


### PR DESCRIPTION
## Problem

`POST /api/chat/start` resolved the session model — which on the human path triggers a
**full live provider-catalog rebuild with network calls** — *before* it reached the guard
that rejects a session which already has an active stream. So a request that was always
going to be thrown away with `409 session already has an active stream` paid the entire
catalog cost first.

In one production log window that was **18 of 22** 409s at a near-constant **4.08 s** each.
The other five came back in **63–128 ms** — the same rejection, for the same reason. Those
were requests that supplied explicit `model` + `model_provider` and so hit the #1855 fast
path in `_resolve_compatible_session_model_state`, skipping the catalog on the way to the
identical answer. The 4.08 s floor is not work; it is the catalog's own 4.0 s budget
timeout firing and serving a fallback.

`active_stream_check` depends on nothing `resolve_model_provider` produces.

## Fix

Ordering, not discovery.

`_blocking_stream_id_for_chat_start_prefilter(session)` is a read-only predicate returning
the stream id that will reject this start, or `None`. `_handle_chat_start` calls it
immediately before `diag.stage("resolve_model_provider")` and returns the identical 409
body.

It mirrors exactly what `_start_chat_stream_for_session` rejects on, covering **both** ways
a session can already own its next turn:

1. a persisted `active_stream_id` that still blocks (`_active_stream_blocks_chat_start`), and
2. the cancel-unwind window where the id was already cleared but the worker still owns the
   session in `ACTIVE_RUNS` (`_active_run_stream_for_session`, #3808/#3822).

Handling only (1) would have been a brittle one-off — the 4 s cost would just have moved to
the other rejection branch.

A **stale** id deliberately returns `None`, so the request still falls through to
`_clear_stale_stream_state` and starts normally. A stale id must never become a permanent
409 (#3822).

`_start_chat_stream_for_session` keeps its original checks under the per-session lock, so it
remains authoritative and the TOCTOU window stays closed — the pre-filter can only ever
*agree early* with a decision that path would also make.

### Siblings checked / scope

- `start_session_turn`, the other caller of `_start_chat_stream_for_session`, needs nothing:
  it already resolves with `prefer_cached_catalog=True` and never paid this cost.
- Placement is just ahead of model resolution rather than right after `get_session` on
  purpose: 400 validation, 404/403 profile authorization, the compression-recovery 409 and
  the MoA gateway checks all keep their existing precedence, so **no request changes its
  status code**. Only the catalog moves.
- Explicitly *not* done: `prefer_cached_catalog=True` on chat/start. That is the wakeup
  path's tradeoff and would change model resolution for successful human starts. The bug is
  ordering, not discovery.

## Tests

`tests/test_chat_start_active_stream_prefilter.py` — 4 cases: blocking stream,
cancel-unwind `ACTIVE_RUNS` sibling, stale-id fall-through, and an idle start that must
still perform live discovery. It asserts on the `get_available_models()` **call count**, not
on a latency number (a warm catalog would hide the bug).

**Failed before the fix, for the right reason:**

```
>       assert calls["catalog"] == 0, "blocking active stream must skip provider catalog"
E       AssertionError: blocking active stream must skip provider catalog
E       assert 1 == 0
2 failed, 2 passed in 6.61s
```

**Passes after:** `4 passed in 8.89s`.

**Full suite** (`./scripts/test.sh`): `3 failed, 13723 passed, 111 skipped, 1 xfailed,
2 xpassed, 34 subtests passed in 579.70s`. The three failures
(`test_issue4685_post_compression_context_metering`, `test_issue5567_profile_home_override`,
`test_xsession_wakeup_misroute`) reproduce identically on a pristine `master` tree at
`21bdd7c1` and are unrelated to this change. Ruff diff gate vs `master`: no new violations
on added/modified lines.

## Live verification (isolated candidate container)

Candidate image built from this branch on port 18787; baseline image built from `master`
(`21bdd7c1`) on 18788. Same Dockerfile, throwaway state dirs and workspace, no credentials,
no production state. The provider catalog was made genuinely slow via an unroutable custom
OpenAI-compat `base_url`, reproducing the production 4.0 s budget timeout. Cold catalog on
both (container restarted, `models_cache.json` deleted), one busy-session
`POST /api/chat/start` each:

| | cold-catalog 409 | body |
|---|---|---|
| baseline `21bdd7c1` (pre-fix) | **4.034 s** | `session already has an active stream` |
| candidate (this PR) | **0.014 s** | byte-identical |

Over 20 rejections the candidate's p95 was **15.8 ms** (max 22.9 ms). The stale-stream
probe still fell through and still paid **4.03 s** of live discovery before returning `200`
with a new stream id — the change reorders the rejection, it does not disable discovery.
Both containers ended `healthy`, `RestartCount=0`, `OOMKilled=false`; all containers,
images and temp state were removed afterwards.

## Release-note wording

> `POST /api/chat/start` no longer rebuilds the live provider catalog before rejecting a
> session that already has an active stream — those 409s now return in milliseconds instead
> of paying the ~4 s catalog budget.

## Not verified

- Production p95 for 409s (acceptance criterion 1) — measurable only after deploy, from the
  `[webui]` access log.
- `CHANGELOG.md` intentionally untouched per AGENTS.md; release-note wording is above.

---
Maint ticket: #0612 — Maint-Manager `tickets/review/0612-hermes-webui-post-api-chat-start-pays-the-full-4-0.md`
On merge: verify this ticket's acceptance boxes against **production** (not tests),
tick them, then move the ticket to `tickets/done/` and set `status: done`.
A merged PR is not a closed ticket — an unmerged PR is not a shipped fix.
