### PR TITLE
feat(providers): Bedrock API key + IAM credentials in Settings

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -729,6 +729,10 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
     # flip to "no key" after upgrading.
     "lmstudio": "LM_API_KEY",
     "nvidia": "NVIDIA_API_KEY",
+    # Bedrock bearer / "Bedrock API Key" (OpenAI-compatible mantle path + SDK).
+    # IAM access-key pairs are handled separately via AWS_ACCESS_KEY_ID /
+    # AWS_SECRET_ACCESS_KEY (see _bedrock_has_iam_keys / set_provider_key).
+    "bedrock": "AWS_BEARER_TOKEN_BEDROCK",
 }
 
 # Read-only legacy env-var aliases.  When `_provider_has_key(pid)` looks up its
@@ -1239,6 +1243,39 @@ def _write_env_file(env_path: Path, updates: dict[str, str | None]) -> None:
             pass
 
 
+def _bedrock_iam_env_values() -> tuple[str, str]:
+    """Return (access_key_id, secret_access_key) from .env then process env."""
+    env_path = _get_hermes_home() / ".env"
+    env_values = _load_env_file(env_path)
+    access = str(
+        env_values.get("AWS_ACCESS_KEY_ID")
+        or _thread_local_env_value("AWS_ACCESS_KEY_ID")
+        or ""
+    ).strip()
+    secret = str(
+        env_values.get("AWS_SECRET_ACCESS_KEY")
+        or _thread_local_env_value("AWS_SECRET_ACCESS_KEY")
+        or ""
+    ).strip()
+    return access, secret
+
+
+def _bedrock_has_iam_keys() -> bool:
+    access, secret = _bedrock_iam_env_values()
+    return bool(access and secret)
+
+
+def _bedrock_has_bearer_token() -> bool:
+    env_var = _PROVIDER_ENV_VAR.get("bedrock") or "AWS_BEARER_TOKEN_BEDROCK"
+    env_path = _get_hermes_home() / ".env"
+    env_values = _load_env_file(env_path)
+    if _provider_value_counts_as_api_key("bedrock", env_values.get(env_var)):
+        return True
+    return _provider_value_counts_as_api_key(
+        "bedrock", _thread_local_env_value(env_var)
+    )
+
+
 def _provider_has_key(provider_id: str) -> bool:
     """Check whether a provider has a configured API key.
 
@@ -1249,6 +1286,10 @@ def _provider_has_key(provider_id: str) -> bool:
     4. ``config.yaml → providers.<id>.api_key``
     5. ``config.yaml → custom_providers[].api_key`` (for custom providers)
     """
+    provider_id = (provider_id or "").strip().lower()
+    # Bedrock also accepts a classic IAM access-key pair (no single "API key").
+    if provider_id == "bedrock" and _bedrock_has_iam_keys():
+        return True
     env_var = _provider_env_var_for(provider_id)
     if env_var:
         env_path = _get_hermes_home() / ".env"
@@ -2773,7 +2814,7 @@ def get_providers() -> dict[str, Any]:
         except Exception:
             provider_base_url = None
         _is_plugin = is_plugin_model_provider(pid)
-        providers.append({
+        entry = {
             "id": pid,
             "display_name": display_name,
             "has_key": has_key,
@@ -2793,7 +2834,24 @@ def get_providers() -> dict[str, Any]:
             # command. For providers that don't trim, models_total ==
             # len(models) and the frontend behaves identically to before.
             "models_total": models_total,
-        })
+        }
+        if pid == "bedrock":
+            # Never present Bedrock as OAuth — auth_type is aws_sdk.
+            entry["is_oauth"] = False
+            has_bearer = _bedrock_has_bearer_token()
+            has_iam = _bedrock_has_iam_keys()
+            entry["has_key"] = bool(has_bearer or has_iam)
+            entry["bedrock_has_bearer"] = has_bearer
+            entry["bedrock_has_iam"] = has_iam
+            if has_bearer and has_iam:
+                entry["key_source"] = "env_file"
+            elif has_bearer:
+                entry["key_source"] = "env_file"
+            elif has_iam:
+                entry["key_source"] = "env_file"
+            elif key_source == "oauth":
+                entry["key_source"] = "none"
+        providers.append(entry)
 
     # Scan custom_providers from config.yaml (e.g. glmcode, timicc)
     custom_providers_cfg = cfg.get("custom_providers", [])
@@ -2866,11 +2924,31 @@ def get_providers() -> dict[str, Any]:
     return _store_cached_providers(cache_key, result)
 
 
-def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
+def _validate_secret_value(label: str, value: str, *, min_len: int = 8) -> str | None:
+    """Return an error string if invalid, else None. ``value`` must already be stripped."""
+    if "\n" in value or "\r" in value:
+        return f"{label} must not contain newline characters."
+    if len(value) < min_len:
+        return f"{label} appears too short."
+    return None
+
+
+def set_provider_key(
+    provider_id: str,
+    api_key: str | None,
+    *,
+    aws_access_key_id: str | None = None,
+    aws_secret_access_key: str | None = None,
+) -> dict[str, Any]:
     """Set or update the API key for a provider.
 
     Writes the key to ``~/.hermes/.env`` using the standard env var name.
     If ``api_key`` is None or empty, the key is removed.
+
+    For ``bedrock``, also accepts optional IAM access-key fields
+    (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``). Passing only those
+    fields updates the IAM pair without clearing the Bedrock API key.
+    Passing ``api_key=None`` via remove clears bearer **and** IAM keys.
 
     Returns a status dict with the operation result.
     """
@@ -2894,17 +2972,63 @@ def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
                      f"This provider does not have a known env var mapping.",
         }
 
-    # Validate API key format (basic sanity check)
-    if api_key:
-        api_key = api_key.strip()
-        if "\n" in api_key or "\r" in api_key:
-            return {"ok": False, "error": "API key must not contain newline characters."}
-        if len(api_key) < 8:
-            return {"ok": False, "error": "API key appears too short."}
+    iam_provided = aws_access_key_id is not None or aws_secret_access_key is not None
+    access = ("" if aws_access_key_id is None else str(aws_access_key_id)).strip()
+    secret = ("" if aws_secret_access_key is None else str(aws_secret_access_key)).strip()
+    if provider_id == "bedrock" and iam_provided:
+        # Empty strings mean "clear this IAM pair" when both empty; partial update
+        # requires both non-empty.
+        if access or secret:
+            if not access or not secret:
+                return {
+                    "ok": False,
+                    "error": "AWS access key ID and secret access key must be provided together.",
+                }
+            err = _validate_secret_value("AWS access key ID", access, min_len=16)
+            if err:
+                return {"ok": False, "error": err}
+            err = _validate_secret_value("AWS secret access key", secret, min_len=16)
+            if err:
+                return {"ok": False, "error": err}
+
+    # Validate API key format (basic sanity check). For bedrock IAM-only saves,
+    # api_key may be omitted (None) without clearing the bearer token.
+    clear_bearer = False
+    if api_key is not None:
+        api_key = str(api_key).strip() or None
+        if api_key:
+            err = _validate_secret_value("API key", api_key, min_len=8)
+            if err:
+                return {"ok": False, "error": err}
+        else:
+            clear_bearer = True
 
     env_path = _get_hermes_home() / ".env"
+    updates: dict[str, str | None] = {}
+
+    if provider_id == "bedrock":
+        # Remove-all path: set_provider_key("bedrock", None) with no IAM kwargs.
+        if api_key is None and not iam_provided:
+            updates[env_var] = None
+            updates["AWS_ACCESS_KEY_ID"] = None
+            updates["AWS_SECRET_ACCESS_KEY"] = None
+        else:
+            if api_key is not None:
+                updates[env_var] = None if clear_bearer else api_key
+            if iam_provided:
+                if access and secret:
+                    updates["AWS_ACCESS_KEY_ID"] = access
+                    updates["AWS_SECRET_ACCESS_KEY"] = secret
+                else:
+                    updates["AWS_ACCESS_KEY_ID"] = None
+                    updates["AWS_SECRET_ACCESS_KEY"] = None
+        if not updates:
+            return {"ok": False, "error": "No Bedrock credentials provided to update."}
+    else:
+        updates[env_var] = api_key
+
     try:
-        _write_env_file(env_path, {env_var: api_key})
+        _write_env_file(env_path, updates)
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     except Exception as exc:
@@ -2918,11 +3042,13 @@ def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
     invalidate_account_usage_status_cache(provider_id)
     invalidate_providers_cache()
 
+    action = "updated" if any(v for v in updates.values()) else "removed"
+
     return {
         "ok": True,
         "provider": provider_id,
         "display_name": _PROVIDER_DISPLAY.get(provider_id, provider_id),
-        "action": "updated" if api_key else "removed",
+        "action": action,
     }
 
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -2946,9 +2946,11 @@ def set_provider_key(
     If ``api_key`` is None or empty, the key is removed.
 
     For ``bedrock``, also accepts optional IAM access-key fields
-    (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``). Passing only those
-    fields updates the IAM pair without clearing the Bedrock API key.
-    Passing ``api_key=None`` via remove clears bearer **and** IAM keys.
+    (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``). Saving a Bedrock
+    API key clears any stored IAM pair (and vice versa) so stale access keys
+    cannot keep winning boto3 SigV4 after a switch. Passing both in one
+    request keeps both. Passing ``api_key=None`` via remove clears bearer
+    **and** IAM keys.
 
     Returns a status dict with the operation result.
     """
@@ -2992,7 +2994,8 @@ def set_provider_key(
                 return {"ok": False, "error": err}
 
     # Validate API key format (basic sanity check). For bedrock IAM-only saves,
-    # api_key may be omitted (None) without clearing the bearer token.
+    # api_key may be omitted (None) without an explicit clear; exclusive
+    # replace still clears bearer when a new IAM pair is written.
     clear_bearer = False
     if api_key is not None:
         api_key = str(api_key).strip() or None
@@ -3013,15 +3016,28 @@ def set_provider_key(
             updates["AWS_ACCESS_KEY_ID"] = None
             updates["AWS_SECRET_ACCESS_KEY"] = None
         else:
+            saving_bearer = bool(api_key) and not clear_bearer
+            saving_iam = bool(iam_provided and access and secret)
+
             if api_key is not None:
                 updates[env_var] = None if clear_bearer else api_key
+            elif saving_iam:
+                # IAM-only replace: drop leftover bearer so boto3 cannot keep
+                # treating a half-switched env as dual-auth.
+                updates[env_var] = None
+
             if iam_provided:
-                if access and secret:
+                if saving_iam:
                     updates["AWS_ACCESS_KEY_ID"] = access
                     updates["AWS_SECRET_ACCESS_KEY"] = secret
                 else:
                     updates["AWS_ACCESS_KEY_ID"] = None
                     updates["AWS_SECRET_ACCESS_KEY"] = None
+            elif saving_bearer:
+                # Bearer-only replace: always clear IAM so deleted access keys
+                # cannot keep signing Bedrock requests.
+                updates["AWS_ACCESS_KEY_ID"] = None
+                updates["AWS_SECRET_ACCESS_KEY"] = None
         if not updates:
             return {"ok": False, "error": "No Bedrock credentials provided to update."}
     else:
@@ -3034,6 +3050,14 @@ def set_provider_key(
     except Exception as exc:
         logger.exception("Failed to write env file for provider %s", provider_id)
         return {"ok": False, "error": f"Failed to save API key: {exc}"}
+
+    if provider_id == "bedrock":
+        try:
+            from agent.bedrock_adapter import reset_client_cache
+
+            reset_client_cache()
+        except Exception:
+            logger.debug("bedrock reset_client_cache unavailable", exc_info=True)
 
     # Invalidate the model cache so the dropdown refreshes on next request.
     # Using invalidate_models_cache() instead of reload_config() to avoid

--- a/api/routes.py
+++ b/api/routes.py
@@ -14496,7 +14496,24 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "provider is required")
         if api_key is not None:
             api_key = str(api_key).strip() or None
-        result = set_provider_key(provider_id, api_key)
+        aws_access_key_id = body.get("aws_access_key_id")
+        aws_secret_access_key = body.get("aws_secret_access_key")
+        if aws_access_key_id is not None:
+            aws_access_key_id = str(aws_access_key_id)
+        if aws_secret_access_key is not None:
+            aws_secret_access_key = str(aws_secret_access_key)
+        # Bedrock may send IAM fields without api_key; omit kwargs for others.
+        if provider_id == "bedrock" and (
+            aws_access_key_id is not None or aws_secret_access_key is not None
+        ):
+            result = set_provider_key(
+                provider_id,
+                api_key,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+            )
+        else:
+            result = set_provider_key(provider_id, api_key)
         if not result.get("ok"):
             return bad(handler, result.get("error", "Unknown error"))
         return j(handler, result)

--- a/static/panels.js
+++ b/static/panels.js
@@ -11347,13 +11347,11 @@ function _buildProviderCard(p){
   if(p.configurable && p.id==='bedrock'){
     const hint=document.createElement('div');
     hint.className='provider-card-hint';
-    hint.textContent='Credential priority: (1) Bedrock API key, then (2) IAM access key + secret. If both are saved, the API key is used. Instance-role (IMDS) is last in the chain and off by default on locked hosts.';
+    hint.textContent='Save either a Bedrock API key or an IAM access key pair — saving one replaces the other. Instance-role (IMDS) is last and off by default on locked hosts.';
     body.appendChild(hint);
     const activeHint=document.createElement('div');
     activeHint.className='provider-card-hint';
-    if(p.bedrock_has_bearer && p.bedrock_has_iam){
-      activeHint.textContent='In use now: Bedrock API key (saved IAM keys are ignored while an API key is present).';
-    }else if(p.bedrock_has_bearer){
+    if(p.bedrock_has_bearer){
       activeHint.textContent='In use now: Bedrock API key.';
     }else if(p.bedrock_has_iam){
       activeHint.textContent='In use now: IAM access key pair.';
@@ -11394,17 +11392,17 @@ function _buildProviderCard(p){
     };
 
     const bearerInput=addSecretField(
-      '1. Bedrock API key (highest priority)',
+      'Bedrock API key',
       p.bedrock_has_bearer?'•••••••• (replace to update)':'AWS_BEARER_TOKEN_BEDROCK',
       'api_key'
     );
     const accessInput=addSecretField(
-      '2. AWS access key ID',
+      'AWS access key ID',
       p.bedrock_has_iam?'•••••••• (replace to update)':'AWS_ACCESS_KEY_ID',
       'aws_access_key_id'
     );
     const secretInput=addSecretField(
-      '2. AWS secret access key',
+      'AWS secret access key',
       p.bedrock_has_iam?'•••••••• (replace to update)':'AWS_SECRET_ACCESS_KEY',
       'aws_secret_access_key'
     );
@@ -11588,8 +11586,13 @@ async function _saveBedrockProviderCredentials(providerId){
   els.saveBtn.textContent=t('providers_saving');
   try{
     const body={provider:providerId};
-    if(bearer) body.api_key=bearer;
-    if(access&&secret){
+    if(bearer){
+      body.api_key=bearer;
+      // Clear IAM so deleted access keys cannot keep signing requests.
+      body.aws_access_key_id='';
+      body.aws_secret_access_key='';
+    }else if(access&&secret){
+      body.api_key='';
       body.aws_access_key_id=access;
       body.aws_secret_access_key=secret;
     }

--- a/static/panels.js
+++ b/static/panels.js
@@ -11344,7 +11344,102 @@ function _buildProviderCard(p){
     return card;
   }
 
-  if(p.configurable){
+  if(p.configurable && p.id==='bedrock'){
+    const hint=document.createElement('div');
+    hint.className='provider-card-hint';
+    hint.textContent='Use a Bedrock API key and/or an IAM access key pair. Instance-role (IMDS) auth is separate and off by default on locked hosts.';
+    body.appendChild(hint);
+
+    const addSecretField=(labelText, placeholder, keyName)=>{
+      const field=document.createElement('div');
+      field.className='provider-card-field';
+      const label=document.createElement('label');
+      label.className='provider-card-label';
+      label.textContent=labelText;
+      field.appendChild(label);
+      const row=document.createElement('div');
+      row.className='provider-card-row';
+      const el=document.createElement('input');
+      el.type='password';
+      el.className='provider-card-input';
+      el.placeholder=placeholder;
+      el.autocomplete='off';
+      el.dataset.bedrockField=keyName;
+      const toggleBtn=document.createElement('button');
+      toggleBtn.type='button';
+      toggleBtn.className='provider-card-btn provider-card-btn-ghost';
+      toggleBtn.textContent='Show';
+      toggleBtn.onclick=()=>{
+        const revealed=el.type==='text';
+        el.type=revealed?'password':'text';
+        toggleBtn.textContent=revealed?'Show':'Hide';
+      };
+      row.appendChild(el);
+      row.appendChild(toggleBtn);
+      field.appendChild(row);
+      body.appendChild(field);
+      return el;
+    };
+
+    const bearerInput=addSecretField(
+      'Bedrock API key',
+      p.bedrock_has_bearer?'•••••••• (replace to update)':'AWS_BEARER_TOKEN_BEDROCK',
+      'api_key'
+    );
+    const accessInput=addSecretField(
+      'AWS access key ID',
+      p.bedrock_has_iam?'•••••••• (replace to update)':'AWS_ACCESS_KEY_ID',
+      'aws_access_key_id'
+    );
+    const secretInput=addSecretField(
+      'AWS secret access key',
+      p.bedrock_has_iam?'•••••••• (replace to update)':'AWS_SECRET_ACCESS_KEY',
+      'aws_secret_access_key'
+    );
+
+    const saveRow=document.createElement('div');
+    saveRow.className='provider-card-row';
+    saveRow.style.marginTop='6px';
+    saveBtn=document.createElement('button');
+    saveBtn.type='button';
+    saveBtn.className='provider-card-btn provider-card-btn-primary';
+    saveBtn.textContent=t('providers_save');
+    saveBtn.disabled=true;
+    saveBtn.onclick=()=>_saveBedrockProviderCredentials(p.id);
+    saveRow.appendChild(saveBtn);
+    if(p.has_key){
+      const removeBtn=document.createElement('button');
+      removeBtn.type='button';
+      removeBtn.className='provider-card-btn provider-card-btn-danger';
+      removeBtn.textContent=t('providers_remove');
+      removeBtn.onclick=()=>_removeProviderKey(p.id);
+      saveRow.appendChild(removeBtn);
+    }
+    body.appendChild(saveRow);
+
+    const syncSave=()=>{
+      const hasBearer=!!bearerInput.value.trim();
+      const hasAccess=!!accessInput.value.trim();
+      const hasSecret=!!secretInput.value.trim();
+      const iamPair=hasAccess&&hasSecret;
+      const iamPartial=(hasAccess||hasSecret)&&!iamPair;
+      saveBtn.disabled=iamPartial||(!hasBearer&&!iamPair);
+    };
+    bearerInput.addEventListener('input',syncSave);
+    accessInput.addEventListener('input',syncSave);
+    secretInput.addEventListener('input',syncSave);
+
+    _providerCardEls.set(p.id,{
+      card,
+      bearerInput,
+      accessInput,
+      secretInput,
+      saveBtn,
+      hasKey:p.has_key,
+      isBedrock:true,
+    });
+    focusInput=bearerInput;
+  }else if(p.configurable){
     const field=document.createElement('div');
     field.className='provider-card-field';
     const label=document.createElement('label');
@@ -11463,9 +11558,52 @@ function _buildProviderCard(p){
   return card;
 }
 
+async function _saveBedrockProviderCredentials(providerId){
+  const els=_providerCardEls.get(providerId);
+  if(!els||!els.isBedrock) return;
+  const bearer=(els.bearerInput&&els.bearerInput.value||'').trim();
+  const access=(els.accessInput&&els.accessInput.value||'').trim();
+  const secret=(els.secretInput&&els.secretInput.value||'').trim();
+  if((access&&!secret)||(!access&&secret)){
+    showToast('AWS access key ID and secret access key must be provided together.');
+    return;
+  }
+  if(!bearer&&!access){
+    showToast(t('providers_enter_key')||'Enter a Bedrock API key or IAM access key pair.');
+    return;
+  }
+  els.saveBtn.disabled=true;
+  els.saveBtn.textContent=t('providers_saving');
+  try{
+    const body={provider:providerId};
+    if(bearer) body.api_key=bearer;
+    if(access&&secret){
+      body.aws_access_key_id=access;
+      body.aws_secret_access_key=secret;
+    }
+    const res=await api('/api/providers',{method:'POST',body:JSON.stringify(body)});
+    if(res&&res.ok===false){
+      showToast(res.error||t('providers_save_failed')||'Failed to save');
+      return;
+    }
+    showToast(t('providers_saved')||'Saved');
+    await loadProvidersPanel();
+  }catch(e){
+    showToast(e.message||String(e));
+  }finally{
+    if(els.saveBtn){
+      els.saveBtn.disabled=false;
+      els.saveBtn.textContent=t('providers_save');
+    }
+  }
+}
+
 async function _saveProviderKey(providerId){
   const els=_providerCardEls.get(providerId);
   if(!els) return;
+  if(els.isBedrock){
+    return _saveBedrockProviderCredentials(providerId);
+  }
   const key=els.input.value.trim();
   if(!key){
     showToast(t('providers_enter_key'));

--- a/static/panels.js
+++ b/static/panels.js
@@ -11347,8 +11347,20 @@ function _buildProviderCard(p){
   if(p.configurable && p.id==='bedrock'){
     const hint=document.createElement('div');
     hint.className='provider-card-hint';
-    hint.textContent='Use a Bedrock API key and/or an IAM access key pair. Instance-role (IMDS) auth is separate and off by default on locked hosts.';
+    hint.textContent='Credential priority: (1) Bedrock API key, then (2) IAM access key + secret. If both are saved, the API key is used. Instance-role (IMDS) is last in the chain and off by default on locked hosts.';
     body.appendChild(hint);
+    const activeHint=document.createElement('div');
+    activeHint.className='provider-card-hint';
+    if(p.bedrock_has_bearer && p.bedrock_has_iam){
+      activeHint.textContent='In use now: Bedrock API key (saved IAM keys are ignored while an API key is present).';
+    }else if(p.bedrock_has_bearer){
+      activeHint.textContent='In use now: Bedrock API key.';
+    }else if(p.bedrock_has_iam){
+      activeHint.textContent='In use now: IAM access key pair.';
+    }else{
+      activeHint.textContent='No API key or IAM keys saved yet.';
+    }
+    body.appendChild(activeHint);
 
     const addSecretField=(labelText, placeholder, keyName)=>{
       const field=document.createElement('div');
@@ -11382,17 +11394,17 @@ function _buildProviderCard(p){
     };
 
     const bearerInput=addSecretField(
-      'Bedrock API key',
+      '1. Bedrock API key (highest priority)',
       p.bedrock_has_bearer?'•••••••• (replace to update)':'AWS_BEARER_TOKEN_BEDROCK',
       'api_key'
     );
     const accessInput=addSecretField(
-      'AWS access key ID',
+      '2. AWS access key ID',
       p.bedrock_has_iam?'•••••••• (replace to update)':'AWS_ACCESS_KEY_ID',
       'aws_access_key_id'
     );
     const secretInput=addSecretField(
-      'AWS secret access key',
+      '2. AWS secret access key',
       p.bedrock_has_iam?'•••••••• (replace to update)':'AWS_SECRET_ACCESS_KEY',
       'aws_secret_access_key'
     );

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -825,3 +825,69 @@ class TestBedrockCredentials:
             config.cfg.clear()
             config.cfg.update(old_cfg)
             config._cfg_mtime = old_mtime
+
+    def test_bedrock_bearer_replaces_iam(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            from api.providers import set_provider_key, get_providers
+            set_provider_key(
+                "bedrock",
+                None,
+                aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+                aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            )
+            result = set_provider_key("bedrock", "bedrock-bearer-token-12345")
+            assert result["ok"] is True
+            content = (tmp_path / ".env").read_text()
+            assert "AWS_BEARER_TOKEN_BEDROCK=bedrock-bearer-token-12345" in content
+            assert "AWS_ACCESS_KEY_ID" not in content
+            assert "AWS_SECRET_ACCESS_KEY" not in content
+            by_id = {p["id"]: p for p in get_providers()["providers"]}
+            assert by_id["bedrock"]["bedrock_has_bearer"] is True
+            assert by_id["bedrock"]["bedrock_has_iam"] is False
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+
+    def test_bedrock_iam_replaces_bearer(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            from api.providers import set_provider_key, get_providers
+            set_provider_key("bedrock", "bedrock-bearer-token-12345")
+            result = set_provider_key(
+                "bedrock",
+                None,
+                aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+                aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            )
+            assert result["ok"] is True
+            content = (tmp_path / ".env").read_text()
+            assert "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE" in content
+            assert "AWS_SECRET_ACCESS_KEY=" in content
+            assert "AWS_BEARER_TOKEN_BEDROCK" not in content
+            by_id = {p["id"]: p for p in get_providers()["providers"]}
+            assert by_id["bedrock"]["bedrock_has_iam"] is True
+            assert by_id["bedrock"]["bedrock_has_bearer"] is False
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -692,3 +692,136 @@ class TestIssue1410OllamaEnvVarBleed:
             config.cfg.clear()
             config.cfg.update(old_cfg)
             config._cfg_mtime = old_mtime
+
+
+class TestBedrockCredentials:
+    """Bedrock API key (bearer) + IAM access-key pair in Settings."""
+
+    def test_bedrock_is_configurable(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            from api.providers import get_providers
+            by_id = {p["id"]: p for p in get_providers()["providers"]}
+            assert "bedrock" in by_id
+            assert by_id["bedrock"]["configurable"] is True
+            assert by_id["bedrock"]["is_oauth"] is False
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+
+    def test_bedrock_bearer_key(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            from api.providers import set_provider_key, _provider_has_key, get_providers
+            result = set_provider_key("bedrock", "bedrock-bearer-token-12345")
+            assert result["ok"] is True
+            assert _provider_has_key("bedrock") is True
+            content = (tmp_path / ".env").read_text()
+            assert "AWS_BEARER_TOKEN_BEDROCK=bedrock-bearer-token-12345" in content
+            by_id = {p["id"]: p for p in get_providers()["providers"]}
+            assert by_id["bedrock"]["bedrock_has_bearer"] is True
+            assert by_id["bedrock"]["bedrock_has_iam"] is False
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+
+    def test_bedrock_iam_pair(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            from api.providers import set_provider_key, _provider_has_key, get_providers
+            result = set_provider_key(
+                "bedrock",
+                None,
+                aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+                aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            )
+            assert result["ok"] is True
+            assert _provider_has_key("bedrock") is True
+            content = (tmp_path / ".env").read_text()
+            assert "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE" in content
+            assert "AWS_SECRET_ACCESS_KEY=" in content
+            assert "AWS_BEARER_TOKEN_BEDROCK" not in content
+            by_id = {p["id"]: p for p in get_providers()["providers"]}
+            assert by_id["bedrock"]["bedrock_has_iam"] is True
+            assert by_id["bedrock"]["bedrock_has_bearer"] is False
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime
+
+    def test_bedrock_iam_partial_rejected(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        from api.providers import set_provider_key
+        result = set_provider_key(
+            "bedrock",
+            None,
+            aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_access_key="",
+        )
+        assert result["ok"] is False
+
+    def test_bedrock_remove_clears_iam_and_bearer(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {}
+        try:
+            from api.providers import set_provider_key, remove_provider_key, _provider_has_key
+            set_provider_key("bedrock", "bedrock-bearer-token-12345")
+            set_provider_key(
+                "bedrock",
+                None,
+                aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+                aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            )
+            result = remove_provider_key("bedrock")
+            assert result["ok"] is True
+            assert _provider_has_key("bedrock") is False
+            content = (tmp_path / ".env").read_text() if (tmp_path / ".env").exists() else ""
+            assert "AWS_BEARER_TOKEN_BEDROCK" not in content
+            assert "AWS_ACCESS_KEY_ID" not in content
+            assert "AWS_SECRET_ACCESS_KEY" not in content
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime


### PR DESCRIPTION
## Summary
- Make **AWS Bedrock** configurable from Settings (it previously vanished or was mislabelled OAuth when only IMDS looked “logged in”).
- Support **Bedrock API key** → `AWS_BEARER_TOKEN_BEDROCK`.
- Support **IAM access key + secret** → `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
- Provider card shows both forms; remove clears bearer and IAM env vars.
- `is_oauth` is forced false for Bedrock (`auth_type=aws_sdk`).

## Test plan
- [x] `./scripts/test.sh tests/test_provider_management.py::TestBedrockCredentials`
- [ ] Settings → Providers → AWS Bedrock: save bearer only
- [ ] Save IAM pair only; remove clears both
- [ ] Partial IAM rejected in UI and API


Made with [Cursor](https://cursor.com)