### PR TITLE
fix(sidebar): tolerate compression timestamp overlap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,6 +232,13 @@ Session is a plain Python class (not a dataclass, not SQLAlchemy):
     With 10 sessions: negligible. With 1000+: will be slow.
     See Architecture Phase C for the index file fix.
 
+Compression lineages keep display history and persistence ownership separate.
+Each archived `pre_compression_snapshot` and live continuation sidecar owns only
+its canonical segment; `GET /api/session` stitches those segments for display.
+Streaming completion may project that stitched transcript in its SSE payload,
+but must not write the projection back into the live tip. This keeps repeated
+compression bounded instead of copying all ancestors into every descendant.
+
 title_from(): takes messages list, finds first user message, returns first 64 chars.
 Called after run_conversation() completes to set the session title retroactively.
 

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1,5 +1,7 @@
 """Shared helpers for reading Hermes Agent sessions from state.db."""
+import json
 import logging
+import math
 import sqlite3
 from contextlib import closing
 from pathlib import Path
@@ -52,6 +54,7 @@ MESSAGING_SOURCES = {
 
 CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
 CLI_MIN_UNTITLED_USER_MESSAGE_COUNT = 2
+COMPRESSION_ROTATION_OVERLAP_TOLERANCE_SECONDS = 1.0
 
 SOURCE_LABELS = {
     'acp': 'ACP',
@@ -305,14 +308,49 @@ def is_cli_session_row_visible(row: dict) -> bool:
     return _count_user_turns(row) >= CLI_MIN_UNTITLED_USER_MESSAGE_COUNT
 
 
+def _session_lineage_identity(row: dict) -> dict[str, str] | None:
+    """Return validated branch/delegate identity, or None when it is ambiguous."""
+    raw_model_config = row.get('_lineage_model_config', row.get('model_config'))
+    if isinstance(raw_model_config, str):
+        raw_model_config = raw_model_config.strip()
+    if raw_model_config in (None, ''):
+        return {}
+    if isinstance(raw_model_config, str):
+        try:
+            parsed_model_config = json.loads(raw_model_config)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(raw_model_config, dict):
+        parsed_model_config = raw_model_config
+    else:
+        return None
+    if not isinstance(parsed_model_config, dict):
+        return None
+
+    identity = {}
+    for key in ('_branched_from', '_delegate_from'):
+        marker = parsed_model_config.get(key)
+        if marker is None:
+            continue
+        if not isinstance(marker, str):
+            return None
+        marker = marker.strip()
+        if marker:
+            identity[key] = marker
+    if len(identity) > 1:
+        return None
+    return identity
+
+
 def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
     """Return True when ``child`` is the next segment of the same conversation.
 
-    Compression rotates session ids automatically. A manual CLI close followed
-    by ``hermes -c`` also records a new child session; for sidebar projection it
-    should continue the same visible conversation rather than becoming a
-    separate child-session row. Plain parent/child links that started before the
-    parent's ended boundary remain child sessions.
+    Compression rotates session ids automatically. The replacement row may be
+    inserted just before the parent closure is committed, so automatic rotation
+    tolerates a bounded timestamp overlap. Production branch/delegate identity
+    in ``model_config`` is authoritative before that allowance is considered.
+    A manual CLI close followed by ``hermes -c`` still requires the child to
+    start after the parent's ended boundary.
 
     Do not collapse lineage across raw sources. A WebUI session that continues
     from a Telegram/CLI/etc. parent must remain visible as its own surface-owned
@@ -323,11 +361,29 @@ def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
         return False
     if str(child.get('session_source') or '').strip().lower() == 'fork':
         return False
+
+    parent_id = str(parent.get('id') or '').strip()
+    child_parent_id = str(child.get('parent_session_id') or '').strip()
+    if parent_id and child_parent_id and parent_id != child_parent_id:
+        return False
+    edge_parent_id = child_parent_id or parent_id
+
+    parent_identity = _session_lineage_identity(parent)
+    child_identity = _session_lineage_identity(child)
+    if parent_identity is None or child_identity is None:
+        return False
+    for key, marker in child_identity.items():
+        if not edge_parent_id or marker == edge_parent_id:
+            return False
+        if parent_identity.get(key) != marker:
+            return False
+
     parent_source = str(parent.get('source') or '').strip().lower()
     child_source = str(child.get('source') or '').strip().lower()
     if parent_source and child_source and parent_source != child_source:
         return False
-    if parent.get('end_reason') not in {'compression', 'cli_close'}:
+    end_reason = parent.get('end_reason')
+    if end_reason not in {'compression', 'cli_close'}:
         return False
     ended_at = parent.get('ended_at')
     if ended_at is None:
@@ -335,10 +391,22 @@ def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
         # the historical contract that compression/cli_close parent links are
         # continuations when no boundary timestamp is available.
         return True
+    started_at = child.get('started_at')
+    if started_at is None:
+        return False
     try:
-        return float(child.get('started_at') or 0) >= float(ended_at)
+        child_started_at = float(started_at)
+        parent_ended_at = float(ended_at)
     except (TypeError, ValueError):
         return False
+    if not math.isfinite(child_started_at) or not math.isfinite(parent_ended_at):
+        return False
+    tolerance = (
+        COMPRESSION_ROTATION_OVERLAP_TOLERANCE_SECONDS
+        if end_reason == 'compression'
+        else 0.0
+    )
+    return child_started_at + tolerance >= parent_ended_at
 
 
 def _continuation_root_id(rows_by_id: dict[str, dict], session_id: str | None) -> str | None:
@@ -488,6 +556,8 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         merged['_compression_segment_count'] = segment_count
         projected.append(merged)
 
+    for row in projected:
+        row.pop('_lineage_model_config', None)
     projected.sort(
         key=lambda row: _as_score(row.get('last_activity'), row.get('started_at')),
         reverse=True,
@@ -559,6 +629,11 @@ def read_importable_agent_session_rows(
 
         parent_expr = _optional_col('parent_session_id', session_cols)
         session_source_expr = _optional_col('session_source', session_cols)
+        model_config_expr = (
+            "s.model_config AS _lineage_model_config"
+            if 'model_config' in session_cols
+            else "NULL AS _lineage_model_config"
+        )
         ended_expr = _optional_col('ended_at', session_cols)
         end_reason_expr = _optional_col('end_reason', session_cols)
         user_id_expr = _optional_col('user_id', session_cols)
@@ -680,6 +755,7 @@ def read_importable_agent_session_rows(
             SELECT s.id, s.title, s.model, s.message_count,
                    s.started_at, s.source,
                    {session_source_expr},
+                   {model_config_expr},
                    {user_id_expr},
                    {chat_id_expr},
                    {chat_type_expr},
@@ -828,6 +904,11 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
 
             source_expr = _optional_col('source', session_cols)
             session_source_expr = _optional_col('session_source', session_cols)
+            model_config_expr = (
+                "s.model_config AS _lineage_model_config"
+                if 'model_config' in session_cols
+                else "NULL AS _lineage_model_config"
+            )
             title_expr = _optional_col('title', session_cols)
             started_expr = _optional_col('started_at', session_cols, '0')
             ended_expr = _optional_col('ended_at', session_cols)
@@ -842,6 +923,7 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
                     SELECT s.id,
                            {source_expr},
                            {session_source_expr},
+                           {model_config_expr},
                            {title_expr},
                            {started_expr},
                            {parent_expr},
@@ -888,6 +970,7 @@ def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops:
                     SELECT s.id,
                            {source_expr},
                            {session_source_expr},
+                           {model_config_expr},
                            {title_expr},
                            {started_expr},
                            {parent_expr},
@@ -965,6 +1048,11 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                 return {}
             session_source_expr = _optional_col('session_source', session_cols)
             source_expr = _optional_col('source', session_cols)
+            model_config_expr = (
+                "s.model_config AS _lineage_model_config"
+                if 'model_config' in session_cols
+                else "NULL AS _lineage_model_config"
+            )
             message_count_expr = _optional_col('message_count', session_cols, '0')
             # Scoped fetch via PRIMARY KEY + idx_sessions_parent rather than a
             # full table scan. The sessions table grows unbounded over time
@@ -1001,7 +1089,7 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     placeholders = ','.join('?' * len(chunk))
                     cur.execute(
                         f"""
-                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
+                        SELECT s.id, {source_expr}, {session_source_expr}, {model_config_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
                         FROM sessions s
                         WHERE s.id IN ({placeholders})
                         """,
@@ -1030,7 +1118,7 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
                     placeholders = ','.join('?' * len(chunk))
                     cur.execute(
                         f"""
-                        SELECT s.id, {source_expr}, {session_source_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
+                        SELECT s.id, {source_expr}, {session_source_expr}, {model_config_expr}, s.title, s.started_at, s.parent_session_id, s.ended_at, s.end_reason, {message_count_expr}
                         FROM sessions s
                         WHERE s.parent_session_id IN ({placeholders})
                         """,
@@ -1187,12 +1275,12 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
 
         root_id, segment_count = continuation_root_and_depth(sid)
 
-        if root_id != sid:
+        if root_id not in lineage_tip_cache:
+            lineage_tip_cache[root_id] = freshest_continuation_tip(root_id)
+        tip_id, tip_depth = lineage_tip_cache[root_id]
+        if root_id != sid or tip_id != sid:
             entry = metadata.setdefault(sid, {})
             entry['_lineage_root_id'] = root_id
-            if root_id not in lineage_tip_cache:
-                lineage_tip_cache[root_id] = freshest_continuation_tip(root_id)
-            tip_id, tip_depth = lineage_tip_cache[root_id]
             entry['_lineage_tip_id'] = tip_id
             entry['_compression_segment_count'] = max(segment_count, tip_depth)
 

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -54,7 +54,6 @@ MESSAGING_SOURCES = {
 
 CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
 CLI_MIN_UNTITLED_USER_MESSAGE_COUNT = 2
-COMPRESSION_ROTATION_OVERLAP_TOLERANCE_SECONDS = 1.0
 
 SOURCE_LABELS = {
     'acp': 'ACP',
@@ -345,12 +344,12 @@ def _session_lineage_identity(row: dict) -> dict[str, str] | None:
 def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
     """Return True when ``child`` is the next segment of the same conversation.
 
-    Compression rotates session ids automatically. The replacement row may be
-    inserted just before the parent closure is committed, so automatic rotation
-    tolerates a bounded timestamp overlap. Production branch/delegate identity
-    in ``model_config`` is authoritative before that allowance is considered.
-    A manual CLI close followed by ``hermes -c`` still requires the child to
-    start after the parent's ended boundary.
+    Compression rotates session ids automatically. The durable writer inserts
+    the physical child and its handoff before stamping the parent closed, with no
+    elapsed wall-clock bound on that work. Once physical parent, identity, fork,
+    and source guards pass, compression is authoritative regardless of timestamp
+    overlap. A manual CLI close followed by ``hermes -c`` still requires the
+    child to start after the parent's ended boundary.
 
     Do not collapse lineage across raw sources. A WebUI session that continues
     from a Telegram/CLI/etc. parent must remain visible as its own surface-owned
@@ -401,12 +400,9 @@ def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
         return False
     if not math.isfinite(child_started_at) or not math.isfinite(parent_ended_at):
         return False
-    tolerance = (
-        COMPRESSION_ROTATION_OVERLAP_TOLERANCE_SECONDS
-        if end_reason == 'compression'
-        else 0.0
-    )
-    return child_started_at + tolerance >= parent_ended_at
+    if end_reason == 'compression':
+        return True
+    return child_started_at >= parent_ended_at
 
 
 def _continuation_root_id(rows_by_id: dict[str, dict], session_id: str | None) -> str | None:

--- a/api/models.py
+++ b/api/models.py
@@ -8000,12 +8000,15 @@ def get_state_db_session_messages(
                 cur.execute("PRAGMA table_info(sessions)")
                 session_cols = {str(row['name']) for row in cur.fetchall()}
                 if {'parent_session_id', 'end_reason', 'started_at', 'source'}.issubset(session_cols):
+                    session_source_expr = (
+                        "session_source" if 'session_source' in session_cols else "NULL AS session_source"
+                    )
                     model_config_expr = (
                         "model_config" if 'model_config' in session_cols else "NULL AS model_config"
                     )
                     lineage_select = (
                         "id, source, started_at, parent_session_id, ended_at, "
-                        f"end_reason, {model_config_expr}"
+                        f"end_reason, {session_source_expr}, {model_config_expr}"
                     )
                     cur.execute(
                         f"SELECT {lineage_select} FROM sessions WHERE id = ?",

--- a/api/models.py
+++ b/api/models.py
@@ -8000,12 +8000,15 @@ def get_state_db_session_messages(
                 cur.execute("PRAGMA table_info(sessions)")
                 session_cols = {str(row['name']) for row in cur.fetchall()}
                 if {'parent_session_id', 'end_reason', 'started_at', 'source'}.issubset(session_cols):
+                    model_config_expr = (
+                        "model_config" if 'model_config' in session_cols else "NULL AS model_config"
+                    )
+                    lineage_select = (
+                        "id, source, started_at, parent_session_id, ended_at, "
+                        f"end_reason, {model_config_expr}"
+                    )
                     cur.execute(
-                        """
-                        SELECT id, source, started_at, parent_session_id, ended_at, end_reason
-                        FROM sessions
-                        WHERE id = ?
-                        """,
+                        f"SELECT {lineage_select} FROM sessions WHERE id = ?",
                         (sid,),
                     )
                     rows_by_id = {}
@@ -8020,11 +8023,7 @@ def get_state_db_session_messages(
                             if not parent_id or parent_id in seen:
                                 break
                             cur.execute(
-                                """
-                                SELECT id, source, started_at, parent_session_id, ended_at, end_reason
-                                FROM sessions
-                                WHERE id = ?
-                                """,
+                                f"SELECT {lineage_select} FROM sessions WHERE id = ?",
                                 (parent_id,),
                             )
                             parent_row = cur.fetchone()

--- a/api/routes.py
+++ b/api/routes.py
@@ -44,6 +44,7 @@ from api.agent_sessions import (
     _looks_like_default_cli_title,
     is_cli_session_row,
     is_cli_session_row_visible,
+    read_session_lineage_metadata,
     read_session_lineage_report,
 )
 from api.compression_anchor import visible_messages_for_anchor
@@ -2526,6 +2527,7 @@ def _build_session_list_cache_payload(
         diag_stage("filter_archived_sessions")
     diag_stage("visible_lineage_metadata")
     _enrich_sidebar_lineage_metadata(scoped)
+    scoped = _dedupe_canonical_sidebar_lineages(scoped)
     # Delegated subagent children (#5307) are view-only, owned by the delegate
     # runner. Coerce their sidebar rows to read_only=True + is_cli_session=False
     # so the UI never offers delete / edit / truncate / pin affordances on them
@@ -9393,6 +9395,92 @@ def _session_lineage_ids(session: dict) -> set[str]:
     return ids
 
 
+def _canonical_sidebar_lineage_key(session: dict) -> tuple[str, str, str] | None:
+    """Return a validated compression-lineage key for final sidebar dedupe."""
+    if not isinstance(session, dict) or session.get("archived"):
+        return None
+    if str(session.get("relationship_type") or "").strip().lower() == "child_session":
+        return None
+    source = str(
+        _safe_first(
+            session.get("raw_source"),
+            session.get("source_tag"),
+            session.get("source"),
+        ) or ""
+    ).strip().lower()
+    session_source = str(session.get("session_source") or "").strip().lower()
+    if source == "subagent" or session_source == "fork":
+        return None
+    root_id = str(session.get("_lineage_root_id") or "").strip()
+    tip_id = str(session.get("_lineage_tip_id") or "").strip()
+    try:
+        segment_count = int(session.get("_compression_segment_count") or 0)
+    except (TypeError, ValueError):
+        return None
+    if not root_id or not tip_id or root_id == tip_id or segment_count < 2:
+        return None
+    return str(session.get("profile") or "default"), root_id, tip_id
+
+
+def _dedupe_canonical_sidebar_lineages(sessions: list[dict]) -> list[dict]:
+    """Collapse duplicate materialized rows after every sidebar source is merged."""
+    grouped: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
+    passthrough: list[dict] = []
+    for session in sessions:
+        key = _canonical_sidebar_lineage_key(session)
+        if key is None:
+            passthrough.append(session)
+        else:
+            grouped[key].append(session)
+
+    for (_profile, _root_id, tip_id), rows in grouped.items():
+        representative = max(
+            rows,
+            key=lambda row: (
+                str(row.get("session_id") or "") == tip_id,
+                _session_sort_timestamp(row),
+                _numeric_count(row.get("message_count")),
+            ),
+        )
+        merged = dict(representative)
+        for key in ("message_count", "actual_message_count", "user_message_count"):
+            values = [_numeric_count(row.get(key)) for row in rows]
+            if any(value > 0 for value in values):
+                merged[key] = max(values)
+        for key in ("last_message_at", "updated_at"):
+            values = []
+            for row in rows:
+                try:
+                    values.append(float(row.get(key) or 0))
+                except (TypeError, ValueError):
+                    continue
+            if values and max(values) > 0:
+                merged[key] = max(values)
+        merged["_compression_segment_count"] = max(
+            _numeric_count(row.get("_compression_segment_count")) for row in rows
+        )
+        passthrough.append(merged)
+
+    passthrough.sort(key=_session_sort_timestamp, reverse=True)
+    return passthrough
+
+
+def _canonical_session_detail_id(session_id: str, *, profile=None) -> str:
+    """Resolve an ordinary detail request to its validated compression tip."""
+    sid = str(session_id or "").strip()
+    if not sid:
+        return sid
+    try:
+        db_path = _agent_state_db_path(profile=profile)
+        if db_path is None:
+            return sid
+        metadata = read_session_lineage_metadata(db_path, {sid})
+    except Exception:
+        return sid
+    tip_id = str((metadata.get(sid) or {}).get("_lineage_tip_id") or "").strip()
+    return tip_id or sid
+
+
 def _is_duplicate_webui_state_projection(session: dict, represented_webui_ids: set[str]) -> bool:
     """Return True when a state.db row is only a duplicate WebUI-origin projection.
 
@@ -9614,6 +9702,7 @@ from api.models import (
     _write_session_index,
     SESSION_INDEX_FILE,
     _active_state_db_path,
+    _agent_state_db_path,
     load_projects,
     save_projects,
     import_cli_session,
@@ -12790,7 +12879,8 @@ def handle_get(handler, parsed) -> bool:
         # 5s slow-request timeout and emits a spurious "Slow WebUI request
         # still running" log. Idempotent — finish() no-ops if already called.
         query = parse_qs(parsed.query)
-        sid = query.get("session_id", [""])[0]
+        requested_sid = query.get("session_id", [""])[0]
+        sid = _canonical_session_detail_id(requested_sid)
         if not sid:
             if _diag: _diag.finish()
             return j(handler, {"error": "session_id is required"}, status=400)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -66,8 +66,10 @@ from api.usage import prompt_cache_hit_percent
 from api.models import (
     _is_empty_partial_activity_message,
     _evict_sessions_over_cap,
+    _session_messages_have_prefix,
     clear_process_wakeup_pause,
     get_state_db_session_messages,
+    merge_session_messages_append_only,
     record_process_wakeup_provider_unavailable_pause,
     reconciled_state_db_messages_for_session,
 )
@@ -84,7 +86,7 @@ from api.process_event_utils import (
 )
 
 
-def _session_payload_with_full_messages(session, *, tool_calls=None):
+def _session_payload_with_full_messages(session, *, tool_calls=None, messages=None):
     """Return compact session metadata plus the embedded full transcript.
 
     ``Session.compact()`` may intentionally use metadata-only counts from an
@@ -92,7 +94,11 @@ def _session_payload_with_full_messages(session, *, tool_calls=None):
     must report the count of that embedded transcript, otherwise completion and
     reconcile paths can mistake a complete payload for a stale short window.
     """
-    messages = list(getattr(session, 'messages', None) or [])
+    messages = list(
+        (getattr(session, 'messages', None) or [])
+        if messages is None
+        else messages
+    )
     raw = session.compact() | {
         'messages': messages,
         'message_count': len(messages),
@@ -4574,7 +4580,7 @@ def generate_session_title_for_session(session, *, prefer_latest: bool = False, 
     return None, llm_status or 'empty_title', raw_preview
 
 
-def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
+def _preserve_pre_compression_snapshot(s, old_sid: str, *, snapshot_messages=None) -> None:
     """Persist old_sid as a read-only pre-compression snapshot.
 
     Context compression rotates the active WebUI session id from old_sid to the
@@ -4589,23 +4595,25 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
         try:
             existing = json.loads(existing_text)
             existing_msgs = len(existing.get('messages') or [])
-            existing_snapshot = bool(existing.get('pre_compression_snapshot'))
         except (json.JSONDecodeError, ValueError):
             # Treat corrupt/malformed old JSON as missing history and rewrite it
             # from the in-memory pre-compression messages below. That is safer
             # than leaving an unreadable recovery snapshot behind.
             existing_msgs = -1
-            existing_snapshot = False
-        if len(s.messages) > existing_msgs:
+
+        if snapshot_messages is not None or len(s.messages) > existing_msgs:
             # In-memory messages are newer than the file; save the full old
             # snapshot from the current session object while preserving its
             # pre-existing parent_session_id lineage.
             saved_sid = s.session_id
             saved_snapshot = bool(getattr(s, 'pre_compression_snapshot', False))
             saved_pinned = bool(getattr(s, 'pinned', False))
+            saved_messages = s.messages
             s.session_id = old_sid
             s.pre_compression_snapshot = True
             s.pinned = False
+            if snapshot_messages is not None:
+                s.messages = list(snapshot_messages)
             # Stage-359 / PR #2295: clear runtime stream-state fields on the
             # archived snapshot so the sidebar does not reopen the parent as
             # a permanently-running session while the child already holds the
@@ -4635,6 +4643,7 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
                 s.session_id = saved_sid
                 s.pre_compression_snapshot = saved_snapshot
                 s.pinned = saved_pinned
+                s.messages = saved_messages
                 s.active_stream_id = saved_active_stream_id
                 s.pending_user_message = saved_pending_user_message
                 s.pending_attachments = saved_pending_attachments
@@ -4670,6 +4679,110 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
         logger.debug("Could not read old session file before preservation")
     except Exception:
         logger.debug("Failed to preserve pre-compression session file", exc_info=True)
+
+
+def _compression_snapshot_ancestor_messages(session, *, max_hops: int = 20) -> list:
+    """Return only archived compression ancestors already persisted elsewhere."""
+    from api.models import Session
+
+    segments = []
+    current = session
+    root_is_fork = str(getattr(session, 'session_source', '') or '').strip().lower() == 'fork'
+    seen = {str(getattr(session, 'session_id', '') or '')}
+    for _ in range(max(0, int(max_hops))):
+        parent_id = str(getattr(current, 'parent_session_id', '') or '').strip()
+        if not parent_id or parent_id in seen:
+            break
+        parent = Session.load(parent_id)
+        if not parent or not getattr(parent, 'pre_compression_snapshot', False):
+            break
+        parent_source = str(getattr(parent, 'session_source', '') or '').strip().lower()
+        if root_is_fork and parent_source != 'fork':
+            break
+        segments.append(parent)
+        seen.add(parent_id)
+        current = parent
+
+    merged = []
+    for segment in reversed(segments):
+        segment_messages = list(getattr(segment, 'messages', None) or [])
+        if _session_messages_have_prefix(segment_messages, merged):
+            merged = segment_messages
+        else:
+            merged = merge_session_messages_append_only(
+                merged,
+                segment_messages,
+                truncation_watermark=getattr(segment, 'truncation_watermark', None),
+                truncation_boundary=getattr(segment, 'truncation_boundary', None),
+            )
+    return merged
+
+
+def _bound_compression_rotation_sidecars(s, *, old_sid: str, previous_messages) -> list:
+    """Archive one canonical segment and leave one segment on the live tip.
+
+    Display/recovery reconciliation can hand streaming a cumulative transcript
+    that already contains every archived compression ancestor. Persisting that
+    projection again on each rotation amplifies sidecars geometrically. Split
+    only when both boundaries are proven prefixes; otherwise retain the complete
+    transcript and use the legacy preservation path so uncertainty cannot lose a
+    user turn.
+    """
+    full_display = list(getattr(s, 'messages', None) or [])
+    previous_messages = list(previous_messages or [])
+    ancestor_messages = _compression_snapshot_ancestor_messages(s)
+    boundaries_proven = (
+        _session_messages_have_prefix(previous_messages, ancestor_messages)
+        and _session_messages_have_prefix(full_display, previous_messages)
+    )
+    if not boundaries_proven:
+        _preserve_pre_compression_snapshot(s, old_sid)
+        return full_display
+
+    archived_segment = previous_messages[len(ancestor_messages):]
+    live_segment = full_display[len(previous_messages):]
+    _preserve_pre_compression_snapshot(
+        s,
+        old_sid,
+        snapshot_messages=archived_segment,
+    )
+    s._compression_live_segment_messages = live_segment
+    return full_display
+
+
+def _apply_compression_live_segment(s) -> None:
+    live_segment = getattr(s, '_compression_live_segment_messages', None)
+    if live_segment is None:
+        return
+    s.messages = list(live_segment)
+    del s._compression_live_segment_messages
+
+
+def _current_compression_display_projection(s, captured_display):
+    """Project the current bounded tip over its archived compression ancestors.
+
+    ``captured_display`` is the full display scene at rotation time. Terminal
+    settlement can subsequently append status/error rows to the bounded live
+    segment, so returning the capture verbatim would omit those rows from SSE.
+    Rebuild from the persisted ancestor segments plus the current live segment
+    when their boundary is proven; otherwise merge append-only so uncertainty
+    cannot hide a terminal row. The projection is never assigned to ``s.messages``.
+    """
+    if captured_display is None:
+        return None
+    captured_display = list(captured_display or [])
+    live_messages = list(getattr(s, 'messages', None) or [])
+    ancestor_messages = _compression_snapshot_ancestor_messages(s)
+    if _session_messages_have_prefix(captured_display, ancestor_messages):
+        captured_live = captured_display[len(ancestor_messages):]
+        if _session_messages_have_prefix(live_messages, captured_live):
+            return ancestor_messages + live_messages
+    return merge_session_messages_append_only(
+        captured_display,
+        live_messages,
+        truncation_watermark=getattr(s, 'truncation_watermark', None),
+        truncation_boundary=getattr(s, 'truncation_boundary', None),
+    )
 
 
 def _maybe_schedule_title_refresh(session, put_event, agent):
@@ -10107,6 +10220,7 @@ def _run_agent_streaming(
                 # reference to the Lock is released.
                 _compression_origin_session_id = session_id
                 _compression_continuation_session_id = None
+                _compression_display_messages = None
                 _agent_sid = getattr(agent, 'session_id', None)
                 _compressed = False
                 if _agent_sid and _agent_sid != session_id:
@@ -10144,7 +10258,11 @@ def _run_agent_streaming(
                     # compression removes messages from the model's context. Skip
                     # the write when the file already contains up-to-date data
                     # (i.e. it was just saved by a checkpoint).
-                    _preserve_pre_compression_snapshot(s, old_sid)
+                    _compression_display_messages = _bound_compression_rotation_sidecars(
+                        s,
+                        old_sid=old_sid,
+                        previous_messages=_previous_messages,
+                    )
                     # The continuation is the live/tip session, not another archived
                     # snapshot. If the in-memory object was itself loaded from a
                     # pre-compression snapshot (possible on repeated compression chains
@@ -10207,6 +10325,7 @@ def _run_agent_streaming(
                             _close_cached_agent_entry_at_session_boundary(old_sid, _skipped_agent_migration_entry)
                         except Exception:
                             logger.debug("Failed to close skipped compression-migration cached agent for session %s", old_sid, exc_info=True)
+                    _apply_compression_live_segment(s)
                     _compressed = True
 
                 # ── Detect silent agent failure (no assistant reply produced) ──
@@ -10546,7 +10665,14 @@ def _run_agent_streaming(
                         except Exception:
                             pass
                         _error_payload['session'] = redact_session_data(
-                            _session_payload_with_full_messages(s, tool_calls=s.tool_calls)
+                            _session_payload_with_full_messages(
+                                s,
+                                tool_calls=s.tool_calls,
+                                messages=_current_compression_display_projection(
+                                    s,
+                                    _compression_display_messages,
+                                ),
+                            )
                         )
                         _error_payload['session_id'] = s.session_id
                         _error_payload['old_session_id'] = _compression_origin_session_id
@@ -11400,7 +11526,14 @@ def _run_agent_streaming(
             except Exception as _goal_exc:
                 logger.debug("Goal continuation hook failed for session %s: %s", session_id, _goal_exc)
             with _stream_writeback_stage(_writeback_timings, "done_payload"):
-                raw_session = _session_payload_with_full_messages(s, tool_calls=tool_calls)
+                raw_session = _session_payload_with_full_messages(
+                    s,
+                    tool_calls=tool_calls,
+                    messages=_current_compression_display_projection(
+                        s,
+                        _compression_display_messages,
+                    ),
+                )
                 _done_payload = {'session': redact_session_data(raw_session), 'usage': usage}
                 if _tool_limit_reached:
                     _done_payload['terminal_state'] = 'tool_limit_reached'

--- a/tests/test_auto_compression_terminal_failure.py
+++ b/tests/test_auto_compression_terminal_failure.py
@@ -7,7 +7,7 @@ import sys
 import types
 from pathlib import Path
 
-from api import models, streaming
+from api import models, routes, streaming
 from api.models import Session
 from api.streaming import (
     _agent_result_terminal_failure,
@@ -36,18 +36,38 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     streaming.SESSION_AGENT_LOCKS.clear()
     old_sid = "old_sid"
     new_sid = "new_sid"
+    root_sid = "root_sid"
     stream_id = "stream-compression-exhausted"
+    root_messages = [
+        {"role": "user", "content": "Ancestor prompt", "timestamp": 1},
+        {"role": "assistant", "content": "Ancestor answer", "timestamp": 2},
+    ]
+    old_segment = [
+        {"role": "user", "content": "Earlier prompt", "timestamp": 3},
+        {"role": "assistant", "content": "Earlier answer", "timestamp": 4},
+    ]
+    root = Session(
+        session_id=root_sid,
+        title="Compression root",
+        workspace=str(tmp_path),
+        model="gpt-4o",
+        messages=copy.deepcopy(root_messages),
+        context_messages=copy.deepcopy(root_messages),
+        pre_compression_snapshot=True,
+    )
+    root.save(touch_updated_at=False)
     session = Session(
         session_id=old_sid,
         title="Compression test",
         workspace=str(tmp_path),
         model="gpt-4o",
-        messages=[],
-        context_messages=[],
+        messages=copy.deepcopy(root_messages + old_segment),
+        context_messages=copy.deepcopy(root_messages + old_segment),
+        parent_session_id=root_sid,
     )
     session.active_stream_id = stream_id
     session.pending_user_message = "Do the long task."
-    session.pending_started_at = 1.0
+    session.pending_started_at = 5.0
     session.save()
     models.SESSIONS[old_sid] = session
     streaming.SESSIONS[old_sid] = session
@@ -97,9 +117,15 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
                 "compression_exhausted": True,
                 "error": "Context length exceeded: cannot compress further.",
                 "messages": [
+                    *(kwargs.get("conversation_history") or []),
                     {"role": "user", "content": kwargs.get("persist_user_message", "")},
                     {"role": "assistant", "content": "I am still working through the files."},
-                    {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}}],
+                        "reasoning_content": "Reasoning before the tool.",
+                        "tool_calls": [{"id": "call_1"}],
+                    },
                     {"role": "tool", "tool_call_id": "call_1", "content": "large output"},
                 ],
             }
@@ -138,9 +164,14 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     assert payload["recommended_recovery_action"] == "start_focused_continuation"
     assert payload["compression_recovery"]["terminal_state"] == "compression_exhausted"
     assert payload["compression_recovery"]["source_session_id"] == new_sid
+    assert payload["session"]["messages"][-1]["_error"] is True
+    assert "Context compression exhausted" in payload["session"]["messages"][-1]["content"]
 
+    root_payload = json.loads((session_dir / f"{root_sid}.json").read_text(encoding="utf-8"))
     old_payload = json.loads((session_dir / f"{old_sid}.json").read_text(encoding="utf-8"))
     new_payload = json.loads((session_dir / f"{new_sid}.json").read_text(encoding="utf-8"))
+    assert root_payload["messages"] == root_messages
+    assert old_payload["messages"] == old_segment
     assert old_payload["pre_compression_snapshot"] is True
     assert old_payload["active_stream_id"] is None
     assert old_payload["pending_user_message"] is None
@@ -152,8 +183,22 @@ def test_compression_exhausted_after_session_rotation_preserves_snapshot_and_err
     assert new_payload["messages"][-1]["_error"] is True
     assert new_payload["messages"][-1]["_compressionRecovery"]["recommended_action"] == "start_focused_continuation"
     assert "Context compression exhausted" in new_payload["messages"][-1]["content"]
+    payload_messages = payload["session"]["messages"]
+    assert payload_messages == root_messages + old_segment + new_payload["messages"]
+    assert sum(message.get("content") == "Ancestor prompt" for message in payload_messages) == 1
+    assert any(message.get("reasoning_content") == "Reasoning before the tool." for message in payload_messages)
+    assert any(message.get("tool_call_id") == "call_1" for message in payload_messages)
+    assert any(
+        isinstance(message.get("content"), list)
+        and message["content"][0].get("type") == "image_url"
+        for message in payload_messages
+    )
     assert old_sid not in streaming.SESSIONS
     assert streaming.SESSIONS[new_sid].session_id == new_sid
+    models.SESSIONS.clear()
+    reloaded = Session.load(new_sid)
+    stitched = routes._webui_sidecar_lineage_messages_for_display(reloaded)
+    assert stitched == payload_messages
 
 
 def test_compression_exhausted_result_is_terminal_failure_even_after_streamed_text():

--- a/tests/test_compression_sidecar_segment_bounds.py
+++ b/tests/test_compression_sidecar_segment_bounds.py
@@ -1,0 +1,110 @@
+"""Regression coverage for cumulative compression sidecar amplification."""
+
+import json
+
+from api import models, routes, streaming
+
+
+def _msg(role, content, timestamp):
+    return {"role": role, "content": content, "timestamp": timestamp}
+
+
+def test_repeated_compression_persists_each_sidecar_as_one_segment(tmp_path, monkeypatch):
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
+    models.SESSIONS.clear()
+
+    root_messages = [_msg("user", "root prompt", 1), _msg("assistant", "root answer", 2)]
+    middle_messages = [_msg("user", "middle prompt", 3), _msg("assistant", "middle answer", 4)]
+    tip_messages = [_msg("user", "tip prompt", 5), _msg("assistant", "tip answer", 6)]
+
+    root = models.Session(
+        session_id="segment_root",
+        messages=root_messages,
+        pre_compression_snapshot=True,
+    )
+    root.save(touch_updated_at=False)
+
+    # Incident shape: the live continuation already contains the stitched parent
+    # transcript, rather than only its own canonical segment.
+    middle = models.Session(
+        session_id="segment_middle",
+        parent_session_id=root.session_id,
+        messages=root_messages + middle_messages,
+    )
+    middle.save(touch_updated_at=False)
+    middle.messages = root_messages + middle_messages + tip_messages
+
+    full_display = streaming._bound_compression_rotation_sidecars(
+        middle,
+        old_sid="segment_middle",
+        previous_messages=root_messages + middle_messages,
+    )
+    middle.session_id = "segment_tip"
+    middle.parent_session_id = "segment_middle"
+    middle.pre_compression_snapshot = False
+    streaming._apply_compression_live_segment(middle)
+    middle.save(touch_updated_at=False)
+
+    archived_middle = json.loads((tmp_path / "segment_middle.json").read_text(encoding="utf-8"))
+    live_tip = json.loads((tmp_path / "segment_tip.json").read_text(encoding="utf-8"))
+
+    assert [m["content"] for m in archived_middle["messages"]] == ["middle prompt", "middle answer"]
+    assert [m["content"] for m in live_tip["messages"]] == ["tip prompt", "tip answer"]
+    assert [m["content"] for m in full_display] == [
+        "root prompt",
+        "root answer",
+        "middle prompt",
+        "middle answer",
+        "tip prompt",
+        "tip answer",
+    ]
+    assert len(archived_middle["messages"]) + len(live_tip["messages"]) == 4
+    stitched = routes._webui_sidecar_lineage_messages_for_display(
+        models.Session.load("segment_tip")
+    )
+    assert [m["content"] for m in stitched] == [m["content"] for m in full_display]
+
+
+def test_done_payload_can_project_full_display_without_reinflating_live_tip():
+    session = models.Session(
+        session_id="segment_payload",
+        messages=[_msg("user", "tip only", 3)],
+    )
+    full_display = [
+        _msg("user", "ancestor", 1),
+        _msg("assistant", "ancestor answer", 2),
+        *session.messages,
+    ]
+
+    payload = streaming._session_payload_with_full_messages(
+        session,
+        messages=full_display,
+    )
+
+    assert payload["messages"] == full_display
+    assert payload["message_count"] == 3
+    assert session.messages == [_msg("user", "tip only", 3)]
+
+
+def test_bounding_fails_closed_when_previous_history_is_not_a_prefix(tmp_path, monkeypatch):
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "_index.json")
+    monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
+    models.SESSIONS.clear()
+
+    previous = [_msg("user", "must not be lost", 1)]
+    session = models.Session(session_id="segment_ambiguous", messages=previous + [_msg("assistant", "answer", 2)])
+    session.save(touch_updated_at=False)
+
+    full_display = streaming._bound_compression_rotation_sidecars(
+        session,
+        old_sid="segment_ambiguous",
+        previous_messages=[_msg("user", "different history", 9)],
+    )
+
+    saved = json.loads((tmp_path / "segment_ambiguous.json").read_text(encoding="utf-8"))
+    assert saved["messages"] == previous + [_msg("assistant", "answer", 2)]
+    assert session.messages == previous + [_msg("assistant", "answer", 2)]
+    assert full_display == session.messages

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -321,7 +321,10 @@ function extractFunc(name) {{
   return src.slice(start, i);
 }}
 var _allSessions = [
-  {{session_id:'child', title:'Duplicate Assistant Text Blocks', parent_session_id:'parent', message_count:86, updated_at:200, last_message_at:200, _lineage_root_id:'parent', _compression_segment_count:2}},
+  {{session_id:'root', title:'Current WebUI conversation', message_count:86, updated_at:100, last_message_at:100, _lineage_root_id:'root', _lineage_tip_id:'tip', _compression_segment_count:4}},
+  {{session_id:'middle-1', title:'Current WebUI conversation', parent_session_id:'root', message_count:86, updated_at:150, last_message_at:150, _lineage_root_id:'root', _lineage_tip_id:'tip', _compression_segment_count:4}},
+  {{session_id:'middle-2', title:'Current WebUI conversation', parent_session_id:'middle-1', message_count:86, updated_at:175, last_message_at:175, _lineage_root_id:'root', _lineage_tip_id:'tip', _compression_segment_count:4}},
+  {{session_id:'tip', title:'Current WebUI conversation', parent_session_id:'middle-2', message_count:86, updated_at:200, last_message_at:200, _lineage_root_id:'root', _lineage_tip_id:'tip', _compression_segment_count:4}},
   {{session_id:'other', title:'Other', message_count:4, updated_at:100, last_message_at:100}},
 ];
 eval(extractFunc('_sessionTimestampMs'));
@@ -331,10 +334,16 @@ eval(extractFunc('_sessionLineageContainsSession'));
 eval(extractFunc('_sidebarLineageKeyForRow'));
 eval(extractFunc('_collapseSessionLineageForSidebar'));
 eval(extractFunc('_resolveSessionIdFromSidebarLineage'));
-console.log(JSON.stringify({{parent:_resolveSessionIdFromSidebarLineage('parent'), child:_resolveSessionIdFromSidebarLineage('child'), other:_resolveSessionIdFromSidebarLineage('other')}}));
+console.log(JSON.stringify({{root:_resolveSessionIdFromSidebarLineage('root'), middle1:_resolveSessionIdFromSidebarLineage('middle-1'), middle2:_resolveSessionIdFromSidebarLineage('middle-2'), tip:_resolveSessionIdFromSidebarLineage('tip'), other:_resolveSessionIdFromSidebarLineage('other')}}));
 """
     result = json.loads(_run_node(source))
-    assert result == {"parent": "child", "child": "child", "other": "other"}
+    assert result == {
+        "root": "tip",
+        "middle1": "tip",
+        "middle2": "tip",
+        "tip": "tip",
+        "other": "other",
+    }
 
 
 def test_sidebar_attaches_child_sessions_to_collapsed_hidden_parent_lineage():
@@ -374,6 +383,99 @@ console.log(JSON.stringify(attached));
     assert [row["session_id"] for row in rows] == ["tip"]
     assert rows[0]["_child_session_count"] == 1
     assert rows[0]["_child_sessions"][0]["session_id"] == "child"
+
+
+def test_live_four_segment_lineage_is_one_current_sidebar_row_without_children():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const raw = [
+  {{session_id:'67731d41a751', updated_at:100, last_message_at:100, _lineage_root_id:'67731d41a751', _lineage_tip_id:'20260811_163454_515676', _compression_segment_count:4}},
+  {{session_id:'20260809_092619_1df4e5', parent_session_id:'67731d41a751', updated_at:150, last_message_at:150, _lineage_root_id:'67731d41a751', _lineage_tip_id:'20260811_163454_515676', _compression_segment_count:4}},
+  {{session_id:'20260809_153027_ecd2d0', parent_session_id:'20260809_092619_1df4e5', updated_at:175, last_message_at:175, _lineage_root_id:'67731d41a751', _lineage_tip_id:'20260811_163454_515676', _compression_segment_count:4}},
+  {{session_id:'20260811_163454_515676', parent_session_id:'20260809_153027_ecd2d0', updated_at:200, last_message_at:200, _lineage_root_id:'67731d41a751', _lineage_tip_id:'20260811_163454_515676', _compression_segment_count:4}},
+];
+const rows = _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(raw), raw);
+const row = rows[0];
+console.log(JSON.stringify({{
+  ids: rows.map(item => item.session_id),
+  childCount: row._child_session_count || 0,
+  segmentCount: row._compression_segment_count,
+  timestampMs: _sessionTimestampMs(row),
+}}));
+"""
+    assert json.loads(_run_node(source)) == {
+        "ids": ["20260811_163454_515676"],
+        "childCount": 0,
+        "segmentCount": 4,
+        "timestampMs": 200000,
+    }
+
+
+def test_jouvence_sidebar_keeps_exactly_three_delegate_children_after_collapse():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_isForkWithResolvableParent'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_sidebarLineageKeyForRow'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+eval(extractFunc('_sessionDisplayTitle'));
+eval(extractFunc('_attachChildSessionsToSidebarRows'));
+const raw = [
+  {{session_id:'20260802_122018_e27695', updated_at:100, _lineage_root_id:'20260802_122018_e27695', _lineage_tip_id:'20260809_100052_0e8b4c', _compression_segment_count:2}},
+  {{session_id:'20260809_100052_0e8b4c', parent_session_id:'20260802_122018_e27695', updated_at:200, _lineage_root_id:'20260802_122018_e27695', _lineage_tip_id:'20260809_100052_0e8b4c', _compression_segment_count:2}},
+  ...[0,1,2].map(index => ({{session_id:`delegate-${{index}}`, parent_session_id:'20260802_122018_e27695', relationship_type:'child_session', raw_source:'subagent', _parent_lineage_root_id:'20260802_122018_e27695', _parent_lineage_tip_id:'20260809_100052_0e8b4c'}})),
+];
+const rows = _attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(raw), raw);
+console.log(JSON.stringify({{
+  ids: rows.map(item => item.session_id),
+  childIds: (rows[0]._child_sessions || []).map(item => item.session_id).sort(),
+  childCount: rows[0]._child_session_count,
+  segmentIds: (rows[0]._lineage_segments || []).map(item => item.session_id).sort(),
+}}));
+"""
+    assert json.loads(_run_node(source)) == {
+        "ids": ["20260809_100052_0e8b4c"],
+        "childIds": ["delegate-0", "delegate-1", "delegate-2"],
+        "childCount": 3,
+        "segmentIds": ["20260802_122018_e27695", "20260809_100052_0e8b4c"],
+    }
 
 
 def test_mixed_source_live_refresh_keeps_authoritative_tip_and_child_set():

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -128,7 +128,8 @@ def test_all_sessions_exposes_state_db_lineage_metadata_for_webui_json_sessions(
         assert rows["lineage_api_tip"].get("parent_session_id") == "lineage_api_root"
         assert rows["lineage_api_tip"].get("_lineage_root_id") == "lineage_api_root"
         assert rows["lineage_api_tip"].get("_compression_segment_count") == 2
-        assert "_lineage_root_id" not in rows["lineage_api_root"]
+        assert rows["lineage_api_root"].get("_lineage_root_id") == "lineage_api_root"
+        assert rows["lineage_api_root"].get("_lineage_tip_id") == "lineage_api_tip"
     finally:
         conn.close()
 

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -1,13 +1,42 @@
 """Regression tests for /api/sessions lineage metadata used by sidebar collapse."""
 
+import json
 import sqlite3
 import time
+from io import BytesIO
+from urllib.parse import urlparse
 
 import pytest
 
 import api.models as models
 import api.routes as routes
 from api.models import SESSIONS, STREAMS, Session, all_sessions
+
+
+class _GetHandler:
+    def __init__(self, path):
+        self.path = path
+        self.headers = {}
+        self.client_address = ("127.0.0.1", 12345)
+        self.status = None
+        self.wfile = BytesIO()
+        self.response_headers = []
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.response_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+    @property
+    def response_json(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
 
 
 @pytest.fixture(autouse=True)
@@ -694,3 +723,198 @@ def test_sessions_route_preserves_visible_child_lineage_when_archived_parent_fil
         ]
     finally:
         conn.close()
+
+
+def test_sessions_route_dedupes_validated_compression_lineage_after_projection_merge(
+    _isolate,
+    monkeypatch,
+):
+    """Two materialized sidecars for one validated lineage return one canonical tip."""
+    conn = _ensure_state_db(_isolate)
+    _ensure_messages_table(conn)
+    t0 = time.time() - 100
+    try:
+        root = Session(
+            session_id="lineage_api_duplicate_root",
+            title="Old title must not split the lineage",
+            messages=[{"role": "user", "content": "old", "timestamp": t0 + 1}],
+            updated_at=t0 + 1,
+        )
+        root.save(touch_updated_at=False)
+        tip = Session(
+            session_id="lineage_api_duplicate_tip",
+            title="Current independent title",
+            messages=[
+                {"role": "user", "content": "new", "timestamp": t0 + 8},
+                {"role": "assistant", "content": "answer", "timestamp": t0 + 9},
+            ],
+            updated_at=t0 + 9,
+        )
+        tip.save(touch_updated_at=False)
+        _insert_state_row(
+            conn,
+            root.session_id,
+            started_at=t0,
+            ended_at=t0 + 5.02,
+            end_reason="compression",
+        )
+        _insert_state_row(
+            conn,
+            tip.session_id,
+            parent=root.session_id,
+            started_at=t0 + 5,
+        )
+        _insert_state_message(
+            conn,
+            root.session_id,
+            role="user",
+            content="old",
+            timestamp=t0 + 1,
+        )
+        _insert_state_message(
+            conn,
+            tip.session_id,
+            role="assistant",
+            content="answer",
+            timestamp=t0 + 9,
+        )
+
+        monkeypatch.setattr(routes, "all_sessions", models.all_sessions)
+        monkeypatch.setattr(
+            routes,
+            "_enrich_sidebar_lineage_metadata",
+            models._enrich_sidebar_lineage_metadata,
+        )
+        monkeypatch.setattr(
+            routes,
+            "_reconcile_stale_stream_state_for_session_rows",
+            lambda _sessions: False,
+        )
+
+        payload = routes._build_session_list_cache_payload(
+            active_profile="default",
+            all_profiles=False,
+            show_cli_sessions=False,
+            show_previous_messaging_sessions=False,
+            show_cron_sessions=False,
+            include_archived=False,
+        )
+
+        assert [row["session_id"] for row in payload["sessions"]] == [tip.session_id]
+        row = payload["sessions"][0]
+        assert row["_lineage_root_id"] == root.session_id
+        assert row["_lineage_tip_id"] == tip.session_id
+        assert row["_compression_segment_count"] == 2
+        assert row["message_count"] == 2
+        assert row["last_message_at"] == t0 + 9
+        assert row["updated_at"] == t0 + 9
+        assert row["title"] == "Current independent title"
+    finally:
+        conn.close()
+
+
+def test_stale_compression_detail_request_returns_canonical_tip(_isolate, monkeypatch):
+    conn = _ensure_state_db(_isolate)
+    _ensure_messages_table(conn)
+    t0 = time.time() - 100
+    try:
+        root = _save_webui_session(
+            "lineage_api_stale_detail_root",
+            title="Old route",
+            updated_at=t0 + 1,
+        )
+        tip = _save_webui_session(
+            "lineage_api_stale_detail_tip",
+            title="Canonical route",
+            updated_at=t0 + 9,
+        )
+        root.messages = [{"role": "user", "content": "root turn", "timestamp": t0 + 1}]
+        root.save(touch_updated_at=False)
+        tip.messages = [{"role": "assistant", "content": "tip turn", "timestamp": t0 + 9}]
+        tip.parent_session_id = root.session_id
+        tip.save(touch_updated_at=False)
+        _insert_state_row(
+            conn,
+            root.session_id,
+            started_at=t0,
+            ended_at=t0 + 5.02,
+            end_reason="compression",
+        )
+        _insert_state_row(
+            conn,
+            tip.session_id,
+            parent=root.session_id,
+            started_at=t0 + 5,
+        )
+        _insert_state_message(
+            conn,
+            root.session_id,
+            role="user",
+            content="root turn",
+            timestamp=t0 + 1,
+        )
+        _insert_state_message(
+            conn,
+            tip.session_id,
+            role="assistant",
+            content="tip turn",
+            timestamp=t0 + 9,
+        )
+        monkeypatch.setattr(models, "_active_state_db_path", lambda: _isolate)
+        monkeypatch.setattr(models, "_agent_state_db_path", lambda profile=None: _isolate)
+        monkeypatch.setattr(routes, "_agent_state_db_path", lambda profile=None: _isolate)
+
+        handler = _GetHandler(
+            f"/api/session?session_id={root.session_id}&messages=1&resolve_model=0"
+        )
+        routes.handle_get(handler, urlparse(handler.path))
+
+        assert handler.status == 200
+        session = handler.response_json["session"]
+        assert session["session_id"] == tip.session_id
+        assert [message["content"] for message in session["messages"]] == [
+            "root turn",
+            "tip turn",
+        ]
+    finally:
+        conn.close()
+
+
+def test_final_sidebar_lineage_dedupe_preserves_forks_delegates_and_subagents():
+    lineage = {
+        "_lineage_root_id": "root",
+        "_lineage_tip_id": "tip",
+        "_compression_segment_count": 2,
+        "profile": "default",
+    }
+    rows = routes._dedupe_canonical_sidebar_lineages(
+        [
+            {"session_id": "root", "updated_at": 1, **lineage},
+            {"session_id": "tip", "updated_at": 2, **lineage},
+            {
+                "session_id": "fork",
+                "session_source": "fork",
+                "updated_at": 3,
+                **lineage,
+            },
+            {
+                "session_id": "delegate",
+                "relationship_type": "child_session",
+                "updated_at": 4,
+                **lineage,
+            },
+            {
+                "session_id": "subagent",
+                "raw_source": "subagent",
+                "updated_at": 5,
+                **lineage,
+            },
+        ]
+    )
+
+    assert {row["session_id"] for row in rows} == {
+        "tip",
+        "fork",
+        "delegate",
+        "subagent",
+    }

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -192,7 +192,7 @@ def test_compression_persist_race_still_collapses_to_one_lineage(tmp_path):
 def test_production_identity_metadata_keeps_branches_out_of_raced_compression_lineage(
     tmp_path, monkeypatch
 ):
-    """Production branch/delegate identity wins before bounded overlap stitching."""
+    """A slow production handoff stitches only after identity/source guards pass."""
     db_path = tmp_path / "state.db"
     conn = _ensure_production_state_db(db_path)
     root_id = "67731d41a751"
@@ -204,7 +204,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
     malformed_id = "malformed_identity"
     ambiguous_id = "ambiguous_identity"
     foreign_identity_id = "foreign_identity"
-    older_id = "materially_older_child"
     inherited_identity = {"_branched_from": "pre_compression_origin"}
     try:
         _insert_production_row(
@@ -237,7 +236,10 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
             conn,
             tip_id,
             parent=middle2_id,
-            started_at=1300.0,
+            # Publishing a large handoff can take longer than one second before
+            # the parent closure is stamped. The Agent contract has no elapsed
+            # wall-clock cutoff once the physical and identity guards validate.
+            started_at=1290.0,
             model_config=inherited_identity,
         )
         _insert_production_row(
@@ -278,13 +280,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
             started_at=1300.02,
             model_config={"_branched_from": "unrelated_lineage"},
         )
-        _insert_production_row(
-            conn,
-            older_id,
-            parent=middle2_id,
-            started_at=1290.0,
-        )
-
         rows = agent_sessions.read_importable_agent_session_rows(
             db_path, limit=None, exclude_sources=()
         )
@@ -296,7 +291,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
             malformed_id,
             ambiguous_id,
             foreign_identity_id,
-            older_id,
         }
         assert rows_by_id[tip_id]["_lineage_root_id"] == root_id
         assert rows_by_id[tip_id]["_lineage_tip_id"] == tip_id
@@ -307,7 +301,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
             malformed_id,
             ambiguous_id,
             foreign_identity_id,
-            older_id,
         ):
             assert rows_by_id[independent_id]["relationship_type"] == "child_session"
             assert "_lineage_root_id" not in rows_by_id[independent_id]
@@ -347,7 +340,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
                 malformed_id,
                 ambiguous_id,
                 foreign_identity_id,
-                older_id,
             },
         )
         assert metadata[tip_id]["_lineage_root_id"] == root_id
@@ -360,7 +352,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
             malformed_id,
             ambiguous_id,
             foreign_identity_id,
-            older_id,
         ):
             assert metadata[independent_id]["relationship_type"] == "child_session"
             assert "_lineage_root_id" not in metadata[independent_id]
@@ -383,7 +374,6 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
             malformed_id,
             ambiguous_id,
             foreign_identity_id,
-            older_id,
         ):
             assert [
                 message["content"]
@@ -699,9 +689,9 @@ def test_cli_close_overlap_remains_a_child_session(tmp_path):
         conn.close()
 
 
-def test_compression_overlap_allowance_is_bounded_at_one_second():
+def test_guarded_compression_handoff_has_no_wall_clock_cutoff():
     parent = {
-        "id": "bounded_parent",
+        "id": "compression_parent",
         "source": "webui",
         "ended_at": 200.0,
         "end_reason": "compression",
@@ -710,19 +700,10 @@ def test_compression_overlap_allowance_is_bounded_at_one_second():
     assert agent_sessions._is_continuation_session(
         parent,
         {
-            "id": "at_boundary",
+            "id": "slow_handoff",
             "source": "webui",
-            "parent_session_id": "bounded_parent",
-            "started_at": 199.0,
-        },
-    )
-    assert not agent_sessions._is_continuation_session(
-        parent,
-        {
-            "id": "past_boundary",
-            "source": "webui",
-            "parent_session_id": "bounded_parent",
-            "started_at": 198.999,
+            "parent_session_id": "compression_parent",
+            "started_at": 150.0,
         },
     )
 

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from unittest.mock import patch
 
 import api.agent_sessions as agent_sessions
+import api.models as models
 import api.routes as routes
 
 
@@ -59,6 +60,64 @@ def _insert_message(conn, sid, *, timestamp=None, role="user"):
     conn.commit()
 
 
+def _ensure_production_state_db(path):
+    """Create the current Agent lineage shape (not the synthetic fork schema)."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            title TEXT,
+            model TEXT,
+            model_config TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL
+        );
+        """
+    )
+    return conn
+
+
+def _insert_production_row(
+    conn,
+    sid,
+    *,
+    parent=None,
+    started_at,
+    ended_at=None,
+    end_reason=None,
+    model_config=None,
+    source="webui",
+):
+    if isinstance(model_config, dict):
+        model_config = json.dumps(model_config)
+    conn.execute(
+        """
+        INSERT INTO sessions
+        (id, source, title, model, model_config, started_at, message_count,
+         parent_session_id, ended_at, end_reason)
+        VALUES (?, ?, ?, 'openai/gpt-5', ?, ?, 1, ?, ?, ?)
+        """,
+        (sid, source, sid, model_config, started_at, parent, ended_at, end_reason),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', ?, ?)",
+        (sid, f"message:{sid}", started_at),
+    )
+    conn.commit()
+
+
 def test_lineage_report_returns_bounded_read_only_tip_and_hidden_segments(tmp_path):
     conn = _ensure_state_db(tmp_path / "state.db")
     t0 = time.time() - 100
@@ -87,6 +146,385 @@ def test_lineage_report_returns_bounded_read_only_tip_and_hidden_segments(tmp_pa
         assert "delete_candidates" not in report
     finally:
         conn.close()
+
+
+def test_compression_persist_race_still_collapses_to_one_lineage(tmp_path):
+    """A child may be inserted just before its compression parent is closed."""
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(
+            conn,
+            "compression_race_root",
+            started_at=t0,
+            ended_at=t0 + 5.020,
+            end_reason="compression",
+        )
+        _insert_state_row(
+            conn,
+            "compression_race_tip",
+            parent="compression_race_root",
+            started_at=t0 + 5.000,
+        )
+        _insert_message(conn, "compression_race_tip", timestamp=t0 + 6)
+
+        report = agent_sessions.read_session_lineage_report(
+            tmp_path / "state.db", "compression_race_tip"
+        )
+        rows = agent_sessions.read_importable_agent_session_rows(
+            tmp_path / "state.db", exclude_sources=()
+        )
+
+        assert report["lineage_key"] == "compression_race_root"
+        assert report["tip_session_id"] == "compression_race_tip"
+        assert [segment["session_id"] for segment in report["segments"]] == [
+            "compression_race_tip",
+            "compression_race_root",
+        ]
+        assert [row["id"] for row in rows] == ["compression_race_tip"]
+        assert rows[0]["_lineage_root_id"] == "compression_race_root"
+        assert rows[0]["_compression_segment_count"] == 2
+    finally:
+        conn.close()
+
+
+def test_production_identity_metadata_keeps_branches_out_of_raced_compression_lineage(
+    tmp_path, monkeypatch
+):
+    """Production branch/delegate identity wins before bounded overlap stitching."""
+    db_path = tmp_path / "state.db"
+    conn = _ensure_production_state_db(db_path)
+    root_id = "67731d41a751"
+    middle_id = "20260809_092619_1df4e5"
+    middle2_id = "20260809_153027_ecd2d0"
+    tip_id = "20260811_163454_515676"
+    branch_id = "production_branch"
+    delegate_id = "production_delegate"
+    malformed_id = "malformed_identity"
+    ambiguous_id = "ambiguous_identity"
+    foreign_identity_id = "foreign_identity"
+    older_id = "materially_older_child"
+    inherited_identity = {"_branched_from": "pre_compression_origin"}
+    try:
+        _insert_production_row(
+            conn,
+            root_id,
+            started_at=1000.0,
+            ended_at=1100.041825,
+            end_reason="compression",
+            model_config=inherited_identity,
+        )
+        _insert_production_row(
+            conn,
+            middle_id,
+            parent=root_id,
+            started_at=1100.0,
+            ended_at=1200.031181,
+            end_reason="compression",
+            model_config=inherited_identity,
+        )
+        _insert_production_row(
+            conn,
+            middle2_id,
+            parent=middle_id,
+            started_at=1200.0,
+            ended_at=1300.042504,
+            end_reason="compression",
+            model_config=inherited_identity,
+        )
+        _insert_production_row(
+            conn,
+            tip_id,
+            parent=middle2_id,
+            started_at=1300.0,
+            model_config=inherited_identity,
+        )
+        _insert_production_row(
+            conn,
+            branch_id,
+            parent=middle2_id,
+            started_at=1300.02,
+            model_config={"_branched_from": middle2_id},
+        )
+        _insert_production_row(
+            conn,
+            delegate_id,
+            parent=middle2_id,
+            started_at=1300.02,
+            model_config={"_delegate_from": middle2_id},
+        )
+        _insert_production_row(
+            conn,
+            malformed_id,
+            parent=middle2_id,
+            started_at=1300.02,
+            model_config='{"_branched_from":',
+        )
+        _insert_production_row(
+            conn,
+            ambiguous_id,
+            parent=middle2_id,
+            started_at=1300.02,
+            model_config={
+                "_branched_from": middle2_id,
+                "_delegate_from": middle2_id,
+            },
+        )
+        _insert_production_row(
+            conn,
+            foreign_identity_id,
+            parent=middle2_id,
+            started_at=1300.02,
+            model_config={"_branched_from": "unrelated_lineage"},
+        )
+        _insert_production_row(
+            conn,
+            older_id,
+            parent=middle2_id,
+            started_at=1290.0,
+        )
+
+        rows = agent_sessions.read_importable_agent_session_rows(
+            db_path, limit=None, exclude_sources=()
+        )
+        rows_by_id = {row["id"]: row for row in rows}
+        assert set(rows_by_id) == {
+            tip_id,
+            branch_id,
+            delegate_id,
+            malformed_id,
+            ambiguous_id,
+            foreign_identity_id,
+            older_id,
+        }
+        assert rows_by_id[tip_id]["_lineage_root_id"] == root_id
+        assert rows_by_id[tip_id]["_lineage_tip_id"] == tip_id
+        assert rows_by_id[tip_id]["_compression_segment_count"] == 4
+        for independent_id in (
+            branch_id,
+            delegate_id,
+            malformed_id,
+            ambiguous_id,
+            foreign_identity_id,
+            older_id,
+        ):
+            assert rows_by_id[independent_id]["relationship_type"] == "child_session"
+            assert "_lineage_root_id" not in rows_by_id[independent_id]
+            assert "model_config" not in rows_by_id[independent_id]
+            assert "_lineage_model_config" not in rows_by_id[independent_id]
+
+        tip_report = agent_sessions.read_session_lineage_report(db_path, tip_id)
+        assert tip_report["lineage_key"] == root_id
+        assert tip_report["tip_session_id"] == tip_id
+        assert tip_report["total_segments"] == 4
+        assert [segment["session_id"] for segment in tip_report["segments"]] == [
+            tip_id,
+            middle2_id,
+            middle_id,
+            root_id,
+        ]
+        for independent_id in (
+            branch_id,
+            delegate_id,
+            malformed_id,
+            ambiguous_id,
+            foreign_identity_id,
+        ):
+            report = agent_sessions.read_session_lineage_report(db_path, independent_id)
+            assert report["lineage_key"] == independent_id
+            assert report["total_segments"] == 1
+
+        metadata = agent_sessions.read_session_lineage_metadata(
+            db_path,
+            {
+                root_id,
+                middle_id,
+                middle2_id,
+                tip_id,
+                branch_id,
+                delegate_id,
+                malformed_id,
+                ambiguous_id,
+                foreign_identity_id,
+                older_id,
+            },
+        )
+        assert metadata[tip_id]["_lineage_root_id"] == root_id
+        assert metadata[tip_id]["_lineage_tip_id"] == tip_id
+        for stale_id in (root_id, middle_id, middle2_id):
+            assert metadata[stale_id]["_lineage_tip_id"] == tip_id
+        for independent_id in (
+            branch_id,
+            delegate_id,
+            malformed_id,
+            ambiguous_id,
+            foreign_identity_id,
+            older_id,
+        ):
+            assert metadata[independent_id]["relationship_type"] == "child_session"
+            assert "_lineage_root_id" not in metadata[independent_id]
+
+        monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+        assert [
+            message["content"]
+            for message in models.get_state_db_session_messages(
+                tip_id, stitch_continuations=True
+            )
+        ] == [
+            f"message:{root_id}",
+            f"message:{middle_id}",
+            f"message:{middle2_id}",
+            f"message:{tip_id}",
+        ]
+        for independent_id in (
+            branch_id,
+            delegate_id,
+            malformed_id,
+            ambiguous_id,
+            foreign_identity_id,
+            older_id,
+        ):
+            assert [
+                message["content"]
+                for message in models.get_state_db_session_messages(
+                    independent_id, stitch_continuations=True
+                )
+            ] == [f"message:{independent_id}"]
+    finally:
+        conn.close()
+
+
+def test_jouvence_compression_collapse_preserves_three_real_delegate_children(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    conn = _ensure_production_state_db(db_path)
+    root_id = "20260802_122018_e27695"
+    tip_id = "20260809_100052_0e8b4c"
+    delegate_ids = [f"jouvence_delegate_{index}" for index in range(3)]
+    try:
+        _insert_production_row(
+            conn,
+            root_id,
+            started_at=1000.0,
+            ended_at=2000.081553,
+            end_reason="compression",
+        )
+        _insert_production_row(conn, tip_id, parent=root_id, started_at=2000.0)
+        for index, delegate_id in enumerate(delegate_ids):
+            _insert_production_row(
+                conn,
+                delegate_id,
+                parent=root_id,
+                started_at=1500.0 + index,
+                source="subagent",
+                model_config={"_delegate_from": root_id},
+            )
+
+        rows = agent_sessions.read_importable_agent_session_rows(
+            db_path, limit=None, exclude_sources=()
+        )
+        assert [row["id"] for row in rows if row.get("relationship_type") != "child_session"] == [
+            tip_id
+        ]
+        tip_row = next(row for row in rows if row["id"] == tip_id)
+        assert tip_row["_lineage_root_id"] == root_id
+        assert tip_row["_lineage_tip_id"] == tip_id
+        assert tip_row["_compression_segment_count"] == 2
+        child_rows = [row for row in rows if row.get("relationship_type") == "child_session"]
+        assert {row["id"] for row in child_rows} == set(delegate_ids)
+        assert all(row["parent_session_id"] == root_id for row in child_rows)
+
+        report = agent_sessions.read_session_lineage_report(db_path, tip_id)
+        assert report["lineage_key"] == root_id
+        assert report["tip_session_id"] == tip_id
+        assert report["total_segments"] == 2
+        assert {child["session_id"] for child in report["children"]} == set(delegate_ids)
+
+        metadata = agent_sessions.read_session_lineage_metadata(
+            db_path, {root_id, tip_id, *delegate_ids}
+        )
+        assert metadata[root_id]["_lineage_tip_id"] == tip_id
+        assert metadata[tip_id]["_lineage_tip_id"] == tip_id
+        assert all(
+            metadata[delegate_id]["relationship_type"] == "child_session"
+            for delegate_id in delegate_ids
+        )
+
+        monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+        assert [
+            message["content"]
+            for message in models.get_state_db_session_messages(
+                tip_id, stitch_continuations=True
+            )
+        ] == [f"message:{root_id}", f"message:{tip_id}"]
+    finally:
+        conn.close()
+
+
+def test_cli_close_overlap_remains_a_child_session(tmp_path):
+    """Only automatic compression may overlap the parent's close timestamp."""
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(
+            conn,
+            "cli_overlap_parent",
+            started_at=t0,
+            ended_at=t0 + 5.020,
+            end_reason="cli_close",
+        )
+        _insert_state_row(
+            conn,
+            "cli_overlap_child",
+            parent="cli_overlap_parent",
+            started_at=t0 + 5.000,
+        )
+
+        child_report = agent_sessions.read_session_lineage_report(
+            tmp_path / "state.db", "cli_overlap_child"
+        )
+        parent_report = agent_sessions.read_session_lineage_report(
+            tmp_path / "state.db", "cli_overlap_parent"
+        )
+
+        assert child_report["lineage_key"] == "cli_overlap_child"
+        assert [segment["session_id"] for segment in child_report["segments"]] == [
+            "cli_overlap_child"
+        ]
+        assert [child["session_id"] for child in parent_report["children"]] == [
+            "cli_overlap_child"
+        ]
+    finally:
+        conn.close()
+
+
+def test_compression_overlap_allowance_is_bounded_at_one_second():
+    parent = {
+        "id": "bounded_parent",
+        "source": "webui",
+        "ended_at": 200.0,
+        "end_reason": "compression",
+    }
+
+    assert agent_sessions._is_continuation_session(
+        parent,
+        {
+            "id": "at_boundary",
+            "source": "webui",
+            "parent_session_id": "bounded_parent",
+            "started_at": 199.0,
+        },
+    )
+    assert not agent_sessions._is_continuation_session(
+        parent,
+        {
+            "id": "past_boundary",
+            "source": "webui",
+            "parent_session_id": "bounded_parent",
+            "started_at": 198.999,
+        },
+    )
 
 
 def test_lineage_report_keeps_cross_surface_parent_out_of_hidden_segments(tmp_path):

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -394,6 +394,49 @@ def test_production_identity_metadata_keeps_branches_out_of_raced_compression_li
         conn.close()
 
 
+def test_state_db_transcript_stitch_keeps_overlapping_synthetic_fork_independent(
+    tmp_path, monkeypatch
+):
+    """Synthetic fork identity must reach the shared continuation predicate."""
+    db_path = tmp_path / "state.db"
+    conn = _ensure_state_db(db_path)
+    try:
+        conn.execute("ALTER TABLE sessions ADD COLUMN model_config TEXT")
+        _insert_state_row(
+            conn,
+            "parent",
+            started_at=100.0,
+            ended_at=200.0,
+            end_reason="compression",
+        )
+        _insert_state_row(
+            conn,
+            "fork",
+            parent="parent",
+            started_at=199.5,
+            session_source="fork",
+        )
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (?, ?, 'user', ?, ?)",
+            [
+                ("parent-message", "parent", "PARENT_MUST_NOT_STITCH", 150.0),
+                ("fork-message", "fork", "FORK_ONLY", 201.0),
+            ],
+        )
+        conn.commit()
+
+        monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+
+        assert [
+            message["content"]
+            for message in models.get_state_db_session_messages(
+                "fork", stitch_continuations=True
+            )
+        ] == ["FORK_ONLY"]
+    finally:
+        conn.close()
+
+
 def test_jouvence_compression_collapse_preserves_three_real_delegate_children(
     tmp_path, monkeypatch
 ):

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -99,6 +99,7 @@ def _insert_production_row(
     end_reason=None,
     model_config=None,
     source="webui",
+    title=None,
 ):
     if isinstance(model_config, dict):
         model_config = json.dumps(model_config)
@@ -109,7 +110,7 @@ def _insert_production_row(
          parent_session_id, ended_at, end_reason)
         VALUES (?, ?, ?, 'openai/gpt-5', ?, ?, 1, ?, ?, ?)
         """,
-        (sid, source, sid, model_config, started_at, parent, ended_at, end_reason),
+        (sid, source, title or sid, model_config, started_at, parent, ended_at, end_reason),
     )
     conn.execute(
         "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', ?, ?)",
@@ -433,6 +434,162 @@ def test_state_db_transcript_stitch_keeps_overlapping_synthetic_fork_independent
                 "fork", stitch_continuations=True
             )
         ] == ["FORK_ONLY"]
+    finally:
+        conn.close()
+
+
+def test_live_title_families_collapse_and_read_back_from_every_stale_segment(
+    tmp_path, monkeypatch
+):
+    """Sanitized 2026-08-11 lineages keep one row, one tip, and full history."""
+    db_path = tmp_path / "state.db"
+    conn = _ensure_production_state_db(db_path)
+    families = [
+        (
+            "Autopilote horaire des conversations Hermes",
+            [
+                ("67731d41a751", 1786199393.152380, 1786260379.268876),
+                ("20260809_092619_1df4e5", 1786260379.227051, 1786282227.910058),
+                ("20260809_153027_ecd2d0", 1786282227.878877, 1786458894.936033),
+                ("20260811_163454_515676", 1786458894.893529, 1786462423.932897),
+                ("20260811_173343_35b01a", 1786462423.579563, 1786466746.646338),
+                ("20260811_184546_6a9d43", 1786466746.605288, None),
+            ],
+        ),
+        (
+            "Continuing Session Compaction Analysis",
+            [
+                ("5614899f20c1", 1785149596.191732, 1785151212.680752),
+                ("20260727_132012_cfd871", 1785151212.659361, 1785153940.767830),
+                ("20260727_140540_d53386", 1785153940.623974, 1785155431.781549),
+                ("20260727_143031_ef4b12", 1785155431.697044, 1785156223.920522),
+                ("20260727_144343_257512", 1785156223.857336, 1785160956.350932),
+                ("20260727_160236_15a54c", 1785160956.085989, 1785161310.475170),
+                ("20260727_160830_ac2f3c", 1785161310.350187, 1785162060.158157),
+                ("20260727_162059_4f40a6", 1785162059.967021, 1785167813.575161),
+                ("20260727_175653_f3e1b1", 1785167813.496525, 1785187411.139954),
+                ("20260727_232331_c5c5d0", 1785187411.110537, 1785190793.448982),
+                ("20260728_001953_9256d5", 1785190793.410722, 1785232651.865177),
+                ("20260728_115731_6ac7d1", 1785232651.368463, 1785666018.332939),
+                ("20260802_122018_e27695", 1785666018.125275, 1786262452.129295),
+                ("20260809_100052_0e8b4c", 1786262452.047742, 1786459582.710381),
+                ("20260811_164622_304865", 1786459582.685995, 1786466779.658785),
+                ("20260811_184619_9bf3d0", 1786466779.633715, None),
+            ],
+        ),
+        (
+            "Résolution des conflits et validation PR (fork)",
+            [
+                ("06fc4aac7a3d", 1785144260.375660, 1785144379.690550),
+                ("20260727_112619_043c7e", 1785144379.661809, 1785151726.380666),
+                ("20260727_132846_261925", 1785151726.347790, 1785153397.592452),
+                ("20260727_135637_389b2a", 1785153397.417235, 1785154116.375054),
+                ("20260727_140836_a1ad57", 1785154116.293680, 1785162081.853102),
+                ("20260727_162121_bfe2e2", 1785162081.782784, 1785166760.640480),
+                ("20260727_173920_c3c7e9", 1785166760.623645, 1785234994.808266),
+                ("20260728_123634_02f377", 1785234994.789763, 1785235430.425519),
+                ("20260728_124350_f27aaf", 1785235430.346803, 1785316501.566468),
+                ("20260729_111501_4bfbc4", 1785316501.487571, 1785428575.902096),
+                ("20260730_182255_cb8af6", 1785428575.842911, 1785693684.900629),
+                ("20260802_200124_2ae2ef", 1785693684.862480, 1786221839.421037),
+                ("20260808_224359_22465b", 1786221839.363932, 1786266062.115920),
+                ("20260809_110101_cc59c5", 1786266061.908550, 1786459562.448499),
+                ("20260811_164602_0577ed", 1786459562.407618, None),
+            ],
+        ),
+    ]
+    try:
+        for title, segments in families:
+            parent = None
+            for index, (sid, started_at, ended_at) in enumerate(segments):
+                _insert_production_row(
+                    conn,
+                    sid,
+                    parent=parent,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                    end_reason="compression" if ended_at is not None else None,
+                    title=title if index == 0 else None,
+                )
+                parent = sid
+
+        rows = agent_sessions.read_importable_agent_session_rows(
+            db_path, limit=None, exclude_sources=()
+        )
+        rows_by_id = {row["id"]: row for row in rows}
+        assert set(rows_by_id) == {segments[-1][0] for _, segments in families}
+
+        all_ids = {sid for _, segments in families for sid, _, _ in segments}
+        metadata = agent_sessions.read_session_lineage_metadata(db_path, all_ids)
+        monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+
+        for title, segments in families:
+            root_id = segments[0][0]
+            tip_id = segments[-1][0]
+            tip_row = rows_by_id[tip_id]
+            assert tip_row["title"] == title
+            assert tip_row["_lineage_root_id"] == root_id
+            assert tip_row["_lineage_tip_id"] == tip_id
+            assert tip_row["_compression_segment_count"] == len(segments)
+            assert tip_row.get("relationship_type") != "child_session"
+
+            report = agent_sessions.read_session_lineage_report(db_path, tip_id)
+            assert report["lineage_key"] == root_id
+            assert report["tip_session_id"] == tip_id
+            assert report["total_segments"] == len(segments)
+            assert report["children"] == []
+
+            for sid, _, _ in segments:
+                assert metadata[sid]["_lineage_root_id"] == root_id
+                assert metadata[sid]["_lineage_tip_id"] == tip_id
+
+            assert [
+                message["content"]
+                for message in models.get_state_db_session_messages(
+                    tip_id, stitch_continuations=True
+                )
+            ] == [f"message:{sid}" for sid, _, _ in segments]
+    finally:
+        conn.close()
+
+
+def test_live_cli_mislabeled_tip_stays_outside_webui_lineage_until_repaired(
+    tmp_path, monkeypatch
+):
+    """Do not weaken the cross-source guard to absorb an autopilot source defect."""
+    db_path = tmp_path / "state.db"
+    conn = _ensure_production_state_db(db_path)
+    try:
+        _insert_production_row(
+            conn,
+            "20260811_164622_304865",
+            started_at=1786459582.685995,
+            ended_at=1786466779.658785,
+            end_reason="compression",
+        )
+        _insert_production_row(
+            conn,
+            "20260811_184619_9bf3d0",
+            parent="20260811_164622_304865",
+            started_at=1786466779.633715,
+            source="cli",
+        )
+
+        rows = agent_sessions.read_importable_agent_session_rows(
+            db_path, limit=None, exclude_sources=()
+        )
+        assert {row["id"] for row in rows} == {
+            "20260811_164622_304865",
+            "20260811_184619_9bf3d0",
+        }
+
+        monkeypatch.setattr(models, "_active_state_db_path", lambda: db_path)
+        assert [
+            message["content"]
+            for message in models.get_state_db_session_messages(
+                "20260811_184619_9bf3d0", stitch_continuations=True
+            )
+        ] == ["message:20260811_184619_9bf3d0"]
     finally:
         conn.close()
 

--- a/tests/test_session_sidebar_relative_time.py
+++ b/tests/test_session_sidebar_relative_time.py
@@ -137,6 +137,31 @@ def test_relative_time_today_bucket():
     assert result["bucket"] == "Today"
 
 
+def test_canonical_compression_tip_activity_avoids_stale_root_bucket():
+    result = _run_session_time_case(
+        """
+        const now = Date.UTC(2026, 7, 11, 17, 0, 0);
+        const canonicalTip = {
+          session_id: '20260811_163454_515676',
+          _lineage_root_id: '67731d41a751',
+          _lineage_tip_id: '20260811_163454_515676',
+          created_at: Date.UTC(2026, 7, 2, 12, 0, 0) / 1000,
+          updated_at: Date.UTC(2026, 7, 11, 16, 34, 54) / 1000,
+          last_message_at: Date.UTC(2026, 7, 11, 16, 34, 54) / 1000,
+        };
+        const activity = _sessionTimestampMs(canonicalTip);
+        process.stdout.write(JSON.stringify({
+          bucket: _sessionTimeBucketLabel(activity, now),
+          activity,
+        }));
+        """
+    )
+    assert result == {
+        "bucket": "Today",
+        "activity": 1786466094000,
+    }
+
+
 def test_relative_time_handles_just_now_and_dst_safe_yesterday_boundary():
     result = _run_session_time_case(
         """

--- a/tests/test_streaming_done_payload_message_count.py
+++ b/tests/test_streaming_done_payload_message_count.py
@@ -36,6 +36,28 @@ def test_full_message_payload_overrides_stale_compact_message_count():
     assert payload["message_count"] != session.compact()["message_count"]
 
 
+def test_full_message_payload_accepts_a_display_projection_without_mutating_the_session():
+    persisted_segment = [{"role": "assistant", "content": "bounded tip"}]
+    display_projection = [
+        {"role": "user", "content": "archived ancestor"},
+        *persisted_segment,
+    ]
+    session = _FakeSession(
+        session_id="compressed-child-session",
+        messages=persisted_segment,
+    )
+
+    payload = _session_payload_with_full_messages(
+        session,
+        tool_calls=[],
+        messages=display_projection,
+    )
+
+    assert payload["messages"] == display_projection
+    assert payload["message_count"] == len(display_projection)
+    assert session.messages == persisted_segment
+
+
 def test_full_message_payload_includes_todo_state_snapshot():
     todo_result = {
         "todos": [
@@ -75,7 +97,9 @@ def test_done_payload_uses_full_message_count_helper():
     block_start = STREAMING_SOURCE.rfind("raw_session =", 0, done_idx)
     block = STREAMING_SOURCE[block_start:done_idx]
 
-    assert "_session_payload_with_full_messages(s, tool_calls=tool_calls)" in block
+    assert "_session_payload_with_full_messages(" in block
+    assert "tool_calls=tool_calls" in block
+    assert "messages=_current_compression_display_projection(" in block
     assert "s.compact() | {'messages': s.messages" not in block
 
 
@@ -84,7 +108,9 @@ def test_apperror_payload_uses_full_message_count_helper():
     block_start = STREAMING_SOURCE.rfind("_error_payload['session']", 0, error_idx)
     block = STREAMING_SOURCE[block_start:error_idx]
 
-    assert "_session_payload_with_full_messages(s, tool_calls=s.tool_calls)" in block
+    assert "_session_payload_with_full_messages(" in block
+    assert "tool_calls=s.tool_calls" in block
+    assert "messages=_current_compression_display_projection(" in block
     assert "s.compact() | {'messages': s.messages" not in block
 
 


### PR DESCRIPTION
## Thinking Path

- Hermes compression publishes the physical child and its handoff before stamping the parent closed; that producer contract has no one-second upper bound.
- Once physical parent, parsed production identity, fork, and source guards validate an edge, `end_reason=compression` is authoritative. `cli_close` keeps its strict timestamp boundary.
- The production incident also exposed a separate persistence amplification at the same compression boundary: WebUI wrote stitched display history back into every descendant sidecar, then fed that cumulative projection back to the model.
- The fix therefore keeps lineage validation strict while separating canonical per-segment persistence from full-history display projection.

## What Changed

### Compression lineage resolution

- Removed the unsupported `COMPRESSION_ROTATION_OVERLAP_TOLERANCE_SECONDS` cutoff.
- A physically linked, same-source compression child with valid production `model_config` identity now continues the lineage regardless of handoff duration.
- Existing direct `_branched_from`, `_delegate_from`, malformed/ambiguous/foreign identity, synthetic `session_source=fork`, cross-source, and physical-parent guards remain fail-closed.
- `cli_close` still requires a finite child timestamp at or after the finite parent closure timestamp.
- Replaced the one-second threshold test with a production-schema handoff that predates parent closure by ten seconds and proves projection, report, metadata, and stitched transcript behavior while retaining branch/delegate/malformed/foreign controls.

### Bounded compression sidecars

- Ported the independently reviewed incident fix from exact source revision `1ec09e01b5e455d209f27ecffdde086a54e23049` (stable patch-id `dedf8cd97b14694ac81c3b120b8a5cef6999f52d`).
- Each archived compression snapshot and live continuation sidecar now owns only its canonical segment when prefix boundaries are proven.
- Full history remains available by lineage stitching and in terminal SSE/session payloads without writing the display projection back into the live tip.
- Uncertain boundaries fail closed to the legacy complete-history persistence path, so no user message is discarded.
- Terminal compression errors/status rows are projected after settlement, preserving SSE, persisted sidecar, returned `session_id`, stale/detail reload, reasoning, tool calls/results, and image rows without duplication.

## Why It Matters

The production lineage rooted at `67731d41a751` reached approximately **1,712,428 prompt tokens** against a 272,000-token context when a stale URL reopened a continuation whose sidecar had accumulated stitched ancestors repeatedly. Compression then exhausted and persistence raced. The updated branch resolves stale lineage IDs to the validated tip, keeps each future sidecar bounded to one segment, and reconstructs complete display history without contaminating model context.

State invariants:

- same logical compression lineage: one canonical visible tip and complete stitched display history;
- model context/live sidecar: current canonical segment only after a proven split;
- true branch/delegate/fork/cross-source rows: independent and never stitched into the parent;
- terminal failure: one consistent error/status outcome across SSE, sidecar, and subsequent detail load.

## Verification

RED on old PR head `2d967f877d5a19ca7567a02ab4a5cb0b4dcbc0b5`:

```text
./scripts/test.sh tests/test_session_lineage_report.py::test_guarded_compression_handoff_has_no_wall_clock_cutoff tests/test_session_lineage_report.py::test_production_identity_metadata_keeps_branches_out_of_raced_compression_lineage -q
# 2 failed: the >1s guarded handoff remained split in the direct predicate and production projection.

./scripts/test.sh tests/test_compression_sidecar_segment_bounds.py -q
# unavailable on old head; the independently reviewed base proof against 19828308 reproduced 3 failures from cumulative sidecar persistence.
```

GREEN on `3becb0dfebd34e7aa0a29b47d6313e21e8b44c75`:

```text
./scripts/test.sh <lineage + compression + stale-writeback + context-meter matrix> -q
# 345 passed

./scripts/test.sh <state.db + reconciliation + streaming-terminal neighbor matrix> -q
# 136 passed

./.venv/bin/python scripts/ruff_lint.py --diff upstream/master
# 7 changed Python files; 0 findings on added/modified lines

./.venv/bin/python -m py_compile api/agent_sessions.py api/models.py api/routes.py api/streaming.py tests/test_session_lineage_report.py tests/test_session_lineage_collapse.py tests/test_session_lineage_metadata_api.py tests/test_session_sidebar_relative_time.py tests/test_auto_compression_terminal_failure.py tests/test_compression_sidecar_segment_bounds.py
# PASS

git diff --check
# PASS
```

The exact focused files included lineage report/projection/metadata/full-transcript/collapse, canonical sidebar/detail merge, production identity and synthetic fork guards, state.db reconciliation/readback, compression sidecar bounds, terminal compression failure, compression card/no-rename/runtime clear/manual recovery, stale stream writeback, duplicate-after-compression, mobile recovery, and post-compression context metering.

## Risks / Follow-ups

- Existing production sidecars are intentionally byte-unchanged. Repairing already polluted sidecars requires a separately reviewed offline migration; this PR changes only future persistence/runtime interpretation.
- No deployment, schema migration, persisted-data rewrite, frontend change, dependency change, or merge is included.
- On a sidecar whose segment boundary cannot be proven, persistence deliberately retains the complete transcript rather than risk message loss; it will not receive the bounded split until a provable future boundary.

Release-note wording: Compression continuations now honor the Agent's physical handoff contract without a wall-clock cutoff, while future WebUI sidecars remain bounded per segment and complete history is reconstructed safely for display.

## Contract Routing

Task type: compression lineage and persistence correctness bug fix  
Touched areas: sidebar/detail canonicalization, lineage projection/report/metadata, state.db transcript stitching, WebUI streaming completion, compression sidecar persistence  
Relevant public docs: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/rfcs/canonical-session-resolution.md`, `ARCHITECTURE.md`  
Scope boundaries: runtime interpretation and future sidecar writes only; no existing-data migration, deployment, or UI change  
Evidence: old-head RED, production-schema guarded >1s handoff, independently reviewed sidecar patch identity, focused/neighboring GREEN matrices, Ruff, `py_compile`, diff check

## Contract Change

Previous rule: otherwise valid compression continuations were accepted only when child start preceded parent closure by at most one second.  
New rule: after physical-parent, production identity, fork, and source guards pass, `end_reason=compression` is authoritative without elapsed-wall-time math; `cli_close` remains timestamp-strict.  
Reason: the Agent writer has no upper time bound between child insertion/handoff persistence and parent closure.

## Model Used

OpenAI GPT-5.6 via Hermes Agent, with repository, test, Git, GitHub, and Kanban tools. Independent incident-patch review was performed by the reviewer profile against exact SHA `1ec09e01b5e455d209f27ecffdde086a54e23049` before integration.
