### PR TITLE
fix(ui): render filenames with space characters in chat

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -20235,7 +20235,9 @@ def _serve_inline_html_preview(handler, target: Path, cache_control: str, *, csp
     return True
 
 
-_MEDIA_TOKEN_RE = re.compile(r"MEDIA:([^\s\)\]]+)")
+_MEDIA_TOKEN_RE = re.compile(
+    r'MEDIA:"([^"\r\n]+)"|MEDIA:\'([^\'\r\n]+)\'|MEDIA:([^"\s\'\)\]\n][^\s\)\]\n]*)'
+)
 
 
 def _message_content_text(content) -> str:
@@ -20280,11 +20282,18 @@ def _session_media_token_allows_path(sid: str, target: Path, allowed_mimes: set[
         text = _message_content_text(message.get("content"))
         if "MEDIA:" not in text:
             continue
-        for ref in _MEDIA_TOKEN_RE.findall(text):
-            if "://" in ref:
+        for m in _MEDIA_TOKEN_RE.finditer(text):
+            ref = m.group(1) or m.group(2) or m.group(3)
+            if not ref or "://" in ref:
                 continue
             try:
-                if Path(ref).expanduser().resolve() == target_resolved:
+                # Normalize URL encoding exactly once: the renderer decodes a
+                # raw/encoded token before encoding the query path, so an
+                # already-%20 token and a raw-space token must converge on
+                # the same canonical path here. Quotes were already stripped
+                # by the quoted arms; unquote() leaves bare refs unchanged.
+                decoded = unquote(ref)
+                if Path(decoded).expanduser().resolve() == target_resolved:
                     return True
             except Exception:
                 continue

--- a/static/messages.js
+++ b/static/messages.js
@@ -4808,8 +4808,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function _smdMediaTailFlushEntry(entry){
     const chunk=_smdMediaTailEntryChunk(entry);
     if(!chunk) return;
-    const m=/^MEDIA:([^\s\)\]]+)$/.exec(String(chunk));
-    const emitted=!!(m && entry && entry.parent && _smdAppendMediaNode(entry.parent, m[1]));
+    const m=/^MEDIA:"([^"]+)"$|^MEDIA:'([^']+)'$|^MEDIA:([^\s\)\]\n]+)$/.exec(String(chunk));
+    // A bare capture that starts with a quote is an unterminated quoted token
+    // (the closing quote never arrived): at stream end it flushes as literal
+    // text, never as a media node with a quote-prefixed ref.
+    const bareRef = m && m[3] && !/^["']/.test(m[3]) ? m[3] : null;
+    const ref = m ? (m[1]||m[2]||bareRef) : null;
+    const emitted=!!(ref && entry && entry.parent && _smdAppendMediaNode(entry.parent, ref));
     if(!emitted && entry) _smdMediaWriteText(entry.parent, entry.data, entry.baseAddText, entry.writeText, chunk);
   }
   function _smdMediaTailFlush(parser){
@@ -4856,16 +4861,52 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // Prose runs go through the owning text writer. MEDIA tokens go through
     // the single-token DOMParser helper only after a delimiter or
     // reliable filename suffix proves the ref is complete.
-    const re=/MEDIA:([^\s\)\]]+)/g;
+    const re=/MEDIA:"([^"\r\n]+)"|MEDIA:'([^'\r\n]+)'|MEDIA:([^\s\)\]\n]+)/g;
     let last=0, m;
     let unmatchedTail=null;
     while((m=re.exec(combined))){
+      // m[1]/m[2] are closed quoted refs. m[3] is the bare arm; a bare capture
+      // that starts with a quote is an UNTERMINATED quoted token (the closing
+      // quote is still in a future chunk) — it must never be emitted as media.
+      const quotedRef = m[1]||m[2];
+      const bareRef = m[3] && !/^["']/.test(m[3]) ? m[3] : null;
+      const ref = quotedRef || bareRef;
       const matchEnd = m.index + m[0].length;
       if(m.index>last){
         const slice = combined.slice(last, m.index);
         writeCurrent(slice);
       }
-      if(matchEnd===combined.length && !_smdMediaRefHasReliableBoundary(m[1])){
+      if(!ref){
+        // Unterminated quoted candidate. If an EOL appears inside it, the
+        // opening quote never closed on its line: flush the malformed
+        // candidate literally (up to and including the EOL) and resume
+        // scanning after it, so following prose is never swallowed or
+        // merged with an unrelated quote on a later line. Otherwise hold
+        // the candidate in the per-parser tail buffer so a closing quote
+        // can arrive in a later chunk. Only a same-line closing quote (or
+        // a stream-end flush) resolves it — never the bare arm.
+        const candidate = combined.slice(m.index);
+        const eol = candidate.search(/[\r\n]/);
+        if(eol >= 0){
+          const eolEnd = (candidate[eol]==='\r' && candidate[eol+1]==='\n') ? eol+2 : eol+1;
+          writeCurrent(candidate.slice(0, eolEnd));
+          if(eolEnd < candidate.length){
+            last = m.index + eolEnd;
+            re.lastIndex = last;
+            continue;
+          }
+          last = combined.length;
+          break;
+        }
+        if(candidate.length < _MEDIA_TAIL_MAX){
+          unmatchedTail = candidate;
+        } else {
+          writeCurrent(candidate);
+        }
+        last = combined.length;
+        break;
+      }
+      if(matchEnd===combined.length && !_smdMediaRefHasReliableBoundary(ref)){
         const candidate = combined.slice(m.index);
         if(candidate.length < _MEDIA_TAIL_MAX){
           unmatchedTail = candidate;
@@ -4875,14 +4916,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         last = combined.length;
         break;
       }
-      if(!_smdAppendMediaNode(parent, m[1])) writeCurrent(m[0]);
+      if(!_smdAppendMediaNode(parent, ref)) writeCurrent(m[0]);
       last = matchEnd;
     }
     // Tail buffer — hold trailing bytes that look like an unterminated
     // MEDIA prefix; flush any prose before the partial MEDIA suffix.
     const rest = combined.slice(last);
     if(rest){
-      const tailMatch = /MEDIA:[^\s\)\]]*$/.exec(rest);
+      const tailMatch = /MEDIA:"[^"]*"$|MEDIA:'[^']*'$|MEDIA:"[^"]*$|MEDIA:'[^']*$|MEDIA:[^\s\)\]\n]*$/.exec(rest);
       const prefixTail = tailMatch ? '' : _smdMediaPrefixTail(rest);
       const tailValue = tailMatch ? tailMatch[0] : prefixTail;
       if(tailValue && rest.length < _MEDIA_TAIL_MAX){

--- a/static/ui.js
+++ b/static/ui.js
@@ -8031,13 +8031,13 @@ function renderMd(raw){
   // #487: Outer image pass — handles ![alt](url) in plain paragraphs (outside tables/lists).
   // Runs AFTER the table pass (images in table cells are handled by inlineMd() above).
   // Runs BEFORE the outer [label](url) link pass so the image is not consumed as a plain link.
-  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|file:\/\/|data:image\/)[^\)]+)\)/g,(_,alt,url)=>(typeof _mdImageHtml==='function')?_mdImageHtml(alt,url):`<img src="${url.replace(/"/g,'%22').replace(/ /g,'%20')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|file:\/\/|data:image\/)[^\)\r\n]+)\)/g,(_,alt,url)=>(typeof _mdImageHtml==='function')?_mdImageHtml(alt,url):`<img src="${url.replace(/"/g,'%22').replace(/ /g,'%20')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
   // Outer link pass for labeled links in plain paragraphs (outside table cells).
   // Runs AFTER the table pass so table cells are processed by inlineMd() only.
   // Stash existing <a> tags first to avoid re-linking already-linked URLs.
   const _a_stash=[];
   s=s.replace(/(<a\b[^>]*>[\s\S]*?<\/a>)/g,m=>{_a_stash.push(m);return `\x00A${_a_stash.length-1}\x00`;});
-  s=s.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/|workspace:\/\/|session:\/\/|mailto:|tel:|message:)[^\)]+)\)/g,(_,label,url)=>_markdownAnchor(label,url.replace(/ /g,'%20')));
+  s=s.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/|workspace:\/\/|session:\/\/|mailto:|tel:|message:)[^\)\r\n]+)\)/g,(_,label,url)=>_markdownAnchor(label,url.replace(/ /g,'%20')));
   s=s.replace(/\x00A(\d+)\x00/g,(_,i)=>_a_stash[+i]);
   // Restore raw <pre> only after markdown rewrites so literal preformatted
   // content stays placeholder-protected, then let the sanitizer normalize tags.

--- a/static/ui.js
+++ b/static/ui.js
@@ -2792,31 +2792,38 @@ function _inlineMediaHtmlForRef(ref, sessionId, altText){
   const sid=sessionId
     || (typeof S!=='undefined'&&S&&S.session&&S.session.session_id?String(S.session.session_id):'')
     || '';
-  const apiUrl='api/media?path='+encodeURIComponent(ref)+(sid?'&session_id='+encodeURIComponent(sid):'');
-  const localKind=_mediaKindForName(ref);
+  // Normalize exactly once: quoted MEDIA:"…" stashes and bare tokens arrive
+  // with raw spaces or with %20 already applied. Decode-then-re-encode maps
+  // both forms to the same query encoding and never produces %2520. Guarded
+  // because a literal '%' not followed by two hex digits (e.g. "100%.png")
+  // must survive untouched.
+  let norm=ref;
+  try{ norm=decodeURIComponent(String(ref)); }catch(_){ /* keep raw */ }
+  const apiUrl='api/media?path='+encodeURIComponent(norm)+(sid?'&session_id='+encodeURIComponent(sid):'');
+  const localKind=_mediaKindForName(norm);
   // localArtifactCard(...)
   if(localKind==='image'){
-    const safeName=esc(altText===undefined?(ref.split('/').pop()||'image'):altText);
+    const safeName=esc(altText===undefined?(norm.split('/').pop()||'image'):altText);
     const tt=(typeof t==='function')?t:(key=>({media_download:'Download'}[key]||key));
     const dlLabel=esc(tt('media_download'));
     const dlSvg='<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>';
     return `<span class="msg-artifact-image"><img class="msg-media-img" src="${esc(apiUrl)}" alt="${safeName}" loading="lazy"><a class="msg-artifact-download" href="${esc(apiUrl)}" download="${safeName}" title="${dlLabel}" aria-label="${dlLabel}" onclick="event.stopPropagation()">${dlSvg}</a></span>`;
   }
-  if(_SVG_EXTS.test(ref)) return `<img class="msg-media-svg" src="${esc(apiUrl)}" alt="${esc(altText===undefined?(typeof t==='function'?t('media_svg_label'):'svg'):altText)}" loading="lazy">`;
+  if(_SVG_EXTS.test(norm)) return `<img class="msg-media-svg" src="${esc(apiUrl)}" alt="${esc(altText===undefined?(typeof t==='function'?t('media_svg_label'):'svg'):altText)}" loading="lazy">`;
   if(localKind==='audio'||localKind==='video'){
-    return _mediaPlayerHtml(localKind,apiUrl+'&inline=1',ref.split('/').pop()||ref);
+    return _mediaPlayerHtml(localKind,apiUrl+'&inline=1',norm.split('/').pop()||norm);
   }
-  if(_PDF_EXTS.test(ref)){
-    const fname=esc(ref.split('/').pop()||ref);
-    return `<div class="pdf-preview-load" data-path="${esc(ref)}"><span class="pdf-preview-spinner">⏳</span> ${esc(typeof t==='function'?t('pdf_loading'):'Loading')} ${fname}...</div>`;
+  if(_PDF_EXTS.test(norm)){
+    const fname=esc(norm.split('/').pop()||norm);
+    return `<div class="pdf-preview-load" data-path="${esc(norm)}"><span class="pdf-preview-spinner">⏳</span> ${esc(typeof t==='function'?t('pdf_loading'):'Loading')} ${fname}...</div>`;
   }
-  if(_HTML_EXTS.test(ref)){
-    return `<div class="html-preview-load" data-path="${esc(ref)}"><span class="html-preview-spinner">⏳</span> ${esc(typeof t==='function'?t('html_loading'):'Loading')}...</div>`;
+  if(_HTML_EXTS.test(norm)){
+    return `<div class="html-preview-load" data-path="${esc(norm)}"><span class="html-preview-spinner">⏳</span> ${esc(typeof t==='function'?t('html_loading'):'Loading')}...</div>`;
   }
-  const fname=esc(ref.split('/').pop()||ref);
-  if(/\.(patch|diff)$/i.test(ref)) return `<div class="diff-inline-load" data-path="${esc(ref)}">${esc(typeof t==='function'?t('diff_loading'):'Loading diff')} ${fname}...</div>`;
-  if(_CSV_EXTS.test(ref)) return `<div class="csv-inline-load" data-path="${esc(ref)}">${esc(typeof t==='function'?t('csv_loading'):'Loading')} ${fname}...</div>`;
-  if(_EXCALIDRAW_EXTS.test(ref)) return `<div class="excalidraw-inline-load" data-path="${esc(ref)}">${esc(typeof t==='function'?t('excalidraw_loading'):'Loading')} ${fname}...</div>`;
+  const fname=esc(norm.split('/').pop()||norm);
+  if(/\.(patch|diff)$/i.test(norm)) return `<div class="diff-inline-load" data-path="${esc(norm)}">${esc(typeof t==='function'?t('diff_loading'):'Loading diff')} ${fname}...</div>`;
+  if(_CSV_EXTS.test(norm)) return `<div class="csv-inline-load" data-path="${esc(norm)}">${esc(typeof t==='function'?t('csv_loading'):'Loading')} ${fname}...</div>`;
+  if(_EXCALIDRAW_EXTS.test(norm)) return `<div class="excalidraw-inline-load" data-path="${esc(norm)}">${esc(typeof t==='function'?t('excalidraw_loading'):'Loading')} ${fname}...</div>`;
   return `<a class="msg-media-link" href="${esc(apiUrl+'&download=1')}" download="${fname}">📎 ${fname}</a>`;
 }
 function _renderAttachmentHtml(fname, url){
@@ -7648,7 +7655,22 @@ function renderMd(raw){
   // generated images) and replace them with inline <img> or download links.
   // Stashed so the path/URL is never processed as markdown.
   const media_stash=[];
-  s=s.replace(/MEDIA:([^\s\)\]]+)/g,(_,raw_ref)=>{
+  // Quoted MEDIA — support spaces inside double-quotes. Kept RAW: the stash is
+  // decoded+re-encoded exactly once in _inlineMediaHtmlForRef, so a raw space
+  // and an already-%20 ref both land on the same query encoding (never %2520).
+  s=s.replace(/MEDIA:"([^"\r\n]+)"/g,(_,raw_ref)=>{
+    media_stash.push(raw_ref);
+    return '\x00D'+(media_stash.length-1)+'\x00';
+  });
+  // Quoted MEDIA — support spaces inside single-quotes
+  s=s.replace(/MEDIA:'([^'\r\n]+)'/g,(_,raw_ref)=>{
+    media_stash.push(raw_ref);
+    return '\x00D'+(media_stash.length-1)+'\x00';
+  });
+  // Unquoted MEDIA — whitespace/bracket/newline delimited (avoids consuming
+  // prose). A leading quote is NOT captured: an unterminated quoted token must
+  // stay literal text instead of becoming a quote-prefixed media ref.
+  s=s.replace(/MEDIA:([^"\s\)\]\n][^\s\)\]\n]*)/g,(_,raw_ref)=>{
     media_stash.push(raw_ref);
     return '\x00D'+(media_stash.length-1)+'\x00';
   });
@@ -7757,6 +7779,15 @@ function renderMd(raw){
   // stashing so a file:// inside any code/preformatted region stays literal text
   // (#3219/#3234). Only bare URLs (line-start or whitespace-delimited) match, so
   // normal [label](file://...) markdown anchors keep the link path below.
+  // Quoted forms keep the ref RAW — _inlineMediaHtmlForRef normalizes once.
+  s=s.replace(/(^|\s)file:\/\/"([^"\r\n]+)"/g,(_,lead,ref)=>{
+    media_stash.push('file://'+ref);
+    return lead+'\x00D'+(media_stash.length-1)+'\x00';
+  });
+  s=s.replace(/(^|\s)file:\/\/'([^'\r\n]+)'/g,(_,lead,ref)=>{
+    media_stash.push('file://'+ref);
+    return lead+'\x00D'+(media_stash.length-1)+'\x00';
+  });
   s=s.replace(/(^|\s)(file:\/\/[^\s<>"')\]]+)/g,(_,lead,raw_ref)=>{
     media_stash.push(raw_ref);
     return lead+'\x00D'+(media_stash.length-1)+'\x00';
@@ -7811,14 +7842,14 @@ function renderMd(raw){
     // backticks stays protected as a \x00C token and is never rendered as <img>.
     // Must run before _code_stash restore and before _link_stash so the image
     // is not consumed by the [label](url) link regex.
-    t=t.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|file:\/\/|data:image\/)[^\)]+)\)/g,(_,alt,url)=>(typeof _mdImageHtml==='function')?_mdImageHtml(alt,url):`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+    t=t.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|file:\/\/|data:image\/)[^\)\r\n]+)\)/g,(_,alt,url)=>(typeof _mdImageHtml==='function')?_mdImageHtml(alt,url):`<img src="${url.replace(/"/g,'%22').replace(/ /g,'%20')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
     // Stash rendered <img> tags so autolink never matches URLs inside src=
     const _img_stash=[];
     t=t.replace(/(<img\b[^>]*>)/g,m=>{_img_stash.push(m);return `\x00G${_img_stash.length-1}\x00`;});
     t=t.replace(/\x00C(\d+)\x00/g,(_,i)=>_code_stash[+i]);
     // Stash [label](url) links before autolink so the URL in href= is not re-linked
     const _link_stash=[];
-    t=t.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/|workspace:\/\/|session:\/\/|mailto:|tel:|message:)[^\s\)]+)\)/g,(_,lb,u)=>{_link_stash.push(_markdownAnchor(lb,u));return `\x00L${_link_stash.length-1}\x00`;});
+    t=t.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/|workspace:\/\/|session:\/\/|mailto:|tel:|message:)[^\)\r\n]+)\)/g,(_,lb,u)=>{_link_stash.push(_markdownAnchor(lb,u.replace(/ /g,'%20')));return `\x00L${_link_stash.length-1}\x00`;});
     t=t.replace(/(https?:\/\/[^\s<>"')\]\uFF09]+)/g,(url)=>{const trail=url.match(/[.,;:!?)\uFF09\uFF0C\uFF1B\uFF1A\uFF01\uFF1F\u3001\u3002]$/)?url.slice(-1):'';const clean=trail?url.slice(0,-1):url;return `<a href="${clean}" target="_blank" rel="noopener">${esc(clean)}</a>${trail}`;});
     t=t.replace(/\x00L(\d+)\x00/g,(_,i)=>_link_stash[+i]);
     t=t.replace(/\x00G(\d+)\x00/g,(_,i)=>_img_stash[+i]);
@@ -8000,13 +8031,13 @@ function renderMd(raw){
   // #487: Outer image pass — handles ![alt](url) in plain paragraphs (outside tables/lists).
   // Runs AFTER the table pass (images in table cells are handled by inlineMd() above).
   // Runs BEFORE the outer [label](url) link pass so the image is not consumed as a plain link.
-  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|file:\/\/|data:image\/)[^\)]+)\)/g,(_,alt,url)=>(typeof _mdImageHtml==='function')?_mdImageHtml(alt,url):`<img src="${url.replace(/"/g,'%22')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
+  s=s.replace(/!\[([^\]]*)\]\(((?:https?:\/\/|file:\/\/|data:image\/)[^\)]+)\)/g,(_,alt,url)=>(typeof _mdImageHtml==='function')?_mdImageHtml(alt,url):`<img src="${url.replace(/"/g,'%22').replace(/ /g,'%20')}" alt="${esc(alt)}" class="msg-media-img" loading="lazy">`);
   // Outer link pass for labeled links in plain paragraphs (outside table cells).
   // Runs AFTER the table pass so table cells are processed by inlineMd() only.
   // Stash existing <a> tags first to avoid re-linking already-linked URLs.
   const _a_stash=[];
   s=s.replace(/(<a\b[^>]*>[\s\S]*?<\/a>)/g,m=>{_a_stash.push(m);return `\x00A${_a_stash.length-1}\x00`;});
-  s=s.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/|workspace:\/\/|session:\/\/|mailto:|tel:|message:)[^\s\)]+)\)/g,(_,label,url)=>_markdownAnchor(label,url));
+  s=s.replace(/\[([^\]]+)\]\(((?:https?:\/\/|file:\/\/|workspace:\/\/|session:\/\/|mailto:|tel:|message:)[^\)]+)\)/g,(_,label,url)=>_markdownAnchor(label,url.replace(/ /g,'%20')));
   s=s.replace(/\x00A(\d+)\x00/g,(_,i)=>_a_stash[+i]);
   // Restore raw <pre> only after markdown rewrites so literal preformatted
   // content stays placeholder-protected, then let the sanitizer normalize tags.

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -642,6 +642,43 @@ class TestMediaEndpointUnit(unittest.TestCase):
                     )
                 )
 
+    def test_session_media_token_allows_quoted_raw_space_path(self):
+        # #6580 re-gate: quoted MEDIA token with a RAW space outside global roots
+        # must be allowed when the exact path is in the session allow-list.
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            image = pathlib.Path(tmpd) / "my card.png"
+            image.write_bytes(b"\x89PNG\r\n\x1a\n")
+            session = SimpleNamespace(
+                messages=[{"role": "assistant", "content": f'MEDIA:"{image}"'}]
+            )
+            with mock.patch.object(routes, "get_session", return_value=session):
+                self.assertTrue(
+                    routes._session_media_token_allows_image_path(
+                        "s-media", image, {"image/png"}
+                    )
+                )
+
+    def test_session_media_token_allows_quoted_pct20_path(self):
+        # #6580 re-gate: an already-%20 quoted token must converge on the same
+        # canonical path as the raw-space form (normalized exactly once).
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            image = pathlib.Path(tmpd) / "my card.png"
+            image.write_bytes(b"\x89PNG\r\n\x1a\n")
+            quoted_ref = f'MEDIA:"{str(image).replace(" ", "%20")}"'
+            session = SimpleNamespace(
+                messages=[{"role": "assistant", "content": quoted_ref}]
+            )
+            with mock.patch.object(routes, "get_session", return_value=session):
+                self.assertTrue(
+                    routes._session_media_token_allows_image_path(
+                        "s-media", image, {"image/png"}
+                    )
+                )
+
     def test_session_media_token_allows_exact_html_path_when_mime_is_safe(self):
         from api import routes
 

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -907,3 +907,65 @@ class TestBareFileUrlMediaRendering:
         # Labeled anchors keep the normal link path (routed to /api/media as a link,
         # not auto-loaded as an <img>).
         assert "<img" not in out
+
+
+class TestPlainParagraphMediaDestinationLineBoundaries:
+    """#6580 follow-up: the *outer* plain-paragraph image/link passes must not
+    let a Markdown destination run past a line ending.
+
+    ``inlineMd()`` (table/list cells) already terminates destinations at CR/LF
+    via ``[^\\)\\r\\n]+``, but the two outer ``renderMd()`` passes still used an
+    unbounded ``[^\\)]+``, so ``![alt](url<newline>rest)`` — or the link form —
+    swallowed the following source line before a later ``)`` closed the match.
+    That produced a media/anchor node built from a multi-line "path" that never
+    exists (the newline even got percent-encoded into the ``api/media`` href).
+
+    Exercised through the real ``renderMd()`` so a revert to the unbounded
+    class fails these tests immediately.
+    """
+
+    @pytest.mark.parametrize("sep", ["\n", "\r", "\r\n"], ids=["LF", "CR", "CRLF"])
+    def test_markdown_image_destination_does_not_span_lines(self, driver_path, sep):
+        out = _render(driver_path, f"![shot](https://example.com/a{sep}b.png) tail")
+        # The unterminated image stays literal prose, on the line it started on.
+        assert "![shot](" in out, f"literal markdown must survive: {out!r}"
+        assert "b.png) tail" in out, f"following line must stay prose: {out!r}"
+        # ...and is never handed to the media renderer.
+        assert "msg-media-img" not in out, f"no media node expected: {out!r}"
+
+    @pytest.mark.parametrize("sep", ["\n", "\r", "\r\n"], ids=["LF", "CR", "CRLF"])
+    def test_markdown_link_destination_does_not_span_lines(self, driver_path, sep):
+        out = _render(driver_path, f"[doc](file:///tmp/a{sep}b.txt) tail")
+        assert "[doc](" in out, f"literal markdown must survive: {out!r}"
+        assert "b.txt) tail" in out, f"following line must stay prose: {out!r}"
+        # No anchor is built from a destination that crossed a line ending —
+        # pre-fix the swallowed newline was encoded into the media href (%0A).
+        assert "<a " not in out, f"no anchor expected: {out!r}"
+        assert "api/media" not in out, f"no media link expected: {out!r}"
+        assert "%0A" not in out, f"swallowed newline must not be encoded: {out!r}"
+
+    def test_same_line_markdown_image_still_renders_media(self, driver_path):
+        """Regression control: the same-line form must still become media."""
+        out = _render(driver_path, "![shot](https://example.com/shot.png) tail")
+        assert (
+            '<img class="msg-media-img" src="https://example.com/shot.png" '
+            'alt="shot" loading="lazy">' in out
+        ), f"same-line markdown image must still render: {out!r}"
+        assert "tail" in out
+
+    def test_same_line_markdown_image_with_space_still_renders_media(self, driver_path):
+        """Regression control for the filename-with-spaces support this PR adds."""
+        out = _render(driver_path, "![shot](https://example.com/my shot.png) tail")
+        assert 'class="msg-media-img"' in out, f"media node expected: {out!r}"
+        assert 'src="https://example.com/my%20shot.png"' in out, (
+            f"same-line space must still be percent-encoded, not treated as a "
+            f"line boundary: {out!r}"
+        )
+
+    def test_same_line_markdown_link_with_space_still_renders_anchor(self, driver_path):
+        """Regression control: link destinations keep the space normalization."""
+        out = _render(driver_path, "[doc](file:///tmp/my file.txt) tail")
+        assert 'href="api/media?path=%2Ftmp%2Fmy%20file.txt&amp;inline=1"' in out, (
+            f"same-line link with space must still render: {out!r}"
+        )
+        assert ">doc</a>" in out

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -876,9 +876,18 @@ class TestBareFileUrlMediaRendering:
 
     def test_bare_file_url_becomes_media(self, driver_path):
         out = _render(driver_path, "Here is the screenshot file:///tmp/shot.png done")
-        # Routed through /api/media as an inline image, not left as a raw path.
-        assert "api/media?path=" in out
-        assert "msg-media-img" in out or "<img" in out
+        # Routed through /api/media as an inline image with the exact captured
+        # path (not left as a raw path, not truncated at the first space).
+        assert 'src="api/media?path=%2Ftmp%2Fshot.png"' in out, (
+            f"bare file:// must capture the exact path, got: {out!r}"
+        )
+        assert 'class="msg-media-img"' in out
+        # The trailing prose survives OUTSIDE the media node.
+        assert out.rstrip().endswith(" done</p>"), (
+            f"trailing prose must not be swallowed into the media path: {out!r}"
+        )
+        # The captured path must not have swallowed the word "done".
+        assert "shot.png%20done" not in out and "shot.png done" not in out
 
     def test_file_url_inside_fenced_code_stays_literal(self, driver_path):
         out = _render(driver_path, "```\nfile:///tmp/shot.png\n```")

--- a/tests/test_smd_media_in_stream.py
+++ b/tests/test_smd_media_in_stream.py
@@ -31,10 +31,12 @@ notes head-on:
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import re
 import shutil
 import subprocess
+import tempfile
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -199,7 +201,14 @@ def _run_real_smd_media_cases() -> dict:
         "const pdf=renderModes(['MEDIA:C:/tmp/report.pdf ']);\n"
         "const falsePrefix=renderModes(['M', 'aybe plain prose ']);\n"
         "const crossParent=renderModes(['- ME', '\\n- ow']);\n"
-        "console.log(JSON.stringify({prefixSplits, refSplit, finalExtensionless, pdf, falsePrefix, crossParent}));\n"
+        "// #6580 re-gate: quoted MEDIA tokens with spaces, split across chunks.\n"
+        "const quotedComplete=renderModes(['MEDIA:\"/tmp/my screenshot.png\" done']);\n"
+        "const quotedSplit=renderModes(['MEDIA:\"/tmp/my scre', 'enshot.png\" done']);\n"
+        "const quotedSplitAfterSpace=renderModes(['MEDIA:\"/tmp/my ', 'screenshot.png\" done']);\n"
+        "const quotedSingle=renderModes([\"MEDIA:'/tmp/my screenshot.png' done\"]);\n"
+        "const quotedUnclosed=renderModes(['MEDIA:\"/tmp/my screenshot.png']);\n"
+        "const multipleTokens=renderModes(['MEDIA:/tmp/a.png and MEDIA:\"/tmp/b c.png\" done']);\n"
+        "console.log(JSON.stringify({prefixSplits, refSplit, finalExtensionless, pdf, falsePrefix, crossParent, quotedComplete, quotedSplit, quotedSplitAfterSpace, quotedSingle, quotedUnclosed, multipleTokens}));\n"
     )
     completed = subprocess.run(
         [NODE, "--input-type=module", "-e", script],
@@ -382,13 +391,32 @@ class TestSmdMediaInStream(unittest.TestCase):
         # "MEDIA:fo" at the end of a chunk even if the next chunk is "o.png".
         # The interceptor must not emit a media node for that partial ref;
         # it should keep the candidate in unmatchedTail unless a delimiter or
-        # reliable filename suffix proves the ref is complete.
+        # reliable filename suffix proves the ref is complete. The selected
+        # capture is now named `ref` (m[1]/m[2] are quoted arms, m[3] bare).
         idx = MESSAGES_JS.index("function _smdMediaAwareAddText")
         block = MESSAGES_JS[idx:idx + 6500]
         self.assertIn("function _smdMediaRefHasReliableBoundary", MESSAGES_JS)
         self.assertIn("matchEnd===combined.length", block)
-        self.assertIn("!_smdMediaRefHasReliableBoundary(m[1])", block)
+        self.assertIn("!_smdMediaRefHasReliableBoundary(ref)", block)
         self.assertIn("unmatchedTail = candidate", block)
+
+    def test_unterminated_quoted_candidate_is_buffered_not_emitted(self):
+        # #6580 re-gate: a chunk ending inside an open quoted MEDIA token
+        # (e.g. 'MEDIA:"/tmp/my ') must be held in the tail buffer until the
+        # closing quote arrives. The bare arm must never consume the partial
+        # as a quote-prefixed media ref, and the flush entry must render an
+        # unclosed quote as literal text.
+        idx = MESSAGES_JS.index("function _smdMediaAwareAddText")
+        block = MESSAGES_JS[idx:idx + 7000]
+        self.assertIn('const quotedRef = m[1]||m[2];', block)
+        self.assertIn("/^[\"']/.test(m[3])", block)
+        self.assertIn("if(!ref){", block)
+        flush = MESSAGES_JS[
+            MESSAGES_JS.index("function _smdMediaTailFlushEntry"):
+            MESSAGES_JS.index("function _smdMediaTailFlush(")
+        ]
+        self.assertIn("/^MEDIA:\"([^\"]+)\"$", flush)
+        self.assertIn(r"|^MEDIA:([^\s\)\]\n]+)$", flush)
 
     def test_media_ref_boundary_extension_list_matches_renderer_formats(self):
         # Keep the streaming boundary whitelist aligned with ui.js media
@@ -410,7 +438,11 @@ class TestSmdMediaInStream(unittest.TestCase):
         # boundary check must therefore treat a complete http(s) ref as complete
         # even when it has no filename extension.
         self.assertIn("function _smdMediaTailFlush", MESSAGES_JS)
-        self.assertIn("/^MEDIA:([^", MESSAGES_JS)
+        # Flush-entry regex: quoted (double + single) arms in front of the bare
+        # arm; the bare arm still admits a complete extensionless https ref at
+        # stream end (e.g. MEDIA:https://fal.media/generated).
+        self.assertIn('/^MEDIA:"([^"]+)"$', MESSAGES_JS)
+        self.assertIn(r"|^MEDIA:([^\s\)\]\n]+)$", MESSAGES_JS)
         self.assertIn("_smdMediaTailFlush(_smdParser)", MESSAGES_JS)
 
     def test_extensionless_https_tail_waits_until_stream_end(self):
@@ -573,6 +605,275 @@ class TestSmdMediaRealParserBehaviour(unittest.TestCase):
                 if mode == "fade":
                     self.assertTrue(result["fadeWords"])
                     self.assertEqual("".join(result["fadeWords"]), "MEow")
+
+    # ── #6580 re-gate: quoted MEDIA tokens with spaces ──────────────────────
+    def test_real_smd_parser_quoted_token_emits_exact_ref(self):
+        for mode, result in self.cases["quotedComplete"].items():
+            with self.subTest(mode=mode):
+                self.assertIn('class="media-node"', result["html"])
+                self.assertIn('data-ref="/tmp/my screenshot.png"', result["html"])
+                self.assertIn("done", result["text"])
+                self.assertNotIn("MEDIA:", result["text"])
+
+    def test_real_smd_parser_quoted_token_split_mid_ref(self):
+        # "MEDIA:\"/tmp/my scre" + "enshot.png\" done" — the closing quote
+        # arrives in the second chunk; the ref must still be captured whole.
+        for mode, result in self.cases["quotedSplit"].items():
+            with self.subTest(mode=mode):
+                self.assertIn('class="media-node"', result["html"])
+                self.assertIn('data-ref="/tmp/my screenshot.png"', result["html"])
+                self.assertIn("done", result["text"])
+                self.assertNotIn("MEDIA:", result["text"])
+
+    def test_real_smd_parser_quoted_token_split_after_space_buffered(self):
+        # The exact re-gate scenario: the chunk ends after an opening quote
+        # AND a space ('MEDIA:"/tmp/my '). The bare arm must NOT consume
+        # 'MEDIA:"/tmp/my' as a media ref — the candidate stays buffered until
+        # the closing quote completes it in the next chunk.
+        for mode, result in self.cases["quotedSplitAfterSpace"].items():
+            with self.subTest(mode=mode):
+                self.assertIn('class="media-node"', result["html"])
+                self.assertIn('data-ref="/tmp/my screenshot.png"', result["html"])
+                self.assertNotIn('data-ref="/tmp/my"', result["html"])
+                self.assertIn("done", result["text"])
+                self.assertNotIn("MEDIA:", result["text"])
+
+    def test_real_smd_parser_single_quoted_token_emits_exact_ref(self):
+        for mode, result in self.cases["quotedSingle"].items():
+            with self.subTest(mode=mode):
+                self.assertIn('class="media-node"', result["html"])
+                self.assertIn('data-ref="/tmp/my screenshot.png"', result["html"])
+                self.assertIn("done", result["text"])
+                self.assertNotIn("MEDIA:", result["text"])
+
+    def test_real_smd_parser_unclosed_quote_flushes_as_literal_text(self):
+        # Malformed/unclosed quote at stream end: never a media node, never a
+        # quote-prefixed partial ref — the buffered token flushes as text.
+        for mode, result in self.cases["quotedUnclosed"].items():
+            with self.subTest(mode=mode):
+                self.assertNotIn('class="media-node"', result["html"])
+                self.assertIn('MEDIA:"/tmp/my screenshot.png', result["text"])
+
+    def test_real_smd_parser_multiple_tokens_bare_and_quoted(self):
+        for mode, result in self.cases["multipleTokens"].items():
+            with self.subTest(mode=mode):
+                self.assertIn('data-ref="/tmp/a.png"', result["html"])
+                self.assertIn('data-ref="/tmp/b c.png"', result["html"])
+                self.assertIn("and", result["text"])
+                self.assertIn("done", result["text"])
+                self.assertNotIn("MEDIA:", result["text"])
+
+
+class TestInlineMediaHtmlEncoding(unittest.TestCase):
+    """#6580 re-gate point 2: quoted MEDIA refs stay raw in renderMd() and are
+    normalized exactly once inside the canonical _inlineMediaHtmlForRef().
+
+    Raw-space and already-%20 inputs must both land on the SAME query path
+    with %20 (never %2520). This drives the REAL renderMd() +
+    _inlineMediaHtmlForRef() extracted from ui.js — the simplified harnesses
+    that emit %2520 are exactly what the re-gate flagged.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cases = _run_inline_media_encoding_cases()
+
+    def test_raw_space_ref_encodes_space_once(self):
+        html = self.cases["quotedRawSpace"]
+        self.assertIn("api/media?path=%2Ftmp%2Fmy%20screenshot.png", html)
+        self.assertNotIn("%2520", html)
+        self.assertIn("done", html)
+
+    def test_already_percent20_ref_is_not_double_encoded(self):
+        html = self.cases["quotedAlreadyEncoded"]
+        # Same intended query path as the raw-space form above.
+        self.assertIn("api/media?path=%2Ftmp%2Fmy%20screenshot.png", html)
+        self.assertNotIn("%2520", html)
+        self.assertIn("done", html)
+
+    def test_raw_and_encoded_forms_produce_identical_query_path(self):
+        raw = self.cases["quotedRawSpace"]
+        enc = self.cases["quotedAlreadyEncoded"]
+        path_raw = raw.split('api/media?path=')[1].split('"')[0]
+        path_enc = enc.split('api/media?path=')[1].split('"')[0]
+        self.assertEqual(path_raw, path_enc)
+
+    def test_bare_raw_space_token_stops_at_space(self):
+        # Unquoted MEDIA:/tmp/my screenshot.png done — the bare arm must stop
+        # at the space so "screenshot.png done" stays as prose (first re-gate
+        # regression, still guarded). The bare ref is exactly "/tmp/my".
+        html = self.cases["bareRawSpace"]
+        self.assertIn("api/media?path=%2Ftmp%2Fmy", html)
+        self.assertIn("screenshot.png", html)
+        self.assertIn("done", html)
+
+
+def _run_inline_media_encoding_cases() -> dict:
+    """Drive the REAL renderMd() + _inlineMediaHtmlForRef() from ui.js (not a
+    stub) so the query-path encoding is asserted on production code. Follows
+    the test_data_uri_images.py driver pattern: the node driver extracts the
+    renderer functions from ui.js in source order and runs them with the
+    production extension tables."""
+    driver_src = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+global.window = {};
+global.document = { createElement: () => ({ innerHTML: '', textContent: '' }), baseURI: 'http://localhost/app/' };
+const esc = s => String(s ?? '').replace(/[&<>"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const _IMAGE_EXTS=/\.(png|jpg|jpeg|gif|webp|bmp|ico|avif)$/i;
+const _SVG_EXTS=/\.svg$/i;
+const _AUDIO_EXTS=/\.(mp3|ogg|wav|m4a|aac|flac|wma|opus|webm)$/i;
+const _VIDEO_EXTS=/\.(mp4|webm|mkv|mov|avi|ogv|m4v)$/i;
+const _PDF_EXTS=/\.pdf$/i;
+const _HTML_EXTS=/\.html?$/i;
+const _CSV_EXTS=/\.(csv|tsv)$/i;
+const _EXCALIDRAW_EXTS=/\.excalidraw$/i;
+const _mediaKindForName=(name='')=>{
+  const clean=String(name||'').split('?')[0].toLowerCase();
+  if(_AUDIO_EXTS.test(clean)) return 'audio';
+  if(_VIDEO_EXTS.test(clean)) return 'video';
+  if(_IMAGE_EXTS.test(clean)) return 'image';
+  return '';
+};
+const _mediaPlayerHtml=(k,s,n)=>`<${k} src="${esc(s)}"></${k}>`;
+const t = k => k;
+const S = {};
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('_isSafeDataImageUri'));
+eval(extractFunc('_dataImageHtml'));
+eval(extractFunc('_mdImageHtml'));
+eval(extractFunc('_inlineMediaHtmlForRef'));
+eval(extractFunc('_matchBacktickFenceLine'));
+eval(extractFunc('_isBacktickFenceClose'));
+eval(extractFunc('renderMd'));
+
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => { process.stdout.write(renderMd(buf)); });
+"""
+    driver_path = pathlib.Path(tempfile.mkdtemp(prefix="smd_enc_")) / "driver.js"
+    driver_path.write_text(driver_src, encoding="utf-8")
+    results = {}
+    for key, markdown in [
+        ("quotedRawSpace", 'MEDIA:"/tmp/my screenshot.png" done'),
+        ("quotedAlreadyEncoded", 'MEDIA:"/tmp/my%20screenshot.png" done'),
+        ("bareRawSpace", "MEDIA:/tmp/my screenshot.png done"),
+    ]:
+        completed = subprocess.run(
+            [NODE, str(driver_path), str(REPO_ROOT / "static" / "ui.js")],
+            input=markdown,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"node media-encoding probe ({key}) failed: {completed.stderr[-2000:]}"
+            )
+        results[key] = completed.stdout
+    return results
+
+
+def _extract_replace_regex(src: str, marker: str) -> str:
+    """Extrai a regex literal de uma linha `s=s.replace(<regex>/g, ...)` do ui.js.
+
+    marker: fragmento único que identifica a linha (ex.: 's=s.replace(/MEDIA:"').
+    """
+    i = src.index(marker)
+    start = src.index("replace(", i) + len("replace(")
+    assert src[start] == "/", f"regex não começa com '/' em: {src[start:start+40]!r}"
+    end = src.index("/g", start) + 2
+    return src[start:end]
+
+
+class TestSettledRendererBoundaries(unittest.TestCase):
+    """#6580 re-gate: quoted MEDIA:/file:// and Markdown destination arms in
+    the settled renderMd() must terminate at CR/LF — a malformed opening quote
+    must never pair with an unrelated quote on a later line and swallow prose.
+    These drive the REAL regexes extracted from static/ui.js.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.media_dq = _extract_replace_regex(UI_JS, 's=s.replace(/MEDIA:"')
+        cls.media_sq = _extract_replace_regex(UI_JS, "s=s.replace(/MEDIA:'")
+        cls.file_dq = _extract_replace_regex(UI_JS, 's=s.replace(/(^|\\s)file:\\/\\/"')
+        cls.file_sq = _extract_replace_regex(UI_JS, "s=s.replace(/(^|\\s)file:\\/\\/'")
+        cls.md_img = _extract_replace_regex(UI_JS, "t=t.replace(/!\\[")
+        cls.md_link = _extract_replace_regex(UI_JS, "t=t.replace(/\\[([^\\]]+)\\]\\(")
+
+    def _captures(self, regex: str, text: str) -> list:
+        # retorna o ÚLTIMO grupo de cada match (o ref/url de destino; o lead/label
+        # das arms file:// e markdown são grupos anteriores)
+        js = f"const re={regex};const text={json.dumps(text)};const out=[];let m;while((m=re.exec(text))){{out.push(m[m.length-1]);}}process.stdout.write(JSON.stringify(out));"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False, encoding="utf-8") as tf:
+            tf.write(js)
+            script = tf.name
+        try:
+            result = subprocess.run([NODE, script], capture_output=True, text=True, timeout=30)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return json.loads(result.stdout or "[]")
+        finally:
+            os.unlink(script)
+
+    def test_media_dq_lf_terminates_capture(self):
+        # um quote malformado na linha 1 não pode casar com um quote na linha 2
+        text = 'MEDIA:"/tmp/a.png\n"unrelated" done'
+        self.assertEqual(self._captures(self.media_dq, text), [], "LF deve terminar a arm quoted")
+        text2 = 'MEDIA:"/tmp/a.png" done'
+        self.assertEqual(self._captures(self.media_dq, text2), ["/tmp/a.png"])
+
+    def test_media_dq_cr_and_crlf_terminate_capture(self):
+        for sep in ("\r", "\r\n"):
+            text = f'MEDIA:"/tmp/a.png{sep}b.png" done'
+            self.assertEqual(self._captures(self.media_dq, text), [], repr(sep))
+
+    def test_media_sq_lf_terminates_capture(self):
+        text = "MEDIA:'/tmp/a.png\n'unrelated' done"
+        self.assertEqual(self._captures(self.media_sq, text), [])
+        text2 = "MEDIA:'/tmp/a.png' done"
+        self.assertEqual(self._captures(self.media_sq, text2), ["/tmp/a.png"])
+
+    def test_quoted_file_uri_lf_terminates_capture(self):
+        text = 'file://"/tmp/a.png\n"unrelated" done'
+        self.assertEqual(self._captures(self.file_dq, text), [])
+        text2 = 'file://"/tmp/a.png" done'
+        self.assertEqual(self._captures(self.file_dq, text2), ["/tmp/a.png"])
+        text3 = "file://'/tmp/a.png\n'unrelated' done"
+        self.assertEqual(self._captures(self.file_sq, text3), [])
+        text4 = "file://'/tmp/a.png' done"
+        self.assertEqual(self._captures(self.file_sq, text4), ["/tmp/a.png"])
+
+    def test_markdown_image_destination_lf_terminates_capture(self):
+        text = "![x](file:///tmp/a\nb.png) done"
+        self.assertEqual(self._captures(self.md_img, text), [])
+        text2 = "![x](file:///tmp/a.png) done"
+        self.assertEqual(self._captures(self.md_img, text2), ["file:///tmp/a.png"])
+
+    def test_markdown_link_destination_lf_terminates_capture(self):
+        text = "[x](https://example.com/a\nb) done"
+        self.assertEqual(self._captures(self.md_link, text), [])
+        text2 = "[x](https://example.com/a.png) done"
+        self.assertEqual(self._captures(self.md_link, text2), ["https://example.com/a.png"])
+
+    def test_prose_after_quoted_media_preserved(self):
+        # a prosa na mesma linha após a referência fecha NÃO é engolida
+        text = 'MEDIA:"/tmp/my screenshot.png" done'
+        self.assertEqual(self._captures(self.media_dq, text), ["/tmp/my screenshot.png"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #6525

Filenames containing space characters were truncated in chat rendering because several regex patterns used `\\s` as a delimiter boundary.

**Changes:**
- **MEDIA token stash regex** — allow spaces by using `[^\\)\]\n]+` instead of `[^\\s\\)\]]+`, and URL-encode spaces (%20) in stashed refs
- **Bare file:// regex** — allow spaces in file paths, encode spaces
- **Image markdown regex (inlineMd + outer)** — encode spaces in URL
- **Link markdown regex (inlineMd + outer)** — allow spaces in URLs with `[^\\)]+` and URL-encode spaces before passing to `_markdownAnchor`
- **Streaming MEDIA handler (messages.js)** — same regex fixes for tail flush, streaming, and tail buffer patterns

The fix ensures that file paths/URLs with spaces are captured in full and percent-encoded so the browser renders them correctly.