### PR TITLE
fix: restore non-WebUI sessions in sidebar (#6542)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -8930,6 +8930,13 @@ async function _autosavePreferencesSettings(payload){
     if(payload&&payload.new_chat_on_workspace_switch!==undefined){
       window._newChatOnWorkspaceSwitch=!!(saved&&saved.new_chat_on_workspace_switch);  // #5473
     }
+    // #6542: synchronise window._showCliSessions with the persisted preference
+    // so the sidebar source tabs (and the API sidebar_source param) update
+    // immediately instead of waiting for a hard reload.
+    if(payload&&payload.show_cli_sessions!==undefined){
+      window._showCliSessions=!!(saved&&saved.show_cli_sessions);
+      if(typeof renderSessionList==='function') renderSessionList();
+    }
     _settingsPreferencesAutosaveRetryPayload=null;
     _setPreferencesAutosaveStatus('saved');
     // Only clear the global dirty flag and hide the unsaved-changes bar when

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2564,7 +2564,15 @@ function _clearSessionSourceTabCounts() {
 }
 
 function _requestedSessionSidebarSource() {
-  return window._showCliSessions ? _sessionSourceFilter : 'webui';
+  // When the source filter is 'cli' AND showCliSessions is enabled, do NOT
+  // send sidebar_source=cli — the server would then filter out all non-CLI
+  // sessions (Telegram, Discord, etc.) from the response.  Instead leave
+  // sidebar_source off so the server returns ALL sessions; the frontend's
+  // _partitionSidebarSessionRows handles tab-level filtering client-side.
+  // When showCliSessions is disabled, always return 'webui' (no tabs).
+  if (!window._showCliSessions) return 'webui';
+  if (_sessionSourceFilter === 'cli') return null;
+  return 'webui';
 }
 
 function _sessionListExcludeHiddenEnabled() {
@@ -2582,7 +2590,8 @@ function _sessionArchivePagingFilterActive() {
 
 function _sessionListQueryString() {
   const qs = new URLSearchParams();
-  qs.set('sidebar_source', _requestedSessionSidebarSource());
+  const sidebarSource = _requestedSessionSidebarSource();
+  if (sidebarSource) qs.set('sidebar_source', sidebarSource);
   if(_sessionListExcludeHiddenEnabled()) qs.set('exclude_hidden','1');
   if(_showAllProfiles) qs.set('all_profiles','1');
   if(_showArchived){
@@ -7571,7 +7580,7 @@ function _partitionSidebarSessionRows(allMatched, activeSidForSidebar){
     if(!_showArchived&&s.archived) continue;
     sessionsRaw.push(s);
   }
-  if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0){
+  if(_sessionSourceFilter==='cli' && cliSessionCount===0){
     _sessionSourceFilter='webui';
   }
   const showCliOnly=_sessionSourceFilter==='cli';

--- a/tests/test_issue4766_sidebar_source_pushdown.py
+++ b/tests/test_issue4766_sidebar_source_pushdown.py
@@ -293,7 +293,8 @@ def test_frontend_sends_sidebar_source_param():
 
     assert "function _requestedSessionSidebarSource()" in src
     assert "function _sessionListQueryString()" in src
-    assert "qs.set('sidebar_source', _requestedSessionSidebarSource());" in src
+    assert "const sidebarSource = _requestedSessionSidebarSource();" in src
+    assert "if (sidebarSource) qs.set('sidebar_source', sidebarSource);" in src
     assert "_serverWebuiSessionCount" in src
     assert "_serverCliSessionCount" in src
     assert "function _sessionSourceTabCount(" in src
@@ -342,7 +343,7 @@ console.log(JSON.stringify({{ first, second, searchFiltered, projectFiltered, ca
 """
     body = _run_node(script)
 
-    assert body["first"] == "?sidebar_source=cli&exclude_hidden=1&all_profiles=1"
+    assert body["first"] == "?exclude_hidden=1&all_profiles=1"
     assert body["second"] == "?sidebar_source=webui&exclude_hidden=1&all_profiles=1&include_archived=1&archived_limit=100"
     assert body["searchFiltered"] == "?sidebar_source=webui&exclude_hidden=1&all_profiles=1&include_archived=1"
     assert body["projectFiltered"] == "?sidebar_source=webui&all_profiles=1&include_archived=1"
@@ -754,16 +755,16 @@ async function runCase(requestedSource, cachedSource) {{
     assert body["mismatch"]["scope"] == {
         "profile": "default",
         "allProfiles": False,
-        "sidebarSource": "cli",
+        "sidebarSource": None,
         "excludeHidden": True,
     }
     assert body["mismatch"]["webui"] is None
     assert body["mismatch"]["cli"] is None
     assert body["mismatch"]["skeleton"] is False
     assert body["mismatch"]["render"]["sessions"] == []
-    assert body["mismatch"]["inflightKeys"] == ["webui-live"]
-    assert body["mismatch"]["cleared"] == []
-    assert body["mismatch"]["render"]["inflightKeys"] == ["webui-live"]
+    assert body["mismatch"]["inflightKeys"] == []
+    assert body["mismatch"]["cleared"] == ["webui-live"]
+    assert body["mismatch"]["render"]["inflightKeys"] == []
     assert body["match"]["sessions"] == ["webui-1"]
     assert body["match"]["scope"] == {
         "profile": "default",

--- a/tests/test_issue6542_non_webui_sessions_filtering.py
+++ b/tests/test_issue6542_non_webui_sessions_filtering.py
@@ -1,0 +1,241 @@
+"""
+Test that non-WebUI (messaging) sessions from state.db appear in the session
+list when ``show_cli_sessions=True``, even when ``sidebar_source=webui``.
+
+Regression test for #6542: Non-WebUI sessions (Discord, Telegram, etc.) were
+silently excluded from the session list even with the preference enabled.
+"""
+import json
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+import pytest
+
+from api import routes
+from api import profiles
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = 200
+        self.headers = {}
+        self.body = b""
+        self.client_address = ("127.0.0.1", 0)
+        self.wfile = self
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body += data
+
+    def json_body(self):
+        return json.loads(self.body)
+
+    def flush(self):
+        pass
+
+
+def test_messaging_sessions_appear_with_show_cli_sessions_enabled(monkeypatch):
+    """Verify that messaging (Telegram/Discord) sessions appear in the session
+    list when ``show_cli_sessions=True`` and the user is on the default sidebar
+    source tab (``sidebar_source=webui``).
+    """
+    # ── Mock the core dependencies ──────────────────────────────────────
+    # Return ONE WebUI-native session and ONE Telegram session (from state.db).
+    webui_rows = [
+        {
+            "session_id": "webui-native-1",
+            "title": "My WebUI Chat",
+            "profile": "default",
+            "archived": False,
+            "message_count": 3,
+            "updated_at": 100,
+            "last_message_at": 100,
+        },
+    ]
+
+    def fake_all_sessions(**kwargs):
+        return list(webui_rows)
+
+    cli_rows = [
+        {
+            "session_id": "telegram-session-1",
+            "title": "Telegram Discussion",
+            "profile": "default",
+            "archived": False,
+            "message_count": 5,
+            "updated_at": 90,
+            "last_message_at": 90,
+            "source_tag": "telegram",
+            "raw_source": "telegram",
+            "session_source": "messaging",
+            "source_label": "Telegram",
+            "is_cli_session": False,
+            "user_message_count": 3,
+            "parent_session_id": None,
+            "end_reason": None,
+        },
+        {
+            "session_id": "discord-chat-1",
+            "title": "Discord General",
+            "profile": "default",
+            "archived": False,
+            "message_count": 8,
+            "updated_at": 80,
+            "last_message_at": 80,
+            "source_tag": "discord",
+            "raw_source": "discord",
+            "session_source": "messaging",
+            "source_label": "Discord",
+            "is_cli_session": False,
+            "user_message_count": 4,
+            "parent_session_id": None,
+            "end_reason": None,
+        },
+    ]
+
+    monkeypatch.setattr(routes, "all_sessions", fake_all_sessions)
+    monkeypatch.setattr(
+        routes,
+        "_reconcile_stale_stream_state_for_session_rows",
+        lambda rows: False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "_enrich_sidebar_lineage_metadata",
+        lambda rows: None,
+    )
+    monkeypatch.setattr(
+        routes,
+        "_session_attention_summary",
+        lambda session_id: None,
+    )
+
+    # Return Telegram + Discord sessions from get_cli_sessions.
+    monkeypatch.setattr(
+        routes,
+        "get_cli_sessions",
+        lambda source_filter=None, all_profiles=False, include_claude_code=True: list(
+            cli_rows
+        ),
+    )
+    monkeypatch.setattr(
+        routes,
+        "agent_session_rows_existing",
+        lambda ids, profile=None: set(ids),
+    )
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": True})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    routes._session_list_cache_clear()
+
+    # ── Request the WebUI-tab session list ─────────────────────────────
+    handler = _FakeHandler()
+    routes.handle_get(
+        handler,
+        urlparse("http://example.com/api/sessions?sidebar_source=webui&exclude_hidden=1"),
+    )
+
+    assert handler.status == 200
+    body = handler.json_body()
+    session_ids = {row["session_id"] for row in body["sessions"]}
+
+    # The WebUI-native session MUST be present.
+    assert "webui-native-1" in session_ids, (
+        "WebUI-native session should always be in the list"
+    )
+
+    # The Telegram and Discord sessions MUST be present — this is the bug
+    # reported in #6542.
+    assert "telegram-session-1" in session_ids, (
+        "Telegram session must appear when show_cli_sessions=True "
+        "and sidebar_source='webui' (regression #6542)"
+    )
+    assert "discord-chat-1" in session_ids, (
+        "Discord session must appear when show_cli_sessions=True "
+        "and sidebar_source='webui' (regression #6542)"
+    )
+
+    # Verify source metadata is preserved in the response.
+    for row in body["sessions"]:
+        if row["session_id"] == "telegram-session-1":
+            assert row.get("session_source") == "messaging"
+            assert row.get("source_tag") == "telegram"
+        if row["session_id"] == "discord-chat-1":
+            assert row.get("session_source") == "messaging"
+            assert row.get("source_tag") == "discord"
+
+    # Verify the tab counts include messaging sessions as non-CLI.
+    assert body.get("webui_session_count", 0) >= 2, (
+        "webui_session_count should count messaging sessions as non-CLI"
+    )
+
+
+def test_messaging_sessions_excluded_when_show_cli_sessions_disabled(monkeypatch):
+    """When ``show_cli_sessions=False``, messaging sessions from state.db
+    should NOT appear (they come through the CLI bridge).
+    """
+    monkeypatch.setattr(routes, "all_sessions", lambda **kwargs: [
+        {"session_id": "webui-1", "title": "WebUI", "profile": "default",
+         "message_count": 1, "updated_at": 100, "last_message_at": 100},
+    ])
+    monkeypatch.setattr(
+        routes,
+        "_reconcile_stale_stream_state_for_session_rows",
+        lambda rows: False,
+    )
+    monkeypatch.setattr(
+        routes,
+        "_enrich_sidebar_lineage_metadata",
+        lambda rows: None,
+    )
+    monkeypatch.setattr(
+        routes,
+        "_session_attention_summary",
+        lambda session_id: None,
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_sessions",
+        lambda source_filter=None, all_profiles=False, include_claude_code=True: [
+            {
+                "session_id": "telegram-hidden",
+                "title": "Hidden Telegram",
+                "profile": "default",
+                "message_count": 5, "updated_at": 90, "last_message_at": 90,
+                "source_tag": "telegram", "raw_source": "telegram",
+                "session_source": "messaging", "source_label": "Telegram",
+                "is_cli_session": False,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        routes,
+        "agent_session_rows_existing",
+        lambda ids, profile=None: set(ids),
+    )
+    monkeypatch.setattr(routes, "load_settings", lambda: {"show_cli_sessions": False})
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+
+    routes._session_list_cache_clear()
+
+    handler = _FakeHandler()
+    routes.handle_get(
+        handler,
+        urlparse("http://example.com/api/sessions?sidebar_source=webui"),
+    )
+
+    assert handler.status == 200
+    body = handler.json_body()
+    session_ids = {row["session_id"] for row in body["sessions"]}
+
+    assert "telegram-hidden" not in session_ids, (
+        "Telegram session must NOT appear when show_cli_sessions=False"
+    )

--- a/tests/test_sidebar_session_partition.py
+++ b/tests/test_sidebar_session_partition.py
@@ -50,7 +50,7 @@ def test_partition_helper_applies_message_source_project_and_archive_gates():
 
     assert "function _sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in SESSIONS_JS
     assert "_sidebarRowHasVisibleMessages(s, activeSidForSidebar)" in block
-    assert "if(_sessionSourceFilter==='cli' && !window._showCliSessions && cliSessionCount===0)" in block
+    assert "if(_sessionSourceFilter==='cli' && cliSessionCount===0)" in block
     assert "const showCliOnly=_sessionSourceFilter==='cli';" in block
     assert "if(!_showArchived&&s.archived) continue;" in block
     assert "if(s.archived){" in block


### PR DESCRIPTION
## Problem

Non-WebUI sessions (Telegram, Discord, etc.) were silently filtered out of the sidebar even when the "Show non-WebUI sessions" preference was enabled.

## Root Cause (Frontend)

3 issues were identified in the frontend:

1. **\_sessionSourceFilter persisted as 'cli'** — when the user clicked the CLI tab, the filter was saved to localStorage. On page reload, `_restoreSessionSourceFilter()` restores 'cli', and `_requestedSessionSidebarSource()` sent `sidebar_source=cli` to the server. The server then filtered out all non-CLI sessions — including Telegram/Discord sessions (`session_source='messaging'`), leaving the sidebar empty.

2. **Auto-reset guard too narrow** — `_partitionSidebarSessionRows` had an auto-reset from 'cli' to 'webui' but only when `window._showCliSessions` was false. When the preference was enabled, the filter stayed 'cli' even with no CLI sessions.

3. **Autosave didn't sync** — toggling "Show non-WebUI sessions" in Settings saved to the server but never updated `window._showCliSessions` or refreshed the sidebar, so the change only took effect after a hard reload.

## Changes

### `static/sessions.js`

- **\_requestedSessionSidebarSource()** — When the active tab is 'cli' with show_cli_sessions enabled, return `null` instead of 'cli'. This omits the `sidebar_source` query parameter so the server returns ALL sessions; the frontend's `_partitionSidebarSessionRows` handles tab-level filtering client-side.
- **\_sessionListQueryString()** — Conditionally set `sidebar_source` only when a value is returned.
- **\_partitionSidebarSessionRows()** — Remove the `!window._showCliSessions` guard from the auto-reset. Falls back to 'webui' when there are no CLI sessions regardless of preference state.

### `static/panels.js`

- **\_autosavePreferencesSettings()** — Sync `window._showCliSessions` and call `renderSessionList()` immediately when the preference is toggled.

### `tests/`

- Added `test_issue6542_non_webui_sessions_filtering.py` — regression test verifying messaging sessions appear with `show_cli_sessions=True`.
- Updated `test_sidebar_session_partition.py` and `test_issue4766_sidebar_source_pushdown.py` for the new `null` sidebar source behavior.

## Testing

- Backend tests confirm the server correctly includes messaging sessions.
- All 37 sidebar/filter tests pass.
- 60 session reconciliation tests pass.

Fixes #6542