### PR TITLE
ci: constrain MCP SDK to compatible 1.x releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,7 +227,7 @@ jobs:
           # it so test coverage exists. If mcp install fails (Python 3.13
           # wheel not yet available, etc.), tests/test_mcp_server.py uses
           # importorskip and the matrix stays green.
-          pip install mcp || echo "mcp install failed — test_mcp_server.py will importorskip"
+          pip install "mcp<2" || echo "mcp install failed — test_mcp_server.py will importorskip"
 
       - name: Get Playwright version
         if: needs.changes.outputs.docs_only != 'true'

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7,7 +7,7 @@ Option A rewrite (2026-05-08): imports api.models and api.profiles
 directly from the webui codebase, using canonical helpers for
 locking, profile scoping, index consistency, and validation.
 
-    pip install mcp       # one-time setup
+    pip install "mcp<2"   # one-time setup
     python3 mcp_server.py # start via stdio
 
 MCP config for Hermes Agent (add to config.yaml):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-timeout
 pytest-asyncio
 pytest-shard
 ruff
-mcp
+mcp<2
 # Optional Office parsers — runtime-optional (commented in requirements.txt), but
 # installed here so the workspace Office-preview tests (tests/test_issue540_*.py)
 # run under the documented ./scripts/test.sh entry point. These files

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,10 +18,8 @@ from pathlib import Path
 import pytest
 
 # Skip the entire module when the optional `mcp` package isn't installed.
-# CI runs with stdlib-only deps (pyyaml + pytest + pytest-timeout), and the
-# `mcp` package is only required for users who actually run the MCP server.
-# Locally with `pip install mcp pytest-asyncio` these tests run; on CI they
-# skip cleanly without breaking the matrix.
+# CI and the local test runner install the compatible dependency; minimal
+# runtime environments can still collect the rest of the suite without it.
 pytest.importorskip("mcp", reason="mcp package not installed (optional MCP server dep)")
 
 # pytest-asyncio is also optional but always installed alongside mcp tests


### PR DESCRIPTION
## Thinking Path

- Every Python CI shard now fails in `tests/test_mcp_server.py` after the unbounded install began resolving `mcp==2.0.0`.
- MCP 2.0 removed the `Server.list_tools` API used by the current server and tests.
- The WebUI integration still targets the MCP 1.x API, so its install surfaces must express that compatibility boundary.

## What Changed

- Constrain the CI MCP install to `mcp<2`.
- Apply the same constraint to local development dependencies and the MCP server setup command.
- Correct the MCP test dependency comment to match current CI and local-runner behavior.

## Why It Matters

This restores the Python test matrix without changing runtime behavior or hiding the MCP tests behind a skip. It also prevents users following the in-file setup command from installing an incompatible major release.

## Verification

- `mcp<2` resolved to `mcp==1.29.0` on Python 3.13.
- Confirmed `mcp.server.Server` exposes `list_tools`.
- `./scripts/test.sh tests/test_mcp_server.py -q`: 50 passed.
- `python -m pip check`: no broken requirements.
- Workflow YAML parse, changed-line ruff, and `git diff --check` passed.

## Risks / Follow-ups

- This intentionally keeps the current MCP integration on 1.x. Supporting MCP 2.x requires a separate API migration.
- No product behavior, public contract, or UI changed.

## Model Used

OpenAI `gpt-5.6-sol` via Hermes Agent. Used for diagnosis, the compatibility-bound edit, and verification.