### PR TITLE
fix: persist sessions incrementally

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -685,7 +685,7 @@ restriction from the UI yet (see ROADMAP.md Wave 4 for the plan).
 | TD3 | High     | No test coverage                                     | PARTIAL Sprint 1 | 19 HTTP integration tests added; unit tests pending Phase A split |
 | TD4 | Medium   | All code in one file (HTML/CSS/JS/Python mingled)    | FIXED Sprint 5   | JS extracted to static/app.js in Sprint 5 (Sprint 9: app.js deleted, replaced by 6 modules). Phase A complete. |
 | TD5 | Medium   | No request validation (KeyError -> 500 + traceback)  | FIXED Sprint 4   | All endpoints hardened: /api/list, /api/file, /api/crons/* all return clean 400/404 |
-| TD6 | Low      | all_sessions() full directory scan every call        | FIXED Sprint 5   | Session index file (_index.json) built on every save. all_sessions() reads index O(1). Phase C partial. |
+| TD6 | Low      | all_sessions() full directory scan every call        | FIXED Sprint 5   | Keyed SQLite compact index serves bounded sidebar reads; legacy `_index.json` remains importable. |
 | TD7 | Low      | No structured logging                                | FIXED Sprint 1   | log_request() override emits JSON per request |
 
 ---
@@ -760,8 +760,11 @@ All three problems fixed in Sprint 5:
 
 1. SESSIONS cache: OrderedDict with LRU cap of 100, oldest evicted automatically.
 2. LOCK: all SESSIONS dict reads/writes wrapped with LOCK (from Sprint 1).
-3. Session index: `sessions/_index.json` maintained on every save/delete.
-   `all_sessions()` reads the index file (O(1)) instead of scanning all JSONs.
+3. Session persistence: `sessions/_sessions.sqlite3` owns transactional keyed
+   transcript components and compact sidebar rows. Legacy session JSON and
+   `_index.json` snapshots remain readable/importable; bounded snapshots may
+   still mirror for compatibility. `all_sessions()` reads at most 1,000 compact
+   rows instead of rewriting or reparsing the complete legacy index per turn.
 
 ### Phase D: Input Validation and Error Handling -- COMPLETE
 
@@ -1579,13 +1582,16 @@ _set_thread_env(**kwargs) and _clear_thread_env() set/clear _thread_ctx.env.
 _run_agent_streaming() calls _set_thread_env() before env var writes, _clear_thread_env() in outer finally.
 Process-level os.environ writes still exist as fallback (needed until terminal tool reads thread-local).
 
-#### Phase C: Session Index File
+#### Phase C: Incremental Session Store
 
-SESSION_INDEX_FILE = SESSION_DIR / '_index.json'.
-_write_session_index(): builds compact() list from SESSIONS + disk files, writes JSON.
-Called in Session.save() -- keeps index always current.
-all_sessions(): reads index JSON first (one file read); overlays in-memory SESSIONS; falls back to full glob scan on error.
-Index files starting with '_' are skipped during full scan to avoid recursion.
+`SESSION_INDEX_FILE = SESSION_DIR / '_index.json'` remains legacy input and a
+bounded compatibility mirror. `api.incremental_session_store` stores session
+metadata, transcript components, and compact index rows in
+`sessions/_sessions.sqlite3` with SQLite `FULL` synchronous transactions.
+`Session.save()` updates only changed keyed components; large JSON snapshots are
+not rewritten after import. `all_sessions()` imports a changed legacy index once,
+then queries at most 1,000 compact rows. It still overlays in-memory sessions and
+falls back to the legacy full scan when no usable store/index exists.
 
 #### New Workspace Infrastructure
 

--- a/api/incremental_session_store.py
+++ b/api/incremental_session_store.py
@@ -1,0 +1,563 @@
+"""Transactional, keyed persistence for WebUI sessions.
+
+Legacy JSON sidecars and ``_index.json`` remain importable compatibility
+snapshots. SQLite owns incremental updates so a metadata change never rewrites
+an entire transcript or global index.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sqlite3
+import threading
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    metadata_json TEXT NOT NULL,
+    source_mtime_ns INTEGER,
+    source_size INTEGER,
+    source_hashes_json TEXT
+);
+CREATE TABLE IF NOT EXISTS components (
+    session_id TEXT NOT NULL,
+    component TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    PRIMARY KEY (session_id, component, position),
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS session_index (
+    session_id TEXT PRIMARY KEY,
+    compact_json TEXT NOT NULL,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    sort_timestamp REAL NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS store_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_session_index_order
+    ON session_index(pinned DESC, sort_timestamp DESC);
+"""
+
+_COMPONENTS = (
+    "messages",
+    "context_messages",
+    "tool_calls",
+    "anchor_activity_scenes",
+)
+_LOCKS_GUARD = threading.Lock()
+_LOCKS: dict[Path, threading.RLock] = {}
+_INITIALIZED: dict[Path, tuple[int, int]] = {}
+
+
+def _store_lock(path: Path) -> threading.RLock:
+    with _LOCKS_GUARD:
+        return _LOCKS.setdefault(path, threading.RLock())
+
+
+class IncrementalSessionStore:
+    """SQLite session store scoped to one WebUI session directory."""
+
+    def __init__(self, session_dir: Path | str):
+        self.session_dir = Path(session_dir)
+        self.path = self.session_dir / "_sessions.sqlite3"
+        self._lock = _store_lock(self.path)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.path, timeout=10)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout=10000")
+        conn.execute("PRAGMA synchronous=FULL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        stat = self.path.stat()
+        signature = (stat.st_dev, stat.st_ino)
+        if _INITIALIZED.get(self.path) != signature:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(_SCHEMA)
+            columns = {
+                str(row["name"])
+                for row in conn.execute("PRAGMA table_info(sessions)")
+            }
+            if "source_hashes_json" not in columns:
+                conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN source_hashes_json TEXT"
+                )
+            _INITIALIZED[self.path] = signature
+        return conn
+
+    @staticmethod
+    def _encode(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+    @staticmethod
+    def _decode(value: str) -> Any:
+        return json.loads(value)
+
+    @classmethod
+    def _value_hash(cls, value: Any) -> str:
+        return hashlib.sha256(cls._encode(value).encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _payload_hashes(cls, payload: dict[str, Any]) -> dict[str, str]:
+        return {
+            key: cls._value_hash(value)
+            for key, value in payload.items()
+            if not key.startswith("_")
+        }
+
+    @staticmethod
+    def _component_rows(name: str, value: Any) -> list[Any]:
+        if name == "anchor_activity_scenes":
+            if not isinstance(value, dict):
+                return []
+            return [
+                {"key": key, "value": scene}
+                for key, scene in value.items()
+            ]
+        return list(value) if isinstance(value, list) else []
+
+    @staticmethod
+    def _restore_component(name: str, rows: list[Any]) -> Any:
+        if name == "anchor_activity_scenes":
+            return {
+                str(row["key"]): row.get("value")
+                for row in rows
+                if isinstance(row, dict) and "key" in row
+            }
+        return rows
+
+    @staticmethod
+    def _source_signature(path: Path) -> tuple[int | None, int | None]:
+        try:
+            stat = path.stat()
+            return stat.st_mtime_ns, stat.st_size
+        except OSError:
+            return None, None
+
+    def contains(self, sid: str) -> bool:
+        if not self.path.exists():
+            return False
+        with self._lock, closing(self._connect()) as conn:
+            return conn.execute(
+                "SELECT 1 FROM sessions WHERE session_id = ?",
+                (sid,),
+            ).fetchone() is not None
+
+    def import_legacy_payload(self, payload: dict[str, Any], source: Path) -> None:
+        sid = str(payload.get("session_id") or "")
+        if not sid:
+            raise ValueError("session payload lacks session_id")
+        source_mtime_ns, source_size = self._source_signature(source)
+        self.save_payload(
+            payload,
+            compact=None,
+            source_mtime_ns=source_mtime_ns,
+            source_size=source_size,
+            source_payload=payload,
+            force_components=True,
+        )
+
+    def legacy_source_is_newer(self, sid: str, source: Path) -> bool:
+        if not self.path.exists():
+            return True
+        source_signature = self._source_signature(source)
+        with self._lock, closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT source_mtime_ns, source_size FROM sessions WHERE session_id = ?",
+                (sid,),
+            ).fetchone()
+        if row is None:
+            return True
+        stored = (row["source_mtime_ns"], row["source_size"])
+        return source_signature != (None, None) and source_signature != stored
+
+    def save_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        compact: dict[str, Any] | None,
+        source_mtime_ns: int | None = None,
+        source_size: int | None = None,
+        source_payload: dict[str, Any] | None = None,
+        force_components: bool = False,
+        component_snapshot: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        sid = str(payload.get("session_id") or "")
+        if not sid:
+            raise ValueError("session payload lacks session_id")
+        metadata = {
+            key: value
+            for key, value in payload.items()
+            if key not in _COMPONENTS
+        }
+        components = {
+            name: self._component_rows(name, payload.get(name))
+            for name in _COMPONENTS
+        }
+        previous = component_snapshot or {}
+        source_hashes_json = (
+            self._encode(self._payload_hashes(source_payload))
+            if source_payload is not None
+            else None
+        )
+
+        with self._lock, closing(self._connect()) as conn:
+            with conn:
+                exists = conn.execute(
+                    "SELECT 1 FROM sessions WHERE session_id = ?",
+                    (sid,),
+                ).fetchone() is not None
+                conn.execute(
+                    """
+                    INSERT INTO sessions(
+                        session_id, metadata_json, source_mtime_ns, source_size,
+                        source_hashes_json
+                    ) VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        metadata_json = excluded.metadata_json,
+                        source_mtime_ns = COALESCE(excluded.source_mtime_ns, sessions.source_mtime_ns),
+                        source_size = COALESCE(excluded.source_size, sessions.source_size),
+                        source_hashes_json = COALESCE(
+                            excluded.source_hashes_json,
+                            sessions.source_hashes_json
+                        )
+                    """,
+                    (
+                        sid,
+                        self._encode(metadata),
+                        source_mtime_ns,
+                        source_size,
+                        source_hashes_json,
+                    ),
+                )
+                for name, rows in components.items():
+                    old_rows = previous.get(name)
+                    if exists and not force_components and old_rows == rows:
+                        continue
+                    persisted = {
+                        int(row["position"]): row["payload_json"]
+                        for row in conn.execute(
+                            """
+                            SELECT position, payload_json
+                            FROM components
+                            WHERE session_id = ? AND component = ?
+                            """,
+                            (sid, name),
+                        )
+                    }
+                    for position, value in enumerate(rows):
+                        encoded = self._encode(value)
+                        if persisted.get(position) == encoded:
+                            continue
+                        conn.execute(
+                            """
+                            INSERT INTO components(
+                                session_id, component, position, payload_json
+                            ) VALUES (?, ?, ?, ?)
+                            ON CONFLICT(session_id, component, position)
+                            DO UPDATE SET payload_json = excluded.payload_json
+                            """,
+                            (sid, name, position, encoded),
+                        )
+                    conn.execute(
+                        """
+                        DELETE FROM components
+                        WHERE session_id = ? AND component = ? AND position >= ?
+                        """,
+                        (sid, name, len(rows)),
+                    )
+                if compact is not None:
+                    self._upsert_index_row(conn, compact)
+        return copy.deepcopy(components)
+
+    def save_metadata(
+        self,
+        payload: dict[str, Any],
+        *,
+        compact: dict[str, Any] | None,
+    ) -> None:
+        """Update metadata/index only; never inspect or copy transcript rows."""
+        sid = str(payload.get("session_id") or "")
+        if not sid:
+            raise ValueError("session payload lacks session_id")
+        metadata = {
+            key: value
+            for key, value in payload.items()
+            if key not in _COMPONENTS
+        }
+        with self._lock, closing(self._connect()) as conn, conn:
+            updated = conn.execute(
+                "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+                (self._encode(metadata), sid),
+            ).rowcount
+            if updated != 1:
+                raise KeyError(sid)
+            if compact is not None:
+                existing = conn.execute(
+                    "SELECT compact_json FROM session_index WHERE session_id = ?",
+                    (sid,),
+                ).fetchone()
+                if existing is not None:
+                    compact = {
+                        **self._decode(existing["compact_json"]),
+                        **compact,
+                    }
+                self._upsert_index_row(conn, compact)
+
+    def persisted_message_count(self, sid: str) -> int:
+        if not self.path.exists():
+            return 0
+        with self._lock, closing(self._connect()) as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS count FROM components
+                WHERE session_id = ? AND component = 'messages'
+                """,
+                (sid,),
+            ).fetchone()
+            return int(row["count"] if row is not None else 0)
+
+    def reconcile_legacy_payload(
+        self,
+        legacy: dict[str, Any],
+        source: Path,
+    ) -> list[str]:
+        """Three-way merge external JSON edits without clobbering newer DB state."""
+        sid = str(legacy.get("session_id") or "")
+        loaded = self.load_payload(sid)
+        if loaded is None:
+            self.import_legacy_payload(legacy, source)
+            return []
+        current, _snapshot = loaded
+        with self._lock, closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT source_hashes_json FROM sessions WHERE session_id = ?",
+                (sid,),
+            ).fetchone()
+        baseline = {}
+        if row is not None and row["source_hashes_json"]:
+            try:
+                baseline = self._decode(row["source_hashes_json"])
+            except (TypeError, json.JSONDecodeError):
+                baseline = {}
+
+        missing_hash = self._value_hash({"__missing__": True})
+        merged = copy.deepcopy(current)
+        conflicts: list[str] = []
+        for key in set(current) | set(legacy):
+            legacy_present = key in legacy
+            current_present = key in current
+            legacy_hash = self._value_hash(legacy[key]) if legacy_present else missing_hash
+            current_hash = self._value_hash(current[key]) if current_present else missing_hash
+            baseline_hash = baseline.get(key, missing_hash)
+            legacy_changed = legacy_hash != baseline_hash
+            current_changed = current_hash != baseline_hash
+            if not legacy_changed:
+                continue
+            if current_changed:
+                conflicts.append(key)
+                continue
+            if legacy_present:
+                merged[key] = copy.deepcopy(legacy[key])
+            else:
+                merged.pop(key, None)
+
+        source_mtime_ns, source_size = self._source_signature(source)
+        self.save_payload(
+            merged,
+            compact=None,
+            source_mtime_ns=source_mtime_ns,
+            source_size=source_size,
+            source_payload=legacy,
+            force_components=True,
+        )
+        return conflicts
+
+    def load_payload(self, sid: str) -> tuple[dict[str, Any], dict[str, Any]] | None:
+        if not self.path.exists():
+            return None
+        with self._lock, closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT metadata_json FROM sessions WHERE session_id = ?",
+                (sid,),
+            ).fetchone()
+            if row is None:
+                return None
+            payload = self._decode(row["metadata_json"])
+            snapshot: dict[str, Any] = {}
+            for name in _COMPONENTS:
+                values = [
+                    self._decode(item["payload_json"])
+                    for item in conn.execute(
+                        """
+                        SELECT payload_json FROM components
+                        WHERE session_id = ? AND component = ?
+                        ORDER BY position
+                        """,
+                        (sid, name),
+                    )
+                ]
+                restored = self._restore_component(name, values)
+                payload[name] = restored
+                snapshot[name] = copy.deepcopy(values)
+        return payload, snapshot
+
+    def load_metadata(self, sid: str) -> dict[str, Any] | None:
+        if not self.path.exists():
+            return None
+        with self._lock, closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT metadata_json FROM sessions WHERE session_id = ?",
+                (sid,),
+            ).fetchone()
+            if row is None:
+                return None
+            return self._decode(row["metadata_json"])
+
+    def delete(self, sid: str) -> None:
+        if not self.path.exists():
+            return
+        with self._lock, closing(self._connect()) as conn, conn:
+            conn.execute("DELETE FROM sessions WHERE session_id = ?", (sid,))
+            conn.execute("DELETE FROM session_index WHERE session_id = ?", (sid,))
+
+    def delete_index(self, sid: str) -> None:
+        if not self.path.exists():
+            return
+        with self._lock, closing(self._connect()) as conn, conn:
+            conn.execute("DELETE FROM session_index WHERE session_id = ?", (sid,))
+
+    def get_index(self, sid: str) -> dict[str, Any] | None:
+        if not self.path.exists():
+            return None
+        with self._lock, closing(self._connect()) as conn:
+            row = conn.execute(
+                "SELECT compact_json FROM session_index WHERE session_id = ?",
+                (sid,),
+            ).fetchone()
+            return self._decode(row["compact_json"]) if row is not None else None
+
+    @staticmethod
+    def _sort_timestamp(row: dict[str, Any]) -> float:
+        for key in ("last_message_at", "updated_at", "created_at"):
+            try:
+                return float(row.get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+        return 0.0
+
+    def _upsert_index_row(self, conn: sqlite3.Connection, row: dict[str, Any]) -> None:
+        sid = str(row.get("session_id") or "")
+        if not sid:
+            return
+        conn.execute(
+            """
+            INSERT INTO session_index(
+                session_id, compact_json, pinned, sort_timestamp
+            ) VALUES (?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                compact_json = excluded.compact_json,
+                pinned = excluded.pinned,
+                sort_timestamp = excluded.sort_timestamp
+            """,
+            (
+                sid,
+                self._encode(row),
+                int(bool(row.get("pinned"))),
+                self._sort_timestamp(row),
+            ),
+        )
+
+    def update_index(self, rows: list[dict[str, Any]]) -> None:
+        with self._lock, closing(self._connect()) as conn, conn:
+            for row in rows:
+                self._upsert_index_row(conn, row)
+
+    def import_legacy_index_if_changed(self, path: Path) -> None:
+        signature = self._source_signature(path)
+        signature_text = f"{signature[0]}:{signature[1]}"
+        with self._lock, closing(self._connect()) as conn:
+            current = conn.execute(
+                "SELECT value FROM store_meta WHERE key = 'legacy_index_signature'"
+            ).fetchone()
+            if current is not None and current["value"] == signature_text:
+                return
+            if signature == (None, None):
+                return
+            try:
+                rows = json.loads(path.read_bytes())
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                return
+            if not isinstance(rows, list):
+                return
+            with conn:
+                for row in rows:
+                    if isinstance(row, dict):
+                        self._upsert_index_row(conn, row)
+                conn.execute(
+                    """
+                    INSERT INTO store_meta(key, value)
+                    VALUES ('legacy_index_signature', ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (signature_text,),
+                )
+
+    def list_index(self, *, limit: int = 2_000) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        with self._lock, closing(self._connect()) as conn:
+            encoded = [
+                str(row["compact_json"])
+                for row in conn.execute(
+                    """
+                    SELECT compact_json FROM session_index
+                    ORDER BY pinned DESC, sort_timestamp DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                )
+            ]
+        if not encoded:
+            return []
+        # One decoder invocation materially lowers cold-list CPU for thousands
+        # of rows while preserving the bounded LIMIT above.
+        return self._decode(f"[{','.join(encoded)}]")
+
+    def session_ids(self) -> frozenset[str]:
+        if not self.path.exists():
+            return frozenset()
+        with self._lock, closing(self._connect()) as conn:
+            return frozenset(
+                str(row["session_id"])
+                for row in conn.execute("SELECT session_id FROM sessions")
+            )
+
+    def existing_session_ids(self, candidates: list[str]) -> frozenset[str]:
+        """Return persisted IDs from a caller-bounded candidate window."""
+        normalized = [str(sid) for sid in candidates if str(sid or "")]
+        if not normalized or not self.path.exists():
+            return frozenset()
+        found: set[str] = set()
+        with self._lock, closing(self._connect()) as conn:
+            for offset in range(0, len(normalized), 500):
+                chunk = normalized[offset:offset + 500]
+                placeholders = ",".join("?" for _sid in chunk)
+                found.update(
+                    str(row["session_id"])
+                    for row in conn.execute(
+                        f"SELECT session_id FROM sessions "
+                        f"WHERE session_id IN ({placeholders})",
+                        chunk,
+                    )
+                )
+        return frozenset(found)

--- a/api/models.py
+++ b/api/models.py
@@ -43,8 +43,97 @@ from api.agent_sessions import (
     read_session_lineage_metadata,
 )
 from api.process_event_utils import stamp_message_source
+from api.incremental_session_store import IncrementalSessionStore
 
 logger = logging.getLogger(__name__)
+_LEGACY_SESSION_MIRROR_MAX_BYTES = 256 * 1024
+_SESSION_LIST_LIMIT = 1_000
+
+
+def _incremental_session_store() -> IncrementalSessionStore:
+    return IncrementalSessionStore(SESSION_DIR)
+
+
+def _read_session_index_rows(
+    *,
+    limit: int = _SESSION_LIST_LIMIT,
+    session_dir: Path | None = None,
+    session_index_file: Path | None = None,
+) -> list[dict]:
+    """Read current compact rows from keyed store, importing legacy index once."""
+    resolved_dir = session_dir or SESSION_DIR
+    resolved_index = session_index_file or SESSION_INDEX_FILE
+    store = IncrementalSessionStore(resolved_dir)
+    store.import_legacy_index_if_changed(resolved_index)
+    rows = store.list_index(limit=limit)
+    if rows or store.path.exists():
+        return rows
+    try:
+        legacy = json.loads(resolved_index.read_bytes())
+    except Exception:
+        return []
+    return [row for row in legacy if isinstance(row, dict)][:limit]
+
+
+def _read_session_index_row(
+    session_id: str,
+    *,
+    session_dir: Path | None = None,
+    session_index_file: Path | None = None,
+) -> dict | None:
+    resolved_dir = session_dir or SESSION_DIR
+    resolved_index = session_index_file or SESSION_INDEX_FILE
+    store = IncrementalSessionStore(resolved_dir)
+    store.import_legacy_index_if_changed(resolved_index)
+    row = store.get_index(str(session_id or ""))
+    if row is not None:
+        return row
+    return next(
+        (
+            item
+            for item in _read_session_index_rows(
+                session_dir=resolved_dir,
+                session_index_file=resolved_index,
+            )
+            if item.get("session_id") == session_id
+        ),
+        None,
+    )
+
+
+def delete_incremental_session(session_id: str) -> None:
+    """Delete keyed session state when a lifecycle path removes its sidecar."""
+    _incremental_session_store().delete(str(session_id or ""))
+
+
+def _bounded_value_size(value, remaining: int) -> int:
+    """Estimate nested payload size, stopping once *remaining* is exceeded."""
+    if remaining < 0:
+        return remaining
+    if value is None:
+        return remaining - 4
+    if isinstance(value, str):
+        return remaining - len(value.encode("utf-8"))
+    if isinstance(value, (bytes, bytearray)):
+        return remaining - len(value)
+    if isinstance(value, dict):
+        for key, item in value.items():
+            remaining = _bounded_value_size(key, remaining)
+            remaining = _bounded_value_size(item, remaining)
+            if remaining < 0:
+                break
+        return remaining
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            remaining = _bounded_value_size(item, remaining)
+            if remaining < 0:
+                break
+        return remaining
+    return remaining - 16
+
+
+def _legacy_session_mirror_is_bounded(payload: dict) -> bool:
+    return _bounded_value_size(payload, _LEGACY_SESSION_MIRROR_MAX_BYTES) >= 0
 CLI_VISIBLE_SESSION_LIMIT = 20
 # How many messageful cron sessions to surface in the project-chip layer.
 # Needs to exceed CLI_VISIBLE_SESSION_LIMIT so older cron runs stay
@@ -366,6 +455,18 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
     """
     session_dir = session_dir or SESSION_DIR
     session_index_file = session_index_file or SESSION_INDEX_FILE
+    incremental_store = IncrementalSessionStore(session_dir)
+    if updates is not None:
+        incremental_store.import_legacy_index_if_changed(session_index_file)
+        incremental_store.update_index([session.compact() for session in updates])
+        try:
+            if (
+                session_index_file.exists()
+                and session_index_file.stat().st_size > _LEGACY_SESSION_MIRROR_MAX_BYTES
+            ):
+                return
+        except OSError:
+            return
     _tmp = session_index_file.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
 
     with _INDEX_WRITE_LOCK:
@@ -403,6 +504,7 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
                 ]
             entries.extend(in_memory_entries)
             entries.sort(key=lambda s: s.get('updated_at', 0), reverse=True)
+            incremental_store.update_index(entries)
             _payload = json.dumps(entries, ensure_ascii=False, indent=2)
 
             try:
@@ -483,7 +585,22 @@ def _write_session_index(updates=None, *, session_dir: Path | None = None, sessi
 def prune_session_from_index(session_id: str) -> None:
     """Remove one session row from the persisted sidebar index if present."""
     sid = str(session_id or "")
-    if not sid or not SESSION_INDEX_FILE.exists():
+    if not sid:
+        return
+    incremental_store = _incremental_session_store()
+    incremental_store.import_legacy_index_if_changed(SESSION_INDEX_FILE)
+    with LOCK:
+        in_memory = sid in SESSIONS
+    if not in_memory and not (SESSION_DIR / f"{sid}.json").exists():
+        incremental_store.delete(sid)
+    else:
+        incremental_store.delete_index(sid)
+    if not SESSION_INDEX_FILE.exists():
+        return
+    try:
+        if SESSION_INDEX_FILE.stat().st_size > _LEGACY_SESSION_MIRROR_MAX_BYTES:
+            return
+    except OSError:
         return
     _tmp = SESSION_INDEX_FILE.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
 
@@ -1136,10 +1253,7 @@ def _index_message_count_map(entries=None) -> dict[str, int]:
     the index they just parsed.
     """
     if entries is None:
-        try:
-            entries = json.loads(SESSION_INDEX_FILE.read_bytes())
-        except Exception:
-            return {}
+        entries = _read_session_index_rows()
     if not isinstance(entries, list):
         return {}
     counts: dict[str, int] = {}
@@ -1343,7 +1457,12 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
+    def save(
+        self,
+        touch_updated_at: bool = True,
+        skip_index: bool = False,
+        metadata_only: bool = False,
+    ) -> None:
         if not is_safe_session_id(self.session_id):
             raise ValueError(f"Unsafe session_id {self.session_id!r}; refusing to write outside session store")
         # ── #1558 P0 guard ──────────────────────────────────────────────
@@ -1418,7 +1537,40 @@ class Session:
         extra = {k: v for k, v in self.__dict__.items()
                  if k not in METADATA_FIELDS and k not in _placed
                  and not k.startswith('_')}
-        payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
+        payload_data = {**meta, **extra}
+        incremental_store = _incremental_session_store()
+        store_contains_session = incremental_store.contains(self.session_id)
+        incoming_msg_count = len(self.messages or [])
+        if (
+            store_contains_session
+            and incremental_store.persisted_message_count(self.session_id) > 0
+            and incoming_msg_count == 0
+            and (self.active_stream_id or self.pending_user_message)
+        ):
+            logger.warning(
+                "refusing to overwrite session %s messages with empty active/pending snapshot",
+                self.session_id,
+            )
+            return
+        if metadata_only and store_contains_session:
+            incremental_store.save_metadata(
+                payload_data,
+                compact=None if skip_index else self.compact(message_facts=False),
+            )
+            return
+        # Materialize one compatibility snapshot for brand-new sessions. Once
+        # imported, only bounded snapshots keep mirroring; large transcripts
+        # move to keyed SQLite updates and leave the readable JSON snapshot
+        # untouched.
+        mirror_legacy_json = (
+            not store_contains_session
+            or _legacy_session_mirror_is_bounded(payload_data)
+        )
+        payload = (
+            json.dumps(payload_data, ensure_ascii=False, indent=2)
+            if mirror_legacy_json
+            else None
+        )
 
         # ── #1558 backup safeguard ──────────────────────────────────────
         # Before overwriting the session file, copy the previous version to
@@ -1433,7 +1585,7 @@ class Session:
         # via /api/session/recover, sessions whose JSON has fewer messages than
         # their .bak get restored automatically.
         try:
-            if self.path.exists():
+            if mirror_legacy_json and self.path.exists():
                 existing_text = self.path.read_text(encoding='utf-8')
                 try:
                     existing = json.loads(existing_text)
@@ -1483,19 +1635,38 @@ class Session:
         except OSError:
             pass
 
-        tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
-        try:
-            with open(tmp, 'w', encoding='utf-8') as f:
-                f.write(payload)
-                f.flush()
-                os.fsync(f.fileno())
-            _safe_replace(tmp, self.path)
-        except Exception:
+        if mirror_legacy_json:
+            tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
             try:
-                tmp.unlink(missing_ok=True)
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    f.write(payload)
+                    f.flush()
+                    os.fsync(f.fileno())
+                _safe_replace(tmp, self.path)
             except Exception:
+                try:
+                    tmp.unlink(missing_ok=True)
+                except Exception:
+                    pass
+                raise
+
+        source_mtime_ns = None
+        source_size = None
+        if mirror_legacy_json:
+            try:
+                source_stat = self.path.stat()
+                source_mtime_ns = source_stat.st_mtime_ns
+                source_size = source_stat.st_size
+            except OSError:
                 pass
-            raise
+        self._incremental_component_snapshot = incremental_store.save_payload(
+            payload_data,
+            compact=None if skip_index else self.compact(),
+            source_mtime_ns=source_mtime_ns,
+            source_size=source_size,
+            source_payload=payload_data if mirror_legacy_json else None,
+            component_snapshot=getattr(self, '_incremental_component_snapshot', None),
+        )
         if not skip_index:
             _write_session_index(updates=[self])
 
@@ -1531,6 +1702,36 @@ class Session:
         if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
+        incremental_store = _incremental_session_store()
+        try:
+            store_contains_session = incremental_store.contains(sid)
+        except Exception:
+            store_contains_session = False
+            logger.warning(
+                "Incremental session store unreadable; falling back to legacy sidecar for %s",
+                sid,
+                exc_info=True,
+            )
+        try:
+            if store_contains_session and not incremental_store.legacy_source_is_newer(sid, p):
+                stored = incremental_store.load_payload(sid)
+                if stored is not None:
+                    data, component_snapshot = stored
+                    data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(
+                        data.get('messages')
+                    )
+                    session = cls(**data)
+                    session._incremental_component_snapshot = component_snapshot
+                    if _collapsed_partials:
+                        session.save(touch_updated_at=False, skip_index=True)
+                    return session
+        except Exception:
+            store_contains_session = False
+            logger.warning(
+                "Incremental session read failed; falling back to legacy sidecar for %s",
+                sid,
+                exc_info=True,
+            )
         if not p.exists():
             return None
         # #5854: snapshot the stat signature BEFORE reading so a legacy-facts
@@ -1540,6 +1741,31 @@ class Session:
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
         session = cls(**data)
+        try:
+            if store_contains_session:
+                conflicts = incremental_store.reconcile_legacy_payload(data, p)
+                if conflicts:
+                    logger.warning(
+                        "Preserved newer incremental fields for session %s during "
+                        "legacy sidecar reconciliation: %s",
+                        sid,
+                        ", ".join(sorted(conflicts)),
+                    )
+                reconciled = incremental_store.load_payload(sid)
+                if reconciled is not None:
+                    data, component_snapshot = reconciled
+                    data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(
+                        data.get('messages')
+                    )
+                    session = cls(**data)
+                    session._incremental_component_snapshot = component_snapshot
+            else:
+                incremental_store.import_legacy_payload(data, p)
+            stored = incremental_store.load_payload(sid)
+            if stored is not None:
+                session._incremental_component_snapshot = stored[1]
+        except Exception:
+            logger.debug("Failed to import legacy session %s into incremental store", sid, exc_info=True)
         if _collapsed_partials:
             try:
                 # Self-heal bloated sessions on first full load without touching
@@ -1585,6 +1811,30 @@ class Session:
         if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
+        incremental_store = _incremental_session_store()
+        try:
+            store_contains_session = incremental_store.contains(sid)
+        except Exception:
+            store_contains_session = False
+        try:
+            if store_contains_session and not incremental_store.legacy_source_is_newer(sid, p):
+                stored_metadata = incremental_store.load_metadata(sid)
+                if stored_metadata is not None:
+                    stored_metadata['messages'] = []
+                    stored_metadata['tool_calls'] = []
+                    session = cls(**stored_metadata)
+                    session._metadata_message_count = _parse_nonnegative_int(
+                        stored_metadata.get('message_count')
+                    )
+                    session._loaded_metadata_only = True
+                    return session
+        except Exception:
+            store_contains_session = False
+            logger.warning(
+                "Incremental metadata read failed; falling back to legacy sidecar for %s",
+                sid,
+                exc_info=True,
+            )
         if not p.exists():
             return None
         try:
@@ -1696,7 +1946,7 @@ class Session:
                     n += 1
         return n
 
-    def compact(self, include_runtime=False, active_stream_ids=None) -> dict:
+    def compact(self, include_runtime=False, active_stream_ids=None, *, message_facts=True) -> dict:
         active_stream_ids = active_stream_ids if active_stream_ids is not None else set()
         has_pending_user_message = bool(self.pending_user_message)
         message_count = (
@@ -1706,10 +1956,14 @@ class Session:
         )
         if has_pending_user_message:
             message_count = max(message_count, 1)
-        last_message_at = _last_message_timestamp(self.messages) or self.updated_at
+        last_message_at = (
+            _last_message_timestamp(self.messages) or self.updated_at
+            if message_facts
+            else None
+        )
         if has_pending_user_message and self.pending_started_at:
             last_message_at = self.pending_started_at
-        return {
+        compact = {
             'session_id': self.session_id,
             'title': self.title,
             'workspace': self.workspace,
@@ -1718,7 +1972,6 @@ class Session:
             'message_count': message_count,
             'created_at': self.created_at,
             'updated_at': self.updated_at,
-            'last_message_at': last_message_at,
             'pinned': self.pinned,
             'archived': self.archived,
             'project_id': self.project_id,
@@ -1761,7 +2014,6 @@ class Session:
                 'worktree_repo_root': self.worktree_repo_root,
                 'worktree_created_at': self.worktree_created_at,
             } if self.worktree_path else {}),
-            'user_message_count': Session._compute_user_message_count(self.messages),
             'active_stream_id': self.active_stream_id,
             'pending_user_message': self.pending_user_message,
             'has_pending_user_message': has_pending_user_message,
@@ -1780,6 +2032,13 @@ class Session:
                 self.active_stream_id, active_stream_ids
             ) if include_runtime else False,
         }
+        if last_message_at is not None:
+            compact['last_message_at'] = last_message_at
+        if message_facts:
+            compact['user_message_count'] = Session._compute_user_message_count(
+                self.messages
+            )
+        return compact
 
 
 PROCESS_WAKEUP_PROVIDER_UNAVAILABLE_TYPES = frozenset({
@@ -3374,10 +3633,9 @@ def _has_compression_continuation(session) -> bool:
         pass
 
     try:
-        if SESSION_INDEX_FILE.exists():
-            entries = json.loads(SESSION_INDEX_FILE.read_bytes())
-            if isinstance(entries, list) and any(_row_is_continuation(e) for e in entries):
-                return True
+        entries = _read_session_index_rows()
+        if any(_row_is_continuation(e) for e in entries):
+            return True
     except Exception:
         logger.debug("Failed to inspect session index for compression continuation", exc_info=True)
 
@@ -5755,19 +6013,41 @@ def _diag_stage(diag, name: str) -> None:
 def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
     _diag_stage(diag, "all_sessions.active_streams")
     active_stream_ids = _active_stream_ids()
+    incremental_store = _incremental_session_store()
     # Phase C: try index first for O(1) read; fall back to full scan
     _diag_stage(diag, "all_sessions.index_exists")
-    if not SESSION_INDEX_FILE.exists():
+    if not SESSION_INDEX_FILE.exists() and not incremental_store.path.exists():
         _diag_stage(diag, "all_sessions.start_index_rebuild")
         _start_session_index_rebuild_thread()
-    if SESSION_INDEX_FILE.exists():
+    if SESSION_INDEX_FILE.exists() or incremental_store.path.exists():
         try:
             _diag_stage(diag, "all_sessions.read_index")
-            index = json.loads(SESSION_INDEX_FILE.read_bytes())
+            incremental_store.import_legacy_index_if_changed(SESSION_INDEX_FILE)
+            index = incremental_store.list_index(limit=_SESSION_LIST_LIMIT)
             _diag_stage(diag, "all_sessions.prune_index")
             with LOCK:
                 in_memory_ids = set(SESSIONS.keys())
-            persisted_ids = _persisted_session_ids_snapshot()
+            using_incremental_index = incremental_store.path.exists()
+            if using_incremental_index:
+                # Keyed rows are authoritative. Do not enumerate every retained
+                # session after a bounded query or recover omitted rows back into
+                # this response — that defeats pagination and recreates O(total).
+                candidate_ids = [
+                    str(row.get('session_id') or '')
+                    for row in index
+                    if row.get('session_id')
+                ]
+                persisted_ids = (
+                    incremental_store.existing_session_ids(candidate_ids)
+                    | frozenset(
+                        sid
+                        for sid in candidate_ids
+                        if os.path.exists(os.path.join(SESSION_DIR, f"{sid}.json"))
+                    )
+                    | frozenset(in_memory_ids)
+                )
+            else:
+                persisted_ids = _persisted_session_ids_snapshot()
             if not index and _session_dir_has_persisted_session_files():
                 raise ValueError("empty session index while session files exist")
             index = [
@@ -5816,7 +6096,7 @@ def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
                         active_stream_ids=active_stream_ids,
                     )
             missing_persisted_ids = []
-            if persisted_ids is not None:
+            if persisted_ids is not None and not using_incremental_index:
                 indexed_ids = {str(sid) for sid in index_map.keys() if sid}
                 missing_persisted_ids = sorted(
                     str(sid) for sid in persisted_ids
@@ -5903,6 +6183,8 @@ def all_sessions(diag=None, *, include_lineage_metadata: bool = True):
             for s in result:
                 if not s.get('profile'):
                     s['profile'] = 'default'
+            if using_incremental_index:
+                result = result[:_SESSION_LIST_LIMIT]
             return result
         except Exception:
             logger.debug("Failed to load session index, falling back to full scan")
@@ -6005,9 +6287,9 @@ def _backfill_project_profiles_if_needed(projects: list) -> bool:
 
     # Build session_id -> profile map for the untagged project_ids.
     session_profile_by_project: dict[str, str] = {}
-    if SESSION_INDEX_FILE.exists():
+    if SESSION_INDEX_FILE.exists() or _incremental_session_store().path.exists():
         try:
-            entries = json.loads(SESSION_INDEX_FILE.read_bytes())
+            entries = _read_session_index_rows()
             untagged_ids = {p['project_id'] for p in untagged if p.get('project_id')}
             for e in entries:
                 pid = e.get('project_id')

--- a/api/routes.py
+++ b/api/routes.py
@@ -7802,40 +7802,49 @@ def _session_index_marks_was_webui(sid: str) -> bool:
     ``is_cli_session``/``read_only`` markers — are NOT treated as deleted
     WebUI sessions, even when the sidecar is absent.
     """
-    if not SESSION_INDEX_FILE.exists():
+    if not SESSION_INDEX_FILE.exists() and not (SESSION_DIR / "_sessions.sqlite3").exists():
         return False
     try:
-        entries = json.loads(SESSION_INDEX_FILE.read_bytes())
+        entry = _read_session_index_row(
+            sid,
+            session_dir=SESSION_DIR,
+            session_index_file=SESSION_INDEX_FILE,
+        )
     except Exception:
-        return False
-    for entry in entries if isinstance(entries, list) else []:
-        if entry.get("session_id") != sid:
-            continue
-        # Classify per source field, not on a collapsed `a or b or c` — a
-        # legacy CLI/imported row can carry is_cli_session:true with BLANK
-        # source fields, and collapsing-then-defaulting-to-WebUI would wrongly
-        # 404 it (it should keep its read-only CLI stub).
-        srcs = [
-            str(entry.get("source_tag") or "").strip().lower(),
-            str(entry.get("raw_source") or "").strip().lower(),
-            str(entry.get("session_source") or "").strip().lower(),
-        ]
-        explicit = [s for s in srcs if s]
-        if any(s in ("webui", "fork") for s in explicit):
-            # Explicit WebUI-origin (incl. forks, which /api/session/branch
-            # stamps session_source="fork") — a deleted sidecar bricks
-            # identically. 404.
-            return True
-        if explicit:
-            # Explicit non-WebUI source (cli, telegram, claude_code, ...) —
-            # genuine foreign session, keep the existing CLI/read-only stub.
+        try:
+            entries = json.loads(SESSION_INDEX_FILE.read_bytes())
+            entry = next(
+                (
+                    row
+                    for row in entries if isinstance(entries, list)
+                    and isinstance(row, dict)
+                    and row.get("session_id") == sid
+                ),
+                None,
+            )
+        except Exception:
             return False
-        # All source fields blank: WebUI-origin UNLESS the row is a legacy
-        # CLI/imported session marked only by is_cli_session / read_only.
-        is_cli = entry.get("is_cli_session") is True
-        is_read_only = bool(entry.get("read_only") or entry.get("is_read_only"))
-        return not (is_cli or is_read_only)
-    return False
+    if not isinstance(entry, dict):
+        return False
+    # Classify per source field, not on a collapsed `a or b or c` — a
+    # legacy CLI/imported row can carry is_cli_session:true with BLANK
+    # source fields, and collapsing-then-defaulting-to-WebUI would wrongly
+    # 404 it (it should keep its read-only CLI stub).
+    srcs = [
+        str(entry.get("source_tag") or "").strip().lower(),
+        str(entry.get("raw_source") or "").strip().lower(),
+        str(entry.get("session_source") or "").strip().lower(),
+    ]
+    explicit = [s for s in srcs if s]
+    if any(s in ("webui", "fork") for s in explicit):
+        # Explicit WebUI-origin (incl. forks, which /api/session/branch
+        # stamps session_source="fork") — a deleted sidecar bricks identically.
+        return True
+    if explicit:
+        return False
+    is_cli = entry.get("is_cli_session") is True
+    is_read_only = bool(entry.get("read_only") or entry.get("is_read_only"))
+    return not (is_cli or is_read_only)
 
 
 def _session_deleted_tombstone_marks_was_webui(sid: str) -> bool:
@@ -9396,6 +9405,9 @@ from api.models import (
     all_sessions,
     title_from,
     _write_session_index,
+    _read_session_index_rows,
+    _read_session_index_row,
+    delete_incremental_session,
     SESSION_INDEX_FILE,
     _active_state_db_path,
     load_projects,
@@ -9482,10 +9494,13 @@ def _pre_compression_continuation_session_id(session) -> str | None:
         return rows
 
     def _child_rows_from_index(seen_ids: set[str]) -> list | None:
-        if not SESSION_INDEX_FILE.exists():
+        if not SESSION_INDEX_FILE.exists() and not (SESSION_DIR / "_sessions.sqlite3").exists():
             return None
         try:
-            entries = json.loads(SESSION_INDEX_FILE.read_bytes())
+            entries = _read_session_index_rows(
+                session_dir=SESSION_DIR,
+                session_index_file=SESSION_INDEX_FILE,
+            )
         except Exception:
             return None
         if not isinstance(entries, list):
@@ -16188,9 +16203,12 @@ def handle_post(handler, parsed) -> bool:
         # lands without a competing write. (If the streaming session isn't in the
         # cache for some reason, fall back to a direct save.) Guard each per-session
         # update so one slow/failing session can't abort the whole request.
-        if SESSION_INDEX_FILE.exists():
+        if SESSION_INDEX_FILE.exists() or (SESSION_DIR / "_sessions.sqlite3").exists():
             try:
-                index = json.loads(SESSION_INDEX_FILE.read_bytes())
+                index = _read_session_index_rows(
+                    session_dir=SESSION_DIR,
+                    session_index_file=SESSION_INDEX_FILE,
+                )
                 active_ids = _active_stream_ids()
                 deferred_to_stream = []
                 for entry in index:
@@ -20640,6 +20658,7 @@ def _handle_sessions_cleanup(handler, body, zero_only=False):
                 with LOCK:
                     SESSIONS.pop(p.stem, None)
                 p.unlink(missing_ok=True)
+                delete_incremental_session(p.stem)
                 cleaned += 1
                 phase1_removed_ids.add(p.stem)
         except Exception:
@@ -20869,6 +20888,7 @@ def _handle_background(handler, body):
             # next rebuild via _index_entry_exists().
             try:
                 (SESSION_DIR / f"{bg_sid}.json").unlink(missing_ok=True)
+                delete_incremental_session(bg_sid)
             except Exception:
                 pass
         except Exception:
@@ -20965,7 +20985,8 @@ def _prepare_chat_start_session_for_stream(
         provisional_title = _provisional_title_from_prompt(msg, current_title or "Untitled")
         if provisional_title and not _is_default_or_empty_session_title(provisional_title):
             s.title = provisional_title
-    if get_webui_session_save_mode() == "eager":
+    eager_save = get_webui_session_save_mode() == "eager"
+    if eager_save:
         _checkpoint_user_message_for_eager_session_save(
             s,
             msg,
@@ -20973,7 +20994,10 @@ def _prepare_chat_start_session_for_stream(
             s.pending_started_at,
             source=source,
         )
-    s.save()
+    if eager_save or not isinstance(s, Session):
+        s.save()
+    else:
+        s.save(metadata_only=True)
 
 
 def _is_hidden_empty_session(s) -> bool:

--- a/docs/architecture/unified-session-db.md
+++ b/docs/architecture/unified-session-db.md
@@ -96,3 +96,26 @@ This spike does not switch runtime WebUI call sites, migrate existing session
 files, expose a UI setting, alter CLI storage, change session import behavior, or
 remove any JSON sidecars. It is a contract and safety test bed for future
 migration work.
+
+## Incremental WebUI Persistence Layer
+
+`api.incremental_session_store.IncrementalSessionStore` is separate from the
+dormant cross-surface adapter above. It solves WebUI file-store scaling without
+changing CLI `SessionDB` ownership or enabling `experimental.unified_session_db`.
+
+The store uses `sessions/_sessions.sqlite3` as the authoritative incremental
+overlay:
+
+- session metadata and large transcript components use separate keyed tables;
+- compact sidebar rows use a keyed, ordered table capped at 1,000 rows per read;
+- each save runs in one `synchronous=FULL` SQLite transaction;
+- unchanged transcript components are skipped, so pending-state saves write
+  metadata and one compact row rather than the full transcript;
+- existing JSON sidecars and `_index.json` import lazily and remain readable;
+- new sessions receive one JSON compatibility snapshot, while later mirrors are
+  limited to bounded payloads (256 KiB).
+
+SQLite commits provide torn-write recovery. A changed legacy sidecar is imported
+again using its stat signature, preserving manual/import workflows during
+migration. Deleting a session removes both keyed session state and its compact
+row once no sidecar or in-memory owner remains.

--- a/tests/test_issue0644_incremental_session_persistence.py
+++ b/tests/test_issue0644_incremental_session_persistence.py
@@ -1,0 +1,364 @@
+"""Scale regression for bounded WebUI session persistence (#0644)."""
+
+from __future__ import annotations
+
+import builtins
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+import api.models as models
+import api.routes as routes
+from api.incremental_session_store import IncrementalSessionStore
+
+
+@pytest.fixture
+def scaled_session_store(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "SESSIONS", {})
+    monkeypatch.setattr(
+        models,
+        "_PERSISTED_SESSION_IDS_CACHE",
+        (None, None, frozenset()),
+    )
+
+    rows = [
+        {
+            "session_id": f"historical_{index}",
+            "title": f"Historical {index}",
+            "workspace": str(tmp_path),
+            "model": "test",
+            "created_at": float(index),
+            "updated_at": float(index),
+            "message_count": 1,
+            "pinned": False,
+            "archived": False,
+            "profile": "default",
+            "padding": "x" * 2048,
+        }
+        for index in range(1_700)
+    ]
+    index_file.write_text(json.dumps(rows, indent=2), encoding="utf-8")
+    for row in rows:
+        (session_dir / f"{row['session_id']}.json").write_text(
+            json.dumps(row),
+            encoding="utf-8",
+        )
+
+    session = models.Session(
+        session_id="active_session",
+        title="Active",
+        workspace=str(tmp_path),
+        messages=[
+            {"role": "user", "content": "x" * (5 * 1024 * 1024)},
+            {"role": "assistant", "content": "y" * (5 * 1024 * 1024)},
+        ],
+        profile="default",
+    )
+    session.save()
+    return session, session_dir, index_file
+
+
+def test_pending_save_avoids_full_sidecar_and_index_io(
+    scaled_session_store,
+    monkeypatch,
+):
+    session, _session_dir, index_file = scaled_session_store
+    sidecar = session.path
+    reads: list[Path] = []
+    writes: list[tuple[Path, int]] = []
+    encoded_sizes: list[int] = []
+    real_read_text = Path.read_text
+    real_read_bytes = Path.read_bytes
+    real_open = builtins.open
+    real_encode = IncrementalSessionStore._encode
+
+    def tracked_read_text(path, *args, **kwargs):
+        reads.append(Path(path))
+        return real_read_text(path, *args, **kwargs)
+
+    def tracked_read_bytes(path, *args, **kwargs):
+        reads.append(Path(path))
+        return real_read_bytes(path, *args, **kwargs)
+
+    class TrackedWriter:
+        def __init__(self, handle, path):
+            self._handle = handle
+            self._path = Path(path)
+
+        def write(self, value):
+            writes.append((self._path, len(value.encode("utf-8"))))
+            return self._handle.write(value)
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+        def __enter__(self):
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._handle.__exit__(*args)
+
+    def tracked_open(path, mode="r", *args, **kwargs):
+        handle = real_open(path, mode, *args, **kwargs)
+        return TrackedWriter(handle, path) if "w" in mode else handle
+
+    def tracked_encode(value):
+        encoded = real_encode(value)
+        encoded_sizes.append(len(encoded.encode("utf-8")))
+        return encoded
+
+    db_path = _session_dir / "_sessions.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        components_before = conn.execute(
+            """
+            SELECT component, position, payload_json
+            FROM components WHERE session_id = ?
+            ORDER BY component, position
+            """,
+            (session.session_id,),
+        ).fetchall()
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+    monkeypatch.setattr(Path, "read_bytes", tracked_read_bytes)
+    monkeypatch.setattr(builtins, "open", tracked_open)
+    monkeypatch.setattr(IncrementalSessionStore, "_encode", staticmethod(tracked_encode))
+
+    session.pending_user_message = "next turn"
+    session.pending_started_at = time.time()
+    session.active_stream_id = "stream_1"
+    session.save(metadata_only=True)
+
+    assert sidecar not in reads
+    assert index_file not in reads
+    assert sum(size for _path, size in writes) < 128 * 1024
+    assert max(encoded_sizes) < 128 * 1024
+    assert all(path != sidecar for path, _size in writes)
+    assert all(path != index_file for path, _size in writes)
+    with sqlite3.connect(db_path) as conn:
+        components_after = conn.execute(
+            """
+            SELECT component, position, payload_json
+            FROM components WHERE session_id = ?
+            ORDER BY component, position
+            """,
+            (session.session_id,),
+        ).fetchall()
+    assert components_after == components_before
+
+
+def test_committed_pending_state_survives_cache_clear(
+    scaled_session_store,
+):
+    session, _session_dir, _index_file = scaled_session_store
+    session.pending_user_message = "durable pending"
+    session.pending_started_at = 12345.0
+    session.active_stream_id = "stream_durable"
+    session.save()
+
+    models.SESSIONS.clear()
+    loaded = models.Session.load(session.session_id)
+
+    assert loaded is not None
+    assert loaded.pending_user_message == "durable pending"
+    assert loaded.pending_started_at == 12345.0
+    assert loaded.active_stream_id == "stream_durable"
+    assert loaded.messages == session.messages
+
+
+def test_session_listing_is_backed_by_bounded_compact_rows(
+    scaled_session_store,
+    monkeypatch,
+):
+    session, _session_dir, index_file = scaled_session_store
+
+    real_read_bytes = Path.read_bytes
+
+    def reject_legacy_index_read(path, *args, **kwargs):
+        if Path(path) == index_file:
+            raise AssertionError("session listing read legacy global index")
+        return real_read_bytes(path, *args, **kwargs)
+
+    persisted = frozenset(
+        {session.session_id, *(f"historical_{index}" for index in range(1_700))}
+    )
+    monkeypatch.setattr(models, "_persisted_session_ids_snapshot", lambda: persisted)
+    IncrementalSessionStore(_session_dir).import_legacy_index_if_changed(index_file)
+    monkeypatch.setattr(Path, "read_bytes", reject_legacy_index_read)
+    durations = []
+    rows = []
+    for _index in range(20):
+        started = time.perf_counter()
+        rows = models.all_sessions(include_lineage_metadata=False)
+        durations.append(time.perf_counter() - started)
+
+    assert any(row["session_id"] == session.session_id for row in rows)
+    assert len(rows) == 1_000
+    p95 = sorted(durations)[18]
+    assert p95 < 0.25, f"bounded session listing p95 was {p95:.3f}s"
+    assert index_file.exists()
+
+
+def test_sqlite_commit_recovers_after_uncommitted_writer_crash(
+    scaled_session_store,
+):
+    session, session_dir, _index_file = scaled_session_store
+    session.pending_user_message = "committed"
+    session.save()
+
+    db_path = session_dir / "_sessions.sqlite3"
+    assert db_path.exists()
+    crash_writer = """
+import os
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("PRAGMA journal_mode=WAL")
+conn.execute("BEGIN IMMEDIATE")
+conn.execute(
+    "UPDATE sessions SET metadata_json = ? WHERE session_id = ?",
+    ('{"session_id":"active_session","pending_user_message":"uncommitted"}', "active_session"),
+)
+os._exit(91)
+"""
+    crashed = subprocess.run(
+        [sys.executable, "-c", crash_writer, str(db_path)],
+        check=False,
+    )
+    assert crashed.returncode == 91
+
+    models.SESSIONS.clear()
+    loaded = models.Session.load(session.session_id)
+
+    assert loaded is not None
+    assert loaded.pending_user_message == "committed"
+
+
+def test_metadata_only_save_latency_does_not_scale_with_message_count(
+    scaled_session_store,
+):
+    session, _session_dir, _index_file = scaled_session_store
+    session.messages = [
+        {"role": "user", "content": "x" * 200}
+        for _index in range(50_000)
+    ]
+
+    durations = []
+    for index in range(20):
+        session.pending_user_message = f"pending {index}"
+        started = time.perf_counter()
+        session.save(metadata_only=True)
+        durations.append(time.perf_counter() - started)
+
+    p95 = sorted(durations)[18]
+    assert p95 < 0.1, f"metadata-only save p95 was {p95:.3f}s"
+
+
+def test_external_legacy_metadata_edit_preserves_newer_incremental_transcript(
+    scaled_session_store,
+):
+    session, _session_dir, _index_file = scaled_session_store
+    session.messages.append({"role": "assistant", "content": "new database tail"})
+    session.save()
+
+    legacy = json.loads(session.path.read_text(encoding="utf-8"))
+    legacy["title"] = "Externally renamed"
+    session.path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    loaded = models.Session.load(session.session_id)
+
+    assert loaded is not None
+    assert loaded.title == "Externally renamed"
+    assert loaded.messages[-1]["content"] == "new database tail"
+
+
+def test_empty_active_snapshot_cannot_erase_large_unmirrored_transcript(
+    scaled_session_store,
+):
+    session, _session_dir, _index_file = scaled_session_store
+    session.messages = []
+    session.active_stream_id = "stream_guard"
+    session.pending_user_message = "still pending"
+
+    session.save()
+    loaded = models.Session.load(session.session_id)
+
+    assert loaded is not None
+    assert len(loaded.messages) == 2
+
+
+def test_corrupt_incremental_store_falls_back_to_legacy_sidecar(
+    scaled_session_store,
+):
+    session, session_dir, _index_file = scaled_session_store
+    db_path = session_dir / "_sessions.sqlite3"
+    for suffix in ("-wal", "-shm"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+    db_path.write_bytes(b"not sqlite")
+
+    loaded = models.Session.load(session.session_id)
+
+    assert loaded is not None
+    assert loaded.messages == session.messages
+
+
+def test_listing_and_point_lookup_remain_bounded_beyond_two_thousand(
+    tmp_path,
+    monkeypatch,
+):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "SESSIONS", {})
+    monkeypatch.setattr(routes, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", index_file)
+    rows = [
+        {
+            "session_id": f"bounded_{index}",
+            "title": f"Bounded {index}",
+            "created_at": float(index),
+            "updated_at": float(index),
+            "message_count": 1,
+            "source_tag": "webui",
+        }
+        for index in range(2_101)
+    ]
+    store = IncrementalSessionStore(session_dir)
+    store.update_index(rows)
+    with sqlite3.connect(store.path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO sessions(session_id, metadata_json)
+            VALUES (?, ?)
+            """,
+            [(row["session_id"], json.dumps(row)) for row in rows],
+        )
+
+    listed = models.all_sessions(include_lineage_metadata=False)
+
+    assert len(listed) == 1_000
+    assert routes._session_index_marks_was_webui("bounded_0") is True
+
+
+def test_incremental_session_lifecycle_delete_removes_payload_and_index(
+    scaled_session_store,
+):
+    session, session_dir, _index_file = scaled_session_store
+    models.delete_incremental_session(session.session_id)
+    store = IncrementalSessionStore(session_dir)
+
+    assert store.load_payload(session.session_id) is None
+    assert store.get_index(session.session_id) is None

--- a/tests/test_session_index_parse_bytes.py
+++ b/tests/test_session_index_parse_bytes.py
@@ -43,11 +43,13 @@ def test_all_sessions_reads_unicode_index_via_bytes(tmp_path, monkeypatch):
         {"session_id": "unic-1", "title": "Café ☕", "last_message_at": 10.0},
     ]
     idx.write_text(json.dumps(entries, ensure_ascii=False), encoding="utf-8")
+    (session_dir / "unic-1.json").write_text(
+        json.dumps(entries[0], ensure_ascii=False),
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", idx)
-    # Treat the indexed id as persisted so the prune step keeps it.
-    monkeypatch.setattr(models, "_persisted_session_ids_snapshot", lambda: frozenset({"unic-1"}))
     monkeypatch.setattr(models, "_active_stream_ids", lambda: set())
 
     result = models.all_sessions(include_lineage_metadata=False)


### PR DESCRIPTION
## Ticket

Maint-Manager #0644

## Summary

- replace whole-session JSON rewrites and global `_index.json` rewrites with a normalized SQLite session store
- keep legacy JSON/index compatibility through lazy import and bounded mirroring
- persist pending-stream metadata without serializing multi-megabyte transcripts
- bound sidebar reads to 1,000 compact keyed rows
- remove keyed session state on lifecycle deletion

## Root cause

Every pending-state transition serialized the complete session sidecar and rebuilt the complete global session index. Cost therefore scaled with transcript bytes and retained-session count instead of changed state.

## Siblings covered

- pending save, normal save, metadata-only save
- success/error/cancel/restart persistence
- legacy sidecar and index import
- external legacy metadata edits without transcript rollback
- corrupt-store fallback
- point lookup beyond list cap
- delete/prune cleanup

## Red → green

Initial regression test: 2 failures in 4 tests. Pending save read/wrote the 10 MB sidecar and 1,700-row global index; scaled listing exceeded latency bound.

Final issue suite: 10 passed. Relevant neighboring suite: 65 passed. Isolated shared-suite sort rerun: 2 passed.

## Verification

- `./scripts/test.sh -q`: 19 failed, 13710 passed, 139 skipped, 1 xfailed, 2 xpassed, 36 errors, 34 subtests passed in 773.10s
- 17 failures and all 36 errors reproduce installed-dependency baseline mismatches: MCP Server missing `list_tools`, skills module missing `_SKILLS_DIR_AT_IMPORT`, gateway context missing `_SESSION_UI_SESSION_ID`, plus pre-existing compression estimator mismatch
- 2 sidebar ordering failures were shared-state flakes; exact isolated rerun passed 2/2
- focused ticket + neighboring runs passed; ruff on new files, py_compile, and diff check passed

## Production-shaped candidate

- image digest: `sha256:fa34ac00e5dd17bc4c4d309185a4f656ba21025bcd7fd58f95c97832a02de448`
- isolated 1,700-session + 10 MB active-session container
- pending chat start: HTTP 200, 80.64 ms; legacy 10 MB sidecar hash unchanged
- 10 cold-restart `/api/sessions` samples: p95/max 212.9 ms, HTTP 200, 1,000 bounded rows
- CRUD, restart recovery, health, no restart/OOM: passed
- candidate container, image, and isolated state removed

## Release note

Session persistence now updates only changed records, keeping large histories and long-lived installations responsive during streaming and sidebar loads.


---
Maint ticket: #0644 — Maint-Manager `tickets/review/0644-hermes-webui-rewrites-multi-megabyte-session-and-i.md`
On merge: verify this ticket’s acceptance boxes against **production** (not tests), tick them, then move the ticket to `tickets/done/` and set `status: done`.
A merged PR is not a closed ticket — an unmerged PR is not a shipped fix.