### PR TITLE
fix(agent_runtime): include diagnostic info in stale-revision error message

### DIFF
--- a/api/agent_runtime.py
+++ b/api/agent_runtime.py
@@ -18,10 +18,51 @@ import threading
 from api.config import _AGENT_DIR  # noqa: F401
 from api.subprocess_utils import windows_hide_flags
 
-_RESTART_MESSAGE = (
-    "Hermes Agent was updated while Hermes WebUI was running. "
-    "Restart Hermes WebUI before retrying this action."
-)
+
+def _format_stale_message(
+    old_revision: str | None,
+    current_agent_dir: Path | None,
+) -> str:
+    """Build a diagnostic error message when Agent HEAD has changed.
+
+    Includes old SHA, new SHA, and the latest commit info so operators
+    can quickly tell *what* changed without extra git commands.
+    """
+    old_str = old_revision[:8] if old_revision else "?"
+
+    # Read current HEAD info for diagnostics
+    new_sha = "?"
+    author_info = ""
+    if current_agent_dir is not None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(current_agent_dir), "rev-parse", "--short", "HEAD"],
+                check=False, capture_output=True, text=True, timeout=2,
+            )
+            if result.returncode == 0:
+                new_sha = result.stdout.strip()
+
+            log_result = subprocess.run(
+                ["git", "-C", str(current_agent_dir), "log", "-1",
+                 "--format=%h %an <%ae> %ai"],
+                check=False, capture_output=True, text=True, timeout=2,
+            )
+            if log_result.returncode == 0:
+                author_info = log_result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    msg = (
+        f"Hermes Agent source revision changed "
+        f"(was {old_str}, now {new_sha})."
+    )
+    if author_info and author_info != new_sha:
+        msg += f" Latest: {author_info}."
+    msg += (
+        " The running WebUI process still holds the old modules in memory. "
+        "Restart Hermes WebUI before retrying this action."
+    )
+    return msg
 
 
 def _read_agent_revision(
@@ -136,11 +177,10 @@ def ensure_agent_runtime_current() -> None:
     """Reject a known Git checkout change instead of mixing Python modules."""
     if _AGENT_REVISION is None:
         return
-    if (
-        _read_agent_revision(_AGENT_SOURCE_DIR, module_path=_AGENT_MODULE_PATH)
-        != _AGENT_REVISION
-    ):
-        raise AgentRuntimeChangedError(_RESTART_MESSAGE)
+    current = _read_agent_revision(_AGENT_SOURCE_DIR, module_path=_AGENT_MODULE_PATH)
+    if current != _AGENT_REVISION:
+        msg = _format_stale_message(_AGENT_REVISION, _AGENT_SOURCE_DIR)
+        raise AgentRuntimeChangedError(msg)
 
 
 def require_ai_agent_class():

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -179,11 +179,19 @@ turn in the exhausted session instead of being blocked with recovery guidance.
 
 ## "Hermes Agent was updated while Hermes WebUI was running"
 
-**Symptom.** An action that uses the in-process Agent runtime stops with a message telling you to restart Hermes WebUI. This can happen after `hermes update`, a Git checkout/pull in the Agent source tree, or another tool updates Hermes Agent without restarting the already-running WebUI backend.
+**Symptom.** An action that uses the in-process Agent runtime stops with a message telling you to restart Hermes WebUI. The message includes the old and new Git revision SHAs and the latest commit author, e.g.:
+
+```
+Hermes Agent source revision changed (was abc1234, now def5678).
+Latest: def5678 User <email> 2026-07-27 08:47:54 -0300.
+Restart Hermes WebUI before retrying this action.
+```
+
+This can happen after `hermes update`, a Git checkout/pull in the Agent source tree, or another tool updates Hermes Agent without restarting the already-running WebUI backend. It can also happen after a legitimate developer commit or branch switch in the Agent repo while WebUI is running — the guard does not distinguish between an external update and local work.
 
 **Why.** WebUI currently imports `run_agent.AIAgent` into its long-lived Python process. Python keeps imported modules in memory. Continuing after a known Agent Git revision changes could combine cached modules from the old revision with source read from the new revision, producing misleading `ImportError`s or inconsistent runtime state. For local Agent-backed chat, WebUI therefore returns a retryable `409 agent_runtime_stale` before claiming or mutating session state instead of attempting a partial in-process reload. Gateway-backed chat runs in the gateway process and is not blocked by this WebUI-local check. Non-Git Agent installs preserve their existing behavior because there is no revision identity to compare.
 
-**Diagnostic.** Compare the running WebUI process start time with the Agent checkout revision and recent update history. If the Agent was updated after WebUI started, restart WebUI before investigating individual missing-symbol errors.
+**Diagnostic.** The error message itself shows the old and new HEAD SHAs and the latest commit — no extra commands needed. If more detail is required, compare the running WebUI process start time with the Agent checkout revision and recent update history. If the Agent was updated after WebUI started, restart WebUI before investigating individual missing-symbol errors.
 
 **Fix.** Restart using the same launch method that started WebUI:
 

--- a/tests/test_agent_runtime_revision_guard.py
+++ b/tests/test_agent_runtime_revision_guard.py
@@ -84,7 +84,7 @@ try:
     streaming._get_ai_agent()
 except RuntimeError as exc:
     message = str(exc)
-    assert "Hermes Agent was updated" in message
+    assert "Hermes Agent source revision changed" in message
     assert "Restart Hermes WebUI" in message
 else:
     raise AssertionError("stale in-process AIAgent was reused after its source revision changed")


### PR DESCRIPTION
## Summary

Improves the `ensure_agent_runtime_current()` error message to include diagnostic info (old SHA, new SHA, latest commit author and timestamp) so operators can identify *what* changed without extra git commands.

## Changes

### `api/agent_runtime.py`
- Added `_format_stale_message()` helper that queries `git rev-parse --short HEAD` and `git log -1 --format="%h %an <%ae> %ai"` on the Agent repo
- `ensure_agent_runtime_current()` now builds a detailed message when it detects a Git HEAD mismatch
- Removed the old static `_RESTART_MESSAGE` constant (superseded by the dynamic formatter)

### Before
```
Hermes Agent was updated while Hermes WebUI was running.
Restart Hermes WebUI before retrying this action.
```

### After
```
Hermes Agent source revision changed (was abc1234, now def5678).
Latest: def5678 User <user@example.com> 2026-07-27 08:47:54 -0300.
The running WebUI process still holds the old modules in memory.
Restart Hermes WebUI before retrying this action.
```

### `docs/troubleshooting.md`
- Updated "Hermes Agent was updated while Hermes WebUI was running" section to show the new message format
- Noted that the guard also triggers on legitimate developer commits/branch switches, not just external updates
- Diagnostic step simplified: "the error message itself shows the old and new HEAD SHAs"

### `tests/test_agent_runtime_revision_guard.py`
- Updated assertion to match the new message prefix

## Testing

- `tests/test_agent_runtime_revision_guard.py`: 21 passed
- `tests/test_issue1013_handoff_dock.py` + `tests/test_sprint46.py`: 39 passed
- All 60 tests pass, proving the message contract change is compatible with existing stale-runtime coverage

## Related

Fixes #6547