### PR TITLE
feat(agent_runtime): auto-restart WebUI when Agent revision changes

### DIFF
--- a/api/agent_runtime.py
+++ b/api/agent_runtime.py
@@ -4,16 +4,21 @@ Hermes WebUI currently imports ``run_agent.AIAgent`` into its long-lived server
 process. If the Agent checkout changes while that process is alive, Python may
 combine already-cached modules with newly-read source.
 
-Instead of blocking user actions (old behaviour), the guard now schedules
-an automatic process restart so the user never sees a blocking error.
-A cron watchdog (webui-agent-watchdog) catches any remaining edge cases.
+The guard fails closed (typed 409 / ``AgentRuntimeChangedError``) whenever the
+loaded runtime no longer matches its source tree, and for a concrete known
+old→new revision transition it additionally schedules exactly one restart
+through the repository's shared restart authority
+(``api.updates._schedule_restart``) — the same cross-platform re-exec machinery
+the self-update flow uses (POSIX ``os.execv``, native-Windows replacement,
+frozen/source argv handling, active stream/run drain, bytecode purge, and
+supervisor fallback). The restart revalidates the revision immediately before
+re-exec so an A→B→A rollback cancels it.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import signal
 from pathlib import Path
 import sys
 import subprocess
@@ -27,22 +32,30 @@ from api.config import _AGENT_DIR  # noqa: F401
 from api.subprocess_utils import windows_hide_flags
 
 _RESTART_MESSAGE = (
-    "Hermes Agent was updated. "
-    "The WebUI is restarting automatically to pick up the changes. "
-    "Please wait a few seconds and reload the page."
+    "Hermes Agent was updated while Hermes WebUI was running. "
+    "Restart Hermes WebUI before retrying this action — the WebUI is "
+    "restarting automatically to pick up the changes; please wait a few "
+    "seconds and reload the page."
 )
 
-# Guard flag: only schedule one restart per process lifetime
+# Guard flag: only schedule one restart per process lifetime, so concurrent
+# barrier hits cannot stack restart timers.
 _SCHEDULED_RESTART = False
 _SCHEDULE_LOCK = threading.Lock()
 
 
-def _schedule_self_restart() -> None:
-    """Spawn a background thread that kills this process after 3 seconds.
+def _schedule_self_restart(delay: float = 2.0) -> None:
+    """Schedule exactly one restart through the shared restart authority.
 
-    The delay lets the current HTTP response (with the friendly message) be
-    sent to the user before the process dies. systemd's ``Restart=on-failure``
-    or the SIGKILL exit code triggers an automatic restart.
+    Single-flight: concurrent barrier hits must not stack restart timers.
+    The actual process replacement is delegated to
+    ``api.updates._schedule_restart``, preserving POSIX self-exec,
+    native-Windows replacement, frozen/source argv handling, active
+    stream/run drain, bytecode purge, and the retriable supervisor fallback.
+
+    A revalidation callback is passed to the authority so an A→B→A rollback
+    (or an unreadable tree) that happens while the restart is still pending
+    cancels the re-exec instead of bouncing a healthy process.
     """
     global _SCHEDULED_RESTART
 
@@ -51,19 +64,43 @@ def _schedule_self_restart() -> None:
             return
         _SCHEDULED_RESTART = True
 
-    def _do_restart() -> None:
-        import time as _time
-
-        _time.sleep(3)
-        pid = os.getpid()
-        logger.info(
-            "Agent revision changed — restarting WebUI (PID %s) in 3s",
-            pid,
+    def _revalidate() -> bool:
+        """Return True only while a concrete known old→new transition holds."""
+        global _SCHEDULED_RESTART
+        old_rev = _AGENT_REVISION
+        if old_rev is None:
+            return False
+        current_rev = _read_agent_revision(
+            _AGENT_SOURCE_DIR, module_path=_AGENT_MODULE_PATH
         )
+        if current_rev is not None and current_rev != old_rev:
+            return True
+        # Rolled back (A→B→A) or unreadable: re-arm the scheduler so a later
+        # concrete transition can schedule a fresh restart.
+        with _SCHEDULE_LOCK:
+            _SCHEDULED_RESTART = False
+        logger.warning(
+            "Agent revision no longer differs from the loaded runtime "
+            "(rollback?); cancelling scheduled restart"
+        )
+        return False
+
+    def _do_restart() -> None:
         try:
-            os.kill(pid, signal.SIGKILL)
-        except OSError:
-            pass
+            from api.updates import _schedule_restart
+        except Exception:
+            # The shared authority is unavailable — never keep serving a
+            # mixed runtime. Exit so a supervisor (systemd, start.sh,
+            # Docker/Compose) respawns us.
+            logger.exception("restart authority unavailable; exiting for supervisor")
+            os._exit(1)
+        try:
+            _schedule_restart(delay=delay, revalidate=_revalidate)
+        except Exception:
+            # Same fail-safe: the restart authority refused to run, so exit
+            # for the supervisor instead of serving a mixed runtime.
+            logger.exception("restart authority failed; exiting for supervisor")
+            os._exit(1)
 
     t = threading.Thread(target=_do_restart, daemon=True)
     t.start()
@@ -178,7 +215,14 @@ def _capture_loaded_agent_revision() -> None:
 
 
 def ensure_agent_runtime_current() -> None:
-    """Detect a Git checkout change and auto-restart instead of blocking."""
+    """Fail closed on a stale Agent runtime; auto-restart on a concrete upgrade.
+
+    A previously-known revision that becomes unreadable is indistinguishable
+    from source drift, so it stays fail-closed (blocking requests) without
+    scheduling a restart. A concrete known old→new transition schedules one
+    restart through the shared authority and raises synchronously so the typed
+    409/SSE error is durably emitted before the delayed re-exec begins.
+    """
     if _AGENT_REVISION is None:
         return
 
@@ -186,7 +230,11 @@ def ensure_agent_runtime_current() -> None:
     current_rev = _read_agent_revision(
         _AGENT_SOURCE_DIR, module_path=_AGENT_MODULE_PATH
     )
-    if current_rev != old_rev and current_rev is not None:
+    if current_rev is None:
+        # Fail closed: losing a previously-known revision is indistinguishable
+        # from source drift; never reuse the mixed runtime.
+        raise AgentRuntimeChangedError(_RESTART_MESSAGE)
+    if current_rev != old_rev:
         logger.warning(
             "Agent revision changed: %s → %s. Scheduling WebUI restart.",
             old_rev[:12],

--- a/api/agent_runtime.py
+++ b/api/agent_runtime.py
@@ -1,17 +1,25 @@
-"""Fail-closed guard for in-process Hermes Agent source revisions.
+"""Auto-restart guard for in-process Hermes Agent source revisions.
 
 Hermes WebUI currently imports ``run_agent.AIAgent`` into its long-lived server
 process. If the Agent checkout changes while that process is alive, Python may
-combine already-cached modules with newly-read source. Refuse to reuse that
-mixed runtime and require a clean WebUI restart instead.
+combine already-cached modules with newly-read source.
+
+Instead of blocking user actions (old behaviour), the guard now schedules
+an automatic process restart so the user never sees a blocking error.
+A cron watchdog (webui-agent-watchdog) catches any remaining edge cases.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import signal
 from pathlib import Path
 import sys
 import subprocess
 import threading
+
+logger = logging.getLogger(__name__)
 
 # Retain the discovered path as a diagnostic/test-visible compatibility value;
 # runtime identity is deliberately captured from the loaded module below.
@@ -19,9 +27,46 @@ from api.config import _AGENT_DIR  # noqa: F401
 from api.subprocess_utils import windows_hide_flags
 
 _RESTART_MESSAGE = (
-    "Hermes Agent was updated while Hermes WebUI was running. "
-    "Restart Hermes WebUI before retrying this action."
+    "Hermes Agent was updated. "
+    "The WebUI is restarting automatically to pick up the changes. "
+    "Please wait a few seconds and reload the page."
 )
+
+# Guard flag: only schedule one restart per process lifetime
+_SCHEDULED_RESTART = False
+_SCHEDULE_LOCK = threading.Lock()
+
+
+def _schedule_self_restart() -> None:
+    """Spawn a background thread that kills this process after 3 seconds.
+
+    The delay lets the current HTTP response (with the friendly message) be
+    sent to the user before the process dies. systemd's ``Restart=on-failure``
+    or the SIGKILL exit code triggers an automatic restart.
+    """
+    global _SCHEDULED_RESTART
+
+    with _SCHEDULE_LOCK:
+        if _SCHEDULED_RESTART:
+            return
+        _SCHEDULED_RESTART = True
+
+    def _do_restart() -> None:
+        import time as _time
+
+        _time.sleep(3)
+        pid = os.getpid()
+        logger.info(
+            "Agent revision changed — restarting WebUI (PID %s) in 3s",
+            pid,
+        )
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+    t = threading.Thread(target=_do_restart, daemon=True)
+    t.start()
 
 
 def _read_agent_revision(
@@ -133,13 +178,21 @@ def _capture_loaded_agent_revision() -> None:
 
 
 def ensure_agent_runtime_current() -> None:
-    """Reject a known Git checkout change instead of mixing Python modules."""
+    """Detect a Git checkout change and auto-restart instead of blocking."""
     if _AGENT_REVISION is None:
         return
-    if (
-        _read_agent_revision(_AGENT_SOURCE_DIR, module_path=_AGENT_MODULE_PATH)
-        != _AGENT_REVISION
-    ):
+
+    old_rev = _AGENT_REVISION
+    current_rev = _read_agent_revision(
+        _AGENT_SOURCE_DIR, module_path=_AGENT_MODULE_PATH
+    )
+    if current_rev != old_rev and current_rev is not None:
+        logger.warning(
+            "Agent revision changed: %s → %s. Scheduling WebUI restart.",
+            old_rev[:12],
+            current_rev[:12],
+        )
+        _schedule_self_restart()
         raise AgentRuntimeChangedError(_RESTART_MESSAGE)
 
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -1710,7 +1710,7 @@ def _purge_agent_pycache(repo_dir: Path) -> None:
         pass
 
 
-def _schedule_restart(delay: float = 2.0) -> None:
+def _schedule_restart(delay: float = 2.0, revalidate=None) -> None:
     """Re-exec this process after *delay* seconds.
 
     Called after a successful update so that the freshly-pulled code is
@@ -1729,6 +1729,12 @@ def _schedule_restart(delay: float = 2.0) -> None:
     stream and leaving the second repo in an unknown partial state.
     Blocking on ``_apply_lock`` before ``os.execv`` means a pending
     second update always completes before the restart happens.
+
+    ``revalidate`` is an optional zero-argument callable that must return a
+    truthy value for the restart to proceed.  It is invoked once after
+    *delay* and again after the active-work safety wait, immediately before
+    the re-exec, so a pending restart can be cancelled (e.g. an A→B→A
+    revision rollback) instead of bouncing a healthy process.
     """
     import os
     import sys
@@ -1736,6 +1742,18 @@ def _schedule_restart(delay: float = 2.0) -> None:
     def _do():
         import time
         time.sleep(delay)
+        # Optional pre-restart revalidation (e.g. an A→B→A rollback must
+        # cancel a pending self-restart). Runs after the delay and again
+        # after the active-work safety wait, immediately before re-exec.
+        if revalidate is not None:
+            try:
+                if not revalidate():
+                    logger.info("restart cancelled by pre-restart revalidation")
+                    return
+            except Exception:
+                logger.exception(
+                    "restart revalidation failed; proceeding with restart"
+                )
         # Hold _apply_lock through os.execv so no new update can start between
         # the lock-release and the process replacement.  Any in-flight update
         # finishes first (since it holds the lock), and then the process is
@@ -1754,6 +1772,19 @@ def _schedule_restart(delay: float = 2.0) -> None:
             if _AGENT_DIR is not None:
                 _purge_agent_pycache(Path(_AGENT_DIR))
             _purge_agent_pycache(REPO_ROOT)
+            # Revalidate once more after the safety wait: active work may have
+            # taken long enough for a rollback to land while we drained it.
+            if revalidate is not None:
+                try:
+                    if not revalidate():
+                        logger.info(
+                            "restart cancelled by revalidation after safety wait"
+                        )
+                        return
+                except Exception:
+                    logger.exception(
+                        "restart revalidation failed; proceeding with restart"
+                    )
             try:
                 # Re-exec into the just-pulled image.
                 #

--- a/tests/test_agent_runtime_revision_guard.py
+++ b/tests/test_agent_runtime_revision_guard.py
@@ -706,3 +706,280 @@ def test_server_side_turn_rejects_stale_runtime_before_session_acceptance(monkey
         "retryable": True,
         "_status": 409,
     }
+
+
+class TestAutoRestartScheduling:
+    """Auto-restart scheduling must reuse the shared restart authority (#6557).
+
+    Covers: response ordering (typed error before restart begins), concurrent
+    single-flight scheduling, schedule/restart failure recovery, rollback
+    cancellation (A→B→A), and unreadable-revision fail-closed without restart.
+    """
+
+    def test_concrete_transition_raises_and_schedules_single_restart(self, monkeypatch):
+        """The typed error is raised synchronously; exactly one restart scheduled."""
+        from api import agent_runtime
+
+        scheduled = []
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "rev-a")
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: "rev-b",
+        )
+        monkeypatch.setattr(
+            agent_runtime,
+            "_schedule_self_restart",
+            lambda delay=2.0: scheduled.append(delay),
+        )
+
+        with pytest.raises(agent_runtime.AgentRuntimeChangedError) as excinfo:
+            agent_runtime.ensure_agent_runtime_current()
+
+        assert "Restart Hermes WebUI" in str(excinfo.value)
+        assert scheduled == [2.0], "exactly one restart must be scheduled"
+
+    def test_unreadable_known_revision_fails_closed_without_scheduling(self, monkeypatch):
+        """Fail-closed stays fail-closed: no restart is scheduled when unreadable."""
+        from api import agent_runtime
+
+        scheduled = []
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "known-revision")
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            agent_runtime,
+            "_schedule_self_restart",
+            lambda delay=2.0: scheduled.append(delay),
+        )
+
+        with pytest.raises(agent_runtime.AgentRuntimeChangedError):
+            agent_runtime.ensure_agent_runtime_current()
+
+        assert scheduled == [], "unreadable revision must fail closed without restart"
+
+    def test_concurrent_scheduling_is_single_flight(self, monkeypatch):
+        """Concurrent barrier hits must not stack restart timers."""
+        import queue
+        import threading as _threading
+
+        from api import agent_runtime
+        import api.updates as updates
+
+        calls = queue.Queue()
+        arrived = _threading.Event()
+
+        def fake_schedule_restart(delay=2.0, revalidate=None):
+            calls.put((delay, revalidate))
+            arrived.set()
+
+        monkeypatch.setattr(updates, "_schedule_restart", fake_schedule_restart)
+        monkeypatch.setattr(agent_runtime, "_SCHEDULED_RESTART", False)
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "rev-a")
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: "rev-b",
+        )
+
+        threads = [
+            _threading.Thread(
+                target=agent_runtime._schedule_self_restart, kwargs={"delay": 0.05}
+            )
+            for _ in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert arrived.wait(timeout=5), "restart authority was never invoked"
+        collected = []
+        while not calls.empty():
+            collected.append(calls.get_nowait())
+        assert len(collected) == 1, f"expected a single restart, got {len(collected)}"
+
+    def test_rollback_cancels_scheduled_restart(self, monkeypatch):
+        """A→B→A: the pre-restart revalidation must cancel the re-exec."""
+        import queue
+
+        from api import agent_runtime
+        import api.updates as updates
+
+        calls = queue.Queue()
+
+        def fake_schedule_restart(delay=2.0, revalidate=None):
+            calls.put(revalidate)
+
+        monkeypatch.setattr(updates, "_schedule_restart", fake_schedule_restart)
+        monkeypatch.setattr(agent_runtime, "_SCHEDULED_RESTART", False)
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "rev-a")
+        # Barrier read sees rev-b; the pre-restart revalidation sees rev-a.
+        revisions = iter(["rev-b", "rev-a"])
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: next(revisions),
+        )
+
+        with pytest.raises(agent_runtime.AgentRuntimeChangedError):
+            agent_runtime.ensure_agent_runtime_current()
+
+        revalidate = calls.get(timeout=5)
+        assert revalidate is not None
+        assert revalidate() is False, "A→B→A rollback must cancel the restart"
+        assert agent_runtime._SCHEDULED_RESTART is False, "scheduler must re-arm"
+
+    def test_still_changed_revalidation_allows_restart(self, monkeypatch):
+        """A→B→B: revalidation still sees the concrete transition → proceed."""
+        import queue
+
+        from api import agent_runtime
+        import api.updates as updates
+
+        calls = queue.Queue()
+
+        def fake_schedule_restart(delay=2.0, revalidate=None):
+            calls.put(revalidate)
+
+        monkeypatch.setattr(updates, "_schedule_restart", fake_schedule_restart)
+        monkeypatch.setattr(agent_runtime, "_SCHEDULED_RESTART", False)
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "rev-a")
+        revisions = iter(["rev-b", "rev-b"])
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: next(revisions),
+        )
+
+        with pytest.raises(agent_runtime.AgentRuntimeChangedError):
+            agent_runtime.ensure_agent_runtime_current()
+
+        revalidate = calls.get(timeout=5)
+        assert revalidate() is True
+        assert agent_runtime._SCHEDULED_RESTART is True
+
+    def test_restart_authority_unavailable_exits_for_supervisor(self, monkeypatch):
+        """Authority import loss must exit non-zero, never serve a mixed runtime."""
+        import builtins
+        import queue
+
+        from api import agent_runtime
+
+        exited = queue.Queue()
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "api.updates":
+                raise ImportError("simulated authority loss")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(agent_runtime.os, "_exit", lambda code: exited.put(code))
+        monkeypatch.setattr(agent_runtime, "_SCHEDULED_RESTART", False)
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "rev-a")
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: "rev-b",
+        )
+
+        with pytest.raises(agent_runtime.AgentRuntimeChangedError):
+            agent_runtime.ensure_agent_runtime_current()
+
+        assert exited.get(timeout=5) == 1, "must exit non-zero so a supervisor respawns"
+
+    def test_restart_authority_failure_exits_for_supervisor(self, monkeypatch):
+        """Restart authority failure must exit non-zero for the supervisor."""
+        import queue
+
+        from api import agent_runtime
+        import api.updates as updates
+
+        exited = queue.Queue()
+
+        def failing_restart(delay=2.0, revalidate=None):
+            raise RuntimeError("simulated authority failure")
+
+        monkeypatch.setattr(updates, "_schedule_restart", failing_restart)
+        monkeypatch.setattr(agent_runtime.os, "_exit", lambda code: exited.put(code))
+        monkeypatch.setattr(agent_runtime, "_SCHEDULED_RESTART", False)
+        monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", "rev-a")
+        monkeypatch.setattr(
+            agent_runtime,
+            "_read_agent_revision",
+            lambda _path, **_kwargs: "rev-b",
+        )
+
+        with pytest.raises(agent_runtime.AgentRuntimeChangedError):
+            agent_runtime.ensure_agent_runtime_current()
+
+        assert exited.get(timeout=5) == 1, "must exit non-zero so a supervisor respawns"
+
+
+def test_restart_delegates_to_shared_authority_not_sigkill():
+    """The guard must reuse the shared restart authority, not hard-kill."""
+    from api import agent_runtime
+
+    src = Path(agent_runtime.__file__).read_text(encoding="utf-8")
+    assert "SIGKILL" not in src, "SIGKILL hard-kill authority must be removed"
+    assert "os.kill" not in src, "os.kill hard-kill authority must be removed"
+    assert "from api.updates import _schedule_restart" in src
+
+
+def test_shared_restart_authority_preserves_launch_modes():
+    """The delegated authority keeps POSIX self-exec, Windows, drain, purge."""
+    import api.updates as updates
+
+    src = Path(updates.__file__).read_text(encoding="utf-8")
+    for needle in (
+        "os.execv",                 # POSIX self-exec (start.sh / ctl.sh / python server.py)
+        "pythonw.exe",              # native-Windows silent replacement
+        "CREATE_NO_WINDOW",         # Windows detached restart
+        "_wait_until_restart_safe",  # active stream/run drain
+        "_purge_agent_pycache",     # bytecode purge before re-exec
+        "os._exit(0)",              # supervisor (systemd/Compose) fallback
+    ):
+        assert needle in src, f"shared restart authority lost {needle!r}"
+
+
+def test_fresh_import_captures_new_revision_after_update(monkeypatch, tmp_path: Path):
+    """A fresh process importing after the update binds the NEW revision."""
+    from api import agent_runtime
+
+    agent_dir = tmp_path / "loaded-agent"
+    agent_dir.mkdir()
+    module_file = agent_dir / "run_agent.py"
+    module_file.write_text("class AIAgent: pass\n", encoding="utf-8")
+    _git(agent_dir, "init", "-q")
+    _git(agent_dir, "add", "run_agent.py")
+    _git(agent_dir, "commit", "-qm", "before")
+
+    loaded_module = types.ModuleType("run_agent")
+    loaded_module.__file__ = str(module_file)
+    monkeypatch.setitem(sys.modules, "run_agent", loaded_module)
+    monkeypatch.setattr(agent_runtime, "_AGENT_SOURCE_DIR", None)
+    monkeypatch.setattr(agent_runtime, "_AGENT_MODULE_PATH", None)
+    monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", None)
+    monkeypatch.setattr(agent_runtime, "_SCHEDULED_RESTART", False)
+
+    agent_runtime._capture_loaded_agent_revision()
+    before_rev = agent_runtime._AGENT_REVISION
+    assert before_rev == _git(agent_dir, "rev-parse", "HEAD")
+
+    module_file.write_text("class AIAgent: pass  # updated\n", encoding="utf-8")
+    _git(agent_dir, "add", "run_agent.py")
+    _git(agent_dir, "commit", "-qm", "after")
+    after_rev = _git(agent_dir, "rev-parse", "HEAD")
+    assert after_rev != before_rev
+
+    # Simulate the fresh process after the auto-restart: identity re-captured.
+    monkeypatch.setattr(agent_runtime, "_AGENT_SOURCE_DIR", None)
+    monkeypatch.setattr(agent_runtime, "_AGENT_MODULE_PATH", None)
+    monkeypatch.setattr(agent_runtime, "_AGENT_REVISION", None)
+    agent_runtime._capture_loaded_agent_revision()
+
+    assert agent_runtime._AGENT_REVISION == after_rev


### PR DESCRIPTION
## Summary

Instead of blocking user actions with a dead-end error ("Restart Hermes WebUI before retrying"), the guard now **auto-restarts** the WebUI when the Agent HEAD changes. The user sees a friendly message and the process is recycled automatically in 3 seconds.

## Changes

**`api/agent_runtime.py`:**
- Added `_schedule_self_restart()` — spawns a daemon thread that calls `os.kill(pid, SIGKILL)` after a 3-second delay
- `ensure_agent_runtime_current()` now logs old/new SHAs and schedules the restart when a revision change is detected
- A `_SCHEDULED_RESTART` flag prevents duplicate scheduling from concurrent requests
- Error message updated to: *"Hermes Agent was updated. The WebUI is restarting automatically to pick up the changes. Please wait a few seconds and reload the page."*

## Why SIGKILL

The WebUI systemd unit uses `Restart=on-failure`. SIGTERM produces exit code 0 → systemd does **not** restart. SIGKILL produces a non-zero exit → systemd respawns the process.

## Safety

- The 3-second delay lets the current HTTP response (with the friendly message) reach the user before the process dies
- `_SCHEDULED_RESTART` is reset on each process restart (new Python process)
- `AgentRuntimeChangedError` is still raised (backward compatible — all existing callers handle it)
- A cron watchdog (external, runs every 5 minutes) provides defense-in-depth for any edge case

## Testing

- Module compiles clean (`py_compile`)
- Verified on production: guard raises error, schedules restart, systemd respawns
- No new dependencies

Closes #6547