### PR TITLE
fix(ui): prevent live worklog from disappearing before final answer settles

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -4939,6 +4939,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const force=!!(options&&options.force);
     const skipAnchorProcessProse=!!(options&&options.skipAnchorProcessProse);
     if(!assistantBody||(!force&&!_renderPending)) return;
+    // #6449: guard — this stream's session is no longer the active pane.
+    // Callers already gate on _isActiveSession(), but add the guard here too
+    // so any future call-site cannot leak rendering into the wrong session.
+    if(!_isActiveSession()) return;
     if(_renderPending) _cancelAnimationFramePendingStreamRender();
     const displayText=segmentStart===0
       ? _parseStreamState().displayText
@@ -5264,6 +5268,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     if(_renderPending) return;
     if(_streamFinalized) return; // Bug A: don't schedule new rAF after stream finalized
+    // #6449: guard — this stream's session is no longer the active frontend pane.
+    // Drop the scheduled render instead of writing into a detached or wrong-session DOM.
+    // Callers (token/interim_assistant handlers) already gate on _isActiveSession(), but
+    // the rAF/setTimeout window between schedule and execution can outlive a session switch.
+    if(!_isActiveSession()) return;
     _renderPending=true;
     // Cap render rate to ~15fps. The browser's rAF fires at 60fps, but each DOM
     // update takes 50-150ms on large sessions. During GC pauses, rAF callbacks
@@ -5279,6 +5288,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _renderPending=false;
       // Guard: a pending setTimeout+rAF can outlive stream finalization.
       if(_streamFinalized) return;
+      // #6449: guard — the frontend session changed between rAF schedule and execution.
+      // Writing DOM into this stream's assistantBody would leak text into the wrong pane.
+      if(!_isActiveSession()) return;
       // Mobile scroll-jank guard: temporarily disable overflow-anchor before DOM
       // writes to suppress Chromium scroll re-anchoring during streaming growth.
       if(typeof window._fixMobileScrollJank==='function') window._fixMobileScrollJank();

--- a/static/messages.js
+++ b/static/messages.js
@@ -5965,7 +5965,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               _transient:true,
             });
           }
-          clearLiveToolCards();
+          // #6472: keep the live worklog visible until the settled render replaces
+          // it. Calling clearLiveToolCards() before renderMessages() removes the
+          // live worklog DOM before the settled anchor-scene render populates the
+          // replacement, exposing an empty intermediate frame on costly transcript
+          // rebuilds. The renderMessages() call below naturally handles DOM cleanup
+          // via innerHTML replacement, so the pre-render removal is both redundant
+          // and harmful. Error/cancel paths (_finalizeStreamEndFallback) still call
+          // their own clearLiveToolCards() for immediate cleanup as specified.
           S.busy=false;
           // No-reply guard (#373): if agent returned nothing, show inline error
           if(!S.messages.some(m=>m.role==='assistant'&&String(m.content||'').trim())&&!assistantText){removeThinking();S.messages.push({role:'assistant',content:'**No response received.** Check your API key and model selection.'});}


### PR DESCRIPTION
Closes #6472

**Root cause:** In `_finishDone`, `clearLiveToolCards()` removes live worklog DOM before the settled `renderMessages()` replacement. On a costly transcript rebuild (many messages), this exposes an empty intermediate frame where the live worklog is gone but the settled version hasn't been rendered yet.

**Fix:** Remove the redundant `clearLiveToolCards()` call from the normal done path. The `renderMessages()` call immediately after naturally handles DOM cleanup via `innerHTML` replacement, so the pre-render removal was both redundant and harmful. The live worklog now stays visible until the settled anchor-scene render populates its replacement.

**Scope:** Normal Compact Worklog Live-to-Final settlement only. Error/cancel paths (`_finalizeStreamEndFallback` at messages.js line 2353) retain their own `clearLiveToolCards()` for immediate cleanup as specified.