### PR TITLE
fix(sessions): clear unread only after successful load

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1995,16 +1995,16 @@ async function loadSession(sid){
   // Sync workspace display immediately so the chip label reflects the new session's workspace
   // before any async message-loading begins (mirrors how model is handled).
   if(typeof syncTopbar==='function') syncTopbar();
-  // Acknowledge the visit as soon as the session metadata is accepted for the
-  // in-flight load: clears the viewed count + any stale completion-unread marker
+  // Do not acknowledge unread state on metadata arrival. The transcript fetch can
+  // still fail or be superseded by a newer navigation; only the final successful
+  // load block below is allowed to mark this selected session read.
   // `let` (not const): re-read below, after the awaited _ensureMessagesLoaded,
   // so a server_turn_started that attaches a live stream MID-RELOAD is honored
   // by the attach/idle decision instead of being clobbered by the stale snapshot.
   let activeStreamId=S.session.active_stream_id||null;
   // If the server says the session is idle, reset browser-side streaming flags
-  // NOW — BEFORE _acknowledgeSessionVisit() below (whose sidebar repaint would
-  // otherwise inherit the PREVIOUS session's busy/stream state) and before the
-  // async _ensureMessagesLoaded gap. Without this, S.busy can remain true from a
+  // NOW — before any sidebar repaint and before the async
+  // _ensureMessagesLoaded gap. Without this, S.busy can remain true from a
   // still-running stream in the PREVIOUS session while S.session.session_id has
   // already advanced to the new one. _isSessionLocallyStreaming() checks
   // (isActive && S.busy), so the new session would appear locally-streaming
@@ -2020,14 +2020,6 @@ async function loadSession(sid){
       if(typeof clearInflightState==='function') clearInflightState(sid);
     }
   }
-
-  // and syncs the polling snapshot so a deferred /api/sessions poll landing
-  // during the async message-load gap below cannot re-flag a stale unread dot.
-  _acknowledgeSessionVisit(
-    S.session.session_id,
-    Number(data.session.message_count || 0),
-    Number(data.session.last_message_at || data.session.updated_at || 0)
-  );
   try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
   _setActiveSessionUrl(S.session.session_id);
   if(typeof startSessionStream==='function') startSessionStream(S.session.session_id);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -3135,8 +3135,10 @@ async function _ensureMessagesLoaded(sid, opts) {
     if (_ownsLoad()) _clearSameSessionForceReloadHint(sid);
   }
   if (!_ownsLoad()) return;
-  // Guard: api() may have redirected (401) and returned undefined.
-  if (!data || !data.session) return;
+  // api() may redirect on 401 and return undefined. That is not a loaded
+  // transcript: reject it so loadSession's existing failure path clears the
+  // loading marker without acknowledging unread state.
+  if (!data || !data.session) throw new Error('Conversation messages response was unavailable');
   _messagesTruncated = !!data.session._messages_truncated;
   _oldestIdx = data.session._messages_offset || 0;
   _msgLimitMax = data.session._msg_limit_max || _MSG_LIMIT_MAX;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2361,15 +2361,12 @@ async function loadSession(sid){
   // flight and re-mark the open session unread; re-syncing here clears that
   // sticky dot once the transcript is settled (#4946).
   //
-  // Gate the final ack on _isSessionActivelyViewedForList(sid): a completion
-  // that lands while _ensureMessagesLoaded() is in flight AND the tab then goes
-  // hidden is correctly marked unread — an UNCONDITIONAL ack here would wrongly
-  // clear that hidden-tab-completion marker. Only clear when the session is
-  // still actively viewed. (#5917 gate finding)
-  if (
-    S.session && S.session.session_id === sid &&
-    (typeof _isSessionActivelyViewedForList !== 'function' || _isSessionActivelyViewedForList(sid))
-  ) {
+  // A successfully loaded selected transcript is read, even if the window lost
+  // focus while _ensureMessagesLoaded() was in flight. Failure and stale-load
+  // exits occur above, so reaching this point proves that `sid` finished loading
+  // and is still the selected session. Completions that arrive later while the
+  // window is hidden still use the normal focus-gated background marker paths.
+  if (S.session && S.session.session_id === sid) {
     _acknowledgeSessionVisit(
       sid,
       Number(S.session.message_count || 0),

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -517,33 +517,29 @@ def test_focus_visibility_return_marks_active_session_viewed_and_clears_marker()
     assert "window.addEventListener('focus', _markActiveSessionViewedOnReturn);" in MESSAGES_JS
 
 
-def test_completion_unread_clears_only_when_session_is_opened():
+def test_completion_unread_clears_only_after_selected_session_load_succeeds():
     load_idx = SESSIONS_JS.find("async function loadSession(sid")
     assert load_idx != -1, "loadSession not found"
     load_block = SESSIONS_JS[load_idx:SESSIONS_JS.find("function _resolveSessionModelForDisplaySoon", load_idx)]
 
-    # The metadata-arrival "mark viewed + clear stale completion unread" pair now
-    # flows through _acknowledgeSessionVisit(S.session.session_id, ...), which
-    # calls _setSessionViewedCount() internally (and _setSessionViewedCount clears
-    # any stale completion-unread marker, #3020) (#4946).
     assign_idx = load_block.find("S.session=data.session;")
-    acknowledge_idx = load_block.find("_acknowledgeSessionVisit(\n    S.session.session_id,", assign_idx)
-    # The last stale-response ownership guard before the visit is acknowledged:
-    # stale loadSession responses must not clear unread markers for sessions the
-    # user did not actually open.
-    stale_guard_idx = load_block.rfind("if (!_isCurrentLoad())", 0, acknowledge_idx)
+    success_idx = load_block.find("if (_isCurrentLoad()) _loadingSessionId = null;\n\n  // Re-acknowledge")
+    acknowledge_idx = load_block.find("_acknowledgeSessionVisit(\n      sid,", success_idx)
+    last_stale_guard_idx = load_block.rfind("if (!_isCurrentLoad())", 0, success_idx)
+    failed_messages_return_idx = load_block.find("return;", load_block.find("Failed to load conversation messages"))
 
-    assert assign_idx != -1, "loadSession must assign S.session before acknowledging the visit"
-    assert acknowledge_idx != -1 and assign_idx < acknowledge_idx, (
-        "loadSession must acknowledge the visit only after the session metadata "
-        "response is accepted for the in-flight load"
+    assert assign_idx != -1 and assign_idx < success_idx
+    assert failed_messages_return_idx != -1 and failed_messages_return_idx < success_idx, (
+        "failed transcript loads must exit before unread is acknowledged"
     )
-    assert stale_guard_idx != -1 and stale_guard_idx < acknowledge_idx, (
-        "stale loadSession responses must be guarded out before the visit-ack "
-        "clears unread markers for sessions the user did not actually open"
+    assert last_stale_guard_idx != -1 and last_stale_guard_idx < success_idx, (
+        "superseded transcript loads must exit before unread is acknowledged"
     )
-    # The acknowledge helper is what clears completion unread on visit, via
-    # _setSessionViewedCount (#3020 stale-marker clear).
+    assert acknowledge_idx > success_idx, (
+        "completion unread must clear only after the selected transcript has loaded successfully"
+    )
+    # The acknowledge helper clears completion unread via _setSessionViewedCount
+    # (#3020 stale-marker clear).
     assert "function _acknowledgeSessionVisit(sid, messageCount = 0, lastMessageAt = 0)" in SESSIONS_JS
     ack_body_start = SESSIONS_JS.find("function _acknowledgeSessionVisit(")
     ack_body = SESSIONS_JS[ack_body_start:SESSIONS_JS.find("function _sessionVisitHasUnreadState", ack_body_start)]

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -21,14 +21,17 @@ def test_full_message_load_updates_viewed_count_after_metadata_fast_path():
     src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
     compact = re.sub(r"\s+", "", src)
 
-    # The metadata-arrival viewed-count update now flows through
-    # _acknowledgeSessionVisit(), which calls _setSessionViewedCount() internally
-    # (and additionally syncs the polling snapshot + repaints so visiting a
-    # session reliably clears a stale sidebar unread dot) (#4946).
+    # Metadata is only the fast first phase; unread is acknowledged by the final
+    # selected-session block after the transcript has loaded successfully.
     assert (
-        "_acknowledgeSessionVisit(S.session.session_id,Number(data.session.message_count||0),"
+        "if(S.session&&S.session.session_id===sid){_acknowledgeSessionVisit("
+        "sid,Number(S.session.message_count||0),"
         in compact
     )
+    assert (
+        "_acknowledgeSessionVisit(S.session.session_id,Number(data.session.message_count||0),"
+        not in compact
+    ), "metadata arrival alone must not clear unread for failed or superseded loads"
     assert "_setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));" in src
 
 

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -35,6 +35,19 @@ def test_full_message_load_updates_viewed_count_after_metadata_fast_path():
     assert "_setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));" in src
 
 
+def test_message_loader_rejects_non_session_response():
+    src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = src.index("async function _ensureMessagesLoaded")
+    end = src.index("function _messageComparableText", start)
+    block = src[start:end]
+
+    assert "if (!data || !data.session) throw" in block, (
+        "undefined or malformed message responses are failed loads, not successful "
+        "transcripts that may be acknowledged as read"
+    )
+    assert "if (!data || !data.session) return;" not in block
+
+
 def test_lazy_message_load_skips_model_resolution():
     src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 

--- a/tests/test_session_unread_dot_on_visit.py
+++ b/tests/test_session_unread_dot_on_visit.py
@@ -19,9 +19,9 @@ snapshot + repaint) and wires it into loadSession at three points:
 
 Two invariants flagged in review are protected here and MUST NOT regress:
 
-  (a) hidden/background completions must still be marked unread — the visit-ack
-      does NOT loosen the focus gate on the completion paths, so a completion in
-      a non-visible/non-focused tab is still flagged (concern a).
+  (a) later hidden/background completions must still be marked unread — the
+      final successful-load ack does NOT loosen the focus gate on completion
+      paths, so a completion after the visit remains flagged (concern a).
   (b) cleaning up a visited child's unread state must not strip a lineage
       PARENT's own unread dot — the visit repaints via
       renderSessionListFromCache(), which recomputes each row's aggregated
@@ -79,19 +79,25 @@ def test_load_session_acknowledges_visit_before_and_after_message_load():
     )
 
 
-def test_post_load_reack_is_guarded_by_active_view():
-    # #5917 gate finding: the post-load re-ack must be gated on
-    # _isSessionActivelyViewedForList(sid). A completion that lands while
-    # _ensureMessagesLoaded() is in flight AND the tab then goes hidden is
-    # correctly marked unread — an UNCONDITIONAL post-load ack would wrongly
-    # clear that hidden-tab-completion marker.
+def test_successful_post_load_reack_is_not_blocked_by_focus_loss():
+    """Once the selected transcript has loaded successfully, it is read.
+
+    Losing focus while the awaited messages request is in flight must not strand
+    the selected conversation in unread forever. Failure and stale-navigation
+    exits occur before this block, so only the successfully loaded current
+    session reaches the final acknowledgement.
+    """
     block = _load_session_block()
     loading_clear = block.find("if (_isCurrentLoad()) _loadingSessionId = null;\n\n  // Re-acknowledge")
-    guard = block.find("_isSessionActivelyViewedForList(sid)", loading_clear)
     second_ack = block.find("_acknowledgeSessionVisit(", loading_clear)
-    assert guard != -1 and guard < second_ack, (
-        "the post-load re-acknowledge must be guarded by "
-        "_isSessionActivelyViewedForList(sid) so a hidden-tab completion stays unread"
+    ack_guard = block.rfind("if (", loading_clear, second_ack)
+    guarded_region = block[ack_guard:second_ack]
+
+    assert loading_clear != -1 and second_ack > loading_clear
+    assert "S.session && S.session.session_id === sid" in guarded_region
+    assert "_isSessionActivelyViewedForList" not in guarded_region, (
+        "a successful current-session load must clear unread even if the window "
+        "lost focus while the transcript was loading"
     )
 
 
@@ -412,18 +418,17 @@ function _hasMarker() {{
 """
 
 
-def test_hidden_tab_completion_during_message_load_survives():
-    """#5917 gate finding (SILENT): a completion that lands while the tab is
-    hidden DURING the awaited message fetch inside _ensureMessagesLoaded() must
-    NOT be silently marked read. The guarded viewed-count clear must skip when
-    the session is no longer actively viewed."""
+def test_hidden_tab_completion_survives_message_helper_until_final_load_ack():
+    """The lower-level message helper must not itself decide that a hidden
+    session is read. ``loadSession`` owns that decision after the selected
+    transcript settles successfully; standalone/background helper calls retain
+    the focus gate."""
     out = _run_node(_hidden_completion_script(hidden=True))
     assert out["apiIssued"] is True, "precondition: the delayed messages fetch was issued"
     assert out["markerBefore"] is True, "precondition: the mid-fetch completion marked the session unread"
     assert out["markerAfter"] is True, (
-        "a hidden-tab completion landing during the awaited message fetch must "
-        "SURVIVE — _ensureMessagesLoaded() must not clear the unread marker via "
-        "an unconditional _setSessionViewedCount when the tab is not actively viewing"
+        "the message helper must preserve the hidden-tab marker until the outer "
+        "successful load performs its final selected-session acknowledgement"
     )
     assert out["viewed"] is None, (
         "the viewed count must NOT be synced for a hidden/background session, "

--- a/tests/test_session_unread_dot_on_visit.py
+++ b/tests/test_session_unread_dot_on_visit.py
@@ -64,18 +64,19 @@ def test_acknowledge_visit_syncs_viewed_snapshot_and_repaints():
     assert "renderSessionListFromCache" in body
 
 
-def test_load_session_acknowledges_visit_before_and_after_message_load():
+def test_load_session_acknowledges_only_after_successful_message_load():
     block = _load_session_block()
-    # Metadata-arrival acknowledgment.
-    first_ack = block.find("_acknowledgeSessionVisit(\n    S.session.session_id,")
     loading_clear = block.find("if (_isCurrentLoad()) _loadingSessionId = null;\n\n  // Re-acknowledge")
-    second_ack = block.find("_acknowledgeSessionVisit(", loading_clear)
+    final_ack = block.find("_acknowledgeSessionVisit(", loading_clear)
+    pre_success_region = block[block.find("_loadingSessionId = sid;"):loading_clear]
 
-    assert first_ack != -1, "loadSession must acknowledge the visit when metadata arrives"
-    assert loading_clear != -1, "loadSession must clear the in-flight marker before the final acknowledge"
-    assert second_ack != -1 and first_ack < loading_clear < second_ack, (
-        "loadSession must re-acknowledge after the async message-load gap so a "
-        "deferred sidebar poll cannot leave a sticky unread dot"
+    assert loading_clear != -1, "loadSession must clear its in-flight marker after successful loading"
+    assert "_acknowledgeSessionVisit(\n    S.session.session_id," not in pre_success_region, (
+        "metadata arrival is not a successful transcript load: failed or superseded "
+        "message fetches must remain unread"
+    )
+    assert final_ack > loading_clear, (
+        "loadSession must acknowledge exactly after the selected transcript finishes loading"
     )
 
 


### PR DESCRIPTION
## Summary

- make a successfully loaded, still-selected conversation authoritative as read
- remove the focus/visibility gate from the final post-load acknowledgement
- remove the earlier metadata-only acknowledgement so failed and superseded transcript loads remain unread
- treat undefined or malformed transcript responses as failed loads rather than acknowledging them
- preserve focus-gated unread markers for later background completions
- update the unread regression contract for focus loss during the loading interval

## Root cause

`loadSession()` already re-acknowledged a visit after `_ensureMessagesLoaded()` settled, but that final acknowledgement required the document to remain visible and focused. If the user opened a conversation and the window lost focus before the transcript finished loading, the successful load skipped the acknowledgement and the persisted completion marker stayed unread indefinitely.

## Validation

- `./scripts/test.sh tests/test_session_unread_dot_on_visit.py -q` — 10 passed
- related unread/load/lineage selection — 111 passed
- `./scripts/test.sh tests/test_session*.py -q` — 747 passed, 2 skipped
- `node --check static/sessions.js`
- `./.venv/bin/ruff check tests/test_session_unread_dot_on_visit.py`
- `git diff --check`
- added-line security scan — no findings

## Scope / exclusions

- no backend or session data changes
- no change to unread events that arrive after the successful load
- no acknowledgement on failed or superseded/stale loads
- no change to child-session or lineage aggregation semantics
