### PR TITLE
fix(ui): sync model selector with actual configured providers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -8488,17 +8488,22 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                         _cache_build_in_progress = False
                         _cache_build_cv.notify_all()
                 raise
-            with _cache_build_cv:
-                if _build_generation == _models_cache_generation:
-                    published_at = time.monotonic()
-                    _available_models_cache = result
-                    _available_models_cache_ts = published_at
-                    _available_models_live_rebuild_ts = published_at
-                    _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
-                    _sync_models_cache_provenance()
             try:
-                if _build_generation == _models_cache_generation:
-                    _save_models_cache_to_disk(result)
+                with _cache_build_cv:
+                    if _build_generation == _models_cache_generation:
+                        published_at = time.monotonic()
+                        _available_models_cache = result
+                        _available_models_cache_ts = published_at
+                        _available_models_live_rebuild_ts = published_at
+                        _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
+                        _sync_models_cache_provenance()
+                        # Hold the cv through the atomic disk rename: an
+                        # invalidation can no longer interleave between the
+                        # generation check and the file write (TOCTOU #6581).
+                        # It either blocks until the rename lands and then
+                        # deletes the file, or runs first and bumps the
+                        # generation so this publish block is skipped.
+                        _save_models_cache_to_disk(result)
             finally:
                 with _cache_build_cv:
                     if _build_generation == _models_cache_generation:
@@ -8557,15 +8562,17 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 )
                 _sync_models_cache_provenance()
             try:
-                # Re-check the generation right before the disk write: an
-                # invalidation between the in-memory publish and here must
-                # also cancel the on-disk write — otherwise the stale catalog
-                # survives a restart and the picker still shows the provider
-                # that was just removed.
+                # Hold the cv from the re-check through the atomic disk
+                # rename: an invalidation can no longer interleave between
+                # the generation check and the file write (TOCTOU #6581). It
+                # either blocks until the rename lands and then deletes the
+                # file, or runs first and bumps the generation so this
+                # publish block is skipped — the stale catalog cannot survive
+                # a restart and resurrect a just-removed provider.
                 with _cache_build_cv:
                     if _build_generation != _models_cache_generation:
                         return
-                _save_models_cache_to_disk(result)
+                    _save_models_cache_to_disk(result)
             except Exception:
                 logger.debug("models cache disk save failed", exc_info=True)
             finally:

--- a/api/config.py
+++ b/api/config.py
@@ -5072,6 +5072,13 @@ _SESSION_VISIT_MODELS_FRESHNESS_SECONDS: float = 300.0
 _available_models_cache_lock = threading.RLock()  # must be RLock: cold path refactoring moved slow work inside this lock, requiring re-entry
 _cache_build_cv = threading.Condition(_available_models_cache_lock)  # shares underlying RLock so notify_all() is safe inside with _available_models_cache_lock
 _cache_build_in_progress = False  # True while a cold path is actively building
+# Monotonic generation/owner token for the models-catalog cache machinery.
+# invalidate_models_cache() bumps it; a rebuild captures it when it starts and
+# discards its result (and skips the disk write) if it advanced while the
+# rebuild was in flight. This prevents an over-budget rebuild worker that
+# started before a provider cleanup from republishing a stale catalog that
+# resurrects just-removed providers (#6581).
+_models_cache_generation = 0
 
 # Memoized (snapshot_ref, {provider_slug: frozenset(model_ids)}) derived from
 # the published models-catalog snapshot. Used by _endpoint_advertised_model_ids
@@ -6478,7 +6485,15 @@ def invalidate_models_cache():
     """
     global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts
     global _available_models_live_rebuild_ts, _available_models_cache_source_fingerprint, _cache_build_cv
+    global _models_cache_generation
     with _available_models_cache_lock:
+        # Bump the generation/owner token so any in-flight rebuild that
+        # captured the previous generation discards its result when it
+        # finishes (see _publish_models_result / _build_generation). Without
+        # this, an over-budget rebuild worker that started before the
+        # invalidation would republish a stale catalog — resurrecting
+        # just-removed providers in memory and on disk (#6581).
+        _models_cache_generation += 1
         _available_models_cache = None
         _available_models_cache_ts = 0.0
         _available_models_live_rebuild_ts = 0.0
@@ -8420,6 +8435,12 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
         # Cold path: full rebuild — only one thread reaches here at a time
         with _cache_build_cv:
             _cache_build_in_progress = True
+            # Capture the generation/owner token for THIS rebuild. If
+            # invalidate_models_cache() runs while we rebuild, the token
+            # advances and this rebuild's result must be discarded — it was
+            # built from a config snapshot that may have just had providers
+            # removed (#6581).
+            _build_generation = _models_cache_generation
 
         # Capture the active per-request profile (#3957). The live provider
         # probe inside the rebuild resolves credentials from os.environ /
@@ -8459,23 +8480,30 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                     result = _invoke_models_rebuild(_build_available_models_uncached)
             except BaseException:
                 # Always reset the flag so waiting threads don't block for 60s
+                # — but only if we still own this rebuild's generation: an
+                # invalidation may have cleared the flag already, or a newer
+                # rebuild may own it now.
                 with _cache_build_cv:
-                    _cache_build_in_progress = False
-                    _cache_build_cv.notify_all()
+                    if _build_generation == _models_cache_generation:
+                        _cache_build_in_progress = False
+                        _cache_build_cv.notify_all()
                 raise
             with _cache_build_cv:
-                published_at = time.monotonic()
-                _available_models_cache = result
-                _available_models_cache_ts = published_at
-                _available_models_live_rebuild_ts = published_at
-                _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
-                _sync_models_cache_provenance()
+                if _build_generation == _models_cache_generation:
+                    published_at = time.monotonic()
+                    _available_models_cache = result
+                    _available_models_cache_ts = published_at
+                    _available_models_live_rebuild_ts = published_at
+                    _available_models_cache_source_fingerprint = _models_cache_source_fingerprint()
+                    _sync_models_cache_provenance()
             try:
-                _save_models_cache_to_disk(result)
+                if _build_generation == _models_cache_generation:
+                    _save_models_cache_to_disk(result)
             finally:
                 with _cache_build_cv:
-                    _cache_build_in_progress = False
-                    _cache_build_cv.notify_all()
+                    if _build_generation == _models_cache_generation:
+                        _cache_build_in_progress = False
+                        _cache_build_cv.notify_all()
             return copy.deepcopy(result)
 
         # ── Bounded rebuild (defense-in-depth) ───────────────────────────────
@@ -8512,6 +8540,14 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
             global _available_models_cache_ts, _available_models_live_rebuild_ts
             global _available_models_cache_source_fingerprint
             with _cache_build_cv:
+                if _build_generation != _models_cache_generation:
+                    # A cache invalidation happened while this rebuild was in
+                    # flight. The result was built from a stale config
+                    # snapshot and would resurrect just-removed providers
+                    # (#6581): discard it, skip the disk write, and leave
+                    # _cache_build_in_progress alone so a newer rebuild (if
+                    # any) keeps its serialization.
+                    return
                 published_at = time.monotonic()
                 _available_models_cache = result
                 _available_models_cache_ts = published_at
@@ -8521,17 +8557,34 @@ def get_available_models(*, prefer_cache: bool = False, force_refresh: bool = Fa
                 )
                 _sync_models_cache_provenance()
             try:
+                # Re-check the generation right before the disk write: an
+                # invalidation between the in-memory publish and here must
+                # also cancel the on-disk write — otherwise the stale catalog
+                # survives a restart and the picker still shows the provider
+                # that was just removed.
+                with _cache_build_cv:
+                    if _build_generation != _models_cache_generation:
+                        return
                 _save_models_cache_to_disk(result)
             except Exception:
                 logger.debug("models cache disk save failed", exc_info=True)
             finally:
+                # Only clear the in-progress flag if we still own this
+                # rebuild's generation: an obsolete worker must never clear a
+                # newer rebuild's in-progress state.
                 with _cache_build_cv:
-                    _cache_build_in_progress = False
-                    _cache_build_cv.notify_all()
+                    if _build_generation == _models_cache_generation:
+                        _cache_build_in_progress = False
+                        _cache_build_cv.notify_all()
 
         def _clear_build_in_progress():
             global _cache_build_in_progress
             with _cache_build_cv:
+                # Same generation guard as _publish_models_result: an
+                # obsolete rebuild (error path) must not clear the in-progress
+                # state of a newer rebuild started after an invalidation.
+                if _build_generation != _models_cache_generation:
+                    return
                 _cache_build_in_progress = False
                 _cache_build_cv.notify_all()
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -3027,6 +3027,15 @@ def _clean_provider_key_from_config(provider_id: str) -> None:
                 if isinstance(provider_cfg, dict) and provider_cfg.get("api_key"):
                     del provider_cfg["api_key"]
                     changed = True
+                    # If the provider entry is now empty (only had api_key),
+                    # remove the entire entry so it does not linger as an
+                    # empty dict that the model-picker detection loop treats
+                    # as a configured provider (#6335).
+                    if isinstance(provider_cfg, dict) and len(provider_cfg) == 0:
+                        del providers_cfg[provider_id]
+                        # Also clean up the providers section if it fell empty
+                        if len(providers_cfg) == 0:
+                            del cfg["providers"]
 
             # 2. Clean model.api_key — only if this provider is the active one
             model_cfg = cfg.get("model", {})
@@ -3055,5 +3064,6 @@ def _clean_provider_key_from_config(provider_id: str) -> None:
         if changed:
             reload_config()
             invalidate_providers_cache()
+            invalidate_models_cache()
     except Exception:
         logger.exception("Failed to clean provider key from config.yaml for %s", provider_id)

--- a/tests/test_issue3928_models_budget_fallback.py
+++ b/tests/test_issue3928_models_budget_fallback.py
@@ -13,6 +13,15 @@ import api.config as cfg
 import api.profiles as profiles
 
 
+# The autouse isolate_models_catalog_state fixture replaces these with hermetic
+# no-ops for every test. The real-disk TOCTOU regression test below needs the
+# genuine implementations, so capture them at import time (before any fixture
+# has run).
+_REAL_SAVE_MODELS_CACHE_TO_DISK = cfg._save_models_cache_to_disk
+_REAL_DELETE_MODELS_CACHE_ON_DISK = cfg._delete_models_cache_on_disk
+_REAL_LOAD_MODELS_CACHE_FROM_DISK = cfg._load_models_cache_from_disk
+
+
 @pytest.fixture(autouse=True)
 def isolate_models_catalog_state(monkeypatch, tmp_path):
     config_path = tmp_path / "config.yaml"
@@ -635,3 +644,147 @@ def test_stale_over_budget_rebuild_discarded_after_invalidation(
     assert disk_writes == [fresh_result], (
         "the stale rebuild must not write its catalog to disk"
     )
+
+
+def test_disk_save_atomic_with_invalidation_real_disk(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    """Regression for #6581 (TOCTOU): generation check + disk save must be
+    atomic under _cache_build_cv, on the real disk.
+
+    The stale-worker race is: (1) the worker passes the generation check,
+    (2) an invalidation advances the generation AND deletes the on-disk cache,
+    (3) the worker proceeds to _save_models_cache_to_disk and re-creates the
+    file with the removed provider + post-removal fingerprint — which the
+    strict boot loader accepts, resurrecting the provider from disk.
+
+    The fix holds _cache_build_cv from the generation check through the atomic
+    disk rename: the invalidation either blocks until the rename lands and
+    then deletes the file, or runs first and bumps the generation so the
+    publish block is skipped entirely. This test drives the REAL disk path
+    (the autouse fixture's no-op saves are replaced by the genuine
+    implementations) and asserts BOTH the on-disk cache file AND a strict
+    restart load stay free of the removed provider.
+    """
+    _configure_local_sources(
+        monkeypatch,
+        isolate_models_catalog_state["auth_store_path"],
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+    # The autouse fixture neutralizes the disk functions for hermetic tests;
+    # this test needs the real I/O so the file state after the race is
+    # genuinely asserted (the fixture still points _get_models_cache_path at
+    # the isolated tmp_path, so no production cache file is touched).
+    monkeypatch.setattr(
+        cfg, "_save_models_cache_to_disk", _REAL_SAVE_MODELS_CACHE_TO_DISK
+    )
+    monkeypatch.setattr(
+        cfg, "_delete_models_cache_on_disk", _REAL_DELETE_MODELS_CACHE_ON_DISK
+    )
+    monkeypatch.setattr(
+        cfg, "_load_models_cache_from_disk", _REAL_LOAD_MODELS_CACHE_FROM_DISK
+    )
+
+    # The catalog the STALE worker builds (still contains the provider the
+    # cleanup removes mid-flight).
+    stale_result = {
+        "active_provider": "openai-api",
+        "default_model": "gpt-5.5",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "OpenAI",
+                "provider_id": "openai-api",
+                "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+            }
+        ],
+        "aliases": {},
+    }
+
+    stale_started = threading.Event()
+    release_stale = threading.Event()
+    disk_save_entered = threading.Event()
+    release_disk_save = threading.Event()
+    invalidation_done = threading.Event()
+
+    def _stale_rebuild(_builder):
+        stale_started.set()
+        assert release_stale.wait(5)
+        return copy.deepcopy(stale_result)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _stale_rebuild)
+
+    def _paused_save(cache):
+        # Only reached after the generation check passed — and, with the fix,
+        # while the worker still holds _cache_build_cv. Pause here so the
+        # test can try to invalidate in the TOCTOU window.
+        disk_save_entered.set()
+        assert release_disk_save.wait(5)
+        _REAL_SAVE_MODELS_CACHE_TO_DISK(cache)
+
+    monkeypatch.setattr(cfg, "_save_models_cache_to_disk", _paused_save)
+
+    def _rebuild_worker_threads():
+        return [
+            t for t in threading.enumerate() if t.name == "models-catalog-rebuild"
+        ]
+
+    baseline_workers = len(_rebuild_worker_threads())
+
+    # 1. Over-budget rebuild: the worker builds a catalog that still contains
+    #    the provider the cleanup removes (openai-api).
+    cfg.get_available_models()
+    assert stale_started.wait(5)
+    assert len(_rebuild_worker_threads()) == baseline_workers + 1
+
+    # 2. Let the worker finish building and publish. The generation check
+    #    passes (no invalidation yet) and it enters the disk save, where it
+    #    pauses — with the fix, still holding _cache_build_cv.
+    release_stale.set()
+    assert disk_save_entered.wait(5)
+
+    # 3. Invalidate on a separate thread: it must BLOCK behind the worker's
+    #    cv-held disk save (the fix) instead of interleaving between the
+    #    generation check and the rename (the TOCTOU bug).
+    def _invalidate():
+        cfg.invalidate_models_cache()
+        invalidation_done.set()
+
+    invalidation_thread = threading.Thread(
+        target=_invalidate, name="test-invalidation", daemon=True
+    )
+    invalidation_thread.start()
+    time.sleep(0.2)
+    assert not invalidation_done.is_set(), (
+        "invalidation must not interleave between the generation check and "
+        "the atomic disk rename (#6581 TOCTOU)"
+    )
+
+    # 4. Resume the worker: it completes the real disk write (the file
+    #    briefly holds the stale catalog), then releases the cv — and only
+    #    then does the invalidation run, strictly after, deleting the file.
+    release_disk_save.set()
+    assert invalidation_done.wait(5)
+    invalidation_thread.join(5)
+
+    # 5. The removed provider must not survive anywhere. Not in memory...
+    assert cfg._available_models_cache is None
+    # ...not in the on-disk cache: the invalidation deleted the file the
+    #    stale worker just wrote (on the buggy code the file survives with
+    #    the removed provider + post-removal fingerprint)...
+    cache_path = cfg._get_models_cache_path()
+    assert not cache_path.exists(), (
+        "the stale on-disk write must be deleted by the post-write "
+        "invalidation, not resurrect the removed provider on next boot"
+    )
+    # ...and not through a strict restart load (a fresh process's boot path).
+    assert cfg._load_models_cache_from_disk() is None
+
+    deadline = time.monotonic() + 5
+    while (
+        time.monotonic() < deadline
+        and len(_rebuild_worker_threads()) > baseline_workers
+    ):
+        time.sleep(0.01)
+    assert len(_rebuild_worker_threads()) == baseline_workers

--- a/tests/test_issue3928_models_budget_fallback.py
+++ b/tests/test_issue3928_models_budget_fallback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import threading
 import time
 
 import pytest
@@ -489,3 +490,148 @@ def test_provider_models_list_of_dicts_without_id_does_not_collapse_catalog(
     assert any(mid.endswith("gpt-5.5") for mid in group_model_ids)
     assert any(mid.endswith("gpt-4.1") for mid in group_model_ids)
     assert any(mid.endswith("gpt-4o") for mid in group_model_ids)
+
+
+def test_stale_over_budget_rebuild_discarded_after_invalidation(
+    monkeypatch,
+    isolate_models_catalog_state,
+):
+    """Regression for #6581: an in-flight rebuild must not republish after invalidation.
+
+    Provider cleanup now calls invalidate_models_cache() (api/providers.py).
+    An over-budget rebuild worker that started BEFORE the cleanup would
+    otherwise republish its stale catalog — resurrecting the just-removed
+    provider in memory and re-creating the on-disk cache, so the picker still
+    shows it (even across a restart). The generation/owner token must discard
+    the stale result, skip the disk write, and leave a newer rebuild's
+    in-progress flag untouched.
+    """
+    _configure_local_sources(
+        monkeypatch,
+        isolate_models_catalog_state["auth_store_path"],
+    )
+    monkeypatch.setattr(cfg, "_LIVE_REBUILD_BUDGET_SECONDS", 0.05, raising=False)
+
+    # The catalog the STALE worker builds (still contains the provider that
+    # the cleanup removes mid-flight).
+    stale_result = {
+        "active_provider": "openai-api",
+        "default_model": "gpt-5.5",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "OpenAI",
+                "provider_id": "openai-api",
+                "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+            }
+        ],
+        "aliases": {},
+    }
+    # The catalog the FRESH (post-removal) rebuild builds.
+    fresh_result = {
+        "active_provider": "anthropic",
+        "default_model": "claude-sonnet-4.6",
+        "configured_model_badges": {},
+        "groups": [
+            {
+                "provider": "Anthropic",
+                "provider_id": "anthropic",
+                "models": [
+                    {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"}
+                ],
+            }
+        ],
+        "aliases": {},
+    }
+
+    stale_started = threading.Event()
+    release_stale = threading.Event()
+    fresh_started = threading.Event()
+    release_fresh = threading.Event()
+
+    def _stale_rebuild(_builder):
+        stale_started.set()
+        assert release_stale.wait(5)
+        return copy.deepcopy(stale_result)
+
+    def _fresh_rebuild(_builder):
+        fresh_started.set()
+        assert release_fresh.wait(5)
+        return copy.deepcopy(fresh_result)
+
+    rebuilds = iter([_stale_rebuild, _fresh_rebuild])
+
+    def _controlled_rebuild(_builder):
+        return next(rebuilds)(_builder)
+
+    monkeypatch.setattr(cfg, "_invoke_models_rebuild", _controlled_rebuild)
+
+    disk_writes = []
+    monkeypatch.setattr(
+        cfg,
+        "_save_models_cache_to_disk",
+        lambda cache: disk_writes.append(copy.deepcopy(cache)),
+    )
+
+    def _rebuild_worker_threads():
+        return [
+            t for t in threading.enumerate() if t.name == "models-catalog-rebuild"
+        ]
+
+    baseline_workers = len(_rebuild_worker_threads())
+
+    # 1. Start a rebuild that exceeds the budget; its worker tries to publish
+    #    out-of-band once it finishes.
+    cfg.get_available_models()
+    assert stale_started.wait(5)
+    assert len(_rebuild_worker_threads()) == baseline_workers + 1
+
+    # 2. Provider cleanup (the _clean_provider_key_from_config path) removes
+    #    the provider and invalidates the model cache mid-flight.
+    cfg.invalidate_models_cache()
+    assert cfg._available_models_cache is None
+
+    # 3. A new caller triggers a FRESH rebuild against the post-removal
+    #    config; it now owns the in-progress flag.
+    cfg.get_available_models()
+    assert fresh_started.wait(5)
+    assert len(_rebuild_worker_threads()) == baseline_workers + 2
+    assert cfg._cache_build_in_progress is True
+
+    # 4. Let the STALE worker finish: its publish attempt must be discarded
+    #    (generation mismatch) — no memory publish, no disk write, and the
+    #    fresh rebuild's in-progress flag must survive.
+    release_stale.set()
+    deadline = time.monotonic() + 5
+    while (
+        time.monotonic() < deadline
+        and len(_rebuild_worker_threads()) > baseline_workers + 1
+    ):
+        time.sleep(0.01)
+    assert len(_rebuild_worker_threads()) == baseline_workers + 1
+    # The stale worker neither republished the removed provider...
+    assert cfg._available_models_cache is None
+    # ...nor cleared the fresh rebuild's in-progress state.
+    assert cfg._cache_build_in_progress is True
+
+    # 5. Let the FRESH worker finish: it publishes the post-removal catalog.
+    release_fresh.set()
+    deadline = time.monotonic() + 5
+    while (
+        time.monotonic() < deadline
+        and len(_rebuild_worker_threads()) > baseline_workers
+    ):
+        time.sleep(0.01)
+    assert len(_rebuild_worker_threads()) == baseline_workers
+    assert cfg._cache_build_in_progress is False
+    assert cfg._available_models_cache == fresh_result
+
+    # 6. The removed provider never reappeared — neither in memory nor in any
+    #    on-disk write.
+    provider_ids = [
+        group["provider_id"] for group in cfg._available_models_cache["groups"]
+    ]
+    assert "openai-api" not in provider_ids
+    assert disk_writes == [fresh_result], (
+        "the stale rebuild must not write its catalog to disk"
+    )

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -495,7 +495,9 @@ class TestRemoveProviderKey:
         stale = yaml.safe_load(stale_config.read_text(encoding="utf-8"))
         active = yaml.safe_load(active_config.read_text(encoding="utf-8"))
         assert stale["providers"]["openai"]["api_key"] == "stale-secret"
-        assert "api_key" not in active["providers"]["openai"]
+        # The providers.openai entry was fully removed since it only had api_key,
+        # and the empty providers section was itself removed (#6335 / #6581).
+        assert "providers" not in active
         assert active["model"] == {"provider": "openai"}
 
     def test_clean_custom_provider_key_matches_safe_name_slug(self, monkeypatch, tmp_path):
@@ -527,6 +529,141 @@ class TestRemoveProviderKey:
         custom_provider = reloaded["custom_providers"][0]
         assert custom_provider["name"] == "Local (127.0.0.1:15721)"
         assert "api_key" not in custom_provider
+
+    def test_clean_provider_key_removes_empty_entry_and_section(self, monkeypatch, tmp_path):
+        """Provider entry with only api_key -> entry removed and empty providers section removed."""
+        import yaml
+
+        import api.config as cfg_mod
+        import api.providers as providers
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "providers": {"openai": {"api_key": "sk-secret"}},
+                "model": {"provider": "openai"},
+            }),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: config_path)
+        monkeypatch.setattr(providers, "reload_config", lambda: None)
+
+        providers._clean_provider_key_from_config("openai")
+
+        reloaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        # The provider entry had only api_key — both the entry and empty
+        # providers section should be removed (#6335).
+        assert "providers" not in reloaded
+        assert reloaded == {"model": {"provider": "openai"}}
+
+    def test_clean_provider_key_preserves_other_config_keys(self, monkeypatch, tmp_path):
+        """Provider with api_key plus other config keys -> only api_key removed, entry stays."""
+        import yaml
+
+        import api.config as cfg_mod
+        import api.providers as providers
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "providers": {
+                    "openai": {
+                        "api_key": "sk-secret",
+                        "base_url": "https://custom-openai.example.com/v1",
+                        "organization_id": "org-abc",
+                    },
+                },
+                "model": {"provider": "openai"},
+            }),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: config_path)
+        monkeypatch.setattr(providers, "reload_config", lambda: None)
+
+        providers._clean_provider_key_from_config("openai")
+
+        reloaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        provider_entry = reloaded["providers"]["openai"]
+        assert "api_key" not in provider_entry
+        assert provider_entry["base_url"] == "https://custom-openai.example.com/v1"
+        assert provider_entry["organization_id"] == "org-abc"
+        # providers section stays because the entry still has other keys
+        assert "providers" in reloaded
+
+    def test_clean_provider_key_preserves_siblings(self, monkeypatch, tmp_path):
+        """Multiple configured providers: removing one empty target preserves siblings."""
+        import yaml
+
+        import api.config as cfg_mod
+        import api.providers as providers
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "providers": {
+                    "openai": {"api_key": "sk-openai"},
+                    "anthropic": {"api_key": "sk-anthropic"},
+                },
+                "model": {"provider": "openai", "api_key": "sk-model"},
+            }),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: config_path)
+        monkeypatch.setattr(providers, "reload_config", lambda: None)
+
+        providers._clean_provider_key_from_config("openai")
+
+        reloaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        # openai entry was removed (only had api_key)
+        assert "openai" not in reloaded["providers"]
+        # anthropic sibling is preserved
+        assert reloaded["providers"]["anthropic"]["api_key"] == "sk-anthropic"
+        # providers section stays because anthropic still exists
+        assert "providers" in reloaded
+        # model.api_key was also cleaned (openai was active provider)
+        assert reloaded["model"] == {"provider": "openai"}
+
+    def test_clean_provider_key_invalidates_model_cache(self, monkeypatch, tmp_path):
+        """_clean_provider_key_from_config must call invalidate_models_cache()."""
+        import yaml
+
+        import api.config as cfg_mod
+        import api.providers as providers
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({
+                "providers": {"openai": {"api_key": "sk-secret"}},
+                "model": {"provider": "openai"},
+            }),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: config_path)
+        monkeypatch.setattr(providers, "reload_config", lambda: None)
+
+        model_cache_invalidated = []
+        providers_cache_invalidated = []
+        monkeypatch.setattr(
+            providers, "invalidate_models_cache",
+            lambda: model_cache_invalidated.append(True),
+        )
+        monkeypatch.setattr(
+            providers, "invalidate_providers_cache",
+            lambda: providers_cache_invalidated.append(True),
+        )
+
+        providers._clean_provider_key_from_config("openai")
+
+        assert model_cache_invalidated == [True], (
+            "_clean_provider_key_from_config must call invalidate_models_cache()"
+        )
+        assert providers_cache_invalidated == [True], (
+            "_clean_provider_key_from_config must call invalidate_providers_cache()"
+        )
 
     def test_remove_provider_key_calls_set_with_none(self, monkeypatch, tmp_path):
         """remove_provider_key should delegate to set_provider_key(id, None)."""


### PR DESCRIPTION
Closes #6335

## Problem

When a provider's API key is removed via the WebUI Settings → Providers page,
the provider was still visible in the chat model selector dropdown. This happened
because:

1. `_clean_provider_key_from_config()` removed the `api_key` field from the
   provider entry in `config.yaml`, but the now-empty dict entry remained
   (e.g., `providers.openai-api: {}`).
2. The model-picker detection loop in `_build_available_models_uncached()`
   iterated over all keys in the `providers:` section and added any known
   provider ID to `detected_providers` — regardless of whether the entry
   had any actual credentials.

## Fix

### `api/providers.py` — `_clean_provider_key_from_config()`

1. **Remove empty provider entries**: After deleting `api_key` from a provider
   config entry, if the entry is now empty (no keys remain), remove the entire
   provider entry from the `providers` dict. Also clean up the `providers`
   section itself if it falls completely empty.
2. **Invalidate models cache**: Added `invalidate_models_cache()` call so
   the `/api/models` TTL cache is busted when provider config is cleaned,
   ensuring the next model selector request picks up the change immediately.

## Verification

- Removing a provider's API key via the WebUI no longer leaves a lingering
  `providers.<id>: {}` entry in config.yaml.
- The model selector correctly excludes providers that have no credentials.
- Existing tests continue to pass (the change only affects the post-cleanup
  state, not the detection logic itself).