### PR TITLE
fix: keep SIGUSR1 stack dumps non-terminating

### DIFF
--- a/api/crash_visibility.py
+++ b/api/crash_visibility.py
@@ -268,8 +268,11 @@ def install_crash_visibility(
             sigusr1 = getattr(signal, "SIGUSR1", None)
             if sigusr1 is not None:
                 try:
+                    # A diagnostic signal must not inherit SIGUSR1's default
+                    # terminate action after the dump.  Chaining here made a
+                    # hang probe kill the server and trigger service restarts.
                     faulthandler.register(
-                        sigusr1, file=_FAULT_STREAM, all_threads=True, chain=True
+                        sigusr1, file=_FAULT_STREAM, all_threads=True, chain=False
                     )
                 except Exception:
                     pass

--- a/tests/test_issue4633_crash_visibility.py
+++ b/tests/test_issue4633_crash_visibility.py
@@ -23,8 +23,12 @@ No live server socket is required — the helpers are exercised directly.
 """
 import faulthandler
 import logging
+import os
+import signal
+import subprocess
 import sys
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -120,6 +124,41 @@ def test_install_is_idempotent(fresh_hooks):
     assert cv.install_crash_visibility(stream=stream, register_sigusr1_dump=False) is True
     # Second call must be a no-op (no stacked hooks / duplicate atexit handlers).
     assert cv.install_crash_visibility(stream=stream, register_sigusr1_dump=False) is False
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGUSR1"), reason="SIGUSR1 is POSIX-only")
+def test_sigusr1_stack_dump_does_not_terminate_process():
+    """The diagnostic signal must dump stacks without chaining to SIG_DFL.
+
+    Chaining invokes SIGUSR1's default action after faulthandler writes the dump,
+    terminating the WebUI process and prompting service managers to restart it.
+    Exercise the real signal in a child so a regression cannot kill pytest.
+    """
+    script = """
+import os
+import signal
+from api.crash_visibility import install_crash_visibility
+
+# An ignored SIGUSR1 disposition survives exec on POSIX.  Force the production
+# default so chain=True would terminate this child after writing the dump.
+signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+install_crash_visibility()
+os.kill(os.getpid(), signal.SIGUSR1)
+print('survived-sigusr1', flush=True)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=os.fspath(Path(__file__).resolve().parents[1]),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "survived-sigusr1" in completed.stdout
+    assert "Current thread" in completed.stderr
+    assert "most recent call first" in completed.stderr
 
 
 # ── 2. threading.excepthook ─────────────────────────────────────────────────


### PR DESCRIPTION
## Thinking Path

1. Traced the behavior to `faulthandler.register(..., chain=True)` in the crash-visibility bootstrap added for #4633.
2. `SIGUSR1` is intended as a diagnostic hang probe, but its default POSIX action terminates the process after the dump when chaining is enabled.
3. Kept faulthandler registration and all-thread output intact while disabling only the post-dump signal chain.
4. Exercised the real signal in an isolated child process so the test can prove both dump emission and process survival without touching a live WebUI process.

## What Changed

- Register the diagnostic `SIGUSR1` faulthandler with `chain=False`.
- Add a POSIX-only subprocess regression that:
  - explicitly resets `SIGUSR1` to `SIG_DFL` so inherited `SIG_IGN` cannot create a false pass;
  - installs the real crash-visibility hooks;
  - signals only the child itself;
  - requires a zero exit code, a survival marker, and faulthandler stack-dump text.

## Why It Matters

`kill -USR1 <pid>` is documented as a way to inspect a hung WebUI. With `chain=True`, the stack was dumped and then the server was terminated, prompting service managers to restart it. The diagnostic action should observe the process, not kill it.

This is a focused follow-up to #4633 and the crash-visibility implementation merged in #5354.

## Verification

- Deterministic RED against parent `21bdd7c1`: the updated subprocess test emitted a faulthandler dump and failed with child return code `-30` (`SIGUSR1`) before reaching the survival marker.
- GREEN on this candidate:

```text
./scripts/test.sh tests/test_issue4633_crash_visibility.py -q
11 passed

./scripts/test.sh -p no:cacheprovider \
  tests/test_issue4633_crash_visibility.py \
  tests/test_issue3407_sigpipe_ignore.py -q
16 passed
```

- Changed-line Ruff: no new violations.
- `git diff --check`: clean.
- Added-line security scan: clean.
- On platforms without `SIGUSR1`, the regression is skipped.

## Risk and Compatibility

- The prior signal handler is intentionally not chained; that is the behavior required for a non-terminating diagnostic signal.
- Native-crash faulthandler enablement, thread/sys exception hooks, exit audit, idempotence, and failure fallback are unchanged.
- No configuration, API, schema, or UI changes.

No UI changes; screenshots are not applicable.
