### PR TITLE
fix(api): filter empty tool_calls array before sending to DeepSeek API

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4932,6 +4932,30 @@ def _sanitize_messages_for_api(
     return final
 
 
+def _strip_empty_tool_calls_from_messages(messages):
+    """Strip empty ``tool_calls`` arrays from assistant messages in place.
+
+    Strict providers (DeepSeek v4, newer OpenAI) reject ``tool_calls: []``
+    with HTTP 400 even when no orphaned calls exist. This runs on result
+    messages returned by ``run_conversation()`` as a defense-in-depth layer
+    — the agent library's own ``sanitize_api_messages`` already strips these
+    before each API call, but the returned messages may still carry empty
+    arrays from intermediate processing. Stripping here prevents the bad
+    state from persisting in session history.
+    """
+    changed = 0
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+        ):
+            msg.pop("tool_calls", None)
+            changed += 1
+    return changed
+
+
 def _api_safe_message_positions(messages):
     """Return [(original_index, sanitized_message)] for API-safe messages."""
     valid_tool_call_ids: set = set()
@@ -9596,6 +9620,13 @@ def _run_agent_streaming(
                 result=result,
                 agent=agent,
             )
+            # Defense-in-depth: strip empty ``tool_calls`` from result messages
+            # so they never persist in session history. The agent library's
+            # ``sanitize_api_messages`` already strips these before each API
+            # call, but intermediate processing may leave empty arrays on the
+            # returned messages that would cause HTTP 400 on subsequent turns.
+            _result_messages = result.get("messages") or []
+            _strip_empty_tool_calls_from_messages(_result_messages)
             # #4729: the run is done — flush any reasoning tail still in the coalescing
             # buffer (the agent never calls reasoning_callback(None), and a turn can end on
             # reasoning with no trailing token/tool boundary to trigger a flush) so the last
@@ -10048,6 +10079,9 @@ def _run_agent_streaming(
                                     _active_turn_identity,
                                     result=_heal_result,
                                     agent=agent,
+                                )
+                                _strip_empty_tool_calls_from_messages(
+                                    _heal_result.get('messages') or []
                                 )
                                 _heal_all_msgs = _heal_result.get('messages') or []
                                 _heal_ok = _has_new_assistant_reply(_heal_all_msgs, _prev_len) or _token_sent
@@ -11272,6 +11306,9 @@ def _run_agent_streaming(
                             _active_turn_identity,
                             result=_heal_result,
                             agent=_heal_agent,
+                        )
+                        _strip_empty_tool_calls_from_messages(
+                            _heal_result.get('messages') or []
                         )
                         # Retry succeeded — persist the result normally
                         if s is not None:


### PR DESCRIPTION
Closes #6545

## Problem
Empty `tool_calls` arrays (`tool_calls: []`) still reach DeepSeek V4 API during the agent's tool-execution loop, causing HTTP 400 errors. The previous fix (#5737) only covered the initial `conversation_history` send path via the WebUI's `_sanitize_messages_for_api`, but internal API calls made by the Hermes Agent library during the tool-call loop bypassed it.

## Root Causes (Agent Library)

Two chokepoints in the Hermes Agent library could produce or preserve empty `tool_calls` arrays:

1. **`_sanitize_tool_calls_for_strict_api`** (`run_agent.py`): The guard `if not isinstance(tool_calls, list): return` passes an empty `[]` through, and the comprehension then re-sets `api_msg[\tool_calls\] = []`. Fixed by adding `or not tool_calls` to the early-return guard.

2. **`repair_message_sequence`** (`agent_runtime_helpers.py`): The consecutive-assistant merge logic checks `if new_calls:` / `elif prev_calls:`, but when both sides have empty-or-absent tool_calls, neither branch fires — leaving a stale `tool_calls: []` on the surviving turn. Fixed by adding an `else` branch that explicitly removes the key.

## Defense-in-Depth (WebUI)

Added `_strip_empty_tool_calls_from_messages()` in `api/streaming.py` and call it on `result_messages` from all three `run_conversation()` paths (main + 2 heal/retry paths). This ensures empty `tool_calls` never persist in session history, even if intermediate processing in the agent library creates them.

## Verification

- The existing `_sanitize_messages_for_api` already strips empty `tool_calls` (fix #5737)
- The agent library's `sanitize_api_messages` also strips them before each API call (fix #58755)
- These two new source fixes prevent the bad state from being created in the first place
- The WebUI defense-in-depth catches any that slip through